### PR TITLE
run-make: enable msvc for `link-dedup`

### DIFF
--- a/tests/run-make/link-dedup/rmake.rs
+++ b/tests/run-make/link-dedup/rmake.rs
@@ -5,20 +5,37 @@
 // Without the --cfg flag, there should be a single -ltesta, no more, no less.
 // See https://github.com/rust-lang/rust/pull/84794
 
-//@ ignore-msvc
+use std::fmt::Write;
 
-use run_make_support::rustc;
+use run_make_support::{is_msvc, rustc};
 
 fn main() {
     rustc().input("depa.rs").run();
     rustc().input("depb.rs").run();
     rustc().input("depc.rs").run();
+
     let output = rustc().input("empty.rs").cfg("bar").run_fail();
-    output.assert_stderr_contains(r#""-ltesta" "-ltestb" "-ltesta""#);
+    output.assert_stderr_contains(needle_from_libs(&["testa", "testb", "testa"]));
+
     let output = rustc().input("empty.rs").run_fail();
-    output.assert_stderr_contains(r#""-ltesta""#);
-    let output = rustc().input("empty.rs").run_fail();
-    output.assert_stderr_not_contains(r#""-ltestb""#);
-    let output = rustc().input("empty.rs").run_fail();
-    output.assert_stderr_not_contains(r#""-ltesta" "-ltesta" "-ltesta""#);
+    output.assert_stderr_contains(needle_from_libs(&["testa"]));
+    output.assert_stderr_not_contains(needle_from_libs(&["testb"]));
+    output.assert_stderr_not_contains(needle_from_libs(&["testa", "testa", "testa"]));
+    // Adjacent identical native libraries are no longer deduplicated if
+    // they come from different crates (https://github.com/rust-lang/rust/pull/103311)
+    // so the following will fail:
+    //output.assert_stderr_not_contains(needle_from_libs(&["testa", "testa"]));
+}
+
+fn needle_from_libs(libs: &[&str]) -> String {
+    let mut needle = String::new();
+    for lib in libs {
+        if is_msvc() {
+            let _ = needle.write_fmt(format_args!(r#""{lib}.lib" "#));
+        } else {
+            let _ = needle.write_fmt(format_args!(r#""-l{lib}" "#));
+        }
+    }
+    needle.pop(); // remove trailing space
+    needle
 }


### PR DESCRIPTION
This is just a case of differing style of linker arguments.

I also cleaned up a bit where we were running the same command three times in a row. Instead I reused the output.

One thing that confused me is why we were testing for the same lib three times in a row but not two. After figuring that out I added a note to hopefully save future readers some confusion.

try-job: x86_64-msvc
try-job: i686-msvc
