### PR TITLE
Format `std::env::consts` docstrings with markdown backticks

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -944,106 +944,167 @@ impl fmt::Debug for ArgsOs {
 pub mod consts {
     use crate::sys::env::os;
 
-    /// A string describing the architecture of the CPU that is currently
-    /// in use.
+    /// A string describing the architecture of the CPU that is currently in use.
+    /// An example value may be: `"x86"`, `"arm"` or `"riscv64"`.
     ///
-    /// Some possible values:
+    /// <details><summary>Full list of possible values</summary>
     ///
-    /// - `x86`
-    /// - `x86_64`
-    /// - `arm`
-    /// - `aarch64`
-    /// - `loongarch64`
-    /// - `m68k`
-    /// - `csky`
-    /// - `mips`
-    /// - `mips64`
-    /// - `powerpc`
-    /// - `powerpc64`
-    /// - `riscv64`
-    /// - `s390x`
-    /// - `sparc64`
+    /// * `"x86"`
+    /// * `"x86_64"`
+    /// * `"arm"`
+    /// * `"aarch64"`
+    /// * `"m68k"`
+    /// * `"mips"`
+    /// * `"mips32r6"`
+    /// * `"mips64"`
+    /// * `"mips64r6"`
+    /// * `"csky"`
+    /// * `"powerpc"`
+    /// * `"powerpc64"`
+    /// * `"riscv32"`
+    /// * `"riscv64"`
+    /// * `"s390x"`
+    /// * `"sparc"`
+    /// * `"sparc64"`
+    /// * `"hexagon"`
+    /// * `"loongarch64"`
+    ///
+    /// </details>
     #[stable(feature = "env", since = "1.0.0")]
     pub const ARCH: &str = env!("STD_ENV_ARCH");
 
-    /// The family of the operating system. Example value is `unix`.
+    /// A string describing the family of the operating system.
+    /// An example value may be: `"unix"`, or `"windows"`.
     ///
-    /// Some possible values:
+    /// This value may be an empty string if the family is unknown.
     ///
-    /// - `unix`
-    /// - `windows`
+    /// <details><summary>Full list of possible values</summary>
+    ///
+    /// * `"unix"`
+    /// * `"windows"`
+    /// * `"itron"`
+    /// * `""`
+    ///
+    /// </details>
     #[stable(feature = "env", since = "1.0.0")]
     pub const FAMILY: &str = os::FAMILY;
 
     /// A string describing the specific operating system in use.
-    /// Example value is `linux`.
+    /// An example value may be: `"linux"`, or `"freebsd"`.
     ///
-    /// Some possible values:
+    /// <details><summary>Full list of possible values</summary>
     ///
-    /// - `linux`
-    /// - `macos`
-    /// - `ios`
-    /// - `freebsd`
-    /// - `dragonfly`
-    /// - `netbsd`
-    /// - `openbsd`
-    /// - `solaris`
-    /// - `android`
-    /// - `windows`
+    /// * `"linux"`
+    /// * `"windows"`
+    /// * `"macos"`
+    /// * `"android"`
+    /// * `"ios"`
+    /// * `"openbsd"`
+    /// * `"freebsd"`
+    /// * `"netbsd"`
+    /// * `"wasi"`
+    /// * `"hermit"`
+    /// * `"aix"`
+    /// * `"apple"`
+    /// * `"dragonfly"`
+    /// * `"emscripten"`
+    /// * `"espidf"`
+    /// * `"fortanix"`
+    /// * `"uefi"`
+    /// * `"fuchsia"`
+    /// * `"haiku"`
+    /// * `"hermit"`
+    /// * `"watchos"`
+    /// * `"visionos"`
+    /// * `"tvos"`
+    /// * `"horizon"`
+    /// * `"hurd"`
+    /// * `"illumos"`
+    /// * `"l4re"`
+    /// * `"nto"`
+    /// * `"redox"`
+    /// * `"solaris"`
+    /// * `"solid_asp3`
+    /// * `"vita"`
+    /// * `"vxworks"`
+    /// * `"xous"`
+    ///
+    /// </details>
     #[stable(feature = "env", since = "1.0.0")]
     pub const OS: &str = os::OS;
 
-    /// Specifies the filename prefix used for shared libraries on this
-    /// platform. Example value is `lib`.
-    ///
-    /// Some possible values:
-    ///
-    /// - `lib`
-    /// - `""` (an empty string)
+    /// Specifies the filename prefix, if any, used for shared libraries on this platform.
+    /// This is either `"lib"` or an empty string. (`""`).
     #[stable(feature = "env", since = "1.0.0")]
     pub const DLL_PREFIX: &str = os::DLL_PREFIX;
 
-    /// Specifies the filename suffix used for shared libraries on this
-    /// platform. Example value is `.so`.
+    /// Specifies the filename suffix, if any, used for shared libraries on this platform.
+    /// An example value may be: `".so"`, `".elf"`, or `".dll"`.
     ///
-    /// Some possible values:
+    /// <details><summary>Full list of possible values</summary>
     ///
-    /// - `.so`
-    /// - `.dylib`
-    /// - `.dll`
+    /// * `".so"`
+    /// * `".dylib"`
+    /// * `".dll"`
+    /// * `".sgxs"`
+    /// * `".a"`
+    /// * `".elf"`
+    /// * `".wasm"`
+    /// * `""` (an empty string)
+    ///
+    /// </details>
     #[stable(feature = "env", since = "1.0.0")]
     pub const DLL_SUFFIX: &str = os::DLL_SUFFIX;
 
-    /// Specifies the file extension used for shared libraries on this
-    /// platform that goes after the dot. Example value is `so`.
+    /// Specifies the file extension, if any, used for shared libraries on this platform that goes after the dot.
+    /// An example value may be: `"so"`, `"elf"`, or `"dll"`.
     ///
-    /// Some possible values:
+    /// <details><summary>Full list of possible values</summary>
     ///
-    /// - `so`
-    /// - `dylib`
-    /// - `dll`
+    /// * `"so"`
+    /// * `"dylib"`
+    /// * `"dll"`
+    /// * `"sgxs"`
+    /// * `"a"`
+    /// * `"elf"`
+    /// * `"wasm"`
+    /// * `""` (an empty string)
+    ///
+    /// </details>
     #[stable(feature = "env", since = "1.0.0")]
     pub const DLL_EXTENSION: &str = os::DLL_EXTENSION;
 
-    /// Specifies the filename suffix used for executable binaries on this
-    /// platform. Example value is `.exe`.
+    /// Specifies the filename suffix, if any, used for executable binaries on this platform.
+    /// An example value may be: `".exe"`, or `".efi"`.
     ///
-    /// Some possible values:
+    /// <details><summary>Full list of possible values</summary>
     ///
-    /// - `.exe`
-    /// - `.nexe`
-    /// - `.pexe`
-    /// - `""` (an empty string)
+    /// * `".exe"`
+    /// * `".efi"`
+    /// * `".js"`
+    /// * `".sgxs"`
+    /// * `".elf"`
+    /// * `".wasm"`
+    /// * `""` (an empty string)
+    ///
+    /// </details>
     #[stable(feature = "env", since = "1.0.0")]
     pub const EXE_SUFFIX: &str = os::EXE_SUFFIX;
 
-    /// Specifies the file extension, if any, used for executable binaries
-    /// on this platform. Example value is `exe`.
+    /// Specifies the file extension, if any, used for executable binaries on this platform.
+    /// An example value may be: `"exe"`, or an empty string (`""`).
     ///
-    /// Some possible values:
+    /// <details><summary>Full list of possible values</summary>
     ///
-    /// - `exe`
-    /// - `""` (an empty string)
+    /// * `"exe"`
+    /// * `"efi"`
+    /// * `"js"`
+    /// * `"sgxs"`
+    /// * `"elf"`
+    /// * `"wasm"`
+    /// * `""` (an empty string)
+    ///
+    /// </details>
     #[stable(feature = "env", since = "1.0.0")]
     pub const EXE_EXTENSION: &str = os::EXE_EXTENSION;
 }

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -983,6 +983,7 @@ pub mod consts {
     /// * `"unix"`
     /// * `"windows"`
     /// * `"itron"`
+    /// * `"wasm"`
     /// * `""`
     ///
     /// </details>
@@ -1041,18 +1042,7 @@ pub mod consts {
     /// Specifies the filename suffix, if any, used for shared libraries on this platform.
     /// An example value may be: `".so"`, `".elf"`, or `".dll"`.
     ///
-    /// <details><summary>Full list of possible values</summary>
-    ///
-    /// * `".so"`
-    /// * `".dylib"`
-    /// * `".dll"`
-    /// * `".sgxs"`
-    /// * `".a"`
-    /// * `".elf"`
-    /// * `".wasm"`
-    /// * `""` (an empty string)
-    ///
-    /// </details>
+    /// The possible values are identical to those of [`DLL_EXTENSION`], but with the leading period included.
     #[stable(feature = "env", since = "1.0.0")]
     pub const DLL_SUFFIX: &str = os::DLL_SUFFIX;
 
@@ -1077,17 +1067,7 @@ pub mod consts {
     /// Specifies the filename suffix, if any, used for executable binaries on this platform.
     /// An example value may be: `".exe"`, or `".efi"`.
     ///
-    /// <details><summary>Full list of possible values</summary>
-    ///
-    /// * `".exe"`
-    /// * `".efi"`
-    /// * `".js"`
-    /// * `".sgxs"`
-    /// * `".elf"`
-    /// * `".wasm"`
-    /// * `""` (an empty string)
-    ///
-    /// </details>
+    /// The possible values are identical to those of [`EXE_EXTENSION`], but with the leading period included.
     #[stable(feature = "env", since = "1.0.0")]
     pub const EXE_SUFFIX: &str = os::EXE_SUFFIX;
 

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -949,20 +949,20 @@ pub mod consts {
     ///
     /// Some possible values:
     ///
-    /// - x86
-    /// - x86_64
-    /// - arm
-    /// - aarch64
-    /// - loongarch64
-    /// - m68k
-    /// - csky
-    /// - mips
-    /// - mips64
-    /// - powerpc
-    /// - powerpc64
-    /// - riscv64
-    /// - s390x
-    /// - sparc64
+    /// - `x86`
+    /// - `x86_64`
+    /// - `arm`
+    /// - `aarch64`
+    /// - `loongarch64`
+    /// - `m68k`
+    /// - `csky`
+    /// - `mips`
+    /// - `mips64`
+    /// - `powerpc`
+    /// - `powerpc64`
+    /// - `riscv64`
+    /// - `s390x`
+    /// - `sparc64`
     #[stable(feature = "env", since = "1.0.0")]
     pub const ARCH: &str = env!("STD_ENV_ARCH");
 
@@ -970,8 +970,8 @@ pub mod consts {
     ///
     /// Some possible values:
     ///
-    /// - unix
-    /// - windows
+    /// - `unix`
+    /// - `windows`
     #[stable(feature = "env", since = "1.0.0")]
     pub const FAMILY: &str = os::FAMILY;
 
@@ -980,16 +980,16 @@ pub mod consts {
     ///
     /// Some possible values:
     ///
-    /// - linux
-    /// - macos
-    /// - ios
-    /// - freebsd
-    /// - dragonfly
-    /// - netbsd
-    /// - openbsd
-    /// - solaris
-    /// - android
-    /// - windows
+    /// - `linux`
+    /// - `macos`
+    /// - `ios`
+    /// - `freebsd`
+    /// - `dragonfly`
+    /// - `netbsd`
+    /// - `openbsd`
+    /// - `solaris`
+    /// - `android`
+    /// - `windows`
     #[stable(feature = "env", since = "1.0.0")]
     pub const OS: &str = os::OS;
 
@@ -998,7 +998,7 @@ pub mod consts {
     ///
     /// Some possible values:
     ///
-    /// - lib
+    /// - `lib`
     /// - `""` (an empty string)
     #[stable(feature = "env", since = "1.0.0")]
     pub const DLL_PREFIX: &str = os::DLL_PREFIX;
@@ -1008,9 +1008,9 @@ pub mod consts {
     ///
     /// Some possible values:
     ///
-    /// - .so
-    /// - .dylib
-    /// - .dll
+    /// - `.so`
+    /// - `.dylib`
+    /// - `.dll`
     #[stable(feature = "env", since = "1.0.0")]
     pub const DLL_SUFFIX: &str = os::DLL_SUFFIX;
 
@@ -1019,9 +1019,9 @@ pub mod consts {
     ///
     /// Some possible values:
     ///
-    /// - so
-    /// - dylib
-    /// - dll
+    /// - `so`
+    /// - `dylib`
+    /// - `dll`
     #[stable(feature = "env", since = "1.0.0")]
     pub const DLL_EXTENSION: &str = os::DLL_EXTENSION;
 
@@ -1030,9 +1030,9 @@ pub mod consts {
     ///
     /// Some possible values:
     ///
-    /// - .exe
-    /// - .nexe
-    /// - .pexe
+    /// - `.exe`
+    /// - `.nexe`
+    /// - `.pexe`
     /// - `""` (an empty string)
     #[stable(feature = "env", since = "1.0.0")]
     pub const EXE_SUFFIX: &str = os::EXE_SUFFIX;
@@ -1042,7 +1042,7 @@ pub mod consts {
     ///
     /// Some possible values:
     ///
-    /// - exe
+    /// - `exe`
     /// - `""` (an empty string)
     #[stable(feature = "env", since = "1.0.0")]
     pub const EXE_EXTENSION: &str = os::EXE_EXTENSION;


### PR DESCRIPTION
This clarifies possible outputs the constants might be.



**Before:**
--
<img src="https://github.com/user-attachments/assets/8ee8772a-7562-42a2-89be-f8772b76dbd5" width="500px">

**After:**
--
<img src="https://github.com/user-attachments/assets/4632e5e2-db3e-4372-b13e-006cc1701eb1" width="500px">




<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
