### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
@@ -939,17 +939,20 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 }
             }
 
-            let span_lo_redundant_lt_args = lt_arg_spans[self.num_expected_lifetime_args()];
+            let span_lo_redundant_lt_args = if self.num_expected_lifetime_args() == 0 {
+                lt_arg_spans[0]
+            } else {
+                lt_arg_spans[self.num_expected_lifetime_args() - 1]
+            };
             let span_hi_redundant_lt_args = lt_arg_spans[lt_arg_spans.len() - 1];
 
-            let span_redundant_lt_args = span_lo_redundant_lt_args.to(span_hi_redundant_lt_args);
+            let span_redundant_lt_args =
+                span_lo_redundant_lt_args.shrink_to_hi().to(span_hi_redundant_lt_args);
             debug!("span_redundant_lt_args: {:?}", span_redundant_lt_args);
 
             let num_redundant_lt_args = lt_arg_spans.len() - self.num_expected_lifetime_args();
-            let msg_lifetimes = format!(
-                "remove the lifetime argument{s}",
-                s = pluralize!(num_redundant_lt_args),
-            );
+            let msg_lifetimes =
+                format!("remove the lifetime argument{s}", s = pluralize!(num_redundant_lt_args));
 
             err.span_suggestion_verbose(
                 span_redundant_lt_args,
@@ -978,11 +981,16 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
             }
 
             let span_lo_redundant_type_or_const_args =
-                gen_arg_spans[self.num_expected_type_or_const_args()];
+                if self.num_expected_type_or_const_args() == 0 {
+                    gen_arg_spans[0]
+                } else {
+                    gen_arg_spans[self.num_expected_type_or_const_args() - 1]
+                };
             let span_hi_redundant_type_or_const_args = gen_arg_spans[gen_arg_spans.len() - 1];
+            let span_redundant_type_or_const_args = span_lo_redundant_type_or_const_args
+                .shrink_to_hi()
+                .to(span_hi_redundant_type_or_const_args);
 
-            let span_redundant_type_or_const_args =
-                span_lo_redundant_type_or_const_args.to(span_hi_redundant_type_or_const_args);
             debug!("span_redundant_type_or_const_args: {:?}", span_redundant_type_or_const_args);
 
             let num_redundant_gen_args =

--- a/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
@@ -888,7 +888,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
         let comma = if args.len() > 0 { ", " } else { "" };
         let trait_path = self.tcx.def_path_str(trait_def_id);
         let method_name = self.tcx.item_name(self.def_id);
-        err.span_suggestion(
+        err.span_suggestion_verbose(
             expr.span,
             msg,
             format!("{trait_path}::{generics}::{method_name}({rcvr}{comma}{rest})"),
@@ -952,7 +952,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 s = pluralize!(num_redundant_lt_args),
             );
 
-            err.span_suggestion(
+            err.span_suggestion_verbose(
                 span_redundant_lt_args,
                 msg_lifetimes,
                 "",
@@ -994,7 +994,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 s = pluralize!(num_redundant_gen_args),
             );
 
-            err.span_suggestion(
+            err.span_suggestion_verbose(
                 span_redundant_type_or_const_args,
                 msg_types_or_consts,
                 "",
@@ -1044,7 +1044,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 },
             );
 
-            err.span_suggestion(span, msg, "", Applicability::MaybeIncorrect);
+            err.span_suggestion_verbose(span, msg, "", Applicability::MaybeIncorrect);
         } else if redundant_lifetime_args && redundant_type_or_const_args {
             remove_lifetime_args(err);
             remove_type_or_const_args(err);

--- a/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
@@ -947,8 +947,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
 
             let num_redundant_lt_args = lt_arg_spans.len() - self.num_expected_lifetime_args();
             let msg_lifetimes = format!(
-                "remove {these} lifetime argument{s}",
-                these = pluralize!("this", num_redundant_lt_args),
+                "remove the lifetime argument{s}",
                 s = pluralize!(num_redundant_lt_args),
             );
 
@@ -989,8 +988,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
             let num_redundant_gen_args =
                 gen_arg_spans.len() - self.num_expected_type_or_const_args();
             let msg_types_or_consts = format!(
-                "remove {these} generic argument{s}",
-                these = pluralize!("this", num_redundant_gen_args),
+                "remove the unnecessary generic argument{s}",
                 s = pluralize!(num_redundant_gen_args),
             );
 
@@ -1036,7 +1034,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 .with_lo(self.path_segment.ident.span.hi());
 
             let msg = format!(
-                "remove these {}generics",
+                "remove the unnecessary {}generics",
                 if self.gen_args.parenthesized == hir::GenericArgsParentheses::ParenSugar {
                     "parenthetical "
                 } else {

--- a/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
@@ -954,7 +954,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
             let msg_lifetimes =
                 format!("remove the lifetime argument{s}", s = pluralize!(num_redundant_lt_args));
 
-            err.span_suggestion_verbose(
+            err.span_suggestion(
                 span_redundant_lt_args,
                 msg_lifetimes,
                 "",
@@ -1000,7 +1000,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 s = pluralize!(num_redundant_gen_args),
             );
 
-            err.span_suggestion_verbose(
+            err.span_suggestion(
                 span_redundant_type_or_const_args,
                 msg_types_or_consts,
                 "",
@@ -1050,7 +1050,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                 },
             );
 
-            err.span_suggestion_verbose(span, msg, "", Applicability::MaybeIncorrect);
+            err.span_suggestion(span, msg, "", Applicability::MaybeIncorrect);
         } else if redundant_lifetime_args && redundant_type_or_const_args {
             remove_lifetime_args(err);
             remove_type_or_const_args(err);

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -101,6 +101,7 @@
 #![feature(array_windows)]
 #![feature(ascii_char)]
 #![feature(assert_matches)]
+#![feature(async_closure)]
 #![feature(async_fn_traits)]
 #![feature(async_iterator)]
 #![feature(clone_to_uninit)]

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -183,6 +183,8 @@ impl Layout {
     ///     - a [slice], then the length of the slice tail must be an initialized
     ///       integer, and the size of the *entire value*
     ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
+    ///       For the special case where the dynamic tail length is 0, this function
+    ///       is safe to call.
     ///     - a [trait object], then the vtable part of the pointer must point
     ///       to a valid vtable for the type `T` acquired by an unsizing coercion,
     ///       and the size of the *entire value*

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -359,6 +359,12 @@ pub const fn size_of_val<T: ?Sized>(val: &T) -> usize {
 ///     - a [slice], then the length of the slice tail must be an initialized
 ///       integer, and the size of the *entire value*
 ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
+///       For the special case where the dynamic tail length is 0, this function
+///       is safe to call.
+//        NOTE: the reason this is safe is that if an overflow were to occur already with size 0,
+//        then we would stop compilation as even the "statically known" part of the type would
+//        already be too big (or the call may be in dead code and optimized away, but then it
+//        doesn't matter).
 ///     - a [trait object], then the vtable part of the pointer must point
 ///       to a valid vtable acquired by an unsizing coercion, and the size
 ///       of the *entire value* (dynamic tail length + statically sized prefix)
@@ -506,6 +512,8 @@ pub const fn align_of_val<T: ?Sized>(val: &T) -> usize {
 ///     - a [slice], then the length of the slice tail must be an initialized
 ///       integer, and the size of the *entire value*
 ///       (dynamic tail length + statically sized prefix) must fit in `isize`.
+///       For the special case where the dynamic tail length is 0, this function
+///       is safe to call.
 ///     - a [trait object], then the vtable part of the pointer must point
 ///       to a valid vtable acquired by an unsizing coercion, and the size
 ///       of the *entire value* (dynamic tail length + statically sized prefix)

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -65,8 +65,13 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("let n = 0b01001100", stringify!($SelfT), ";")]
-        ///
         /// assert_eq!(n.count_ones(), 3);
+        ///
+        #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
+        #[doc = concat!("assert_eq!(max.count_ones(), ", stringify!($BITS), ");")]
+        ///
+        #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
+        /// assert_eq!(zero.count_ones(), 0);
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_stable(feature = "const_math", since = "1.32.0")]
@@ -86,7 +91,11 @@ macro_rules! uint_impl {
         /// Basic usage:
         ///
         /// ```
-        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MAX.count_zeros(), 0);")]
+        #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
+        #[doc = concat!("assert_eq!(zero.count_zeros(), ", stringify!($BITS), ");")]
+        ///
+        #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
+        /// assert_eq!(max.count_zeros(), 0);
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_stable(feature = "const_math", since = "1.32.0")]
@@ -108,8 +117,13 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("let n = ", stringify!($SelfT), "::MAX >> 2;")]
-        ///
         /// assert_eq!(n.leading_zeros(), 2);
+        ///
+        #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
+        #[doc = concat!("assert_eq!(zero.leading_zeros(), ", stringify!($BITS), ");")]
+        ///
+        #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
+        /// assert_eq!(max.leading_zeros(), 0);
         /// ```
         #[doc = concat!("[`ilog2`]: ", stringify!($SelfT), "::ilog2")]
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -130,8 +144,13 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("let n = 0b0101000", stringify!($SelfT), ";")]
-        ///
         /// assert_eq!(n.trailing_zeros(), 3);
+        ///
+        #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
+        #[doc = concat!("assert_eq!(zero.trailing_zeros(), ", stringify!($BITS), ");")]
+        ///
+        #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
+        #[doc = concat!("assert_eq!(max.trailing_zeros(), 0);")]
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_stable(feature = "const_math", since = "1.32.0")]
@@ -150,8 +169,13 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("let n = !(", stringify!($SelfT), "::MAX >> 2);")]
-        ///
         /// assert_eq!(n.leading_ones(), 2);
+        ///
+        #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
+        /// assert_eq!(zero.leading_ones(), 0);
+        ///
+        #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
+        #[doc = concat!("assert_eq!(max.leading_ones(), ", stringify!($BITS), ");")]
         /// ```
         #[stable(feature = "leading_trailing_ones", since = "1.46.0")]
         #[rustc_const_stable(feature = "leading_trailing_ones", since = "1.46.0")]
@@ -171,8 +195,13 @@ macro_rules! uint_impl {
         ///
         /// ```
         #[doc = concat!("let n = 0b1010111", stringify!($SelfT), ";")]
-        ///
         /// assert_eq!(n.trailing_ones(), 3);
+        ///
+        #[doc = concat!("let zero = 0", stringify!($SelfT), ";")]
+        /// assert_eq!(zero.trailing_ones(), 0);
+        ///
+        #[doc = concat!("let max = ", stringify!($SelfT),"::MAX;")]
+        #[doc = concat!("assert_eq!(max.trailing_ones(), ", stringify!($BITS), ");")]
         /// ```
         #[stable(feature = "leading_trailing_ones", since = "1.46.0")]
         #[rustc_const_stable(feature = "leading_trailing_ones", since = "1.46.0")]

--- a/library/core/src/ops/async_function.rs
+++ b/library/core/src/ops/async_function.rs
@@ -4,7 +4,7 @@ use crate::marker::Tuple;
 /// An async-aware version of the [`Fn`](crate::ops::Fn) trait.
 ///
 /// All `async fn` and functions returning futures implement this trait.
-#[unstable(feature = "async_fn_traits", issue = "none")]
+#[unstable(feature = "async_closure", issue = "62290")]
 #[rustc_paren_sugar]
 #[fundamental]
 #[must_use = "async closures are lazy and do nothing unless called"]
@@ -18,7 +18,7 @@ pub trait AsyncFn<Args: Tuple>: AsyncFnMut<Args> {
 /// An async-aware version of the [`FnMut`](crate::ops::FnMut) trait.
 ///
 /// All `async fn` and functions returning futures implement this trait.
-#[unstable(feature = "async_fn_traits", issue = "none")]
+#[unstable(feature = "async_closure", issue = "62290")]
 #[rustc_paren_sugar]
 #[fundamental]
 #[must_use = "async closures are lazy and do nothing unless called"]
@@ -39,7 +39,7 @@ pub trait AsyncFnMut<Args: Tuple>: AsyncFnOnce<Args> {
 /// An async-aware version of the [`FnOnce`](crate::ops::FnOnce) trait.
 ///
 /// All `async fn` and functions returning futures implement this trait.
-#[unstable(feature = "async_fn_traits", issue = "none")]
+#[unstable(feature = "async_closure", issue = "62290")]
 #[rustc_paren_sugar]
 #[fundamental]
 #[must_use = "async closures are lazy and do nothing unless called"]

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -1,10 +1,9 @@
 #![stable(feature = "futures_api", since = "1.36.0")]
 
-use crate::mem::transmute;
-
 use crate::any::Any;
 use crate::fmt;
 use crate::marker::PhantomData;
+use crate::mem::{transmute, ManuallyDrop};
 use crate::panic::AssertUnwindSafe;
 use crate::ptr;
 
@@ -465,16 +464,14 @@ impl Waker {
     pub fn wake(self) {
         // The actual wakeup call is delegated through a virtual function call
         // to the implementation which is defined by the executor.
-        let wake = self.waker.vtable.wake;
-        let data = self.waker.data;
 
         // Don't call `drop` -- the waker will be consumed by `wake`.
-        crate::mem::forget(self);
+        let this = ManuallyDrop::new(self);
 
         // SAFETY: This is safe because `Waker::from_raw` is the only way
         // to initialize `wake` and `data` requiring the user to acknowledge
         // that the contract of `RawWaker` is upheld.
-        unsafe { (wake)(data) };
+        unsafe { (this.waker.vtable.wake)(this.waker.data) };
     }
 
     /// Wake up the task associated with this `Waker` without consuming the `Waker`.
@@ -726,16 +723,14 @@ impl LocalWaker {
     pub fn wake(self) {
         // The actual wakeup call is delegated through a virtual function call
         // to the implementation which is defined by the executor.
-        let wake = self.waker.vtable.wake;
-        let data = self.waker.data;
 
         // Don't call `drop` -- the waker will be consumed by `wake`.
-        crate::mem::forget(self);
+        let this = ManuallyDrop::new(self);
 
         // SAFETY: This is safe because `Waker::from_raw` is the only way
         // to initialize `wake` and `data` requiring the user to acknowledge
         // that the contract of `RawWaker` is upheld.
-        unsafe { (wake)(data) };
+        unsafe { (this.waker.vtable.wake)(this.waker.data) };
     }
 
     /// Wake up the task associated with this `LocalWaker` without consuming the `LocalWaker`.

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -51,9 +51,7 @@ macro_rules! define_client_handles {
 
             impl<S> Encode<S> for $oty {
                 fn encode(self, w: &mut Writer, s: &mut S) {
-                    let handle = self.handle;
-                    mem::forget(self);
-                    handle.encode(w, s);
+                    mem::ManuallyDrop::new(self).handle.encode(w, s);
                 }
             }
 

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -8,7 +8,7 @@ use crate::fmt;
 use crate::fs;
 use crate::io;
 use crate::marker::PhantomData;
-use crate::mem::forget;
+use crate::mem::ManuallyDrop;
 #[cfg(not(any(target_arch = "wasm32", target_env = "sgx", target_os = "hermit")))]
 use crate::sys::cvt;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
@@ -141,9 +141,7 @@ impl AsRawFd for OwnedFd {
 impl IntoRawFd for OwnedFd {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
-        let fd = self.fd;
-        forget(self);
-        fd
+        ManuallyDrop::new(self).fd
     }
 }
 

--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -49,7 +49,7 @@
 
 use crate::fmt;
 use crate::marker::PhantomData;
-use crate::mem::forget;
+use crate::mem::ManuallyDrop;
 use crate::net;
 use crate::sys;
 use crate::sys_common::{self, AsInner, FromInner, IntoInner};
@@ -149,9 +149,7 @@ impl AsRawFd for OwnedFd {
 impl IntoRawFd for OwnedFd {
     #[inline]
     fn into_raw_fd(self) -> RawFd {
-        let fd = self.fd;
-        forget(self);
-        fd
+        ManuallyDrop::new(self).fd
     }
 }
 

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -1064,7 +1064,7 @@ pub fn lchown<P: AsRef<Path>>(dir: P, uid: Option<u32>, gid: Option<u32>) -> io:
 /// }
 /// ```
 #[stable(feature = "unix_chroot", since = "1.56.0")]
-#[cfg(not(any(target_os = "fuchsia", target_os = "vxworks")))]
+#[cfg(not(target_os = "fuchsia"))]
 pub fn chroot<P: AsRef<Path>>(dir: P) -> io::Result<()> {
     sys::fs::chroot(dir.as_ref())
 }

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -7,7 +7,7 @@ use crate::fmt;
 use crate::fs;
 use crate::io;
 use crate::marker::PhantomData;
-use crate::mem::{forget, ManuallyDrop};
+use crate::mem::ManuallyDrop;
 use crate::ptr;
 use crate::sys;
 use crate::sys::cvt;
@@ -319,9 +319,7 @@ impl AsRawHandle for OwnedHandle {
 impl IntoRawHandle for OwnedHandle {
     #[inline]
     fn into_raw_handle(self) -> RawHandle {
-        let handle = self.handle;
-        forget(self);
-        handle
+        ManuallyDrop::new(self).handle
     }
 }
 

--- a/library/std/src/os/windows/io/socket.rs
+++ b/library/std/src/os/windows/io/socket.rs
@@ -6,8 +6,7 @@ use super::raw::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
 use crate::fmt;
 use crate::io;
 use crate::marker::PhantomData;
-use crate::mem;
-use crate::mem::forget;
+use crate::mem::{self, ManuallyDrop};
 use crate::sys;
 #[cfg(not(target_vendor = "uwp"))]
 use crate::sys::cvt;
@@ -191,9 +190,7 @@ impl AsRawSocket for OwnedSocket {
 impl IntoRawSocket for OwnedSocket {
     #[inline]
     fn into_raw_socket(self) -> RawSocket {
-        let socket = self.socket;
-        forget(self);
-        socket
+        ManuallyDrop::new(self).socket
     }
 }
 

--- a/library/std/src/sys/pal/hermit/thread.rs
+++ b/library/std/src/sys/pal/hermit/thread.rs
@@ -3,7 +3,7 @@
 use super::hermit_abi;
 use crate::ffi::CStr;
 use crate::io;
-use crate::mem;
+use crate::mem::ManuallyDrop;
 use crate::num::NonZero;
 use crate::ptr;
 use crate::time::Duration;
@@ -90,9 +90,7 @@ impl Thread {
 
     #[inline]
     pub fn into_id(self) -> Tid {
-        let id = self.tid;
-        mem::forget(self);
-        id
+        ManuallyDrop::new(self).tid
     }
 }
 

--- a/library/std/src/sys/pal/sgx/abi/tls/mod.rs
+++ b/library/std/src/sys/pal/sgx/abi/tls/mod.rs
@@ -95,8 +95,8 @@ impl Tls {
     #[allow(unused)]
     pub unsafe fn activate_persistent(self: Box<Self>) {
         // FIXME: Needs safety information. See entry.S for `set_tls_ptr` definition.
-        unsafe { set_tls_ptr(core::ptr::addr_of!(*self) as _) };
-        mem::forget(self);
+        let ptr = Box::into_raw(self).cast_const().cast::<u8>();
+        unsafe { set_tls_ptr(ptr) };
     }
 
     unsafe fn current<'a>() -> &'a Tls {

--- a/library/std/src/sys/pal/sgx/fd.rs
+++ b/library/std/src/sys/pal/sgx/fd.rs
@@ -2,7 +2,7 @@ use fortanix_sgx_abi::Fd;
 
 use super::abi::usercalls;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut};
-use crate::mem;
+use crate::mem::ManuallyDrop;
 use crate::sys::{AsInner, FromInner, IntoInner};
 
 #[derive(Debug)]
@@ -21,9 +21,7 @@ impl FileDesc {
 
     /// Extracts the actual file descriptor without closing it.
     pub fn into_raw(self) -> Fd {
-        let fd = self.fd;
-        mem::forget(self);
-        fd
+        ManuallyDrop::new(self).fd
     }
 
     pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
@@ -70,9 +68,7 @@ impl AsInner<Fd> for FileDesc {
 
 impl IntoInner<Fd> for FileDesc {
     fn into_inner(self) -> Fd {
-        let fd = self.fd;
-        mem::forget(self);
-        fd
+        ManuallyDrop::new(self).fd
     }
 }
 

--- a/library/std/src/sys/pal/teeos/thread.rs
+++ b/library/std/src/sys/pal/teeos/thread.rs
@@ -1,9 +1,7 @@
-use core::convert::TryInto;
-
 use crate::cmp;
 use crate::ffi::CStr;
 use crate::io;
-use crate::mem;
+use crate::mem::{self, ManuallyDrop};
 use crate::num::NonZero;
 use crate::ptr;
 use crate::sys::os;
@@ -113,11 +111,9 @@ impl Thread {
 
     /// must join, because no pthread_detach supported
     pub fn join(self) {
-        unsafe {
-            let ret = libc::pthread_join(self.id, ptr::null_mut());
-            mem::forget(self);
-            assert!(ret == 0, "failed to join thread: {}", io::Error::from_raw_os_error(ret));
-        }
+        let id = self.into_id();
+        let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
+        assert!(ret == 0, "failed to join thread: {}", io::Error::from_raw_os_error(ret));
     }
 
     pub fn id(&self) -> libc::pthread_t {
@@ -125,9 +121,7 @@ impl Thread {
     }
 
     pub fn into_id(self) -> libc::pthread_t {
-        let id = self.id;
-        mem::forget(self);
-        id
+        ManuallyDrop::new(self).id
     }
 }
 

--- a/library/std/src/sys/pal/unix/fd.rs
+++ b/library/std/src/sys/pal/unix/fd.rs
@@ -120,6 +120,7 @@ impl FileDesc {
         (&mut me).read_to_end(buf)
     }
 
+    #[cfg_attr(target_os = "vxworks", allow(unused_unsafe))]
     pub fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize> {
         #[cfg(not(any(
             all(target_os = "linux", not(target_env = "musl")),
@@ -313,6 +314,7 @@ impl FileDesc {
         cfg!(not(any(target_os = "espidf", target_os = "horizon", target_os = "vita")))
     }
 
+    #[cfg_attr(target_os = "vxworks", allow(unused_unsafe))]
     pub fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize> {
         #[cfg(not(any(
             all(target_os = "linux", not(target_env = "musl")),

--- a/library/std/src/sys/pal/unix/fs.rs
+++ b/library/std/src/sys/pal/unix/fs.rs
@@ -1980,12 +1980,18 @@ pub fn lchown(path: &Path, uid: u32, gid: u32) -> io::Result<()> {
 #[cfg(target_os = "vxworks")]
 pub fn lchown(path: &Path, uid: u32, gid: u32) -> io::Result<()> {
     let (_, _, _) = (path, uid, gid);
-    Err(io::const_io_error!(io::ErrorKind::Unsupported, "lchown not supported by vxworks",))
+    Err(io::const_io_error!(io::ErrorKind::Unsupported, "lchown not supported by vxworks"))
 }
 
 #[cfg(not(any(target_os = "fuchsia", target_os = "vxworks")))]
 pub fn chroot(dir: &Path) -> io::Result<()> {
     run_path_with_cstr(dir, &|dir| cvt(unsafe { libc::chroot(dir.as_ptr()) }).map(|_| ()))
+}
+
+#[cfg(target_os = "vxworks")]
+pub fn chroot(dir: &Path) -> io::Result<()> {
+    let _ = dir;
+    Err(io::const_io_error!(io::ErrorKind::Unsupported, "chroot not supported by vxworks"))
 }
 
 pub use remove_dir_impl::remove_dir_all;

--- a/library/std/src/sys/pal/unix/mod.rs
+++ b/library/std/src/sys/pal/unix/mod.rs
@@ -210,6 +210,7 @@ pub unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
     target_os = "emscripten",
     target_os = "fuchsia",
     target_os = "horizon",
+    target_os = "vxworks",
 )))]
 static ON_BROKEN_PIPE_FLAG_USED: crate::sync::atomic::AtomicBool =
     crate::sync::atomic::AtomicBool::new(false);
@@ -219,6 +220,7 @@ static ON_BROKEN_PIPE_FLAG_USED: crate::sync::atomic::AtomicBool =
     target_os = "emscripten",
     target_os = "fuchsia",
     target_os = "horizon",
+    target_os = "vxworks",
 )))]
 pub(crate) fn on_broken_pipe_flag_used() -> bool {
     ON_BROKEN_PIPE_FLAG_USED.load(crate::sync::atomic::Ordering::Relaxed)

--- a/library/std/src/sys/pal/unix/mod.rs
+++ b/library/std/src/sys/pal/unix/mod.rs
@@ -164,6 +164,7 @@ pub unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
             target_os = "emscripten",
             target_os = "fuchsia",
             target_os = "horizon",
+            target_os = "vxworks",
             // Unikraft's `signal` implementation is currently broken:
             // https://github.com/unikraft/lib-musl/issues/57
             target_vendor = "unikraft",

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -1,7 +1,7 @@
 use crate::cmp;
 use crate::ffi::CStr;
 use crate::io;
-use crate::mem;
+use crate::mem::{self, ManuallyDrop};
 use crate::num::NonZero;
 use crate::ptr;
 use crate::sys::{os, stack_overflow};
@@ -268,11 +268,9 @@ impl Thread {
     }
 
     pub fn join(self) {
-        unsafe {
-            let ret = libc::pthread_join(self.id, ptr::null_mut());
-            mem::forget(self);
-            assert!(ret == 0, "failed to join thread: {}", io::Error::from_raw_os_error(ret));
-        }
+        let id = self.into_id();
+        let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
+        assert!(ret == 0, "failed to join thread: {}", io::Error::from_raw_os_error(ret));
     }
 
     pub fn id(&self) -> libc::pthread_t {
@@ -280,9 +278,7 @@ impl Thread {
     }
 
     pub fn into_id(self) -> libc::pthread_t {
-        let id = self.id;
-        mem::forget(self);
-        id
+        ManuallyDrop::new(self).id
     }
 }
 

--- a/library/std/src/sys/pal/windows/alloc.rs
+++ b/library/std/src/sys/pal/windows/alloc.rs
@@ -37,7 +37,7 @@ windows_targets::link!("kernel32.dll" "system" fn GetProcessHeap() -> c::HANDLE)
 // Note that `dwBytes` is allowed to be zero, contrary to some other allocators.
 //
 // See https://docs.microsoft.com/windows/win32/api/heapapi/nf-heapapi-heapalloc
-windows_targets::link!("kernel32.dll" "system" fn HeapAlloc(hheap: c::HANDLE, dwflags: u32, dwbytes: usize) -> *mut core::ffi::c_void);
+windows_targets::link!("kernel32.dll" "system" fn HeapAlloc(hheap: c::HANDLE, dwflags: u32, dwbytes: usize) -> *mut c_void);
 
 // Reallocate a block of memory behind a given pointer `lpMem` from a given heap `hHeap`,
 // to a block of at least `dwBytes` bytes, either shrinking the block in place,
@@ -61,9 +61,9 @@ windows_targets::link!("kernel32.dll" "system" fn HeapAlloc(hheap: c::HANDLE, dw
 windows_targets::link!("kernel32.dll" "system" fn HeapReAlloc(
     hheap: c::HANDLE,
     dwflags : u32,
-    lpmem: *const core::ffi::c_void,
+    lpmem: *const c_void,
     dwbytes: usize
-) -> *mut core::ffi::c_void);
+) -> *mut c_void);
 
 // Free a block of memory behind a given pointer `lpMem` from a given heap `hHeap`.
 // Returns a nonzero value if the operation is successful, and zero if the operation fails.
@@ -79,7 +79,7 @@ windows_targets::link!("kernel32.dll" "system" fn HeapReAlloc(
 // Note that `lpMem` is allowed to be null, which will not cause the operation to fail.
 //
 // See https://docs.microsoft.com/windows/win32/api/heapapi/nf-heapapi-heapfree
-windows_targets::link!("kernel32.dll" "system" fn HeapFree(hheap: c::HANDLE, dwflags: u32, lpmem: *const core::ffi::c_void) -> c::BOOL);
+windows_targets::link!("kernel32.dll" "system" fn HeapFree(hheap: c::HANDLE, dwflags: u32, lpmem: *const c_void) -> c::BOOL);
 
 // Cached handle to the default heap of the current process.
 // Either a non-null handle returned by `GetProcessHeap`, or null when not yet initialized or `GetProcessHeap` failed.

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -134,26 +134,26 @@ compat_fn_with_fallback! {
     // >= Win10 1607
     // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreaddescription
     pub fn SetThreadDescription(hthread: HANDLE, lpthreaddescription: PCWSTR) -> HRESULT {
-        SetLastError(ERROR_CALL_NOT_IMPLEMENTED as u32); E_NOTIMPL
+        unsafe { SetLastError(ERROR_CALL_NOT_IMPLEMENTED as u32); E_NOTIMPL }
     }
 
     // >= Win10 1607
     // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getthreaddescription
     pub fn GetThreadDescription(hthread: HANDLE, lpthreaddescription: *mut PWSTR) -> HRESULT {
-        SetLastError(ERROR_CALL_NOT_IMPLEMENTED as u32); E_NOTIMPL
+        unsafe { SetLastError(ERROR_CALL_NOT_IMPLEMENTED as u32); E_NOTIMPL }
     }
 
     // >= Win8 / Server 2012
     // https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime
     #[cfg(target_vendor = "win7")]
     pub fn GetSystemTimePreciseAsFileTime(lpsystemtimeasfiletime: *mut FILETIME) -> () {
-        GetSystemTimeAsFileTime(lpsystemtimeasfiletime)
+        unsafe { GetSystemTimeAsFileTime(lpsystemtimeasfiletime) }
     }
 
     // >= Win11 / Server 2022
     // https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppath2a
     pub fn GetTempPath2W(bufferlength: u32, buffer: PWSTR) -> u32 {
-        GetTempPathW(bufferlength, buffer)
+        unsafe {  GetTempPathW(bufferlength, buffer) }
     }
 }
 

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -4,12 +4,10 @@
 #![cfg_attr(test, allow(dead_code))]
 #![unstable(issue = "none", feature = "windows_c")]
 #![allow(clippy::style)]
-#![allow(unsafe_op_in_unsafe_fn)]
 
-use crate::ffi::CStr;
-use crate::mem;
-use crate::os::raw::{c_uint, c_ulong, c_ushort, c_void};
-use crate::ptr;
+use core::ffi::{c_uint, c_ulong, c_ushort, c_void, CStr};
+use core::mem;
+use core::ptr;
 
 pub(super) mod windows_targets;
 
@@ -188,12 +186,12 @@ extern "system" {
 compat_fn_optional! {
     crate::sys::compat::load_synch_functions();
     pub fn WaitOnAddress(
-        address: *const ::core::ffi::c_void,
-        compareaddress: *const ::core::ffi::c_void,
+        address: *const c_void,
+        compareaddress: *const c_void,
         addresssize: usize,
         dwmilliseconds: u32
     ) -> BOOL;
-    pub fn WakeByAddressSingle(address: *const ::core::ffi::c_void);
+    pub fn WakeByAddressSingle(address: *const c_void);
 }
 
 #[cfg(any(target_vendor = "win7", target_vendor = "uwp"))]
@@ -240,7 +238,7 @@ compat_fn_with_fallback! {
         shareaccess: FILE_SHARE_MODE,
         createdisposition: NTCREATEFILE_CREATE_DISPOSITION,
         createoptions: NTCREATEFILE_CREATE_OPTIONS,
-        eabuffer: *const ::core::ffi::c_void,
+        eabuffer: *const c_void,
         ealength: u32
     ) -> NTSTATUS {
         STATUS_NOT_IMPLEMENTED
@@ -250,9 +248,9 @@ compat_fn_with_fallback! {
         filehandle: HANDLE,
         event: HANDLE,
         apcroutine: PIO_APC_ROUTINE,
-        apccontext: *const core::ffi::c_void,
+        apccontext: *const c_void,
         iostatusblock: *mut IO_STATUS_BLOCK,
-        buffer: *mut core::ffi::c_void,
+        buffer: *mut c_void,
         length: u32,
         byteoffset: *const i64,
         key: *const u32
@@ -264,9 +262,9 @@ compat_fn_with_fallback! {
         filehandle: HANDLE,
         event: HANDLE,
         apcroutine: PIO_APC_ROUTINE,
-        apccontext: *const core::ffi::c_void,
+        apccontext: *const c_void,
         iostatusblock: *mut IO_STATUS_BLOCK,
-        buffer: *const core::ffi::c_void,
+        buffer: *const c_void,
         length: u32,
         byteoffset: *const i64,
         key: *const u32

--- a/library/std/src/sys/pal/windows/compat.rs
+++ b/library/std/src/sys/pal/windows/compat.rs
@@ -158,8 +158,10 @@ macro_rules! compat_fn_with_fallback {
             static PTR: AtomicPtr<c_void> = AtomicPtr::new(load as *mut _);
 
             unsafe extern "system" fn load($($argname: $argtype),*) -> $rettype {
-                let func = load_from_module(Module::new($module));
-                func($($argname),*)
+                unsafe {
+                    let func = load_from_module(Module::new($module));
+                    func($($argname),*)
+                }
             }
 
             fn load_from_module(module: Option<Module>) -> F {
@@ -182,8 +184,10 @@ macro_rules! compat_fn_with_fallback {
 
             #[inline(always)]
             pub unsafe fn call($($argname: $argtype),*) -> $rettype {
-                let func: F = mem::transmute(PTR.load(Ordering::Relaxed));
-                func($($argname),*)
+                unsafe {
+                    let func: F = mem::transmute(PTR.load(Ordering::Relaxed));
+                    func($($argname),*)
+                }
             }
         }
         #[allow(unused)]
@@ -225,7 +229,7 @@ macro_rules! compat_fn_optional {
             }
             #[inline]
             pub unsafe extern "system" fn $symbol($($argname: $argtype),*) $(-> $rettype)? {
-                $symbol::option().unwrap()($($argname),*)
+                unsafe { $symbol::option().unwrap()($($argname),*) }
             }
         )+
     )

--- a/library/std/src/sys/pal/windows/handle.rs
+++ b/library/std/src/sys/pal/windows/handle.rs
@@ -3,16 +3,17 @@
 #[cfg(test)]
 mod tests;
 
-use crate::cmp;
 use crate::io::{self, BorrowedCursor, ErrorKind, IoSlice, IoSliceMut, Read};
-use crate::mem;
 use crate::os::windows::io::{
     AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, IntoRawHandle, OwnedHandle, RawHandle,
 };
-use crate::ptr;
 use crate::sys::c;
 use crate::sys::cvt;
 use crate::sys_common::{AsInner, FromInner, IntoInner};
+use core::cmp;
+use core::ffi::c_void;
+use core::mem;
+use core::ptr;
 
 /// An owned container for `HANDLE` object, closing them on Drop.
 ///
@@ -255,7 +256,7 @@ impl Handle {
                 None,
                 ptr::null_mut(),
                 &mut io_status,
-                buf.cast::<core::ffi::c_void>(),
+                buf.cast::<c_void>(),
                 len,
                 offset.as_ref().map(|n| ptr::from_ref(n).cast::<i64>()).unwrap_or(ptr::null()),
                 ptr::null(),
@@ -305,7 +306,7 @@ impl Handle {
                 None,
                 ptr::null_mut(),
                 &mut io_status,
-                buf.as_ptr().cast::<core::ffi::c_void>(),
+                buf.as_ptr().cast::<c_void>(),
                 len,
                 offset.as_ref().map(|n| ptr::from_ref(n).cast::<i64>()).unwrap_or(ptr::null()),
                 ptr::null(),

--- a/library/std/src/sys/pal/windows/mod.rs
+++ b/library/std/src/sys/pal/windows/mod.rs
@@ -1,5 +1,5 @@
 #![allow(missing_docs, nonstandard_style)]
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use crate::ffi::{OsStr, OsString};
 use crate::io::ErrorKind;

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -165,7 +165,7 @@ use crate::ffi::{CStr, CString};
 use crate::fmt;
 use crate::io;
 use crate::marker::PhantomData;
-use crate::mem::{self, forget};
+use crate::mem::{self, forget, ManuallyDrop};
 use crate::num::NonZero;
 use crate::panic;
 use crate::panicking;
@@ -514,11 +514,10 @@ impl Builder {
                 MaybeDangling(mem::MaybeUninit::new(x))
             }
             fn into_inner(self) -> T {
-                // SAFETY: we are always initialized.
-                let ret = unsafe { self.0.assume_init_read() };
                 // Make sure we don't drop.
-                mem::forget(self);
-                ret
+                let this = ManuallyDrop::new(self);
+                // SAFETY: we are always initialized.
+                unsafe { this.0.assume_init_read() }
             }
         }
         impl<T> Drop for MaybeDangling<T> {

--- a/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.stderr
+++ b/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_mutex_deadlock.stderr
@@ -10,7 +10,7 @@ LL |             assert_eq!(libc::pthread_mutex_lock(lock_copy.0.get() as *mut _
 error: deadlock: the evaluated program deadlocked
   --> RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
    |
-LL |             let ret = libc::pthread_join(self.id, ptr::null_mut());
+LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
    |                                                                  ^ the evaluated program deadlocked
    |
    = note: BACKTRACE:

--- a/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.stderr
+++ b/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_rwlock_write_read_deadlock.stderr
@@ -10,7 +10,7 @@ LL |             assert_eq!(libc::pthread_rwlock_wrlock(lock_copy.0.get() as *mu
 error: deadlock: the evaluated program deadlocked
   --> RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
    |
-LL |             let ret = libc::pthread_join(self.id, ptr::null_mut());
+LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
    |                                                                  ^ the evaluated program deadlocked
    |
    = note: BACKTRACE:

--- a/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.stderr
+++ b/src/tools/miri/tests/fail-dep/concurrency/libc_pthread_rwlock_write_write_deadlock.stderr
@@ -10,7 +10,7 @@ LL |             assert_eq!(libc::pthread_rwlock_wrlock(lock_copy.0.get() as *mu
 error: deadlock: the evaluated program deadlocked
   --> RUSTLIB/std/src/sys/pal/PLATFORM/thread.rs:LL:CC
    |
-LL |             let ret = libc::pthread_join(self.id, ptr::null_mut());
+LL |         let ret = unsafe { libc::pthread_join(id, ptr::null_mut()) };
    |                                                                  ^ the evaluated program deadlocked
    |
    = note: BACKTRACE:

--- a/src/tools/tidy/src/style/tests.rs
+++ b/src/tools/tidy/src/style/tests.rs
@@ -1,17 +1,10 @@
 use super::*;
 
 #[test]
-fn test_generate_problematic_strings() {
-    let problematic_regex = RegexSet::new(
-        generate_problematic_strings(
-            ROOT_PROBLEMATIC_CONSTS,
-            &[('A', '4'), ('B', '8'), ('E', '3'), ('0', 'F')].iter().cloned().collect(), // use "futile" F intentionally
-        )
-        .as_slice(),
-    )
-    .unwrap();
-    assert!(problematic_regex.is_match("786357")); // check with no "decimal" hex digits - converted to integer
-    assert!(problematic_regex.is_match("589701")); // check with "decimal" replacements - converted to integer
-    assert!(problematic_regex.is_match("8FF85")); // check for hex display
-    assert!(!problematic_regex.is_match("1193046")); // check for non-matching value
+fn test_contains_problematic_const() {
+    assert!(contains_problematic_const("721077")); // check with no "decimal" hex digits - converted to integer
+    assert!(contains_problematic_const("524421")); // check with "decimal" replacements - converted to integer
+    assert!(contains_problematic_const(&(285 * 281).to_string())); // check for hex display
+    assert!(contains_problematic_const(&format!("{:x}B5", 2816))); // check for case-alternating hex display
+    assert!(!contains_problematic_const("1193046")); // check for non-matching value
 }

--- a/tests/rustdoc-ui/invalid_const_in_lifetime_position.stderr
+++ b/tests/rustdoc-ui/invalid_const_in_lifetime_position.stderr
@@ -18,15 +18,18 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/invalid_const_in_lifetime_position.rs:4:26
    |
 LL | fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                          ^--- help: remove these generics
-   |                          |
-   |                          expected 0 generic arguments
+   |                          ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/invalid_const_in_lifetime_position.rs:2:10
    |
 LL |     type Y<'a>;
    |          ^
+help: remove these generics
+   |
+LL - fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+LL + fn f<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
+   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/invalid_const_in_lifetime_position.rs:4:26
@@ -49,9 +52,7 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/invalid_const_in_lifetime_position.rs:4:26
    |
 LL | fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                          ^--- help: remove these generics
-   |                          |
-   |                          expected 0 generic arguments
+   |                          ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/invalid_const_in_lifetime_position.rs:2:10
@@ -59,6 +60,11 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: remove these generics
+   |
+LL - fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+LL + fn f<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
+   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/invalid_const_in_lifetime_position.rs:4:26
@@ -81,9 +87,7 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/invalid_const_in_lifetime_position.rs:4:26
    |
 LL | fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                          ^--- help: remove these generics
-   |                          |
-   |                          expected 0 generic arguments
+   |                          ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/invalid_const_in_lifetime_position.rs:2:10
@@ -91,6 +95,11 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: remove these generics
+   |
+LL - fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+LL + fn f<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
+   |
 
 error[E0038]: the trait `X` cannot be made into an object
   --> $DIR/invalid_const_in_lifetime_position.rs:4:20

--- a/tests/rustdoc-ui/invalid_const_in_lifetime_position.stderr
+++ b/tests/rustdoc-ui/invalid_const_in_lifetime_position.stderr
@@ -18,18 +18,15 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/invalid_const_in_lifetime_position.rs:4:26
    |
 LL | fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                          ^ expected 0 generic arguments
+   |                          ^--- help: remove the unnecessary generics
+   |                          |
+   |                          expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/invalid_const_in_lifetime_position.rs:2:10
    |
 LL |     type Y<'a>;
    |          ^
-help: remove the unnecessary generics
-   |
-LL - fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-LL + fn f<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
-   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/invalid_const_in_lifetime_position.rs:4:26
@@ -52,7 +49,9 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/invalid_const_in_lifetime_position.rs:4:26
    |
 LL | fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                          ^ expected 0 generic arguments
+   |                          ^--- help: remove the unnecessary generics
+   |                          |
+   |                          expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/invalid_const_in_lifetime_position.rs:2:10
@@ -60,11 +59,6 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove the unnecessary generics
-   |
-LL - fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-LL + fn f<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
-   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/invalid_const_in_lifetime_position.rs:4:26
@@ -87,7 +81,9 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/invalid_const_in_lifetime_position.rs:4:26
    |
 LL | fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                          ^ expected 0 generic arguments
+   |                          ^--- help: remove the unnecessary generics
+   |                          |
+   |                          expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/invalid_const_in_lifetime_position.rs:2:10
@@ -95,11 +91,6 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove the unnecessary generics
-   |
-LL - fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-LL + fn f<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
-   |
 
 error[E0038]: the trait `X` cannot be made into an object
   --> $DIR/invalid_const_in_lifetime_position.rs:4:20

--- a/tests/rustdoc-ui/invalid_const_in_lifetime_position.stderr
+++ b/tests/rustdoc-ui/invalid_const_in_lifetime_position.stderr
@@ -25,7 +25,7 @@ note: associated type defined here, with 0 generic parameters
    |
 LL |     type Y<'a>;
    |          ^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
 LL + fn f<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
@@ -60,7 +60,7 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
 LL + fn f<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
@@ -95,7 +95,7 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
 LL + fn f<'a>(arg : Box<dyn X<Y = &'a ()>>) {}

--- a/tests/rustdoc-ui/mismatched_arg_count.stderr
+++ b/tests/rustdoc-ui/mismatched_arg_count.stderr
@@ -9,7 +9,7 @@ note: type alias defined here, with 1 lifetime parameter: `'a`
    |
 LL | type Alias<'a, T> = <T as Trait<'a>>::Assoc;
    |      ^^^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL - fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
 LL + fn bar<'a, T: Trait<'a>>(_: Alias<'a, , T>) {}

--- a/tests/rustdoc-ui/mismatched_arg_count.stderr
+++ b/tests/rustdoc-ui/mismatched_arg_count.stderr
@@ -2,15 +2,18 @@ error[E0107]: type alias takes 1 lifetime argument but 2 lifetime arguments were
   --> $DIR/mismatched_arg_count.rs:7:29
    |
 LL | fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
-   |                             ^^^^^     -- help: remove this lifetime argument
-   |                             |
-   |                             expected 1 lifetime argument
+   |                             ^^^^^ expected 1 lifetime argument
    |
 note: type alias defined here, with 1 lifetime parameter: `'a`
   --> $DIR/mismatched_arg_count.rs:5:6
    |
 LL | type Alias<'a, T> = <T as Trait<'a>>::Assoc;
    |      ^^^^^ --
+help: remove this lifetime argument
+   |
+LL - fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
+LL + fn bar<'a, T: Trait<'a>>(_: Alias<'a, , T>) {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/mismatched_arg_count.stderr
+++ b/tests/rustdoc-ui/mismatched_arg_count.stderr
@@ -2,18 +2,15 @@ error[E0107]: type alias takes 1 lifetime argument but 2 lifetime arguments were
   --> $DIR/mismatched_arg_count.rs:7:29
    |
 LL | fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
-   |                             ^^^^^ expected 1 lifetime argument
+   |                             ^^^^^   ---- help: remove the lifetime argument
+   |                             |
+   |                             expected 1 lifetime argument
    |
 note: type alias defined here, with 1 lifetime parameter: `'a`
   --> $DIR/mismatched_arg_count.rs:5:6
    |
 LL | type Alias<'a, T> = <T as Trait<'a>>::Assoc;
    |      ^^^^^ --
-help: remove the lifetime argument
-   |
-LL - fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
-LL + fn bar<'a, T: Trait<'a>>(_: Alias<'a, T>) {}
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/mismatched_arg_count.stderr
+++ b/tests/rustdoc-ui/mismatched_arg_count.stderr
@@ -12,7 +12,7 @@ LL | type Alias<'a, T> = <T as Trait<'a>>::Assoc;
 help: remove the lifetime argument
    |
 LL - fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
-LL + fn bar<'a, T: Trait<'a>>(_: Alias<'a, , T>) {}
+LL + fn bar<'a, T: Trait<'a>>(_: Alias<'a, T>) {}
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/argument-suggestions/issue-100154.stderr
+++ b/tests/ui/argument-suggestions/issue-100154.stderr
@@ -10,7 +10,7 @@ note: function defined here, with 0 generic parameters
 LL | fn foo(i: impl std::fmt::Display) {}
    |    ^^^
    = note: `impl Trait` cannot be explicitly specified as a generic argument
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     foo::<()>(());
 LL +     foo(());

--- a/tests/ui/argument-suggestions/issue-100154.stderr
+++ b/tests/ui/argument-suggestions/issue-100154.stderr
@@ -2,9 +2,7 @@ error[E0107]: function takes 0 generic arguments but 1 generic argument was supp
   --> $DIR/issue-100154.rs:4:5
    |
 LL |     foo::<()>(());
-   |     ^^^------ help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^ expected 0 generic arguments
    |
 note: function defined here, with 0 generic parameters
   --> $DIR/issue-100154.rs:1:4
@@ -12,6 +10,11 @@ note: function defined here, with 0 generic parameters
 LL | fn foo(i: impl std::fmt::Display) {}
    |    ^^^
    = note: `impl Trait` cannot be explicitly specified as a generic argument
+help: remove these generics
+   |
+LL -     foo::<()>(());
+LL +     foo(());
+   |
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/issue-100154.rs:4:11

--- a/tests/ui/argument-suggestions/issue-100154.stderr
+++ b/tests/ui/argument-suggestions/issue-100154.stderr
@@ -2,7 +2,9 @@ error[E0107]: function takes 0 generic arguments but 1 generic argument was supp
   --> $DIR/issue-100154.rs:4:5
    |
 LL |     foo::<()>(());
-   |     ^^^ expected 0 generic arguments
+   |     ^^^------ help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: function defined here, with 0 generic parameters
   --> $DIR/issue-100154.rs:1:4
@@ -10,11 +12,6 @@ note: function defined here, with 0 generic parameters
 LL | fn foo(i: impl std::fmt::Display) {}
    |    ^^^
    = note: `impl Trait` cannot be explicitly specified as a generic argument
-help: remove the unnecessary generics
-   |
-LL -     foo::<()>(());
-LL +     foo(());
-   |
 
 error[E0277]: `()` doesn't implement `std::fmt::Display`
   --> $DIR/issue-100154.rs:4:11

--- a/tests/ui/async-await/async-fn/edition-2015.rs
+++ b/tests/ui/async-await/async-fn/edition-2015.rs
@@ -3,5 +3,7 @@ fn foo(x: impl async Fn()) -> impl async Fn() { x }
 //~| ERROR `async` trait bounds are only allowed in Rust 2018 or later
 //~| ERROR async closures are unstable
 //~| ERROR async closures are unstable
+//~| ERROR use of unstable library feature 'async_closure'
+//~| ERROR use of unstable library feature 'async_closure'
 
 fn main() {}

--- a/tests/ui/async-await/async-fn/edition-2015.stderr
+++ b/tests/ui/async-await/async-fn/edition-2015.stderr
@@ -38,6 +38,26 @@ LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: to use an async block, remove the `||`: `async {`
 
-error: aborting due to 4 previous errors
+error[E0658]: use of unstable library feature 'async_closure'
+  --> $DIR/edition-2015.rs:1:22
+   |
+LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
+   |                      ^^^^
+   |
+   = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
+   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature 'async_closure'
+  --> $DIR/edition-2015.rs:1:42
+   |
+LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
+   |                                          ^^^^
+   |
+   = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
+   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/async-await/async-fn/simple.rs
+++ b/tests/ui/async-await/async-fn/simple.rs
@@ -2,7 +2,7 @@
 //@ edition: 2021
 //@ build-pass
 
-#![feature(async_fn_traits)]
+#![feature(async_closure)]
 
 extern crate block_on;
 

--- a/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
+++ b/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
@@ -2,18 +2,15 @@ error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supp
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:16:59
    |
 LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
-   |                                                           ^^^^^^^^^^^^ expected 0 lifetime arguments
+   |                                                           ^^^^^^^^^^^^---- help: remove the unnecessary generics
+   |                                                           |
+   |                                                           expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:24:8
    |
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^
-help: remove the unnecessary generics
-   |
-LL - async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
-LL + async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket {
-   |
 
 error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:16:59
@@ -35,7 +32,9 @@ error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supp
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:16:59
    |
 LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
-   |                                                           ^^^^^^^^^^^^ expected 0 lifetime arguments
+   |                                                           ^^^^^^^^^^^^---- help: remove the unnecessary generics
+   |                                                           |
+   |                                                           expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:24:8
@@ -43,11 +42,6 @@ note: struct defined here, with 0 lifetime parameters
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove the unnecessary generics
-   |
-LL - async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
-LL + async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket {
-   |
 
 error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:16:59

--- a/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
+++ b/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
@@ -2,15 +2,18 @@ error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supp
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:16:59
    |
 LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
-   |                                                           ^^^^^^^^^^^^---- help: remove these generics
-   |                                                           |
-   |                                                           expected 0 lifetime arguments
+   |                                                           ^^^^^^^^^^^^ expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:24:8
    |
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^
+help: remove these generics
+   |
+LL - async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
+LL + async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket {
+   |
 
 error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:16:59
@@ -32,9 +35,7 @@ error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supp
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:16:59
    |
 LL | async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
-   |                                                           ^^^^^^^^^^^^---- help: remove these generics
-   |                                                           |
-   |                                                           expected 0 lifetime arguments
+   |                                                           ^^^^^^^^^^^^ expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:24:8
@@ -42,6 +43,11 @@ note: struct defined here, with 0 lifetime parameters
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: remove these generics
+   |
+LL - async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
+LL + async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket {
+   |
 
 error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/issue-82126-mismatched-subst-and-hir.rs:16:59

--- a/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
+++ b/tests/ui/borrowck/issue-82126-mismatched-subst-and-hir.stderr
@@ -9,7 +9,7 @@ note: struct defined here, with 0 lifetime parameters
    |
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
 LL + async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket {
@@ -43,7 +43,7 @@ note: struct defined here, with 0 lifetime parameters
 LL | struct LockedMarket<T>(T);
    |        ^^^^^^^^^^^^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket<'_> {
 LL + async fn buy_lock(coroutine: &Mutex<MarketMultiplier>) -> LockedMarket {

--- a/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.stderr
+++ b/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.stderr
@@ -2,13 +2,9 @@ error[E0107]: trait takes at most 2 generic arguments but 3 generic arguments we
   --> $DIR/transmutable-ice-110969.rs:11:14
    |
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
-   |              ^^^^^^^^^^^^^^^^^^^^^ expected at most 2 generic arguments
-   |
-help: remove the unnecessary generic argument
-   |
-LL -         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
-LL +         Dst: BikeshedIntrinsicFrom<Src, Context>,
-   |
+   |              ^^^^^^^^^^^^^^^^^^^^^             -------- help: remove the unnecessary generic argument
+   |              |
+   |              expected at most 2 generic arguments
 
 error[E0308]: mismatched types
   --> $DIR/transmutable-ice-110969.rs:25:74

--- a/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.stderr
+++ b/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.stderr
@@ -7,7 +7,7 @@ LL |         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
 help: remove the unnecessary generic argument
    |
 LL -         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
-LL +         Dst: BikeshedIntrinsicFrom<Src, Context, >,
+LL +         Dst: BikeshedIntrinsicFrom<Src, Context>,
    |
 
 error[E0308]: mismatched types

--- a/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.stderr
+++ b/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.stderr
@@ -4,7 +4,7 @@ error[E0107]: trait takes at most 2 generic arguments but 3 generic arguments we
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
    |              ^^^^^^^^^^^^^^^^^^^^^ expected at most 2 generic arguments
    |
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
 LL +         Dst: BikeshedIntrinsicFrom<Src, Context, >,

--- a/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.stderr
+++ b/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.stderr
@@ -2,9 +2,13 @@ error[E0107]: trait takes at most 2 generic arguments but 3 generic arguments we
   --> $DIR/transmutable-ice-110969.rs:11:14
    |
 LL |         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
-   |              ^^^^^^^^^^^^^^^^^^^^^               ------ help: remove this generic argument
-   |              |
-   |              expected at most 2 generic arguments
+   |              ^^^^^^^^^^^^^^^^^^^^^ expected at most 2 generic arguments
+   |
+help: remove this generic argument
+   |
+LL -         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
+LL +         Dst: BikeshedIntrinsicFrom<Src, Context, >,
+   |
 
 error[E0308]: mismatched types
   --> $DIR/transmutable-ice-110969.rs:25:74

--- a/tests/ui/const-generics/generic_arg_infer/infer-arg-test.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/infer-arg-test.stderr
@@ -23,15 +23,18 @@ error[E0107]: struct takes 2 generic arguments but 3 generic arguments were supp
   --> $DIR/infer-arg-test.rs:18:10
    |
 LL |   let a: All<_, _, _>;
-   |          ^^^       - help: remove this generic argument
-   |          |
-   |          expected 2 generic arguments
+   |          ^^^ expected 2 generic arguments
    |
 note: struct defined here, with 2 generic parameters: `T`, `N`
   --> $DIR/infer-arg-test.rs:3:8
    |
 LL | struct All<'a, T, const N: usize> {
    |        ^^^     -  --------------
+help: remove this generic argument
+   |
+LL -   let a: All<_, _, _>;
+LL +   let a: All<_, _, >;
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/generic_arg_infer/infer-arg-test.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/infer-arg-test.stderr
@@ -33,7 +33,7 @@ LL | struct All<'a, T, const N: usize> {
 help: remove the unnecessary generic argument
    |
 LL -   let a: All<_, _, _>;
-LL +   let a: All<_, _, >;
+LL +   let a: All<_, _>;
    |
 
 error: aborting due to 4 previous errors

--- a/tests/ui/const-generics/generic_arg_infer/infer-arg-test.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/infer-arg-test.stderr
@@ -23,18 +23,15 @@ error[E0107]: struct takes 2 generic arguments but 3 generic arguments were supp
   --> $DIR/infer-arg-test.rs:18:10
    |
 LL |   let a: All<_, _, _>;
-   |          ^^^ expected 2 generic arguments
+   |          ^^^     --- help: remove the unnecessary generic argument
+   |          |
+   |          expected 2 generic arguments
    |
 note: struct defined here, with 2 generic parameters: `T`, `N`
   --> $DIR/infer-arg-test.rs:3:8
    |
 LL | struct All<'a, T, const N: usize> {
    |        ^^^     -  --------------
-help: remove the unnecessary generic argument
-   |
-LL -   let a: All<_, _, _>;
-LL +   let a: All<_, _>;
-   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/generic_arg_infer/infer-arg-test.stderr
+++ b/tests/ui/const-generics/generic_arg_infer/infer-arg-test.stderr
@@ -30,7 +30,7 @@ note: struct defined here, with 2 generic parameters: `T`, `N`
    |
 LL | struct All<'a, T, const N: usize> {
    |        ^^^     -  --------------
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -   let a: All<_, _, _>;
 LL +   let a: All<_, _, >;

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
@@ -9,7 +9,7 @@ note: function defined here, with 1 generic parameter: `N`
    |
 LL | fn foo<const N: usize>(
    |    ^^^ --------------
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     foo::<_, L>([(); L + 1 + L]);
 LL +     foo::<_, >([(); L + 1 + L]);

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
@@ -2,15 +2,18 @@ error[E0107]: function takes 1 generic argument but 2 generic arguments were sup
   --> $DIR/issue_114151.rs:17:5
    |
 LL |     foo::<_, L>([(); L + 1 + L]);
-   |     ^^^      - help: remove this generic argument
-   |     |
-   |     expected 1 generic argument
+   |     ^^^ expected 1 generic argument
    |
 note: function defined here, with 1 generic parameter: `N`
   --> $DIR/issue_114151.rs:4:4
    |
 LL | fn foo<const N: usize>(
    |    ^^^ --------------
+help: remove this generic argument
+   |
+LL -     foo::<_, L>([(); L + 1 + L]);
+LL +     foo::<_, >([(); L + 1 + L]);
+   |
 
 error[E0308]: mismatched types
   --> $DIR/issue_114151.rs:17:18

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
@@ -2,18 +2,15 @@ error[E0107]: function takes 1 generic argument but 2 generic arguments were sup
   --> $DIR/issue_114151.rs:17:5
    |
 LL |     foo::<_, L>([(); L + 1 + L]);
-   |     ^^^ expected 1 generic argument
+   |     ^^^    --- help: remove the unnecessary generic argument
+   |     |
+   |     expected 1 generic argument
    |
 note: function defined here, with 1 generic parameter: `N`
   --> $DIR/issue_114151.rs:4:4
    |
 LL | fn foo<const N: usize>(
    |    ^^^ --------------
-help: remove the unnecessary generic argument
-   |
-LL -     foo::<_, L>([(); L + 1 + L]);
-LL +     foo::<_>([(); L + 1 + L]);
-   |
 
 error[E0308]: mismatched types
   --> $DIR/issue_114151.rs:17:18

--- a/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/const_kind_expr/issue_114151.stderr
@@ -12,7 +12,7 @@ LL | fn foo<const N: usize>(
 help: remove the unnecessary generic argument
    |
 LL -     foo::<_, L>([(); L + 1 + L]);
-LL +     foo::<_, >([(); L + 1 + L]);
+LL +     foo::<_>([(); L + 1 + L]);
    |
 
 error[E0308]: mismatched types

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
@@ -25,7 +25,7 @@ note: associated type defined here, with 0 generic parameters
    |
 LL |     type Y<'a>;
    |          ^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
 LL +     fn f2<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
@@ -60,7 +60,7 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
 LL +     fn f2<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
@@ -95,7 +95,7 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
 LL +     fn f2<'a>(arg: Box<dyn X<Y = &'a ()>>) {}

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
@@ -18,15 +18,18 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/issue-102768.rs:9:30
    |
 LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
-   |                              ^--- help: remove these generics
-   |                              |
-   |                              expected 0 generic arguments
+   |                              ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/issue-102768.rs:5:10
    |
 LL |     type Y<'a>;
    |          ^
+help: remove these generics
+   |
+LL -     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+LL +     fn f2<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
+   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/issue-102768.rs:9:30
@@ -49,9 +52,7 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/issue-102768.rs:9:30
    |
 LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
-   |                              ^--- help: remove these generics
-   |                              |
-   |                              expected 0 generic arguments
+   |                              ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/issue-102768.rs:5:10
@@ -59,6 +60,11 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: remove these generics
+   |
+LL -     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+LL +     fn f2<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
+   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/issue-102768.rs:9:30
@@ -81,9 +87,7 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/issue-102768.rs:9:30
    |
 LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
-   |                              ^--- help: remove these generics
-   |                              |
-   |                              expected 0 generic arguments
+   |                              ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/issue-102768.rs:5:10
@@ -91,6 +95,11 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: remove these generics
+   |
+LL -     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
+LL +     fn f2<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
+   |
 
 error[E0038]: the trait `X` cannot be made into an object
   --> $DIR/issue-102768.rs:9:24

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
@@ -18,18 +18,15 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/issue-102768.rs:9:30
    |
 LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
-   |                              ^ expected 0 generic arguments
+   |                              ^--- help: remove the unnecessary generics
+   |                              |
+   |                              expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/issue-102768.rs:5:10
    |
 LL |     type Y<'a>;
    |          ^
-help: remove the unnecessary generics
-   |
-LL -     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
-LL +     fn f2<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
-   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/issue-102768.rs:9:30
@@ -52,7 +49,9 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/issue-102768.rs:9:30
    |
 LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
-   |                              ^ expected 0 generic arguments
+   |                              ^--- help: remove the unnecessary generics
+   |                              |
+   |                              expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/issue-102768.rs:5:10
@@ -60,11 +59,6 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove the unnecessary generics
-   |
-LL -     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
-LL +     fn f2<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
-   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/issue-102768.rs:9:30
@@ -87,7 +81,9 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/issue-102768.rs:9:30
    |
 LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
-   |                              ^ expected 0 generic arguments
+   |                              ^--- help: remove the unnecessary generics
+   |                              |
+   |                              expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/issue-102768.rs:5:10
@@ -95,11 +91,6 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove the unnecessary generics
-   |
-LL -     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
-LL +     fn f2<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
-   |
 
 error[E0038]: the trait `X` cannot be made into an object
   --> $DIR/issue-102768.rs:9:24

--- a/tests/ui/const-generics/incorrect-number-of-const-args.stderr
+++ b/tests/ui/const-generics/incorrect-number-of-const-args.stderr
@@ -20,18 +20,15 @@ error[E0107]: function takes 2 generic arguments but 3 generic arguments were su
   --> $DIR/incorrect-number-of-const-args.rs:9:5
    |
 LL |     foo::<0, 0, 0>();
-   |     ^^^ expected 2 generic arguments
+   |     ^^^       --- help: remove the unnecessary generic argument
+   |     |
+   |     expected 2 generic arguments
    |
 note: function defined here, with 2 generic parameters: `X`, `Y`
   --> $DIR/incorrect-number-of-const-args.rs:1:4
    |
 LL | fn foo<const X: usize, const Y: usize>() -> usize {
    |    ^^^ --------------  --------------
-help: remove the unnecessary generic argument
-   |
-LL -     foo::<0, 0, 0>();
-LL +     foo::<0, 0>();
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/incorrect-number-of-const-args.stderr
+++ b/tests/ui/const-generics/incorrect-number-of-const-args.stderr
@@ -30,7 +30,7 @@ LL | fn foo<const X: usize, const Y: usize>() -> usize {
 help: remove the unnecessary generic argument
    |
 LL -     foo::<0, 0, 0>();
-LL +     foo::<0, 0, >();
+LL +     foo::<0, 0>();
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/const-generics/incorrect-number-of-const-args.stderr
+++ b/tests/ui/const-generics/incorrect-number-of-const-args.stderr
@@ -20,15 +20,18 @@ error[E0107]: function takes 2 generic arguments but 3 generic arguments were su
   --> $DIR/incorrect-number-of-const-args.rs:9:5
    |
 LL |     foo::<0, 0, 0>();
-   |     ^^^         - help: remove this generic argument
-   |     |
-   |     expected 2 generic arguments
+   |     ^^^ expected 2 generic arguments
    |
 note: function defined here, with 2 generic parameters: `X`, `Y`
   --> $DIR/incorrect-number-of-const-args.rs:1:4
    |
 LL | fn foo<const X: usize, const Y: usize>() -> usize {
    |    ^^^ --------------  --------------
+help: remove this generic argument
+   |
+LL -     foo::<0, 0, 0>();
+LL +     foo::<0, 0, >();
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/incorrect-number-of-const-args.stderr
+++ b/tests/ui/const-generics/incorrect-number-of-const-args.stderr
@@ -27,7 +27,7 @@ note: function defined here, with 2 generic parameters: `X`, `Y`
    |
 LL | fn foo<const X: usize, const Y: usize>() -> usize {
    |    ^^^ --------------  --------------
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     foo::<0, 0, 0>();
 LL +     foo::<0, 0, >();

--- a/tests/ui/const-generics/invalid-const-arg-for-type-param.stderr
+++ b/tests/ui/const-generics/invalid-const-arg-for-type-param.stderr
@@ -27,15 +27,18 @@ error[E0107]: struct takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/invalid-const-arg-for-type-param.rs:12:5
    |
 LL |     S::<0>;
-   |     ^----- help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^ expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/invalid-const-arg-for-type-param.rs:3:8
    |
 LL | struct S;
    |        ^
+help: remove these generics
+   |
+LL -     S::<0>;
+LL +     S;
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/invalid-const-arg-for-type-param.stderr
+++ b/tests/ui/const-generics/invalid-const-arg-for-type-param.stderr
@@ -27,18 +27,15 @@ error[E0107]: struct takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/invalid-const-arg-for-type-param.rs:12:5
    |
 LL |     S::<0>;
-   |     ^ expected 0 generic arguments
+   |     ^----- help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/invalid-const-arg-for-type-param.rs:3:8
    |
 LL | struct S;
    |        ^
-help: remove the unnecessary generics
-   |
-LL -     S::<0>;
-LL +     S;
-   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/const-generics/invalid-const-arg-for-type-param.stderr
+++ b/tests/ui/const-generics/invalid-const-arg-for-type-param.stderr
@@ -8,7 +8,7 @@ help: consider moving this generic argument to the `TryInto` trait, which takes 
    |
 LL |     let _: u32 = TryInto::<32>::try_into(5i32).unwrap();
    |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     let _: u32 = 5i32.try_into::<32>().unwrap();
 LL +     let _: u32 = 5i32.try_into().unwrap();
@@ -34,7 +34,7 @@ note: struct defined here, with 0 generic parameters
    |
 LL | struct S;
    |        ^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     S::<0>;
 LL +     S;

--- a/tests/ui/const-generics/invalid-constant-in-args.stderr
+++ b/tests/ui/const-generics/invalid-constant-in-args.stderr
@@ -7,7 +7,7 @@ LL |     let _: Cell<&str, "a"> = Cell::new("");
 help: remove the unnecessary generic argument
    |
 LL -     let _: Cell<&str, "a"> = Cell::new("");
-LL +     let _: Cell<&str, > = Cell::new("");
+LL +     let _: Cell<&str> = Cell::new("");
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/const-generics/invalid-constant-in-args.stderr
+++ b/tests/ui/const-generics/invalid-constant-in-args.stderr
@@ -2,9 +2,13 @@ error[E0107]: struct takes 1 generic argument but 2 generic arguments were suppl
   --> $DIR/invalid-constant-in-args.rs:4:12
    |
 LL |     let _: Cell<&str, "a"> = Cell::new("");
-   |            ^^^^       --- help: remove this generic argument
-   |            |
-   |            expected 1 generic argument
+   |            ^^^^ expected 1 generic argument
+   |
+help: remove this generic argument
+   |
+LL -     let _: Cell<&str, "a"> = Cell::new("");
+LL +     let _: Cell<&str, > = Cell::new("");
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/invalid-constant-in-args.stderr
+++ b/tests/ui/const-generics/invalid-constant-in-args.stderr
@@ -2,13 +2,9 @@ error[E0107]: struct takes 1 generic argument but 2 generic arguments were suppl
   --> $DIR/invalid-constant-in-args.rs:4:12
    |
 LL |     let _: Cell<&str, "a"> = Cell::new("");
-   |            ^^^^ expected 1 generic argument
-   |
-help: remove the unnecessary generic argument
-   |
-LL -     let _: Cell<&str, "a"> = Cell::new("");
-LL +     let _: Cell<&str> = Cell::new("");
-   |
+   |            ^^^^     ----- help: remove the unnecessary generic argument
+   |            |
+   |            expected 1 generic argument
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/invalid-constant-in-args.stderr
+++ b/tests/ui/const-generics/invalid-constant-in-args.stderr
@@ -4,7 +4,7 @@ error[E0107]: struct takes 1 generic argument but 2 generic arguments were suppl
 LL |     let _: Cell<&str, "a"> = Cell::new("");
    |            ^^^^ expected 1 generic argument
    |
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     let _: Cell<&str, "a"> = Cell::new("");
 LL +     let _: Cell<&str, > = Cell::new("");

--- a/tests/ui/constructor-lifetime-args.stderr
+++ b/tests/ui/constructor-lifetime-args.stderr
@@ -27,7 +27,7 @@ note: struct defined here, with 2 lifetime parameters: `'a`, `'b`
    |
 LL | struct S<'a, 'b>(&'a u8, &'b u8);
    |        ^ --  --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     S::<'static, 'static, 'static>(&0, &0);
 LL +     S::<'static, 'static, >(&0, &0);
@@ -62,7 +62,7 @@ note: enum defined here, with 2 lifetime parameters: `'a`, `'b`
    |
 LL | enum E<'a, 'b> {
    |      ^ --  --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     E::V::<'static, 'static, 'static>(&0);
 LL +     E::V::<'static, 'static, >(&0);

--- a/tests/ui/constructor-lifetime-args.stderr
+++ b/tests/ui/constructor-lifetime-args.stderr
@@ -20,18 +20,15 @@ error[E0107]: struct takes 2 lifetime arguments but 3 lifetime arguments were su
   --> $DIR/constructor-lifetime-args.rs:19:5
    |
 LL |     S::<'static, 'static, 'static>(&0, &0);
-   |     ^ expected 2 lifetime arguments
+   |     ^                   --------- help: remove the lifetime argument
+   |     |
+   |     expected 2 lifetime arguments
    |
 note: struct defined here, with 2 lifetime parameters: `'a`, `'b`
   --> $DIR/constructor-lifetime-args.rs:9:8
    |
 LL | struct S<'a, 'b>(&'a u8, &'b u8);
    |        ^ --  --
-help: remove the lifetime argument
-   |
-LL -     S::<'static, 'static, 'static>(&0, &0);
-LL +     S::<'static, 'static>(&0, &0);
-   |
 
 error[E0107]: enum takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/constructor-lifetime-args.rs:22:8
@@ -55,18 +52,15 @@ error[E0107]: enum takes 2 lifetime arguments but 3 lifetime arguments were supp
   --> $DIR/constructor-lifetime-args.rs:24:8
    |
 LL |     E::V::<'static, 'static, 'static>(&0);
-   |        ^ expected 2 lifetime arguments
+   |        ^                   --------- help: remove the lifetime argument
+   |        |
+   |        expected 2 lifetime arguments
    |
 note: enum defined here, with 2 lifetime parameters: `'a`, `'b`
   --> $DIR/constructor-lifetime-args.rs:10:6
    |
 LL | enum E<'a, 'b> {
    |      ^ --  --
-help: remove the lifetime argument
-   |
-LL -     E::V::<'static, 'static, 'static>(&0);
-LL +     E::V::<'static, 'static>(&0);
-   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/constructor-lifetime-args.stderr
+++ b/tests/ui/constructor-lifetime-args.stderr
@@ -30,7 +30,7 @@ LL | struct S<'a, 'b>(&'a u8, &'b u8);
 help: remove the lifetime argument
    |
 LL -     S::<'static, 'static, 'static>(&0, &0);
-LL +     S::<'static, 'static, >(&0, &0);
+LL +     S::<'static, 'static>(&0, &0);
    |
 
 error[E0107]: enum takes 2 lifetime arguments but 1 lifetime argument was supplied
@@ -65,7 +65,7 @@ LL | enum E<'a, 'b> {
 help: remove the lifetime argument
    |
 LL -     E::V::<'static, 'static, 'static>(&0);
-LL +     E::V::<'static, 'static, >(&0);
+LL +     E::V::<'static, 'static>(&0);
    |
 
 error: aborting due to 4 previous errors

--- a/tests/ui/constructor-lifetime-args.stderr
+++ b/tests/ui/constructor-lifetime-args.stderr
@@ -20,15 +20,18 @@ error[E0107]: struct takes 2 lifetime arguments but 3 lifetime arguments were su
   --> $DIR/constructor-lifetime-args.rs:19:5
    |
 LL |     S::<'static, 'static, 'static>(&0, &0);
-   |     ^                     ------- help: remove this lifetime argument
-   |     |
-   |     expected 2 lifetime arguments
+   |     ^ expected 2 lifetime arguments
    |
 note: struct defined here, with 2 lifetime parameters: `'a`, `'b`
   --> $DIR/constructor-lifetime-args.rs:9:8
    |
 LL | struct S<'a, 'b>(&'a u8, &'b u8);
    |        ^ --  --
+help: remove this lifetime argument
+   |
+LL -     S::<'static, 'static, 'static>(&0, &0);
+LL +     S::<'static, 'static, >(&0, &0);
+   |
 
 error[E0107]: enum takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/constructor-lifetime-args.rs:22:8
@@ -52,15 +55,18 @@ error[E0107]: enum takes 2 lifetime arguments but 3 lifetime arguments were supp
   --> $DIR/constructor-lifetime-args.rs:24:8
    |
 LL |     E::V::<'static, 'static, 'static>(&0);
-   |        ^                     ------- help: remove this lifetime argument
-   |        |
-   |        expected 2 lifetime arguments
+   |        ^ expected 2 lifetime arguments
    |
 note: enum defined here, with 2 lifetime parameters: `'a`, `'b`
   --> $DIR/constructor-lifetime-args.rs:10:6
    |
 LL | enum E<'a, 'b> {
    |      ^ --  --
+help: remove this lifetime argument
+   |
+LL -     E::V::<'static, 'static, 'static>(&0);
+LL +     E::V::<'static, 'static, >(&0);
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/effect_param.stderr
+++ b/tests/ui/consts/effect_param.stderr
@@ -4,7 +4,7 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
 LL |     i8::checked_sub::<false>(42, 43);
    |         ^^^^^^^^^^^ expected 0 generic arguments
    |
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     i8::checked_sub::<false>(42, 43);
 LL +     i8::checked_sub(42, 43);
@@ -16,7 +16,7 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
 LL |     i8::checked_sub::<true>(42, 43);
    |         ^^^^^^^^^^^ expected 0 generic arguments
    |
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     i8::checked_sub::<true>(42, 43);
 LL +     i8::checked_sub(42, 43);
@@ -28,7 +28,7 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
 LL |     i8::checked_sub::<true>(42, 43);
    |         ^^^^^^^^^^^ expected 0 generic arguments
    |
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     i8::checked_sub::<true>(42, 43);
 LL +     i8::checked_sub(42, 43);
@@ -40,7 +40,7 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
 LL |     i8::checked_sub::<false>(42, 43);
    |         ^^^^^^^^^^^ expected 0 generic arguments
    |
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     i8::checked_sub::<false>(42, 43);
 LL +     i8::checked_sub(42, 43);

--- a/tests/ui/consts/effect_param.stderr
+++ b/tests/ui/consts/effect_param.stderr
@@ -2,49 +2,33 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/effect_param.rs:11:9
    |
 LL |     i8::checked_sub::<false>(42, 43);
-   |         ^^^^^^^^^^^ expected 0 generic arguments
-   |
-help: remove the unnecessary generics
-   |
-LL -     i8::checked_sub::<false>(42, 43);
-LL +     i8::checked_sub(42, 43);
-   |
+   |         ^^^^^^^^^^^--------- help: remove the unnecessary generics
+   |         |
+   |         expected 0 generic arguments
 
 error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/effect_param.rs:13:9
    |
 LL |     i8::checked_sub::<true>(42, 43);
-   |         ^^^^^^^^^^^ expected 0 generic arguments
-   |
-help: remove the unnecessary generics
-   |
-LL -     i8::checked_sub::<true>(42, 43);
-LL +     i8::checked_sub(42, 43);
-   |
+   |         ^^^^^^^^^^^-------- help: remove the unnecessary generics
+   |         |
+   |         expected 0 generic arguments
 
 error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/effect_param.rs:4:9
    |
 LL |     i8::checked_sub::<true>(42, 43);
-   |         ^^^^^^^^^^^ expected 0 generic arguments
-   |
-help: remove the unnecessary generics
-   |
-LL -     i8::checked_sub::<true>(42, 43);
-LL +     i8::checked_sub(42, 43);
-   |
+   |         ^^^^^^^^^^^-------- help: remove the unnecessary generics
+   |         |
+   |         expected 0 generic arguments
 
 error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/effect_param.rs:6:9
    |
 LL |     i8::checked_sub::<false>(42, 43);
-   |         ^^^^^^^^^^^ expected 0 generic arguments
-   |
-help: remove the unnecessary generics
-   |
-LL -     i8::checked_sub::<false>(42, 43);
-LL +     i8::checked_sub(42, 43);
-   |
+   |         ^^^^^^^^^^^--------- help: remove the unnecessary generics
+   |         |
+   |         expected 0 generic arguments
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/consts/effect_param.stderr
+++ b/tests/ui/consts/effect_param.stderr
@@ -2,33 +2,49 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/effect_param.rs:11:9
    |
 LL |     i8::checked_sub::<false>(42, 43);
-   |         ^^^^^^^^^^^--------- help: remove these generics
-   |         |
-   |         expected 0 generic arguments
+   |         ^^^^^^^^^^^ expected 0 generic arguments
+   |
+help: remove these generics
+   |
+LL -     i8::checked_sub::<false>(42, 43);
+LL +     i8::checked_sub(42, 43);
+   |
 
 error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/effect_param.rs:13:9
    |
 LL |     i8::checked_sub::<true>(42, 43);
-   |         ^^^^^^^^^^^-------- help: remove these generics
-   |         |
-   |         expected 0 generic arguments
+   |         ^^^^^^^^^^^ expected 0 generic arguments
+   |
+help: remove these generics
+   |
+LL -     i8::checked_sub::<true>(42, 43);
+LL +     i8::checked_sub(42, 43);
+   |
 
 error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/effect_param.rs:4:9
    |
 LL |     i8::checked_sub::<true>(42, 43);
-   |         ^^^^^^^^^^^-------- help: remove these generics
-   |         |
-   |         expected 0 generic arguments
+   |         ^^^^^^^^^^^ expected 0 generic arguments
+   |
+help: remove these generics
+   |
+LL -     i8::checked_sub::<true>(42, 43);
+LL +     i8::checked_sub(42, 43);
+   |
 
 error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/effect_param.rs:6:9
    |
 LL |     i8::checked_sub::<false>(42, 43);
-   |         ^^^^^^^^^^^--------- help: remove these generics
-   |         |
-   |         expected 0 generic arguments
+   |         ^^^^^^^^^^^ expected 0 generic arguments
+   |
+help: remove these generics
+   |
+LL -     i8::checked_sub::<false>(42, 43);
+LL +     i8::checked_sub(42, 43);
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/error-codes/E0107.rs
+++ b/tests/ui/error-codes/E0107.rs
@@ -16,35 +16,35 @@ struct Baz<'a, 'b, 'c> {
 
     bar: Bar<'a>,
     //~^ ERROR enum takes 0 lifetime arguments
-    //~| HELP remove these generics
+    //~| HELP remove the unnecessary generics
 
     foo2: Foo<'a, 'b, 'c>,
     //~^ ERROR struct takes 1 lifetime argument
-    //~| HELP remove these lifetime arguments
+    //~| HELP remove the lifetime arguments
 
     qux1: Qux<'a, 'b, i32>,
     //~^ ERROR struct takes 1 lifetime argument
-    //~| HELP remove this lifetime argument
+    //~| HELP remove the lifetime argument
 
     qux2: Qux<'a, i32, 'b>,
     //~^ ERROR struct takes 1 lifetime argument
-    //~| HELP remove this lifetime argument
+    //~| HELP remove the lifetime argument
 
     qux3: Qux<'a, 'b, 'c, i32>,
     //~^ ERROR struct takes 1 lifetime argument
-    //~| HELP remove these lifetime arguments
+    //~| HELP remove the lifetime arguments
 
     qux4: Qux<'a, i32, 'b, 'c>,
     //~^ ERROR struct takes 1 lifetime argument
-    //~| HELP remove these lifetime arguments
+    //~| HELP remove the lifetime arguments
 
     qux5: Qux<'a, 'b, i32, 'c>,
     //~^ ERROR struct takes 1 lifetime argument
-    //~| HELP remove this lifetime argument
+    //~| HELP remove the lifetime argument
 
     quux: Quux<'a, i32, 'b>,
     //~^ ERROR struct takes 0 lifetime arguments
-    //~| HELP remove this lifetime argument
+    //~| HELP remove the lifetime argument
 }
 
 pub trait T {

--- a/tests/ui/error-codes/E0107.stderr
+++ b/tests/ui/error-codes/E0107.stderr
@@ -27,7 +27,7 @@ note: enum defined here, with 0 lifetime parameters
    |
 LL | enum Bar {
    |      ^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     bar: Bar<'a>,
 LL +     bar: Bar,
@@ -44,7 +44,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
    |
 LL | struct Foo<'a>(&'a str);
    |        ^^^ --
-help: remove these lifetime arguments
+help: remove the lifetime arguments
    |
 LL -     foo2: Foo<'a, 'b, 'c>,
 LL +     foo2: Foo<'a, >,
@@ -61,7 +61,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     qux1: Qux<'a, 'b, i32>,
 LL +     qux1: Qux<'a, , i32>,
@@ -78,7 +78,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     qux2: Qux<'a, i32, 'b>,
 LL +     qux2: Qux<'a, i32, >,
@@ -95,7 +95,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
-help: remove these lifetime arguments
+help: remove the lifetime arguments
    |
 LL -     qux3: Qux<'a, 'b, 'c, i32>,
 LL +     qux3: Qux<'a, , i32>,
@@ -112,7 +112,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
-help: remove these lifetime arguments
+help: remove the lifetime arguments
    |
 LL -     qux4: Qux<'a, i32, 'b, 'c>,
 LL +     qux4: Qux<'a, i32, >,
@@ -129,7 +129,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     qux5: Qux<'a, 'b, i32, 'c>,
 LL +     qux5: Qux<'a, , i32, 'c>,
@@ -146,7 +146,7 @@ note: struct defined here, with 0 lifetime parameters
    |
 LL | struct Quux<T>(T);
    |        ^^^^
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     quux: Quux<'a, i32, 'b>,
 LL +     quux: Quux<, i32, 'b>,

--- a/tests/ui/error-codes/E0107.stderr
+++ b/tests/ui/error-codes/E0107.stderr
@@ -47,7 +47,7 @@ LL | struct Foo<'a>(&'a str);
 help: remove the lifetime arguments
    |
 LL -     foo2: Foo<'a, 'b, 'c>,
-LL +     foo2: Foo<'a, >,
+LL +     foo2: Foo<'a>,
    |
 
 error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
@@ -64,7 +64,7 @@ LL | struct Qux<'a, T>(&'a T);
 help: remove the lifetime argument
    |
 LL -     qux1: Qux<'a, 'b, i32>,
-LL +     qux1: Qux<'a, , i32>,
+LL +     qux1: Qux<'a, i32>,
    |
 
 error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
@@ -81,7 +81,7 @@ LL | struct Qux<'a, T>(&'a T);
 help: remove the lifetime argument
    |
 LL -     qux2: Qux<'a, i32, 'b>,
-LL +     qux2: Qux<'a, i32, >,
+LL +     qux2: Qux<'a>,
    |
 
 error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
@@ -98,7 +98,7 @@ LL | struct Qux<'a, T>(&'a T);
 help: remove the lifetime arguments
    |
 LL -     qux3: Qux<'a, 'b, 'c, i32>,
-LL +     qux3: Qux<'a, , i32>,
+LL +     qux3: Qux<'a, i32>,
    |
 
 error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
@@ -115,7 +115,7 @@ LL | struct Qux<'a, T>(&'a T);
 help: remove the lifetime arguments
    |
 LL -     qux4: Qux<'a, i32, 'b, 'c>,
-LL +     qux4: Qux<'a, i32, >,
+LL +     qux4: Qux<'a>,
    |
 
 error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
@@ -132,7 +132,7 @@ LL | struct Qux<'a, T>(&'a T);
 help: remove the lifetime argument
    |
 LL -     qux5: Qux<'a, 'b, i32, 'c>,
-LL +     qux5: Qux<'a, , i32, 'c>,
+LL +     qux5: Qux<'a, i32, 'c>,
    |
 
 error[E0107]: struct takes 0 lifetime arguments but 2 lifetime arguments were supplied

--- a/tests/ui/error-codes/E0107.stderr
+++ b/tests/ui/error-codes/E0107.stderr
@@ -20,113 +20,137 @@ error[E0107]: enum takes 0 lifetime arguments but 1 lifetime argument was suppli
   --> $DIR/E0107.rs:17:10
    |
 LL |     bar: Bar<'a>,
-   |          ^^^---- help: remove these generics
-   |          |
-   |          expected 0 lifetime arguments
+   |          ^^^ expected 0 lifetime arguments
    |
 note: enum defined here, with 0 lifetime parameters
   --> $DIR/E0107.rs:6:6
    |
 LL | enum Bar {
    |      ^^^
+help: remove these generics
+   |
+LL -     bar: Bar<'a>,
+LL +     bar: Bar,
+   |
 
 error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
   --> $DIR/E0107.rs:21:11
    |
 LL |     foo2: Foo<'a, 'b, 'c>,
-   |           ^^^     ------ help: remove these lifetime arguments
-   |           |
-   |           expected 1 lifetime argument
+   |           ^^^ expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/E0107.rs:1:8
    |
 LL | struct Foo<'a>(&'a str);
    |        ^^^ --
+help: remove these lifetime arguments
+   |
+LL -     foo2: Foo<'a, 'b, 'c>,
+LL +     foo2: Foo<'a, >,
+   |
 
 error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/E0107.rs:25:11
    |
 LL |     qux1: Qux<'a, 'b, i32>,
-   |           ^^^     -- help: remove this lifetime argument
-   |           |
-   |           expected 1 lifetime argument
+   |           ^^^ expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/E0107.rs:3:8
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
+help: remove this lifetime argument
+   |
+LL -     qux1: Qux<'a, 'b, i32>,
+LL +     qux1: Qux<'a, , i32>,
+   |
 
 error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/E0107.rs:29:11
    |
 LL |     qux2: Qux<'a, i32, 'b>,
-   |           ^^^          -- help: remove this lifetime argument
-   |           |
-   |           expected 1 lifetime argument
+   |           ^^^ expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/E0107.rs:3:8
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
+help: remove this lifetime argument
+   |
+LL -     qux2: Qux<'a, i32, 'b>,
+LL +     qux2: Qux<'a, i32, >,
+   |
 
 error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
   --> $DIR/E0107.rs:33:11
    |
 LL |     qux3: Qux<'a, 'b, 'c, i32>,
-   |           ^^^     ------ help: remove these lifetime arguments
-   |           |
-   |           expected 1 lifetime argument
+   |           ^^^ expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/E0107.rs:3:8
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
+help: remove these lifetime arguments
+   |
+LL -     qux3: Qux<'a, 'b, 'c, i32>,
+LL +     qux3: Qux<'a, , i32>,
+   |
 
 error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
   --> $DIR/E0107.rs:37:11
    |
 LL |     qux4: Qux<'a, i32, 'b, 'c>,
-   |           ^^^          ------ help: remove these lifetime arguments
-   |           |
-   |           expected 1 lifetime argument
+   |           ^^^ expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/E0107.rs:3:8
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
+help: remove these lifetime arguments
+   |
+LL -     qux4: Qux<'a, i32, 'b, 'c>,
+LL +     qux4: Qux<'a, i32, >,
+   |
 
 error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
   --> $DIR/E0107.rs:41:11
    |
 LL |     qux5: Qux<'a, 'b, i32, 'c>,
-   |           ^^^     -- help: remove this lifetime argument
-   |           |
-   |           expected 1 lifetime argument
+   |           ^^^ expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/E0107.rs:3:8
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
+help: remove this lifetime argument
+   |
+LL -     qux5: Qux<'a, 'b, i32, 'c>,
+LL +     qux5: Qux<'a, , i32, 'c>,
+   |
 
 error[E0107]: struct takes 0 lifetime arguments but 2 lifetime arguments were supplied
   --> $DIR/E0107.rs:45:11
    |
 LL |     quux: Quux<'a, i32, 'b>,
-   |           ^^^^ -- help: remove this lifetime argument
-   |           |
-   |           expected 0 lifetime arguments
+   |           ^^^^ expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/E0107.rs:4:8
    |
 LL | struct Quux<T>(T);
    |        ^^^^
+help: remove this lifetime argument
+   |
+LL -     quux: Quux<'a, i32, 'b>,
+LL +     quux: Quux<, i32, 'b>,
+   |
 
 error[E0107]: trait takes 0 generic arguments but 2 generic arguments were supplied
   --> $DIR/E0107.rs:55:27

--- a/tests/ui/error-codes/E0107.stderr
+++ b/tests/ui/error-codes/E0107.stderr
@@ -20,137 +20,113 @@ error[E0107]: enum takes 0 lifetime arguments but 1 lifetime argument was suppli
   --> $DIR/E0107.rs:17:10
    |
 LL |     bar: Bar<'a>,
-   |          ^^^ expected 0 lifetime arguments
+   |          ^^^---- help: remove the unnecessary generics
+   |          |
+   |          expected 0 lifetime arguments
    |
 note: enum defined here, with 0 lifetime parameters
   --> $DIR/E0107.rs:6:6
    |
 LL | enum Bar {
    |      ^^^
-help: remove the unnecessary generics
-   |
-LL -     bar: Bar<'a>,
-LL +     bar: Bar,
-   |
 
 error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
   --> $DIR/E0107.rs:21:11
    |
 LL |     foo2: Foo<'a, 'b, 'c>,
-   |           ^^^ expected 1 lifetime argument
+   |           ^^^   -------- help: remove the lifetime arguments
+   |           |
+   |           expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/E0107.rs:1:8
    |
 LL | struct Foo<'a>(&'a str);
    |        ^^^ --
-help: remove the lifetime arguments
-   |
-LL -     foo2: Foo<'a, 'b, 'c>,
-LL +     foo2: Foo<'a>,
-   |
 
 error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/E0107.rs:25:11
    |
 LL |     qux1: Qux<'a, 'b, i32>,
-   |           ^^^ expected 1 lifetime argument
+   |           ^^^   ---- help: remove the lifetime argument
+   |           |
+   |           expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/E0107.rs:3:8
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
-help: remove the lifetime argument
-   |
-LL -     qux1: Qux<'a, 'b, i32>,
-LL +     qux1: Qux<'a, i32>,
-   |
 
 error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/E0107.rs:29:11
    |
 LL |     qux2: Qux<'a, i32, 'b>,
-   |           ^^^ expected 1 lifetime argument
+   |           ^^^   --------- help: remove the lifetime argument
+   |           |
+   |           expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/E0107.rs:3:8
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
-help: remove the lifetime argument
-   |
-LL -     qux2: Qux<'a, i32, 'b>,
-LL +     qux2: Qux<'a>,
-   |
 
 error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
   --> $DIR/E0107.rs:33:11
    |
 LL |     qux3: Qux<'a, 'b, 'c, i32>,
-   |           ^^^ expected 1 lifetime argument
+   |           ^^^   -------- help: remove the lifetime arguments
+   |           |
+   |           expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/E0107.rs:3:8
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
-help: remove the lifetime arguments
-   |
-LL -     qux3: Qux<'a, 'b, 'c, i32>,
-LL +     qux3: Qux<'a, i32>,
-   |
 
 error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
   --> $DIR/E0107.rs:37:11
    |
 LL |     qux4: Qux<'a, i32, 'b, 'c>,
-   |           ^^^ expected 1 lifetime argument
+   |           ^^^   ------------- help: remove the lifetime arguments
+   |           |
+   |           expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/E0107.rs:3:8
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
-help: remove the lifetime arguments
-   |
-LL -     qux4: Qux<'a, i32, 'b, 'c>,
-LL +     qux4: Qux<'a>,
-   |
 
 error[E0107]: struct takes 1 lifetime argument but 3 lifetime arguments were supplied
   --> $DIR/E0107.rs:41:11
    |
 LL |     qux5: Qux<'a, 'b, i32, 'c>,
-   |           ^^^ expected 1 lifetime argument
+   |           ^^^   ---- help: remove the lifetime argument
+   |           |
+   |           expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/E0107.rs:3:8
    |
 LL | struct Qux<'a, T>(&'a T);
    |        ^^^ --
-help: remove the lifetime argument
-   |
-LL -     qux5: Qux<'a, 'b, i32, 'c>,
-LL +     qux5: Qux<'a, i32, 'c>,
-   |
 
 error[E0107]: struct takes 0 lifetime arguments but 2 lifetime arguments were supplied
   --> $DIR/E0107.rs:45:11
    |
 LL |     quux: Quux<'a, i32, 'b>,
-   |           ^^^^ expected 0 lifetime arguments
+   |           ^^^^ -- help: remove the lifetime argument
+   |           |
+   |           expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/E0107.rs:4:8
    |
 LL | struct Quux<T>(T);
    |        ^^^^
-help: remove the lifetime argument
-   |
-LL -     quux: Quux<'a, i32, 'b>,
-LL +     quux: Quux<, i32, 'b>,
-   |
 
 error[E0107]: trait takes 0 generic arguments but 2 generic arguments were supplied
   --> $DIR/E0107.rs:55:27

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
@@ -43,15 +43,18 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
    |
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
-   |                           ^---- help: remove these generics
-   |                           |
-   |                           expected 0 generic arguments
+   |                           ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
    |
 LL |   type Y<'a>;
    |        ^
+help: remove these generics
+   |
+LL - fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+LL + fn foo<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
+   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
@@ -74,9 +77,7 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
    |
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
-   |                           ^---- help: remove these generics
-   |                           |
-   |                           expected 0 generic arguments
+   |                           ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
@@ -84,6 +85,11 @@ note: associated type defined here, with 0 generic parameters
 LL |   type Y<'a>;
    |        ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: remove these generics
+   |
+LL - fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+LL + fn foo<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
+   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
@@ -106,9 +112,7 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
    |
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
-   |                           ^---- help: remove these generics
-   |                           |
-   |                           expected 0 generic arguments
+   |                           ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
@@ -116,6 +120,11 @@ note: associated type defined here, with 0 generic parameters
 LL |   type Y<'a>;
    |        ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: remove these generics
+   |
+LL - fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
+LL + fn foo<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
+   |
 
 error[E0224]: at least one trait is required for an object type
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:29

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
@@ -50,7 +50,7 @@ note: associated type defined here, with 0 generic parameters
    |
 LL |   type Y<'a>;
    |        ^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
 LL + fn foo<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
@@ -85,7 +85,7 @@ note: associated type defined here, with 0 generic parameters
 LL |   type Y<'a>;
    |        ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
 LL + fn foo<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
@@ -120,7 +120,7 @@ note: associated type defined here, with 0 generic parameters
 LL |   type Y<'a>;
    |        ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
 LL + fn foo<'a>(arg: Box<dyn X<Y = &'a ()>>) {}

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
@@ -43,18 +43,15 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
    |
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
-   |                           ^ expected 0 generic arguments
+   |                           ^---- help: remove the unnecessary generics
+   |                           |
+   |                           expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
    |
 LL |   type Y<'a>;
    |        ^
-help: remove the unnecessary generics
-   |
-LL - fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
-LL + fn foo<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
-   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
@@ -77,7 +74,9 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
    |
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
-   |                           ^ expected 0 generic arguments
+   |                           ^---- help: remove the unnecessary generics
+   |                           |
+   |                           expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
@@ -85,11 +84,6 @@ note: associated type defined here, with 0 generic parameters
 LL |   type Y<'a>;
    |        ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove the unnecessary generics
-   |
-LL - fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
-LL + fn foo<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
-   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
@@ -112,7 +106,9 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:27
    |
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
-   |                           ^ expected 0 generic arguments
+   |                           ^---- help: remove the unnecessary generics
+   |                           |
+   |                           expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
@@ -120,11 +116,6 @@ note: associated type defined here, with 0 generic parameters
 LL |   type Y<'a>;
    |        ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove the unnecessary generics
-   |
-LL - fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
-LL + fn foo<'a>(arg: Box<dyn X<Y = &'a ()>>) {}
-   |
 
 error[E0224]: at least one trait is required for an object type
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:29

--- a/tests/ui/generic-associated-types/parameter_number_and_kind.stderr
+++ b/tests/ui/generic-associated-types/parameter_number_and_kind.stderr
@@ -9,7 +9,7 @@ note: associated type defined here, with 1 lifetime parameter: `'a`
    |
 LL |     type E<'a, T>;
    |          ^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     type FErr1 = Self::E<'static, 'static>;
 LL +     type FErr1 = Self::E<'static, >;
@@ -42,7 +42,7 @@ note: associated type defined here, with 1 generic parameter: `T`
    |
 LL |     type E<'a, T>;
    |          ^     -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     type FErr2<T> = Self::E<'static, T, u32>;
 LL +     type FErr2<T> = Self::E<'static, T, >;

--- a/tests/ui/generic-associated-types/parameter_number_and_kind.stderr
+++ b/tests/ui/generic-associated-types/parameter_number_and_kind.stderr
@@ -2,15 +2,18 @@ error[E0107]: associated type takes 1 lifetime argument but 2 lifetime arguments
   --> $DIR/parameter_number_and_kind.rs:11:24
    |
 LL |     type FErr1 = Self::E<'static, 'static>;
-   |                        ^          ------- help: remove this lifetime argument
-   |                        |
-   |                        expected 1 lifetime argument
+   |                        ^ expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
   --> $DIR/parameter_number_and_kind.rs:8:10
    |
 LL |     type E<'a, T>;
    |          ^ --
+help: remove this lifetime argument
+   |
+LL -     type FErr1 = Self::E<'static, 'static>;
+LL +     type FErr1 = Self::E<'static, >;
+   |
 
 error[E0107]: associated type takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/parameter_number_and_kind.rs:11:24
@@ -32,15 +35,18 @@ error[E0107]: associated type takes 1 generic argument but 2 generic arguments w
   --> $DIR/parameter_number_and_kind.rs:14:27
    |
 LL |     type FErr2<T> = Self::E<'static, T, u32>;
-   |                           ^             --- help: remove this generic argument
-   |                           |
-   |                           expected 1 generic argument
+   |                           ^ expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
   --> $DIR/parameter_number_and_kind.rs:8:10
    |
 LL |     type E<'a, T>;
    |          ^     -
+help: remove this generic argument
+   |
+LL -     type FErr2<T> = Self::E<'static, T, u32>;
+LL +     type FErr2<T> = Self::E<'static, T, >;
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/generic-associated-types/parameter_number_and_kind.stderr
+++ b/tests/ui/generic-associated-types/parameter_number_and_kind.stderr
@@ -12,7 +12,7 @@ LL |     type E<'a, T>;
 help: remove the lifetime argument
    |
 LL -     type FErr1 = Self::E<'static, 'static>;
-LL +     type FErr1 = Self::E<'static, >;
+LL +     type FErr1 = Self::E<'static>;
    |
 
 error[E0107]: associated type takes 1 generic argument but 0 generic arguments were supplied
@@ -45,7 +45,7 @@ LL |     type E<'a, T>;
 help: remove the unnecessary generic argument
    |
 LL -     type FErr2<T> = Self::E<'static, T, u32>;
-LL +     type FErr2<T> = Self::E<'static, T, >;
+LL +     type FErr2<T> = Self::E<'static, T>;
    |
 
 error: aborting due to 3 previous errors

--- a/tests/ui/generic-associated-types/parameter_number_and_kind.stderr
+++ b/tests/ui/generic-associated-types/parameter_number_and_kind.stderr
@@ -2,18 +2,15 @@ error[E0107]: associated type takes 1 lifetime argument but 2 lifetime arguments
   --> $DIR/parameter_number_and_kind.rs:11:24
    |
 LL |     type FErr1 = Self::E<'static, 'static>;
-   |                        ^ expected 1 lifetime argument
+   |                        ^        --------- help: remove the lifetime argument
+   |                        |
+   |                        expected 1 lifetime argument
    |
 note: associated type defined here, with 1 lifetime parameter: `'a`
   --> $DIR/parameter_number_and_kind.rs:8:10
    |
 LL |     type E<'a, T>;
    |          ^ --
-help: remove the lifetime argument
-   |
-LL -     type FErr1 = Self::E<'static, 'static>;
-LL +     type FErr1 = Self::E<'static>;
-   |
 
 error[E0107]: associated type takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/parameter_number_and_kind.rs:11:24
@@ -35,18 +32,15 @@ error[E0107]: associated type takes 1 generic argument but 2 generic arguments w
   --> $DIR/parameter_number_and_kind.rs:14:27
    |
 LL |     type FErr2<T> = Self::E<'static, T, u32>;
-   |                           ^ expected 1 generic argument
+   |                           ^           ----- help: remove the unnecessary generic argument
+   |                           |
+   |                           expected 1 generic argument
    |
 note: associated type defined here, with 1 generic parameter: `T`
   --> $DIR/parameter_number_and_kind.rs:8:10
    |
 LL |     type E<'a, T>;
    |          ^     -
-help: remove the unnecessary generic argument
-   |
-LL -     type FErr2<T> = Self::E<'static, T, u32>;
-LL +     type FErr2<T> = Self::E<'static, T>;
-   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
@@ -25,7 +25,7 @@ note: associated type defined here, with 0 generic parameters
    |
 LL |     type Y<'a>;
    |          ^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
 LL +   fn f2<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
@@ -60,7 +60,7 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
 LL +   fn f2<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
@@ -95,7 +95,7 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
 LL +   fn f2<'a>(arg : Box<dyn X<Y = &'a ()>>) {}

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
@@ -18,18 +18,15 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/trait-path-type-error-once-implemented.rs:6:29
    |
 LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                             ^ expected 0 generic arguments
+   |                             ^--- help: remove the unnecessary generics
+   |                             |
+   |                             expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/trait-path-type-error-once-implemented.rs:2:10
    |
 LL |     type Y<'a>;
    |          ^
-help: remove the unnecessary generics
-   |
-LL -   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-LL +   fn f2<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
-   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/trait-path-type-error-once-implemented.rs:6:29
@@ -52,7 +49,9 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/trait-path-type-error-once-implemented.rs:6:29
    |
 LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                             ^ expected 0 generic arguments
+   |                             ^--- help: remove the unnecessary generics
+   |                             |
+   |                             expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/trait-path-type-error-once-implemented.rs:2:10
@@ -60,11 +59,6 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove the unnecessary generics
-   |
-LL -   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-LL +   fn f2<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
-   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/trait-path-type-error-once-implemented.rs:6:29
@@ -87,7 +81,9 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/trait-path-type-error-once-implemented.rs:6:29
    |
 LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                             ^ expected 0 generic arguments
+   |                             ^--- help: remove the unnecessary generics
+   |                             |
+   |                             expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/trait-path-type-error-once-implemented.rs:2:10
@@ -95,11 +91,6 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove the unnecessary generics
-   |
-LL -   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-LL +   fn f2<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
-   |
 
 error[E0038]: the trait `X` cannot be made into an object
   --> $DIR/trait-path-type-error-once-implemented.rs:6:23

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
@@ -18,15 +18,18 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/trait-path-type-error-once-implemented.rs:6:29
    |
 LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                             ^--- help: remove these generics
-   |                             |
-   |                             expected 0 generic arguments
+   |                             ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/trait-path-type-error-once-implemented.rs:2:10
    |
 LL |     type Y<'a>;
    |          ^
+help: remove these generics
+   |
+LL -   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+LL +   fn f2<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
+   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/trait-path-type-error-once-implemented.rs:6:29
@@ -49,9 +52,7 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/trait-path-type-error-once-implemented.rs:6:29
    |
 LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                             ^--- help: remove these generics
-   |                             |
-   |                             expected 0 generic arguments
+   |                             ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/trait-path-type-error-once-implemented.rs:2:10
@@ -59,6 +60,11 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: remove these generics
+   |
+LL -   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+LL +   fn f2<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
+   |
 
 error[E0107]: associated type takes 1 lifetime argument but 0 lifetime arguments were supplied
   --> $DIR/trait-path-type-error-once-implemented.rs:6:29
@@ -81,9 +87,7 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/trait-path-type-error-once-implemented.rs:6:29
    |
 LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                             ^--- help: remove these generics
-   |                             |
-   |                             expected 0 generic arguments
+   |                             ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/trait-path-type-error-once-implemented.rs:2:10
@@ -91,6 +95,11 @@ note: associated type defined here, with 0 generic parameters
 LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: remove these generics
+   |
+LL -   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
+LL +   fn f2<'a>(arg : Box<dyn X<Y = &'a ()>>) {}
+   |
 
 error[E0038]: the trait `X` cannot be made into an object
   --> $DIR/trait-path-type-error-once-implemented.rs:6:23

--- a/tests/ui/generics/bad-mid-path-type-params.stderr
+++ b/tests/ui/generics/bad-mid-path-type-params.stderr
@@ -12,7 +12,7 @@ LL |     fn new<U>(x: T, _: U) -> S<T> {
 help: remove the unnecessary generic argument
    |
 LL -     let _ = S::new::<isize,f64>(1, 1.0);
-LL +     let _ = S::new::<isize,>(1, 1.0);
+LL +     let _ = S::new::<isize>(1, 1.0);
    |
 
 error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
@@ -46,7 +46,7 @@ LL |     fn new<U>(x: T, y: U) -> Self;
 help: remove the unnecessary generic argument
    |
 LL -     let _: S2 = Trait::new::<isize,f64>(1, 1.0);
-LL +     let _: S2 = Trait::new::<isize,>(1, 1.0);
+LL +     let _: S2 = Trait::new::<isize>(1, 1.0);
    |
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
@@ -80,7 +80,7 @@ LL |     fn new<U>(x: T, y: U) -> Self;
 help: remove the unnecessary generic argument
    |
 LL -     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
-LL +     let _: S2 = Trait::<'a,isize>::new::<f64,>(1, 1.0);
+LL +     let _: S2 = Trait::<'a,isize>::new::<f64>(1, 1.0);
    |
 
 error: aborting due to 5 previous errors

--- a/tests/ui/generics/bad-mid-path-type-params.stderr
+++ b/tests/ui/generics/bad-mid-path-type-params.stderr
@@ -9,7 +9,7 @@ note: associated function defined here, with 1 generic parameter: `U`
    |
 LL |     fn new<U>(x: T, _: U) -> S<T> {
    |        ^^^ -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     let _ = S::new::<isize,f64>(1, 1.0);
 LL +     let _ = S::new::<isize,>(1, 1.0);
@@ -26,7 +26,7 @@ note: struct defined here, with 0 lifetime parameters
    |
 LL | struct S<T> {
    |        ^
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     let _ = S::<'a,isize>::new::<f64>(1, 1.0);
 LL +     let _ = S::<,isize>::new::<f64>(1, 1.0);
@@ -43,7 +43,7 @@ note: associated function defined here, with 1 generic parameter: `U`
    |
 LL |     fn new<U>(x: T, y: U) -> Self;
    |        ^^^ -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     let _: S2 = Trait::new::<isize,f64>(1, 1.0);
 LL +     let _: S2 = Trait::new::<isize,>(1, 1.0);
@@ -60,7 +60,7 @@ note: trait defined here, with 0 lifetime parameters
    |
 LL | trait Trait<T> {
    |       ^^^^^
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
 LL +     let _: S2 = Trait::<,isize>::new::<f64,f64>(1, 1.0);
@@ -77,7 +77,7 @@ note: associated function defined here, with 1 generic parameter: `U`
    |
 LL |     fn new<U>(x: T, y: U) -> Self;
    |        ^^^ -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
 LL +     let _: S2 = Trait::<'a,isize>::new::<f64,>(1, 1.0);

--- a/tests/ui/generics/bad-mid-path-type-params.stderr
+++ b/tests/ui/generics/bad-mid-path-type-params.stderr
@@ -2,86 +2,71 @@ error[E0107]: associated function takes 1 generic argument but 2 generic argumen
   --> $DIR/bad-mid-path-type-params.rs:30:16
    |
 LL |     let _ = S::new::<isize,f64>(1, 1.0);
-   |                ^^^ expected 1 generic argument
+   |                ^^^        ---- help: remove the unnecessary generic argument
+   |                |
+   |                expected 1 generic argument
    |
 note: associated function defined here, with 1 generic parameter: `U`
   --> $DIR/bad-mid-path-type-params.rs:6:8
    |
 LL |     fn new<U>(x: T, _: U) -> S<T> {
    |        ^^^ -
-help: remove the unnecessary generic argument
-   |
-LL -     let _ = S::new::<isize,f64>(1, 1.0);
-LL +     let _ = S::new::<isize>(1, 1.0);
-   |
 
 error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/bad-mid-path-type-params.rs:33:13
    |
 LL |     let _ = S::<'a,isize>::new::<f64>(1, 1.0);
-   |             ^ expected 0 lifetime arguments
+   |             ^   -- help: remove the lifetime argument
+   |             |
+   |             expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/bad-mid-path-type-params.rs:1:8
    |
 LL | struct S<T> {
    |        ^
-help: remove the lifetime argument
-   |
-LL -     let _ = S::<'a,isize>::new::<f64>(1, 1.0);
-LL +     let _ = S::<,isize>::new::<f64>(1, 1.0);
-   |
 
 error[E0107]: associated function takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/bad-mid-path-type-params.rs:36:24
    |
 LL |     let _: S2 = Trait::new::<isize,f64>(1, 1.0);
-   |                        ^^^ expected 1 generic argument
+   |                        ^^^        ---- help: remove the unnecessary generic argument
+   |                        |
+   |                        expected 1 generic argument
    |
 note: associated function defined here, with 1 generic parameter: `U`
   --> $DIR/bad-mid-path-type-params.rs:14:8
    |
 LL |     fn new<U>(x: T, y: U) -> Self;
    |        ^^^ -
-help: remove the unnecessary generic argument
-   |
-LL -     let _: S2 = Trait::new::<isize,f64>(1, 1.0);
-LL +     let _: S2 = Trait::new::<isize>(1, 1.0);
-   |
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/bad-mid-path-type-params.rs:39:17
    |
 LL |     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
-   |                 ^^^^^ expected 0 lifetime arguments
+   |                 ^^^^^   -- help: remove the lifetime argument
+   |                 |
+   |                 expected 0 lifetime arguments
    |
 note: trait defined here, with 0 lifetime parameters
   --> $DIR/bad-mid-path-type-params.rs:13:7
    |
 LL | trait Trait<T> {
    |       ^^^^^
-help: remove the lifetime argument
-   |
-LL -     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
-LL +     let _: S2 = Trait::<,isize>::new::<f64,f64>(1, 1.0);
-   |
 
 error[E0107]: associated function takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/bad-mid-path-type-params.rs:39:36
    |
 LL |     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
-   |                                    ^^^ expected 1 generic argument
+   |                                    ^^^      ---- help: remove the unnecessary generic argument
+   |                                    |
+   |                                    expected 1 generic argument
    |
 note: associated function defined here, with 1 generic parameter: `U`
   --> $DIR/bad-mid-path-type-params.rs:14:8
    |
 LL |     fn new<U>(x: T, y: U) -> Self;
    |        ^^^ -
-help: remove the unnecessary generic argument
-   |
-LL -     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
-LL +     let _: S2 = Trait::<'a,isize>::new::<f64>(1, 1.0);
-   |
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/generics/bad-mid-path-type-params.stderr
+++ b/tests/ui/generics/bad-mid-path-type-params.stderr
@@ -2,71 +2,86 @@ error[E0107]: associated function takes 1 generic argument but 2 generic argumen
   --> $DIR/bad-mid-path-type-params.rs:30:16
    |
 LL |     let _ = S::new::<isize,f64>(1, 1.0);
-   |                ^^^         --- help: remove this generic argument
-   |                |
-   |                expected 1 generic argument
+   |                ^^^ expected 1 generic argument
    |
 note: associated function defined here, with 1 generic parameter: `U`
   --> $DIR/bad-mid-path-type-params.rs:6:8
    |
 LL |     fn new<U>(x: T, _: U) -> S<T> {
    |        ^^^ -
+help: remove this generic argument
+   |
+LL -     let _ = S::new::<isize,f64>(1, 1.0);
+LL +     let _ = S::new::<isize,>(1, 1.0);
+   |
 
 error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/bad-mid-path-type-params.rs:33:13
    |
 LL |     let _ = S::<'a,isize>::new::<f64>(1, 1.0);
-   |             ^   -- help: remove this lifetime argument
-   |             |
-   |             expected 0 lifetime arguments
+   |             ^ expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/bad-mid-path-type-params.rs:1:8
    |
 LL | struct S<T> {
    |        ^
+help: remove this lifetime argument
+   |
+LL -     let _ = S::<'a,isize>::new::<f64>(1, 1.0);
+LL +     let _ = S::<,isize>::new::<f64>(1, 1.0);
+   |
 
 error[E0107]: associated function takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/bad-mid-path-type-params.rs:36:24
    |
 LL |     let _: S2 = Trait::new::<isize,f64>(1, 1.0);
-   |                        ^^^         --- help: remove this generic argument
-   |                        |
-   |                        expected 1 generic argument
+   |                        ^^^ expected 1 generic argument
    |
 note: associated function defined here, with 1 generic parameter: `U`
   --> $DIR/bad-mid-path-type-params.rs:14:8
    |
 LL |     fn new<U>(x: T, y: U) -> Self;
    |        ^^^ -
+help: remove this generic argument
+   |
+LL -     let _: S2 = Trait::new::<isize,f64>(1, 1.0);
+LL +     let _: S2 = Trait::new::<isize,>(1, 1.0);
+   |
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/bad-mid-path-type-params.rs:39:17
    |
 LL |     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
-   |                 ^^^^^   -- help: remove this lifetime argument
-   |                 |
-   |                 expected 0 lifetime arguments
+   |                 ^^^^^ expected 0 lifetime arguments
    |
 note: trait defined here, with 0 lifetime parameters
   --> $DIR/bad-mid-path-type-params.rs:13:7
    |
 LL | trait Trait<T> {
    |       ^^^^^
+help: remove this lifetime argument
+   |
+LL -     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
+LL +     let _: S2 = Trait::<,isize>::new::<f64,f64>(1, 1.0);
+   |
 
 error[E0107]: associated function takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/bad-mid-path-type-params.rs:39:36
    |
 LL |     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
-   |                                    ^^^       --- help: remove this generic argument
-   |                                    |
-   |                                    expected 1 generic argument
+   |                                    ^^^ expected 1 generic argument
    |
 note: associated function defined here, with 1 generic parameter: `U`
   --> $DIR/bad-mid-path-type-params.rs:14:8
    |
 LL |     fn new<U>(x: T, y: U) -> Self;
    |        ^^^ -
+help: remove this generic argument
+   |
+LL -     let _: S2 = Trait::<'a,isize>::new::<f64,f64>(1, 1.0);
+LL +     let _: S2 = Trait::<'a,isize>::new::<f64,>(1, 1.0);
+   |
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/generics/foreign-generic-mismatch.stderr
+++ b/tests/ui/generics/foreign-generic-mismatch.stderr
@@ -30,7 +30,7 @@ LL | pub fn lt_arg<'a: 'a>() {}
 help: remove the lifetime argument
    |
 LL -     foreign_generic_mismatch::lt_arg::<'static, 'static>();
-LL +     foreign_generic_mismatch::lt_arg::<'static, >();
+LL +     foreign_generic_mismatch::lt_arg::<'static>();
    |
 
 error: aborting due to 2 previous errors

--- a/tests/ui/generics/foreign-generic-mismatch.stderr
+++ b/tests/ui/generics/foreign-generic-mismatch.stderr
@@ -20,15 +20,18 @@ error[E0107]: function takes 1 lifetime argument but 2 lifetime arguments were s
   --> $DIR/foreign-generic-mismatch.rs:8:31
    |
 LL |     foreign_generic_mismatch::lt_arg::<'static, 'static>();
-   |                               ^^^^^^            ------- help: remove this lifetime argument
-   |                               |
-   |                               expected 1 lifetime argument
+   |                               ^^^^^^ expected 1 lifetime argument
    |
 note: function defined here, with 1 lifetime parameter: `'a`
   --> $DIR/auxiliary/foreign-generic-mismatch.rs:3:8
    |
 LL | pub fn lt_arg<'a: 'a>() {}
    |        ^^^^^^ --
+help: remove this lifetime argument
+   |
+LL -     foreign_generic_mismatch::lt_arg::<'static, 'static>();
+LL +     foreign_generic_mismatch::lt_arg::<'static, >();
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generics/foreign-generic-mismatch.stderr
+++ b/tests/ui/generics/foreign-generic-mismatch.stderr
@@ -27,7 +27,7 @@ note: function defined here, with 1 lifetime parameter: `'a`
    |
 LL | pub fn lt_arg<'a: 'a>() {}
    |        ^^^^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     foreign_generic_mismatch::lt_arg::<'static, 'static>();
 LL +     foreign_generic_mismatch::lt_arg::<'static, >();

--- a/tests/ui/generics/foreign-generic-mismatch.stderr
+++ b/tests/ui/generics/foreign-generic-mismatch.stderr
@@ -20,18 +20,15 @@ error[E0107]: function takes 1 lifetime argument but 2 lifetime arguments were s
   --> $DIR/foreign-generic-mismatch.rs:8:31
    |
 LL |     foreign_generic_mismatch::lt_arg::<'static, 'static>();
-   |                               ^^^^^^ expected 1 lifetime argument
+   |                               ^^^^^^          --------- help: remove the lifetime argument
+   |                               |
+   |                               expected 1 lifetime argument
    |
 note: function defined here, with 1 lifetime parameter: `'a`
   --> $DIR/auxiliary/foreign-generic-mismatch.rs:3:8
    |
 LL | pub fn lt_arg<'a: 'a>() {}
    |        ^^^^^^ --
-help: remove the lifetime argument
-   |
-LL -     foreign_generic_mismatch::lt_arg::<'static, 'static>();
-LL +     foreign_generic_mismatch::lt_arg::<'static>();
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/generics/generic-arg-mismatch-recover.stderr
+++ b/tests/ui/generics/generic-arg-mismatch-recover.stderr
@@ -2,52 +2,43 @@ error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were sup
   --> $DIR/generic-arg-mismatch-recover.rs:6:5
    |
 LL |     Foo::<'static, 'static, ()>(&0);
-   |     ^^^ expected 1 lifetime argument
+   |     ^^^          --------- help: remove the lifetime argument
+   |     |
+   |     expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/generic-arg-mismatch-recover.rs:1:8
    |
 LL | struct Foo<'a, T: 'a>(&'a T);
    |        ^^^ --
-help: remove the lifetime argument
-   |
-LL -     Foo::<'static, 'static, ()>(&0);
-LL +     Foo::<'static, ()>(&0);
-   |
 
 error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/generic-arg-mismatch-recover.rs:9:5
    |
 LL |     Bar::<'static, 'static, ()>(&());
-   |     ^^^ expected 1 lifetime argument
+   |     ^^^          --------- help: remove the lifetime argument
+   |     |
+   |     expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/generic-arg-mismatch-recover.rs:3:8
    |
 LL | struct Bar<'a>(&'a ());
    |        ^^^ --
-help: remove the lifetime argument
-   |
-LL -     Bar::<'static, 'static, ()>(&());
-LL +     Bar::<'static, ()>(&());
-   |
 
 error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/generic-arg-mismatch-recover.rs:9:5
    |
 LL |     Bar::<'static, 'static, ()>(&());
-   |     ^^^ expected 0 generic arguments
+   |     ^^^                     -- help: remove the unnecessary generic argument
+   |     |
+   |     expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/generic-arg-mismatch-recover.rs:3:8
    |
 LL | struct Bar<'a>(&'a ());
    |        ^^^
-help: remove the unnecessary generic argument
-   |
-LL -     Bar::<'static, 'static, ()>(&());
-LL +     Bar::<'static, 'static, >(&());
-   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/generics/generic-arg-mismatch-recover.stderr
+++ b/tests/ui/generics/generic-arg-mismatch-recover.stderr
@@ -2,43 +2,52 @@ error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were sup
   --> $DIR/generic-arg-mismatch-recover.rs:6:5
    |
 LL |     Foo::<'static, 'static, ()>(&0);
-   |     ^^^            ------- help: remove this lifetime argument
-   |     |
-   |     expected 1 lifetime argument
+   |     ^^^ expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/generic-arg-mismatch-recover.rs:1:8
    |
 LL | struct Foo<'a, T: 'a>(&'a T);
    |        ^^^ --
+help: remove this lifetime argument
+   |
+LL -     Foo::<'static, 'static, ()>(&0);
+LL +     Foo::<'static, , ()>(&0);
+   |
 
 error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/generic-arg-mismatch-recover.rs:9:5
    |
 LL |     Bar::<'static, 'static, ()>(&());
-   |     ^^^            ------- help: remove this lifetime argument
-   |     |
-   |     expected 1 lifetime argument
+   |     ^^^ expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/generic-arg-mismatch-recover.rs:3:8
    |
 LL | struct Bar<'a>(&'a ());
    |        ^^^ --
+help: remove this lifetime argument
+   |
+LL -     Bar::<'static, 'static, ()>(&());
+LL +     Bar::<'static, , ()>(&());
+   |
 
 error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/generic-arg-mismatch-recover.rs:9:5
    |
 LL |     Bar::<'static, 'static, ()>(&());
-   |     ^^^                     -- help: remove this generic argument
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^ expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/generic-arg-mismatch-recover.rs:3:8
    |
 LL | struct Bar<'a>(&'a ());
    |        ^^^
+help: remove this generic argument
+   |
+LL -     Bar::<'static, 'static, ()>(&());
+LL +     Bar::<'static, 'static, >(&());
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/generics/generic-arg-mismatch-recover.stderr
+++ b/tests/ui/generics/generic-arg-mismatch-recover.stderr
@@ -9,7 +9,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
    |
 LL | struct Foo<'a, T: 'a>(&'a T);
    |        ^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     Foo::<'static, 'static, ()>(&0);
 LL +     Foo::<'static, , ()>(&0);
@@ -26,7 +26,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
    |
 LL | struct Bar<'a>(&'a ());
    |        ^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     Bar::<'static, 'static, ()>(&());
 LL +     Bar::<'static, , ()>(&());
@@ -43,7 +43,7 @@ note: struct defined here, with 0 generic parameters
    |
 LL | struct Bar<'a>(&'a ());
    |        ^^^
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     Bar::<'static, 'static, ()>(&());
 LL +     Bar::<'static, 'static, >(&());

--- a/tests/ui/generics/generic-arg-mismatch-recover.stderr
+++ b/tests/ui/generics/generic-arg-mismatch-recover.stderr
@@ -12,7 +12,7 @@ LL | struct Foo<'a, T: 'a>(&'a T);
 help: remove the lifetime argument
    |
 LL -     Foo::<'static, 'static, ()>(&0);
-LL +     Foo::<'static, , ()>(&0);
+LL +     Foo::<'static, ()>(&0);
    |
 
 error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were supplied
@@ -29,7 +29,7 @@ LL | struct Bar<'a>(&'a ());
 help: remove the lifetime argument
    |
 LL -     Bar::<'static, 'static, ()>(&());
-LL +     Bar::<'static, , ()>(&());
+LL +     Bar::<'static, ()>(&());
    |
 
 error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied

--- a/tests/ui/generics/generic-impl-more-params-with-defaults.stderr
+++ b/tests/ui/generics/generic-impl-more-params-with-defaults.stderr
@@ -2,15 +2,18 @@ error[E0107]: struct takes at most 2 generic arguments but 3 generic arguments w
   --> $DIR/generic-impl-more-params-with-defaults.rs:13:5
    |
 LL |     Vec::<isize, Heap, bool>::new();
-   |     ^^^                ---- help: remove this generic argument
-   |     |
-   |     expected at most 2 generic arguments
+   |     ^^^ expected at most 2 generic arguments
    |
 note: struct defined here, with at most 2 generic parameters: `T`, `A`
   --> $DIR/generic-impl-more-params-with-defaults.rs:5:8
    |
 LL | struct Vec<T, A = Heap>(
    |        ^^^ -  --------
+help: remove this generic argument
+   |
+LL -     Vec::<isize, Heap, bool>::new();
+LL +     Vec::<isize, Heap, >::new();
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/generic-impl-more-params-with-defaults.stderr
+++ b/tests/ui/generics/generic-impl-more-params-with-defaults.stderr
@@ -9,7 +9,7 @@ note: struct defined here, with at most 2 generic parameters: `T`, `A`
    |
 LL | struct Vec<T, A = Heap>(
    |        ^^^ -  --------
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     Vec::<isize, Heap, bool>::new();
 LL +     Vec::<isize, Heap, >::new();

--- a/tests/ui/generics/generic-impl-more-params-with-defaults.stderr
+++ b/tests/ui/generics/generic-impl-more-params-with-defaults.stderr
@@ -2,18 +2,15 @@ error[E0107]: struct takes at most 2 generic arguments but 3 generic arguments w
   --> $DIR/generic-impl-more-params-with-defaults.rs:13:5
    |
 LL |     Vec::<isize, Heap, bool>::new();
-   |     ^^^ expected at most 2 generic arguments
+   |     ^^^              ------ help: remove the unnecessary generic argument
+   |     |
+   |     expected at most 2 generic arguments
    |
 note: struct defined here, with at most 2 generic parameters: `T`, `A`
   --> $DIR/generic-impl-more-params-with-defaults.rs:5:8
    |
 LL | struct Vec<T, A = Heap>(
    |        ^^^ -  --------
-help: remove the unnecessary generic argument
-   |
-LL -     Vec::<isize, Heap, bool>::new();
-LL +     Vec::<isize, Heap>::new();
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/generic-impl-more-params-with-defaults.stderr
+++ b/tests/ui/generics/generic-impl-more-params-with-defaults.stderr
@@ -12,7 +12,7 @@ LL | struct Vec<T, A = Heap>(
 help: remove the unnecessary generic argument
    |
 LL -     Vec::<isize, Heap, bool>::new();
-LL +     Vec::<isize, Heap, >::new();
+LL +     Vec::<isize, Heap>::new();
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/generics/generic-type-more-params-with-defaults.stderr
+++ b/tests/ui/generics/generic-type-more-params-with-defaults.stderr
@@ -2,18 +2,15 @@ error[E0107]: struct takes at most 2 generic arguments but 3 generic arguments w
   --> $DIR/generic-type-more-params-with-defaults.rs:9:12
    |
 LL |     let _: Vec<isize, Heap, bool>;
-   |            ^^^ expected at most 2 generic arguments
+   |            ^^^            ------ help: remove the unnecessary generic argument
+   |            |
+   |            expected at most 2 generic arguments
    |
 note: struct defined here, with at most 2 generic parameters: `T`, `A`
   --> $DIR/generic-type-more-params-with-defaults.rs:5:8
    |
 LL | struct Vec<T, A = Heap>(
    |        ^^^ -  --------
-help: remove the unnecessary generic argument
-   |
-LL -     let _: Vec<isize, Heap, bool>;
-LL +     let _: Vec<isize, Heap>;
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/generic-type-more-params-with-defaults.stderr
+++ b/tests/ui/generics/generic-type-more-params-with-defaults.stderr
@@ -9,7 +9,7 @@ note: struct defined here, with at most 2 generic parameters: `T`, `A`
    |
 LL | struct Vec<T, A = Heap>(
    |        ^^^ -  --------
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     let _: Vec<isize, Heap, bool>;
 LL +     let _: Vec<isize, Heap, >;

--- a/tests/ui/generics/generic-type-more-params-with-defaults.stderr
+++ b/tests/ui/generics/generic-type-more-params-with-defaults.stderr
@@ -2,15 +2,18 @@ error[E0107]: struct takes at most 2 generic arguments but 3 generic arguments w
   --> $DIR/generic-type-more-params-with-defaults.rs:9:12
    |
 LL |     let _: Vec<isize, Heap, bool>;
-   |            ^^^              ---- help: remove this generic argument
-   |            |
-   |            expected at most 2 generic arguments
+   |            ^^^ expected at most 2 generic arguments
    |
 note: struct defined here, with at most 2 generic parameters: `T`, `A`
   --> $DIR/generic-type-more-params-with-defaults.rs:5:8
    |
 LL | struct Vec<T, A = Heap>(
    |        ^^^ -  --------
+help: remove this generic argument
+   |
+LL -     let _: Vec<isize, Heap, bool>;
+LL +     let _: Vec<isize, Heap, >;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generics/generic-type-more-params-with-defaults.stderr
+++ b/tests/ui/generics/generic-type-more-params-with-defaults.stderr
@@ -12,7 +12,7 @@ LL | struct Vec<T, A = Heap>(
 help: remove the unnecessary generic argument
    |
 LL -     let _: Vec<isize, Heap, bool>;
-LL +     let _: Vec<isize, Heap, >;
+LL +     let _: Vec<isize, Heap>;
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/generics/wrong-number-of-args.rs
+++ b/tests/ui/generics/wrong-number-of-args.rs
@@ -5,19 +5,19 @@ mod no_generics {
 
     type B = Ty<'static>;
     //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument
-    //~| HELP remove these generics
+    //~| HELP remove the unnecessary generics
 
     type C = Ty<'static, usize>;
     //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument
     //~| ERROR struct takes 0 generic arguments but 1 generic argument
-    //~| HELP remove this lifetime argument
-    //~| HELP remove this generic argument
+    //~| HELP remove the lifetime argument
+    //~| HELP remove the unnecessary generic argument
 
     type D = Ty<'static, usize, { 0 }>;
     //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument
     //~| ERROR struct takes 0 generic arguments but 2 generic arguments
-    //~| HELP remove this lifetime argument
-    //~| HELP remove these generic arguments
+    //~| HELP remove the lifetime argument
+    //~| HELP remove the unnecessary generic arguments
 }
 
 mod type_and_type {
@@ -35,7 +35,7 @@ mod type_and_type {
 
     type D = Ty<usize, String, char>;
     //~^ ERROR struct takes 2 generic arguments but 3 generic arguments
-    //~| HELP remove this
+    //~| HELP remove the
 
     type E = Ty<>;
     //~^ ERROR struct takes 2 generic arguments but 0 generic arguments were supplied
@@ -70,8 +70,8 @@ mod lifetime_and_type {
     type F = Ty<'static, usize, 'static, usize>;
     //~^ ERROR struct takes 1 lifetime argument but 2 lifetime arguments
     //~| ERROR struct takes 1 generic argument but 2 generic arguments
-    //~| HELP remove this lifetime argument
-    //~| HELP remove this generic argument
+    //~| HELP remove the lifetime argument
+    //~| HELP remove the unnecessary generic argument
 }
 
 mod type_and_type_and_type {
@@ -317,13 +317,13 @@ mod stdlib {
 
         type C = HashMap<'static>;
         //~^ ERROR struct takes 0 lifetime arguments but 1 lifetime argument
-        //~| HELP remove these generics
+        //~| HELP remove the
         //~| ERROR struct takes at least 2
         //~| HELP add missing
 
         type D = HashMap<usize, String, char, f64>;
         //~^ ERROR struct takes at most 3
-        //~| HELP remove this
+        //~| HELP remove the
 
         type E = HashMap<>;
         //~^ ERROR struct takes at least 2 generic arguments but 0 generic arguments
@@ -341,7 +341,7 @@ mod stdlib {
 
         type C = Result<'static>;
         //~^ ERROR enum takes 0 lifetime arguments but 1 lifetime argument
-        //~| HELP remove these generics
+        //~| HELP remove the unnecessary generics
         //~| ERROR enum takes 2 generic arguments but 0 generic arguments
         //~| HELP add missing
 

--- a/tests/ui/generics/wrong-number-of-args.stderr
+++ b/tests/ui/generics/wrong-number-of-args.stderr
@@ -171,86 +171,71 @@ error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supp
   --> $DIR/wrong-number-of-args.rs:6:14
    |
 LL |     type B = Ty<'static>;
-   |              ^^ expected 0 lifetime arguments
+   |              ^^--------- help: remove the unnecessary generics
+   |              |
+   |              expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/wrong-number-of-args.rs:2:12
    |
 LL |     struct Ty;
    |            ^^
-help: remove the unnecessary generics
-   |
-LL -     type B = Ty<'static>;
-LL +     type B = Ty;
-   |
 
 error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:10:14
    |
 LL |     type C = Ty<'static, usize>;
-   |              ^^ expected 0 lifetime arguments
+   |              ^^ ------- help: remove the lifetime argument
+   |              |
+   |              expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/wrong-number-of-args.rs:2:12
    |
 LL |     struct Ty;
    |            ^^
-help: remove the lifetime argument
-   |
-LL -     type C = Ty<'static, usize>;
-LL +     type C = Ty<, usize>;
-   |
 
 error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:10:14
    |
 LL |     type C = Ty<'static, usize>;
-   |              ^^ expected 0 generic arguments
+   |              ^^          ----- help: remove the unnecessary generic argument
+   |              |
+   |              expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/wrong-number-of-args.rs:2:12
    |
 LL |     struct Ty;
    |            ^^
-help: remove the unnecessary generic argument
-   |
-LL -     type C = Ty<'static, usize>;
-LL +     type C = Ty<'static, >;
-   |
 
 error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:16:14
    |
 LL |     type D = Ty<'static, usize, { 0 }>;
-   |              ^^ expected 0 lifetime arguments
+   |              ^^ ------- help: remove the lifetime argument
+   |              |
+   |              expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/wrong-number-of-args.rs:2:12
    |
 LL |     struct Ty;
    |            ^^
-help: remove the lifetime argument
-   |
-LL -     type D = Ty<'static, usize, { 0 }>;
-LL +     type D = Ty<, usize, { 0 }>;
-   |
 
 error[E0107]: struct takes 0 generic arguments but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:16:14
    |
 LL |     type D = Ty<'static, usize, { 0 }>;
-   |              ^^ expected 0 generic arguments
+   |              ^^               ------- help: remove the unnecessary generic arguments
+   |              |
+   |              expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/wrong-number-of-args.rs:2:12
    |
 LL |     struct Ty;
    |            ^^
-help: remove the unnecessary generic arguments
-   |
-LL -     type D = Ty<'static, usize, { 0 }>;
-LL +     type D = Ty<'static, usize>;
-   |
 
 error[E0107]: missing generics for struct `type_and_type::Ty`
   --> $DIR/wrong-number-of-args.rs:26:14
@@ -290,18 +275,15 @@ error[E0107]: struct takes 2 generic arguments but 3 generic arguments were supp
   --> $DIR/wrong-number-of-args.rs:36:14
    |
 LL |     type D = Ty<usize, String, char>;
-   |              ^^ expected 2 generic arguments
+   |              ^^              ------ help: remove the unnecessary generic argument
+   |              |
+   |              expected 2 generic arguments
    |
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
 LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
-help: remove the unnecessary generic argument
-   |
-LL -     type D = Ty<usize, String, char>;
-LL +     type D = Ty<usize, String>;
-   |
 
 error[E0107]: struct takes 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:40:14
@@ -371,35 +353,29 @@ error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were sup
   --> $DIR/wrong-number-of-args.rs:70:14
    |
 LL |     type F = Ty<'static, usize, 'static, usize>;
-   |              ^^ expected 1 lifetime argument
+   |              ^^        ---------------- help: remove the lifetime argument
+   |              |
+   |              expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
 LL |     struct Ty<'a, T>(&'a T);
    |            ^^ --
-help: remove the lifetime argument
-   |
-LL -     type F = Ty<'static, usize, 'static, usize>;
-LL +     type F = Ty<'static, usize>;
-   |
 
 error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:70:14
    |
 LL |     type F = Ty<'static, usize, 'static, usize>;
-   |              ^^ expected 1 generic argument
+   |              ^^               ---------------- help: remove the unnecessary generic argument
+   |              |
+   |              expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
 LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
-help: remove the unnecessary generic argument
-   |
-LL -     type F = Ty<'static, usize, 'static, usize>;
-LL +     type F = Ty<'static, usize>;
-   |
 
 error[E0107]: missing generics for struct `type_and_type_and_type::Ty`
   --> $DIR/wrong-number-of-args.rs:80:14
@@ -439,18 +415,15 @@ error[E0107]: struct takes at most 3 generic arguments but 4 generic arguments w
   --> $DIR/wrong-number-of-args.rs:92:14
    |
 LL |     type E = Ty<usize, String, char, f64>;
-   |              ^^ expected at most 3 generic arguments
+   |              ^^                    ----- help: remove the unnecessary generic argument
+   |              |
+   |              expected at most 3 generic arguments
    |
 note: struct defined here, with at most 3 generic parameters: `A`, `B`, `C`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
 LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -  ----------------
-help: remove the unnecessary generic argument
-   |
-LL -     type E = Ty<usize, String, char, f64>;
-LL +     type E = Ty<usize, String, char>;
-   |
 
 error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:96:14
@@ -472,35 +445,29 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/wrong-number-of-args.rs:116:22
    |
 LL |     type A = Box<dyn NonGeneric<usize>>;
-   |                      ^^^^^^^^^^ expected 0 generic arguments
+   |                      ^^^^^^^^^^------- help: remove the unnecessary generics
+   |                      |
+   |                      expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/wrong-number-of-args.rs:104:11
    |
 LL |     trait NonGeneric {
    |           ^^^^^^^^^^
-help: remove the unnecessary generics
-   |
-LL -     type A = Box<dyn NonGeneric<usize>>;
-LL +     type A = Box<dyn NonGeneric>;
-   |
 
 error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:125:22
    |
 LL |     type C = Box<dyn GenericLifetime<'static, 'static>>;
-   |                      ^^^^^^^^^^^^^^^ expected 1 lifetime argument
+   |                      ^^^^^^^^^^^^^^^        --------- help: remove the lifetime argument
+   |                      |
+   |                      expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:108:11
    |
 LL |     trait GenericLifetime<'a> {
    |           ^^^^^^^^^^^^^^^ --
-help: remove the lifetime argument
-   |
-LL -     type C = Box<dyn GenericLifetime<'static, 'static>>;
-LL +     type C = Box<dyn GenericLifetime<'static>>;
-   |
 
 error[E0107]: missing generics for trait `GenericType`
   --> $DIR/wrong-number-of-args.rs:129:22
@@ -522,18 +489,15 @@ error[E0107]: trait takes 1 generic argument but 2 generic arguments were suppli
   --> $DIR/wrong-number-of-args.rs:133:22
    |
 LL |     type E = Box<dyn GenericType<String, usize>>;
-   |                      ^^^^^^^^^^^ expected 1 generic argument
+   |                      ^^^^^^^^^^^       ------- help: remove the unnecessary generic argument
+   |                      |
+   |                      expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
   --> $DIR/wrong-number-of-args.rs:112:11
    |
 LL |     trait GenericType<A> {
    |           ^^^^^^^^^^^ -
-help: remove the unnecessary generic argument
-   |
-LL -     type E = Box<dyn GenericType<String, usize>>;
-LL +     type E = Box<dyn GenericType<String>>;
-   |
 
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:142:22
@@ -555,52 +519,43 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/wrong-number-of-args.rs:153:26
    |
 LL |         type A = Box<dyn NonGenericAT<usize, AssocTy=()>>;
-   |                          ^^^^^^^^^^^^ expected 0 generic arguments
+   |                          ^^^^^^^^^^^^------------------- help: remove the unnecessary generics
+   |                          |
+   |                          expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/wrong-number-of-args.rs:149:15
    |
 LL |         trait NonGenericAT {
    |               ^^^^^^^^^^^^
-help: remove the unnecessary generics
-   |
-LL -         type A = Box<dyn NonGenericAT<usize, AssocTy=()>>;
-LL +         type A = Box<dyn NonGenericAT>;
-   |
 
 error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:168:26
    |
 LL |         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^ expected 1 lifetime argument
+   |                          ^^^^^^^^^^^^^^^^^        --------- help: remove the lifetime argument
+   |                          |
+   |                          expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:159:15
    |
 LL |         trait GenericLifetimeAT<'a> {
    |               ^^^^^^^^^^^^^^^^^ --
-help: remove the lifetime argument
-   |
-LL -         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
-LL +         type B = Box<dyn GenericLifetimeAT<'static, AssocTy=()>>;
-   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:172:26
    |
 LL |         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^ expected 0 generic arguments
+   |                          ^^^^^^^^^^^^^^^^^ -- help: remove the unnecessary generic argument
+   |                          |
+   |                          expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/wrong-number-of-args.rs:159:15
    |
 LL |         trait GenericLifetimeAT<'a> {
    |               ^^^^^^^^^^^^^^^^^
-help: remove the unnecessary generic argument
-   |
-LL -         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
-LL +         type C = Box<dyn GenericLifetimeAT<, AssocTy=()>>;
-   |
 
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:185:26
@@ -622,35 +577,29 @@ error[E0107]: trait takes 1 generic argument but 2 generic arguments were suppli
   --> $DIR/wrong-number-of-args.rs:189:26
    |
 LL |         type B = Box<dyn GenericTypeAT<(), (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^ expected 1 generic argument
+   |                          ^^^^^^^^^^^^^   ---- help: remove the unnecessary generic argument
+   |                          |
+   |                          expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
   --> $DIR/wrong-number-of-args.rs:181:15
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^ -
-help: remove the unnecessary generic argument
-   |
-LL -         type B = Box<dyn GenericTypeAT<(), (), AssocTy=()>>;
-LL +         type B = Box<dyn GenericTypeAT<(), AssocTy=()>>;
-   |
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:193:26
    |
 LL |         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^ expected 0 lifetime arguments
+   |                          ^^^^^^^^^^^^^--------------------- help: remove the unnecessary generics
+   |                          |
+   |                          expected 0 lifetime arguments
    |
 note: trait defined here, with 0 lifetime parameters
   --> $DIR/wrong-number-of-args.rs:181:15
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^
-help: remove the unnecessary generics
-   |
-LL -         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
-LL +         type C = Box<dyn GenericTypeAT>;
-   |
 
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:193:26
@@ -704,18 +653,15 @@ error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supp
   --> $DIR/wrong-number-of-args.rs:216:26
    |
 LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 lifetime argument
+   |                          ^^^^^^^^^^^^^^^^^^^^^        --------- help: remove the lifetime argument
+   |                          |
+   |                          expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
-help: remove the lifetime argument
-   |
-LL -         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
-LL +         type C = Box<dyn GenericLifetimeTypeAT<'static, AssocTy=()>>;
-   |
 
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:216:26
@@ -737,86 +683,71 @@ error[E0107]: trait takes 1 generic argument but 2 generic arguments were suppli
   --> $DIR/wrong-number-of-args.rs:227:26
    |
 LL |         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
+   |                          ^^^^^^^^^^^^^^^^^^^^^   ---- help: remove the unnecessary generic argument
+   |                          |
+   |                          expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
   --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
-help: remove the unnecessary generic argument
-   |
-LL -         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
-LL +         type E = Box<dyn GenericLifetimeTypeAT<(), AssocTy=()>>;
-   |
 
 error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:234:26
    |
 LL |         type F = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 lifetime argument
+   |                          ^^^^^^^^^^^^^^^^^^^^^        --------- help: remove the lifetime argument
+   |                          |
+   |                          expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
-help: remove the lifetime argument
-   |
-LL -         type F = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocTy=()>>;
-LL +         type F = Box<dyn GenericLifetimeTypeAT<'static, (), AssocTy=()>>;
-   |
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:238:26
    |
 LL |         type G = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
+   |                          ^^^^^^^^^^^^^^^^^^^^^            ---- help: remove the unnecessary generic argument
+   |                          |
+   |                          expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
   --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
-help: remove the unnecessary generic argument
-   |
-LL -         type G = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>>;
-LL +         type G = Box<dyn GenericLifetimeTypeAT<'static, (), AssocTy=()>>;
-   |
 
 error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:242:26
    |
 LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 lifetime argument
+   |                          ^^^^^^^^^^^^^^^^^^^^^        --------- help: remove the lifetime argument
+   |                          |
+   |                          expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
-help: remove the lifetime argument
-   |
-LL -         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
-LL +         type H = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>>;
-   |
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:242:26
    |
 LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
+   |                          ^^^^^^^^^^^^^^^^^^^^^                     ---- help: remove the unnecessary generic argument
+   |                          |
+   |                          expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
   --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
-help: remove the unnecessary generic argument
-   |
-LL -         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
-LL +         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocTy=()>>;
-   |
 
 error[E0107]: trait takes 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:254:26
@@ -856,18 +787,15 @@ error[E0107]: trait takes 2 generic arguments but 3 generic arguments were suppl
   --> $DIR/wrong-number-of-args.rs:262:26
    |
 LL |         type C = Box<dyn GenericTypeTypeAT<(), (), (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^ expected 2 generic arguments
+   |                          ^^^^^^^^^^^^^^^^^       ---- help: remove the unnecessary generic argument
+   |                          |
+   |                          expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:250:15
    |
 LL |         trait GenericTypeTypeAT<A, B> {
    |               ^^^^^^^^^^^^^^^^^ -  -
-help: remove the unnecessary generic argument
-   |
-LL -         type C = Box<dyn GenericTypeTypeAT<(), (), (), AssocTy=()>>;
-LL +         type C = Box<dyn GenericTypeTypeAT<(), (), AssocTy=()>>;
-   |
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:277:26
@@ -983,13 +911,9 @@ error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supp
   --> $DIR/wrong-number-of-args.rs:318:18
    |
 LL |         type C = HashMap<'static>;
-   |                  ^^^^^^^ expected 0 lifetime arguments
-   |
-help: remove the unnecessary generics
-   |
-LL -         type C = HashMap<'static>;
-LL +         type C = HashMap;
-   |
+   |                  ^^^^^^^--------- help: remove the unnecessary generics
+   |                  |
+   |                  expected 0 lifetime arguments
 
 error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:318:18
@@ -1006,13 +930,9 @@ error[E0107]: struct takes at most 3 generic arguments but 4 generic arguments w
   --> $DIR/wrong-number-of-args.rs:324:18
    |
 LL |         type D = HashMap<usize, String, char, f64>;
-   |                  ^^^^^^^ expected at most 3 generic arguments
-   |
-help: remove the unnecessary generic argument
-   |
-LL -         type D = HashMap<usize, String, char, f64>;
-LL +         type D = HashMap<usize, String, char>;
-   |
+   |                  ^^^^^^^                    ----- help: remove the unnecessary generic argument
+   |                  |
+   |                  expected at most 3 generic arguments
 
 error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:328:18
@@ -1053,13 +973,9 @@ error[E0107]: enum takes 0 lifetime arguments but 1 lifetime argument was suppli
   --> $DIR/wrong-number-of-args.rs:342:18
    |
 LL |         type C = Result<'static>;
-   |                  ^^^^^^ expected 0 lifetime arguments
-   |
-help: remove the unnecessary generics
-   |
-LL -         type C = Result<'static>;
-LL +         type C = Result;
-   |
+   |                  ^^^^^^--------- help: remove the unnecessary generics
+   |                  |
+   |                  expected 0 lifetime arguments
 
 error[E0107]: enum takes 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:342:18
@@ -1076,13 +992,9 @@ error[E0107]: enum takes 2 generic arguments but 3 generic arguments were suppli
   --> $DIR/wrong-number-of-args.rs:348:18
    |
 LL |         type D = Result<usize, String, char>;
-   |                  ^^^^^^ expected 2 generic arguments
-   |
-help: remove the unnecessary generic argument
-   |
-LL -         type D = Result<usize, String, char>;
-LL +         type D = Result<usize, String>;
-   |
+   |                  ^^^^^^              ------ help: remove the unnecessary generic argument
+   |                  |
+   |                  expected 2 generic arguments
 
 error[E0107]: enum takes 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:352:18

--- a/tests/ui/generics/wrong-number-of-args.stderr
+++ b/tests/ui/generics/wrong-number-of-args.stderr
@@ -178,7 +178,7 @@ note: struct defined here, with 0 lifetime parameters
    |
 LL |     struct Ty;
    |            ^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     type B = Ty<'static>;
 LL +     type B = Ty;
@@ -195,7 +195,7 @@ note: struct defined here, with 0 lifetime parameters
    |
 LL |     struct Ty;
    |            ^^
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     type C = Ty<'static, usize>;
 LL +     type C = Ty<, usize>;
@@ -212,7 +212,7 @@ note: struct defined here, with 0 generic parameters
    |
 LL |     struct Ty;
    |            ^^
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     type C = Ty<'static, usize>;
 LL +     type C = Ty<'static, >;
@@ -229,7 +229,7 @@ note: struct defined here, with 0 lifetime parameters
    |
 LL |     struct Ty;
    |            ^^
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     type D = Ty<'static, usize, { 0 }>;
 LL +     type D = Ty<, usize, { 0 }>;
@@ -246,7 +246,7 @@ note: struct defined here, with 0 generic parameters
    |
 LL |     struct Ty;
    |            ^^
-help: remove these generic arguments
+help: remove the unnecessary generic arguments
    |
 LL -     type D = Ty<'static, usize, { 0 }>;
 LL +     type D = Ty<'static, >;
@@ -297,7 +297,7 @@ note: struct defined here, with 2 generic parameters: `A`, `B`
    |
 LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     type D = Ty<usize, String, char>;
 LL +     type D = Ty<usize, String, >;
@@ -378,7 +378,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
    |
 LL |     struct Ty<'a, T>(&'a T);
    |            ^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     type F = Ty<'static, usize, 'static, usize>;
 LL +     type F = Ty<'static, usize, , usize>;
@@ -395,7 +395,7 @@ note: struct defined here, with 1 generic parameter: `T`
    |
 LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     type F = Ty<'static, usize, 'static, usize>;
 LL +     type F = Ty<'static, usize, 'static, >;
@@ -446,7 +446,7 @@ note: struct defined here, with at most 3 generic parameters: `A`, `B`, `C`
    |
 LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -  ----------------
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     type E = Ty<usize, String, char, f64>;
 LL +     type E = Ty<usize, String, char, >;
@@ -479,7 +479,7 @@ note: trait defined here, with 0 generic parameters
    |
 LL |     trait NonGeneric {
    |           ^^^^^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     type A = Box<dyn NonGeneric<usize>>;
 LL +     type A = Box<dyn NonGeneric>;
@@ -496,7 +496,7 @@ note: trait defined here, with 1 lifetime parameter: `'a`
    |
 LL |     trait GenericLifetime<'a> {
    |           ^^^^^^^^^^^^^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     type C = Box<dyn GenericLifetime<'static, 'static>>;
 LL +     type C = Box<dyn GenericLifetime<'static, >>;
@@ -529,7 +529,7 @@ note: trait defined here, with 1 generic parameter: `A`
    |
 LL |     trait GenericType<A> {
    |           ^^^^^^^^^^^ -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     type E = Box<dyn GenericType<String, usize>>;
 LL +     type E = Box<dyn GenericType<String, >>;
@@ -562,7 +562,7 @@ note: trait defined here, with 0 generic parameters
    |
 LL |         trait NonGenericAT {
    |               ^^^^^^^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -         type A = Box<dyn NonGenericAT<usize, AssocTy=()>>;
 LL +         type A = Box<dyn NonGenericAT>;
@@ -579,7 +579,7 @@ note: trait defined here, with 1 lifetime parameter: `'a`
    |
 LL |         trait GenericLifetimeAT<'a> {
    |               ^^^^^^^^^^^^^^^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
 LL +         type B = Box<dyn GenericLifetimeAT<'static, , AssocTy=()>>;
@@ -596,7 +596,7 @@ note: trait defined here, with 0 generic parameters
    |
 LL |         trait GenericLifetimeAT<'a> {
    |               ^^^^^^^^^^^^^^^^^
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
 LL +         type C = Box<dyn GenericLifetimeAT<, AssocTy=()>>;
@@ -629,7 +629,7 @@ note: trait defined here, with 1 generic parameter: `A`
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^ -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -         type B = Box<dyn GenericTypeAT<(), (), AssocTy=()>>;
 LL +         type B = Box<dyn GenericTypeAT<(), , AssocTy=()>>;
@@ -646,7 +646,7 @@ note: trait defined here, with 0 lifetime parameters
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
 LL +         type C = Box<dyn GenericTypeAT>;
@@ -711,7 +711,7 @@ note: trait defined here, with 1 lifetime parameter: `'a`
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
 LL +         type C = Box<dyn GenericLifetimeTypeAT<'static, , AssocTy=()>>;
@@ -744,7 +744,7 @@ note: trait defined here, with 1 generic parameter: `A`
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
 LL +         type E = Box<dyn GenericLifetimeTypeAT<(), , AssocTy=()>>;
@@ -761,7 +761,7 @@ note: trait defined here, with 1 lifetime parameter: `'a`
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -         type F = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocTy=()>>;
 LL +         type F = Box<dyn GenericLifetimeTypeAT<'static, , (), AssocTy=()>>;
@@ -778,7 +778,7 @@ note: trait defined here, with 1 generic parameter: `A`
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -         type G = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>>;
 LL +         type G = Box<dyn GenericLifetimeTypeAT<'static, (), , AssocTy=()>>;
@@ -795,7 +795,7 @@ note: trait defined here, with 1 lifetime parameter: `'a`
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
 LL +         type H = Box<dyn GenericLifetimeTypeAT<'static, , (), (), AssocTy=()>>;
@@ -812,7 +812,7 @@ note: trait defined here, with 1 generic parameter: `A`
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
 LL +         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), , AssocTy=()>>;
@@ -863,7 +863,7 @@ note: trait defined here, with 2 generic parameters: `A`, `B`
    |
 LL |         trait GenericTypeTypeAT<A, B> {
    |               ^^^^^^^^^^^^^^^^^ -  -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -         type C = Box<dyn GenericTypeTypeAT<(), (), (), AssocTy=()>>;
 LL +         type C = Box<dyn GenericTypeTypeAT<(), (), , AssocTy=()>>;
@@ -985,7 +985,7 @@ error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supp
 LL |         type C = HashMap<'static>;
    |                  ^^^^^^^ expected 0 lifetime arguments
    |
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -         type C = HashMap<'static>;
 LL +         type C = HashMap;
@@ -1008,7 +1008,7 @@ error[E0107]: struct takes at most 3 generic arguments but 4 generic arguments w
 LL |         type D = HashMap<usize, String, char, f64>;
    |                  ^^^^^^^ expected at most 3 generic arguments
    |
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -         type D = HashMap<usize, String, char, f64>;
 LL +         type D = HashMap<usize, String, char, >;
@@ -1055,7 +1055,7 @@ error[E0107]: enum takes 0 lifetime arguments but 1 lifetime argument was suppli
 LL |         type C = Result<'static>;
    |                  ^^^^^^ expected 0 lifetime arguments
    |
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -         type C = Result<'static>;
 LL +         type C = Result;
@@ -1078,7 +1078,7 @@ error[E0107]: enum takes 2 generic arguments but 3 generic arguments were suppli
 LL |         type D = Result<usize, String, char>;
    |                  ^^^^^^ expected 2 generic arguments
    |
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -         type D = Result<usize, String, char>;
 LL +         type D = Result<usize, String, >;

--- a/tests/ui/generics/wrong-number-of-args.stderr
+++ b/tests/ui/generics/wrong-number-of-args.stderr
@@ -249,7 +249,7 @@ LL |     struct Ty;
 help: remove the unnecessary generic arguments
    |
 LL -     type D = Ty<'static, usize, { 0 }>;
-LL +     type D = Ty<'static, >;
+LL +     type D = Ty<'static, usize>;
    |
 
 error[E0107]: missing generics for struct `type_and_type::Ty`
@@ -300,7 +300,7 @@ LL |     struct Ty<A, B>(A, B);
 help: remove the unnecessary generic argument
    |
 LL -     type D = Ty<usize, String, char>;
-LL +     type D = Ty<usize, String, >;
+LL +     type D = Ty<usize, String>;
    |
 
 error[E0107]: struct takes 2 generic arguments but 0 generic arguments were supplied
@@ -381,7 +381,7 @@ LL |     struct Ty<'a, T>(&'a T);
 help: remove the lifetime argument
    |
 LL -     type F = Ty<'static, usize, 'static, usize>;
-LL +     type F = Ty<'static, usize, , usize>;
+LL +     type F = Ty<'static, usize>;
    |
 
 error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
@@ -398,7 +398,7 @@ LL |     struct Ty<'a, T>(&'a T);
 help: remove the unnecessary generic argument
    |
 LL -     type F = Ty<'static, usize, 'static, usize>;
-LL +     type F = Ty<'static, usize, 'static, >;
+LL +     type F = Ty<'static, usize>;
    |
 
 error[E0107]: missing generics for struct `type_and_type_and_type::Ty`
@@ -449,7 +449,7 @@ LL |     struct Ty<A, B, C = &'static str>(A, B, C);
 help: remove the unnecessary generic argument
    |
 LL -     type E = Ty<usize, String, char, f64>;
-LL +     type E = Ty<usize, String, char, >;
+LL +     type E = Ty<usize, String, char>;
    |
 
 error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
@@ -499,7 +499,7 @@ LL |     trait GenericLifetime<'a> {
 help: remove the lifetime argument
    |
 LL -     type C = Box<dyn GenericLifetime<'static, 'static>>;
-LL +     type C = Box<dyn GenericLifetime<'static, >>;
+LL +     type C = Box<dyn GenericLifetime<'static>>;
    |
 
 error[E0107]: missing generics for trait `GenericType`
@@ -532,7 +532,7 @@ LL |     trait GenericType<A> {
 help: remove the unnecessary generic argument
    |
 LL -     type E = Box<dyn GenericType<String, usize>>;
-LL +     type E = Box<dyn GenericType<String, >>;
+LL +     type E = Box<dyn GenericType<String>>;
    |
 
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
@@ -582,7 +582,7 @@ LL |         trait GenericLifetimeAT<'a> {
 help: remove the lifetime argument
    |
 LL -         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
-LL +         type B = Box<dyn GenericLifetimeAT<'static, , AssocTy=()>>;
+LL +         type B = Box<dyn GenericLifetimeAT<'static, AssocTy=()>>;
    |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
@@ -632,7 +632,7 @@ LL |         trait GenericTypeAT<A> {
 help: remove the unnecessary generic argument
    |
 LL -         type B = Box<dyn GenericTypeAT<(), (), AssocTy=()>>;
-LL +         type B = Box<dyn GenericTypeAT<(), , AssocTy=()>>;
+LL +         type B = Box<dyn GenericTypeAT<(), AssocTy=()>>;
    |
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
@@ -714,7 +714,7 @@ LL |         trait GenericLifetimeTypeAT<'a, A> {
 help: remove the lifetime argument
    |
 LL -         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
-LL +         type C = Box<dyn GenericLifetimeTypeAT<'static, , AssocTy=()>>;
+LL +         type C = Box<dyn GenericLifetimeTypeAT<'static, AssocTy=()>>;
    |
 
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
@@ -747,7 +747,7 @@ LL |         trait GenericLifetimeTypeAT<'a, A> {
 help: remove the unnecessary generic argument
    |
 LL -         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
-LL +         type E = Box<dyn GenericLifetimeTypeAT<(), , AssocTy=()>>;
+LL +         type E = Box<dyn GenericLifetimeTypeAT<(), AssocTy=()>>;
    |
 
 error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
@@ -764,7 +764,7 @@ LL |         trait GenericLifetimeTypeAT<'a, A> {
 help: remove the lifetime argument
    |
 LL -         type F = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocTy=()>>;
-LL +         type F = Box<dyn GenericLifetimeTypeAT<'static, , (), AssocTy=()>>;
+LL +         type F = Box<dyn GenericLifetimeTypeAT<'static, (), AssocTy=()>>;
    |
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
@@ -781,7 +781,7 @@ LL |         trait GenericLifetimeTypeAT<'a, A> {
 help: remove the unnecessary generic argument
    |
 LL -         type G = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>>;
-LL +         type G = Box<dyn GenericLifetimeTypeAT<'static, (), , AssocTy=()>>;
+LL +         type G = Box<dyn GenericLifetimeTypeAT<'static, (), AssocTy=()>>;
    |
 
 error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
@@ -798,7 +798,7 @@ LL |         trait GenericLifetimeTypeAT<'a, A> {
 help: remove the lifetime argument
    |
 LL -         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
-LL +         type H = Box<dyn GenericLifetimeTypeAT<'static, , (), (), AssocTy=()>>;
+LL +         type H = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>>;
    |
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
@@ -815,7 +815,7 @@ LL |         trait GenericLifetimeTypeAT<'a, A> {
 help: remove the unnecessary generic argument
    |
 LL -         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
-LL +         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), , AssocTy=()>>;
+LL +         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocTy=()>>;
    |
 
 error[E0107]: trait takes 2 generic arguments but 0 generic arguments were supplied
@@ -866,7 +866,7 @@ LL |         trait GenericTypeTypeAT<A, B> {
 help: remove the unnecessary generic argument
    |
 LL -         type C = Box<dyn GenericTypeTypeAT<(), (), (), AssocTy=()>>;
-LL +         type C = Box<dyn GenericTypeTypeAT<(), (), , AssocTy=()>>;
+LL +         type C = Box<dyn GenericTypeTypeAT<(), (), AssocTy=()>>;
    |
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
@@ -1011,7 +1011,7 @@ LL |         type D = HashMap<usize, String, char, f64>;
 help: remove the unnecessary generic argument
    |
 LL -         type D = HashMap<usize, String, char, f64>;
-LL +         type D = HashMap<usize, String, char, >;
+LL +         type D = HashMap<usize, String, char>;
    |
 
 error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
@@ -1081,7 +1081,7 @@ LL |         type D = Result<usize, String, char>;
 help: remove the unnecessary generic argument
    |
 LL -         type D = Result<usize, String, char>;
-LL +         type D = Result<usize, String, >;
+LL +         type D = Result<usize, String>;
    |
 
 error[E0107]: enum takes 2 generic arguments but 0 generic arguments were supplied

--- a/tests/ui/generics/wrong-number-of-args.stderr
+++ b/tests/ui/generics/wrong-number-of-args.stderr
@@ -171,71 +171,86 @@ error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supp
   --> $DIR/wrong-number-of-args.rs:6:14
    |
 LL |     type B = Ty<'static>;
-   |              ^^--------- help: remove these generics
-   |              |
-   |              expected 0 lifetime arguments
+   |              ^^ expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/wrong-number-of-args.rs:2:12
    |
 LL |     struct Ty;
    |            ^^
+help: remove these generics
+   |
+LL -     type B = Ty<'static>;
+LL +     type B = Ty;
+   |
 
 error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:10:14
    |
 LL |     type C = Ty<'static, usize>;
-   |              ^^ ------- help: remove this lifetime argument
-   |              |
-   |              expected 0 lifetime arguments
+   |              ^^ expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/wrong-number-of-args.rs:2:12
    |
 LL |     struct Ty;
    |            ^^
+help: remove this lifetime argument
+   |
+LL -     type C = Ty<'static, usize>;
+LL +     type C = Ty<, usize>;
+   |
 
 error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:10:14
    |
 LL |     type C = Ty<'static, usize>;
-   |              ^^          ----- help: remove this generic argument
-   |              |
-   |              expected 0 generic arguments
+   |              ^^ expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/wrong-number-of-args.rs:2:12
    |
 LL |     struct Ty;
    |            ^^
+help: remove this generic argument
+   |
+LL -     type C = Ty<'static, usize>;
+LL +     type C = Ty<'static, >;
+   |
 
 error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:16:14
    |
 LL |     type D = Ty<'static, usize, { 0 }>;
-   |              ^^ ------- help: remove this lifetime argument
-   |              |
-   |              expected 0 lifetime arguments
+   |              ^^ expected 0 lifetime arguments
    |
 note: struct defined here, with 0 lifetime parameters
   --> $DIR/wrong-number-of-args.rs:2:12
    |
 LL |     struct Ty;
    |            ^^
+help: remove this lifetime argument
+   |
+LL -     type D = Ty<'static, usize, { 0 }>;
+LL +     type D = Ty<, usize, { 0 }>;
+   |
 
 error[E0107]: struct takes 0 generic arguments but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:16:14
    |
 LL |     type D = Ty<'static, usize, { 0 }>;
-   |              ^^          ------------ help: remove these generic arguments
-   |              |
-   |              expected 0 generic arguments
+   |              ^^ expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/wrong-number-of-args.rs:2:12
    |
 LL |     struct Ty;
    |            ^^
+help: remove these generic arguments
+   |
+LL -     type D = Ty<'static, usize, { 0 }>;
+LL +     type D = Ty<'static, >;
+   |
 
 error[E0107]: missing generics for struct `type_and_type::Ty`
   --> $DIR/wrong-number-of-args.rs:26:14
@@ -275,15 +290,18 @@ error[E0107]: struct takes 2 generic arguments but 3 generic arguments were supp
   --> $DIR/wrong-number-of-args.rs:36:14
    |
 LL |     type D = Ty<usize, String, char>;
-   |              ^^                ---- help: remove this generic argument
-   |              |
-   |              expected 2 generic arguments
+   |              ^^ expected 2 generic arguments
    |
 note: struct defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:24:12
    |
 LL |     struct Ty<A, B>(A, B);
    |            ^^ -  -
+help: remove this generic argument
+   |
+LL -     type D = Ty<usize, String, char>;
+LL +     type D = Ty<usize, String, >;
+   |
 
 error[E0107]: struct takes 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:40:14
@@ -353,29 +371,35 @@ error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were sup
   --> $DIR/wrong-number-of-args.rs:70:14
    |
 LL |     type F = Ty<'static, usize, 'static, usize>;
-   |              ^^                 ------- help: remove this lifetime argument
-   |              |
-   |              expected 1 lifetime argument
+   |              ^^ expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
 LL |     struct Ty<'a, T>(&'a T);
    |            ^^ --
+help: remove this lifetime argument
+   |
+LL -     type F = Ty<'static, usize, 'static, usize>;
+LL +     type F = Ty<'static, usize, , usize>;
+   |
 
 error[E0107]: struct takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:70:14
    |
 LL |     type F = Ty<'static, usize, 'static, usize>;
-   |              ^^                          ----- help: remove this generic argument
-   |              |
-   |              expected 1 generic argument
+   |              ^^ expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/wrong-number-of-args.rs:46:12
    |
 LL |     struct Ty<'a, T>(&'a T);
    |            ^^     -
+help: remove this generic argument
+   |
+LL -     type F = Ty<'static, usize, 'static, usize>;
+LL +     type F = Ty<'static, usize, 'static, >;
+   |
 
 error[E0107]: missing generics for struct `type_and_type_and_type::Ty`
   --> $DIR/wrong-number-of-args.rs:80:14
@@ -415,15 +439,18 @@ error[E0107]: struct takes at most 3 generic arguments but 4 generic arguments w
   --> $DIR/wrong-number-of-args.rs:92:14
    |
 LL |     type E = Ty<usize, String, char, f64>;
-   |              ^^                      --- help: remove this generic argument
-   |              |
-   |              expected at most 3 generic arguments
+   |              ^^ expected at most 3 generic arguments
    |
 note: struct defined here, with at most 3 generic parameters: `A`, `B`, `C`
   --> $DIR/wrong-number-of-args.rs:78:12
    |
 LL |     struct Ty<A, B, C = &'static str>(A, B, C);
    |            ^^ -  -  ----------------
+help: remove this generic argument
+   |
+LL -     type E = Ty<usize, String, char, f64>;
+LL +     type E = Ty<usize, String, char, >;
+   |
 
 error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:96:14
@@ -445,29 +472,35 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/wrong-number-of-args.rs:116:22
    |
 LL |     type A = Box<dyn NonGeneric<usize>>;
-   |                      ^^^^^^^^^^------- help: remove these generics
-   |                      |
-   |                      expected 0 generic arguments
+   |                      ^^^^^^^^^^ expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/wrong-number-of-args.rs:104:11
    |
 LL |     trait NonGeneric {
    |           ^^^^^^^^^^
+help: remove these generics
+   |
+LL -     type A = Box<dyn NonGeneric<usize>>;
+LL +     type A = Box<dyn NonGeneric>;
+   |
 
 error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:125:22
    |
 LL |     type C = Box<dyn GenericLifetime<'static, 'static>>;
-   |                      ^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
-   |                      |
-   |                      expected 1 lifetime argument
+   |                      ^^^^^^^^^^^^^^^ expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:108:11
    |
 LL |     trait GenericLifetime<'a> {
    |           ^^^^^^^^^^^^^^^ --
+help: remove this lifetime argument
+   |
+LL -     type C = Box<dyn GenericLifetime<'static, 'static>>;
+LL +     type C = Box<dyn GenericLifetime<'static, >>;
+   |
 
 error[E0107]: missing generics for trait `GenericType`
   --> $DIR/wrong-number-of-args.rs:129:22
@@ -489,15 +522,18 @@ error[E0107]: trait takes 1 generic argument but 2 generic arguments were suppli
   --> $DIR/wrong-number-of-args.rs:133:22
    |
 LL |     type E = Box<dyn GenericType<String, usize>>;
-   |                      ^^^^^^^^^^^         ----- help: remove this generic argument
-   |                      |
-   |                      expected 1 generic argument
+   |                      ^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
   --> $DIR/wrong-number-of-args.rs:112:11
    |
 LL |     trait GenericType<A> {
    |           ^^^^^^^^^^^ -
+help: remove this generic argument
+   |
+LL -     type E = Box<dyn GenericType<String, usize>>;
+LL +     type E = Box<dyn GenericType<String, >>;
+   |
 
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:142:22
@@ -519,43 +555,52 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/wrong-number-of-args.rs:153:26
    |
 LL |         type A = Box<dyn NonGenericAT<usize, AssocTy=()>>;
-   |                          ^^^^^^^^^^^^------------------- help: remove these generics
-   |                          |
-   |                          expected 0 generic arguments
+   |                          ^^^^^^^^^^^^ expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/wrong-number-of-args.rs:149:15
    |
 LL |         trait NonGenericAT {
    |               ^^^^^^^^^^^^
+help: remove these generics
+   |
+LL -         type A = Box<dyn NonGenericAT<usize, AssocTy=()>>;
+LL +         type A = Box<dyn NonGenericAT>;
+   |
 
 error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:168:26
    |
 LL |         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
-   |                          |
-   |                          expected 1 lifetime argument
+   |                          ^^^^^^^^^^^^^^^^^ expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:159:15
    |
 LL |         trait GenericLifetimeAT<'a> {
    |               ^^^^^^^^^^^^^^^^^ --
+help: remove this lifetime argument
+   |
+LL -         type B = Box<dyn GenericLifetimeAT<'static, 'static, AssocTy=()>>;
+LL +         type B = Box<dyn GenericLifetimeAT<'static, , AssocTy=()>>;
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/wrong-number-of-args.rs:172:26
    |
 LL |         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^ -- help: remove this generic argument
-   |                          |
-   |                          expected 0 generic arguments
+   |                          ^^^^^^^^^^^^^^^^^ expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/wrong-number-of-args.rs:159:15
    |
 LL |         trait GenericLifetimeAT<'a> {
    |               ^^^^^^^^^^^^^^^^^
+help: remove this generic argument
+   |
+LL -         type C = Box<dyn GenericLifetimeAT<(), AssocTy=()>>;
+LL +         type C = Box<dyn GenericLifetimeAT<, AssocTy=()>>;
+   |
 
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:185:26
@@ -577,29 +622,35 @@ error[E0107]: trait takes 1 generic argument but 2 generic arguments were suppli
   --> $DIR/wrong-number-of-args.rs:189:26
    |
 LL |         type B = Box<dyn GenericTypeAT<(), (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^     -- help: remove this generic argument
-   |                          |
-   |                          expected 1 generic argument
+   |                          ^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
   --> $DIR/wrong-number-of-args.rs:181:15
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^ -
+help: remove this generic argument
+   |
+LL -         type B = Box<dyn GenericTypeAT<(), (), AssocTy=()>>;
+LL +         type B = Box<dyn GenericTypeAT<(), , AssocTy=()>>;
+   |
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:193:26
    |
 LL |         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^--------------------- help: remove these generics
-   |                          |
-   |                          expected 0 lifetime arguments
+   |                          ^^^^^^^^^^^^^ expected 0 lifetime arguments
    |
 note: trait defined here, with 0 lifetime parameters
   --> $DIR/wrong-number-of-args.rs:181:15
    |
 LL |         trait GenericTypeAT<A> {
    |               ^^^^^^^^^^^^^
+help: remove these generics
+   |
+LL -         type C = Box<dyn GenericTypeAT<'static, AssocTy=()>>;
+LL +         type C = Box<dyn GenericTypeAT>;
+   |
 
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:193:26
@@ -653,15 +704,18 @@ error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supp
   --> $DIR/wrong-number-of-args.rs:216:26
    |
 LL |         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
-   |                          |
-   |                          expected 1 lifetime argument
+   |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
+help: remove this lifetime argument
+   |
+LL -         type C = Box<dyn GenericLifetimeTypeAT<'static, 'static, AssocTy=()>>;
+LL +         type C = Box<dyn GenericLifetimeTypeAT<'static, , AssocTy=()>>;
+   |
 
 error[E0107]: trait takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:216:26
@@ -683,71 +737,86 @@ error[E0107]: trait takes 1 generic argument but 2 generic arguments were suppli
   --> $DIR/wrong-number-of-args.rs:227:26
    |
 LL |         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^     -- help: remove this generic argument
-   |                          |
-   |                          expected 1 generic argument
+   |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
   --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
+help: remove this generic argument
+   |
+LL -         type E = Box<dyn GenericLifetimeTypeAT<(), (), AssocTy=()>>;
+LL +         type E = Box<dyn GenericLifetimeTypeAT<(), , AssocTy=()>>;
+   |
 
 error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:234:26
    |
 LL |         type F = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
-   |                          |
-   |                          expected 1 lifetime argument
+   |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
+help: remove this lifetime argument
+   |
+LL -         type F = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), AssocTy=()>>;
+LL +         type F = Box<dyn GenericLifetimeTypeAT<'static, , (), AssocTy=()>>;
+   |
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:238:26
    |
 LL |         type G = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^              -- help: remove this generic argument
-   |                          |
-   |                          expected 1 generic argument
+   |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
   --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
+help: remove this generic argument
+   |
+LL -         type G = Box<dyn GenericLifetimeTypeAT<'static, (), (), AssocTy=()>>;
+LL +         type G = Box<dyn GenericLifetimeTypeAT<'static, (), , AssocTy=()>>;
+   |
 
 error[E0107]: trait takes 1 lifetime argument but 2 lifetime arguments were supplied
   --> $DIR/wrong-number-of-args.rs:242:26
    |
 LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^          ------- help: remove this lifetime argument
-   |                          |
-   |                          expected 1 lifetime argument
+   |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 lifetime argument
    |
 note: trait defined here, with 1 lifetime parameter: `'a`
   --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^ --
+help: remove this lifetime argument
+   |
+LL -         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
+LL +         type H = Box<dyn GenericLifetimeTypeAT<'static, , (), (), AssocTy=()>>;
+   |
 
 error[E0107]: trait takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:242:26
    |
 LL |         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^^^^^                       -- help: remove this generic argument
-   |                          |
-   |                          expected 1 generic argument
+   |                          ^^^^^^^^^^^^^^^^^^^^^ expected 1 generic argument
    |
 note: trait defined here, with 1 generic parameter: `A`
   --> $DIR/wrong-number-of-args.rs:201:15
    |
 LL |         trait GenericLifetimeTypeAT<'a, A> {
    |               ^^^^^^^^^^^^^^^^^^^^^     -
+help: remove this generic argument
+   |
+LL -         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), (), AssocTy=()>>;
+LL +         type H = Box<dyn GenericLifetimeTypeAT<'static, 'static, (), , AssocTy=()>>;
+   |
 
 error[E0107]: trait takes 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:254:26
@@ -787,15 +856,18 @@ error[E0107]: trait takes 2 generic arguments but 3 generic arguments were suppl
   --> $DIR/wrong-number-of-args.rs:262:26
    |
 LL |         type C = Box<dyn GenericTypeTypeAT<(), (), (), AssocTy=()>>;
-   |                          ^^^^^^^^^^^^^^^^^         -- help: remove this generic argument
-   |                          |
-   |                          expected 2 generic arguments
+   |                          ^^^^^^^^^^^^^^^^^ expected 2 generic arguments
    |
 note: trait defined here, with 2 generic parameters: `A`, `B`
   --> $DIR/wrong-number-of-args.rs:250:15
    |
 LL |         trait GenericTypeTypeAT<A, B> {
    |               ^^^^^^^^^^^^^^^^^ -  -
+help: remove this generic argument
+   |
+LL -         type C = Box<dyn GenericTypeTypeAT<(), (), (), AssocTy=()>>;
+LL +         type C = Box<dyn GenericTypeTypeAT<(), (), , AssocTy=()>>;
+   |
 
 error[E0107]: trait takes 2 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/wrong-number-of-args.rs:277:26
@@ -911,9 +983,13 @@ error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supp
   --> $DIR/wrong-number-of-args.rs:318:18
    |
 LL |         type C = HashMap<'static>;
-   |                  ^^^^^^^--------- help: remove these generics
-   |                  |
-   |                  expected 0 lifetime arguments
+   |                  ^^^^^^^ expected 0 lifetime arguments
+   |
+help: remove these generics
+   |
+LL -         type C = HashMap<'static>;
+LL +         type C = HashMap;
+   |
 
 error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:318:18
@@ -930,9 +1006,13 @@ error[E0107]: struct takes at most 3 generic arguments but 4 generic arguments w
   --> $DIR/wrong-number-of-args.rs:324:18
    |
 LL |         type D = HashMap<usize, String, char, f64>;
-   |                  ^^^^^^^                      --- help: remove this generic argument
-   |                  |
-   |                  expected at most 3 generic arguments
+   |                  ^^^^^^^ expected at most 3 generic arguments
+   |
+help: remove this generic argument
+   |
+LL -         type D = HashMap<usize, String, char, f64>;
+LL +         type D = HashMap<usize, String, char, >;
+   |
 
 error[E0107]: struct takes at least 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:328:18
@@ -973,9 +1053,13 @@ error[E0107]: enum takes 0 lifetime arguments but 1 lifetime argument was suppli
   --> $DIR/wrong-number-of-args.rs:342:18
    |
 LL |         type C = Result<'static>;
-   |                  ^^^^^^--------- help: remove these generics
-   |                  |
-   |                  expected 0 lifetime arguments
+   |                  ^^^^^^ expected 0 lifetime arguments
+   |
+help: remove these generics
+   |
+LL -         type C = Result<'static>;
+LL +         type C = Result;
+   |
 
 error[E0107]: enum takes 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:342:18
@@ -992,9 +1076,13 @@ error[E0107]: enum takes 2 generic arguments but 3 generic arguments were suppli
   --> $DIR/wrong-number-of-args.rs:348:18
    |
 LL |         type D = Result<usize, String, char>;
-   |                  ^^^^^^                ---- help: remove this generic argument
-   |                  |
-   |                  expected 2 generic arguments
+   |                  ^^^^^^ expected 2 generic arguments
+   |
+help: remove this generic argument
+   |
+LL -         type D = Result<usize, String, char>;
+LL +         type D = Result<usize, String, >;
+   |
 
 error[E0107]: enum takes 2 generic arguments but 0 generic arguments were supplied
   --> $DIR/wrong-number-of-args.rs:352:18

--- a/tests/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
+++ b/tests/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
@@ -13,7 +13,7 @@ LL | fn foo<T: ?Sized>(_f: impl AsRef<T>) {}
 help: remove the unnecessary generic argument
    |
 LL -     foo::<str, String>("".to_string());
-LL +     foo::<str, >("".to_string());
+LL +     foo::<str>("".to_string());
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
+++ b/tests/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
@@ -2,7 +2,9 @@ error[E0107]: function takes 1 generic argument but 2 generic arguments were sup
   --> $DIR/explicit-generic-args-for-impl.rs:4:5
    |
 LL |     foo::<str, String>("".to_string());
-   |     ^^^ expected 1 generic argument
+   |     ^^^      -------- help: remove the unnecessary generic argument
+   |     |
+   |     expected 1 generic argument
    |
 note: function defined here, with 1 generic parameter: `T`
   --> $DIR/explicit-generic-args-for-impl.rs:1:4
@@ -10,11 +12,6 @@ note: function defined here, with 1 generic parameter: `T`
 LL | fn foo<T: ?Sized>(_f: impl AsRef<T>) {}
    |    ^^^ -
    = note: `impl Trait` cannot be explicitly specified as a generic argument
-help: remove the unnecessary generic argument
-   |
-LL -     foo::<str, String>("".to_string());
-LL +     foo::<str>("".to_string());
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
+++ b/tests/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
@@ -2,9 +2,7 @@ error[E0107]: function takes 1 generic argument but 2 generic arguments were sup
   --> $DIR/explicit-generic-args-for-impl.rs:4:5
    |
 LL |     foo::<str, String>("".to_string());
-   |     ^^^        ------ help: remove this generic argument
-   |     |
-   |     expected 1 generic argument
+   |     ^^^ expected 1 generic argument
    |
 note: function defined here, with 1 generic parameter: `T`
   --> $DIR/explicit-generic-args-for-impl.rs:1:4
@@ -12,6 +10,11 @@ note: function defined here, with 1 generic parameter: `T`
 LL | fn foo<T: ?Sized>(_f: impl AsRef<T>) {}
    |    ^^^ -
    = note: `impl Trait` cannot be explicitly specified as a generic argument
+help: remove this generic argument
+   |
+LL -     foo::<str, String>("".to_string());
+LL +     foo::<str, >("".to_string());
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
+++ b/tests/ui/impl-trait/explicit-generic-args-with-impl-trait/explicit-generic-args-for-impl.stderr
@@ -10,7 +10,7 @@ note: function defined here, with 1 generic parameter: `T`
 LL | fn foo<T: ?Sized>(_f: impl AsRef<T>) {}
    |    ^^^ -
    = note: `impl Trait` cannot be explicitly specified as a generic argument
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     foo::<str, String>("".to_string());
 LL +     foo::<str, >("".to_string());

--- a/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.stderr
+++ b/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.stderr
@@ -38,29 +38,35 @@ error[E0107]: struct takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/opaque-and-lifetime-mismatch.rs:4:17
    |
 LL |     fn bar() -> Wrapper<impl Sized>;
-   |                 ^^^^^^^ ---------- help: remove this generic argument
-   |                 |
-   |                 expected 0 generic arguments
+   |                 ^^^^^^^ expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/opaque-and-lifetime-mismatch.rs:1:8
    |
 LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
+help: remove this generic argument
+   |
+LL -     fn bar() -> Wrapper<impl Sized>;
+LL +     fn bar() -> Wrapper<>;
+   |
 
 error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/opaque-and-lifetime-mismatch.rs:18:17
    |
 LL |     fn foo() -> Wrapper<impl Sized>;
-   |                 ^^^^^^^ ---------- help: remove this generic argument
-   |                 |
-   |                 expected 0 generic arguments
+   |                 ^^^^^^^ expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/opaque-and-lifetime-mismatch.rs:1:8
    |
 LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
+help: remove this generic argument
+   |
+LL -     fn foo() -> Wrapper<impl Sized>;
+LL +     fn foo() -> Wrapper<>;
+   |
 
 error[E0053]: method `bar` has an incompatible return type for trait
   --> $DIR/opaque-and-lifetime-mismatch.rs:10:17
@@ -93,15 +99,18 @@ error[E0107]: struct takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/opaque-and-lifetime-mismatch.rs:24:17
    |
 LL |     fn foo() -> Wrapper<impl Sized> {
-   |                 ^^^^^^^ ---------- help: remove this generic argument
-   |                 |
-   |                 expected 0 generic arguments
+   |                 ^^^^^^^ expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/opaque-and-lifetime-mismatch.rs:1:8
    |
 LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
+help: remove this generic argument
+   |
+LL -     fn foo() -> Wrapper<impl Sized> {
+LL +     fn foo() -> Wrapper<> {
+   |
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.stderr
+++ b/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.stderr
@@ -38,35 +38,29 @@ error[E0107]: struct takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/opaque-and-lifetime-mismatch.rs:4:17
    |
 LL |     fn bar() -> Wrapper<impl Sized>;
-   |                 ^^^^^^^ expected 0 generic arguments
+   |                 ^^^^^^^ ---------- help: remove the unnecessary generic argument
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/opaque-and-lifetime-mismatch.rs:1:8
    |
 LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
-help: remove the unnecessary generic argument
-   |
-LL -     fn bar() -> Wrapper<impl Sized>;
-LL +     fn bar() -> Wrapper<>;
-   |
 
 error[E0107]: struct takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/opaque-and-lifetime-mismatch.rs:18:17
    |
 LL |     fn foo() -> Wrapper<impl Sized>;
-   |                 ^^^^^^^ expected 0 generic arguments
+   |                 ^^^^^^^ ---------- help: remove the unnecessary generic argument
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/opaque-and-lifetime-mismatch.rs:1:8
    |
 LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
-help: remove the unnecessary generic argument
-   |
-LL -     fn foo() -> Wrapper<impl Sized>;
-LL +     fn foo() -> Wrapper<>;
-   |
 
 error[E0053]: method `bar` has an incompatible return type for trait
   --> $DIR/opaque-and-lifetime-mismatch.rs:10:17
@@ -99,18 +93,15 @@ error[E0107]: struct takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/opaque-and-lifetime-mismatch.rs:24:17
    |
 LL |     fn foo() -> Wrapper<impl Sized> {
-   |                 ^^^^^^^ expected 0 generic arguments
+   |                 ^^^^^^^ ---------- help: remove the unnecessary generic argument
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/opaque-and-lifetime-mismatch.rs:1:8
    |
 LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
-help: remove the unnecessary generic argument
-   |
-LL -     fn foo() -> Wrapper<impl Sized> {
-LL +     fn foo() -> Wrapper<> {
-   |
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.stderr
+++ b/tests/ui/impl-trait/in-trait/opaque-and-lifetime-mismatch.stderr
@@ -45,7 +45,7 @@ note: struct defined here, with 0 generic parameters
    |
 LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     fn bar() -> Wrapper<impl Sized>;
 LL +     fn bar() -> Wrapper<>;
@@ -62,7 +62,7 @@ note: struct defined here, with 0 generic parameters
    |
 LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     fn foo() -> Wrapper<impl Sized>;
 LL +     fn foo() -> Wrapper<>;
@@ -106,7 +106,7 @@ note: struct defined here, with 0 generic parameters
    |
 LL | struct Wrapper<'rom>(&'rom ());
    |        ^^^^^^^
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     fn foo() -> Wrapper<impl Sized> {
 LL +     fn foo() -> Wrapper<> {

--- a/tests/ui/issues/issue-18423.stderr
+++ b/tests/ui/issues/issue-18423.stderr
@@ -2,13 +2,9 @@ error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supp
   --> $DIR/issue-18423.rs:4:8
    |
 LL |     x: Box<'a, isize>
-   |        ^^^ expected 0 lifetime arguments
-   |
-help: remove the lifetime argument
-   |
-LL -     x: Box<'a, isize>
-LL +     x: Box<, isize>
-   |
+   |        ^^^ -- help: remove the lifetime argument
+   |        |
+   |        expected 0 lifetime arguments
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-18423.stderr
+++ b/tests/ui/issues/issue-18423.stderr
@@ -2,9 +2,13 @@ error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supp
   --> $DIR/issue-18423.rs:4:8
    |
 LL |     x: Box<'a, isize>
-   |        ^^^ -- help: remove this lifetime argument
-   |        |
-   |        expected 0 lifetime arguments
+   |        ^^^ expected 0 lifetime arguments
+   |
+help: remove this lifetime argument
+   |
+LL -     x: Box<'a, isize>
+LL +     x: Box<, isize>
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-18423.stderr
+++ b/tests/ui/issues/issue-18423.stderr
@@ -4,7 +4,7 @@ error[E0107]: struct takes 0 lifetime arguments but 1 lifetime argument was supp
 LL |     x: Box<'a, isize>
    |        ^^^ expected 0 lifetime arguments
    |
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     x: Box<'a, isize>
 LL +     x: Box<, isize>

--- a/tests/ui/issues/issue-53251.stderr
+++ b/tests/ui/issues/issue-53251.stderr
@@ -2,7 +2,9 @@ error[E0107]: associated function takes 0 generic arguments but 1 generic argume
   --> $DIR/issue-53251.rs:11:20
    |
 LL |                 S::f::<i64>();
-   |                    ^ expected 0 generic arguments
+   |                    ^------- help: remove the unnecessary generics
+   |                    |
+   |                    expected 0 generic arguments
 ...
 LL | impl_add!(a b);
    | -------------- in this macro invocation
@@ -13,17 +15,14 @@ note: associated function defined here, with 0 generic parameters
 LL |     fn f() {}
    |        ^
    = note: this error originates in the macro `impl_add` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: remove the unnecessary generics
-   |
-LL -                 S::f::<i64>();
-LL +                 S::f();
-   |
 
 error[E0107]: associated function takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-53251.rs:11:20
    |
 LL |                 S::f::<i64>();
-   |                    ^ expected 0 generic arguments
+   |                    ^------- help: remove the unnecessary generics
+   |                    |
+   |                    expected 0 generic arguments
 ...
 LL | impl_add!(a b);
    | -------------- in this macro invocation
@@ -35,11 +34,6 @@ LL |     fn f() {}
    |        ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this error originates in the macro `impl_add` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: remove the unnecessary generics
-   |
-LL -                 S::f::<i64>();
-LL +                 S::f();
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-53251.stderr
+++ b/tests/ui/issues/issue-53251.stderr
@@ -13,7 +13,7 @@ note: associated function defined here, with 0 generic parameters
 LL |     fn f() {}
    |        ^
    = note: this error originates in the macro `impl_add` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -                 S::f::<i64>();
 LL +                 S::f();
@@ -35,7 +35,7 @@ LL |     fn f() {}
    |        ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this error originates in the macro `impl_add` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -                 S::f::<i64>();
 LL +                 S::f();

--- a/tests/ui/issues/issue-53251.stderr
+++ b/tests/ui/issues/issue-53251.stderr
@@ -2,9 +2,7 @@ error[E0107]: associated function takes 0 generic arguments but 1 generic argume
   --> $DIR/issue-53251.rs:11:20
    |
 LL |                 S::f::<i64>();
-   |                    ^------- help: remove these generics
-   |                    |
-   |                    expected 0 generic arguments
+   |                    ^ expected 0 generic arguments
 ...
 LL | impl_add!(a b);
    | -------------- in this macro invocation
@@ -15,14 +13,17 @@ note: associated function defined here, with 0 generic parameters
 LL |     fn f() {}
    |        ^
    = note: this error originates in the macro `impl_add` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove these generics
+   |
+LL -                 S::f::<i64>();
+LL +                 S::f();
+   |
 
 error[E0107]: associated function takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-53251.rs:11:20
    |
 LL |                 S::f::<i64>();
-   |                    ^------- help: remove these generics
-   |                    |
-   |                    expected 0 generic arguments
+   |                    ^ expected 0 generic arguments
 ...
 LL | impl_add!(a b);
    | -------------- in this macro invocation
@@ -34,6 +35,11 @@ LL |     fn f() {}
    |        ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
    = note: this error originates in the macro `impl_add` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: remove these generics
+   |
+LL -                 S::f::<i64>();
+LL +                 S::f();
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-60622.stderr
+++ b/tests/ui/issues/issue-60622.stderr
@@ -20,15 +20,18 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/issue-60622.rs:10:7
    |
 LL |     b.a::<'_, T>();
-   |       ^       - help: remove this generic argument
-   |       |
-   |       expected 0 generic arguments
+   |       ^ expected 0 generic arguments
    |
 note: method defined here, with 0 generic parameters
   --> $DIR/issue-60622.rs:6:8
    |
 LL |     fn a(&self) {}
    |        ^
+help: remove this generic argument
+   |
+LL -     b.a::<'_, T>();
+LL +     b.a::<'_, >();
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-60622.stderr
+++ b/tests/ui/issues/issue-60622.stderr
@@ -20,18 +20,15 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/issue-60622.rs:10:7
    |
 LL |     b.a::<'_, T>();
-   |       ^ expected 0 generic arguments
+   |       ^       - help: remove the unnecessary generic argument
+   |       |
+   |       expected 0 generic arguments
    |
 note: method defined here, with 0 generic parameters
   --> $DIR/issue-60622.rs:6:8
    |
 LL |     fn a(&self) {}
    |        ^
-help: remove the unnecessary generic argument
-   |
-LL -     b.a::<'_, T>();
-LL +     b.a::<'_, >();
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/issues/issue-60622.stderr
+++ b/tests/ui/issues/issue-60622.stderr
@@ -27,7 +27,7 @@ note: method defined here, with 0 generic parameters
    |
 LL |     fn a(&self) {}
    |        ^
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     b.a::<'_, T>();
 LL +     b.a::<'_, >();

--- a/tests/ui/late-bound-lifetimes/mismatched_arg_count.stderr
+++ b/tests/ui/late-bound-lifetimes/mismatched_arg_count.stderr
@@ -9,7 +9,7 @@ note: type alias defined here, with 1 lifetime parameter: `'a`
    |
 LL | type Alias<'a, T> = <T as Trait<'a>>::Assoc;
    |      ^^^^^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL - fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
 LL + fn bar<'a, T: Trait<'a>>(_: Alias<'a, , T>) {}

--- a/tests/ui/late-bound-lifetimes/mismatched_arg_count.stderr
+++ b/tests/ui/late-bound-lifetimes/mismatched_arg_count.stderr
@@ -2,18 +2,15 @@ error[E0107]: type alias takes 1 lifetime argument but 2 lifetime arguments were
   --> $DIR/mismatched_arg_count.rs:9:29
    |
 LL | fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
-   |                             ^^^^^ expected 1 lifetime argument
+   |                             ^^^^^   ---- help: remove the lifetime argument
+   |                             |
+   |                             expected 1 lifetime argument
    |
 note: type alias defined here, with 1 lifetime parameter: `'a`
   --> $DIR/mismatched_arg_count.rs:7:6
    |
 LL | type Alias<'a, T> = <T as Trait<'a>>::Assoc;
    |      ^^^^^ --
-help: remove the lifetime argument
-   |
-LL - fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
-LL + fn bar<'a, T: Trait<'a>>(_: Alias<'a, T>) {}
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/late-bound-lifetimes/mismatched_arg_count.stderr
+++ b/tests/ui/late-bound-lifetimes/mismatched_arg_count.stderr
@@ -2,15 +2,18 @@ error[E0107]: type alias takes 1 lifetime argument but 2 lifetime arguments were
   --> $DIR/mismatched_arg_count.rs:9:29
    |
 LL | fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
-   |                             ^^^^^     -- help: remove this lifetime argument
-   |                             |
-   |                             expected 1 lifetime argument
+   |                             ^^^^^ expected 1 lifetime argument
    |
 note: type alias defined here, with 1 lifetime parameter: `'a`
   --> $DIR/mismatched_arg_count.rs:7:6
    |
 LL | type Alias<'a, T> = <T as Trait<'a>>::Assoc;
    |      ^^^^^ --
+help: remove this lifetime argument
+   |
+LL - fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
+LL + fn bar<'a, T: Trait<'a>>(_: Alias<'a, , T>) {}
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/late-bound-lifetimes/mismatched_arg_count.stderr
+++ b/tests/ui/late-bound-lifetimes/mismatched_arg_count.stderr
@@ -12,7 +12,7 @@ LL | type Alias<'a, T> = <T as Trait<'a>>::Assoc;
 help: remove the lifetime argument
    |
 LL - fn bar<'a, T: Trait<'a>>(_: Alias<'a, 'a, T>) {}
-LL + fn bar<'a, T: Trait<'a>>(_: Alias<'a, , T>) {}
+LL + fn bar<'a, T: Trait<'a>>(_: Alias<'a, T>) {}
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/layout/size-of-val-raw-too-big.rs
+++ b/tests/ui/layout/size-of-val-raw-too-big.rs
@@ -1,0 +1,18 @@
+//@ build-fail
+//@ compile-flags: --crate-type lib
+//@ only-32bit Layout computation rejects this layout for different reasons on 64-bit.
+//@ error-pattern: too big for the current architecture
+#![feature(core_intrinsics)]
+#![allow(internal_features)]
+
+// isize::MAX is fine, but with the padding for the unsized tail it is too big.
+#[repr(C)]
+pub struct Example([u8; isize::MAX as usize], [u16]);
+
+// We guarantee that with length 0, `size_of_val_raw` (which calls the `size_of_val` intrinsic)
+// is safe to call. The compiler aborts compilation if a length of 0 would overflow.
+// So let's construct a case where length 0 just barely overflows, and ensure that
+// does abort compilation.
+pub fn check(x: *const Example) -> usize {
+    unsafe { std::intrinsics::size_of_val(x) }
+}

--- a/tests/ui/layout/size-of-val-raw-too-big.stderr
+++ b/tests/ui/layout/size-of-val-raw-too-big.stderr
@@ -1,0 +1,4 @@
+error: values of the type `Example` are too big for the current architecture
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lifetimes/noisy-follow-up-erro.stderr
+++ b/tests/ui/lifetimes/noisy-follow-up-erro.stderr
@@ -12,7 +12,7 @@ LL | struct Foo<'c, 'd>(&'c (), &'d ());
 help: remove the lifetime argument
    |
 LL -     fn boom(&self, foo: &mut Foo<'_, '_, 'a>) -> Result<(), &'a ()> {
-LL +     fn boom(&self, foo: &mut Foo<'_, '_, >) -> Result<(), &'a ()> {
+LL +     fn boom(&self, foo: &mut Foo<'_, '_>) -> Result<(), &'a ()> {
    |
 
 error[E0621]: explicit lifetime required in the type of `foo`

--- a/tests/ui/lifetimes/noisy-follow-up-erro.stderr
+++ b/tests/ui/lifetimes/noisy-follow-up-erro.stderr
@@ -9,7 +9,7 @@ note: struct defined here, with 2 lifetime parameters: `'c`, `'d`
    |
 LL | struct Foo<'c, 'd>(&'c (), &'d ());
    |        ^^^ --  --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     fn boom(&self, foo: &mut Foo<'_, '_, 'a>) -> Result<(), &'a ()> {
 LL +     fn boom(&self, foo: &mut Foo<'_, '_, >) -> Result<(), &'a ()> {

--- a/tests/ui/lifetimes/noisy-follow-up-erro.stderr
+++ b/tests/ui/lifetimes/noisy-follow-up-erro.stderr
@@ -2,18 +2,15 @@ error[E0107]: struct takes 2 lifetime arguments but 3 lifetime arguments were su
   --> $DIR/noisy-follow-up-erro.rs:12:30
    |
 LL |     fn boom(&self, foo: &mut Foo<'_, '_, 'a>) -> Result<(), &'a ()> {
-   |                              ^^^ expected 2 lifetime arguments
+   |                              ^^^       ---- help: remove the lifetime argument
+   |                              |
+   |                              expected 2 lifetime arguments
    |
 note: struct defined here, with 2 lifetime parameters: `'c`, `'d`
   --> $DIR/noisy-follow-up-erro.rs:1:8
    |
 LL | struct Foo<'c, 'd>(&'c (), &'d ());
    |        ^^^ --  --
-help: remove the lifetime argument
-   |
-LL -     fn boom(&self, foo: &mut Foo<'_, '_, 'a>) -> Result<(), &'a ()> {
-LL +     fn boom(&self, foo: &mut Foo<'_, '_>) -> Result<(), &'a ()> {
-   |
 
 error[E0621]: explicit lifetime required in the type of `foo`
   --> $DIR/noisy-follow-up-erro.rs:14:9

--- a/tests/ui/lifetimes/noisy-follow-up-erro.stderr
+++ b/tests/ui/lifetimes/noisy-follow-up-erro.stderr
@@ -2,15 +2,18 @@ error[E0107]: struct takes 2 lifetime arguments but 3 lifetime arguments were su
   --> $DIR/noisy-follow-up-erro.rs:12:30
    |
 LL |     fn boom(&self, foo: &mut Foo<'_, '_, 'a>) -> Result<(), &'a ()> {
-   |                              ^^^         -- help: remove this lifetime argument
-   |                              |
-   |                              expected 2 lifetime arguments
+   |                              ^^^ expected 2 lifetime arguments
    |
 note: struct defined here, with 2 lifetime parameters: `'c`, `'d`
   --> $DIR/noisy-follow-up-erro.rs:1:8
    |
 LL | struct Foo<'c, 'd>(&'c (), &'d ());
    |        ^^^ --  --
+help: remove this lifetime argument
+   |
+LL -     fn boom(&self, foo: &mut Foo<'_, '_, 'a>) -> Result<(), &'a ()> {
+LL +     fn boom(&self, foo: &mut Foo<'_, '_, >) -> Result<(), &'a ()> {
+   |
 
 error[E0621]: explicit lifetime required in the type of `foo`
   --> $DIR/noisy-follow-up-erro.rs:14:9

--- a/tests/ui/methods/method-call-lifetime-args-fail.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-fail.stderr
@@ -27,7 +27,7 @@ note: method defined here, with 2 lifetime parameters: `'a`, `'b`
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
    |        ^^^^^ --  --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     S.early::<'static, 'static, 'static>();
 LL +     S.early::<'static, 'static, >();
@@ -230,7 +230,7 @@ note: method defined here, with 2 lifetime parameters: `'a`, `'b`
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
    |        ^^^^^ --  --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     S::early::<'static, 'static, 'static>(S);
 LL +     S::early::<'static, 'static, >(S);

--- a/tests/ui/methods/method-call-lifetime-args-fail.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-fail.stderr
@@ -30,7 +30,7 @@ LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
 help: remove the lifetime argument
    |
 LL -     S.early::<'static, 'static, 'static>();
-LL +     S.early::<'static, 'static, >();
+LL +     S.early::<'static, 'static>();
    |
 
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
@@ -233,7 +233,7 @@ LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
 help: remove the lifetime argument
    |
 LL -     S::early::<'static, 'static, 'static>(S);
-LL +     S::early::<'static, 'static, >(S);
+LL +     S::early::<'static, 'static>(S);
    |
 
 error: aborting due to 18 previous errors

--- a/tests/ui/methods/method-call-lifetime-args-fail.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-fail.stderr
@@ -20,18 +20,15 @@ error[E0107]: method takes 2 lifetime arguments but 3 lifetime arguments were su
   --> $DIR/method-call-lifetime-args-fail.rs:18:7
    |
 LL |     S.early::<'static, 'static, 'static>();
-   |       ^^^^^ expected 2 lifetime arguments
+   |       ^^^^^                   --------- help: remove the lifetime argument
+   |       |
+   |       expected 2 lifetime arguments
    |
 note: method defined here, with 2 lifetime parameters: `'a`, `'b`
   --> $DIR/method-call-lifetime-args-fail.rs:6:8
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
    |        ^^^^^ --  --
-help: remove the lifetime argument
-   |
-LL -     S.early::<'static, 'static, 'static>();
-LL +     S.early::<'static, 'static>();
-   |
 
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:27:15
@@ -223,18 +220,15 @@ error[E0107]: method takes 2 lifetime arguments but 3 lifetime arguments were su
   --> $DIR/method-call-lifetime-args-fail.rs:65:8
    |
 LL |     S::early::<'static, 'static, 'static>(S);
-   |        ^^^^^ expected 2 lifetime arguments
+   |        ^^^^^                   --------- help: remove the lifetime argument
+   |        |
+   |        expected 2 lifetime arguments
    |
 note: method defined here, with 2 lifetime parameters: `'a`, `'b`
   --> $DIR/method-call-lifetime-args-fail.rs:6:8
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
    |        ^^^^^ --  --
-help: remove the lifetime argument
-   |
-LL -     S::early::<'static, 'static, 'static>(S);
-LL +     S::early::<'static, 'static>(S);
-   |
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/methods/method-call-lifetime-args-fail.stderr
+++ b/tests/ui/methods/method-call-lifetime-args-fail.stderr
@@ -20,15 +20,18 @@ error[E0107]: method takes 2 lifetime arguments but 3 lifetime arguments were su
   --> $DIR/method-call-lifetime-args-fail.rs:18:7
    |
 LL |     S.early::<'static, 'static, 'static>();
-   |       ^^^^^                     ------- help: remove this lifetime argument
-   |       |
-   |       expected 2 lifetime arguments
+   |       ^^^^^ expected 2 lifetime arguments
    |
 note: method defined here, with 2 lifetime parameters: `'a`, `'b`
   --> $DIR/method-call-lifetime-args-fail.rs:6:8
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
    |        ^^^^^ --  --
+help: remove this lifetime argument
+   |
+LL -     S.early::<'static, 'static, 'static>();
+LL +     S.early::<'static, 'static, >();
+   |
 
 error[E0794]: cannot specify lifetime arguments explicitly if late bound lifetime parameters are present
   --> $DIR/method-call-lifetime-args-fail.rs:27:15
@@ -220,15 +223,18 @@ error[E0107]: method takes 2 lifetime arguments but 3 lifetime arguments were su
   --> $DIR/method-call-lifetime-args-fail.rs:65:8
    |
 LL |     S::early::<'static, 'static, 'static>(S);
-   |        ^^^^^                     ------- help: remove this lifetime argument
-   |        |
-   |        expected 2 lifetime arguments
+   |        ^^^^^ expected 2 lifetime arguments
    |
 note: method defined here, with 2 lifetime parameters: `'a`, `'b`
   --> $DIR/method-call-lifetime-args-fail.rs:6:8
    |
 LL |     fn early<'a, 'b>(self) -> (&'a u8, &'b u8) { loop {} }
    |        ^^^^^ --  --
+help: remove this lifetime argument
+   |
+LL -     S::early::<'static, 'static, 'static>(S);
+LL +     S::early::<'static, 'static, >(S);
+   |
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/proc-macro/cfg-eval-inner.stdout
+++ b/tests/ui/proc-macro/cfg-eval-inner.stdout
@@ -73,7 +73,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                                 span: $DIR/cfg-eval-inner.rs:19:40: 19:54 (#0),
                             },
                         ],
-                        span: $DIR/cfg-eval-inner.rs:19:5: 19:6 (#0),
+                        span: $DIR/cfg-eval-inner.rs:19:7: 19:56 (#0),
                     },
                     Punct {
                         ch: '#',
@@ -168,7 +168,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                                                         span: $DIR/cfg-eval-inner.rs:23:48: 23:70 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/cfg-eval-inner.rs:23:13: 23:14 (#0),
+                                                span: $DIR/cfg-eval-inner.rs:23:15: 23:72 (#0),
                                             },
                                             Literal {
                                                 kind: Integer,
@@ -233,7 +233,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                         span: $DIR/cfg-eval-inner.rs:32:40: 32:56 (#0),
                     },
                 ],
-                span: $DIR/cfg-eval-inner.rs:32:5: 32:6 (#0),
+                span: $DIR/cfg-eval-inner.rs:32:7: 32:58 (#0),
             },
             Ident {
                 ident: "fn",

--- a/tests/ui/proc-macro/cfg-eval.stdout
+++ b/tests/ui/proc-macro/cfg-eval.stdout
@@ -60,7 +60,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                         span: $DIR/cfg-eval.rs:22:36: 22:38 (#0),
                     },
                 ],
-                span: $DIR/cfg-eval.rs:22:5: 22:6 (#0),
+                span: $DIR/cfg-eval.rs:22:6: 22:40 (#0),
             },
             Ident {
                 ident: "field_true",
@@ -99,7 +99,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                 span: $DIR/cfg-eval.rs:35:62: 35:73 (#0),
             },
         ],
-        span: $DIR/cfg-eval.rs:35:39: 35:40 (#0),
+        span: $DIR/cfg-eval.rs:35:40: 35:75 (#0),
     },
     Group {
         delimiter: Parenthesis,

--- a/tests/ui/proc-macro/expand-to-derive.stdout
+++ b/tests/ui/proc-macro/expand-to-derive.stdout
@@ -57,7 +57,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                         span: $DIR/expand-to-derive.rs:27:28: 27:39 (#0),
                                     },
                                 ],
-                                span: $DIR/expand-to-derive.rs:27:5: 27:6 (#0),
+                                span: $DIR/expand-to-derive.rs:27:6: 27:41 (#0),
                             },
                             Ident {
                                 ident: "struct",

--- a/tests/ui/proc-macro/inner-attrs.stdout
+++ b/tests/ui/proc-macro/inner-attrs.stdout
@@ -674,7 +674,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                                         span: $DIR/inner-attrs.rs:41:52: 41:59 (#0),
                                                     },
                                                 ],
-                                                span: $DIR/inner-attrs.rs:41:17: 41:18 (#0),
+                                                span: $DIR/inner-attrs.rs:41:19: 41:61 (#0),
                                             },
                                             Ident {
                                                 ident: "true",

--- a/tests/ui/proc-macro/issue-75930-derive-cfg.stdout
+++ b/tests/ui/proc-macro/issue-75930-derive-cfg.stdout
@@ -119,7 +119,7 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
                 span: $DIR/issue-75930-derive-cfg.rs:50:29: 50:40 (#0),
             },
         ],
-        span: $DIR/issue-75930-derive-cfg.rs:50:1: 50:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:50:2: 50:42 (#0),
     },
     Punct {
         ch: '#',
@@ -1395,7 +1395,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                 span: $DIR/issue-75930-derive-cfg.rs:50:29: 50:40 (#0),
             },
         ],
-        span: $DIR/issue-75930-derive-cfg.rs:50:1: 50:2 (#0),
+        span: $DIR/issue-75930-derive-cfg.rs:50:2: 50:42 (#0),
     },
     Punct {
         ch: '#',
@@ -1571,7 +1571,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                                 span: $DIR/issue-75930-derive-cfg.rs:63:41: 63:51 (#0),
                                             },
                                         ],
-                                        span: $DIR/issue-75930-derive-cfg.rs:63:13: 63:14 (#0),
+                                        span: $DIR/issue-75930-derive-cfg.rs:63:14: 63:53 (#0),
                                     },
                                     Ident {
                                         ident: "false",

--- a/tests/ui/proc-macro/macro-rules-derive-cfg.stdout
+++ b/tests/ui/proc-macro/macro-rules-derive-cfg.stdout
@@ -88,7 +88,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                         span: $DIR/macro-rules-derive-cfg.rs:19:59: 19:66 (#3),
                                     },
                                 ],
-                                span: $DIR/macro-rules-derive-cfg.rs:19:25: 19:26 (#3),
+                                span: $DIR/macro-rules-derive-cfg.rs:19:26: 19:68 (#3),
                             },
                             Punct {
                                 ch: '#',
@@ -113,7 +113,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                         span: $DIR/macro-rules-derive-cfg.rs:26:47: 26:55 (#0),
                                     },
                                 ],
-                                span: $DIR/macro-rules-derive-cfg.rs:26:13: 26:14 (#0),
+                                span: $DIR/macro-rules-derive-cfg.rs:26:14: 26:57 (#0),
                             },
                             Group {
                                 delimiter: Brace,
@@ -146,7 +146,7 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                                 span: $DIR/macro-rules-derive-cfg.rs:27:34: 27:42 (#0),
                                             },
                                         ],
-                                        span: $DIR/macro-rules-derive-cfg.rs:27:5: 27:6 (#0),
+                                        span: $DIR/macro-rules-derive-cfg.rs:27:7: 27:44 (#0),
                                     },
                                     Literal {
                                         kind: Integer,

--- a/tests/ui/resolve/issue-3214.stderr
+++ b/tests/ui/resolve/issue-3214.stderr
@@ -12,18 +12,15 @@ error[E0107]: struct takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/issue-3214.rs:6:22
    |
 LL |     impl<T> Drop for Foo<T> {
-   |                      ^^^ expected 0 generic arguments
+   |                      ^^^--- help: remove the unnecessary generics
+   |                      |
+   |                      expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/issue-3214.rs:2:12
    |
 LL |     struct Foo {
    |            ^^^
-help: remove the unnecessary generics
-   |
-LL -     impl<T> Drop for Foo<T> {
-LL +     impl<T> Drop for Foo {
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/issue-3214.stderr
+++ b/tests/ui/resolve/issue-3214.stderr
@@ -12,15 +12,18 @@ error[E0107]: struct takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/issue-3214.rs:6:22
    |
 LL |     impl<T> Drop for Foo<T> {
-   |                      ^^^--- help: remove these generics
-   |                      |
-   |                      expected 0 generic arguments
+   |                      ^^^ expected 0 generic arguments
    |
 note: struct defined here, with 0 generic parameters
   --> $DIR/issue-3214.rs:2:12
    |
 LL |     struct Foo {
    |            ^^^
+help: remove these generics
+   |
+LL -     impl<T> Drop for Foo<T> {
+LL +     impl<T> Drop for Foo {
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/issue-3214.stderr
+++ b/tests/ui/resolve/issue-3214.stderr
@@ -19,7 +19,7 @@ note: struct defined here, with 0 generic parameters
    |
 LL |     struct Foo {
    |            ^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     impl<T> Drop for Foo<T> {
 LL +     impl<T> Drop for Foo {

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/no-explicit-const-params-cross-crate.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/no-explicit-const-params-cross-crate.stderr
@@ -9,7 +9,7 @@ note: function defined here, with 0 generic parameters
    |
 LL | pub const fn foo() {}
    |              ^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     foo::<false>();
 LL +     foo();
@@ -42,7 +42,7 @@ note: function defined here, with 0 generic parameters
    |
 LL | pub const fn foo() {}
    |              ^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     foo::<true>();
 LL +     foo();

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/no-explicit-const-params-cross-crate.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/no-explicit-const-params-cross-crate.stderr
@@ -2,18 +2,15 @@ error[E0107]: function takes 0 generic arguments but 1 generic argument was supp
   --> $DIR/no-explicit-const-params-cross-crate.rs:14:5
    |
 LL |     foo::<false>();
-   |     ^^^ expected 0 generic arguments
+   |     ^^^--------- help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: function defined here, with 0 generic parameters
   --> $DIR/auxiliary/cross-crate.rs:5:14
    |
 LL | pub const fn foo() {}
    |              ^^^
-help: remove the unnecessary generics
-   |
-LL -     foo::<false>();
-LL +     foo();
-   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/no-explicit-const-params-cross-crate.rs:16:12
@@ -35,18 +32,15 @@ error[E0107]: function takes 0 generic arguments but 1 generic argument was supp
   --> $DIR/no-explicit-const-params-cross-crate.rs:7:5
    |
 LL |     foo::<true>();
-   |     ^^^ expected 0 generic arguments
+   |     ^^^-------- help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: function defined here, with 0 generic parameters
   --> $DIR/auxiliary/cross-crate.rs:5:14
    |
 LL | pub const fn foo() {}
    |              ^^^
-help: remove the unnecessary generics
-   |
-LL -     foo::<true>();
-LL +     foo();
-   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/no-explicit-const-params-cross-crate.rs:9:12

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/no-explicit-const-params-cross-crate.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/no-explicit-const-params-cross-crate.stderr
@@ -2,15 +2,18 @@ error[E0107]: function takes 0 generic arguments but 1 generic argument was supp
   --> $DIR/no-explicit-const-params-cross-crate.rs:14:5
    |
 LL |     foo::<false>();
-   |     ^^^--------- help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^ expected 0 generic arguments
    |
 note: function defined here, with 0 generic parameters
   --> $DIR/auxiliary/cross-crate.rs:5:14
    |
 LL | pub const fn foo() {}
    |              ^^^
+help: remove these generics
+   |
+LL -     foo::<false>();
+LL +     foo();
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/no-explicit-const-params-cross-crate.rs:16:12
@@ -32,15 +35,18 @@ error[E0107]: function takes 0 generic arguments but 1 generic argument was supp
   --> $DIR/no-explicit-const-params-cross-crate.rs:7:5
    |
 LL |     foo::<true>();
-   |     ^^^-------- help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^ expected 0 generic arguments
    |
 note: function defined here, with 0 generic parameters
   --> $DIR/auxiliary/cross-crate.rs:5:14
    |
 LL | pub const fn foo() {}
    |              ^^^
+help: remove these generics
+   |
+LL -     foo::<true>();
+LL +     foo();
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/no-explicit-const-params-cross-crate.rs:9:12

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/no-explicit-const-params.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/no-explicit-const-params.stderr
@@ -23,7 +23,7 @@ note: function defined here, with 0 generic parameters
    |
 LL | const fn foo() {}
    |          ^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     foo::<false>();
 LL +     foo();
@@ -65,7 +65,7 @@ note: function defined here, with 0 generic parameters
    |
 LL | const fn foo() {}
    |          ^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     foo::<true>();
 LL +     foo();

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/no-explicit-const-params.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/no-explicit-const-params.stderr
@@ -16,15 +16,18 @@ error[E0107]: function takes 0 generic arguments but 1 generic argument was supp
   --> $DIR/no-explicit-const-params.rs:22:5
    |
 LL |     foo::<false>();
-   |     ^^^--------- help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^ expected 0 generic arguments
    |
 note: function defined here, with 0 generic parameters
   --> $DIR/no-explicit-const-params.rs:3:10
    |
 LL | const fn foo() {}
    |          ^^^
+help: remove these generics
+   |
+LL -     foo::<false>();
+LL +     foo();
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/no-explicit-const-params.rs:24:12
@@ -55,15 +58,18 @@ error[E0107]: function takes 0 generic arguments but 1 generic argument was supp
   --> $DIR/no-explicit-const-params.rs:15:5
    |
 LL |     foo::<true>();
-   |     ^^^-------- help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^ expected 0 generic arguments
    |
 note: function defined here, with 0 generic parameters
   --> $DIR/no-explicit-const-params.rs:3:10
    |
 LL | const fn foo() {}
    |          ^^^
+help: remove these generics
+   |
+LL -     foo::<true>();
+LL +     foo();
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/no-explicit-const-params.rs:17:12

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/no-explicit-const-params.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/no-explicit-const-params.stderr
@@ -16,18 +16,15 @@ error[E0107]: function takes 0 generic arguments but 1 generic argument was supp
   --> $DIR/no-explicit-const-params.rs:22:5
    |
 LL |     foo::<false>();
-   |     ^^^ expected 0 generic arguments
+   |     ^^^--------- help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: function defined here, with 0 generic parameters
   --> $DIR/no-explicit-const-params.rs:3:10
    |
 LL | const fn foo() {}
    |          ^^^
-help: remove the unnecessary generics
-   |
-LL -     foo::<false>();
-LL +     foo();
-   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/no-explicit-const-params.rs:24:12
@@ -58,18 +55,15 @@ error[E0107]: function takes 0 generic arguments but 1 generic argument was supp
   --> $DIR/no-explicit-const-params.rs:15:5
    |
 LL |     foo::<true>();
-   |     ^^^ expected 0 generic arguments
+   |     ^^^-------- help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: function defined here, with 0 generic parameters
   --> $DIR/no-explicit-const-params.rs:3:10
    |
 LL | const fn foo() {}
    |          ^^^
-help: remove the unnecessary generics
-   |
-LL -     foo::<true>();
-LL +     foo();
-   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/no-explicit-const-params.rs:17:12

--- a/tests/ui/seq-args.stderr
+++ b/tests/ui/seq-args.stderr
@@ -2,35 +2,29 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/seq-args.rs:4:13
    |
 LL |     impl<T> Seq<T> for Vec<T> {
-   |             ^^^ expected 0 generic arguments
+   |             ^^^--- help: remove the unnecessary generics
+   |             |
+   |             expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/seq-args.rs:2:11
    |
 LL |     trait Seq { }
    |           ^^^
-help: remove the unnecessary generics
-   |
-LL -     impl<T> Seq<T> for Vec<T> {
-LL +     impl<T> Seq for Vec<T> {
-   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/seq-args.rs:9:10
    |
 LL |     impl Seq<bool> for u32 {
-   |          ^^^ expected 0 generic arguments
+   |          ^^^------ help: remove the unnecessary generics
+   |          |
+   |          expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/seq-args.rs:2:11
    |
 LL |     trait Seq { }
    |           ^^^
-help: remove the unnecessary generics
-   |
-LL -     impl Seq<bool> for u32 {
-LL +     impl Seq for u32 {
-   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/seq-args.stderr
+++ b/tests/ui/seq-args.stderr
@@ -9,7 +9,7 @@ note: trait defined here, with 0 generic parameters
    |
 LL |     trait Seq { }
    |           ^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     impl<T> Seq<T> for Vec<T> {
 LL +     impl<T> Seq for Vec<T> {
@@ -26,7 +26,7 @@ note: trait defined here, with 0 generic parameters
    |
 LL |     trait Seq { }
    |           ^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     impl Seq<bool> for u32 {
 LL +     impl Seq for u32 {

--- a/tests/ui/seq-args.stderr
+++ b/tests/ui/seq-args.stderr
@@ -2,29 +2,35 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/seq-args.rs:4:13
    |
 LL |     impl<T> Seq<T> for Vec<T> {
-   |             ^^^--- help: remove these generics
-   |             |
-   |             expected 0 generic arguments
+   |             ^^^ expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/seq-args.rs:2:11
    |
 LL |     trait Seq { }
    |           ^^^
+help: remove these generics
+   |
+LL -     impl<T> Seq<T> for Vec<T> {
+LL +     impl<T> Seq for Vec<T> {
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/seq-args.rs:9:10
    |
 LL |     impl Seq<bool> for u32 {
-   |          ^^^------ help: remove these generics
-   |          |
-   |          expected 0 generic arguments
+   |          ^^^ expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/seq-args.rs:2:11
    |
 LL |     trait Seq { }
    |           ^^^
+help: remove these generics
+   |
+LL -     impl Seq<bool> for u32 {
+LL +     impl Seq for u32 {
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/structs/struct-path-associated-type.stderr
+++ b/tests/ui/structs/struct-path-associated-type.stderr
@@ -15,7 +15,7 @@ note: associated type defined here, with 0 generic parameters
    |
 LL |     type A;
    |          ^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     let z = T::A::<u8> {};
 LL +     let z = T::A {};
@@ -44,7 +44,7 @@ note: associated type defined here, with 0 generic parameters
    |
 LL |     type A;
    |          ^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     let z = T::A::<u8> {};
 LL +     let z = T::A {};

--- a/tests/ui/structs/struct-path-associated-type.stderr
+++ b/tests/ui/structs/struct-path-associated-type.stderr
@@ -8,15 +8,18 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/struct-path-associated-type.rs:14:16
    |
 LL |     let z = T::A::<u8> {};
-   |                ^------ help: remove these generics
-   |                |
-   |                expected 0 generic arguments
+   |                ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/struct-path-associated-type.rs:4:10
    |
 LL |     type A;
    |          ^
+help: remove these generics
+   |
+LL -     let z = T::A::<u8> {};
+LL +     let z = T::A {};
+   |
 
 error[E0071]: expected struct, variant or union type, found associated type
   --> $DIR/struct-path-associated-type.rs:14:13
@@ -34,15 +37,18 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/struct-path-associated-type.rs:25:16
    |
 LL |     let z = T::A::<u8> {};
-   |                ^------ help: remove these generics
-   |                |
-   |                expected 0 generic arguments
+   |                ^ expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/struct-path-associated-type.rs:4:10
    |
 LL |     type A;
    |          ^
+help: remove these generics
+   |
+LL -     let z = T::A::<u8> {};
+LL +     let z = T::A {};
+   |
 
 error[E0223]: ambiguous associated type
   --> $DIR/struct-path-associated-type.rs:32:13

--- a/tests/ui/structs/struct-path-associated-type.stderr
+++ b/tests/ui/structs/struct-path-associated-type.stderr
@@ -8,18 +8,15 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/struct-path-associated-type.rs:14:16
    |
 LL |     let z = T::A::<u8> {};
-   |                ^ expected 0 generic arguments
+   |                ^------ help: remove the unnecessary generics
+   |                |
+   |                expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/struct-path-associated-type.rs:4:10
    |
 LL |     type A;
    |          ^
-help: remove the unnecessary generics
-   |
-LL -     let z = T::A::<u8> {};
-LL +     let z = T::A {};
-   |
 
 error[E0071]: expected struct, variant or union type, found associated type
   --> $DIR/struct-path-associated-type.rs:14:13
@@ -37,18 +34,15 @@ error[E0107]: associated type takes 0 generic arguments but 1 generic argument w
   --> $DIR/struct-path-associated-type.rs:25:16
    |
 LL |     let z = T::A::<u8> {};
-   |                ^ expected 0 generic arguments
+   |                ^------ help: remove the unnecessary generics
+   |                |
+   |                expected 0 generic arguments
    |
 note: associated type defined here, with 0 generic parameters
   --> $DIR/struct-path-associated-type.rs:4:10
    |
 LL |     type A;
    |          ^
-help: remove the unnecessary generics
-   |
-LL -     let z = T::A::<u8> {};
-LL +     let z = T::A {};
-   |
 
 error[E0223]: ambiguous associated type
   --> $DIR/struct-path-associated-type.rs:32:13

--- a/tests/ui/structs/structure-constructor-type-mismatch.stderr
+++ b/tests/ui/structs/structure-constructor-type-mismatch.stderr
@@ -75,7 +75,7 @@ note: type alias defined here, with 0 generic parameters
    |
 LL | type PointF = Point<f32>;
    |      ^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     let pt3 = PointF::<i32> {
 LL +     let pt3 = PointF {
@@ -114,7 +114,7 @@ note: type alias defined here, with 0 generic parameters
    |
 LL | type PointF = Point<f32>;
    |      ^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -         PointF::<u32> { .. } => {}
 LL +         PointF { .. } => {}

--- a/tests/ui/structs/structure-constructor-type-mismatch.stderr
+++ b/tests/ui/structs/structure-constructor-type-mismatch.stderr
@@ -68,15 +68,18 @@ error[E0107]: type alias takes 0 generic arguments but 1 generic argument was su
   --> $DIR/structure-constructor-type-mismatch.rs:48:15
    |
 LL |     let pt3 = PointF::<i32> {
-   |               ^^^^^^------- help: remove these generics
-   |               |
-   |               expected 0 generic arguments
+   |               ^^^^^^ expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/structure-constructor-type-mismatch.rs:6:6
    |
 LL | type PointF = Point<f32>;
    |      ^^^^^^
+help: remove these generics
+   |
+LL -     let pt3 = PointF::<i32> {
+LL +     let pt3 = PointF {
+   |
 
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:49:12
@@ -104,15 +107,18 @@ error[E0107]: type alias takes 0 generic arguments but 1 generic argument was su
   --> $DIR/structure-constructor-type-mismatch.rs:54:9
    |
 LL |         PointF::<u32> { .. } => {}
-   |         ^^^^^^------- help: remove these generics
-   |         |
-   |         expected 0 generic arguments
+   |         ^^^^^^ expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/structure-constructor-type-mismatch.rs:6:6
    |
 LL | type PointF = Point<f32>;
    |      ^^^^^^
+help: remove these generics
+   |
+LL -         PointF::<u32> { .. } => {}
+LL +         PointF { .. } => {}
+   |
 
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:54:9

--- a/tests/ui/structs/structure-constructor-type-mismatch.stderr
+++ b/tests/ui/structs/structure-constructor-type-mismatch.stderr
@@ -68,18 +68,15 @@ error[E0107]: type alias takes 0 generic arguments but 1 generic argument was su
   --> $DIR/structure-constructor-type-mismatch.rs:48:15
    |
 LL |     let pt3 = PointF::<i32> {
-   |               ^^^^^^ expected 0 generic arguments
+   |               ^^^^^^------- help: remove the unnecessary generics
+   |               |
+   |               expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/structure-constructor-type-mismatch.rs:6:6
    |
 LL | type PointF = Point<f32>;
    |      ^^^^^^
-help: remove the unnecessary generics
-   |
-LL -     let pt3 = PointF::<i32> {
-LL +     let pt3 = PointF {
-   |
 
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:49:12
@@ -107,18 +104,15 @@ error[E0107]: type alias takes 0 generic arguments but 1 generic argument was su
   --> $DIR/structure-constructor-type-mismatch.rs:54:9
    |
 LL |         PointF::<u32> { .. } => {}
-   |         ^^^^^^ expected 0 generic arguments
+   |         ^^^^^^------- help: remove the unnecessary generics
+   |         |
+   |         expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/structure-constructor-type-mismatch.rs:6:6
    |
 LL | type PointF = Point<f32>;
    |      ^^^^^^
-help: remove the unnecessary generics
-   |
-LL -         PointF::<u32> { .. } => {}
-LL +         PointF { .. } => {}
-   |
 
 error[E0308]: mismatched types
   --> $DIR/structure-constructor-type-mismatch.rs:54:9

--- a/tests/ui/suggestions/issue-101421.stderr
+++ b/tests/ui/suggestions/issue-101421.stderr
@@ -2,15 +2,18 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/issue-101421.rs:10:8
    |
 LL |     ().f::<()>(());
-   |        ^------ help: remove these generics
-   |        |
-   |        expected 0 generic arguments
+   |        ^ expected 0 generic arguments
    |
 note: method defined here, with 0 generic parameters
   --> $DIR/issue-101421.rs:2:8
    |
 LL |     fn f(&self, _: ());
    |        ^
+help: remove these generics
+   |
+LL -     ().f::<()>(());
+LL +     ().f(());
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/issue-101421.stderr
+++ b/tests/ui/suggestions/issue-101421.stderr
@@ -9,7 +9,7 @@ note: method defined here, with 0 generic parameters
    |
 LL |     fn f(&self, _: ());
    |        ^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     ().f::<()>(());
 LL +     ().f(());

--- a/tests/ui/suggestions/issue-101421.stderr
+++ b/tests/ui/suggestions/issue-101421.stderr
@@ -2,18 +2,15 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/issue-101421.rs:10:8
    |
 LL |     ().f::<()>(());
-   |        ^ expected 0 generic arguments
+   |        ^------ help: remove the unnecessary generics
+   |        |
+   |        expected 0 generic arguments
    |
 note: method defined here, with 0 generic parameters
   --> $DIR/issue-101421.rs:2:8
    |
 LL |     fn f(&self, _: ());
    |        ^
-help: remove the unnecessary generics
-   |
-LL -     ().f::<()>(());
-LL +     ().f(());
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/issue-104287.stderr
+++ b/tests/ui/suggestions/issue-104287.stderr
@@ -9,7 +9,7 @@ note: method defined here, with 0 generic parameters
    |
 LL |     fn foo(&self) {}
    |        ^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     foo::<()>(x);
 LL +     foo(x);

--- a/tests/ui/suggestions/issue-104287.stderr
+++ b/tests/ui/suggestions/issue-104287.stderr
@@ -2,18 +2,15 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/issue-104287.rs:10:5
    |
 LL |     foo::<()>(x);
-   |     ^^^ expected 0 generic arguments
+   |     ^^^------ help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: method defined here, with 0 generic parameters
   --> $DIR/issue-104287.rs:6:8
    |
 LL |     fn foo(&self) {}
    |        ^^^
-help: remove the unnecessary generics
-   |
-LL -     foo::<()>(x);
-LL +     foo(x);
-   |
 
 error[E0425]: cannot find function `foo` in this scope
   --> $DIR/issue-104287.rs:10:5

--- a/tests/ui/suggestions/issue-104287.stderr
+++ b/tests/ui/suggestions/issue-104287.stderr
@@ -2,15 +2,18 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/issue-104287.rs:10:5
    |
 LL |     foo::<()>(x);
-   |     ^^^------ help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^ expected 0 generic arguments
    |
 note: method defined here, with 0 generic parameters
   --> $DIR/issue-104287.rs:6:8
    |
 LL |     fn foo(&self) {}
    |        ^^^
+help: remove these generics
+   |
+LL -     foo::<()>(x);
+LL +     foo(x);
+   |
 
 error[E0425]: cannot find function `foo` in this scope
   --> $DIR/issue-104287.rs:10:5

--- a/tests/ui/suggestions/issue-89064.rs
+++ b/tests/ui/suggestions/issue-89064.rs
@@ -16,20 +16,20 @@ impl<T, U> B<T, U> for S {}
 fn main() {
     let _ = A::foo::<S>();
     //~^ ERROR
-    //~| HELP remove these generics
+    //~| HELP remove the unnecessary generics
     //~| HELP consider moving this generic argument
 
     let _ = B::bar::<S, S>();
     //~^ ERROR
-    //~| HELP remove these generics
+    //~| HELP remove the unnecessary generics
     //~| HELP consider moving these generic arguments
 
     let _ = A::<S>::foo::<S>();
     //~^ ERROR
-    //~| HELP remove these generics
+    //~| HELP remove the unnecessary generics
 
     let _ = 42.into::<Option<_>>();
     //~^ ERROR
-    //~| HELP remove these generics
+    //~| HELP remove the unnecessary generics
     //~| HELP consider moving this generic argument
 }

--- a/tests/ui/suggestions/issue-89064.stderr
+++ b/tests/ui/suggestions/issue-89064.stderr
@@ -46,18 +46,15 @@ error[E0107]: associated function takes 0 generic arguments but 1 generic argume
   --> $DIR/issue-89064.rs:27:21
    |
 LL |     let _ = A::<S>::foo::<S>();
-   |                     ^^^ expected 0 generic arguments
+   |                     ^^^----- help: remove the unnecessary generics
+   |                     |
+   |                     expected 0 generic arguments
    |
 note: associated function defined here, with 0 generic parameters
   --> $DIR/issue-89064.rs:4:8
    |
 LL |     fn foo() {}
    |        ^^^
-help: remove the unnecessary generics
-   |
-LL -     let _ = A::<S>::foo::<S>();
-LL +     let _ = A::<S>::foo();
-   |
 
 error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-89064.rs:31:16

--- a/tests/ui/suggestions/issue-89064.stderr
+++ b/tests/ui/suggestions/issue-89064.stderr
@@ -14,7 +14,7 @@ help: consider moving this generic argument to the `A` trait, which takes up to 
 LL -     let _ = A::foo::<S>();
 LL +     let _ = A::<S>::foo();
    |
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     let _ = A::foo::<S>();
 LL +     let _ = A::foo();
@@ -36,7 +36,7 @@ help: consider moving these generic arguments to the `B` trait, which takes up t
 LL -     let _ = B::bar::<S, S>();
 LL +     let _ = B::<S, S>::bar();
    |
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     let _ = B::bar::<S, S>();
 LL +     let _ = B::bar();
@@ -53,7 +53,7 @@ note: associated function defined here, with 0 generic parameters
    |
 LL |     fn foo() {}
    |        ^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     let _ = A::<S>::foo::<S>();
 LL +     let _ = A::<S>::foo();
@@ -69,7 +69,7 @@ help: consider moving this generic argument to the `Into` trait, which takes up 
    |
 LL |     let _ = Into::<Option<_>>::into(42);
    |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     let _ = 42.into::<Option<_>>();
 LL +     let _ = 42.into();

--- a/tests/ui/suggestions/issue-89064.stderr
+++ b/tests/ui/suggestions/issue-89064.stderr
@@ -46,15 +46,18 @@ error[E0107]: associated function takes 0 generic arguments but 1 generic argume
   --> $DIR/issue-89064.rs:27:21
    |
 LL |     let _ = A::<S>::foo::<S>();
-   |                     ^^^----- help: remove these generics
-   |                     |
-   |                     expected 0 generic arguments
+   |                     ^^^ expected 0 generic arguments
    |
 note: associated function defined here, with 0 generic parameters
   --> $DIR/issue-89064.rs:4:8
    |
 LL |     fn foo() {}
    |        ^^^
+help: remove these generics
+   |
+LL -     let _ = A::<S>::foo::<S>();
+LL +     let _ = A::<S>::foo();
+   |
 
 error[E0107]: method takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/issue-89064.rs:31:16

--- a/tests/ui/suggestions/move-generic-to-trait-in-method-with-params.rs
+++ b/tests/ui/suggestions/move-generic-to-trait-in-method-with-params.rs
@@ -14,5 +14,5 @@ fn main() {
     1.bar::<i32>(0);
     //~^ ERROR method takes 0 generic arguments but 1 generic argument was supplied
     //~| HELP consider moving this generic argument to the `Foo` trait, which takes up to 1 argument
-    //~| HELP remove these generics
+    //~| HELP remove the unnecessary generics
 }

--- a/tests/ui/suggestions/move-generic-to-trait-in-method-with-params.stderr
+++ b/tests/ui/suggestions/move-generic-to-trait-in-method-with-params.stderr
@@ -13,7 +13,7 @@ help: consider moving this generic argument to the `Foo` trait, which takes up t
    |
 LL |     Foo::<i32>::bar(1, 0);
    |     ~~~~~~~~~~~~~~~~~~~~~
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     1.bar::<i32>(0);
 LL +     1.bar(0);

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
@@ -117,15 +117,18 @@ error[E0107]: struct takes 1 generic argument but 2 generic arguments were suppl
   --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:40:58
    |
 LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
-   |                                                          ^^^^^^    - help: remove this generic argument
-   |                                                          |
-   |                                                          expected 1 generic argument
+   |                                                          ^^^^^^ expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:26:8
    |
 LL | struct Struct<T: Trait<u32, String>> {
    |        ^^^^^^ -
+help: remove this generic argument
+   |
+LL - impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
+LL + impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, > {}
+   |
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
@@ -124,7 +124,7 @@ note: struct defined here, with 1 generic parameter: `T`
    |
 LL | struct Struct<T: Trait<u32, String>> {
    |        ^^^^^^ -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL - impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
 LL + impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, > {}

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
@@ -127,7 +127,7 @@ LL | struct Struct<T: Trait<u32, String>> {
 help: remove the unnecessary generic argument
    |
 LL - impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
-LL + impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, > {}
+LL + impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T> {}
    |
 
 error: aborting due to 9 previous errors

--- a/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
+++ b/tests/ui/traits/associated_type_bound/116464-invalid-assoc-type-suggestion-in-trait-impl.stderr
@@ -117,18 +117,15 @@ error[E0107]: struct takes 1 generic argument but 2 generic arguments were suppl
   --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:40:58
    |
 LL | impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
-   |                                                          ^^^^^^ expected 1 generic argument
+   |                                                          ^^^^^^  --- help: remove the unnecessary generic argument
+   |                                                          |
+   |                                                          expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/116464-invalid-assoc-type-suggestion-in-trait-impl.rs:26:8
    |
 LL | struct Struct<T: Trait<u32, String>> {
    |        ^^^^^^ -
-help: remove the unnecessary generic argument
-   |
-LL - impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T, U> {}
-LL + impl<T: Trait<u32, Assoc=String>, U> YetAnotherTrait for Struct<T> {}
-   |
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/traits/object/vs-lifetime.stderr
+++ b/tests/ui/traits/object/vs-lifetime.stderr
@@ -8,15 +8,18 @@ error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were sup
   --> $DIR/vs-lifetime.rs:11:12
    |
 LL |     let _: S<'static, 'static>;
-   |            ^          ------- help: remove this lifetime argument
-   |            |
-   |            expected 1 lifetime argument
+   |            ^ expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/vs-lifetime.rs:4:8
    |
 LL | struct S<'a, T>(&'a u8, T);
    |        ^ --
+help: remove this lifetime argument
+   |
+LL -     let _: S<'static, 'static>;
+LL +     let _: S<'static, >;
+   |
 
 error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/vs-lifetime.rs:11:12

--- a/tests/ui/traits/object/vs-lifetime.stderr
+++ b/tests/ui/traits/object/vs-lifetime.stderr
@@ -15,7 +15,7 @@ note: struct defined here, with 1 lifetime parameter: `'a`
    |
 LL | struct S<'a, T>(&'a u8, T);
    |        ^ --
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL -     let _: S<'static, 'static>;
 LL +     let _: S<'static, >;

--- a/tests/ui/traits/object/vs-lifetime.stderr
+++ b/tests/ui/traits/object/vs-lifetime.stderr
@@ -18,7 +18,7 @@ LL | struct S<'a, T>(&'a u8, T);
 help: remove the lifetime argument
    |
 LL -     let _: S<'static, 'static>;
-LL +     let _: S<'static, >;
+LL +     let _: S<'static>;
    |
 
 error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied

--- a/tests/ui/traits/object/vs-lifetime.stderr
+++ b/tests/ui/traits/object/vs-lifetime.stderr
@@ -8,18 +8,15 @@ error[E0107]: struct takes 1 lifetime argument but 2 lifetime arguments were sup
   --> $DIR/vs-lifetime.rs:11:12
    |
 LL |     let _: S<'static, 'static>;
-   |            ^ expected 1 lifetime argument
+   |            ^        --------- help: remove the lifetime argument
+   |            |
+   |            expected 1 lifetime argument
    |
 note: struct defined here, with 1 lifetime parameter: `'a`
   --> $DIR/vs-lifetime.rs:4:8
    |
 LL | struct S<'a, T>(&'a u8, T);
    |        ^ --
-help: remove the lifetime argument
-   |
-LL -     let _: S<'static, 'static>;
-LL +     let _: S<'static>;
-   |
 
 error[E0107]: struct takes 1 generic argument but 0 generic arguments were supplied
   --> $DIR/vs-lifetime.rs:11:12

--- a/tests/ui/traits/test-2.stderr
+++ b/tests/ui/traits/test-2.stderr
@@ -2,35 +2,29 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/test-2.rs:9:8
    |
 LL |     10.dup::<i32>();
-   |        ^^^ expected 0 generic arguments
+   |        ^^^------- help: remove the unnecessary generics
+   |        |
+   |        expected 0 generic arguments
    |
 note: method defined here, with 0 generic parameters
   --> $DIR/test-2.rs:4:16
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |                ^^^
-help: remove the unnecessary generics
-   |
-LL -     10.dup::<i32>();
-LL +     10.dup();
-   |
 
 error[E0107]: method takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/test-2.rs:11:8
    |
 LL |     10.blah::<i32, i32>();
-   |        ^^^^ expected 1 generic argument
+   |        ^^^^      ----- help: remove the unnecessary generic argument
+   |        |
+   |        expected 1 generic argument
    |
 note: method defined here, with 1 generic parameter: `X`
   --> $DIR/test-2.rs:4:39
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |                                       ^^^^ -
-help: remove the unnecessary generic argument
-   |
-LL -     10.blah::<i32, i32>();
-LL +     10.blah::<i32>();
-   |
 
 error[E0038]: the trait `bar` cannot be made into an object
   --> $DIR/test-2.rs:13:22

--- a/tests/ui/traits/test-2.stderr
+++ b/tests/ui/traits/test-2.stderr
@@ -2,29 +2,35 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/test-2.rs:9:8
    |
 LL |     10.dup::<i32>();
-   |        ^^^------- help: remove these generics
-   |        |
-   |        expected 0 generic arguments
+   |        ^^^ expected 0 generic arguments
    |
 note: method defined here, with 0 generic parameters
   --> $DIR/test-2.rs:4:16
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |                ^^^
+help: remove these generics
+   |
+LL -     10.dup::<i32>();
+LL +     10.dup();
+   |
 
 error[E0107]: method takes 1 generic argument but 2 generic arguments were supplied
   --> $DIR/test-2.rs:11:8
    |
 LL |     10.blah::<i32, i32>();
-   |        ^^^^        --- help: remove this generic argument
-   |        |
-   |        expected 1 generic argument
+   |        ^^^^ expected 1 generic argument
    |
 note: method defined here, with 1 generic parameter: `X`
   --> $DIR/test-2.rs:4:39
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |                                       ^^^^ -
+help: remove this generic argument
+   |
+LL -     10.blah::<i32, i32>();
+LL +     10.blah::<i32, >();
+   |
 
 error[E0038]: the trait `bar` cannot be made into an object
   --> $DIR/test-2.rs:13:22

--- a/tests/ui/traits/test-2.stderr
+++ b/tests/ui/traits/test-2.stderr
@@ -29,7 +29,7 @@ LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
 help: remove the unnecessary generic argument
    |
 LL -     10.blah::<i32, i32>();
-LL +     10.blah::<i32, >();
+LL +     10.blah::<i32>();
    |
 
 error[E0038]: the trait `bar` cannot be made into an object

--- a/tests/ui/traits/test-2.stderr
+++ b/tests/ui/traits/test-2.stderr
@@ -9,7 +9,7 @@ note: method defined here, with 0 generic parameters
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |                ^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     10.dup::<i32>();
 LL +     10.dup();
@@ -26,7 +26,7 @@ note: method defined here, with 1 generic parameter: `X`
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |                                       ^^^^ -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     10.blah::<i32, i32>();
 LL +     10.blah::<i32, >();

--- a/tests/ui/transmutability/issue-101739-2.stderr
+++ b/tests/ui/transmutability/issue-101739-2.stderr
@@ -1,13 +1,16 @@
 error[E0107]: trait takes at most 2 generic arguments but 5 generic arguments were supplied
   --> $DIR/issue-101739-2.rs:17:14
    |
-LL |           Dst: BikeshedIntrinsicFrom<
-   |                ^^^^^^^^^^^^^^^^^^^^^ expected at most 2 generic arguments
-...
-LL | /             ASSUME_LIFETIMES,
-LL | |             ASSUME_VALIDITY,
-LL | |             ASSUME_VISIBILITY,
-   | |_____________________________- help: remove these generic arguments
+LL |         Dst: BikeshedIntrinsicFrom<
+   |              ^^^^^^^^^^^^^^^^^^^^^ expected at most 2 generic arguments
+   |
+help: remove these generic arguments
+   |
+LL -             ASSUME_LIFETIMES,
+LL -             ASSUME_VALIDITY,
+LL -             ASSUME_VISIBILITY,
+LL +             ,
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/transmutability/issue-101739-2.stderr
+++ b/tests/ui/transmutability/issue-101739-2.stderr
@@ -6,10 +6,11 @@ LL |         Dst: BikeshedIntrinsicFrom<
    |
 help: remove the unnecessary generic arguments
    |
+LL -             ASSUME_ALIGNMENT,
 LL -             ASSUME_LIFETIMES,
 LL -             ASSUME_VALIDITY,
 LL -             ASSUME_VISIBILITY,
-LL +             ,
+LL +             ASSUME_ALIGNMENT,
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/transmutability/issue-101739-2.stderr
+++ b/tests/ui/transmutability/issue-101739-2.stderr
@@ -4,7 +4,7 @@ error[E0107]: trait takes at most 2 generic arguments but 5 generic arguments we
 LL |         Dst: BikeshedIntrinsicFrom<
    |              ^^^^^^^^^^^^^^^^^^^^^ expected at most 2 generic arguments
    |
-help: remove these generic arguments
+help: remove the unnecessary generic arguments
    |
 LL -             ASSUME_LIFETIMES,
 LL -             ASSUME_VALIDITY,

--- a/tests/ui/transmutability/issue-101739-2.stderr
+++ b/tests/ui/transmutability/issue-101739-2.stderr
@@ -1,17 +1,15 @@
 error[E0107]: trait takes at most 2 generic arguments but 5 generic arguments were supplied
   --> $DIR/issue-101739-2.rs:17:14
    |
-LL |         Dst: BikeshedIntrinsicFrom<
-   |              ^^^^^^^^^^^^^^^^^^^^^ expected at most 2 generic arguments
-   |
-help: remove the unnecessary generic arguments
-   |
-LL -             ASSUME_ALIGNMENT,
-LL -             ASSUME_LIFETIMES,
-LL -             ASSUME_VALIDITY,
-LL -             ASSUME_VISIBILITY,
-LL +             ASSUME_ALIGNMENT,
-   |
+LL |           Dst: BikeshedIntrinsicFrom<
+   |                ^^^^^^^^^^^^^^^^^^^^^ expected at most 2 generic arguments
+LL |               Src,
+LL |               ASSUME_ALIGNMENT,
+   |  _____________________________-
+LL | |             ASSUME_LIFETIMES,
+LL | |             ASSUME_VALIDITY,
+LL | |             ASSUME_VISIBILITY,
+   | |_____________________________- help: remove the unnecessary generic arguments
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/tests/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -308,35 +308,29 @@ error[E0107]: type alias takes 0 generic arguments but 1 generic argument was su
   --> $DIR/enum-variant-generic-args.rs:64:5
    |
 LL |     AliasFixed::<()>::TSVariant(());
-   |     ^^^^^^^^^^ expected 0 generic arguments
+   |     ^^^^^^^^^^------ help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/enum-variant-generic-args.rs:9:6
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
-help: remove the unnecessary generics
-   |
-LL -     AliasFixed::<()>::TSVariant(());
-LL +     AliasFixed::TSVariant(());
-   |
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:66:5
    |
 LL |     AliasFixed::<()>::TSVariant::<()>(());
-   |     ^^^^^^^^^^ expected 0 generic arguments
+   |     ^^^^^^^^^^------ help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/enum-variant-generic-args.rs:9:6
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
-help: remove the unnecessary generics
-   |
-LL -     AliasFixed::<()>::TSVariant::<()>(());
-LL +     AliasFixed::TSVariant::<()>(());
-   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:66:35
@@ -405,35 +399,29 @@ error[E0107]: type alias takes 0 generic arguments but 1 generic argument was su
   --> $DIR/enum-variant-generic-args.rs:82:5
    |
 LL |     AliasFixed::<()>::SVariant { v: () };
-   |     ^^^^^^^^^^ expected 0 generic arguments
+   |     ^^^^^^^^^^------ help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/enum-variant-generic-args.rs:9:6
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
-help: remove the unnecessary generics
-   |
-LL -     AliasFixed::<()>::SVariant { v: () };
-LL +     AliasFixed::SVariant { v: () };
-   |
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:84:5
    |
 LL |     AliasFixed::<()>::SVariant::<()> { v: () };
-   |     ^^^^^^^^^^ expected 0 generic arguments
+   |     ^^^^^^^^^^------ help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/enum-variant-generic-args.rs:9:6
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
-help: remove the unnecessary generics
-   |
-LL -     AliasFixed::<()>::SVariant::<()> { v: () };
-LL +     AliasFixed::SVariant::<()> { v: () };
-   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:84:34
@@ -486,35 +474,29 @@ error[E0107]: type alias takes 0 generic arguments but 1 generic argument was su
   --> $DIR/enum-variant-generic-args.rs:100:5
    |
 LL |     AliasFixed::<()>::UVariant;
-   |     ^^^^^^^^^^ expected 0 generic arguments
+   |     ^^^^^^^^^^------ help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/enum-variant-generic-args.rs:9:6
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
-help: remove the unnecessary generics
-   |
-LL -     AliasFixed::<()>::UVariant;
-LL +     AliasFixed::UVariant;
-   |
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:102:5
    |
 LL |     AliasFixed::<()>::UVariant::<()>;
-   |     ^^^^^^^^^^ expected 0 generic arguments
+   |     ^^^^^^^^^^------ help: remove the unnecessary generics
+   |     |
+   |     expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/enum-variant-generic-args.rs:9:6
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
-help: remove the unnecessary generics
-   |
-LL -     AliasFixed::<()>::UVariant::<()>;
-LL +     AliasFixed::UVariant::<()>;
-   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:102:34

--- a/tests/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/tests/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -308,29 +308,35 @@ error[E0107]: type alias takes 0 generic arguments but 1 generic argument was su
   --> $DIR/enum-variant-generic-args.rs:64:5
    |
 LL |     AliasFixed::<()>::TSVariant(());
-   |     ^^^^^^^^^^------ help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^^^^^^^^ expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/enum-variant-generic-args.rs:9:6
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
+help: remove these generics
+   |
+LL -     AliasFixed::<()>::TSVariant(());
+LL +     AliasFixed::TSVariant(());
+   |
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:66:5
    |
 LL |     AliasFixed::<()>::TSVariant::<()>(());
-   |     ^^^^^^^^^^------ help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^^^^^^^^ expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/enum-variant-generic-args.rs:9:6
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
+help: remove these generics
+   |
+LL -     AliasFixed::<()>::TSVariant::<()>(());
+LL +     AliasFixed::TSVariant::<()>(());
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:66:35
@@ -399,29 +405,35 @@ error[E0107]: type alias takes 0 generic arguments but 1 generic argument was su
   --> $DIR/enum-variant-generic-args.rs:82:5
    |
 LL |     AliasFixed::<()>::SVariant { v: () };
-   |     ^^^^^^^^^^------ help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^^^^^^^^ expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/enum-variant-generic-args.rs:9:6
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
+help: remove these generics
+   |
+LL -     AliasFixed::<()>::SVariant { v: () };
+LL +     AliasFixed::SVariant { v: () };
+   |
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:84:5
    |
 LL |     AliasFixed::<()>::SVariant::<()> { v: () };
-   |     ^^^^^^^^^^------ help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^^^^^^^^ expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/enum-variant-generic-args.rs:9:6
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
+help: remove these generics
+   |
+LL -     AliasFixed::<()>::SVariant::<()> { v: () };
+LL +     AliasFixed::SVariant::<()> { v: () };
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:84:34
@@ -474,29 +486,35 @@ error[E0107]: type alias takes 0 generic arguments but 1 generic argument was su
   --> $DIR/enum-variant-generic-args.rs:100:5
    |
 LL |     AliasFixed::<()>::UVariant;
-   |     ^^^^^^^^^^------ help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^^^^^^^^ expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/enum-variant-generic-args.rs:9:6
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
+help: remove these generics
+   |
+LL -     AliasFixed::<()>::UVariant;
+LL +     AliasFixed::UVariant;
+   |
 
 error[E0107]: type alias takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/enum-variant-generic-args.rs:102:5
    |
 LL |     AliasFixed::<()>::UVariant::<()>;
-   |     ^^^^^^^^^^------ help: remove these generics
-   |     |
-   |     expected 0 generic arguments
+   |     ^^^^^^^^^^ expected 0 generic arguments
    |
 note: type alias defined here, with 0 generic parameters
   --> $DIR/enum-variant-generic-args.rs:9:6
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
+help: remove these generics
+   |
+LL -     AliasFixed::<()>::UVariant::<()>;
+LL +     AliasFixed::UVariant::<()>;
+   |
 
 error[E0109]: type arguments are not allowed on this type
   --> $DIR/enum-variant-generic-args.rs:102:34

--- a/tests/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
+++ b/tests/ui/type-alias-enum-variants/enum-variant-generic-args.stderr
@@ -315,7 +315,7 @@ note: type alias defined here, with 0 generic parameters
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     AliasFixed::<()>::TSVariant(());
 LL +     AliasFixed::TSVariant(());
@@ -332,7 +332,7 @@ note: type alias defined here, with 0 generic parameters
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     AliasFixed::<()>::TSVariant::<()>(());
 LL +     AliasFixed::TSVariant::<()>(());
@@ -412,7 +412,7 @@ note: type alias defined here, with 0 generic parameters
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     AliasFixed::<()>::SVariant { v: () };
 LL +     AliasFixed::SVariant { v: () };
@@ -429,7 +429,7 @@ note: type alias defined here, with 0 generic parameters
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     AliasFixed::<()>::SVariant::<()> { v: () };
 LL +     AliasFixed::SVariant::<()> { v: () };
@@ -493,7 +493,7 @@ note: type alias defined here, with 0 generic parameters
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     AliasFixed::<()>::UVariant;
 LL +     AliasFixed::UVariant;
@@ -510,7 +510,7 @@ note: type alias defined here, with 0 generic parameters
    |
 LL | type AliasFixed = Enum<()>;
    |      ^^^^^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     AliasFixed::<()>::UVariant::<()>;
 LL +     AliasFixed::UVariant::<()>;

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
@@ -2,99 +2,69 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/typeck-builtin-bound-type-parameters.rs:1:11
    |
 LL | fn foo1<T:Copy<U>, U>(x: T) {}
-   |           ^^^^ expected 0 generic arguments
-   |
-help: remove the unnecessary generics
-   |
-LL - fn foo1<T:Copy<U>, U>(x: T) {}
-LL + fn foo1<T:Copy, U>(x: T) {}
-   |
+   |           ^^^^--- help: remove the unnecessary generics
+   |           |
+   |           expected 0 generic arguments
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:4:14
    |
 LL | trait Trait: Copy<dyn Send> {}
-   |              ^^^^ expected 0 generic arguments
-   |
-help: remove the unnecessary generics
-   |
-LL - trait Trait: Copy<dyn Send> {}
-LL + trait Trait: Copy {}
-   |
+   |              ^^^^---------- help: remove the unnecessary generics
+   |              |
+   |              expected 0 generic arguments
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:4:14
    |
 LL | trait Trait: Copy<dyn Send> {}
-   |              ^^^^ expected 0 generic arguments
+   |              ^^^^---------- help: remove the unnecessary generics
+   |              |
+   |              expected 0 generic arguments
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove the unnecessary generics
-   |
-LL - trait Trait: Copy<dyn Send> {}
-LL + trait Trait: Copy {}
-   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:4:14
    |
 LL | trait Trait: Copy<dyn Send> {}
-   |              ^^^^ expected 0 generic arguments
+   |              ^^^^---------- help: remove the unnecessary generics
+   |              |
+   |              expected 0 generic arguments
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove the unnecessary generics
-   |
-LL - trait Trait: Copy<dyn Send> {}
-LL + trait Trait: Copy {}
-   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:9:21
    |
 LL | struct MyStruct1<T: Copy<T>>(T);
-   |                     ^^^^ expected 0 generic arguments
-   |
-help: remove the unnecessary generics
-   |
-LL - struct MyStruct1<T: Copy<T>>(T);
-LL + struct MyStruct1<T: Copy>(T);
-   |
+   |                     ^^^^--- help: remove the unnecessary generics
+   |                     |
+   |                     expected 0 generic arguments
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:12:25
    |
 LL | struct MyStruct2<'a, T: Copy<'a>>(&'a T);
-   |                         ^^^^ expected 0 lifetime arguments
-   |
-help: remove the unnecessary generics
-   |
-LL - struct MyStruct2<'a, T: Copy<'a>>(&'a T);
-LL + struct MyStruct2<'a, T: Copy>(&'a T);
-   |
+   |                         ^^^^---- help: remove the unnecessary generics
+   |                         |
+   |                         expected 0 lifetime arguments
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:15:15
    |
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
-   |               ^^^^ expected 0 lifetime arguments
-   |
-help: remove the lifetime argument
-   |
-LL - fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
-LL + fn foo2<'a, T:Copy<, U>, U>(x: T) {}
-   |
+   |               ^^^^ -- help: remove the lifetime argument
+   |               |
+   |               expected 0 lifetime arguments
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:15:15
    |
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
-   |               ^^^^ expected 0 generic arguments
-   |
-help: remove the unnecessary generic argument
-   |
-LL - fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
-LL + fn foo2<'a, T:Copy<'a, >, U>(x: T) {}
-   |
+   |               ^^^^     - help: remove the unnecessary generic argument
+   |               |
+   |               expected 0 generic arguments
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
@@ -4,7 +4,7 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
 LL | fn foo1<T:Copy<U>, U>(x: T) {}
    |           ^^^^ expected 0 generic arguments
    |
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - fn foo1<T:Copy<U>, U>(x: T) {}
 LL + fn foo1<T:Copy, U>(x: T) {}
@@ -16,7 +16,7 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
 LL | trait Trait: Copy<dyn Send> {}
    |              ^^^^ expected 0 generic arguments
    |
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - trait Trait: Copy<dyn Send> {}
 LL + trait Trait: Copy {}
@@ -29,7 +29,7 @@ LL | trait Trait: Copy<dyn Send> {}
    |              ^^^^ expected 0 generic arguments
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - trait Trait: Copy<dyn Send> {}
 LL + trait Trait: Copy {}
@@ -42,7 +42,7 @@ LL | trait Trait: Copy<dyn Send> {}
    |              ^^^^ expected 0 generic arguments
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - trait Trait: Copy<dyn Send> {}
 LL + trait Trait: Copy {}
@@ -54,7 +54,7 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
 LL | struct MyStruct1<T: Copy<T>>(T);
    |                     ^^^^ expected 0 generic arguments
    |
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - struct MyStruct1<T: Copy<T>>(T);
 LL + struct MyStruct1<T: Copy>(T);
@@ -66,7 +66,7 @@ error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was suppl
 LL | struct MyStruct2<'a, T: Copy<'a>>(&'a T);
    |                         ^^^^ expected 0 lifetime arguments
    |
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - struct MyStruct2<'a, T: Copy<'a>>(&'a T);
 LL + struct MyStruct2<'a, T: Copy>(&'a T);
@@ -78,7 +78,7 @@ error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was suppl
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               ^^^^ expected 0 lifetime arguments
    |
-help: remove this lifetime argument
+help: remove the lifetime argument
    |
 LL - fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
 LL + fn foo2<'a, T:Copy<, U>, U>(x: T) {}
@@ -90,7 +90,7 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
    |               ^^^^ expected 0 generic arguments
    |
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL - fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
 LL + fn foo2<'a, T:Copy<'a, >, U>(x: T) {}

--- a/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
+++ b/tests/ui/typeck/typeck-builtin-bound-type-parameters.stderr
@@ -2,69 +2,99 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/typeck-builtin-bound-type-parameters.rs:1:11
    |
 LL | fn foo1<T:Copy<U>, U>(x: T) {}
-   |           ^^^^--- help: remove these generics
-   |           |
-   |           expected 0 generic arguments
+   |           ^^^^ expected 0 generic arguments
+   |
+help: remove these generics
+   |
+LL - fn foo1<T:Copy<U>, U>(x: T) {}
+LL + fn foo1<T:Copy, U>(x: T) {}
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:4:14
    |
 LL | trait Trait: Copy<dyn Send> {}
-   |              ^^^^---------- help: remove these generics
-   |              |
-   |              expected 0 generic arguments
+   |              ^^^^ expected 0 generic arguments
+   |
+help: remove these generics
+   |
+LL - trait Trait: Copy<dyn Send> {}
+LL + trait Trait: Copy {}
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:4:14
    |
 LL | trait Trait: Copy<dyn Send> {}
-   |              ^^^^---------- help: remove these generics
-   |              |
-   |              expected 0 generic arguments
+   |              ^^^^ expected 0 generic arguments
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: remove these generics
+   |
+LL - trait Trait: Copy<dyn Send> {}
+LL + trait Trait: Copy {}
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:4:14
    |
 LL | trait Trait: Copy<dyn Send> {}
-   |              ^^^^---------- help: remove these generics
-   |              |
-   |              expected 0 generic arguments
+   |              ^^^^ expected 0 generic arguments
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+help: remove these generics
+   |
+LL - trait Trait: Copy<dyn Send> {}
+LL + trait Trait: Copy {}
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:9:21
    |
 LL | struct MyStruct1<T: Copy<T>>(T);
-   |                     ^^^^--- help: remove these generics
-   |                     |
-   |                     expected 0 generic arguments
+   |                     ^^^^ expected 0 generic arguments
+   |
+help: remove these generics
+   |
+LL - struct MyStruct1<T: Copy<T>>(T);
+LL + struct MyStruct1<T: Copy>(T);
+   |
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:12:25
    |
 LL | struct MyStruct2<'a, T: Copy<'a>>(&'a T);
-   |                         ^^^^---- help: remove these generics
-   |                         |
-   |                         expected 0 lifetime arguments
+   |                         ^^^^ expected 0 lifetime arguments
+   |
+help: remove these generics
+   |
+LL - struct MyStruct2<'a, T: Copy<'a>>(&'a T);
+LL + struct MyStruct2<'a, T: Copy>(&'a T);
+   |
 
 error[E0107]: trait takes 0 lifetime arguments but 1 lifetime argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:15:15
    |
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
-   |               ^^^^ -- help: remove this lifetime argument
-   |               |
-   |               expected 0 lifetime arguments
+   |               ^^^^ expected 0 lifetime arguments
+   |
+help: remove this lifetime argument
+   |
+LL - fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
+LL + fn foo2<'a, T:Copy<, U>, U>(x: T) {}
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/typeck-builtin-bound-type-parameters.rs:15:15
    |
 LL | fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
-   |               ^^^^     - help: remove this generic argument
-   |               |
-   |               expected 0 generic arguments
+   |               ^^^^ expected 0 generic arguments
+   |
+help: remove this generic argument
+   |
+LL - fn foo2<'a, T:Copy<'a, U>, U>(x: T) {}
+LL + fn foo2<'a, T:Copy<'a, >, U>(x: T) {}
+   |
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/typeck/typeck_type_placeholder_lifetime_1.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_lifetime_1.stderr
@@ -2,15 +2,18 @@ error[E0107]: struct takes 1 generic argument but 2 generic arguments were suppl
   --> $DIR/typeck_type_placeholder_lifetime_1.rs:9:12
    |
 LL |     let c: Foo<_, _> = Foo { r: &5 };
-   |            ^^^    - help: remove this generic argument
-   |            |
-   |            expected 1 generic argument
+   |            ^^^ expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/typeck_type_placeholder_lifetime_1.rs:4:8
    |
 LL | struct Foo<'a, T:'a> {
    |        ^^^     -
+help: remove this generic argument
+   |
+LL -     let c: Foo<_, _> = Foo { r: &5 };
+LL +     let c: Foo<_, > = Foo { r: &5 };
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/typeck_type_placeholder_lifetime_1.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_lifetime_1.stderr
@@ -2,18 +2,15 @@ error[E0107]: struct takes 1 generic argument but 2 generic arguments were suppl
   --> $DIR/typeck_type_placeholder_lifetime_1.rs:9:12
    |
 LL |     let c: Foo<_, _> = Foo { r: &5 };
-   |            ^^^ expected 1 generic argument
+   |            ^^^  --- help: remove the unnecessary generic argument
+   |            |
+   |            expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/typeck_type_placeholder_lifetime_1.rs:4:8
    |
 LL | struct Foo<'a, T:'a> {
    |        ^^^     -
-help: remove the unnecessary generic argument
-   |
-LL -     let c: Foo<_, _> = Foo { r: &5 };
-LL +     let c: Foo<_> = Foo { r: &5 };
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/typeck_type_placeholder_lifetime_1.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_lifetime_1.stderr
@@ -12,7 +12,7 @@ LL | struct Foo<'a, T:'a> {
 help: remove the unnecessary generic argument
    |
 LL -     let c: Foo<_, _> = Foo { r: &5 };
-LL +     let c: Foo<_, > = Foo { r: &5 };
+LL +     let c: Foo<_> = Foo { r: &5 };
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/typeck/typeck_type_placeholder_lifetime_1.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_lifetime_1.stderr
@@ -9,7 +9,7 @@ note: struct defined here, with 1 generic parameter: `T`
    |
 LL | struct Foo<'a, T:'a> {
    |        ^^^     -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     let c: Foo<_, _> = Foo { r: &5 };
 LL +     let c: Foo<_, > = Foo { r: &5 };

--- a/tests/ui/typeck/typeck_type_placeholder_lifetime_2.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_lifetime_2.stderr
@@ -9,7 +9,7 @@ note: struct defined here, with 1 generic parameter: `T`
    |
 LL | struct Foo<'a, T:'a> {
    |        ^^^     -
-help: remove this generic argument
+help: remove the unnecessary generic argument
    |
 LL -     let c: Foo<_, usize> = Foo { r: &5 };
 LL +     let c: Foo<_, > = Foo { r: &5 };

--- a/tests/ui/typeck/typeck_type_placeholder_lifetime_2.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_lifetime_2.stderr
@@ -12,7 +12,7 @@ LL | struct Foo<'a, T:'a> {
 help: remove the unnecessary generic argument
    |
 LL -     let c: Foo<_, usize> = Foo { r: &5 };
-LL +     let c: Foo<_, > = Foo { r: &5 };
+LL +     let c: Foo<_> = Foo { r: &5 };
    |
 
 error: aborting due to 1 previous error

--- a/tests/ui/typeck/typeck_type_placeholder_lifetime_2.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_lifetime_2.stderr
@@ -2,18 +2,15 @@ error[E0107]: struct takes 1 generic argument but 2 generic arguments were suppl
   --> $DIR/typeck_type_placeholder_lifetime_2.rs:9:12
    |
 LL |     let c: Foo<_, usize> = Foo { r: &5 };
-   |            ^^^ expected 1 generic argument
+   |            ^^^  ------- help: remove the unnecessary generic argument
+   |            |
+   |            expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/typeck_type_placeholder_lifetime_2.rs:4:8
    |
 LL | struct Foo<'a, T:'a> {
    |        ^^^     -
-help: remove the unnecessary generic argument
-   |
-LL -     let c: Foo<_, usize> = Foo { r: &5 };
-LL +     let c: Foo<_> = Foo { r: &5 };
-   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/typeck_type_placeholder_lifetime_2.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_lifetime_2.stderr
@@ -2,15 +2,18 @@ error[E0107]: struct takes 1 generic argument but 2 generic arguments were suppl
   --> $DIR/typeck_type_placeholder_lifetime_2.rs:9:12
    |
 LL |     let c: Foo<_, usize> = Foo { r: &5 };
-   |            ^^^    ----- help: remove this generic argument
-   |            |
-   |            expected 1 generic argument
+   |            ^^^ expected 1 generic argument
    |
 note: struct defined here, with 1 generic parameter: `T`
   --> $DIR/typeck_type_placeholder_lifetime_2.rs:4:8
    |
 LL | struct Foo<'a, T:'a> {
    |        ^^^     -
+help: remove this generic argument
+   |
+LL -     let c: Foo<_, usize> = Foo { r: &5 };
+LL +     let c: Foo<_, > = Foo { r: &5 };
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/ufcs/ufcs-qpath-missing-params.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-missing-params.stderr
@@ -34,18 +34,15 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/ufcs-qpath-missing-params.rs:17:26
    |
 LL |     <String as IntoCow>::into_cow::<str>("foo".to_string());
-   |                          ^^^^^^^^ expected 0 generic arguments
+   |                          ^^^^^^^^------- help: remove the unnecessary generics
+   |                          |
+   |                          expected 0 generic arguments
    |
 note: method defined here, with 0 generic parameters
   --> $DIR/ufcs-qpath-missing-params.rs:4:8
    |
 LL |     fn into_cow(self) -> Cow<'a, B>;
    |        ^^^^^^^^
-help: remove the unnecessary generics
-   |
-LL -     <String as IntoCow>::into_cow::<str>("foo".to_string());
-LL +     <String as IntoCow>::into_cow("foo".to_string());
-   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/ufcs/ufcs-qpath-missing-params.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-missing-params.stderr
@@ -34,15 +34,18 @@ error[E0107]: method takes 0 generic arguments but 1 generic argument was suppli
   --> $DIR/ufcs-qpath-missing-params.rs:17:26
    |
 LL |     <String as IntoCow>::into_cow::<str>("foo".to_string());
-   |                          ^^^^^^^^------- help: remove these generics
-   |                          |
-   |                          expected 0 generic arguments
+   |                          ^^^^^^^^ expected 0 generic arguments
    |
 note: method defined here, with 0 generic parameters
   --> $DIR/ufcs-qpath-missing-params.rs:4:8
    |
 LL |     fn into_cow(self) -> Cow<'a, B>;
    |        ^^^^^^^^
+help: remove these generics
+   |
+LL -     <String as IntoCow>::into_cow::<str>("foo".to_string());
+LL +     <String as IntoCow>::into_cow("foo".to_string());
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/ufcs/ufcs-qpath-missing-params.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-missing-params.stderr
@@ -41,7 +41,7 @@ note: method defined here, with 0 generic parameters
    |
 LL |     fn into_cow(self) -> Cow<'a, B>;
    |        ^^^^^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL -     <String as IntoCow>::into_cow::<str>("foo".to_string());
 LL +     <String as IntoCow>::into_cow("foo".to_string());

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
@@ -9,7 +9,7 @@ note: trait defined here, with 0 generic parameters
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
-help: remove these parenthetical generics
+help: remove the unnecessary parenthetical generics
    |
 LL - fn foo1(_: &dyn Zero()) {
 LL + fn foo1(_: &dyn Zero) {
@@ -32,7 +32,7 @@ note: trait defined here, with 0 generic parameters
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - fn foo2(_: &dyn Zero<usize>) {
 LL + fn foo2(_: &dyn Zero) {
@@ -49,7 +49,7 @@ note: trait defined here, with 0 generic parameters
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
-help: remove these generics
+help: remove the unnecessary generics
    |
 LL - fn foo3(_: &dyn Zero <   usize   >) {
 LL + fn foo3(_: &dyn Zero) {
@@ -66,7 +66,7 @@ note: trait defined here, with 0 generic parameters
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
-help: remove these parenthetical generics
+help: remove the unnecessary parenthetical generics
    |
 LL - fn foo4(_: &dyn Zero(usize)) {
 LL + fn foo4(_: &dyn Zero) {
@@ -89,7 +89,7 @@ note: trait defined here, with 0 generic parameters
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
-help: remove these parenthetical generics
+help: remove the unnecessary parenthetical generics
    |
 LL - fn foo5(_: &dyn Zero (   usize   )) {
 LL + fn foo5(_: &dyn Zero) {

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
@@ -2,15 +2,18 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:17
    |
 LL | fn foo1(_: &dyn Zero()) {
-   |                 ^^^^-- help: remove these parenthetical generics
-   |                 |
-   |                 expected 0 generic arguments
+   |                 ^^^^ expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
+help: remove these parenthetical generics
+   |
+LL - fn foo1(_: &dyn Zero()) {
+LL + fn foo1(_: &dyn Zero) {
+   |
 
 error[E0220]: associated type `Output` not found for `Zero`
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:17
@@ -22,43 +25,52 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:10:17
    |
 LL | fn foo2(_: &dyn Zero<usize>) {
-   |                 ^^^^------- help: remove these generics
-   |                 |
-   |                 expected 0 generic arguments
+   |                 ^^^^ expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
+help: remove these generics
+   |
+LL - fn foo2(_: &dyn Zero<usize>) {
+LL + fn foo2(_: &dyn Zero) {
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:14:17
    |
 LL | fn foo3(_: &dyn Zero <   usize   >) {
-   |                 ^^^^-------------- help: remove these generics
-   |                 |
-   |                 expected 0 generic arguments
+   |                 ^^^^ expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
+help: remove these generics
+   |
+LL - fn foo3(_: &dyn Zero <   usize   >) {
+LL + fn foo3(_: &dyn Zero) {
+   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:17
    |
 LL | fn foo4(_: &dyn Zero(usize)) {
-   |                 ^^^^------- help: remove these parenthetical generics
-   |                 |
-   |                 expected 0 generic arguments
+   |                 ^^^^ expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
+help: remove these parenthetical generics
+   |
+LL - fn foo4(_: &dyn Zero(usize)) {
+LL + fn foo4(_: &dyn Zero) {
+   |
 
 error[E0220]: associated type `Output` not found for `Zero`
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:17
@@ -70,15 +82,18 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:17
    |
 LL | fn foo5(_: &dyn Zero (   usize   )) {
-   |                 ^^^^-------------- help: remove these parenthetical generics
-   |                 |
-   |                 expected 0 generic arguments
+   |                 ^^^^ expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
+help: remove these parenthetical generics
+   |
+LL - fn foo5(_: &dyn Zero (   usize   )) {
+LL + fn foo5(_: &dyn Zero) {
+   |
 
 error[E0220]: associated type `Output` not found for `Zero`
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:17

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-number-number-type-parameters.stderr
@@ -2,18 +2,15 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:17
    |
 LL | fn foo1(_: &dyn Zero()) {
-   |                 ^^^^ expected 0 generic arguments
+   |                 ^^^^-- help: remove the unnecessary parenthetical generics
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
-help: remove the unnecessary parenthetical generics
-   |
-LL - fn foo1(_: &dyn Zero()) {
-LL + fn foo1(_: &dyn Zero) {
-   |
 
 error[E0220]: associated type `Output` not found for `Zero`
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:5:17
@@ -25,52 +22,43 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:10:17
    |
 LL | fn foo2(_: &dyn Zero<usize>) {
-   |                 ^^^^ expected 0 generic arguments
+   |                 ^^^^------- help: remove the unnecessary generics
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
-help: remove the unnecessary generics
-   |
-LL - fn foo2(_: &dyn Zero<usize>) {
-LL + fn foo2(_: &dyn Zero) {
-   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:14:17
    |
 LL | fn foo3(_: &dyn Zero <   usize   >) {
-   |                 ^^^^ expected 0 generic arguments
+   |                 ^^^^-------------- help: remove the unnecessary generics
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
-help: remove the unnecessary generics
-   |
-LL - fn foo3(_: &dyn Zero <   usize   >) {
-LL + fn foo3(_: &dyn Zero) {
-   |
 
 error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:17
    |
 LL | fn foo4(_: &dyn Zero(usize)) {
-   |                 ^^^^ expected 0 generic arguments
+   |                 ^^^^------- help: remove the unnecessary parenthetical generics
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
-help: remove the unnecessary parenthetical generics
-   |
-LL - fn foo4(_: &dyn Zero(usize)) {
-LL + fn foo4(_: &dyn Zero) {
-   |
 
 error[E0220]: associated type `Output` not found for `Zero`
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:18:17
@@ -82,18 +70,15 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:17
    |
 LL | fn foo5(_: &dyn Zero (   usize   )) {
-   |                 ^^^^ expected 0 generic arguments
+   |                 ^^^^-------------- help: remove the unnecessary parenthetical generics
+   |                 |
+   |                 expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:3:7
    |
 LL | trait Zero { fn dummy(&self); }
    |       ^^^^
-help: remove the unnecessary parenthetical generics
-   |
-LL - fn foo5(_: &dyn Zero (   usize   )) {
-LL + fn foo5(_: &dyn Zero) {
-   |
 
 error[E0220]: associated type `Output` not found for `Zero`
   --> $DIR/unboxed-closure-sugar-wrong-number-number-type-parameters.rs:23:17

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
@@ -2,18 +2,15 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/unboxed-closure-sugar-wrong-trait.rs:5:8
    |
 LL | fn f<F:Trait(isize) -> isize>(x: F) {}
-   |        ^^^^^ expected 0 generic arguments
+   |        ^^^^^------- help: remove the unnecessary parenthetical generics
+   |        |
+   |        expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-trait.rs:3:7
    |
 LL | trait Trait {}
    |       ^^^^^
-help: remove the unnecessary parenthetical generics
-   |
-LL - fn f<F:Trait(isize) -> isize>(x: F) {}
-LL + fn f<F:Trait -> isize>(x: F) {}
-   |
 
 error[E0220]: associated type `Output` not found for `Trait`
   --> $DIR/unboxed-closure-sugar-wrong-trait.rs:5:24

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
@@ -9,7 +9,7 @@ note: trait defined here, with 0 generic parameters
    |
 LL | trait Trait {}
    |       ^^^^^
-help: remove these parenthetical generics
+help: remove the unnecessary parenthetical generics
    |
 LL - fn f<F:Trait(isize) -> isize>(x: F) {}
 LL + fn f<F:Trait -> isize>(x: F) {}

--- a/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-sugar-wrong-trait.stderr
@@ -2,15 +2,18 @@ error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplie
   --> $DIR/unboxed-closure-sugar-wrong-trait.rs:5:8
    |
 LL | fn f<F:Trait(isize) -> isize>(x: F) {}
-   |        ^^^^^------- help: remove these parenthetical generics
-   |        |
-   |        expected 0 generic arguments
+   |        ^^^^^ expected 0 generic arguments
    |
 note: trait defined here, with 0 generic parameters
   --> $DIR/unboxed-closure-sugar-wrong-trait.rs:3:7
    |
 LL | trait Trait {}
    |       ^^^^^
+help: remove these parenthetical generics
+   |
+LL - fn f<F:Trait(isize) -> isize>(x: F) {}
+LL + fn f<F:Trait -> isize>(x: F) {}
+   |
 
 error[E0220]: associated type `Output` not found for `Trait`
   --> $DIR/unboxed-closure-sugar-wrong-trait.rs:5:24


### PR DESCRIPTION
Successful merges:

 - #126152 (size_of_val_raw: for length 0 this is safe to call)
 - #127252 (Add edge-case examples to `{count,leading,trailing}_{ones,zeros}` methods)
 - #127374 (Tweak "wrong # of generics" suggestions)
 - #127457 (Make tidy fast without compromising case alternation)
 - #127480 (Fix build failure on vxworks #127084 )
 - #127733 (Replace some `mem::forget`'s with `ManuallyDrop`)
 - #128120 (Gate `AsyncFn*` under `async_closure` feature)
 - #128131 (Import `c_void` rather than using the full path)
 - #128133 (Improve spans on evaluated `cfg_attr`s.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=126152,127252,127374,127457,127480,127733,128120,128131,128133)
<!-- homu-ignore:end -->