### PR TITLE
Stop using `MoveDataParamEnv` for places that don't need a param-env

### DIFF
--- a/compiler/rustc_mir_dataflow/src/drop_flag_effects.rs
+++ b/compiler/rustc_mir_dataflow/src/drop_flag_effects.rs
@@ -3,7 +3,6 @@ use rustc_target::abi::VariantIdx;
 use tracing::debug;
 
 use super::move_paths::{InitKind, LookupResult, MoveData, MovePathIndex};
-use super::MoveDataParamEnv;
 use crate::elaborate_drops::DropFlagState;
 
 pub fn move_path_children_matching<'tcx, F>(
@@ -70,12 +69,11 @@ pub fn on_all_children_bits<'tcx, F>(
 
 pub fn drop_flag_effects_for_function_entry<'tcx, F>(
     body: &Body<'tcx>,
-    ctxt: &MoveDataParamEnv<'tcx>,
+    move_data: &MoveData<'tcx>,
     mut callback: F,
 ) where
     F: FnMut(MovePathIndex, DropFlagState),
 {
-    let move_data = &ctxt.move_data;
     for arg in body.args_iter() {
         let place = mir::Place::from(arg);
         let lookup_result = move_data.rev_lookup.find(place.as_ref());
@@ -87,13 +85,12 @@ pub fn drop_flag_effects_for_function_entry<'tcx, F>(
 
 pub fn drop_flag_effects_for_location<'tcx, F>(
     body: &Body<'tcx>,
-    ctxt: &MoveDataParamEnv<'tcx>,
+    move_data: &MoveData<'tcx>,
     loc: Location,
     mut callback: F,
 ) where
     F: FnMut(MovePathIndex, DropFlagState),
 {
-    let move_data = &ctxt.move_data;
     debug!("drop_flag_effects_for_location({:?})", loc);
 
     // first, move out of the RHS

--- a/compiler/rustc_mir_dataflow/src/impls/initialized.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/initialized.rs
@@ -11,7 +11,7 @@ use crate::move_paths::{HasMoveData, InitIndex, InitKind, LookupResult, MoveData
 use crate::{
     drop_flag_effects, drop_flag_effects_for_function_entry, drop_flag_effects_for_location,
     lattice, on_all_children_bits, on_lookup_result_bits, AnalysisDomain, GenKill, GenKillAnalysis,
-    MaybeReachable, MoveDataParamEnv,
+    MaybeReachable,
 };
 
 /// `MaybeInitializedPlaces` tracks all places that might be
@@ -52,17 +52,13 @@ use crate::{
 pub struct MaybeInitializedPlaces<'a, 'mir, 'tcx> {
     tcx: TyCtxt<'tcx>,
     body: &'mir Body<'tcx>,
-    mdpe: &'a MoveDataParamEnv<'tcx>,
+    move_data: &'a MoveData<'tcx>,
     skip_unreachable_unwind: bool,
 }
 
 impl<'a, 'mir, 'tcx> MaybeInitializedPlaces<'a, 'mir, 'tcx> {
-    pub fn new(
-        tcx: TyCtxt<'tcx>,
-        body: &'mir Body<'tcx>,
-        mdpe: &'a MoveDataParamEnv<'tcx>,
-    ) -> Self {
-        MaybeInitializedPlaces { tcx, body, mdpe, skip_unreachable_unwind: false }
+    pub fn new(tcx: TyCtxt<'tcx>, body: &'mir Body<'tcx>, move_data: &'a MoveData<'tcx>) -> Self {
+        MaybeInitializedPlaces { tcx, body, move_data, skip_unreachable_unwind: false }
     }
 
     pub fn skipping_unreachable_unwind(mut self) -> Self {
@@ -89,7 +85,7 @@ impl<'a, 'mir, 'tcx> MaybeInitializedPlaces<'a, 'mir, 'tcx> {
 
 impl<'a, 'mir, 'tcx> HasMoveData<'tcx> for MaybeInitializedPlaces<'a, 'mir, 'tcx> {
     fn move_data(&self) -> &MoveData<'tcx> {
-        &self.mdpe.move_data
+        self.move_data
     }
 }
 
@@ -131,22 +127,18 @@ impl<'a, 'mir, 'tcx> HasMoveData<'tcx> for MaybeInitializedPlaces<'a, 'mir, 'tcx
 pub struct MaybeUninitializedPlaces<'a, 'mir, 'tcx> {
     tcx: TyCtxt<'tcx>,
     body: &'mir Body<'tcx>,
-    mdpe: &'a MoveDataParamEnv<'tcx>,
+    move_data: &'a MoveData<'tcx>,
 
     mark_inactive_variants_as_uninit: bool,
     skip_unreachable_unwind: BitSet<mir::BasicBlock>,
 }
 
 impl<'a, 'mir, 'tcx> MaybeUninitializedPlaces<'a, 'mir, 'tcx> {
-    pub fn new(
-        tcx: TyCtxt<'tcx>,
-        body: &'mir Body<'tcx>,
-        mdpe: &'a MoveDataParamEnv<'tcx>,
-    ) -> Self {
+    pub fn new(tcx: TyCtxt<'tcx>, body: &'mir Body<'tcx>, move_data: &'a MoveData<'tcx>) -> Self {
         MaybeUninitializedPlaces {
             tcx,
             body,
-            mdpe,
+            move_data,
             mark_inactive_variants_as_uninit: false,
             skip_unreachable_unwind: BitSet::new_empty(body.basic_blocks.len()),
         }
@@ -173,7 +165,7 @@ impl<'a, 'mir, 'tcx> MaybeUninitializedPlaces<'a, 'mir, 'tcx> {
 
 impl<'a, 'tcx> HasMoveData<'tcx> for MaybeUninitializedPlaces<'a, '_, 'tcx> {
     fn move_data(&self) -> &MoveData<'tcx> {
-        &self.mdpe.move_data
+        self.move_data
     }
 }
 
@@ -213,18 +205,18 @@ impl<'a, 'tcx> HasMoveData<'tcx> for MaybeUninitializedPlaces<'a, '_, 'tcx> {
 /// that would require a dynamic drop-flag at that statement.
 pub struct DefinitelyInitializedPlaces<'a, 'tcx> {
     body: &'a Body<'tcx>,
-    mdpe: &'a MoveDataParamEnv<'tcx>,
+    move_data: &'a MoveData<'tcx>,
 }
 
 impl<'a, 'tcx> DefinitelyInitializedPlaces<'a, 'tcx> {
-    pub fn new(body: &'a Body<'tcx>, mdpe: &'a MoveDataParamEnv<'tcx>) -> Self {
-        DefinitelyInitializedPlaces { body, mdpe }
+    pub fn new(body: &'a Body<'tcx>, move_data: &'a MoveData<'tcx>) -> Self {
+        DefinitelyInitializedPlaces { body, move_data }
     }
 }
 
 impl<'a, 'tcx> HasMoveData<'tcx> for DefinitelyInitializedPlaces<'a, 'tcx> {
     fn move_data(&self) -> &MoveData<'tcx> {
-        &self.mdpe.move_data
+        self.move_data
     }
 }
 
@@ -259,18 +251,18 @@ impl<'a, 'tcx> HasMoveData<'tcx> for DefinitelyInitializedPlaces<'a, 'tcx> {
 /// ```
 pub struct EverInitializedPlaces<'a, 'mir, 'tcx> {
     body: &'mir Body<'tcx>,
-    mdpe: &'a MoveDataParamEnv<'tcx>,
+    move_data: &'a MoveData<'tcx>,
 }
 
 impl<'a, 'mir, 'tcx> EverInitializedPlaces<'a, 'mir, 'tcx> {
-    pub fn new(body: &'mir Body<'tcx>, mdpe: &'a MoveDataParamEnv<'tcx>) -> Self {
-        EverInitializedPlaces { body, mdpe }
+    pub fn new(body: &'mir Body<'tcx>, move_data: &'a MoveData<'tcx>) -> Self {
+        EverInitializedPlaces { body, move_data }
     }
 }
 
 impl<'a, 'tcx> HasMoveData<'tcx> for EverInitializedPlaces<'a, '_, 'tcx> {
     fn move_data(&self) -> &MoveData<'tcx> {
-        &self.mdpe.move_data
+        self.move_data
     }
 }
 
@@ -328,7 +320,7 @@ impl<'tcx> AnalysisDomain<'tcx> for MaybeInitializedPlaces<'_, '_, 'tcx> {
     fn initialize_start_block(&self, _: &mir::Body<'tcx>, state: &mut Self::Domain) {
         *state =
             MaybeReachable::Reachable(ChunkedBitSet::new_empty(self.move_data().move_paths.len()));
-        drop_flag_effects_for_function_entry(self.body, self.mdpe, |path, s| {
+        drop_flag_effects_for_function_entry(self.body, self.move_data, |path, s| {
             assert!(s == DropFlagState::Present);
             state.gen_(path);
         });
@@ -348,7 +340,7 @@ impl<'tcx> GenKillAnalysis<'tcx> for MaybeInitializedPlaces<'_, '_, 'tcx> {
         statement: &mir::Statement<'tcx>,
         location: Location,
     ) {
-        drop_flag_effects_for_location(self.body, self.mdpe, location, |path, s| {
+        drop_flag_effects_for_location(self.body, self.move_data, location, |path, s| {
             Self::update_bits(trans, path, s)
         });
 
@@ -380,7 +372,7 @@ impl<'tcx> GenKillAnalysis<'tcx> for MaybeInitializedPlaces<'_, '_, 'tcx> {
         {
             edges = TerminatorEdges::Single(target);
         }
-        drop_flag_effects_for_location(self.body, self.mdpe, location, |path, s| {
+        drop_flag_effects_for_location(self.body, self.move_data, location, |path, s| {
             Self::update_bits(state, path, s)
         });
         edges
@@ -465,7 +457,7 @@ impl<'tcx> AnalysisDomain<'tcx> for MaybeUninitializedPlaces<'_, '_, 'tcx> {
         // set all bits to 1 (uninit) before gathering counter-evidence
         state.insert_all();
 
-        drop_flag_effects_for_function_entry(self.body, self.mdpe, |path, s| {
+        drop_flag_effects_for_function_entry(self.body, self.move_data, |path, s| {
             assert!(s == DropFlagState::Present);
             state.remove(path);
         });
@@ -485,7 +477,7 @@ impl<'tcx> GenKillAnalysis<'tcx> for MaybeUninitializedPlaces<'_, '_, 'tcx> {
         _statement: &mir::Statement<'tcx>,
         location: Location,
     ) {
-        drop_flag_effects_for_location(self.body, self.mdpe, location, |path, s| {
+        drop_flag_effects_for_location(self.body, self.move_data, location, |path, s| {
             Self::update_bits(trans, path, s)
         });
 
@@ -499,7 +491,7 @@ impl<'tcx> GenKillAnalysis<'tcx> for MaybeUninitializedPlaces<'_, '_, 'tcx> {
         terminator: &'mir mir::Terminator<'tcx>,
         location: Location,
     ) -> TerminatorEdges<'mir, 'tcx> {
-        drop_flag_effects_for_location(self.body, self.mdpe, location, |path, s| {
+        drop_flag_effects_for_location(self.body, self.move_data, location, |path, s| {
             Self::update_bits(trans, path, s)
         });
         if self.skip_unreachable_unwind.contains(location.block) {
@@ -592,7 +584,7 @@ impl<'a, 'tcx> AnalysisDomain<'tcx> for DefinitelyInitializedPlaces<'a, 'tcx> {
     fn initialize_start_block(&self, _: &mir::Body<'tcx>, state: &mut Self::Domain) {
         state.0.clear();
 
-        drop_flag_effects_for_function_entry(self.body, self.mdpe, |path, s| {
+        drop_flag_effects_for_function_entry(self.body, self.move_data, |path, s| {
             assert!(s == DropFlagState::Present);
             state.0.insert(path);
         });
@@ -612,7 +604,7 @@ impl<'tcx> GenKillAnalysis<'tcx> for DefinitelyInitializedPlaces<'_, 'tcx> {
         _statement: &mir::Statement<'tcx>,
         location: Location,
     ) {
-        drop_flag_effects_for_location(self.body, self.mdpe, location, |path, s| {
+        drop_flag_effects_for_location(self.body, self.move_data, location, |path, s| {
             Self::update_bits(trans, path, s)
         })
     }
@@ -623,7 +615,7 @@ impl<'tcx> GenKillAnalysis<'tcx> for DefinitelyInitializedPlaces<'_, 'tcx> {
         terminator: &'mir mir::Terminator<'tcx>,
         location: Location,
     ) -> TerminatorEdges<'mir, 'tcx> {
-        drop_flag_effects_for_location(self.body, self.mdpe, location, |path, s| {
+        drop_flag_effects_for_location(self.body, self.move_data, location, |path, s| {
             Self::update_bits(trans, path, s)
         });
         terminator.edges()

--- a/compiler/rustc_mir_dataflow/src/rustc_peek.rs
+++ b/compiler/rustc_mir_dataflow/src/rustc_peek.rs
@@ -16,7 +16,7 @@ use crate::impls::{
     DefinitelyInitializedPlaces, MaybeInitializedPlaces, MaybeLiveLocals, MaybeUninitializedPlaces,
 };
 use crate::move_paths::{HasMoveData, LookupResult, MoveData, MovePathIndex};
-use crate::{Analysis, JoinSemiLattice, MoveDataParamEnv, ResultsCursor};
+use crate::{Analysis, JoinSemiLattice, ResultsCursor};
 
 pub struct SanityCheck;
 
@@ -46,10 +46,9 @@ impl<'tcx> MirPass<'tcx> for SanityCheck {
 
         let param_env = tcx.param_env(def_id);
         let move_data = MoveData::gather_moves(body, tcx, param_env, |_| true);
-        let mdpe = MoveDataParamEnv { move_data, param_env };
 
         if has_rustc_mir_with(tcx, def_id, sym::rustc_peek_maybe_init).is_some() {
-            let flow_inits = MaybeInitializedPlaces::new(tcx, body, &mdpe)
+            let flow_inits = MaybeInitializedPlaces::new(tcx, body, &move_data)
                 .into_engine(tcx, body)
                 .iterate_to_fixpoint();
 
@@ -57,7 +56,7 @@ impl<'tcx> MirPass<'tcx> for SanityCheck {
         }
 
         if has_rustc_mir_with(tcx, def_id, sym::rustc_peek_maybe_uninit).is_some() {
-            let flow_uninits = MaybeUninitializedPlaces::new(tcx, body, &mdpe)
+            let flow_uninits = MaybeUninitializedPlaces::new(tcx, body, &move_data)
                 .into_engine(tcx, body)
                 .iterate_to_fixpoint();
 
@@ -65,7 +64,7 @@ impl<'tcx> MirPass<'tcx> for SanityCheck {
         }
 
         if has_rustc_mir_with(tcx, def_id, sym::rustc_peek_definite_init).is_some() {
-            let flow_def_inits = DefinitelyInitializedPlaces::new(body, &mdpe)
+            let flow_def_inits = DefinitelyInitializedPlaces::new(body, &move_data)
                 .into_engine(tcx, body)
                 .iterate_to_fixpoint();
 

--- a/compiler/rustc_mir_transform/src/remove_uninit_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_uninit_drops.rs
@@ -3,7 +3,7 @@ use rustc_middle::mir::{Body, TerminatorKind};
 use rustc_middle::ty::{self, GenericArgsRef, ParamEnv, Ty, TyCtxt, VariantDef};
 use rustc_mir_dataflow::impls::MaybeInitializedPlaces;
 use rustc_mir_dataflow::move_paths::{LookupResult, MoveData, MovePathIndex};
-use rustc_mir_dataflow::{move_path_children_matching, Analysis, MaybeReachable, MoveDataParamEnv};
+use rustc_mir_dataflow::{move_path_children_matching, Analysis, MaybeReachable};
 use rustc_target::abi::FieldIdx;
 
 use crate::MirPass;
@@ -24,8 +24,7 @@ impl<'tcx> MirPass<'tcx> for RemoveUninitDrops {
         let move_data =
             MoveData::gather_moves(body, tcx, param_env, |ty| ty.needs_drop(tcx, param_env));
 
-        let mdpe = MoveDataParamEnv { move_data, param_env };
-        let mut maybe_inits = MaybeInitializedPlaces::new(tcx, body, &mdpe)
+        let mut maybe_inits = MaybeInitializedPlaces::new(tcx, body, &move_data)
             .into_engine(tcx, body)
             .pass_name("remove_uninit_drops")
             .iterate_to_fixpoint()
@@ -40,7 +39,7 @@ impl<'tcx> MirPass<'tcx> for RemoveUninitDrops {
             let MaybeReachable::Reachable(maybe_inits) = maybe_inits.get() else { continue };
 
             // If there's no move path for the dropped place, it's probably a `Deref`. Let it alone.
-            let LookupResult::Exact(mpi) = mdpe.move_data.rev_lookup.find(place.as_ref()) else {
+            let LookupResult::Exact(mpi) = move_data.rev_lookup.find(place.as_ref()) else {
                 continue;
             };
 
@@ -48,7 +47,7 @@ impl<'tcx> MirPass<'tcx> for RemoveUninitDrops {
                 tcx,
                 param_env,
                 maybe_inits,
-                &mdpe.move_data,
+                &move_data,
                 place.ty(body, tcx).ty,
                 mpi,
             );


### PR DESCRIPTION
I think not threading through a `ParamEnv` makes it clearer that these functions don't do anything particularly "type systems"-y.

r? cjgillot