### PR TITLE
 Perform instsimplify before inline to eliminate some trivial calls 

### DIFF
--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -13,9 +13,25 @@ use rustc_target::spec::abi::Abi;
 use crate::simplify::simplify_duplicate_switch_targets;
 use crate::take_array;
 
-pub struct InstSimplify;
+pub enum InstSimplify {
+    BeforeInline,
+    AfterSimplifyCfg,
+}
+
+impl InstSimplify {
+    pub fn name(&self) -> &'static str {
+        match self {
+            InstSimplify::BeforeInline => "InstSimplify-before-inline",
+            InstSimplify::AfterSimplifyCfg => "InstSimplify-after-simplifycfg",
+        }
+    }
+}
 
 impl<'tcx> MirPass<'tcx> for InstSimplify {
+    fn name(&self) -> &'static str {
+        self.name()
+    }
+
     fn is_enabled(&self, sess: &rustc_session::Session) -> bool {
         sess.mir_opt_level() > 0
     }

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -155,7 +155,7 @@ fn make_shim<'tcx>(tcx: TyCtxt<'tcx>, instance: ty::InstanceKind<'tcx>) -> Body<
             &deref_separator::Derefer,
             &remove_noop_landing_pads::RemoveNoopLandingPads,
             &simplify::SimplifyCfg::MakeShim,
-            &instsimplify::InstSimplify,
+            &instsimplify::InstSimplify::BeforeInline,
             &abort_unwinding_calls::AbortUnwindingCalls,
             &add_call_guards::CriticalCallEdges,
         ],

--- a/tests/incremental/hashes/call_expressions.rs
+++ b/tests/incremental/hashes/call_expressions.rs
@@ -162,7 +162,7 @@ pub fn change_to_ufcs() {
 }
 
 #[cfg(not(any(cfail1,cfail4)))]
-#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,typeck")]
+#[rustc_clean(cfg="cfail2", except="opt_hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail3")]
 #[rustc_clean(cfg="cfail5", except="opt_hir_owner_nodes,optimized_mir,typeck")]
 #[rustc_clean(cfg="cfail6")]

--- a/tests/mir-opt/const_prop/slice_len.rs
+++ b/tests/mir-opt/const_prop/slice_len.rs
@@ -1,5 +1,5 @@
 //@ test-mir-pass: GVN
-//@ compile-flags: -Zmir-enable-passes=+InstSimplify -Zdump-mir-exclude-alloc-bytes
+//@ compile-flags: -Zmir-enable-passes=+InstSimplify-after-simplifycfg -Zdump-mir-exclude-alloc-bytes
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 

--- a/tests/mir-opt/dataflow-const-prop/slice_len.rs
+++ b/tests/mir-opt/dataflow-const-prop/slice_len.rs
@@ -1,6 +1,6 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 //@ test-mir-pass: DataflowConstProp
-//@ compile-flags: -Zmir-enable-passes=+InstSimplify
+//@ compile-flags: -Zmir-enable-passes=+InstSimplify-after-simplifycfg
 // EMIT_MIR_FOR_EACH_BIT_WIDTH
 
 // EMIT_MIR slice_len.main.DataflowConstProp.diff

--- a/tests/mir-opt/inline/dyn_trait.get_query.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/dyn_trait.get_query.Inline.panic-abort.diff
@@ -21,14 +21,14 @@
       bb0: {
           StorageLive(_2);
           StorageLive(_3);
-          _3 = &(*_1);
+          _3 = _1;
           _2 = <Q as Query>::cache::<T>(move _3) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
           StorageDead(_3);
           StorageLive(_4);
-          _4 = &(*_2);
+          _4 = _2;
 -         _0 = try_execute_query::<<Q as Query>::C>(move _4) -> [return: bb2, unwind unreachable];
 +         StorageLive(_5);
 +         _5 = _4 as &dyn Cache<V = <Q as Query>::V> (PointerCoercion(Unsize));

--- a/tests/mir-opt/inline/dyn_trait.get_query.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/dyn_trait.get_query.Inline.panic-unwind.diff
@@ -21,14 +21,14 @@
       bb0: {
           StorageLive(_2);
           StorageLive(_3);
-          _3 = &(*_1);
+          _3 = _1;
           _2 = <Q as Query>::cache::<T>(move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {
           StorageDead(_3);
           StorageLive(_4);
-          _4 = &(*_2);
+          _4 = _2;
 -         _0 = try_execute_query::<<Q as Query>::C>(move _4) -> [return: bb2, unwind continue];
 +         StorageLive(_5);
 +         _5 = _4 as &dyn Cache<V = <Q as Query>::V> (PointerCoercion(Unsize));

--- a/tests/mir-opt/inline/dyn_trait.mk_cycle.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/dyn_trait.mk_cycle.Inline.panic-abort.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           StorageLive(_2);
-          _2 = &(*_1);
+          _2 = _1;
           _0 = <dyn Cache<V = V> as Cache>::store_nocache(move _2) -> [return: bb1, unwind unreachable];
       }
   

--- a/tests/mir-opt/inline/dyn_trait.mk_cycle.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/dyn_trait.mk_cycle.Inline.panic-unwind.diff
@@ -8,7 +8,7 @@
   
       bb0: {
           StorageLive(_2);
-          _2 = &(*_1);
+          _2 = _1;
           _0 = <dyn Cache<V = V> as Cache>::store_nocache(move _2) -> [return: bb1, unwind continue];
       }
   

--- a/tests/mir-opt/inline/dyn_trait.try_execute_query.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/dyn_trait.try_execute_query.Inline.panic-abort.diff
@@ -13,7 +13,7 @@
       bb0: {
           StorageLive(_2);
           StorageLive(_3);
-          _3 = &(*_1);
+          _3 = _1;
           _2 = move _3 as &dyn Cache<V = <C as Cache>::V> (PointerCoercion(Unsize));
           StorageDead(_3);
 -         _0 = mk_cycle::<<C as Cache>::V>(move _2) -> [return: bb1, unwind unreachable];

--- a/tests/mir-opt/inline/dyn_trait.try_execute_query.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/dyn_trait.try_execute_query.Inline.panic-unwind.diff
@@ -13,7 +13,7 @@
       bb0: {
           StorageLive(_2);
           StorageLive(_3);
-          _3 = &(*_1);
+          _3 = _1;
           _2 = move _3 as &dyn Cache<V = <C as Cache>::V> (PointerCoercion(Unsize));
           StorageDead(_3);
 -         _0 = mk_cycle::<<C as Cache>::V>(move _2) -> [return: bb1, unwind continue];

--- a/tests/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
+++ b/tests/mir-opt/inline/inline_closure_borrows_arg.foo.Inline.after.mir
@@ -26,9 +26,9 @@ fn foo(_1: T, _2: &i32) -> i32 {
         _4 = &_3;
         StorageLive(_5);
         StorageLive(_6);
-        _6 = &(*_2);
+        _6 = _2;
         StorageLive(_7);
-        _7 = &(*_2);
+        _7 = _2;
         _5 = (move _6, move _7);
         StorageLive(_8);
         _8 = move (_5.0: &i32);

--- a/tests/mir-opt/inline/inline_retag.bar.Inline.after.mir
+++ b/tests/mir-opt/inline/inline_retag.bar.Inline.after.mir
@@ -31,14 +31,14 @@ fn bar() -> bool {
         StorageLive(_4);
         _10 = const bar::promoted[1];
         Retag(_10);
-        _4 = &(*_10);
-        _3 = &(*_4);
+        _4 = _10;
+        _3 = _4;
         StorageLive(_6);
         StorageLive(_7);
         _9 = const bar::promoted[0];
         Retag(_9);
-        _7 = &(*_9);
-        _6 = &(*_7);
+        _7 = _9;
+        _6 = _7;
         Retag(_3);
         Retag(_6);
         StorageLive(_11);

--- a/tests/mir-opt/inline/inline_trait_method.test.Inline.after.panic-abort.mir
+++ b/tests/mir-opt/inline/inline_trait_method.test.Inline.after.panic-abort.mir
@@ -7,7 +7,7 @@ fn test(_1: &dyn X) -> u32 {
 
     bb0: {
         StorageLive(_2);
-        _2 = &(*_1);
+        _2 = _1;
         _0 = <dyn X as X>::y(move _2) -> [return: bb1, unwind unreachable];
     }
 

--- a/tests/mir-opt/inline/inline_trait_method.test.Inline.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/inline_trait_method.test.Inline.after.panic-unwind.mir
@@ -7,7 +7,7 @@ fn test(_1: &dyn X) -> u32 {
 
     bb0: {
         StorageLive(_2);
-        _2 = &(*_1);
+        _2 = _1;
         _0 = <dyn X as X>::y(move _2) -> [return: bb1, unwind continue];
     }
 

--- a/tests/mir-opt/inline/inline_trait_method_2.test2.Inline.after.panic-abort.mir
+++ b/tests/mir-opt/inline/inline_trait_method_2.test2.Inline.after.panic-abort.mir
@@ -12,8 +12,8 @@ fn test2(_1: &dyn X) -> bool {
     bb0: {
         StorageLive(_2);
         StorageLive(_3);
-        _3 = &(*_1);
-        _2 = move _3 as &dyn X (PointerCoercion(Unsize));
+        _3 = _1;
+        _2 = move _3;
         StorageDead(_3);
         _0 = <dyn X as X>::y(move _2) -> [return: bb1, unwind unreachable];
     }

--- a/tests/mir-opt/inline/inline_trait_method_2.test2.Inline.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/inline_trait_method_2.test2.Inline.after.panic-unwind.mir
@@ -12,8 +12,8 @@ fn test2(_1: &dyn X) -> bool {
     bb0: {
         StorageLive(_2);
         StorageLive(_3);
-        _3 = &(*_1);
-        _2 = move _3 as &dyn X (PointerCoercion(Unsize));
+        _3 = _1;
+        _2 = move _3;
         StorageDead(_3);
         _0 = <dyn X as X>::y(move _2) -> [return: bb1, unwind continue];
     }

--- a/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
+++ b/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.a.Inline.after.mir
@@ -14,11 +14,11 @@ fn a(_1: &mut [T]) -> &mut [T] {
         StorageLive(_2);
         StorageLive(_3);
         StorageLive(_4);
-        _4 = &mut (*_1);
+        _4 = _1;
         _3 = _4;
-        _2 = &mut (*_3);
+        _2 = _3;
         StorageDead(_4);
-        _0 = &mut (*_2);
+        _0 = _2;
         StorageDead(_3);
         StorageDead(_2);
         return;

--- a/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
+++ b/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.b.Inline.after.mir
@@ -16,7 +16,7 @@ fn b(_1: &mut Box<T>) -> &mut T {
         StorageLive(_2);
         StorageLive(_3);
         StorageLive(_4);
-        _4 = &mut (*_1);
+        _4 = _1;
         StorageLive(_5);
         StorageLive(_6);
         _5 = (*_4);
@@ -24,9 +24,9 @@ fn b(_1: &mut Box<T>) -> &mut T {
         _3 = &mut (*_6);
         StorageDead(_6);
         StorageDead(_5);
-        _2 = &mut (*_3);
+        _2 = _3;
         StorageDead(_4);
-        _0 = &mut (*_2);
+        _0 = _2;
         StorageDead(_3);
         StorageDead(_2);
         return;

--- a/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.c.Inline.after.mir
+++ b/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.c.Inline.after.mir
@@ -12,9 +12,9 @@ fn c(_1: &[T]) -> &[T] {
     bb0: {
         StorageLive(_2);
         StorageLive(_3);
-        _3 = &(*_1);
+        _3 = _1;
         _2 = _3;
-        _0 = &(*_2);
+        _0 = _2;
         StorageDead(_3);
         StorageDead(_2);
         return;

--- a/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
+++ b/tests/mir-opt/inline/issue_58867_inline_as_ref_as_mut.d.Inline.after.mir
@@ -14,7 +14,7 @@ fn d(_1: &Box<T>) -> &T {
     bb0: {
         StorageLive(_2);
         StorageLive(_3);
-        _3 = &(*_1);
+        _3 = _1;
         StorageLive(_4);
         StorageLive(_5);
         _4 = (*_3);
@@ -22,7 +22,7 @@ fn d(_1: &Box<T>) -> &T {
         _2 = &(*_5);
         StorageDead(_5);
         StorageDead(_4);
-        _0 = &(*_2);
+        _0 = _2;
         StorageDead(_3);
         StorageDead(_2);
         return;

--- a/tests/mir-opt/instsimplify/bool_compare.eq_false.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/bool_compare.eq_false.InstSimplify-after-simplifycfg.diff
@@ -1,7 +1,7 @@
-- // MIR for `true_ne` before InstSimplify
-+ // MIR for `true_ne` after InstSimplify
+- // MIR for `eq_false` before InstSimplify-after-simplifycfg
++ // MIR for `eq_false` after InstSimplify-after-simplifycfg
   
-  fn true_ne(_1: bool) -> u32 {
+  fn eq_false(_1: bool) -> u32 {
       debug x => _1;
       let mut _0: u32;
       let mut _2: bool;
@@ -11,7 +11,7 @@
           StorageLive(_2);
           StorageLive(_3);
           _3 = _1;
--         _2 = Ne(const true, move _3);
+-         _2 = Eq(move _3, const false);
 +         _2 = Not(move _3);
           switchInt(move _2) -> [0: bb2, otherwise: bb1];
       }

--- a/tests/mir-opt/instsimplify/bool_compare.eq_true.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/bool_compare.eq_true.InstSimplify-after-simplifycfg.diff
@@ -1,7 +1,7 @@
-- // MIR for `false_ne` before InstSimplify
-+ // MIR for `false_ne` after InstSimplify
+- // MIR for `eq_true` before InstSimplify-after-simplifycfg
++ // MIR for `eq_true` after InstSimplify-after-simplifycfg
   
-  fn false_ne(_1: bool) -> u32 {
+  fn eq_true(_1: bool) -> u32 {
       debug x => _1;
       let mut _0: u32;
       let mut _2: bool;
@@ -11,7 +11,7 @@
           StorageLive(_2);
           StorageLive(_3);
           _3 = _1;
--         _2 = Ne(const false, move _3);
+-         _2 = Eq(move _3, const true);
 +         _2 = move _3;
           switchInt(move _2) -> [0: bb2, otherwise: bb1];
       }

--- a/tests/mir-opt/instsimplify/bool_compare.false_eq.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/bool_compare.false_eq.InstSimplify-after-simplifycfg.diff
@@ -1,7 +1,7 @@
-- // MIR for `eq_true` before InstSimplify
-+ // MIR for `eq_true` after InstSimplify
+- // MIR for `false_eq` before InstSimplify-after-simplifycfg
++ // MIR for `false_eq` after InstSimplify-after-simplifycfg
   
-  fn eq_true(_1: bool) -> u32 {
+  fn false_eq(_1: bool) -> u32 {
       debug x => _1;
       let mut _0: u32;
       let mut _2: bool;
@@ -11,8 +11,8 @@
           StorageLive(_2);
           StorageLive(_3);
           _3 = _1;
--         _2 = Eq(move _3, const true);
-+         _2 = move _3;
+-         _2 = Eq(const false, move _3);
++         _2 = Not(move _3);
           switchInt(move _2) -> [0: bb2, otherwise: bb1];
       }
   

--- a/tests/mir-opt/instsimplify/bool_compare.false_ne.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/bool_compare.false_ne.InstSimplify-after-simplifycfg.diff
@@ -1,7 +1,7 @@
-- // MIR for `eq_false` before InstSimplify
-+ // MIR for `eq_false` after InstSimplify
+- // MIR for `false_ne` before InstSimplify-after-simplifycfg
++ // MIR for `false_ne` after InstSimplify-after-simplifycfg
   
-  fn eq_false(_1: bool) -> u32 {
+  fn false_ne(_1: bool) -> u32 {
       debug x => _1;
       let mut _0: u32;
       let mut _2: bool;
@@ -11,8 +11,8 @@
           StorageLive(_2);
           StorageLive(_3);
           _3 = _1;
--         _2 = Eq(move _3, const false);
-+         _2 = Not(move _3);
+-         _2 = Ne(const false, move _3);
++         _2 = move _3;
           switchInt(move _2) -> [0: bb2, otherwise: bb1];
       }
   

--- a/tests/mir-opt/instsimplify/bool_compare.ne_false.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/bool_compare.ne_false.InstSimplify-after-simplifycfg.diff
@@ -1,7 +1,7 @@
-- // MIR for `false_eq` before InstSimplify
-+ // MIR for `false_eq` after InstSimplify
+- // MIR for `ne_false` before InstSimplify-after-simplifycfg
++ // MIR for `ne_false` after InstSimplify-after-simplifycfg
   
-  fn false_eq(_1: bool) -> u32 {
+  fn ne_false(_1: bool) -> u32 {
       debug x => _1;
       let mut _0: u32;
       let mut _2: bool;
@@ -11,8 +11,8 @@
           StorageLive(_2);
           StorageLive(_3);
           _3 = _1;
--         _2 = Eq(const false, move _3);
-+         _2 = Not(move _3);
+-         _2 = Ne(move _3, const false);
++         _2 = move _3;
           switchInt(move _2) -> [0: bb2, otherwise: bb1];
       }
   

--- a/tests/mir-opt/instsimplify/bool_compare.ne_true.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/bool_compare.ne_true.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `ne_true` before InstSimplify
-+ // MIR for `ne_true` after InstSimplify
+- // MIR for `ne_true` before InstSimplify-after-simplifycfg
++ // MIR for `ne_true` after InstSimplify-after-simplifycfg
   
   fn ne_true(_1: bool) -> u32 {
       debug x => _1;

--- a/tests/mir-opt/instsimplify/bool_compare.rs
+++ b/tests/mir-opt/instsimplify/bool_compare.rs
@@ -1,55 +1,55 @@
-//@ test-mir-pass: InstSimplify
+//@ test-mir-pass: InstSimplify-after-simplifycfg
 
-// EMIT_MIR bool_compare.eq_true.InstSimplify.diff
+// EMIT_MIR bool_compare.eq_true.InstSimplify-after-simplifycfg.diff
 fn eq_true(x: bool) -> u32 {
     // CHECK-LABEL: fn eq_true(
     // CHECK-NOT: Eq(
     if x == true { 0 } else { 1 }
 }
 
-// EMIT_MIR bool_compare.true_eq.InstSimplify.diff
+// EMIT_MIR bool_compare.true_eq.InstSimplify-after-simplifycfg.diff
 fn true_eq(x: bool) -> u32 {
     // CHECK-LABEL: fn true_eq(
     // CHECK-NOT: Eq(
     if true == x { 0 } else { 1 }
 }
 
-// EMIT_MIR bool_compare.ne_true.InstSimplify.diff
+// EMIT_MIR bool_compare.ne_true.InstSimplify-after-simplifycfg.diff
 fn ne_true(x: bool) -> u32 {
     // CHECK-LABEL: fn ne_true(
     // CHECK: Not(
     if x != true { 0 } else { 1 }
 }
 
-// EMIT_MIR bool_compare.true_ne.InstSimplify.diff
+// EMIT_MIR bool_compare.true_ne.InstSimplify-after-simplifycfg.diff
 fn true_ne(x: bool) -> u32 {
     // CHECK-LABEL: fn true_ne(
     // CHECK: Not(
     if true != x { 0 } else { 1 }
 }
 
-// EMIT_MIR bool_compare.eq_false.InstSimplify.diff
+// EMIT_MIR bool_compare.eq_false.InstSimplify-after-simplifycfg.diff
 fn eq_false(x: bool) -> u32 {
     // CHECK-LABEL: fn eq_false(
     // CHECK: Not(
     if x == false { 0 } else { 1 }
 }
 
-// EMIT_MIR bool_compare.false_eq.InstSimplify.diff
+// EMIT_MIR bool_compare.false_eq.InstSimplify-after-simplifycfg.diff
 fn false_eq(x: bool) -> u32 {
     // CHECK-LABEL: fn false_eq(
     // CHECK: Not(
     if false == x { 0 } else { 1 }
 }
 
-// EMIT_MIR bool_compare.ne_false.InstSimplify.diff
+// EMIT_MIR bool_compare.ne_false.InstSimplify-after-simplifycfg.diff
 fn ne_false(x: bool) -> u32 {
     // CHECK-LABEL: fn ne_false(
     // CHECK-NOT: Ne(
     if x != false { 0 } else { 1 }
 }
 
-// EMIT_MIR bool_compare.false_ne.InstSimplify.diff
+// EMIT_MIR bool_compare.false_ne.InstSimplify-after-simplifycfg.diff
 fn false_ne(x: bool) -> u32 {
     // CHECK-LABEL: fn false_ne(
     // CHECK-NOT: Ne(

--- a/tests/mir-opt/instsimplify/bool_compare.true_eq.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/bool_compare.true_eq.InstSimplify-after-simplifycfg.diff
@@ -1,7 +1,7 @@
-- // MIR for `ne_false` before InstSimplify
-+ // MIR for `ne_false` after InstSimplify
+- // MIR for `true_eq` before InstSimplify-after-simplifycfg
++ // MIR for `true_eq` after InstSimplify-after-simplifycfg
   
-  fn ne_false(_1: bool) -> u32 {
+  fn true_eq(_1: bool) -> u32 {
       debug x => _1;
       let mut _0: u32;
       let mut _2: bool;
@@ -11,7 +11,7 @@
           StorageLive(_2);
           StorageLive(_3);
           _3 = _1;
--         _2 = Ne(move _3, const false);
+-         _2 = Eq(const true, move _3);
 +         _2 = move _3;
           switchInt(move _2) -> [0: bb2, otherwise: bb1];
       }

--- a/tests/mir-opt/instsimplify/bool_compare.true_ne.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/bool_compare.true_ne.InstSimplify-after-simplifycfg.diff
@@ -1,7 +1,7 @@
-- // MIR for `true_eq` before InstSimplify
-+ // MIR for `true_eq` after InstSimplify
+- // MIR for `true_ne` before InstSimplify-after-simplifycfg
++ // MIR for `true_ne` after InstSimplify-after-simplifycfg
   
-  fn true_eq(_1: bool) -> u32 {
+  fn true_ne(_1: bool) -> u32 {
       debug x => _1;
       let mut _0: u32;
       let mut _2: bool;
@@ -11,8 +11,8 @@
           StorageLive(_2);
           StorageLive(_3);
           _3 = _1;
--         _2 = Eq(const true, move _3);
-+         _2 = move _3;
+-         _2 = Ne(const true, move _3);
++         _2 = Not(move _3);
           switchInt(move _2) -> [0: bb2, otherwise: bb1];
       }
   

--- a/tests/mir-opt/instsimplify/casts.redundant.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/casts.redundant.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `redundant` before InstSimplify
-+ // MIR for `redundant` after InstSimplify
+- // MIR for `redundant` before InstSimplify-after-simplifycfg
++ // MIR for `redundant` after InstSimplify-after-simplifycfg
   
   fn redundant(_1: *const &u8) -> *const &u8 {
       debug x => _1;

--- a/tests/mir-opt/instsimplify/casts.roundtrip.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/casts.roundtrip.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `roundtrip` before InstSimplify
-+ // MIR for `roundtrip` after InstSimplify
+- // MIR for `roundtrip` before InstSimplify-after-simplifycfg
++ // MIR for `roundtrip` after InstSimplify-after-simplifycfg
   
   fn roundtrip(_1: *const u8) -> *const u8 {
       debug x => _1;

--- a/tests/mir-opt/instsimplify/casts.rs
+++ b/tests/mir-opt/instsimplify/casts.rs
@@ -1,4 +1,4 @@
-//@ test-mir-pass: InstSimplify
+//@ test-mir-pass: InstSimplify-after-simplifycfg
 //@ compile-flags: -Zinline-mir
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]
@@ -8,7 +8,7 @@ fn generic_cast<T, U>(x: *const T) -> *const U {
     x as *const U
 }
 
-// EMIT_MIR casts.redundant.InstSimplify.diff
+// EMIT_MIR casts.redundant.InstSimplify-after-simplifycfg.diff
 pub fn redundant<'a, 'b: 'a>(x: *const &'a u8) -> *const &'a u8 {
     // CHECK-LABEL: fn redundant(
     // CHECK: inlined generic_cast
@@ -16,7 +16,7 @@ pub fn redundant<'a, 'b: 'a>(x: *const &'a u8) -> *const &'a u8 {
     generic_cast::<&'a u8, &'b u8>(x) as *const &'a u8
 }
 
-// EMIT_MIR casts.roundtrip.InstSimplify.diff
+// EMIT_MIR casts.roundtrip.InstSimplify-after-simplifycfg.diff
 pub fn roundtrip(x: *const u8) -> *const u8 {
     // CHECK-LABEL: fn roundtrip(
     // CHECK: _4 = _1;
@@ -25,7 +25,7 @@ pub fn roundtrip(x: *const u8) -> *const u8 {
     x as *mut u8 as *const u8
 }
 
-// EMIT_MIR casts.roundtrip.InstSimplify.diff
+// EMIT_MIR casts.roundtrip.InstSimplify-after-simplifycfg.diff
 pub fn cast_thin_via_aggregate(x: *const u8) -> *const () {
     // CHECK-LABEL: fn cast_thin_via_aggregate(
     // CHECK: _2 = _1;

--- a/tests/mir-opt/instsimplify/combine_array_len.norm2.InstSimplify-after-simplifycfg.panic-abort.diff
+++ b/tests/mir-opt/instsimplify/combine_array_len.norm2.InstSimplify-after-simplifycfg.panic-abort.diff
@@ -1,5 +1,5 @@
-- // MIR for `norm2` before InstSimplify
-+ // MIR for `norm2` after InstSimplify
+- // MIR for `norm2` before InstSimplify-after-simplifycfg
++ // MIR for `norm2` after InstSimplify-after-simplifycfg
   
   fn norm2(_1: [f32; 2]) -> f32 {
       debug x => _1;

--- a/tests/mir-opt/instsimplify/combine_array_len.norm2.InstSimplify-after-simplifycfg.panic-unwind.diff
+++ b/tests/mir-opt/instsimplify/combine_array_len.norm2.InstSimplify-after-simplifycfg.panic-unwind.diff
@@ -1,5 +1,5 @@
-- // MIR for `norm2` before InstSimplify
-+ // MIR for `norm2` after InstSimplify
+- // MIR for `norm2` before InstSimplify-after-simplifycfg
++ // MIR for `norm2` after InstSimplify-after-simplifycfg
   
   fn norm2(_1: [f32; 2]) -> f32 {
       debug x => _1;

--- a/tests/mir-opt/instsimplify/combine_array_len.rs
+++ b/tests/mir-opt/instsimplify/combine_array_len.rs
@@ -1,7 +1,7 @@
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
-//@ test-mir-pass: InstSimplify
+//@ test-mir-pass: InstSimplify-after-simplifycfg
 
-// EMIT_MIR combine_array_len.norm2.InstSimplify.diff
+// EMIT_MIR combine_array_len.norm2.InstSimplify-after-simplifycfg.diff
 fn norm2(x: [f32; 2]) -> f32 {
     // CHECK-LABEL: fn norm2(
     // CHECK-NOT: Len(

--- a/tests/mir-opt/instsimplify/combine_clone_of_primitives.rs
+++ b/tests/mir-opt/instsimplify/combine_clone_of_primitives.rs
@@ -1,7 +1,7 @@
-//@ test-mir-pass: InstSimplify
+//@ test-mir-pass: InstSimplify-after-simplifycfg
 // EMIT_MIR_FOR_EACH_PANIC_STRATEGY
 
-// EMIT_MIR combine_clone_of_primitives.{impl#0}-clone.InstSimplify.diff
+// EMIT_MIR combine_clone_of_primitives.{impl#0}-clone.InstSimplify-after-simplifycfg.diff
 #[derive(Clone)]
 struct MyThing<T> {
     v: T,

--- a/tests/mir-opt/instsimplify/combine_clone_of_primitives.{impl#0}-clone.InstSimplify-after-simplifycfg.panic-abort.diff
+++ b/tests/mir-opt/instsimplify/combine_clone_of_primitives.{impl#0}-clone.InstSimplify-after-simplifycfg.panic-abort.diff
@@ -1,5 +1,5 @@
-- // MIR for `<impl at $DIR/combine_clone_of_primitives.rs:5:10: 5:15>::clone` before InstSimplify
-+ // MIR for `<impl at $DIR/combine_clone_of_primitives.rs:5:10: 5:15>::clone` after InstSimplify
+- // MIR for `<impl at $DIR/combine_clone_of_primitives.rs:5:10: 5:15>::clone` before InstSimplify-after-simplifycfg
++ // MIR for `<impl at $DIR/combine_clone_of_primitives.rs:5:10: 5:15>::clone` after InstSimplify-after-simplifycfg
   
   fn <impl at $DIR/combine_clone_of_primitives.rs:5:10: 5:15>::clone(_1: &MyThing<T>) -> MyThing<T> {
       debug self => _1;
@@ -21,7 +21,7 @@
           _4 = &((*_1).0: T);
 -         _3 = &(*_4);
 +         _3 = _4;
-          _2 = <T as Clone>::clone(move _3) -> [return: bb1, unwind continue];
+          _2 = <T as Clone>::clone(move _3) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {
@@ -31,7 +31,7 @@
           StorageLive(_7);
           _7 = &((*_1).1: u64);
 -         _6 = &(*_7);
--         _5 = <u64 as Clone>::clone(move _6) -> [return: bb2, unwind: bb4];
+-         _5 = <u64 as Clone>::clone(move _6) -> [return: bb2, unwind unreachable];
 +         _6 = _7;
 +         _5 = (*_6);
 +         goto -> bb2;
@@ -44,7 +44,7 @@
           StorageLive(_10);
           _10 = &((*_1).2: [f32; 3]);
 -         _9 = &(*_10);
--         _8 = <[f32; 3] as Clone>::clone(move _9) -> [return: bb3, unwind: bb4];
+-         _8 = <[f32; 3] as Clone>::clone(move _9) -> [return: bb3, unwind unreachable];
 +         _9 = _10;
 +         _8 = (*_9);
 +         goto -> bb3;
@@ -60,14 +60,6 @@
           StorageDead(_7);
           StorageDead(_4);
           return;
-      }
-  
-      bb4 (cleanup): {
-          drop(_2) -> [return: bb5, unwind terminate(cleanup)];
-      }
-  
-      bb5 (cleanup): {
-          resume;
       }
   }
   

--- a/tests/mir-opt/instsimplify/combine_clone_of_primitives.{impl#0}-clone.InstSimplify-after-simplifycfg.panic-unwind.diff
+++ b/tests/mir-opt/instsimplify/combine_clone_of_primitives.{impl#0}-clone.InstSimplify-after-simplifycfg.panic-unwind.diff
@@ -1,5 +1,5 @@
-- // MIR for `<impl at $DIR/combine_clone_of_primitives.rs:5:10: 5:15>::clone` before InstSimplify
-+ // MIR for `<impl at $DIR/combine_clone_of_primitives.rs:5:10: 5:15>::clone` after InstSimplify
+- // MIR for `<impl at $DIR/combine_clone_of_primitives.rs:5:10: 5:15>::clone` before InstSimplify-after-simplifycfg
++ // MIR for `<impl at $DIR/combine_clone_of_primitives.rs:5:10: 5:15>::clone` after InstSimplify-after-simplifycfg
   
   fn <impl at $DIR/combine_clone_of_primitives.rs:5:10: 5:15>::clone(_1: &MyThing<T>) -> MyThing<T> {
       debug self => _1;
@@ -21,7 +21,7 @@
           _4 = &((*_1).0: T);
 -         _3 = &(*_4);
 +         _3 = _4;
-          _2 = <T as Clone>::clone(move _3) -> [return: bb1, unwind unreachable];
+          _2 = <T as Clone>::clone(move _3) -> [return: bb1, unwind continue];
       }
   
       bb1: {
@@ -31,7 +31,7 @@
           StorageLive(_7);
           _7 = &((*_1).1: u64);
 -         _6 = &(*_7);
--         _5 = <u64 as Clone>::clone(move _6) -> [return: bb2, unwind unreachable];
+-         _5 = <u64 as Clone>::clone(move _6) -> [return: bb2, unwind: bb4];
 +         _6 = _7;
 +         _5 = (*_6);
 +         goto -> bb2;
@@ -44,7 +44,7 @@
           StorageLive(_10);
           _10 = &((*_1).2: [f32; 3]);
 -         _9 = &(*_10);
--         _8 = <[f32; 3] as Clone>::clone(move _9) -> [return: bb3, unwind unreachable];
+-         _8 = <[f32; 3] as Clone>::clone(move _9) -> [return: bb3, unwind: bb4];
 +         _9 = _10;
 +         _8 = (*_9);
 +         goto -> bb3;
@@ -60,6 +60,14 @@
           StorageDead(_7);
           StorageDead(_4);
           return;
+      }
+  
+      bb4 (cleanup): {
+          drop(_2) -> [return: bb5, unwind terminate(cleanup)];
+      }
+  
+      bb5 (cleanup): {
+          resume;
       }
   }
   

--- a/tests/mir-opt/instsimplify/combine_transmutes.adt_transmutes.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/combine_transmutes.adt_transmutes.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `adt_transmutes` before InstSimplify
-+ // MIR for `adt_transmutes` after InstSimplify
+- // MIR for `adt_transmutes` before InstSimplify-after-simplifycfg
++ // MIR for `adt_transmutes` after InstSimplify-after-simplifycfg
   
   fn adt_transmutes() -> () {
       let mut _0: ();

--- a/tests/mir-opt/instsimplify/combine_transmutes.identity_transmutes.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/combine_transmutes.identity_transmutes.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `identity_transmutes` before InstSimplify
-+ // MIR for `identity_transmutes` after InstSimplify
+- // MIR for `identity_transmutes` before InstSimplify-after-simplifycfg
++ // MIR for `identity_transmutes` after InstSimplify-after-simplifycfg
   
   fn identity_transmutes() -> () {
       let mut _0: ();

--- a/tests/mir-opt/instsimplify/combine_transmutes.integer_transmutes.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/combine_transmutes.integer_transmutes.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `integer_transmutes` before InstSimplify
-+ // MIR for `integer_transmutes` after InstSimplify
+- // MIR for `integer_transmutes` before InstSimplify-after-simplifycfg
++ // MIR for `integer_transmutes` after InstSimplify-after-simplifycfg
   
   fn integer_transmutes() -> () {
       let mut _0: ();

--- a/tests/mir-opt/instsimplify/combine_transmutes.rs
+++ b/tests/mir-opt/instsimplify/combine_transmutes.rs
@@ -1,4 +1,4 @@
-//@ test-mir-pass: InstSimplify
+//@ test-mir-pass: InstSimplify-after-simplifycfg
 //@ compile-flags: -C panic=abort
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]
@@ -7,7 +7,7 @@
 use std::intrinsics::mir::*;
 use std::mem::{transmute, ManuallyDrop, MaybeUninit};
 
-// EMIT_MIR combine_transmutes.identity_transmutes.InstSimplify.diff
+// EMIT_MIR combine_transmutes.identity_transmutes.InstSimplify-after-simplifycfg.diff
 pub unsafe fn identity_transmutes() {
     // CHECK-LABEL: fn identity_transmutes(
     // CHECK-NOT: as i32 (Transmute);
@@ -19,7 +19,7 @@ pub unsafe fn identity_transmutes() {
 }
 
 #[custom_mir(dialect = "runtime", phase = "initial")]
-// EMIT_MIR combine_transmutes.integer_transmutes.InstSimplify.diff
+// EMIT_MIR combine_transmutes.integer_transmutes.InstSimplify-after-simplifycfg.diff
 pub unsafe fn integer_transmutes() {
     // CHECK-LABEL: fn integer_transmutes(
     // CHECK-NOT: _i32 as u32 (Transmute);
@@ -43,7 +43,7 @@ pub unsafe fn integer_transmutes() {
     }
 }
 
-// EMIT_MIR combine_transmutes.adt_transmutes.InstSimplify.diff
+// EMIT_MIR combine_transmutes.adt_transmutes.InstSimplify-after-simplifycfg.diff
 pub unsafe fn adt_transmutes() {
     // CHECK-LABEL: fn adt_transmutes(
     // CHECK: as u8 (Transmute);

--- a/tests/mir-opt/instsimplify/duplicate_switch_targets.assert_zero.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/duplicate_switch_targets.assert_zero.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `assert_zero` before InstSimplify
-+ // MIR for `assert_zero` after InstSimplify
+- // MIR for `assert_zero` before InstSimplify-after-simplifycfg
++ // MIR for `assert_zero` after InstSimplify-after-simplifycfg
   
   fn assert_zero(_1: u8) -> u8 {
       let mut _0: u8;

--- a/tests/mir-opt/instsimplify/duplicate_switch_targets.rs
+++ b/tests/mir-opt/instsimplify/duplicate_switch_targets.rs
@@ -1,11 +1,11 @@
-//@ test-mir-pass: InstSimplify
+//@ test-mir-pass: InstSimplify-after-simplifycfg
 
 #![feature(custom_mir, core_intrinsics)]
 #![crate_type = "lib"]
 
 use std::intrinsics::mir::*;
 
-// EMIT_MIR duplicate_switch_targets.assert_zero.InstSimplify.diff
+// EMIT_MIR duplicate_switch_targets.assert_zero.InstSimplify-after-simplifycfg.diff
 #[custom_mir(dialect = "runtime", phase = "post-cleanup")]
 pub unsafe fn assert_zero(x: u8) -> u8 {
     // CHECK-LABEL: fn assert_zero(

--- a/tests/mir-opt/instsimplify/intrinsic_asserts.generic.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/intrinsic_asserts.generic.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `generic` before InstSimplify
-+ // MIR for `generic` after InstSimplify
+- // MIR for `generic` before InstSimplify-after-simplifycfg
++ // MIR for `generic` after InstSimplify-after-simplifycfg
   
   fn generic() -> () {
       let mut _0: ();

--- a/tests/mir-opt/instsimplify/intrinsic_asserts.generic_ref.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/intrinsic_asserts.generic_ref.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `generic_ref` before InstSimplify
-+ // MIR for `generic_ref` after InstSimplify
+- // MIR for `generic_ref` before InstSimplify-after-simplifycfg
++ // MIR for `generic_ref` after InstSimplify-after-simplifycfg
   
   fn generic_ref() -> () {
       let mut _0: ();

--- a/tests/mir-opt/instsimplify/intrinsic_asserts.panics.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/intrinsic_asserts.panics.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `panics` before InstSimplify
-+ // MIR for `panics` after InstSimplify
+- // MIR for `panics` before InstSimplify-after-simplifycfg
++ // MIR for `panics` after InstSimplify-after-simplifycfg
   
   fn panics() -> () {
       let mut _0: ();

--- a/tests/mir-opt/instsimplify/intrinsic_asserts.removable.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/intrinsic_asserts.removable.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `removable` before InstSimplify
-+ // MIR for `removable` after InstSimplify
+- // MIR for `removable` before InstSimplify-after-simplifycfg
++ // MIR for `removable` after InstSimplify-after-simplifycfg
   
   fn removable() -> () {
       let mut _0: ();

--- a/tests/mir-opt/instsimplify/intrinsic_asserts.rs
+++ b/tests/mir-opt/instsimplify/intrinsic_asserts.rs
@@ -1,10 +1,10 @@
-//@ test-mir-pass: InstSimplify
+//@ test-mir-pass: InstSimplify-after-simplifycfg
 
 #![crate_type = "lib"]
 #![feature(core_intrinsics)]
 
 // All these assertions pass, so all the intrinsic calls should be deleted.
-// EMIT_MIR intrinsic_asserts.removable.InstSimplify.diff
+// EMIT_MIR intrinsic_asserts.removable.InstSimplify-after-simplifycfg.diff
 pub fn removable() {
     // CHECK-LABEL: fn removable(
     // CHECK-NOT: assert_inhabited
@@ -18,7 +18,7 @@ pub fn removable() {
 enum Never {}
 
 // These assertions all diverge, so their target blocks should become None.
-// EMIT_MIR intrinsic_asserts.panics.InstSimplify.diff
+// EMIT_MIR intrinsic_asserts.panics.InstSimplify-after-simplifycfg.diff
 pub fn panics() {
     // CHECK-LABEL: fn panics(
     // CHECK: assert_inhabited::<Never>() -> unwind
@@ -30,7 +30,7 @@ pub fn panics() {
 }
 
 // Whether or not these asserts pass isn't known, so they shouldn't be modified.
-// EMIT_MIR intrinsic_asserts.generic.InstSimplify.diff
+// EMIT_MIR intrinsic_asserts.generic.InstSimplify-after-simplifycfg.diff
 pub fn generic<T>() {
     // CHECK-LABEL: fn generic(
     // CHECK: assert_inhabited::<T>() -> [return:
@@ -42,7 +42,7 @@ pub fn generic<T>() {
 }
 
 // Whether or not these asserts pass isn't known, so they shouldn't be modified.
-// EMIT_MIR intrinsic_asserts.generic_ref.InstSimplify.diff
+// EMIT_MIR intrinsic_asserts.generic_ref.InstSimplify-after-simplifycfg.diff
 pub fn generic_ref<T>() {
     // CHECK-LABEL: fn generic_ref(
     // CHECK: assert_mem_uninitialized_valid::<&T>() -> [return:

--- a/tests/mir-opt/instsimplify/ref_of_deref.pointers.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/ref_of_deref.pointers.InstSimplify-after-simplifycfg.diff
@@ -1,26 +1,26 @@
-- // MIR for `references` before InstSimplify
-+ // MIR for `references` after InstSimplify
+- // MIR for `pointers` before InstSimplify-after-simplifycfg
++ // MIR for `pointers` after InstSimplify-after-simplifycfg
   
-  fn references(_1: &i32, _2: &mut [i32]) -> () {
-      debug const_ref => _1;
-      debug mut_ref => _2;
+  fn pointers(_1: *const [i32], _2: *mut i32) -> () {
+      debug const_ptr => _1;
+      debug mut_ptr => _2;
       let mut _0: ();
-      let _3: &i32;
+      let _3: &[i32];
       scope 1 {
           debug _a => _3;
-          let _4: &[i32];
+          let _4: &i32;
           scope 2 {
               debug _b => _4;
-              let _5: &mut [i32];
+              let _5: &mut i32;
               scope 3 {
                   debug _c => _5;
-                  let _6: *const i32;
+                  let _6: *const [i32];
                   scope 4 {
                       debug _d => _6;
-                      let _7: *const [i32];
+                      let _7: *const i32;
                       scope 5 {
                           debug _e => _7;
-                          let _8: *mut [i32];
+                          let _8: *mut i32;
                           scope 6 {
                               debug _f => _8;
                           }
@@ -32,19 +32,19 @@
   
       bb0: {
           StorageLive(_3);
--         _3 = &(*_1);
-+         _3 = _1;
+          _3 = &(*_1);
           StorageLive(_4);
           _4 = &(*_2);
           StorageLive(_5);
--         _5 = &mut (*_2);
-+         _5 = _2;
+          _5 = &mut (*_2);
           StorageLive(_6);
-          _6 = &raw const (*_1);
+-         _6 = &raw const (*_1);
++         _6 = _1;
           StorageLive(_7);
           _7 = &raw const (*_2);
           StorageLive(_8);
-          _8 = &raw mut (*_2);
+-         _8 = &raw mut (*_2);
++         _8 = _2;
           _0 = const ();
           StorageDead(_8);
           StorageDead(_7);

--- a/tests/mir-opt/instsimplify/ref_of_deref.references.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/ref_of_deref.references.InstSimplify-after-simplifycfg.diff
@@ -1,26 +1,26 @@
-- // MIR for `pointers` before InstSimplify
-+ // MIR for `pointers` after InstSimplify
+- // MIR for `references` before InstSimplify-after-simplifycfg
++ // MIR for `references` after InstSimplify-after-simplifycfg
   
-  fn pointers(_1: *const [i32], _2: *mut i32) -> () {
-      debug const_ptr => _1;
-      debug mut_ptr => _2;
+  fn references(_1: &i32, _2: &mut [i32]) -> () {
+      debug const_ref => _1;
+      debug mut_ref => _2;
       let mut _0: ();
-      let _3: &[i32];
+      let _3: &i32;
       scope 1 {
           debug _a => _3;
-          let _4: &i32;
+          let _4: &[i32];
           scope 2 {
               debug _b => _4;
-              let _5: &mut i32;
+              let _5: &mut [i32];
               scope 3 {
                   debug _c => _5;
-                  let _6: *const [i32];
+                  let _6: *const i32;
                   scope 4 {
                       debug _d => _6;
-                      let _7: *const i32;
+                      let _7: *const [i32];
                       scope 5 {
                           debug _e => _7;
-                          let _8: *mut i32;
+                          let _8: *mut [i32];
                           scope 6 {
                               debug _f => _8;
                           }
@@ -32,19 +32,19 @@
   
       bb0: {
           StorageLive(_3);
-          _3 = &(*_1);
+-         _3 = &(*_1);
++         _3 = _1;
           StorageLive(_4);
           _4 = &(*_2);
           StorageLive(_5);
-          _5 = &mut (*_2);
+-         _5 = &mut (*_2);
++         _5 = _2;
           StorageLive(_6);
--         _6 = &raw const (*_1);
-+         _6 = _1;
+          _6 = &raw const (*_1);
           StorageLive(_7);
           _7 = &raw const (*_2);
           StorageLive(_8);
--         _8 = &raw mut (*_2);
-+         _8 = _2;
+          _8 = &raw mut (*_2);
           _0 = const ();
           StorageDead(_8);
           StorageDead(_7);

--- a/tests/mir-opt/instsimplify/ref_of_deref.rs
+++ b/tests/mir-opt/instsimplify/ref_of_deref.rs
@@ -1,11 +1,11 @@
-//@ test-mir-pass: InstSimplify
+//@ test-mir-pass: InstSimplify-after-simplifycfg
 #![crate_type = "lib"]
 #![feature(raw_ref_op)]
 
 // For each of these, only 2 of the 6 should simplify,
 // as the others have the wrong types.
 
-// EMIT_MIR ref_of_deref.references.InstSimplify.diff
+// EMIT_MIR ref_of_deref.references.InstSimplify-after-simplifycfg.diff
 // CHECK-LABEL: references
 pub fn references(const_ref: &i32, mut_ref: &mut [i32]) {
     // CHECK: _3 = _1;
@@ -22,7 +22,7 @@ pub fn references(const_ref: &i32, mut_ref: &mut [i32]) {
     let _f = &raw mut *mut_ref;
 }
 
-// EMIT_MIR ref_of_deref.pointers.InstSimplify.diff
+// EMIT_MIR ref_of_deref.pointers.InstSimplify-after-simplifycfg.diff
 // CHECK-LABEL: pointers
 pub unsafe fn pointers(const_ptr: *const [i32], mut_ptr: *mut i32) {
     // CHECK: _3 = &(*_1);

--- a/tests/mir-opt/instsimplify/ub_check.rs
+++ b/tests/mir-opt/instsimplify/ub_check.rs
@@ -1,7 +1,7 @@
-//@ test-mir-pass: InstSimplify
+//@ test-mir-pass: InstSimplify-after-simplifycfg
 //@ compile-flags: -Cdebug-assertions=no -Zinline-mir
 
-// EMIT_MIR ub_check.unwrap_unchecked.InstSimplify.diff
+// EMIT_MIR ub_check.unwrap_unchecked.InstSimplify-after-simplifycfg.diff
 pub fn unwrap_unchecked(x: Option<i32>) -> i32 {
     // CHECK-LABEL: fn unwrap_unchecked(
     // CHECK-NOT: UbChecks()

--- a/tests/mir-opt/instsimplify/ub_check.unwrap_unchecked.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/ub_check.unwrap_unchecked.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `unwrap_unchecked` before InstSimplify
-+ // MIR for `unwrap_unchecked` after InstSimplify
+- // MIR for `unwrap_unchecked` before InstSimplify-after-simplifycfg
++ // MIR for `unwrap_unchecked` after InstSimplify-after-simplifycfg
   
   fn unwrap_unchecked(_1: Option<i32>) -> i32 {
       debug x => _1;

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-abort.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-abort.diff
@@ -5,7 +5,7 @@
       debug x => _1;
       let mut _0: ();
       let _2: &[T];
-      let mut _3: &[T; 3];
+      let _3: &[T; 3];
       let _4: [T; 3];
       let mut _5: usize;
       let mut _6: bool;
@@ -23,12 +23,10 @@
       }
   
       bb0: {
-          StorageLive(_3);
           StorageLive(_4);
           _4 = [_1, _1, _1];
           _3 = &_4;
-          _2 = move _3 as &[T] (PointerCoercion(Unsize));
-          StorageDead(_3);
+          _2 = _3 as &[T] (PointerCoercion(Unsize));
           nop;
           nop;
           goto -> bb2;

--- a/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
+++ b/tests/mir-opt/issue_76432.test.SimplifyComparisonIntegral.panic-unwind.diff
@@ -5,7 +5,7 @@
       debug x => _1;
       let mut _0: ();
       let _2: &[T];
-      let mut _3: &[T; 3];
+      let _3: &[T; 3];
       let _4: [T; 3];
       let mut _5: usize;
       let mut _6: bool;
@@ -23,12 +23,10 @@
       }
   
       bb0: {
-          StorageLive(_3);
           StorageLive(_4);
           _4 = [_1, _1, _1];
           _3 = &_4;
-          _2 = move _3 as &[T] (PointerCoercion(Unsize));
-          StorageDead(_3);
+          _2 = _3 as &[T] (PointerCoercion(Unsize));
           nop;
           nop;
           goto -> bb2;

--- a/tests/mir-opt/issue_78192.f.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/issue_78192.f.InstSimplify-after-simplifycfg.diff
@@ -1,5 +1,5 @@
-- // MIR for `f` before InstSimplify
-+ // MIR for `f` after InstSimplify
+- // MIR for `f` before InstSimplify-after-simplifycfg
++ // MIR for `f` after InstSimplify-after-simplifycfg
   
   fn f(_1: &T) -> *const T {
       debug a => _1;
@@ -17,8 +17,7 @@
           StorageLive(_4);
           _4 = &raw const (*_1);
           _3 = &_4;
--         _2 = &(*_3);
-+         _2 = _3;
+          _2 = _3;
           StorageDead(_3);
           _0 = (*_2);
           StorageDead(_4);

--- a/tests/mir-opt/issue_78192.rs
+++ b/tests/mir-opt/issue_78192.rs
@@ -9,4 +9,4 @@ fn main() {
     f(&2);
 }
 
-// EMIT_MIR issue_78192.f.InstSimplify.diff
+// EMIT_MIR issue_78192.f.InstSimplify-after-simplifycfg.diff

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -24,7 +24,7 @@
               let _13: std::alloc::AllocError;
               let mut _14: !;
               let mut _15: &dyn std::fmt::Debug;
-              let mut _16: &std::alloc::AllocError;
+              let _16: &std::alloc::AllocError;
               scope 7 {
               }
               scope 8 {
@@ -86,21 +86,21 @@
           StorageDead(_8);
           StorageDead(_7);
           StorageLive(_12);
+          StorageLive(_16);
           _12 = discriminant(_6);
           switchInt(move _12) -> [0: bb6, 1: bb5, otherwise: bb1];
       }
   
       bb5: {
           StorageLive(_15);
-          StorageLive(_16);
           _16 = &_13;
-          _15 = move _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize));
-          StorageDead(_16);
+          _15 = _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize));
           _14 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _15) -> unwind unreachable;
       }
   
       bb6: {
           _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
+          StorageDead(_16);
           StorageDead(_12);
           StorageDead(_6);
 -         StorageLive(_17);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -24,7 +24,7 @@
               let _13: std::alloc::AllocError;
               let mut _14: !;
               let mut _15: &dyn std::fmt::Debug;
-              let mut _16: &std::alloc::AllocError;
+              let _16: &std::alloc::AllocError;
               scope 7 {
               }
               scope 8 {
@@ -86,21 +86,21 @@
           StorageDead(_8);
           StorageDead(_7);
           StorageLive(_12);
+          StorageLive(_16);
           _12 = discriminant(_6);
           switchInt(move _12) -> [0: bb6, 1: bb5, otherwise: bb1];
       }
   
       bb5: {
           StorageLive(_15);
-          StorageLive(_16);
           _16 = &_13;
-          _15 = move _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize));
-          StorageDead(_16);
+          _15 = _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize));
           _14 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _15) -> unwind unreachable;
       }
   
       bb6: {
           _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
+          StorageDead(_16);
           StorageDead(_12);
           StorageDead(_6);
 -         StorageLive(_17);

--- a/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.vec_move.PreCodegen.after.mir
@@ -30,13 +30,11 @@ fn vec_move(_1: Vec<impl Sized>) -> () {
 
     bb2: {
         StorageLive(_5);
-        StorageLive(_4);
         _4 = &mut _3;
         _5 = <std::vec::IntoIter<impl Sized> as Iterator>::next(move _4) -> [return: bb3, unwind: bb9];
     }
 
     bb3: {
-        StorageDead(_4);
         _6 = discriminant(_5);
         switchInt(move _6) -> [0: bb4, 1: bb6, otherwise: bb8];
     }

--- a/tests/mir-opt/pre-codegen/no_inlined_clone.rs
+++ b/tests/mir-opt/pre-codegen/no_inlined_clone.rs
@@ -1,0 +1,12 @@
+#![crate_type = "lib"]
+
+// EMIT_MIR no_inlined_clone.{impl#0}-clone.PreCodegen.after.mir
+
+// CHECK-LABEL: ::clone(
+// CHECK-NOT: inlined clone::impls::<impl Clone for {{.*}}>::clone
+// CHECK: return;
+
+#[derive(Clone)]
+struct Foo {
+    a: i32,
+}

--- a/tests/mir-opt/pre-codegen/no_inlined_clone.{impl#0}-clone.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/no_inlined_clone.{impl#0}-clone.PreCodegen.after.mir
@@ -1,0 +1,15 @@
+// MIR for `<impl at $DIR/no_inlined_clone.rs:9:10: 9:15>::clone` after PreCodegen
+
+fn <impl at $DIR/no_inlined_clone.rs:9:10: 9:15>::clone(_1: &Foo) -> Foo {
+    debug self => _1;
+    let mut _0: Foo;
+    let mut _2: i32;
+
+    bb0: {
+        StorageLive(_2);
+        _2 = ((*_1).0: i32);
+        _0 = Foo { a: move _2 };
+        StorageDead(_2);
+        return;
+    }
+}

--- a/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.32bit.panic-abort.diff
@@ -37,7 +37,7 @@
           _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32];
           StorageLive(_5);
           _5 = const 3_usize;
-          _6 = Len(_4);
+          _6 = const 6_usize;
           _7 = Lt(_5, _6);
           assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> [success: bb2, unwind unreachable];
       }

--- a/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.32bit.panic-unwind.diff
@@ -37,7 +37,7 @@
           _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32];
           StorageLive(_5);
           _5 = const 3_usize;
-          _6 = Len(_4);
+          _6 = const 6_usize;
           _7 = Lt(_5, _6);
           assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> [success: bb2, unwind continue];
       }

--- a/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.panic-abort.diff
@@ -37,7 +37,7 @@
           _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32];
           StorageLive(_5);
           _5 = const 3_usize;
-          _6 = Len(_4);
+          _6 = const 6_usize;
           _7 = Lt(_5, _6);
           assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> [success: bb2, unwind unreachable];
       }

--- a/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/optimizes_into_variable.main.ScalarReplacementOfAggregates.64bit.panic-unwind.diff
@@ -37,7 +37,7 @@
           _4 = [const 0_i32, const 1_i32, const 2_i32, const 3_i32, const 4_i32, const 5_i32];
           StorageLive(_5);
           _5 = const 3_usize;
-          _6 = Len(_4);
+          _6 = const 6_usize;
           _7 = Lt(_5, _6);
           assert(move _7, "index out of bounds: the length is {} but the index is {}", move _6, _5) -> [success: bb2, unwind continue];
       }

--- a/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-abort.mir
@@ -36,13 +36,11 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
 
     bb1: {
         StorageLive(_7);
-        StorageLive(_6);
         _6 = &mut _5;
         _7 = <RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next(move _6) -> [return: bb2, unwind unreachable];
     }
 
     bb2: {
-        StorageDead(_6);
         _8 = discriminant(_7);
         switchInt(move _8) -> [0: bb3, 1: bb5, otherwise: bb7];
     }

--- a/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
@@ -36,13 +36,11 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
 
     bb1: {
         StorageLive(_7);
-        StorageLive(_6);
         _6 = &mut _5;
         _7 = <RangeInclusive<u32> as iter::range::RangeInclusiveIteratorImpl>::spec_next(move _6) -> [return: bb2, unwind: bb8];
     }
 
     bb2: {
-        StorageDead(_6);
         _8 = discriminant(_7);
         switchInt(move _8) -> [0: bb3, 1: bb5, otherwise: bb7];
     }

--- a/tests/mir-opt/pre-codegen/slice_filter.variant_a-{closure#0}.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_filter.variant_a-{closure#0}.PreCodegen.after.mir
@@ -32,7 +32,7 @@ fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2
             debug other => _10;
             scope 3 (inlined std::cmp::impls::<impl PartialOrd for usize>::le) {
                 debug self => _4;
-                debug other => _9;
+                debug other => _6;
                 let mut _11: usize;
                 let mut _12: usize;
             }
@@ -42,7 +42,7 @@ fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2
             debug other => _16;
             scope 5 (inlined std::cmp::impls::<impl PartialOrd for usize>::le) {
                 debug self => _7;
-                debug other => _15;
+                debug other => _5;
                 let mut _17: usize;
                 let mut _18: usize;
             }
@@ -52,7 +52,7 @@ fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2
             debug other => _22;
             scope 7 (inlined std::cmp::impls::<impl PartialOrd for usize>::le) {
                 debug self => _6;
-                debug other => _21;
+                debug other => _4;
             }
         }
         scope 8 (inlined std::cmp::impls::<impl PartialOrd for &usize>::le) {
@@ -60,7 +60,7 @@ fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2
             debug other => _26;
             scope 9 (inlined std::cmp::impls::<impl PartialOrd for usize>::le) {
                 debug self => _5;
-                debug other => _25;
+                debug other => _7;
                 let mut _27: usize;
                 let mut _28: usize;
             }
@@ -77,7 +77,8 @@ fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2
         StorageLive(_8);
         _8 = &_4;
         StorageLive(_10);
-        _9 = &((*_3).2: usize);
+        StorageLive(_9);
+        _9 = _6;
         _10 = &_9;
         _11 = ((*_3).0: usize);
         _12 = ((*_3).2: usize);
@@ -86,19 +87,22 @@ fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2
     }
 
     bb1: {
+        StorageDead(_9);
         StorageDead(_10);
         StorageDead(_8);
         goto -> bb4;
     }
 
     bb2: {
+        StorageDead(_9);
         StorageDead(_10);
         StorageDead(_8);
         StorageLive(_19);
         StorageLive(_14);
         _14 = &_7;
         StorageLive(_16);
-        _15 = &((*_3).1: usize);
+        StorageLive(_15);
+        _15 = _5;
         _16 = &_15;
         StorageLive(_17);
         _17 = ((*_3).3: usize);
@@ -111,6 +115,7 @@ fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2
     }
 
     bb3: {
+        StorageDead(_15);
         StorageDead(_16);
         StorageDead(_14);
         goto -> bb4;
@@ -121,13 +126,15 @@ fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2
         StorageLive(_20);
         _20 = &_6;
         StorageLive(_22);
-        _21 = &((*_3).0: usize);
+        StorageLive(_21);
+        _21 = _4;
         _22 = &_21;
         _23 = Le(_12, _11);
         switchInt(move _23) -> [0: bb5, otherwise: bb6];
     }
 
     bb5: {
+        StorageDead(_21);
         StorageDead(_22);
         StorageDead(_20);
         _0 = const false;
@@ -135,12 +142,14 @@ fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2
     }
 
     bb6: {
+        StorageDead(_21);
         StorageDead(_22);
         StorageDead(_20);
         StorageLive(_24);
         _24 = &_5;
         StorageLive(_26);
-        _25 = &((*_3).3: usize);
+        StorageLive(_25);
+        _25 = _7;
         _26 = &_25;
         StorageLive(_27);
         _27 = ((*_3).1: usize);
@@ -149,6 +158,7 @@ fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2
         _0 = Le(move _27, move _28);
         StorageDead(_28);
         StorageDead(_27);
+        StorageDead(_25);
         StorageDead(_26);
         StorageDead(_24);
         goto -> bb7;
@@ -160,6 +170,7 @@ fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2
     }
 
     bb8: {
+        StorageDead(_15);
         StorageDead(_16);
         StorageDead(_14);
         _0 = const true;

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-abort.mir
@@ -20,7 +20,7 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
     }
 
     bb0: {
-        StorageLive(_7);
+        StorageLive(_8);
         StorageLive(_4);
         StorageLive(_3);
         _3 = PtrMetadata(_1);
@@ -36,7 +36,7 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
 
     bb2: {
         StorageDead(_3);
-        StorageLive(_8);
+        StorageLive(_7);
         StorageLive(_5);
         _5 = &raw mut (*_1);
         StorageLive(_6);
@@ -45,14 +45,14 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
         StorageDead(_6);
         StorageDead(_5);
         _8 = &mut (*_7);
-        _0 = Option::<&mut u32>::Some(move _8);
-        StorageDead(_8);
+        _0 = Option::<&mut u32>::Some(_8);
+        StorageDead(_7);
         goto -> bb3;
     }
 
     bb3: {
         StorageDead(_4);
-        StorageDead(_7);
+        StorageDead(_8);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_mut_usize.PreCodegen.after.panic-unwind.mir
@@ -20,7 +20,7 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
     }
 
     bb0: {
-        StorageLive(_7);
+        StorageLive(_8);
         StorageLive(_4);
         StorageLive(_3);
         _3 = PtrMetadata(_1);
@@ -36,7 +36,7 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
 
     bb2: {
         StorageDead(_3);
-        StorageLive(_8);
+        StorageLive(_7);
         StorageLive(_5);
         _5 = &raw mut (*_1);
         StorageLive(_6);
@@ -45,14 +45,14 @@ fn slice_get_mut_usize(_1: &mut [u32], _2: usize) -> Option<&mut u32> {
         StorageDead(_6);
         StorageDead(_5);
         _8 = &mut (*_7);
-        _0 = Option::<&mut u32>::Some(move _8);
-        StorageDead(_8);
+        _0 = Option::<&mut u32>::Some(_8);
+        StorageDead(_7);
         goto -> bb3;
     }
 
     bb3: {
         StorageDead(_4);
-        StorageDead(_7);
+        StorageDead(_8);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-abort.mir
@@ -35,6 +35,7 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     bb0: {
         _3 = move (_2.0: usize);
         _4 = move (_2.1: usize);
+        StorageLive(_11);
         StorageLive(_5);
         _5 = &raw mut (*_1);
         StorageLive(_8);
@@ -56,6 +57,7 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
         StorageDead(_8);
         StorageDead(_5);
         _0 = &mut (*_11);
+        StorageDead(_11);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_index.slice_get_unchecked_mut_range.PreCodegen.after.panic-unwind.mir
@@ -35,6 +35,7 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
     bb0: {
         _3 = move (_2.0: usize);
         _4 = move (_2.1: usize);
+        StorageLive(_11);
         StorageLive(_5);
         _5 = &raw mut (*_1);
         StorageLive(_8);
@@ -56,6 +57,7 @@ fn slice_get_unchecked_mut_range(_1: &mut [u32], _2: std::ops::Range<usize>) -> 
         StorageDead(_8);
         StorageDead(_5);
         _0 = &mut (*_11);
+        StorageDead(_11);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -108,13 +108,11 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
 
     bb4: {
         StorageLive(_15);
-        StorageLive(_14);
         _14 = &mut _13;
         _15 = <Enumerate<std::slice::Iter<'_, T>> as Iterator>::next(move _14) -> [return: bb5, unwind: bb11];
     }
 
     bb5: {
-        StorageDead(_14);
         _16 = discriminant(_15);
         switchInt(move _16) -> [0: bb6, 1: bb8, otherwise: bb10];
     }

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
@@ -98,13 +98,11 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
 
     bb4: {
         StorageLive(_14);
-        StorageLive(_13);
         _13 = &mut _12;
         _14 = <std::slice::Iter<'_, T> as Iterator>::next(move _13) -> [return: bb5, unwind unreachable];
     }
 
     bb5: {
-        StorageDead(_13);
         _15 = discriminant(_14);
         switchInt(move _15) -> [0: bb6, 1: bb8, otherwise: bb10];
     }

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -98,13 +98,11 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
 
     bb4: {
         StorageLive(_14);
-        StorageLive(_13);
         _13 = &mut _12;
         _14 = <std::slice::Iter<'_, T> as Iterator>::next(move _13) -> [return: bb5, unwind: bb11];
     }
 
     bb5: {
-        StorageDead(_13);
         _15 = discriminant(_14);
         switchInt(move _15) -> [0: bb6, 1: bb8, otherwise: bb10];
     }

--- a/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-abort.mir
@@ -3,16 +3,14 @@
 fn outer(_1: u8) -> u8 {
     debug v => _1;                       // in scope 0 at $DIR/spans.rs:10:14: 10:15
     let mut _0: u8;                      // return place in scope 0 at $DIR/spans.rs:10:24: 10:26
-    let mut _2: &u8;                     // in scope 0 at $DIR/spans.rs:11:11: 11:13
+    let _2: &u8;                         // in scope 0 at $DIR/spans.rs:11:11: 11:13
     scope 1 (inlined inner) {            // at $DIR/spans.rs:11:5: 11:14
         debug x => _2;                   // in scope 1 at $DIR/spans.rs:14:14: 14:15
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/spans.rs:11:11: 11:13
         _2 = &_1;                        // scope 0 at $DIR/spans.rs:11:11: 11:13
         _0 = _1;                         // scope 1 at $DIR/spans.rs:15:5: 15:7
-        StorageDead(_2);                 // scope 0 at $DIR/spans.rs:11:13: 11:14
         return;                          // scope 0 at $DIR/spans.rs:12:2: 12:2
     }
 }

--- a/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/spans.outer.PreCodegen.after.panic-unwind.mir
@@ -3,16 +3,14 @@
 fn outer(_1: u8) -> u8 {
     debug v => _1;                       // in scope 0 at $DIR/spans.rs:10:14: 10:15
     let mut _0: u8;                      // return place in scope 0 at $DIR/spans.rs:10:24: 10:26
-    let mut _2: &u8;                     // in scope 0 at $DIR/spans.rs:11:11: 11:13
+    let _2: &u8;                         // in scope 0 at $DIR/spans.rs:11:11: 11:13
     scope 1 (inlined inner) {            // at $DIR/spans.rs:11:5: 11:14
         debug x => _2;                   // in scope 1 at $DIR/spans.rs:14:14: 14:15
     }
 
     bb0: {
-        StorageLive(_2);                 // scope 0 at $DIR/spans.rs:11:11: 11:13
         _2 = &_1;                        // scope 0 at $DIR/spans.rs:11:11: 11:13
         _0 = _1;                         // scope 1 at $DIR/spans.rs:15:5: 15:7
-        StorageDead(_2);                 // scope 0 at $DIR/spans.rs:11:13: 11:14
         return;                          // scope 0 at $DIR/spans.rs:12:2: 12:2
     }
 }

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
@@ -56,10 +56,12 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
         StorageDead(_2);
         StorageLive(_5);
         _5 = ((*_1).1: usize);
+        StorageLive(_6);
         _6 = *const [u8] from (_4, _5);
+        _0 = &(*_6);
+        StorageDead(_6);
         StorageDead(_5);
         StorageDead(_4);
-        _0 = &(*_6);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
@@ -56,10 +56,12 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
         StorageDead(_2);
         StorageLive(_5);
         _5 = ((*_1).1: usize);
+        StorageLive(_6);
         _6 = *const [u8] from (_4, _5);
+        _0 = &(*_6);
+        StorageDead(_6);
         StorageDead(_5);
         StorageDead(_4);
-        _0 = &(*_6);
         return;
     }
 }


### PR DESCRIPTION
I am currently working on #128081. In the current pipeline, we can get the following clone statements ([godbolt](https://rust.godbolt.org/z/931316fhP)):

```
    bb0: {
        StorageLive(_2);
        _2 = ((*_1).0: i32);
        StorageLive(_3);
        _3 = ((*_1).1: u64);
        _0 = Foo { a: move _2, b: move _3 };
        StorageDead(_3);
        StorageDead(_2);
        return;
    }
```

Analyzing such statements will be simple and fast. We don't need to consider branches or some interfering statements. However, this requires us to run `InstSimplify`, `ReferencePropagation`, and `SimplifyCFG` at least once. I can introduce a new pass, but I think the best place for it would be within `InstSimplify`.

I put `InstSimplify` before `Inline`, which takes some of the burden away from `Inline`.

r? @saethlin