### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,18 +2571,6 @@ dependencies = [
  "indexmap",
  "memchr",
  "ruzstd 0.5.0",
- "wasmparser 0.118.2",
-]
-
-[[package]]
-name = "object"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7090bae93f8585aad99e595b7073c5de9ba89fbd6b4e9f0cdd7a10177273ac8"
-dependencies = [
- "flate2",
- "memchr",
- "ruzstd 0.6.0",
 ]
 
 [[package]]
@@ -2596,14 +2584,20 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.0"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576dfe1fc8f9df304abb159d767a29d0476f7750fbf8aa7ad07816004a207434"
+checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
 dependencies = [
  "compiler_builtins",
+ "crc32fast",
+ "flate2",
+ "hashbrown",
+ "indexmap",
  "memchr",
  "rustc-std-workspace-alloc",
  "rustc-std-workspace-core",
+ "ruzstd 0.7.0",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
@@ -3334,10 +3328,10 @@ dependencies = [
  "bstr",
  "build_helper",
  "gimli 0.31.0",
- "object 0.34.0",
+ "object 0.36.2",
  "regex",
  "similar",
- "wasmparser 0.118.2",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
@@ -3643,7 +3637,7 @@ dependencies = [
  "itertools",
  "libc",
  "measureme",
- "object 0.32.2",
+ "object 0.36.2",
  "rustc-demangle",
  "rustc_ast",
  "rustc_attr",
@@ -3682,7 +3676,7 @@ dependencies = [
  "itertools",
  "jobserver",
  "libc",
- "object 0.32.2",
+ "object 0.36.2",
  "pathdiff",
  "regex",
  "rustc_arena",
@@ -3712,7 +3706,7 @@ dependencies = [
  "thin-vec",
  "thorin-dwp",
  "tracing",
- "wasm-encoder 0.200.0",
+ "wasm-encoder 0.210.0",
  "windows",
 ]
 
@@ -4666,7 +4660,7 @@ name = "rustc_target"
 version = "0.0.0"
 dependencies = [
  "bitflags 2.5.0",
- "object 0.32.2",
+ "object 0.36.2",
  "rustc_abi",
  "rustc_data_structures",
  "rustc_feature",
@@ -4951,12 +4945,11 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
+checksum = "5022b253619b1ba797f243056276bed8ed1a73b0f5a7ce7225d524067644bf8f"
 dependencies = [
  "byteorder",
- "derive_more",
  "twox-hash",
 ]
 
@@ -5242,7 +5235,7 @@ dependencies = [
  "hermit-abi 0.4.0",
  "libc",
  "miniz_oxide",
- "object 0.36.0",
+ "object 0.36.2",
  "panic_abort",
  "panic_unwind",
  "profiler_builtins",
@@ -6181,15 +6174,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.200.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e3fb0c8fbddd78aa6095b850dfeedbc7506cf5f81e633f69cf8f2333ab84b9"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.210.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e3764d9d6edabd8c9e16195e177be0d20f6ab942ad18af52860f12f82bc59a"
@@ -6224,16 +6208,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.118.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f1154f1ab868e2a01d9834a805faca7bf8b50d041b4ca714d005d0dab1c50c"
-dependencies = [
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.210.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7bbcd21e7581619d9f6ca00f8c4f08f1cacfe58bf63f83af57cd0476f1026f5"
@@ -6244,6 +6218,16 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
+dependencies = [
+ "bitflags 2.5.0",
+ "indexmap",
 ]
 
 [[package]]

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -12,7 +12,7 @@ bitflags = "2.4.1"
 itertools = "0.12"
 libc = "0.2"
 measureme = "11"
-object = { version = "0.32.0", default-features = false, features = ["std", "read"] }
+object = { version = "0.36.2", default-features = false, features = ["std", "read"] }
 rustc-demangle = "0.1.21"
 rustc_ast = { path = "../rustc_ast" }
 rustc_attr = { path = "../rustc_attr" }

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -41,7 +41,7 @@ tempfile = "3.2"
 thin-vec = "0.2.12"
 thorin-dwp = "0.7"
 tracing = "0.1"
-wasm-encoder = "0.200.0"
+wasm-encoder = "0.210.0"
 # tidy-alphabetical-end
 
 [target.'cfg(unix)'.dependencies]
@@ -50,7 +50,7 @@ libc = "0.2.50"
 # tidy-alphabetical-end
 
 [dependencies.object]
-version = "0.32.1"
+version = "0.36.2"
 default-features = false
 features = ["read_core", "elf", "macho", "pe", "xcoff", "unaligned", "archive", "write", "wasm"]
 

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -110,13 +110,11 @@ impl<'a> ArArchiveBuilder<'a> {
 }
 
 fn try_filter_fat_archs(
-    archs: object::read::Result<&[impl FatArch]>,
+    archs: &[impl FatArch],
     target_arch: object::Architecture,
     archive_path: &Path,
     archive_map_data: &[u8],
 ) -> io::Result<Option<PathBuf>> {
-    let archs = archs.map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-
     let desired = match archs.iter().find(|a| a.architecture() == target_arch) {
         Some(a) => a,
         None => return Ok(None),
@@ -146,17 +144,15 @@ pub fn try_extract_macho_fat_archive(
         _ => return Ok(None),
     };
 
-    match object::macho::FatHeader::parse(&*archive_map) {
-        Ok(h) if h.magic.get(object::endian::BigEndian) == object::macho::FAT_MAGIC => {
-            let archs = object::macho::FatHeader::parse_arch32(&*archive_map);
-            try_filter_fat_archs(archs, target_arch, archive_path, &*archive_map)
-        }
-        Ok(h) if h.magic.get(object::endian::BigEndian) == object::macho::FAT_MAGIC_64 => {
-            let archs = object::macho::FatHeader::parse_arch64(&*archive_map);
-            try_filter_fat_archs(archs, target_arch, archive_path, &*archive_map)
-        }
+    if let Ok(h) = object::read::macho::MachOFatFile32::parse(&*archive_map) {
+        let archs = h.arches();
+        try_filter_fat_archs(archs, target_arch, archive_path, &*archive_map)
+    } else if let Ok(h) = object::read::macho::MachOFatFile64::parse(&*archive_map) {
+        let archs = h.arches();
+        try_filter_fat_archs(archs, target_arch, archive_path, &*archive_map)
+    } else {
         // Not a FatHeader at all, just return None.
-        _ => Ok(None),
+        Ok(None)
     }
 }
 

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -700,7 +700,7 @@ fn link_dwarf_object(sess: &Session, cg_results: &CodegenResults, executable_out
                 .truncate(true)
                 .open(dwp_out_filename)?,
         );
-        let mut output_stream = object::write::StreamingBuffer::new(output_stream);
+        let mut output_stream = thorin::object::write::StreamingBuffer::new(output_stream);
         package.finish()?.emit(&mut output_stream)?;
         output_stream.result()?;
         output_stream.into_inner().flush()?;

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -656,7 +656,13 @@ pub fn create_metadata_file_for_wasm(sess: &Session, data: &[u8], section_name: 
         imports.import(
             "env",
             "__linear_memory",
-            wasm_encoder::MemoryType { minimum: 0, maximum: None, memory64: true, shared: false },
+            wasm_encoder::MemoryType {
+                minimum: 0,
+                maximum: None,
+                memory64: true,
+                shared: false,
+                page_size_log2: None,
+            },
         );
     }
 

--- a/compiler/rustc_target/Cargo.toml
+++ b/compiler/rustc_target/Cargo.toml
@@ -22,5 +22,5 @@ tracing = "0.1"
 # tidy-alphabetical-start
 default-features = false
 features = ["elf", "macho"]
-version = "0.32.0"
+version = "0.36.2"
 # tidy-alphabetical-end

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -57,7 +57,7 @@ pub struct Global;
 #[cfg(test)]
 pub use std::alloc::Global;
 
-/// Allocate memory with the global allocator.
+/// Allocates memory with the global allocator.
 ///
 /// This function forwards calls to the [`GlobalAlloc::alloc`] method
 /// of the allocator registered with the `#[global_allocator]` attribute
@@ -101,7 +101,7 @@ pub unsafe fn alloc(layout: Layout) -> *mut u8 {
     }
 }
 
-/// Deallocate memory with the global allocator.
+/// Deallocates memory with the global allocator.
 ///
 /// This function forwards calls to the [`GlobalAlloc::dealloc`] method
 /// of the allocator registered with the `#[global_allocator]` attribute
@@ -119,7 +119,7 @@ pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
 }
 
-/// Reallocate memory with the global allocator.
+/// Reallocates memory with the global allocator.
 ///
 /// This function forwards calls to the [`GlobalAlloc::realloc`] method
 /// of the allocator registered with the `#[global_allocator]` attribute
@@ -138,7 +138,7 @@ pub unsafe fn realloc(ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 
     unsafe { __rust_realloc(ptr, layout.size(), layout.align(), new_size) }
 }
 
-/// Allocate zero-initialized memory with the global allocator.
+/// Allocates zero-initialized memory with the global allocator.
 ///
 /// This function forwards calls to the [`GlobalAlloc::alloc_zeroed`] method
 /// of the allocator registered with the `#[global_allocator]` attribute
@@ -345,7 +345,7 @@ extern "Rust" {
     fn __rust_alloc_error_handler(size: usize, align: usize) -> !;
 }
 
-/// Signal a memory allocation error.
+/// Signals a memory allocation error.
 ///
 /// Callers of memory allocation APIs wishing to cease execution
 /// in response to an allocation error are encouraged to call this function,

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1268,9 +1268,11 @@ impl<T: ?Sized, A: Allocator> Box<T, A> {
     }
 
     /// Consumes and leaks the `Box`, returning a mutable reference,
-    /// `&'a mut T`. Note that the type `T` must outlive the chosen lifetime
-    /// `'a`. If the type has only static references, or none at all, then this
-    /// may be chosen to be `'static`.
+    /// `&'a mut T`.
+    ///
+    /// Note that the type `T` must outlive the chosen lifetime `'a`. If the type
+    /// has only static references, or none at all, then this may be chosen to be
+    /// `'static`.
     ///
     /// This function is mainly useful for data that lives for the remainder of
     /// the program's life. Dropping the returned reference will cause a memory
@@ -1853,7 +1855,7 @@ impl<T, const N: usize> TryFrom<Vec<T>> for Box<[T; N]> {
 }
 
 impl<A: Allocator> Box<dyn Any, A> {
-    /// Attempt to downcast the box to a concrete type.
+    /// Attempts to downcast the box to a concrete type.
     ///
     /// # Examples
     ///
@@ -1912,7 +1914,7 @@ impl<A: Allocator> Box<dyn Any, A> {
 }
 
 impl<A: Allocator> Box<dyn Any + Send, A> {
-    /// Attempt to downcast the box to a concrete type.
+    /// Attempts to downcast the box to a concrete type.
     ///
     /// # Examples
     ///
@@ -1971,7 +1973,7 @@ impl<A: Allocator> Box<dyn Any + Send, A> {
 }
 
 impl<A: Allocator> Box<dyn Any + Send + Sync, A> {
-    /// Attempt to downcast the box to a concrete type.
+    /// Attempts to downcast the box to a concrete type.
     ///
     /// # Examples
     ///

--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -965,6 +965,7 @@ impl<T, A: Allocator> BinaryHeap<T, A> {
     }
 
     /// Returns an iterator which retrieves elements in heap order.
+    ///
     /// This method consumes the original heap.
     ///
     /// # Examples
@@ -1361,7 +1362,7 @@ struct Hole<'a, T: 'a> {
 }
 
 impl<'a, T> Hole<'a, T> {
-    /// Create a new `Hole` at index `pos`.
+    /// Creates a new `Hole` at index `pos`.
     ///
     /// Unsafe because pos must be within the data slice.
     #[inline]

--- a/library/alloc/src/collections/btree/map/entry.rs
+++ b/library/alloc/src/collections/btree/map/entry.rs
@@ -189,6 +189,7 @@ impl<'a, K: Ord, V, A: Allocator + Clone> Entry<'a, K, V, A> {
     }
 
     /// Ensures a value is in the entry by inserting, if empty, the result of the default function.
+    ///
     /// This method allows for generating key-derived values for insertion by providing the default
     /// function a reference to the key that was moved during the `.entry(key)` method call.
     ///

--- a/library/alloc/src/fmt.rs
+++ b/library/alloc/src/fmt.rs
@@ -600,8 +600,7 @@ pub use core::fmt::{LowerHex, Pointer, UpperHex};
 #[cfg(not(no_global_oom_handling))]
 use crate::string;
 
-/// The `format` function takes an [`Arguments`] struct and returns the resulting
-/// formatted string.
+/// Takes an [`Arguments`] struct and returns the resulting formatted string.
 ///
 /// The [`Arguments`] instance can be created with the [`format_args!`] macro.
 ///

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -117,7 +117,6 @@
 #![feature(const_pin)]
 #![feature(const_refs_to_cell)]
 #![feature(const_size_of_val)]
-#![feature(const_waker)]
 #![feature(core_intrinsics)]
 #![feature(deprecated_suggestion)]
 #![feature(deref_pure_trait)]

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -52,7 +52,7 @@ impl Cap {
 /// * Produces `Unique::dangling()` on zero-length allocations.
 /// * Avoids freeing `Unique::dangling()`.
 /// * Catches all overflows in capacity computations (promotes them to "capacity overflow" panics).
-/// * Guards against 32-bit systems allocating more than isize::MAX bytes.
+/// * Guards against 32-bit systems allocating more than `isize::MAX` bytes.
 /// * Guards against overflowing your length.
 /// * Calls `handle_alloc_error` for fallible allocations.
 /// * Contains a `ptr::Unique` and thus endows the user with all related benefits.
@@ -484,7 +484,7 @@ impl<T, A: Allocator> RawVec<T, A> {
 
         // `finish_grow` is non-generic over `T`.
         let ptr = finish_grow(new_layout, self.current_memory(), &mut self.alloc)?;
-        // SAFETY: finish_grow would have resulted in a capacity overflow if we tried to allocate more than isize::MAX items
+        // SAFETY: finish_grow would have resulted in a capacity overflow if we tried to allocate more than `isize::MAX` items
         unsafe { self.set_ptr_and_cap(ptr, cap) };
         Ok(())
     }
@@ -504,7 +504,7 @@ impl<T, A: Allocator> RawVec<T, A> {
 
         // `finish_grow` is non-generic over `T`.
         let ptr = finish_grow(new_layout, self.current_memory(), &mut self.alloc)?;
-        // SAFETY: finish_grow would have resulted in a capacity overflow if we tried to allocate more than isize::MAX items
+        // SAFETY: `finish_grow` would have resulted in a capacity overflow if we tried to allocate more than `isize::MAX` items
         unsafe {
             self.set_ptr_and_cap(ptr, cap);
         }

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -439,7 +439,7 @@ impl<T> Rc<T> {
     /// }
     ///
     /// impl Gadget {
-    ///     /// Construct a reference counted Gadget.
+    ///     /// Constructs a reference counted Gadget.
     ///     fn new() -> Rc<Self> {
     ///         // `me` is a `Weak<Gadget>` pointing at the new allocation of the
     ///         // `Rc` we're constructing.
@@ -449,7 +449,7 @@ impl<T> Rc<T> {
     ///         })
     ///     }
     ///
-    ///     /// Return a reference counted pointer to Self.
+    ///     /// Returns a reference counted pointer to Self.
     ///     fn me(&self) -> Rc<Self> {
     ///         self.me.upgrade().unwrap()
     ///     }
@@ -1900,7 +1900,7 @@ impl<T: Clone, A: Allocator> Rc<T, A> {
 }
 
 impl<A: Allocator> Rc<dyn Any, A> {
-    /// Attempt to downcast the `Rc<dyn Any>` to a concrete type.
+    /// Attempts to downcast the `Rc<dyn Any>` to a concrete type.
     ///
     /// # Examples
     ///
@@ -2586,7 +2586,7 @@ impl<T, const N: usize> From<[T; N]> for Rc<[T]> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl<T: Clone> From<&[T]> for Rc<[T]> {
-    /// Allocate a reference-counted slice and fill it by cloning `v`'s items.
+    /// Allocates a reference-counted slice and fills it by cloning `v`'s items.
     ///
     /// # Example
     ///
@@ -2605,7 +2605,7 @@ impl<T: Clone> From<&[T]> for Rc<[T]> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl From<&str> for Rc<str> {
-    /// Allocate a reference-counted string slice and copy `v` into it.
+    /// Allocates a reference-counted string slice and copies `v` into it.
     ///
     /// # Example
     ///
@@ -2624,7 +2624,7 @@ impl From<&str> for Rc<str> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl From<String> for Rc<str> {
-    /// Allocate a reference-counted string slice and copy `v` into it.
+    /// Allocates a reference-counted string slice and copies `v` into it.
     ///
     /// # Example
     ///
@@ -2662,7 +2662,7 @@ impl<T: ?Sized, A: Allocator> From<Box<T, A>> for Rc<T, A> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl<T, A: Allocator> From<Vec<T, A>> for Rc<[T], A> {
-    /// Allocate a reference-counted slice and move `v`'s items into it.
+    /// Allocates a reference-counted slice and moves `v`'s items into it.
     ///
     /// # Example
     ///
@@ -2695,8 +2695,8 @@ where
     B: ToOwned + ?Sized,
     Rc<B>: From<&'a B> + From<B::Owned>,
 {
-    /// Create a reference-counted pointer from
-    /// a clone-on-write pointer by copying its content.
+    /// Creates a reference-counted pointer from a clone-on-write pointer by
+    /// copying its content.
     ///
     /// # Example
     ///
@@ -3526,7 +3526,7 @@ impl<T: ?Sized, A: Allocator> AsRef<T> for Rc<T, A> {
 #[stable(feature = "pin", since = "1.33.0")]
 impl<T: ?Sized, A: Allocator> Unpin for Rc<T, A> {}
 
-/// Get the offset within an `RcBox` for the payload behind a pointer.
+/// Gets the offset within an `RcBox` for the payload behind a pointer.
 ///
 /// # Safety
 ///
@@ -3734,7 +3734,7 @@ struct UniqueRcUninit<T: ?Sized, A: Allocator> {
 
 #[cfg(not(no_global_oom_handling))]
 impl<T: ?Sized, A: Allocator> UniqueRcUninit<T, A> {
-    /// Allocate a RcBox with layout suitable to contain `for_value` or a clone of it.
+    /// Allocates a RcBox with layout suitable to contain `for_value` or a clone of it.
     fn new(for_value: &T, alloc: A) -> UniqueRcUninit<T, A> {
         let layout = Layout::for_value(for_value);
         let ptr = unsafe {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -428,7 +428,7 @@ impl<T> Arc<T> {
     /// }
     ///
     /// impl Gadget {
-    ///     /// Construct a reference counted Gadget.
+    ///     /// Constructs a reference counted Gadget.
     ///     fn new() -> Arc<Self> {
     ///         // `me` is a `Weak<Gadget>` pointing at the new allocation of the
     ///         // `Arc` we're constructing.
@@ -438,7 +438,7 @@ impl<T> Arc<T> {
     ///         })
     ///     }
     ///
-    ///     /// Return a reference counted pointer to Self.
+    ///     /// Returns a reference counted pointer to Self.
     ///     fn me(&self) -> Arc<Self> {
     ///         self.me.upgrade().unwrap()
     ///     }
@@ -2531,7 +2531,7 @@ unsafe impl<#[may_dangle] T: ?Sized, A: Allocator> Drop for Arc<T, A> {
 }
 
 impl<A: Allocator> Arc<dyn Any + Send + Sync, A> {
-    /// Attempt to downcast the `Arc<dyn Any + Send + Sync>` to a concrete type.
+    /// Attempts to downcast the `Arc<dyn Any + Send + Sync>` to a concrete type.
     ///
     /// # Examples
     ///
@@ -3545,7 +3545,7 @@ impl<T, const N: usize> From<[T; N]> for Arc<[T]> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl<T: Clone> From<&[T]> for Arc<[T]> {
-    /// Allocate a reference-counted slice and fill it by cloning `v`'s items.
+    /// Allocates a reference-counted slice and fills it by cloning `v`'s items.
     ///
     /// # Example
     ///
@@ -3564,7 +3564,7 @@ impl<T: Clone> From<&[T]> for Arc<[T]> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl From<&str> for Arc<str> {
-    /// Allocate a reference-counted `str` and copy `v` into it.
+    /// Allocates a reference-counted `str` and copies `v` into it.
     ///
     /// # Example
     ///
@@ -3583,7 +3583,7 @@ impl From<&str> for Arc<str> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl From<String> for Arc<str> {
-    /// Allocate a reference-counted `str` and copy `v` into it.
+    /// Allocates a reference-counted `str` and copies `v` into it.
     ///
     /// # Example
     ///
@@ -3621,7 +3621,7 @@ impl<T: ?Sized, A: Allocator> From<Box<T, A>> for Arc<T, A> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "shared_from_slice", since = "1.21.0")]
 impl<T, A: Allocator + Clone> From<Vec<T, A>> for Arc<[T], A> {
-    /// Allocate a reference-counted slice and move `v`'s items into it.
+    /// Allocates a reference-counted slice and moves `v`'s items into it.
     ///
     /// # Example
     ///
@@ -3654,8 +3654,8 @@ where
     B: ToOwned + ?Sized,
     Arc<B>: From<&'a B> + From<B::Owned>,
 {
-    /// Create an atomically reference-counted pointer from
-    /// a clone-on-write pointer by copying its content.
+    /// Creates an atomically reference-counted pointer from a clone-on-write
+    /// pointer by copying its content.
     ///
     /// # Example
     ///
@@ -3811,7 +3811,7 @@ impl<T: ?Sized, A: Allocator> AsRef<T> for Arc<T, A> {
 #[stable(feature = "pin", since = "1.33.0")]
 impl<T: ?Sized, A: Allocator> Unpin for Arc<T, A> {}
 
-/// Get the offset within an `ArcInner` for the payload behind a pointer.
+/// Gets the offset within an `ArcInner` for the payload behind a pointer.
 ///
 /// # Safety
 ///
@@ -3833,7 +3833,7 @@ fn data_offset_align(align: usize) -> usize {
     layout.size() + layout.padding_needed_for(align)
 }
 
-/// A unique owning pointer to a [`ArcInner`] **that does not imply the contents are initialized,**
+/// A unique owning pointer to an [`ArcInner`] **that does not imply the contents are initialized,**
 /// but will deallocate it (without dropping the value) when dropped.
 ///
 /// This is a helper for [`Arc::make_mut()`] to ensure correct cleanup on panic.
@@ -3846,7 +3846,7 @@ struct UniqueArcUninit<T: ?Sized, A: Allocator> {
 
 #[cfg(not(no_global_oom_handling))]
 impl<T: ?Sized, A: Allocator> UniqueArcUninit<T, A> {
-    /// Allocate a ArcInner with layout suitable to contain `for_value` or a clone of it.
+    /// Allocates an ArcInner with layout suitable to contain `for_value` or a clone of it.
     fn new(for_value: &T, alloc: A) -> UniqueArcUninit<T, A> {
         let layout = Layout::for_value(for_value);
         let ptr = unsafe {

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -114,8 +114,9 @@ impl<T, A: Allocator> IntoIter<T, A> {
     }
 
     /// Drops remaining elements and relinquishes the backing allocation.
-    /// This method guarantees it won't panic before relinquishing
-    /// the backing allocation.
+    ///
+    /// This method guarantees it won't panic before relinquishing the backing
+    /// allocation.
     ///
     /// This is roughly equivalent to the following, but more efficient
     ///

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2373,9 +2373,11 @@ impl<T, A: Allocator> Vec<T, A> {
     }
 
     /// Consumes and leaks the `Vec`, returning a mutable reference to the contents,
-    /// `&'a mut [T]`. Note that the type `T` must outlive the chosen lifetime
-    /// `'a`. If the type has only static references, or none at all, then this
-    /// may be chosen to be `'static`.
+    /// `&'a mut [T]`.
+    ///
+    /// Note that the type `T` must outlive the chosen lifetime `'a`. If the type
+    /// has only static references, or none at all, then this may be chosen to be
+    /// `'static`.
     ///
     /// As of Rust 1.57, this method does not reallocate or shrink the `Vec`,
     /// so the leaked allocation may include unused capacity that is not part
@@ -3359,7 +3361,7 @@ impl<T, A: Allocator> AsMut<[T]> for Vec<T, A> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Clone> From<&[T]> for Vec<T> {
-    /// Allocate a `Vec<T>` and fill it by cloning `s`'s items.
+    /// Allocates a `Vec<T>` and fills it by cloning `s`'s items.
     ///
     /// # Examples
     ///
@@ -3379,7 +3381,7 @@ impl<T: Clone> From<&[T]> for Vec<T> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "vec_from_mut", since = "1.19.0")]
 impl<T: Clone> From<&mut [T]> for Vec<T> {
-    /// Allocate a `Vec<T>` and fill it by cloning `s`'s items.
+    /// Allocates a `Vec<T>` and fills it by cloning `s`'s items.
     ///
     /// # Examples
     ///
@@ -3399,7 +3401,7 @@ impl<T: Clone> From<&mut [T]> for Vec<T> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "vec_from_array_ref", since = "1.74.0")]
 impl<T: Clone, const N: usize> From<&[T; N]> for Vec<T> {
-    /// Allocate a `Vec<T>` and fill it by cloning `s`'s items.
+    /// Allocates a `Vec<T>` and fills it by cloning `s`'s items.
     ///
     /// # Examples
     ///
@@ -3414,7 +3416,7 @@ impl<T: Clone, const N: usize> From<&[T; N]> for Vec<T> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "vec_from_array_ref", since = "1.74.0")]
 impl<T: Clone, const N: usize> From<&mut [T; N]> for Vec<T> {
-    /// Allocate a `Vec<T>` and fill it by cloning `s`'s items.
+    /// Allocates a `Vec<T>` and fills it by cloning `s`'s items.
     ///
     /// # Examples
     ///
@@ -3429,7 +3431,7 @@ impl<T: Clone, const N: usize> From<&mut [T; N]> for Vec<T> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "vec_from_array", since = "1.44.0")]
 impl<T, const N: usize> From<[T; N]> for Vec<T> {
-    /// Allocate a `Vec<T>` and move `s`'s items into it.
+    /// Allocates a `Vec<T>` and moves `s`'s items into it.
     ///
     /// # Examples
     ///
@@ -3452,7 +3454,7 @@ impl<'a, T> From<Cow<'a, [T]>> for Vec<T>
 where
     [T]: ToOwned<Owned = Vec<T>>,
 {
-    /// Convert a clone-on-write slice into a vector.
+    /// Converts a clone-on-write slice into a vector.
     ///
     /// If `s` already owns a `Vec<T>`, it will be returned directly.
     /// If `s` is borrowing a slice, a new `Vec<T>` will be allocated and
@@ -3475,7 +3477,7 @@ where
 #[cfg(not(test))]
 #[stable(feature = "vec_from_box", since = "1.18.0")]
 impl<T, A: Allocator> From<Box<[T], A>> for Vec<T, A> {
-    /// Convert a boxed slice into a vector by transferring ownership of
+    /// Converts a boxed slice into a vector by transferring ownership of
     /// the existing heap allocation.
     ///
     /// # Examples
@@ -3494,7 +3496,7 @@ impl<T, A: Allocator> From<Box<[T], A>> for Vec<T, A> {
 #[cfg(not(test))]
 #[stable(feature = "box_from_vec", since = "1.20.0")]
 impl<T, A: Allocator> From<Vec<T, A>> for Box<[T], A> {
-    /// Convert a vector into a boxed slice.
+    /// Converts a vector into a boxed slice.
     ///
     /// Before doing the conversion, this method discards excess capacity like [`Vec::shrink_to_fit`].
     ///
@@ -3522,7 +3524,7 @@ impl<T, A: Allocator> From<Vec<T, A>> for Box<[T], A> {
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "rust1", since = "1.0.0")]
 impl From<&str> for Vec<u8> {
-    /// Allocate a `Vec<u8>` and fill it with a UTF-8 string.
+    /// Allocates a `Vec<u8>` and fills it with a UTF-8 string.
     ///
     /// # Examples
     ///

--- a/library/core/src/alloc/global.rs
+++ b/library/core/src/alloc/global.rs
@@ -118,7 +118,7 @@ use crate::ptr;
 ///   having side effects.
 #[stable(feature = "global_alloc", since = "1.28.0")]
 pub unsafe trait GlobalAlloc {
-    /// Allocate memory as described by the given `layout`.
+    /// Allocates memory as described by the given `layout`.
     ///
     /// Returns a pointer to newly-allocated memory,
     /// or null to indicate allocation failure.
@@ -153,7 +153,7 @@ pub unsafe trait GlobalAlloc {
     #[stable(feature = "global_alloc", since = "1.28.0")]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8;
 
-    /// Deallocate the block of memory at the given `ptr` pointer with the given `layout`.
+    /// Deallocates the block of memory at the given `ptr` pointer with the given `layout`.
     ///
     /// # Safety
     ///
@@ -200,7 +200,7 @@ pub unsafe trait GlobalAlloc {
         ptr
     }
 
-    /// Shrink or grow a block of memory to the given `new_size` in bytes.
+    /// Shrinks or grows a block of memory to the given `new_size` in bytes.
     /// The block is described by the given `ptr` pointer and `layout`.
     ///
     /// If this returns a non-null pointer, then ownership of the memory block
@@ -232,7 +232,7 @@ pub unsafe trait GlobalAlloc {
     /// * `new_size` must be greater than zero.
     ///
     /// * `new_size`, when rounded up to the nearest multiple of `layout.align()`,
-    ///   must not overflow isize (i.e., the rounded value must be less than or
+    ///   must not overflow `isize` (i.e., the rounded value must be less than or
     ///   equal to `isize::MAX`).
     ///
     /// (Extension subtraits might provide more specific bounds on

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -26,7 +26,7 @@ const fn size_align<T>() -> (usize, usize) {
 /// You build a `Layout` up as an input to give to an allocator.
 ///
 /// All layouts have an associated size and a power-of-two alignment. The size, when rounded up to
-/// the nearest multiple of `align`, does not overflow isize (i.e., the rounded value will always be
+/// the nearest multiple of `align`, does not overflow `isize` (i.e., the rounded value will always be
 /// less than or equal to `isize::MAX`).
 ///
 /// (Note that layouts are *not* required to have non-zero size,
@@ -61,7 +61,7 @@ impl Layout {
     /// * `align` must be a power of two,
     ///
     /// * `size`, when rounded up to the nearest multiple of `align`,
-    ///    must not overflow isize (i.e., the rounded value must be
+    ///    must not overflow `isize` (i.e., the rounded value must be
     ///    less than or equal to `isize::MAX`).
     #[stable(feature = "alloc_layout", since = "1.28.0")]
     #[rustc_const_stable(feature = "const_alloc_layout_size_align", since = "1.50.0")]

--- a/library/core/src/array/ascii.rs
+++ b/library/core/src/array/ascii.rs
@@ -2,7 +2,7 @@ use crate::ascii;
 
 #[cfg(not(test))]
 impl<const N: usize> [u8; N] {
-    /// Converts this array of bytes into a array of ASCII characters,
+    /// Converts this array of bytes into an array of ASCII characters,
     /// or returns `None` if any of the characters is non-ASCII.
     ///
     /// # Examples
@@ -29,7 +29,7 @@ impl<const N: usize> [u8; N] {
         }
     }
 
-    /// Converts this array of bytes into a array of ASCII characters,
+    /// Converts this array of bytes into an array of ASCII characters,
     /// without checking whether they're valid.
     ///
     /// # Safety

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -47,8 +47,10 @@ impl<T, const N: usize> IntoIterator for [T; N] {
     type IntoIter = IntoIter<T, N>;
 
     /// Creates a consuming iterator, that is, one that moves each value out of
-    /// the array (from start to end). The array cannot be used after calling
-    /// this unless `T` implements `Copy`, so the whole array is copied.
+    /// the array (from start to end).
+    ///
+    /// The array cannot be used after calling this unless `T` implements
+    /// `Copy`, so the whole array is copied.
     ///
     /// Arrays have special behavior when calling `.into_iter()` prior to the
     /// 2021 edition -- see the [array] Editions section for more information.

--- a/library/core/src/async_iter/async_iter.rs
+++ b/library/core/src/async_iter/async_iter.rs
@@ -18,7 +18,7 @@ pub trait AsyncIterator {
     /// The type of items yielded by the async iterator.
     type Item;
 
-    /// Attempt to pull out the next value of this async iterator, registering the
+    /// Attempts to pull out the next value of this async iterator, registering the
     /// current task for wakeup if the value is not yet available, and returning
     /// `None` if the async iterator is exhausted.
     ///
@@ -139,7 +139,7 @@ impl<T> Poll<Option<T>> {
     pub const FINISHED: Self = Poll::Ready(None);
 }
 
-/// Convert something into an async iterator
+/// Converts something into an async iterator
 #[unstable(feature = "async_iterator", issue = "79024")]
 pub trait IntoAsyncIterator {
     /// The type of the item yielded by the iterator

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -427,7 +427,9 @@ impl<T> Cell<T> {
     }
 
     /// Swaps the values of two `Cell`s.
-    /// Difference with `std::mem::swap` is that this function doesn't require `&mut` reference.
+    ///
+    /// The difference with `std::mem::swap` is that this function doesn't
+    /// require a `&mut` reference.
     ///
     /// # Panics
     ///
@@ -1579,7 +1581,7 @@ impl<'b, T: ?Sized> Ref<'b, T> {
         )
     }
 
-    /// Convert into a reference to the underlying data.
+    /// Converts into a reference to the underlying data.
     ///
     /// The underlying `RefCell` can never be mutably borrowed from again and will always appear
     /// already immutably borrowed. It is not a good idea to leak more than a constant number of
@@ -1747,7 +1749,7 @@ impl<'b, T: ?Sized> RefMut<'b, T> {
         )
     }
 
-    /// Convert into a mutable reference to the underlying data.
+    /// Converts into a mutable reference to the underlying data.
     ///
     /// The underlying `RefCell` can not be borrowed from again and will always appear already
     /// mutably borrowed, making the returned reference the only to the interior.
@@ -1879,7 +1881,7 @@ impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
 ///
 /// If you have a reference `&T`, then normally in Rust the compiler performs optimizations based on
 /// the knowledge that `&T` points to immutable data. Mutating that data, for example through an
-/// alias or by transmuting an `&T` into an `&mut T`, is considered undefined behavior.
+/// alias or by transmuting a `&T` into a `&mut T`, is considered undefined behavior.
 /// `UnsafeCell<T>` opts-out of the immutability guarantee for `&T`: a shared reference
 /// `&UnsafeCell<T>` may point to data that is being mutated. This is called "interior mutability".
 ///
@@ -1936,7 +1938,7 @@ impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
 /// to have multiple `&mut UnsafeCell<T>` aliases. That is, `UnsafeCell` is a wrapper
 /// designed to have a special interaction with _shared_ accesses (_i.e._, through an
 /// `&UnsafeCell<_>` reference); there is no magic whatsoever when dealing with _exclusive_
-/// accesses (_e.g._, through an `&mut UnsafeCell<_>`): neither the cell nor the wrapped value
+/// accesses (_e.g._, through a `&mut UnsafeCell<_>`): neither the cell nor the wrapped value
 /// may be aliased for the duration of that `&mut` borrow.
 /// This is showcased by the [`.get_mut()`] accessor, which is a _safe_ getter that yields
 /// a `&mut T`.

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -246,15 +246,14 @@ use self::Ordering::*;
 )]
 #[rustc_diagnostic_item = "PartialEq"]
 pub trait PartialEq<Rhs: ?Sized = Self> {
-    /// This method tests for `self` and `other` values to be equal, and is used
-    /// by `==`.
+    /// Tests for `self` and `other` values to be equal, and is used by `==`.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_diagnostic_item = "cmp_partialeq_eq"]
     fn eq(&self, other: &Rhs) -> bool;
 
-    /// This method tests for `!=`. The default implementation is almost always
-    /// sufficient, and should not be overridden without very good reason.
+    /// Tests for `!=`. The default implementation is almost always sufficient,
+    /// and should not be overridden without very good reason.
     #[inline]
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
@@ -1163,7 +1162,7 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
     #[rustc_diagnostic_item = "cmp_partialord_cmp"]
     fn partial_cmp(&self, other: &Rhs) -> Option<Ordering>;
 
-    /// This method tests less than (for `self` and `other`) and is used by the `<` operator.
+    /// Tests less than (for `self` and `other`) and is used by the `<` operator.
     ///
     /// # Examples
     ///
@@ -1180,8 +1179,8 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
         matches!(self.partial_cmp(other), Some(Less))
     }
 
-    /// This method tests less than or equal to (for `self` and `other`) and is used by the `<=`
-    /// operator.
+    /// Tests less than or equal to (for `self` and `other`) and is used by the
+    /// `<=` operator.
     ///
     /// # Examples
     ///
@@ -1198,7 +1197,8 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
         matches!(self.partial_cmp(other), Some(Less | Equal))
     }
 
-    /// This method tests greater than (for `self` and `other`) and is used by the `>` operator.
+    /// Tests greater than (for `self` and `other`) and is used by the `>`
+    /// operator.
     ///
     /// # Examples
     ///
@@ -1215,8 +1215,8 @@ pub trait PartialOrd<Rhs: ?Sized = Self>: PartialEq<Rhs> {
         matches!(self.partial_cmp(other), Some(Greater))
     }
 
-    /// This method tests greater than or equal to (for `self` and `other`) and is used by the `>=`
-    /// operator.
+    /// Tests greater than or equal to (for `self` and `other`) and is used by
+    /// the `>=` operator.
     ///
     /// # Examples
     ///

--- a/library/core/src/convert/num.rs
+++ b/library/core/src/convert/num.rs
@@ -208,7 +208,7 @@ macro_rules! impl_try_from_unbounded {
         impl TryFrom<$source> for $target {
             type Error = TryFromIntError;
 
-            /// Try to create the target number type from a source
+            /// Tries to create the target number type from a source
             /// number type. This returns an error if the source value
             /// is outside of the range of the target type.
             #[inline]
@@ -226,7 +226,7 @@ macro_rules! impl_try_from_lower_bounded {
         impl TryFrom<$source> for $target {
             type Error = TryFromIntError;
 
-            /// Try to create the target number type from a source
+            /// Tries to create the target number type from a source
             /// number type. This returns an error if the source value
             /// is outside of the range of the target type.
             #[inline]
@@ -248,7 +248,7 @@ macro_rules! impl_try_from_upper_bounded {
         impl TryFrom<$source> for $target {
             type Error = TryFromIntError;
 
-            /// Try to create the target number type from a source
+            /// Tries to create the target number type from a source
             /// number type. This returns an error if the source value
             /// is outside of the range of the target type.
             #[inline]
@@ -270,7 +270,7 @@ macro_rules! impl_try_from_both_bounded {
         impl TryFrom<$source> for $target {
             type Error = TryFromIntError;
 
-            /// Try to create the target number type from a source
+            /// Tries to create the target number type from a source
             /// number type. This returns an error if the source value
             /// is outside of the range of the target type.
             #[inline]

--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -30,7 +30,7 @@ use crate::fmt::{Debug, Display, Formatter, Result};
 #[rustc_has_incoherent_inherent_impls]
 #[allow(multiple_supertrait_upcastable)]
 pub trait Error: Debug + Display {
-    /// The lower-level source of this error, if any.
+    /// Returns the lower-level source of this error, if any.
     ///
     /// # Examples
     ///
@@ -121,7 +121,7 @@ pub trait Error: Debug + Display {
         self.source()
     }
 
-    /// Provides type based access to context intended for error reports.
+    /// Provides type-based access to context intended for error reports.
     ///
     /// Used in conjunction with [`Request::provide_value`] and [`Request::provide_ref`] to extract
     /// references to member variables from `dyn Error` trait objects.
@@ -353,7 +353,7 @@ impl dyn Error {
     }
 }
 
-/// Request a value of type `T` from the given `impl Error`.
+/// Requests a value of type `T` from the given `impl Error`.
 ///
 /// # Examples
 ///
@@ -376,7 +376,7 @@ where
     request_by_type_tag::<'a, tags::Value<T>>(err)
 }
 
-/// Request a reference of type `T` from the given `impl Error`.
+/// Requests a reference of type `T` from the given `impl Error`.
 ///
 /// # Examples
 ///
@@ -510,7 +510,7 @@ where
 pub struct Request<'a>(Tagged<dyn Erased<'a> + 'a>);
 
 impl<'a> Request<'a> {
-    /// Provide a value or other type with only static lifetimes.
+    /// Provides a value or other type with only static lifetimes.
     ///
     /// # Examples
     ///
@@ -544,7 +544,7 @@ impl<'a> Request<'a> {
         self.provide::<tags::Value<T>>(value)
     }
 
-    /// Provide a value or other type with only static lifetimes computed using a closure.
+    /// Provides a value or other type with only static lifetimes computed using a closure.
     ///
     /// # Examples
     ///
@@ -578,7 +578,7 @@ impl<'a> Request<'a> {
         self.provide_with::<tags::Value<T>>(fulfil)
     }
 
-    /// Provide a reference. The referee type must be bounded by `'static`,
+    /// Provides a reference. The referee type must be bounded by `'static`,
     /// but may be unsized.
     ///
     /// # Examples
@@ -610,7 +610,7 @@ impl<'a> Request<'a> {
         self.provide::<tags::Ref<tags::MaybeSizedValue<T>>>(value)
     }
 
-    /// Provide a reference computed using a closure. The referee type
+    /// Provides a reference computed using a closure. The referee type
     /// must be bounded by `'static`, but may be unsized.
     ///
     /// # Examples
@@ -652,7 +652,7 @@ impl<'a> Request<'a> {
         self.provide_with::<tags::Ref<tags::MaybeSizedValue<T>>>(fulfil)
     }
 
-    /// Provide a value with the given `Type` tag.
+    /// Provides a value with the given `Type` tag.
     fn provide<I>(&mut self, value: I::Reified) -> &mut Self
     where
         I: tags::Type<'a>,
@@ -663,7 +663,7 @@ impl<'a> Request<'a> {
         self
     }
 
-    /// Provide a value with the given `Type` tag, using a closure to prevent unnecessary work.
+    /// Provides a value with the given `Type` tag, using a closure to prevent unnecessary work.
     fn provide_with<I>(&mut self, fulfil: impl FnOnce() -> I::Reified) -> &mut Self
     where
         I: tags::Type<'a>,
@@ -674,13 +674,13 @@ impl<'a> Request<'a> {
         self
     }
 
-    /// Check if the `Request` would be satisfied if provided with a
+    /// Checks if the `Request` would be satisfied if provided with a
     /// value of the specified type. If the type does not match or has
     /// already been provided, returns false.
     ///
     /// # Examples
     ///
-    /// Check if an `u8` still needs to be provided and then provides
+    /// Checks if a `u8` still needs to be provided and then provides
     /// it.
     ///
     /// ```rust
@@ -761,13 +761,14 @@ impl<'a> Request<'a> {
         self.would_be_satisfied_by::<tags::Value<T>>()
     }
 
-    /// Check if the `Request` would be satisfied if provided with a
-    /// reference to a value of the specified type. If the type does
-    /// not match or has already been provided, returns false.
+    /// Checks if the `Request` would be satisfied if provided with a
+    /// reference to a value of the specified type.
+    ///
+    /// If the type does not match or has already been provided, returns false.
     ///
     /// # Examples
     ///
-    /// Check if a `&str` still needs to be provided and then provides
+    /// Checks if a `&str` still needs to be provided and then provides
     /// it.
     ///
     /// ```rust

--- a/library/core/src/ffi/va_list.rs
+++ b/library/core/src/ffi/va_list.rs
@@ -162,7 +162,7 @@ pub struct VaList<'a, 'f: 'a> {
     windows,
 ))]
 impl<'f> VaListImpl<'f> {
-    /// Convert a `VaListImpl` into a `VaList` that is binary-compatible with C's `va_list`.
+    /// Converts a `VaListImpl` into a `VaList` that is binary-compatible with C's `va_list`.
     #[inline]
     pub fn as_va_list<'a>(&'a mut self) -> VaList<'a, 'f> {
         VaList { inner: VaListImpl { ..*self }, _marker: PhantomData }
@@ -182,7 +182,7 @@ impl<'f> VaListImpl<'f> {
     not(windows),
 ))]
 impl<'f> VaListImpl<'f> {
-    /// Convert a `VaListImpl` into a `VaList` that is binary-compatible with C's `va_list`.
+    /// Converts a `VaListImpl` into a `VaList` that is binary-compatible with C's `va_list`.
     #[inline]
     pub fn as_va_list<'a>(&'a mut self) -> VaList<'a, 'f> {
         VaList { inner: self, _marker: PhantomData }

--- a/library/core/src/fmt/mod.rs
+++ b/library/core/src/fmt/mod.rs
@@ -354,7 +354,7 @@ impl<'a> Arguments<'a> {
         Arguments { pieces, fmt: None, args }
     }
 
-    /// This function is used to specify nonstandard formatting parameters.
+    /// Specifies nonstandard formatting parameters.
     ///
     /// An `rt::UnsafeArg` is required because the following invariants must be held
     /// in order for this function to be safe:
@@ -396,7 +396,7 @@ impl<'a> Arguments<'a> {
 }
 
 impl<'a> Arguments<'a> {
-    /// Get the formatted string, if it has no arguments to be formatted at runtime.
+    /// Gets the formatted string, if it has no arguments to be formatted at runtime.
     ///
     /// This can be used to avoid allocations in some cases.
     ///
@@ -1129,8 +1129,8 @@ pub trait UpperExp {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result;
 }
 
-/// The `write` function takes an output stream, and an `Arguments` struct
-/// that can be precompiled with the `format_args!` macro.
+/// Takes an output stream and an `Arguments` struct that can be precompiled with
+/// the `format_args!` macro.
 ///
 /// The arguments will be formatted according to the specified format string
 /// into the output stream provided.
@@ -1257,7 +1257,7 @@ impl PostPadding {
         PostPadding { fill, padding }
     }
 
-    /// Write this post padding.
+    /// Writes this post padding.
     pub(crate) fn write(self, f: &mut Formatter<'_>) -> Result {
         for _ in 0..self.padding {
             f.buf.write_char(self.fill)?;
@@ -1398,9 +1398,10 @@ impl<'a> Formatter<'a> {
         }
     }
 
-    /// This function takes a string slice and emits it to the internal buffer
-    /// after applying the relevant formatting flags specified. The flags
-    /// recognized for generic strings are:
+    /// Takes a string slice and emits it to the internal buffer after applying
+    /// the relevant formatting flags specified.
+    ///
+    /// The flags recognized for generic strings are:
     ///
     /// * width - the minimum width of what to emit
     /// * fill/align - what to emit and where to emit it if the string
@@ -1474,9 +1475,10 @@ impl<'a> Formatter<'a> {
         }
     }
 
-    /// Write the pre-padding and return the unwritten post-padding. Callers are
-    /// responsible for ensuring post-padding is written after the thing that is
-    /// being padded.
+    /// Writes the pre-padding and returns the unwritten post-padding.
+    ///
+    /// Callers are responsible for ensuring post-padding is written after the
+    /// thing that is being padded.
     pub(crate) fn padding(
         &mut self,
         padding: usize,
@@ -1503,6 +1505,7 @@ impl<'a> Formatter<'a> {
     }
 
     /// Takes the formatted parts and applies the padding.
+    ///
     /// Assumes that the caller already has rendered the parts with required precision,
     /// so that `self.precision` can be ignored.
     ///
@@ -1655,7 +1658,7 @@ impl<'a> Formatter<'a> {
         }
     }
 
-    /// Flags for formatting
+    /// Returns flags for formatting.
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[deprecated(
@@ -1667,7 +1670,7 @@ impl<'a> Formatter<'a> {
         self.flags
     }
 
-    /// Character used as 'fill' whenever there is alignment.
+    /// Returns the character used as 'fill' whenever there is alignment.
     ///
     /// # Examples
     ///
@@ -1700,7 +1703,7 @@ impl<'a> Formatter<'a> {
         self.fill
     }
 
-    /// Flag indicating what form of alignment was requested.
+    /// Returns a flag indicating what form of alignment was requested.
     ///
     /// # Examples
     ///
@@ -1740,7 +1743,7 @@ impl<'a> Formatter<'a> {
         }
     }
 
-    /// Optionally specified integer width that the output should be.
+    /// Returns the optionally specified integer width that the output should be.
     ///
     /// # Examples
     ///
@@ -1770,8 +1773,8 @@ impl<'a> Formatter<'a> {
         self.width
     }
 
-    /// Optionally specified precision for numeric types. Alternatively, the
-    /// maximum width for string types.
+    /// Returns the optionally specified precision for numeric types.
+    /// Alternatively, the maximum width for string types.
     ///
     /// # Examples
     ///
@@ -1967,8 +1970,9 @@ impl<'a> Formatter<'a> {
         builders::debug_struct_new(self, name)
     }
 
-    /// Used to shrink `derive(Debug)` code, for faster compilation and smaller binaries.
-    /// `debug_struct_fields_finish` is more general, but this is faster for 1 field.
+    /// Shrinks `derive(Debug)` code, for faster compilation and smaller
+    /// binaries. `debug_struct_fields_finish` is more general, but this is
+    /// faster for 1 field.
     #[doc(hidden)]
     #[unstable(feature = "fmt_helpers_for_derive", issue = "none")]
     pub fn debug_struct_field1_finish<'b>(
@@ -1982,8 +1986,9 @@ impl<'a> Formatter<'a> {
         builder.finish()
     }
 
-    /// Used to shrink `derive(Debug)` code, for faster compilation and smaller binaries.
-    /// `debug_struct_fields_finish` is more general, but this is faster for 2 fields.
+    /// Shrinks `derive(Debug)` code, for faster compilation and smaller
+    /// binaries. `debug_struct_fields_finish` is more general, but this is
+    /// faster for 2 fields.
     #[doc(hidden)]
     #[unstable(feature = "fmt_helpers_for_derive", issue = "none")]
     pub fn debug_struct_field2_finish<'b>(
@@ -2000,8 +2005,9 @@ impl<'a> Formatter<'a> {
         builder.finish()
     }
 
-    /// Used to shrink `derive(Debug)` code, for faster compilation and smaller binaries.
-    /// `debug_struct_fields_finish` is more general, but this is faster for 3 fields.
+    /// Shrinks `derive(Debug)` code, for faster compilation and smaller
+    /// binaries. `debug_struct_fields_finish` is more general, but this is
+    /// faster for 3 fields.
     #[doc(hidden)]
     #[unstable(feature = "fmt_helpers_for_derive", issue = "none")]
     pub fn debug_struct_field3_finish<'b>(
@@ -2021,8 +2027,9 @@ impl<'a> Formatter<'a> {
         builder.finish()
     }
 
-    /// Used to shrink `derive(Debug)` code, for faster compilation and smaller binaries.
-    /// `debug_struct_fields_finish` is more general, but this is faster for 4 fields.
+    /// Shrinks `derive(Debug)` code, for faster compilation and smaller
+    /// binaries. `debug_struct_fields_finish` is more general, but this is
+    /// faster for 4 fields.
     #[doc(hidden)]
     #[unstable(feature = "fmt_helpers_for_derive", issue = "none")]
     pub fn debug_struct_field4_finish<'b>(
@@ -2045,8 +2052,9 @@ impl<'a> Formatter<'a> {
         builder.finish()
     }
 
-    /// Used to shrink `derive(Debug)` code, for faster compilation and smaller binaries.
-    /// `debug_struct_fields_finish` is more general, but this is faster for 5 fields.
+    /// Shrinks `derive(Debug)` code, for faster compilation and smaller
+    /// binaries. `debug_struct_fields_finish` is more general, but this is
+    /// faster for 5 fields.
     #[doc(hidden)]
     #[unstable(feature = "fmt_helpers_for_derive", issue = "none")]
     pub fn debug_struct_field5_finish<'b>(
@@ -2072,7 +2080,7 @@ impl<'a> Formatter<'a> {
         builder.finish()
     }
 
-    /// Used to shrink `derive(Debug)` code, for faster compilation and smaller binaries.
+    /// Shrinks `derive(Debug)` code, for faster compilation and smaller binaries.
     /// For the cases not covered by `debug_struct_field[12345]_finish`.
     #[doc(hidden)]
     #[unstable(feature = "fmt_helpers_for_derive", issue = "none")]
@@ -2121,8 +2129,9 @@ impl<'a> Formatter<'a> {
         builders::debug_tuple_new(self, name)
     }
 
-    /// Used to shrink `derive(Debug)` code, for faster compilation and smaller binaries.
-    /// `debug_tuple_fields_finish` is more general, but this is faster for 1 field.
+    /// Shrinks `derive(Debug)` code, for faster compilation and smaller
+    /// binaries. `debug_tuple_fields_finish` is more general, but this is faster
+    /// for 1 field.
     #[doc(hidden)]
     #[unstable(feature = "fmt_helpers_for_derive", issue = "none")]
     pub fn debug_tuple_field1_finish<'b>(&'b mut self, name: &str, value1: &dyn Debug) -> Result {
@@ -2131,8 +2140,9 @@ impl<'a> Formatter<'a> {
         builder.finish()
     }
 
-    /// Used to shrink `derive(Debug)` code, for faster compilation and smaller binaries.
-    /// `debug_tuple_fields_finish` is more general, but this is faster for 2 fields.
+    /// Shrinks `derive(Debug)` code, for faster compilation and smaller
+    /// binaries. `debug_tuple_fields_finish` is more general, but this is faster
+    /// for 2 fields.
     #[doc(hidden)]
     #[unstable(feature = "fmt_helpers_for_derive", issue = "none")]
     pub fn debug_tuple_field2_finish<'b>(
@@ -2147,8 +2157,9 @@ impl<'a> Formatter<'a> {
         builder.finish()
     }
 
-    /// Used to shrink `derive(Debug)` code, for faster compilation and smaller binaries.
-    /// `debug_tuple_fields_finish` is more general, but this is faster for 3 fields.
+    /// Shrinks `derive(Debug)` code, for faster compilation and smaller
+    /// binaries. `debug_tuple_fields_finish` is more general, but this is faster
+    /// for 3 fields.
     #[doc(hidden)]
     #[unstable(feature = "fmt_helpers_for_derive", issue = "none")]
     pub fn debug_tuple_field3_finish<'b>(
@@ -2165,8 +2176,9 @@ impl<'a> Formatter<'a> {
         builder.finish()
     }
 
-    /// Used to shrink `derive(Debug)` code, for faster compilation and smaller binaries.
-    /// `debug_tuple_fields_finish` is more general, but this is faster for 4 fields.
+    /// Shrinks `derive(Debug)` code, for faster compilation and smaller
+    /// binaries. `debug_tuple_fields_finish` is more general, but this is faster
+    /// for 4 fields.
     #[doc(hidden)]
     #[unstable(feature = "fmt_helpers_for_derive", issue = "none")]
     pub fn debug_tuple_field4_finish<'b>(
@@ -2185,8 +2197,9 @@ impl<'a> Formatter<'a> {
         builder.finish()
     }
 
-    /// Used to shrink `derive(Debug)` code, for faster compilation and smaller binaries.
-    /// `debug_tuple_fields_finish` is more general, but this is faster for 5 fields.
+    /// Shrinks `derive(Debug)` code, for faster compilation and smaller
+    /// binaries. `debug_tuple_fields_finish` is more general, but this is faster
+    /// for 5 fields.
     #[doc(hidden)]
     #[unstable(feature = "fmt_helpers_for_derive", issue = "none")]
     pub fn debug_tuple_field5_finish<'b>(
@@ -2207,8 +2220,8 @@ impl<'a> Formatter<'a> {
         builder.finish()
     }
 
-    /// Used to shrink `derive(Debug)` code, for faster compilation and smaller binaries.
-    /// For the cases not covered by `debug_tuple_field[12345]_finish`.
+    /// Shrinks `derive(Debug)` code, for faster compilation and smaller
+    /// binaries. For the cases not covered by `debug_tuple_field[12345]_finish`.
     #[doc(hidden)]
     #[unstable(feature = "fmt_helpers_for_derive", issue = "none")]
     pub fn debug_tuple_fields_finish<'b>(
@@ -2496,8 +2509,9 @@ impl<T: ?Sized> Pointer for *const T {
     }
 }
 
-/// Since the formatting will be identical for all pointer types, use a non-monomorphized
-/// implementation for the actual formatting to reduce the amount of codegen work needed.
+/// Since the formatting will be identical for all pointer types, uses a
+/// non-monomorphized implementation for the actual formatting to reduce the
+/// amount of codegen work needed.
 ///
 /// This uses `ptr_addr: usize` and not `ptr: *const ()` to be able to use this for
 /// `fn(...) -> ...` without using [problematic] "Oxford Casts".

--- a/library/core/src/future/async_drop.rs
+++ b/library/core/src/future/async_drop.rs
@@ -205,7 +205,7 @@ async unsafe fn slice<T>(s: *mut [T]) {
     }
 }
 
-/// Construct a chain of two futures, which awaits them sequentially as
+/// Constructs a chain of two futures, which awaits them sequentially as
 /// a future.
 #[lang = "async_drop_chain"]
 async fn chain<F, G>(first: F, last: G)
@@ -235,8 +235,8 @@ async unsafe fn defer<T: ?Sized>(to_drop: *mut T) {
 ///
 /// # Safety
 ///
-/// User should carefully manage returned future, since it would
-/// try creating an immutable referece from `this` and get pointee's
+/// Users should carefully manage the returned future, since it would
+/// try creating an immutable reference from `this` and get pointee's
 /// discriminant.
 // FIXME(zetanumbers): Send and Sync impls
 #[lang = "async_drop_either"]

--- a/library/core/src/future/future.rs
+++ b/library/core/src/future/future.rs
@@ -38,7 +38,7 @@ pub trait Future {
     #[lang = "future_output"]
     type Output;
 
-    /// Attempt to resolve the future to a final value, registering
+    /// Attempts to resolve the future to a final value, registering
     /// the current task for wakeup if the value is not yet available.
     ///
     /// # Return value

--- a/library/core/src/future/into_future.rs
+++ b/library/core/src/future/into_future.rs
@@ -40,7 +40,7 @@ use crate::future::Future;
 /// }
 ///
 /// impl Multiply {
-///     /// Construct a new instance of `Multiply`.
+///     /// Constructs a new instance of `Multiply`.
 ///     pub fn new(num: u16, factor: u16) -> Self {
 ///         Self { num, factor }
 ///     }
@@ -89,7 +89,7 @@ use crate::future::Future;
 /// ```rust
 /// use std::future::IntoFuture;
 ///
-/// /// Convert the output of a future to a string.
+/// /// Converts the output of a future to a string.
 /// async fn fut_to_string<Fut>(fut: Fut) -> String
 /// where
 ///     Fut: IntoFuture,

--- a/library/core/src/internal_macros.rs
+++ b/library/core/src/internal_macros.rs
@@ -80,7 +80,7 @@ macro_rules! forward_ref_op_assign {
     }
 }
 
-/// Create a zero-size type similar to a closure type, but named.
+/// Creates a zero-size type similar to a closure type, but named.
 macro_rules! impl_fn_for_zst {
     ($(
         $( #[$attr: meta] )*

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1252,7 +1252,7 @@ extern "rust-intrinsic" {
     /// - If the code actually wants to work on the address the pointer points to, it can use `as`
     ///   casts or [`ptr.addr()`][pointer::addr].
     ///
-    /// Turning a `*mut T` into an `&mut T`:
+    /// Turning a `*mut T` into a `&mut T`:
     ///
     /// ```
     /// let ptr: *mut i32 = &mut 0;
@@ -1264,7 +1264,7 @@ extern "rust-intrinsic" {
     /// let ref_casted = unsafe { &mut *ptr };
     /// ```
     ///
-    /// Turning an `&mut T` into an `&mut U`:
+    /// Turning a `&mut T` into a `&mut U`:
     ///
     /// ```
     /// let ptr = &mut 0;
@@ -1277,7 +1277,7 @@ extern "rust-intrinsic" {
     /// let val_casts = unsafe { &mut *(ptr as *mut i32 as *mut u32) };
     /// ```
     ///
-    /// Turning an `&str` into a `&[u8]`:
+    /// Turning a `&str` into a `&[u8]`:
     ///
     /// ```
     /// // this is not a good way to do this.
@@ -1363,7 +1363,7 @@ extern "rust-intrinsic" {
     /// }
     ///
     /// // This gets rid of the type safety problems; `&mut *` will *only* give
-    /// // you an `&mut T` from an `&mut T` or `*mut T`.
+    /// // you a `&mut T` from a `&mut T` or `*mut T`.
     /// fn split_at_mut_casts<T>(slice: &mut [T], mid: usize)
     ///                          -> (&mut [T], &mut [T]) {
     ///     let len = slice.len();
@@ -1944,7 +1944,7 @@ extern "rust-intrinsic" {
     #[rustc_safe_intrinsic]
     pub fn frem_algebraic<T: Copy>(a: T, b: T) -> T;
 
-    /// Convert with LLVM’s fptoui/fptosi, which may return undef for values out of range
+    /// Converts with LLVM’s fptoui/fptosi, which may return undef for values out of range
     /// (<https://github.com/rust-lang/rust/issues/10184>)
     ///
     /// Stabilized as [`f32::to_int_unchecked`] and [`f64::to_int_unchecked`].

--- a/library/core/src/intrinsics/simd.rs
+++ b/library/core/src/intrinsics/simd.rs
@@ -3,7 +3,7 @@
 //! In this module, a "vector" is any `repr(simd)` type.
 
 extern "rust-intrinsic" {
-    /// Insert an element into a vector, returning the updated vector.
+    /// Inserts an element into a vector, returning the updated vector.
     ///
     /// `T` must be a vector with element type `U`.
     ///
@@ -13,7 +13,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_insert<T, U>(x: T, idx: u32, val: U) -> T;
 
-    /// Extract an element from a vector.
+    /// Extracts an element from a vector.
     ///
     /// `T` must be a vector with element type `U`.
     ///
@@ -23,25 +23,25 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_extract<T, U>(x: T, idx: u32) -> U;
 
-    /// Add two simd vectors elementwise.
+    /// Adds two simd vectors elementwise.
     ///
     /// `T` must be a vector of integer or floating point primitive types.
     #[rustc_nounwind]
     pub fn simd_add<T>(x: T, y: T) -> T;
 
-    /// Subtract `rhs` from `lhs` elementwise.
+    /// Subtracts `rhs` from `lhs` elementwise.
     ///
     /// `T` must be a vector of integer or floating point primitive types.
     #[rustc_nounwind]
     pub fn simd_sub<T>(lhs: T, rhs: T) -> T;
 
-    /// Multiply two simd vectors elementwise.
+    /// Multiplies two simd vectors elementwise.
     ///
     /// `T` must be a vector of integer or floating point primitive types.
     #[rustc_nounwind]
     pub fn simd_mul<T>(x: T, y: T) -> T;
 
-    /// Divide `lhs` by `rhs` elementwise.
+    /// Divides `lhs` by `rhs` elementwise.
     ///
     /// `T` must be a vector of integer or floating point primitive types.
     ///
@@ -51,7 +51,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_div<T>(lhs: T, rhs: T) -> T;
 
-    /// Remainder of two vectors elementwise
+    /// Returns remainder of two vectors elementwise.
     ///
     /// `T` must be a vector of integer or floating point primitive types.
     ///
@@ -61,9 +61,9 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_rem<T>(lhs: T, rhs: T) -> T;
 
-    /// Elementwise vector left shift, with UB on overflow.
+    /// Shifts vector left elementwise, with UB on overflow.
     ///
-    /// Shift `lhs` left by `rhs`, shifting in sign bits for signed types.
+    /// Shifts `lhs` left by `rhs`, shifting in sign bits for signed types.
     ///
     /// `T` must be a vector of integer primitive types.
     ///
@@ -73,11 +73,11 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_shl<T>(lhs: T, rhs: T) -> T;
 
-    /// Elementwise vector right shift, with UB on overflow.
+    /// Shifts vector right elementwise, with UB on overflow.
     ///
     /// `T` must be a vector of integer primitive types.
     ///
-    /// Shift `lhs` right by `rhs`, shifting in sign bits for signed types.
+    /// Shifts `lhs` right by `rhs`, shifting in sign bits for signed types.
     ///
     /// # Safety
     ///
@@ -85,25 +85,25 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_shr<T>(lhs: T, rhs: T) -> T;
 
-    /// Elementwise vector "and".
+    /// "Ands" vectors elementwise.
     ///
     /// `T` must be a vector of integer primitive types.
     #[rustc_nounwind]
     pub fn simd_and<T>(x: T, y: T) -> T;
 
-    /// Elementwise vector "or".
+    /// "Ors" vectors elementwise.
     ///
     /// `T` must be a vector of integer primitive types.
     #[rustc_nounwind]
     pub fn simd_or<T>(x: T, y: T) -> T;
 
-    /// Elementwise vector "exclusive or".
+    /// "Exclusive ors" vectors elementwise.
     ///
     /// `T` must be a vector of integer primitive types.
     #[rustc_nounwind]
     pub fn simd_xor<T>(x: T, y: T) -> T;
 
-    /// Numerically cast a vector, elementwise.
+    /// Numerically casts a vector, elementwise.
     ///
     /// `T` and `U` must be vectors of integer or floating point primitive types, and must have the
     /// same length.
@@ -124,7 +124,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_cast<T, U>(x: T) -> U;
 
-    /// Numerically cast a vector, elementwise.
+    /// Numerically casts a vector, elementwise.
     ///
     /// `T` and `U` be a vectors of integer or floating point primitive types, and must have the
     /// same length.
@@ -138,7 +138,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_as<T, U>(x: T) -> U;
 
-    /// Elementwise negation of a vector.
+    /// Negates a vector elementwise.
     ///
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
@@ -146,13 +146,13 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_neg<T>(x: T) -> T;
 
-    /// Elementwise absolute value of a vector.
+    /// Returns absolute value of a vector, elementwise.
     ///
     /// `T` must be a vector of floating-point primitive types.
     #[rustc_nounwind]
     pub fn simd_fabs<T>(x: T) -> T;
 
-    /// Elementwise minimum of two vectors.
+    /// Returns the minimum of two vectors, elementwise.
     ///
     /// `T` must be a vector of floating-point primitive types.
     ///
@@ -160,7 +160,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_fmin<T>(x: T, y: T) -> T;
 
-    /// Elementwise maximum of two vectors.
+    /// Returns the maximum of two vectors, elementwise.
     ///
     /// `T` must be a vector of floating-point primitive types.
     ///
@@ -228,7 +228,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_ge<T, U>(x: T, y: T) -> U;
 
-    /// Shuffle two vectors by const indices.
+    /// Shuffles two vectors by const indices.
     ///
     /// `T` must be a vector.
     ///
@@ -243,7 +243,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_shuffle<T, U, V>(x: T, y: T, idx: U) -> V;
 
-    /// Read a vector of pointers.
+    /// Reads a vector of pointers.
     ///
     /// `T` must be a vector.
     ///
@@ -263,7 +263,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_gather<T, U, V>(val: T, ptr: U, mask: V) -> T;
 
-    /// Write to a vector of pointers.
+    /// Writes to a vector of pointers.
     ///
     /// `T` must be a vector.
     ///
@@ -286,7 +286,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_scatter<T, U, V>(val: T, ptr: U, mask: V);
 
-    /// Read a vector of pointers.
+    /// Reads a vector of pointers.
     ///
     /// `T` must be a vector.
     ///
@@ -308,7 +308,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_masked_load<V, U, T>(mask: V, ptr: U, val: T) -> T;
 
-    /// Write to a vector of pointers.
+    /// Writes to a vector of pointers.
     ///
     /// `T` must be a vector.
     ///
@@ -329,13 +329,13 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_masked_store<V, U, T>(mask: V, ptr: U, val: T);
 
-    /// Add two simd vectors elementwise, with saturation.
+    /// Adds two simd vectors elementwise, with saturation.
     ///
     /// `T` must be a vector of integer primitive types.
     #[rustc_nounwind]
     pub fn simd_saturating_add<T>(x: T, y: T) -> T;
 
-    /// Subtract two simd vectors elementwise, with saturation.
+    /// Subtracts two simd vectors elementwise, with saturation.
     ///
     /// `T` must be a vector of integer primitive types.
     ///
@@ -343,7 +343,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_saturating_sub<T>(lhs: T, rhs: T) -> T;
 
-    /// Add elements within a vector from left to right.
+    /// Adds elements within a vector from left to right.
     ///
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
@@ -353,7 +353,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_reduce_add_ordered<T, U>(x: T, y: U) -> U;
 
-    /// Add elements within a vector in arbitrary order. May also be re-associated with
+    /// Adds elements within a vector in arbitrary order. May also be re-associated with
     /// unordered additions on the inputs/outputs.
     ///
     /// `T` must be a vector of integer or floating-point primitive types.
@@ -362,7 +362,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_reduce_add_unordered<T, U>(x: T) -> U;
 
-    /// Multiply elements within a vector from left to right.
+    /// Multiplies elements within a vector from left to right.
     ///
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
@@ -372,7 +372,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_reduce_mul_ordered<T, U>(x: T, y: U) -> U;
 
-    /// Multiply elements within a vector in arbitrary order. May also be re-associated with
+    /// Multiplies elements within a vector in arbitrary order. May also be re-associated with
     /// unordered additions on the inputs/outputs.
     ///
     /// `T` must be a vector of integer or floating-point primitive types.
@@ -381,7 +381,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_reduce_mul_unordered<T, U>(x: T) -> U;
 
-    /// Check if all mask values are true.
+    /// Checks if all mask values are true.
     ///
     /// `T` must be a vector of integer primitive types.
     ///
@@ -390,7 +390,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_reduce_all<T>(x: T) -> bool;
 
-    /// Check if any mask value is true.
+    /// Checks if any mask value is true.
     ///
     /// `T` must be a vector of integer primitive types.
     ///
@@ -399,7 +399,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_reduce_any<T>(x: T) -> bool;
 
-    /// Return the maximum element of a vector.
+    /// Returns the maximum element of a vector.
     ///
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
@@ -409,7 +409,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_reduce_max<T, U>(x: T) -> U;
 
-    /// Return the minimum element of a vector.
+    /// Returns the minimum element of a vector.
     ///
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
@@ -419,7 +419,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_reduce_min<T, U>(x: T) -> U;
 
-    /// Logical "and" all elements together.
+    /// Logical "ands" all elements together.
     ///
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
@@ -427,7 +427,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_reduce_and<T, U>(x: T) -> U;
 
-    /// Logical "or" all elements together.
+    /// Logical "ors" all elements together.
     ///
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
@@ -435,7 +435,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_reduce_or<T, U>(x: T) -> U;
 
-    /// Logical "exclusive or" all elements together.
+    /// Logical "exclusive ors" all elements together.
     ///
     /// `T` must be a vector of integer or floating-point primitive types.
     ///
@@ -443,7 +443,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_reduce_xor<T, U>(x: T) -> U;
 
-    /// Truncate an integer vector to a bitmask.
+    /// Truncates an integer vector to a bitmask.
     ///
     /// `T` must be an integer vector.
     ///
@@ -479,7 +479,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_bitmask<T, U>(x: T) -> U;
 
-    /// Select elements from a mask.
+    /// Selects elements from a mask.
     ///
     /// `M` must be an integer vector.
     ///
@@ -494,7 +494,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_select<M, T>(mask: M, if_true: T, if_false: T) -> T;
 
-    /// Select elements from a bitmask.
+    /// Selects elements from a bitmask.
     ///
     /// `M` must be an unsigned integer or array of `u8`, matching `simd_bitmask`.
     ///
@@ -511,7 +511,8 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_select_bitmask<M, T>(m: M, yes: T, no: T) -> T;
 
-    /// Elementwise calculates the offset from a pointer vector, potentially wrapping.
+    /// Calculates the offset from a pointer vector elementwise, potentially
+    /// wrapping.
     ///
     /// `T` must be a vector of pointers.
     ///
@@ -521,13 +522,13 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_arith_offset<T, U>(ptr: T, offset: U) -> T;
 
-    /// Cast a vector of pointers.
+    /// Casts a vector of pointers.
     ///
     /// `T` and `U` must be vectors of pointers with the same number of elements.
     #[rustc_nounwind]
     pub fn simd_cast_ptr<T, U>(ptr: T) -> U;
 
-    /// Expose a vector of pointers as a vector of addresses.
+    /// Exposes a vector of pointers as a vector of addresses.
     ///
     /// `T` must be a vector of pointers.
     ///
@@ -535,7 +536,7 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_expose_provenance<T, U>(ptr: T) -> U;
 
-    /// Create a vector of pointers from a vector of addresses.
+    /// Creates a vector of pointers from a vector of addresses.
     ///
     /// `T` must be a vector of `usize`.
     ///
@@ -543,56 +544,56 @@ extern "rust-intrinsic" {
     #[rustc_nounwind]
     pub fn simd_with_exposed_provenance<T, U>(addr: T) -> U;
 
-    /// Swap bytes of each element.
+    /// Swaps bytes of each element.
     ///
     /// `T` must be a vector of integers.
     #[rustc_nounwind]
     pub fn simd_bswap<T>(x: T) -> T;
 
-    /// Reverse bits of each element.
+    /// Reverses bits of each element.
     ///
     /// `T` must be a vector of integers.
     #[rustc_nounwind]
     pub fn simd_bitreverse<T>(x: T) -> T;
 
-    /// Count the leading zeros of each element.
+    /// Counts the leading zeros of each element.
     ///
     /// `T` must be a vector of integers.
     #[rustc_nounwind]
     pub fn simd_ctlz<T>(x: T) -> T;
 
-    /// Count the number of ones in each element.
+    /// Counts the number of ones in each element.
     ///
     /// `T` must be a vector of integers.
     #[rustc_nounwind]
     pub fn simd_ctpop<T>(x: T) -> T;
 
-    /// Count the trailing zeros of each element.
+    /// Counts the trailing zeros of each element.
     ///
     /// `T` must be a vector of integers.
     #[rustc_nounwind]
     pub fn simd_cttz<T>(x: T) -> T;
 
-    /// Round up each element to the next highest integer-valued float.
+    /// Rounds up each element to the next highest integer-valued float.
     ///
     /// `T` must be a vector of floats.
     #[rustc_nounwind]
     pub fn simd_ceil<T>(x: T) -> T;
 
-    /// Round down each element to the next lowest integer-valued float.
+    /// Rounds down each element to the next lowest integer-valued float.
     ///
     /// `T` must be a vector of floats.
     #[rustc_nounwind]
     pub fn simd_floor<T>(x: T) -> T;
 
-    /// Round each element to the closest integer-valued float.
+    /// Rounds each element to the closest integer-valued float.
     /// Ties are resolved by rounding away from 0.
     ///
     /// `T` must be a vector of floats.
     #[rustc_nounwind]
     pub fn simd_round<T>(x: T) -> T;
 
-    /// Return the integer part of each element as an integer-valued float.
+    /// Returns the integer part of each element as an integer-valued float.
     /// In other words, non-integer values are truncated towards zero.
     ///
     /// `T` must be a vector of floats.

--- a/library/core/src/io/borrowed_buf.rs
+++ b/library/core/src/io/borrowed_buf.rs
@@ -44,7 +44,7 @@ impl Debug for BorrowedBuf<'_> {
     }
 }
 
-/// Create a new `BorrowedBuf` from a fully initialized slice.
+/// Creates a new `BorrowedBuf` from a fully initialized slice.
 impl<'data> From<&'data mut [u8]> for BorrowedBuf<'data> {
     #[inline]
     fn from(slice: &'data mut [u8]) -> BorrowedBuf<'data> {
@@ -59,7 +59,7 @@ impl<'data> From<&'data mut [u8]> for BorrowedBuf<'data> {
     }
 }
 
-/// Create a new `BorrowedBuf` from an uninitialized buffer.
+/// Creates a new `BorrowedBuf` from an uninitialized buffer.
 ///
 /// Use `set_init` if part of the buffer is known to be already initialized.
 impl<'data> From<&'data mut [MaybeUninit<u8>]> for BorrowedBuf<'data> {
@@ -174,7 +174,7 @@ pub struct BorrowedCursor<'a> {
 }
 
 impl<'a> BorrowedCursor<'a> {
-    /// Reborrow this cursor by cloning it with a smaller lifetime.
+    /// Reborrows this cursor by cloning it with a smaller lifetime.
     ///
     /// Since a cursor maintains unique access to its underlying buffer, the borrowed cursor is
     /// not accessible while the new cursor exists.
@@ -247,7 +247,7 @@ impl<'a> BorrowedCursor<'a> {
         unsafe { self.buf.buf.get_unchecked_mut(self.buf.filled..) }
     }
 
-    /// Advance the cursor by asserting that `n` bytes have been filled.
+    /// Advances the cursor by asserting that `n` bytes have been filled.
     ///
     /// After advancing, the `n` bytes are no longer accessible via the cursor and can only be
     /// accessed via the underlying buffer. I.e., the buffer's filled portion grows by `n` elements
@@ -268,7 +268,7 @@ impl<'a> BorrowedCursor<'a> {
         self
     }
 
-    /// Advance the cursor by asserting that `n` bytes have been filled.
+    /// Advances the cursor by asserting that `n` bytes have been filled.
     ///
     /// After advancing, the `n` bytes are no longer accessible via the cursor and can only be
     /// accessed via the underlying buffer. I.e., the buffer's filled portion grows by `n` elements

--- a/library/core/src/iter/adapters/step_by.rs
+++ b/library/core/src/iter/adapters/step_by.rs
@@ -414,9 +414,9 @@ unsafe impl<I: DoubleEndedIterator + ExactSizeIterator> StepByBackImpl<I> for St
 /// These only work for unsigned types, and will need to be reworked
 /// if you want to use it to specialize on signed types.
 ///
-/// Currently these are only implemented for integers up to usize due to
-/// correctness issues around ExactSizeIterator impls on 16bit platforms.
-/// And since ExactSizeIterator is a prerequisite for backwards iteration
+/// Currently these are only implemented for integers up to `usize` due to
+/// correctness issues around `ExactSizeIterator` impls on 16bit platforms.
+/// And since `ExactSizeIterator` is a prerequisite for backwards iteration
 /// and we must consistently specialize backwards and forwards iteration
 /// that makes the situation complicated enough that it's not covered
 /// for now.

--- a/library/core/src/iter/traits/accum.rs
+++ b/library/core/src/iter/traits/accum.rs
@@ -15,8 +15,8 @@ use crate::num::Wrapping;
     label = "value of type `{Self}` cannot be made by summing a `std::iter::Iterator<Item={A}>`"
 )]
 pub trait Sum<A = Self>: Sized {
-    /// Method which takes an iterator and generates `Self` from the elements by
-    /// "summing up" the items.
+    /// Takes an iterator and generates `Self` from the elements by "summing up"
+    /// the items.
     #[stable(feature = "iter_arith_traits", since = "1.12.0")]
     fn sum<I: Iterator<Item = A>>(iter: I) -> Self;
 }
@@ -36,8 +36,8 @@ pub trait Sum<A = Self>: Sized {
     label = "value of type `{Self}` cannot be made by multiplying all elements from a `std::iter::Iterator<Item={A}>`"
 )]
 pub trait Product<A = Self>: Sized {
-    /// Method which takes an iterator and generates `Self` from the elements by
-    /// multiplying the items.
+    /// Takes an iterator and generates `Self` from the elements by multiplying
+    /// the items.
     #[stable(feature = "iter_arith_traits", since = "1.12.0")]
     fn product<I: Iterator<Item = A>>(iter: I) -> Self;
 }

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -163,7 +163,6 @@
 #![feature(const_ub_checks)]
 #![feature(const_unicode_case_lookup)]
 #![feature(const_unsafecell_get_mut)]
-#![feature(const_waker)]
 #![feature(coverage_attribute)]
 #![feature(do_not_recommend)]
 #![feature(duration_consts_float)]

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -633,7 +633,7 @@ macro_rules! write {
     };
 }
 
-/// Write formatted data into a buffer, with a newline appended.
+/// Writes formatted data into a buffer, with a newline appended.
 ///
 /// On all platforms, the newline is the LINE FEED character (`\n`/`U+000A`) alone
 /// (no additional CARRIAGE RETURN (`\r`/`U+000D`).

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -14,6 +14,12 @@ macro_rules! panic {
 
 /// Asserts that two expressions are equal to each other (using [`PartialEq`]).
 ///
+/// Assertions are always checked in both debug and release builds, and cannot
+/// be disabled. See [`debug_assert_eq!`] for assertions that are disabled in
+/// release builds by default.
+///
+/// [`debug_assert_eq!`]: crate::debug_assert_eq
+///
 /// On panic, this macro will print the values of the expressions with their
 /// debug representations.
 ///
@@ -63,6 +69,12 @@ macro_rules! assert_eq {
 }
 
 /// Asserts that two expressions are not equal to each other (using [`PartialEq`]).
+///
+/// Assertions are always checked in both debug and release builds, and cannot
+/// be disabled. See [`debug_assert_ne!`] for assertions that are disabled in
+/// release builds by default.
+///
+/// [`debug_assert_ne!`]: crate::debug_assert_ne
 ///
 /// On panic, this macro will print the values of the expressions with their
 /// debug representations.
@@ -121,6 +133,12 @@ macro_rules! assert_ne {
 /// The pattern syntax is exactly the same as found in a match arm and the `matches!` macro. The
 /// optional if guard can be used to add additional checks that must be true for the matched value,
 /// otherwise this macro will panic.
+///
+/// Assertions are always checked in both debug and release builds, and cannot
+/// be disabled. See [`debug_assert_matches!`] for assertions that are disabled in
+/// release builds by default.
+///
+/// [`debug_assert_matches!`]: crate::assert_matches::debug_assert_matches
 ///
 /// On panic, this macro will print the value of the expression with its debug representation.
 ///

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -871,7 +871,7 @@ marker_impls! {
 ///
 /// *However*, you cannot use [`mem::replace`] on `!Unpin` data which is *pinned* by being wrapped
 /// inside a [`Pin<Ptr>`] pointing at it. This is because you cannot (safely) use a
-/// [`Pin<Ptr>`] to get an `&mut T` to its pointee value, which you would need to call
+/// [`Pin<Ptr>`] to get a `&mut T` to its pointee value, which you would need to call
 /// [`mem::replace`], and *that* is what makes this system work.
 ///
 /// So this, for example, can only be done on types implementing `Unpin`:

--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -118,10 +118,12 @@ impl<T> ManuallyDrop<T> {
 }
 
 impl<T: ?Sized> ManuallyDrop<T> {
-    /// Manually drops the contained value. This is exactly equivalent to calling
-    /// [`ptr::drop_in_place`] with a pointer to the contained value. As such, unless
-    /// the contained value is a packed struct, the destructor will be called in-place
-    /// without moving the value, and thus can be used to safely drop [pinned] data.
+    /// Manually drops the contained value.
+    ///
+    /// This is exactly equivalent to calling [`ptr::drop_in_place`] with a
+    /// pointer to the contained value. As such, unless the contained value is a
+    /// packed struct, the destructor will be called in-place without moving the
+    /// value, and thus can be used to safely drop [pinned] data.
     ///
     /// If you have ownership of the value, you can use [`ManuallyDrop::into_inner`] instead.
     ///

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -310,7 +310,7 @@ impl<T> MaybeUninit<T> {
         MaybeUninit { uninit: () }
     }
 
-    /// Create a new array of `MaybeUninit<T>` items, in an uninitialized state.
+    /// Creates a new array of `MaybeUninit<T>` items, in an uninitialized state.
     ///
     /// Note: in a future Rust version this method may become unnecessary
     /// when Rust allows

--- a/library/core/src/net/ip_addr.rs
+++ b/library/core/src/net/ip_addr.rs
@@ -406,8 +406,8 @@ impl IpAddr {
         matches!(self, IpAddr::V6(_))
     }
 
-    /// Converts this address to an `IpAddr::V4` if it is an IPv4-mapped IPv6 address, otherwise it
-    /// returns `self` as-is.
+    /// Converts this address to an `IpAddr::V4` if it is an IPv4-mapped IPv6
+    /// address, otherwise returns `self` as-is.
     ///
     /// # Examples
     ///
@@ -549,7 +549,7 @@ impl Ipv4Addr {
     #[stable(feature = "ip_constructors", since = "1.30.0")]
     pub const UNSPECIFIED: Self = Ipv4Addr::new(0, 0, 0, 0);
 
-    /// An IPv4 address representing the broadcast address: `255.255.255.255`
+    /// An IPv4 address representing the broadcast address: `255.255.255.255`.
     ///
     /// # Examples
     ///
@@ -686,10 +686,10 @@ impl Ipv4Addr {
 
     /// Returns [`true`] if the address appears to be globally reachable
     /// as specified by the [IANA IPv4 Special-Purpose Address Registry].
-    /// Whether or not an address is practically reachable will depend on your network configuration.
     ///
-    /// Most IPv4 addresses are globally reachable;
-    /// unless they are specifically defined as *not* globally reachable.
+    /// Whether or not an address is practically reachable will depend on your
+    /// network configuration. Most IPv4 addresses are globally reachable, unless
+    /// they are specifically defined as *not* globally reachable.
     ///
     /// Non-exhaustive list of notable addresses that are not globally reachable:
     ///
@@ -802,8 +802,10 @@ impl Ipv4Addr {
     }
 
     /// Returns [`true`] if this address part of the `198.18.0.0/15` range, which is reserved for
-    /// network devices benchmarking. This range is defined in [IETF RFC 2544] as `192.18.0.0`
-    /// through `198.19.255.255` but [errata 423] corrects it to `198.18.0.0/15`.
+    /// network devices benchmarking.
+    ///
+    /// This range is defined in [IETF RFC 2544] as `192.18.0.0` through
+    /// `198.19.255.255` but [errata 423] corrects it to `198.18.0.0/15`.
     ///
     /// [IETF RFC 2544]: https://tools.ietf.org/html/rfc2544
     /// [errata 423]: https://www.rfc-editor.org/errata/eid423
@@ -827,10 +829,12 @@ impl Ipv4Addr {
         self.octets()[0] == 198 && (self.octets()[1] & 0xfe) == 18
     }
 
-    /// Returns [`true`] if this address is reserved by IANA for future use. [IETF RFC 1112]
-    /// defines the block of reserved addresses as `240.0.0.0/4`. This range normally includes the
-    /// broadcast address `255.255.255.255`, but this implementation explicitly excludes it, since
-    /// it is obviously not reserved for future use.
+    /// Returns [`true`] if this address is reserved by IANA for future use.
+    ///
+    /// [IETF RFC 1112] defines the block of reserved addresses as `240.0.0.0/4`.
+    /// This range normally includes the broadcast address `255.255.255.255`, but
+    /// this implementation explicitly excludes it, since it is obviously not
+    /// reserved for future use.
     ///
     /// [IETF RFC 1112]: https://tools.ietf.org/html/rfc1112
     ///
@@ -1328,7 +1332,7 @@ impl Ipv6Addr {
     #[stable(feature = "ip_constructors", since = "1.30.0")]
     pub const LOCALHOST: Self = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
 
-    /// An IPv6 address representing the unspecified address: `::`
+    /// An IPv6 address representing the unspecified address: `::`.
     ///
     /// This corresponds to constant `IN6ADDR_ANY_INIT` or `in6addr_any` in other languages.
     ///
@@ -1424,10 +1428,10 @@ impl Ipv6Addr {
 
     /// Returns [`true`] if the address appears to be globally reachable
     /// as specified by the [IANA IPv6 Special-Purpose Address Registry].
-    /// Whether or not an address is practically reachable will depend on your network configuration.
     ///
-    /// Most IPv6 addresses are globally reachable;
-    /// unless they are specifically defined as *not* globally reachable.
+    /// Whether or not an address is practically reachable will depend on your
+    /// network configuration. Most IPv6 addresses are globally reachable, unless
+    /// they are specifically defined as *not* globally reachable.
     ///
     /// Non-exhaustive list of notable addresses that are not globally reachable:
     /// - The [unspecified address] ([`is_unspecified`](Ipv6Addr::is_unspecified))
@@ -1879,8 +1883,8 @@ impl Ipv6Addr {
         }
     }
 
-    /// Converts this address to an `IpAddr::V4` if it is an IPv4-mapped address, otherwise it
-    /// returns self wrapped in an `IpAddr::V6`.
+    /// Converts this address to an `IpAddr::V4` if it is an IPv4-mapped address,
+    /// otherwise returns self wrapped in an `IpAddr::V6`.
     ///
     /// # Examples
     ///
@@ -1919,7 +1923,7 @@ impl Ipv6Addr {
     }
 }
 
-/// Write an Ipv6Addr, conforming to the canonical style described by
+/// Writes an Ipv6Addr, conforming to the canonical style described by
 /// [RFC 5952](https://tools.ietf.org/html/rfc5952).
 #[stable(feature = "rust1", since = "1.0.0")]
 impl fmt::Display for Ipv6Addr {
@@ -1962,7 +1966,7 @@ impl fmt::Display for Ipv6Addr {
                     longest
                 };
 
-                /// Write a colon-separated part of the address
+                /// Writes a colon-separated part of the address.
                 #[inline]
                 fn fmt_subslice(f: &mut fmt::Formatter<'_>, chunk: &[u16]) -> fmt::Result {
                     if let Some((first, tail)) = chunk.split_first() {

--- a/library/core/src/net/parser.rs
+++ b/library/core/src/net/parser.rs
@@ -68,7 +68,7 @@ impl<'a> Parser<'a> {
         self.state.first().map(|&b| char::from(b))
     }
 
-    /// Read the next character from the input
+    /// Reads the next character from the input
     fn read_char(&mut self) -> Option<char> {
         self.state.split_first().map(|(&b, tail)| {
             self.state = tail;
@@ -77,7 +77,7 @@ impl<'a> Parser<'a> {
     }
 
     #[must_use]
-    /// Read the next character from the input if it matches the target.
+    /// Reads the next character from the input if it matches the target.
     fn read_given_char(&mut self, target: char) -> Option<()> {
         self.read_atomically(|p| {
             p.read_char().and_then(|c| if c == target { Some(()) } else { None })
@@ -165,7 +165,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Read an IPv4 address.
+    /// Reads an IPv4 address.
     fn read_ipv4_addr(&mut self) -> Option<Ipv4Addr> {
         self.read_atomically(|p| {
             let mut groups = [0; 4];
@@ -182,7 +182,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Read an IPv6 Address.
+    /// Reads an IPv6 address.
     fn read_ipv6_addr(&mut self) -> Option<Ipv6Addr> {
         /// Read a chunk of an IPv6 address into `groups`. Returns the number
         /// of groups read, along with a bool indicating if an embedded
@@ -249,12 +249,12 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Read an IP Address, either IPv4 or IPv6.
+    /// Reads an IP address, either IPv4 or IPv6.
     fn read_ip_addr(&mut self) -> Option<IpAddr> {
         self.read_ipv4_addr().map(IpAddr::V4).or_else(move || self.read_ipv6_addr().map(IpAddr::V6))
     }
 
-    /// Read a `:` followed by a port in base 10.
+    /// Reads a `:` followed by a port in base 10.
     fn read_port(&mut self) -> Option<u16> {
         self.read_atomically(|p| {
             p.read_given_char(':')?;
@@ -262,7 +262,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Read a `%` followed by a scope ID in base 10.
+    /// Reads a `%` followed by a scope ID in base 10.
     fn read_scope_id(&mut self) -> Option<u32> {
         self.read_atomically(|p| {
             p.read_given_char('%')?;
@@ -270,7 +270,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Read an IPv4 address with a port.
+    /// Reads an IPv4 address with a port.
     fn read_socket_addr_v4(&mut self) -> Option<SocketAddrV4> {
         self.read_atomically(|p| {
             let ip = p.read_ipv4_addr()?;
@@ -279,7 +279,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Read an IPv6 address with a port.
+    /// Reads an IPv6 address with a port.
     fn read_socket_addr_v6(&mut self) -> Option<SocketAddrV6> {
         self.read_atomically(|p| {
             p.read_given_char('[')?;
@@ -292,7 +292,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    /// Read an IP address with a port
+    /// Reads an IP address with a port.
     fn read_socket_addr(&mut self) -> Option<SocketAddr> {
         self.read_socket_addr_v4()
             .map(SocketAddr::V4)

--- a/library/core/src/num/dec2flt/common.rs
+++ b/library/core/src/num/dec2flt/common.rs
@@ -2,10 +2,10 @@
 
 /// Helper methods to process immutable bytes.
 pub(crate) trait ByteSlice {
-    /// Read 8 bytes as a 64-bit integer in little-endian order.
+    /// Reads 8 bytes as a 64-bit integer in little-endian order.
     fn read_u64(&self) -> u64;
 
-    /// Write a 64-bit integer as 8 bytes in little-endian order.
+    /// Writes a 64-bit integer as 8 bytes in little-endian order.
     fn write_u64(&mut self, value: u64);
 
     /// Calculate the offset of a slice from another.

--- a/library/core/src/num/dec2flt/float.rs
+++ b/library/core/src/num/dec2flt/float.rs
@@ -81,7 +81,7 @@ pub trait RawFloat:
     // Maximum mantissa for the fast-path (`1 << 53` for f64).
     const MAX_MANTISSA_FAST_PATH: u64 = 2_u64 << Self::MANTISSA_EXPLICIT_BITS;
 
-    /// Convert integer into float through an as cast.
+    /// Converts integer into float through an as cast.
     /// This is only called in the fast-path algorithm, and therefore
     /// will not lose precision, since the value will always have
     /// only if the value is <= Self::MAX_MANTISSA_FAST_PATH.
@@ -90,7 +90,7 @@ pub trait RawFloat:
     /// Performs a raw transmutation from an integer.
     fn from_u64_bits(v: u64) -> Self;
 
-    /// Get a small power-of-ten for fast-path multiplication.
+    /// Gets a small power-of-ten for fast-path multiplication.
     fn pow10_fast_path(exponent: usize) -> Self;
 
     /// Returns the category that this number falls into.

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -898,7 +898,7 @@ impl f128 {
         intrinsics::const_eval_select((v,), ct_u128_to_f128, rt_u128_to_f128)
     }
 
-    /// Return the memory representation of this floating point number as a byte array in
+    /// Returns the memory representation of this floating point number as a byte array in
     /// big-endian (network) byte order.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
@@ -924,7 +924,7 @@ impl f128 {
         self.to_bits().to_be_bytes()
     }
 
-    /// Return the memory representation of this floating point number as a byte array in
+    /// Returns the memory representation of this floating point number as a byte array in
     /// little-endian byte order.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
@@ -950,7 +950,7 @@ impl f128 {
         self.to_bits().to_le_bytes()
     }
 
-    /// Return the memory representation of this floating point number as a byte array in
+    /// Returns the memory representation of this floating point number as a byte array in
     /// native byte order.
     ///
     /// As the target platform's native endianness is used, portable code
@@ -987,7 +987,7 @@ impl f128 {
         self.to_bits().to_ne_bytes()
     }
 
-    /// Create a floating point value from its representation as a byte array in big endian.
+    /// Creates a floating point value from its representation as a byte array in big endian.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
     /// portability of this operation (there are almost no issues).
@@ -1014,7 +1014,7 @@ impl f128 {
         Self::from_bits(u128::from_be_bytes(bytes))
     }
 
-    /// Create a floating point value from its representation as a byte array in little endian.
+    /// Creates a floating point value from its representation as a byte array in little endian.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
     /// portability of this operation (there are almost no issues).
@@ -1041,7 +1041,7 @@ impl f128 {
         Self::from_bits(u128::from_le_bytes(bytes))
     }
 
-    /// Create a floating point value from its representation as a byte array in native endian.
+    /// Creates a floating point value from its representation as a byte array in native endian.
     ///
     /// As the target platform's native endianness is used, portable code
     /// likely wants to use [`from_be_bytes`] or [`from_le_bytes`], as
@@ -1078,7 +1078,7 @@ impl f128 {
         Self::from_bits(u128::from_ne_bytes(bytes))
     }
 
-    /// Return the ordering between `self` and `other`.
+    /// Returns the ordering between `self` and `other`.
     ///
     /// Unlike the standard partial comparison between floating point numbers,
     /// this comparison always produces an ordering in accordance to

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -933,7 +933,7 @@ impl f16 {
         intrinsics::const_eval_select((v,), ct_u16_to_f16, rt_u16_to_f16)
     }
 
-    /// Return the memory representation of this floating point number as a byte array in
+    /// Returns the memory representation of this floating point number as a byte array in
     /// big-endian (network) byte order.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
@@ -958,7 +958,7 @@ impl f16 {
         self.to_bits().to_be_bytes()
     }
 
-    /// Return the memory representation of this floating point number as a byte array in
+    /// Returns the memory representation of this floating point number as a byte array in
     /// little-endian byte order.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
@@ -983,7 +983,7 @@ impl f16 {
         self.to_bits().to_le_bytes()
     }
 
-    /// Return the memory representation of this floating point number as a byte array in
+    /// Returns the memory representation of this floating point number as a byte array in
     /// native byte order.
     ///
     /// As the target platform's native endianness is used, portable code
@@ -1021,7 +1021,7 @@ impl f16 {
         self.to_bits().to_ne_bytes()
     }
 
-    /// Create a floating point value from its representation as a byte array in big endian.
+    /// Creates a floating point value from its representation as a byte array in big endian.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
     /// portability of this operation (there are almost no issues).
@@ -1044,7 +1044,7 @@ impl f16 {
         Self::from_bits(u16::from_be_bytes(bytes))
     }
 
-    /// Create a floating point value from its representation as a byte array in little endian.
+    /// Creates a floating point value from its representation as a byte array in little endian.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
     /// portability of this operation (there are almost no issues).
@@ -1067,7 +1067,7 @@ impl f16 {
         Self::from_bits(u16::from_le_bytes(bytes))
     }
 
-    /// Create a floating point value from its representation as a byte array in native endian.
+    /// Creates a floating point value from its representation as a byte array in native endian.
     ///
     /// As the target platform's native endianness is used, portable code
     /// likely wants to use [`from_be_bytes`] or [`from_le_bytes`], as
@@ -1101,7 +1101,7 @@ impl f16 {
         Self::from_bits(u16::from_ne_bytes(bytes))
     }
 
-    /// Return the ordering between `self` and `other`.
+    /// Returns the ordering between `self` and `other`.
     ///
     /// Unlike the standard partial comparison between floating point numbers,
     /// this comparison always produces an ordering in accordance to

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -721,11 +721,13 @@ impl f32 {
     }
 
     /// Returns `true` if `self` has a positive sign, including `+0.0`, NaNs with
-    /// positive sign bit and positive infinity. Note that IEEE 754 doesn't assign any
-    /// meaning to the sign bit in case of a NaN, and as Rust doesn't guarantee that
-    /// the bit pattern of NaNs are conserved over arithmetic operations, the result of
-    /// `is_sign_positive` on a NaN might produce an unexpected result in some cases.
-    /// See [explanation of NaN as a special value](f32) for more info.
+    /// positive sign bit and positive infinity.
+    ///
+    /// Note that IEEE 754 doesn't assign any meaning to the sign bit in case of
+    /// a NaN, and as Rust doesn't guarantee that the bit pattern of NaNs are
+    /// conserved over arithmetic operations, the result of `is_sign_positive` on
+    /// a NaN might produce an unexpected result in some cases. See [explanation
+    /// of NaN as a special value](f32) for more info.
     ///
     /// ```
     /// let f = 7.0_f32;
@@ -743,11 +745,13 @@ impl f32 {
     }
 
     /// Returns `true` if `self` has a negative sign, including `-0.0`, NaNs with
-    /// negative sign bit and negative infinity. Note that IEEE 754 doesn't assign any
-    /// meaning to the sign bit in case of a NaN, and as Rust doesn't guarantee that
-    /// the bit pattern of NaNs are conserved over arithmetic operations, the result of
-    /// `is_sign_negative` on a NaN might produce an unexpected result in some cases.
-    /// See [explanation of NaN as a special value](f32) for more info.
+    /// negative sign bit and negative infinity.
+    ///
+    /// Note that IEEE 754 doesn't assign any meaning to the sign bit in case of
+    /// a NaN, and as Rust doesn't guarantee that the bit pattern of NaNs are
+    /// conserved over arithmetic operations, the result of `is_sign_negative` on
+    /// a NaN might produce an unexpected result in some cases. See [explanation
+    /// of NaN as a special value](f32) for more info.
     ///
     /// ```
     /// let f = 7.0f32;
@@ -1274,7 +1278,7 @@ impl f32 {
         intrinsics::const_eval_select((v,), ct_u32_to_f32, rt_u32_to_f32)
     }
 
-    /// Return the memory representation of this floating point number as a byte array in
+    /// Returns the memory representation of this floating point number as a byte array in
     /// big-endian (network) byte order.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
@@ -1295,7 +1299,7 @@ impl f32 {
         self.to_bits().to_be_bytes()
     }
 
-    /// Return the memory representation of this floating point number as a byte array in
+    /// Returns the memory representation of this floating point number as a byte array in
     /// little-endian byte order.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
@@ -1316,7 +1320,7 @@ impl f32 {
         self.to_bits().to_le_bytes()
     }
 
-    /// Return the memory representation of this floating point number as a byte array in
+    /// Returns the memory representation of this floating point number as a byte array in
     /// native byte order.
     ///
     /// As the target platform's native endianness is used, portable code
@@ -1350,7 +1354,7 @@ impl f32 {
         self.to_bits().to_ne_bytes()
     }
 
-    /// Create a floating point value from its representation as a byte array in big endian.
+    /// Creates a floating point value from its representation as a byte array in big endian.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
     /// portability of this operation (there are almost no issues).
@@ -1369,7 +1373,7 @@ impl f32 {
         Self::from_bits(u32::from_be_bytes(bytes))
     }
 
-    /// Create a floating point value from its representation as a byte array in little endian.
+    /// Creates a floating point value from its representation as a byte array in little endian.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
     /// portability of this operation (there are almost no issues).
@@ -1388,7 +1392,7 @@ impl f32 {
         Self::from_bits(u32::from_le_bytes(bytes))
     }
 
-    /// Create a floating point value from its representation as a byte array in native endian.
+    /// Creates a floating point value from its representation as a byte array in native endian.
     ///
     /// As the target platform's native endianness is used, portable code
     /// likely wants to use [`from_be_bytes`] or [`from_le_bytes`], as
@@ -1418,7 +1422,7 @@ impl f32 {
         Self::from_bits(u32::from_ne_bytes(bytes))
     }
 
-    /// Return the ordering between `self` and `other`.
+    /// Returns the ordering between `self` and `other`.
     ///
     /// Unlike the standard partial comparison between floating point numbers,
     /// this comparison always produces an ordering in accordance to

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -711,11 +711,13 @@ impl f64 {
     }
 
     /// Returns `true` if `self` has a positive sign, including `+0.0`, NaNs with
-    /// positive sign bit and positive infinity. Note that IEEE 754 doesn't assign any
-    /// meaning to the sign bit in case of a NaN, and as Rust doesn't guarantee that
-    /// the bit pattern of NaNs are conserved over arithmetic operations, the result of
-    /// `is_sign_positive` on a NaN might produce an unexpected result in some cases.
-    /// See [explanation of NaN as a special value](f32) for more info.
+    /// positive sign bit and positive infinity.
+    ///
+    /// Note that IEEE 754 doesn't assign any meaning to the sign bit in case of
+    /// a NaN, and as Rust doesn't guarantee that the bit pattern of NaNs are
+    /// conserved over arithmetic operations, the result of `is_sign_positive` on
+    /// a NaN might produce an unexpected result in some cases. See [explanation
+    /// of NaN as a special value](f32) for more info.
     ///
     /// ```
     /// let f = 7.0_f64;
@@ -742,11 +744,13 @@ impl f64 {
     }
 
     /// Returns `true` if `self` has a negative sign, including `-0.0`, NaNs with
-    /// negative sign bit and negative infinity. Note that IEEE 754 doesn't assign any
-    /// meaning to the sign bit in case of a NaN, and as Rust doesn't guarantee that
-    /// the bit pattern of NaNs are conserved over arithmetic operations, the result of
-    /// `is_sign_negative` on a NaN might produce an unexpected result in some cases.
-    /// See [explanation of NaN as a special value](f32) for more info.
+    /// negative sign bit and negative infinity.
+    ///
+    /// Note that IEEE 754 doesn't assign any meaning to the sign bit in case of
+    /// a NaN, and as Rust doesn't guarantee that the bit pattern of NaNs are
+    /// conserved over arithmetic operations, the result of `is_sign_negative` on
+    /// a NaN might produce an unexpected result in some cases. See [explanation
+    /// of NaN as a special value](f32) for more info.
     ///
     /// ```
     /// let f = 7.0_f64;
@@ -1252,7 +1256,7 @@ impl f64 {
         intrinsics::const_eval_select((v,), ct_u64_to_f64, rt_u64_to_f64)
     }
 
-    /// Return the memory representation of this floating point number as a byte array in
+    /// Returns the memory representation of this floating point number as a byte array in
     /// big-endian (network) byte order.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
@@ -1273,7 +1277,7 @@ impl f64 {
         self.to_bits().to_be_bytes()
     }
 
-    /// Return the memory representation of this floating point number as a byte array in
+    /// Returns the memory representation of this floating point number as a byte array in
     /// little-endian byte order.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
@@ -1294,7 +1298,7 @@ impl f64 {
         self.to_bits().to_le_bytes()
     }
 
-    /// Return the memory representation of this floating point number as a byte array in
+    /// Returns the memory representation of this floating point number as a byte array in
     /// native byte order.
     ///
     /// As the target platform's native endianness is used, portable code
@@ -1328,7 +1332,7 @@ impl f64 {
         self.to_bits().to_ne_bytes()
     }
 
-    /// Create a floating point value from its representation as a byte array in big endian.
+    /// Creates a floating point value from its representation as a byte array in big endian.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
     /// portability of this operation (there are almost no issues).
@@ -1347,7 +1351,7 @@ impl f64 {
         Self::from_bits(u64::from_be_bytes(bytes))
     }
 
-    /// Create a floating point value from its representation as a byte array in little endian.
+    /// Creates a floating point value from its representation as a byte array in little endian.
     ///
     /// See [`from_bits`](Self::from_bits) for some discussion of the
     /// portability of this operation (there are almost no issues).
@@ -1366,7 +1370,7 @@ impl f64 {
         Self::from_bits(u64::from_le_bytes(bytes))
     }
 
-    /// Create a floating point value from its representation as a byte array in native endian.
+    /// Creates a floating point value from its representation as a byte array in native endian.
     ///
     /// As the target platform's native endianness is used, portable code
     /// likely wants to use [`from_be_bytes`] or [`from_le_bytes`], as
@@ -1396,7 +1400,7 @@ impl f64 {
         Self::from_bits(u64::from_ne_bytes(bytes))
     }
 
-    /// Return the ordering between `self` and `other`.
+    /// Returns the ordering between `self` and `other`.
     ///
     /// Unlike the standard partial comparison between floating point numbers,
     /// this comparison always produces an ordering in accordance to

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -2196,10 +2196,11 @@ macro_rules! int_impl {
             acc.wrapping_mul(base)
         }
 
-        /// Calculates `self` + `rhs`
+        /// Calculates `self` + `rhs`.
         ///
-        /// Returns a tuple of the addition along with a boolean indicating whether an arithmetic overflow would
-        /// occur. If an overflow would have occurred then the wrapped value is returned.
+        /// Returns a tuple of the addition along with a boolean indicating
+        /// whether an arithmetic overflow would occur. If an overflow would have
+        /// occurred then the wrapped value is returned.
         ///
         /// # Examples
         ///
@@ -2277,7 +2278,7 @@ macro_rules! int_impl {
             (c, b != d)
         }
 
-        /// Calculates `self` + `rhs` with an unsigned `rhs`
+        /// Calculates `self` + `rhs` with an unsigned `rhs`.
         ///
         /// Returns a tuple of the addition along with a boolean indicating
         /// whether an arithmetic overflow would occur. If an overflow would
@@ -3389,7 +3390,7 @@ macro_rules! int_impl {
         #[inline(always)]
         pub const fn is_negative(self) -> bool { self < 0 }
 
-        /// Return the memory representation of this integer as a byte array in
+        /// Returns the memory representation of this integer as a byte array in
         /// big-endian (network) byte order.
         ///
         #[doc = $to_xe_bytes_doc]
@@ -3409,7 +3410,7 @@ macro_rules! int_impl {
             self.to_be().to_ne_bytes()
         }
 
-        /// Return the memory representation of this integer as a byte array in
+        /// Returns the memory representation of this integer as a byte array in
         /// little-endian byte order.
         ///
         #[doc = $to_xe_bytes_doc]
@@ -3429,7 +3430,7 @@ macro_rules! int_impl {
             self.to_le().to_ne_bytes()
         }
 
-        /// Return the memory representation of this integer as a byte array in
+        /// Returns the memory representation of this integer as a byte array in
         /// native byte order.
         ///
         /// As the target platform's native endianness is used, portable code
@@ -3467,7 +3468,7 @@ macro_rules! int_impl {
             unsafe { mem::transmute(self) }
         }
 
-        /// Create an integer value from its representation as a byte array in
+        /// Creates an integer value from its representation as a byte array in
         /// big endian.
         ///
         #[doc = $from_xe_bytes_doc]
@@ -3496,7 +3497,7 @@ macro_rules! int_impl {
             Self::from_be(Self::from_ne_bytes(bytes))
         }
 
-        /// Create an integer value from its representation as a byte array in
+        /// Creates an integer value from its representation as a byte array in
         /// little endian.
         ///
         #[doc = $from_xe_bytes_doc]
@@ -3525,7 +3526,7 @@ macro_rules! int_impl {
             Self::from_le(Self::from_ne_bytes(bytes))
         }
 
-        /// Create an integer value from its memory representation as a byte
+        /// Creates an integer value from its memory representation as a byte
         /// array in native endianness.
         ///
         /// As the target platform's native endianness is used, portable code

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -949,10 +949,10 @@ macro_rules! uint_impl {
         }
 
         /// Strict integer division. Computes `self / rhs`.
-        /// Strict division on unsigned types is just normal division.
-        /// There's no way overflow could ever happen.
-        /// This function exists, so that all operations
-        /// are accounted for in the strict operations.
+        ///
+        /// Strict division on unsigned types is just normal division. There's no
+        /// way overflow could ever happen. This function exists so that all
+        /// operations are accounted for in the strict operations.
         ///
         /// # Panics
         ///
@@ -1008,12 +1008,11 @@ macro_rules! uint_impl {
         }
 
         /// Strict Euclidean division. Computes `self.div_euclid(rhs)`.
-        /// Strict division on unsigned types is just normal division.
-        /// There's no way overflow could ever happen.
-        /// This function exists, so that all operations
-        /// are accounted for in the strict operations.
-        /// Since, for the positive integers, all common
-        /// definitions of division are equal, this
+        ///
+        /// Strict division on unsigned types is just normal division. There's no
+        /// way overflow could ever happen. This function exists so that all
+        /// operations are accounted for in the strict operations. Since, for the
+        /// positive integers, all common definitions of division are equal, this
         /// is exactly equal to `self.strict_div(rhs)`.
         ///
         /// # Panics
@@ -1071,11 +1070,11 @@ macro_rules! uint_impl {
         }
 
         /// Strict integer remainder. Computes `self % rhs`.
-        /// Strict remainder calculation on unsigned types is
-        /// just the regular remainder calculation.
-        /// There's no way overflow could ever happen.
-        /// This function exists, so that all operations
-        /// are accounted for in the strict operations.
+        ///
+        /// Strict remainder calculation on unsigned types is just the regular
+        /// remainder calculation. There's no way overflow could ever happen.
+        /// This function exists so that all operations are accounted for in the
+        /// strict operations.
         ///
         /// # Panics
         ///
@@ -1131,14 +1130,13 @@ macro_rules! uint_impl {
         }
 
         /// Strict Euclidean modulo. Computes `self.rem_euclid(rhs)`.
-        /// Strict modulo calculation on unsigned types is
-        /// just the regular remainder calculation.
-        /// There's no way overflow could ever happen.
-        /// This function exists, so that all operations
-        /// are accounted for in the strict operations.
-        /// Since, for the positive integers, all common
-        /// definitions of division are equal, this
-        /// is exactly equal to `self.strict_rem(rhs)`.
+        ///
+        /// Strict modulo calculation on unsigned types is just the regular
+        /// remainder calculation. There's no way overflow could ever happen.
+        /// This function exists so that all operations are accounted for in the
+        /// strict operations. Since, for the positive integers, all common
+        /// definitions of division are equal, this is exactly equal to
+        /// `self.strict_rem(rhs)`.
         ///
         /// # Panics
         ///
@@ -1914,10 +1912,10 @@ macro_rules! uint_impl {
         }
 
         /// Wrapping (modular) division. Computes `self / rhs`.
-        /// Wrapped division on unsigned types is just normal division.
-        /// There's no way wrapping could ever happen.
-        /// This function exists, so that all operations
-        /// are accounted for in the wrapping operations.
+        ///
+        /// Wrapped division on unsigned types is just normal division. There's
+        /// no way wrapping could ever happen. This function exists so that all
+        /// operations are accounted for in the wrapping operations.
         ///
         /// # Panics
         ///
@@ -1941,13 +1939,12 @@ macro_rules! uint_impl {
         }
 
         /// Wrapping Euclidean division. Computes `self.div_euclid(rhs)`.
-        /// Wrapped division on unsigned types is just normal division.
-        /// There's no way wrapping could ever happen.
-        /// This function exists, so that all operations
-        /// are accounted for in the wrapping operations.
-        /// Since, for the positive integers, all common
-        /// definitions of division are equal, this
-        /// is exactly equal to `self.wrapping_div(rhs)`.
+        ///
+        /// Wrapped division on unsigned types is just normal division. There's
+        /// no way wrapping could ever happen. This function exists so that all
+        /// operations are accounted for in the wrapping operations. Since, for
+        /// the positive integers, all common definitions of division are equal,
+        /// this is exactly equal to `self.wrapping_div(rhs)`.
         ///
         /// # Panics
         ///
@@ -1971,11 +1968,11 @@ macro_rules! uint_impl {
         }
 
         /// Wrapping (modular) remainder. Computes `self % rhs`.
-        /// Wrapped remainder calculation on unsigned types is
-        /// just the regular remainder calculation.
-        /// There's no way wrapping could ever happen.
-        /// This function exists, so that all operations
-        /// are accounted for in the wrapping operations.
+        ///
+        /// Wrapped remainder calculation on unsigned types is just the regular
+        /// remainder calculation. There's no way wrapping could ever happen.
+        /// This function exists so that all operations are accounted for in the
+        /// wrapping operations.
         ///
         /// # Panics
         ///
@@ -1999,14 +1996,13 @@ macro_rules! uint_impl {
         }
 
         /// Wrapping Euclidean modulo. Computes `self.rem_euclid(rhs)`.
-        /// Wrapped modulo calculation on unsigned types is
-        /// just the regular remainder calculation.
-        /// There's no way wrapping could ever happen.
-        /// This function exists, so that all operations
-        /// are accounted for in the wrapping operations.
-        /// Since, for the positive integers, all common
-        /// definitions of division are equal, this
-        /// is exactly equal to `self.wrapping_rem(rhs)`.
+        ///
+        /// Wrapped modulo calculation on unsigned types is just the regular
+        /// remainder calculation. There's no way wrapping could ever happen.
+        /// This function exists so that all operations are accounted for in the
+        /// wrapping operations. Since, for the positive integers, all common
+        /// definitions of division are equal, this is exactly equal to
+        /// `self.wrapping_rem(rhs)`.
         ///
         /// # Panics
         ///
@@ -2162,7 +2158,7 @@ macro_rules! uint_impl {
             acc.wrapping_mul(base)
         }
 
-        /// Calculates `self` + `rhs`
+        /// Calculates `self` + `rhs`.
         ///
         /// Returns a tuple of the addition along with a boolean indicating
         /// whether an arithmetic overflow would occur. If an overflow would
@@ -2236,7 +2232,7 @@ macro_rules! uint_impl {
             (c, b || d)
         }
 
-        /// Calculates `self` + `rhs` with a signed `rhs`
+        /// Calculates `self` + `rhs` with a signed `rhs`.
         ///
         /// Returns a tuple of the addition along with a boolean indicating
         /// whether an arithmetic overflow would occur. If an overflow would
@@ -2967,7 +2963,7 @@ macro_rules! uint_impl {
             self.one_less_than_next_power_of_two().wrapping_add(1)
         }
 
-        /// Return the memory representation of this integer as a byte array in
+        /// Returns the memory representation of this integer as a byte array in
         /// big-endian (network) byte order.
         ///
         #[doc = $to_xe_bytes_doc]
@@ -2987,7 +2983,7 @@ macro_rules! uint_impl {
             self.to_be().to_ne_bytes()
         }
 
-        /// Return the memory representation of this integer as a byte array in
+        /// Returns the memory representation of this integer as a byte array in
         /// little-endian byte order.
         ///
         #[doc = $to_xe_bytes_doc]
@@ -3007,7 +3003,7 @@ macro_rules! uint_impl {
             self.to_le().to_ne_bytes()
         }
 
-        /// Return the memory representation of this integer as a byte array in
+        /// Returns the memory representation of this integer as a byte array in
         /// native byte order.
         ///
         /// As the target platform's native endianness is used, portable code
@@ -3045,7 +3041,7 @@ macro_rules! uint_impl {
             unsafe { mem::transmute(self) }
         }
 
-        /// Create a native endian integer value from its representation
+        /// Creates a native endian integer value from its representation
         /// as a byte array in big endian.
         ///
         #[doc = $from_xe_bytes_doc]
@@ -3074,7 +3070,7 @@ macro_rules! uint_impl {
             Self::from_be(Self::from_ne_bytes(bytes))
         }
 
-        /// Create a native endian integer value from its representation
+        /// Creates a native endian integer value from its representation
         /// as a byte array in little endian.
         ///
         #[doc = $from_xe_bytes_doc]
@@ -3103,7 +3099,7 @@ macro_rules! uint_impl {
             Self::from_le(Self::from_ne_bytes(bytes))
         }
 
-        /// Create a native endian integer value from its memory representation
+        /// Creates a native endian integer value from its memory representation
         /// as a byte array in native endianness.
         ///
         /// As the target platform's native endianness is used, portable code

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2764,6 +2764,35 @@ macro_rules! uint_impl {
             }
         }
 
+        /// Returns `true` if `self` is an integer multiple of `rhs`, and false otherwise.
+        ///
+        /// This function is equivalent to `self % rhs == 0`, except that it will not panic
+        /// for `rhs == 0`. Instead, `0.is_multiple_of(0) == true`, and for any non-zero `n`,
+        /// `n.is_multiple_of(0) == false`.
+        ///
+        /// # Examples
+        ///
+        /// Basic usage:
+        ///
+        /// ```
+        /// #![feature(unsigned_is_multiple_of)]
+        #[doc = concat!("assert!(6_", stringify!($SelfT), ".is_multiple_of(2));")]
+        #[doc = concat!("assert!(!5_", stringify!($SelfT), ".is_multiple_of(2));")]
+        ///
+        #[doc = concat!("assert!(0_", stringify!($SelfT), ".is_multiple_of(0));")]
+        #[doc = concat!("assert!(!6_", stringify!($SelfT), ".is_multiple_of(0));")]
+        /// ```
+        #[unstable(feature = "unsigned_is_multiple_of", issue = "128101")]
+        #[must_use]
+        #[inline]
+        #[rustc_inherit_overflow_checks]
+        pub const fn is_multiple_of(self, rhs: Self) -> bool {
+            match rhs {
+                0 => self == 0,
+                _ => self % rhs == 0,
+            }
+        }
+
         /// Returns `true` if and only if `self == 2^k` for some `k`.
         ///
         /// # Examples

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -238,7 +238,7 @@ impl<B, C> ControlFlow<B, C> {
 /// They have mediocre names and non-obvious semantics, so aren't
 /// currently on a path to potential stabilization.
 impl<R: ops::Try> ControlFlow<R, R::Output> {
-    /// Create a `ControlFlow` from any type implementing `Try`.
+    /// Creates a `ControlFlow` from any type implementing `Try`.
     #[inline]
     pub(crate) fn from_try(r: R) -> Self {
         match R::branch(r) {
@@ -247,7 +247,7 @@ impl<R: ops::Try> ControlFlow<R, R::Output> {
         }
     }
 
-    /// Convert a `ControlFlow` into any type implementing `Try`;
+    /// Converts a `ControlFlow` into any type implementing `Try`.
     #[inline]
     pub(crate) fn into_try(self) -> R {
         match self {

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -160,7 +160,7 @@ pub unsafe trait PanicPayload: crate::fmt::Display {
     /// Just borrow the contents.
     fn get(&mut self) -> &(dyn Any + Send);
 
-    /// Try to borrow the contents as `&str`, if possible without doing any allocations.
+    /// Tries to borrow the contents as `&str`, if possible without doing any allocations.
     fn as_str(&mut self) -> Option<&str> {
         None
     }

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -152,7 +152,7 @@ impl Display for PanicInfo<'_> {
 }
 
 impl<'a> PanicMessage<'a> {
-    /// Get the formatted message, if it has no arguments to be formatted at runtime.
+    /// Gets the formatted message, if it has no arguments to be formatted at runtime.
     ///
     /// This can be used to avoid allocations in some cases.
     ///

--- a/library/core/src/panicking.rs
+++ b/library/core/src/panicking.rs
@@ -294,10 +294,11 @@ fn panic_misaligned_pointer_dereference(required: usize, found: usize) -> ! {
     )
 }
 
-/// Panic because we cannot unwind out of a function.
+/// Panics because we cannot unwind out of a function.
 ///
 /// This is a separate function to avoid the codesize impact of each crate containing the string to
 /// pass to `panic_nounwind`.
+///
 /// This function is called directly by the codegen backend, and must not have
 /// any extra arguments (including those synthesized by track_caller).
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never), cold)]
@@ -309,10 +310,11 @@ fn panic_cannot_unwind() -> ! {
     panic_nounwind("panic in a function that cannot unwind")
 }
 
-/// Panic because we are unwinding out of a destructor during cleanup.
+/// Panics because we are unwinding out of a destructor during cleanup.
 ///
 /// This is a separate function to avoid the codesize impact of each crate containing the string to
 /// pass to `panic_nounwind`.
+///
 /// This function is called directly by the codegen backend, and must not have
 /// any extra arguments (including those synthesized by track_caller).
 #[cfg_attr(not(feature = "panic_immediate_abort"), inline(never), cold)]

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -421,7 +421,7 @@
 //! }
 //!
 //! impl Unmovable {
-//!     /// Create a new `Unmovable`.
+//!     /// Creates a new `Unmovable`.
 //!     ///
 //!     /// To ensure the data doesn't move we place it on the heap behind a pinning Box.
 //!     /// Note that the data is pinned, but the `Pin<Box<Self>>` which is pinning it can
@@ -1168,7 +1168,7 @@ impl<Ptr: Deref<Target: Hash>> Hash for Pin<Ptr> {
 }
 
 impl<Ptr: Deref<Target: Unpin>> Pin<Ptr> {
-    /// Construct a new `Pin<Ptr>` around a pointer to some data of a type that
+    /// Constructs a new `Pin<Ptr>` around a pointer to some data of a type that
     /// implements [`Unpin`].
     ///
     /// Unlike `Pin::new_unchecked`, this method is safe because the pointer
@@ -1223,7 +1223,7 @@ impl<Ptr: Deref<Target: Unpin>> Pin<Ptr> {
 }
 
 impl<Ptr: Deref> Pin<Ptr> {
-    /// Construct a new `Pin<Ptr>` around a reference to some data of a type that
+    /// Constructs a new `Pin<Ptr>` around a reference to some data of a type that
     /// may or may not implement [`Unpin`].
     ///
     /// If `pointer` dereferences to an [`Unpin`] type, [`Pin::new`] should be used
@@ -1569,7 +1569,7 @@ impl<'a, T: ?Sized> Pin<&'a mut T> {
         self.__pointer
     }
 
-    /// Construct a new pin by mapping the interior value.
+    /// Constructs a new pin by mapping the interior value.
     ///
     /// For example, if you wanted to get a `Pin` of a field of something,
     /// you could use this to get access to that field in one line of code.
@@ -1602,7 +1602,7 @@ impl<'a, T: ?Sized> Pin<&'a mut T> {
 }
 
 impl<T: ?Sized> Pin<&'static T> {
-    /// Get a pinning reference from a `&'static` reference.
+    /// Gets a pinning reference from a `&'static` reference.
     ///
     /// This is safe because `T` is borrowed immutably for the `'static` lifetime, which
     /// never ends.
@@ -1639,8 +1639,8 @@ impl<'a, Ptr: DerefMut> Pin<&'a mut Pin<Ptr>> {
         //
         // We need to ensure that two things hold for that to be the case:
         //
-        // 1) Once we give out a `Pin<&mut Ptr::Target>`, an `&mut Ptr::Target` will not be given out.
-        // 2) By giving out a `Pin<&mut Ptr::Target>`, we do not risk of violating
+        // 1) Once we give out a `Pin<&mut Ptr::Target>`, a `&mut Ptr::Target` will not be given out.
+        // 2) By giving out a `Pin<&mut Ptr::Target>`, we do not risk violating
         // `Pin<&mut Pin<Ptr>>`
         //
         // The existence of `Pin<Ptr>` is sufficient to guarantee #1: since we already have a
@@ -1656,7 +1656,7 @@ impl<'a, Ptr: DerefMut> Pin<&'a mut Pin<Ptr>> {
 }
 
 impl<T: ?Sized> Pin<&'static mut T> {
-    /// Get a pinning mutable reference from a static mutable reference.
+    /// Gets a pinning mutable reference from a static mutable reference.
     ///
     /// This is safe because `T` is borrowed for the `'static` lifetime, which
     /// never ends.

--- a/library/core/src/ptr/const_ptr.rs
+++ b/library/core/src/ptr/const_ptr.rs
@@ -61,7 +61,7 @@ impl<T: ?Sized> *const T {
         self as _
     }
 
-    /// Use the pointer value in a new pointer of another type.
+    /// Uses the pointer value in a new pointer of another type.
     ///
     /// In case `meta` is a (fat) pointer to an unsized type, this operation
     /// will ignore the pointer part, whereas for (thin) pointers to sized

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -81,7 +81,7 @@ pub trait Pointee {
 // NOTE: don’t stabilize this before trait aliases are stable in the language?
 pub trait Thin = Pointee<Metadata = ()>;
 
-/// Extract the metadata component of a pointer.
+/// Extracts the metadata component of a pointer.
 ///
 /// Values of type `*mut T`, `&T`, or `&mut T` can be passed directly to this function
 /// as they implicitly coerce to `*const T`.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -196,9 +196,9 @@
 //! * The **provenance** it has, defining the memory it has permission to access.
 //!   Provenance can be absent, in which case the pointer does not have permission to access any memory.
 //!
-//! Under Strict Provenance, a usize *cannot* accurately represent a pointer, and converting from
-//! a pointer to a usize is generally an operation which *only* extracts the address. It is
-//! therefore *impossible* to construct a valid pointer from a usize because there is no way
+//! Under Strict Provenance, a `usize` *cannot* accurately represent a pointer, and converting from
+//! a pointer to a `usize` is generally an operation which *only* extracts the address. It is
+//! therefore *impossible* to construct a valid pointer from a `usize` because there is no way
 //! to restore the address-space and provenance. In other words, pointer-integer-pointer
 //! roundtrips are not possible (in the sense that the resulting pointer is not dereferenceable).
 //!
@@ -234,16 +234,16 @@
 //!
 //! Most code needs no changes to conform to strict provenance, as the only really concerning
 //! operation that *wasn't* obviously already Undefined Behaviour is casts from usize to a
-//! pointer. For code which *does* cast a usize to a pointer, the scope of the change depends
+//! pointer. For code which *does* cast a `usize` to a pointer, the scope of the change depends
 //! on exactly what you're doing.
 //!
-//! In general, you just need to make sure that if you want to convert a usize address to a
+//! In general, you just need to make sure that if you want to convert a `usize` address to a
 //! pointer and then use that pointer to read/write memory, you need to keep around a pointer
 //! that has sufficient provenance to perform that read/write itself. In this way all of your
 //! casts from an address to a pointer are essentially just applying offsets/indexing.
 //!
 //! This is generally trivial to do for simple cases like tagged pointers *as long as you
-//! represent the tagged pointer as an actual pointer and not a usize*. For instance:
+//! represent the tagged pointer as an actual pointer and not a `usize`*. For instance:
 //!
 //! ```
 //! #![feature(strict_provenance)]
@@ -606,7 +606,7 @@ pub const fn null_mut<T: ?Sized + Thin>() -> *mut T {
 /// Without provenance, this pointer is not associated with any actual allocation. Such a
 /// no-provenance pointer may be used for zero-sized memory accesses (if suitably aligned), but
 /// non-zero-sized memory accesses with a no-provenance pointer are UB. No-provenance pointers are
-/// little more than a usize address in disguise.
+/// little more than a `usize` address in disguise.
 ///
 /// This is different from `addr as *const T`, which creates a pointer that picks up a previously
 /// exposed provenance. See [`with_exposed_provenance`] for more details on that operation.
@@ -650,7 +650,7 @@ pub const fn dangling<T>() -> *const T {
 /// Without provenance, this pointer is not associated with any actual allocation. Such a
 /// no-provenance pointer may be used for zero-sized memory accesses (if suitably aligned), but
 /// non-zero-sized memory accesses with a no-provenance pointer are UB. No-provenance pointers are
-/// little more than a usize address in disguise.
+/// little more than a `usize` address in disguise.
 ///
 /// This is different from `addr as *mut T`, which creates a pointer that picks up a previously
 /// exposed provenance. See [`with_exposed_provenance_mut`] for more details on that operation.
@@ -687,7 +687,7 @@ pub const fn dangling_mut<T>() -> *mut T {
     without_provenance_mut(mem::align_of::<T>())
 }
 
-/// Convert an address back to a pointer, picking up a previously 'exposed' provenance.
+/// Converts an address back to a pointer, picking up a previously 'exposed' provenance.
 ///
 /// This is a more rigorously specified alternative to `addr as *const T`. The provenance of the
 /// returned pointer is that of *any* pointer that was previously exposed by passing it to
@@ -735,7 +735,7 @@ where
     addr as *const T
 }
 
-/// Convert an address back to a mutable pointer, picking up a previously 'exposed' provenance.
+/// Converts an address back to a mutable pointer, picking up a previously 'exposed' provenance.
 ///
 /// This is a more rigorously specified alternative to `addr as *mut T`. The provenance of the
 /// returned pointer is that of *any* pointer that was previously passed to
@@ -775,7 +775,7 @@ where
     addr as *mut T
 }
 
-/// Convert a reference to a raw pointer.
+/// Converts a reference to a raw pointer.
 ///
 /// This is equivalent to `r as *const T`, but is a bit safer since it will never silently change
 /// type or mutability, in particular if the code is refactored.
@@ -789,7 +789,7 @@ pub const fn from_ref<T: ?Sized>(r: &T) -> *const T {
     r
 }
 
-/// Convert a mutable reference to a raw pointer.
+/// Converts a mutable reference to a raw pointer.
 ///
 /// This is equivalent to `r as *mut T`, but is a bit safer since it will never silently change
 /// type or mutability, in particular if the code is refactored.
@@ -1388,7 +1388,7 @@ pub const unsafe fn read<T>(src: *const T) -> T {
 ///
 /// # Examples
 ///
-/// Read a usize value from a byte buffer:
+/// Read a `usize` value from a byte buffer:
 ///
 /// ```
 /// use std::mem;
@@ -1599,7 +1599,7 @@ pub const unsafe fn write<T>(dst: *mut T, src: T) {
 ///
 /// # Examples
 ///
-/// Write a usize value to a byte buffer:
+/// Write a `usize` value to a byte buffer:
 ///
 /// ```
 /// use std::mem;
@@ -1934,7 +1934,7 @@ pub(crate) const unsafe fn align_offset<T: Sized>(p: *const T, a: usize) -> usiz
         let y = cttz_nonzero(a);
         if x < y { x } else { y }
     };
-    // SAFETY: gcdpow has an upper-bound that’s at most the number of bits in a usize.
+    // SAFETY: gcdpow has an upper-bound that’s at most the number of bits in a `usize`.
     let gcd = unsafe { unchecked_shl(1usize, gcdpow) };
     // SAFETY: gcd is always greater or equal to 1.
     if addr & unsafe { unchecked_sub(gcd, 1) } == 0 {
@@ -2133,7 +2133,7 @@ impl<F: FnPtr> fmt::Debug for F {
     }
 }
 
-/// Create a `const` raw pointer to a place, without creating an intermediate reference.
+/// Creates a `const` raw pointer to a place, without creating an intermediate reference.
 ///
 /// Creating a reference with `&`/`&mut` is only allowed if the pointer is properly aligned
 /// and points to initialized data. For cases where those requirements do not hold,
@@ -2207,7 +2207,7 @@ pub macro addr_of($place:expr) {
     &raw const $place
 }
 
-/// Create a `mut` raw pointer to a place, without creating an intermediate reference.
+/// Creates a `mut` raw pointer to a place, without creating an intermediate reference.
 ///
 /// Creating a reference with `&`/`&mut` is only allowed if the pointer is properly aligned
 /// and points to initialized data. For cases where those requirements do not hold,

--- a/library/core/src/ptr/mut_ptr.rs
+++ b/library/core/src/ptr/mut_ptr.rs
@@ -60,7 +60,7 @@ impl<T: ?Sized> *mut T {
         self as _
     }
 
-    /// Use the pointer value in a new pointer of another type.
+    /// Uses the pointer value in a new pointer of another type.
     ///
     /// In case `meta` is a (fat) pointer to an unsized type, this operation
     /// will ignore the pointer part, whereas for (thin) pointers to sized

--- a/library/core/src/range.rs
+++ b/library/core/src/range.rs
@@ -72,7 +72,7 @@ impl<Idx: fmt::Debug> fmt::Debug for Range<Idx> {
 }
 
 impl<Idx: Step> Range<Idx> {
-    /// Create an iterator over the elements within this range.
+    /// Creates an iterator over the elements within this range.
     ///
     /// Shorthand for `.clone().into_iter()`
     ///
@@ -292,7 +292,7 @@ impl<Idx: PartialOrd<Idx>> RangeInclusive<Idx> {
 }
 
 impl<Idx: Step> RangeInclusive<Idx> {
-    /// Create an iterator over the elements within this range.
+    /// Creates an iterator over the elements within this range.
     ///
     /// Shorthand for `.clone().into_iter()`
     ///
@@ -408,7 +408,7 @@ impl<Idx: fmt::Debug> fmt::Debug for RangeFrom<Idx> {
 }
 
 impl<Idx: Step> RangeFrom<Idx> {
-    /// Create an iterator over the elements within this range.
+    /// Creates an iterator over the elements within this range.
     ///
     /// Shorthand for `.clone().into_iter()`
     ///

--- a/library/core/src/slice/index.rs
+++ b/library/core/src/slice/index.rs
@@ -214,6 +214,7 @@ pub unsafe trait SliceIndex<T: ?Sized>: private_slice_index::Sealed {
 
     /// Returns a pointer to the output at this location, without
     /// performing any bounds checking.
+    ///
     /// Calling this method with an out-of-bounds index or a dangling `slice` pointer
     /// is *[undefined behavior]* even if the resulting pointer is not used.
     ///
@@ -223,6 +224,7 @@ pub unsafe trait SliceIndex<T: ?Sized>: private_slice_index::Sealed {
 
     /// Returns a mutable pointer to the output at this location, without
     /// performing any bounds checking.
+    ///
     /// Calling this method with an out-of-bounds index or a dangling `slice` pointer
     /// is *[undefined behavior]* even if the resulting pointer is not used.
     ///
@@ -802,13 +804,13 @@ unsafe impl<T> SliceIndex<[T]> for ops::RangeToInclusive<usize> {
     }
 }
 
-/// Performs bounds-checking of a range.
+/// Performs bounds checking of a range.
 ///
 /// This method is similar to [`Index::index`] for slices, but it returns a
 /// [`Range`] equivalent to `range`. You can use this method to turn any range
 /// into `start` and `end` values.
 ///
-/// `bounds` is the range of the slice to use for bounds-checking. It should
+/// `bounds` is the range of the slice to use for bounds checking. It should
 /// be a [`RangeTo`] range that ends at the length of the slice.
 ///
 /// The returned [`Range`] is safe to pass to [`slice::get_unchecked`] and
@@ -898,7 +900,7 @@ where
     ops::Range { start, end }
 }
 
-/// Performs bounds-checking of a range without panicking.
+/// Performs bounds checking of a range without panicking.
 ///
 /// This is a version of [`range()`] that returns [`None`] instead of panicking.
 ///
@@ -951,7 +953,8 @@ where
     if start > end || end > len { None } else { Some(ops::Range { start, end }) }
 }
 
-/// Convert pair of `ops::Bound`s into `ops::Range` without performing any bounds checking and (in debug) overflow checking
+/// Converts a pair of `ops::Bound`s into `ops::Range` without performing any
+/// bounds checking or (in debug) overflow checking.
 pub(crate) fn into_range_unchecked(
     len: usize,
     (start, end): (ops::Bound<usize>, ops::Bound<usize>),
@@ -970,7 +973,7 @@ pub(crate) fn into_range_unchecked(
     start..end
 }
 
-/// Convert pair of `ops::Bound`s into `ops::Range`.
+/// Converts pair of `ops::Bound`s into `ops::Range`.
 /// Returns `None` on overflowing indices.
 pub(crate) fn into_range(
     len: usize,
@@ -995,7 +998,7 @@ pub(crate) fn into_range(
     Some(start..end)
 }
 
-/// Convert pair of `ops::Bound`s into `ops::Range`.
+/// Converts pair of `ops::Bound`s into `ops::Range`.
 /// Panics on overflowing indices.
 pub(crate) fn into_slice_range(
     len: usize,

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -321,7 +321,7 @@ impl<T> [T] {
         if let [.., last] = self { Some(last) } else { None }
     }
 
-    /// Return an array reference to the first `N` items in the slice.
+    /// Returns an array reference to the first `N` items in the slice.
     ///
     /// If the slice is not at least `N` in length, this will return `None`.
     ///
@@ -350,7 +350,7 @@ impl<T> [T] {
         }
     }
 
-    /// Return a mutable array reference to the first `N` items in the slice.
+    /// Returns a mutable array reference to the first `N` items in the slice.
     ///
     /// If the slice is not at least `N` in length, this will return `None`.
     ///
@@ -381,7 +381,7 @@ impl<T> [T] {
         }
     }
 
-    /// Return an array reference to the first `N` items in the slice and the remaining slice.
+    /// Returns an array reference to the first `N` items in the slice and the remaining slice.
     ///
     /// If the slice is not at least `N` in length, this will return `None`.
     ///
@@ -413,7 +413,7 @@ impl<T> [T] {
         }
     }
 
-    /// Return a mutable array reference to the first `N` items in the slice and the remaining
+    /// Returns a mutable array reference to the first `N` items in the slice and the remaining
     /// slice.
     ///
     /// If the slice is not at least `N` in length, this will return `None`.
@@ -451,7 +451,7 @@ impl<T> [T] {
         }
     }
 
-    /// Return an array reference to the last `N` items in the slice and the remaining slice.
+    /// Returns an array reference to the last `N` items in the slice and the remaining slice.
     ///
     /// If the slice is not at least `N` in length, this will return `None`.
     ///
@@ -483,7 +483,7 @@ impl<T> [T] {
         }
     }
 
-    /// Return a mutable array reference to the last `N` items in the slice and the remaining
+    /// Returns a mutable array reference to the last `N` items in the slice and the remaining
     /// slice.
     ///
     /// If the slice is not at least `N` in length, this will return `None`.
@@ -521,7 +521,7 @@ impl<T> [T] {
         }
     }
 
-    /// Return an array reference to the last `N` items in the slice.
+    /// Returns an array reference to the last `N` items in the slice.
     ///
     /// If the slice is not at least `N` in length, this will return `None`.
     ///
@@ -554,7 +554,7 @@ impl<T> [T] {
         }
     }
 
-    /// Return a mutable array reference to the last `N` items in the slice.
+    /// Returns a mutable array reference to the last `N` items in the slice.
     ///
     /// If the slice is not at least `N` in length, this will return `None`.
     ///
@@ -828,7 +828,7 @@ impl<T> [T] {
         //   - Both pointers are part of the same object, as pointing directly
         //     past the object also counts.
         //
-        //   - The size of the slice is never larger than isize::MAX bytes, as
+        //   - The size of the slice is never larger than `isize::MAX` bytes, as
         //     noted here:
         //       - https://github.com/rust-lang/unsafe-code-guidelines/issues/102#issuecomment-473340447
         //       - https://doc.rust-lang.org/reference/behavior-considered-undefined.html
@@ -839,7 +839,7 @@ impl<T> [T] {
         //   - There is no wrapping around involved, as slices do not wrap past
         //     the end of the address space.
         //
-        // See the documentation of pointer::add.
+        // See the documentation of [`pointer::add`].
         let end = unsafe { start.add(self.len()) };
         start..end
     }
@@ -3021,7 +3021,7 @@ impl<T> [T] {
         sort::unstable::sort(self, &mut |a, b| f(a).lt(&f(b)));
     }
 
-    /// Reorder the slice such that the element at `index` after the reordering is at its final
+    /// Reorders the slice such that the element at `index` after the reordering is at its final
     /// sorted position.
     ///
     /// This reordering has the additional property that any value at position `i < index` will be
@@ -3082,7 +3082,7 @@ impl<T> [T] {
         sort::select::partition_at_index(self, index, T::lt)
     }
 
-    /// Reorder the slice with a comparator function such that the element at `index` after the
+    /// Reorders the slice with a comparator function such that the element at `index` after the
     /// reordering is at its final sorted position.
     ///
     /// This reordering has the additional property that any value at position `i < index` will be
@@ -3147,7 +3147,7 @@ impl<T> [T] {
         sort::select::partition_at_index(self, index, |a: &T, b: &T| compare(a, b) == Less)
     }
 
-    /// Reorder the slice with a key extraction function such that the element at `index` after the
+    /// Reorders the slice with a key extraction function such that the element at `index` after the
     /// reordering is at its final sorted position.
     ///
     /// This reordering has the additional property that any value at position `i < index` will be
@@ -3405,8 +3405,10 @@ impl<T> [T] {
 
     /// Rotates the slice in-place such that the first `mid` elements of the
     /// slice move to the end while the last `self.len() - mid` elements move to
-    /// the front. After calling `rotate_left`, the element previously at index
-    /// `mid` will become the first element in the slice.
+    /// the front.
+    ///
+    /// After calling `rotate_left`, the element previously at index `mid` will
+    /// become the first element in the slice.
     ///
     /// # Panics
     ///
@@ -3448,8 +3450,10 @@ impl<T> [T] {
 
     /// Rotates the slice in-place such that the first `self.len() - k`
     /// elements of the slice move to the end while the last `k` elements move
-    /// to the front. After calling `rotate_right`, the element previously at
-    /// index `self.len() - k` will become the first element in the slice.
+    /// to the front.
+    ///
+    /// After calling `rotate_right`, the element previously at index `self.len()
+    /// - k` will become the first element in the slice.
     ///
     /// # Panics
     ///
@@ -3819,7 +3823,7 @@ impl<T> [T] {
         (us_len, ts_len)
     }
 
-    /// Transmute the slice to a slice of another type, ensuring alignment of the types is
+    /// Transmutes the slice to a slice of another type, ensuring alignment of the types is
     /// maintained.
     ///
     /// This method splits the slice into three distinct slices: prefix, correctly aligned middle
@@ -3884,7 +3888,7 @@ impl<T> [T] {
         }
     }
 
-    /// Transmute the mutable slice to a mutable slice of another type, ensuring alignment of the
+    /// Transmutes the mutable slice to a mutable slice of another type, ensuring alignment of the
     /// types is maintained.
     ///
     /// This method splits the slice into three distinct slices: prefix, correctly aligned middle
@@ -3957,7 +3961,7 @@ impl<T> [T] {
         }
     }
 
-    /// Split a slice into a prefix, a middle of aligned SIMD types, and a suffix.
+    /// Splits a slice into a prefix, a middle of aligned SIMD types, and a suffix.
     ///
     /// This is a safe wrapper around [`slice::align_to`], so inherits the same
     /// guarantees as that method.
@@ -4021,7 +4025,7 @@ impl<T> [T] {
         unsafe { self.align_to() }
     }
 
-    /// Split a mutable slice into a mutable prefix, a middle of aligned SIMD types,
+    /// Splits a mutable slice into a mutable prefix, a middle of aligned SIMD types,
     /// and a mutable suffix.
     ///
     /// This is a safe wrapper around [`slice::align_to_mut`], so inherits the same

--- a/library/core/src/slice/sort/select.rs
+++ b/library/core/src/slice/sort/select.rs
@@ -12,7 +12,7 @@ use crate::slice::sort::shared::pivot::choose_pivot;
 use crate::slice::sort::shared::smallsort::insertion_sort_shift_left;
 use crate::slice::sort::unstable::quicksort::partition;
 
-/// Reorder the slice such that the element at `index` is at its final sorted position.
+/// Reorders the slice such that the element at `index` is at its final sorted position.
 pub(crate) fn partition_at_index<T, F>(
     v: &mut [T],
     index: usize,

--- a/library/core/src/slice/sort/stable/drift.rs
+++ b/library/core/src/slice/sort/stable/drift.rs
@@ -273,7 +273,7 @@ fn stable_quicksort<T, F: FnMut(&T, &T) -> bool>(
 }
 
 /// Compactly stores the length of a run, and whether or not it is sorted. This
-/// can always fit in a usize because the maximum slice length is isize::MAX.
+/// can always fit in a `usize` because the maximum slice length is [`isize::MAX`].
 #[derive(Copy, Clone)]
 struct DriftsortRun(usize);
 

--- a/library/core/src/slice/sort/stable/quicksort.rs
+++ b/library/core/src/slice/sort/stable/quicksort.rs
@@ -196,7 +196,8 @@ struct PartitionState<T> {
 
 impl<T> PartitionState<T> {
     /// # Safety
-    /// scan and scratch must point to valid disjoint buffers of length len. The
+    ///
+    /// `scan` and `scratch` must point to valid disjoint buffers of length `len`. The
     /// scan buffer must be initialized.
     unsafe fn new(scan: *const T, scratch: *mut T, len: usize) -> Self {
         // SAFETY: See function safety comment.
@@ -208,6 +209,7 @@ impl<T> PartitionState<T> {
     /// branchless core of the partition.
     ///
     /// # Safety
+    ///
     /// This function may be called at most `len` times. If it is called exactly
     /// `len` times the scratch buffer then contains a copy of each element from
     /// the scan buffer exactly once - a permutation, and num_left <= len.

--- a/library/core/src/str/converts.rs
+++ b/library/core/src/str/converts.rs
@@ -206,7 +206,7 @@ pub const unsafe fn from_utf8_unchecked_mut(v: &mut [u8]) -> &mut str {
     unsafe { &mut *(v as *mut [u8] as *mut str) }
 }
 
-/// Creates an `&str` from a pointer and a length.
+/// Creates a `&str` from a pointer and a length.
 ///
 /// The pointed-to bytes must be valid UTF-8.
 /// If this might not be the case, use `str::from_utf8(slice::from_raw_parts(ptr, len))`,
@@ -225,7 +225,7 @@ pub const unsafe fn from_raw_parts<'a>(ptr: *const u8, len: usize) -> &'a str {
     unsafe { &*ptr::from_raw_parts(ptr, len) }
 }
 
-/// Creates an `&mut str` from a pointer and a length.
+/// Creates a `&mut str` from a pointer and a length.
 ///
 /// The pointed-to bytes must be valid UTF-8.
 /// If this might not be the case, use `str::from_utf8_mut(slice::from_raw_parts_mut(ptr, len))`,

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -592,6 +592,7 @@ impl str {
 
     /// Creates a string slice from another string slice, bypassing safety
     /// checks.
+    ///
     /// This is generally not recommended, use with caution! For a safe
     /// alternative see [`str`] and [`IndexMut`].
     ///
@@ -623,7 +624,7 @@ impl str {
         unsafe { &mut *(begin..end).get_unchecked_mut(self) }
     }
 
-    /// Divide one string slice into two at an index.
+    /// Divides one string slice into two at an index.
     ///
     /// The argument, `mid`, should be a byte offset from the start of the
     /// string. It must also be on the boundary of a UTF-8 code point.
@@ -662,7 +663,7 @@ impl str {
         }
     }
 
-    /// Divide one mutable string slice into two at an index.
+    /// Divides one mutable string slice into two at an index.
     ///
     /// The argument, `mid`, should be a byte offset from the start of the
     /// string. It must also be on the boundary of a UTF-8 code point.
@@ -705,7 +706,7 @@ impl str {
         }
     }
 
-    /// Divide one string slice into two at an index.
+    /// Divides one string slice into two at an index.
     ///
     /// The argument, `mid`, should be a valid byte offset from the start of the
     /// string. It must also be on the boundary of a UTF-8 code point. The
@@ -744,7 +745,7 @@ impl str {
         }
     }
 
-    /// Divide one mutable string slice into two at an index.
+    /// Divides one mutable string slice into two at an index.
     ///
     /// The argument, `mid`, should be a valid byte offset from the start of the
     /// string. It must also be on the boundary of a UTF-8 code point. The
@@ -784,7 +785,7 @@ impl str {
         }
     }
 
-    /// Divide one string slice into two at an index.
+    /// Divides one string slice into two at an index.
     ///
     /// # Safety
     ///
@@ -912,7 +913,7 @@ impl str {
         CharIndices { front_offset: 0, iter: self.chars() }
     }
 
-    /// An iterator over the bytes of a string slice.
+    /// Returns an iterator over the bytes of a string slice.
     ///
     /// As a string slice consists of a sequence of bytes, we can iterate
     /// through a string slice by byte. This method returns such an iterator.
@@ -1038,7 +1039,7 @@ impl str {
         SplitAsciiWhitespace { inner }
     }
 
-    /// An iterator over the lines of a string, as string slices.
+    /// Returns an iterator over the lines of a string, as string slices.
     ///
     /// Lines are split at line endings that are either newlines (`\n`) or
     /// sequences of a carriage return followed by a line feed (`\r\n`).
@@ -1089,7 +1090,7 @@ impl str {
         Lines(self.split_inclusive('\n').map(LinesMap))
     }
 
-    /// An iterator over the lines of a string.
+    /// Returns an iterator over the lines of a string.
     #[stable(feature = "rust1", since = "1.0.0")]
     #[deprecated(since = "1.4.0", note = "use lines() instead now", suggestion = "lines")]
     #[inline]
@@ -1303,7 +1304,7 @@ impl str {
         pat.into_searcher(self).next_match_back().map(|(i, _)| i)
     }
 
-    /// An iterator over substrings of this string slice, separated by
+    /// Returns an iterator over substrings of this string slice, separated by
     /// characters matched by a pattern.
     ///
     /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
@@ -1428,10 +1429,11 @@ impl str {
         })
     }
 
-    /// An iterator over substrings of this string slice, separated by
-    /// characters matched by a pattern. Differs from the iterator produced by
-    /// `split` in that `split_inclusive` leaves the matched part as the
-    /// terminator of the substring.
+    /// Returns an iterator over substrings of this string slice, separated by
+    /// characters matched by a pattern.
+    ///
+    /// Differs from the iterator produced by `split` in that `split_inclusive`
+    /// leaves the matched part as the terminator of the substring.
     ///
     /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
     /// function or closure that determines if a character matches.
@@ -1468,8 +1470,8 @@ impl str {
         })
     }
 
-    /// An iterator over substrings of the given string slice, separated by
-    /// characters matched by a pattern and yielded in reverse order.
+    /// Returns an iterator over substrings of the given string slice, separated
+    /// by characters matched by a pattern and yielded in reverse order.
     ///
     /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
     /// function or closure that determines if a character matches.
@@ -1520,8 +1522,8 @@ impl str {
         RSplit(self.split(pat).0)
     }
 
-    /// An iterator over substrings of the given string slice, separated by
-    /// characters matched by a pattern.
+    /// Returns an iterator over substrings of the given string slice, separated
+    /// by characters matched by a pattern.
     ///
     /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
     /// function or closure that determines if a character matches.
@@ -1566,7 +1568,7 @@ impl str {
         SplitTerminator(SplitInternal { allow_trailing_empty: false, ..self.split(pat).0 })
     }
 
-    /// An iterator over substrings of `self`, separated by characters
+    /// Returns an iterator over substrings of `self`, separated by characters
     /// matched by a pattern and yielded in reverse order.
     ///
     /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
@@ -1615,8 +1617,8 @@ impl str {
         RSplitTerminator(self.split_terminator(pat).0)
     }
 
-    /// An iterator over substrings of the given string slice, separated by a
-    /// pattern, restricted to returning at most `n` items.
+    /// Returns an iterator over substrings of the given string slice, separated
+    /// by a pattern, restricted to returning at most `n` items.
     ///
     /// If `n` substrings are returned, the last substring (the `n`th substring)
     /// will contain the remainder of the string.
@@ -1667,9 +1669,9 @@ impl str {
         SplitN(SplitNInternal { iter: self.split(pat).0, count: n })
     }
 
-    /// An iterator over substrings of this string slice, separated by a
-    /// pattern, starting from the end of the string, restricted to returning
-    /// at most `n` items.
+    /// Returns an iterator over substrings of this string slice, separated by a
+    /// pattern, starting from the end of the string, restricted to returning at
+    /// most `n` items.
     ///
     /// If `n` substrings are returned, the last substring (the `n`th substring)
     /// will contain the remainder of the string.
@@ -1759,8 +1761,8 @@ impl str {
         unsafe { Some((self.get_unchecked(..start), self.get_unchecked(end..))) }
     }
 
-    /// An iterator over the disjoint matches of a pattern within the given string
-    /// slice.
+    /// Returns an iterator over the disjoint matches of a pattern within the
+    /// given string slice.
     ///
     /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
     /// function or closure that determines if a character matches.
@@ -1794,8 +1796,8 @@ impl str {
         Matches(MatchesInternal(pat.into_searcher(self)))
     }
 
-    /// An iterator over the disjoint matches of a pattern within this string slice,
-    /// yielded in reverse order.
+    /// Returns an iterator over the disjoint matches of a pattern within this
+    /// string slice, yielded in reverse order.
     ///
     /// The [pattern] can be a `&str`, [`char`], a slice of [`char`]s, or a
     /// function or closure that determines if a character matches.
@@ -1831,7 +1833,7 @@ impl str {
         RMatches(self.matches(pat).0)
     }
 
-    /// An iterator over the disjoint matches of a pattern within this string
+    /// Returns an iterator over the disjoint matches of a pattern within this string
     /// slice as well as the index that the match starts at.
     ///
     /// For matches of `pat` within `self` that overlap, only the indices
@@ -1872,7 +1874,7 @@ impl str {
         MatchIndices(MatchIndicesInternal(pat.into_searcher(self)))
     }
 
-    /// An iterator over the disjoint matches of a pattern within `self`,
+    /// Returns an iterator over the disjoint matches of a pattern within `self`,
     /// yielded in reverse order along with the index of the match.
     ///
     /// For matches of `pat` within `self` that overlap, only the indices
@@ -2597,7 +2599,7 @@ impl str {
         unsafe { core::str::from_utf8_unchecked(self.as_bytes().trim_ascii()) }
     }
 
-    /// Return an iterator that escapes each char in `self` with [`char::escape_debug`].
+    /// Returns an iterator that escapes each char in `self` with [`char::escape_debug`].
     ///
     /// Note: only extended grapheme codepoints that begin the string will be
     /// escaped.
@@ -2646,7 +2648,7 @@ impl str {
         }
     }
 
-    /// Return an iterator that escapes each char in `self` with [`char::escape_default`].
+    /// Returns an iterator that escapes each char in `self` with [`char::escape_default`].
     ///
     /// # Examples
     ///
@@ -2684,7 +2686,7 @@ impl str {
         EscapeDefault { inner: self.chars().flat_map(CharEscapeDefault) }
     }
 
-    /// Return an iterator that escapes each char in `self` with [`char::escape_unicode`].
+    /// Returns an iterator that escapes each char in `self` with [`char::escape_unicode`].
     ///
     /// # Examples
     ///

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -481,7 +481,7 @@ impl AtomicBool {
         unsafe { &mut *(self.v.get() as *mut bool) }
     }
 
-    /// Get atomic access to a `&mut bool`.
+    /// Gets atomic access to a `&mut bool`.
     ///
     /// # Examples
     ///
@@ -503,7 +503,7 @@ impl AtomicBool {
         unsafe { &mut *(v as *mut bool as *mut Self) }
     }
 
-    /// Get non-atomic access to a `&mut [AtomicBool]` slice.
+    /// Gets non-atomic access to a `&mut [AtomicBool]` slice.
     ///
     /// This is safe because the mutable reference guarantees that no other threads are
     /// concurrently accessing the atomic data.
@@ -537,7 +537,7 @@ impl AtomicBool {
         unsafe { &mut *(this as *mut [Self] as *mut [bool]) }
     }
 
-    /// Get atomic access to a `&mut [bool]` slice.
+    /// Gets atomic access to a `&mut [bool]` slice.
     ///
     /// # Examples
     ///
@@ -1276,7 +1276,7 @@ impl<T> AtomicPtr<T> {
         self.p.get_mut()
     }
 
-    /// Get atomic access to a pointer.
+    /// Gets atomic access to a pointer.
     ///
     /// # Examples
     ///
@@ -1303,7 +1303,7 @@ impl<T> AtomicPtr<T> {
         unsafe { &mut *(v as *mut *mut T as *mut Self) }
     }
 
-    /// Get non-atomic access to a `&mut [AtomicPtr]` slice.
+    /// Gets non-atomic access to a `&mut [AtomicPtr]` slice.
     ///
     /// This is safe because the mutable reference guarantees that no other threads are
     /// concurrently accessing the atomic data.
@@ -1343,7 +1343,7 @@ impl<T> AtomicPtr<T> {
         unsafe { &mut *(this as *mut [Self] as *mut [*mut T]) }
     }
 
-    /// Get atomic access to a slice of pointers.
+    /// Gets atomic access to a slice of pointers.
     ///
     /// # Examples
     ///

--- a/library/core/src/sync/exclusive.rs
+++ b/library/core/src/sync/exclusive.rs
@@ -114,7 +114,7 @@ impl<T: Sized> Exclusive<T> {
 }
 
 impl<T: ?Sized> Exclusive<T> {
-    /// Get exclusive access to the underlying value.
+    /// Gets exclusive access to the underlying value.
     #[unstable(feature = "exclusive_wrapper", issue = "98407")]
     #[must_use]
     #[inline]
@@ -122,7 +122,7 @@ impl<T: ?Sized> Exclusive<T> {
         &mut self.inner
     }
 
-    /// Get pinned exclusive access to the underlying value.
+    /// Gets pinned exclusive access to the underlying value.
     ///
     /// `Exclusive` is considered to _structurally pin_ the underlying
     /// value, which means _unpinned_ `Exclusive`s can produce _unpinned_

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -61,7 +61,7 @@ impl RawWaker {
         RawWaker { data, vtable }
     }
 
-    /// Get the `data` pointer used to create this `RawWaker`.
+    /// Gets the `data` pointer used to create this `RawWaker`.
     #[inline]
     #[must_use]
     #[unstable(feature = "waker_getters", issue = "96992")]
@@ -69,7 +69,7 @@ impl RawWaker {
         self.data
     }
 
-    /// Get the `vtable` pointer used to create this `RawWaker`.
+    /// Gets the `vtable` pointer used to create this `RawWaker`.
     #[inline]
     #[must_use]
     #[unstable(feature = "waker_getters", issue = "96992")]
@@ -150,7 +150,7 @@ pub struct RawWakerVTable {
     /// pointer.
     wake_by_ref: unsafe fn(*const ()),
 
-    /// This function gets called when a [`Waker`] gets dropped.
+    /// This function will be called when a [`Waker`] gets dropped.
     ///
     /// The implementation of this function must make sure to release any
     /// resources that are associated with this instance of a [`RawWaker`] and
@@ -203,7 +203,8 @@ impl RawWakerVTable {
     ///
     /// # `drop`
     ///
-    /// This function gets called when a [`Waker`]/[`LocalWaker`] gets dropped.
+    /// This function will be called when a [`Waker`]/[`LocalWaker`] gets
+    /// dropped.
     ///
     /// The implementation of this function must make sure to release any
     /// resources that are associated with this instance of a [`RawWaker`] and
@@ -248,7 +249,7 @@ pub struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
-    /// Create a new `Context` from a [`&Waker`](Waker).
+    /// Creates a new `Context` from a [`&Waker`](Waker).
     #[stable(feature = "futures_api", since = "1.36.0")]
     #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
     #[must_use]
@@ -334,7 +335,7 @@ pub struct ContextBuilder<'a> {
 }
 
 impl<'a> ContextBuilder<'a> {
-    /// Create a ContextBuilder from a Waker.
+    /// Creates a ContextBuilder from a Waker.
     #[inline]
     #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
     #[unstable(feature = "local_waker", issue = "118959")]
@@ -350,7 +351,7 @@ impl<'a> ContextBuilder<'a> {
         }
     }
 
-    /// Create a ContextBuilder from an existing Context.
+    /// Creates a ContextBuilder from an existing Context.
     #[inline]
     #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
     #[unstable(feature = "context_ext", issue = "123392")]
@@ -368,7 +369,7 @@ impl<'a> ContextBuilder<'a> {
         }
     }
 
-    /// This method is used to set the value for the waker on `Context`.
+    /// Sets the value for the waker on `Context`.
     #[inline]
     #[unstable(feature = "context_ext", issue = "123392")]
     #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
@@ -376,7 +377,7 @@ impl<'a> ContextBuilder<'a> {
         Self { waker, ..self }
     }
 
-    /// This method is used to set the value for the local waker on `Context`.
+    /// Sets the value for the local waker on `Context`.
     #[inline]
     #[unstable(feature = "local_waker", issue = "118959")]
     #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
@@ -384,7 +385,7 @@ impl<'a> ContextBuilder<'a> {
         Self { local_waker, ..self }
     }
 
-    /// This method is used to set the value for the extension data on `Context`.
+    /// Sets the value for the extension data on `Context`.
     #[inline]
     #[unstable(feature = "context_ext", issue = "123392")]
     #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
@@ -442,7 +443,7 @@ unsafe impl Send for Waker {}
 unsafe impl Sync for Waker {}
 
 impl Waker {
-    /// Wake up the task associated with this `Waker`.
+    /// Wakes up the task associated with this `Waker`.
     ///
     /// As long as the executor keeps running and the task is not finished, it is
     /// guaranteed that each invocation of [`wake()`](Self::wake) (or
@@ -474,7 +475,7 @@ impl Waker {
         unsafe { (this.waker.vtable.wake)(this.waker.data) };
     }
 
-    /// Wake up the task associated with this `Waker` without consuming the `Waker`.
+    /// Wakes up the task associated with this `Waker` without consuming the `Waker`.
     ///
     /// This is similar to [`wake()`](Self::wake), but may be slightly less efficient in
     /// the case where an owned `Waker` is available. This method should be preferred to
@@ -555,7 +556,7 @@ impl Waker {
         WAKER
     }
 
-    /// Get a reference to the underlying [`RawWaker`].
+    /// Gets a reference to the underlying [`RawWaker`].
     #[inline]
     #[must_use]
     #[unstable(feature = "waker_getters", issue = "96992")]
@@ -701,7 +702,7 @@ pub struct LocalWaker {
 impl Unpin for LocalWaker {}
 
 impl LocalWaker {
-    /// Wake up the task associated with this `LocalWaker`.
+    /// Wakes up the task associated with this `LocalWaker`.
     ///
     /// As long as the executor keeps running and the task is not finished, it is
     /// guaranteed that each invocation of [`wake()`](Self::wake) (or
@@ -733,7 +734,7 @@ impl LocalWaker {
         unsafe { (this.waker.vtable.wake)(this.waker.data) };
     }
 
-    /// Wake up the task associated with this `LocalWaker` without consuming the `LocalWaker`.
+    /// Wakes up the task associated with this `LocalWaker` without consuming the `LocalWaker`.
     ///
     /// This is similar to [`wake()`](Self::wake), but may be slightly less efficient in
     /// the case where an owned `Waker` is available. This method should be preferred to
@@ -807,7 +808,7 @@ impl LocalWaker {
         WAKER
     }
 
-    /// Get a reference to the underlying [`RawWaker`].
+    /// Gets a reference to the underlying [`RawWaker`].
     #[inline]
     #[must_use]
     #[unstable(feature = "waker_getters", issue = "96992")]

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -250,7 +250,7 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     /// Create a new `Context` from a [`&Waker`](Waker).
     #[stable(feature = "futures_api", since = "1.36.0")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_stable(feature = "const_waker", since = "CURRENT_RUSTC_VERSION")]
     #[must_use]
     #[inline]
     pub const fn from_waker(waker: &'a Waker) -> Self {
@@ -261,7 +261,7 @@ impl<'a> Context<'a> {
     #[inline]
     #[must_use]
     #[stable(feature = "futures_api", since = "1.36.0")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_stable(feature = "const_waker", since = "CURRENT_RUSTC_VERSION")]
     pub const fn waker(&self) -> &'a Waker {
         &self.waker
     }
@@ -269,7 +269,7 @@ impl<'a> Context<'a> {
     /// Returns a reference to the [`LocalWaker`] for the current task.
     #[inline]
     #[unstable(feature = "local_waker", issue = "118959")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_unstable(feature = "local_waker", issue = "118959")]
     pub const fn local_waker(&self) -> &'a LocalWaker {
         &self.local_waker
     }
@@ -277,7 +277,7 @@ impl<'a> Context<'a> {
     /// Returns a reference to the extension data for the current task.
     #[inline]
     #[unstable(feature = "context_ext", issue = "123392")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_unstable(feature = "context_ext", issue = "123392")]
     pub const fn ext(&mut self) -> &mut dyn Any {
         // FIXME: this field makes Context extra-weird about unwind safety
         // can we justify AssertUnwindSafe if we stabilize this? do we care?
@@ -336,8 +336,8 @@ pub struct ContextBuilder<'a> {
 impl<'a> ContextBuilder<'a> {
     /// Create a ContextBuilder from a Waker.
     #[inline]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
     #[unstable(feature = "local_waker", issue = "118959")]
+    #[rustc_const_stable(feature = "const_waker", since = "CURRENT_RUSTC_VERSION")]
     pub const fn from_waker(waker: &'a Waker) -> Self {
         // SAFETY: LocalWaker is just Waker without thread safety
         let local_waker = unsafe { transmute(waker) };
@@ -352,8 +352,8 @@ impl<'a> ContextBuilder<'a> {
 
     /// Create a ContextBuilder from an existing Context.
     #[inline]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
     #[unstable(feature = "context_ext", issue = "123392")]
+    #[rustc_const_unstable(feature = "context_ext", issue = "123392")]
     pub const fn from(cx: &'a mut Context<'_>) -> Self {
         let ext = match &mut cx.ext.0 {
             ExtData::Some(ext) => ExtData::Some(*ext),
@@ -371,7 +371,7 @@ impl<'a> ContextBuilder<'a> {
     /// This method is used to set the value for the waker on `Context`.
     #[inline]
     #[unstable(feature = "context_ext", issue = "123392")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_unstable(feature = "context_ext", issue = "123392")]
     pub const fn waker(self, waker: &'a Waker) -> Self {
         Self { waker, ..self }
     }
@@ -379,7 +379,7 @@ impl<'a> ContextBuilder<'a> {
     /// This method is used to set the value for the local waker on `Context`.
     #[inline]
     #[unstable(feature = "local_waker", issue = "118959")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_unstable(feature = "local_waker", issue = "118959")]
     pub const fn local_waker(self, local_waker: &'a LocalWaker) -> Self {
         Self { local_waker, ..self }
     }
@@ -387,7 +387,7 @@ impl<'a> ContextBuilder<'a> {
     /// This method is used to set the value for the extension data on `Context`.
     #[inline]
     #[unstable(feature = "context_ext", issue = "123392")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_unstable(feature = "context_ext", issue = "123392")]
     pub const fn ext(self, data: &'a mut dyn Any) -> Self {
         Self { ext: ExtData::Some(data), ..self }
     }
@@ -395,7 +395,7 @@ impl<'a> ContextBuilder<'a> {
     /// Builds the `Context`.
     #[inline]
     #[unstable(feature = "local_waker", issue = "118959")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_stable(feature = "const_waker", since = "CURRENT_RUSTC_VERSION")]
     pub const fn build(self) -> Context<'a> {
         let ContextBuilder { waker, local_waker, ext, _marker, _marker2 } = self;
         Context { waker, local_waker, ext: AssertUnwindSafe(ext), _marker, _marker2 }
@@ -521,7 +521,7 @@ impl Waker {
     #[inline]
     #[must_use]
     #[stable(feature = "futures_api", since = "1.36.0")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_stable(feature = "const_waker", since = "CURRENT_RUSTC_VERSION")]
     pub const unsafe fn from_raw(waker: RawWaker) -> Waker {
         Waker { waker }
     }
@@ -772,7 +772,7 @@ impl LocalWaker {
     #[inline]
     #[must_use]
     #[unstable(feature = "local_waker", issue = "118959")]
-    #[rustc_const_unstable(feature = "const_waker", issue = "102012")]
+    #[rustc_const_unstable(feature = "local_waker", issue = "118959")]
     pub const unsafe fn from_raw(waker: RawWaker) -> LocalWaker {
         Self { waker }
     }

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -1037,7 +1037,7 @@ impl Duration {
         Duration::from_secs_f32(rhs * self.as_secs_f32())
     }
 
-    /// Divide `Duration` by `f64`.
+    /// Divides `Duration` by `f64`.
     ///
     /// # Panics
     /// This method will panic if result is negative, overflows `Duration` or not finite.
@@ -1058,7 +1058,7 @@ impl Duration {
         Duration::from_secs_f64(self.as_secs_f64() / rhs)
     }
 
-    /// Divide `Duration` by `f32`.
+    /// Divides `Duration` by `f32`.
     ///
     /// # Panics
     /// This method will panic if result is negative, overflows `Duration` or not finite.
@@ -1081,7 +1081,7 @@ impl Duration {
         Duration::from_secs_f32(self.as_secs_f32() / rhs)
     }
 
-    /// Divide `Duration` by `Duration` and return `f64`.
+    /// Divides `Duration` by `Duration` and returns `f64`.
     ///
     /// # Examples
     /// ```
@@ -1102,7 +1102,7 @@ impl Duration {
         self_nanos / rhs_nanos
     }
 
-    /// Divide `Duration` by `Duration` and return `f32`.
+    /// Divides `Duration` by `Duration` and returns `f32`.
     ///
     /// # Examples
     /// ```

--- a/library/core/src/ub_checks.rs
+++ b/library/core/src/ub_checks.rs
@@ -3,9 +3,11 @@
 
 use crate::intrinsics::{self, const_eval_select};
 
-/// Check that the preconditions of an unsafe function are followed. The check is enabled at
-/// runtime if debug assertions are enabled when the caller is monomorphized. In const-eval/Miri
-/// checks implemented with this macro for language UB are always ignored.
+/// Checks that the preconditions of an unsafe function are followed.
+///
+/// The check is enabled at runtime if debug assertions are enabled when the
+/// caller is monomorphized. In const-eval/Miri checks implemented with this
+/// macro for language UB are always ignored.
 ///
 /// This macro should be called as
 /// `assert_unsafe_precondition!(check_{library,lang}_ub, "message", (ident: type = expr, ident: type = expr) => check_expr)`

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -61,6 +61,7 @@
 #![feature(num_midpoint)]
 #![feature(offset_of_nested)]
 #![feature(isqrt)]
+#![feature(unsigned_is_multiple_of)]
 #![feature(step_trait)]
 #![feature(str_internals)]
 #![feature(std_internals)]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -88,7 +88,6 @@
 #![feature(const_ipv6)]
 #![feature(const_mut_refs)]
 #![feature(const_pin)]
-#![feature(const_waker)]
 #![feature(never_type)]
 #![feature(unwrap_infallible)]
 #![feature(pointer_is_aligned_to)]

--- a/library/core/tests/num/uint_macros.rs
+++ b/library/core/tests/num/uint_macros.rs
@@ -261,6 +261,14 @@ macro_rules! uint_module {
             }
 
             #[test]
+            fn test_is_next_multiple_of() {
+                assert!((12 as $T).is_multiple_of(4));
+                assert!(!(12 as $T).is_multiple_of(5));
+                assert!((0 as $T).is_multiple_of(0));
+                assert!(!(12 as $T).is_multiple_of(0));
+            }
+
+            #[test]
             fn test_carrying_add() {
                 assert_eq!($T::MAX.carrying_add(1, false), (0, true));
                 assert_eq!($T::MAX.carrying_add(0, true), (0, true));

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -1050,7 +1050,7 @@ fn nonnull_tagged_pointer_with_provenance() {
         /// A mask for the non-data-carrying bits of the address.
         pub const ADDRESS_MASK: usize = usize::MAX << Self::NUM_BITS;
 
-        /// Create a new tagged pointer from a possibly null pointer.
+        /// Creates a new tagged pointer from a possibly null pointer.
         pub fn new(pointer: *mut T) -> Option<TaggedPointer<T>> {
             Some(TaggedPointer(NonNull::new(pointer)?))
         }

--- a/library/core/tests/waker.rs
+++ b/library/core/tests/waker.rs
@@ -20,3 +20,35 @@ static WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
     |_| {},
     |_| {},
 );
+
+// https://github.com/rust-lang/rust/issues/102012#issuecomment-1915282956
+mod nop_waker {
+    use core::{
+        future::{ready, Future},
+        pin::Pin,
+        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+    };
+
+    const NOP_RAWWAKER: RawWaker = {
+        fn nop(_: *const ()) {}
+        const VTAB: RawWakerVTable = RawWakerVTable::new(|_| NOP_RAWWAKER, nop, nop, nop);
+        RawWaker::new(&() as *const (), &VTAB)
+    };
+
+    const NOP_WAKER: &Waker = &unsafe { Waker::from_raw(NOP_RAWWAKER) };
+
+    const NOP_CONTEXT: Context<'static> = Context::from_waker(NOP_WAKER);
+
+    fn poll_once<T, F>(f: &mut F) -> Poll<T>
+    where
+        F: Future<Output = T> + ?Sized + Unpin,
+    {
+        let mut cx = NOP_CONTEXT;
+        Pin::new(f).as_mut().poll(&mut cx)
+    }
+
+    #[test]
+    fn test_const_waker() {
+        assert_eq!(poll_once(&mut ready(1)), Poll::Ready(1));
+    }
+}

--- a/library/portable-simd/crates/core_simd/src/masks.rs
+++ b/library/portable-simd/crates/core_simd/src/masks.rs
@@ -137,7 +137,7 @@ where
     T: MaskElement,
     LaneCount<N>: SupportedLaneCount,
 {
-    /// Construct a mask by setting all elements to the given value.
+    /// Constructs a mask by setting all elements to the given value.
     #[inline]
     pub fn splat(value: bool) -> Self {
         Self(mask_impl::Mask::splat(value))
@@ -288,7 +288,7 @@ where
         self.0.all()
     }
 
-    /// Create a bitmask from a mask.
+    /// Creates a bitmask from a mask.
     ///
     /// Each bit is set if the corresponding element in the mask is `true`.
     /// If the mask contains more than 64 elements, the bitmask is truncated to the first 64.
@@ -298,7 +298,7 @@ where
         self.0.to_bitmask_integer()
     }
 
-    /// Create a mask from a bitmask.
+    /// Creates a mask from a bitmask.
     ///
     /// For each bit, if it is set, the corresponding element in the mask is set to `true`.
     /// If the mask contains more than 64 elements, the remainder are set to `false`.
@@ -308,7 +308,7 @@ where
         Self(mask_impl::Mask::from_bitmask_integer(bitmask))
     }
 
-    /// Create a bitmask vector from a mask.
+    /// Creates a bitmask vector from a mask.
     ///
     /// Each bit is set if the corresponding element in the mask is `true`.
     /// The remaining bits are unset.
@@ -328,7 +328,7 @@ where
         self.0.to_bitmask_vector()
     }
 
-    /// Create a mask from a bitmask vector.
+    /// Creates a mask from a bitmask vector.
     ///
     /// For each bit, if it is set, the corresponding element in the mask is set to `true`.
     ///
@@ -350,7 +350,7 @@ where
         Self(mask_impl::Mask::from_bitmask_vector(bitmask))
     }
 
-    /// Find the index of the first set element.
+    /// Finds the index of the first set element.
     ///
     /// ```
     /// # #![feature(portable_simd)]

--- a/library/portable-simd/crates/core_simd/src/simd/ptr/const_ptr.rs
+++ b/library/portable-simd/crates/core_simd/src/simd/ptr/const_ptr.rs
@@ -54,7 +54,7 @@ pub trait SimdConstPtr: Copy + Sealed {
     /// [`Self::with_exposed_provenance`] and returns the "address" portion.
     fn expose_provenance(self) -> Self::Usize;
 
-    /// Convert an address back to a pointer, picking up a previously "exposed" provenance.
+    /// Converts an address back to a pointer, picking up a previously "exposed" provenance.
     ///
     /// Equivalent to calling [`core::ptr::with_exposed_provenance`] on each element.
     fn with_exposed_provenance(addr: Self::Usize) -> Self;

--- a/library/portable-simd/crates/core_simd/src/simd/ptr/mut_ptr.rs
+++ b/library/portable-simd/crates/core_simd/src/simd/ptr/mut_ptr.rs
@@ -51,7 +51,7 @@ pub trait SimdMutPtr: Copy + Sealed {
     /// [`Self::with_exposed_provenance`] and returns the "address" portion.
     fn expose_provenance(self) -> Self::Usize;
 
-    /// Convert an address back to a pointer, picking up a previously "exposed" provenance.
+    /// Converts an address back to a pointer, picking up a previously "exposed" provenance.
     ///
     /// Equivalent to calling [`core::ptr::with_exposed_provenance_mut`] on each element.
     fn with_exposed_provenance(addr: Self::Usize) -> Self;

--- a/library/portable-simd/crates/core_simd/src/swizzle.rs
+++ b/library/portable-simd/crates/core_simd/src/swizzle.rs
@@ -69,12 +69,12 @@ pub macro simd_swizzle {
     }
 }
 
-/// Create a vector from the elements of another vector.
+/// Creates a vector from the elements of another vector.
 pub trait Swizzle<const N: usize> {
     /// Map from the elements of the input vector to the output vector.
     const INDEX: [usize; N];
 
-    /// Create a new vector from the elements of `vector`.
+    /// Creates a new vector from the elements of `vector`.
     ///
     /// Lane `i` of the output is `vector[Self::INDEX[i]]`.
     #[inline]
@@ -109,7 +109,7 @@ pub trait Swizzle<const N: usize> {
         }
     }
 
-    /// Create a new vector from the elements of `first` and `second`.
+    /// Creates a new vector from the elements of `first` and `second`.
     ///
     /// Lane `i` of the output is `concat[Self::INDEX[i]]`, where `concat` is the concatenation of
     /// `first` and `second`.
@@ -145,7 +145,7 @@ pub trait Swizzle<const N: usize> {
         }
     }
 
-    /// Create a new mask from the elements of `mask`.
+    /// Creates a new mask from the elements of `mask`.
     ///
     /// Element `i` of the output is `concat[Self::INDEX[i]]`, where `concat` is the concatenation of
     /// `first` and `second`.
@@ -161,7 +161,7 @@ pub trait Swizzle<const N: usize> {
         unsafe { Mask::from_int_unchecked(Self::swizzle(mask.to_int())) }
     }
 
-    /// Create a new mask from the elements of `first` and `second`.
+    /// Creates a new mask from the elements of `first` and `second`.
     ///
     /// Element `i` of the output is `concat[Self::INDEX[i]]`, where `concat` is the concatenation of
     /// `first` and `second`.

--- a/library/portable-simd/crates/core_simd/src/to_bytes.rs
+++ b/library/portable-simd/crates/core_simd/src/to_bytes.rs
@@ -10,7 +10,7 @@ mod sealed {
 }
 use sealed::Sealed;
 
-/// Convert SIMD vectors to vectors of bytes
+/// Converts SIMD vectors to vectors of bytes
 pub trait ToBytes: Sealed {
     /// This type, reinterpreted as bytes.
     type Bytes: Copy
@@ -22,26 +22,26 @@ pub trait ToBytes: Sealed {
         + SimdUint<Scalar = u8>
         + 'static;
 
-    /// Return the memory representation of this integer as a byte array in native byte
+    /// Returns the memory representation of this integer as a byte array in native byte
     /// order.
     fn to_ne_bytes(self) -> Self::Bytes;
 
-    /// Return the memory representation of this integer as a byte array in big-endian
+    /// Returns the memory representation of this integer as a byte array in big-endian
     /// (network) byte order.
     fn to_be_bytes(self) -> Self::Bytes;
 
-    /// Return the memory representation of this integer as a byte array in little-endian
+    /// Returns the memory representation of this integer as a byte array in little-endian
     /// byte order.
     fn to_le_bytes(self) -> Self::Bytes;
 
-    /// Create a native endian integer value from its memory representation as a byte array
+    /// Creates a native endian integer value from its memory representation as a byte array
     /// in native endianness.
     fn from_ne_bytes(bytes: Self::Bytes) -> Self;
 
-    /// Create an integer value from its representation as a byte array in big endian.
+    /// Creates an integer value from its representation as a byte array in big endian.
     fn from_be_bytes(bytes: Self::Bytes) -> Self;
 
-    /// Create an integer value from its representation as a byte array in little endian.
+    /// Creates an integer value from its representation as a byte array in little endian.
     fn from_le_bytes(bytes: Self::Bytes) -> Self;
 }
 

--- a/library/portable-simd/crates/core_simd/src/vector.rs
+++ b/library/portable-simd/crates/core_simd/src/vector.rs
@@ -187,7 +187,7 @@ where
         unsafe { &mut *(self as *mut Self as *mut [T; N]) }
     }
 
-    /// Load a vector from an array of `T`.
+    /// Loads a vector from an array of `T`.
     ///
     /// This function is necessary since `repr(simd)` has padding for non-power-of-2 vectors (at the time of writing).
     /// With padding, `read_unaligned` will read past the end of an array of N elements.
@@ -567,7 +567,7 @@ where
         unsafe { Self::gather_select_ptr(ptrs, enable, or) }
     }
 
-    /// Read elementwise from pointers into a SIMD vector.
+    /// Reads elementwise from pointers into a SIMD vector.
     ///
     /// # Safety
     ///
@@ -808,7 +808,7 @@ where
         }
     }
 
-    /// Write pointers elementwise into a SIMD vector.
+    /// Writes pointers elementwise into a SIMD vector.
     ///
     /// # Safety
     ///

--- a/library/proc_macro/src/bridge/server.rs
+++ b/library/proc_macro/src/bridge/server.rs
@@ -350,7 +350,7 @@ where
 
 /// A message pipe used for communicating between server and client threads.
 pub trait MessagePipe<T>: Sized {
-    /// Create a new pair of endpoints for the message pipe.
+    /// Creates a new pair of endpoints for the message pipe.
     fn new() -> (Self, Self);
 
     /// Send a message to the other endpoint of this pipe.

--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -28,7 +28,7 @@ impl Symbol {
         INTERNER.with_borrow_mut(|i| i.intern(string))
     }
 
-    /// Create a new `Symbol` for an identifier.
+    /// Creates a new `Symbol` for an identifier.
     ///
     /// Validates and normalizes before converting it to a symbol.
     pub(crate) fn new_ident(string: &str, is_raw: bool) -> Self {
@@ -63,7 +63,7 @@ impl Symbol {
         INTERNER.with_borrow_mut(|i| i.clear());
     }
 
-    /// Check if the ident is a valid ASCII identifier.
+    /// Checks if the ident is a valid ASCII identifier.
     ///
     /// This is a short-circuit which is cheap to implement within the
     /// proc-macro client to avoid RPC when creating simple idents, but may
@@ -177,7 +177,7 @@ impl Interner {
         name
     }
 
-    /// Read a symbol's value from the store while it is held.
+    /// Reads a symbol's value from the store while it is held.
     fn get(&self, symbol: Symbol) -> &str {
         // NOTE: Subtract out the offset which was added to make the symbol
         // nonzero and prevent symbol name re-use.

--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -271,7 +271,7 @@ impl Backtrace {
         enabled
     }
 
-    /// Capture a stack backtrace of the current thread.
+    /// Captures a stack backtrace of the current thread.
     ///
     /// This function will capture a stack backtrace of the current OS thread of
     /// execution, returning a `Backtrace` type which can be later used to print

--- a/library/std/src/error.rs
+++ b/library/std/src/error.rs
@@ -234,7 +234,7 @@ impl<E> Report<E>
 where
     Report<E>: From<E>,
 {
-    /// Create a new `Report` from an input error.
+    /// Creates a new `Report` from an input error.
     #[unstable(feature = "error_reporter", issue = "90172")]
     pub fn new(error: E) -> Report<E> {
         Self::from(error)

--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -50,7 +50,7 @@ use crate::time::SystemTime;
 /// }
 /// ```
 ///
-/// Read the contents of a file into a [`String`] (you can also use [`read`]):
+/// Reads the contents of a file into a [`String`] (you can also use [`read`]):
 ///
 /// ```no_run
 /// use std::fs::File;
@@ -229,7 +229,7 @@ pub struct DirBuilder {
     recursive: bool,
 }
 
-/// Read the entire contents of a file into a bytes vector.
+/// Reads the entire contents of a file into a bytes vector.
 ///
 /// This is a convenience function for using [`File::open`] and [`read_to_end`]
 /// with fewer imports and without an intermediate variable.
@@ -268,7 +268,7 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
     inner(path.as_ref())
 }
 
-/// Read the entire contents of a file into a string.
+/// Reads the entire contents of a file into a string.
 ///
 /// This is a convenience function for using [`File::open`] and [`read_to_string`]
 /// with fewer imports and without an intermediate variable.
@@ -311,7 +311,7 @@ pub fn read_to_string<P: AsRef<Path>>(path: P) -> io::Result<String> {
     inner(path.as_ref())
 }
 
-/// Write a slice as the entire contents of a file.
+/// Writes a slice as the entire contents of a file.
 ///
 /// This function will create a file if it does not exist,
 /// and will entirely replace its contents if it does.
@@ -767,7 +767,7 @@ fn buffer_capacity_required(mut file: &File) -> Option<usize> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Read for &File {
-    /// Read some bytes from the file.
+    /// Reads some bytes from the file.
     ///
     /// See [`Read::read`] docs for more info.
     ///
@@ -835,7 +835,7 @@ impl Read for &File {
 }
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Write for &File {
-    /// Write some bytes from the file.
+    /// Writes some bytes from the file.
     ///
     /// See [`Write::write`] docs for more info.
     ///
@@ -1526,7 +1526,7 @@ impl FromInner<fs_imp::FileAttr> for Metadata {
 }
 
 impl FileTimes {
-    /// Create a new `FileTimes` with no times set.
+    /// Creates a new `FileTimes` with no times set.
     ///
     /// Using the resulting `FileTimes` in [`File::set_times`] will not modify any timestamps.
     #[stable(feature = "file_set_times", since = "1.75.0")]
@@ -2005,7 +2005,7 @@ pub fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
     fs_imp::unlink(path.as_ref())
 }
 
-/// Given a path, query the file system to get information about a file,
+/// Given a path, queries the file system to get information about a file,
 /// directory, etc.
 ///
 /// This function will traverse symbolic links to query information about the
@@ -2044,7 +2044,7 @@ pub fn metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
     fs_imp::stat(path.as_ref()).map(Metadata)
 }
 
-/// Query the metadata about a file without following symlinks.
+/// Queries the metadata about a file without following symlinks.
 ///
 /// # Platform-specific behavior
 ///
@@ -2079,7 +2079,7 @@ pub fn symlink_metadata<P: AsRef<Path>>(path: P) -> io::Result<Metadata> {
     fs_imp::lstat(path.as_ref()).map(Metadata)
 }
 
-/// Rename a file or directory to a new name, replacing the original file if
+/// Renames a file or directory to a new name, replacing the original file if
 /// `to` already exists.
 ///
 /// This will not work if the new name is on a different mount point.

--- a/library/std/src/io/buffered/linewritershim.rs
+++ b/library/std/src/io/buffered/linewritershim.rs
@@ -2,6 +2,7 @@ use crate::io::{self, BufWriter, IoSlice, Write};
 use core::slice::memchr;
 
 /// Private helper struct for implementing the line-buffered writing logic.
+///
 /// This shim temporarily wraps a BufWriter, and uses its internals to
 /// implement a line-buffered writer (specifically by using the internal
 /// methods like write_to_buf and flush_buf). In this way, a more
@@ -20,27 +21,27 @@ impl<'a, W: ?Sized + Write> LineWriterShim<'a, W> {
         Self { buffer }
     }
 
-    /// Get a reference to the inner writer (that is, the writer
+    /// Gets a reference to the inner writer (that is, the writer
     /// wrapped by the BufWriter).
     fn inner(&self) -> &W {
         self.buffer.get_ref()
     }
 
-    /// Get a mutable reference to the inner writer (that is, the writer
+    /// Gets a mutable reference to the inner writer (that is, the writer
     /// wrapped by the BufWriter). Be careful with this writer, as writes to
     /// it will bypass the buffer.
     fn inner_mut(&mut self) -> &mut W {
         self.buffer.get_mut()
     }
 
-    /// Get the content currently buffered in self.buffer
+    /// Gets the content currently buffered in self.buffer
     fn buffered(&self) -> &[u8] {
         self.buffer.buffer()
     }
 
-    /// Flush the buffer iff the last byte is a newline (indicating that an
+    /// Flushes the buffer iff the last byte is a newline (indicating that an
     /// earlier write only succeeded partially, and we want to retry flushing
-    /// the buffered line before continuing with a subsequent write)
+    /// the buffered line before continuing with a subsequent write).
     fn flush_if_completed_line(&mut self) -> io::Result<()> {
         match self.buffered().last().copied() {
             Some(b'\n') => self.buffer.flush_buf(),
@@ -50,10 +51,11 @@ impl<'a, W: ?Sized + Write> LineWriterShim<'a, W> {
 }
 
 impl<'a, W: ?Sized + Write> Write for LineWriterShim<'a, W> {
-    /// Write some data into this BufReader with line buffering. This means
-    /// that, if any newlines are present in the data, the data up to the last
-    /// newline is sent directly to the underlying writer, and data after it
-    /// is buffered. Returns the number of bytes written.
+    /// Writes some data into this BufReader with line buffering.
+    ///
+    /// This means that, if any newlines are present in the data, the data up to
+    /// the last newline is sent directly to the underlying writer, and data
+    /// after it is buffered. Returns the number of bytes written.
     ///
     /// This function operates on a "best effort basis"; in keeping with the
     /// convention of `Write::write`, it makes at most one attempt to write
@@ -136,11 +138,12 @@ impl<'a, W: ?Sized + Write> Write for LineWriterShim<'a, W> {
         self.buffer.flush()
     }
 
-    /// Write some vectored data into this BufReader with line buffering. This
-    /// means that, if any newlines are present in the data, the data up to
-    /// and including the buffer containing the last newline is sent directly
-    /// to the inner writer, and the data after it is buffered. Returns the
-    /// number of bytes written.
+    /// Writes some vectored data into this BufReader with line buffering.
+    ///
+    /// This means that, if any newlines are present in the data, the data up to
+    /// and including the buffer containing the last newline is sent directly to
+    /// the inner writer, and the data after it is buffered. Returns the number
+    /// of bytes written.
     ///
     /// This function operates on a "best effort basis"; in keeping with the
     /// convention of `Write::write`, it makes at most one attempt to write
@@ -245,10 +248,11 @@ impl<'a, W: ?Sized + Write> Write for LineWriterShim<'a, W> {
         self.inner().is_write_vectored()
     }
 
-    /// Write some data into this BufReader with line buffering. This means
-    /// that, if any newlines are present in the data, the data up to the last
-    /// newline is sent directly to the underlying writer, and data after it
-    /// is buffered.
+    /// Writes some data into this BufReader with line buffering.
+    ///
+    /// This means that, if any newlines are present in the data, the data up to
+    /// the last newline is sent directly to the underlying writer, and data
+    /// after it is buffered.
     ///
     /// Because this function attempts to send completed lines to the underlying
     /// writer, it will also flush the existing buffer if it contains any

--- a/library/std/src/io/buffered/mod.rs
+++ b/library/std/src/io/buffered/mod.rs
@@ -48,7 +48,7 @@ pub use bufwriter::WriterPanicked;
 pub struct IntoInnerError<W>(W, Error);
 
 impl<W> IntoInnerError<W> {
-    /// Construct a new IntoInnerError
+    /// Constructs a new IntoInnerError
     fn new(writer: W, error: Error) -> Self {
         Self(writer, error)
     }

--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -167,7 +167,7 @@ impl SimpleMessage {
     }
 }
 
-/// Create and return an `io::Error` for a given `ErrorKind` and constant
+/// Creates and returns an `io::Error` for a given `ErrorKind` and constant
 /// message. This doesn't allocate.
 pub(crate) macro const_io_error($kind:expr, $message:expr $(,)?) {
     $crate::io::error::Error::from_static_message({
@@ -852,7 +852,7 @@ impl Error {
         }
     }
 
-    /// Attempt to downcast the custom boxed error to `E`.
+    /// Attempts to downcast the custom boxed error to `E`.
     ///
     /// If this [`Error`] contains a custom boxed error,
     /// then it would attempt downcasting on the boxed error,

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -782,7 +782,7 @@ pub trait Read {
         false
     }
 
-    /// Read all bytes until EOF in this source, placing them into `buf`.
+    /// Reads all bytes until EOF in this source, placing them into `buf`.
     ///
     /// All bytes read from this source will be appended to the specified buffer
     /// `buf`. This function will continuously call [`read()`] to append more data to
@@ -866,7 +866,7 @@ pub trait Read {
         default_read_to_end(self, buf, None)
     }
 
-    /// Read all bytes until EOF in this source, appending them to `buf`.
+    /// Reads all bytes until EOF in this source, appending them to `buf`.
     ///
     /// If successful, this function returns the number of bytes which were read
     /// and appended to `buf`.
@@ -909,7 +909,7 @@ pub trait Read {
         default_read_to_string(self, buf, None)
     }
 
-    /// Read the exact number of bytes required to fill `buf`.
+    /// Reads the exact number of bytes required to fill `buf`.
     ///
     /// This function reads as many bytes as necessary to completely fill the
     /// specified buffer `buf`.
@@ -973,7 +973,7 @@ pub trait Read {
         default_read_buf(|b| self.read(b), buf)
     }
 
-    /// Read the exact number of bytes required to fill `cursor`.
+    /// Reads the exact number of bytes required to fill `cursor`.
     ///
     /// This is similar to the [`read_exact`](Read::read_exact) method, except
     /// that it is passed a [`BorrowedCursor`] rather than `[u8]` to allow use
@@ -1159,7 +1159,7 @@ pub trait Read {
     }
 }
 
-/// Read all bytes from a [reader][Read] into a new [`String`].
+/// Reads all bytes from a [reader][Read] into a new [`String`].
 ///
 /// This is a convenience function for [`Read::read_to_string`]. Using this
 /// function avoids having to create a variable first and provides more type
@@ -1212,7 +1212,7 @@ pub fn read_to_string<R: Read>(mut reader: R) -> Result<String> {
 
 /// A buffer type used with `Read::read_vectored`.
 ///
-/// It is semantically a wrapper around an `&mut [u8]`, but is guaranteed to be
+/// It is semantically a wrapper around a `&mut [u8]`, but is guaranteed to be
 /// ABI compatible with the `iovec` type on Unix platforms and `WSABUF` on
 /// Windows.
 #[stable(feature = "iovec", since = "1.36.0")]
@@ -1531,7 +1531,7 @@ impl<'a> Deref for IoSlice<'a> {
 #[doc(notable_trait)]
 #[cfg_attr(not(test), rustc_diagnostic_item = "IoWrite")]
 pub trait Write {
-    /// Write a buffer into this writer, returning how many bytes were written.
+    /// Writes a buffer into this writer, returning how many bytes were written.
     ///
     /// This function will attempt to write the entire contents of `buf`, but
     /// the entire write might not succeed, or the write may also generate an
@@ -1630,7 +1630,7 @@ pub trait Write {
         false
     }
 
-    /// Flush this output stream, ensuring that all intermediately buffered
+    /// Flushes this output stream, ensuring that all intermediately buffered
     /// contents reach their destination.
     ///
     /// # Errors
@@ -2247,7 +2247,7 @@ pub trait BufRead: Read {
     #[stable(feature = "rust1", since = "1.0.0")]
     fn consume(&mut self, amt: usize);
 
-    /// Check if the underlying `Read` has any data left to be read.
+    /// Checks if the underlying `Read` has any data left to be read.
     ///
     /// This function may fill the buffer to check for data,
     /// so this functions returns `Result<bool>`, not `bool`.
@@ -2278,7 +2278,7 @@ pub trait BufRead: Read {
         self.fill_buf().map(|b| !b.is_empty())
     }
 
-    /// Read all bytes into `buf` until the delimiter `byte` or EOF is reached.
+    /// Reads all bytes into `buf` until the delimiter `byte` or EOF is reached.
     ///
     /// This function will read bytes from the underlying stream until the
     /// delimiter or EOF is found. Once found, all bytes up to, and including,
@@ -2337,7 +2337,7 @@ pub trait BufRead: Read {
         read_until(self, byte, buf)
     }
 
-    /// Skip all bytes until the delimiter `byte` or EOF is reached.
+    /// Skips all bytes until the delimiter `byte` or EOF is reached.
     ///
     /// This function will read (and discard) bytes from the underlying stream until the
     /// delimiter or EOF is found.
@@ -2399,7 +2399,7 @@ pub trait BufRead: Read {
         skip_until(self, byte)
     }
 
-    /// Read all bytes until a newline (the `0xA` byte) is reached, and append
+    /// Reads all bytes until a newline (the `0xA` byte) is reached, and append
     /// them to the provided `String` buffer.
     ///
     /// Previous content of the buffer will be preserved. To avoid appending to
@@ -3038,7 +3038,7 @@ where
     }
 }
 
-/// Read a single byte in a slow, generic way. This is used by the default
+/// Reads a single byte in a slow, generic way. This is used by the default
 /// `spec_read_byte`.
 #[inline]
 fn inlined_slow_read_byte<R: Read>(reader: &mut R) -> Option<Result<u8>> {

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -1092,7 +1092,7 @@ pub fn try_set_output_capture(
     OUTPUT_CAPTURE.try_with(move |slot| slot.replace(sink))
 }
 
-/// Write `args` to the capture buffer if enabled and possible, or `global_s`
+/// Writes `args` to the capture buffer if enabled and possible, or `global_s`
 /// otherwise. `label` identifies the stream in a panic message.
 ///
 /// This function is used to print error messages, so it takes extra

--- a/library/std/src/io/tests.rs
+++ b/library/std/src/io/tests.rs
@@ -530,7 +530,7 @@ fn io_slice_advance_slices_beyond_total_length() {
     assert!(bufs.is_empty());
 }
 
-/// Create a new writer that reads from at most `n_bufs` and reads
+/// Creates a new writer that reads from at most `n_bufs` and reads
 /// `per_call` bytes (in total) per call to write.
 fn test_writer(n_bufs: usize, per_call: usize) -> TestWriter {
     TestWriter { n_bufs, per_call, written: Vec::new() }

--- a/library/std/src/keyword_docs.rs
+++ b/library/std/src/keyword_docs.rs
@@ -1175,7 +1175,7 @@ mod ref_keyword {}
 
 #[doc(keyword = "return")]
 //
-/// Return a value from a function.
+/// Returns a value from a function.
 ///
 /// A `return` marks the end of an execution path in a function:
 ///
@@ -2310,7 +2310,7 @@ mod where_keyword {}
 #[doc(alias = "promise")]
 #[doc(keyword = "async")]
 //
-/// Return a [`Future`] instead of blocking the current thread.
+/// Returns a [`Future`] instead of blocking the current thread.
 ///
 /// Use `async` in front of `fn`, `closure`, or a `block` to turn the marked code into a `Future`.
 /// As such the code will not be run immediately, but will only be evaluated when the returned

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -407,7 +407,6 @@
 #![feature(const_ip)]
 #![feature(const_ipv4)]
 #![feature(const_ipv6)]
-#![feature(const_waker)]
 #![feature(thread_local_internals)]
 // tidy-alphabetical-end
 //

--- a/library/std/src/os/fd/owned.rs
+++ b/library/std/src/os/fd/owned.rs
@@ -70,7 +70,7 @@ pub struct OwnedFd {
 }
 
 impl BorrowedFd<'_> {
-    /// Return a `BorrowedFd` holding the given raw file descriptor.
+    /// Returns a `BorrowedFd` holding the given raw file descriptor.
     ///
     /// # Safety
     ///

--- a/library/std/src/os/freebsd/net.rs
+++ b/library/std/src/os/freebsd/net.rs
@@ -42,7 +42,7 @@ pub trait UnixSocketExt: Sealed {
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     fn set_local_creds_persistent(&self, local_creds_persistent: bool) -> io::Result<()>;
 
-    /// Get a filter name if one had been set previously on the socket.
+    /// Gets a filter name if one had been set previously on the socket.
     #[unstable(feature = "acceptfilter", issue = "121891")]
     fn acceptfilter(&self) -> io::Result<&CStr>;
 

--- a/library/std/src/os/netbsd/net.rs
+++ b/library/std/src/os/netbsd/net.rs
@@ -42,7 +42,7 @@ pub trait UnixSocketExt: Sealed {
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     fn set_local_creds(&self, local_creds: bool) -> io::Result<()>;
 
-    /// Get a filter name if one had been set previously on the socket.
+    /// Gets a filter name if one had been set previously on the socket.
     #[unstable(feature = "acceptfilter", issue = "121891")]
     fn acceptfilter(&self) -> io::Result<&CStr>;
 

--- a/library/std/src/os/solid/io.rs
+++ b/library/std/src/os/solid/io.rs
@@ -98,7 +98,7 @@ pub struct OwnedFd {
 }
 
 impl BorrowedFd<'_> {
-    /// Return a `BorrowedFd` holding the given raw file descriptor.
+    /// Returns a `BorrowedFd` holding the given raw file descriptor.
     ///
     /// # Safety
     ///

--- a/library/std/src/os/uefi/env.rs
+++ b/library/std/src/os/uefi/env.rs
@@ -26,7 +26,7 @@ static BOOT_SERVICES_FLAG: AtomicBool = AtomicBool::new(false);
 /// standard library is loaded.
 ///
 /// # SAFETY
-/// Calling this function more than once will panic
+/// Calling this function more than once will panic.
 pub(crate) unsafe fn init_globals(handle: NonNull<c_void>, system_table: NonNull<c_void>) {
     IMAGE_HANDLE
         .compare_exchange(
@@ -47,23 +47,25 @@ pub(crate) unsafe fn init_globals(handle: NonNull<c_void>, system_table: NonNull
     BOOT_SERVICES_FLAG.store(true, Ordering::Release)
 }
 
-/// Get the SystemTable Pointer.
+/// Gets the SystemTable Pointer.
+///
 /// If you want to use `BootServices` then please use [`boot_services`] as it performs some
 /// additional checks.
 ///
-/// Note: This function panics if the System Table or Image Handle is not initialized
+/// Note: This function panics if the System Table or Image Handle is not initialized.
 pub fn system_table() -> NonNull<c_void> {
     try_system_table().unwrap()
 }
 
-/// Get the ImageHandle Pointer.
+/// Gets the ImageHandle Pointer.
 ///
-/// Note: This function panics if the System Table or Image Handle is not initialized
+/// Note: This function panics if the System Table or Image Handle is not initialized.
 pub fn image_handle() -> NonNull<c_void> {
     try_image_handle().unwrap()
 }
 
-/// Get the BootServices Pointer.
+/// Gets the BootServices Pointer.
+///
 /// This function also checks if `ExitBootServices` has already been called.
 pub fn boot_services() -> Option<NonNull<c_void>> {
     if BOOT_SERVICES_FLAG.load(Ordering::Acquire) {
@@ -75,14 +77,16 @@ pub fn boot_services() -> Option<NonNull<c_void>> {
     }
 }
 
-/// Get the SystemTable Pointer.
-/// This function is mostly intended for places where panic is not an option
+/// Gets the SystemTable Pointer.
+///
+/// This function is mostly intended for places where panic is not an option.
 pub(crate) fn try_system_table() -> Option<NonNull<c_void>> {
     NonNull::new(SYSTEM_TABLE.load(Ordering::Acquire))
 }
 
-/// Get the SystemHandle Pointer.
-/// This function is mostly intended for places where panicking is not an option
+/// Gets the SystemHandle Pointer.
+///
+/// This function is mostly intended for places where panicking is not an option.
 pub(crate) fn try_image_handle() -> Option<NonNull<c_void>> {
     NonNull::new(IMAGE_HANDLE.load(Ordering::Acquire))
 }

--- a/library/std/src/os/unix/net/ancillary.rs
+++ b/library/std/src/os/unix/net/ancillary.rs
@@ -164,7 +164,7 @@ struct AncillaryDataIter<'a, T> {
 }
 
 impl<'a, T> AncillaryDataIter<'a, T> {
-    /// Create `AncillaryDataIter` struct to iterate through the data unit in the control message.
+    /// Creates `AncillaryDataIter` struct to iterate through the data unit in the control message.
     ///
     /// # Safety
     ///
@@ -220,7 +220,7 @@ pub struct SocketCred(libc::sockcred2);
 #[doc(cfg(any(target_os = "android", target_os = "linux")))]
 #[cfg(any(target_os = "android", target_os = "linux"))]
 impl SocketCred {
-    /// Create a Unix credential struct.
+    /// Creates a Unix credential struct.
     ///
     /// PID, UID and GID is set to 0.
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
@@ -235,7 +235,7 @@ impl SocketCred {
         self.0.pid = pid;
     }
 
-    /// Get the current PID.
+    /// Gets the current PID.
     #[must_use]
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn get_pid(&self) -> libc::pid_t {
@@ -248,7 +248,7 @@ impl SocketCred {
         self.0.uid = uid;
     }
 
-    /// Get the current UID.
+    /// Gets the current UID.
     #[must_use]
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn get_uid(&self) -> libc::uid_t {
@@ -261,7 +261,7 @@ impl SocketCred {
         self.0.gid = gid;
     }
 
-    /// Get the current GID.
+    /// Gets the current GID.
     #[must_use]
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn get_gid(&self) -> libc::gid_t {
@@ -271,7 +271,7 @@ impl SocketCred {
 
 #[cfg(target_os = "freebsd")]
 impl SocketCred {
-    /// Create a Unix credential struct.
+    /// Creates a Unix credential struct.
     ///
     /// PID, UID and GID is set to 0.
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
@@ -295,7 +295,7 @@ impl SocketCred {
         self.0.sc_pid = pid;
     }
 
-    /// Get the current PID.
+    /// Gets the current PID.
     #[must_use]
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn get_pid(&self) -> libc::pid_t {
@@ -308,7 +308,7 @@ impl SocketCred {
         self.0.sc_euid = uid;
     }
 
-    /// Get the current UID.
+    /// Gets the current UID.
     #[must_use]
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn get_uid(&self) -> libc::uid_t {
@@ -321,7 +321,7 @@ impl SocketCred {
         self.0.sc_egid = gid;
     }
 
-    /// Get the current GID.
+    /// Gets the current GID.
     #[must_use]
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn get_gid(&self) -> libc::gid_t {
@@ -331,7 +331,7 @@ impl SocketCred {
 
 #[cfg(target_os = "netbsd")]
 impl SocketCred {
-    /// Create a Unix credential struct.
+    /// Creates a Unix credential struct.
     ///
     /// PID, UID and GID is set to 0.
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
@@ -353,7 +353,7 @@ impl SocketCred {
         self.0.sc_pid = pid;
     }
 
-    /// Get the current PID.
+    /// Gets the current PID.
     #[must_use]
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn get_pid(&self) -> libc::pid_t {
@@ -366,7 +366,7 @@ impl SocketCred {
         self.0.sc_uid = uid;
     }
 
-    /// Get the current UID.
+    /// Gets the current UID.
     #[must_use]
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn get_uid(&self) -> libc::uid_t {
@@ -379,7 +379,7 @@ impl SocketCred {
         self.0.sc_gid = gid;
     }
 
-    /// Get the current GID.
+    /// Gets the current GID.
     #[must_use]
     #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
     pub fn get_gid(&self) -> libc::gid_t {
@@ -466,7 +466,7 @@ pub enum AncillaryData<'a> {
 }
 
 impl<'a> AncillaryData<'a> {
-    /// Create an `AncillaryData::ScmRights` variant.
+    /// Creates an `AncillaryData::ScmRights` variant.
     ///
     /// # Safety
     ///
@@ -478,7 +478,7 @@ impl<'a> AncillaryData<'a> {
         AncillaryData::ScmRights(scm_rights)
     }
 
-    /// Create an `AncillaryData::ScmCredentials` variant.
+    /// Creates an `AncillaryData::ScmCredentials` variant.
     ///
     /// # Safety
     ///
@@ -605,7 +605,7 @@ pub struct SocketAncillary<'a> {
 }
 
 impl<'a> SocketAncillary<'a> {
-    /// Create an ancillary data with the given buffer.
+    /// Creates an ancillary data with the given buffer.
     ///
     /// # Example
     ///

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -444,7 +444,7 @@ impl From<crate::process::ChildStdin> for OwnedFd {
     }
 }
 
-/// Create a `ChildStdin` from the provided `OwnedFd`.
+/// Creates a `ChildStdin` from the provided `OwnedFd`.
 ///
 /// The provided file descriptor must point to a pipe
 /// with the `CLOEXEC` flag set.
@@ -475,7 +475,7 @@ impl From<crate::process::ChildStdout> for OwnedFd {
     }
 }
 
-/// Create a `ChildStdout` from the provided `OwnedFd`.
+/// Creates a `ChildStdout` from the provided `OwnedFd`.
 ///
 /// The provided file descriptor must point to a pipe
 /// with the `CLOEXEC` flag set.
@@ -506,7 +506,7 @@ impl From<crate::process::ChildStderr> for OwnedFd {
     }
 }
 
-/// Create a `ChildStderr` from the provided `OwnedFd`.
+/// Creates a `ChildStderr` from the provided `OwnedFd`.
 ///
 /// The provided file descriptor must point to a pipe
 /// with the `CLOEXEC` flag set.

--- a/library/std/src/os/wasi/fs.rs
+++ b/library/std/src/os/wasi/fs.rs
@@ -169,55 +169,55 @@ pub trait FileExt {
     #[doc(alias = "fd_tell")]
     fn tell(&self) -> io::Result<u64>;
 
-    /// Adjust the flags associated with this file.
+    /// Adjusts the flags associated with this file.
     ///
     /// This corresponds to the `fd_fdstat_set_flags` syscall.
     #[doc(alias = "fd_fdstat_set_flags")]
     fn fdstat_set_flags(&self, flags: u16) -> io::Result<()>;
 
-    /// Adjust the rights associated with this file.
+    /// Adjusts the rights associated with this file.
     ///
     /// This corresponds to the `fd_fdstat_set_rights` syscall.
     #[doc(alias = "fd_fdstat_set_rights")]
     fn fdstat_set_rights(&self, rights: u64, inheriting: u64) -> io::Result<()>;
 
-    /// Provide file advisory information on a file descriptor.
+    /// Provides file advisory information on a file descriptor.
     ///
     /// This corresponds to the `fd_advise` syscall.
     #[doc(alias = "fd_advise")]
     fn advise(&self, offset: u64, len: u64, advice: u8) -> io::Result<()>;
 
-    /// Force the allocation of space in a file.
+    /// Forces the allocation of space in a file.
     ///
     /// This corresponds to the `fd_allocate` syscall.
     #[doc(alias = "fd_allocate")]
     fn allocate(&self, offset: u64, len: u64) -> io::Result<()>;
 
-    /// Create a directory.
+    /// Creates a directory.
     ///
     /// This corresponds to the `path_create_directory` syscall.
     #[doc(alias = "path_create_directory")]
     fn create_directory<P: AsRef<Path>>(&self, dir: P) -> io::Result<()>;
 
-    /// Read the contents of a symbolic link.
+    /// Reads the contents of a symbolic link.
     ///
     /// This corresponds to the `path_readlink` syscall.
     #[doc(alias = "path_readlink")]
     fn read_link<P: AsRef<Path>>(&self, path: P) -> io::Result<PathBuf>;
 
-    /// Return the attributes of a file or directory.
+    /// Returns the attributes of a file or directory.
     ///
     /// This corresponds to the `path_filestat_get` syscall.
     #[doc(alias = "path_filestat_get")]
     fn metadata_at<P: AsRef<Path>>(&self, lookup_flags: u32, path: P) -> io::Result<Metadata>;
 
-    /// Unlink a file.
+    /// Unlinks a file.
     ///
     /// This corresponds to the `path_unlink_file` syscall.
     #[doc(alias = "path_unlink_file")]
     fn remove_file<P: AsRef<Path>>(&self, path: P) -> io::Result<()>;
 
-    /// Remove a directory.
+    /// Removes a directory.
     ///
     /// This corresponds to the `path_remove_directory` syscall.
     #[doc(alias = "path_remove_directory")]
@@ -501,7 +501,7 @@ impl DirEntryExt for fs::DirEntry {
     }
 }
 
-/// Create a hard link.
+/// Creates a hard link.
 ///
 /// This corresponds to the `path_link` syscall.
 #[doc(alias = "path_link")]
@@ -520,7 +520,7 @@ pub fn link<P: AsRef<Path>, U: AsRef<Path>>(
     )
 }
 
-/// Rename a file or directory.
+/// Renames a file or directory.
 ///
 /// This corresponds to the `path_rename` syscall.
 #[doc(alias = "path_rename")]
@@ -537,7 +537,7 @@ pub fn rename<P: AsRef<Path>, U: AsRef<Path>>(
     )
 }
 
-/// Create a symbolic link.
+/// Creates a symbolic link.
 ///
 /// This corresponds to the `path_symlink` syscall.
 #[doc(alias = "path_symlink")]
@@ -551,7 +551,7 @@ pub fn symlink<P: AsRef<Path>, U: AsRef<Path>>(
         .symlink(osstr2str(old_path.as_ref().as_ref())?, osstr2str(new_path.as_ref().as_ref())?)
 }
 
-/// Create a symbolic link.
+/// Creates a symbolic link.
 ///
 /// This is a convenience API similar to `std::os::unix::fs::symlink` and
 /// `std::os::windows::fs::symlink_file` and `std::os::windows::fs::symlink_dir`.

--- a/library/std/src/os/windows/fs.rs
+++ b/library/std/src/os/windows/fs.rs
@@ -631,7 +631,7 @@ pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::
     sys::fs::symlink_inner(original.as_ref(), link.as_ref(), true)
 }
 
-/// Create a junction point.
+/// Creates a junction point.
 ///
 /// The `link` path will be a directory junction pointing to the original path.
 /// If `link` is a relative path then it will be made absolute prior to creating the junction point.

--- a/library/std/src/os/windows/io/handle.rs
+++ b/library/std/src/os/windows/io/handle.rs
@@ -135,7 +135,7 @@ unsafe impl Sync for HandleOrInvalid {}
 unsafe impl Sync for BorrowedHandle<'_> {}
 
 impl BorrowedHandle<'_> {
-    /// Return a `BorrowedHandle` holding the given raw handle.
+    /// Returns a `BorrowedHandle` holding the given raw handle.
     ///
     /// # Safety
     ///

--- a/library/std/src/os/windows/io/raw.rs
+++ b/library/std/src/os/windows/io/raw.rs
@@ -44,7 +44,7 @@ pub trait AsRawHandle {
     fn as_raw_handle(&self) -> RawHandle;
 }
 
-/// Construct I/O objects from raw handles.
+/// Constructs I/O objects from raw handles.
 #[stable(feature = "from_raw_os", since = "1.1.0")]
 pub trait FromRawHandle {
     /// Constructs a new I/O object from the specified raw handle.

--- a/library/std/src/os/windows/io/socket.rs
+++ b/library/std/src/os/windows/io/socket.rs
@@ -63,7 +63,7 @@ pub struct OwnedSocket {
 }
 
 impl BorrowedSocket<'_> {
-    /// Return a `BorrowedSocket` holding the given raw socket.
+    /// Returns a `BorrowedSocket` holding the given raw socket.
     ///
     /// # Safety
     ///

--- a/library/std/src/os/windows/process.rs
+++ b/library/std/src/os/windows/process.rs
@@ -109,7 +109,7 @@ impl IntoRawHandle for process::ChildStderr {
     }
 }
 
-/// Create a `ChildStdin` from the provided `OwnedHandle`.
+/// Creates a `ChildStdin` from the provided `OwnedHandle`.
 ///
 /// The provided handle must be asynchronous, as reading and
 /// writing from and to it is implemented using asynchronous APIs.
@@ -122,7 +122,7 @@ impl From<OwnedHandle> for process::ChildStdin {
     }
 }
 
-/// Create a `ChildStdout` from the provided `OwnedHandle`.
+/// Creates a `ChildStdout` from the provided `OwnedHandle`.
 ///
 /// The provided handle must be asynchronous, as reading and
 /// writing from and to it is implemented using asynchronous APIs.
@@ -135,7 +135,7 @@ impl From<OwnedHandle> for process::ChildStdout {
     }
 }
 
-/// Create a `ChildStderr` from the provided `OwnedHandle`.
+/// Creates a `ChildStderr` from the provided `OwnedHandle`.
 ///
 /// The provided handle must be asynchronous, as reading and
 /// writing from and to it is implemented using asynchronous APIs.

--- a/library/std/src/os/xous/ffi.rs
+++ b/library/std/src/os/xous/ffi.rs
@@ -274,7 +274,7 @@ fn connect_impl(address: ServerAddress, blocking: bool) -> Result<Connection, Er
     }
 }
 
-/// Connect to a Xous server represented by the specified `address`.
+/// Connects to a Xous server represented by the specified `address`.
 ///
 /// The current thread will block until the server is available. Returns
 /// an error if the server cannot accept any more connections.
@@ -282,7 +282,7 @@ pub(crate) fn connect(address: ServerAddress) -> Result<Connection, Error> {
     connect_impl(address, true)
 }
 
-/// Attempt to connect to a Xous server represented by the specified `address`.
+/// Attempts to connect to a Xous server represented by the specified `address`.
 ///
 /// If the server does not exist then None is returned.
 pub(crate) fn try_connect(address: ServerAddress) -> Result<Option<Connection>, Error> {
@@ -293,7 +293,7 @@ pub(crate) fn try_connect(address: ServerAddress) -> Result<Option<Connection>, 
     }
 }
 
-/// Terminate the current process and return the specified code to the parent process.
+/// Terminates the current process and returns the specified code to the parent process.
 pub(crate) fn exit(return_code: u32) -> ! {
     let a0 = Syscall::TerminateProcess as usize;
     let a1 = return_code as usize;
@@ -320,7 +320,7 @@ pub(crate) fn exit(return_code: u32) -> ! {
     unreachable!();
 }
 
-/// Suspend the current thread and allow another thread to run. This thread may
+/// Suspends the current thread and allow another thread to run. This thread may
 /// continue executing again immediately if there are no other threads available
 /// to run on the system.
 pub(crate) fn do_yield() {
@@ -348,9 +348,11 @@ pub(crate) fn do_yield() {
     };
 }
 
-/// Allocate memory from the system. An optional physical and/or virtual address
-/// may be specified in order to ensure memory is allocated at specific offsets,
-/// otherwise the kernel will select an address.
+/// Allocates memory from the system.
+///
+/// An optional physical and/or virtual address may be specified in order to
+/// ensure memory is allocated at specific offsets, otherwise the kernel will
+/// select an address.
 ///
 /// # Safety
 ///
@@ -400,7 +402,7 @@ pub(crate) unsafe fn map_memory<T>(
     }
 }
 
-/// Destroy the given memory, returning it to the compiler.
+/// Destroys the given memory, returning it to the compiler.
 ///
 /// Safety: The memory pointed to by `range` should not be used after this
 /// function returns, even if this function returns Err().
@@ -439,9 +441,10 @@ pub(crate) unsafe fn unmap_memory<T>(range: *mut [T]) -> Result<(), Error> {
     }
 }
 
-/// Adjust the memory flags for the given range. This can be used to remove flags
-/// from a given region in order to harden memory access. Note that flags may
-/// only be removed and may never be added.
+/// Adjusts the memory flags for the given range.
+///
+/// This can be used to remove flags from a given region in order to harden
+/// memory access. Note that flags may only be removed and may never be added.
 ///
 /// Safety: The memory pointed to by `range` may become inaccessible or have its
 /// mutability removed. It is up to the caller to ensure that the flags specified
@@ -484,7 +487,7 @@ pub(crate) unsafe fn update_memory_flags<T>(
     }
 }
 
-/// Create a thread with a given stack and up to four arguments
+/// Creates a thread with a given stack and up to four arguments.
 pub(crate) fn create_thread(
     start: *mut usize,
     stack: *mut [u8],
@@ -527,7 +530,7 @@ pub(crate) fn create_thread(
     }
 }
 
-/// Wait for the given thread to terminate and return the exit code from that thread.
+/// Waits for the given thread to terminate and returns the exit code from that thread.
 pub(crate) fn join_thread(thread_id: ThreadId) -> Result<usize, Error> {
     let mut a0 = Syscall::JoinThread as usize;
     let mut a1 = thread_id.into();
@@ -567,7 +570,7 @@ pub(crate) fn join_thread(thread_id: ThreadId) -> Result<usize, Error> {
     }
 }
 
-/// Get the current thread's ID
+/// Gets the current thread's ID.
 pub(crate) fn thread_id() -> Result<ThreadId, Error> {
     let mut a0 = Syscall::GetThreadId as usize;
     let mut a1 = 0;
@@ -603,7 +606,7 @@ pub(crate) fn thread_id() -> Result<ThreadId, Error> {
     }
 }
 
-/// Adjust the given `knob` limit to match the new value `new`. The current value must
+/// Adjusts the given `knob` limit to match the new value `new`. The current value must
 /// match the `current` in order for this to take effect.
 ///
 /// The new value is returned as a result of this call. If the call fails, then the old

--- a/library/std/src/os/xous/services.rs
+++ b/library/std/src/os/xous/services.rs
@@ -83,7 +83,7 @@ mod ns {
     }
 }
 
-/// Attempt to connect to a server by name. If the server does not exist, this will
+/// Attempts to connect to a server by name. If the server does not exist, this will
 /// block until the server is created.
 ///
 /// Note that this is different from connecting to a server by address. Server
@@ -94,7 +94,7 @@ pub fn connect(name: &str) -> Option<Connection> {
     ns::connect_with_name(name)
 }
 
-/// Attempt to connect to a server by name. If the server does not exist, this will
+/// Attempts to connect to a server by name. If the server does not exist, this will
 /// immediately return `None`.
 ///
 /// Note that this is different from connecting to a server by address. Server
@@ -107,7 +107,7 @@ pub fn try_connect(name: &str) -> Option<Connection> {
 
 static NAME_SERVER_CONNECTION: AtomicU32 = AtomicU32::new(0);
 
-/// Return a `Connection` to the name server. If the name server has not been started,
+/// Returns a `Connection` to the name server. If the name server has not been started,
 /// then this call will block until the name server has been started. The `Connection`
 /// will be shared among all connections in a process, so it is safe to call this
 /// multiple times.

--- a/library/std/src/os/xous/services/dns.rs
+++ b/library/std/src/os/xous/services/dns.rs
@@ -13,7 +13,7 @@ impl Into<usize> for DnsLendMut {
     }
 }
 
-/// Return a `Connection` to the DNS lookup server. This server is used for
+/// Returns a `Connection` to the DNS lookup server. This server is used for
 /// querying domain name values.
 pub(crate) fn dns_server() -> Connection {
     static DNS_CONNECTION: AtomicU32 = AtomicU32::new(0);

--- a/library/std/src/os/xous/services/log.rs
+++ b/library/std/src/os/xous/services/log.rs
@@ -1,10 +1,10 @@
 use crate::os::xous::ffi::Connection;
 use core::sync::atomic::{AtomicU32, Ordering};
 
-/// Group `usize` bytes into a `usize` and return it, beginning
-/// from `offset` * sizeof(usize) bytes from the start. For example,
-/// `group_or_null([1,2,3,4,5,6,7,8], 1)` on a 32-bit system will
-/// return a usize with 5678 packed into it.
+/// Group a `usize` worth of bytes into a `usize` and return it, beginning from
+/// `offset` * sizeof(usize) bytes from the start. For example,
+/// `group_or_null([1,2,3,4,5,6,7,8], 1)` on a 32-bit system will return a
+/// `usize` with 5678 packed into it.
 fn group_or_null(data: &[u8], offset: usize) -> usize {
     let start = offset * core::mem::size_of::<usize>();
     let mut out_array = [0u8; core::mem::size_of::<usize>()];
@@ -56,10 +56,12 @@ impl Into<usize> for LogLend {
     }
 }
 
-/// Return a `Connection` to the log server, which is used for printing messages to
-/// the console and reporting panics. If the log server has not yet started, this
-/// will block until the server is running. It is safe to call this multiple times,
-/// because the address is shared among all threads in a process.
+/// Returns a `Connection` to the log server, which is used for printing messages to
+/// the console and reporting panics.
+///
+/// If the log server has not yet started, this will block until the server is
+/// running. It is safe to call this multiple times, because the address is
+/// shared among all threads in a process.
 pub(crate) fn log_server() -> Connection {
     static LOG_SERVER_CONNECTION: AtomicU32 = AtomicU32::new(0);
 

--- a/library/std/src/os/xous/services/net.rs
+++ b/library/std/src/os/xous/services/net.rs
@@ -80,7 +80,7 @@ impl<'a> Into<[usize; 5]> for NetBlockingScalar {
     }
 }
 
-/// Return a `Connection` to the Network server. This server provides all
+/// Returns a `Connection` to the Network server. This server provides all
 /// OS-level networking functions.
 pub(crate) fn net_server() -> Connection {
     static NET_CONNECTION: AtomicU32 = AtomicU32::new(0);

--- a/library/std/src/os/xous/services/systime.rs
+++ b/library/std/src/os/xous/services/systime.rs
@@ -13,7 +13,7 @@ impl Into<[usize; 5]> for SystimeScalar {
     }
 }
 
-/// Return a `Connection` to the systime server. This server is used for reporting the
+/// Returns a `Connection` to the systime server. This server is used for reporting the
 /// realtime clock.
 pub(crate) fn systime_server() -> Connection {
     static SYSTIME_SERVER_CONNECTION: AtomicU32 = AtomicU32::new(0);

--- a/library/std/src/os/xous/services/ticktimer.rs
+++ b/library/std/src/os/xous/services/ticktimer.rs
@@ -27,7 +27,7 @@ impl Into<[usize; 5]> for TicktimerScalar {
     }
 }
 
-/// Return a `Connection` to the ticktimer server. This server is used for synchronization
+/// Returns a `Connection` to the ticktimer server. This server is used for synchronization
 /// primitives such as sleep, Mutex, and Condvar.
 pub(crate) fn ticktimer_server() -> Connection {
     static TICKTIMER_SERVER_CONNECTION: AtomicU32 = AtomicU32::new(0);

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -249,7 +249,7 @@ pub use core::panic::Location;
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 pub use core::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
 
-/// Panic the current thread with the given message as the panic payload.
+/// Panics the current thread with the given message as the panic payload.
 ///
 /// The message can be of any (`Any + Send`) type, not just strings.
 ///
@@ -380,7 +380,7 @@ pub fn resume_unwind(payload: Box<dyn Any + Send>) -> ! {
     panicking::rust_panic_without_hook(payload)
 }
 
-/// Make all future panics abort directly without running the panic hook or unwinding.
+/// Makes all future panics abort directly without running the panic hook or unwinding.
 ///
 /// There is no way to undo this; the effect lasts until the process exits or
 /// execs (or the equivalent).
@@ -461,7 +461,7 @@ impl BacktraceStyle {
 // Internally stores equivalent of an Option<BacktraceStyle>.
 static SHOULD_CAPTURE: AtomicU8 = AtomicU8::new(0);
 
-/// Configure whether the default panic hook will capture and display a
+/// Configures whether the default panic hook will capture and display a
 /// backtrace.
 ///
 /// The default value for this setting may be set by the `RUST_BACKTRACE`

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1797,7 +1797,7 @@ impl<T: ?Sized + AsRef<OsStr>> From<&T> for PathBuf {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl From<OsString> for PathBuf {
-    /// Converts an [`OsString`] into a [`PathBuf`]
+    /// Converts an [`OsString`] into a [`PathBuf`].
     ///
     /// This conversion does not allocate or copy memory.
     #[inline]

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -2056,7 +2056,7 @@ impl ExitCode {
     // representation of an ExitCode
     //
     // More info: https://internals.rust-lang.org/t/mini-pre-rfc-redesigning-process-exitstatus/5426
-    /// Convert an `ExitCode` into an i32
+    /// Converts an `ExitCode` into an i32
     #[unstable(
         feature = "process_exitcode_internals",
         reason = "exposed only for libstd",
@@ -2079,7 +2079,7 @@ impl Default for ExitCode {
 
 #[stable(feature = "process_exitcode", since = "1.61.0")]
 impl From<u8> for ExitCode {
-    /// Construct an `ExitCode` from an arbitrary u8 value.
+    /// Constructs an `ExitCode` from an arbitrary u8 value.
     fn from(code: u8) -> Self {
         ExitCode(imp::ExitCode::from(code))
     }

--- a/library/std/src/sync/lazy_lock.rs
+++ b/library/std/src/sync/lazy_lock.rs
@@ -175,7 +175,7 @@ impl<T, F: FnOnce() -> T> LazyLock<T, F> {
 }
 
 impl<T, F> LazyLock<T, F> {
-    /// Get the inner value if it has already been initialized.
+    /// Gets the inner value if it has already been initialized.
     fn get(&self) -> Option<&T> {
         if self.once.is_completed() {
             // SAFETY:

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -578,7 +578,7 @@ impl<T: Clone> Clone for OnceLock<T> {
 
 #[stable(feature = "once_cell", since = "1.70.0")]
 impl<T> From<T> for OnceLock<T> {
-    /// Create a new cell with its contents set to `value`.
+    /// Creates a new cell with its contents set to `value`.
     ///
     /// # Example
     ///

--- a/library/std/src/sync/poison.rs
+++ b/library/std/src/sync/poison.rs
@@ -31,13 +31,13 @@ impl Flag {
         }
     }
 
-    /// Check the flag for an unguarded borrow, where we only care about existing poison.
+    /// Checks the flag for an unguarded borrow, where we only care about existing poison.
     #[inline]
     pub fn borrow(&self) -> LockResult<()> {
         if self.get() { Err(PoisonError::new(())) } else { Ok(()) }
     }
 
-    /// Check the flag for a guarded borrow, where we may also set poison when `done`.
+    /// Checks the flag for a guarded borrow, where we may also set poison when `done`.
     #[inline]
     pub fn guard(&self) -> LockResult<Guard> {
         let ret = Guard {

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -573,7 +573,7 @@ impl<T> From<T> for RwLock<T> {
 }
 
 impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
-    /// Create a new instance of `RwLockReadGuard<T>` from a `RwLock<T>`.
+    /// Creates a new instance of `RwLockReadGuard<T>` from a `RwLock<T>`.
     // SAFETY: if and only if `lock.inner.read()` (or `lock.inner.try_read()`) has been
     // successfully called from the same thread before instantiating this object.
     unsafe fn new(lock: &'rwlock RwLock<T>) -> LockResult<RwLockReadGuard<'rwlock, T>> {
@@ -585,7 +585,7 @@ impl<'rwlock, T: ?Sized> RwLockReadGuard<'rwlock, T> {
 }
 
 impl<'rwlock, T: ?Sized> RwLockWriteGuard<'rwlock, T> {
-    /// Create a new instance of `RwLockWriteGuard<T>` from a `RwLock<T>`.
+    /// Creates a new instance of `RwLockWriteGuard<T>` from a `RwLock<T>`.
     // SAFETY: if and only if `lock.inner.write()` (or `lock.inner.try_write()`) has been
     // successfully called from the same thread before instantiating this object.
     unsafe fn new(lock: &'rwlock RwLock<T>) -> LockResult<RwLockWriteGuard<'rwlock, T>> {

--- a/library/std/src/sys/pal/itron/error.rs
+++ b/library/std/src/sys/pal/itron/error.rs
@@ -9,7 +9,7 @@ pub struct ItronError {
 }
 
 impl ItronError {
-    /// Construct `ItronError` from the specified error code. Returns `None` if the
+    /// Constructs `ItronError` from the specified error code. Returns `None` if the
     /// error code does not represent a failure or warning.
     #[inline]
     pub fn new(er: abi::ER) -> Option<Self> {
@@ -22,7 +22,7 @@ impl ItronError {
         if let Some(error) = Self::new(er) { Err(error) } else { Ok(er) }
     }
 
-    /// Get the raw error code.
+    /// Gets the raw error code.
     #[inline]
     pub fn as_raw(&self) -> abi::ER {
         self.er

--- a/library/std/src/sys/pal/itron/task.rs
+++ b/library/std/src/sys/pal/itron/task.rs
@@ -5,19 +5,19 @@ use super::{
 
 use crate::mem::MaybeUninit;
 
-/// Get the ID of the task in Running state. Panics on failure.
+/// Gets the ID of the task in Running state. Panics on failure.
 #[inline]
 pub fn current_task_id() -> abi::ID {
     try_current_task_id().unwrap_or_else(|e| fail(e, &"get_tid"))
 }
 
-/// Get the ID of the task in Running state. Aborts on failure.
+/// Gets the ID of the task in Running state. Aborts on failure.
 #[inline]
 pub fn current_task_id_aborting() -> abi::ID {
     try_current_task_id().unwrap_or_else(|e| fail_aborting(e, &"get_tid"))
 }
 
-/// Get the ID of the task in Running state.
+/// Gets the ID of the task in Running state.
 #[inline]
 pub fn try_current_task_id() -> Result<abi::ID, ItronError> {
     unsafe {
@@ -27,13 +27,13 @@ pub fn try_current_task_id() -> Result<abi::ID, ItronError> {
     }
 }
 
-/// Get the specified task's priority. Panics on failure.
+/// Gets the specified task's priority. Panics on failure.
 #[inline]
 pub fn task_priority(task: abi::ID) -> abi::PRI {
     try_task_priority(task).unwrap_or_else(|e| fail(e, &"get_pri"))
 }
 
-/// Get the specified task's priority.
+/// Gets the specified task's priority.
 #[inline]
 pub fn try_task_priority(task: abi::ID) -> Result<abi::PRI, ItronError> {
     unsafe {

--- a/library/std/src/sys/pal/itron/thread.rs
+++ b/library/std/src/sys/pal/itron/thread.rs
@@ -308,7 +308,7 @@ impl Drop for Thread {
     }
 }
 
-/// Terminate and delete the specified task.
+/// Terminates and deletes the specified task.
 ///
 /// This function will abort if `deleted_task` refers to the calling task.
 ///
@@ -337,7 +337,7 @@ unsafe fn terminate_and_delete_task(deleted_task: abi::ID) {
     expect_success_aborting(unsafe { abi::del_tsk(deleted_task) }, &"del_tsk");
 }
 
-/// Terminate and delete the calling task.
+/// Terminates and deletes the calling task.
 ///
 /// Atomicity is not required - i.e., it can be assumed that other threads won't
 /// `ter_tsk` the calling task while this function is still in progress. (This

--- a/library/std/src/sys/pal/sgx/abi/usercalls/alloc.rs
+++ b/library/std/src/sys/pal/sgx/abi/usercalls/alloc.rs
@@ -67,7 +67,7 @@ pub unsafe trait UserSafe {
     /// Equivalent to `mem::align_of::<Self>`.
     fn align_of() -> usize;
 
-    /// Construct a pointer to `Self` given a memory range in user space.
+    /// Constructs a pointer to `Self` given a memory range in user space.
     ///
     /// N.B., this takes a size, not a length!
     ///
@@ -77,7 +77,7 @@ pub unsafe trait UserSafe {
     /// correct size and is correctly aligned and points to the right type.
     unsafe fn from_raw_sized_unchecked(ptr: *mut u8, size: usize) -> *mut Self;
 
-    /// Construct a pointer to `Self` given a memory range.
+    /// Constructs a pointer to `Self` given a memory range.
     ///
     /// N.B., this takes a size, not a length!
     ///
@@ -276,7 +276,7 @@ impl<T> User<T>
 where
     T: UserSafe,
 {
-    /// Allocate space for `T` in user memory.
+    /// Allocates space for `T` in user memory.
     pub fn uninitialized() -> Self {
         Self::new_uninit_bytes(mem::size_of::<T>())
     }
@@ -287,7 +287,7 @@ impl<T> User<[T]>
 where
     [T]: UserSafe,
 {
-    /// Allocate space for a `[T]` of `n` elements in user memory.
+    /// Allocates space for a `[T]` of `n` elements in user memory.
     pub fn uninitialized(n: usize) -> Self {
         Self::new_uninit_bytes(n * mem::size_of::<T>())
     }

--- a/library/std/src/sys/pal/sgx/abi/usercalls/mod.rs
+++ b/library/std/src/sys/pal/sgx/abi/usercalls/mod.rs
@@ -171,10 +171,12 @@ pub fn wait(event_mask: u64, mut timeout: u64) -> IoResult<u64> {
     unsafe { raw::wait(event_mask, timeout).from_sgx_result() }
 }
 
-/// This function makes an effort to wait for a non-spurious event at least as
-/// long as `duration`. Note that in general there is no guarantee about accuracy
-/// of time and timeouts in SGX model. The enclave runner serving usercalls may
-/// lie about current time and/or ignore timeout values.
+/// Makes an effort to wait for a non-spurious event at least as long as
+/// `duration`.
+///
+/// Note that in general there is no guarantee about accuracy of time and
+/// timeouts in SGX model. The enclave runner serving usercalls may lie about
+/// current time and/or ignore timeout values.
 ///
 /// Once the event is observed, `should_wake_up` will be used to determine
 /// whether or not the event was spurious.

--- a/library/std/src/sys/pal/uefi/args.rs
+++ b/library/std/src/sys/pal/uefi/args.rs
@@ -76,7 +76,7 @@ impl DoubleEndedIterator for Args {
 /// This implementation is based on what is defined in Section 3.4 of
 /// [UEFI Shell Specification](https://uefi.org/sites/default/files/resources/UEFI_Shell_Spec_2_0.pdf)
 ///
-/// Return None in the following cases:
+/// Returns None in the following cases:
 /// - Invalid UTF-16 (unpaired surrogate)
 /// - Empty/improper arguments
 fn parse_lp_cmd_line(code_units: &[u16]) -> Option<Vec<OsString>> {

--- a/library/std/src/sys/pal/uefi/helpers.rs
+++ b/library/std/src/sys/pal/uefi/helpers.rs
@@ -30,8 +30,9 @@ type BootUninstallMultipleProtocolInterfaces =
 const BOOT_SERVICES_UNAVAILABLE: io::Error =
     const_io_error!(io::ErrorKind::Other, "Boot Services are no longer available");
 
-/// Locate Handles with a particular Protocol GUID
-/// Implemented using `EFI_BOOT_SERVICES.LocateHandles()`
+/// Locates Handles with a particular Protocol GUID.
+///
+/// Implemented using `EFI_BOOT_SERVICES.LocateHandles()`.
 ///
 /// Returns an array of [Handles](r_efi::efi::Handle) that support a specified protocol.
 pub(crate) fn locate_handles(mut guid: Guid) -> io::Result<Vec<NonNull<crate::ffi::c_void>>> {
@@ -148,8 +149,9 @@ pub(crate) unsafe fn close_event(evt: NonNull<crate::ffi::c_void>) -> io::Result
     if r.is_error() { Err(crate::io::Error::from_raw_os_error(r.as_usize())) } else { Ok(()) }
 }
 
-/// Get the Protocol for current system handle.
-/// Note: Some protocols need to be manually freed. It is the callers responsibility to do so.
+/// Gets the Protocol for current system handle.
+///
+/// Note: Some protocols need to be manually freed. It is the caller's responsibility to do so.
 pub(crate) fn image_handle_protocol<T>(protocol_guid: Guid) -> io::Result<NonNull<T>> {
     let system_handle = uefi::env::try_image_handle().ok_or(io::const_io_error!(
         io::ErrorKind::NotFound,
@@ -220,7 +222,7 @@ pub(crate) fn device_path_to_text(path: NonNull<device_path::Protocol>) -> io::R
     Err(io::const_io_error!(io::ErrorKind::NotFound, "No device path to text protocol found"))
 }
 
-/// Get RuntimeServices
+/// Gets RuntimeServices.
 pub(crate) fn runtime_services() -> Option<NonNull<r_efi::efi::RuntimeServices>> {
     let system_table: NonNull<r_efi::efi::SystemTable> =
         crate::os::uefi::env::try_system_table()?.cast();

--- a/library/std/src/sys/pal/unix/futex.rs
+++ b/library/std/src/sys/pal/unix/futex.rs
@@ -16,7 +16,7 @@ pub type SmallAtomic = AtomicU32;
 /// Must be the underlying type of SmallAtomic
 pub type SmallPrimitive = u32;
 
-/// Wait for a futex_wake operation to wake us.
+/// Waits for a `futex_wake` operation to wake us.
 ///
 /// Returns directly if the futex doesn't hold the expected value.
 ///
@@ -87,7 +87,7 @@ pub fn futex_wait(futex: &AtomicU32, expected: u32, timeout: Option<Duration>) -
     }
 }
 
-/// Wake up one thread that's blocked on futex_wait on this futex.
+/// Wakes up one thread that's blocked on `futex_wait` on this futex.
 ///
 /// Returns true if this actually woke up such a thread,
 /// or false if no thread was waiting on this futex.
@@ -100,7 +100,7 @@ pub fn futex_wake(futex: &AtomicU32) -> bool {
     unsafe { libc::syscall(libc::SYS_futex, ptr, op, 1) > 0 }
 }
 
-/// Wake up all threads that are waiting on futex_wait on this futex.
+/// Wakes up all threads that are waiting on `futex_wait` on this futex.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn futex_wake_all(futex: &AtomicU32) {
     let ptr = futex as *const AtomicU32;

--- a/library/std/src/sys/pal/unix/mod.rs
+++ b/library/std/src/sys/pal/unix/mod.rs
@@ -308,7 +308,7 @@ macro_rules! impl_is_minus_one {
 
 impl_is_minus_one! { i8 i16 i32 i64 isize }
 
-/// Convert native return values to Result using the *-1 means error is in `errno`*  convention.
+/// Converts native return values to Result using the *-1 means error is in `errno`*  convention.
 /// Non-error values are `Ok`-wrapped.
 pub fn cvt<T: IsMinusOne>(t: T) -> crate::io::Result<T> {
     if t.is_minus_one() { Err(crate::io::Error::last_os_error()) } else { Ok(t) }

--- a/library/std/src/sys/pal/unix/process/process_unix.rs
+++ b/library/std/src/sys/pal/unix/process/process_unix.rs
@@ -1047,7 +1047,7 @@ impl From<c_int> for ExitStatus {
     }
 }
 
-/// Convert a signal number to a readable, searchable name.
+/// Converts a signal number to a readable, searchable name.
 ///
 /// This string should be displayed right after the signal number.
 /// If a signal is unrecognized, it returns the empty string, so that

--- a/library/std/src/sys/pal/wasm/atomics/futex.rs
+++ b/library/std/src/sys/pal/wasm/atomics/futex.rs
@@ -24,7 +24,7 @@ pub fn futex_wait(futex: &AtomicU32, expected: u32, timeout: Option<Duration>) -
     }
 }
 
-/// Wake up one thread that's blocked on futex_wait on this futex.
+/// Wakes up one thread that's blocked on `futex_wait` on this futex.
 ///
 /// Returns true if this actually woke up such a thread,
 /// or false if no thread was waiting on this futex.
@@ -32,7 +32,7 @@ pub fn futex_wake(futex: &AtomicU32) -> bool {
     unsafe { wasm::memory_atomic_notify(futex as *const AtomicU32 as *mut i32, 1) > 0 }
 }
 
-/// Wake up all threads that are waiting on futex_wait on this futex.
+/// Wakes up all threads that are waiting on `futex_wait` on this futex.
 pub fn futex_wake_all(futex: &AtomicU32) {
     unsafe {
         wasm::memory_atomic_notify(futex as *const AtomicU32 as *mut i32, i32::MAX as u32);

--- a/library/std/src/sys/pal/windows/fs.rs
+++ b/library/std/src/sys/pal/windows/fs.rs
@@ -637,7 +637,7 @@ impl File {
         Ok(())
     }
 
-    /// Get only basic file information such as attributes and file times.
+    /// Gets only basic file information such as attributes and file times.
     fn basic_info(&self) -> io::Result<c::FILE_BASIC_INFO> {
         unsafe {
             let mut info: c::FILE_BASIC_INFO = mem::zeroed();

--- a/library/std/src/sys/pal/windows/process.rs
+++ b/library/std/src/sys/pal/windows/process.rs
@@ -549,7 +549,7 @@ where
     None
 }
 
-/// Check if a file exists without following symlinks.
+/// Checks if a file exists without following symlinks.
 fn program_exists(path: &Path) -> Option<Vec<u16>> {
     unsafe {
         let path = args::to_user_path(path).ok()?;

--- a/library/std/src/sys/pal/windows/time.rs
+++ b/library/std/src/sys/pal/windows/time.rs
@@ -230,7 +230,7 @@ pub(super) struct WaitableTimer {
     handle: c::HANDLE,
 }
 impl WaitableTimer {
-    /// Create a high-resolution timer. Will fail before Windows 10, version 1803.
+    /// Creates a high-resolution timer. Will fail before Windows 10, version 1803.
     pub fn high_resolution() -> Result<Self, ()> {
         let handle = unsafe {
             c::CreateWaitableTimerExW(

--- a/library/std/src/sys/path/windows.rs
+++ b/library/std/src/sys/path/windows.rs
@@ -218,7 +218,7 @@ pub(crate) fn maybe_verbatim(path: &Path) -> io::Result<Vec<u16>> {
     get_long_path(path, true)
 }
 
-/// Get a normalized absolute path that can bypass path length limits.
+/// Gets a normalized absolute path that can bypass path length limits.
 ///
 /// Setting prefer_verbatim to true suggests a stronger preference for verbatim
 /// paths even when not strictly necessary. This allows the Windows API to avoid

--- a/library/std/src/sys/personality/dwarf/eh.rs
+++ b/library/std/src/sys/personality/dwarf/eh.rs
@@ -170,7 +170,7 @@ fn round_up(unrounded: usize, align: usize) -> Result<usize, ()> {
     if align.is_power_of_two() { Ok((unrounded + align - 1) & !(align - 1)) } else { Err(()) }
 }
 
-/// Read a offset (`usize`) from `reader` whose encoding is described by `encoding`.
+/// Reads an offset (`usize`) from `reader` whose encoding is described by `encoding`.
 ///
 /// `encoding` must be a [DWARF Exception Header Encoding as described by the LSB spec][LSB-dwarf-ext].
 /// In addition the upper ("application") part must be zero.
@@ -202,7 +202,7 @@ unsafe fn read_encoded_offset(reader: &mut DwarfReader, encoding: u8) -> Result<
     Ok(result)
 }
 
-/// Read a pointer from `reader` whose encoding is described by `encoding`.
+/// Reads a pointer from `reader` whose encoding is described by `encoding`.
 ///
 /// `encoding` must be a [DWARF Exception Header Encoding as described by the LSB spec][LSB-dwarf-ext].
 ///

--- a/library/std/src/sys/sync/mutex/itron.rs
+++ b/library/std/src/sys/sync/mutex/itron.rs
@@ -13,7 +13,7 @@ pub struct Mutex {
     mtx: SpinIdOnceCell<()>,
 }
 
-/// Create a mutex object. This function never panics.
+/// Creates a mutex object. This function never panics.
 fn new_mtx() -> Result<abi::ID, ItronError> {
     ItronError::err_if_negative(unsafe {
         abi::acre_mtx(&abi::T_CMTX {
@@ -31,7 +31,7 @@ impl Mutex {
         Mutex { mtx: SpinIdOnceCell::new() }
     }
 
-    /// Get the inner mutex's ID, which is lazily created.
+    /// Gets the inner mutex's ID, which is lazily created.
     fn raw(&self) -> abi::ID {
         match self.mtx.get_or_try_init(|| new_mtx().map(|id| (id, ()))) {
             Ok((id, ())) => id,

--- a/library/std/src/sys/sync/rwlock/futex.rs
+++ b/library/std/src/sys/sync/rwlock/futex.rs
@@ -222,7 +222,7 @@ impl RwLock {
         }
     }
 
-    /// Wake up waiting threads after unlocking.
+    /// Wakes up waiting threads after unlocking.
     ///
     /// If both are waiting, this will wake up only one writer, but will fall
     /// back to waking up readers if there was no writer to wake up.

--- a/library/std/src/sys/sync/rwlock/queue.rs
+++ b/library/std/src/sys/sync/rwlock/queue.rs
@@ -186,7 +186,7 @@ struct Node {
 }
 
 impl Node {
-    /// Create a new queue node.
+    /// Creates a new queue node.
     fn new(write: bool) -> Node {
         Node {
             next: AtomicLink::new(None),

--- a/library/std/src/sys/sync/rwlock/solid.rs
+++ b/library/std/src/sys/sync/rwlock/solid.rs
@@ -28,7 +28,7 @@ impl RwLock {
         RwLock { rwl: SpinIdOnceCell::new() }
     }
 
-    /// Get the inner mutex's ID, which is lazily created.
+    /// Gets the inner mutex's ID, which is lazily created.
     fn raw(&self) -> abi::ID {
         match self.rwl.get_or_try_init(|| new_rwl().map(|id| (id, ()))) {
             Ok((id, ())) => id,

--- a/library/std/src/sys/sync/thread_parking/futex.rs
+++ b/library/std/src/sys/sync/thread_parking/futex.rs
@@ -36,7 +36,7 @@ pub struct Parker {
 // Ordering::Release when writing NOTIFIED (the 'token') in unpark(), and using
 // Ordering::Acquire when checking for this state in park().
 impl Parker {
-    /// Construct the futex parker. The UNIX parker implementation
+    /// Constructs the futex parker. The UNIX parker implementation
     /// requires this to happen in-place.
     pub unsafe fn new_in_place(parker: *mut Parker) {
         unsafe { parker.write(Self { state: Atomic::new(EMPTY) }) };

--- a/library/std/src/sys/sync/thread_parking/id.rs
+++ b/library/std/src/sys/sync/thread_parking/id.rs
@@ -30,7 +30,7 @@ impl Parker {
         Parker { state: AtomicI8::new(EMPTY), tid: UnsafeCell::new(None) }
     }
 
-    /// Create a new thread parker. UNIX requires this to happen in-place.
+    /// Creates a new thread parker. UNIX requires this to happen in-place.
     pub unsafe fn new_in_place(parker: *mut Parker) {
         parker.write(Parker::new())
     }

--- a/library/std/src/sys/sync/thread_parking/pthread.rs
+++ b/library/std/src/sys/sync/thread_parking/pthread.rs
@@ -92,7 +92,7 @@ pub struct Parker {
 }
 
 impl Parker {
-    /// Construct the UNIX parker in-place.
+    /// Constructs the UNIX parker in-place.
     ///
     /// # Safety
     /// The constructed parker must never be moved.

--- a/library/std/src/sys/sync/thread_parking/windows7.rs
+++ b/library/std/src/sys/sync/thread_parking/windows7.rs
@@ -95,7 +95,7 @@ const NOTIFIED: i8 = 1;
 // Ordering::Release when writing NOTIFIED (the 'token') in unpark(), and using
 // Ordering::Acquire when reading this state in park() after waking up.
 impl Parker {
-    /// Construct the Windows parker. The UNIX parker implementation
+    /// Constructs the Windows parker. The UNIX parker implementation
     /// requires this to happen in-place.
     pub unsafe fn new_in_place(parker: *mut Parker) {
         parker.write(Self { state: AtomicI8::new(EMPTY) });

--- a/library/std/src/sys/thread_local/key/xous.rs
+++ b/library/std/src/sys/thread_local/key/xous.rs
@@ -79,7 +79,7 @@ fn tls_ptr_addr() -> *mut *mut u8 {
     core::ptr::with_exposed_provenance_mut::<*mut u8>(tp)
 }
 
-/// Create an area of memory that's unique per thread. This area will
+/// Creates an area of memory that's unique per thread. This area will
 /// contain all thread local pointers.
 fn tls_table() -> &'static mut [*mut u8] {
     let tp = tls_ptr_addr();

--- a/library/std/src/sys/thread_local/native/eager.rs
+++ b/library/std/src/sys/thread_local/native/eager.rs
@@ -21,7 +21,7 @@ impl<T> Storage<T> {
         Storage { state: Cell::new(State::Initial), val: UnsafeCell::new(val) }
     }
 
-    /// Get a pointer to the TLS value. If the TLS variable has been destroyed,
+    /// Gets a pointer to the TLS value. If the TLS variable has been destroyed,
     /// a null pointer is returned.
     ///
     /// The resulting pointer may not be used after thread destruction has

--- a/library/std/src/sys/thread_local/native/lazy.rs
+++ b/library/std/src/sys/thread_local/native/lazy.rs
@@ -39,7 +39,7 @@ where
         Storage { state: UnsafeCell::new(State::Initial) }
     }
 
-    /// Get a pointer to the TLS value, potentially initializing it with the
+    /// Gets a pointer to the TLS value, potentially initializing it with the
     /// provided parameters. If the TLS variable has been destroyed, a null
     /// pointer is returned.
     ///

--- a/library/std/src/sys/thread_local/os.rs
+++ b/library/std/src/sys/thread_local/os.rs
@@ -60,7 +60,7 @@ impl<T: 'static> Storage<T> {
         Storage { key: LazyKey::new(Some(destroy_value::<T>)), marker: PhantomData }
     }
 
-    /// Get a pointer to the TLS value, potentially initializing it with the
+    /// Gets a pointer to the TLS value, potentially initializing it with the
     /// provided parameters. If the TLS variable has been destroyed, a null
     /// pointer is returned.
     ///

--- a/library/std/src/sys/thread_local/statik.rs
+++ b/library/std/src/sys/thread_local/statik.rs
@@ -63,7 +63,7 @@ impl<T> LazyStorage<T> {
         LazyStorage { value: UnsafeCell::new(None) }
     }
 
-    /// Get a pointer to the TLS value, potentially initializing it with the
+    /// Gets a pointer to the TLS value, potentially initializing it with the
     /// provided parameters.
     ///
     /// The resulting pointer may not be used after reentrant inialialization

--- a/library/std/src/sys_common/wstr.rs
+++ b/library/std/src/sys_common/wstr.rs
@@ -15,7 +15,7 @@ pub struct WStrUnits<'a> {
 }
 
 impl WStrUnits<'_> {
-    /// Create the iterator. Returns `None` if `lpwstr` is null.
+    /// Creates the iterator. Returns `None` if `lpwstr` is null.
     ///
     /// SAFETY: `lpwstr` must point to a null-terminated wide string that lives
     /// at least as long as the lifetime of this struct.

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -849,7 +849,7 @@ pub fn panicking() -> bool {
     panicking::panicking()
 }
 
-/// Use [`sleep`].
+/// Uses [`sleep`].
 ///
 /// Puts the current thread to sleep for at least the specified amount of time.
 ///
@@ -1120,7 +1120,7 @@ pub fn park() {
     forget(guard);
 }
 
-/// Use [`park_timeout`].
+/// Uses [`park_timeout`].
 ///
 /// Blocks unless or until the current thread's token is made available or
 /// the specified duration has been reached (may wake spuriously).

--- a/library/std/src/thread/scoped.rs
+++ b/library/std/src/thread/scoped.rs
@@ -67,7 +67,7 @@ impl ScopeData {
     }
 }
 
-/// Create a scope for spawning scoped threads.
+/// Creates a scope for spawning scoped threads.
 ///
 /// The function passed to `scope` will be provided a [`Scope`] object,
 /// through which scoped threads can be [spawned][`Scope::spawn`].

--- a/library/test/src/stats.rs
+++ b/library/test/src/stats.rs
@@ -116,7 +116,7 @@ pub struct Summary {
 }
 
 impl Summary {
-    /// Construct a new summary of a sample set.
+    /// Constructs a new summary of a sample set.
     pub fn new(samples: &[f64]) -> Summary {
         Summary {
             sum: samples.sum(),

--- a/library/test/src/term/terminfo/searcher.rs
+++ b/library/test/src/term/terminfo/searcher.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 #[cfg(test)]
 mod tests;
 
-/// Return path to database entry for `term`
+/// Returns path to database entry for `term`
 #[allow(deprecated)]
 pub(crate) fn get_dbpath_for_term(term: &str) -> Option<PathBuf> {
     let mut dirs_to_search = Vec::new();

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -25,14 +25,8 @@ xmlns="http://www.w3.org/2000/svg" aria-label="Copy to clipboard">\
 2s-1.75.755-1.75 1.667c0 .911-.793 1.666-1.75 1.666H4.75C3.793 5.333 3 6.09 3 7z"/>\
 <path d="M4 19h6v2H4zM12 11H4v2h8zM4 17h4v-2H4zM15 15v-3l-4.5 4.5L15 21v-3l8.027-.032L23 15z"/>\
 </svg>');
-	--clipboard-image-big: url('data:image/svg+xml,<svg width="22" height="23" viewBox="0 0 24 25" \
-xmlns="http://www.w3.org/2000/svg" aria-label="Copy to clipboard">\
-<path d="M18 20h2v3c0 1-1 2-2 2H2c-.998 0-2-1-2-2V5c0-.911.755-1.667 1.667-1.667h5A3.323 3.323 0 \
-0110 0a3.323 3.323 0 013.333 3.333h5C19.245 3.333 20 4.09 20 5v8.333h-2V9H2v14h16v-3zM3 \
-7h14c0-.911-.793-1.667-1.75-1.667H13.5c-.957 0-1.75-.755-1.75-1.666C11.75 2.755 10.957 2 10 \
-2s-1.75.755-1.75 1.667c0 .911-.793 1.666-1.75 1.666H4.75C3.793 5.333 3 6.09 3 7z"/>\
-<path d="M4 19h6v2H4zM12 11H4v2h8zM4 17h4v-2H4zM15 15v-3l-4.5 4.5L15 21v-3l8.027-.032L23 15z"/>\
-</svg>');
+	--copy-path-height: 34px;
+	--copy-path-width: 33px;
 	/* Checkmark <https://www.svgrepo.com/svg/335033/checkmark> */
 	--checkmark-image: url('data:image/svg+xml,<svg viewBox="-1 -1 23 23" \
 xmlns="http://www.w3.org/2000/svg" fill="black" height="18px">\
@@ -1453,9 +1447,9 @@ documentation. */
 	z-index: 1;
 }
 a.test-arrow {
-	padding: 5px 10px 5px 10px;
+	padding: 5px 7px;
 	border-radius: 5px;
-	font-size: 1.375rem;
+	font-size: 1rem;
 	color: var(--test-arrow-color);
 	background-color: var(--test-arrow-background-color);
 }
@@ -1467,7 +1461,7 @@ a.test-arrow:hover {
 	display: flex;
 }
 .example-wrap:hover > .test-arrow {
-	padding: 3px 10px;
+	padding: 2px 7px;
 }
 .example-wrap:hover > .test-arrow, .example-wrap:hover > .button-holder {
 	visibility: visible;
@@ -1475,28 +1469,24 @@ a.test-arrow:hover {
 .example-wrap .button-holder .copy-button {
 	color: var(--copy-path-button-color);
 	background: var(--main-background-color);
-	height: 43px;
-	width: 40px;
+	height: var(--copy-path-height);
+	width: var(--copy-path-width);
 	margin-left: 5px;
 	padding: 2px 0 0 4px;
 	border: 0;
 	cursor: pointer;
 	border-radius: 5px;
 }
-.example-wrap .button-holder .copy-button.clicked {
-	padding-top: 4px;
-}
 .example-wrap .button-holder .copy-button::before {
 	filter: var(--copy-path-img-filter);
-	content: var(--clipboard-image-big);
-	width: 23px;
-	height: 22px;
+	content: var(--clipboard-image);
 }
 .example-wrap .button-holder .copy-button:hover::before {
 	filter: var(--copy-path-img-hover-filter);
 }
 .example-wrap .button-holder .copy-button.clicked::before {
 	content: var(--checkmark-image);
+	padding-right: 5px;
 }
 
 .code-attribute {
@@ -1745,8 +1735,8 @@ a.tooltip:hover::after {
 #copy-path {
 	color: var(--copy-path-button-color);
 	background: var(--main-background-color);
-	height: 34px;
-	width: 33px;
+	height: var(--copy-path-height);
+	width: var(--copy-path-width);
 	margin-left: 10px;
 	padding: 0;
 	padding-left: 2px;
@@ -1756,8 +1746,6 @@ a.tooltip:hover::after {
 #copy-path::before {
 	filter: var(--copy-path-img-filter);
 	content: var(--clipboard-image);
-	width: 19px;
-	height: 18px;
 }
 #copy-path:hover::before {
 	filter: var(--copy-path-img-hover-filter);

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -32,6 +32,8 @@ xmlns="http://www.w3.org/2000/svg" aria-label="Copy to clipboard">\
 xmlns="http://www.w3.org/2000/svg" fill="black" height="18px">\
 <g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"></path>\
 </g></svg>');
+	--button-left-margin: 4px;
+	--button-border-radius: 2px;
 }
 
 /* See FiraSans-LICENSE.txt for the Fira Sans license. */
@@ -740,6 +742,11 @@ ul.block, .block li {
 	position: relative;
 	margin-bottom: 10px;
 }
+
+.rustdoc .example-wrap > pre {
+	border-radius: 6px;
+}
+
 /* For the last child of a div, the margin will be taken care of
 	by the margin-top of the next item. */
 .rustdoc .example-wrap:last-child {
@@ -1442,13 +1449,13 @@ documentation. */
 .example-wrap > a.test-arrow, .example-wrap .button-holder {
 	visibility: hidden;
 	position: absolute;
-	top: 5px;
-	right: 5px;
+	top: 4px;
+	right: 4px;
 	z-index: 1;
 }
 a.test-arrow {
 	padding: 5px 7px;
-	border-radius: 5px;
+	border-radius: var(--button-border-radius);
 	font-size: 1rem;
 	color: var(--test-arrow-color);
 	background-color: var(--test-arrow-background-color);
@@ -1471,11 +1478,11 @@ a.test-arrow:hover {
 	background: var(--main-background-color);
 	height: var(--copy-path-height);
 	width: var(--copy-path-width);
-	margin-left: 5px;
+	margin-left: var(--button-left-margin);
 	padding: 2px 0 0 4px;
 	border: 0;
 	cursor: pointer;
-	border-radius: 5px;
+	border-radius: var(--button-border-radius);
 }
 .example-wrap .button-holder .copy-button::before {
 	filter: var(--copy-path-img-filter);
@@ -1652,7 +1659,7 @@ a.tooltip:hover::after {
 }
 
 #settings-menu, #help-button {
-	margin-left: 4px;
+	margin-left: var(--button-left-margin);
 	display: flex;
 }
 #sidebar-button {
@@ -1683,7 +1690,7 @@ a.tooltip:hover::after {
 	justify-content: center;
 	background-color: var(--button-background-color);
 	border: 1px solid var(--border-color);
-	border-radius: 2px;
+	border-radius: var(--button-border-radius);
 	color: var(--settings-button-color);
 	/* Rare exception to specifying font sizes in rem. Since this is acting
 	   as an icon, it's okay to specify their sizes in pixels. */

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -16,6 +16,28 @@
 	--src-sidebar-width: 300px;
 	--desktop-sidebar-z-index: 100;
 	--sidebar-elems-left-padding: 24px;
+	/* clipboard <https://github.com/rust-lang/crates.io/commits/main/public/assets/copy.svg> */
+	--clipboard-image: url('data:image/svg+xml,<svg width="19" height="18" viewBox="0 0 24 25" \
+xmlns="http://www.w3.org/2000/svg" aria-label="Copy to clipboard">\
+<path d="M18 20h2v3c0 1-1 2-2 2H2c-.998 0-2-1-2-2V5c0-.911.755-1.667 1.667-1.667h5A3.323 3.323 0 \
+0110 0a3.323 3.323 0 013.333 3.333h5C19.245 3.333 20 4.09 20 5v8.333h-2V9H2v14h16v-3zM3 \
+7h14c0-.911-.793-1.667-1.75-1.667H13.5c-.957 0-1.75-.755-1.75-1.666C11.75 2.755 10.957 2 10 \
+2s-1.75.755-1.75 1.667c0 .911-.793 1.666-1.75 1.666H4.75C3.793 5.333 3 6.09 3 7z"/>\
+<path d="M4 19h6v2H4zM12 11H4v2h8zM4 17h4v-2H4zM15 15v-3l-4.5 4.5L15 21v-3l8.027-.032L23 15z"/>\
+</svg>');
+	--clipboard-image-big: url('data:image/svg+xml,<svg width="22" height="23" viewBox="0 0 24 25" \
+xmlns="http://www.w3.org/2000/svg" aria-label="Copy to clipboard">\
+<path d="M18 20h2v3c0 1-1 2-2 2H2c-.998 0-2-1-2-2V5c0-.911.755-1.667 1.667-1.667h5A3.323 3.323 0 \
+0110 0a3.323 3.323 0 013.333 3.333h5C19.245 3.333 20 4.09 20 5v8.333h-2V9H2v14h16v-3zM3 \
+7h14c0-.911-.793-1.667-1.75-1.667H13.5c-.957 0-1.75-.755-1.75-1.666C11.75 2.755 10.957 2 10 \
+2s-1.75.755-1.75 1.667c0 .911-.793 1.666-1.75 1.666H4.75C3.793 5.333 3 6.09 3 7z"/>\
+<path d="M4 19h6v2H4zM12 11H4v2h8zM4 17h4v-2H4zM15 15v-3l-4.5 4.5L15 21v-3l8.027-.032L23 15z"/>\
+</svg>');
+	/* Checkmark <https://www.svgrepo.com/svg/335033/checkmark> */
+	--checkmark-image: url('data:image/svg+xml,<svg viewBox="-1 -1 23 23" \
+xmlns="http://www.w3.org/2000/svg" fill="black" height="18px">\
+<g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"></path>\
+</g></svg>');
 }
 
 /* See FiraSans-LICENSE.txt for the Fira Sans license. */
@@ -1423,15 +1445,17 @@ documentation. */
 	top: 20px;
 }
 
-a.test-arrow {
+.example-wrap > a.test-arrow, .example-wrap .button-holder {
 	visibility: hidden;
 	position: absolute;
-	padding: 5px 10px 5px 10px;
-	border-radius: 5px;
-	font-size: 1.375rem;
 	top: 5px;
 	right: 5px;
 	z-index: 1;
+}
+a.test-arrow {
+	padding: 5px 10px 5px 10px;
+	border-radius: 5px;
+	font-size: 1.375rem;
 	color: var(--test-arrow-color);
 	background-color: var(--test-arrow-background-color);
 }
@@ -1439,8 +1463,40 @@ a.test-arrow:hover {
 	color: var(--test-arrow-hover-color);
 	background-color: var(--test-arrow-hover-background-color);
 }
-.example-wrap:hover .test-arrow {
+.example-wrap .button-holder {
+	display: flex;
+}
+.example-wrap:hover > .test-arrow {
+	padding: 3px 10px;
+}
+.example-wrap:hover > .test-arrow, .example-wrap:hover > .button-holder {
 	visibility: visible;
+}
+.example-wrap .button-holder .copy-button {
+	color: var(--copy-path-button-color);
+	background: var(--main-background-color);
+	height: 43px;
+	width: 40px;
+	margin-left: 5px;
+	padding: 2px 0 0 4px;
+	border: 0;
+	cursor: pointer;
+	border-radius: 5px;
+}
+.example-wrap .button-holder .copy-button.clicked {
+	padding-top: 4px;
+}
+.example-wrap .button-holder .copy-button::before {
+	filter: var(--copy-path-img-filter);
+	content: var(--clipboard-image-big);
+	width: 23px;
+	height: 22px;
+}
+.example-wrap .button-holder .copy-button:hover::before {
+	filter: var(--copy-path-img-hover-filter);
+}
+.example-wrap .button-holder .copy-button.clicked::before {
+	content: var(--checkmark-image);
 }
 
 .code-attribute {
@@ -1699,15 +1755,7 @@ a.tooltip:hover::after {
 }
 #copy-path::before {
 	filter: var(--copy-path-img-filter);
-	/* clipboard <https://github.com/rust-lang/crates.io/commits/main/public/assets/copy.svg> */
-	content: url('data:image/svg+xml,<svg width="19" height="18" viewBox="0 0 24 25" \
-xmlns="http://www.w3.org/2000/svg" aria-label="Copy to clipboard">\
-<path d="M18 20h2v3c0 1-1 2-2 2H2c-.998 0-2-1-2-2V5c0-.911.755-1.667 1.667-1.667h5A3.323 3.323 0 \
-0110 0a3.323 3.323 0 013.333 3.333h5C19.245 3.333 20 4.09 20 5v8.333h-2V9H2v14h16v-3zM3 \
-7h14c0-.911-.793-1.667-1.75-1.667H13.5c-.957 0-1.75-.755-1.75-1.666C11.75 2.755 10.957 2 10 \
-2s-1.75.755-1.75 1.667c0 .911-.793 1.666-1.75 1.666H4.75C3.793 5.333 3 6.09 3 7z"/>\
-<path d="M4 19h6v2H4zM12 11H4v2h8zM4 17h4v-2H4zM15 15v-3l-4.5 4.5L15 21v-3l8.027-.032L23 15z"/>\
-</svg>');
+	content: var(--clipboard-image);
 	width: 19px;
 	height: 18px;
 }
@@ -1715,11 +1763,7 @@ xmlns="http://www.w3.org/2000/svg" aria-label="Copy to clipboard">\
 	filter: var(--copy-path-img-hover-filter);
 }
 #copy-path.clicked::before {
-	/* Checkmark <https://www.svgrepo.com/svg/335033/checkmark> */
-	content: url('data:image/svg+xml,<svg viewBox="-1 -1 23 23" xmlns="http://www.w3.org/2000/svg" \
-		fill="black" height="18px">\
-		<g><path d="M9 19.414l-6.707-6.707 1.414-1.414L9 16.586 20.293 5.293l1.414 1.414"></path>\
-		</g></svg>');
+	content: var(--checkmark-image);
 }
 
 @keyframes rotating {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1769,9 +1769,37 @@ href="https://doc.rust-lang.org/${channel}/rustdoc/read-documentation/search.htm
 }());
 
 // This section handles the copy button that appears next to the path breadcrumbs
+// and the copy buttons on the code examples.
 (function() {
-    let reset_button_timeout = null;
+    // Common functions to copy buttons.
+    function copyContentToClipboard(content) {
+        const el = document.createElement("textarea");
+        el.value = content;
+        el.setAttribute("readonly", "");
+        // To not make it appear on the screen.
+        el.style.position = "absolute";
+        el.style.left = "-9999px";
 
+        document.body.appendChild(el);
+        el.select();
+        document.execCommand("copy");
+        document.body.removeChild(el);
+    }
+
+    function copyButtonAnimation(button) {
+        button.classList.add("clicked");
+
+        if (button.reset_button_timeout !== undefined) {
+            window.clearTimeout(button.reset_button_timeout);
+        }
+
+        button.reset_button_timeout = window.setTimeout(() => {
+            button.reset_button_timeout = undefined;
+            button.classList.remove("clicked");
+        }, 1000);
+    }
+
+    // Copy button that appears next to the path breadcrumbs.
     const but = document.getElementById("copy-path");
     if (!but) {
         return;
@@ -1786,29 +1814,49 @@ href="https://doc.rust-lang.org/${channel}/rustdoc/read-documentation/search.htm
             }
         });
 
-        const el = document.createElement("textarea");
-        el.value = path.join("::");
-        el.setAttribute("readonly", "");
-        // To not make it appear on the screen.
-        el.style.position = "absolute";
-        el.style.left = "-9999px";
-
-        document.body.appendChild(el);
-        el.select();
-        document.execCommand("copy");
-        document.body.removeChild(el);
-
-        but.classList.add("clicked");
-
-        if (reset_button_timeout !== null) {
-            window.clearTimeout(reset_button_timeout);
-        }
-
-        function reset_button() {
-            reset_button_timeout = null;
-            but.classList.remove("clicked");
-        }
-
-        reset_button_timeout = window.setTimeout(reset_button, 1000);
+        copyContentToClipboard(path.join("::"));
+        copyButtonAnimation(but);
     };
+
+    // Copy buttons on code examples.
+    function copyCode(codeElem) {
+        if (!codeElem) {
+            // Should never happen, but the world is a dark and dangerous place.
+            return;
+        }
+        copyContentToClipboard(codeElem.textContent);
+    }
+
+    function addCopyButton(event) {
+        let elem = event.target;
+        while (!hasClass(elem, "example-wrap")) {
+            elem = elem.parentElement;
+            if (elem.tagName === "body" || hasClass(elem, "docblock")) {
+                return;
+            }
+        }
+        // Since the button will be added, no need to keep this listener around.
+        elem.removeEventListener("mouseover", addCopyButton);
+
+        const parent = document.createElement("div");
+        parent.className = "button-holder";
+        const runButton = elem.querySelector(".test-arrow");
+        if (runButton !== null) {
+            // If there is a run button, we move it into the same div.
+            parent.appendChild(runButton);
+        }
+        elem.appendChild(parent);
+        const copyButton = document.createElement("button");
+        copyButton.className = "copy-button";
+        copyButton.title = "Copy code to clipboard";
+        copyButton.addEventListener("click", () => {
+            copyCode(elem.querySelector("pre > code"));
+            copyButtonAnimation(copyButton);
+        });
+        parent.appendChild(copyButton);
+    }
+
+    onEachLazy(document.querySelectorAll(".docblock .example-wrap"), elem => {
+        elem.addEventListener("mouseover", addCopyButton);
+    });
 }());

--- a/src/tools/run-make-support/Cargo.toml
+++ b/src/tools/run-make-support/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 [dependencies]
 bstr = "1.6.0"
-object = "0.34.0"
+object = "0.36.2"
 similar = "2.5.0"
-wasmparser = "0.118.2"
+wasmparser = { version = "0.214", default-features = false, features = ["std"] }
 regex = "1.8" # 1.8 to avoid memchr 2.6.0, as 2.5.0 is pinned in the workspace
 gimli = "0.31.0"
 build_helper = { path = "../build_helper" }

--- a/tests/rustdoc-gui/copy-code.goml
+++ b/tests/rustdoc-gui/copy-code.goml
@@ -14,6 +14,12 @@ define-function: (
         assert-css: (".example-wrap .copy-button", { "visibility": "visible" })
         move-cursor-to: ".search-input"
         assert-css: (".example-wrap .copy-button", { "visibility": "hidden" })
+        // Checking that the copy button has the same size as the "copy path" button.
+        compare-elements-size: (
+            "#copy-path",
+            ".example-wrap:nth-of-type(1) .copy-button",
+            ["height", "width"],
+        )
     },
 )
 

--- a/tests/rustdoc-gui/copy-code.goml
+++ b/tests/rustdoc-gui/copy-code.goml
@@ -1,0 +1,48 @@
+// Checks that the "copy code" button is not triggering JS error and its display
+// isn't broken.
+go-to: "file://" + |DOC_PATH| + "/test_docs/fn.foo.html"
+
+define-function: (
+    "check-copy-button",
+    [],
+    block {
+        // First we ensure that there are no "copy code" currently existing.
+        assert-count: (".example-wrap .copy-button", 0)
+        move-cursor-to: ".example-wrap"
+        assert-count: (".example-wrap .copy-button", 1)
+        // We now ensure it's only displayed when the example is hovered.
+        assert-css: (".example-wrap .copy-button", { "visibility": "visible" })
+        move-cursor-to: ".search-input"
+        assert-css: (".example-wrap .copy-button", { "visibility": "hidden" })
+    },
+)
+
+call-function: ("check-copy-button", {})
+// Checking that the run button and the copy button have the same height.
+compare-elements-size: (
+    ".example-wrap:nth-of-type(1) .test-arrow",
+    ".example-wrap:nth-of-type(1) .copy-button",
+    ["height"],
+)
+// ... and the same y position.
+compare-elements-position: (
+    ".example-wrap:nth-of-type(1) .test-arrow",
+    ".example-wrap:nth-of-type(1) .copy-button",
+    ["y"],
+)
+store-size: (".example-wrap:nth-of-type(1) .copy-button", {
+    "height": copy_height,
+    "width": copy_width,
+})
+assert: |copy_height| > 0 && |copy_width| > 0
+
+// Checking same things for the copy button when there is no run button.
+go-to: "file://" + |DOC_PATH| + "/lib2/sub_mod/struct.Foo.html"
+call-function: ("check-copy-button", {})
+// Ensure there is no run button.
+assert-count: (".example-wrap .test-arrow", 0)
+// Check it's the same size without a run button.
+assert-size: (".example-wrap:nth-of-type(1) .copy-button", {
+    "height": |copy_height|,
+    "width": |copy_width|,
+})

--- a/tests/rustdoc-gui/run-on-hover.goml
+++ b/tests/rustdoc-gui/run-on-hover.goml
@@ -17,7 +17,7 @@ define-function: (
             "visibility": "visible",
             "color": |color|,
             "background-color": |background|,
-            "font-size": "22px",
+            "font-size": "16px",
             "border-radius": "5px",
         })
         move-cursor-to: ".test-arrow"
@@ -25,7 +25,7 @@ define-function: (
             "visibility": "visible",
             "color": |hover_color|,
             "background-color": |hover_background|,
-            "font-size": "22px",
+            "font-size": "16px",
             "border-radius": "5px",
         })
     },

--- a/tests/rustdoc-gui/run-on-hover.goml
+++ b/tests/rustdoc-gui/run-on-hover.goml
@@ -18,7 +18,7 @@ define-function: (
             "color": |color|,
             "background-color": |background|,
             "font-size": "16px",
-            "border-radius": "5px",
+            "border-radius": "2px",
         })
         move-cursor-to: ".test-arrow"
         assert-css: (".test-arrow:hover", {
@@ -26,7 +26,7 @@ define-function: (
             "color": |hover_color|,
             "background-color": |hover_background|,
             "font-size": "16px",
-            "border-radius": "5px",
+            "border-radius": "2px",
         })
     },
 )

--- a/tests/ui/async-await/for-await-consumes-iter.rs
+++ b/tests/ui/async-await/for-await-consumes-iter.rs
@@ -1,5 +1,5 @@
 //@ edition: 2021
-#![feature(async_iterator, async_iter_from_iter, const_waker, async_for_loop, noop_waker)]
+#![feature(async_iterator, async_iter_from_iter, async_for_loop, noop_waker)]
 
 use std::future::Future;
 

--- a/tests/ui/async-await/for-await-passthrough.rs
+++ b/tests/ui/async-await/for-await-passthrough.rs
@@ -1,7 +1,7 @@
 //@ run-pass
 //@ edition: 2024
 //@ compile-flags: -Zunstable-options
-#![feature(async_iterator, async_iter_from_iter, const_waker, async_for_loop, noop_waker,
+#![feature(async_iterator, async_iter_from_iter, async_for_loop, noop_waker,
            gen_blocks)]
 
 async gen fn async_iter() -> i32 {

--- a/tests/ui/async-await/for-await.rs
+++ b/tests/ui/async-await/for-await.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 //@ edition: 2021
-#![feature(async_iterator, async_iter_from_iter, const_waker, async_for_loop, noop_waker)]
+#![feature(async_iterator, async_iter_from_iter, async_for_loop, noop_waker)]
 
 use std::future::Future;
 


### PR DESCRIPTION
Successful merges:

 - #125779 ([rustdoc] Add copy code feature)
 - #127765 (Fix doc nits)
 - #127860 (deps: dedup object, wasmparser, wasm-encoder)
 - #128103 (add `is_multiple_of` for unsigned integer types)
 - #128228 (Stabilize `const_waker`)
 - #128240 (Add links from `assert_eq!` docs to `debug_assert_eq!`, etc.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=125779,127765,127860,128103,128228,128240)
<!-- homu-ignore:end -->