### PR TITLE
Ignore .git directory when formatting

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -11,6 +11,7 @@ ignore = [
     "/*-build/",
     "/build-*/",
     "/vendor/",
+    "/.git/",
 
     # Some tests are not formatted, for various reasons.
     "/tests/codegen/simd-intrinsic/", # Many types like `u8x64` are better hand-formatted.


### PR DESCRIPTION
Fixes #128503

From the issue I found Walker was iterating all the files in `.git` and `.github` for formatting, which is nonsense.

