### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_resolve/src/imports.rs
+++ b/compiler/rustc_resolve/src/imports.rs
@@ -48,6 +48,7 @@ pub(crate) enum ImportKind<'a> {
         /// `source` in `use prefix::source as target`.
         source: Ident,
         /// `target` in `use prefix::source as target`.
+        /// It will directly use `source` when the format is `use prefix::source`.
         target: Ident,
         /// Bindings to which `source` refers to.
         source_bindings: PerNS<Cell<Result<NameBinding<'a>, Determinacy>>>,

--- a/config.example.toml
+++ b/config.example.toml
@@ -472,7 +472,8 @@
 # This is mostly useful for tools; if you have changes to `compiler/` or `library/` they will be ignored.
 #
 # Set this to "if-unchanged" to only download if the compiler and standard library have not been modified.
-# Set this to `true` to download unconditionally (useful if e.g. you are only changing doc-comments).
+# Set this to `true` to download unconditionally. This is useful if you are working on tools, doc-comments,
+# or library (you will be able to build the standard library without needing to build the compiler).
 #download-rustc = false
 
 # Number of codegen units to use for each compiler invocation. A value of 0

--- a/library/std/src/sys/pal/unix/thread.rs
+++ b/library/std/src/sys/pal/unix/thread.rs
@@ -462,8 +462,18 @@ pub fn available_parallelism() -> io::Result<NonZero<usize>> {
 
                 Ok(NonZero::new_unchecked(sinfo.cpu_count as usize))
             }
+        } else if #[cfg(target_os = "vxworks")] {
+            // Note: there is also `vxCpuConfiguredGet`, closer to _SC_NPROCESSORS_CONF
+            // expectations than the actual cores availability.
+            extern "C" {
+                fn vxCpuEnabledGet() -> libc::cpuset_t;
+            }
+
+            // always fetches a valid bitmask
+            let set = unsafe { vxCpuEnabledGet() };
+            Ok(NonZero::new_unchecked(set.count_ones() as usize))
         } else {
-            // FIXME: implement on vxWorks, Redox, l4re
+            // FIXME: implement on Redox, l4re
             Err(io::const_io_error!(io::ErrorKind::Unsupported, "Getting the number of hardware threads is not supported on the target platform"))
         }
     }

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -110,11 +110,17 @@ impl Step for JsonDocs {
         ));
 
         let dest = "share/doc/rust/json";
+        let out = builder.json_doc_out(host);
+
+        // Make sure these are present in the component.
+        for f in ["alloc.json", "core.json", "std.json"] {
+            assert!(out.join(f).exists(), "rust-docs-json is missing `{f}`.");
+        }
 
         let mut tarball = Tarball::new(builder, "rust-docs-json", &host.triple);
         tarball.set_product_name("Rust Documentation In JSON Format");
         tarball.is_preview(true);
-        tarball.add_bulk_dir(builder.json_doc_out(host), dest);
+        tarball.add_bulk_dir(out, dest);
         Some(tarball.generate())
     }
 }

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -599,6 +599,16 @@ impl Step for Std {
     fn run(self, builder: &Builder<'_>) {
         let stage = self.stage;
         let target = self.target;
+        let crates = if self.crates.is_empty() {
+            builder
+                .in_tree_crates("sysroot", Some(target))
+                .iter()
+                .map(|c| c.name.to_string())
+                .collect()
+        } else {
+            self.crates
+        };
+
         let out = match self.format {
             DocumentationFormat::Html => builder.doc_out(target),
             DocumentationFormat::Json => builder.json_doc_out(target),
@@ -627,7 +637,7 @@ impl Step for Std {
             extra_args.push("--disable-minification");
         }
 
-        doc_std(builder, self.format, stage, target, &out, &extra_args, &self.crates);
+        doc_std(builder, self.format, stage, target, &out, &extra_args, &crates);
 
         // Don't open if the format is json
         if let DocumentationFormat::Json = self.format {
@@ -639,7 +649,7 @@ impl Step for Std {
             let index = out.join("std").join("index.html");
             builder.open_in_browser(index);
         } else {
-            for requested_crate in &*self.crates {
+            for requested_crate in crates {
                 if STD_PUBLIC_CRATES.iter().any(|&k| k == requested_crate) {
                     let index = out.join(requested_crate).join("index.html");
                     builder.open_in_browser(index);

--- a/tests/codegen/issues/issue-122600-ptr-discriminant-update.rs
+++ b/tests/codegen/issues/issue-122600-ptr-discriminant-update.rs
@@ -1,0 +1,19 @@
+//@ compile-flags: -O
+//@ min-llvm-version: 19
+
+#![crate_type = "lib"]
+
+pub enum State {
+    A([u8; 753]),
+    B([u8; 753]),
+}
+
+// CHECK-LABEL: @update
+#[no_mangle]
+pub unsafe fn update(s: *mut State) {
+    // CHECK-NEXT: start:
+    // CHECK-NEXT: store i8
+    // CHECK-NEXT: ret
+    let State::A(v) = s.read() else { std::hint::unreachable_unchecked() };
+    s.write(State::B(v));
+}

--- a/tests/run-make/link-dedup/rmake.rs
+++ b/tests/run-make/link-dedup/rmake.rs
@@ -5,20 +5,37 @@
 // Without the --cfg flag, there should be a single -ltesta, no more, no less.
 // See https://github.com/rust-lang/rust/pull/84794
 
-//@ ignore-msvc
+use std::fmt::Write;
 
-use run_make_support::rustc;
+use run_make_support::{is_msvc, rustc};
 
 fn main() {
     rustc().input("depa.rs").run();
     rustc().input("depb.rs").run();
     rustc().input("depc.rs").run();
+
     let output = rustc().input("empty.rs").cfg("bar").run_fail();
-    output.assert_stderr_contains(r#""-ltesta" "-ltestb" "-ltesta""#);
+    output.assert_stderr_contains(needle_from_libs(&["testa", "testb", "testa"]));
+
     let output = rustc().input("empty.rs").run_fail();
-    output.assert_stderr_contains(r#""-ltesta""#);
-    let output = rustc().input("empty.rs").run_fail();
-    output.assert_stderr_not_contains(r#""-ltestb""#);
-    let output = rustc().input("empty.rs").run_fail();
-    output.assert_stderr_not_contains(r#""-ltesta" "-ltesta" "-ltesta""#);
+    output.assert_stderr_contains(needle_from_libs(&["testa"]));
+    output.assert_stderr_not_contains(needle_from_libs(&["testb"]));
+    output.assert_stderr_not_contains(needle_from_libs(&["testa", "testa", "testa"]));
+    // Adjacent identical native libraries are no longer deduplicated if
+    // they come from different crates (https://github.com/rust-lang/rust/pull/103311)
+    // so the following will fail:
+    //output.assert_stderr_not_contains(needle_from_libs(&["testa", "testa"]));
+}
+
+fn needle_from_libs(libs: &[&str]) -> String {
+    let mut needle = String::new();
+    for lib in libs {
+        if is_msvc() {
+            let _ = needle.write_fmt(format_args!(r#""{lib}.lib" "#));
+        } else {
+            let _ = needle.write_fmt(format_args!(r#""-l{lib}" "#));
+        }
+    }
+    needle.pop(); // remove trailing space
+    needle
 }

--- a/tests/run-make/naked-symbol-visibility/a_rust_dylib.rs
+++ b/tests/run-make/naked-symbol-visibility/a_rust_dylib.rs
@@ -1,0 +1,87 @@
+#![feature(naked_functions, asm_const, linkage)]
+#![crate_type = "dylib"]
+
+use std::arch::asm;
+
+pub trait TraitWithConst {
+    const COUNT: u32;
+}
+
+struct Test;
+
+impl TraitWithConst for Test {
+    const COUNT: u32 = 1;
+}
+
+#[no_mangle]
+fn entry() {
+    private_vanilla_rust_function_from_rust_dylib();
+    private_naked_rust_function_from_rust_dylib();
+
+    public_vanilla_generic_function_from_rust_dylib::<Test>();
+    public_naked_generic_function_from_rust_dylib::<Test>();
+}
+
+extern "C" fn private_vanilla_rust_function_from_rust_dylib() -> u32 {
+    42
+}
+
+#[no_mangle]
+pub extern "C" fn public_vanilla_rust_function_from_rust_dylib() -> u32 {
+    42
+}
+
+pub extern "C" fn public_vanilla_generic_function_from_rust_dylib<T: TraitWithConst>() -> u32 {
+    T::COUNT
+}
+
+#[linkage = "weak"]
+extern "C" fn vanilla_weak_linkage() -> u32 {
+    42
+}
+
+#[linkage = "external"]
+extern "C" fn vanilla_external_linkage() -> u32 {
+    42
+}
+
+#[naked]
+extern "C" fn private_naked_rust_function_from_rust_dylib() -> u32 {
+    unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
+}
+
+#[naked]
+#[no_mangle]
+pub extern "C" fn public_naked_rust_function_from_rust_dylib() -> u32 {
+    unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
+}
+
+#[naked]
+pub extern "C" fn public_naked_generic_function_from_rust_dylib<T: TraitWithConst>() -> u32 {
+    unsafe { asm!("mov rax, {}", "ret", const T::COUNT, options(noreturn)) }
+}
+
+#[naked]
+#[linkage = "weak"]
+extern "C" fn naked_weak_linkage() -> u32 {
+    unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
+}
+
+#[naked]
+#[linkage = "external"]
+extern "C" fn naked_external_linkage() -> u32 {
+    unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
+}
+
+// functions that are declared in an `extern "C"` block are currently not exported
+// this maybe should change in the future, this is just tracking the current behavior
+// reported in https://github.com/rust-lang/rust/issues/128071
+std::arch::global_asm! {
+    ".globl function_defined_in_global_asm",
+    "function_defined_in_global_asm:",
+    "ret",
+}
+
+extern "C" {
+    pub fn function_defined_in_global_asm();
+}

--- a/tests/run-make/naked-symbol-visibility/rmake.rs
+++ b/tests/run-make/naked-symbol-visibility/rmake.rs
@@ -1,0 +1,80 @@
+//@ only-x86_64
+use run_make_support::object::read::{File, Object, Symbol};
+use run_make_support::object::ObjectSymbol;
+use run_make_support::{dynamic_lib_name, rfs, rustc};
+
+fn main() {
+    let rdylib_name = dynamic_lib_name("a_rust_dylib");
+    rustc().arg("-Zshare-generics=no").input("a_rust_dylib.rs").run();
+
+    let binary_data = rfs::read(&rdylib_name);
+    let rdylib = File::parse(&*binary_data).unwrap();
+
+    // check vanilla symbols
+    not_exported(&rdylib, "private_vanilla_rust_function_from_rust_dylib");
+    global_function(&rdylib, "public_vanilla_rust_function_from_rust_dylib");
+    not_exported(&rdylib, "public_vanilla_generic_function_from_rust_dylib");
+
+    weak_function(&rdylib, "vanilla_weak_linkage");
+    global_function(&rdylib, "vanilla_external_linkage");
+
+    // naked should mirror vanilla
+    not_exported(&rdylib, "private_naked_rust_function_from_rust_dylib");
+    global_function(&rdylib, "public_naked_rust_function_from_rust_dylib");
+    not_exported(&rdylib, "public_naked_generic_function_from_rust_dylib");
+
+    weak_function(&rdylib, "naked_weak_linkage");
+    global_function(&rdylib, "naked_external_linkage");
+
+    // functions that are declared in an `extern "C"` block are currently not exported
+    // this maybe should change in the future, this is just tracking the current behavior
+    // reported in https://github.com/rust-lang/rust/issues/128071
+    not_exported(&rdylib, "function_defined_in_global_asm");
+
+    // share generics should expose the generic functions
+    rustc().arg("-Zshare-generics=yes").input("a_rust_dylib.rs").run();
+    let binary_data = rfs::read(&rdylib_name);
+    let rdylib = File::parse(&*binary_data).unwrap();
+
+    global_function(&rdylib, "public_vanilla_generic_function_from_rust_dylib");
+    global_function(&rdylib, "public_naked_generic_function_from_rust_dylib");
+}
+
+#[track_caller]
+fn global_function(file: &File, symbol_name: &str) {
+    let symbols = find_dynamic_symbol(file, symbol_name);
+    let [symbol] = symbols.as_slice() else {
+        panic!("symbol {symbol_name} occurs {} times", symbols.len())
+    };
+
+    assert!(symbol.is_definition(), "`{symbol_name}` is not a function");
+    assert!(symbol.is_global(), "`{symbol_name}` is not marked as global");
+}
+
+#[track_caller]
+fn weak_function(file: &File, symbol_name: &str) {
+    let symbols = find_dynamic_symbol(file, symbol_name);
+    let [symbol] = symbols.as_slice() else {
+        panic!("symbol {symbol_name} occurs {} times", symbols.len())
+    };
+
+    assert!(symbol.is_definition(), "`{symbol_name}` is not a function");
+    assert!(symbol.is_weak(), "`{symbol_name}` is not marked as weak");
+}
+
+#[track_caller]
+fn not_exported(file: &File, symbol_name: &str) {
+    assert_eq!(find_dynamic_symbol(file, symbol_name).len(), 0)
+}
+
+fn find_dynamic_symbol<'file, 'data>(
+    file: &'file File<'data>,
+    expected: &str,
+) -> Vec<Symbol<'data, 'file>> {
+    file.dynamic_symbols()
+        .filter(|symbol| {
+            let name = symbol.name().unwrap();
+            !name.contains("__imp_") && name.contains(expected)
+        })
+        .collect()
+}


### PR DESCRIPTION
Successful merges:

 - #127974 (force compiling std from source if modified)
 - #128026 (std::thread: available_parallelism implementation for vxWorks proposal.)
 - #128362 (add test for symbol visibility of `#[naked]` functions)
 - #128500 (Add test for updating enum discriminant through pointer)
 - #128630 (docs(resolve): more explain about `target`)
 - #128631 (handle crates when they are not specified for std docs)
 - #128638 (run-make: enable msvc for `link-dedup`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=127974,128026,128362,128500,128630,128631,128638)
<!-- homu-ignore:end -->