### PR TITLE
Create COFF archives for non-LLVM backends

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -224,11 +224,7 @@ impl<'a> ArArchiveBuilder<'a> {
             "gnu" => ArchiveKind::Gnu,
             "bsd" => ArchiveKind::Bsd,
             "darwin" => ArchiveKind::Darwin,
-            "coff" => {
-                // FIXME: ar_archive_writer doesn't support COFF archives yet.
-                // https://github.com/rust-lang/ar_archive_writer/issues/9
-                ArchiveKind::Gnu
-            }
+            "coff" => ArchiveKind::Coff,
             "aix_big" => ArchiveKind::AixBig,
             kind => {
                 self.sess.dcx().emit_fatal(UnknownArchiveKind { kind });


### PR DESCRIPTION
`ar_archive_writer` now supports creating COFF archives, so enable them for the non-LLVM backends when requested.

r? @bjorn3 
