### PR TITLE
Forbid unused unsafe in vxworks-specific std modules

### DIFF
--- a/library/std/src/os/vxworks/mod.rs
+++ b/library/std/src/os/vxworks/mod.rs
@@ -1,6 +1,7 @@
 //! VxWorks-specific definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 pub mod fs;
 pub mod raw;

--- a/library/std/src/sys/pal/unix/process/process_vxworks.rs
+++ b/library/std/src/sys/pal/unix/process/process_vxworks.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_op_in_unsafe_fn)]
 use libc::{self, c_char, c_int, RTP_ID};
 
 use crate::io::{self, ErrorKind};


### PR DESCRIPTION
Tracking issue #127747 
Adding deny(unsafe_op_in_unsafe_fn) in VxWorks specific files did not cause any error. 
Most of VxWorks falls back on Unix libraries. So we'll have to wait for Unix changes.


r? @workingjubilee 
