### PR TITLE
Finish blessing `coverage/mcdc` tests after LLVM 19 upgrade

### DIFF
--- a/tests/coverage/mcdc/condition-limit.coverage
+++ b/tests/coverage/mcdc/condition-limit.coverage
@@ -1,6 +1,7 @@
    LL|       |#![feature(coverage_attribute)]
    LL|       |//@ edition: 2021
    LL|       |//@ min-llvm-version: 18
+   LL|       |//@ ignore-llvm-version: 19 - 99
    LL|       |//@ compile-flags: -Zcoverage-options=mcdc
    LL|       |//@ llvm-cov-flags: --show-branches=count --show-mcdc
    LL|       |

--- a/tests/coverage/mcdc/if.coverage
+++ b/tests/coverage/mcdc/if.coverage
@@ -1,6 +1,7 @@
    LL|       |#![feature(coverage_attribute)]
    LL|       |//@ edition: 2021
    LL|       |//@ min-llvm-version: 18
+   LL|       |//@ ignore-llvm-version: 19 - 99
    LL|       |//@ compile-flags: -Zcoverage-options=mcdc
    LL|       |//@ llvm-cov-flags: --show-branches=count --show-mcdc
    LL|       |

--- a/tests/coverage/mcdc/inlined_expressions.coverage
+++ b/tests/coverage/mcdc/inlined_expressions.coverage
@@ -1,6 +1,7 @@
    LL|       |#![feature(coverage_attribute)]
    LL|       |//@ edition: 2021
    LL|       |//@ min-llvm-version: 18
+   LL|       |//@ ignore-llvm-version: 19 - 99
    LL|       |//@ compile-flags: -Zcoverage-options=mcdc -Copt-level=z -Cllvm-args=--inline-threshold=0
    LL|       |//@ llvm-cov-flags: --show-branches=count --show-mcdc
    LL|       |

--- a/tests/coverage/mcdc/nested_if.coverage
+++ b/tests/coverage/mcdc/nested_if.coverage
@@ -1,6 +1,7 @@
    LL|       |#![feature(coverage_attribute)]
    LL|       |//@ edition: 2021
    LL|       |//@ min-llvm-version: 18
+   LL|       |//@ ignore-llvm-version: 19 - 99
    LL|       |//@ compile-flags: -Zcoverage-options=mcdc
    LL|       |//@ llvm-cov-flags: --show-branches=count --show-mcdc
    LL|       |

--- a/tests/coverage/mcdc/non_control_flow.coverage
+++ b/tests/coverage/mcdc/non_control_flow.coverage
@@ -1,6 +1,7 @@
    LL|       |#![feature(coverage_attribute)]
    LL|       |//@ edition: 2021
    LL|       |//@ min-llvm-version: 18
+   LL|       |//@ ignore-llvm-version: 19 - 99
    LL|       |//@ compile-flags: -Zcoverage-options=mcdc
    LL|       |//@ llvm-cov-flags: --show-branches=count --show-mcdc
    LL|       |


### PR DESCRIPTION
Context: https://github.com/rust-lang/rust/pull/127513#issuecomment-2260887708

These changes aren't needed for Rust CI, because after the LLVM 19 upgrade we have no jobs that run these tests in `coverage-run` mode against LLVM 18. But they might help external builds.

The longer-term plan is to completely drop (unstable) MC/DC support on LLVM 18, as part of getting it working on LLVM 19 in #126733.

cc @cuviper 