### PR TITLE
run-make: Enable msvc for `no-duplicate-libs` and `zero-extend-abi-param-passing`

### DIFF
--- a/src/tools/run-make-support/src/external_deps/c_build.rs
+++ b/src/tools/run-make-support/src/external_deps/c_build.rs
@@ -13,14 +13,31 @@ use crate::targets::{is_darwin, is_msvc, is_windows};
 /// Built from a C file.
 #[track_caller]
 pub fn build_native_static_lib(lib_name: &str) -> PathBuf {
+    build_native_static_lib_internal(lib_name, false)
+}
+
+/// Builds an optimized static lib (`.lib` on Windows MSVC and `.a` for the rest) with the given name.
+/// Built from a C file.
+#[track_caller]
+pub fn build_native_static_lib_optimized(lib_name: &str) -> PathBuf {
+    build_native_static_lib_internal(lib_name, true)
+}
+
+#[track_caller]
+fn build_native_static_lib_internal(lib_name: &str, optimzed: bool) -> PathBuf {
     let obj_file = if is_msvc() { format!("{lib_name}") } else { format!("{lib_name}.o") };
     let src = format!("{lib_name}.c");
     let lib_path = static_lib_name(lib_name);
-    if is_msvc() {
-        cc().arg("-c").out_exe(&obj_file).input(src).run();
-    } else {
-        cc().arg("-v").arg("-c").out_exe(&obj_file).input(src).run();
-    };
+
+    let mut cc = cc();
+    if !is_msvc() {
+        cc.arg("-v");
+    }
+    if optimzed {
+        cc.optimize();
+    }
+    cc.arg("-c").out_exe(&obj_file).input(src).optimize().run();
+
     let obj_file = if is_msvc() {
         PathBuf::from(format!("{lib_name}.obj"))
     } else {

--- a/src/tools/run-make-support/src/external_deps/cc.rs
+++ b/src/tools/run-make-support/src/external_deps/cc.rs
@@ -117,6 +117,17 @@ impl Cc {
         self.cmd.arg(path.as_ref());
         self
     }
+
+    /// Optimize the output.
+    /// Equivalent to `-O3` for GNU-compatible linkers or `-O2` for MSVC linkers.
+    pub fn optimize(&mut self) -> &mut Self {
+        if is_msvc() {
+            self.cmd.arg("-O2");
+        } else {
+            self.cmd.arg("-O3");
+        }
+        self
+    }
 }
 
 /// `EXTRACFLAGS`

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -45,7 +45,7 @@ pub use external_deps::{c_build, cc, clang, htmldocck, llvm, python, rustc, rust
 
 // These rely on external dependencies.
 pub use cc::{cc, cxx, extra_c_flags, extra_cxx_flags, Cc};
-pub use c_build::{build_native_dynamic_lib, build_native_static_lib, build_native_static_lib_cxx};
+pub use c_build::{build_native_dynamic_lib, build_native_static_lib, build_native_static_lib_optimized, build_native_static_lib_cxx};
 pub use clang::{clang, Clang};
 pub use htmldocck::htmldocck;
 pub use llvm::{

--- a/tests/run-make/no-duplicate-libs/main.rs
+++ b/tests/run-make/no-duplicate-libs/main.rs
@@ -1,6 +1,6 @@
-#[link(name = "foo")] // linker should drop this library, no symbols used
-#[link(name = "bar")] // symbol comes from this library
-#[link(name = "foo")] // now linker picks up `foo` b/c `bar` library needs it
+#[link(name = "foo", kind = "static")] // linker should drop this library, no symbols used
+#[link(name = "bar", kind = "static")] // symbol comes from this library
+#[link(name = "foo", kind = "static")] // now linker picks up `foo` b/c `bar` library needs it
 extern "C" {
     fn bar();
 }

--- a/tests/run-make/no-duplicate-libs/rmake.rs
+++ b/tests/run-make/no-duplicate-libs/rmake.rs
@@ -9,9 +9,6 @@
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
 
-//@ ignore-msvc
-// Reason: native compilation results in an unresolved external symbol
-
 use run_make_support::{build_native_static_lib, run, rustc};
 
 fn main() {

--- a/tests/run-make/zero-extend-abi-param-passing/param_passing.rs
+++ b/tests/run-make/zero-extend-abi-param-passing/param_passing.rs
@@ -2,7 +2,7 @@
 // LLVM optimization choices. See additional note below for an
 // example.
 
-#[link(name = "bad")]
+#[link(name = "bad", kind = "static")]
 extern "C" {
     pub fn c_read_value(a: u32, b: u32, c: u32) -> u16;
 }

--- a/tests/run-make/zero-extend-abi-param-passing/rmake.rs
+++ b/tests/run-make/zero-extend-abi-param-passing/rmake.rs
@@ -6,20 +6,13 @@
 // while simultaneously interfacing with a C library and using the -O3 flag.
 // See https://github.com/rust-lang/rust/issues/97463
 
-//@ ignore-msvc
-// Reason: the rustc compilation fails due to an unresolved external symbol
-
 //@ ignore-cross-compile
 // Reason: The compiled binary is executed.
-
-use run_make_support::{cc, is_msvc, llvm_ar, run, rustc, static_lib_name};
+use run_make_support::{build_native_static_lib_optimized, run, rustc};
 
 fn main() {
-    // The issue exercised by this test specifically needs needs `-O`
-    // flags (like `-O3`) to reproduce. Thus, we call `cc()` instead of
-    // the nicer `build_native_static_lib`.
-    cc().arg("-c").arg("-O3").out_exe("bad.o").input("bad.c").run();
-    llvm_ar().obj_to_ar().output_input(static_lib_name("bad"), "bad.o").run();
-    rustc().input("param_passing.rs").arg("-lbad").opt_level("3").run();
+    // The issue exercised by this test specifically needs an optimized native static lib.
+    build_native_static_lib_optimized("bad");
+    rustc().input("param_passing.rs").opt_level("3").run();
     run("param_passing");
 }


### PR DESCRIPTION
The common thing between these two tests is to use `#[link(..., kind="static")]` so that it doesn't try to do a DLL import.

`zero-extend-abi-param-passing` also needs to have an optimized static library but there's only helper function for a non-optimized version. Rather than copy/pasting the code (and adding the optimization flag) I reused the same code so that it more easily be kept in sync.

try-job: i686-msvc
try-job: x86_64-msvc