### PR TITLE
Improve `extern "<abi>" unsafe fn()` error message

### DIFF
--- a/tests/ui/parser/issues/issue-19398.rs
+++ b/tests/ui/parser/issues/issue-19398.rs
@@ -1,6 +1,10 @@
 trait T {
     extern "Rust" unsafe fn foo();
-    //~^ ERROR expected `{`, found keyword `unsafe`
+    //~^ ERROR expected `fn`, found keyword `unsafe`
+    //~| NOTE expected `fn`
+    //~| HELP `unsafe` must come before `extern "Rust"`
+    //~| SUGGESTION unsafe extern "Rust"
+    //~| NOTE keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 }
 
 fn main() {}

--- a/tests/ui/parser/issues/issue-19398.stderr
+++ b/tests/ui/parser/issues/issue-19398.stderr
@@ -1,13 +1,13 @@
-error: expected `{`, found keyword `unsafe`
+error: expected `fn`, found keyword `unsafe`
   --> $DIR/issue-19398.rs:2:19
    |
-LL | trait T {
-   |         - while parsing this item list starting here
 LL |     extern "Rust" unsafe fn foo();
-   |                   ^^^^^^ expected `{`
-LL |
-LL | }
-   | - the item list ends here
+   |     --------------^^^^^^
+   |     |             |
+   |     |             expected `fn`
+   |     help: `unsafe` must come before `extern "Rust"`: `unsafe extern "Rust"`
+   |
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe-abi.rs
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe-abi.rs
@@ -7,6 +7,10 @@
 // Visibilities are tested elsewhere.
 
 extern "C" unsafe fn test() {}
-//~^ ERROR
+//~^ ERROR expected `fn`, found keyword `unsafe`
+//~| NOTE expected `fn`
+//~| HELP `unsafe` must come before `extern "C"`
+//~| SUGGESTION unsafe extern "C"
+//~| NOTE keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 fn main() {}

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe-abi.rs
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe-abi.rs
@@ -1,0 +1,12 @@
+//@ edition:2018
+
+// There is an order to respect for keywords before a function:
+// `<visibility>, const, async, unsafe, extern, "<ABI>"`
+//
+// This test ensures the compiler is helpful about them being misplaced.
+// Visibilities are tested elsewhere.
+
+extern "C" unsafe fn test() {}
+//~^ ERROR
+
+fn main() {}

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe-abi.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe-abi.stderr
@@ -1,8 +1,13 @@
-error: expected `{`, found keyword `unsafe`
+error: expected `fn`, found keyword `unsafe`
   --> $DIR/wrong-unsafe-abi.rs:9:12
    |
 LL | extern "C" unsafe fn test() {}
-   |            ^^^^^^ expected `{`
+   | -----------^^^^^^
+   | |          |
+   | |          expected `fn`
+   | help: `unsafe` must come before `extern "C"`: `unsafe extern "C"`
+   |
+   = note: keyword order for functions declaration is `pub`, `default`, `const`, `async`, `unsafe`, `extern`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe-abi.stderr
+++ b/tests/ui/parser/issues/issue-87217-keyword-order/wrong-unsafe-abi.stderr
@@ -1,0 +1,8 @@
+error: expected `{`, found keyword `unsafe`
+  --> $DIR/wrong-unsafe-abi.rs:9:12
+   |
+LL | extern "C" unsafe fn test() {}
+   |            ^^^^^^ expected `{`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

These errors were already reported in #87217, and fixed by #87235 but missed the case of an explicit ABI.

This PR does not cover multiple keywords like `extern "C" pub const unsafe fn()`, but I don't know what a good way to cover this  would be. It also seems rarer than `extern "C" unsafe` which I saw happen a few times in workshops. 
