### PR TITLE
Remove logic to suggest clone of function output

### DIFF
--- a/tests/ui/associated-types/associated-types-outlives.stderr
+++ b/tests/ui/associated-types/associated-types-outlives.stderr
@@ -11,10 +11,14 @@ LL |         drop(x);
 LL |         return f(y);
    |                  - borrow later used here
    |
-help: consider cloning the value if the performance cost is acceptable
+help: if `T` implemented `Clone`, you could clone the value
+  --> $DIR/associated-types-outlives.rs:17:21
    |
-LL |         's: loop { y = denormalise(&x).clone(); break }
-   |                                       ++++++++
+LL | pub fn free_and_use<T: for<'a> Foo<'a>,
+   |                     ^ consider constraining this type parameter with `Clone`
+...
+LL |         's: loop { y = denormalise(&x); break }
+   |                                    -- you could clone this value
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/variance/variance-issue-20533.stderr
+++ b/tests/ui/variance/variance-issue-20533.stderr
@@ -73,10 +73,14 @@ LL |         drop(a);
 LL |         drop(x);
    |              - borrow later used here
    |
-help: consider cloning the value if the performance cost is acceptable
+note: if `AffineU32` implemented `Clone`, you could clone the value
+  --> $DIR/variance-issue-20533.rs:26:1
    |
-LL |         let x = bat(&a).clone();
-   |                        ++++++++
+LL | struct AffineU32(u32);
+   | ^^^^^^^^^^^^^^^^ consider implementing `Clone` for this type
+...
+LL |         let x = bat(&a);
+   |                     -- you could clone this value
 
 error[E0505]: cannot move out of `a` because it is borrowed
   --> $DIR/variance-issue-20533.rs:59:14


### PR DESCRIPTION
I can't exactly tell, but I believe that this suggestion is operating off of a heuristic that the lifetime of a function's input is correlated with the lifetime of a function's output in such a way that cloning would fix an error. I don't think that actually manages to hit the bar of "actually provides useful suggestions" most of the time.

Specifically, I've hit false-positives due to this suggestion *twice* when fixing ICEs in the compiler, so I don't think it's worthwhile having this logic around. Neither of the two affected UI tests are actually fixed by the suggestion.