### PR TITLE
Bump ar_archive_writer to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,11 +231,11 @@ dependencies = [
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8412a2d690663356cba5a2532f3ed55d1e8090743bc6695b88403b27df67733"
+checksum = "9c39fa49fe538a6966c7b05c2ef464b92138e717d73812053be1c643ae6f9d1f"
 dependencies = [
- "object 0.35.0",
+ "object 0.36.2",
 ]
 
 [[package]]
@@ -2562,15 +2562,6 @@ dependencies = [
  "indexmap",
  "memchr",
  "ruzstd 0.5.0",
-]
-
-[[package]]
-name = "object"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
-dependencies = [
- "memchr",
 ]
 
 [[package]]


### PR DESCRIPTION
`ar_archive_writer` 0.3.2 adds support for correctly adding Windows import libraries into archives - this is required to enable `raw-dylib` support in the Cranelift backend.

r? @bjorn3 