### PR TITLE
Enable msvc for link-args-order

### DIFF
--- a/tests/run-make/link-args-order/rmake.rs
+++ b/tests/run-make/link-args-order/rmake.rs
@@ -3,15 +3,14 @@
 // checks that linker arguments remain intact and in the order they were originally passed in.
 // See https://github.com/rust-lang/rust/pull/70665
 
-//@ ignore-msvc
-// Reason: the ld linker does not exist on Windows.
-
-use run_make_support::rustc;
+use run_make_support::{is_msvc, rustc};
 
 fn main() {
+    let linker = if is_msvc() { "msvc" } else { "ld" };
+
     rustc()
         .input("empty.rs")
-        .linker_flavor("ld")
+        .linker_flavor(linker)
         .link_arg("a")
         .link_args("b c")
         .link_args("d e")
@@ -20,7 +19,7 @@ fn main() {
         .assert_stderr_contains(r#""a" "b" "c" "d" "e" "f""#);
     rustc()
         .input("empty.rs")
-        .linker_flavor("ld")
+        .linker_flavor(linker)
         .arg("-Zpre-link-arg=a")
         .arg("-Zpre-link-args=b c")
         .arg("-Zpre-link-args=d e")


### PR DESCRIPTION
I could not see any reason in #70665 why this test needs to specifically use `ld`. Maybe to provide a consistent linker input line? In any case, the test does work for the MSVC linker.

try-job: i686-msvc
try-job: x86_64-msvc