### PR TITLE
Structured suggestion for `extern crate foo` when `foo` isn't resolved in import

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -544,7 +544,13 @@ fn resolver_for_lowering_raw<'tcx>(
     let arenas = Resolver::arenas();
     let _ = tcx.registered_tools(()); // Uses `crate_for_resolver`.
     let (krate, pre_configured_attrs) = tcx.crate_for_resolver(()).steal();
-    let mut resolver = Resolver::new(tcx, &pre_configured_attrs, krate.spans.inner_span, &arenas);
+    let mut resolver = Resolver::new(
+        tcx,
+        &pre_configured_attrs,
+        krate.spans.inner_span,
+        krate.spans.inject_use_span,
+        &arenas,
+    );
     let krate = configure_and_expand(krate, &pre_configured_attrs, &mut resolver);
 
     // Make sure we don't mutate the cstore from here on.

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2026,14 +2026,17 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         Applicability::MaybeIncorrect,
                     )),
                 )
+            } else if ident.name == kw::Underscore {
+                (format!("`_` is not a valid crate or module name"), None)
             } else if self.tcx.sess.is_rust_2015() {
                 (
                     format!("you might be missing crate `{ident}`"),
                     Some((
-                        vec![],
-                        format!(
-                            "consider adding `extern crate {ident}` to use the `{ident}` crate"
-                        ),
+                        vec![(
+                            self.current_crate_outer_attr_insert_span,
+                            format!("extern crate {ident};\n"),
+                        )],
+                        format!("consider importing the `{ident}` crate"),
                         Applicability::MaybeIncorrect,
                     )),
                 )

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1180,6 +1180,10 @@ pub struct Resolver<'a, 'tcx> {
     /// Simplified analogue of module `resolutions` but in trait impls, excluding glob delegations.
     /// Needed because glob delegations exclude explicitly defined names.
     impl_binding_keys: FxHashMap<LocalDefId, FxHashSet<BindingKey>>,
+
+    /// This is the `Span` where an `extern crate foo;` suggestion would be inserted, if `foo`
+    /// could be a crate that wasn't imported. For diagnostics use only.
+    current_crate_outer_attr_insert_span: Span,
 }
 
 /// Nothing really interesting here; it just provides memory for the rest of the crate.
@@ -1342,6 +1346,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         tcx: TyCtxt<'tcx>,
         attrs: &[ast::Attribute],
         crate_span: Span,
+        current_crate_outer_attr_insert_span: Span,
         arenas: &'a ResolverArenas<'a>,
     ) -> Resolver<'a, 'tcx> {
         let root_def_id = CRATE_DEF_ID.to_def_id();
@@ -1525,6 +1530,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             glob_delegation_invoc_ids: Default::default(),
             impl_unexpanded_invocations: Default::default(),
             impl_binding_keys: Default::default(),
+            current_crate_outer_attr_insert_span,
         };
 
         let root_parent_scope = ParentScope::module(graph_root, &resolver);

--- a/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `inner`
 LL |     pub use inner::S;
    |             ^^^^^ you might be missing crate `inner`
    |
-   = help: consider adding `extern crate inner` to use the `inner` crate
+help: consider importing the `inner` crate
+   |
+LL + extern crate inner;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.stderr
+++ b/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.stderr
@@ -4,7 +4,10 @@ error[E0433]: failed to resolve: you might be missing crate `unresolved_crate`
 LL | use unresolved_crate::module::Name;
    |     ^^^^^^^^^^^^^^^^ you might be missing crate `unresolved_crate`
    |
-   = help: consider adding `extern crate unresolved_crate` to use the `unresolved_crate` crate
+help: consider importing the `unresolved_crate` crate
+   |
+LL + extern crate unresolved_crate;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/issues/issue-61732.stderr
+++ b/tests/rustdoc-ui/issues/issue-61732.stderr
@@ -4,7 +4,10 @@ error[E0433]: failed to resolve: you might be missing crate `r#mod`
 LL | pub(in crate::r#mod) fn main() {}
    |               ^^^^^ you might be missing crate `r#mod`
    |
-   = help: consider adding `extern crate r#mod` to use the `r#mod` crate
+help: consider importing the `r#mod` crate
+   |
+LL + extern crate r#mod;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/attributes/field-attributes-vis-unresolved.stderr
+++ b/tests/ui/attributes/field-attributes-vis-unresolved.stderr
@@ -4,7 +4,10 @@ error[E0433]: failed to resolve: you might be missing crate `nonexistent`
 LL |     pub(in nonexistent) field: u8
    |            ^^^^^^^^^^^ you might be missing crate `nonexistent`
    |
-   = help: consider adding `extern crate nonexistent` to use the `nonexistent` crate
+help: consider importing the `nonexistent` crate
+   |
+LL + extern crate nonexistent;
+   |
 
 error[E0433]: failed to resolve: you might be missing crate `nonexistent`
   --> $DIR/field-attributes-vis-unresolved.rs:22:12
@@ -12,7 +15,10 @@ error[E0433]: failed to resolve: you might be missing crate `nonexistent`
 LL |     pub(in nonexistent) u8
    |            ^^^^^^^^^^^ you might be missing crate `nonexistent`
    |
-   = help: consider adding `extern crate nonexistent` to use the `nonexistent` crate
+help: consider importing the `nonexistent` crate
+   |
+LL + extern crate nonexistent;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0432.stderr
+++ b/tests/ui/error-codes/E0432.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `something`
 LL | use something::Foo;
    |     ^^^^^^^^^ you might be missing crate `something`
    |
-   = help: consider adding `extern crate something` to use the `something` crate
+help: consider importing the `something` crate
+   |
+LL + extern crate something;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/import-from-missing-star-2.stderr
+++ b/tests/ui/imports/import-from-missing-star-2.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `spam`
 LL |     use spam::*;
    |         ^^^^ you might be missing crate `spam`
    |
-   = help: consider adding `extern crate spam` to use the `spam` crate
+help: consider importing the `spam` crate
+   |
+LL + extern crate spam;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/import-from-missing-star-3.stderr
+++ b/tests/ui/imports/import-from-missing-star-3.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `spam`
 LL |     use spam::*;
    |         ^^^^ you might be missing crate `spam`
    |
-   = help: consider adding `extern crate spam` to use the `spam` crate
+help: consider importing the `spam` crate
+   |
+LL + extern crate spam;
+   |
 
 error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star-3.rs:27:13
@@ -12,7 +15,10 @@ error[E0432]: unresolved import `spam`
 LL |         use spam::*;
    |             ^^^^ you might be missing crate `spam`
    |
-   = help: consider adding `extern crate spam` to use the `spam` crate
+help: consider importing the `spam` crate
+   |
+LL + extern crate spam;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/imports/import-from-missing-star.stderr
+++ b/tests/ui/imports/import-from-missing-star.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `spam`
 LL | use spam::*;
    |     ^^^^ you might be missing crate `spam`
    |
-   = help: consider adding `extern crate spam` to use the `spam` crate
+help: consider importing the `spam` crate
+   |
+LL + extern crate spam;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/import3.stderr
+++ b/tests/ui/imports/import3.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `main`
 LL | use main::bar;
    |     ^^^^ you might be missing crate `main`
    |
-   = help: consider adding `extern crate main` to use the `main` crate
+help: consider importing the `main` crate
+   |
+LL + extern crate main;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-109343.stderr
+++ b/tests/ui/imports/issue-109343.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `unresolved`
 LL | pub use unresolved::f;
    |         ^^^^^^^^^^ you might be missing crate `unresolved`
    |
-   = help: consider adding `extern crate unresolved` to use the `unresolved` crate
+help: consider importing the `unresolved` crate
+   |
+LL + extern crate unresolved;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-1697.rs
+++ b/tests/ui/imports/issue-1697.rs
@@ -3,6 +3,6 @@
 use unresolved::*;
 //~^ ERROR unresolved import `unresolved` [E0432]
 //~| NOTE you might be missing crate `unresolved`
-//~| HELP consider adding `extern crate unresolved` to use the `unresolved` crate
+//~| HELP consider importing the `unresolved` crate
 
 fn main() {}

--- a/tests/ui/imports/issue-1697.stderr
+++ b/tests/ui/imports/issue-1697.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `unresolved`
 LL | use unresolved::*;
    |     ^^^^^^^^^^ you might be missing crate `unresolved`
    |
-   = help: consider adding `extern crate unresolved` to use the `unresolved` crate
+help: consider importing the `unresolved` crate
+   |
+LL + extern crate unresolved;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-33464.stderr
+++ b/tests/ui/imports/issue-33464.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `abc`
 LL | use abc::one_el;
    |     ^^^ you might be missing crate `abc`
    |
-   = help: consider adding `extern crate abc` to use the `abc` crate
+help: consider importing the `abc` crate
+   |
+LL + extern crate abc;
+   |
 
 error[E0432]: unresolved import `abc`
   --> $DIR/issue-33464.rs:5:5
@@ -12,7 +15,10 @@ error[E0432]: unresolved import `abc`
 LL | use abc::{a, bbb, cccccc};
    |     ^^^ you might be missing crate `abc`
    |
-   = help: consider adding `extern crate abc` to use the `abc` crate
+help: consider importing the `abc` crate
+   |
+LL + extern crate abc;
+   |
 
 error[E0432]: unresolved import `a_very_long_name`
   --> $DIR/issue-33464.rs:7:5
@@ -20,7 +26,10 @@ error[E0432]: unresolved import `a_very_long_name`
 LL | use a_very_long_name::{el, el2};
    |     ^^^^^^^^^^^^^^^^ you might be missing crate `a_very_long_name`
    |
-   = help: consider adding `extern crate a_very_long_name` to use the `a_very_long_name` crate
+help: consider importing the `a_very_long_name` crate
+   |
+LL + extern crate a_very_long_name;
+   |
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/imports/issue-36881.stderr
+++ b/tests/ui/imports/issue-36881.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `issue_36881_aux`
 LL |     use issue_36881_aux::Foo;
    |         ^^^^^^^^^^^^^^^ you might be missing crate `issue_36881_aux`
    |
-   = help: consider adding `extern crate issue_36881_aux` to use the `issue_36881_aux` crate
+help: consider importing the `issue_36881_aux` crate
+   |
+LL + extern crate issue_36881_aux;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/issue-37887.stderr
+++ b/tests/ui/imports/issue-37887.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `test`
 LL |     use test::*;
    |         ^^^^ you might be missing crate `test`
    |
-   = help: consider adding `extern crate test` to use the `test` crate
+help: consider importing the `test` crate
+   |
+LL + extern crate test;
+   |
 
 error[E0658]: use of unstable library feature 'test'
   --> $DIR/issue-37887.rs:2:5

--- a/tests/ui/imports/issue-53269.stderr
+++ b/tests/ui/imports/issue-53269.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `nonexistent_module`
 LL |     use nonexistent_module::mac;
    |         ^^^^^^^^^^^^^^^^^^ you might be missing crate `nonexistent_module`
    |
-   = help: consider adding `extern crate nonexistent_module` to use the `nonexistent_module` crate
+help: consider importing the `nonexistent_module` crate
+   |
+LL + extern crate nonexistent_module;
+   |
 
 error[E0659]: `mac` is ambiguous
   --> $DIR/issue-53269.rs:8:5

--- a/tests/ui/imports/issue-55457.stderr
+++ b/tests/ui/imports/issue-55457.stderr
@@ -13,7 +13,10 @@ error[E0432]: unresolved import `non_existent`
 LL | use non_existent::non_existent;
    |     ^^^^^^^^^^^^ you might be missing crate `non_existent`
    |
-   = help: consider adding `extern crate non_existent` to use the `non_existent` crate
+help: consider importing the `non_existent` crate
+   |
+LL + extern crate non_existent;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/imports/issue-81413.stderr
+++ b/tests/ui/imports/issue-81413.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `doesnt_exist`
 LL | pub use doesnt_exist::*;
    |         ^^^^^^^^^^^^ you might be missing crate `doesnt_exist`
    |
-   = help: consider adding `extern crate doesnt_exist` to use the `doesnt_exist` crate
+help: consider importing the `doesnt_exist` crate
+   |
+LL + extern crate doesnt_exist;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/tool-mod-child.stderr
+++ b/tests/ui/imports/tool-mod-child.stderr
@@ -4,7 +4,10 @@ error[E0433]: failed to resolve: you might be missing crate `clippy`
 LL | use clippy::a::b;
    |     ^^^^^^ you might be missing crate `clippy`
    |
-   = help: consider adding `extern crate clippy` to use the `clippy` crate
+help: consider importing the `clippy` crate
+   |
+LL + extern crate clippy;
+   |
 
 error[E0432]: unresolved import `clippy`
   --> $DIR/tool-mod-child.rs:1:5
@@ -12,7 +15,10 @@ error[E0432]: unresolved import `clippy`
 LL | use clippy::a;
    |     ^^^^^^ you might be missing crate `clippy`
    |
-   = help: consider adding `extern crate clippy` to use the `clippy` crate
+help: consider importing the `clippy` crate
+   |
+LL + extern crate clippy;
+   |
 
 error[E0433]: failed to resolve: you might be missing crate `rustdoc`
   --> $DIR/tool-mod-child.rs:5:5
@@ -20,7 +26,10 @@ error[E0433]: failed to resolve: you might be missing crate `rustdoc`
 LL | use rustdoc::a::b;
    |     ^^^^^^^ you might be missing crate `rustdoc`
    |
-   = help: consider adding `extern crate rustdoc` to use the `rustdoc` crate
+help: consider importing the `rustdoc` crate
+   |
+LL + extern crate rustdoc;
+   |
 
 error[E0432]: unresolved import `rustdoc`
   --> $DIR/tool-mod-child.rs:4:5
@@ -28,7 +37,10 @@ error[E0432]: unresolved import `rustdoc`
 LL | use rustdoc::a;
    |     ^^^^^^^ you might be missing crate `rustdoc`
    |
-   = help: consider adding `extern crate rustdoc` to use the `rustdoc` crate
+help: consider importing the `rustdoc` crate
+   |
+LL + extern crate rustdoc;
+   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/imports/unresolved-imports-used.stderr
+++ b/tests/ui/imports/unresolved-imports-used.stderr
@@ -16,7 +16,10 @@ error[E0432]: unresolved import `foo`
 LL | use foo::bar;
    |     ^^^ you might be missing crate `foo`
    |
-   = help: consider adding `extern crate foo` to use the `foo` crate
+help: consider importing the `foo` crate
+   |
+LL + extern crate foo;
+   |
 
 error[E0432]: unresolved import `baz`
   --> $DIR/unresolved-imports-used.rs:12:5
@@ -24,7 +27,10 @@ error[E0432]: unresolved import `baz`
 LL | use baz::*;
    |     ^^^ you might be missing crate `baz`
    |
-   = help: consider adding `extern crate baz` to use the `baz` crate
+help: consider importing the `baz` crate
+   |
+LL + extern crate baz;
+   |
 
 error[E0432]: unresolved import `foo2`
   --> $DIR/unresolved-imports-used.rs:14:5
@@ -32,7 +38,10 @@ error[E0432]: unresolved import `foo2`
 LL | use foo2::bar2;
    |     ^^^^ you might be missing crate `foo2`
    |
-   = help: consider adding `extern crate foo2` to use the `foo2` crate
+help: consider importing the `foo2` crate
+   |
+LL + extern crate foo2;
+   |
 
 error[E0432]: unresolved import `baz2`
   --> $DIR/unresolved-imports-used.rs:15:5
@@ -40,7 +49,10 @@ error[E0432]: unresolved import `baz2`
 LL | use baz2::*;
    |     ^^^^ you might be missing crate `baz2`
    |
-   = help: consider adding `extern crate baz2` to use the `baz2` crate
+help: consider importing the `baz2` crate
+   |
+LL + extern crate baz2;
+   |
 
 error[E0603]: function `quz` is private
   --> $DIR/unresolved-imports-used.rs:9:10

--- a/tests/ui/keyword/extern/keyword-extern-as-identifier-use.stderr
+++ b/tests/ui/keyword/extern/keyword-extern-as-identifier-use.stderr
@@ -15,7 +15,10 @@ error[E0432]: unresolved import `r#extern`
 LL | use extern::foo;
    |     ^^^^^^ you might be missing crate `r#extern`
    |
-   = help: consider adding `extern crate r#extern` to use the `r#extern` crate
+help: consider importing the `r#extern` crate
+   |
+LL + extern crate r#extern;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/privacy/restricted/test.stderr
+++ b/tests/ui/privacy/restricted/test.stderr
@@ -4,7 +4,10 @@ error[E0433]: failed to resolve: you might be missing crate `bad`
 LL |     pub(in bad::path) mod m1 {}
    |            ^^^ you might be missing crate `bad`
    |
-   = help: consider adding `extern crate bad` to use the `bad` crate
+help: consider importing the `bad` crate
+   |
+LL + extern crate bad;
+   |
 
 error[E0742]: visibilities can only be restricted to ancestor modules
   --> $DIR/test.rs:51:12

--- a/tests/ui/resolve/editions-crate-root-2015.stderr
+++ b/tests/ui/resolve/editions-crate-root-2015.stderr
@@ -4,7 +4,10 @@ error[E0433]: failed to resolve: you might be missing crate `nonexistant`
 LL |     fn global_inner(_: ::nonexistant::Foo) {
    |                          ^^^^^^^^^^^ you might be missing crate `nonexistant`
    |
-   = help: consider adding `extern crate nonexistant` to use the `nonexistant` crate
+help: consider importing the `nonexistant` crate
+   |
+LL + extern crate nonexistant;
+   |
 
 error[E0433]: failed to resolve: you might be missing crate `nonexistant`
   --> $DIR/editions-crate-root-2015.rs:7:30
@@ -12,7 +15,10 @@ error[E0433]: failed to resolve: you might be missing crate `nonexistant`
 LL |     fn crate_inner(_: crate::nonexistant::Foo) {
    |                              ^^^^^^^^^^^ you might be missing crate `nonexistant`
    |
-   = help: consider adding `extern crate nonexistant` to use the `nonexistant` crate
+help: consider importing the `nonexistant` crate
+   |
+LL + extern crate nonexistant;
+   |
 
 error[E0412]: cannot find type `nonexistant` in the crate root
   --> $DIR/editions-crate-root-2015.rs:11:25

--- a/tests/ui/resolve/extern-prelude-fail.stderr
+++ b/tests/ui/resolve/extern-prelude-fail.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `extern_prelude`
 LL |     use extern_prelude::S;
    |         ^^^^^^^^^^^^^^ you might be missing crate `extern_prelude`
    |
-   = help: consider adding `extern crate extern_prelude` to use the `extern_prelude` crate
+help: consider importing the `extern_prelude` crate
+   |
+LL + extern crate extern_prelude;
+   |
 
 error[E0433]: failed to resolve: you might be missing crate `extern_prelude`
   --> $DIR/extern-prelude-fail.rs:8:15
@@ -12,7 +15,10 @@ error[E0433]: failed to resolve: you might be missing crate `extern_prelude`
 LL |     let s = ::extern_prelude::S;
    |               ^^^^^^^^^^^^^^ you might be missing crate `extern_prelude`
    |
-   = help: consider adding `extern crate extern_prelude` to use the `extern_prelude` crate
+help: consider importing the `extern_prelude` crate
+   |
+LL + extern crate extern_prelude;
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/issue-82865.stderr
+++ b/tests/ui/resolve/issue-82865.stderr
@@ -4,7 +4,10 @@ error[E0433]: failed to resolve: you might be missing crate `x`
 LL | use x::y::z;
    |     ^ you might be missing crate `x`
    |
-   = help: consider adding `extern crate x` to use the `x` crate
+help: consider importing the `x` crate
+   |
+LL + extern crate x;
+   |
 
 error[E0599]: no function or associated item named `z` found for struct `Box<_, _>` in the current scope
   --> $DIR/issue-82865.rs:8:10

--- a/tests/ui/resolve/resolve-bad-visibility.stderr
+++ b/tests/ui/resolve/resolve-bad-visibility.stderr
@@ -22,7 +22,10 @@ error[E0433]: failed to resolve: you might be missing crate `nonexistent`
 LL | pub(in nonexistent) struct G;
    |        ^^^^^^^^^^^ you might be missing crate `nonexistent`
    |
-   = help: consider adding `extern crate nonexistent` to use the `nonexistent` crate
+help: consider importing the `nonexistent` crate
+   |
+LL + extern crate nonexistent;
+   |
 
 error[E0433]: failed to resolve: you might be missing crate `too_soon`
   --> $DIR/resolve-bad-visibility.rs:8:8
@@ -30,7 +33,10 @@ error[E0433]: failed to resolve: you might be missing crate `too_soon`
 LL | pub(in too_soon) struct H;
    |        ^^^^^^^^ you might be missing crate `too_soon`
    |
-   = help: consider adding `extern crate too_soon` to use the `too_soon` crate
+help: consider importing the `too_soon` crate
+   |
+LL + extern crate too_soon;
+   |
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/underscore-imports/issue-110164.stderr
+++ b/tests/ui/underscore-imports/issue-110164.stderr
@@ -38,33 +38,25 @@ error[E0432]: unresolved import `_`
   --> $DIR/issue-110164.rs:8:5
    |
 LL | use _::*;
-   |     ^ you might be missing crate `_`
-   |
-   = help: consider adding `extern crate _` to use the `_` crate
+   |     ^ `_` is not a valid crate or module name
 
 error[E0432]: unresolved import `_`
   --> $DIR/issue-110164.rs:5:5
    |
 LL | use _::a;
-   |     ^ you might be missing crate `_`
-   |
-   = help: consider adding `extern crate _` to use the `_` crate
+   |     ^ `_` is not a valid crate or module name
 
 error[E0432]: unresolved import `_`
   --> $DIR/issue-110164.rs:13:9
    |
 LL |     use _::a;
-   |         ^ you might be missing crate `_`
-   |
-   = help: consider adding `extern crate _` to use the `_` crate
+   |         ^ `_` is not a valid crate or module name
 
 error[E0432]: unresolved import `_`
   --> $DIR/issue-110164.rs:16:9
    |
 LL |     use _::*;
-   |         ^ you might be missing crate `_`
-   |
-   = help: consider adding `extern crate _` to use the `_` crate
+   |         ^ `_` is not a valid crate or module name
 
 error: aborting due to 10 previous errors
 

--- a/tests/ui/unresolved/unresolved-asterisk-imports.stderr
+++ b/tests/ui/unresolved/unresolved-asterisk-imports.stderr
@@ -4,7 +4,10 @@ error[E0432]: unresolved import `not_existing_crate`
 LL | use not_existing_crate::*;
    |     ^^^^^^^^^^^^^^^^^^ you might be missing crate `not_existing_crate`
    |
-   = help: consider adding `extern crate not_existing_crate` to use the `not_existing_crate` crate
+help: consider importing the `not_existing_crate` crate
+   |
+LL + extern crate not_existing_crate;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/unresolved/unresolved-import.rs
+++ b/tests/ui/unresolved/unresolved-import.rs
@@ -1,7 +1,8 @@
 use foo::bar;
 //~^ ERROR unresolved import `foo` [E0432]
 //~| NOTE you might be missing crate `foo`
-//~| HELP consider adding `extern crate foo` to use the `foo` crate
+//~| HELP consider importing the `foo` crate
+//~| SUGGESTION extern crate foo;
 
 use bar::Baz as x;
 //~^ ERROR unresolved import `bar::Baz` [E0432]

--- a/tests/ui/unresolved/unresolved-import.stderr
+++ b/tests/ui/unresolved/unresolved-import.stderr
@@ -4,10 +4,13 @@ error[E0432]: unresolved import `foo`
 LL | use foo::bar;
    |     ^^^ you might be missing crate `foo`
    |
-   = help: consider adding `extern crate foo` to use the `foo` crate
+help: consider importing the `foo` crate
+   |
+LL + extern crate foo;
+   |
 
 error[E0432]: unresolved import `bar::Baz`
-  --> $DIR/unresolved-import.rs:6:5
+  --> $DIR/unresolved-import.rs:7:5
    |
 LL | use bar::Baz as x;
    |     ^^^^^---^^^^^
@@ -16,7 +19,7 @@ LL | use bar::Baz as x;
    |     no `Baz` in `bar`
 
 error[E0432]: unresolved import `food::baz`
-  --> $DIR/unresolved-import.rs:12:5
+  --> $DIR/unresolved-import.rs:13:5
    |
 LL | use food::baz;
    |     ^^^^^^---
@@ -25,7 +28,7 @@ LL | use food::baz;
    |     no `baz` in `food`
 
 error[E0432]: unresolved import `food::beens`
-  --> $DIR/unresolved-import.rs:18:12
+  --> $DIR/unresolved-import.rs:19:12
    |
 LL | use food::{beens as Foo};
    |            -----^^^^^^^
@@ -34,13 +37,13 @@ LL | use food::{beens as Foo};
    |            help: a similar name exists in the module: `beans`
 
 error[E0432]: unresolved import `MyEnum`
-  --> $DIR/unresolved-import.rs:43:9
+  --> $DIR/unresolved-import.rs:44:9
    |
 LL |     use MyEnum::*;
    |         ^^^^^^ help: a similar path exists: `self::MyEnum`
 
 error[E0432]: unresolved import `Enum`
-  --> $DIR/unresolved-import.rs:54:9
+  --> $DIR/unresolved-import.rs:55:9
    |
 LL |     use Enum::*;
    |         ^^^^ help: a similar path exists: `self::Enum`


### PR DESCRIPTION
When encountering a name in an import that could have come from a crate that wasn't imported, use a structured suggestion to suggest `extern crate foo;` pointing at the right place in the crate.

When encountering `_` in an import, do not suggest `extern crate _;`.

```
error[E0432]: unresolved import `spam`
  --> $DIR/import-from-missing-star-3.rs:2:9
   |
LL |     use spam::*;
   |         ^^^^ maybe a missing crate `spam`?
   |
help: consider importing the `spam` crate
   |
LL + extern crate spam;
   |
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
