### PR TITLE
compiler: suggest `const _` for a misplaced `const {}`

### DIFF
--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -85,15 +85,21 @@ impl<'a> Parser<'a> {
                         span,
                         "consider using `const` or `static` instead of `let` for global variables",
                     );
-                } else if self.parse_const_block(span, false).is_ok() {
-                    err.span_label(
-                        span,
-                        "if you meant to create an anonymous const, use `const _: () = {};` instead"
-                    );
                 } else {
-                    err.span_label(span, "expected item")
-                        .note("for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>");
-                };
+                    match self.parse_const_block(span, false) {
+                        Ok(_) => {
+                            err.span_label(
+                                span,
+                                "if you meant to create an anonymous const, use `const _: () = {};` instead"
+                            );
+                        }
+                        Err(bomb) => {
+                            bomb.cancel();
+                            err.span_label(span, "expected item")
+                                .note("for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>");
+                        }
+                    }
+                }
                 return Err(err);
             }
         }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -88,7 +88,7 @@ impl<'a> Parser<'a> {
                 } else if self.parse_const_block(span, false).is_ok() {
                     err.span_label(
                         span,
-                        "if you meant to create an anonymous const, use `const (): _ = {};` instead"
+                        "if you meant to create an anonymous const, use `const _: () = {};` instead"
                     );
                 } else {
                     err.span_label(span, "expected item")

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -89,9 +89,11 @@ impl<'a> Parser<'a> {
                     let snapshot = self.create_snapshot_for_diagnostic();
                     match self.parse_const_block(span, false) {
                         Ok(_) => {
-                            err.span_label(
-                                span,
-                                "if you meant to create an anonymous const, use `const _: () = {};` instead"
+                            err.span_suggestion_verbose(
+                                span.shrink_to_lo(),
+                                "to evaluate a const expression, use an anonymous const",
+                                "const _: () = ",
+                                Applicability::MaybeIncorrect,
                             );
                         }
                         Err(diag) => {

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -86,6 +86,7 @@ impl<'a> Parser<'a> {
                         "consider using `const` or `static` instead of `let` for global variables",
                     );
                 } else {
+                    let snapshot = self.create_snapshot_for_diagnostic();
                     match self.parse_const_block(span, false) {
                         Ok(_) => {
                             err.span_label(
@@ -93,8 +94,9 @@ impl<'a> Parser<'a> {
                                 "if you meant to create an anonymous const, use `const _: () = {};` instead"
                             );
                         }
-                        Err(bomb) => {
-                            bomb.cancel();
+                        Err(diag) => {
+                            diag.cancel();
+                            self.restore_snapshot(snapshot);
                             err.span_label(span, "expected item")
                                 .note("for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>");
                         }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -85,6 +85,11 @@ impl<'a> Parser<'a> {
                         span,
                         "consider using `const` or `static` instead of `let` for global variables",
                     );
+                } else if self.parse_const_block(span, false).is_ok() {
+                    err.span_label(
+                        span,
+                        "if you meant to create an anonymous const, use `const (): _ = {};` instead"
+                    );
                 } else {
                     err.span_label(span, "expected item")
                         .note("for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>");

--- a/tests/ui/inline-const/expr-in-item-context.rs
+++ b/tests/ui/inline-const/expr-in-item-context.rs
@@ -8,7 +8,7 @@ const _: () = {};
 
 const { assert!(size_of::<u32>() <= size_of::<usize>()) };
 //~^ expected item, found keyword
-//~| if you meant to create an anonymous const
+//~| if you meant to create an anonymous const, use `const _: () =
 
 fn main() {
     const { assert!(size_of::<u32>() <= size_of::<usize>()) };

--- a/tests/ui/inline-const/expr-in-item-context.rs
+++ b/tests/ui/inline-const/expr-in-item-context.rs
@@ -1,0 +1,15 @@
+// reported in https://github.com/rust-lang/rust/issues/128338
+
+// This had an overly-terse diagnostic, because we recognized this is where an item should be, but
+// but didn't recognize an inline const in this place is probably trying to be an "anon const item".
+// Those are written like this:
+const _: () = {};
+// const _ are often used as compile-time assertions that don't conflict with other const items
+
+const { assert!(size_of::<u32>() <= size_of::<usize>()) };
+//~^ error: expected item
+//~| for a full list of items
+
+fn main() {
+    const { assert!(size_of::<u32>() <= size_of::<usize>()) };
+}

--- a/tests/ui/inline-const/expr-in-item-context.rs
+++ b/tests/ui/inline-const/expr-in-item-context.rs
@@ -8,7 +8,7 @@ const _: () = {};
 
 const { assert!(size_of::<u32>() <= size_of::<usize>()) };
 //~^ expected item, found keyword
-//~| if you meant to create an anonymous const, use `const _: () =
+//~| to evaluate a const expression, use an anonymous const
 
 fn main() {
     const { assert!(size_of::<u32>() <= size_of::<usize>()) };

--- a/tests/ui/inline-const/expr-in-item-context.rs
+++ b/tests/ui/inline-const/expr-in-item-context.rs
@@ -7,8 +7,8 @@ const _: () = {};
 // const _ are often used as compile-time assertions that don't conflict with other const items
 
 const { assert!(size_of::<u32>() <= size_of::<usize>()) };
-//~^ error: expected item
-//~| for a full list of items
+//~^ expected item, found keyword
+//~| if you meant to create an anonymous const
 
 fn main() {
     const { assert!(size_of::<u32>() <= size_of::<usize>()) };

--- a/tests/ui/inline-const/expr-in-item-context.stderr
+++ b/tests/ui/inline-const/expr-in-item-context.stderr
@@ -2,7 +2,12 @@ error: expected item, found keyword `const`
   --> $DIR/expr-in-item-context.rs:9:1
    |
 LL | const { assert!(size_of::<u32>() <= size_of::<usize>()) };
-   | ^^^^^ if you meant to create an anonymous const, use `const _: () = {};` instead
+   | ^^^^^
+   |
+help: to evaluate a const expression, use an anonymous const
+   |
+LL | const _: () = const { assert!(size_of::<u32>() <= size_of::<usize>()) };
+   | +++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inline-const/expr-in-item-context.stderr
+++ b/tests/ui/inline-const/expr-in-item-context.stderr
@@ -2,7 +2,7 @@ error: expected item, found keyword `const`
   --> $DIR/expr-in-item-context.rs:9:1
    |
 LL | const { assert!(size_of::<u32>() <= size_of::<usize>()) };
-   | ^^^^^ if you meant to create an anonymous const, use `const (): _ = {};` instead
+   | ^^^^^ if you meant to create an anonymous const, use `const _: () = {};` instead
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inline-const/expr-in-item-context.stderr
+++ b/tests/ui/inline-const/expr-in-item-context.stderr
@@ -2,9 +2,7 @@ error: expected item, found keyword `const`
   --> $DIR/expr-in-item-context.rs:9:1
    |
 LL | const { assert!(size_of::<u32>() <= size_of::<usize>()) };
-   | ^^^^^ expected item
-   |
-   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
+   | ^^^^^ if you meant to create an anonymous const, use `const (): _ = {};` instead
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/inline-const/expr-in-item-context.stderr
+++ b/tests/ui/inline-const/expr-in-item-context.stderr
@@ -1,0 +1,10 @@
+error: expected item, found keyword `const`
+  --> $DIR/expr-in-item-context.rs:9:1
+   |
+LL | const { assert!(size_of::<u32>() <= size_of::<usize>()) };
+   | ^^^^^ expected item
+   |
+   = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
<!-- homu-ignore:start -->

Fixes https://github.com/rust-lang/rust/issues/128338

<!-- homu-ignore:end -->
