### PR TITLE
Fix : Rustdoc: struct fields are spaced too closely

### DIFF
--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -351,7 +351,11 @@ a.test-arrow {
 }
 
 .structfield {  
-    padding-bottom: 0.2rem; 
+    padding-bottom: 0.2rem;
+    margin-block-start: 1.33em;
+    margin-block-end: 1.33em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
 }
 
 .error-described {

--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -350,6 +350,11 @@ a.test-arrow {
 	margin-bottom: 1em;
 }
 
+.structfield { 
+    padding-top: 0.8rem; 
+    padding-bottom: 0.2rem; 
+}
+
 .error-described {
 	position: relative;
 }

--- a/src/doc/rust.css
+++ b/src/doc/rust.css
@@ -350,8 +350,7 @@ a.test-arrow {
 	margin-bottom: 1em;
 }
 
-.structfield { 
-    padding-top: 0.8rem; 
+.structfield {  
     padding-bottom: 0.2rem; 
 }
 

--- a/src/librustdoc/html/templates/item_union.html
+++ b/src/librustdoc/html/templates/item_union.html
@@ -10,7 +10,7 @@
     {% for (field, ty) in self.fields_iter() %}
         {% let name = field.name.expect("union field name") %}
         <span id="structfield.{{ name }}" {#+ #}
-            class="{{ ItemType::StructField +}} section-header"> {# #}
+            class="struct-filed {{ ItemType::StructField +}} section-header"> {# #}
             <a href="#structfield.{{ name }}" class="anchor field">§</a> {# #}
             <code>{{ name }}: {{+ self.print_ty(ty)|safe }}</code> {# #}
         </span>

--- a/src/librustdoc/html/templates/item_union.html
+++ b/src/librustdoc/html/templates/item_union.html
@@ -10,7 +10,7 @@
     {% for (field, ty) in self.fields_iter() %}
         {% let name = field.name.expect("union field name") %}
         <span id="structfield.{{ name }}" {#+ #}
-            class="struct-filed {{ ItemType::StructField +}} section-header"> {# #}
+            class="structfield {{ ItemType::StructField +}} section-header"> {# #}
             <a href="#structfield.{{ name }}" class="anchor field">§</a> {# #}
             <code>{{ name }}: {{+ self.print_ty(ty)|safe }}</code> {# #}
         </span>


### PR DESCRIPTION
Closes #128260 

Description -:
Implement spacing between struct fields.