### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3282,20 +3282,22 @@ dependencies = [
 
 [[package]]
 name = "rinja"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d47a46d7729e891c8accf260e9daa02ae6d570aa2a94fb1fb27eb5364a2323"
+checksum = "6d3762e3740cdbf2fd2be465cc2c26d643ad17353cc2e0223d211c1b096118bd"
 dependencies = [
+ "itoa",
  "rinja_derive",
 ]
 
 [[package]]
 name = "rinja_derive"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dae9afe59d58ed8d988d67d1945f3638125d2fd2104058399382e11bd3ea2a"
+checksum = "fd01fd8e15e7d19c8b8052c1d428325131e02ff1633cdcf695190c2e56ab682c"
 dependencies = [
  "basic-toml",
+ "memchr",
  "mime",
  "mime_guess",
  "once_map",
@@ -3308,10 +3310,11 @@ dependencies = [
 
 [[package]]
 name = "rinja_parser"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1771c78cd5d3b1646ef8d8f2ed100db936e8b291d3cc06e92a339ff346858c"
+checksum = "a2f6bf7cef118c6de21206edf0b3f19f5ede60006be674a58ca21b6e003a1b57"
 dependencies = [
+ "memchr",
  "nom",
 ]
 

--- a/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/eval_queries.rs
@@ -396,7 +396,7 @@ fn const_validate_mplace<'tcx>(
     let alloc_id = mplace.ptr().provenance.unwrap().alloc_id();
     let mut ref_tracking = RefTracking::new(mplace.clone());
     let mut inner = false;
-    while let Some((mplace, path)) = ref_tracking.todo.pop() {
+    while let Some((mplace, path)) = ref_tracking.next() {
         let mode = match ecx.tcx.static_mutability(cid.instance.def_id()) {
             _ if cid.promoted.is_some() => CtfeValidationMode::Promoted,
             Some(mutbl) => CtfeValidationMode::Static { mutbl }, // a `static`

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -165,6 +165,13 @@ pub trait Machine<'tcx>: Sized {
 
     /// Whether to enforce the validity invariant for a specific layout.
     fn enforce_validity(ecx: &InterpCx<'tcx, Self>, layout: TyAndLayout<'tcx>) -> bool;
+    /// Whether to enforce the validity invariant *recursively*.
+    fn enforce_validity_recursively(
+        _ecx: &InterpCx<'tcx, Self>,
+        _layout: TyAndLayout<'tcx>,
+    ) -> bool {
+        false
+    }
 
     /// Whether function calls should be [ABI](CallAbi)-checked.
     fn enforce_abi(_ecx: &InterpCx<'tcx, Self>) -> bool {

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -1006,8 +1006,11 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         })
     }
 
-    /// Runs the close in "validation" mode, which means the machine's memory read hooks will be
+    /// Runs the closure in "validation" mode, which means the machine's memory read hooks will be
     /// suppressed. Needless to say, this must only be set with great care! Cannot be nested.
+    ///
+    /// We do this so Miri's allocation access tracking does not show the validation
+    /// reads as spurious accesses.
     pub(super) fn run_for_validation<R>(&self, f: impl FnOnce() -> R) -> R {
         // This deliberately uses `==` on `bool` to follow the pattern
         // `assert!(val.replace(new) == old)`.

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -572,7 +572,10 @@ where
 
         if M::enforce_validity(self, dest.layout()) {
             // Data got changed, better make sure it matches the type!
-            self.validate_operand(&dest.to_op(self)?)?;
+            self.validate_operand(
+                &dest.to_op(self)?,
+                M::enforce_validity_recursively(self, dest.layout()),
+            )?;
         }
 
         Ok(())
@@ -811,7 +814,10 @@ where
         // Generally for transmutation, data must be valid both at the old and new type.
         // But if the types are the same, the 2nd validation below suffices.
         if src.layout().ty != dest.layout().ty && M::enforce_validity(self, src.layout()) {
-            self.validate_operand(&src.to_op(self)?)?;
+            self.validate_operand(
+                &src.to_op(self)?,
+                M::enforce_validity_recursively(self, src.layout()),
+            )?;
         }
 
         // Do the actual copy.
@@ -819,7 +825,10 @@ where
 
         if validate_dest && M::enforce_validity(self, dest.layout()) {
             // Data got changed, better make sure it matches the type!
-            self.validate_operand(&dest.to_op(self)?)?;
+            self.validate_operand(
+                &dest.to_op(self)?,
+                M::enforce_validity_recursively(self, dest.layout()),
+            )?;
         }
 
         Ok(())

--- a/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
+++ b/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
@@ -67,7 +67,7 @@ fn might_permit_raw_init_strict<'tcx>(
     // This does *not* actually check that references are dereferenceable, but since all types that
     // require dereferenceability also require non-null, we don't actually get any false negatives
     // due to this.
-    Ok(cx.validate_operand(&ot).is_ok())
+    Ok(cx.validate_operand(&ot, /*recursive*/ false).is_ok())
 }
 
 /// Implements the 'lax' (default) version of the `might_permit_raw_init` checks; see that function for

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -617,8 +617,6 @@ impl Duration {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::time::Duration;
     ///
@@ -639,8 +637,6 @@ impl Duration {
     /// if overflow occurred.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::time::Duration;
@@ -700,8 +696,6 @@ impl Duration {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::time::Duration;
     ///
@@ -758,8 +752,6 @@ impl Duration {
     ///
     /// # Examples
     ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::time::Duration;
     ///
@@ -813,8 +805,6 @@ impl Duration {
     /// if `other == 0`.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
     ///
     /// ```
     /// use std::time::Duration;

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1840,6 +1840,23 @@ impl Config {
             config.llvm_from_ci = config.parse_download_ci_llvm(download_ci_llvm, asserts);
 
             if config.llvm_from_ci {
+                let warn = |option: &str| {
+                    println!(
+                        "WARNING: `{option}` will only be used on `compiler/rustc_llvm` build, not for the LLVM build."
+                    );
+                    println!(
+                        "HELP: To use `{option}` for LLVM builds, set `download-ci-llvm` option to false."
+                    );
+                };
+
+                if static_libstdcpp.is_some() {
+                    warn("static-libstdcpp");
+                }
+
+                if link_shared.is_some() {
+                    warn("link-shared");
+                }
+
                 // None of the LLVM options, except assertions, are supported
                 // when using downloaded LLVM. We could just ignore these but
                 // that's potentially confusing, so force them to not be
@@ -1849,9 +1866,6 @@ impl Config {
                 check_ci_llvm!(optimize_toml);
                 check_ci_llvm!(thin_lto);
                 check_ci_llvm!(release_debuginfo);
-                // CI-built LLVM can be either dynamic or static. We won't know until we download it.
-                check_ci_llvm!(link_shared);
-                check_ci_llvm!(static_libstdcpp);
                 check_ci_llvm!(targets);
                 check_ci_llvm!(experimental_targets);
                 check_ci_llvm!(clang_cl);

--- a/src/librustdoc/Cargo.toml
+++ b/src/librustdoc/Cargo.toml
@@ -8,7 +8,7 @@ path = "lib.rs"
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
-rinja = { version = "0.2", default-features = false, features = ["config"] }
+rinja = { version = "0.3", default-features = false, features = ["config"] }
 base64 = "0.21.7"
 itertools = "0.12"
 indexmap = "2"

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1680,13 +1680,16 @@ impl Type {
         }
     }
 
-    fn inner_def_id(&self, cache: Option<&Cache>) -> Option<DefId> {
+    /// Use this method to get the [DefId] of a [clean] AST node, including [PrimitiveType]s.
+    ///
+    /// [clean]: crate::clean
+    pub(crate) fn def_id(&self, cache: &Cache) -> Option<DefId> {
         let t: PrimitiveType = match *self {
             Type::Path { ref path } => return Some(path.def_id()),
             DynTrait(ref bounds, _) => return bounds.get(0).map(|b| b.trait_.def_id()),
-            Primitive(p) => return cache.and_then(|c| c.primitive_locations.get(&p).cloned()),
+            Primitive(p) => return cache.primitive_locations.get(&p).cloned(),
             BorrowedRef { type_: box Generic(..), .. } => PrimitiveType::Reference,
-            BorrowedRef { ref type_, .. } => return type_.inner_def_id(cache),
+            BorrowedRef { ref type_, .. } => return type_.def_id(cache),
             Tuple(ref tys) => {
                 if tys.is_empty() {
                     PrimitiveType::Unit
@@ -1699,17 +1702,10 @@ impl Type {
             Array(..) => PrimitiveType::Array,
             Type::Pat(..) => PrimitiveType::Pat,
             RawPointer(..) => PrimitiveType::RawPointer,
-            QPath(box QPathData { ref self_type, .. }) => return self_type.inner_def_id(cache),
+            QPath(box QPathData { ref self_type, .. }) => return self_type.def_id(cache),
             Generic(_) | Infer | ImplTrait(_) => return None,
         };
-        cache.and_then(|c| Primitive(t).def_id(c))
-    }
-
-    /// Use this method to get the [DefId] of a [clean] AST node, including [PrimitiveType]s.
-    ///
-    /// [clean]: crate::clean
-    pub(crate) fn def_id(&self, cache: &Cache) -> Option<DefId> {
-        self.inner_def_id(Some(cache))
+        Primitive(t).def_id(cache)
     }
 }
 

--- a/src/librustdoc/formats/cache.rs
+++ b/src/librustdoc/formats/cache.rs
@@ -260,17 +260,20 @@ impl<'a, 'tcx> DocFolder for CacheBuilder<'a, 'tcx> {
         }
 
         // Index this method for searching later on.
-        if let Some(name) = item.name.or_else(|| {
-            if item.is_stripped() {
-                None
-            } else if let clean::ImportItem(ref i) = *item.kind
-                && let clean::ImportKind::Simple(s) = i.kind
-            {
-                Some(s)
-            } else {
-                None
-            }
-        }) {
+        let search_name = if !item.is_stripped() {
+            item.name.or_else(|| {
+                if let clean::ImportItem(ref i) = *item.kind
+                    && let clean::ImportKind::Simple(s) = i.kind
+                {
+                    Some(s)
+                } else {
+                    None
+                }
+            })
+        } else {
+            None
+        };
+        if let Some(name) = search_name {
             add_item_to_search_index(self.tcx, &mut self.cache, &item, name)
         }
 

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -930,7 +930,7 @@ a.doc-anchor {
 	left: -17px;
 	/* We add this padding so that when the cursor moves from the heading's text to the anchor,
 	   the anchor doesn't disappear. */
-	padding-right: 5px;
+	padding-right: 10px;
 	/* And this padding is used to make the anchor larger and easier to click on. */
 	padding-left: 3px;
 }

--- a/src/tools/miri/README.md
+++ b/src/tools/miri/README.md
@@ -398,6 +398,8 @@ to Miri failing to detect cases of undefined behavior in a program.
   application instead of raising an error within the context of Miri (and halting
   execution). Note that code might not expect these operations to ever panic, so
   this flag can lead to strange (mis)behavior.
+* `-Zmiri-recursive-validation` is a *highly experimental* flag that makes validity checking
+  recurse below references.
 * `-Zmiri-retag-fields[=<all|none|scalar>]` controls when Stacked Borrows retagging recurses into
   fields. `all` means it always recurses (the default, and equivalent to `-Zmiri-retag-fields`
   without an explicit value), `none` means it never recurses, `scalar` means it only recurses for

--- a/src/tools/miri/src/bin/miri.rs
+++ b/src/tools/miri/src/bin/miri.rs
@@ -44,7 +44,7 @@ use rustc_session::config::{CrateType, ErrorOutputType, OptLevel};
 use rustc_session::search_paths::PathKind;
 use rustc_session::{CtfeBacktrace, EarlyDiagCtxt};
 
-use miri::{BacktraceStyle, BorrowTrackerMethod, ProvenanceMode, RetagFields};
+use miri::{BacktraceStyle, BorrowTrackerMethod, ProvenanceMode, RetagFields, ValidationMode};
 
 struct MiriCompilerCalls {
     miri_config: miri::MiriConfig,
@@ -421,7 +421,9 @@ fn main() {
         } else if arg == "--" {
             after_dashdash = true;
         } else if arg == "-Zmiri-disable-validation" {
-            miri_config.validate = false;
+            miri_config.validation = ValidationMode::No;
+        } else if arg == "-Zmiri-recursive-validation" {
+            miri_config.validation = ValidationMode::Deep;
         } else if arg == "-Zmiri-disable-stacked-borrows" {
             miri_config.borrow_tracker = None;
         } else if arg == "-Zmiri-tree-borrows" {

--- a/src/tools/miri/src/eval.rs
+++ b/src/tools/miri/src/eval.rs
@@ -68,7 +68,7 @@ pub enum IsolatedOp {
     Allow,
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BacktraceStyle {
     /// Prints a terser backtrace which ideally only contains relevant information.
     Short,
@@ -78,6 +78,16 @@ pub enum BacktraceStyle {
     Off,
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ValidationMode {
+    /// Do not perform any kind of validation.
+    No,
+    /// Validate the interior of the value, but not things behind references.
+    Shallow,
+    /// Fully recursively validate references.
+    Deep,
+}
+
 /// Configuration needed to spawn a Miri instance.
 #[derive(Clone)]
 pub struct MiriConfig {
@@ -85,7 +95,7 @@ pub struct MiriConfig {
     /// (This is still subject to isolation as well as `forwarded_env_vars`.)
     pub env: Vec<(OsString, OsString)>,
     /// Determine if validity checking is enabled.
-    pub validate: bool,
+    pub validation: ValidationMode,
     /// Determines if Stacked Borrows or Tree Borrows is enabled.
     pub borrow_tracker: Option<BorrowTrackerMethod>,
     /// Whether `core::ptr::Unique` receives special treatment.
@@ -162,7 +172,7 @@ impl Default for MiriConfig {
     fn default() -> MiriConfig {
         MiriConfig {
             env: vec![],
-            validate: true,
+            validation: ValidationMode::Shallow,
             borrow_tracker: Some(BorrowTrackerMethod::StackedBorrows),
             unique_is_unique: false,
             check_alignment: AlignmentCheck::Int,

--- a/src/tools/miri/src/intrinsics/mod.rs
+++ b/src/tools/miri/src/intrinsics/mod.rs
@@ -153,7 +153,7 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
             // Would not be considered UB, or the other way around (`is_val_statically_known(0)`).
             "is_val_statically_known" => {
                 let [arg] = check_arg_count(args)?;
-                this.validate_operand(arg)?;
+                this.validate_operand(arg, /*recursive*/ false)?;
                 let branch: bool = this.machine.rng.get_mut().gen();
                 this.write_scalar(Scalar::from_bool(branch), dest)?;
             }

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -142,6 +142,7 @@ pub use crate::diagnostics::{
 };
 pub use crate::eval::{
     create_ecx, eval_entry, AlignmentCheck, BacktraceStyle, IsolatedOp, MiriConfig, RejectOpWith,
+    ValidationMode,
 };
 pub use crate::helpers::{AccessKind, EvalContextExt as _};
 pub use crate::machine::{

--- a/src/tools/miri/tests/fail/validity/recursive-validity-ref-bool.rs
+++ b/src/tools/miri/tests/fail/validity/recursive-validity-ref-bool.rs
@@ -1,0 +1,8 @@
+//@compile-flags: -Zmiri-recursive-validation
+
+fn main() {
+    let x = 3u8;
+    let xref = &x;
+    let xref_wrong_type: &bool = unsafe { std::mem::transmute(xref) }; //~ERROR: encountered 0x03, but expected a boolean
+    let _val = *xref_wrong_type;
+}

--- a/src/tools/miri/tests/fail/validity/recursive-validity-ref-bool.stderr
+++ b/src/tools/miri/tests/fail/validity/recursive-validity-ref-bool.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: constructing invalid value at .<deref>: encountered 0x03, but expected a boolean
+  --> $DIR/recursive-validity-ref-bool.rs:LL:CC
+   |
+LL |     let xref_wrong_type: &bool = unsafe { std::mem::transmute(xref) };
+   |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^ constructing invalid value at .<deref>: encountered 0x03, but expected a boolean
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/recursive-validity-ref-bool.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+

--- a/tests/run-make/naked-symbol-visibility/a_rust_dylib.rs
+++ b/tests/run-make/naked-symbol-visibility/a_rust_dylib.rs
@@ -72,3 +72,16 @@ extern "C" fn naked_weak_linkage() -> u32 {
 extern "C" fn naked_external_linkage() -> u32 {
     unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
 }
+
+// functions that are declared in an `extern "C"` block are currently not exported
+// this maybe should change in the future, this is just tracking the current behavior
+// reported in https://github.com/rust-lang/rust/issues/128071
+std::arch::global_asm! {
+    ".globl function_defined_in_global_asm",
+    "function_defined_in_global_asm:",
+    "ret",
+}
+
+extern "C" {
+    pub fn function_defined_in_global_asm();
+}

--- a/tests/run-make/naked-symbol-visibility/a_rust_dylib.rs
+++ b/tests/run-make/naked-symbol-visibility/a_rust_dylib.rs
@@ -1,0 +1,74 @@
+#![feature(naked_functions, asm_const, linkage)]
+#![crate_type = "dylib"]
+
+use std::arch::asm;
+
+pub trait TraitWithConst {
+    const COUNT: u32;
+}
+
+struct Test;
+
+impl TraitWithConst for Test {
+    const COUNT: u32 = 1;
+}
+
+#[no_mangle]
+fn entry() {
+    private_vanilla_rust_function_from_rust_dylib();
+    private_naked_rust_function_from_rust_dylib();
+
+    public_vanilla_generic_function_from_rust_dylib::<Test>();
+    public_naked_generic_function_from_rust_dylib::<Test>();
+}
+
+extern "C" fn private_vanilla_rust_function_from_rust_dylib() -> u32 {
+    42
+}
+
+#[no_mangle]
+pub extern "C" fn public_vanilla_rust_function_from_rust_dylib() -> u32 {
+    42
+}
+
+pub extern "C" fn public_vanilla_generic_function_from_rust_dylib<T: TraitWithConst>() -> u32 {
+    T::COUNT
+}
+
+#[linkage = "weak"]
+extern "C" fn vanilla_weak_linkage() -> u32 {
+    42
+}
+
+#[linkage = "external"]
+extern "C" fn vanilla_external_linkage() -> u32 {
+    42
+}
+
+#[naked]
+extern "C" fn private_naked_rust_function_from_rust_dylib() -> u32 {
+    unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
+}
+
+#[naked]
+#[no_mangle]
+pub extern "C" fn public_naked_rust_function_from_rust_dylib() -> u32 {
+    unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
+}
+
+#[naked]
+pub extern "C" fn public_naked_generic_function_from_rust_dylib<T: TraitWithConst>() -> u32 {
+    unsafe { asm!("mov rax, {}", "ret", const T::COUNT, options(noreturn)) }
+}
+
+#[naked]
+#[linkage = "weak"]
+extern "C" fn naked_weak_linkage() -> u32 {
+    unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
+}
+
+#[naked]
+#[linkage = "external"]
+extern "C" fn naked_external_linkage() -> u32 {
+    unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
+}

--- a/tests/run-make/naked-symbol-visibility/rmake.rs
+++ b/tests/run-make/naked-symbol-visibility/rmake.rs
@@ -1,0 +1,63 @@
+// @only-x86_64
+use run_make_support::{dynamic_lib_name, llvm_readobj, regex, rustc};
+
+fn main() {
+    let rdylib_name = dynamic_lib_name("a_rust_dylib");
+    rustc().arg("-Zshare-generics=no").input("a_rust_dylib.rs").run();
+
+    // check vanilla symbols
+    not_exported(&rdylib_name, "private_vanilla_rust_function_from_rust_dylib");
+    global_function(&rdylib_name, "public_vanilla_rust_function_from_rust_dylib");
+    not_exported(&rdylib_name, "public_vanilla_generic_function_from_rust_dylib");
+
+    weak_function(&rdylib_name, "vanilla_weak_linkage");
+    global_function(&rdylib_name, "vanilla_external_linkage");
+
+    // naked should mirror vanilla
+    not_exported(&rdylib_name, "private_naked_rust_function_from_rust_dylib");
+    global_function(&rdylib_name, "public_naked_rust_function_from_rust_dylib");
+    not_exported(&rdylib_name, "public_naked_generic_function_from_rust_dylib");
+
+    weak_function(&rdylib_name, "naked_weak_linkage");
+    global_function(&rdylib_name, "naked_external_linkage");
+
+    // share generics should expose the generic functions
+    rustc().arg("-Zshare-generics=yes").input("a_rust_dylib.rs").run();
+    global_function(&rdylib_name, "public_vanilla_generic_function_from_rust_dylib");
+    global_function(&rdylib_name, "public_naked_generic_function_from_rust_dylib");
+}
+
+#[track_caller]
+fn global_function(path: &str, symbol_name: &str) {
+    let lines = find_dynamic_symbol(path, symbol_name);
+    let [line] = lines.as_slice() else {
+        panic!("symbol {symbol_name} occurs {} times", lines.len())
+    };
+
+    assert!(line.contains("FUNC"), "`{symbol_name}` is not a function");
+    assert!(line.contains("GLOBAL"), "`{symbol_name}` is not marked as global");
+}
+
+#[track_caller]
+fn weak_function(path: &str, symbol_name: &str) {
+    let lines = find_dynamic_symbol(path, symbol_name);
+    let [line] = lines.as_slice() else {
+        panic!("symbol {symbol_name} occurs {} times", lines.len())
+    };
+
+    assert!(line.contains("FUNC"), "`{symbol_name}` is not a function");
+    assert!(line.contains("WEAK"), "`{symbol_name}` is not marked as weak");
+}
+
+#[track_caller]
+fn not_exported(path: &str, symbol_name: &str) {
+    assert_eq!(find_dynamic_symbol(path, symbol_name).len(), 0)
+}
+
+fn find_dynamic_symbol<'a>(path: &str, symbol_name: &str) -> Vec<String> {
+    let out = llvm_readobj().arg("--dyn-symbols").input(path).run().stdout_utf8();
+    out.lines()
+        .filter(|&line| !line.contains("__imp_") && line.contains(symbol_name))
+        .map(|line| line.to_string())
+        .collect()
+}

--- a/tests/run-make/naked-symbol-visibility/rmake.rs
+++ b/tests/run-make/naked-symbol-visibility/rmake.rs
@@ -1,63 +1,80 @@
 // @only-x86_64
-use run_make_support::{dynamic_lib_name, llvm_readobj, regex, rustc};
+use run_make_support::object::read::{File, Object, Symbol};
+use run_make_support::object::ObjectSymbol;
+use run_make_support::{dynamic_lib_name, rfs, rustc};
 
 fn main() {
     let rdylib_name = dynamic_lib_name("a_rust_dylib");
     rustc().arg("-Zshare-generics=no").input("a_rust_dylib.rs").run();
 
-    // check vanilla symbols
-    not_exported(&rdylib_name, "private_vanilla_rust_function_from_rust_dylib");
-    global_function(&rdylib_name, "public_vanilla_rust_function_from_rust_dylib");
-    not_exported(&rdylib_name, "public_vanilla_generic_function_from_rust_dylib");
+    let binary_data = rfs::read(&rdylib_name);
+    let rdylib = File::parse(&*binary_data).unwrap();
 
-    weak_function(&rdylib_name, "vanilla_weak_linkage");
-    global_function(&rdylib_name, "vanilla_external_linkage");
+    // check vanilla symbols
+    not_exported(&rdylib, "private_vanilla_rust_function_from_rust_dylib");
+    global_function(&rdylib, "public_vanilla_rust_function_from_rust_dylib");
+    not_exported(&rdylib, "public_vanilla_generic_function_from_rust_dylib");
+
+    weak_function(&rdylib, "vanilla_weak_linkage");
+    global_function(&rdylib, "vanilla_external_linkage");
 
     // naked should mirror vanilla
-    not_exported(&rdylib_name, "private_naked_rust_function_from_rust_dylib");
-    global_function(&rdylib_name, "public_naked_rust_function_from_rust_dylib");
-    not_exported(&rdylib_name, "public_naked_generic_function_from_rust_dylib");
+    not_exported(&rdylib, "private_naked_rust_function_from_rust_dylib");
+    global_function(&rdylib, "public_naked_rust_function_from_rust_dylib");
+    not_exported(&rdylib, "public_naked_generic_function_from_rust_dylib");
 
-    weak_function(&rdylib_name, "naked_weak_linkage");
-    global_function(&rdylib_name, "naked_external_linkage");
+    weak_function(&rdylib, "naked_weak_linkage");
+    global_function(&rdylib, "naked_external_linkage");
+
+    // functions that are declared in an `extern "C"` block are currently not exported
+    // this maybe should change in the future, this is just tracking the current behavior
+    // reported in https://github.com/rust-lang/rust/issues/128071
+    not_exported(&rdylib, "function_defined_in_global_asm");
 
     // share generics should expose the generic functions
     rustc().arg("-Zshare-generics=yes").input("a_rust_dylib.rs").run();
-    global_function(&rdylib_name, "public_vanilla_generic_function_from_rust_dylib");
-    global_function(&rdylib_name, "public_naked_generic_function_from_rust_dylib");
+    let binary_data = rfs::read(&rdylib_name);
+    let rdylib = File::parse(&*binary_data).unwrap();
+
+    global_function(&rdylib, "public_vanilla_generic_function_from_rust_dylib");
+    global_function(&rdylib, "public_naked_generic_function_from_rust_dylib");
 }
 
 #[track_caller]
-fn global_function(path: &str, symbol_name: &str) {
-    let lines = find_dynamic_symbol(path, symbol_name);
-    let [line] = lines.as_slice() else {
-        panic!("symbol {symbol_name} occurs {} times", lines.len())
+fn global_function(file: &File, symbol_name: &str) {
+    let symbols = find_dynamic_symbol(file, symbol_name);
+    let [symbol] = symbols.as_slice() else {
+        panic!("symbol {symbol_name} occurs {} times", symbols.len())
     };
 
-    assert!(line.contains("FUNC"), "`{symbol_name}` is not a function");
-    assert!(line.contains("GLOBAL"), "`{symbol_name}` is not marked as global");
+    assert!(symbol.is_definition(), "`{symbol_name}` is not a function");
+    assert!(symbol.is_global(), "`{symbol_name}` is not marked as global");
 }
 
 #[track_caller]
-fn weak_function(path: &str, symbol_name: &str) {
-    let lines = find_dynamic_symbol(path, symbol_name);
-    let [line] = lines.as_slice() else {
-        panic!("symbol {symbol_name} occurs {} times", lines.len())
+fn weak_function(file: &File, symbol_name: &str) {
+    let symbols = find_dynamic_symbol(file, symbol_name);
+    let [symbol] = symbols.as_slice() else {
+        panic!("symbol {symbol_name} occurs {} times", symbols.len())
     };
 
-    assert!(line.contains("FUNC"), "`{symbol_name}` is not a function");
-    assert!(line.contains("WEAK"), "`{symbol_name}` is not marked as weak");
+    assert!(symbol.is_definition(), "`{symbol_name}` is not a function");
+    assert!(symbol.is_weak(), "`{symbol_name}` is not marked as weak");
 }
 
 #[track_caller]
-fn not_exported(path: &str, symbol_name: &str) {
-    assert_eq!(find_dynamic_symbol(path, symbol_name).len(), 0)
+fn not_exported(file: &File, symbol_name: &str) {
+    assert_eq!(find_dynamic_symbol(file, symbol_name).len(), 0)
 }
 
-fn find_dynamic_symbol<'a>(path: &str, symbol_name: &str) -> Vec<String> {
-    let out = llvm_readobj().arg("--dyn-symbols").input(path).run().stdout_utf8();
-    out.lines()
-        .filter(|&line| !line.contains("__imp_") && line.contains(symbol_name))
-        .map(|line| line.to_string())
+fn find_dynamic_symbol<'file, 'data>(
+    file: &'file File<'data>,
+    expected: &str,
+) -> Vec<Symbol<'data, 'file>> {
+    file.dynamic_symbols()
+        .filter(|symbol| {
+            let name = symbol.name().unwrap();
+            !name.contains("__imp_") && name.contains(expected)
+        })
         .collect()
 }


### PR DESCRIPTION
Successful merges:

 - #128362 (add test for symbol visibility of `#[naked]` functions)
 - #128526 (time.rs: remove "Basic usage text")
 - #128531 (Miri: add a flag to do recursive validity checking)
 - #128578 (rustdoc: Cleanup `CacheBuilder` code for building search index)
 - #128589 (allow setting `link-shared` and `static-libstdcpp` with CI LLVM)
 - #128615 (rustdoc: make the hover trail for doc anchors a bit bigger)
 - #128620 (Update rinja version to 0.3.0)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=128362,128526,128531,128578,128589,128615,128620)
<!-- homu-ignore:end -->