### PR TITLE
linker: when emitting static executables, explicitly hint static

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -480,6 +480,10 @@ impl<'a> Linker for GccLinker<'a> {
                 }
             }
             LinkOutputKind::StaticNoPicExe => {
+                // Hint static again, as we would otherwise emit
+                // a dynamically linked executable with no interp
+                // (due to libc/builtins wrongly being linked dynamically)
+                self.hint_static();
                 // `-static` works for both gcc wrapper and ld.
                 self.link_or_cc_arg("-static");
                 if !self.is_ld && self.is_gnu {
@@ -487,6 +491,8 @@ impl<'a> Linker for GccLinker<'a> {
                 }
             }
             LinkOutputKind::StaticPicExe => {
+                // See the StaticNoPicExe case above
+                self.hint_static();
                 if !self.is_ld {
                     // Note that combination `-static -pie` doesn't work as expected
                     // for the gcc wrapper, `-static` in that case suppresses `-pie`.
@@ -502,6 +508,8 @@ impl<'a> Linker for GccLinker<'a> {
             }
             LinkOutputKind::DynamicDylib => self.build_dylib(out_filename),
             LinkOutputKind::StaticDylib => {
+                // Ditto
+                self.hint_static();
                 self.link_or_cc_arg("-static");
                 self.build_dylib(out_filename);
             }


### PR DESCRIPTION
This is important as rustc is not always in charge of what it is linking (due to some targets not necessarily passing -nodefaultlibs) and it assumes that resetting to dynamic is always the default.

This would result in executables that have no interpreter but are still dynamically linked (despite static being requested).

By explicitly hinting static again before passing the -static or -static-pie, we tell the linker to always link whatever implicit libs statically as expected.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
