### PR TITLE
Implement cursors for `BTreeSet`

### DIFF
--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -1250,16 +1250,16 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// let mut set = BTreeSet::from([1, 2, 3, 4]);
     ///
     /// let mut cursor = set.lower_bound_mut(Bound::Included(&2));
-    /// assert_eq!(cursor.peek_prev(), Some(&mut 1));
-    /// assert_eq!(cursor.peek_next(), Some(&mut 2));
+    /// assert_eq!(cursor.peek_prev(), Some(&1));
+    /// assert_eq!(cursor.peek_next(), Some(&2));
     ///
     /// let mut cursor = set.lower_bound_mut(Bound::Excluded(&2));
-    /// assert_eq!(cursor.peek_prev(), Some(&mut 2));
-    /// assert_eq!(cursor.peek_next(), Some(&mut 3));
+    /// assert_eq!(cursor.peek_prev(), Some(&2));
+    /// assert_eq!(cursor.peek_next(), Some(&3));
     ///
     /// let mut cursor = set.lower_bound_mut(Bound::Unbounded);
     /// assert_eq!(cursor.peek_prev(), None);
-    /// assert_eq!(cursor.peek_next(), Some(&mut 1));
+    /// assert_eq!(cursor.peek_next(), Some(&1));
     /// ```
     #[unstable(feature = "btree_cursors", issue = "107540")]
     pub fn lower_bound_mut<Q: ?Sized>(&mut self, bound: Bound<&Q>) -> CursorMut<'_, T, A>
@@ -1336,15 +1336,15 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// let mut set = BTreeSet::from([1, 2, 3, 4]);
     ///
     /// let mut cursor = unsafe { set.upper_bound_mut(Bound::Included(&3)) };
-    /// assert_eq!(cursor.peek_prev(), Some(&mut 3));
-    /// assert_eq!(cursor.peek_next(), Some(&mut 4));
+    /// assert_eq!(cursor.peek_prev(), Some(&3));
+    /// assert_eq!(cursor.peek_next(), Some(&4));
     ///
     /// let mut cursor = unsafe { set.upper_bound_mut(Bound::Excluded(&3)) };
-    /// assert_eq!(cursor.peek_prev(), Some(&mut 2));
-    /// assert_eq!(cursor.peek_next(), Some(&mut 3));
+    /// assert_eq!(cursor.peek_prev(), Some(&2));
+    /// assert_eq!(cursor.peek_next(), Some(&3));
     ///
     /// let mut cursor = unsafe { set.upper_bound_mut(Bound::Unbounded) };
-    /// assert_eq!(cursor.peek_prev(), Some(&mut 4));
+    /// assert_eq!(cursor.peek_prev(), Some(&4));
     /// assert_eq!(cursor.peek_next(), None);
     /// ```
     #[unstable(feature = "btree_cursors", issue = "107540")]

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -2,7 +2,6 @@ use crate::vec::Vec;
 use core::borrow::Borrow;
 use core::cmp::Ordering::{self, Equal, Greater, Less};
 use core::cmp::{max, min};
-use core::error::Error;
 use core::fmt::{self, Debug};
 use core::hash::{Hash, Hasher};
 use core::iter::{FusedIterator, Peekable};
@@ -2177,11 +2176,11 @@ impl<'a, T: Ord, A: Allocator + Clone> CursorMut<'a, T, A> {
     ///
     /// If the inserted element is not greater than the element before the
     /// cursor (if any), or if it not less than the element after the cursor (if
-    /// any), then an [`UnorderedError`] is returned since this would
+    /// any), then an [`UnorderedKeyError`] is returned since this would
     /// invalidate the [`Ord`] invariant between the elements of the set.
     #[unstable(feature = "btree_cursors", issue = "107540")]
-    pub fn insert_after(&mut self, value: T) -> Result<(), UnorderedError> {
-        self.inner.insert_after(value, SetValZST).map_err(UnorderedError::from_map_error)
+    pub fn insert_after(&mut self, value: T) -> Result<(), UnorderedKeyError> {
+        self.inner.insert_after(value, SetValZST)
     }
 
     /// Inserts a new element into the set in the gap that the
@@ -2192,11 +2191,11 @@ impl<'a, T: Ord, A: Allocator + Clone> CursorMut<'a, T, A> {
     ///
     /// If the inserted element is not greater than the element before the
     /// cursor (if any), or if it not less than the element after the cursor (if
-    /// any), then an [`UnorderedError`] is returned since this would
+    /// any), then an [`UnorderedKeyError`] is returned since this would
     /// invalidate the [`Ord`] invariant between the elements of the set.
     #[unstable(feature = "btree_cursors", issue = "107540")]
-    pub fn insert_before(&mut self, value: T) -> Result<(), UnorderedError> {
-        self.inner.insert_before(value, SetValZST).map_err(UnorderedError::from_map_error)
+    pub fn insert_before(&mut self, value: T) -> Result<(), UnorderedKeyError> {
+        self.inner.insert_before(value, SetValZST)
     }
 
     /// Removes the next element from the `BTreeSet`.
@@ -2218,29 +2217,8 @@ impl<'a, T: Ord, A: Allocator + Clone> CursorMut<'a, T, A> {
     }
 }
 
-/// Error type returned by [`CursorMut::insert_before`] and
-/// [`CursorMut::insert_after`] if the element being inserted is not properly
-/// ordered with regards to adjacent elements.
-#[derive(Clone, PartialEq, Eq, Debug)]
 #[unstable(feature = "btree_cursors", issue = "107540")]
-pub struct UnorderedError {}
-
-impl UnorderedError {
-    fn from_map_error(error: super::map::UnorderedKeyError) -> Self {
-        let super::map::UnorderedKeyError {} = error;
-        Self {}
-    }
-}
-
-#[unstable(feature = "btree_cursors", issue = "107540")]
-impl fmt::Display for UnorderedError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "value is not properly ordered relative to neighbors")
-    }
-}
-
-#[unstable(feature = "btree_cursors", issue = "107540")]
-impl Error for UnorderedError {}
+pub use super::map::UnorderedKeyError;
 
 #[cfg(test)]
 mod tests;

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -1194,7 +1194,7 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// gap before the smallest element greater than `x`.
     ///
     /// Passing `Bound::Unbounded` will return a cursor pointing to the
-    /// gap before the smallest element in the map.
+    /// gap before the smallest element in the set.
     ///
     /// # Examples
     ///
@@ -1237,7 +1237,7 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// gap before the smallest element greater than `x`.
     ///
     /// Passing `Bound::Unbounded` will return a cursor pointing to the
-    /// gap before the smallest element in the map.
+    /// gap before the smallest element in the set.
     ///
     /// # Examples
     ///
@@ -1280,7 +1280,7 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// gap after the greatest element smaller than `x`.
     ///
     /// Passing `Bound::Unbounded` will return a cursor pointing to the
-    /// gap after the greatest element in the map.
+    /// gap after the greatest element in the set.
     ///
     /// # Examples
     ///
@@ -1323,7 +1323,7 @@ impl<T, A: Allocator + Clone> BTreeSet<T, A> {
     /// gap after the greatest element smaller than `x`.
     ///
     /// Passing `Bound::Unbounded` will return a cursor pointing to the
-    /// gap after the greatest element in the map.
+    /// gap after the greatest element in the set.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/107540

This is a straightforward wrapping of the map API, except that map's `CursorMut` does not make sense, because there is no value to mutate. Hence, map's `CursorMutKey` is wrapped here as just `CursorMut`, since it's unambiguous for sets and we don't normally speak of "keys". On the other hand, I can see some potential for confusion with `CursorMut` meaning different things in each module. I'm happy to take suggestions to improve that.

r? @Amanieu