### PR TITLE
rustdoc: make the hover trail for doc anchors a bit bigger

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -930,7 +930,7 @@ a.doc-anchor {
 	left: -17px;
 	/* We add this padding so that when the cursor moves from the heading's text to the anchor,
 	   the anchor doesn't disappear. */
-	padding-right: 5px;
+	padding-right: 10px;
 	/* And this padding is used to make the anchor larger and easier to click on. */
 	padding-left: 3px;
 }


### PR DESCRIPTION
https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/Weird.20markdown.20heading.20rendering.3F

r? @GuillaumeGomez 

### Screenshots (the purple part is the padding, which the mouse can pass through to hover over it)

| Before | After |
|--|--|
| ![image](https://github.com/user-attachments/assets/5070eebe-84ac-4f5d-8950-58664370191c) | ![image](https://github.com/user-attachments/assets/55340161-ad8a-41bd-a120-8cdab11f4af0)

