### PR TITLE
[`macro_metavar_expr_concat`] Dogfooding

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -302,6 +302,7 @@
 #![feature(let_chains)]
 #![feature(link_cfg)]
 #![feature(linkage)]
+#![feature(macro_metavar_expr_concat)]
 #![feature(min_exhaustive_patterns)]
 #![feature(min_specialization)]
 #![feature(must_not_suspend)]

--- a/library/std/src/sys/pal/unix/weak.rs
+++ b/library/std/src/sys/pal/unix/weak.rs
@@ -168,14 +168,7 @@ pub(crate) macro syscall {
             if let Some(fun) = $name.get() {
                 fun($($arg_name),*)
             } else {
-                // This looks like a hack, but concat_idents only accepts idents
-                // (not paths).
-                use libc::*;
-
-                syscall(
-                    concat_idents!(SYS_, $name),
-                    $($arg_name),*
-                ) as $ret
+                libc::syscall(libc::${concat(SYS_, $name)}, $($arg_name),*) as $ret
             }
         }
     )
@@ -185,14 +178,7 @@ pub(crate) macro syscall {
 pub(crate) macro raw_syscall {
     (fn $name:ident($($arg_name:ident: $t:ty),*) -> $ret:ty) => (
         unsafe fn $name($($arg_name:$t),*) -> $ret {
-            // This looks like a hack, but concat_idents only accepts idents
-            // (not paths).
-            use libc::*;
-
-            syscall(
-                concat_idents!(SYS_, $name),
-                $($arg_name),*
-            ) as $ret
+            libc::syscall(libc::${concat(SYS_, $name)}, $($arg_name),*) as $ret
         }
     )
 }


### PR DESCRIPTION
cc #124225

Starts inner usage to test the robustness of the implementation.