### PR TITLE
Cleanup sys module to match house style

### DIFF
--- a/library/std/src/pipe/tests.rs
+++ b/library/std/src/pipe/tests.rs
@@ -2,6 +2,7 @@ use crate::io::{Read, Write};
 use crate::pipe::pipe;
 
 #[test]
+#[cfg(all(windows, unix, not(miri)))]
 fn pipe_creation_clone_and_rw() {
     let (rx, tx) = pipe().unwrap();
 

--- a/library/std/src/sys/anonymous_pipe/mod.rs
+++ b/library/std/src/sys/anonymous_pipe/mod.rs
@@ -1,18 +1,14 @@
+#![forbid(unsafe_op_in_unsafe_fn)]
+
 cfg_if::cfg_if! {
     if #[cfg(unix)] {
         mod unix;
-        pub(crate) use unix::{AnonPipe, pipe};
-
-        #[cfg(all(test, not(miri)))]
-        mod tests;
+        pub use unix::{AnonPipe, pipe};
     } else if #[cfg(windows)] {
         mod windows;
-        pub(crate) use windows::{AnonPipe, pipe};
-
-        #[cfg(all(test, not(miri)))]
-        mod tests;
+        pub use windows::{AnonPipe, pipe};
     } else {
         mod unsupported;
-        pub(crate) use unsupported::{AnonPipe, pipe};
+        pub use unsupported::{AnonPipe, pipe};
     }
 }

--- a/library/std/src/sys/anonymous_pipe/unix.rs
+++ b/library/std/src/sys/anonymous_pipe/unix.rs
@@ -6,10 +6,10 @@ use crate::sys::fd::FileDesc;
 use crate::sys::pipe::anon_pipe;
 use crate::sys_common::{FromInner, IntoInner};
 
-pub(crate) type AnonPipe = FileDesc;
+pub type AnonPipe = FileDesc;
 
 #[inline]
-pub(crate) fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
+pub fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     anon_pipe().map(|(rx, wx)| (rx.into_inner(), wx.into_inner()))
 }
 
@@ -34,7 +34,7 @@ impl From<PipeReader> for OwnedFd {
 #[unstable(feature = "anonymous_pipe", issue = "127154")]
 impl FromRawFd for PipeReader {
     unsafe fn from_raw_fd(raw_fd: RawFd) -> Self {
-        Self(FileDesc::from_raw_fd(raw_fd))
+        unsafe { Self(FileDesc::from_raw_fd(raw_fd)) }
     }
 }
 #[unstable(feature = "anonymous_pipe", issue = "127154")]
@@ -71,7 +71,7 @@ impl From<PipeWriter> for OwnedFd {
 #[unstable(feature = "anonymous_pipe", issue = "127154")]
 impl FromRawFd for PipeWriter {
     unsafe fn from_raw_fd(raw_fd: RawFd) -> Self {
-        Self(FileDesc::from_raw_fd(raw_fd))
+        unsafe { Self(FileDesc::from_raw_fd(raw_fd)) }
     }
 }
 #[unstable(feature = "anonymous_pipe", issue = "127154")]

--- a/library/std/src/sys/anonymous_pipe/unsupported.rs
+++ b/library/std/src/sys/anonymous_pipe/unsupported.rs
@@ -1,7 +1,7 @@
 use crate::io;
 use crate::pipe::{PipeReader, PipeWriter};
 use crate::process::Stdio;
-pub(crate) use crate::sys::pipe::AnonPipe;
+pub use crate::sys::pipe::AnonPipe;
 
 #[inline]
 pub fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {

--- a/library/std/src/sys/anonymous_pipe/unsupported.rs
+++ b/library/std/src/sys/anonymous_pipe/unsupported.rs
@@ -4,7 +4,7 @@ use crate::process::Stdio;
 pub(crate) use crate::sys::pipe::AnonPipe;
 
 #[inline]
-pub(crate) fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
+pub fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     Err(io::Error::UNSUPPORTED_PLATFORM)
 }
 

--- a/library/std/src/sys/anonymous_pipe/windows.rs
+++ b/library/std/src/sys/anonymous_pipe/windows.rs
@@ -1,18 +1,26 @@
-use crate::io;
 use crate::os::windows::io::{
     AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, IntoRawHandle, OwnedHandle, RawHandle,
 };
 use crate::pipe::{PipeReader, PipeWriter};
 use crate::process::Stdio;
+use crate::sys::c;
 use crate::sys::handle::Handle;
-use crate::sys::pipe::unnamed_anon_pipe;
 use crate::sys_common::{FromInner, IntoInner};
+use crate::{io, ptr};
 
 pub type AnonPipe = Handle;
 
-#[inline]
 pub fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
-    unnamed_anon_pipe().map(|(rx, wx)| (rx.into_inner(), wx.into_inner()))
+    let mut read_pipe = c::INVALID_HANDLE_VALUE;
+    let mut write_pipe = c::INVALID_HANDLE_VALUE;
+
+    let ret = unsafe { c::CreatePipe(&mut read_pipe, &mut write_pipe, ptr::null_mut(), 0) };
+
+    if ret == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        unsafe { Ok((Handle::from_raw_handle(read_pipe), Handle::from_raw_handle(write_pipe))) }
+    }
 }
 
 #[unstable(feature = "anonymous_pipe", issue = "127154")]

--- a/library/std/src/sys/anonymous_pipe/windows.rs
+++ b/library/std/src/sys/anonymous_pipe/windows.rs
@@ -8,10 +8,10 @@ use crate::sys::handle::Handle;
 use crate::sys::pipe::unnamed_anon_pipe;
 use crate::sys_common::{FromInner, IntoInner};
 
-pub(crate) type AnonPipe = Handle;
+pub type AnonPipe = Handle;
 
 #[inline]
-pub(crate) fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
+pub fn pipe() -> io::Result<(AnonPipe, AnonPipe)> {
     unnamed_anon_pipe().map(|(rx, wx)| (rx.into_inner(), wx.into_inner()))
 }
 
@@ -31,7 +31,7 @@ impl AsRawHandle for PipeReader {
 #[unstable(feature = "anonymous_pipe", issue = "127154")]
 impl FromRawHandle for PipeReader {
     unsafe fn from_raw_handle(raw_handle: RawHandle) -> Self {
-        Self(Handle::from_raw_handle(raw_handle))
+        unsafe { Self(Handle::from_raw_handle(raw_handle)) }
     }
 }
 #[unstable(feature = "anonymous_pipe", issue = "127154")]
@@ -70,7 +70,7 @@ impl AsRawHandle for PipeWriter {
 #[unstable(feature = "anonymous_pipe", issue = "127154")]
 impl FromRawHandle for PipeWriter {
     unsafe fn from_raw_handle(raw_handle: RawHandle) -> Self {
-        Self(Handle::from_raw_handle(raw_handle))
+        unsafe { Self(Handle::from_raw_handle(raw_handle)) }
     }
 }
 #[unstable(feature = "anonymous_pipe", issue = "127154")]

--- a/library/std/src/sys/mod.rs
+++ b/library/std/src/sys/mod.rs
@@ -7,7 +7,6 @@ mod pal;
 
 mod personality;
 
-#[unstable(feature = "anonymous_pipe", issue = "127154")]
 pub mod anonymous_pipe;
 pub mod backtrace;
 pub mod cmath;

--- a/library/std/src/sys/pal/windows/pipe.rs
+++ b/library/std/src/sys/pal/windows/pipe.rs
@@ -36,23 +36,6 @@ pub struct Pipes {
     pub theirs: AnonPipe,
 }
 
-/// Create true unnamed anonymous pipe.
-pub fn unnamed_anon_pipe() -> io::Result<(AnonPipe, AnonPipe)> {
-    let mut read_pipe = c::INVALID_HANDLE_VALUE;
-    let mut write_pipe = c::INVALID_HANDLE_VALUE;
-
-    let ret = unsafe { c::CreatePipe(&mut read_pipe, &mut write_pipe, ptr::null_mut(), 0) };
-
-    if ret == 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok((
-            AnonPipe::from_inner(unsafe { Handle::from_raw_handle(read_pipe) }),
-            AnonPipe::from_inner(unsafe { Handle::from_raw_handle(write_pipe) }),
-        ))
-    }
-}
-
 /// Although this looks similar to `anon_pipe` in the Unix module it's actually
 /// subtly different. Here we'll return two pipes in the `Pipes` return value,
 /// but one is intended for "us" where as the other is intended for "someone


### PR DESCRIPTION
This moves a test file out of sys as it's just testing std types. Also cleans up some assorted bits including making the `use` statements match the house style.

<!-- homu-ignore:start -->
<!--
    r​? libs
-->
<!-- homu-ignore:end -->
