### PR TITLE
codegen: do not set attributes on foreign function imports

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -324,7 +324,7 @@ impl<'a> Visitor<'a> for PostExpansionVisitor<'a> {
                         &self,
                         link_llvm_intrinsics,
                         i.span,
-                        "linking to LLVM intrinsics is experimental"
+                        "linking to LLVM intrinsics is an internal feature reserved for the standard library"
                     );
                 }
             }

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -663,7 +663,12 @@ impl<'ll, 'tcx> FnAbiLlvmExt<'ll, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
         }
 
         // If the call site has an associated instance, compute extra attributes based on that.
-        if let Some(instance) = instance {
+        // However, only do that for calls to imported functions: all the others have these
+        // attributes applied already to the declaration, so we can save some work by not also
+        // applying them here (and this really shows in perf).
+        if let Some(instance) = instance
+            && bx.tcx.is_foreign_item(instance.def_id())
+        {
             llfn_attrs_from_instance(bx.cx, instance, None, |place, attrs| {
                 attributes::apply_to_callsite(callsite, place, attrs)
             });

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -262,7 +262,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
             )
         };
         if let Some(fn_abi) = fn_abi {
-            fn_abi.apply_attrs_callsite(self, invoke);
+            fn_abi.apply_attrs_callsite(self, invoke, instance);
         }
         invoke
     }
@@ -1307,7 +1307,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
             )
         };
         if let Some(fn_abi) = fn_abi {
-            fn_abi.apply_attrs_callsite(self, call);
+            fn_abi.apply_attrs_callsite(self, call, instance);
         }
         call
     }
@@ -1657,7 +1657,7 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
             )
         };
         if let Some(fn_abi) = fn_abi {
-            fn_abi.apply_attrs_callsite(self, callbr);
+            fn_abi.apply_attrs_callsite(self, callbr, instance);
         }
         callbr
     }

--- a/tests/codegen/aarch64-struct-align-128.rs
+++ b/tests/codegen/aarch64-struct-align-128.rs
@@ -39,10 +39,15 @@ pub struct Wrapped8 {
 }
 
 extern "C" {
-    // linux:  declare void @test_8([2 x i64], [2 x i64], [2 x i64])
-    // darwin: declare void @test_8([2 x i64], [2 x i64], [2 x i64])
-    // win:    declare void @test_8([2 x i64], [2 x i64], [2 x i64])
     fn test_8(a: Align8, b: Transparent8, c: Wrapped8);
+}
+
+#[no_mangle]
+fn call_test_8(a: Align8, b: Transparent8, c: Wrapped8) {
+    // linux:  call void @test_8([2 x i64] {{%.*}}, [2 x i64] {{%.*}}, [2 x i64] {{%.*}})
+    // darwin: call void @test_8([2 x i64] {{%.*}}, [2 x i64] {{%.*}}, [2 x i64] {{%.*}})
+    // win:    call void @test_8([2 x i64] {{%.*}}, [2 x i64] {{%.*}}, [2 x i64] {{%.*}})
+    unsafe { test_8(a, b, c) }
 }
 
 // Passed as `i128`, since it's an aggregate with size <= 128 bits, align = 128 bits.
@@ -69,10 +74,15 @@ pub struct Wrapped16 {
 }
 
 extern "C" {
-    // linux:  declare void @test_16([2 x i64], [2 x i64], i128)
-    // darwin: declare void @test_16(i128, i128, i128)
-    // win:    declare void @test_16(i128, i128, i128)
     fn test_16(a: Align16, b: Transparent16, c: Wrapped16);
+}
+
+#[no_mangle]
+fn call_test_16(a: Align16, b: Transparent16, c: Wrapped16) {
+    // linux:  call void @test_16([2 x i64] {{%.*}}, [2 x i64] {{%.*}}, i128 {{%.*}})
+    // darwin: call void @test_16(i128 {{%.*}}, i128 {{%.*}}, i128 {{%.*}})
+    // win:    call void @test_16(i128 {{%.*}}, i128 {{%.*}}, i128 {{%.*}})
+    unsafe { test_16(a, b, c) }
 }
 
 // Passed as `i128`, since it's an aggregate with size <= 128 bits, align = 128 bits.
@@ -94,10 +104,15 @@ pub struct WrappedI128 {
 }
 
 extern "C" {
-    // linux:  declare void @test_i128(i128, i128, i128)
-    // darwin: declare void @test_i128(i128, i128, i128)
-    // win:    declare void @test_i128(i128, i128, i128)
     fn test_i128(a: I128, b: TransparentI128, c: WrappedI128);
+}
+
+#[no_mangle]
+fn call_test_i128(a: I128, b: TransparentI128, c: WrappedI128) {
+    // linux:  call void @test_i128(i128 {{%.*}}, i128 {{%.*}}, i128 {{%.*}})
+    // darwin: call void @test_i128(i128 {{%.*}}, i128 {{%.*}}, i128 {{%.*}})
+    // win:    call void @test_i128(i128 {{%.*}}, i128 {{%.*}}, i128 {{%.*}})
+    unsafe { test_i128(a, b, c) }
 }
 
 // Passed as `[2 x i64]`, since it's an aggregate with size <= 128 bits, align < 128 bits.
@@ -121,10 +136,15 @@ pub struct WrappedPacked {
 }
 
 extern "C" {
-    // linux:  declare void @test_packed([2 x i64], [2 x i64], [2 x i64])
-    // darwin: declare void @test_packed([2 x i64], [2 x i64], [2 x i64])
-    // win:    declare void @test_packed([2 x i64], [2 x i64], [2 x i64])
     fn test_packed(a: Packed, b: TransparentPacked, c: WrappedPacked);
+}
+
+#[no_mangle]
+fn call_test_packed(a: Packed, b: TransparentPacked, c: WrappedPacked) {
+    // linux:  call void @test_packed([2 x i64] {{%.*}}, [2 x i64] {{%.*}}, [2 x i64] {{%.*}})
+    // darwin: call void @test_packed([2 x i64] {{%.*}}, [2 x i64] {{%.*}}, [2 x i64] {{%.*}})
+    // win:    call void @test_packed([2 x i64] {{%.*}}, [2 x i64] {{%.*}}, [2 x i64] {{%.*}})
+    unsafe { test_packed(a, b, c) }
 }
 
 pub unsafe fn main(
@@ -141,8 +161,8 @@ pub unsafe fn main(
     d2: TransparentPacked,
     d3: WrappedPacked,
 ) {
-    test_8(a1, a2, a3);
-    test_16(b1, b2, b3);
-    test_i128(c1, c2, c3);
-    test_packed(d1, d2, d3);
+    call_test_8(a1, a2, a3);
+    call_test_16(b1, b2, b3);
+    call_test_i128(c1, c2, c3);
+    call_test_packed(d1, d2, d3);
 }

--- a/tests/codegen/align-byval-vector.rs
+++ b/tests/codegen/align-byval-vector.rs
@@ -37,18 +37,18 @@ pub struct DoubleFoo {
 }
 
 extern "C" {
-    // x86-linux: declare void @f({{.*}}byval([32 x i8]) align 4{{.*}})
-    // x86-darwin: declare void @f({{.*}}byval([32 x i8]) align 16{{.*}})
     fn f(foo: Foo);
 
-    // x86-linux: declare void @g({{.*}}byval([64 x i8]) align 4{{.*}})
-    // x86-darwin: declare void @g({{.*}}byval([64 x i8]) align 16{{.*}})
     fn g(foo: DoubleFoo);
 }
 
 pub fn main() {
+    // x86-linux: call void @f({{.*}}byval([32 x i8]) align 4 {{.*}})
+    // x86-darwin: call void @f({{.*}}byval([32 x i8]) align 16 {{.*}})
     unsafe { f(Foo { a: i32x4([1, 2, 3, 4]), b: 0 }) }
 
+    // x86-linux: call void @g({{.*}}byval([64 x i8]) align 4 {{.*}})
+    // x86-darwin: call void @g({{.*}}byval([64 x i8]) align 16 {{.*}})
     unsafe {
         g(DoubleFoo {
             one: Foo { a: i32x4([1, 2, 3, 4]), b: 0 },

--- a/tests/codegen/align-byval.rs
+++ b/tests/codegen/align-byval.rs
@@ -107,6 +107,10 @@ pub struct ForceAlign16 {
 // CHECK-LABEL: @call_na1
 #[no_mangle]
 pub unsafe fn call_na1(x: NaturalAlign1) {
+    extern "C" {
+        fn natural_align_1(x: NaturalAlign1);
+    }
+
     // CHECK: start:
 
     // m68k: [[ALLOCA:%[a-z0-9+]]] = alloca [2 x i8], align 1
@@ -115,9 +119,9 @@ pub unsafe fn call_na1(x: NaturalAlign1) {
     // wasm: [[ALLOCA:%[a-z0-9+]]] = alloca [2 x i8], align 1
     // wasm: call void @natural_align_1({{.*}}byval([2 x i8]) align 1{{.*}} [[ALLOCA]])
 
-    // x86_64-linux: call void @natural_align_1(i16
+    // x86_64-linux: call void @natural_align_1(i16 %
 
-    // x86_64-windows: call void @natural_align_1(i16
+    // x86_64-windows: call void @natural_align_1(i16 %
 
     // i686-linux: [[ALLOCA:%[a-z0-9+]]] = alloca [2 x i8], align 4
     // i686-linux: call void @natural_align_1({{.*}}byval([2 x i8]) align 4{{.*}} [[ALLOCA]])
@@ -130,12 +134,19 @@ pub unsafe fn call_na1(x: NaturalAlign1) {
 // CHECK-LABEL: @call_na2
 #[no_mangle]
 pub unsafe fn call_na2(x: NaturalAlign2) {
+    extern "C" {
+        fn natural_align_2(x: NaturalAlign2);
+    }
+
     // CHECK: start:
 
-    // m68k-NEXT: call void @natural_align_2
-    // wasm-NEXT: call void @natural_align_2
-    // x86_64-linux-NEXT: call void @natural_align_2
+    // m68k-NEXT: call void @natural_align_2({{.*}}byval([34 x i8]) align 2{{.*}})
+    // wasm-NEXT: call void @natural_align_2({{.*}}byval([34 x i8]) align 2{{.*}})
+    // x86_64-linux-NEXT: call void @natural_align_2({{.*}}byval([34 x i8]) align 2{{.*}})
+
     // x86_64-windows-NEXT: call void @natural_align_2
+    // x86_64-windows-NOT: byval
+    // x86_64-windows-SAME: align 2{{.*}})
 
     // i686-linux: [[ALLOCA:%[0-9]+]] = alloca [34 x i8], align 4
     // i686-linux: call void @natural_align_2({{.*}}byval([34 x i8]) align 4{{.*}} [[ALLOCA]])
@@ -148,198 +159,175 @@ pub unsafe fn call_na2(x: NaturalAlign2) {
 // CHECK-LABEL: @call_fa4
 #[no_mangle]
 pub unsafe fn call_fa4(x: ForceAlign4) {
+    extern "C" {
+        fn force_align_4(x: ForceAlign4);
+    }
+
     // CHECK: start:
-    // CHECK-NEXT: call void @force_align_4
+    // m68k-NEXT: call void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
+
+    // wasm-NEXT: call void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
+
+    // x86_64-linux-NEXT: call void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
+
+    // x86_64-windows-NEXT: call void @force_align_4(
+    // x86_64-windows-NOT: byval
+    // x86_64-windows-SAME: align 4{{.*}})
+
+    // i686-linux-NEXT: call void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
+
+    // i686-windows-NEXT: call void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
     force_align_4(x);
 }
 
 // CHECK-LABEL: @call_na8
 #[no_mangle]
 pub unsafe fn call_na8(x: NaturalAlign8) {
+    extern "C" {
+        fn natural_align_8(x: NaturalAlign8);
+    }
+
     // CHECK: start:
-    // CHECK-NEXT: call void @natural_align_8
+    // m68k-NEXT: call void @natural_align_8({{.*}}byval([24 x i8]) align 4{{.*}})
+
+    // wasm-NEXT: call void @natural_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // x86_64-linux-NEXT: call void @natural_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // x86_64-windows-NEXT: call void @natural_align_8(
+    // x86_64-windows-NOT: byval
+    // x86_64-windows-SAME: align 8{{.*}})
+
+    // i686-linux-NEXT: call void @natural_align_8({{.*}}byval([24 x i8]) align 4{{.*}})
+
+    // i686-windows-NEXT: call void @natural_align_8({{.*}}byval([24 x i8]) align 4{{.*}})
     natural_align_8(x);
 }
 
 // CHECK-LABEL: @call_fa8
 #[no_mangle]
 pub unsafe fn call_fa8(x: ForceAlign8) {
+    extern "C" {
+        fn force_align_8(x: ForceAlign8);
+    }
+
     // CHECK: start:
-    // CHECK-NEXT: call void @force_align_8
+    // m68k-NEXT: call void @force_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // wasm-NEXT: call void @force_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // x86_64-linux-NEXT: call void @force_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // x86_64-windows-NEXT: call void @force_align_8(
+    // x86_64-windows-NOT: byval
+    // x86_64-windows-SAME: align 8{{.*}})
+
+    // i686-linux-NEXT: call void @force_align_8({{.*}}byval([24 x i8]) align 4{{.*}})
+
+    // i686-windows-NEXT: call void @force_align_8(
+    // i686-windows-NOT: byval
+    // i686-windows-SAME: align 8{{.*}})
     force_align_8(x);
 }
 
 // CHECK-LABEL: @call_lfa8
 #[no_mangle]
 pub unsafe fn call_lfa8(x: LowerFA8) {
+    extern "C" {
+        fn lower_fa8(x: LowerFA8);
+    }
+
     // CHECK: start:
-    // CHECK-NEXT: call void @lower_fa8
+    // m68k-NEXT: call void @lower_fa8({{.*}}byval([24 x i8]) align 4{{.*}})
+
+    // wasm-NEXT: call void @lower_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // x86_64-linux-NEXT: call void @lower_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // x86_64-windows-NEXT: call void @lower_fa8(
+    // x86_64-windows-NOT: byval
+    // x86_64-windows-SAME: align 8{{.*}})
+
+    // i686-linux-NEXT: call void @lower_fa8({{.*}}byval([24 x i8]) align 4{{.*}})
+
+    // i686-windows-NEXT: call void @lower_fa8({{.*}}byval([24 x i8]) align 4{{.*}})
     lower_fa8(x);
 }
 
 // CHECK-LABEL: @call_wfa8
 #[no_mangle]
 pub unsafe fn call_wfa8(x: WrappedFA8) {
+    extern "C" {
+        fn wrapped_fa8(x: WrappedFA8);
+    }
+
     // CHECK: start:
-    // CHECK-NEXT: call void @wrapped_fa8
+    // m68k-NEXT: call void @wrapped_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // wasm-NEXT: call void @wrapped_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // x86_64-linux-NEXT: call void @wrapped_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // x86_64-windows-NEXT: call void @wrapped_fa8(
+    // x86_64-windows-NOT: byval
+    // x86_64-windows-SAME: align 8{{.*}})
+
+    // i686-linux-NEXT: call void @wrapped_fa8({{.*}}byval([24 x i8]) align 4{{.*}})
+
+    // i686-windows-NEXT: call void @wrapped_fa8(
+    // i686-windows-NOT: byval
+    // i686-windows-SAME: align 8{{.*}})
     wrapped_fa8(x);
 }
 
 // CHECK-LABEL: @call_tfa8
 #[no_mangle]
 pub unsafe fn call_tfa8(x: TransparentFA8) {
+    extern "C" {
+        fn transparent_fa8(x: TransparentFA8);
+    }
+
     // CHECK: start:
-    // CHECK-NEXT: call void @transparent_fa8
+    // m68k-NEXT: call void @transparent_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // wasm-NEXT: call void @transparent_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // x86_64-linux-NEXT: call void @transparent_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
+
+    // x86_64-windows-NEXT: call void @transparent_fa8(
+    // x86_64-windows-NOT: byval
+    // x86_64-windows-SAME: align 8{{.*}})
+
+    // i686-linux-NEXT: call void @transparent_fa8({{.*}}byval([24 x i8]) align 4{{.*}})
+
+    // i686-windows-NEXT: call void @transparent_fa8(
+    // i686-windows-NOT: byval
+    // i686-windows-SAME: align 8{{.*}})
     transparent_fa8(x);
 }
 
 // CHECK-LABEL: @call_fa16
 #[no_mangle]
 pub unsafe fn call_fa16(x: ForceAlign16) {
+    extern "C" {
+        fn force_align_16(x: ForceAlign16);
+    }
+
     // CHECK: start:
-    // CHECK-NEXT: call void @force_align_16
-    force_align_16(x);
-}
+    // m68k-NEXT: call void @force_align_16({{.*}}byval([80 x i8]) align 16{{.*}})
 
-extern "C" {
-    // m68k: declare void @natural_align_1({{.*}}byval([2 x i8]) align 1{{.*}})
+    // wasm-NEXT: call void @force_align_16({{.*}}byval([80 x i8]) align 16{{.*}})
 
-    // wasm: declare void @natural_align_1({{.*}}byval([2 x i8]) align 1{{.*}})
+    // x86_64-linux-NEXT: call void @force_align_16({{.*}}byval([80 x i8]) align 16{{.*}})
 
-    // x86_64-linux: declare void @natural_align_1(i16)
-
-    // x86_64-windows: declare void @natural_align_1(i16)
-
-    // i686-linux: declare void @natural_align_1({{.*}}byval([2 x i8]) align 4{{.*}})
-
-    // i686-windows: declare void @natural_align_1({{.*}}byval([2 x i8]) align 4{{.*}})
-    fn natural_align_1(x: NaturalAlign1);
-
-    // m68k: declare void @natural_align_2({{.*}}byval([34 x i8]) align 2{{.*}})
-
-    // wasm: declare void @natural_align_2({{.*}}byval([34 x i8]) align 2{{.*}})
-
-    // x86_64-linux: declare void @natural_align_2({{.*}}byval([34 x i8]) align 2{{.*}})
-
-    // x86_64-windows: declare void @natural_align_2(
-    // x86_64-windows-NOT: byval
-    // x86_64-windows-SAME: align 2{{.*}})
-
-    // i686-linux: declare void @natural_align_2({{.*}}byval([34 x i8]) align 4{{.*}})
-
-    // i686-windows: declare void @natural_align_2({{.*}}byval([34 x i8]) align 4{{.*}})
-    fn natural_align_2(x: NaturalAlign2);
-
-    // m68k: declare void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
-
-    // wasm: declare void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
-
-    // x86_64-linux: declare void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
-
-    // x86_64-windows: declare void @force_align_4(
-    // x86_64-windows-NOT: byval
-    // x86_64-windows-SAME: align 4{{.*}})
-
-    // i686-linux: declare void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
-
-    // i686-windows: declare void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
-    fn force_align_4(x: ForceAlign4);
-
-    // m68k: declare void @natural_align_8({{.*}}byval([24 x i8]) align 4{{.*}})
-
-    // wasm: declare void @natural_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // x86_64-linux: declare void @natural_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // x86_64-windows: declare void @natural_align_8(
-    // x86_64-windows-NOT: byval
-    // x86_64-windows-SAME: align 8{{.*}})
-
-    // i686-linux: declare void @natural_align_8({{.*}}byval([24 x i8]) align 4{{.*}})
-
-    // i686-windows: declare void @natural_align_8({{.*}}byval([24 x i8]) align 4{{.*}})
-    fn natural_align_8(x: NaturalAlign8);
-
-    // m68k: declare void @force_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // wasm: declare void @force_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // x86_64-linux: declare void @force_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // x86_64-windows: declare void @force_align_8(
-    // x86_64-windows-NOT: byval
-    // x86_64-windows-SAME: align 8{{.*}})
-
-    // i686-linux: declare void @force_align_8({{.*}}byval([24 x i8]) align 4{{.*}})
-
-    // i686-windows: declare void @force_align_8(
-    // i686-windows-NOT: byval
-    // i686-windows-SAME: align 8{{.*}})
-    fn force_align_8(x: ForceAlign8);
-
-    // m68k: declare void @lower_fa8({{.*}}byval([24 x i8]) align 4{{.*}})
-
-    // wasm: declare void @lower_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // x86_64-linux: declare void @lower_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // x86_64-windows: declare void @lower_fa8(
-    // x86_64-windows-NOT: byval
-    // x86_64-windows-SAME: align 8{{.*}})
-
-    // i686-linux: declare void @lower_fa8({{.*}}byval([24 x i8]) align 4{{.*}})
-
-    // i686-windows: declare void @lower_fa8({{.*}}byval([24 x i8]) align 4{{.*}})
-    fn lower_fa8(x: LowerFA8);
-
-    // m68k: declare void @wrapped_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // wasm: declare void @wrapped_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // x86_64-linux: declare void @wrapped_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // x86_64-windows: declare void @wrapped_fa8(
-    // x86_64-windows-NOT: byval
-    // x86_64-windows-SAME: align 8{{.*}})
-
-    // i686-linux: declare void @wrapped_fa8({{.*}}byval([24 x i8]) align 4{{.*}})
-
-    // i686-windows: declare void @wrapped_fa8(
-    // i686-windows-NOT: byval
-    // i686-windows-SAME: align 8{{.*}})
-    fn wrapped_fa8(x: WrappedFA8);
-
-    // m68k: declare void @transparent_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // wasm: declare void @transparent_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // x86_64-linux: declare void @transparent_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // x86_64-windows: declare void @transparent_fa8(
-    // x86_64-windows-NOT: byval
-    // x86_64-windows-SAME: align 8{{.*}})
-
-    // i686-linux: declare void @transparent_fa8({{.*}}byval([24 x i8]) align 4{{.*}})
-
-    // i686-windows: declare void @transparent_fa8(
-    // i686-windows-NOT: byval
-    // i686-windows-SAME: align 8{{.*}})
-    fn transparent_fa8(x: TransparentFA8);
-
-    // m68k: declare void @force_align_16({{.*}}byval([80 x i8]) align 16{{.*}})
-
-    // wasm: declare void @force_align_16({{.*}}byval([80 x i8]) align 16{{.*}})
-
-    // x86_64-linux: declare void @force_align_16({{.*}}byval([80 x i8]) align 16{{.*}})
-
-    // x86_64-windows: declare void @force_align_16(
+    // x86_64-windows-NEXT: call void @force_align_16(
     // x86_64-windows-NOT: byval
     // x86_64-windows-SAME: align 16{{.*}})
 
-    // i686-linux: declare void @force_align_16({{.*}}byval([80 x i8]) align 4{{.*}})
+    // i686-linux-NEXT: call void @force_align_16({{.*}}byval([80 x i8]) align 4{{.*}})
 
-    // i686-windows: declare void @force_align_16(
+    // i686-windows-NEXT: call void @force_align_16(
     // i686-windows-NOT: byval
     // i686-windows-SAME: align 16{{.*}})
-    fn force_align_16(x: ForceAlign16);
+    force_align_16(x);
 }

--- a/tests/codegen/box-uninit-bytes.rs
+++ b/tests/codegen/box-uninit-bytes.rs
@@ -8,7 +8,7 @@ use std::mem::MaybeUninit;
 pub fn box_uninitialized() -> Box<MaybeUninit<usize>> {
     // CHECK-LABEL: @box_uninitialized
     // CHECK-NOT: store
-    // CHECK-NOT: alloca
+    // CHECK-NOT: alloca{{ }}
     // CHECK-NOT: memcpy
     // CHECK-NOT: memset
     Box::new(MaybeUninit::uninit())
@@ -19,7 +19,7 @@ pub fn box_uninitialized() -> Box<MaybeUninit<usize>> {
 pub fn box_uninitialized2() -> Box<MaybeUninit<[usize; 1024 * 1024]>> {
     // CHECK-LABEL: @box_uninitialized2
     // CHECK-NOT: store
-    // CHECK-NOT: alloca
+    // CHECK-NOT: alloca{{ }}
     // CHECK-NOT: memcpy
     // CHECK-NOT: memset
     Box::new(MaybeUninit::uninit())
@@ -32,7 +32,7 @@ pub struct LotsaPadding(usize);
 #[no_mangle]
 pub fn box_lotsa_padding() -> Box<LotsaPadding> {
     // CHECK-LABEL: @box_lotsa_padding
-    // CHECK-NOT: alloca
+    // CHECK-NOT: alloca{{ }}
     // CHECK-NOT: getelementptr
     // CHECK-NOT: memcpy
     // CHECK-NOT: memset

--- a/tests/codegen/cffi/ffi-const.rs
+++ b/tests/codegen/cffi/ffi-const.rs
@@ -2,15 +2,18 @@
 #![crate_type = "lib"]
 #![feature(ffi_const)]
 
+#[no_mangle]
 pub fn bar() {
+    // CHECK-LABEL: @bar
+    // CHECK: @foo
+    // CHECK-SAME: [[ATTRS:#[0-9]+]]
     unsafe { foo() }
 }
 
 extern "C" {
-    // CHECK-LABEL: declare{{.*}}void @foo()
-    // CHECK-SAME: [[ATTRS:#[0-9]+]]
-    // The attribute changed from `readnone` to `memory(none)` with LLVM 16.0.
-    // CHECK-DAG: attributes [[ATTRS]] = { {{.*}}{{readnone|memory\(none\)}}{{.*}} }
     #[ffi_const]
     pub fn foo();
 }
+
+// The attribute changed from `readnone` to `memory(none)` with LLVM 16.0.
+// CHECK: attributes [[ATTRS]] = { {{.*}}{{readnone|memory\(none\)}}{{.*}} }

--- a/tests/codegen/cffi/ffi-out-of-bounds-loads.rs
+++ b/tests/codegen/cffi/ffi-out-of-bounds-loads.rs
@@ -1,6 +1,6 @@
 //@ revisions: linux apple
 //@ min-llvm-version: 19
-//@ compile-flags: -Copt-level=0 -Cno-prepopulate-passes -Zlint-llvm-ir -Cllvm-args=-lint-abort-on-error
+//@ compile-flags: -Copt-level=0 -Cno-prepopulate-passes -Zlint-llvm-ir
 
 //@[linux] compile-flags: --target x86_64-unknown-linux-gnu
 //@[linux] needs-llvm-components: x86

--- a/tests/codegen/cffi/ffi-pure.rs
+++ b/tests/codegen/cffi/ffi-pure.rs
@@ -2,15 +2,18 @@
 #![crate_type = "lib"]
 #![feature(ffi_pure)]
 
+#[no_mangle]
 pub fn bar() {
+    // CHECK-LABEL: @bar
+    // CHECK: @foo
+    // CHECK-SAME: [[ATTRS:#[0-9]+]]
     unsafe { foo() }
 }
 
 extern "C" {
-    // CHECK-LABEL: declare{{.*}}void @foo()
-    // CHECK-SAME: [[ATTRS:#[0-9]+]]
-    // The attribute changed from `readonly` to `memory(read)` with LLVM 16.0.
-    // CHECK-DAG: attributes [[ATTRS]] = { {{.*}}{{readonly|memory\(read\)}}{{.*}} }
     #[ffi_pure]
     pub fn foo();
 }
+
+// The attribute changed from `readonly` to `memory(read)` with LLVM 16.0.
+// CHECK: attributes [[ATTRS]] = { {{.*}}{{readonly|memory\(read\)}}{{.*}} }

--- a/tests/codegen/issues/issue-111603.rs
+++ b/tests/codegen/issues/issue-111603.rs
@@ -12,7 +12,7 @@ pub fn new_from_array(x: u64) -> Arc<[u64]> {
 
     // CHECK: alloca
     // CHECK-SAME: [8000 x i8]
-    // CHECK-NOT: alloca
+    // CHECK-NOT: alloca{{ }}
     let array = [x; 1000];
     Arc::new(array)
 }

--- a/tests/codegen/iter-repeat-n-trivial-drop.rs
+++ b/tests/codegen/iter-repeat-n-trivial-drop.rs
@@ -47,7 +47,7 @@ pub fn iter_repeat_n_next(it: &mut std::iter::RepeatN<NotCopy>) -> Option<NotCop
 #[no_mangle]
 // CHECK-LABEL: @vec_extend_via_iter_repeat_n
 pub fn vec_extend_via_iter_repeat_n() -> Vec<u8> {
-    // CHECK: %[[ADDR:.+]] = tail call {{(noalias )?}}noundef dereferenceable_or_null(1234) ptr @__rust_alloc(i64 noundef 1234, i64 noundef 1)
+    // CHECK: %[[ADDR:.+]] = tail call {{(noalias )?}}noundef dereferenceable_or_null(1234) ptr @__rust_alloc(i64 noundef 1234, i64 {{(allocalign )?}}noundef 1)
     // CHECK: tail call void @llvm.memset.p0.i64(ptr noundef nonnull align 1 dereferenceable(1234) %[[ADDR]], i8 42, i64 1234,
 
     let n = 1234_usize;

--- a/tests/codegen/no_builtins-at-crate.rs
+++ b/tests/codegen/no_builtins-at-crate.rs
@@ -10,15 +10,13 @@
 pub unsafe extern "C" fn __aeabi_memcpy(dest: *mut u8, src: *const u8, size: usize) {
     // CHECK: call
     // CHECK-SAME: @memcpy(
+    // CHECK-SAME: #2
     memcpy(dest, src, size);
 }
 
-// CHECK: declare
-// CHECK-SAME: @memcpy
-// CHECK-SAME: #0
 extern "C" {
     pub fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8;
 }
 
-// CHECK: attributes #0
+// CHECK: attributes #2
 // CHECK-SAME: "no-builtins"

--- a/tests/codegen/pic-relocation-model.rs
+++ b/tests/codegen/pic-relocation-model.rs
@@ -8,10 +8,7 @@ pub fn call_foreign_fn() -> u8 {
     unsafe { foreign_fn() }
 }
 
-// (Allow but do not require `zeroext` here, because it is not worth effort to
-// spell out which targets have it and which ones do not; see rust#97800.)
-
-// CHECK: declare{{( zeroext)?}} i8 @foreign_fn()
+// CHECK: declare void @foreign_fn()
 extern "C" {
     fn foreign_fn() -> u8;
 }

--- a/tests/codegen/pie-relocation-model.rs
+++ b/tests/codegen/pie-relocation-model.rs
@@ -13,7 +13,7 @@ pub fn call_foreign_fn() -> u8 {
 
 // External functions are still marked as non-dso_local, since we don't know if the symbol
 // is defined in the binary or in the shared library.
-// CHECK: declare zeroext i8 @foreign_fn()
+// CHECK: declare void @foreign_fn()
 extern "C" {
     fn foreign_fn() -> u8;
 }

--- a/tests/codegen/powerpc64le-struct-align-128.rs
+++ b/tests/codegen/powerpc64le-struct-align-128.rs
@@ -32,8 +32,13 @@ pub struct Wrapped8 {
 }
 
 extern "C" {
-    // CHECK: declare void @test_8([2 x i64], [2 x i64], [2 x i64])
     fn test_8(a: Align8, b: Transparent8, c: Wrapped8);
+}
+
+#[no_mangle]
+fn call_test_8(a: Align8, b: Transparent8, c: Wrapped8) {
+    // CHECK: call void @test_8([2 x i64] {{%.*}}, [2 x i64] {{%.*}}, [2 x i64] {{%.*}})
+    unsafe { test_8(a, b, c) }
 }
 
 #[repr(C)]
@@ -54,9 +59,14 @@ pub struct Wrapped16 {
 }
 
 extern "C" {
-    // It's important that this produces [1 x i128]  rather than just i128!
-    // CHECK: declare void @test_16([1 x i128], [1 x i128], [1 x i128])
     fn test_16(a: Align16, b: Transparent16, c: Wrapped16);
+}
+
+#[no_mangle]
+fn call_test_16(a: Align16, b: Transparent16, c: Wrapped16) {
+    // It's important that this produces [1 x i128]  rather than just i128!
+    // CHECK: call void @test_16([1 x i128] {{%.*}}, [1 x i128] {{%.*}}, [1 x i128] {{%.*}})
+    unsafe { test_16(a, b, c) }
 }
 
 #[repr(C)]
@@ -78,8 +88,13 @@ pub struct Wrapped32 {
 }
 
 extern "C" {
-    // CHECK: declare void @test_32([2 x i128], [2 x i128], [2 x i128])
     fn test_32(a: Align32, b: Transparent32, c: Wrapped32);
+}
+
+#[no_mangle]
+fn call_test_32(a: Align32, b: Transparent32, c: Wrapped32) {
+    // CHECK: call void @test_32([2 x i128] {{%.*}}, [2 x i128] {{%.*}}, [2 x i128] {{%.*}})
+    unsafe { test_32(a, b, c) }
 }
 
 pub unsafe fn main(
@@ -93,7 +108,7 @@ pub unsafe fn main(
     c2: Transparent32,
     c3: Wrapped32,
 ) {
-    test_8(a1, a2, a3);
-    test_16(b1, b2, b3);
-    test_32(c1, c2, c3);
+    call_test_8(a1, a2, a3);
+    call_test_16(b1, b2, b3);
+    call_test_32(c1, c2, c3);
 }

--- a/tests/codegen/unwind-extern-imports.rs
+++ b/tests/codegen/unwind-extern-imports.rs
@@ -3,9 +3,20 @@
 
 #![crate_type = "lib"]
 
+// The flag are only at the call sites, not at the declarations.
+// CHECK-LABEL: @force_declare
+#[no_mangle]
+pub unsafe fn force_declare() {
+    // CHECK: call void @extern_fn() [[NOUNWIND_ATTR:#[0-9]+]]
+    extern_fn();
+    // Call without attributes.
+    // CHECK: call void @c_unwind_extern_fn() [[UNWIND_ATTR:#[0-9]+]]
+    c_unwind_extern_fn();
+}
+
 extern "C" {
-    // CHECK: Function Attrs:{{.*}}nounwind
-    // CHECK-NEXT: declare{{.*}}void @extern_fn
+    // CHECK-NOT: nounwind
+    // CHECK: declare{{.*}}void @extern_fn
     fn extern_fn();
 }
 
@@ -15,7 +26,6 @@ extern "C-unwind" {
     fn c_unwind_extern_fn();
 }
 
-pub unsafe fn force_declare() {
-    extern_fn();
-    c_unwind_extern_fn();
-}
+// CHECK: attributes [[NOUNWIND_ATTR]] = { {{.*}}nounwind{{.*}} }
+// CHECK: attributes [[UNWIND_ATTR]]
+// CHECK-NOT: nounwind

--- a/tests/codegen/unwind-landingpad-cold.rs
+++ b/tests/codegen/unwind-landingpad-cold.rs
@@ -8,7 +8,8 @@
 
 // CHECK-LABEL: @check_cold
 // CHECK: {{(call|invoke) void .+}}drop_in_place{{.+}} [[ATTRIBUTES:#[0-9]+]]
-// CHECK: attributes [[ATTRIBUTES]] = { cold }
+// CHECK: attributes [[ATTRIBUTES]]
+// CHECK-SAME: cold
 #[no_mangle]
 pub fn check_cold(f: fn(), x: Box<u32>) {
     // this may unwind

--- a/tests/ui/extern/auxiliary/foreign-vectorcall.rs
+++ b/tests/ui/extern/auxiliary/foreign-vectorcall.rs
@@ -1,0 +1,10 @@
+// Make the aux build not use `dylib` to avoid https://github.com/rust-lang/rust/issues/130196
+//@ no-prefer-dynamic
+#![feature(abi_vectorcall)]
+#![crate_type = "lib"]
+
+#[no_mangle]
+#[inline(never)]
+pub extern "vectorcall" fn call_with_42(i: i32) {
+    assert_eq!(i, 42);
+}

--- a/tests/ui/extern/extern-vectorcall.rs
+++ b/tests/ui/extern/extern-vectorcall.rs
@@ -1,9 +1,18 @@
 //@ run-pass
+//@ aux-build:foreign-vectorcall.rs
 //@ revisions: x64 x32
 //@ [x64]only-x86_64
 //@ [x32]only-x86
 
 #![feature(abi_vectorcall)]
+
+extern crate foreign_vectorcall;
+
+// Import this as a foreign function, that's the code path we are interested in
+// (LLVM has to do some name mangling here).
+extern "vectorcall" {
+    fn call_with_42(i: i32);
+}
 
 trait A {
     extern "vectorcall" fn test1(i: i32);
@@ -24,4 +33,5 @@ extern "vectorcall" fn test2(i: i32) {
 fn main() {
     <S as A>::test1(1);
     test2(2);
+    unsafe { call_with_42(42) };
 }

--- a/tests/ui/feature-gates/feature-gate-link_llvm_intrinsics.rs
+++ b/tests/ui/feature-gates/feature-gate-link_llvm_intrinsics.rs
@@ -1,7 +1,7 @@
 extern "C" {
     #[link_name = "llvm.sqrt.f32"]
     fn sqrt(x: f32) -> f32;
-//~^ ERROR linking to LLVM intrinsics is experimental
+//~^ ERROR linking to LLVM intrinsics
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-link_llvm_intrinsics.stderr
+++ b/tests/ui/feature-gates/feature-gate-link_llvm_intrinsics.stderr
@@ -1,4 +1,4 @@
-error[E0658]: linking to LLVM intrinsics is experimental
+error[E0658]: linking to LLVM intrinsics is an internal feature reserved for the standard library
   --> $DIR/feature-gate-link_llvm_intrinsics.rs:3:5
    |
 LL |     fn sqrt(x: f32) -> f32;

--- a/tests/ui/issues/issue-20313.rs
+++ b/tests/ui/issues/issue-20313.rs
@@ -1,6 +1,6 @@
 extern "C" {
     #[link_name = "llvm.sqrt.f32"]
-    fn sqrt(x: f32) -> f32; //~ ERROR linking to LLVM intrinsics is experimental
+    fn sqrt(x: f32) -> f32; //~ ERROR linking to LLVM intrinsics
 }
 
 fn main() {}

--- a/tests/ui/issues/issue-20313.stderr
+++ b/tests/ui/issues/issue-20313.stderr
@@ -1,4 +1,4 @@
-error[E0658]: linking to LLVM intrinsics is experimental
+error[E0658]: linking to LLVM intrinsics is an internal feature reserved for the standard library
   --> $DIR/issue-20313.rs:3:5
    |
 LL |     fn sqrt(x: f32) -> f32;


### PR DESCRIPTION
Currently we are setting all the usual attributes when translating an FFI import, like
```rust
    extern {
        pub fn myfun(x: NonZeroI32) -> &'static mut ();
    }
```
into LLVM. However, if the same function is imported multiple times as different items in Rust, that all becomes a single LLVM declaration. The attributes set on any one of them may then apply to calls done via other imported items. For instance, the import above, *even if it is never called*, can introduce UB if there is another part of the program that also imports `myfun`, calls it via that import, and passes 0 or `myfun` returns NULL.

To fix that, this PR changes the function declarations we emit to all look like `declare @fn()`. The one exception are Rust's own allocator functions, which have a bunch of attributes that LLVM currently only honors in the declaration, not the call site -- though with https://github.com/llvm/llvm-project/commit/195362929cd79c0202f73bcbab9a09b8a1a3beaa we can maybe avoid that in the future.

The hope is that this fixes https://github.com/rust-lang/rust/issues/46188. The only cases I can still think of where we emit different declarations with the same name and one of them "wins" are:
- Rust's native allocation functions. Even then, the "wrong" declarations will just have no argument and return value so I don't think this should cause problems.
- Two `extern static` with the same name but different type, or an `extern static` with the same name as an imported function. Again I doubt the "type of the static" will lead LLVM to deduce things about the function or vice versa, so probably the worst that can happen is LLVM crashes. (And of course if this static actually ends up resolving to a function, that's UB unless the static has size 0. And conversely, if it resolves to a static instead of code then calling the function is UB.)

Fixes https://github.com/rust-lang/miri/issues/3581 by making this not UB.

Cc @nikic 

try-job: x86_64-msvc
try-job: i686-msvc