### PR TITLE
repr(int) fieldless enums are ABI-compatible with int

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1667,6 +1667,8 @@ mod prim_ref {}
 ///   Pointee>::Metadata`).
 /// - `usize` is ABI-compatible with the `uN` integer type of the same size, and likewise `isize` is
 ///   ABI-compatible with the `iN` integer type of the same size.
+/// - A fieldless enum with `repr(u*)` or `repr(i*)` is ABI-compatible with the integer type given
+///   in the `repr`.
 /// - `char` is ABI-compatible with `u32`.
 /// - Any two `fn` (function pointer) types are ABI-compatible with each other if they have the same
 ///   ABI string or the ABI string only differs in a trailing `-unwind`, independent of the rest of

--- a/src/tools/miri/tests/pass/function_calls/abi_compat.rs
+++ b/src/tools/miri/tests/pass/function_calls/abi_compat.rs
@@ -71,6 +71,23 @@ fn main() {
         test_abi_compat(0isize, 0i64);
     }
     test_abi_compat(42u32, num::NonZero::new(1u32).unwrap());
+    // - `repr(int)` enums and the corresponding integer.
+    #[repr(i16)]
+    #[derive(Copy, Clone)]
+    enum I16 {
+        Var1 = 0,
+        Var2 = -5,
+    }
+    test_abi_compat(I16::Var1, 0i16);
+    test_abi_compat(I16::Var2, -5i16);
+    #[repr(u64)]
+    #[derive(Copy, Clone)]
+    enum U64 {
+        Var1 = 0,
+        Var2 = u64::MAX,
+    }
+    test_abi_compat(U64::Var1, 0u64);
+    test_abi_compat(U64::Var2, u64::MAX);
     // - `char` and `u32`.
     test_abi_compat(42u32, 'x');
     // - Reference/pointer types with the same pointee.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

Given that we already allow mixing `char` and `u32`, as well as `usize`/`isize` and the corresponding fixed-size type, it seems odd to not also do this for enums. However, if we declare this legal, then Rust code may start relying on it, so arguably CFI should also allow this, which could miss some real bugs where the mismatch is accidental.

So we have to decide -- do we say this is ABI-compatible, or do we declare this to be "erroneous behavior": similar to overflow in (non-wrapping) arithmetic, such behavior is always a bug, but implementations are not required to detect the bug (with a panic or abort), they can also continue execution in some well-defined way. (For the ABI question, that well-defined way is to transmute the argument from the caller type to the callee type. This is well-defined in the sense that we say exactly what happens, but it *may* be UB if the caller uses e.g. `u32` and the callee expects a `repr(u32)` enum for which the chosen argument value is not valid.)

I am not sure if we are already guaranteeing anything like this somewhere. (The nomicon talks about these `repr` flags affecting the ABI, but the nomicon is not normative, and also it's not entirely clear whether ABI here also includes function call concerns.)
Cc @rust-lang/lang @rust-lang/opsem 

This is part of a wider set of discussions around CFI vs ABI compatibility:
- https://github.com/rust-lang/rust/issues/128728
- https://github.com/rust-lang/unsafe-code-guidelines/issues/489