### PR TITLE
Check no pointee attribute pos

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -158,6 +158,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     self.check_rustc_std_internal_symbol(attr, span, target)
                 }
                 [sym::naked] => self.check_naked(hir_id, attr, span, target, attrs),
+                [sym:pointee] => self.check_pointee(hir_id, attr, span, target, attrs),
                 [sym::rustc_never_returns_null_ptr] => {
                     self.check_applied_to_fn_or_method(hir_id, attr, span, target)
                 }
@@ -2278,6 +2279,11 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             infcx.err_ctxt().report_fulfillment_errors(errors);
             self.abort.set(true);
         }
+    }
+
+    /// Check if `#[pointee]` has been applied to a function
+    fn check_pointee(&self, hir_id: HirId, attr: &Attribute, span: Span, target: Target) {
+        self.check_applied_to_fn_or_method(hir_id, attr, span, target)
     }
 }
 

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -158,9 +158,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     self.check_rustc_std_internal_symbol(attr, span, target)
                 }
                 [sym::naked] => self.check_naked(hir_id, attr, span, target, attrs),
-                [sym::pointee] => {
-                    self.check_applied_to_fn_or_method(hir_id, attr, span, target)
-                }
+                [sym::pointee] => self.check_applied_to_fn_or_method(hir_id, attr, span, target),
                 [sym::rustc_never_returns_null_ptr] => {
                     self.check_applied_to_fn_or_method(hir_id, attr, span, target)
                 }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -158,7 +158,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     self.check_rustc_std_internal_symbol(attr, span, target)
                 }
                 [sym::naked] => self.check_naked(hir_id, attr, span, target, attrs),
-                [sym:pointee] => self.check_pointee(hir_id, attr, span, target, attrs),
+                [sym::pointee] => self.check_pointee(hir_id, attr, span, target, attrs),
                 [sym::rustc_never_returns_null_ptr] => {
                     self.check_applied_to_fn_or_method(hir_id, attr, span, target)
                 }

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -158,7 +158,9 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     self.check_rustc_std_internal_symbol(attr, span, target)
                 }
                 [sym::naked] => self.check_naked(hir_id, attr, span, target, attrs),
-                [sym::pointee] => self.check_pointee(hir_id, attr, span, target, attrs),
+                [sym::pointee] => {
+                    self.check_applied_to_fn_or_method(hir_id, attr, span, target)
+                }
                 [sym::rustc_never_returns_null_ptr] => {
                     self.check_applied_to_fn_or_method(hir_id, attr, span, target)
                 }
@@ -2279,11 +2281,6 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             infcx.err_ctxt().report_fulfillment_errors(errors);
             self.abort.set(true);
         }
-    }
-
-    /// Check if `#[pointee]` has been applied to a function
-    fn check_pointee(&self, hir_id: HirId, attr: &Attribute, span: Span, target: Target) {
-        self.check_applied_to_fn_or_method(hir_id, attr, span, target)
     }
 }
 

--- a/tests/ui/attributes/pointee.rs
+++ b/tests/ui/attributes/pointee.rs
@@ -1,5 +1,6 @@
 #![feature(pointee)]
 #![feature(stmt_expr_attributes)]
+#![feature(derive_smart_pointer)]
 #![deny(unused_attributes)]
 #![allow(dead_code)]
 

--- a/tests/ui/attributes/pointee.rs
+++ b/tests/ui/attributes/pointee.rs
@@ -1,0 +1,34 @@
+#![feature(pointee)]
+#![feature(stmt_expr_attributes)]
+#![deny(unused_attributes)]
+#![allow(dead_code)]
+
+fn invalid() {
+    #[pointee] //~ ERROR attribute should be applied to a function definition
+    {
+        1
+    };
+}
+
+#[pointee] //~ ERROR attribute should be applied to a function definition
+type InvalidTy = ();
+
+#[pointee] //~ ERROR attribute should be applied to a function definition
+mod invalid_module {}
+
+fn main() {
+    let _ = #[pointee] //~ ERROR attribute should be applied to a function definition
+    (|| 1);
+}
+
+#[pointee] //~ ERROR attribute should be applied to a function definition
+struct F;
+
+#[pointee] //~ ERROR attribute should be applied to a function definition
+impl F {
+    #[pointee]
+    fn valid(&self) {}
+}
+
+#[pointee]
+fn valid() {}

--- a/tests/ui/attributes/pointee.stderr
+++ b/tests/ui/attributes/pointee.stderr
@@ -1,0 +1,54 @@
+error: attribute should be applied to a function definition
+  --> $DIR/pointee.rs:7:5
+   |
+LL |       #[pointee]
+   |       ^^^^^^^^^^
+LL | /     {
+LL | |         1
+LL | |     };
+   | |_____- not a function definition
+
+error: attribute should be applied to a function definition
+  --> $DIR/pointee.rs:13:1
+   |
+LL | #[pointee]
+   | ^^^^^^^^^^
+LL | type InvalidTy = ();
+   | -------------------- not a function definition
+
+error: attribute should be applied to a function definition
+  --> $DIR/pointee.rs:16:1
+   |
+LL | #[pointee]
+   | ^^^^^^^^^^
+LL | mod invalid_module {}
+   | --------------------- not a function definition
+
+error: attribute should be applied to a function definition
+  --> $DIR/pointee.rs:20:13
+   |
+LL |     let _ = #[pointee]
+   |             ^^^^^^^^^^
+LL |     (|| 1);
+   |     ------ not a function definition
+
+error: attribute should be applied to a function definition
+  --> $DIR/pointee.rs:24:1
+   |
+LL | #[pointee]
+   | ^^^^^^^^^^
+LL | struct F;
+   | --------- not a function definition
+
+error: attribute should be applied to a function definition
+  --> $DIR/pointee.rs:27:1
+   |
+LL |   #[pointee]
+   |   ^^^^^^^^^^
+LL | / impl F {
+LL | |     #[pointee]
+LL | |     fn valid(&self) {}
+LL | | }
+   | |_- not a function definition
+
+error: aborting due to 6 previous errors

--- a/tests/ui/attributes/pointee.stderr
+++ b/tests/ui/attributes/pointee.stderr
@@ -1,5 +1,5 @@
 error: attribute should be applied to a function definition
-  --> $DIR/pointee.rs:7:5
+  --> $DIR/pointee.rs:8:5
    |
 LL |       #[pointee]
    |       ^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | |     };
    | |_____- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/pointee.rs:13:1
+  --> $DIR/pointee.rs:14:1
    |
 LL | #[pointee]
    | ^^^^^^^^^^
@@ -17,7 +17,7 @@ LL | type InvalidTy = ();
    | -------------------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/pointee.rs:16:1
+  --> $DIR/pointee.rs:17:1
    |
 LL | #[pointee]
    | ^^^^^^^^^^
@@ -25,7 +25,7 @@ LL | mod invalid_module {}
    | --------------------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/pointee.rs:20:13
+  --> $DIR/pointee.rs:21:13
    |
 LL |     let _ = #[pointee]
    |             ^^^^^^^^^^
@@ -33,7 +33,7 @@ LL |     (|| 1);
    |     ------ not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/pointee.rs:24:1
+  --> $DIR/pointee.rs:25:1
    |
 LL | #[pointee]
    | ^^^^^^^^^^
@@ -41,7 +41,7 @@ LL | struct F;
    | --------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/pointee.rs:27:1
+  --> $DIR/pointee.rs:28:1
    |
 LL |   #[pointee]
    |   ^^^^^^^^^^


### PR DESCRIPTION
takes on the example from #128552 and refactors it so we have correct usage of `#[pointee]`