### PR TITLE
Match LLVM ABI in `extern "C"` functions for `f128` on Windows

### DIFF
--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -94,7 +94,7 @@ fn main() {
         // Unsupported <https://github.com/llvm/llvm-project/issues/94434>
         ("arm64ec", _) => false,
         // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054>
-        ("x86", "windows") => false,
+        ("x86_64", "windows") => false,
         // x86 has ABI bugs that show up with optimizations. This should be partially fixed with
         // the compiler-builtins update. <https://github.com/rust-lang/rust/issues/123885>
         ("x86" | "x86_64", _) => false,
@@ -122,6 +122,8 @@ fn main() {
         ("nvptx64", _) => false,
         // ABI unsupported  <https://github.com/llvm/llvm-project/issues/41838>
         ("sparc", _) => false,
+        // MinGW ABI bugs <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054>
+        ("x86_64", "windows") => false,
         // 64-bit Linux is about the only platform to have f128 symbols by default
         (_, "linux") if target_pointer_width == 64 => true,
         // Same as for f16, except MacOS is also missing f128 symbols.

--- a/tests/assembly/x86_64-windows-float-abi.rs
+++ b/tests/assembly/x86_64-windows-float-abi.rs
@@ -1,0 +1,39 @@
+//@ assembly-output: emit-asm
+//@ compile-flags: -O
+//@ only-windows
+//@ only-x86_64
+
+#![feature(f16, f128)]
+#![crate_type = "lib"]
+
+// CHECK-LABEL: second_f16
+// CHECK: movaps %xmm1, %xmm0
+// CHECK-NEXT: retq
+#[no_mangle]
+pub extern "C" fn second_f16(_: f16, x: f16) -> f16 {
+    x
+}
+
+// CHECK-LABEL: second_f32
+// CHECK: movaps %xmm1, %xmm0
+// CHECK-NEXT: retq
+#[no_mangle]
+pub extern "C" fn second_f32(_: f32, x: f32) -> f32 {
+    x
+}
+
+// CHECK-LABEL: second_f64
+// CHECK: movaps %xmm1, %xmm0
+// CHECK-NEXT: retq
+#[no_mangle]
+pub extern "C" fn second_f64(_: f64, x: f64) -> f64 {
+    x
+}
+
+// CHECK-LABEL: second_f128
+// CHECK: movaps %xmm1, %xmm0
+// CHECK-NEXT: retq
+#[no_mangle]
+pub extern "C" fn second_f128(_: f128, x: f128) -> f128 {
+    x
+}


### PR DESCRIPTION
As MSVC doesn't support `_Float128`, x86-64 Windows doesn't have a defined ABI for `f128`. Currently, Rust will pass and return `f128` indirectly for `extern "C"` functions. This is inconsistent with LLVM, which passes and returns `f128` in XMM registers, meaning that e.g. the ABI of `extern "C"` compiler builtins won't match. This PR fixes this discrepancy by making the x86-64 Windows `extern "C"` ABI pass `f128` directly through to LLVM, so that Rust will follow whatever LLVM does. This still leaves the difference between LLVM and GCC (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115054) but this PR is still an improvement as at least Rust is now consistent with it's primary codegen backend and compiler builtins from `compiler-builtins` will now work.

I've also fixed the x86-64 Windows `has_reliable_f16` match arm in `std` `build.rs` to refer to the correct target, and added an equivalent match arm to `has_reliable_f128` as the LLVM-GCC ABI difference affects both `f16` and `f128`.

Tracking issue: #116909

try-job: x86_64-msvc
try-job: x86_64-mingw