### PR TITLE
[perf] Use Blake2 for the type-id hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1026,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -3227,8 +3237,10 @@ checksum = "5be1bdc7edf596692617627bbfeaba522131b18e06ca4df2b6b689e3c5d5ce84"
 [[package]]
 name = "rustc-stable-hash"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c9f15eec8235d7cb775ee6f81891db79b98fd54ba1ad8fae565b88ef1ae4e2"
+source = "git+https://github.com/Urgau/rustc-stable-hash.git?rev=543696a#543696a0b6299c4cc8a8c9c30651e5cc0056655a"
+dependencies = [
+ "blake2",
+]
 
 [[package]]
 name = "rustc_abi"
@@ -5066,6 +5078,12 @@ dependencies = [
  "rustversion",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suggest-tests"

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -23,7 +23,7 @@ use std::{cmp, fmt, mem};
 
 pub use rustc_ast_ir::{Movability, Mutability};
 use rustc_data_structures::packed::Pu128;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_data_structures::sync::Lrc;
 use rustc_macros::{Decodable, Encodable, HashStable_Generic};
@@ -105,7 +105,7 @@ impl PartialEq<Symbol> for Path {
 }
 
 impl<CTX: rustc_span::HashStableContext> HashStable<CTX> for Path {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.segments.len().hash_stable(hcx, hasher);
         for segment in &self.segments {
             segment.ident.hash_stable(hcx, hasher);
@@ -1723,7 +1723,7 @@ impl<CTX> HashStable<CTX> for AttrArgs
 where
     CTX: crate::HashStableContext,
 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         mem::discriminant(self).hash_stable(ctx, hasher);
         match self {
             AttrArgs::Empty => {}
@@ -1759,7 +1759,7 @@ impl<CTX> HashStable<CTX> for DelimArgs
 where
     CTX: crate::HashStableContext,
 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         let DelimArgs { dspan, delim, tokens } = self;
         dspan.hash_stable(ctx, hasher);
         delim.hash_stable(ctx, hasher);

--- a/compiler/rustc_ast/src/lib.rs
+++ b/compiler/rustc_ast/src/lib.rs
@@ -43,7 +43,7 @@ pub mod token;
 pub mod tokenstream;
 pub mod visit;
 
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 
 pub use self::ast::*;
 pub use self::ast_traits::{AstDeref, AstNodeWrapper, HasAttrs, HasNodeId, HasTokens};
@@ -52,11 +52,19 @@ pub use self::ast_traits::{AstDeref, AstNodeWrapper, HasAttrs, HasNodeId, HasTok
 /// This is a hack to allow using the `HashStable_Generic` derive macro
 /// instead of implementing everything in `rustc_middle`.
 pub trait HashStableContext: rustc_span::HashStableContext {
-    fn hash_attr(&mut self, _: &ast::Attribute, hasher: &mut StableHasher);
+    fn hash_attr<H: ExtendedHasher>(
+        &mut self,
+        _: &ast::Attribute,
+        hasher: &mut GenericStableHasher<H>,
+    );
 }
 
 impl<AstCtx: crate::HashStableContext> HashStable<AstCtx> for ast::Attribute {
-    fn hash_stable(&self, hcx: &mut AstCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(
+        &self,
+        hcx: &mut AstCtx,
+        hasher: &mut GenericStableHasher<H>,
+    ) {
         hcx.hash_attr(self, hasher)
     }
 }

--- a/compiler/rustc_ast/src/ptr.rs
+++ b/compiler/rustc_ast/src/ptr.rs
@@ -21,7 +21,7 @@ use std::fmt::{self, Debug, Display};
 use std::ops::{Deref, DerefMut};
 use std::{slice, vec};
 
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 /// An owned smart pointer.
 ///
@@ -203,7 +203,7 @@ impl<CTX, T> HashStable<CTX> for P<T>
 where
     T: ?Sized + HashStable<CTX>,
 {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         (**self).hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_ast/src/token.rs
+++ b/compiler/rustc_ast/src/token.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::fmt;
 
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 use rustc_data_structures::sync::Lrc;
 use rustc_macros::{Decodable, Encodable, HashStable_Generic};
 use rustc_span::edition::Edition;
@@ -1055,7 +1055,7 @@ impl<CTX> HashStable<CTX> for Nonterminal
 where
     CTX: crate::HashStableContext,
 {
-    fn hash_stable(&self, _hcx: &mut CTX, _hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, _hcx: &mut CTX, _hasher: &mut GenericStableHasher<H>) {
         panic!("interpolated tokens should not be present in the HIR")
     }
 }

--- a/compiler/rustc_ast/src/tokenstream.rs
+++ b/compiler/rustc_ast/src/tokenstream.rs
@@ -16,7 +16,7 @@
 use std::borrow::Cow;
 use std::{cmp, fmt, iter};
 
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 use rustc_data_structures::sync::{self, Lrc};
 use rustc_macros::{Decodable, Encodable, HashStable_Generic};
 use rustc_serialize::{Decodable, Encodable};
@@ -99,7 +99,7 @@ impl<CTX> HashStable<CTX> for TokenStream
 where
     CTX: crate::HashStableContext,
 {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         for sub_tt in self.trees() {
             sub_tt.hash_stable(hcx, hasher);
         }
@@ -151,7 +151,7 @@ impl<D: SpanDecoder> Decodable<D> for LazyAttrTokenStream {
 }
 
 impl<CTX> HashStable<CTX> for LazyAttrTokenStream {
-    fn hash_stable(&self, _hcx: &mut CTX, _hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, _hcx: &mut CTX, _hasher: &mut GenericStableHasher<H>) {
         panic!("Attempted to compute stable hash for LazyAttrTokenStream");
     }
 }

--- a/compiler/rustc_codegen_cranelift/src/driver/aot.rs
+++ b/compiler/rustc_codegen_cranelift/src/driver/aot.rs
@@ -15,7 +15,7 @@ use rustc_codegen_ssa::{
     errors as ssa_errors, CodegenResults, CompiledModule, CrateInfo, ModuleKind,
 };
 use rustc_data_structures::profiling::SelfProfilerRef;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 use rustc_data_structures::sync::{par_map, IntoDynSyncSend};
 use rustc_metadata::fs::copy_to_stdout;
 use rustc_metadata::EncodedMetadata;
@@ -43,7 +43,7 @@ enum OngoingModuleCodegen {
 }
 
 impl<HCX> HashStable<HCX> for OngoingModuleCodegen {
-    fn hash_stable(&self, _: &mut HCX, _: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, _: &mut HCX, _: &mut GenericStableHasher<H>) {
         // do nothing
     }
 }

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata/type_map.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata/type_map.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::fx::FxHashMap;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{HashStable, StableBlake2sHasher256};
 use rustc_macros::HashStable;
 use rustc_middle::bug;
 use rustc_middle::ty::{ParamEnv, PolyExistentialTraitRef, Ty, TyCtxt};
@@ -94,7 +94,7 @@ impl<'tcx> UniqueTypeId<'tcx> {
     ///
     /// Right now this takes the form of a hex-encoded opaque hash value.
     pub fn generate_unique_id_string(self, tcx: TyCtxt<'tcx>) -> String {
-        let mut hasher = StableHasher::new();
+        let mut hasher = StableBlake2sHasher256::new();
         tcx.with_stable_hashing_context(|mut hcx| {
             hcx.while_hashing_spans(false, |hcx| self.hash_stable(hcx, &mut hasher))
         });

--- a/compiler/rustc_codegen_ssa/src/common.rs
+++ b/compiler/rustc_codegen_ssa/src/common.rs
@@ -107,12 +107,12 @@ pub enum TypeKind {
 //            for now we content ourselves with providing a no-op HashStable
 //            implementation for CGUs.
 mod temp_stable_hash_impls {
-    use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+    use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 
     use crate::ModuleCodegen;
 
     impl<HCX, M> HashStable<HCX> for ModuleCodegen<M> {
-        fn hash_stable(&self, _: &mut HCX, _: &mut StableHasher) {
+        fn hash_stable<H: ExtendedHasher>(&self, _: &mut HCX, _: &mut GenericStableHasher<H>) {
             // do nothing
         }
     }

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -15,7 +15,7 @@ jobserver_crate = { version = "0.1.28", package = "jobserver" }
 measureme = "11"
 rustc-hash = "1.1.0"
 rustc-rayon = { version = "0.5.0", optional = true }
-rustc-stable-hash = { version = "0.1.0", features = ["nightly"] }
+rustc-stable-hash = { git = "https://github.com/Urgau/rustc-stable-hash.git", rev = "543696a", features = ["nightly"] }
 rustc_arena = { path = "../rustc_arena" }
 rustc_graphviz = { path = "../rustc_graphviz" }
 rustc_index = { path = "../rustc_index", package = "rustc_index" }

--- a/compiler/rustc_data_structures/src/fingerprint.rs
+++ b/compiler/rustc_data_structures/src/fingerprint.rs
@@ -1,6 +1,7 @@
 use std::hash::{Hash, Hasher};
 
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+use rustc_stable_hash::hashers::Blake2s256Hash;
 
 use crate::stable_hasher::{
     impl_stable_traits_for_trivial_type, FromStableHash, Hash64, StableHasherHash,
@@ -161,6 +162,20 @@ impl FromStableHash<StableHasherHash> for Fingerprint {
     #[inline]
     fn from(StableHasherHash([_0, _1]): StableHasherHash) -> Self {
         Fingerprint(_0, _1)
+    }
+}
+
+impl FromStableHash<Blake2s256Hash> for Fingerprint {
+    #[inline]
+    fn from(Blake2s256Hash(bytes): Blake2s256Hash) -> Self {
+        let p0 = u64::from_le_bytes(bytes[0..8].try_into().unwrap());
+        let p1 = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
+        let p2 = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
+        let p3 = u64::from_le_bytes(bytes[24..32].try_into().unwrap());
+
+        // See https://stackoverflow.com/a/27952689 on why this function is
+        // implemented this way.
+        Fingerprint(p0.wrapping_mul(3).wrapping_add(p1), p2.wrapping_mul(3).wrapping_add(p3))
     }
 }
 

--- a/compiler/rustc_data_structures/src/fingerprint.rs
+++ b/compiler/rustc_data_structures/src/fingerprint.rs
@@ -157,11 +157,9 @@ impl FingerprintHasher for crate::unhash::Unhasher {
     }
 }
 
-impl FromStableHash for Fingerprint {
-    type Hash = StableHasherHash;
-
+impl FromStableHash<StableHasherHash> for Fingerprint {
     #[inline]
-    fn from(StableHasherHash([_0, _1]): Self::Hash) -> Self {
+    fn from(StableHasherHash([_0, _1]): StableHasherHash) -> Self {
         Fingerprint(_0, _1)
     }
 }

--- a/compiler/rustc_data_structures/src/hashes.rs
+++ b/compiler/rustc_data_structures/src/hashes.rs
@@ -58,11 +58,9 @@ impl<D: Decoder> Decodable<D> for Hash64 {
     }
 }
 
-impl FromStableHash for Hash64 {
-    type Hash = StableHasherHash;
-
+impl FromStableHash<StableHasherHash> for Hash64 {
     #[inline]
-    fn from(StableHasherHash([_0, __1]): Self::Hash) -> Self {
+    fn from(StableHasherHash([_0, __1]): StableHasherHash) -> Self {
         Self { inner: _0 }
     }
 }
@@ -125,11 +123,9 @@ impl<D: Decoder> Decodable<D> for Hash128 {
     }
 }
 
-impl FromStableHash for Hash128 {
-    type Hash = StableHasherHash;
-
+impl FromStableHash<StableHasherHash> for Hash128 {
     #[inline]
-    fn from(StableHasherHash([_0, _1]): Self::Hash) -> Self {
+    fn from(StableHasherHash([_0, _1]): StableHasherHash) -> Self {
         Self { inner: u128::from(_0) | (u128::from(_1) << 64) }
     }
 }

--- a/compiler/rustc_data_structures/src/hashes.rs
+++ b/compiler/rustc_data_structures/src/hashes.rs
@@ -15,6 +15,7 @@ use std::fmt;
 use std::ops::BitXorAssign;
 
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
+use rustc_stable_hash::hashers::Blake2s256Hash;
 
 use crate::stable_hasher::{FromStableHash, StableHasherHash};
 
@@ -127,6 +128,18 @@ impl FromStableHash<StableHasherHash> for Hash128 {
     #[inline]
     fn from(StableHasherHash([_0, _1]): StableHasherHash) -> Self {
         Self { inner: u128::from(_0) | (u128::from(_1) << 64) }
+    }
+}
+
+impl FromStableHash<Blake2s256Hash> for Hash128 {
+    #[inline]
+    fn from(Blake2s256Hash(bytes): Blake2s256Hash) -> Self {
+        let p0 = u128::from_le_bytes(bytes[0..16].try_into().unwrap());
+        let p1 = u128::from_le_bytes(bytes[16..32].try_into().unwrap());
+
+        // See https://stackoverflow.com/a/27952689 on why this function is
+        // implemented this way.
+        Self { inner: p0.wrapping_mul(3).wrapping_add(p1) }
     }
 }
 

--- a/compiler/rustc_data_structures/src/intern.rs
+++ b/compiler/rustc_data_structures/src/intern.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 use std::ptr;
 
-use crate::stable_hasher::{HashStable, StableHasher};
+use crate::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 
 mod private {
     #[derive(Clone, Copy, Debug)]
@@ -104,7 +104,7 @@ impl<T, CTX> HashStable<CTX> for Interned<'_, T>
 where
     T: HashStable<CTX>,
 {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.0.hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/packed.rs
+++ b/compiler/rustc_data_structures/src/packed.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
-use crate::stable_hasher::{HashStable, StableHasher};
+use crate::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 
 /// A packed 128-bit integer. Useful for reducing the size of structures in
 /// some cases.
@@ -55,7 +55,7 @@ impl fmt::UpperHex for Pu128 {
 
 impl<CTX> HashStable<CTX> for Pu128 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         { self.0 }.hash_stable(ctx, hasher)
     }
 }

--- a/compiler/rustc_data_structures/src/sorted_map.rs
+++ b/compiler/rustc_data_structures/src/sorted_map.rs
@@ -5,7 +5,7 @@ use std::ops::{Bound, Index, IndexMut, RangeBounds};
 
 use rustc_macros::{Decodable_Generic, Encodable_Generic};
 
-use crate::stable_hasher::{HashStable, StableHasher, StableOrd};
+use crate::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable, StableOrd};
 
 mod index_map;
 
@@ -311,7 +311,7 @@ impl<K: Ord, V> FromIterator<(K, V)> for SortedMap<K, V> {
 
 impl<K: HashStable<CTX> + StableOrd, V: HashStable<CTX>, CTX> HashStable<CTX> for SortedMap<K, V> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.data.hash_stable(ctx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/sorted_map/index_map.rs
+++ b/compiler/rustc_data_structures/src/sorted_map/index_map.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 
 use rustc_index::{Idx, IndexVec};
 
-use crate::stable_hasher::{HashStable, StableHasher};
+use crate::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 
 /// An indexed multi-map that preserves insertion order while permitting both *O*(log *n*) lookup of
 /// an item by key and *O*(1) lookup by index.
@@ -131,7 +131,7 @@ where
     K: HashStable<C>,
     V: HashStable<C>,
 {
-    fn hash_stable(&self, ctx: &mut C, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut C, hasher: &mut GenericStableHasher<H>) {
         let SortedIndexMultiMap {
             items,
             // We can ignore this field because it is not observable from the outside.

--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -11,9 +11,18 @@ use smallvec::SmallVec;
 mod tests;
 
 pub use rustc_stable_hash::{
-    FromStableHash, SipHasher128Hash as StableHasherHash, StableSipHasher128 as StableHasher,
+    FromStableHash, IntoStableHash, SipHasher128Hash as StableHasherHash,
+    StableHasher as GenericStableHasher, StableSipHasher128 as StableHasher,
 };
 
+pub trait ExtendedHasher:
+    rustc_stable_hash::ExtendedHasher<Hash: IntoStableHash<Fingerprint>> + Default
+{
+}
+
+impl ExtendedHasher for rustc_stable_hash::hashers::SipHasher128 {}
+
+use crate::fingerprint::Fingerprint;
 pub use crate::hashes::{Hash128, Hash64};
 
 /// Something that implements `HashStable<CTX>` can be hashed in a way that is
@@ -43,7 +52,7 @@ pub use crate::hashes::{Hash128, Hash64};
 ///   `StableHasher` takes care of endianness and `isize`/`usize` platform
 ///   differences.
 pub trait HashStable<CTX> {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher);
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>);
 }
 
 /// Implement this for types that can be turned into stable keys like, for
@@ -139,7 +148,11 @@ macro_rules! impl_stable_traits_for_trivial_type {
     ($t:ty) => {
         impl<CTX> $crate::stable_hasher::HashStable<CTX> for $t {
             #[inline]
-            fn hash_stable(&self, _: &mut CTX, hasher: &mut $crate::stable_hasher::StableHasher) {
+            fn hash_stable<H: $crate::stable_hasher::ExtendedHasher>(
+                &self,
+                _: &mut CTX,
+                hasher: &mut $crate::stable_hasher::GenericStableHasher<H>,
+            ) {
                 ::std::hash::Hash::hash(self, hasher);
             }
         }
@@ -180,7 +193,7 @@ impl_stable_traits_for_trivial_type!(Hash64);
 // hashing we want to hash the full 128-bit hash.
 impl<CTX> HashStable<CTX> for Hash128 {
     #[inline]
-    fn hash_stable(&self, _: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, _: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.as_u128().hash(hasher);
     }
 }
@@ -194,38 +207,39 @@ impl StableOrd for Hash128 {
 }
 
 impl<CTX> HashStable<CTX> for ! {
-    fn hash_stable(&self, _ctx: &mut CTX, _hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, _ctx: &mut CTX, _hasher: &mut GenericStableHasher<H>) {
         unreachable!()
     }
 }
 
 impl<CTX, T> HashStable<CTX> for PhantomData<T> {
-    fn hash_stable(&self, _ctx: &mut CTX, _hasher: &mut StableHasher) {}
+    fn hash_stable<H: ExtendedHasher>(&self, _ctx: &mut CTX, _hasher: &mut GenericStableHasher<H>) {
+    }
 }
 
 impl<CTX> HashStable<CTX> for NonZero<u32> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.get().hash_stable(ctx, hasher)
     }
 }
 
 impl<CTX> HashStable<CTX> for NonZero<usize> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.get().hash_stable(ctx, hasher)
     }
 }
 
 impl<CTX> HashStable<CTX> for f32 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         let val: u32 = self.to_bits();
         val.hash_stable(ctx, hasher);
     }
 }
 
 impl<CTX> HashStable<CTX> for f64 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         let val: u64 = self.to_bits();
         val.hash_stable(ctx, hasher);
     }
@@ -233,21 +247,21 @@ impl<CTX> HashStable<CTX> for f64 {
 
 impl<CTX> HashStable<CTX> for ::std::cmp::Ordering {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         (*self as i8).hash_stable(ctx, hasher);
     }
 }
 
 impl<T1: HashStable<CTX>, CTX> HashStable<CTX> for (T1,) {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         let (ref _0,) = *self;
         _0.hash_stable(ctx, hasher);
     }
 }
 
 impl<T1: HashStable<CTX>, T2: HashStable<CTX>, CTX> HashStable<CTX> for (T1, T2) {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         let (ref _0, ref _1) = *self;
         _0.hash_stable(ctx, hasher);
         _1.hash_stable(ctx, hasher);
@@ -268,7 +282,7 @@ where
     T2: HashStable<CTX>,
     T3: HashStable<CTX>,
 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         let (ref _0, ref _1, ref _2) = *self;
         _0.hash_stable(ctx, hasher);
         _1.hash_stable(ctx, hasher);
@@ -292,7 +306,7 @@ where
     T3: HashStable<CTX>,
     T4: HashStable<CTX>,
 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         let (ref _0, ref _1, ref _2, ref _3) = *self;
         _0.hash_stable(ctx, hasher);
         _1.hash_stable(ctx, hasher);
@@ -313,7 +327,11 @@ impl<T1: StableOrd, T2: StableOrd, T3: StableOrd, T4: StableOrd> StableOrd for (
 }
 
 impl<T: HashStable<CTX>, CTX> HashStable<CTX> for [T] {
-    default fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    default fn hash_stable<H: ExtendedHasher>(
+        &self,
+        ctx: &mut CTX,
+        hasher: &mut GenericStableHasher<H>,
+    ) {
         self.len().hash_stable(ctx, hasher);
         for item in self {
             item.hash_stable(ctx, hasher);
@@ -322,7 +340,7 @@ impl<T: HashStable<CTX>, CTX> HashStable<CTX> for [T] {
 }
 
 impl<CTX> HashStable<CTX> for [u8] {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.len().hash_stable(ctx, hasher);
         hasher.write(self);
     }
@@ -330,7 +348,7 @@ impl<CTX> HashStable<CTX> for [u8] {
 
 impl<T: HashStable<CTX>, CTX> HashStable<CTX> for Vec<T> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self[..].hash_stable(ctx, hasher);
     }
 }
@@ -342,7 +360,7 @@ where
     R: BuildHasher,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.len().hash_stable(ctx, hasher);
         for kv in self {
             kv.hash_stable(ctx, hasher);
@@ -356,7 +374,7 @@ where
     R: BuildHasher,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.len().hash_stable(ctx, hasher);
         for key in self {
             key.hash_stable(ctx, hasher);
@@ -369,35 +387,35 @@ where
     A: HashStable<CTX>,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self[..].hash_stable(ctx, hasher);
     }
 }
 
 impl<T: ?Sized + HashStable<CTX>, CTX> HashStable<CTX> for Box<T> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         (**self).hash_stable(ctx, hasher);
     }
 }
 
 impl<T: ?Sized + HashStable<CTX>, CTX> HashStable<CTX> for ::std::rc::Rc<T> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         (**self).hash_stable(ctx, hasher);
     }
 }
 
 impl<T: ?Sized + HashStable<CTX>, CTX> HashStable<CTX> for ::std::sync::Arc<T> {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         (**self).hash_stable(ctx, hasher);
     }
 }
 
 impl<CTX> HashStable<CTX> for str {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.as_bytes().hash_stable(ctx, hasher);
     }
 }
@@ -412,7 +430,7 @@ impl StableOrd for &str {
 
 impl<CTX> HashStable<CTX> for String {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self[..].hash_stable(hcx, hasher);
     }
 }
@@ -443,7 +461,7 @@ impl<HCX, T1: ToStableHashKey<HCX>, T2: ToStableHashKey<HCX>> ToStableHashKey<HC
 
 impl<CTX> HashStable<CTX> for bool {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         (if *self { 1u8 } else { 0u8 }).hash_stable(ctx, hasher);
     }
 }
@@ -460,7 +478,7 @@ where
     T: HashStable<CTX>,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         if let Some(ref value) = *self {
             1u8.hash_stable(ctx, hasher);
             value.hash_stable(ctx, hasher);
@@ -483,7 +501,7 @@ where
     T2: HashStable<CTX>,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         mem::discriminant(self).hash_stable(ctx, hasher);
         match *self {
             Ok(ref x) => x.hash_stable(ctx, hasher),
@@ -497,14 +515,14 @@ where
     T: HashStable<CTX> + ?Sized,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         (**self).hash_stable(ctx, hasher);
     }
 }
 
 impl<T, CTX> HashStable<CTX> for ::std::mem::Discriminant<T> {
     #[inline]
-    fn hash_stable(&self, _: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, _: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }
@@ -514,7 +532,7 @@ where
     T: HashStable<CTX>,
 {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.start().hash_stable(ctx, hasher);
         self.end().hash_stable(ctx, hasher);
     }
@@ -524,7 +542,7 @@ impl<I: Idx, T, CTX> HashStable<CTX> for IndexSlice<I, T>
 where
     T: HashStable<CTX>,
 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.len().hash_stable(ctx, hasher);
         for v in &self.raw {
             v.hash_stable(ctx, hasher);
@@ -536,7 +554,7 @@ impl<I: Idx, T, CTX> HashStable<CTX> for IndexVec<I, T>
 where
     T: HashStable<CTX>,
 {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.len().hash_stable(ctx, hasher);
         for v in &self.raw {
             v.hash_stable(ctx, hasher);
@@ -545,13 +563,13 @@ where
 }
 
 impl<I: Idx, CTX> HashStable<CTX> for BitSet<I> {
-    fn hash_stable(&self, _ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, _ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }
 
 impl<R: Idx, C: Idx, CTX> HashStable<CTX> for bit_set::BitMatrix<R, C> {
-    fn hash_stable(&self, _ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, _ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }
@@ -560,7 +578,7 @@ impl<T, CTX> HashStable<CTX> for bit_set::FiniteBitSet<T>
 where
     T: HashStable<CTX> + bit_set::FiniteBitSetTy,
 {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.0.hash_stable(hcx, hasher);
     }
 }
@@ -579,7 +597,7 @@ where
     K: HashStable<HCX> + StableOrd,
     V: HashStable<HCX>,
 {
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut HCX, hasher: &mut GenericStableHasher<H>) {
         self.len().hash_stable(hcx, hasher);
         for entry in self.iter() {
             entry.hash_stable(hcx, hasher);
@@ -591,7 +609,7 @@ impl<K, HCX> HashStable<HCX> for ::std::collections::BTreeSet<K>
 where
     K: HashStable<HCX> + StableOrd,
 {
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut HCX, hasher: &mut GenericStableHasher<H>) {
         self.len().hash_stable(hcx, hasher);
         for entry in self.iter() {
             entry.hash_stable(hcx, hasher);

--- a/compiler/rustc_data_structures/src/stable_hasher.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher.rs
@@ -10,6 +10,7 @@ use smallvec::SmallVec;
 #[cfg(test)]
 mod tests;
 
+pub use rustc_stable_hash::hashers::StableBlake2sHasher256;
 pub use rustc_stable_hash::{
     FromStableHash, IntoStableHash, SipHasher128Hash as StableHasherHash,
     StableHasher as GenericStableHasher, StableSipHasher128 as StableHasher,
@@ -21,6 +22,7 @@ pub trait ExtendedHasher:
 }
 
 impl ExtendedHasher for rustc_stable_hash::hashers::SipHasher128 {}
+impl ExtendedHasher for rustc_stable_hash::hashers::Blake2sHasher256 {}
 
 use crate::fingerprint::Fingerprint;
 pub use crate::hashes::{Hash128, Hash64};

--- a/compiler/rustc_data_structures/src/stable_hasher/tests.rs
+++ b/compiler/rustc_data_structures/src/stable_hasher/tests.rs
@@ -45,7 +45,11 @@ fn test_attribute_permutation() {
             }
 
             impl<CTX> HashStable<CTX> for Foo {
-                fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+                fn hash_stable<H: ExtendedHasher>(
+                    &self,
+                    hcx: &mut CTX,
+                    hasher: &mut GenericStableHasher<H>,
+                ) {
                     self.a.hash_stable(hcx, hasher);
                     self.b.hash_stable(hcx, hasher);
                 }

--- a/compiler/rustc_data_structures/src/steal.rs
+++ b/compiler/rustc_data_structures/src/steal.rs
@@ -1,4 +1,4 @@
-use crate::stable_hasher::{HashStable, StableHasher};
+use crate::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 use crate::sync::{MappedReadGuard, ReadGuard, RwLock};
 
 /// The `Steal` struct is intended to used as the value for a query.
@@ -63,7 +63,7 @@ impl<T> Steal<T> {
 }
 
 impl<CTX, T: HashStable<CTX>> HashStable<CTX> for Steal<T> {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.borrow().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/svh.rs
+++ b/compiler/rustc_data_structures/src/svh.rs
@@ -42,7 +42,11 @@ impl fmt::Display for Svh {
 
 impl<T> stable_hasher::HashStable<T> for Svh {
     #[inline]
-    fn hash_stable(&self, ctx: &mut T, hasher: &mut stable_hasher::StableHasher) {
+    fn hash_stable<H: stable_hasher::ExtendedHasher>(
+        &self,
+        ctx: &mut T,
+        hasher: &mut stable_hasher::GenericStableHasher<H>,
+    ) {
         let Svh { hash } = *self;
         hash.hash_stable(ctx, hasher);
     }

--- a/compiler/rustc_data_structures/src/tagged_ptr.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr.rs
@@ -277,7 +277,11 @@ unsafe impl Tag for Tag2 {
 
 #[cfg(test)]
 impl<HCX> crate::stable_hasher::HashStable<HCX> for Tag2 {
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut crate::stable_hasher::StableHasher) {
+    fn hash_stable<H: crate::stable_hasher::ExtendedHasher>(
+        &self,
+        hcx: &mut HCX,
+        hasher: &mut crate::stable_hasher::GenericStableHasher<H>,
+    ) {
         (*self as u8).hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/copy.rs
@@ -7,7 +7,7 @@ use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
 
 use super::{Pointer, Tag};
-use crate::stable_hasher::{HashStable, StableHasher};
+use crate::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 
 /// A [`Copy`] tagged pointer.
 ///
@@ -273,7 +273,7 @@ where
     P: Pointer + HashStable<HCX>,
     T: Tag + HashStable<HCX>,
 {
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut HCX, hasher: &mut GenericStableHasher<H>) {
         self.with_pointer_ref(|ptr| ptr.hash_stable(hcx, hasher));
         self.tag().hash_stable(hcx, hasher);
     }

--- a/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
+++ b/compiler/rustc_data_structures/src/tagged_ptr/drop.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
 
 use super::{CopyTaggedPtr, Pointer, Tag};
-use crate::stable_hasher::{HashStable, StableHasher};
+use crate::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 
 /// A tagged pointer that supports pointers that implement [`Drop`].
 ///
@@ -142,7 +142,7 @@ where
     P: Pointer + HashStable<HCX>,
     T: Tag + HashStable<HCX>,
 {
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut HCX, hasher: &mut GenericStableHasher<H>) {
         self.raw.hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_hir/src/diagnostic_items.rs
+++ b/compiler/rustc_hir/src/diagnostic_items.rs
@@ -1,5 +1,5 @@
 use rustc_data_structures::fx::FxIndexMap;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 use rustc_span::def_id::DefIdMap;
 use rustc_span::Symbol;
 
@@ -13,7 +13,7 @@ pub struct DiagnosticItems {
 
 impl<CTX: crate::HashStableContext> HashStable<CTX> for DiagnosticItems {
     #[inline]
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.name_to_id.hash_stable(ctx, hasher);
     }
 }

--- a/compiler/rustc_hir/src/hir_id.rs
+++ b/compiler/rustc_hir/src/hir_id.rs
@@ -1,6 +1,8 @@
 use std::fmt::{self, Debug};
 
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher, StableOrd, ToStableHashKey};
+use rustc_data_structures::stable_hasher::{
+    ExtendedHasher, GenericStableHasher, HashStable, StableOrd, ToStableHashKey,
+};
 use rustc_macros::{Decodable, Encodable, HashStable_Generic};
 use rustc_span::def_id::DefPathHash;
 use rustc_span::HashStableContext;
@@ -52,7 +54,7 @@ impl rustc_index::Idx for OwnerId {
 
 impl<CTX: HashStableContext> HashStable<CTX> for OwnerId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.to_stable_hash_key(hcx).hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -9,7 +9,7 @@
 
 use rustc_ast as ast;
 use rustc_data_structures::fx::FxIndexMap;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 use rustc_macros::{Decodable, Encodable, HashStable_Generic};
 use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::Span;
@@ -137,7 +137,7 @@ macro_rules! language_item_table {
 }
 
 impl<CTX> HashStable<CTX> for LangItem {
-    fn hash_stable(&self, _: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, _: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         ::std::hash::Hash::hash(self, hasher);
     }
 }

--- a/compiler/rustc_hir/src/stable_hash_impls.rs
+++ b/compiler/rustc_hir/src/stable_hash_impls.rs
@@ -1,4 +1,6 @@
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher, ToStableHashKey};
+use rustc_data_structures::stable_hasher::{
+    ExtendedHasher, GenericStableHasher, HashStable, ToStableHashKey,
+};
 use rustc_span::def_id::DefPathHash;
 
 use crate::hir::{
@@ -87,7 +89,11 @@ impl<HirCtx: crate::HashStableContext> ToStableHashKey<HirCtx> for ForeignItemId
 // in "DefPath Mode".
 
 impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for OwnerNodes<'tcx> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(
+        &self,
+        hcx: &mut HirCtx,
+        hasher: &mut GenericStableHasher<H>,
+    ) {
         // We ignore the `nodes` and `bodies` fields since these refer to information included in
         // `hash` which is hashed in the collector and used for the crate hash.
         // `local_id_to_def_id` is also ignored because is dependent on the body, then just hashing
@@ -99,7 +105,11 @@ impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for OwnerNodes<'
 }
 
 impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for AttributeMap<'tcx> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(
+        &self,
+        hcx: &mut HirCtx,
+        hasher: &mut GenericStableHasher<H>,
+    ) {
         // We ignore the `map` since it refers to information included in `opt_hash` which is
         // hashed in the collector and used for the crate hash.
         let AttributeMap { opt_hash, map: _ } = *self;
@@ -108,7 +118,11 @@ impl<'tcx, HirCtx: crate::HashStableContext> HashStable<HirCtx> for AttributeMap
 }
 
 impl<HirCtx: crate::HashStableContext> HashStable<HirCtx> for Crate<'_> {
-    fn hash_stable(&self, hcx: &mut HirCtx, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(
+        &self,
+        hcx: &mut HirCtx,
+        hasher: &mut GenericStableHasher<H>,
+    ) {
         let Crate { owners: _, opt_hir_hash } = self;
         opt_hir_hash.unwrap().hash_stable(hcx, hasher)
     }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -2,7 +2,7 @@ use rustc_ast::node_id::NodeId;
 use rustc_ast::{AttrId, Attribute};
 use rustc_data_structures::fx::{FxIndexMap, FxIndexSet};
 use rustc_data_structures::stable_hasher::{
-    HashStable, StableCompare, StableHasher, ToStableHashKey,
+    ExtendedHasher, GenericStableHasher, HashStable, StableCompare, ToStableHashKey,
 };
 use rustc_error_messages::{DiagMessage, MultiSpan};
 use rustc_hir::def::Namespace;
@@ -135,7 +135,7 @@ impl LintExpectationId {
 
 impl<HCX: rustc_hir::HashStableContext> HashStable<HCX> for LintExpectationId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut HCX, hasher: &mut GenericStableHasher<H>) {
         match self {
             LintExpectationId::Stable {
                 hir_id,
@@ -529,7 +529,7 @@ impl LintId {
 
 impl<HCX> HashStable<HCX> for LintId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut HCX, hasher: &mut GenericStableHasher<H>) {
         self.lint_name_raw().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_macros/src/hash_stable.rs
+++ b/compiler/rustc_macros/src/hash_stable.rs
@@ -111,10 +111,10 @@ fn hash_stable_derive_with_mode(
         ),
         quote! {
             #[inline]
-            fn hash_stable(
+            fn hash_stable<__H: ::rustc_data_structures::stable_hasher::ExtendedHasher>(
                 &self,
                 __hcx: &mut #context,
-                __hasher: &mut ::rustc_data_structures::stable_hasher::StableHasher) {
+                __hasher: &mut ::rustc_data_structures::stable_hasher::GenericStableHasher<__H>) {
                 #discriminant
                 match *self { #body }
             }

--- a/compiler/rustc_middle/src/middle/privacy.rs
+++ b/compiler/rustc_middle/src/middle/privacy.rs
@@ -5,7 +5,7 @@
 use std::hash::Hash;
 
 use rustc_data_structures::fx::{FxIndexMap, IndexEntry};
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 use rustc_hir::def::DefKind;
 use rustc_macros::HashStable;
 use rustc_query_system::ich::StableHashingContext;
@@ -278,7 +278,11 @@ impl<Id> Default for EffectiveVisibilities<Id> {
 }
 
 impl<'a> HashStable<StableHashingContext<'a>> for EffectiveVisibilities {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut GenericStableHasher<H>,
+    ) {
         let EffectiveVisibilities { ref map } = *self;
         map.hash_stable(hcx, hasher);
     }

--- a/compiler/rustc_middle/src/mir/basic_blocks.rs
+++ b/compiler/rustc_middle/src/mir/basic_blocks.rs
@@ -1,7 +1,7 @@
 use rustc_data_structures::fx::FxHashMap;
 use rustc_data_structures::graph;
 use rustc_data_structures::graph::dominators::{dominators, Dominators};
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 use rustc_data_structures::sync::OnceLock;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_macros::{HashStable, TyDecodable, TyEncodable, TypeFoldable, TypeVisitable};
@@ -186,5 +186,5 @@ impl<D: Decoder> Decodable<D> for Cache {
 
 impl<CTX> HashStable<CTX> for Cache {
     #[inline]
-    fn hash_stable(&self, _: &mut CTX, _: &mut StableHasher) {}
+    fn hash_stable<H: ExtendedHasher>(&self, _: &mut CTX, _: &mut GenericStableHasher<H>) {}
 }

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -994,11 +994,15 @@ pub enum BindingForm<'tcx> {
 TrivialTypeTraversalImpls! { BindingForm<'tcx> }
 
 mod binding_form_impl {
-    use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+    use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
     use rustc_query_system::ich::StableHashingContext;
 
     impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for super::BindingForm<'tcx> {
-        fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+        fn hash_stable<H: ExtendedHasher>(
+            &self,
+            hcx: &mut StableHashingContext<'a>,
+            hasher: &mut GenericStableHasher<H>,
+        ) {
             use super::BindingForm::*;
             std::mem::discriminant(self).hash_stable(hcx, hasher);
 

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -139,7 +139,11 @@ pub struct ScalarInt {
 // Cannot derive these, as the derives take references to the fields, and we
 // can't take references to fields of packed structs.
 impl<CTX> crate::ty::HashStable<CTX> for ScalarInt {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut crate::ty::StableHasher) {
+    fn hash_stable<H: crate::ty::ExtendedHasher>(
+        &self,
+        hcx: &mut CTX,
+        hasher: &mut crate::ty::GenericStableHasher<H>,
+    ) {
         // Using a block `{self.data}` here to force a copy instead of using `self.data`
         // directly, because `hash_stable` takes `&self` and would thus borrow `self.data`.
         // Since `Self` is a packed struct, that would create a possibly unaligned reference,

--- a/compiler/rustc_middle/src/ty/impls_ty.rs
+++ b/compiler/rustc_middle/src/ty/impls_ty.rs
@@ -35,7 +35,11 @@ where
                 return hash;
             }
 
-            let mut hasher = GenericStableHasher::<H>::new();
+            // FIXME: This caching doesn't work with a generic stable hasher.
+            // We therefor force the use of `StableHasher`. We should figure out
+            // a way to have to either cache for each hasher or only cache with
+            // the primary `StableHasher` hasher.
+            let mut hasher = StableHasher::new();
             self[..].hash_stable(hcx, &mut hasher);
 
             let hash: Fingerprint = hasher.finish();

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -29,7 +29,7 @@ use rustc_ast::node_id::NodeMap;
 pub use rustc_ast_ir::{try_visit, Movability, Mutability};
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
 use rustc_data_structures::intern::Interned;
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 use rustc_data_structures::steal::Steal;
 use rustc_data_structures::tagged_ptr::CopyTaggedPtr;
 use rustc_errors::{Diag, ErrorGuaranteed, StashKey};
@@ -529,7 +529,11 @@ impl<'tcx> From<Const<'tcx>> for Term<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for Term<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut GenericStableHasher<H>,
+    ) {
         self.unpack().hash_stable(hcx, hasher);
     }
 }
@@ -1017,7 +1021,11 @@ impl<'tcx> fmt::Debug for ParamEnv<'tcx> {
 }
 
 impl<'a, 'tcx> HashStable<StableHashingContext<'a>> for ParamEnv<'tcx> {
-    fn hash_stable(&self, hcx: &mut StableHashingContext<'a>, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(
+        &self,
+        hcx: &mut StableHashingContext<'a>,
+        hasher: &mut GenericStableHasher<H>,
+    ) {
         self.caller_bounds().hash_stable(hcx, hasher);
         self.reveal().hash_stable(hcx, hasher);
     }

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -4,7 +4,7 @@ use std::{fmt, iter};
 
 use rustc_apfloat::Float as _;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
-use rustc_data_structures::stable_hasher::{Hash128, HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{Hash128, HashStable, StableBlake2sHasher256};
 use rustc_data_structures::stack::ensure_sufficient_stack;
 use rustc_errors::ErrorGuaranteed;
 use rustc_hir as hir;
@@ -134,7 +134,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let ty = self.erase_regions(ty);
 
         self.with_stable_hashing_context(|mut hcx| {
-            let mut hasher = StableHasher::new();
+            let mut hasher = StableBlake2sHasher256::new();
             hcx.while_hashing_spans(false, |hcx| ty.hash_stable(hcx, &mut hasher));
             hasher.finish()
         })

--- a/compiler/rustc_query_system/src/dep_graph/dep_node.rs
+++ b/compiler/rustc_query_system/src/dep_graph/dep_node.rs
@@ -46,7 +46,9 @@ use std::fmt;
 use std::hash::Hash;
 
 use rustc_data_structures::fingerprint::{Fingerprint, PackedFingerprint};
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher, StableOrd, ToStableHashKey};
+use rustc_data_structures::stable_hasher::{
+    ExtendedHasher, GenericStableHasher, HashStable, StableHasher, StableOrd, ToStableHashKey,
+};
 use rustc_data_structures::AtomicRef;
 use rustc_hir::definitions::DefPathHash;
 use rustc_macros::{Decodable, Encodable};
@@ -291,7 +293,7 @@ impl WorkProductId {
 
 impl<HCX> HashStable<HCX> for WorkProductId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut HCX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut HCX, hasher: &mut GenericStableHasher<H>) {
         self.hash.hash_stable(hcx, hasher)
     }
 }

--- a/compiler/rustc_query_system/src/ich/hcx.rs
+++ b/compiler/rustc_query_system/src/ich/hcx.rs
@@ -1,5 +1,7 @@
 use rustc_ast as ast;
-use rustc_data_structures::stable_hasher::{HashStable, HashingControls, StableHasher};
+use rustc_data_structures::stable_hasher::{
+    ExtendedHasher, GenericStableHasher, HashStable, HashingControls,
+};
 use rustc_data_structures::sync::Lrc;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::definitions::DefPathHash;
@@ -88,7 +90,11 @@ impl<'a> StableHashingContext<'a> {
 
 impl<'a> HashStable<StableHashingContext<'a>> for ast::NodeId {
     #[inline]
-    fn hash_stable(&self, _: &mut StableHashingContext<'a>, _: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(
+        &self,
+        _: &mut StableHashingContext<'a>,
+        _: &mut GenericStableHasher<H>,
+    ) {
         panic!("Node IDs should not appear in incremental state");
     }
 }

--- a/compiler/rustc_span/src/def_id.rs
+++ b/compiler/rustc_span/src/def_id.rs
@@ -3,7 +3,8 @@ use std::hash::{BuildHasherDefault, Hash, Hasher};
 
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::stable_hasher::{
-    Hash64, HashStable, StableHasher, StableOrd, ToStableHashKey,
+    ExtendedHasher, GenericStableHasher, Hash64, HashStable, StableHasher, StableOrd,
+    ToStableHashKey,
 };
 use rustc_data_structures::unhash::Unhasher;
 use rustc_data_structures::AtomicRef;
@@ -404,21 +405,21 @@ rustc_data_structures::define_id_collections!(
 
 impl<CTX: HashStableContext> HashStable<CTX> for DefId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.to_stable_hash_key(hcx).hash_stable(hcx, hasher);
     }
 }
 
 impl<CTX: HashStableContext> HashStable<CTX> for LocalDefId {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.to_stable_hash_key(hcx).hash_stable(hcx, hasher);
     }
 }
 
 impl<CTX: HashStableContext> HashStable<CTX> for CrateNum {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.to_stable_hash_key(hcx).hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -31,7 +31,9 @@ use std::hash::Hash;
 
 use rustc_data_structures::fingerprint::Fingerprint;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
-use rustc_data_structures::stable_hasher::{Hash64, HashStable, HashingControls, StableHasher};
+use rustc_data_structures::stable_hasher::{
+    ExtendedHasher, GenericStableHasher, Hash64, HashStable, HashingControls, StableHasher,
+};
 use rustc_data_structures::sync::{Lock, Lrc, WorkerLocal};
 use rustc_data_structures::unhash::UnhashMap;
 use rustc_index::IndexVec;
@@ -1536,7 +1538,7 @@ fn update_disambiguator(expn_data: &mut ExpnData, mut ctx: impl HashStableContex
 }
 
 impl<CTX: HashStableContext> HashStable<CTX> for SyntaxContext {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         const TAG_EXPANSION: u8 = 0;
         const TAG_NO_EXPANSION: u8 = 1;
 
@@ -1552,7 +1554,7 @@ impl<CTX: HashStableContext> HashStable<CTX> for SyntaxContext {
 }
 
 impl<CTX: HashStableContext> HashStable<CTX> for ExpnId {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         assert_default_hashing_controls(ctx, "ExpnId");
         let hash = if *self == ExpnId::root() {
             // Avoid fetching TLS storage for a trivial often-used value.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -8,7 +8,7 @@ use std::{fmt, str};
 use rustc_arena::DroplessArena;
 use rustc_data_structures::fx::FxIndexSet;
 use rustc_data_structures::stable_hasher::{
-    HashStable, StableCompare, StableHasher, ToStableHashKey,
+    ExtendedHasher, GenericStableHasher, HashStable, StableCompare, ToStableHashKey,
 };
 use rustc_data_structures::sync::Lock;
 use rustc_macros::{symbols, Decodable, Encodable, HashStable_Generic};
@@ -2364,7 +2364,7 @@ impl ToString for Symbol {
 
 impl<CTX> HashStable<CTX> for Symbol {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         self.as_str().hash_stable(hcx, hasher);
     }
 }

--- a/compiler/rustc_type_ir/src/const_kind.rs
+++ b/compiler/rustc_type_ir/src/const_kind.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use derive_where::derive_where;
 #[cfg(feature = "nightly")]
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 #[cfg(feature = "nightly")]
 use rustc_macros::{HashStable_NoContext, TyDecodable, TyEncodable};
 use rustc_type_ir_macros::{Lift_Generic, TypeFoldable_Generic, TypeVisitable_Generic};
@@ -126,7 +126,7 @@ impl fmt::Debug for InferConst {
 
 #[cfg(feature = "nightly")]
 impl<CTX> HashStable<CTX> for InferConst {
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         match self {
             InferConst::Var(_) | InferConst::EffectVar(_) => {
                 panic!("const variables should not be hashed: {self:?}")

--- a/compiler/rustc_type_ir/src/region_kind.rs
+++ b/compiler/rustc_type_ir/src/region_kind.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use derive_where::derive_where;
 #[cfg(feature = "nightly")]
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 #[cfg(feature = "nightly")]
 use rustc_macros::{HashStable_NoContext, TyDecodable, TyEncodable};
 
@@ -215,7 +215,7 @@ where
     I::PlaceholderRegion: HashStable<CTX>,
 {
     #[inline]
-    fn hash_stable(&self, hcx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, hcx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         std::mem::discriminant(self).hash_stable(hcx, hasher);
         match self {
             ReErased | ReStatic | ReError(_) => {

--- a/compiler/rustc_type_ir/src/ty_info.rs
+++ b/compiler/rustc_type_ir/src/ty_info.rs
@@ -5,7 +5,9 @@ use std::ops::Deref;
 #[cfg(feature = "nightly")]
 use rustc_data_structures::fingerprint::Fingerprint;
 #[cfg(feature = "nightly")]
-use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
+use rustc_data_structures::stable_hasher::{
+    ExtendedHasher, GenericStableHasher, HashStable, StableHasher,
+};
 
 use crate::{DebruijnIndex, TypeFlags};
 
@@ -106,7 +108,10 @@ impl<T: HashStable<CTX>, CTX> HashStable<CTX> for WithCachedTypeInfo<T> {
             // We need to build the hash as if we cached it and then hash that hash, as
             // otherwise the hashes will differ between cached and non-cached mode.
             let stable_hash: Fingerprint = {
-                let mut hasher = GenericStableHasher::<H>::new();
+                // FIXME: Using the generic stable hasher creates a cache coherency issue
+                // so for now always use the `StableHasher` instead.
+                // let mut hasher = GenericStableHasher::<H>::new();
+                let mut hasher = StableHasher::new();
                 self.internee.hash_stable(hcx, &mut hasher);
                 hasher.finish()
             };

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use derive_where::derive_where;
 use rustc_ast_ir::Mutability;
 #[cfg(feature = "nightly")]
-use rustc_data_structures::stable_hasher::{HashStable, StableHasher};
+use rustc_data_structures::stable_hasher::{ExtendedHasher, GenericStableHasher, HashStable};
 #[cfg(feature = "nightly")]
 use rustc_data_structures::unify::{NoError, UnifyKey, UnifyValue};
 #[cfg(feature = "nightly")]
@@ -791,7 +791,7 @@ impl UnifyKey for FloatVid {
 
 #[cfg(feature = "nightly")]
 impl<CTX> HashStable<CTX> for InferTy {
-    fn hash_stable(&self, ctx: &mut CTX, hasher: &mut StableHasher) {
+    fn hash_stable<H: ExtendedHasher>(&self, ctx: &mut CTX, hasher: &mut GenericStableHasher<H>) {
         use InferTy::*;
         std::mem::discriminant(self).hash_stable(ctx, hasher);
         match self {

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -98,6 +98,7 @@ const EXCEPTIONS: ExceptionList = &[
     ("ryu", "Apache-2.0 OR BSL-1.0"), // BSL is not acceptble, but we use it under Apache-2.0                       // cargo/... (because of serde)
     ("self_cell", "Apache-2.0"),                             // rustc (fluent translations)
     ("snap", "BSD-3-Clause"),                                // rustc
+    ("subtle", "BSD-3-Clause"),                              // rustc
     ("wasm-encoder", "Apache-2.0 WITH LLVM-exception"),      // rustc
     ("wasm-metadata", "Apache-2.0 WITH LLVM-exception"),     // rustc
     ("wasmparser", "Apache-2.0 WITH LLVM-exception"),        // rustc
@@ -258,6 +259,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "arrayvec",
     "autocfg",
     "bitflags",
+    "blake2",
     "block-buffer",
     "byteorder", // via ruzstd in object in thorin-dwp
     "cc",
@@ -393,6 +395,7 @@ const PERMITTED_RUSTC_DEPENDENCIES: &[&str] = &[
     "stacker",
     "static_assertions",
     "strsim",
+    "subtle",
     "syn",
     "synstructure",
     "tempfile",

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -8,6 +8,8 @@ const ALLOWED_SOURCES: &[&str] = &[
     r#""registry+https://github.com/rust-lang/crates.io-index""#,
     // This is `rust_team_data` used by `site` in src/tools/rustc-perf,
     r#""git+https://github.com/rust-lang/team#a5260e76d3aa894c64c56e6ddc8545b9a98043ec""#,
+    // WIP Blake2 in rustc-stable-hash
+    r#""git+https://github.com/Urgau/rustc-stable-hash.git?rev=543696a#543696a0b6299c4cc8a8c9c30651e5cc0056655a""#,
 ];
 
 /// Checks for external package sources. `root` is the path to the directory that contains the


### PR DESCRIPTION
and only for the `TypeId` hash, not as a general stable hasher.

cc @michaelwoerister