### PR TITLE
Update run-make/used to use `any_symbol_contains`

### DIFF
--- a/tests/run-make/used/rmake.rs
+++ b/tests/run-make/used/rmake.rs
@@ -10,5 +10,4 @@ use run_make_support::symbols::any_symbol_contains;
 fn main() {
     rustc().opt_level("3").emit("obj").input("used.rs").run();
     assert!(any_symbol_contains("used.o", &["FOO"]));
-    assert!(!any_symbol_contains("used.o", &["BAR"]));
 }

--- a/tests/run-make/used/rmake.rs
+++ b/tests/run-make/used/rmake.rs
@@ -4,12 +4,11 @@
 // It comes from #39987 which implements this RFC for the #[used] attribute:
 // https://rust-lang.github.io/rfcs/2386-used.html
 
-//@ ignore-msvc
-
-use run_make_support::{cmd, rustc};
+use run_make_support::rustc;
+use run_make_support::symbols::any_symbol_contains;
 
 fn main() {
     rustc().opt_level("3").emit("obj").input("used.rs").run();
-
-    cmd("nm").arg("used.o").run().assert_stdout_contains("FOO");
+    assert!(any_symbol_contains("used.o", &["FOO"]));
+    assert!(!any_symbol_contains("used.o", &["BAR"]));
 }

--- a/tests/run-make/used/used.rs
+++ b/tests/run-make/used/used.rs
@@ -2,5 +2,3 @@
 
 #[used]
 static FOO: u32 = 0;
-
-static BAR: u32 = 0;


### PR DESCRIPTION
This makes it so we don't need `nm` or `llvm-nm`.

I also tested that `BAR` is removed. I'm not sure if this is wanted though.