### PR TITLE
Stabilize `const_waker`

### DIFF
--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -117,7 +117,6 @@
 #![feature(const_pin)]
 #![feature(const_refs_to_cell)]
 #![feature(const_size_of_val)]
-#![feature(const_waker)]
 #![feature(core_intrinsics)]
 #![feature(deprecated_suggestion)]
 #![feature(deref_pure_trait)]

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -163,7 +163,6 @@
 #![feature(const_ub_checks)]
 #![feature(const_unicode_case_lookup)]
 #![feature(const_unsafecell_get_mut)]
-#![feature(const_waker)]
 #![feature(coverage_attribute)]
 #![feature(do_not_recommend)]
 #![feature(duration_consts_float)]

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -250,7 +250,7 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     /// Create a new `Context` from a [`&Waker`](Waker).
     #[stable(feature = "futures_api", since = "1.36.0")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_stable(feature = "const_waker", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     #[inline]
     pub const fn from_waker(waker: &'a Waker) -> Self {
@@ -261,7 +261,7 @@ impl<'a> Context<'a> {
     #[inline]
     #[must_use]
     #[stable(feature = "futures_api", since = "1.36.0")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_stable(feature = "const_waker", since = "CURRENT_RUSTC_VERSION")]
     pub const fn waker(&self) -> &'a Waker {
         &self.waker
     }
@@ -269,7 +269,7 @@ impl<'a> Context<'a> {
     /// Returns a reference to the [`LocalWaker`] for the current task.
     #[inline]
     #[unstable(feature = "local_waker", issue = "118959")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_unstable(feature = "local_waker", issue = "118959")]
     pub const fn local_waker(&self) -> &'a LocalWaker {
         &self.local_waker
     }
@@ -277,7 +277,7 @@ impl<'a> Context<'a> {
     /// Returns a reference to the extension data for the current task.
     #[inline]
     #[unstable(feature = "context_ext", issue = "123392")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_unstable(feature = "context_ext", issue = "123392")]
     pub const fn ext(&mut self) -> &mut dyn Any {
         // FIXME: this field makes Context extra-weird about unwind safety
         // can we justify AssertUnwindSafe if we stabilize this? do we care?
@@ -336,8 +336,8 @@ pub struct ContextBuilder<'a> {
 impl<'a> ContextBuilder<'a> {
     /// Create a ContextBuilder from a Waker.
     #[inline]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
     #[unstable(feature = "local_waker", issue = "118959")]
+    #[rustc_const_stable(feature = "const_waker", since = "CURRENT_RUSTC_VERSION")]
     pub const fn from_waker(waker: &'a Waker) -> Self {
         // SAFETY: LocalWaker is just Waker without thread safety
         let local_waker = unsafe { transmute(waker) };
@@ -352,8 +352,8 @@ impl<'a> ContextBuilder<'a> {
 
     /// Create a ContextBuilder from an existing Context.
     #[inline]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
     #[unstable(feature = "context_ext", issue = "123392")]
+    #[rustc_const_unstable(feature = "context_ext", issue = "123392")]
     pub const fn from(cx: &'a mut Context<'_>) -> Self {
         let ext = match &mut cx.ext.0 {
             ExtData::Some(ext) => ExtData::Some(*ext),
@@ -371,7 +371,7 @@ impl<'a> ContextBuilder<'a> {
     /// This method is used to set the value for the waker on `Context`.
     #[inline]
     #[unstable(feature = "context_ext", issue = "123392")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_unstable(feature = "context_ext", issue = "123392")]
     pub const fn waker(self, waker: &'a Waker) -> Self {
         Self { waker, ..self }
     }
@@ -379,7 +379,7 @@ impl<'a> ContextBuilder<'a> {
     /// This method is used to set the value for the local waker on `Context`.
     #[inline]
     #[unstable(feature = "local_waker", issue = "118959")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_unstable(feature = "local_waker", issue = "118959")]
     pub const fn local_waker(self, local_waker: &'a LocalWaker) -> Self {
         Self { local_waker, ..self }
     }
@@ -387,7 +387,7 @@ impl<'a> ContextBuilder<'a> {
     /// This method is used to set the value for the extension data on `Context`.
     #[inline]
     #[unstable(feature = "context_ext", issue = "123392")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_unstable(feature = "context_ext", issue = "123392")]
     pub const fn ext(self, data: &'a mut dyn Any) -> Self {
         Self { ext: ExtData::Some(data), ..self }
     }
@@ -395,7 +395,7 @@ impl<'a> ContextBuilder<'a> {
     /// Builds the `Context`.
     #[inline]
     #[unstable(feature = "local_waker", issue = "118959")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_stable(feature = "const_waker", since = "CURRENT_RUSTC_VERSION")]
     pub const fn build(self) -> Context<'a> {
         let ContextBuilder { waker, local_waker, ext, _marker, _marker2 } = self;
         Context { waker, local_waker, ext: AssertUnwindSafe(ext), _marker, _marker2 }
@@ -521,7 +521,7 @@ impl Waker {
     #[inline]
     #[must_use]
     #[stable(feature = "futures_api", since = "1.36.0")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_stable(feature = "const_waker", since = "CURRENT_RUSTC_VERSION")]
     pub const unsafe fn from_raw(waker: RawWaker) -> Waker {
         Waker { waker }
     }
@@ -772,7 +772,7 @@ impl LocalWaker {
     #[inline]
     #[must_use]
     #[unstable(feature = "local_waker", issue = "118959")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_unstable(feature = "local_waker", issue = "118959")]
     pub const unsafe fn from_raw(waker: RawWaker) -> LocalWaker {
         Self { waker }
     }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -88,7 +88,6 @@
 #![feature(const_ipv6)]
 #![feature(const_mut_refs)]
 #![feature(const_pin)]
-#![feature(const_waker)]
 #![feature(never_type)]
 #![feature(unwrap_infallible)]
 #![feature(pointer_is_aligned_to)]

--- a/library/core/tests/waker.rs
+++ b/library/core/tests/waker.rs
@@ -20,3 +20,35 @@ static WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
     |_| {},
     |_| {},
 );
+
+// https://github.com/rust-lang/rust/issues/102012#issuecomment-1915282956
+mod nop_waker {
+    use core::{
+        future::{ready, Future},
+        pin::Pin,
+        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+    };
+
+    const NOP_RAWWAKER: RawWaker = {
+        fn nop(_: *const ()) {}
+        const VTAB: RawWakerVTable = RawWakerVTable::new(|_| NOP_RAWWAKER, nop, nop, nop);
+        RawWaker::new(&() as *const (), &VTAB)
+    };
+
+    const NOP_WAKER: &Waker = &unsafe { Waker::from_raw(NOP_RAWWAKER) };
+
+    const NOP_CONTEXT: Context<'static> = Context::from_waker(NOP_WAKER);
+
+    fn poll_once<T, F>(f: &mut F) -> Poll<T>
+    where
+        F: Future<Output = T> + ?Sized + Unpin,
+    {
+        let mut cx = NOP_CONTEXT;
+        Pin::new(f).as_mut().poll(&mut cx)
+    }
+
+    #[test]
+    fn test_const_waker() {
+        assert_eq!(poll_once(&mut ready(1)), Poll::Ready(1));
+    }
+}

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -407,7 +407,6 @@
 #![feature(const_ip)]
 #![feature(const_ipv4)]
 #![feature(const_ipv6)]
-#![feature(const_waker)]
 #![feature(thread_local_internals)]
 // tidy-alphabetical-end
 //

--- a/tests/ui/async-await/for-await-consumes-iter.rs
+++ b/tests/ui/async-await/for-await-consumes-iter.rs
@@ -1,5 +1,5 @@
 //@ edition: 2021
-#![feature(async_iterator, async_iter_from_iter, const_waker, async_for_loop, noop_waker)]
+#![feature(async_iterator, async_iter_from_iter, async_for_loop, noop_waker)]
 
 use std::future::Future;
 

--- a/tests/ui/async-await/for-await-passthrough.rs
+++ b/tests/ui/async-await/for-await-passthrough.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ edition: 2024
 //@ compile-flags: -Zunstable-options
-#![feature(async_iterator, async_iter_from_iter, const_waker, async_for_loop, noop_waker,
+#![feature(async_iterator, async_iter_from_iter, async_for_loop, noop_waker,
            gen_blocks)]
 
 async gen fn async_iter() -> i32 {

--- a/tests/ui/async-await/for-await.rs
+++ b/tests/ui/async-await/for-await.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 //@ edition: 2021
-#![feature(async_iterator, async_iter_from_iter, const_waker, async_for_loop, noop_waker)]
+#![feature(async_iterator, async_iter_from_iter, async_for_loop, noop_waker)]
 
 use std::future::Future;
 


### PR DESCRIPTION
Closes: https://github.com/rust-lang/rust/issues/102012.

For `local_waker` and `context_ext` related things, I just ~~moved them to dedicated feature gates and reused their own tracking issue (maybe it's better to open a new one later, but at least they should not be tracked under https://github.com/rust-lang/rust/issues/102012 from the beginning IMO.)~~ reused their own feature gates as suggested by @tgross35.

@rustbot label: +T-libs-api

r? libs-api