### PR TITLE
Enable msvc for run-make/rust-lld

### DIFF
--- a/tests/run-make/rust-lld/rmake.rs
+++ b/tests/run-make/rust-lld/rmake.rs
@@ -2,15 +2,17 @@
 // see https://github.com/rust-lang/compiler-team/issues/510 for more info
 
 //@ needs-rust-lld
-//@ ignore-msvc
 //@ ignore-s390x lld does not yet support s390x as target
 
 use std::process::Output;
 
 use run_make_support::regex::Regex;
-use run_make_support::rustc;
+use run_make_support::{is_msvc, rustc};
 
 fn main() {
+    // lld-link is used if msvc, otherwise a gnu-compatible lld is used.
+    let linker_version_flag = if is_msvc() { "--version" } else { "-Wl,-v" };
+
     // Opt-in to lld and the self-contained linker, to link with rust-lld. We'll check that by
     // asking the linker to display its version number with a link-arg.
     let output = rustc()
@@ -18,7 +20,7 @@ fn main() {
         .arg("-Zlinker-features=+lld")
         .arg("-Clink-self-contained=+linker")
         .arg("-Zunstable-options")
-        .link_arg("-Wl,-v")
+        .link_arg(linker_version_flag)
         .input("main.rs")
         .run();
     assert!(
@@ -27,10 +29,10 @@ fn main() {
         output.stderr_utf8()
     );
 
-    // It should not be used when we explictly opt-out of lld.
+    // It should not be used when we explicitly opt-out of lld.
     let output = rustc()
         .env("RUSTC_LOG", "rustc_codegen_ssa::back::link=info")
-        .link_arg("-Wl,-v")
+        .link_arg(linker_version_flag)
         .arg("-Zlinker-features=-lld")
         .input("main.rs")
         .run();
@@ -44,7 +46,7 @@ fn main() {
     // times to rustc.
     let output = rustc()
         .env("RUSTC_LOG", "rustc_codegen_ssa::back::link=info")
-        .link_arg("-Wl,-v")
+        .link_arg(linker_version_flag)
         .arg("-Clink-self-contained=+linker")
         .arg("-Zunstable-options")
         .arg("-Zlinker-features=-lld")


### PR DESCRIPTION
This is simply a matter of using the right argument for lld-link.

As a bonus, I also fixed a typo.

try-job: i686-msvc
try-job: x86_64-msvc