### PR TITLE
add `naked_asm!` macro for use in `#[naked]` functions

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2435,7 +2435,7 @@ pub enum AsmMacro {
 }
 
 impl AsmMacro {
-    pub const fn macro_name(&self) -> &'static str {
+    pub const fn macro_name(self) -> &'static str {
         match self {
             AsmMacro::Asm => "asm",
             AsmMacro::GlobalAsm => "global_asm",
@@ -2443,11 +2443,19 @@ impl AsmMacro {
         }
     }
 
-    pub const fn is_supported_option(&self, option: InlineAsmOptions) -> bool {
+    pub const fn is_supported_option(self, option: InlineAsmOptions) -> bool {
         match self {
             AsmMacro::Asm => true,
             AsmMacro::GlobalAsm => InlineAsmOptions::GLOBAL_OPTIONS.contains(option),
             AsmMacro::NakedAsm => InlineAsmOptions::NAKED_OPTIONS.contains(option),
+        }
+    }
+
+    pub const fn diverges(self, options: InlineAsmOptions) -> bool {
+        match self {
+            AsmMacro::Asm => options.contains(InlineAsmOptions::NORETURN),
+            AsmMacro::GlobalAsm => true,
+            AsmMacro::NakedAsm => true,
         }
     }
 }

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2278,7 +2278,7 @@ impl InlineAsmOptions {
     pub const COUNT: usize = Self::all().bits().count_ones() as usize;
 
     pub const GLOBAL_OPTIONS: Self = Self::ATT_SYNTAX.union(Self::RAW);
-    pub const NAKED_OPTIONS: Self = Self::ATT_SYNTAX.union(Self::RAW).union(Self::NORETURN);
+    pub const NAKED_OPTIONS: Self = Self::ATT_SYNTAX.union(Self::RAW);
 
     pub fn human_readable_names(&self) -> Vec<&'static str> {
         let mut options = vec![];
@@ -2432,6 +2432,24 @@ pub enum AsmMacro {
     GlobalAsm,
     /// The `naked_asm!` macro
     NakedAsm,
+}
+
+impl AsmMacro {
+    pub const fn macro_name(&self) -> &'static str {
+        match self {
+            AsmMacro::Asm => "asm",
+            AsmMacro::GlobalAsm => "global_asm",
+            AsmMacro::NakedAsm => "naked_asm",
+        }
+    }
+
+    pub const fn is_supported_option(&self, option: InlineAsmOptions) -> bool {
+        match self {
+            AsmMacro::Asm => true,
+            AsmMacro::GlobalAsm => InlineAsmOptions::GLOBAL_OPTIONS.contains(option),
+            AsmMacro::NakedAsm => InlineAsmOptions::NAKED_OPTIONS.contains(option),
+        }
+    }
 }
 
 /// Inline assembly.

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -742,6 +742,7 @@ impl<'a, 'tcx, R> rustc_mir_dataflow::ResultsVisitor<'a, 'tcx, R>
             }
 
             TerminatorKind::InlineAsm {
+                asm_macro: _,
                 template: _,
                 operands,
                 options: _,

--- a/compiler/rustc_borrowck/src/polonius/loan_invalidations.rs
+++ b/compiler/rustc_borrowck/src/polonius/loan_invalidations.rs
@@ -169,6 +169,7 @@ impl<'a, 'tcx> Visitor<'tcx> for LoanInvalidationsGenerator<'a, 'tcx> {
                 }
             }
             TerminatorKind::InlineAsm {
+                asm_macro: _,
                 template: _,
                 operands,
                 options: _,

--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -12,9 +12,9 @@ builtin_macros_asm_duplicate_arg = duplicate argument named `{$name}`
 builtin_macros_asm_expected_comma = expected token: `,`
     .label = expected `,`
 
-builtin_macros_asm_expected_other = expected operand, {$is_global_asm ->
-    [true] options
-    *[false] clobber_abi, options
+builtin_macros_asm_expected_other = expected operand, {$is_inline_asm ->
+    [false] options
+    *[true] clobber_abi, options
     }, or additional template string
 
 builtin_macros_asm_expected_string_literal = expected string literal
@@ -50,6 +50,15 @@ builtin_macros_asm_requires_template = requires at least a template string argum
 builtin_macros_asm_sym_no_path = expected a path for argument to `sym`
 
 builtin_macros_asm_underscore_input = _ cannot be used for input operands
+
+builtin_macros_asm_unsupported_clobber_abi = `clobber_abi` cannot be used with `{$macro_name}!`
+
+builtin_macros_asm_unsupported_operand = the `{$symbol}` operand cannot be used with `{$macro_name}!`
+    .label = the `{$symbol}` operand is not meaningful for global-scoped inline assembly, remove it
+
+builtin_macros_asm_unsupported_option = the `{$symbol}` option cannot be used with `{$macro_name}!`
+    .label = the `{$symbol}` option is not meaningful for global-scoped inline assembly
+    .suggestion = remove this option
 
 builtin_macros_assert_missing_comma = unexpected string literal
     .suggestion = try adding a comma
@@ -193,15 +202,6 @@ builtin_macros_format_unused_args = multiple unused formatting arguments
     .label = multiple missing formatting specifiers
 
 builtin_macros_format_use_positional = consider using a positional formatting argument instead
-
-builtin_macros_global_asm_clobber_abi = `clobber_abi` cannot be used with `global_asm!`
-
-builtin_macros_global_asm_unsupported_operand = the `{$symbol}` operand cannot be used with `global_asm!`
-    .label = the `{$symbol}` operand is not meaningful for global-scoped inline assembly, remove it
-
-builtin_macros_global_asm_unsupported_option = the `{$symbol}` option cannot be used with `global_asm!`
-    .label = the `{$symbol}` option is not meaningful for global-scoped inline assembly
-    .suggestion = remove this option
 
 builtin_macros_invalid_crate_attribute = invalid crate attribute
 

--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -850,22 +850,13 @@ pub(super) fn expand_naked_asm<'cx>(
                 return ExpandResult::Retry(());
             };
             let expr = match mac {
-                Ok(mut inline_asm) => {
-                    // for future compatibility, we always set the NORETURN option.
-                    //
-                    // When we turn `asm!` into `naked_asm!` with this implementation, we can drop
-                    // the `options(noreturn)`, which makes the upgrade smooth when `naked_asm!`
-                    // starts disallowing the `noreturn` option in the future
-                    inline_asm.options |= ast::InlineAsmOptions::NORETURN;
-
-                    P(ast::Expr {
-                        id: ast::DUMMY_NODE_ID,
-                        kind: ast::ExprKind::InlineAsm(P(inline_asm)),
-                        span: sp,
-                        attrs: ast::AttrVec::new(),
-                        tokens: None,
-                    })
-                }
+                Ok(inline_asm) => P(ast::Expr {
+                    id: ast::DUMMY_NODE_ID,
+                    kind: ast::ExprKind::InlineAsm(P(inline_asm)),
+                    span: sp,
+                    attrs: ast::AttrVec::new(),
+                    tokens: None,
+                }),
                 Err(guar) => DummyResult::raw_expr(sp, Some(guar)),
             };
             MacEager::expr(expr)

--- a/compiler/rustc_builtin_macros/src/asm.rs
+++ b/compiler/rustc_builtin_macros/src/asm.rs
@@ -37,17 +37,54 @@ pub struct AsmArgs {
 /// - `Ok(true)` if the current token matches the keyword, and was expected
 /// - `Ok(false)` if the current token does not match the keyword
 /// - `Err(_)` if the current token matches the keyword, but was not expected
-fn eat_operand_keyword<'a>(p: &mut Parser<'a>, symbol: Symbol, expect: bool) -> PResult<'a, bool> {
-    if expect {
+fn eat_operand_keyword<'a>(
+    p: &mut Parser<'a>,
+    symbol: Symbol,
+    asm_macro: AsmMacro,
+) -> PResult<'a, bool> {
+    if matches!(asm_macro, AsmMacro::Asm) {
         Ok(p.eat_keyword(symbol))
     } else {
         let span = p.token.span;
         if p.eat_keyword_noexpect(symbol) {
             // in gets printed as `r#in` otherwise
             let symbol = if symbol == kw::In { "in" } else { symbol.as_str() };
-            Err(p.dcx().create_err(errors::GlobalAsmUnsupportedOperand { span, symbol }))
+            Err(p.dcx().create_err(errors::AsmUnsupportedOperand {
+                span,
+                symbol,
+                macro_name: asm_macro.macro_name(),
+            }))
         } else {
             Ok(false)
+        }
+    }
+}
+
+// Public for rustfmt consumption.
+#[derive(Copy, Clone)]
+pub enum AsmMacro {
+    /// The `asm!` macro
+    Asm,
+    /// The `global_asm!` macro
+    GlobalAsm,
+    /// The `naked_asm!` macro
+    NakedAsm,
+}
+
+impl AsmMacro {
+    const fn macro_name(&self) -> &'static str {
+        match self {
+            AsmMacro::Asm => "asm",
+            AsmMacro::GlobalAsm => "global_asm",
+            AsmMacro::NakedAsm => "naked_asm",
+        }
+    }
+
+    const fn is_supported_option(&self, option: ast::InlineAsmOptions) -> bool {
+        match self {
+            AsmMacro::Asm => true,
+            AsmMacro::GlobalAsm => ast::InlineAsmOptions::GLOBAL_OPTIONS.contains(option),
+            AsmMacro::NakedAsm => ast::InlineAsmOptions::NAKED_OPTIONS.contains(option),
         }
     }
 }
@@ -56,10 +93,10 @@ fn parse_args<'a>(
     ecx: &ExtCtxt<'a>,
     sp: Span,
     tts: TokenStream,
-    is_global_asm: bool,
+    asm_macro: AsmMacro,
 ) -> PResult<'a, AsmArgs> {
     let mut p = ecx.new_parser_from_tts(tts);
-    parse_asm_args(&mut p, sp, is_global_asm)
+    parse_asm_args(&mut p, sp, asm_macro)
 }
 
 // Primarily public for rustfmt consumption.
@@ -67,7 +104,7 @@ fn parse_args<'a>(
 pub fn parse_asm_args<'a>(
     p: &mut Parser<'a>,
     sp: Span,
-    is_global_asm: bool,
+    asm_macro: AsmMacro,
 ) -> PResult<'a, AsmArgs> {
     let dcx = p.dcx();
 
@@ -110,7 +147,7 @@ pub fn parse_asm_args<'a>(
 
         // Parse options
         if p.eat_keyword(sym::options) {
-            parse_options(p, &mut args, is_global_asm)?;
+            parse_options(p, &mut args, asm_macro)?;
             allow_templates = false;
             continue;
         }
@@ -129,7 +166,7 @@ pub fn parse_asm_args<'a>(
         };
 
         let mut explicit_reg = false;
-        let op = if eat_operand_keyword(p, kw::In, !is_global_asm)? {
+        let op = if eat_operand_keyword(p, kw::In, asm_macro)? {
             let reg = parse_reg(p, &mut explicit_reg)?;
             if p.eat_keyword(kw::Underscore) {
                 let err = dcx.create_err(errors::AsmUnderscoreInput { span: p.token.span });
@@ -137,15 +174,15 @@ pub fn parse_asm_args<'a>(
             }
             let expr = p.parse_expr()?;
             ast::InlineAsmOperand::In { reg, expr }
-        } else if eat_operand_keyword(p, sym::out, !is_global_asm)? {
+        } else if eat_operand_keyword(p, sym::out, asm_macro)? {
             let reg = parse_reg(p, &mut explicit_reg)?;
             let expr = if p.eat_keyword(kw::Underscore) { None } else { Some(p.parse_expr()?) };
             ast::InlineAsmOperand::Out { reg, expr, late: false }
-        } else if eat_operand_keyword(p, sym::lateout, !is_global_asm)? {
+        } else if eat_operand_keyword(p, sym::lateout, asm_macro)? {
             let reg = parse_reg(p, &mut explicit_reg)?;
             let expr = if p.eat_keyword(kw::Underscore) { None } else { Some(p.parse_expr()?) };
             ast::InlineAsmOperand::Out { reg, expr, late: true }
-        } else if eat_operand_keyword(p, sym::inout, !is_global_asm)? {
+        } else if eat_operand_keyword(p, sym::inout, asm_macro)? {
             let reg = parse_reg(p, &mut explicit_reg)?;
             if p.eat_keyword(kw::Underscore) {
                 let err = dcx.create_err(errors::AsmUnderscoreInput { span: p.token.span });
@@ -159,7 +196,7 @@ pub fn parse_asm_args<'a>(
             } else {
                 ast::InlineAsmOperand::InOut { reg, expr, late: false }
             }
-        } else if eat_operand_keyword(p, sym::inlateout, !is_global_asm)? {
+        } else if eat_operand_keyword(p, sym::inlateout, asm_macro)? {
             let reg = parse_reg(p, &mut explicit_reg)?;
             if p.eat_keyword(kw::Underscore) {
                 let err = dcx.create_err(errors::AsmUnderscoreInput { span: p.token.span });
@@ -173,7 +210,7 @@ pub fn parse_asm_args<'a>(
             } else {
                 ast::InlineAsmOperand::InOut { reg, expr, late: true }
             }
-        } else if eat_operand_keyword(p, sym::label, !is_global_asm)? {
+        } else if eat_operand_keyword(p, sym::label, asm_macro)? {
             let block = p.parse_block()?;
             ast::InlineAsmOperand::Label { block }
         } else if p.eat_keyword(kw::Const) {
@@ -205,7 +242,7 @@ pub fn parse_asm_args<'a>(
                 _ => {
                     let err = dcx.create_err(errors::AsmExpectedOther {
                         span: template.span,
-                        is_global_asm,
+                        is_inline_asm: matches!(asm_macro, AsmMacro::Asm),
                     });
                     return Err(err);
                 }
@@ -301,20 +338,25 @@ pub fn parse_asm_args<'a>(
         dcx.emit_err(errors::AsmMayUnwind { labels_sp });
     }
 
-    if args.clobber_abis.len() > 0 {
-        if is_global_asm {
-            let err = dcx.create_err(errors::GlobalAsmClobberAbi {
-                spans: args.clobber_abis.iter().map(|(_, span)| *span).collect(),
-            });
+    if !args.clobber_abis.is_empty() {
+        match asm_macro {
+            AsmMacro::GlobalAsm | AsmMacro::NakedAsm => {
+                let err = dcx.create_err(errors::AsmUnsupportedClobberAbi {
+                    spans: args.clobber_abis.iter().map(|(_, span)| *span).collect(),
+                    macro_name: asm_macro.macro_name(),
+                });
 
-            // Bail out now since this is likely to confuse later stages
-            return Err(err);
-        }
-        if !regclass_outputs.is_empty() {
-            dcx.emit_err(errors::AsmClobberNoReg {
-                spans: regclass_outputs,
-                clobbers: args.clobber_abis.iter().map(|(_, span)| *span).collect(),
-            });
+                // Bail out now since this is likely to confuse later stages
+                return Err(err);
+            }
+            AsmMacro::Asm => {
+                if !regclass_outputs.is_empty() {
+                    dcx.emit_err(errors::AsmClobberNoReg {
+                        spans: regclass_outputs,
+                        clobbers: args.clobber_abis.iter().map(|(_, span)| *span).collect(),
+                    });
+                }
+            }
         }
     }
 
@@ -335,10 +377,15 @@ fn err_duplicate_option(p: &Parser<'_>, symbol: Symbol, span: Span) {
 ///
 /// This function must be called immediately after the option token is parsed.
 /// Otherwise, the suggestion will be incorrect.
-fn err_unsupported_option(p: &Parser<'_>, symbol: Symbol, span: Span) {
+fn err_unsupported_option(p: &Parser<'_>, asm_macro: AsmMacro, symbol: Symbol, span: Span) {
     // Tool-only output
     let full_span = if p.token == token::Comma { span.to(p.token.span) } else { span };
-    p.dcx().emit_err(errors::GlobalAsmUnsupportedOption { span, symbol, full_span });
+    p.dcx().emit_err(errors::AsmUnsupportedOption {
+        span,
+        symbol,
+        full_span,
+        macro_name: asm_macro.macro_name(),
+    });
 }
 
 /// Try to set the provided option in the provided `AsmArgs`.
@@ -349,12 +396,12 @@ fn err_unsupported_option(p: &Parser<'_>, symbol: Symbol, span: Span) {
 fn try_set_option<'a>(
     p: &Parser<'a>,
     args: &mut AsmArgs,
-    is_global_asm: bool,
+    asm_macro: AsmMacro,
     symbol: Symbol,
     option: ast::InlineAsmOptions,
 ) {
-    if is_global_asm && !ast::InlineAsmOptions::GLOBAL_OPTIONS.contains(option) {
-        err_unsupported_option(p, symbol, p.prev_token.span);
+    if !asm_macro.is_supported_option(option) {
+        err_unsupported_option(p, asm_macro, symbol, p.prev_token.span);
     } else if args.options.contains(option) {
         err_duplicate_option(p, symbol, p.prev_token.span);
     } else {
@@ -365,7 +412,7 @@ fn try_set_option<'a>(
 fn parse_options<'a>(
     p: &mut Parser<'a>,
     args: &mut AsmArgs,
-    is_global_asm: bool,
+    asm_macro: AsmMacro,
 ) -> PResult<'a, ()> {
     let span_start = p.prev_token.span;
 
@@ -386,15 +433,14 @@ fn parse_options<'a>(
 
         'blk: {
             for (symbol, option) in OPTIONS {
-                let kw_matched =
-                    if !is_global_asm || ast::InlineAsmOptions::GLOBAL_OPTIONS.contains(option) {
-                        p.eat_keyword(symbol)
-                    } else {
-                        p.eat_keyword_noexpect(symbol)
-                    };
+                let kw_matched = if asm_macro.is_supported_option(option) {
+                    p.eat_keyword(symbol)
+                } else {
+                    p.eat_keyword_noexpect(symbol)
+                };
 
                 if kw_matched {
-                    try_set_option(p, args, is_global_asm, symbol, option);
+                    try_set_option(p, args, asm_macro, symbol, option);
                     break 'blk;
                 }
             }
@@ -797,7 +843,7 @@ pub(super) fn expand_asm<'cx>(
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {
-    ExpandResult::Ready(match parse_args(ecx, sp, tts, false) {
+    ExpandResult::Ready(match parse_args(ecx, sp, tts, AsmMacro::Asm) {
         Ok(args) => {
             let ExpandResult::Ready(mac) = expand_preparsed_asm(ecx, AsmMacro::Asm, args) else {
                 return ExpandResult::Retry(());
@@ -865,7 +911,7 @@ pub(super) fn expand_global_asm<'cx>(
     sp: Span,
     tts: TokenStream,
 ) -> MacroExpanderResult<'cx> {
-    ExpandResult::Ready(match parse_args(ecx, sp, tts, true) {
+    ExpandResult::Ready(match parse_args(ecx, sp, tts, AsmMacro::GlobalAsm) {
         Ok(args) => {
             let ExpandResult::Ready(mac) = expand_preparsed_asm(ecx, AsmMacro::GlobalAsm, args)
             else {
@@ -887,6 +933,35 @@ pub(super) fn expand_global_asm<'cx>(
                 })]),
                 Err(guar) => DummyResult::any(sp, guar),
             }
+        }
+        Err(err) => {
+            let guar = err.emit();
+            DummyResult::any(sp, guar)
+        }
+    })
+}
+
+pub(super) fn expand_naked_asm<'cx>(
+    ecx: &'cx mut ExtCtxt<'_>,
+    sp: Span,
+    tts: TokenStream,
+) -> MacroExpanderResult<'cx> {
+    ExpandResult::Ready(match parse_args(ecx, sp, tts, AsmMacro::NakedAsm) {
+        Ok(args) => {
+            let ExpandResult::Ready(mac) = expand_preparsed_asm(ecx, args) else {
+                return ExpandResult::Retry(());
+            };
+            let expr = match mac {
+                Ok(inline_asm) => P(ast::Expr {
+                    id: ast::DUMMY_NODE_ID,
+                    kind: ast::ExprKind::InlineAsm(P(inline_asm)),
+                    span: sp,
+                    attrs: ast::AttrVec::new(),
+                    tokens: None,
+                }),
+                Err(guar) => DummyResult::raw_expr(sp, Some(guar)),
+            };
+            MacEager::expr(expr)
         }
         Err(err) => {
             let guar = err.emit();

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -751,7 +751,7 @@ pub(crate) struct AsmExpectedOther {
     #[primary_span]
     #[label(builtin_macros_asm_expected_other)]
     pub(crate) span: Span,
-    pub(crate) is_global_asm: bool,
+    pub(crate) is_inline_asm: bool,
 }
 
 #[derive(Diagnostic)]
@@ -799,13 +799,6 @@ pub(crate) struct AsmMayUnwind {
     pub(crate) labels_sp: Vec<Span>,
 }
 
-#[derive(Diagnostic)]
-#[diag(builtin_macros_global_asm_clobber_abi)]
-pub(crate) struct GlobalAsmClobberAbi {
-    #[primary_span]
-    pub(crate) spans: Vec<Span>,
-}
-
 pub(crate) struct AsmClobberNoReg {
     pub(crate) spans: Vec<Span>,
     pub(crate) clobbers: Vec<Span>,
@@ -841,23 +834,33 @@ pub(crate) struct AsmOptAlreadyprovided {
 }
 
 #[derive(Diagnostic)]
-#[diag(builtin_macros_global_asm_unsupported_option)]
-pub(crate) struct GlobalAsmUnsupportedOption {
+#[diag(builtin_macros_asm_unsupported_option)]
+pub(crate) struct AsmUnsupportedOption {
     #[primary_span]
     #[label]
     pub(crate) span: Span,
     pub(crate) symbol: Symbol,
     #[suggestion(code = "", applicability = "machine-applicable", style = "tool-only")]
     pub(crate) full_span: Span,
+    pub(crate) macro_name: &'static str,
 }
 
 #[derive(Diagnostic)]
-#[diag(builtin_macros_global_asm_unsupported_operand)]
-pub(crate) struct GlobalAsmUnsupportedOperand<'a> {
+#[diag(builtin_macros_asm_unsupported_operand)]
+pub(crate) struct AsmUnsupportedOperand<'a> {
     #[primary_span]
     #[label]
     pub(crate) span: Span,
     pub(crate) symbol: &'a str,
+    pub(crate) macro_name: &'static str,
+}
+
+#[derive(Diagnostic)]
+#[diag(builtin_macros_asm_unsupported_clobber_abi)]
+pub(crate) struct AsmUnsupportedClobberAbi {
+    #[primary_span]
+    pub(crate) spans: Vec<Span>,
+    pub(crate) macro_name: &'static str,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -726,6 +726,12 @@ pub macro global_asm() {
     /* compiler built-in */
 }
 
+#[rustc_builtin_macro]
+#[rustc_macro_transparency = "semitransparent"]
+pub macro naked_asm() {
+    /* compiler built-in */
+}
+
 pub static A_STATIC: u8 = 42;
 
 #[lang = "panic_location"]

--- a/compiler/rustc_codegen_cranelift/example/mini_core_hello_world.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core_hello_world.rs
@@ -390,7 +390,7 @@ global_asm! {
 #[naked]
 extern "C" fn naked_test() {
     unsafe {
-        asm!("ret", options(noreturn));
+        naked_asm!("ret");
     }
 }
 

--- a/compiler/rustc_codegen_cranelift/src/base.rs
+++ b/compiler/rustc_codegen_cranelift/src/base.rs
@@ -8,6 +8,7 @@ use rustc_ast::InlineAsmOptions;
 use rustc_codegen_ssa::base::is_call_from_compiler_builtins_to_upstream_monomorphization;
 use rustc_index::IndexVec;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
+use rustc_middle::mir::InlineAsmMacro;
 use rustc_middle::ty::TypeVisitableExt;
 use rustc_middle::ty::adjustment::PointerCoercion;
 use rustc_middle::ty::layout::FnAbiOf;
@@ -57,6 +58,7 @@ pub(crate) fn codegen_fn<'tcx>(
 
         match &mir.basic_blocks[START_BLOCK].terminator().kind {
             TerminatorKind::InlineAsm {
+                asm_macro: InlineAsmMacro::NakedAsm,
                 template,
                 operands,
                 options,
@@ -498,6 +500,7 @@ fn codegen_fn_body(fx: &mut FunctionCx<'_, '_, '_>, start_block: Block) {
                 "tail calls are not yet supported in `rustc_codegen_cranelift` backend"
             ),
             TerminatorKind::InlineAsm {
+                asm_macro: _,
                 template,
                 operands,
                 options,

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -3,7 +3,9 @@ use std::cmp;
 use rustc_ast as ast;
 use rustc_ast::{InlineAsmOptions, InlineAsmTemplatePiece};
 use rustc_hir::lang_items::LangItem;
-use rustc_middle::mir::{self, AssertKind, BasicBlock, SwitchTargets, UnwindTerminateReason};
+use rustc_middle::mir::{
+    self, AssertKind, BasicBlock, InlineAsmMacro, SwitchTargets, UnwindTerminateReason,
+};
 use rustc_middle::ty::layout::{HasTyCtxt, LayoutOf, ValidityRequirement};
 use rustc_middle::ty::print::{with_no_trimmed_paths, with_no_visible_paths};
 use rustc_middle::ty::{self, Instance, Ty};
@@ -1133,6 +1135,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         &mut self,
         helper: TerminatorCodegenHelper<'tcx>,
         bx: &mut Bx,
+        asm_macro: InlineAsmMacro,
         terminator: &mir::Terminator<'tcx>,
         template: &[ast::InlineAsmTemplatePiece],
         operands: &[mir::InlineAsmOperand<'tcx>],
@@ -1203,11 +1206,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             &operands,
             options,
             line_spans,
-            if options.contains(InlineAsmOptions::NORETURN) {
-                None
-            } else {
-                targets.get(0).copied()
-            },
+            if asm_macro.diverges(options) { None } else { targets.get(0).copied() },
             unwind,
             instance,
             mergeable_succ,
@@ -1381,6 +1380,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
 
             mir::TerminatorKind::InlineAsm {
+                asm_macro,
                 template,
                 ref operands,
                 options,
@@ -1390,6 +1390,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             } => self.codegen_asm_terminator(
                 helper,
                 bx,
+                asm_macro,
                 terminator,
                 template,
                 operands,

--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -395,7 +395,7 @@ pub trait Machine<'tcx>: Sized {
     ///
     /// This should take care of jumping to the next block (one of `targets`) when asm goto
     /// is triggered, `targets[0]` when the assembly falls through, or diverge in case of
-    /// `InlineAsmOptions::NORETURN` being set.
+    /// naked_asm! or `InlineAsmOptions::NORETURN` being set.
     fn eval_inline_asm(
         _ecx: &mut InterpCx<'tcx, Self>,
         _template: &'tcx [InlineAsmTemplatePiece],

--- a/compiler/rustc_error_codes/src/error_codes/E0787.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0787.md
@@ -11,11 +11,10 @@ pub extern "C" fn f() -> u32 {
 }
 ```
 
-The naked functions must be defined using a single inline assembly
-block.
+The naked function must be defined using a single `naked_asm!` assembly block.
 
 The execution must never fall through past the end of the assembly
-code so the block must use `noreturn` option. The asm block can also
+code, so it must either return or diverge. The asm block can also
 use `att_syntax` and `raw` options, but others options are not allowed.
 
 The asm block must not contain any operands other than `const` and

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -3507,11 +3507,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     fn check_expr_asm(&self, asm: &'tcx hir::InlineAsm<'tcx>) -> Ty<'tcx> {
-        let mut diverge = match asm.asm_macro {
-            rustc_ast::AsmMacro::Asm => asm.options.contains(ast::InlineAsmOptions::NORETURN),
-            rustc_ast::AsmMacro::GlobalAsm => true,
-            rustc_ast::AsmMacro::NakedAsm => true,
-        };
+        let mut diverge = asm.asm_macro.diverges(asm.options);
 
         for (op, _op_sp) in asm.operands {
             match op {

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -3507,7 +3507,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     }
 
     fn check_expr_asm(&self, asm: &'tcx hir::InlineAsm<'tcx>) -> Ty<'tcx> {
-        let mut diverge = asm.options.contains(ast::InlineAsmOptions::NORETURN);
+        let mut diverge = match asm.asm_macro {
+            rustc_ast::AsmMacro::Asm => asm.options.contains(ast::InlineAsmOptions::NORETURN),
+            rustc_ast::AsmMacro::GlobalAsm => true,
+            rustc_ast::AsmMacro::NakedAsm => true,
+        };
 
         for (op, _op_sp) in asm.operands {
             match op {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2926,16 +2926,16 @@ declare_lint! {
     /// ```rust
     /// #![feature(asm_experimental_arch, naked_functions)]
     ///
-    /// use std::arch::asm;
+    /// use std::arch::naked_asm;
     ///
     /// #[naked]
     /// pub fn default_abi() -> u32 {
-    ///     unsafe { asm!("", options(noreturn)); }
+    ///     unsafe { naked_asm!(""); }
     /// }
     ///
     /// #[naked]
     /// pub extern "Rust" fn rust_abi() -> u32 {
-    ///     unsafe { asm!("", options(noreturn)); }
+    ///     unsafe { naked_asm!(""); }
     /// }
     /// ```
     ///

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
 
-use rustc_ast::{InlineAsmOptions, InlineAsmTemplatePiece};
+use rustc_ast::InlineAsmTemplatePiece;
 use rustc_middle::mir::interpret::{
     AllocBytes, AllocId, Allocation, GlobalAlloc, Pointer, Provenance, alloc_range,
     read_target_uint,
@@ -1024,9 +1024,9 @@ impl<'tcx> TerminatorKind<'tcx> {
                 vec!["real".into(), "unwind".into()]
             }
             FalseUnwind { unwind: _, .. } => vec!["real".into()],
-            InlineAsm { options, ref targets, unwind, .. } => {
+            InlineAsm { asm_macro, options, ref targets, unwind, .. } => {
                 let mut vec = Vec::with_capacity(targets.len() + 1);
-                if !options.contains(InlineAsmOptions::NORETURN) {
+                if !asm_macro.diverges(options) {
                     vec.push("return".into());
                 }
                 vec.resize(targets.len(), "label".into());

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -605,6 +605,25 @@ impl CallSource {
     }
 }
 
+#[derive(Clone, Copy, Debug, TyEncodable, TyDecodable, Hash, HashStable, PartialEq)]
+#[derive(TypeFoldable, TypeVisitable)]
+/// The macro that an inline assembly block was created by
+pub enum InlineAsmMacro {
+    /// The `asm!` macro
+    Asm,
+    /// The `naked_asm!` macro
+    NakedAsm,
+}
+
+impl InlineAsmMacro {
+    pub const fn diverges(self, options: InlineAsmOptions) -> bool {
+        match self {
+            InlineAsmMacro::Asm => options.contains(InlineAsmOptions::NORETURN),
+            InlineAsmMacro::NakedAsm => true,
+        }
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 // Terminators
 
@@ -859,6 +878,9 @@ pub enum TerminatorKind<'tcx> {
     /// Block ends with an inline assembly block. This is a terminator since
     /// inline assembly is allowed to diverge.
     InlineAsm {
+        /// Macro used to create this inline asm: one of `asm!` or `naked_asm!`
+        asm_macro: InlineAsmMacro,
+
         /// The template for the inline assembly, with placeholders.
         template: &'tcx [InlineAsmTemplatePiece],
 
@@ -874,7 +896,7 @@ pub enum TerminatorKind<'tcx> {
 
         /// Valid targets for the inline assembly.
         /// The first element is the fallthrough destination, unless
-        /// InlineAsmOptions::NORETURN is set.
+        /// asm_macro == InlineAsmMacro::NakedAsm or InlineAsmOptions::NORETURN is set.
         targets: Box<[BasicBlock]>,
 
         /// Action to be taken if the inline assembly unwinds. This is present

--- a/compiler/rustc_middle/src/mir/terminator.rs
+++ b/compiler/rustc_middle/src/mir/terminator.rs
@@ -666,6 +666,7 @@ impl<'tcx> TerminatorKind<'tcx> {
             },
 
             InlineAsm {
+                asm_macro: _,
                 template: _,
                 ref operands,
                 options: _,

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -576,6 +576,7 @@ macro_rules! make_mir_visitor {
                     }
 
                     TerminatorKind::InlineAsm {
+                        asm_macro: _,
                         template: _,
                         operands,
                         options: _,

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -12,7 +12,7 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::ops::Index;
 
-use rustc_ast::{InlineAsmOptions, InlineAsmTemplatePiece};
+use rustc_ast::{AsmMacro, InlineAsmOptions, InlineAsmTemplatePiece};
 use rustc_hir as hir;
 use rustc_hir::def_id::DefId;
 use rustc_hir::{BindingMode, ByRef, HirId, MatchSource, RangeEnd};
@@ -173,6 +173,7 @@ pub struct ClosureExpr<'tcx> {
 
 #[derive(Clone, Debug, HashStable)]
 pub struct InlineAsmExpr<'tcx> {
+    pub asm_macro: AsmMacro,
     pub template: &'tcx [InlineAsmTemplatePiece],
     pub operands: Box<[InlineAsmOperand<'tcx>]>,
     pub options: InlineAsmOptions,

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -148,7 +148,13 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         NamedConst { def_id: _, args: _, user_ty: _ } => {}
         ConstParam { param: _, def_id: _ } => {}
         StaticRef { alloc_id: _, ty: _, def_id: _ } => {}
-        InlineAsm(box InlineAsmExpr { ref operands, template: _, options: _, line_spans: _ }) => {
+        InlineAsm(box InlineAsmExpr {
+            asm_macro: _,
+            ref operands,
+            template: _,
+            options: _,
+            line_spans: _,
+        }) => {
             for op in &**operands {
                 use InlineAsmOperand::*;
                 match op {

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -672,6 +672,7 @@ impl<'tcx> Cx<'tcx> {
             }
 
             hir::ExprKind::InlineAsm(asm) => ExprKind::InlineAsm(Box::new(InlineAsmExpr {
+                asm_macro: asm.asm_macro,
                 template: asm.template,
                 operands: asm
                     .operands

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -818,9 +818,11 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
     }
 
     fn print_inline_asm_expr(&mut self, expr: &InlineAsmExpr<'tcx>, depth_lvl: usize) {
-        let InlineAsmExpr { template, operands, options, line_spans } = expr;
+        let InlineAsmExpr { asm_macro, template, operands, options, line_spans } = expr;
 
         print_indented!(self, "InlineAsmExpr {", depth_lvl);
+
+        print_indented!(self, format!("asm_macro: {:?}", asm_macro), depth_lvl + 1);
 
         print_indented!(self, "template: [", depth_lvl + 1);
         for template_piece in template.iter() {

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -481,6 +481,7 @@ impl<'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> MoveDataBuilder<'a, 'tcx, F> {
                 }
             }
             TerminatorKind::InlineAsm {
+                asm_macro: _,
                 template: _,
                 ref operands,
                 options: _,

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -499,7 +499,7 @@ passes_naked_functions_incompatible_attribute =
 
 passes_naked_functions_must_naked_asm =
     the `asm!` macro is not allowed in naked functions
-    .suggestion = consider using the `naked_asm!` macro instead
+    .label = consider using the `naked_asm!` macro instead
 
 passes_no_link =
     attribute should be applied to an `extern crate` item

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -492,9 +492,6 @@ passes_naked_functions_asm_block =
     .label_multiple_asm = multiple `naked_asm!` invocations are not allowed in naked functions
     .label_non_asm = not allowed in naked functions
 
-passes_naked_functions_asm_options =
-    asm options unsupported in naked functions: {$unsupported_options}
-
 passes_naked_functions_incompatible_attribute =
     attribute incompatible with `#[naked]`
     .label = the `{$attr}` attribute is incompatible with `#[naked]`
@@ -503,9 +500,6 @@ passes_naked_functions_incompatible_attribute =
 passes_naked_functions_must_naked_asm =
     the `asm!` macro is not allowed in naked functions
     .suggestion = consider using the `naked_asm!` macro instead
-
-passes_naked_functions_operands =
-    only `const` and `sym` operands are supported in naked functions
 
 passes_no_link =
     attribute should be applied to an `extern crate` item

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -488,9 +488,9 @@ passes_naked_asm_outside_naked_fn =
     the `naked_asm!` macro can only be used in functions marked with `#[naked]`
 
 passes_naked_functions_asm_block =
-    naked functions must contain a single asm block
-    .label_multiple_asm = multiple asm blocks are unsupported in naked functions
-    .label_non_asm = non-asm is unsupported in naked functions
+    naked functions must contain a single `naked_asm!` invocation
+    .label_multiple_asm = multiple `naked_asm!` invocations are not allowed in naked functions
+    .label_non_asm = not allowed in naked functions
 
 passes_naked_functions_asm_options =
     asm options unsupported in naked functions: {$unsupported_options}
@@ -500,9 +500,9 @@ passes_naked_functions_incompatible_attribute =
     .label = the `{$attr}` attribute is incompatible with `#[naked]`
     .naked_attribute = function marked with `#[naked]` here
 
-passes_naked_functions_must_use_noreturn =
-    asm in naked functions must use `noreturn` option
-    .suggestion = consider specifying that the asm block is responsible for returning from the function
+passes_naked_functions_must_naked_asm =
+    the `asm!` macro is not allowed in naked functions
+    .suggestion = consider using the `naked_asm!` macro instead
 
 passes_naked_functions_operands =
     only `const` and `sym` operands are supported in naked functions

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1187,21 +1187,6 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for NakedFunctionsAsmBlock {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes_naked_functions_operands, code = E0787)]
-pub(crate) struct NakedFunctionsOperands {
-    #[primary_span]
-    pub unsupported_operands: Vec<Span>,
-}
-
-#[derive(Diagnostic)]
-#[diag(passes_naked_functions_asm_options, code = E0787)]
-pub(crate) struct NakedFunctionsAsmOptions {
-    #[primary_span]
-    pub span: Span,
-    pub unsupported_options: String,
-}
-
-#[derive(Diagnostic)]
 #[diag(passes_naked_functions_must_naked_asm, code = E0787)]
 pub(crate) struct NakedFunctionsMustNakedAsm {
     #[primary_span]

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1190,9 +1190,8 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for NakedFunctionsAsmBlock {
 #[diag(passes_naked_functions_must_naked_asm, code = E0787)]
 pub(crate) struct NakedFunctionsMustNakedAsm {
     #[primary_span]
+    #[label]
     pub span: Span,
-    #[suggestion(code = "naked_asm!", applicability = "machine-applicable")]
-    pub macro_span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1202,12 +1202,12 @@ pub(crate) struct NakedFunctionsAsmOptions {
 }
 
 #[derive(Diagnostic)]
-#[diag(passes_naked_functions_must_use_noreturn, code = E0787)]
-pub(crate) struct NakedFunctionsMustUseNoreturn {
+#[diag(passes_naked_functions_must_naked_asm, code = E0787)]
+pub(crate) struct NakedFunctionsMustNakedAsm {
     #[primary_span]
     pub span: Span,
-    #[suggestion(code = ", options(noreturn)", applicability = "machine-applicable")]
-    pub last_span: Span,
+    #[suggestion(code = "naked_asm!", applicability = "machine-applicable")]
+    pub macro_span: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
@@ -655,6 +655,7 @@ impl<'tcx> Stable<'tcx> for mir::TerminatorKind<'tcx> {
                 }
             }
             mir::TerminatorKind::InlineAsm {
+                asm_macro: _,
                 template,
                 operands,
                 options,

--- a/library/core/src/arch.rs
+++ b/library/core/src/arch.rs
@@ -77,3 +77,17 @@ pub macro naked_asm("assembly template", $(operands,)* $(options($(option),*))?)
 pub macro global_asm("assembly template", $(operands,)* $(options($(option),*))?) {
     /* compiler built-in */
 }
+
+/// Inline assembly used in combination with `#[naked]` functions.
+///
+/// Refer to [Rust By Example] for a usage guide and the [reference] for
+/// detailed information about the syntax and available options.
+///
+/// [Rust By Example]: https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html
+/// [reference]: https://doc.rust-lang.org/nightly/reference/inline-assembly.html
+#[unstable(feature = "naked_functions", issue = "90957")]
+#[rustc_builtin_macro]
+#[cfg(not(bootstrap))]
+pub macro naked_asm("assembly template", $(operands,)* $(options($(option),*))?) {
+    /* compiler built-in */
+}

--- a/library/core/src/arch.rs
+++ b/library/core/src/arch.rs
@@ -77,17 +77,3 @@ pub macro naked_asm("assembly template", $(operands,)* $(options($(option),*))?)
 pub macro global_asm("assembly template", $(operands,)* $(options($(option),*))?) {
     /* compiler built-in */
 }
-
-/// Inline assembly used in combination with `#[naked]` functions.
-///
-/// Refer to [Rust By Example] for a usage guide and the [reference] for
-/// detailed information about the syntax and available options.
-///
-/// [Rust By Example]: https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html
-/// [reference]: https://doc.rust-lang.org/nightly/reference/inline-assembly.html
-#[unstable(feature = "naked_functions", issue = "90957")]
-#[rustc_builtin_macro]
-#[cfg(not(bootstrap))]
-pub macro naked_asm("assembly template", $(operands,)* $(options($(option),*))?) {
-    /* compiler built-in */
-}

--- a/src/tools/rustfmt/src/parse/macros/asm.rs
+++ b/src/tools/rustfmt/src/parse/macros/asm.rs
@@ -1,5 +1,5 @@
 use rustc_ast::ast;
-use rustc_builtin_macros::asm::{parse_asm_args, AsmArgs};
+use rustc_builtin_macros::asm::{AsmArgs, parse_asm_args};
 
 use crate::rewrite::RewriteContext;
 

--- a/src/tools/rustfmt/src/parse/macros/asm.rs
+++ b/src/tools/rustfmt/src/parse/macros/asm.rs
@@ -1,5 +1,5 @@
 use rustc_ast::ast;
-use rustc_builtin_macros::asm::{parse_asm_args, AsmArgs, AsmMacro};
+use rustc_builtin_macros::asm::{parse_asm_args, AsmArgs};
 
 use crate::rewrite::RewriteContext;
 
@@ -7,5 +7,5 @@ use crate::rewrite::RewriteContext;
 pub(crate) fn parse_asm(context: &RewriteContext<'_>, mac: &ast::MacCall) -> Option<AsmArgs> {
     let ts = mac.args.tokens.clone();
     let mut parser = super::build_parser(context, ts);
-    parse_asm_args(&mut parser, mac.span(), AsmMacro::Asm).ok()
+    parse_asm_args(&mut parser, mac.span(), ast::AsmMacro::Asm).ok()
 }

--- a/src/tools/rustfmt/src/parse/macros/asm.rs
+++ b/src/tools/rustfmt/src/parse/macros/asm.rs
@@ -1,5 +1,5 @@
 use rustc_ast::ast;
-use rustc_builtin_macros::asm::{AsmArgs, parse_asm_args};
+use rustc_builtin_macros::asm::{parse_asm_args, AsmArgs, AsmMacro};
 
 use crate::rewrite::RewriteContext;
 
@@ -7,5 +7,5 @@ use crate::rewrite::RewriteContext;
 pub(crate) fn parse_asm(context: &RewriteContext<'_>, mac: &ast::MacCall) -> Option<AsmArgs> {
     let ts = mac.args.tokens.clone();
     let mut parser = super::build_parser(context, ts);
-    parse_asm_args(&mut parser, mac.span(), false).ok()
+    parse_asm_args(&mut parser, mac.span(), AsmMacro::Asm).ok()
 }

--- a/tests/assembly/aarch64-naked-fn-no-bti-prolog.rs
+++ b/tests/assembly/aarch64-naked-fn-no-bti-prolog.rs
@@ -5,7 +5,7 @@
 
 #![crate_type = "lib"]
 #![feature(naked_functions)]
-use std::arch::asm;
+use std::arch::naked_asm;
 
 // The problem at hand: Rust has adopted a fairly strict meaning for "naked functions",
 // meaning "no prologue whatsoever, no, really, not one instruction."
@@ -17,5 +17,5 @@ use std::arch::asm;
 pub unsafe extern "C" fn _hlt() -> ! {
     // CHECK-NOT: hint #34
     // CHECK: hlt #0x1
-    asm!("hlt #1", options(noreturn))
+    naked_asm!("hlt #1")
 }

--- a/tests/assembly/x86_64-naked-fn-no-cet-prolog.rs
+++ b/tests/assembly/x86_64-naked-fn-no-cet-prolog.rs
@@ -5,7 +5,7 @@
 
 #![crate_type = "lib"]
 #![feature(naked_functions)]
-use std::arch::asm;
+use std::arch::naked_asm;
 
 // The problem at hand: Rust has adopted a fairly strict meaning for "naked functions",
 // meaning "no prologue whatsoever, no, really, not one instruction."
@@ -17,7 +17,7 @@ use std::arch::asm;
 pub unsafe extern "sysv64" fn will_halt() -> ! {
     // CHECK-NOT: endbr{{32|64}}
     // CHECK: hlt
-    asm!("hlt", options(noreturn))
+    naked_asm!("hlt")
 }
 
 // what about aarch64?

--- a/tests/codegen/cffi/c-variadic-naked.rs
+++ b/tests/codegen/cffi/c-variadic-naked.rs
@@ -12,8 +12,7 @@
 pub unsafe extern "C" fn c_variadic(_: usize, _: ...) {
     // CHECK-NOT: va_start
     // CHECK-NOT: alloca
-    core::arch::asm! {
+    core::arch::naked_asm! {
         "ret",
-        options(noreturn),
     }
 }

--- a/tests/codegen/naked-asan.rs
+++ b/tests/codegen/naked-asan.rs
@@ -14,7 +14,7 @@
 #[no_mangle]
 pub extern "x86-interrupt" fn page_fault_handler(_: u64, _: u64) {
     unsafe {
-        core::arch::asm!("ud2", options(noreturn));
+        core::arch::naked_asm!("ud2");
     }
 }
 

--- a/tests/codegen/naked-fn/aligned.rs
+++ b/tests/codegen/naked-fn/aligned.rs
@@ -4,7 +4,7 @@
 
 #![crate_type = "lib"]
 #![feature(naked_functions, fn_align)]
-use std::arch::asm;
+use std::arch::naked_asm;
 
 // CHECK: Function Attrs: naked
 // CHECK-NEXT: define{{.*}}void @naked_empty()
@@ -16,5 +16,5 @@ pub unsafe extern "C" fn naked_empty() {
     // CHECK-NEXT: start:
     // CHECK-NEXT: call void asm
     // CHECK-NEXT: unreachable
-    asm!("ret", options(noreturn));
+    naked_asm!("ret");
 }

--- a/tests/codegen/naked-fn/naked-functions.rs
+++ b/tests/codegen/naked-fn/naked-functions.rs
@@ -4,7 +4,7 @@
 
 #![crate_type = "lib"]
 #![feature(naked_functions)]
-use std::arch::asm;
+use std::arch::naked_asm;
 
 // CHECK: Function Attrs: naked
 // CHECK-NEXT: define{{.*}}void @naked_empty()
@@ -14,7 +14,7 @@ pub unsafe extern "C" fn naked_empty() {
     // CHECK-NEXT: {{.+}}:
     // CHECK-NEXT: call void asm
     // CHECK-NEXT: unreachable
-    asm!("ret", options(noreturn));
+    naked_asm!("ret", options(noreturn));
 }
 
 // CHECK: Function Attrs: naked
@@ -25,5 +25,5 @@ pub unsafe extern "C" fn naked_with_args_and_return(a: isize, b: isize) -> isize
     // CHECK-NEXT: {{.+}}:
     // CHECK-NEXT: call void asm
     // CHECK-NEXT: unreachable
-    asm!("lea rax, [rdi + rsi]", "ret", options(noreturn));
+    naked_asm!("lea rax, [rdi + rsi]", "ret", options(noreturn));
 }

--- a/tests/codegen/naked-fn/naked-functions.rs
+++ b/tests/codegen/naked-fn/naked-functions.rs
@@ -14,7 +14,7 @@ pub unsafe extern "C" fn naked_empty() {
     // CHECK-NEXT: {{.+}}:
     // CHECK-NEXT: call void asm
     // CHECK-NEXT: unreachable
-    naked_asm!("ret", options(noreturn));
+    naked_asm!("ret");
 }
 
 // CHECK: Function Attrs: naked
@@ -25,5 +25,5 @@ pub unsafe extern "C" fn naked_with_args_and_return(a: isize, b: isize) -> isize
     // CHECK-NEXT: {{.+}}:
     // CHECK-NEXT: call void asm
     // CHECK-NEXT: unreachable
-    naked_asm!("lea rax, [rdi + rsi]", "ret", options(noreturn));
+    naked_asm!("lea rax, [rdi + rsi]", "ret");
 }

--- a/tests/codegen/naked-fn/naked-nocoverage.rs
+++ b/tests/codegen/naked-fn/naked-nocoverage.rs
@@ -6,7 +6,7 @@
 //@ compile-flags: -Cinstrument-coverage
 #![crate_type = "lib"]
 #![feature(naked_functions)]
-use std::arch::asm;
+use std::arch::naked_asm;
 
 #[naked]
 #[no_mangle]
@@ -15,5 +15,5 @@ pub unsafe extern "C" fn f() {
     // CHECK-NEXT:  start:
     // CHECK-NEXT:    call void asm
     // CHECK-NEXT:    unreachable
-    asm!("", options(noreturn));
+    naked_asm!("");
 }

--- a/tests/codegen/naked-fn/naked-noinline.rs
+++ b/tests/codegen/naked-fn/naked-noinline.rs
@@ -5,7 +5,7 @@
 #![crate_type = "lib"]
 #![feature(naked_functions)]
 
-use std::arch::asm;
+use std::arch::naked_asm;
 
 #[naked]
 #[no_mangle]
@@ -15,7 +15,7 @@ pub unsafe extern "C" fn f() {
     // CHECK:       define {{(dso_local )?}}void @f() unnamed_addr [[ATTR:#[0-9]+]]
     // CHECK-NEXT:  start:
     // CHECK-NEXT:    call void asm
-    asm!("", options(noreturn));
+    naked_asm!("");
 }
 
 #[no_mangle]

--- a/tests/crashes/124375.rs
+++ b/tests/crashes/124375.rs
@@ -3,9 +3,9 @@
 //@ only-x86_64
 #![crate_type = "lib"]
 #![feature(naked_functions)]
-use std::arch::asm;
+use std::arch::naked_asm;
 
 #[naked]
 pub unsafe extern "C" fn naked_with_args_and_return(a: isize, b: isize) -> isize {
-    asm!("lea rax, [rdi + rsi]", "ret", options(noreturn));
+    naked_asm!("lea rax, [rdi + rsi]", "ret");
 }

--- a/tests/run-make/naked-symbol-visibility/a_rust_dylib.rs
+++ b/tests/run-make/naked-symbol-visibility/a_rust_dylib.rs
@@ -72,7 +72,7 @@ extern "C" fn vanilla_weak_linkage() -> u32 {
 #[cfg(not(windows))]
 #[linkage = "weak"]
 extern "C" fn naked_weak_linkage() -> u32 {
-    unsafe { naked_asm!("mov rax, 42", "ret", options(noreturn)) }
+    unsafe { naked_asm!("mov rax, 42", "ret") }
 }
 
 // functions that are declared in an `extern "C"` block are currently not exported

--- a/tests/run-make/naked-symbol-visibility/a_rust_dylib.rs
+++ b/tests/run-make/naked-symbol-visibility/a_rust_dylib.rs
@@ -1,7 +1,7 @@
 #![feature(naked_functions, asm_const, linkage)]
 #![crate_type = "dylib"]
 
-use std::arch::asm;
+use std::arch::naked_asm;
 
 pub trait TraitWithConst {
     const COUNT: u32;
@@ -28,7 +28,7 @@ extern "C" fn private_vanilla() -> u32 {
 
 #[naked]
 extern "C" fn private_naked() -> u32 {
-    unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
+    unsafe { naked_asm!("mov rax, 42", "ret") }
 }
 
 #[no_mangle]
@@ -39,7 +39,7 @@ pub extern "C" fn public_vanilla() -> u32 {
 #[naked]
 #[no_mangle]
 pub extern "C" fn public_naked() -> u32 {
-    unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
+    unsafe { naked_asm!("mov rax, 42", "ret") }
 }
 
 pub extern "C" fn public_vanilla_generic<T: TraitWithConst>() -> u32 {
@@ -48,7 +48,7 @@ pub extern "C" fn public_vanilla_generic<T: TraitWithConst>() -> u32 {
 
 #[naked]
 pub extern "C" fn public_naked_generic<T: TraitWithConst>() -> u32 {
-    unsafe { asm!("mov rax, {}", "ret", const T::COUNT, options(noreturn)) }
+    unsafe { naked_asm!("mov rax, {}", "ret", const T::COUNT) }
 }
 
 #[linkage = "external"]
@@ -59,7 +59,7 @@ extern "C" fn vanilla_external_linkage() -> u32 {
 #[naked]
 #[linkage = "external"]
 extern "C" fn naked_external_linkage() -> u32 {
-    unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
+    unsafe { naked_asm!("mov rax, 42", "ret") }
 }
 
 #[cfg(not(windows))]
@@ -72,7 +72,7 @@ extern "C" fn vanilla_weak_linkage() -> u32 {
 #[cfg(not(windows))]
 #[linkage = "weak"]
 extern "C" fn naked_weak_linkage() -> u32 {
-    unsafe { asm!("mov rax, 42", "ret", options(noreturn)) }
+    unsafe { naked_asm!("mov rax, 42", "ret", options(noreturn)) }
 }
 
 // functions that are declared in an `extern "C"` block are currently not exported

--- a/tests/ui/asm/naked-functions-ffi.rs
+++ b/tests/ui/asm/naked-functions-ffi.rs
@@ -3,13 +3,13 @@
 #![feature(naked_functions)]
 #![crate_type = "lib"]
 
-use std::arch::asm;
+use std::arch::naked_asm;
 
 #[naked]
 pub extern "C" fn naked(p: char) -> u128 {
     //~^ WARN uses type `char`
     //~| WARN uses type `u128`
     unsafe {
-        asm!("", options(noreturn));
+        naked_asm!("", options(noreturn));
     }
 }

--- a/tests/ui/asm/naked-functions-ffi.rs
+++ b/tests/ui/asm/naked-functions-ffi.rs
@@ -10,6 +10,6 @@ pub extern "C" fn naked(p: char) -> u128 {
     //~^ WARN uses type `char`
     //~| WARN uses type `u128`
     unsafe {
-        naked_asm!("", options(noreturn));
+        naked_asm!("");
     }
 }

--- a/tests/ui/asm/naked-functions-inline.rs
+++ b/tests/ui/asm/naked-functions-inline.rs
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn inline_hint() {
 #[naked]
 #[inline(always)]
 //~^ ERROR [E0736]
-<<<<<<< HEAD
+pub unsafe extern "C" fn inline_always() {
     naked_asm!("");
 }
 

--- a/tests/ui/asm/naked-functions-inline.rs
+++ b/tests/ui/asm/naked-functions-inline.rs
@@ -19,7 +19,7 @@ pub unsafe extern "C" fn inline_hint() {
 #[naked]
 #[inline(always)]
 //~^ ERROR [E0736]
-pub unsafe extern "C" fn inline_always() {
+<<<<<<< HEAD
     naked_asm!("");
 }
 

--- a/tests/ui/asm/naked-functions-instruction-set.rs
+++ b/tests/ui/asm/naked-functions-instruction-set.rs
@@ -19,12 +19,12 @@ trait Sized {}
 #[naked]
 #[instruction_set(arm::t32)]
 unsafe extern "C" fn test_thumb() {
-    naked_asm!("bx lr", options(noreturn));
+    naked_asm!("bx lr");
 }
 
 #[no_mangle]
 #[naked]
 #[instruction_set(arm::t32)]
 unsafe extern "C" fn test_arm() {
-    naked_asm!("bx lr", options(noreturn));
+    naked_asm!("bx lr");
 }

--- a/tests/ui/asm/naked-functions-instruction-set.rs
+++ b/tests/ui/asm/naked-functions-instruction-set.rs
@@ -8,7 +8,7 @@
 #![no_core]
 
 #[rustc_builtin_macro]
-macro_rules! asm {
+macro_rules! naked_asm {
     () => {};
 }
 
@@ -19,12 +19,12 @@ trait Sized {}
 #[naked]
 #[instruction_set(arm::t32)]
 unsafe extern "C" fn test_thumb() {
-    asm!("bx lr", options(noreturn));
+    naked_asm!("bx lr", options(noreturn));
 }
 
 #[no_mangle]
 #[naked]
 #[instruction_set(arm::t32)]
 unsafe extern "C" fn test_arm() {
-    asm!("bx lr", options(noreturn));
+    naked_asm!("bx lr", options(noreturn));
 }

--- a/tests/ui/asm/naked-functions-testattrs.rs
+++ b/tests/ui/asm/naked-functions-testattrs.rs
@@ -6,13 +6,13 @@
 #![feature(test)]
 #![crate_type = "lib"]
 
-use std::arch::asm;
+use std::arch::naked_asm;
 
 #[test]
 #[naked]
 //~^ ERROR [E0736]
 fn test_naked() {
-    unsafe { asm!("", options(noreturn)) };
+    unsafe { naked_asm!("", options(noreturn)) };
 }
 
 #[should_panic]
@@ -20,7 +20,7 @@ fn test_naked() {
 #[naked]
 //~^ ERROR [E0736]
 fn test_naked_should_panic() {
-    unsafe { asm!("", options(noreturn)) };
+    unsafe { naked_asm!("", options(noreturn)) };
 }
 
 #[ignore]
@@ -28,12 +28,12 @@ fn test_naked_should_panic() {
 #[naked]
 //~^ ERROR [E0736]
 fn test_naked_ignore() {
-    unsafe { asm!("", options(noreturn)) };
+    unsafe { naked_asm!("", options(noreturn)) };
 }
 
 #[bench]
 #[naked]
 //~^ ERROR [E0736]
 fn bench_naked() {
-    unsafe { asm!("", options(noreturn)) };
+    unsafe { naked_asm!("", options(noreturn)) };
 }

--- a/tests/ui/asm/naked-functions-testattrs.rs
+++ b/tests/ui/asm/naked-functions-testattrs.rs
@@ -12,7 +12,7 @@ use std::arch::naked_asm;
 #[naked]
 //~^ ERROR [E0736]
 fn test_naked() {
-    unsafe { naked_asm!("", options(noreturn)) };
+    unsafe { naked_asm!("") };
 }
 
 #[should_panic]
@@ -20,7 +20,7 @@ fn test_naked() {
 #[naked]
 //~^ ERROR [E0736]
 fn test_naked_should_panic() {
-    unsafe { naked_asm!("", options(noreturn)) };
+    unsafe { naked_asm!("") };
 }
 
 #[ignore]
@@ -28,12 +28,12 @@ fn test_naked_should_panic() {
 #[naked]
 //~^ ERROR [E0736]
 fn test_naked_ignore() {
-    unsafe { naked_asm!("", options(noreturn)) };
+    unsafe { naked_asm!("") };
 }
 
 #[bench]
 #[naked]
 //~^ ERROR [E0736]
 fn bench_naked() {
-    unsafe { naked_asm!("", options(noreturn)) };
+    unsafe { naked_asm!("") };
 }

--- a/tests/ui/asm/naked-functions-unused.aarch64.stderr
+++ b/tests/ui/asm/naked-functions-unused.aarch64.stderr
@@ -18,49 +18,49 @@ LL |     pub extern "C" fn function(a: usize, b: usize) -> usize {
    |                                          ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:26:38
+  --> $DIR/naked-functions-unused.rs:28:38
    |
 LL |         pub extern "C" fn associated(a: usize, b: usize) -> usize {
    |                                      ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:26:48
+  --> $DIR/naked-functions-unused.rs:28:48
    |
 LL |         pub extern "C" fn associated(a: usize, b: usize) -> usize {
    |                                                ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:32:41
+  --> $DIR/naked-functions-unused.rs:36:41
    |
 LL |         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
    |                                         ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:32:51
+  --> $DIR/naked-functions-unused.rs:36:51
    |
 LL |         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
    |                                                   ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:40:40
+  --> $DIR/naked-functions-unused.rs:46:40
    |
 LL |         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
    |                                        ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:40:50
+  --> $DIR/naked-functions-unused.rs:46:50
    |
 LL |         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
    |                                                  ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:46:43
+  --> $DIR/naked-functions-unused.rs:54:43
    |
 LL |         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
    |                                           ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:46:53
+  --> $DIR/naked-functions-unused.rs:54:53
    |
 LL |         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
    |                                                     ^ help: if this is intentional, prefix it with an underscore: `_b`

--- a/tests/ui/asm/naked-functions-unused.rs
+++ b/tests/ui/asm/naked-functions-unused.rs
@@ -17,7 +17,9 @@ pub mod normal {
     pub extern "C" fn function(a: usize, b: usize) -> usize {
         //~^ ERROR unused variable: `a`
         //~| ERROR unused variable: `b`
-        unsafe { asm!("", options(noreturn)); }
+        unsafe {
+            asm!("", options(noreturn));
+        }
     }
 
     pub struct Normal;
@@ -26,13 +28,17 @@ pub mod normal {
         pub extern "C" fn associated(a: usize, b: usize) -> usize {
             //~^ ERROR unused variable: `a`
             //~| ERROR unused variable: `b`
-            unsafe { asm!("", options(noreturn)); }
+            unsafe {
+                asm!("", options(noreturn));
+            }
         }
 
         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
             //~^ ERROR unused variable: `a`
             //~| ERROR unused variable: `b`
-            unsafe { asm!("", options(noreturn)); }
+            unsafe {
+                asm!("", options(noreturn));
+            }
         }
     }
 
@@ -40,23 +46,29 @@ pub mod normal {
         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
             //~^ ERROR unused variable: `a`
             //~| ERROR unused variable: `b`
-            unsafe { asm!("", options(noreturn)); }
+            unsafe {
+                asm!("", options(noreturn));
+            }
         }
 
         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
             //~^ ERROR unused variable: `a`
             //~| ERROR unused variable: `b`
-            unsafe { asm!("", options(noreturn)); }
+            unsafe {
+                asm!("", options(noreturn));
+            }
         }
     }
 }
 
 pub mod naked {
-    use std::arch::asm;
+    use std::arch::naked_asm;
 
     #[naked]
     pub extern "C" fn function(a: usize, b: usize) -> usize {
-        unsafe { asm!("", options(noreturn)); }
+        unsafe {
+            naked_asm!("", options(noreturn));
+        }
     }
 
     pub struct Naked;
@@ -64,24 +76,32 @@ pub mod naked {
     impl Naked {
         #[naked]
         pub extern "C" fn associated(a: usize, b: usize) -> usize {
-            unsafe { asm!("", options(noreturn)); }
+            unsafe {
+                naked_asm!("", options(noreturn));
+            }
         }
 
         #[naked]
         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
-            unsafe { asm!("", options(noreturn)); }
+            unsafe {
+                naked_asm!("", options(noreturn));
+            }
         }
     }
 
     impl super::Trait for Naked {
         #[naked]
         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
-            unsafe { asm!("", options(noreturn)); }
+            unsafe {
+                naked_asm!("", options(noreturn));
+            }
         }
 
         #[naked]
         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
-            unsafe { asm!("", options(noreturn)); }
+            unsafe {
+                naked_asm!("", options(noreturn));
+            }
         }
     }
 }

--- a/tests/ui/asm/naked-functions-unused.rs
+++ b/tests/ui/asm/naked-functions-unused.rs
@@ -67,7 +67,7 @@ pub mod naked {
     #[naked]
     pub extern "C" fn function(a: usize, b: usize) -> usize {
         unsafe {
-            naked_asm!("", options(noreturn));
+            naked_asm!("");
         }
     }
 
@@ -77,14 +77,14 @@ pub mod naked {
         #[naked]
         pub extern "C" fn associated(a: usize, b: usize) -> usize {
             unsafe {
-                naked_asm!("", options(noreturn));
+                naked_asm!("");
             }
         }
 
         #[naked]
         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
             unsafe {
-                naked_asm!("", options(noreturn));
+                naked_asm!("");
             }
         }
     }
@@ -93,14 +93,14 @@ pub mod naked {
         #[naked]
         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
             unsafe {
-                naked_asm!("", options(noreturn));
+                naked_asm!("");
             }
         }
 
         #[naked]
         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
             unsafe {
-                naked_asm!("", options(noreturn));
+                naked_asm!("");
             }
         }
     }

--- a/tests/ui/asm/naked-functions-unused.x86_64.stderr
+++ b/tests/ui/asm/naked-functions-unused.x86_64.stderr
@@ -18,49 +18,49 @@ LL |     pub extern "C" fn function(a: usize, b: usize) -> usize {
    |                                          ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:26:38
+  --> $DIR/naked-functions-unused.rs:28:38
    |
 LL |         pub extern "C" fn associated(a: usize, b: usize) -> usize {
    |                                      ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:26:48
+  --> $DIR/naked-functions-unused.rs:28:48
    |
 LL |         pub extern "C" fn associated(a: usize, b: usize) -> usize {
    |                                                ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:32:41
+  --> $DIR/naked-functions-unused.rs:36:41
    |
 LL |         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
    |                                         ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:32:51
+  --> $DIR/naked-functions-unused.rs:36:51
    |
 LL |         pub extern "C" fn method(&self, a: usize, b: usize) -> usize {
    |                                                   ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:40:40
+  --> $DIR/naked-functions-unused.rs:46:40
    |
 LL |         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
    |                                        ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:40:50
+  --> $DIR/naked-functions-unused.rs:46:50
    |
 LL |         extern "C" fn trait_associated(a: usize, b: usize) -> usize {
    |                                                  ^ help: if this is intentional, prefix it with an underscore: `_b`
 
 error: unused variable: `a`
-  --> $DIR/naked-functions-unused.rs:46:43
+  --> $DIR/naked-functions-unused.rs:54:43
    |
 LL |         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
    |                                           ^ help: if this is intentional, prefix it with an underscore: `_a`
 
 error: unused variable: `b`
-  --> $DIR/naked-functions-unused.rs:46:53
+  --> $DIR/naked-functions-unused.rs:54:53
    |
 LL |         extern "C" fn trait_method(&self, a: usize, b: usize) -> usize {
    |                                                     ^ help: if this is intentional, prefix it with an underscore: `_b`

--- a/tests/ui/asm/naked-functions.stderr
+++ b/tests/ui/asm/naked-functions.stderr
@@ -1,220 +1,184 @@
 error: the `in` operand cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:41:29
+  --> $DIR/naked-functions.rs:47:29
    |
-LL |     naked_asm!("/* {0} */", in(reg) a, options(noreturn))
+LL |     naked_asm!("/* {0} */", in(reg) a)
    |                             ^^ the `in` operand is not meaningful for global-scoped inline assembly, remove it
 
 error: the `in` operand cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:62:10
+  --> $DIR/naked-functions.rs:68:10
    |
 LL |          in(reg) a,
    |          ^^ the `in` operand is not meaningful for global-scoped inline assembly, remove it
 
-error: the `nomem` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:104:28
+error: the `noreturn` option cannot be used with `naked_asm!`
+  --> $DIR/naked-functions.rs:88:32
    |
-LL |     naked_asm!("", options(nomem, preserves_flags, noreturn));
+LL |         naked_asm!("", options(noreturn));
+   |                                ^^^^^^^^ the `noreturn` option is not meaningful for global-scoped inline assembly
+
+error: the `nomem` option cannot be used with `naked_asm!`
+  --> $DIR/naked-functions.rs:106:28
+   |
+LL |     naked_asm!("", options(nomem, preserves_flags));
    |                            ^^^^^ the `nomem` option is not meaningful for global-scoped inline assembly
 
 error: the `preserves_flags` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:104:35
+  --> $DIR/naked-functions.rs:106:35
    |
-LL |     naked_asm!("", options(nomem, preserves_flags, noreturn));
+LL |     naked_asm!("", options(nomem, preserves_flags));
    |                                   ^^^^^^^^^^^^^^^ the `preserves_flags` option is not meaningful for global-scoped inline assembly
 
 error: the `readonly` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:111:28
+  --> $DIR/naked-functions.rs:113:28
    |
 LL |     naked_asm!("", options(readonly, nostack), options(pure));
    |                            ^^^^^^^^ the `readonly` option is not meaningful for global-scoped inline assembly
 
 error: the `nostack` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:111:38
+  --> $DIR/naked-functions.rs:113:38
    |
 LL |     naked_asm!("", options(readonly, nostack), options(pure));
    |                                      ^^^^^^^ the `nostack` option is not meaningful for global-scoped inline assembly
 
 error: the `pure` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:111:56
+  --> $DIR/naked-functions.rs:113:56
    |
 LL |     naked_asm!("", options(readonly, nostack), options(pure));
    |                                                        ^^^^ the `pure` option is not meaningful for global-scoped inline assembly
 
 error: the `may_unwind` option cannot be used with `naked_asm!`
-  --> $DIR/naked-functions.rs:120:38
+  --> $DIR/naked-functions.rs:121:28
    |
-LL |     naked_asm!("", options(noreturn, may_unwind));
-   |                                      ^^^^^^^^^^ the `may_unwind` option is not meaningful for global-scoped inline assembly
+LL |     naked_asm!("", options(may_unwind));
+   |                            ^^^^^^^^^^ the `may_unwind` option is not meaningful for global-scoped inline assembly
 
 error: this is a user specified error
-  --> $DIR/naked-functions.rs:168:5
+  --> $DIR/naked-functions.rs:169:5
    |
 LL |     compile_error!("this is a user specified error")
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this is a user specified error
-  --> $DIR/naked-functions.rs:174:5
+  --> $DIR/naked-functions.rs:175:5
    |
 LL |     compile_error!("this is a user specified error");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm template must be a string literal
-  --> $DIR/naked-functions.rs:181:16
+  --> $DIR/naked-functions.rs:182:16
    |
 LL |     naked_asm!(invalid_syntax)
    |                ^^^^^^^^^^^^^^
 
+error[E0787]: the `asm!` macro is not allowed in naked functions
+  --> $DIR/naked-functions.rs:13:5
+   |
+LL |     asm!("", options(raw));
+   |     ----^^^^^^^^^^^^^^^^^^
+   |     |
+   |     help: consider using the `naked_asm!` macro instead: `naked_asm!`
+
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:19:5
+  --> $DIR/naked-functions.rs:25:5
    |
 LL |     mut a: u32,
    |     ^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:21:5
+  --> $DIR/naked-functions.rs:27:5
    |
 LL |     &b: &i32,
    |     ^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:23:6
+  --> $DIR/naked-functions.rs:29:6
    |
 LL |     (None | Some(_)): Option<std::ptr::NonNull<u8>>,
    |      ^^^^^^^^^^^^^^
 
 error: patterns not allowed in naked function parameters
-  --> $DIR/naked-functions.rs:25:5
+  --> $DIR/naked-functions.rs:31:5
    |
 LL |     P { x, y }: P,
    |     ^^^^^^^^^^
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:34:5
+  --> $DIR/naked-functions.rs:40:5
    |
 LL |     a + 1
    |     ^
    |
    = help: follow the calling convention in asm block to use parameters
 
-error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:32:1
+error[E0787]: naked functions must contain a single `naked_asm!` invocation
+  --> $DIR/naked-functions.rs:38:1
    |
 LL | pub unsafe extern "C" fn inc(a: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |     a + 1
-   |     ----- non-asm is unsupported in naked functions
+   |     ----- not allowed in naked functions
 
-error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:46:1
+error[E0787]: naked functions must contain a single `naked_asm!` invocation
+  --> $DIR/naked-functions.rs:52:1
    |
 LL | pub unsafe extern "C" fn inc_closure(a: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |     (|| a + 1)()
-   |     ------------ non-asm is unsupported in naked functions
+   |     ------------ not allowed in naked functions
 
-error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:52:1
+error[E0787]: naked functions must contain a single `naked_asm!` invocation
+  --> $DIR/naked-functions.rs:58:1
    |
 LL | pub unsafe extern "C" fn unsupported_operands() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |     let mut a = 0usize;
-   |     ------------------- non-asm is unsupported in naked functions
+   |     ------------------- not allowed in naked functions
 LL |     let mut b = 0usize;
-   |     ------------------- non-asm is unsupported in naked functions
+   |     ------------------- not allowed in naked functions
 LL |     let mut c = 0usize;
-   |     ------------------- non-asm is unsupported in naked functions
+   |     ------------------- not allowed in naked functions
 LL |     let mut d = 0usize;
-   |     ------------------- non-asm is unsupported in naked functions
+   |     ------------------- not allowed in naked functions
 LL |     let mut e = 0usize;
-   |     ------------------- non-asm is unsupported in naked functions
+   |     ------------------- not allowed in naked functions
 
-error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:74:1
+error[E0787]: naked functions must contain a single `naked_asm!` invocation
+  --> $DIR/naked-functions.rs:80:1
    |
 LL | pub extern "C" fn missing_assembly() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:82:9
-   |
-LL |         naked_asm!("");
-   |         ^^^^^^^^^^^^^^
-   |
-help: consider specifying that the asm block is responsible for returning from the function
-   |
-LL |         naked_asm!("", options(noreturn));
-   |                      +++++++++++++++++++
-
-error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:84:9
-   |
-LL |         naked_asm!("");
-   |         ^^^^^^^^^^^^^^
-   |
-help: consider specifying that the asm block is responsible for returning from the function
-   |
-LL |         naked_asm!("", options(noreturn));
-   |                      +++++++++++++++++++
-
-error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:86:9
-   |
-LL |         naked_asm!("");
-   |         ^^^^^^^^^^^^^^
-   |
-help: consider specifying that the asm block is responsible for returning from the function
-   |
-LL |         naked_asm!("", options(noreturn));
-   |                      +++++++++++++++++++
-
-error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:79:1
+error[E0787]: naked functions must contain a single `naked_asm!` invocation
+  --> $DIR/naked-functions.rs:85:1
    |
 LL | pub extern "C" fn too_many_asm_blocks() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
 LL |         naked_asm!("");
-   |         -------------- multiple asm blocks are unsupported in naked functions
-LL |
-LL |         naked_asm!("");
-   |         -------------- multiple asm blocks are unsupported in naked functions
-LL |
-LL |         naked_asm!("", options(noreturn));
-   |         --------------------------------- multiple asm blocks are unsupported in naked functions
+   |         -------------- multiple `naked_asm!` invocations are not allowed in naked functions
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:96:11
+  --> $DIR/naked-functions.rs:98:11
    |
 LL |         *&y
    |           ^
    |
    = help: follow the calling convention in asm block to use parameters
 
-error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:94:5
+error[E0787]: naked functions must contain a single `naked_asm!` invocation
+  --> $DIR/naked-functions.rs:96:5
    |
 LL |     pub extern "C" fn inner(y: usize) -> usize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 LL |
 LL |         *&y
-   |         --- non-asm is unsupported in naked functions
-
-error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:111:5
-   |
-LL |     naked_asm!("", options(readonly, nostack), options(pure));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: consider specifying that the asm block is responsible for returning from the function
-   |
-LL |     naked_asm!("", options(noreturn), options(readonly, nostack), options(pure));
-   |                  +++++++++++++++++++
+   |         --- not allowed in naked functions
 
 warning: Rust ABI is unsupported in naked functions
-  --> $DIR/naked-functions.rs:125:1
+  --> $DIR/naked-functions.rs:126:1
    |
 LL | pub unsafe fn default_abi() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -222,11 +186,11 @@ LL | pub unsafe fn default_abi() {
    = note: `#[warn(undefined_naked_function_abi)]` on by default
 
 warning: Rust ABI is unsupported in naked functions
-  --> $DIR/naked-functions.rs:131:1
+  --> $DIR/naked-functions.rs:132:1
    |
 LL | pub unsafe fn rust_abi() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 27 previous errors; 2 warnings emitted
+error: aborting due to 25 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0787`.

--- a/tests/ui/asm/naked-functions.stderr
+++ b/tests/ui/asm/naked-functions.stderr
@@ -74,9 +74,7 @@ error[E0787]: the `asm!` macro is not allowed in naked functions
   --> $DIR/naked-functions.rs:13:5
    |
 LL |     asm!("", options(raw));
-   |     ----^^^^^^^^^^^^^^^^^^
-   |     |
-   |     help: consider using the `naked_asm!` macro instead: `naked_asm!`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ consider using the `naked_asm!` macro instead
 
 error: patterns not allowed in naked function parameters
   --> $DIR/naked-functions.rs:25:5

--- a/tests/ui/asm/naked-functions.stderr
+++ b/tests/ui/asm/naked-functions.stderr
@@ -1,8 +1,50 @@
-error: asm with the `pure` option must have at least one output
-  --> $DIR/naked-functions.rs:112:14
+error: the `in` operand cannot be used with `naked_asm!`
+  --> $DIR/naked-functions.rs:41:29
    |
-LL |     asm!("", options(readonly, nostack), options(pure));
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^
+LL |     naked_asm!("/* {0} */", in(reg) a, options(noreturn))
+   |                             ^^ the `in` operand is not meaningful for global-scoped inline assembly, remove it
+
+error: the `in` operand cannot be used with `naked_asm!`
+  --> $DIR/naked-functions.rs:62:10
+   |
+LL |          in(reg) a,
+   |          ^^ the `in` operand is not meaningful for global-scoped inline assembly, remove it
+
+error: the `nomem` option cannot be used with `naked_asm!`
+  --> $DIR/naked-functions.rs:104:28
+   |
+LL |     naked_asm!("", options(nomem, preserves_flags, noreturn));
+   |                            ^^^^^ the `nomem` option is not meaningful for global-scoped inline assembly
+
+error: the `preserves_flags` option cannot be used with `naked_asm!`
+  --> $DIR/naked-functions.rs:104:35
+   |
+LL |     naked_asm!("", options(nomem, preserves_flags, noreturn));
+   |                                   ^^^^^^^^^^^^^^^ the `preserves_flags` option is not meaningful for global-scoped inline assembly
+
+error: the `readonly` option cannot be used with `naked_asm!`
+  --> $DIR/naked-functions.rs:111:28
+   |
+LL |     naked_asm!("", options(readonly, nostack), options(pure));
+   |                            ^^^^^^^^ the `readonly` option is not meaningful for global-scoped inline assembly
+
+error: the `nostack` option cannot be used with `naked_asm!`
+  --> $DIR/naked-functions.rs:111:38
+   |
+LL |     naked_asm!("", options(readonly, nostack), options(pure));
+   |                                      ^^^^^^^ the `nostack` option is not meaningful for global-scoped inline assembly
+
+error: the `pure` option cannot be used with `naked_asm!`
+  --> $DIR/naked-functions.rs:111:56
+   |
+LL |     naked_asm!("", options(readonly, nostack), options(pure));
+   |                                                        ^^^^ the `pure` option is not meaningful for global-scoped inline assembly
+
+error: the `may_unwind` option cannot be used with `naked_asm!`
+  --> $DIR/naked-functions.rs:120:38
+   |
+LL |     naked_asm!("", options(noreturn, may_unwind));
+   |                                      ^^^^^^^^^^ the `may_unwind` option is not meaningful for global-scoped inline assembly
 
 error: this is a user specified error
   --> $DIR/naked-functions.rs:168:5
@@ -17,10 +59,10 @@ LL |     compile_error!("this is a user specified error");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: asm template must be a string literal
-  --> $DIR/naked-functions.rs:181:10
+  --> $DIR/naked-functions.rs:181:16
    |
-LL |     asm!(invalid_syntax)
-   |          ^^^^^^^^^^^^^^
+LL |     naked_asm!(invalid_syntax)
+   |                ^^^^^^^^^^^^^^
 
 error: patterns not allowed in naked function parameters
   --> $DIR/naked-functions.rs:19:5
@@ -63,22 +105,8 @@ LL |
 LL |     a + 1
    |     ----- non-asm is unsupported in naked functions
 
-error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:41:31
-   |
-LL |     asm!("/* {0} */", in(reg) a, options(noreturn));
-   |                               ^
-   |
-   = help: follow the calling convention in asm block to use parameters
-
-error[E0787]: only `const` and `sym` operands are supported in naked functions
-  --> $DIR/naked-functions.rs:41:23
-   |
-LL |     asm!("/* {0} */", in(reg) a, options(noreturn));
-   |                       ^^^^^^^^^
-
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:47:1
+  --> $DIR/naked-functions.rs:46:1
    |
 LL | pub unsafe extern "C" fn inc_closure(a: u32) -> u32 {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -86,40 +114,8 @@ LL |
 LL |     (|| a + 1)()
    |     ------------ non-asm is unsupported in naked functions
 
-error[E0787]: only `const` and `sym` operands are supported in naked functions
-  --> $DIR/naked-functions.rs:64:10
-   |
-LL |          in(reg) a,
-   |          ^^^^^^^^^
-LL |
-LL |          inlateout(reg) b,
-   |          ^^^^^^^^^^^^^^^^
-LL |          inout(reg) c,
-   |          ^^^^^^^^^^^^
-LL |          lateout(reg) d,
-   |          ^^^^^^^^^^^^^^
-LL |          out(reg) e,
-   |          ^^^^^^^^^^
-
-error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:62:5
-   |
-LL | /     asm!("/* {0} {1} {2} {3} {4} {5} {6} */",
-LL | |
-LL | |          in(reg) a,
-LL | |
-...  |
-LL | |          sym G,
-LL | |     );
-   | |_____^
-   |
-help: consider specifying that the asm block is responsible for returning from the function
-   |
-LL |          sym G, options(noreturn),
-   |               +++++++++++++++++++
-
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:53:1
+  --> $DIR/naked-functions.rs:52:1
    |
 LL | pub unsafe extern "C" fn unsupported_operands() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,61 +132,61 @@ LL |     let mut e = 0usize;
    |     ------------------- non-asm is unsupported in naked functions
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:76:1
+  --> $DIR/naked-functions.rs:74:1
    |
 LL | pub extern "C" fn missing_assembly() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:84:9
+  --> $DIR/naked-functions.rs:82:9
    |
-LL |         asm!("");
-   |         ^^^^^^^^
+LL |         naked_asm!("");
+   |         ^^^^^^^^^^^^^^
    |
 help: consider specifying that the asm block is responsible for returning from the function
    |
-LL |         asm!("", options(noreturn));
-   |                +++++++++++++++++++
+LL |         naked_asm!("", options(noreturn));
+   |                      +++++++++++++++++++
+
+error[E0787]: asm in naked functions must use `noreturn` option
+  --> $DIR/naked-functions.rs:84:9
+   |
+LL |         naked_asm!("");
+   |         ^^^^^^^^^^^^^^
+   |
+help: consider specifying that the asm block is responsible for returning from the function
+   |
+LL |         naked_asm!("", options(noreturn));
+   |                      +++++++++++++++++++
 
 error[E0787]: asm in naked functions must use `noreturn` option
   --> $DIR/naked-functions.rs:86:9
    |
-LL |         asm!("");
-   |         ^^^^^^^^
+LL |         naked_asm!("");
+   |         ^^^^^^^^^^^^^^
    |
 help: consider specifying that the asm block is responsible for returning from the function
    |
-LL |         asm!("", options(noreturn));
-   |                +++++++++++++++++++
-
-error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:88:9
-   |
-LL |         asm!("");
-   |         ^^^^^^^^
-   |
-help: consider specifying that the asm block is responsible for returning from the function
-   |
-LL |         asm!("", options(noreturn));
-   |                +++++++++++++++++++
+LL |         naked_asm!("", options(noreturn));
+   |                      +++++++++++++++++++
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:81:1
+  --> $DIR/naked-functions.rs:79:1
    |
 LL | pub extern "C" fn too_many_asm_blocks() {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-LL |         asm!("");
-   |         -------- multiple asm blocks are unsupported in naked functions
+LL |         naked_asm!("");
+   |         -------------- multiple asm blocks are unsupported in naked functions
 LL |
-LL |         asm!("");
-   |         -------- multiple asm blocks are unsupported in naked functions
+LL |         naked_asm!("");
+   |         -------------- multiple asm blocks are unsupported in naked functions
 LL |
-LL |         asm!("", options(noreturn));
-   |         --------------------------- multiple asm blocks are unsupported in naked functions
+LL |         naked_asm!("", options(noreturn));
+   |         --------------------------------- multiple asm blocks are unsupported in naked functions
 
 error: referencing function parameters is not allowed in naked functions
-  --> $DIR/naked-functions.rs:98:11
+  --> $DIR/naked-functions.rs:96:11
    |
 LL |         *&y
    |           ^
@@ -198,7 +194,7 @@ LL |         *&y
    = help: follow the calling convention in asm block to use parameters
 
 error[E0787]: naked functions must contain a single asm block
-  --> $DIR/naked-functions.rs:96:5
+  --> $DIR/naked-functions.rs:94:5
    |
 LL |     pub extern "C" fn inner(y: usize) -> usize {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -206,34 +202,16 @@ LL |
 LL |         *&y
    |         --- non-asm is unsupported in naked functions
 
-error[E0787]: asm options unsupported in naked functions: `nomem`, `preserves_flags`
-  --> $DIR/naked-functions.rs:106:5
-   |
-LL |     asm!("", options(nomem, preserves_flags, noreturn));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error[E0787]: asm options unsupported in naked functions: `pure`, `readonly`, `nostack`
-  --> $DIR/naked-functions.rs:112:5
-   |
-LL |     asm!("", options(readonly, nostack), options(pure));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error[E0787]: asm in naked functions must use `noreturn` option
-  --> $DIR/naked-functions.rs:112:5
+  --> $DIR/naked-functions.rs:111:5
    |
-LL |     asm!("", options(readonly, nostack), options(pure));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     naked_asm!("", options(readonly, nostack), options(pure));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: consider specifying that the asm block is responsible for returning from the function
    |
-LL |     asm!("", options(noreturn), options(readonly, nostack), options(pure));
-   |            +++++++++++++++++++
-
-error[E0787]: asm options unsupported in naked functions: `may_unwind`
-  --> $DIR/naked-functions.rs:120:5
-   |
-LL |     asm!("", options(noreturn, may_unwind));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     naked_asm!("", options(noreturn), options(readonly, nostack), options(pure));
+   |                  +++++++++++++++++++
 
 warning: Rust ABI is unsupported in naked functions
   --> $DIR/naked-functions.rs:125:1

--- a/tests/ui/asm/naked-invalid-attr.rs
+++ b/tests/ui/asm/naked-invalid-attr.rs
@@ -4,7 +4,7 @@
 #![feature(naked_functions)]
 #![naked] //~ ERROR should be applied to a function definition
 
-use std::arch::asm;
+use std::arch::naked_asm;
 
 extern "C" {
     #[naked] //~ ERROR should be applied to a function definition
@@ -26,27 +26,28 @@ trait Invoke {
 impl Invoke for S {
     #[naked]
     extern "C" fn invoke(&self) {
-        unsafe { asm!("", options(noreturn)) }
+        unsafe { naked_asm!("") }
     }
 }
 
 #[naked]
 extern "C" fn ok() {
-    unsafe { asm!("", options(noreturn)) }
+    unsafe { naked_asm!("") }
 }
 
 impl S {
     #[naked]
     extern "C" fn g() {
-        unsafe { asm!("", options(noreturn)) }
+        unsafe { naked_asm!("") }
     }
 
     #[naked]
     extern "C" fn h(&self) {
-        unsafe { asm!("", options(noreturn)) }
+        unsafe { naked_asm!("") }
     }
 }
 
 fn main() {
-    #[naked] || {}; //~ ERROR should be applied to a function definition
+    #[naked] //~ ERROR should be applied to a function definition
+    || {};
 }

--- a/tests/ui/asm/naked-invalid-attr.stderr
+++ b/tests/ui/asm/naked-invalid-attr.stderr
@@ -13,8 +13,10 @@ LL | | }
 error: attribute should be applied to a function definition
   --> $DIR/naked-invalid-attr.rs:51:5
    |
-LL |     #[naked] || {};
-   |     ^^^^^^^^ ----- not a function definition
+LL |     #[naked]
+   |     ^^^^^^^^
+LL |     || {};
+   |     ----- not a function definition
 
 error: attribute should be applied to a function definition
   --> $DIR/naked-invalid-attr.rs:22:5

--- a/tests/ui/asm/naked-with-invalid-repr-attr.rs
+++ b/tests/ui/asm/naked-with-invalid-repr-attr.rs
@@ -2,14 +2,14 @@
 #![feature(naked_functions)]
 #![feature(fn_align)]
 #![crate_type = "lib"]
-use std::arch::asm;
+use std::arch::naked_asm;
 
 #[repr(C)]
 //~^ ERROR attribute should be applied to a struct, enum, or union [E0517]
 #[naked]
 extern "C" fn example1() {
     //~^ NOTE not a struct, enum, or union
-    unsafe { asm!("", options(noreturn)) }
+    unsafe { naked_asm!("") }
 }
 
 #[repr(transparent)]
@@ -17,7 +17,7 @@ extern "C" fn example1() {
 #[naked]
 extern "C" fn example2() {
     //~^ NOTE not a struct, enum, or union
-    unsafe { asm!("", options(noreturn)) }
+    unsafe { naked_asm!("") }
 }
 
 #[repr(align(16), C)]
@@ -25,7 +25,7 @@ extern "C" fn example2() {
 #[naked]
 extern "C" fn example3() {
     //~^ NOTE not a struct, enum, or union
-    unsafe { asm!("", options(noreturn)) }
+    unsafe { naked_asm!("") }
 }
 
 // note: two errors because of packed and C
@@ -36,7 +36,7 @@ extern "C" fn example3() {
 extern "C" fn example4() {
     //~^ NOTE not a struct, enum, or union
     //~| NOTE not a struct or union
-    unsafe { asm!("", options(noreturn)) }
+    unsafe { naked_asm!("") }
 }
 
 #[repr(u8)]
@@ -44,5 +44,5 @@ extern "C" fn example4() {
 #[naked]
 extern "C" fn example5() {
     //~^ NOTE not an enum
-    unsafe { asm!("", options(noreturn)) }
+    unsafe { naked_asm!("") }
 }

--- a/tests/ui/asm/naked-with-invalid-repr-attr.stderr
+++ b/tests/ui/asm/naked-with-invalid-repr-attr.stderr
@@ -6,7 +6,7 @@ LL |   #[repr(C)]
 ...
 LL | / extern "C" fn example1() {
 LL | |
-LL | |     unsafe { asm!("", options(noreturn)) }
+LL | |     unsafe { naked_asm!("") }
 LL | | }
    | |_- not a struct, enum, or union
 
@@ -18,7 +18,7 @@ LL |   #[repr(transparent)]
 ...
 LL | / extern "C" fn example2() {
 LL | |
-LL | |     unsafe { asm!("", options(noreturn)) }
+LL | |     unsafe { naked_asm!("") }
 LL | | }
    | |_- not a struct, enum, or union
 
@@ -30,7 +30,7 @@ LL |   #[repr(align(16), C)]
 ...
 LL | / extern "C" fn example3() {
 LL | |
-LL | |     unsafe { asm!("", options(noreturn)) }
+LL | |     unsafe { naked_asm!("") }
 LL | | }
    | |_- not a struct, enum, or union
 
@@ -43,7 +43,7 @@ LL |   #[repr(C, packed)]
 LL | / extern "C" fn example4() {
 LL | |
 LL | |
-LL | |     unsafe { asm!("", options(noreturn)) }
+LL | |     unsafe { naked_asm!("") }
 LL | | }
    | |_- not a struct, enum, or union
 
@@ -56,7 +56,7 @@ LL |   #[repr(C, packed)]
 LL | / extern "C" fn example4() {
 LL | |
 LL | |
-LL | |     unsafe { asm!("", options(noreturn)) }
+LL | |     unsafe { naked_asm!("") }
 LL | | }
    | |_- not a struct or union
 
@@ -68,7 +68,7 @@ LL |   #[repr(u8)]
 ...
 LL | / extern "C" fn example5() {
 LL | |
-LL | |     unsafe { asm!("", options(noreturn)) }
+LL | |     unsafe { naked_asm!("") }
 LL | | }
    | |_- not an enum
 

--- a/tests/ui/asm/named-asm-labels.rs
+++ b/tests/ui/asm/named-asm-labels.rs
@@ -12,7 +12,7 @@
 
 #![feature(naked_functions)]
 
-use std::arch::{asm, global_asm};
+use std::arch::{asm, global_asm, naked_asm};
 
 #[no_mangle]
 pub static FOO: usize = 42;
@@ -177,7 +177,7 @@ fn main() {
 // label or LTO can cause labels to break
 #[naked]
 pub extern "C" fn foo() -> i32 {
-    unsafe { asm!(".Lfoo: mov rax, {}; ret;", "nop", const 1, options(noreturn)) }
+    unsafe { naked_asm!(".Lfoo: mov rax, {}; ret;", "nop", const 1) }
     //~^ ERROR avoid using named labels
 }
 
@@ -192,7 +192,7 @@ pub extern "C" fn bar() {
 pub extern "C" fn aaa() {
     fn _local() {}
 
-    unsafe { asm!(".Laaa: nop; ret;", options(noreturn)) } //~ ERROR avoid using named labels
+    unsafe { naked_asm!(".Laaa: nop; ret;") } //~ ERROR avoid using named labels
 }
 
 pub fn normal() {
@@ -202,7 +202,7 @@ pub fn normal() {
     pub extern "C" fn bbb() {
         fn _very_local() {}
 
-        unsafe { asm!(".Lbbb: nop; ret;", options(noreturn)) } //~ ERROR avoid using named labels
+        unsafe { naked_asm!(".Lbbb: nop; ret;") } //~ ERROR avoid using named labels
     }
 
     fn _local2() {}
@@ -221,7 +221,7 @@ fn closures() {
     || {
         #[naked]
         unsafe extern "C" fn _nested() {
-            asm!("ret;", options(noreturn));
+            naked_asm!("ret;");
         }
 
         unsafe {

--- a/tests/ui/asm/named-asm-labels.stderr
+++ b/tests/ui/asm/named-asm-labels.stderr
@@ -475,10 +475,10 @@ LL |         #[warn(named_asm_labels)]
    |                ^^^^^^^^^^^^^^^^
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:180:20
+  --> $DIR/named-asm-labels.rs:180:26
    |
-LL |     unsafe { asm!(".Lfoo: mov rax, {}; ret;", "nop", const 1, options(noreturn)) }
-   |                    ^^^^^
+LL |     unsafe { naked_asm!(".Lfoo: mov rax, {}; ret;", "nop", const 1) }
+   |                          ^^^^^
    |
    = help: only local labels of the form `<number>:` should be used in inline asm
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
@@ -493,19 +493,19 @@ LL |     unsafe { asm!(".Lbar: mov rax, {}; ret;", "nop", const 1, options(noret
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:195:20
+  --> $DIR/named-asm-labels.rs:195:26
    |
-LL |     unsafe { asm!(".Laaa: nop; ret;", options(noreturn)) }
-   |                    ^^^^^
+LL |     unsafe { naked_asm!(".Laaa: nop; ret;") }
+   |                          ^^^^^
    |
    = help: only local labels of the form `<number>:` should be used in inline asm
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information
 
 error: avoid using named labels in inline assembly
-  --> $DIR/named-asm-labels.rs:205:24
+  --> $DIR/named-asm-labels.rs:205:30
    |
-LL |         unsafe { asm!(".Lbbb: nop; ret;", options(noreturn)) }
-   |                        ^^^^^
+LL |         unsafe { naked_asm!(".Lbbb: nop; ret;") }
+   |                              ^^^^^
    |
    = help: only local labels of the form `<number>:` should be used in inline asm
    = note: see the asm section of Rust By Example <https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html#labels> for more information

--- a/tests/ui/feature-gates/feature-gate-naked_functions.rs
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.rs
@@ -1,19 +1,22 @@
 //@ needs-asm-support
 
-use std::arch::asm;
+use std::arch::naked_asm;
+//~^ ERROR use of unstable library feature 'naked_functions'
 
 #[naked]
 //~^ the `#[naked]` attribute is an experimental feature
 extern "C" fn naked() {
     naked_asm!("", options(noreturn))
-    //~^ ERROR: requires unsafe
+    //~^ ERROR use of unstable library feature 'naked_functions'
+    //~| ERROR: requires unsafe
 }
 
 #[naked]
 //~^ the `#[naked]` attribute is an experimental feature
 extern "C" fn naked_2() -> isize {
     naked_asm!("", options(noreturn))
-    //~^ ERROR: requires unsafe
+    //~^ ERROR use of unstable library feature 'naked_functions'
+    //~| ERROR: requires unsafe
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-naked_functions.rs
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.rs
@@ -5,14 +5,14 @@ use std::arch::asm;
 #[naked]
 //~^ the `#[naked]` attribute is an experimental feature
 extern "C" fn naked() {
-    asm!("", options(noreturn))
+    naked_asm!("", options(noreturn))
     //~^ ERROR: requires unsafe
 }
 
 #[naked]
 //~^ the `#[naked]` attribute is an experimental feature
 extern "C" fn naked_2() -> isize {
-    asm!("", options(noreturn))
+    naked_asm!("", options(noreturn))
     //~^ ERROR: requires unsafe
 }
 

--- a/tests/ui/feature-gates/feature-gate-naked_functions.rs
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.rs
@@ -6,7 +6,7 @@ use std::arch::naked_asm;
 #[naked]
 //~^ the `#[naked]` attribute is an experimental feature
 extern "C" fn naked() {
-    naked_asm!("", options(noreturn))
+    naked_asm!("")
     //~^ ERROR use of unstable library feature 'naked_functions'
     //~| ERROR: requires unsafe
 }
@@ -14,7 +14,7 @@ extern "C" fn naked() {
 #[naked]
 //~^ the `#[naked]` attribute is an experimental feature
 extern "C" fn naked_2() -> isize {
-    naked_asm!("", options(noreturn))
+    naked_asm!("")
     //~^ ERROR use of unstable library feature 'naked_functions'
     //~| ERROR: requires unsafe
 }

--- a/tests/ui/feature-gates/feature-gate-naked_functions.stderr
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.stderr
@@ -1,5 +1,25 @@
+error[E0658]: use of unstable library feature 'naked_functions'
+  --> $DIR/feature-gate-naked_functions.rs:9:5
+   |
+LL |     naked_asm!("", options(noreturn))
+   |     ^^^^^^^^^
+   |
+   = note: see issue #90957 <https://github.com/rust-lang/rust/issues/90957> for more information
+   = help: add `#![feature(naked_functions)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature 'naked_functions'
+  --> $DIR/feature-gate-naked_functions.rs:17:5
+   |
+LL |     naked_asm!("", options(noreturn))
+   |     ^^^^^^^^^
+   |
+   = note: see issue #90957 <https://github.com/rust-lang/rust/issues/90957> for more information
+   = help: add `#![feature(naked_functions)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: the `#[naked]` attribute is an experimental feature
-  --> $DIR/feature-gate-naked_functions.rs:5:1
+  --> $DIR/feature-gate-naked_functions.rs:6:1
    |
 LL | #[naked]
    | ^^^^^^^^
@@ -9,7 +29,7 @@ LL | #[naked]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: the `#[naked]` attribute is an experimental feature
-  --> $DIR/feature-gate-naked_functions.rs:12:1
+  --> $DIR/feature-gate-naked_functions.rs:14:1
    |
 LL | #[naked]
    | ^^^^^^^^
@@ -18,23 +38,33 @@ LL | #[naked]
    = help: add `#![feature(naked_functions)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
-  --> $DIR/feature-gate-naked_functions.rs:8:5
+error[E0658]: use of unstable library feature 'naked_functions'
+  --> $DIR/feature-gate-naked_functions.rs:3:5
    |
-LL |     asm!("", options(noreturn))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of inline assembly
+LL | use std::arch::naked_asm;
+   |     ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #90957 <https://github.com/rust-lang/rust/issues/90957> for more information
+   = help: add `#![feature(naked_functions)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
+  --> $DIR/feature-gate-naked_functions.rs:9:5
+   |
+LL |     naked_asm!("", options(noreturn))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of inline assembly
    |
    = note: inline assembly is entirely unchecked and can cause undefined behavior
 
 error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
-  --> $DIR/feature-gate-naked_functions.rs:15:5
+  --> $DIR/feature-gate-naked_functions.rs:17:5
    |
-LL |     asm!("", options(noreturn))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of inline assembly
+LL |     naked_asm!("", options(noreturn))
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of inline assembly
    |
    = note: inline assembly is entirely unchecked and can cause undefined behavior
 
-error: aborting due to 4 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0133, E0658.
 For more information about an error, try `rustc --explain E0133`.

--- a/tests/ui/feature-gates/feature-gate-naked_functions.stderr
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.stderr
@@ -1,7 +1,7 @@
 error[E0658]: use of unstable library feature 'naked_functions'
   --> $DIR/feature-gate-naked_functions.rs:9:5
    |
-LL |     naked_asm!("", options(noreturn))
+LL |     naked_asm!("")
    |     ^^^^^^^^^
    |
    = note: see issue #90957 <https://github.com/rust-lang/rust/issues/90957> for more information
@@ -11,7 +11,7 @@ LL |     naked_asm!("", options(noreturn))
 error[E0658]: use of unstable library feature 'naked_functions'
   --> $DIR/feature-gate-naked_functions.rs:17:5
    |
-LL |     naked_asm!("", options(noreturn))
+LL |     naked_asm!("")
    |     ^^^^^^^^^
    |
    = note: see issue #90957 <https://github.com/rust-lang/rust/issues/90957> for more information
@@ -51,16 +51,16 @@ LL | use std::arch::naked_asm;
 error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
   --> $DIR/feature-gate-naked_functions.rs:9:5
    |
-LL |     naked_asm!("", options(noreturn))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of inline assembly
+LL |     naked_asm!("")
+   |     ^^^^^^^^^^^^^^ use of inline assembly
    |
    = note: inline assembly is entirely unchecked and can cause undefined behavior
 
 error[E0133]: use of inline assembly is unsafe and requires unsafe function or block
   --> $DIR/feature-gate-naked_functions.rs:17:5
    |
-LL |     naked_asm!("", options(noreturn))
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of inline assembly
+LL |     naked_asm!("")
+   |     ^^^^^^^^^^^^^^ use of inline assembly
    |
    = note: inline assembly is entirely unchecked and can cause undefined behavior
 

--- a/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.rs
+++ b/tests/ui/rfcs/rfc-2091-track-caller/error-with-naked.rs
@@ -1,14 +1,14 @@
 //@ needs-asm-support
 #![feature(naked_functions)]
 
-use std::arch::asm;
+use std::arch::naked_asm;
 
 #[track_caller] //~ ERROR [E0736]
 //~^ ERROR `#[track_caller]` requires Rust ABI
 #[naked]
 extern "C" fn f() {
     unsafe {
-        asm!("", options(noreturn));
+        naked_asm!("");
     }
 }
 
@@ -20,7 +20,7 @@ impl S {
     #[naked]
     extern "C" fn g() {
         unsafe {
-            asm!("", options(noreturn));
+            naked_asm!("");
         }
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/128651)*
<!-- homu-ignore:end -->

tracking issue: https://github.com/rust-lang/rust/issues/90957

Adds the `core::arch::naked_asm` macro, to be used in `#[naked]` functions, but providing better error messages and a place to explain the restrictions on assembly in naked functions.

This PR does not yet require that the `naked_asm!` macro is used inside of `#[naked]` functions:

- the `asm!` macro can still be used in `#[naked]` functions currently, with the same restrictions and error messages as before.
- the `naked_asm!` macro can be used outside of `#[naked]` functions. It has not yet been decided whether that should be allowed long-term.

In this PR, the parsing code of `naked_asm!` now enforces the restrictions on assembly in naked functions, with the exception of checking that the `noreturn` option is specified. It also has not currently been decided if `noreturn` should be implicit or not.

This PR looks large because it touches a bunch of tests. The code changes are mostly straightforward I think: we now have 3 flavors of assembly macro, and that information must be propagated through the parsing code and error messages.

cc @Lokathor  

r? @Amanieu 