### PR TITLE
WASI: forbid `unsafe_op_in_unsafe_fn` for `std::{os, sys}`

### DIFF
--- a/library/std/src/os/wasi/fs.rs
+++ b/library/std/src/os/wasi/fs.rs
@@ -2,7 +2,6 @@
 //!
 //! [`std::fs`]: crate::fs
 
-#![deny(unsafe_op_in_unsafe_fn)]
 #![unstable(feature = "wasi_ext", issue = "71213")]
 
 // Used for `File::read` on intra-doc links

--- a/library/std/src/os/wasi/mod.rs
+++ b/library/std/src/os/wasi/mod.rs
@@ -30,7 +30,7 @@
 
 #![cfg_attr(not(target_env = "p2"), stable(feature = "rust1", since = "1.0.0"))]
 #![cfg_attr(target_env = "p2", unstable(feature = "wasip2", issue = "none"))]
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 #![doc(cfg(target_os = "wasi"))]
 
 pub mod ffi;

--- a/library/std/src/os/wasip2/mod.rs
+++ b/library/std/src/os/wasip2/mod.rs
@@ -2,4 +2,5 @@
 //!
 //! This module is currently empty, but will be filled over time as wasi-libc support for WASI Preview 2 is stabilized.
 
+#![forbid(unsafe_op_in_unsafe_fn)]
 #![stable(feature = "raw_ext", since = "1.1.0")]

--- a/library/std/src/sys/pal/wasi/args.rs
+++ b/library/std/src/sys/pal/wasi/args.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use crate::ffi::{CStr, OsStr, OsString};
 use crate::os::wasi::ffi::OsStrExt;

--- a/library/std/src/sys/pal/wasi/env.rs
+++ b/library/std/src/sys/pal/wasi/env.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_op_in_unsafe_fn)]
+
 pub mod os {
     pub const FAMILY: &str = "";
     pub const OS: &str = "";

--- a/library/std/src/sys/pal/wasi/fd.rs
+++ b/library/std/src/sys/pal/wasi/fd.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 #![allow(dead_code)]
 
 use super::err2io;

--- a/library/std/src/sys/pal/wasi/fs.rs
+++ b/library/std/src/sys/pal/wasi/fs.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use super::fd::WasiFd;
 use crate::ffi::{CStr, OsStr, OsString};

--- a/library/std/src/sys/pal/wasi/helpers.rs
+++ b/library/std/src/sys/pal/wasi/helpers.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_op_in_unsafe_fn)]
+
 use crate::{io as std_io, mem};
 
 #[inline]

--- a/library/std/src/sys/pal/wasi/io.rs
+++ b/library/std/src/sys/pal/wasi/io.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use crate::marker::PhantomData;
 use crate::os::fd::{AsFd, AsRawFd};

--- a/library/std/src/sys/pal/wasi/net.rs
+++ b/library/std/src/sys/pal/wasi/net.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use super::err2io;
 use super::fd::WasiFd;

--- a/library/std/src/sys/pal/wasi/os.rs
+++ b/library/std/src/sys/pal/wasi/os.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use core::slice::memchr;
 

--- a/library/std/src/sys/pal/wasi/stdio.rs
+++ b/library/std/src/sys/pal/wasi/stdio.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use super::fd::WasiFd;
 use crate::io::{self, IoSlice, IoSliceMut};

--- a/library/std/src/sys/pal/wasi/thread.rs
+++ b/library/std/src/sys/pal/wasi/thread.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_op_in_unsafe_fn)]
+
 use crate::ffi::CStr;
 use crate::num::NonZero;
 use crate::sys::unsupported;
@@ -73,13 +75,13 @@ impl Thread {
         if #[cfg(target_feature = "atomics")] {
             pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
                 let p = Box::into_raw(Box::new(p));
-                let mut native: libc::pthread_t = mem::zeroed();
-                let mut attr: libc::pthread_attr_t = mem::zeroed();
-                assert_eq!(libc::pthread_attr_init(&mut attr), 0);
+                let mut native: libc::pthread_t = unsafe { mem::zeroed() };
+                let mut attr: libc::pthread_attr_t = unsafe { mem::zeroed() };
+                assert_eq!(unsafe { libc::pthread_attr_init(&mut attr) }, 0);
 
                 let stack_size = cmp::max(stack, DEFAULT_MIN_STACK_SIZE);
 
-                match libc::pthread_attr_setstacksize(&mut attr, stack_size) {
+                match unsafe { libc::pthread_attr_setstacksize(&mut attr, stack_size) } {
                     0 => {}
                     n => {
                         assert_eq!(n, libc::EINVAL);
@@ -90,20 +92,20 @@ impl Thread {
                         let page_size = os::page_size();
                         let stack_size =
                             (stack_size + page_size - 1) & (-(page_size as isize - 1) as usize - 1);
-                        assert_eq!(libc::pthread_attr_setstacksize(&mut attr, stack_size), 0);
+                        assert_eq!(unsafe { libc::pthread_attr_setstacksize(&mut attr, stack_size) }, 0);
                     }
                 };
 
-                let ret = libc::pthread_create(&mut native, &attr, thread_start, p as *mut _);
+                let ret = unsafe { libc::pthread_create(&mut native, &attr, thread_start, p as *mut _) };
                 // Note: if the thread creation fails and this assert fails, then p will
                 // be leaked. However, an alternative design could cause double-free
                 // which is clearly worse.
-                assert_eq!(libc::pthread_attr_destroy(&mut attr), 0);
+                assert_eq!(unsafe {libc::pthread_attr_destroy(&mut attr) }, 0);
 
                 return if ret != 0 {
                     // The thread failed to start and as a result p was not consumed. Therefore, it is
                     // safe to reconstruct the box so that it gets deallocated.
-                    drop(Box::from_raw(p));
+                    unsafe { drop(Box::from_raw(p)); }
                     Err(io::Error::from_raw_os_error(ret))
                 } else {
                     Ok(Thread { id: native })

--- a/library/std/src/sys/pal/wasi/time.rs
+++ b/library/std/src/sys/pal/wasi/time.rs
@@ -1,4 +1,4 @@
-#![deny(unsafe_op_in_unsafe_fn)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use crate::time::Duration;
 


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/issues/127747 for WASI

try-job: test-various