### PR TITLE
Split detecting unconstructible pub structs into a new lint from dead_code

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -281,6 +281,7 @@ fn register_builtins(store: &mut LintStore) {
         UNUSED_VARIABLES,
         UNUSED_ASSIGNMENTS,
         DEAD_CODE,
+        UNCONSTRUCTIBLE_PUB_STRUCT,
         UNUSED_MUT,
         UNREACHABLE_CODE,
         UNREACHABLE_PATTERNS,

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -106,6 +106,7 @@ declare_lint_pass! {
         TYVAR_BEHIND_RAW_POINTER,
         UNCONDITIONAL_PANIC,
         UNCONDITIONAL_RECURSION,
+        UNCONSTRUCTIBLE_PUB_STRUCT,
         UNCOVERED_PARAM_IN_PROJECTION,
         UNDEFINED_NAKED_FUNCTION_ABI,
         UNEXPECTED_CFGS,
@@ -723,6 +724,38 @@ declare_lint! {
     pub DEAD_CODE,
     Warn,
     "detect unused, unexported items"
+}
+
+declare_lint! {
+    /// The `unconstructible_pub_struct` lint detects public structs that
+    /// are unused locally and cannot be constructed externally.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(unconstructible_pub_struct)]
+    ///
+    /// pub struct Foo(i32);
+    /// # fn main() {}
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Unconstructible pub structs may signal a mistake or unfinished code.
+    /// To silence the warning for individual items, prefix the name with an
+    /// underscore such as `_Foo`.
+    ///
+    /// To preserve this lint, add a field with units or never types which
+    /// indicates that the behaivor is intentional, or use `PhantomData` as
+    /// fields' type if the struct is only used at the type level to check
+    /// things like well-formedness.
+    ///
+    /// Otherwise, consider removing it if the struct is no longer in use.
+    pub UNCONSTRUCTIBLE_PUB_STRUCT,
+    Allow,
+    "detects pub structs that are unused locally and cannot be constructed externally"
 }
 
 declare_lint! {

--- a/tests/ui/const-generics/defaults/repr-c-issue-82792.rs
+++ b/tests/ui/const-generics/defaults/repr-c-issue-82792.rs
@@ -2,7 +2,6 @@
 
 //@ run-pass
 
-#[allow(dead_code)]
 #[repr(C)]
 pub struct Loaf<T: Sized, const N: usize = 1> {
     head: [T; N],

--- a/tests/ui/const-generics/generic_const_exprs/associated-consts.rs
+++ b/tests/ui/const-generics/generic_const_exprs/associated-consts.rs
@@ -16,7 +16,6 @@ impl BlockCipher for BarCipher {
     const BLOCK_SIZE: usize = 32;
 }
 
-#[allow(dead_code)]
 pub struct Block<C>(C);
 
 pub fn test<C: BlockCipher, const M: usize>()

--- a/tests/ui/const-generics/transparent-maybeunit-array-wrapper.rs
+++ b/tests/ui/const-generics/transparent-maybeunit-array-wrapper.rs
@@ -6,7 +6,6 @@
 
 use std::mem::MaybeUninit;
 
-#[allow(dead_code)]
 #[repr(transparent)]
 pub struct MaybeUninitWrapper<const N: usize>(MaybeUninit<[u64; N]>);
 

--- a/tests/ui/issues/issue-5708.rs
+++ b/tests/ui/issues/issue-5708.rs
@@ -44,7 +44,6 @@ pub trait MyTrait<T> {
     fn dummy(&self, t: T) -> T { panic!() }
 }
 
-#[allow(dead_code)]
 pub struct MyContainer<'a, T:'a> {
     foos: Vec<&'a (dyn MyTrait<T>+'a)> ,
 }

--- a/tests/ui/lint/dead-code/lint-dead-code-1.rs
+++ b/tests/ui/lint/dead-code/lint-dead-code-1.rs
@@ -3,6 +3,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![deny(dead_code)]
+#![deny(unconstructible_pub_struct)]
 
 #![crate_type="lib"]
 

--- a/tests/ui/lint/dead-code/lint-dead-code-1.stderr
+++ b/tests/ui/lint/dead-code/lint-dead-code-1.stderr
@@ -1,5 +1,5 @@
 error: static `priv_static` is never used
-  --> $DIR/lint-dead-code-1.rs:20:8
+  --> $DIR/lint-dead-code-1.rs:21:8
    |
 LL | static priv_static: isize = 0;
    |        ^^^^^^^^^^^
@@ -11,37 +11,43 @@ LL | #![deny(dead_code)]
    |         ^^^^^^^^^
 
 error: constant `priv_const` is never used
-  --> $DIR/lint-dead-code-1.rs:27:7
+  --> $DIR/lint-dead-code-1.rs:28:7
    |
 LL | const priv_const: isize = 0;
    |       ^^^^^^^^^^
 
 error: struct `PrivStruct` is never constructed
-  --> $DIR/lint-dead-code-1.rs:35:8
+  --> $DIR/lint-dead-code-1.rs:36:8
    |
 LL | struct PrivStruct;
    |        ^^^^^^^^^^
 
 error: struct `StructUsedAsField` is never constructed
-  --> $DIR/lint-dead-code-1.rs:49:8
+  --> $DIR/lint-dead-code-1.rs:50:8
    |
 LL | struct StructUsedAsField;
    |        ^^^^^^^^^^^^^^^^^
 
 error: struct `PubStruct2` is never constructed
-  --> $DIR/lint-dead-code-1.rs:52:12
+  --> $DIR/lint-dead-code-1.rs:53:12
    |
 LL | pub struct PubStruct2 {
    |            ^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/lint-dead-code-1.rs:6:9
+   |
+LL | #![deny(unconstructible_pub_struct)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: enum `priv_enum` is never used
-  --> $DIR/lint-dead-code-1.rs:63:6
+  --> $DIR/lint-dead-code-1.rs:64:6
    |
 LL | enum priv_enum { foo2, bar2 }
    |      ^^^^^^^^^
 
 error: variant `bar3` is never constructed
-  --> $DIR/lint-dead-code-1.rs:66:5
+  --> $DIR/lint-dead-code-1.rs:67:5
    |
 LL | enum used_enum {
    |      --------- variant in this enum
@@ -50,31 +56,31 @@ LL |     bar3
    |     ^^^^
 
 error: function `priv_fn` is never used
-  --> $DIR/lint-dead-code-1.rs:87:4
+  --> $DIR/lint-dead-code-1.rs:88:4
    |
 LL | fn priv_fn() {
    |    ^^^^^^^
 
 error: function `foo` is never used
-  --> $DIR/lint-dead-code-1.rs:92:4
+  --> $DIR/lint-dead-code-1.rs:93:4
    |
 LL | fn foo() {
    |    ^^^
 
 error: function `bar` is never used
-  --> $DIR/lint-dead-code-1.rs:97:4
+  --> $DIR/lint-dead-code-1.rs:98:4
    |
 LL | fn bar() {
    |    ^^^
 
 error: function `baz` is never used
-  --> $DIR/lint-dead-code-1.rs:101:4
+  --> $DIR/lint-dead-code-1.rs:102:4
    |
 LL | fn baz() -> impl Copy {
    |    ^^^
 
 error: struct `Bar` is never constructed
-  --> $DIR/lint-dead-code-1.rs:12:16
+  --> $DIR/lint-dead-code-1.rs:13:16
    |
 LL |     pub struct Bar;
    |                ^^^

--- a/tests/ui/lint/dead-code/unconstructible-pub-struct.rs
+++ b/tests/ui/lint/dead-code/unconstructible-pub-struct.rs
@@ -1,5 +1,5 @@
 #![feature(never_type)]
-#![deny(dead_code)]
+#![deny(unconstructible_pub_struct)]
 
 pub struct T1(!);
 pub struct T2(());
@@ -30,6 +30,12 @@ pub struct T8<X> {
 pub struct T9<X> { //~ ERROR struct `T9` is never constructed
     _x: std::marker::PhantomData<X>,
     _y: i32,
+}
+
+pub struct _T10(i32);
+
+mod pri {
+    pub struct Unreachable(i32);
 }
 
 fn main() {}

--- a/tests/ui/lint/dead-code/unconstructible-pub-struct.stderr
+++ b/tests/ui/lint/dead-code/unconstructible-pub-struct.stderr
@@ -7,8 +7,8 @@ LL | pub struct T9<X> {
 note: the lint level is defined here
   --> $DIR/unconstructible-pub-struct.rs:2:9
    |
-LL | #![deny(dead_code)]
-   |         ^^^^^^^^^
+LL | #![deny(unconstructible_pub_struct)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/dead-code/unused-adt-impl-pub-trait-with-assoc-const.rs
+++ b/tests/ui/lint/dead-code/unused-adt-impl-pub-trait-with-assoc-const.rs
@@ -1,4 +1,4 @@
-#![deny(dead_code)]
+#![deny(unused)]
 
 struct T1; //~ ERROR struct `T1` is never constructed
 struct T2; //~ ERROR struct `T2` is never constructed

--- a/tests/ui/lint/dead-code/unused-adt-impl-pub-trait-with-assoc-const.stderr
+++ b/tests/ui/lint/dead-code/unused-adt-impl-pub-trait-with-assoc-const.stderr
@@ -7,8 +7,9 @@ LL | struct T1;
 note: the lint level is defined here
   --> $DIR/unused-adt-impl-pub-trait-with-assoc-const.rs:1:9
    |
-LL | #![deny(dead_code)]
-   |         ^^^^^^^^^
+LL | #![deny(unused)]
+   |         ^^^^^^
+   = note: `#[deny(dead_code)]` implied by `#[deny(unused)]`
 
 error: struct `T2` is never constructed
   --> $DIR/unused-adt-impl-pub-trait-with-assoc-const.rs:4:8
@@ -21,6 +22,8 @@ error: struct `T3` is never constructed
    |
 LL | pub struct T3(i32);
    |            ^^
+   |
+   = note: `#[deny(unconstructible_pub_struct)]` implied by `#[deny(unused)]`
 
 error: field `0` is never read
   --> $DIR/unused-adt-impl-pub-trait-with-assoc-const.rs:6:15

--- a/tests/ui/lint/dead-code/unused-pub-struct.rs
+++ b/tests/ui/lint/dead-code/unused-pub-struct.rs
@@ -1,4 +1,4 @@
-#![deny(dead_code)]
+#![deny(unused)]
 
 pub struct NotLint1(());
 pub struct NotLint2(std::marker::PhantomData<i32>);

--- a/tests/ui/lint/dead-code/unused-pub-struct.stderr
+++ b/tests/ui/lint/dead-code/unused-pub-struct.stderr
@@ -7,8 +7,9 @@ LL | pub struct NeverConstructed(i32);
 note: the lint level is defined here
   --> $DIR/unused-pub-struct.rs:1:9
    |
-LL | #![deny(dead_code)]
-   |         ^^^^^^^^^
+LL | #![deny(unused)]
+   |         ^^^^^^
+   = note: `#[deny(unconstructible_pub_struct)]` implied by `#[deny(unused)]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/regions/regions-issue-21422.rs
+++ b/tests/ui/regions/regions-issue-21422.rs
@@ -5,7 +5,6 @@
 
 //@ pretty-expanded FIXME #23616
 
-#[allow(dead_code)]
 pub struct P<'a> {
     _ptr: *const &'a u8,
 }

--- a/tests/ui/structs-enums/newtype-struct-with-dtor.rs
+++ b/tests/ui/structs-enums/newtype-struct-with-dtor.rs
@@ -3,10 +3,8 @@
 #![allow(unused_variables)]
 //@ pretty-expanded FIXME #23616
 
-#[allow(dead_code)]
 pub struct Fd(u32);
 
-#[allow(dead_code)]
 fn foo(a: u32) {}
 
 impl Drop for Fd {

--- a/tests/ui/suggestions/option-content-move.fixed
+++ b/tests/ui/suggestions/option-content-move.fixed
@@ -1,5 +1,5 @@
 //@ run-rustfix
-#[allow(dead_code)]
+
 pub struct LipogramCorpora {
     selections: Vec<(char, Option<String>)>,
 }
@@ -18,7 +18,6 @@ impl LipogramCorpora {
     }
 }
 
-#[allow(dead_code)]
 pub struct LipogramCorpora2 {
     selections: Vec<(char, Result<String, String>)>,
 }

--- a/tests/ui/suggestions/option-content-move.rs
+++ b/tests/ui/suggestions/option-content-move.rs
@@ -1,5 +1,5 @@
 //@ run-rustfix
-#[allow(dead_code)]
+
 pub struct LipogramCorpora {
     selections: Vec<(char, Option<String>)>,
 }
@@ -18,7 +18,6 @@ impl LipogramCorpora {
     }
 }
 
-#[allow(dead_code)]
 pub struct LipogramCorpora2 {
     selections: Vec<(char, Result<String, String>)>,
 }

--- a/tests/ui/suggestions/option-content-move.stderr
+++ b/tests/ui/suggestions/option-content-move.stderr
@@ -19,7 +19,7 @@ LL |                 if selection.1.clone().unwrap().contains(selection.0) {
    |                               ++++++++
 
 error[E0507]: cannot move out of `selection.1` which is behind a shared reference
-  --> $DIR/option-content-move.rs:30:20
+  --> $DIR/option-content-move.rs:29:20
    |
 LL |                 if selection.1.unwrap().contains(selection.0) {
    |                    ^^^^^^^^^^^ -------- `selection.1` moved due to this method call

--- a/tests/ui/traits/object/generics.rs
+++ b/tests/ui/traits/object/generics.rs
@@ -7,7 +7,6 @@ pub trait Trait2<A> {
     fn doit(&self) -> A;
 }
 
-#[allow(dead_code)]
 pub struct Impl<A1, A2, A3> {
     m1: marker::PhantomData<(A1,A2,A3)>,
     /*


### PR DESCRIPTION
#125572 detects never constructed pub structs, but introduces some regressions (#126169 and #128272).

This does not fix the regressions but just split the detection into a new lint, #127104 and #128329 try to fix them.

I don't know if it is late or not for this PR. But this could at least provide a way to help silence the lint separately for current or potential future regressions.