### PR TITLE
Defid derive hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,7 +1309,7 @@ dependencies = [
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "self_cell 0.10.3",
  "smallvec",
  "unic-langid",
@@ -2019,7 +2019,7 @@ dependencies = [
  "anyhow",
  "clap",
  "fs-err",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustdoc-json-types",
  "serde",
  "serde_json",
@@ -2290,7 +2290,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "perf-event-open-sys",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "smallvec",
 ]
 
@@ -2934,7 +2934,7 @@ checksum = "c4e8e505342045d397d0b6674dcb82d6faf5cf40484d30eeb88fc82ef14e903f"
 dependencies = [
  "datafrog",
  "log",
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -3373,6 +3373,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc-main"
 version = "0.0.0"
 dependencies = [
@@ -3761,7 +3767,7 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "portable-atomic",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustc-rayon",
  "rustc-stable-hash",
  "rustc_arena",
@@ -4452,7 +4458,7 @@ dependencies = [
 name = "rustc_pattern_analysis"
 version = "0.0.0"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustc_apfloat",
  "rustc_arena",
  "rustc_data_structures",
@@ -4843,7 +4849,7 @@ name = "rustdoc-json-types"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "serde",
  "serde_json",
 ]
@@ -5557,7 +5563,7 @@ dependencies = [
  "ignore",
  "miropt-test-tools",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "semver",
  "similar",
  "termcolor",
@@ -5786,7 +5792,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb68604048ff8fa93347f02441e4487594adc20bb8a084f9e564d2b827a0a9f"
 dependencies = [
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -13,7 +13,7 @@ ena = "0.14.3"
 indexmap = { version = "2.0.0" }
 jobserver_crate = { version = "0.1.28", package = "jobserver" }
 measureme = "11"
-rustc-hash = "1.1.0"
+rustc-hash = "2.0.0"
 rustc-rayon = { version = "0.5.0", optional = true }
 rustc-stable-hash = { version = "0.1.0", features = ["nightly"] }
 rustc_arena = { path = "../rustc_arena" }

--- a/compiler/rustc_pattern_analysis/Cargo.toml
+++ b/compiler/rustc_pattern_analysis/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # tidy-alphabetical-start
-rustc-hash = "1.1.0"
+rustc-hash = "2.0.0"
 rustc_apfloat = "0.2.0"
 rustc_arena = { path = "../rustc_arena", optional = true }
 rustc_data_structures = { path = "../rustc_data_structures", optional = true }

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -219,21 +219,12 @@ rustc_index::newtype_index! {
 /// index and a def index.
 ///
 /// You can create a `DefId` from a `LocalDefId` using `local_def_id.to_def_id()`.
-#[derive(Clone, PartialEq, Eq, Copy)]
-// On below-64 bit systems we can simply use the derived `Hash` impl
-#[cfg_attr(not(target_pointer_width = "64"), derive(Hash))]
+#[derive(Clone, PartialEq, Eq, Copy, Hash)]
 #[repr(C)]
 #[rustc_pass_by_value]
-// We guarantee field order. Note that the order is essential here, see below why.
 pub struct DefId {
-    // cfg-ing the order of fields so that the `DefIndex` which is high entropy always ends up in
-    // the lower bits no matter the endianness. This allows the compiler to turn that `Hash` impl
-    // into a direct call to `u64::hash(_)`.
-    #[cfg(not(all(target_pointer_width = "64", target_endian = "big")))]
     pub index: DefIndex,
     pub krate: CrateNum,
-    #[cfg(all(target_pointer_width = "64", target_endian = "big"))]
-    pub index: DefIndex,
 }
 
 // To ensure correctness of incremental compilation,
@@ -241,24 +232,6 @@ pub struct DefId {
 // See https://github.com/rust-lang/rust/issues/90317.
 impl !Ord for DefId {}
 impl !PartialOrd for DefId {}
-
-// On 64-bit systems, we can hash the whole `DefId` as one `u64` instead of two `u32`s. This
-// improves performance without impairing `FxHash` quality. So the below code gets compiled to a
-// noop on little endian systems because the memory layout of `DefId` is as follows:
-//
-// ```
-//     +-1--------------31-+-32-------------63-+
-//     ! index             ! krate             !
-//     +-------------------+-------------------+
-// ```
-//
-// On 64-bit big-endian systems, this compiles to a 64-bit rotation by 32 bits, or a 64-bit load.
-#[cfg(target_pointer_width = "64")]
-impl Hash for DefId {
-    fn hash<H: Hasher>(&self, h: &mut H) {
-        (((self.krate.as_u32() as u64) << 32) | (self.index.as_u32() as u64)).hash(h)
-    }
-}
 
 impl DefId {
     /// Makes a local `DefId` from the given `DefIndex`.

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -252,14 +252,7 @@ impl !PartialOrd for DefId {}
 //     +-------------------+-------------------+
 // ```
 //
-// The order here has direct impact on `FxHash` quality because we have far more `DefIndex` per
-// crate than we have `Crate`s within one compilation. Or in other words, this arrangement puts
-// more entropy in the low bits than the high bits. The reason this matters is that `FxHash`, which
-// is used throughout rustc, has problems distributing the entropy from the high bits, so reversing
-// the order would lead to a large number of collisions and thus far worse performance.
-//
-// On 64-bit big-endian systems, this compiles to a 64-bit rotation by 32 bits, which is still
-// faster than another `FxHash` round.
+// On 64-bit big-endian systems, this compiles to a 64-bit rotation by 32 bits, or a 64-bit load.
 #[cfg(target_pointer_width = "64")]
 impl Hash for DefId {
     fn hash<H: Hasher>(&self, h: &mut H) {

--- a/src/rustdoc-json-types/Cargo.toml
+++ b/src/rustdoc-json-types/Cargo.toml
@@ -8,7 +8,7 @@ path = "lib.rs"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-rustc-hash = "1.1.0"
+rustc-hash = "2.0.0"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/tools/jsondoclint/Cargo.toml
+++ b/src/tools/jsondoclint/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 anyhow = "1.0.62"
 clap = { version = "4.0.15", features = ["derive"] }
 fs-err = "2.8.1"
-rustc-hash = "1.1.0"
+rustc-hash = "2.0.0"
 rustdoc-json-types = { version = "0.1.0", path = "../../rustdoc-json-types" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"


### PR DESCRIPTION
r? @ghost

Built on-top of #128323, to see if using new fxhash lets us eliminate DefId custom hashing.

(prediction: this kills perf, as we'll hash 2 u32's instead of 1 u64)