### PR TITLE
Consider const fn with `&self` while checking liveness

### DIFF
--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -833,8 +833,9 @@ fn check_item<'tcx>(
                 if let Some(fn_sig) =
                     tcx.hir().fn_sig_by_hir_id(tcx.local_def_id_to_hir_id(local_def_id))
                 {
-                    may_construct_self =
-                        matches!(fn_sig.decl.implicit_self, hir::ImplicitSelfKind::None);
+                    may_construct_self = matches!(fn_sig.decl.implicit_self, hir::ImplicitSelfKind::None)
+                            // Also considering const functions with `&self` to fix #128272
+                            || fn_sig.header.is_const() && matches!(fn_sig.decl.implicit_self, hir::ImplicitSelfKind::RefImm);
                 }
 
                 // for trait impl blocks,

--- a/tests/ui/lint/dead-code/false-positive-builder-with-self-128272.rs
+++ b/tests/ui/lint/dead-code/false-positive-builder-with-self-128272.rs
@@ -1,0 +1,25 @@
+// Regression test for #128272
+// Tests that we do not consider a struct
+// dead code if it is constructed in a
+// const function taking `&self`
+
+
+//@ check-pass
+
+#![deny(dead_code)]
+
+pub struct Foo {
+    _f: i32
+}
+
+impl Foo {
+    // This function constructs Foo but in #128272
+    // the compiler warned that Foo is never constructed
+    pub const fn new(&self) -> Foo {
+        Foo { _f: 5 }
+    }
+}
+
+fn main() {
+    static _X: Foo = _X.new();
+}


### PR DESCRIPTION
Fixes #128272 

The issue occurred because we weren't considering for liveness check builder methods that can be called from a static context (e.g. `static X: Foo = X.new()`). Now we do.