### PR TITLE
Stabilize `<[T]>::get_many_mut()`

### DIFF
--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -41,7 +41,7 @@ pub use core::slice::ArrayChunksMut;
 pub use core::slice::ArrayWindows;
 #[stable(feature = "inherent_ascii_escape", since = "1.60.0")]
 pub use core::slice::EscapeAscii;
-#[unstable(feature = "get_many_mut", issue = "104642")]
+#[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
 pub use core::slice::GetManyMutError;
 #[stable(feature = "slice_get_slice", since = "1.28.0")]
 pub use core::slice::SliceIndex;

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -41,6 +41,8 @@ pub use core::slice::ArrayChunksMut;
 pub use core::slice::ArrayWindows;
 #[stable(feature = "inherent_ascii_escape", since = "1.60.0")]
 pub use core::slice::EscapeAscii;
+#[unstable(feature = "get_many_mut", issue = "104642")]
+pub use core::slice::GetManyMutError;
 #[stable(feature = "slice_get_slice", since = "1.28.0")]
 pub use core::slice::SliceIndex;
 #[stable(feature = "from_ref", since = "1.28.0")]

--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -1076,5 +1076,5 @@ impl Error for crate::time::TryFromFloatSecsError {}
 #[stable(feature = "cstr_from_bytes_until_nul", since = "1.69.0")]
 impl Error for crate::ffi::FromBytesUntilNulError {}
 
-#[unstable(feature = "get_many_mut", issue = "104642")]
+#[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
 impl<const N: usize> Error for crate::slice::GetManyMutError<N> {}

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -4453,7 +4453,7 @@ impl<T> [T] {
     /// let x = &mut [1, 2, 4];
     ///
     /// unsafe {
-    ///     let [a, b] = x.get_many_unchecked_mut([0, 2]);
+    ///     let [a, b] = x.get_many_unchecked_mut(&[0, 2]);
     ///     *a *= 10;
     ///     *b *= 100;
     /// }
@@ -4466,7 +4466,7 @@ impl<T> [T] {
     #[inline]
     pub unsafe fn get_many_unchecked_mut<const N: usize>(
         &mut self,
-        indices: [usize; N],
+        indices: &[usize; N],
     ) -> [&mut T; N] {
         // NB: This implementation is written as it is because any variation of
         // `indices.map(|i| self.get_unchecked_mut(i))` would make miri unhappy,
@@ -4498,7 +4498,7 @@ impl<T> [T] {
     /// #![feature(get_many_mut)]
     ///
     /// let v = &mut [1, 2, 3];
-    /// if let Ok([a, b]) = v.get_many_mut([0, 2]) {
+    /// if let Ok([a, b]) = v.get_many_mut(&[0, 2]) {
     ///     *a = 413;
     ///     *b = 612;
     /// }
@@ -4508,9 +4508,9 @@ impl<T> [T] {
     #[inline]
     pub fn get_many_mut<const N: usize>(
         &mut self,
-        indices: [usize; N],
+        indices: &[usize; N],
     ) -> Result<[&mut T; N], GetManyMutError<N>> {
-        if !get_many_check_valid(&indices, self.len()) {
+        if !get_many_check_valid(indices, self.len()) {
             return Err(GetManyMutError { _private: () });
         }
         // SAFETY: The `get_many_check_valid()` call checked that all indices
@@ -4889,8 +4889,8 @@ fn get_many_check_valid<const N: usize>(indices: &[usize; N], len: usize) -> boo
 /// #![feature(get_many_mut)]
 ///
 /// let v = &mut [1, 2, 3];
-/// assert!(v.get_many_mut([0, 999]).is_err());
-/// assert!(v.get_many_mut([1, 1]).is_err());
+/// assert!(v.get_many_mut(&[0, 999]).is_err());
+/// assert!(v.get_many_mut(&[1, 1]).is_err());
 /// ```
 #[unstable(feature = "get_many_mut", issue = "104642")]
 // NB: The N and the private field here is there to be forward-compatible with

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -4448,8 +4448,6 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
-    /// #![feature(get_many_mut)]
-    ///
     /// let x = &mut [1, 2, 4];
     ///
     /// unsafe {
@@ -4462,7 +4460,7 @@ impl<T> [T] {
     ///
     /// [`get_many_mut`]: slice::get_many_mut
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
-    #[unstable(feature = "get_many_mut", issue = "104642")]
+    #[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub unsafe fn get_many_unchecked_mut<const N: usize>(
         &mut self,
@@ -4495,8 +4493,6 @@ impl<T> [T] {
     /// # Examples
     ///
     /// ```
-    /// #![feature(get_many_mut)]
-    ///
     /// let v = &mut [1, 2, 3];
     /// if let Ok([a, b]) = v.get_many_mut(&[0, 2]) {
     ///     *a = 413;
@@ -4504,7 +4500,7 @@ impl<T> [T] {
     /// }
     /// assert_eq!(v, &[413, 2, 612]);
     /// ```
-    #[unstable(feature = "get_many_mut", issue = "104642")]
+    #[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
     pub fn get_many_mut<const N: usize>(
         &mut self,
@@ -4886,27 +4882,25 @@ fn get_many_check_valid<const N: usize>(indices: &[usize; N], len: usize) -> boo
 /// # Examples
 ///
 /// ```
-/// #![feature(get_many_mut)]
-///
 /// let v = &mut [1, 2, 3];
 /// assert!(v.get_many_mut(&[0, 999]).is_err());
 /// assert!(v.get_many_mut(&[1, 1]).is_err());
 /// ```
-#[unstable(feature = "get_many_mut", issue = "104642")]
+#[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
 // NB: The N and the private field here is there to be forward-compatible with
 // adding more details to the error type at a later point
 pub struct GetManyMutError<const N: usize> {
     _private: (),
 }
 
-#[unstable(feature = "get_many_mut", issue = "104642")]
+#[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
 impl<const N: usize> fmt::Debug for GetManyMutError<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GetManyMutError").finish_non_exhaustive()
     }
 }
 
-#[unstable(feature = "get_many_mut", issue = "104642")]
+#[stable(feature = "get_many_mut", since = "CURRENT_RUSTC_VERSION")]
 impl<const N: usize> fmt::Display for GetManyMutError<N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt("an index is out of bounds or appeared multiple times in the array", f)

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -110,7 +110,6 @@
 #![feature(error_generic_member_access)]
 #![feature(trait_upcasting)]
 #![feature(is_ascii_octdigit)]
-#![feature(get_many_mut)]
 #![feature(iter_map_windows)]
 #![allow(internal_features)]
 #![deny(unsafe_op_in_unsafe_fn)]

--- a/library/core/tests/slice.rs
+++ b/library/core/tests/slice.rs
@@ -2599,7 +2599,7 @@ fn test_flatten_mut_size_overflow() {
 #[test]
 fn test_get_many_mut_normal_2() {
     let mut v = vec![1, 2, 3, 4, 5];
-    let [a, b] = v.get_many_mut([3, 0]).unwrap();
+    let [a, b] = v.get_many_mut(&[3, 0]).unwrap();
     *a += 10;
     *b += 100;
     assert_eq!(v, vec![101, 2, 3, 14, 5]);
@@ -2608,7 +2608,7 @@ fn test_get_many_mut_normal_2() {
 #[test]
 fn test_get_many_mut_normal_3() {
     let mut v = vec![1, 2, 3, 4, 5];
-    let [a, b, c] = v.get_many_mut([0, 4, 2]).unwrap();
+    let [a, b, c] = v.get_many_mut(&[0, 4, 2]).unwrap();
     *a += 10;
     *b += 100;
     *c += 1000;
@@ -2618,14 +2618,14 @@ fn test_get_many_mut_normal_3() {
 #[test]
 fn test_get_many_mut_empty() {
     let mut v = vec![1, 2, 3, 4, 5];
-    let [] = v.get_many_mut([]).unwrap();
+    let [] = v.get_many_mut(&[]).unwrap();
     assert_eq!(v, vec![1, 2, 3, 4, 5]);
 }
 
 #[test]
 fn test_get_many_mut_single_first() {
     let mut v = vec![1, 2, 3, 4, 5];
-    let [a] = v.get_many_mut([0]).unwrap();
+    let [a] = v.get_many_mut(&[0]).unwrap();
     *a += 10;
     assert_eq!(v, vec![11, 2, 3, 4, 5]);
 }
@@ -2633,7 +2633,7 @@ fn test_get_many_mut_single_first() {
 #[test]
 fn test_get_many_mut_single_last() {
     let mut v = vec![1, 2, 3, 4, 5];
-    let [a] = v.get_many_mut([4]).unwrap();
+    let [a] = v.get_many_mut(&[4]).unwrap();
     *a += 10;
     assert_eq!(v, vec![1, 2, 3, 4, 15]);
 }
@@ -2641,19 +2641,19 @@ fn test_get_many_mut_single_last() {
 #[test]
 fn test_get_many_mut_oob_nonempty() {
     let mut v = vec![1, 2, 3, 4, 5];
-    assert!(v.get_many_mut([5]).is_err());
+    assert!(v.get_many_mut(&[5]).is_err());
 }
 
 #[test]
 fn test_get_many_mut_oob_empty() {
     let mut v: Vec<i32> = vec![];
-    assert!(v.get_many_mut([0]).is_err());
+    assert!(v.get_many_mut(&[0]).is_err());
 }
 
 #[test]
 fn test_get_many_mut_duplicate() {
     let mut v = vec![1, 2, 3, 4, 5];
-    assert!(v.get_many_mut([1, 3, 3, 4]).is_err());
+    assert!(v.get_many_mut(&[1, 3, 3, 4]).is_err());
 }
 
 #[test]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -392,7 +392,6 @@
 #![feature(custom_test_frameworks)]
 #![feature(edition_panic)]
 #![feature(format_args_nl)]
-#![feature(get_many_mut)]
 #![feature(log_syntax)]
 #![feature(test)]
 #![feature(trace_macros)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

Tracking issue: https://github.com/rust-lang/rust/issues/104642.

Best reviewed commit by commit.

Closes #104642.

------------------

# Stabilization Report

## Implementation History

Implemented in https://github.com/rust-lang/rust/pull/83608. Originally included an immutable version too, but that was deemed unnecessary. Also, at first the indices array was required to be sorted, but this was changed.

It was suggested that a `DisjointIndices` type will be added, that will encapsulate the invariant and allow you to index with O(1). This has the benefits that it allows reuse of the same keys, and possibly to add a constructor that allows O(N) instead of O(NlgN) check by requiring the indices array to be sorted. has I decided to not go for this route, since (1) it is unclear how useful those benefits are (I've never needed them personally), (2) about the second benefit, we can always add a `get_many_sorted_mut()` method, and that will have roughly the same implementation and API complexity as `DisjointIndices` with two constructors, if not better, and (3) we provide the `get_many_unchecked_mut()` primitive, so anyone can build on top of that while the tricky unsafe details of how to soundly implement `get_many_unchecked_mut()` are hidden from them. Also, it will make the call significantly more convoluted (`get_many_mut(&DisjointIndices::new([...])?)?` instead of `get_many_mut(&[...])?`, and while it is possible to simplify that with a trait, that will imply more implementation complexity and weaker inference.

It was also suggested that we add the ability to index with ranges. I decided to not do that either. The reasons being unclear benefit and greater implementation and API complexity.

Another suggestion was to add a `index_many_mut()` method that will panic on out of bounds/overlapping indices, possibly with a better panic message than `get_many_mut().expect()` (due to the ability to differentiate between the two error conditions). While not in this stabilization request, we can always add it later if deemed worthy.

Yet another request that came is the ability to tell from the error whether it was out of bounds or overlapping indices. I reserved the right to do this (by having a private field on the error type), but didn't actually do it now because it leads to worse codegen on common cases (https://github.com/rust-lang/rust/issues/128214).

In this PR, I:

 1. Changed the implementation to switch to sort when N>=9. I don't know how likely this case is, but it doesn't add a lot of code, and it seems to be a footgun if we don't add it.
 2. Changed the API to take a reference to the array of indices, instead of an owned array. The reason, as per the commit message:
    > We only need an immutable access to the indices array, and it we take it owned we may force a copy for big arrays. For small arrays, LLVM will fully inline and unroll the body anyway, so this doesn't matter.
    >
    > In simple cases, LLVM is able to avoid the copy, but it has troubles in more complex cases (https://godbolt.org/z/s371G4r9e). Given that I expect `get_many_mut()` to be used most of the times with few, probably only two, indices, this seems unlikely to matter and adds one character to type, but it isn't that bad and avoiding a copy seems nice.
 3. Re-exported `GetManyMutError` from std and alloc, which was probably just forgotten.

## API Summary

```rust
impl [T] {
    pub unsafe fn get_many_unchecked_mut<const N: usize>(&mut self, indices: &[usize; N]) -> [&mut T; N];
    pub fn get_many_mut<const N: usize>(&mut self, indices: &[usize; N]) -> Result<[&mut T; N], GetManyMutError<N>>;
}

pub struct GetManyMutError<const N: usize> { /* private */ }
```

## Experience Report

[I used it in Advent of Code 2022 day 5](https://adventofcode.com/2022/day/5), and also suggested it [here](https://fasterthanli.me/series/advent-of-code-2022/part-5#reader-suggestion-use-nightly-rust-s-get-many-mut). It worked great, but in this case I didn't have to handle the error so I can't tell if knowing the kind of error is really needed.

There are few polyfill crates (https://crates.io/crates/indices, https://crates.io/crates/index_many, https://crates.io/crates/get_many_mut). They don't seem to get much usage. [There is also a highly upvoted question on Stack Overflow](https://stackoverflow.com/questions/30073684/how-to-get-mutable-references-to-two-array-elements-at-the-same-time), and I see this question popping up there sometimes.