### PR TITLE
Don't record trait aliases as marker traits

### DIFF
--- a/tests/crashes/127222.rs
+++ b/tests/crashes/127222.rs
@@ -1,3 +1,0 @@
-//@ known-bug: rust-lang/rust#127222
-#[marker]
-trait Foo = PartialEq<i32> + Send;

--- a/tests/ui/traits/alias/not-a-marker.rs
+++ b/tests/ui/traits/alias/not-a-marker.rs
@@ -1,0 +1,7 @@
+#![feature(trait_alias, marker_trait_attr)]
+
+#[marker]
+//~^ ERROR attribute should be applied to a trait
+trait Foo = Send;
+
+fn main() {}

--- a/tests/ui/traits/alias/not-a-marker.stderr
+++ b/tests/ui/traits/alias/not-a-marker.stderr
@@ -1,0 +1,11 @@
+error: attribute should be applied to a trait
+  --> $DIR/not-a-marker.rs:3:1
+   |
+LL | #[marker]
+   | ^^^^^^^^^
+LL |
+LL | trait Foo = Send;
+   | ----------------- not a trait
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Don't record `#[marker]` on trait aliases, since we use that to check for the (non-presence of) associated types and other things which don't make sense of trait aliases. We already enforce this attr is only applied to a trait.

Also do the same for `#[const_trait]`, which we also enforce is only applied to a trait. This is a drive-by change, but also worthwhile just in case.

Fixes #127222 