### PR TITLE
Stop using `unsized_const_parameters` in core/std

### DIFF
--- a/library/core/src/intrinsics/simd.rs
+++ b/library/core/src/intrinsics/simd.rs
@@ -243,18 +243,6 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_shuffle<T, U, V>(x: T, y: T, idx: U) -> V;
 
-    /// Shuffle two vectors by const indices.
-    ///
-    /// `T` must be a vector.
-    ///
-    /// `U` must be a vector with the same element type as `T` and the same length as `IDX`.
-    ///
-    /// Returns a new vector such that element `i` is selected from `xy[IDX[i]]`, where `xy`
-    /// is the concatenation of `x` and `y`. It is a compile-time error if `IDX[i]` is out-of-bounds
-    /// of `xy`.
-    #[rustc_nounwind]
-    pub fn simd_shuffle_generic<T, U, const IDX: &'static [u32]>(x: T, y: T) -> U;
-
     /// Read a vector of pointers.
     ///
     /// `T` must be a vector.

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -249,7 +249,6 @@
 #![feature(transparent_unions)]
 #![feature(try_blocks)]
 #![feature(unboxed_closures)]
-#![feature(unsized_const_params)]
 #![feature(unsized_fn_params)]
 #![feature(with_negative_coherence)]
 // tidy-alphabetical-end

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -42,6 +42,8 @@ use crate::hash::Hasher;
 /// }
 /// ```
 #[unstable(feature = "internal_impls_macro", issue = "none")]
+// Allow implementations of `UnsizedConstParamTy` even though std cannot use that feature.
+#[allow_internal_unstable(unsized_const_params)]
 macro marker_impls {
     ( $(#[$($meta:tt)*])* $Trait:ident for $({$($bounds:tt)*})? $T:ty $(, $($rest:tt)*)? ) => {
         $(#[$($meta)*])* impl< $($($bounds)*)? > $Trait for $T {}

--- a/src/tools/miri/tests/pass/intrinsics/portable-simd.rs
+++ b/src/tools/miri/tests/pass/intrinsics/portable-simd.rs
@@ -1,9 +1,22 @@
 //@compile-flags: -Zmiri-strict-provenance
-#![feature(portable_simd, adt_const_params, core_intrinsics, repr_simd)]
+#![feature(
+    portable_simd,
+    unsized_const_params,
+    adt_const_params,
+    rustc_attrs,
+    intrinsics,
+    core_intrinsics,
+    repr_simd
+)]
 #![allow(incomplete_features, internal_features)]
 use std::intrinsics::simd as intrinsics;
 use std::ptr;
 use std::simd::{prelude::*, StdFloat};
+
+extern "rust-intrinsic" {
+    #[rustc_nounwind]
+    pub fn simd_shuffle_generic<T, U, const IDX: &'static [u32]>(x: T, y: T) -> U;
+}
 
 fn simd_ops_f32() {
     let a = f32x4::splat(10.0);


### PR DESCRIPTION
`feature(unsized_const_parameters)` is an incomplete feature and should not be used by core/std as it makes it can make it significantly harder to evolve the feature. It also just generally opens the possibility of introducing bugs on stable through std's backdoor.

The only usage of this feature in std is the `simd_shuffle_intrinsic` added in #119213. It doesn't seem to be used anywhere as far as I can tell so it is removed in this PR. All tests and codegen logic etc have been kept however.

r? @workingjubilee 