### PR TITLE
Promote aarch64-apple-darwin to Tier 1

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -269,10 +269,6 @@
 #![cfg_attr(any(windows, target_os = "uefi"), feature(round_char_boundary))]
 #![cfg_attr(target_family = "wasm", feature(stdarch_wasm_atomic_wait))]
 #![cfg_attr(target_arch = "wasm64", feature(simd_wasm64))]
-#![cfg_attr(
-    all(any(target_arch = "x86_64", target_arch = "x86"), target_os = "uefi"),
-    feature(stdarch_x86_has_cpuid)
-)]
 //
 // Language features:
 // tidy-alphabetical-start

--- a/library/std/src/sys/pal/uefi/time.rs
+++ b/library/std/src/sys/pal/uefi/time.rs
@@ -175,10 +175,6 @@ pub(crate) mod instant_internal {
 
     #[cfg(target_arch = "x86_64")]
     fn timestamp_rdtsc() -> Option<Duration> {
-        if !crate::arch::x86_64::has_cpuid() {
-            return None;
-        }
-
         static FREQUENCY: crate::sync::OnceLock<u64> = crate::sync::OnceLock::new();
 
         // Get Frequency in Mhz
@@ -200,10 +196,6 @@ pub(crate) mod instant_internal {
 
     #[cfg(target_arch = "x86")]
     fn timestamp_rdtsc() -> Option<Duration> {
-        if !crate::arch::x86::has_cpuid() {
-            return None;
-        }
-
         static FREQUENCY: crate::sync::OnceLock<u64> = crate::sync::OnceLock::new();
 
         let freq = FREQUENCY

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -194,6 +194,7 @@ pub(crate) fn is_ci_llvm_available(config: &Config, asserts: bool) -> bool {
     let supported_platforms = [
         // tier 1
         ("aarch64-unknown-linux-gnu", false),
+        ("aarch64-apple-darwin", false),
         ("i686-pc-windows-gnu", false),
         ("i686-pc-windows-msvc", false),
         ("i686-unknown-linux-gnu", false),
@@ -202,7 +203,6 @@ pub(crate) fn is_ci_llvm_available(config: &Config, asserts: bool) -> bool {
         ("x86_64-pc-windows-gnu", true),
         ("x86_64-pc-windows-msvc", true),
         // tier 2 with host tools
-        ("aarch64-apple-darwin", false),
         ("aarch64-pc-windows-msvc", false),
         ("aarch64-unknown-linux-musl", false),
         ("arm-unknown-linux-gnueabi", false),

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -33,6 +33,7 @@ All tier 1 targets with host tools support the full standard library.
 target | notes
 -------|-------
 `aarch64-unknown-linux-gnu` | ARM64 Linux (kernel 4.1, glibc 2.17+)
+[`aarch64-apple-darwin`](platform-support/apple-darwin.md) | ARM64 macOS (11.0+, Big Sur+)
 `i686-pc-windows-gnu` | 32-bit MinGW (Windows 10+, Windows Server 2016+) [^x86_32-floats-return-ABI]
 `i686-pc-windows-msvc` | 32-bit MSVC (Windows 10+, Windows Server 2016+) [^x86_32-floats-return-ABI]
 `i686-unknown-linux-gnu` | 32-bit Linux (kernel 3.2+, glibc 2.17+) [^x86_32-floats-return-ABI]
@@ -86,7 +87,6 @@ so Rustup may install the documentation for a similar tier 1 target instead.
 
 target | notes
 -------|-------
-[`aarch64-apple-darwin`](platform-support/apple-darwin.md) | ARM64 macOS (11.0+, Big Sur+)
 `aarch64-pc-windows-msvc` | ARM64 Windows MSVC
 `aarch64-unknown-linux-musl` | ARM64 Linux with musl 1.2.3
 `arm-unknown-linux-gnueabi` | Armv6 Linux (kernel 3.2, glibc 2.17)

--- a/src/doc/rustc/src/platform-support/apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/apple-darwin.md
@@ -5,9 +5,6 @@ Apple macOS targets.
 **Tier: 1**
 
 - `x86_64-apple-darwin`: macOS on 64-bit x86.
-
-**Tier: 2 (with Host Tools)**
-
 - `aarch64-apple-darwin`: macOS on ARM64 (M1-family or later Apple Silicon CPUs).
 
 ## Target maintainers

--- a/src/tools/miri/README.md
+++ b/src/tools/miri/README.md
@@ -212,7 +212,6 @@ degree documented below):
 - All Rust [Tier 1 targets](https://doc.rust-lang.org/rustc/platform-support.html) are supported by
   Miri. They are all checked on Miri's CI, and some (at least one per OS) are even checked on every
   Rust PR, so the shipped Miri should always work on these targets.
-- `aarch64-apple-darwin` is supported.
 - `s390x-unknown-linux-gnu` is supported as our "big-endian target of choice".
 - For every other target with OS `linux`, `macos`, or `windows`, Miri should generally work, but we
   make no promises and we don't run tests for such targets.

--- a/src/tools/miri/ci/ci.sh
+++ b/src/tools/miri/ci/ci.sh
@@ -137,7 +137,7 @@ case $HOST_TARGET in
     MANY_SEEDS=16 TEST_TARGET=x86_64-pc-windows-gnu run_tests
     ;;
   aarch64-apple-darwin)
-    # Host (tier 2)
+    # Host
     GC_STRESS=1 MIR_OPT=1 MANY_SEEDS=64 TEST_BENCH=1 CARGO_MIRI_ENV=1 run_tests
     # Extra tier 1
     MANY_SEEDS=64 TEST_TARGET=i686-pc-windows-gnu run_tests

--- a/src/tools/rustfmt/tests/source/cfg_if/detect/os/x86.rs
+++ b/src/tools/rustfmt/tests/source/cfg_if/detect/os/x86.rs
@@ -34,15 +34,6 @@ pub fn check_for(x: Feature) -> bool {
 fn detect_features() -> cache::Initializer {
     let mut value = cache::Initializer::default();
 
-    // If the x86 CPU does not support the CPUID instruction then it is too
-    // old to support any of the currently-detectable features.
-    if !has_cpuid() {
-        return value;
-    }
-
-    // Calling `__cpuid`/`__cpuid_count` from here on is safe because the CPU
-    // has `cpuid` support.
-
     // 0. EAX = 0: Basic Information:
     // - EAX returns the "Highest Function Parameter", that is, the maximum
     // leaf value for subsequent calls of `cpuinfo` in range [0,

--- a/src/tools/rustfmt/tests/target/cfg_if/detect/os/x86.rs
+++ b/src/tools/rustfmt/tests/target/cfg_if/detect/os/x86.rs
@@ -34,15 +34,6 @@ pub fn check_for(x: Feature) -> bool {
 fn detect_features() -> cache::Initializer {
     let mut value = cache::Initializer::default();
 
-    // If the x86 CPU does not support the CPUID instruction then it is too
-    // old to support any of the currently-detectable features.
-    if !has_cpuid() {
-        return value;
-    }
-
-    // Calling `__cpuid`/`__cpuid_count` from here on is safe because the CPU
-    // has `cpuid` support.
-
     // 0. EAX = 0: Basic Information:
     // - EAX returns the "Highest Function Parameter", that is, the maximum
     // leaf value for subsequent calls of `cpuinfo` in range [0,


### PR DESCRIPTION
This promotes aarch64-apple-darwin to Tier 1 status as per rust-lang/rfcs#3671. Not sure what else is necessary for this to impement the aforementioned RFC, however I figured I'd try. I did read in previous issues and PRs that the necessary infrastructure was already in place for the aarch64-apple-darwin target, and the RFC mentions the same. So this should be all thats necessary in order for the target to be promoted.