### PR TITLE
Don't inline tainted MIR bodies

### DIFF
--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -505,6 +505,10 @@ impl<'tcx> Inliner<'tcx> {
     ) -> Result<(), &'static str> {
         let tcx = self.tcx;
 
+        if let Some(_) = callee_body.tainted_by_errors {
+            return Err("Body is tainted");
+        }
+
         let mut threshold = if self.caller_is_inline_forwarder {
             self.tcx.sess.opts.unstable_opts.inline_mir_forwarder_threshold.unwrap_or(30)
         } else if cross_crate_inlinable {

--- a/tests/ui/polymorphization/inline-tainted-body.rs
+++ b/tests/ui/polymorphization/inline-tainted-body.rs
@@ -1,15 +1,21 @@
 //@ compile-flags: -Zvalidate-mir -Zinline-mir=yes
-//@ known-bug: #122909
 
+#![feature(unboxed_closures)]
 
-use std::sync::{Arc, Context, Weak};
+use std::sync::Arc;
 
 pub struct WeakOnce<T>();
+//~^ ERROR type parameter `T` is never used
+
 impl<T> WeakOnce<T> {
     extern "rust-call" fn try_get(&self) -> Option<Arc<T>> {}
+    //~^ ERROR functions with the "rust-call" ABI must take a single non-self tuple argument
+    //~| ERROR mismatched types
 
     pub fn get(&self) -> Arc<T> {
         self.try_get()
             .unwrap_or_else(|| panic!("Singleton {} not available", std::any::type_name::<T>()))
     }
 }
+
+fn main() {}

--- a/tests/ui/polymorphization/inline-tainted-body.stderr
+++ b/tests/ui/polymorphization/inline-tainted-body.stderr
@@ -1,0 +1,30 @@
+error[E0392]: type parameter `T` is never used
+  --> $DIR/inline-tainted-body.rs:7:21
+   |
+LL | pub struct WeakOnce<T>();
+   |                     ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error: functions with the "rust-call" ABI must take a single non-self tuple argument
+  --> $DIR/inline-tainted-body.rs:11:35
+   |
+LL |     extern "rust-call" fn try_get(&self) -> Option<Arc<T>> {}
+   |                                   ^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/inline-tainted-body.rs:11:45
+   |
+LL |     extern "rust-call" fn try_get(&self) -> Option<Arc<T>> {}
+   |                           -------           ^^^^^^^^^^^^^^ expected `Option<Arc<T>>`, found `()`
+   |                           |
+   |                           implicitly returns `()` as its body has no tail or `return` expression
+   |
+   = note:   expected enum `Option<Arc<T>>`
+           found unit type `()`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0392.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Don't inline MIR bodies that are tainted, since they're not necessarily well-formed.

Fixes #128601 (I didn't add a new test, just copied one from the crashes, since they're the same root cause).
Fixes #122909.