### PR TITLE
CI: do not respect custom try jobs for unrolled perf builds

### DIFF
--- a/src/ci/github-actions/calculate-job-matrix.py
+++ b/src/ci/github-actions/calculate-job-matrix.py
@@ -97,9 +97,15 @@ def find_run_type(ctx: GitHubCtx) -> Optional[WorkflowRunType]:
             "refs/heads/automation/bors/try"
         )
 
+        # Unrolled branch from a rollup for testing perf
+        # This should **not** allow custom try jobs
+        is_unrolled_perf_build = ctx.ref == "refs/heads/try-perf"
+
         if try_build:
-            jobs = get_custom_jobs(ctx)
-            return TryRunType(custom_jobs=jobs)
+            custom_jobs = []
+            if not is_unrolled_perf_build:
+                custom_jobs = get_custom_jobs(ctx)
+            return TryRunType(custom_jobs=custom_jobs)
 
         if ctx.ref == "refs/heads/auto":
             return AutoRunType()


### PR DESCRIPTION
Before this PR, if a pull request merged in a rollup had some `try-job` annotations, the unrolled perf builds were running the custom try jobs instead of the default job, which was wrong.

Found out [here](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/try-perf.20jobs.20respect.20try-job.20annotations).