### PR TITLE
Emit an error for invalid use of the `#[no_sanitize]` attribute

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -125,6 +125,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 [sym::inline, ..] => self.check_inline(hir_id, attr, span, target),
                 [sym::coverage, ..] => self.check_coverage(attr, span, target),
                 [sym::optimize, ..] => self.check_optimize(hir_id, attr, target),
+                [sym::no_sanitize, ..] => self.check_no_sanitize(hir_id, attr, span, target),
                 [sym::non_exhaustive, ..] => self.check_non_exhaustive(hir_id, attr, span, target),
                 [sym::marker, ..] => self.check_marker(hir_id, attr, span, target),
                 [sym::target_feature, ..] => {
@@ -255,7 +256,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     | sym::may_dangle // FIXME(dropck_eyepatch)
                     | sym::pointee // FIXME(derive_smart_pointer)
                     | sym::linkage // FIXME(linkage)
-                    | sym::no_sanitize // FIXME(no_sanitize)
                     | sym::omit_gdb_pretty_printer_section // FIXME(omit_gdb_pretty_printer_section)
                     | sym::used // handled elsewhere to restrict to static items
                     | sym::repr // handled elsewhere to restrict to type decls items
@@ -448,6 +448,11 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 );
             }
         }
+    }
+
+    /// Checks that `#[no_sanitize(..)]` is applied to a function or method.
+    fn check_no_sanitize(&self, hir_id: HirId, attr: &Attribute, span: Span, target: Target) {
+        self.check_applied_to_fn_or_method(hir_id, attr, span, target)
     }
 
     fn check_generic_attr(

--- a/tests/ui/attributes/no-sanitize.rs
+++ b/tests/ui/attributes/no-sanitize.rs
@@ -1,0 +1,34 @@
+#![feature(no_sanitize)]
+#![feature(stmt_expr_attributes)]
+#![deny(unused_attributes)]
+#![allow(dead_code)]
+
+fn invalid() {
+    #[no_sanitize(memory)] //~ ERROR attribute should be applied to a function definition
+    {
+        1
+    };
+}
+
+#[no_sanitize(memory)] //~ ERROR attribute should be applied to a function definition
+type InvalidTy = ();
+
+#[no_sanitize(memory)] //~ ERROR attribute should be applied to a function definition
+mod invalid_module {}
+
+fn main() {
+    let _ = #[no_sanitize(memory)] //~ ERROR attribute should be applied to a function definition
+    (|| 1);
+}
+
+#[no_sanitize(memory)] //~ ERROR attribute should be applied to a function definition
+struct F;
+
+#[no_sanitize(memory)] //~ ERROR attribute should be applied to a function definition
+impl F {
+    #[no_sanitize(memory)]
+    fn valid(&self) {}
+}
+
+#[no_sanitize(memory)]
+fn valid() {}

--- a/tests/ui/attributes/no-sanitize.stderr
+++ b/tests/ui/attributes/no-sanitize.stderr
@@ -1,0 +1,55 @@
+error: attribute should be applied to a function definition
+  --> $DIR/no-sanitize.rs:7:5
+   |
+LL |       #[no_sanitize(memory)]
+   |       ^^^^^^^^^^^^^^^^^^^^^^
+LL | /     {
+LL | |         1
+LL | |     };
+   | |_____- not a function definition
+
+error: attribute should be applied to a function definition
+  --> $DIR/no-sanitize.rs:13:1
+   |
+LL | #[no_sanitize(memory)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+LL | type InvalidTy = ();
+   | -------------------- not a function definition
+
+error: attribute should be applied to a function definition
+  --> $DIR/no-sanitize.rs:16:1
+   |
+LL | #[no_sanitize(memory)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+LL | mod invalid_module {}
+   | --------------------- not a function definition
+
+error: attribute should be applied to a function definition
+  --> $DIR/no-sanitize.rs:20:13
+   |
+LL |     let _ = #[no_sanitize(memory)]
+   |             ^^^^^^^^^^^^^^^^^^^^^^
+LL |     (|| 1);
+   |     ------ not a function definition
+
+error: attribute should be applied to a function definition
+  --> $DIR/no-sanitize.rs:24:1
+   |
+LL | #[no_sanitize(memory)]
+   | ^^^^^^^^^^^^^^^^^^^^^^
+LL | struct F;
+   | --------- not a function definition
+
+error: attribute should be applied to a function definition
+  --> $DIR/no-sanitize.rs:27:1
+   |
+LL |   #[no_sanitize(memory)]
+   |   ^^^^^^^^^^^^^^^^^^^^^^
+LL | / impl F {
+LL | |     #[no_sanitize(memory)]
+LL | |     fn valid(&self) {}
+LL | | }
+   | |_- not a function definition
+
+error: aborting due to 6 previous errors
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

fixes #128487.

Currently, the use of the `#[no_sanitize]` attribute for Mod, Impl,... is incorrectly permitted. This PR will correct this issue by generating errors, and I've also added some UI test cases for it.

Referenced #128458. As far as I know, the `#[no_sanitize]` attribute can only be used with functions, so I changed that part to `Fn` and `Method` using `check_applied_to_fn_or_method`. However, I couldn't find explicit documentation on this, so I could be mistaken...