### PR TITLE
Remove `crate_level_only` from `ELIDED_LIFETIMES_IN_PATHS`

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1836,8 +1836,7 @@ declare_lint! {
     /// [placeholder lifetime]: https://doc.rust-lang.org/reference/lifetime-elision.html#lifetime-elision-in-functions
     pub ELIDED_LIFETIMES_IN_PATHS,
     Allow,
-    "hidden lifetime parameters in types are deprecated",
-    crate_level_only
+    "hidden lifetime parameters in types are deprecated"
 }
 
 declare_lint! {

--- a/tests/ui/lifetimes/elided-lint-in-mod.rs
+++ b/tests/ui/lifetimes/elided-lint-in-mod.rs
@@ -1,0 +1,11 @@
+struct Foo<'a>(&'a ());
+
+fn test(_: Foo) {}
+
+#[deny(elided_lifetimes_in_paths)]
+mod w {
+    fn test2(_: super::Foo) {}
+    //~^ ERROR hidden lifetime parameters in types are deprecated
+}
+
+fn main() {}

--- a/tests/ui/lifetimes/elided-lint-in-mod.stderr
+++ b/tests/ui/lifetimes/elided-lint-in-mod.stderr
@@ -1,0 +1,20 @@
+error: hidden lifetime parameters in types are deprecated
+  --> $DIR/elided-lint-in-mod.rs:7:24
+   |
+LL |     fn test2(_: super::Foo) {}
+   |                 -------^^^
+   |                 |
+   |                 expected lifetime parameter
+   |
+note: the lint level is defined here
+  --> $DIR/elided-lint-in-mod.rs:5:8
+   |
+LL | #[deny(elided_lifetimes_in_paths)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+help: indicate the anonymous lifetime
+   |
+LL |     fn test2(_: super::Foo<'_>) {}
+   |                           ++++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
As far as I can tell, we provide the right node id to the `ELIDED_LIFETIMES_IN_PATHS` lint:

https://github.com/rust-lang/rust/blob/f8060d282d42770fadd73905e3eefb85660d3278/compiler/rustc_resolve/src/late.rs#L2015-L2027

So I've gone ahead and removed the restriction from this lint.