### PR TITLE
Fix `Iterator::filter` docs

### DIFF
--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -823,7 +823,7 @@ pub trait Iterator {
     ///
     /// Given an element the closure must return `true` or `false`. The returned
     /// iterator will yield only the elements for which the closure returns
-    /// true.
+    /// `true`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Small fix to add code formatting around `Iterator::filter` `true` return type