### PR TITLE
tidy: Fix quote in error message

### DIFF
--- a/src/tools/tidy/src/error_codes.rs
+++ b/src/tools/tidy/src/error_codes.rs
@@ -319,7 +319,7 @@ fn check_error_codes_tests(
         if !found_code {
             verbose_print!(
                 verbose,
-                "warning: Error code {code}`` has a UI test file, but doesn't contain its own error code!"
+                "warning: Error code `{code}` has a UI test file, but doesn't contain its own error code!"
             );
         }
     }


### PR DESCRIPTION
I noticed that the backticks around the error code wasn't done properly in this string when I was building Rust 1.80.0 and found it is still this way in nightly.  Example:

```
warning: Error code `E0595` needs to have at least one UI test in the `tests/error-codes/` directory`!
warning: Error code E0602`` has a UI test file, but doesn't contain its own error code!
warning: Error code `E0619` needs to have at least one UI test in the `tests/error-codes/` directory`!
```

This commit fixes it to match the other warning strings.