### PR TITLE
CI: move RFL job forward to v6.11-rc1

### DIFF
--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-LINUX_VERSION=c13320499ba0efd93174ef6462ae8a7a2933f6e7
+LINUX_VERSION=v6.11-rc1
 
 # Build rustc, rustdoc and cargo
 ../x.py build --stage 1 library rustdoc


### PR DESCRIPTION
The tag has been released today, and since the original hash we had in the Rust CI (which was ~v6.10-rc1), we have accumulated a fair amount of changes and new code.

In particular, v6.11-rc1 is the first Linux tag where the kernel is supporting an actual minimum Rust version (1.78.0), rather than a single version.

---
Let's try to do the move independently first.
r? @Kobzol

try-job: x86_64-rust-for-linux