### PR TITLE
Change generate-copyright to generate HTML, with cargo dependencies included

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,6 +1406,7 @@ name = "generate-copyright"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cargo_metadata 0.18.1",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,9 +1407,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
+ "rinja 0.2.0",
  "serde",
  "serde_json",
- "tempfile",
  "thiserror",
 ]
 
@@ -3102,12 +3102,41 @@ dependencies = [
 
 [[package]]
 name = "rinja"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d47a46d7729e891c8accf260e9daa02ae6d570aa2a94fb1fb27eb5364a2323"
+dependencies = [
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+ "rinja_derive 0.2.0",
+]
+
+[[package]]
+name = "rinja"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d3762e3740cdbf2fd2be465cc2c26d643ad17353cc2e0223d211c1b096118bd"
 dependencies = [
  "itoa",
- "rinja_derive",
+ "rinja_derive 0.3.0",
+]
+
+[[package]]
+name = "rinja_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dae9afe59d58ed8d988d67d1945f3638125d2fd2104058399382e11bd3ea2a"
+dependencies = [
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "once_map",
+ "proc-macro2",
+ "quote",
+ "rinja_parser 0.2.0",
+ "serde",
+ "syn 2.0.67",
 ]
 
 [[package]]
@@ -3123,9 +3152,18 @@ dependencies = [
  "once_map",
  "proc-macro2",
  "quote",
- "rinja_parser",
+ "rinja_parser 0.3.0",
  "serde",
  "syn 2.0.67",
+]
+
+[[package]]
+name = "rinja_parser"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1771c78cd5d3b1646ef8d8f2ed100db936e8b291d3cc06e92a339ff346858c"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -4606,7 +4644,7 @@ dependencies = [
  "minifier",
  "pulldown-cmark 0.9.6",
  "regex",
- "rinja",
+ "rinja 0.3.0",
  "rustdoc-json-types",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,8 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
+ "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,7 +1407,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
- "rinja 0.2.0",
+ "rinja",
  "serde",
  "serde_json",
  "thiserror",
@@ -3102,41 +3102,15 @@ dependencies = [
 
 [[package]]
 name = "rinja"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d47a46d7729e891c8accf260e9daa02ae6d570aa2a94fb1fb27eb5364a2323"
-dependencies = [
- "humansize",
- "num-traits",
- "percent-encoding",
- "rinja_derive 0.2.0",
-]
-
-[[package]]
-name = "rinja"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d3762e3740cdbf2fd2be465cc2c26d643ad17353cc2e0223d211c1b096118bd"
 dependencies = [
+ "humansize",
  "itoa",
- "rinja_derive 0.3.0",
-]
-
-[[package]]
-name = "rinja_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dae9afe59d58ed8d988d67d1945f3638125d2fd2104058399382e11bd3ea2a"
-dependencies = [
- "basic-toml",
- "mime",
- "mime_guess",
- "once_map",
- "proc-macro2",
- "quote",
- "rinja_parser 0.2.0",
- "serde",
- "syn 2.0.67",
+ "num-traits",
+ "percent-encoding",
+ "rinja_derive",
 ]
 
 [[package]]
@@ -3152,18 +3126,9 @@ dependencies = [
  "once_map",
  "proc-macro2",
  "quote",
- "rinja_parser 0.3.0",
+ "rinja_parser",
  "serde",
  "syn 2.0.67",
-]
-
-[[package]]
-name = "rinja_parser"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1771c78cd5d3b1646ef8d8f2ed100db936e8b291d3cc06e92a339ff346858c"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -4644,7 +4609,7 @@ dependencies = [
  "minifier",
  "pulldown-cmark 0.9.6",
  "regex",
- "rinja 0.3.0",
+ "rinja",
  "rustdoc-json-types",
  "serde",
  "serde_json",

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -163,7 +163,7 @@ SPDX-License-Identifier = "MIT OR Apache-2.0"
 path = "src/llvm-project/**"
 precedence = "override"
 SPDX-FileCopyrightText = [
-    "2003-2019 by the contributors listed in [CREDITS.TXT](https://github.com/rust-lang/llvm-project/blob/7738295178045041669876bf32b0543ec8319a5c/llvm/CREDITS.TXT)",
+    "2003-2019 by the contributors listed in CREDITS.TXT (https://github.com/rust-lang/llvm-project/blob/7738295178045041669876bf32b0543ec8319a5c/llvm/CREDITS.TXT)",
     "2010 Apple Inc",
     "2003-2019 University of Illinois at Urbana-Champaign.",
 ]

--- a/src/bootstrap/src/core/build_steps/run.rs
+++ b/src/bootstrap/src/core/build_steps/run.rs
@@ -217,6 +217,8 @@ impl Step for GenerateCopyright {
         let mut cmd = builder.tool_cmd(Tool::GenerateCopyright);
         cmd.env("LICENSE_METADATA", &license_metadata);
         cmd.env("DEST", &dest);
+        cmd.env("OUT_DIR", &builder.out);
+        cmd.env("CARGO", &builder.initial_cargo);
         cmd.run(builder);
 
         dest

--- a/src/bootstrap/src/core/build_steps/run.rs
+++ b/src/bootstrap/src/core/build_steps/run.rs
@@ -212,7 +212,7 @@ impl Step for GenerateCopyright {
         let license_metadata = builder.ensure(CollectLicenseMetadata);
 
         // Temporary location, it will be moved to the proper one once it's accurate.
-        let dest = builder.out.join("COPYRIGHT.md");
+        let dest = builder.out.join("COPYRIGHT.html");
 
         let mut cmd = builder.tool_cmd(Tool::GenerateCopyright);
         cmd.env("LICENSE_METADATA", &license_metadata);

--- a/src/tools/collect-license-metadata/Cargo.toml
+++ b/src/tools/collect-license-metadata/Cargo.toml
@@ -2,6 +2,8 @@
 name = "collect-license-metadata"
 version = "0.1.0"
 edition = "2021"
+description = "Runs the reuse tool and caches the output, so rust toolchain devs don't need to have reuse installed"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.65"

--- a/src/tools/collect-license-metadata/src/main.rs
+++ b/src/tools/collect-license-metadata/src/main.rs
@@ -8,6 +8,11 @@ use anyhow::Error;
 
 use crate::licenses::LicensesInterner;
 
+/// The entry point to the binary.
+///
+/// You should probably let `bootstrap` execute this program instead of running it directly.
+///
+/// Run `x.py run collect-license-metadata`
 fn main() -> Result<(), Error> {
     let reuse_exe: PathBuf = std::env::var_os("REUSE_EXE").expect("Missing REUSE_EXE").into();
     let dest: PathBuf = std::env::var_os("DEST").expect("Missing DEST").into();

--- a/src/tools/generate-copyright/Cargo.toml
+++ b/src/tools/generate-copyright/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.85"
 thiserror = "1"
 tempfile = "3"
+cargo_metadata = "0.18.1"

--- a/src/tools/generate-copyright/Cargo.toml
+++ b/src/tools/generate-copyright/Cargo.toml
@@ -2,6 +2,7 @@
 name = "generate-copyright"
 version = "0.1.0"
 edition = "2021"
+description = "Produces a manifest of all the copyrighted materials in the Rust Toolchain"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,3 +10,5 @@ edition = "2021"
 anyhow = "1.0.65"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.85"
+thiserror = "1"
+tempfile = "3"

--- a/src/tools/generate-copyright/Cargo.toml
+++ b/src/tools/generate-copyright/Cargo.toml
@@ -8,8 +8,10 @@ description = "Produces a manifest of all the copyrighted materials in the Rust 
 
 [dependencies]
 anyhow = "1.0.65"
+cargo_metadata = "0.18.1"
+html-escape = "0.2.13"
+rinja = "0.2.0"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.85"
-thiserror = "1"
 tempfile = "3"
-cargo_metadata = "0.18.1"
+thiserror = "1"

--- a/src/tools/generate-copyright/Cargo.toml
+++ b/src/tools/generate-copyright/Cargo.toml
@@ -9,7 +9,7 @@ description = "Produces a manifest of all the copyrighted materials in the Rust 
 [dependencies]
 anyhow = "1.0.65"
 cargo_metadata = "0.18.1"
-rinja = "0.2.0"
+rinja = "0.3.0"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.85"
 thiserror = "1"

--- a/src/tools/generate-copyright/Cargo.toml
+++ b/src/tools/generate-copyright/Cargo.toml
@@ -9,9 +9,7 @@ description = "Produces a manifest of all the copyrighted materials in the Rust 
 [dependencies]
 anyhow = "1.0.65"
 cargo_metadata = "0.18.1"
-html-escape = "0.2.13"
 rinja = "0.2.0"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.85"
-tempfile = "3"
 thiserror = "1"

--- a/src/tools/generate-copyright/src/cargo_metadata.rs
+++ b/src/tools/generate-copyright/src/cargo_metadata.rs
@@ -1,0 +1,196 @@
+//! Gets metadata about a workspace from Cargo
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+
+/// Describes how this module can fail
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Failed to run cargo metadata: {0:?}")]
+    LaunchingMetadata(#[from] std::io::Error),
+    #[error("Failed get output from cargo metadata: {0:?}")]
+    GettingMetadata(String),
+    #[error("Failed parse JSON output from cargo metadata: {0:?}")]
+    ParsingJson(#[from] serde_json::Error),
+    #[error("Failed find expected JSON element {0} in output from cargo metadata")]
+    MissingJsonElement(&'static str),
+    #[error("Failed find expected JSON element {0} in output from cargo metadata for package {1}")]
+    MissingJsonElementForPackage(String, String),
+    #[error("Failed to run cargo vendor: {0:?}")]
+    LaunchingVendor(std::io::Error),
+    #[error("Failed to complete cargo vendor")]
+    RunningVendor,
+}
+
+/// Describes one of our dependencies
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Dependency {
+    /// The name of the package
+    pub name: String,
+    /// The version number
+    pub version: String,
+    /// The license it is under
+    pub license: String,
+    /// The list of authors from the package metadata
+    pub authors: Vec<String>,
+    /// A list of important files from the package, with their contents.
+    ///
+    /// This includes *COPYRIGHT*, *NOTICE*, *AUTHOR*, *LICENSE*, and *LICENCE* files, case-insensitive.
+    pub notices: BTreeMap<OsString, String>,
+}
+
+/// Use `cargo` to get a list of dependencies and their license data.
+///
+/// This will involve running `cargo vendor` into `${BUILD}/vendor` so we can
+/// grab the license files.
+///
+/// Any dependency with a path beginning with `root_path` is ignored, as we
+/// assume `reuse` has covered it already.
+pub fn get(
+    cargo: &Path,
+    dest: &Path,
+    root_path: &Path,
+    manifest_paths: &[&Path],
+) -> Result<BTreeSet<Dependency>, Error> {
+    let mut temp_set = BTreeSet::new();
+    // Look at the metadata for each manifest
+    for manifest_path in manifest_paths {
+        if manifest_path.file_name() != Some(OsStr::new("Cargo.toml")) {
+            panic!("cargo_manifest::get requires a path to a Cargo.toml file");
+        }
+        let metadata_json = get_metadata_json(cargo, manifest_path)?;
+        let packages = metadata_json["packages"]
+            .as_array()
+            .ok_or_else(|| Error::MissingJsonElement("packages array"))?;
+        for package in packages {
+            let package =
+                package.as_object().ok_or_else(|| Error::MissingJsonElement("package object"))?;
+            let manifest_path = package
+                .get("manifest_path")
+                .and_then(|v| v.as_str())
+                .map(Path::new)
+                .ok_or_else(|| Error::MissingJsonElement("package.manifest_path"))?;
+            if manifest_path.starts_with(&root_path) {
+                // it's an in-tree dependency and reuse covers it
+                continue;
+            }
+            // otherwise it's an out-of-tree dependency
+            let get_string = |field_name: &str, package_name: &str| {
+                package.get(field_name).and_then(|v| v.as_str()).ok_or_else(|| {
+                    Error::MissingJsonElementForPackage(
+                        format!("package.{field_name}"),
+                        package_name.to_owned(),
+                    )
+                })
+            };
+            let name = get_string("name", "unknown")?;
+            let license = get_string("license", name)?;
+            let version = get_string("version", name)?;
+            let authors_list = package
+                .get("authors")
+                .and_then(|v| v.as_array())
+                .ok_or_else(|| Error::MissingJsonElement("package.authors"))?;
+            let authors: Vec<String> =
+                authors_list.iter().filter_map(|v| v.as_str()).map(|s| s.to_owned()).collect();
+            temp_set.insert(Dependency {
+                name: name.to_owned(),
+                version: version.to_owned(),
+                license: license.to_owned(),
+                authors,
+                notices: BTreeMap::new(),
+            });
+        }
+    }
+
+    // Now do a cargo-vendor and grab everything
+    let vendor_path = dest.join("vendor");
+    println!("Vendoring deps into {}...", vendor_path.display());
+    run_cargo_vendor(cargo, &vendor_path, manifest_paths)?;
+
+    // Now for each dependency we found, go and grab any important looking files
+    let mut output = BTreeSet::new();
+    for mut dep in temp_set {
+        load_important_files(&mut dep, &vendor_path)?;
+        output.insert(dep);
+    }
+
+    Ok(output)
+}
+
+/// Get cargo-metdata for a package, as JSON
+fn get_metadata_json(cargo: &Path, manifest_path: &Path) -> Result<serde_json::Value, Error> {
+    let metadata_output = std::process::Command::new(cargo)
+        .arg("metadata")
+        .arg("--format-version=1")
+        .arg("--all-features")
+        .arg("--manifest-path")
+        .arg(manifest_path)
+        .env("RUSTC_BOOTSTRAP", "1")
+        .output()
+        .map_err(|e| Error::LaunchingMetadata(e))?;
+    if !metadata_output.status.success() {
+        return Err(Error::GettingMetadata(
+            String::from_utf8(metadata_output.stderr).expect("UTF-8 output from cargo"),
+        ));
+    }
+    let json = serde_json::from_slice(&metadata_output.stdout)?;
+    Ok(json)
+}
+
+/// Run cargo-vendor, fetching into the given dir
+fn run_cargo_vendor(cargo: &Path, dest: &Path, manifest_paths: &[&Path]) -> Result<(), Error> {
+    let mut vendor_command = std::process::Command::new(cargo);
+    vendor_command.env("RUSTC_BOOTSTRAP", "1");
+    vendor_command.arg("vendor");
+    vendor_command.arg("--quiet");
+    vendor_command.arg("--versioned-dirs");
+    for manifest_path in manifest_paths {
+        vendor_command.arg("-s");
+        vendor_command.arg(manifest_path);
+    }
+    vendor_command.arg(dest);
+
+    let vendor_status = vendor_command.status().map_err(|e| Error::LaunchingVendor(e))?;
+
+    if !vendor_status.success() {
+        return Err(Error::RunningVendor);
+    }
+
+    Ok(())
+}
+
+/// Add important files off disk into this dependency.
+///
+/// Maybe one-day Cargo.toml will contain enough information that we don't need
+/// to do this manual scraping.
+fn load_important_files(dep: &mut Dependency, vendor_root: &Path) -> Result<(), Error> {
+    let name_version = format!("{}-{}", dep.name, dep.version);
+    println!("Scraping notices for {}...", name_version);
+    let dep_vendor_path = vendor_root.join(name_version);
+    for entry in std::fs::read_dir(dep_vendor_path)? {
+        let entry = entry?;
+        let metadata = entry.metadata()?;
+        let path = entry.path();
+        if let Some(filename) = path.file_name() {
+            let lc_filename = filename.to_ascii_lowercase();
+            let lc_filename_str = lc_filename.to_string_lossy();
+            let mut keep = false;
+            for m in ["copyright", "licence", "license", "author", "notice"] {
+                if lc_filename_str.contains(m) {
+                    keep = true;
+                    break;
+                }
+            }
+            if keep {
+                if metadata.is_dir() {
+                    // scoop up whole directory
+                } else if metadata.is_file() {
+                    println!("Scraping {}", filename.to_string_lossy());
+                    dep.notices.insert(filename.to_owned(), std::fs::read_to_string(path)?);
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/tools/generate-copyright/src/cargo_metadata.rs
+++ b/src/tools/generate-copyright/src/cargo_metadata.rs
@@ -1,7 +1,7 @@
 //! Gets metadata about a workspace from Cargo
 
 use std::collections::BTreeMap;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsStr;
 use std::path::Path;
 
 /// Describes how this module can fail
@@ -36,7 +36,9 @@ pub struct PackageMetadata {
     /// A list of important files from the package, with their contents.
     ///
     /// This includes *COPYRIGHT*, *NOTICE*, *AUTHOR*, *LICENSE*, and *LICENCE* files, case-insensitive.
-    pub notices: BTreeMap<OsString, String>,
+    pub notices: BTreeMap<String, String>,
+    /// If this is true, this dep is in the Rust Standard Library
+    pub is_in_libstd: Option<bool>,
 }
 
 /// Use `cargo metadata` and `cargo vendor` to get a list of dependencies and their license data.
@@ -101,6 +103,7 @@ pub fn get_metadata(
                     license: package.license.unwrap_or_else(|| String::from("Unspecified")),
                     authors: package.authors,
                     notices: BTreeMap::new(),
+                    is_in_libstd: None,
                 },
             );
         }
@@ -161,8 +164,9 @@ fn load_important_files(
                 if metadata.is_dir() {
                     // scoop up whole directory
                 } else if metadata.is_file() {
-                    println!("Scraping {}", filename.to_string_lossy());
-                    dep.notices.insert(filename.to_owned(), std::fs::read_to_string(path)?);
+                    let filename = filename.to_string_lossy();
+                    println!("Scraping {}", filename);
+                    dep.notices.insert(filename.to_string(), std::fs::read_to_string(path)?);
                 }
             }
         }

--- a/src/tools/generate-copyright/src/main.rs
+++ b/src/tools/generate-copyright/src/main.rs
@@ -1,54 +1,114 @@
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Error;
 
+mod cargo_metadata;
+
+/// The entry point to the binary.
+///
+/// You should probably let `bootstrap` execute this program instead of running it directly.
+///
+/// Run `x.py run generate-metadata`
 fn main() -> Result<(), Error> {
-    let dest = env_path("DEST")?;
+    let dest_file = env_path("DEST")?;
+    let out_dir = env_path("OUT_DIR")?;
+    let cargo = env_path("CARGO")?;
     let license_metadata = env_path("LICENSE_METADATA")?;
 
-    let metadata: Metadata = serde_json::from_slice(&std::fs::read(&license_metadata)?)?;
+    let collected_tree_metadata: Metadata =
+        serde_json::from_slice(&std::fs::read(&license_metadata)?)?;
+
+    let root_path = std::path::absolute(".")?;
+    let workspace_paths = [
+        Path::new("./Cargo.toml"),
+        Path::new("./src/tools/cargo/Cargo.toml"),
+        Path::new("./library/std/Cargo.toml"),
+    ];
+    let collected_cargo_metadata =
+        cargo_metadata::get(&cargo, &out_dir, &root_path, &workspace_paths)?;
 
     let mut buffer = Vec::new();
-    render_recursive(&metadata.files, &mut buffer, 0)?;
 
-    std::fs::write(&dest, &buffer)?;
+    writeln!(buffer, "# COPYRIGHT for Rust")?;
+    writeln!(buffer)?;
+    writeln!(
+        buffer,
+        "This file describes the copyright and licensing information for the source code within The Rust Project git tree, and the third-party dependencies used when building the Rust toolchain (including the Rust Standard Library)"
+    )?;
+    writeln!(buffer)?;
+    writeln!(buffer, "## Table of Contents")?;
+    writeln!(buffer)?;
+    writeln!(buffer, "* [In-tree files](#in-tree-files)")?;
+    writeln!(buffer, "* [Out-of-tree files](#out-of-tree-files)")?;
+    // writeln!(buffer, "* [License Texts](#license-texts)")?;
+    writeln!(buffer)?;
+
+    writeln!(buffer, "## In-tree files")?;
+    writeln!(buffer)?;
+    writeln!(
+        buffer,
+        "The following licenses cover the in-tree source files that were used in this release:"
+    )?;
+    writeln!(buffer)?;
+    render_tree_recursive(&collected_tree_metadata.files, &mut buffer, 0)?;
+
+    writeln!(buffer)?;
+
+    writeln!(buffer, "## Out-of-tree files")?;
+    writeln!(buffer)?;
+    writeln!(
+        buffer,
+        "The following licenses cover the out-of-tree crates that were used in this release:"
+    )?;
+    writeln!(buffer)?;
+    render_deps(collected_cargo_metadata.iter(), &mut buffer)?;
+
+    std::fs::write(&dest_file, &buffer)?;
 
     Ok(())
 }
 
-fn render_recursive(node: &Node, buffer: &mut Vec<u8>, depth: usize) -> Result<(), Error> {
+/// Recursively draw the tree of files/folders we found on disk and their licenses, as
+/// markdown, into the given Vec.
+fn render_tree_recursive(node: &Node, buffer: &mut Vec<u8>, depth: usize) -> Result<(), Error> {
     let prefix = std::iter::repeat("> ").take(depth + 1).collect::<String>();
 
     match node {
         Node::Root { children } => {
             for child in children {
-                render_recursive(child, buffer, depth)?;
+                render_tree_recursive(child, buffer, depth)?;
             }
         }
         Node::Directory { name, children, license } => {
-            render_license(&prefix, std::iter::once(name), license.as_ref(), buffer)?;
+            render_tree_license(&prefix, std::iter::once(name), license.as_ref(), buffer)?;
             if !children.is_empty() {
                 writeln!(buffer, "{prefix}")?;
                 writeln!(buffer, "{prefix}*Exceptions:*")?;
                 for child in children {
                     writeln!(buffer, "{prefix}")?;
-                    render_recursive(child, buffer, depth + 1)?;
+                    render_tree_recursive(child, buffer, depth + 1)?;
                 }
             }
         }
         Node::Group { files, directories, license } => {
-            render_license(&prefix, directories.iter().chain(files.iter()), Some(license), buffer)?;
+            render_tree_license(
+                &prefix,
+                directories.iter().chain(files.iter()),
+                Some(license),
+                buffer,
+            )?;
         }
         Node::File { name, license } => {
-            render_license(&prefix, std::iter::once(name), Some(license), buffer)?;
+            render_tree_license(&prefix, std::iter::once(name), Some(license), buffer)?;
         }
     }
 
     Ok(())
 }
 
-fn render_license<'a>(
+/// Draw a series of sibling files/folders, as markdown, into the given Vec.
+fn render_tree_license<'a>(
     prefix: &str,
     names: impl Iterator<Item = &'a String>,
     license: Option<&License>,
@@ -67,11 +127,47 @@ fn render_license<'a>(
     Ok(())
 }
 
+/// Render a list of out-of-tree dependencies as markdown into the given Vec.
+fn render_deps<'a, 'b>(
+    deps: impl Iterator<Item = &'a cargo_metadata::Dependency>,
+    buffer: &'b mut Vec<u8>,
+) -> Result<(), Error> {
+    for dep in deps {
+        let authors_list = dep.authors.join(", ").replace("<", "\\<").replace(">", "\\>");
+        let url = format!("https://crates.io/crates/{}/{}", dep.name, dep.version);
+        writeln!(buffer)?;
+        writeln!(
+            buffer,
+            "### [{name} {version}]({url})",
+            name = dep.name,
+            version = dep.version,
+            url = url,
+        )?;
+        writeln!(buffer)?;
+        writeln!(buffer, "* Authors: {}", authors_list)?;
+        writeln!(buffer, "* License: {}", dep.license)?;
+        for (name, contents) in &dep.notices {
+            writeln!(buffer)?;
+            writeln!(buffer, "#### {}", name.to_string_lossy())?;
+            writeln!(buffer)?;
+            writeln!(buffer, "<details><summary>Click to expand</summary>")?;
+            writeln!(buffer)?;
+            writeln!(buffer, "```")?;
+            writeln!(buffer, "{}", contents)?;
+            writeln!(buffer, "```")?;
+            writeln!(buffer)?;
+            writeln!(buffer, "</details>")?;
+        }
+    }
+    Ok(())
+}
+/// Describes a tree of metadata for our filesystem tree
 #[derive(serde::Deserialize)]
 struct Metadata {
     files: Node,
 }
 
+/// Describes one node in our metadata tree
 #[derive(serde::Deserialize)]
 #[serde(rename_all = "kebab-case", tag = "type")]
 pub(crate) enum Node {
@@ -81,12 +177,14 @@ pub(crate) enum Node {
     Group { files: Vec<String>, directories: Vec<String>, license: License },
 }
 
+/// A License has an SPDX license name and a list of copyright holders.
 #[derive(serde::Deserialize)]
 struct License {
     spdx: String,
     copyright: Vec<String>,
 }
 
+/// Grab an environment variable as a PathBuf, or fail nicely.
 fn env_path(var: &str) -> Result<PathBuf, Error> {
     if let Some(var) = std::env::var_os(var) {
         Ok(var.into())

--- a/src/tools/generate-copyright/src/main.rs
+++ b/src/tools/generate-copyright/src/main.rs
@@ -1,37 +1,17 @@
 use std::collections::BTreeMap;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::Error;
+use rinja::Template;
 
 mod cargo_metadata;
 
-static TOP_BOILERPLATE: &str = r##"
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>Copyright notices for The Rust Toolchain</title>
-</head>
-<body>
-
-<h1>Copyright notices for The Rust Toolchain</h1>
-
-<p>This file describes the copyright and licensing information for the source
-code within The Rust Project git tree, and the third-party dependencies used
-when building the Rust toolchain (including the Rust Standard Library).</p>
-
-<h2>Table of Contents</h2>
-<ul>
-    <li><a href="#in-tree-files">In-tree files</a></li>
-    <li><a href="#out-of-tree-dependencies">Out-of-tree dependencies</a></li>
-</ul>
-"##;
-
-static BOTTOM_BOILERPLATE: &str = r#"
-</body>
-</html>
-"#;
+#[derive(Template)]
+#[template(path = "COPYRIGHT.html")]
+struct CopyrightTemplate {
+    in_tree: Node,
+    dependencies: BTreeMap<cargo_metadata::Package, cargo_metadata::PackageMetadata>,
+}
 
 /// The entry point to the binary.
 ///
@@ -53,134 +33,28 @@ fn main() -> Result<(), Error> {
         Path::new("./src/tools/cargo/Cargo.toml"),
         Path::new("./library/std/Cargo.toml"),
     ];
-    let collected_cargo_metadata =
+    let mut collected_cargo_metadata =
         cargo_metadata::get_metadata_and_notices(&cargo, &out_dir, &root_path, &workspace_paths)?;
 
     let stdlib_set =
         cargo_metadata::get_metadata(&cargo, &root_path, &[Path::new("./library/std/Cargo.toml")])?;
 
-    let mut buffer = Vec::new();
+    for (key, value) in collected_cargo_metadata.iter_mut() {
+        value.is_in_libstd = Some(stdlib_set.contains_key(key));
+    }
 
-    writeln!(buffer, "{}", TOP_BOILERPLATE)?;
+    let template = CopyrightTemplate {
+        in_tree: collected_tree_metadata.files,
+        dependencies: collected_cargo_metadata,
+    };
 
-    writeln!(
-        buffer,
-        r#"<h2 id="in-tree-files">In-tree files</h2><p>The following licenses cover the in-tree source files that were used in this release:</p>"#
-    )?;
-    render_tree_recursive(&collected_tree_metadata.files, &mut buffer)?;
+    let output = template.render()?;
 
-    writeln!(
-        buffer,
-        r#"<h2 id="out-of-tree-dependencies">Out-of-tree dependencies</h2><p>The following licenses cover the out-of-tree crates that were used in this release:</p>"#
-    )?;
-    render_deps(&collected_cargo_metadata, &stdlib_set, &mut buffer)?;
-
-    writeln!(buffer, "{}", BOTTOM_BOILERPLATE)?;
-
-    std::fs::write(&dest_file, &buffer)?;
+    std::fs::write(&dest_file, output)?;
 
     Ok(())
 }
 
-/// Recursively draw the tree of files/folders we found on disk and their licenses, as
-/// markdown, into the given Vec.
-fn render_tree_recursive(node: &Node, buffer: &mut Vec<u8>) -> Result<(), Error> {
-    writeln!(buffer, r#"<div style="border:1px solid black; padding: 5px;">"#)?;
-    match node {
-        Node::Root { children } => {
-            for child in children {
-                render_tree_recursive(child, buffer)?;
-            }
-        }
-        Node::Directory { name, children, license } => {
-            render_tree_license(std::iter::once(name), license.as_ref(), buffer)?;
-            if !children.is_empty() {
-                writeln!(buffer, "<p><b>Exceptions:</b></p>")?;
-                for child in children {
-                    render_tree_recursive(child, buffer)?;
-                }
-            }
-        }
-        Node::Group { files, directories, license } => {
-            render_tree_license(directories.iter().chain(files.iter()), Some(license), buffer)?;
-        }
-        Node::File { name, license } => {
-            render_tree_license(std::iter::once(name), Some(license), buffer)?;
-        }
-    }
-    writeln!(buffer, "</div>")?;
-
-    Ok(())
-}
-
-/// Draw a series of sibling files/folders, as markdown, into the given Vec.
-fn render_tree_license<'a>(
-    names: impl Iterator<Item = &'a String>,
-    license: Option<&License>,
-    buffer: &mut Vec<u8>,
-) -> Result<(), Error> {
-    writeln!(buffer, "<p><b>File/Directory:</b> ")?;
-    for name in names {
-        writeln!(buffer, "<code>{name}</code>")?;
-    }
-    writeln!(buffer, "</p>")?;
-
-    if let Some(license) = license {
-        writeln!(buffer, "<p><b>License:</b> {}</p>", license.spdx)?;
-        for copyright in license.copyright.iter() {
-            writeln!(buffer, "<p><b>Copyright:</b> {copyright}</p>")?;
-        }
-    }
-
-    Ok(())
-}
-
-/// Render a list of out-of-tree dependencies as markdown into the given Vec.
-fn render_deps(
-    all_deps: &BTreeMap<cargo_metadata::Package, cargo_metadata::PackageMetadata>,
-    stdlib_set: &BTreeMap<cargo_metadata::Package, cargo_metadata::PackageMetadata>,
-    buffer: &mut Vec<u8>,
-) -> Result<(), Error> {
-    for (package, metadata) in all_deps {
-        let authors_list = if metadata.authors.is_empty() {
-            "None Specified".to_owned()
-        } else {
-            metadata.authors.join(", ")
-        };
-        let url = format!("https://crates.io/crates/{}/{}", package.name, package.version);
-        writeln!(buffer)?;
-        writeln!(
-            buffer,
-            r#"<h3>📦 {name}-{version}</h3>"#,
-            name = package.name,
-            version = package.version,
-        )?;
-        writeln!(buffer, r#"<p><b>URL:</b> <a href="{url}">{url}</a></p>"#,)?;
-        writeln!(
-            buffer,
-            "<p><b>In libstd:</b> {}</p>",
-            if stdlib_set.contains_key(package) { "Yes" } else { "No" }
-        )?;
-        writeln!(buffer, "<p><b>Authors:</b> {}</p>", escape_html(&authors_list))?;
-        writeln!(buffer, "<p><b>License:</b> {}</p>", escape_html(&metadata.license))?;
-        writeln!(buffer, "<p><b>Notices:</b> ")?;
-        if metadata.notices.is_empty() {
-            writeln!(buffer, "None")?;
-        } else {
-            for (name, contents) in &metadata.notices {
-                writeln!(
-                    buffer,
-                    "<details><summary><code>{}</code></summary>",
-                    name.to_string_lossy()
-                )?;
-                writeln!(buffer, "<pre>\n{}\n</pre>", contents)?;
-                writeln!(buffer, "</details>")?;
-            }
-        }
-        writeln!(buffer, "</p>")?;
-    }
-    Ok(())
-}
 /// Describes a tree of metadata for our filesystem tree
 #[derive(serde::Deserialize)]
 struct Metadata {
@@ -197,6 +71,76 @@ pub(crate) enum Node {
     Group { files: Vec<String>, directories: Vec<String>, license: License },
 }
 
+fn with_box<F>(fmt: &mut std::fmt::Formatter<'_>, inner: F) -> std::fmt::Result
+where
+    F: FnOnce(&mut std::fmt::Formatter<'_>) -> std::fmt::Result,
+{
+    writeln!(fmt, r#"<div style="border:1px solid black; padding: 5px;">"#)?;
+    inner(fmt)?;
+    writeln!(fmt, "</div>")?;
+    Ok(())
+}
+
+impl std::fmt::Display for Node {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Node::Root { children } => {
+                if children.len() > 1 {
+                    with_box(fmt, |f| {
+                        for child in children {
+                            writeln!(f, "{child}")?;
+                        }
+                        Ok(())
+                    })
+                } else {
+                    for child in children {
+                        writeln!(fmt, "{child}")?;
+                    }
+                    Ok(())
+                }
+            }
+            Node::Directory { name, children, license } => with_box(fmt, |f| {
+                render_tree_license(std::iter::once(name), license.as_ref(), f)?;
+                if !children.is_empty() {
+                    writeln!(f, "<p><b>Exceptions:</b></p>")?;
+                    for child in children {
+                        writeln!(f, "{child}")?;
+                    }
+                }
+                Ok(())
+            }),
+            Node::Group { files, directories, license } => with_box(fmt, |f| {
+                render_tree_license(directories.iter().chain(files.iter()), Some(license), f)
+            }),
+            Node::File { name, license } => {
+                with_box(fmt, |f| render_tree_license(std::iter::once(name), Some(license), f))
+            }
+        }
+    }
+}
+
+/// Draw a series of sibling files/folders, as HTML, into the given formatter.
+fn render_tree_license<'a>(
+    names: impl Iterator<Item = &'a String>,
+    license: Option<&License>,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    writeln!(f, "<p><b>File/Directory:</b> ")?;
+    for name in names {
+        writeln!(f, "<code>{}</code>", html_escape::encode_text(&name))?;
+    }
+    writeln!(f, "</p>")?;
+
+    if let Some(license) = license {
+        writeln!(f, "<p><b>License:</b> {}</p>", html_escape::encode_text(&license.spdx))?;
+        for copyright in license.copyright.iter() {
+            writeln!(f, "<p><b>Copyright:</b> {}</p>", html_escape::encode_text(&copyright))?;
+        }
+    }
+
+    Ok(())
+}
+
 /// A License has an SPDX license name and a list of copyright holders.
 #[derive(serde::Deserialize)]
 struct License {
@@ -211,14 +155,4 @@ fn env_path(var: &str) -> Result<PathBuf, Error> {
     } else {
         anyhow::bail!("missing environment variable {var}")
     }
-}
-
-/// Escapes any invalid HTML characters
-fn escape_html(input: &str) -> String {
-    static MAPPING: [(char, &str); 3] = [('&', "&amp;"), ('<', "&lt;"), ('>', "&gt;")];
-    let mut output = input.to_owned();
-    for (ch, s) in &MAPPING {
-        output = output.replace(*ch, s);
-    }
-    output
 }

--- a/src/tools/generate-copyright/src/main.rs
+++ b/src/tools/generate-copyright/src/main.rs
@@ -37,7 +37,7 @@ static BOTTOM_BOILERPLATE: &str = r#"
 ///
 /// You should probably let `bootstrap` execute this program instead of running it directly.
 ///
-/// Run `x.py run generate-metadata`
+/// Run `x.py run generate-copyright`
 fn main() -> Result<(), Error> {
     let dest_file = env_path("DEST")?;
     let out_dir = env_path("OUT_DIR")?;

--- a/src/tools/generate-copyright/src/main.rs
+++ b/src/tools/generate-copyright/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Error> {
     let workspace_paths = [
         Path::new("./Cargo.toml"),
         Path::new("./src/tools/cargo/Cargo.toml"),
-        Path::new("./library/std/Cargo.toml"),
+        Path::new("./library/Cargo.toml"),
     ];
     let mut collected_cargo_metadata =
         cargo_metadata::get_metadata_and_notices(&cargo, &out_dir, &root_path, &workspace_paths)?;

--- a/src/tools/generate-copyright/templates/COPYRIGHT.html
+++ b/src/tools/generate-copyright/templates/COPYRIGHT.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Copyright notices for The Rust Toolchain</title>
+</head>
+<body>
+
+<h1>Copyright notices for The Rust Toolchain</h1>
+
+<p>This file describes the copyright and licensing information for the source
+code within The Rust Project git tree, and the third-party dependencies used
+when building the Rust toolchain (including the Rust Standard Library).</p>
+
+<h2>Table of Contents</h2>
+<ul>
+    <li><a href="#in-tree-files">In-tree files</a></li>
+    <li><a href="#out-of-tree-dependencies">Out-of-tree dependencies</a></li>
+</ul>
+
+<h2 id="in-tree-files">In-tree files</h2>
+
+<p>The following licenses cover the in-tree source files that were used in this
+release:</p>
+
+{{ in_tree|safe }}
+
+<h2 id="out-of-tree-dependencies">Out-of-tree dependencies</h2>
+
+<p>The following licenses cover the out-of-tree crates that were used in this
+release:</p>
+
+{% for (key, value) in dependencies %}
+    <h3>📦 {{key.name}}-{{key.version}}</h3>
+    <p><b>URL:</b> <a href="https://crates.io/crates/{{ key.name }}/{{ key.version }}">https://crates.io/crates/{{ key.name }}/{{ key.version }}</a></p>
+    <p><b>In libstd:</b> {% if value.is_in_libstd.unwrap() %} Yes {% else %} No {% endif %}</p>
+    <p><b>Authors:</b> {{ value.authors|join(", ") }}</p>
+    <p><b>License:</b> {{ value.license }}</p>
+    {% let len = value.notices.len() %}
+    {% if len > 0 %}
+        <p><b>Notices:</b>
+        {% for (notice_name, notice_text) in value.notices %}
+            <details>
+                <summary><code>{{ notice_name }}</code></summary>
+                <pre>
+{{ notice_text }}
+                </pre>
+            </details>
+        {% endfor %}
+        </p>
+    {% endif %}
+{% endfor %}
+</body>
+</html>

--- a/src/tools/generate-copyright/templates/Node.html
+++ b/src/tools/generate-copyright/templates/Node.html
@@ -1,0 +1,71 @@
+{% match self %}
+
+{% when Node::Root { children } %}
+
+{% for child in children %}
+{{ child|safe }}
+{% endfor %}
+
+{% when Node::Directory { name, children, license } %}
+
+<div style="border:1px solid black; padding: 5px;">
+
+    <p>
+    <b>File/Directory:</b> <code>{{ name }}</code>
+    </p>
+
+    {% if let Some(license) = license %}
+
+    <p><b>License:</b> {{ license.spdx }}</p>
+    {% for copyright in license.copyright.iter() %}
+    <p><b>Copyright:</b> {{ copyright }}</p>
+    {% endfor %}
+
+    {% endif %}
+
+    {% if !children.is_empty() %}
+
+    <p><b>Exceptions:</b></p>
+    {% for child in children %}
+    {{ child|safe }}
+    {% endfor %}
+
+    {% endif %}
+
+</div>
+
+{% when Node::File { name, license } %}
+
+<div style="border:1px solid black; padding: 5px;">
+    <p>
+    <b>File/Directory:</b> <code>{{ name }}</code>
+    </p>
+
+    <p><b>License:</b> {{ license.spdx }}</p>
+    {% for copyright in license.copyright.iter() %}
+    <p><b>Copyright:</b> {{ copyright }}</p>
+    {% endfor %}
+</div>
+
+{% when Node::Group { files, directories, license } %}
+
+<div style="border:1px solid black; padding: 5px;">
+
+    <p>
+        <b>File/Directory:</b>
+        {% for name in files %}
+        <code>{{ name }}</code>
+        {% endfor %}
+        {% for name in directories %}
+        <code>{{ name }}</code>
+        {% endfor %}
+    </p>
+
+    <p><b>License:</b> {{ license.spdx }}</p>
+    {% for copyright in license.copyright.iter() %}
+    <p><b>Copyright:</b> {{ copyright }}</p>
+    {% endfor %}
+
+</div>
+
+{% endmatch %}


### PR DESCRIPTION
`x.py run generate-copyright` now produces `build/COPYRIGHT.html`. This includes a new format for in-tree dependencies, and also adds out-of-tree cargo dependencies.

After consulting expert opinion, I have elected to include every top-level:

* `*NOTICE*`
* `*AUTHOR*`
* `*LICENSE*`
* `*LICENCE*`, and
* `*COPYRIGHT*` file I can find - case-insensitive.

This is because the cargo package metadata's `author` field is not a list of copyright holders and does not meet the requirements of the Apache-2.0 license (which says you must include a NOTICE file with the binary if one was supplied by the author) nor the MIT license (which says you must include 'the above copyright notice').

I believe it would be appropriate to include this file with every Rust release, in order to do an even better job of appropriately recognising the efforts of the authors of the first-party and third-party libraries we are using here.

The output includes something like 524 copies of the Apache-2.0 text because they are not all identical. I think I count about 50 different variations by shasum - some differ in whitespace, while some have the boilerplate block at the bottom erroneously modified (don't modify the copy in the license, modify the copy you paste into your own source code!). Running `gzip` on the HTML file largely makes this problem go away, and the average browser is far happier with a ~6 MiB HTML file than the average Markdown viewer is with a ~6 MiB markdown file. But, if someone wants to, do they could submit a follow-up which de-dups the license text files and adds back-links to earlier identical copies (for some value of 'identical copy').

```console
$ xpy run generate-copyright
$ cd build
$ gzip -c COPYRIGHT.html > COPYRIGHT.gz
$ xz -c COPYRIGHT.html > COPYRIGHT.xz
$ ls -lh COPYRIGHT.*
-rw-r--r--  1 jonathan  staff   241K 29 Jul 17:19 COPYRIGHT.gz
-rw-r--r--@ 1 jonathan  staff   6.6M 29 Jul 11:30 COPYRIGHT.html
-rw-r--r--  1 jonathan  staff    59K 29 Jul 17:19 COPYRIGHT.xz
```

Here's an example [COPYRIGHT.gz](https://github.com/user-attachments/files/16416147/COPYRIGHT.gz).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
