### PR TITLE
Finish removing `has_cpuid`

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -269,10 +269,6 @@
 #![cfg_attr(any(windows, target_os = "uefi"), feature(round_char_boundary))]
 #![cfg_attr(target_family = "wasm", feature(stdarch_wasm_atomic_wait))]
 #![cfg_attr(target_arch = "wasm64", feature(simd_wasm64))]
-#![cfg_attr(
-    all(any(target_arch = "x86_64", target_arch = "x86"), target_os = "uefi"),
-    feature(stdarch_x86_has_cpuid)
-)]
 //
 // Language features:
 // tidy-alphabetical-start

--- a/library/std/src/sys/pal/uefi/time.rs
+++ b/library/std/src/sys/pal/uefi/time.rs
@@ -175,10 +175,6 @@ pub(crate) mod instant_internal {
 
     #[cfg(target_arch = "x86_64")]
     fn timestamp_rdtsc() -> Option<Duration> {
-        if !crate::arch::x86_64::has_cpuid() {
-            return None;
-        }
-
         static FREQUENCY: crate::sync::OnceLock<u64> = crate::sync::OnceLock::new();
 
         // Get Frequency in Mhz
@@ -200,10 +196,6 @@ pub(crate) mod instant_internal {
 
     #[cfg(target_arch = "x86")]
     fn timestamp_rdtsc() -> Option<Duration> {
-        if !crate::arch::x86::has_cpuid() {
-            return None;
-        }
-
         static FREQUENCY: crate::sync::OnceLock<u64> = crate::sync::OnceLock::new();
 
         let freq = FREQUENCY

--- a/src/tools/rustfmt/tests/source/cfg_if/detect/os/x86.rs
+++ b/src/tools/rustfmt/tests/source/cfg_if/detect/os/x86.rs
@@ -34,15 +34,6 @@ pub fn check_for(x: Feature) -> bool {
 fn detect_features() -> cache::Initializer {
     let mut value = cache::Initializer::default();
 
-    // If the x86 CPU does not support the CPUID instruction then it is too
-    // old to support any of the currently-detectable features.
-    if !has_cpuid() {
-        return value;
-    }
-
-    // Calling `__cpuid`/`__cpuid_count` from here on is safe because the CPU
-    // has `cpuid` support.
-
     // 0. EAX = 0: Basic Information:
     // - EAX returns the "Highest Function Parameter", that is, the maximum
     // leaf value for subsequent calls of `cpuinfo` in range [0,

--- a/src/tools/rustfmt/tests/target/cfg_if/detect/os/x86.rs
+++ b/src/tools/rustfmt/tests/target/cfg_if/detect/os/x86.rs
@@ -34,15 +34,6 @@ pub fn check_for(x: Feature) -> bool {
 fn detect_features() -> cache::Initializer {
     let mut value = cache::Initializer::default();
 
-    // If the x86 CPU does not support the CPUID instruction then it is too
-    // old to support any of the currently-detectable features.
-    if !has_cpuid() {
-        return value;
-    }
-
-    // Calling `__cpuid`/`__cpuid_count` from here on is safe because the CPU
-    // has `cpuid` support.
-
     // 0. EAX = 0: Basic Information:
     // - EAX returns the "Highest Function Parameter", that is, the maximum
     // leaf value for subsequent calls of `cpuinfo` in range [0,


### PR DESCRIPTION
The one use of it was guaranteed to be always true.

try-job: test-various