### PR TITLE
Emit an error if `#[optimize]` is applied to an incompatible item

### DIFF
--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -542,6 +542,10 @@ passes_only_has_effect_on =
         *[unspecified] (unspecified--this is a compiler bug)
     }
 
+passes_optimize_not_fn_or_closure =
+    attribute should be applied to function or closure
+    .label = not a function or closure
+
 passes_outer_crate_level_attr =
     crate-level attribute should be an inner attribute: add an exclamation mark: `#![foo]`
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -68,6 +68,10 @@ pub struct CoverageNotFnOrClosure {
     pub defn_span: Span,
 }
 
+#[derive(LintDiagnostic)]
+#[diag(passes_optimize_not_fn_or_closure)]
+pub struct OptimizeNotFnOrClosure;
+
 #[derive(Diagnostic)]
 #[diag(passes_should_be_applied_to_fn)]
 pub struct AttrShouldBeAppliedToFn {

--- a/tests/ui/attributes/optimize.rs
+++ b/tests/ui/attributes/optimize.rs
@@ -1,0 +1,28 @@
+#![feature(optimize_attribute)]
+#![feature(stmt_expr_attributes)]
+#![deny(unused_attributes)]
+#![allow(dead_code)]
+
+#[optimize(speed)] //~ ERROR attribute should be applied to function or closure
+struct F;
+
+fn invalid() {
+    #[optimize(speed)] //~ ERROR attribute should be applied to function or closure
+    {
+        1
+    };
+}
+
+#[optimize(speed)]
+fn valid() {}
+
+#[optimize(speed)]
+mod valid_module {}
+
+#[optimize(speed)]
+impl F {}
+
+fn main() {
+    let _ = #[optimize(speed)]
+    (|| 1);
+}

--- a/tests/ui/attributes/optimize.stderr
+++ b/tests/ui/attributes/optimize.stderr
@@ -1,0 +1,20 @@
+error: attribute should be applied to function or closure
+  --> $DIR/optimize.rs:6:1
+   |
+LL | #[optimize(speed)]
+   | ^^^^^^^^^^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/optimize.rs:3:9
+   |
+LL | #![deny(unused_attributes)]
+   |         ^^^^^^^^^^^^^^^^^
+
+error: attribute should be applied to function or closure
+  --> $DIR/optimize.rs:10:5
+   |
+LL |     #[optimize(speed)]
+   |     ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
#54882

The RFC specifies that this should emit a lint. I used the same allow logic as the `coverage` attribute (also allowing modules and impl blocks) - this should possibly be changed depending on if it's decided to allow 'propogation' of the attribute.