### PR TITLE
Fix a span error when parsing a wrong param of function.

### DIFF
--- a/tests/ui/suggestions/suggest-add-self-issue-128042.rs
+++ b/tests/ui/suggestions/suggest-add-self-issue-128042.rs
@@ -1,0 +1,12 @@
+struct Thing {
+    state: u8,
+}
+
+impl Thing {
+    fn oof(*mut Self) { //~ ERROR expected parameter name, found `*`
+        self.state = 1;
+        //~^ ERROR expected value, found module `self`
+    }
+}
+
+fn main() {}

--- a/tests/ui/suggestions/suggest-add-self-issue-128042.stderr
+++ b/tests/ui/suggestions/suggest-add-self-issue-128042.stderr
@@ -1,0 +1,22 @@
+error: expected parameter name, found `*`
+  --> $DIR/suggest-add-self-issue-128042.rs:6:12
+   |
+LL |     fn oof(*mut Self) {
+   |            ^ expected parameter name
+
+error[E0424]: expected value, found module `self`
+  --> $DIR/suggest-add-self-issue-128042.rs:7:9
+   |
+LL |     fn oof(*mut Self) {
+   |        --- this function doesn't have a `self` parameter
+LL |         self.state = 1;
+   |         ^^^^ `self` value is a keyword only available in methods with a `self` parameter
+   |
+help: add a `self` receiver parameter to make the associated `fn` a method
+   |
+LL |     fn oof(&self, *mut Self) {
+   |            ++++++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0424`.


### PR DESCRIPTION
fixes #128042

Before this change, the span of param `*mut Self` in  `fn oof(*mut Self)` contains `(` before it, so the suggestion in E0424 will be error. 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
