### PR TITLE
rustdoc: normalise type/field names

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -156,7 +156,7 @@ impl FromWithTcx<clean::GenericArgs> for GenericArgs {
         match args {
             AngleBracketed { args, constraints } => GenericArgs::AngleBracketed {
                 args: args.into_vec().into_tcx(tcx),
-                bindings: constraints.into_tcx(tcx),
+                constraints: constraints.into_tcx(tcx),
             },
             Parenthesized { inputs, output } => GenericArgs::Parenthesized {
                 inputs: inputs.into_vec().into_tcx(tcx),
@@ -198,9 +198,9 @@ impl FromWithTcx<clean::ConstantKind> for Constant {
     }
 }
 
-impl FromWithTcx<clean::AssocItemConstraint> for TypeBinding {
+impl FromWithTcx<clean::AssocItemConstraint> for AssocItemConstraint {
     fn from_tcx(constraint: clean::AssocItemConstraint, tcx: TyCtxt<'_>) -> Self {
-        TypeBinding {
+        AssocItemConstraint {
             name: constraint.assoc.name.to_string(),
             args: constraint.assoc.args.into_tcx(tcx),
             binding: constraint.kind.into_tcx(tcx),
@@ -208,12 +208,12 @@ impl FromWithTcx<clean::AssocItemConstraint> for TypeBinding {
     }
 }
 
-impl FromWithTcx<clean::AssocItemConstraintKind> for TypeBindingKind {
+impl FromWithTcx<clean::AssocItemConstraintKind> for AssocItemConstraintKind {
     fn from_tcx(kind: clean::AssocItemConstraintKind, tcx: TyCtxt<'_>) -> Self {
         use clean::AssocItemConstraintKind::*;
         match kind {
-            Equality { term } => TypeBindingKind::Equality(term.into_tcx(tcx)),
-            Bound { bounds } => TypeBindingKind::Constraint(bounds.into_tcx(tcx)),
+            Equality { term } => AssocItemConstraintKind::Equality(term.into_tcx(tcx)),
+            Bound { bounds } => AssocItemConstraintKind::Constraint(bounds.into_tcx(tcx)),
         }
     }
 }
@@ -314,7 +314,7 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
         ModuleItem(m) => {
             ItemEnum::Module(Module { is_crate, items: ids(m.items, tcx), is_stripped: false })
         }
-        ImportItem(i) => ItemEnum::Import(i.into_tcx(tcx)),
+        ImportItem(i) => ItemEnum::Use(i.into_tcx(tcx)),
         StructItem(s) => ItemEnum::Struct(s.into_tcx(tcx)),
         UnionItem(u) => ItemEnum::Union(u.into_tcx(tcx)),
         StructFieldItem(f) => ItemEnum::StructField(f.into_tcx(tcx)),
@@ -331,7 +331,7 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
         ImplItem(i) => ItemEnum::Impl((*i).into_tcx(tcx)),
         StaticItem(s) => ItemEnum::Static(s.into_tcx(tcx)),
         ForeignStaticItem(s, _) => ItemEnum::Static(s.into_tcx(tcx)),
-        ForeignTypeItem => ItemEnum::ForeignType,
+        ForeignTypeItem => ItemEnum::ExternType,
         TypeAliasItem(t) => ItemEnum::TypeAlias(t.into_tcx(tcx)),
         // FIXME(generic_const_items): Add support for generic free consts
         ConstantItem(ci) => {
@@ -347,21 +347,19 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
         }
         // FIXME(generic_const_items): Add support for generic associated consts.
         TyAssocConstItem(_generics, ty) => {
-            ItemEnum::AssocConst { type_: (*ty).into_tcx(tcx), default: None }
+            ItemEnum::AssocConst { type_: (*ty).into_tcx(tcx), value: None }
         }
         // FIXME(generic_const_items): Add support for generic associated consts.
         AssocConstItem(ci) => {
-            ItemEnum::AssocConst { type_: ci.type_.into_tcx(tcx), default: Some(ci.kind.expr(tcx)) }
+            ItemEnum::AssocConst { type_: ci.type_.into_tcx(tcx), value: Some(ci.kind.expr(tcx)) }
         }
-        TyAssocTypeItem(g, b) => ItemEnum::AssocType {
-            generics: g.into_tcx(tcx),
-            bounds: b.into_tcx(tcx),
-            default: None,
-        },
+        TyAssocTypeItem(g, b) => {
+            ItemEnum::AssocType { generics: g.into_tcx(tcx), bounds: b.into_tcx(tcx), type_: None }
+        }
         AssocTypeItem(t, b) => ItemEnum::AssocType {
             generics: t.generics.into_tcx(tcx),
             bounds: b.into_tcx(tcx),
-            default: Some(t.item_type.unwrap_or(t.type_).into_tcx(tcx)),
+            type_: Some(t.item_type.unwrap_or(t.type_).into_tcx(tcx)),
         },
         // `convert_item` early returns `None` for stripped items and keywords.
         KeywordItem => unreachable!(),
@@ -385,7 +383,7 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
 
 impl FromWithTcx<clean::Struct> for Struct {
     fn from_tcx(struct_: clean::Struct, tcx: TyCtxt<'_>) -> Self {
-        let fields_stripped = struct_.has_stripped_entries();
+        let has_stripped_fields = struct_.has_stripped_entries();
         let clean::Struct { ctor_kind, generics, fields } = struct_;
 
         let kind = match ctor_kind {
@@ -394,7 +392,7 @@ impl FromWithTcx<clean::Struct> for Struct {
                 assert!(fields.is_empty());
                 StructKind::Unit
             }
-            None => StructKind::Plain { fields: ids(fields, tcx), fields_stripped },
+            None => StructKind::Plain { fields: ids(fields, tcx), has_stripped_fields },
         };
 
         Struct {
@@ -407,22 +405,22 @@ impl FromWithTcx<clean::Struct> for Struct {
 
 impl FromWithTcx<clean::Union> for Union {
     fn from_tcx(union_: clean::Union, tcx: TyCtxt<'_>) -> Self {
-        let fields_stripped = union_.has_stripped_entries();
+        let has_stripped_fields = union_.has_stripped_entries();
         let clean::Union { generics, fields } = union_;
         Union {
             generics: generics.into_tcx(tcx),
-            fields_stripped,
+            has_stripped_fields,
             fields: ids(fields, tcx),
             impls: Vec::new(), // Added in JsonRenderer::item
         }
     }
 }
 
-pub(crate) fn from_fn_header(header: &rustc_hir::FnHeader) -> Header {
-    Header {
-        async_: header.is_async(),
-        const_: header.is_const(),
-        unsafe_: header.is_unsafe(),
+pub(crate) fn from_fn_header(header: &rustc_hir::FnHeader) -> FunctionHeader {
+    FunctionHeader {
+        is_async: header.is_async(),
+        is_const: header.is_const(),
+        is_unsafe: header.is_unsafe(),
         abi: convert_abi(header.abi),
     }
 }
@@ -474,7 +472,7 @@ impl FromWithTcx<clean::GenericParamDefKind> for GenericParamDefKind {
             Type { bounds, default, synthetic } => GenericParamDefKind::Type {
                 bounds: bounds.into_tcx(tcx),
                 default: default.map(|x| (*x).into_tcx(tcx)),
-                synthetic,
+                is_synthetic: synthetic,
             },
             Const { ty, default, synthetic: _ } => GenericParamDefKind::Const {
                 type_: (*ty).into_tcx(tcx),
@@ -508,7 +506,7 @@ impl FromWithTcx<clean::WherePredicate> for WherePredicate {
                                         .map(|bound| bound.into_tcx(tcx))
                                         .collect(),
                                     default: default.map(|ty| (*ty).into_tcx(tcx)),
-                                    synthetic,
+                                    is_synthetic: synthetic,
                                 }
                             }
                             clean::GenericParamDefKind::Const { ty, default, synthetic: _ } => {
@@ -602,12 +600,12 @@ impl FromWithTcx<clean::Type> for Type {
             ImplTrait(g) => Type::ImplTrait(g.into_tcx(tcx)),
             Infer => Type::Infer,
             RawPointer(mutability, type_) => Type::RawPointer {
-                mutable: mutability == ast::Mutability::Mut,
+                is_mutable: mutability == ast::Mutability::Mut,
                 type_: Box::new((*type_).into_tcx(tcx)),
             },
             BorrowedRef { lifetime, mutability, type_ } => Type::BorrowedRef {
                 lifetime: lifetime.map(convert_lifetime),
-                mutable: mutability == ast::Mutability::Mut,
+                is_mutable: mutability == ast::Mutability::Mut,
                 type_: Box::new((*type_).into_tcx(tcx)),
             },
             QPath(box clean::QPathData { assoc, self_type, trait_, .. }) => Type::QualifiedPath {
@@ -643,29 +641,29 @@ impl FromWithTcx<clean::BareFunctionDecl> for FunctionPointer {
     fn from_tcx(bare_decl: clean::BareFunctionDecl, tcx: TyCtxt<'_>) -> Self {
         let clean::BareFunctionDecl { safety, generic_params, decl, abi } = bare_decl;
         FunctionPointer {
-            header: Header {
-                unsafe_: matches!(safety, rustc_hir::Safety::Unsafe),
-                const_: false,
-                async_: false,
+            header: FunctionHeader {
+                is_unsafe: matches!(safety, rustc_hir::Safety::Unsafe),
+                is_const: false,
+                is_async: false,
                 abi: convert_abi(abi),
             },
             generic_params: generic_params.into_tcx(tcx),
-            decl: decl.into_tcx(tcx),
+            sig: decl.into_tcx(tcx),
         }
     }
 }
 
-impl FromWithTcx<clean::FnDecl> for FnDecl {
+impl FromWithTcx<clean::FnDecl> for FunctionSignature {
     fn from_tcx(decl: clean::FnDecl, tcx: TyCtxt<'_>) -> Self {
         let clean::FnDecl { inputs, output, c_variadic } = decl;
-        FnDecl {
+        FunctionSignature {
             inputs: inputs
                 .values
                 .into_iter()
                 .map(|arg| (arg.name.to_string(), arg.type_.into_tcx(tcx)))
                 .collect(),
             output: if output.is_unit() { None } else { Some(output.into_tcx(tcx)) },
-            c_variadic,
+            is_c_variadic: c_variadic,
         }
     }
 }
@@ -702,12 +700,12 @@ impl FromWithTcx<clean::Impl> for Impl {
         let provided_trait_methods = impl_.provided_trait_methods(tcx);
         let clean::Impl { safety, generics, trait_, for_, items, polarity, kind } = impl_;
         // FIXME: use something like ImplKind in JSON?
-        let (synthetic, blanket_impl) = match kind {
+        let (is_synthetic, blanket_impl) = match kind {
             clean::ImplKind::Normal | clean::ImplKind::FakeVariadic => (false, None),
             clean::ImplKind::Auto => (true, None),
             clean::ImplKind::Blanket(ty) => (false, Some(*ty)),
         };
-        let negative_polarity = match polarity {
+        let is_negative = match polarity {
             ty::ImplPolarity::Positive | ty::ImplPolarity::Reservation => false,
             ty::ImplPolarity::Negative => true,
         };
@@ -721,8 +719,8 @@ impl FromWithTcx<clean::Impl> for Impl {
             trait_: trait_.map(|path| path.into_tcx(tcx)),
             for_: for_.into_tcx(tcx),
             items: ids(items, tcx),
-            negative: negative_polarity,
-            synthetic,
+            is_negative,
+            is_synthetic,
             blanket_impl: blanket_impl.map(|x| x.into_tcx(tcx)),
         }
     }
@@ -736,7 +734,7 @@ pub(crate) fn from_function(
 ) -> Function {
     let clean::Function { decl, generics } = *function;
     Function {
-        decl: decl.into_tcx(tcx),
+        sig: decl.into_tcx(tcx),
         generics: generics.into_tcx(tcx),
         header: from_fn_header(&header),
         has_body,
@@ -745,11 +743,11 @@ pub(crate) fn from_function(
 
 impl FromWithTcx<clean::Enum> for Enum {
     fn from_tcx(enum_: clean::Enum, tcx: TyCtxt<'_>) -> Self {
-        let variants_stripped = enum_.has_stripped_entries();
+        let has_stripped_variants = enum_.has_stripped_entries();
         let clean::Enum { variants, generics } = enum_;
         Enum {
             generics: generics.into_tcx(tcx),
-            variants_stripped,
+            has_stripped_variants,
             variants: ids(variants, tcx),
             impls: Vec::new(), // Added in JsonRenderer::item
         }
@@ -766,7 +764,7 @@ impl FromWithTcx<clean::Variant> for Variant {
             CLike => VariantKind::Plain,
             Tuple(fields) => VariantKind::Tuple(ids_keeping_stripped(fields, tcx)),
             Struct(s) => VariantKind::Struct {
-                fields_stripped: s.has_stripped_entries(),
+                has_stripped_fields: s.has_stripped_entries(),
                 fields: ids(s.fields, tcx),
             },
         };
@@ -787,21 +785,21 @@ impl FromWithTcx<clean::Discriminant> for Discriminant {
     }
 }
 
-impl FromWithTcx<clean::Import> for Import {
+impl FromWithTcx<clean::Import> for Use {
     fn from_tcx(import: clean::Import, tcx: TyCtxt<'_>) -> Self {
         use clean::ImportKind::*;
-        let (name, glob) = match import.kind {
+        let (name, is_glob) = match import.kind {
             Simple(s) => (s.to_string(), false),
             Glob => (
                 import.source.path.last_opt().unwrap_or_else(|| Symbol::intern("*")).to_string(),
                 true,
             ),
         };
-        Import {
+        Use {
             source: import.source.path.whole_name(),
             name,
             id: import.source.did.map(ItemId::from).map(|i| id_from_item_default(i, tcx)),
-            glob,
+            is_glob,
         }
     }
 }
@@ -835,7 +833,7 @@ impl FromWithTcx<clean::Static> for Static {
     fn from_tcx(stat: clean::Static, tcx: TyCtxt<'_>) -> Self {
         Static {
             type_: (*stat.type_).into_tcx(tcx),
-            mutable: stat.mutability == ast::Mutability::Mut,
+            is_mutable: stat.mutability == ast::Mutability::Mut,
             expr: stat
                 .expr
                 .map(|e| rendered_const(tcx, tcx.hir().body(e), tcx.hir().body_owner_def_id(e)))
@@ -856,7 +854,7 @@ impl FromWithTcx<ItemType> for ItemKind {
         match kind {
             Module => ItemKind::Module,
             ExternCrate => ItemKind::ExternCrate,
-            Import => ItemKind::Import,
+            Import => ItemKind::Use,
             Struct => ItemKind::Struct,
             Union => ItemKind::Union,
             Enum => ItemKind::Enum,
@@ -872,7 +870,7 @@ impl FromWithTcx<ItemType> for ItemKind {
             Primitive => ItemKind::Primitive,
             AssocConst => ItemKind::AssocConst,
             AssocType => ItemKind::AssocType,
-            ForeignType => ItemKind::ForeignType,
+            ForeignType => ItemKind::ExternType,
             Keyword => ItemKind::Keyword,
             TraitAlias => ItemKind::TraitAlias,
             ProcAttribute => ItemKind::ProcAttribute,

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -197,7 +197,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
 
                 types::ItemEnum::Function(_)
                 | types::ItemEnum::Module(_)
-                | types::ItemEnum::Import(_)
+                | types::ItemEnum::Use(_)
                 | types::ItemEnum::AssocConst { .. }
                 | types::ItemEnum::AssocType { .. } => true,
                 types::ItemEnum::ExternCrate { .. }
@@ -208,7 +208,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
                 | types::ItemEnum::TypeAlias(_)
                 | types::ItemEnum::Constant { .. }
                 | types::ItemEnum::Static(_)
-                | types::ItemEnum::ForeignType
+                | types::ItemEnum::ExternType
                 | types::ItemEnum::Macro(_)
                 | types::ItemEnum::ProcMacro(_) => false,
             };

--- a/src/rustdoc-json-types/tests.rs
+++ b/src/rustdoc-json-types/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 fn test_struct_info_roundtrip() {
     let s = ItemEnum::Struct(Struct {
         generics: Generics { params: vec![], where_predicates: vec![] },
-        kind: StructKind::Plain { fields: vec![], fields_stripped: false },
+        kind: StructKind::Plain { fields: vec![], has_stripped_fields: false },
         impls: vec![],
     });
 
@@ -23,7 +23,7 @@ fn test_struct_info_roundtrip() {
 fn test_union_info_roundtrip() {
     let u = ItemEnum::Union(Union {
         generics: Generics { params: vec![], where_predicates: vec![] },
-        fields_stripped: false,
+        has_stripped_fields: false,
         fields: vec![],
         impls: vec![],
     });

--- a/src/tools/jsondoclint/src/item_kind.rs
+++ b/src/tools/jsondoclint/src/item_kind.rs
@@ -5,7 +5,7 @@ use rustdoc_json_types::{Item, ItemEnum, ItemKind, ItemSummary};
 pub(crate) enum Kind {
     Module,
     ExternCrate,
-    Import,
+    Use,
     Struct,
     StructField,
     Union,
@@ -18,7 +18,7 @@ pub(crate) enum Kind {
     TraitAlias,
     Impl,
     Static,
-    ForeignType,
+    ExternType,
     Macro,
     ProcAttribute,
     ProcDerive,
@@ -36,7 +36,7 @@ impl Kind {
         match self {
             Module => true,
             ExternCrate => true,
-            Import => true,
+            Use => true,
             Union => true,
             Struct => true,
             Enum => true,
@@ -50,7 +50,7 @@ impl Kind {
             Macro => true,
             ProcMacro => true,
             Primitive => true,
-            ForeignType => true,
+            ExternType => true,
 
             // FIXME(adotinthevoid): I'm not sure if these are correct
             Keyword => false,
@@ -69,7 +69,7 @@ impl Kind {
     pub fn can_appear_in_import(self) -> bool {
         match self {
             Kind::Variant => true,
-            Kind::Import => false,
+            Kind::Use => false,
             other => other.can_appear_in_mod(),
         }
     }
@@ -90,7 +90,7 @@ impl Kind {
 
             Kind::Module => false,
             Kind::ExternCrate => false,
-            Kind::Import => false,
+            Kind::Use => false,
             Kind::Struct => false,
             Kind::StructField => false,
             Kind::Union => false,
@@ -102,7 +102,7 @@ impl Kind {
             Kind::TraitAlias => false,
             Kind::Impl => false,
             Kind::Static => false,
-            Kind::ForeignType => false,
+            Kind::ExternType => false,
             Kind::Macro => false,
             Kind::ProcAttribute => false,
             Kind::ProcDerive => false,
@@ -135,7 +135,7 @@ impl Kind {
         use Kind::*;
         match i.inner {
             ItemEnum::Module(_) => Module,
-            ItemEnum::Import(_) => Import,
+            ItemEnum::Use(_) => Use,
             ItemEnum::Union(_) => Union,
             ItemEnum::Struct(_) => Struct,
             ItemEnum::StructField(_) => StructField,
@@ -151,7 +151,7 @@ impl Kind {
             ItemEnum::Macro(_) => Macro,
             ItemEnum::ProcMacro(_) => ProcMacro,
             ItemEnum::Primitive(_) => Primitive,
-            ItemEnum::ForeignType => ForeignType,
+            ItemEnum::ExternType => ExternType,
             ItemEnum::ExternCrate { .. } => ExternCrate,
             ItemEnum::AssocConst { .. } => AssocConst,
             ItemEnum::AssocType { .. } => AssocType,
@@ -166,10 +166,10 @@ impl Kind {
             ItemKind::Constant => Constant,
             ItemKind::Enum => Enum,
             ItemKind::ExternCrate => ExternCrate,
-            ItemKind::ForeignType => ForeignType,
+            ItemKind::ExternType => ExternType,
             ItemKind::Function => Function,
             ItemKind::Impl => Impl,
-            ItemKind::Import => Import,
+            ItemKind::Use => Use,
             ItemKind::Keyword => Keyword,
             ItemKind::Macro => Macro,
             ItemKind::Module => Module,

--- a/tests/rustdoc-json/assoc_items.rs
+++ b/tests/rustdoc-json/assoc_items.rs
@@ -9,12 +9,12 @@ impl Simple {
 
 pub trait EasyToImpl {
     //@ has "$.index[*][?(@.docs=='ToDeclare trait')].inner.assoc_type"
-    //@ is "$.index[*][?(@.docs=='ToDeclare trait')].inner.assoc_type.default" null
+    //@ is "$.index[*][?(@.docs=='ToDeclare trait')].inner.assoc_type.type" null
     //@ is "$.index[*][?(@.docs=='ToDeclare trait')].inner.assoc_type.bounds" []
     /// ToDeclare trait
     type ToDeclare;
     //@ has "$.index[*][?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const"
-    //@ is "$.index[*][?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const.default" null
+    //@ is "$.index[*][?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const.value" null
     //@ is "$.index[*][?(@.docs=='AN_ATTRIBUTE trait')].inner.assoc_const.type.primitive" '"usize"'
     /// AN_ATTRIBUTE trait
     const AN_ATTRIBUTE: usize;
@@ -22,13 +22,13 @@ pub trait EasyToImpl {
 
 impl EasyToImpl for Simple {
     //@ has "$.index[*][?(@.docs=='ToDeclare impl')].inner.assoc_type"
-    //@ is "$.index[*][?(@.docs=='ToDeclare impl')].inner.assoc_type.default.primitive" \"usize\"
+    //@ is "$.index[*][?(@.docs=='ToDeclare impl')].inner.assoc_type.type.primitive" \"usize\"
     /// ToDeclare impl
     type ToDeclare = usize;
 
     //@ has "$.index[*][?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const"
     //@ is "$.index[*][?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const.type.primitive" \"usize\"
-    //@ is "$.index[*][?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const.default" \"12\"
+    //@ is "$.index[*][?(@.docs=='AN_ATTRIBUTE impl')].inner.assoc_const.value" \"12\"
     /// AN_ATTRIBUTE impl
     const AN_ATTRIBUTE: usize = 12;
 }

--- a/tests/rustdoc-json/blanket_impls.rs
+++ b/tests/rustdoc-json/blanket_impls.rs
@@ -3,6 +3,6 @@
 #![no_std]
 
 //@ has "$.index[*][?(@.name=='Error')].inner.assoc_type"
-//@ has "$.index[*][?(@.name=='Error')].inner.assoc_type.default.resolved_path"
-//@ has "$.index[*][?(@.name=='Error')].inner.assoc_type.default.resolved_path.name" \"Infallible\"
+//@ has "$.index[*][?(@.name=='Error')].inner.assoc_type.type.resolved_path"
+//@ has "$.index[*][?(@.name=='Error')].inner.assoc_type.type.resolved_path.name" \"Infallible\"
 pub struct ForBlanketTryFromImpl;

--- a/tests/rustdoc-json/enums/kind.rs
+++ b/tests/rustdoc-json/enums/kind.rs
@@ -5,7 +5,7 @@ pub enum Foo {
     //@ is "$.index[*][?(@.name=='Unit')].inner.variant.kind" '"plain"'
     Unit,
     //@ set Named = "$.index[*][?(@.name=='Named')].id"
-    //@ is "$.index[*][?(@.name=='Named')].inner.variant.kind.struct" '{"fields": [], "fields_stripped": false}'
+    //@ is "$.index[*][?(@.name=='Named')].inner.variant.kind.struct" '{"fields": [], "has_stripped_fields": false}'
     Named {},
     //@ set Tuple = "$.index[*][?(@.name=='Tuple')].id"
     //@ is "$.index[*][?(@.name=='Tuple')].inner.variant.kind.tuple" []
@@ -13,7 +13,7 @@ pub enum Foo {
     //@ set NamedField = "$.index[*][?(@.name=='NamedField')].id"
     //@ set x = "$.index[*][?(@.name=='x' && @.inner.struct_field)].id"
     //@ is "$.index[*][?(@.name=='NamedField')].inner.variant.kind.struct.fields[*]" $x
-    //@ is "$.index[*][?(@.name=='NamedField')].inner.variant.kind.struct.fields_stripped" false
+    //@ is "$.index[*][?(@.name=='NamedField')].inner.variant.kind.struct.has_stripped_fields" false
     NamedField { x: i32 },
     //@ set TupleField = "$.index[*][?(@.name=='TupleField')].id"
     //@ set tup_field = "$.index[*][?(@.name=='0' && @.inner.struct_field)].id"

--- a/tests/rustdoc-json/enums/struct_field_hidden.rs
+++ b/tests/rustdoc-json/enums/struct_field_hidden.rs
@@ -9,7 +9,7 @@ pub enum Foo {
         //@ set y = "$.index[*][?(@.name=='y')].id"
         y: i32,
     },
-    //@ is "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.fields_stripped" true
+    //@ is "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.has_stripped_fields" true
     //@ is "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.fields[0]" $b
     //@ is "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.fields[1]" $y
     //@ count "$.index[*][?(@.name=='Variant')].inner.variant.kind.struct.fields[*]" 2

--- a/tests/rustdoc-json/enums/use_glob.rs
+++ b/tests/rustdoc-json/enums/use_glob.rs
@@ -7,9 +7,9 @@ pub enum Color {
     Blue,
 }
 
-//@ set use_Color = "$.index[*][?(@.inner.import)].id"
-//@ is "$.index[*][?(@.inner.import)].inner.import.id" $Color
-//@ is "$.index[*][?(@.inner.import)].inner.import.glob" true
+//@ set use_Color = "$.index[*][?(@.inner.use)].id"
+//@ is "$.index[*][?(@.inner.use)].inner.use.id" $Color
+//@ is "$.index[*][?(@.inner.use)].inner.use.is_glob" true
 pub use Color::*;
 
 //@ ismany "$.index[*][?(@.name == 'use_glob')].inner.module.items[*]" $Color $use_Color

--- a/tests/rustdoc-json/enums/use_variant.rs
+++ b/tests/rustdoc-json/enums/use_variant.rs
@@ -5,8 +5,8 @@ pub enum AlwaysNone {
 }
 //@ is "$.index[*][?(@.name == 'AlwaysNone')].inner.enum.variants[*]" $None
 
-//@ set use_None = "$.index[*][?(@.inner.import)].id"
-//@ is "$.index[*][?(@.inner.import)].inner.import.id" $None
+//@ set use_None = "$.index[*][?(@.inner.use)].id"
+//@ is "$.index[*][?(@.inner.use)].inner.use.id" $None
 pub use AlwaysNone::None;
 
 //@ ismany "$.index[*][?(@.name == 'use_variant')].inner.module.items[*]" $AlwaysNone $use_None

--- a/tests/rustdoc-json/enums/use_variant_foreign.rs
+++ b/tests/rustdoc-json/enums/use_variant_foreign.rs
@@ -2,7 +2,7 @@
 
 extern crate color;
 
-//@ has "$.index[*].inner.import[?(@.name == 'Red')]"
+//@ has "$.index[*].inner.use[?(@.name == 'Red')]"
 pub use color::Color::Red;
 
 //@ !has "$.index[*][?(@.name == 'Red')]"

--- a/tests/rustdoc-json/fn_pointer/generics.rs
+++ b/tests/rustdoc-json/fn_pointer/generics.rs
@@ -1,9 +1,9 @@
 // ignore-tidy-linelength
 
-//@ count "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.inputs[*]" 1
-//@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.inputs[0][0]" '"val"'
-//@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.inputs[0][1].borrowed_ref.lifetime" \"\'c\"
-//@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.decl.output.primitive" \"i32\"
+//@ count "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.inputs[*]" 1
+//@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.inputs[0][0]" '"val"'
+//@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.inputs[0][1].borrowed_ref.lifetime" \"\'c\"
+//@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.sig.output.primitive" \"i32\"
 //@ count "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[*]" 1
 //@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[0].name" \"\'c\"
 //@ is "$.index[*][?(@.name=='WithHigherRankTraitBounds')].inner.type_alias.type.function_pointer.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'

--- a/tests/rustdoc-json/fn_pointer/qualifiers.rs
+++ b/tests/rustdoc-json/fn_pointer/qualifiers.rs
@@ -1,11 +1,11 @@
 // ignore-tidy-linelength
 
-//@ is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.unsafe" false
-//@ is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.const" false
-//@ is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.async" false
+//@ is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.is_unsafe" false
+//@ is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.is_const" false
+//@ is "$.index[*][?(@.name=='FnPointer')].inner.type_alias.type.function_pointer.header.is_async" false
 pub type FnPointer = fn();
 
-//@ is "$.index[*][?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.unsafe" true
-//@ is "$.index[*][?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.const" false
-//@ is "$.index[*][?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.async" false
+//@ is "$.index[*][?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.is_unsafe" true
+//@ is "$.index[*][?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.is_const" false
+//@ is "$.index[*][?(@.name=='UnsafePointer')].inner.type_alias.type.function_pointer.header.is_async" false
 pub type UnsafePointer = unsafe fn();

--- a/tests/rustdoc-json/fns/async_return.rs
+++ b/tests/rustdoc-json/fns/async_return.rs
@@ -5,30 +5,30 @@
 
 use std::future::Future;
 
-//@ is "$.index[*][?(@.name=='get_int')].inner.function.decl.output.primitive" \"i32\"
-//@ is "$.index[*][?(@.name=='get_int')].inner.function.header.async" false
+//@ is "$.index[*][?(@.name=='get_int')].inner.function.sig.output.primitive" \"i32\"
+//@ is "$.index[*][?(@.name=='get_int')].inner.function.header.is_async" false
 pub fn get_int() -> i32 {
     42
 }
 
-//@ is "$.index[*][?(@.name=='get_int_async')].inner.function.decl.output.primitive" \"i32\"
-//@ is "$.index[*][?(@.name=='get_int_async')].inner.function.header.async" true
+//@ is "$.index[*][?(@.name=='get_int_async')].inner.function.sig.output.primitive" \"i32\"
+//@ is "$.index[*][?(@.name=='get_int_async')].inner.function.header.is_async" true
 pub async fn get_int_async() -> i32 {
     42
 }
 
-//@ is "$.index[*][?(@.name=='get_int_future')].inner.function.decl.output.impl_trait[0].trait_bound.trait.name" '"Future"'
-//@ is "$.index[*][?(@.name=='get_int_future')].inner.function.decl.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].name" '"Output"'
-//@ is "$.index[*][?(@.name=='get_int_future')].inner.function.decl.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].binding.equality.type.primitive"  \"i32\"
-//@ is "$.index[*][?(@.name=='get_int_future')].inner.function.header.async" false
+//@ is "$.index[*][?(@.name=='get_int_future')].inner.function.sig.output.impl_trait[0].trait_bound.trait.name" '"Future"'
+//@ is "$.index[*][?(@.name=='get_int_future')].inner.function.sig.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].name" '"Output"'
+//@ is "$.index[*][?(@.name=='get_int_future')].inner.function.sig.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].binding.equality.type.primitive"  \"i32\"
+//@ is "$.index[*][?(@.name=='get_int_future')].inner.function.header.is_async" false
 pub fn get_int_future() -> impl Future<Output = i32> {
     async { 42 }
 }
 
-//@ is "$.index[*][?(@.name=='get_int_future_async')].inner.function.decl.output.impl_trait[0].trait_bound.trait.name" '"Future"'
-//@ is "$.index[*][?(@.name=='get_int_future_async')].inner.function.decl.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].name" '"Output"'
-//@ is "$.index[*][?(@.name=='get_int_future_async')].inner.function.decl.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].binding.equality.type.primitive" \"i32\"
-//@ is "$.index[*][?(@.name=='get_int_future_async')].inner.function.header.async" true
+//@ is "$.index[*][?(@.name=='get_int_future_async')].inner.function.sig.output.impl_trait[0].trait_bound.trait.name" '"Future"'
+//@ is "$.index[*][?(@.name=='get_int_future_async')].inner.function.sig.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].name" '"Output"'
+//@ is "$.index[*][?(@.name=='get_int_future_async')].inner.function.sig.output.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].binding.equality.type.primitive" \"i32\"
+//@ is "$.index[*][?(@.name=='get_int_future_async')].inner.function.header.is_async" true
 pub async fn get_int_future_async() -> impl Future<Output = i32> {
     async { 42 }
 }

--- a/tests/rustdoc-json/fns/extern_c_variadic.rs
+++ b/tests/rustdoc-json/fns/extern_c_variadic.rs
@@ -1,6 +1,6 @@
 extern "C" {
-    //@ is "$.index[*][?(@.name == 'not_variadic')].inner.function.decl.c_variadic" false
+    //@ is "$.index[*][?(@.name == 'not_variadic')].inner.function.sig.is_c_variadic" false
     pub fn not_variadic(_: i32);
-    //@ is "$.index[*][?(@.name == 'variadic')].inner.function.decl.c_variadic" true
+    //@ is "$.index[*][?(@.name == 'variadic')].inner.function.sig.is_c_variadic" true
     pub fn variadic(_: i32, ...);
 }

--- a/tests/rustdoc-json/fns/generic_args.rs
+++ b/tests/rustdoc-json/fns/generic_args.rs
@@ -12,27 +12,27 @@ pub trait GenericFoo<'a> {}
 //@ is "$.index[*][?(@.name=='generics')].inner.function.generics.params[0].kind.type.default" 'null'
 //@ count "$.index[*][?(@.name=='generics')].inner.function.generics.params[0].kind.type.bounds[*]" 1
 //@ is "$.index[*][?(@.name=='generics')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" '$foo'
-//@ count "$.index[*][?(@.name=='generics')].inner.function.decl.inputs[*]" 1
-//@ is "$.index[*][?(@.name=='generics')].inner.function.decl.inputs[0][0]" '"f"'
-//@ is "$.index[*][?(@.name=='generics')].inner.function.decl.inputs[0][1].generic" '"F"'
+//@ count "$.index[*][?(@.name=='generics')].inner.function.sig.inputs[*]" 1
+//@ is "$.index[*][?(@.name=='generics')].inner.function.sig.inputs[0][0]" '"f"'
+//@ is "$.index[*][?(@.name=='generics')].inner.function.sig.inputs[0][1].generic" '"F"'
 pub fn generics<F: Foo>(f: F) {}
 
 //@ is "$.index[*][?(@.name=='impl_trait')].inner.function.generics.where_predicates" "[]"
 //@ count "$.index[*][?(@.name=='impl_trait')].inner.function.generics.params[*]" 1
 //@ is "$.index[*][?(@.name=='impl_trait')].inner.function.generics.params[0].name" '"impl Foo"'
 //@ is "$.index[*][?(@.name=='impl_trait')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $foo
-//@ count "$.index[*][?(@.name=='impl_trait')].inner.function.decl.inputs[*]" 1
-//@ is "$.index[*][?(@.name=='impl_trait')].inner.function.decl.inputs[0][0]" '"f"'
-//@ count "$.index[*][?(@.name=='impl_trait')].inner.function.decl.inputs[0][1].impl_trait[*]" 1
-//@ is "$.index[*][?(@.name=='impl_trait')].inner.function.decl.inputs[0][1].impl_trait[0].trait_bound.trait.id" $foo
+//@ count "$.index[*][?(@.name=='impl_trait')].inner.function.sig.inputs[*]" 1
+//@ is "$.index[*][?(@.name=='impl_trait')].inner.function.sig.inputs[0][0]" '"f"'
+//@ count "$.index[*][?(@.name=='impl_trait')].inner.function.sig.inputs[0][1].impl_trait[*]" 1
+//@ is "$.index[*][?(@.name=='impl_trait')].inner.function.sig.inputs[0][1].impl_trait[0].trait_bound.trait.id" $foo
 pub fn impl_trait(f: impl Foo) {}
 
 //@ count "$.index[*][?(@.name=='where_clase')].inner.function.generics.params[*]" 3
 //@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.params[0].name" '"F"'
-//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.params[0].kind" '{"type": {"bounds": [], "default": null, "synthetic": false}}'
-//@ count "$.index[*][?(@.name=='where_clase')].inner.function.decl.inputs[*]" 3
-//@ is "$.index[*][?(@.name=='where_clase')].inner.function.decl.inputs[0][0]" '"f"'
-//@ is "$.index[*][?(@.name=='where_clase')].inner.function.decl.inputs[0][1].generic" '"F"'
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.params[0].kind" '{"type": {"bounds": [], "default": null, "is_synthetic": false}}'
+//@ count "$.index[*][?(@.name=='where_clase')].inner.function.sig.inputs[*]" 3
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.sig.inputs[0][0]" '"f"'
+//@ is "$.index[*][?(@.name=='where_clase')].inner.function.sig.inputs[0][1].generic" '"F"'
 //@ count "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[*]" 3
 
 //@ is "$.index[*][?(@.name=='where_clase')].inner.function.generics.where_predicates[0].bound_predicate.type.generic" \"F\"

--- a/tests/rustdoc-json/fns/generic_returns.rs
+++ b/tests/rustdoc-json/fns/generic_returns.rs
@@ -5,9 +5,9 @@
 //@ set foo = "$.index[*][?(@.name=='Foo')].id"
 pub trait Foo {}
 
-//@ is "$.index[*][?(@.name=='get_foo')].inner.function.decl.inputs" []
-//@ count "$.index[*][?(@.name=='get_foo')].inner.function.decl.output.impl_trait[*]" 1
-//@ is "$.index[*][?(@.name=='get_foo')].inner.function.decl.output.impl_trait[0].trait_bound.trait.id" $foo
+//@ is "$.index[*][?(@.name=='get_foo')].inner.function.sig.inputs" []
+//@ count "$.index[*][?(@.name=='get_foo')].inner.function.sig.output.impl_trait[*]" 1
+//@ is "$.index[*][?(@.name=='get_foo')].inner.function.sig.output.impl_trait[0].trait_bound.trait.id" $foo
 pub fn get_foo() -> impl Foo {
     Fooer {}
 }

--- a/tests/rustdoc-json/fns/generics.rs
+++ b/tests/rustdoc-json/fns/generics.rs
@@ -6,17 +6,17 @@ pub trait Wham {}
 //@ is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.where_predicates" []
 //@ count "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[*]" 1
 //@ is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].name" '"T"'
-//@ is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].kind.type.synthetic" false
+//@ is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].kind.type.is_synthetic" false
 //@ is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $wham_id
-//@ is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.decl.inputs" '[["w", {"generic": "T"}]]'
+//@ is    "$.index[*][?(@.name=='one_generic_param_fn')].inner.function.sig.inputs" '[["w", {"generic": "T"}]]'
 pub fn one_generic_param_fn<T: Wham>(w: T) {}
 
 //@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.where_predicates" []
 //@ count "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[*]" 1
 //@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].name" '"impl Wham"'
-//@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].kind.type.synthetic" true
+//@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].kind.type.is_synthetic" true
 //@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $wham_id
-//@ count "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.decl.inputs[*]" 1
-//@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.decl.inputs[0][0]" '"w"'
-//@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.decl.inputs[0][1].impl_trait[0].trait_bound.trait.id" $wham_id
+//@ count "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.sig.inputs[*]" 1
+//@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.sig.inputs[0][0]" '"w"'
+//@ is    "$.index[*][?(@.name=='one_synthetic_generic_param_fn')].inner.function.sig.inputs[0][1].impl_trait[0].trait_bound.trait.id" $wham_id
 pub fn one_synthetic_generic_param_fn(w: impl Wham) {}

--- a/tests/rustdoc-json/fns/pattern_arg.rs
+++ b/tests/rustdoc-json/fns/pattern_arg.rs
@@ -1,7 +1,7 @@
-//@ is "$.index[*][?(@.name=='fst')].inner.function.decl.inputs[0][0]" '"(x, _)"'
+//@ is "$.index[*][?(@.name=='fst')].inner.function.sig.inputs[0][0]" '"(x, _)"'
 pub fn fst<X, Y>((x, _): (X, Y)) -> X {
     x
 }
 
-//@ is "$.index[*][?(@.name=='drop_int')].inner.function.decl.inputs[0][0]" '"_"'
+//@ is "$.index[*][?(@.name=='drop_int')].inner.function.sig.inputs[0][0]" '"_"'
 pub fn drop_int(_: i32) {}

--- a/tests/rustdoc-json/fns/qualifiers.rs
+++ b/tests/rustdoc-json/fns/qualifiers.rs
@@ -1,33 +1,33 @@
 //@ edition:2018
 
-//@ is "$.index[*][?(@.name=='nothing_fn')].inner.function.header.async" false
-//@ is "$.index[*][?(@.name=='nothing_fn')].inner.function.header.const"  false
-//@ is "$.index[*][?(@.name=='nothing_fn')].inner.function.header.unsafe" false
+//@ is "$.index[*][?(@.name=='nothing_fn')].inner.function.header.is_async" false
+//@ is "$.index[*][?(@.name=='nothing_fn')].inner.function.header.is_const"  false
+//@ is "$.index[*][?(@.name=='nothing_fn')].inner.function.header.is_unsafe" false
 pub fn nothing_fn() {}
 
-//@ is "$.index[*][?(@.name=='unsafe_fn')].inner.function.header.async"  false
-//@ is "$.index[*][?(@.name=='unsafe_fn')].inner.function.header.const"  false
-//@ is "$.index[*][?(@.name=='unsafe_fn')].inner.function.header.unsafe" true
+//@ is "$.index[*][?(@.name=='unsafe_fn')].inner.function.header.is_async"  false
+//@ is "$.index[*][?(@.name=='unsafe_fn')].inner.function.header.is_const"  false
+//@ is "$.index[*][?(@.name=='unsafe_fn')].inner.function.header.is_unsafe" true
 pub unsafe fn unsafe_fn() {}
 
-//@ is "$.index[*][?(@.name=='const_fn')].inner.function.header.async"  false
-//@ is "$.index[*][?(@.name=='const_fn')].inner.function.header.const"  true
-//@ is "$.index[*][?(@.name=='const_fn')].inner.function.header.unsafe" false
+//@ is "$.index[*][?(@.name=='const_fn')].inner.function.header.is_async"  false
+//@ is "$.index[*][?(@.name=='const_fn')].inner.function.header.is_const"  true
+//@ is "$.index[*][?(@.name=='const_fn')].inner.function.header.is_unsafe" false
 pub const fn const_fn() {}
 
-//@ is "$.index[*][?(@.name=='async_fn')].inner.function.header.async"  true
-//@ is "$.index[*][?(@.name=='async_fn')].inner.function.header.const"  false
-//@ is "$.index[*][?(@.name=='async_fn')].inner.function.header.unsafe" false
+//@ is "$.index[*][?(@.name=='async_fn')].inner.function.header.is_async"  true
+//@ is "$.index[*][?(@.name=='async_fn')].inner.function.header.is_const"  false
+//@ is "$.index[*][?(@.name=='async_fn')].inner.function.header.is_unsafe" false
 pub async fn async_fn() {}
 
-//@ is "$.index[*][?(@.name=='async_unsafe_fn')].inner.function.header.async"  true
-//@ is "$.index[*][?(@.name=='async_unsafe_fn')].inner.function.header.const"  false
-//@ is "$.index[*][?(@.name=='async_unsafe_fn')].inner.function.header.unsafe" true
+//@ is "$.index[*][?(@.name=='async_unsafe_fn')].inner.function.header.is_async"  true
+//@ is "$.index[*][?(@.name=='async_unsafe_fn')].inner.function.header.is_const"  false
+//@ is "$.index[*][?(@.name=='async_unsafe_fn')].inner.function.header.is_unsafe" true
 pub async unsafe fn async_unsafe_fn() {}
 
-//@ is "$.index[*][?(@.name=='const_unsafe_fn')].inner.function.header.async"  false
-//@ is "$.index[*][?(@.name=='const_unsafe_fn')].inner.function.header.const"  true
-//@ is "$.index[*][?(@.name=='const_unsafe_fn')].inner.function.header.unsafe" true
+//@ is "$.index[*][?(@.name=='const_unsafe_fn')].inner.function.header.is_async"  false
+//@ is "$.index[*][?(@.name=='const_unsafe_fn')].inner.function.header.is_const"  true
+//@ is "$.index[*][?(@.name=='const_unsafe_fn')].inner.function.header.is_unsafe" true
 pub const unsafe fn const_unsafe_fn() {}
 
 // It's impossible for a function to be both const and async, so no test for that

--- a/tests/rustdoc-json/fns/return_type_alias.rs
+++ b/tests/rustdoc-json/fns/return_type_alias.rs
@@ -3,7 +3,7 @@
 ///@ set foo = "$.index[*][?(@.name=='Foo')].id"
 pub type Foo = i32;
 
-//@ is "$.index[*][?(@.name=='demo')].inner.function.decl.output.resolved_path.id" $foo
+//@ is "$.index[*][?(@.name=='demo')].inner.function.sig.output.resolved_path.id" $foo
 pub fn demo() -> Foo {
     42
 }

--- a/tests/rustdoc-json/generic-associated-types/gats.rs
+++ b/tests/rustdoc-json/generic-associated-types/gats.rs
@@ -13,10 +13,10 @@ pub trait LendingIterator {
     where
         Self: 'a;
 
-    //@ count "$.index[*][?(@.name=='lending_next')].inner.function.decl.output.qualified_path.args.angle_bracketed.args[*]" 1
-    //@ count "$.index[*][?(@.name=='lending_next')].inner.function.decl.output.qualified_path.args.angle_bracketed.bindings[*]" 0
-    //@ is "$.index[*][?(@.name=='lending_next')].inner.function.decl.output.qualified_path.self_type.generic" \"Self\"
-    //@ is "$.index[*][?(@.name=='lending_next')].inner.function.decl.output.qualified_path.name" \"LendingItem\"
+    //@ count "$.index[*][?(@.name=='lending_next')].inner.function.sig.output.qualified_path.args.angle_bracketed.args[*]" 1
+    //@ count "$.index[*][?(@.name=='lending_next')].inner.function.sig.output.qualified_path.args.angle_bracketed.bindings[*]" 0
+    //@ is "$.index[*][?(@.name=='lending_next')].inner.function.sig.output.qualified_path.self_type.generic" \"Self\"
+    //@ is "$.index[*][?(@.name=='lending_next')].inner.function.sig.output.qualified_path.name" \"LendingItem\"
     fn lending_next<'a>(&'a self) -> Self::LendingItem<'a>;
 }
 
@@ -26,9 +26,9 @@ pub trait Iterator {
     //@ count "$.index[*][?(@.name=='Item')].inner.assoc_type.bounds[*]" 1
     type Item: Display;
 
-    //@ count "$.index[*][?(@.name=='next')].inner.function.decl.output.qualified_path.args.angle_bracketed.args[*]" 0
-    //@ count "$.index[*][?(@.name=='next')].inner.function.decl.output.qualified_path.args.angle_bracketed.bindings[*]" 0
-    //@ is "$.index[*][?(@.name=='next')].inner.function.decl.output.qualified_path.self_type.generic" \"Self\"
-    //@ is "$.index[*][?(@.name=='next')].inner.function.decl.output.qualified_path.name" \"Item\"
+    //@ count "$.index[*][?(@.name=='next')].inner.function.sig.output.qualified_path.args.angle_bracketed.args[*]" 0
+    //@ count "$.index[*][?(@.name=='next')].inner.function.sig.output.qualified_path.args.angle_bracketed.bindings[*]" 0
+    //@ is "$.index[*][?(@.name=='next')].inner.function.sig.output.qualified_path.self_type.generic" \"Self\"
+    //@ is "$.index[*][?(@.name=='next')].inner.function.sig.output.qualified_path.name" \"Item\"
     fn next<'a>(&'a self) -> Self::Item;
 }

--- a/tests/rustdoc-json/glob_import.rs
+++ b/tests/rustdoc-json/glob_import.rs
@@ -3,7 +3,7 @@
 #![no_std]
 
 //@ has "$.index[*][?(@.name=='glob')]"
-//@ has "$.index[*][?(@.inner.import)].inner.import.name" \"*\"
+//@ has "$.index[*][?(@.inner.use)].inner.use.name" \"*\"
 
 mod m1 {
     pub fn f() {}

--- a/tests/rustdoc-json/impl-trait-in-assoc-type.rs
+++ b/tests/rustdoc-json/impl-trait-in-assoc-type.rs
@@ -9,11 +9,11 @@ impl IntoIterator for AlwaysTrue {
     /// type Item
     type Item = bool;
 
-    //@ count '$.index[*][?(@.docs=="type IntoIter")].inner.assoc_type.default.impl_trait[*]' 1
-    //@ is    '$.index[*][?(@.docs=="type IntoIter")].inner.assoc_type.default.impl_trait[0].trait_bound.trait.name' '"Iterator"'
-    //@ count '$.index[*][?(@.docs=="type IntoIter")].inner.assoc_type.default.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[*]' 1
-    //@ is    '$.index[*][?(@.docs=="type IntoIter")].inner.assoc_type.default.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].name' '"Item"'
-    //@ is    '$.index[*][?(@.docs=="type IntoIter")].inner.assoc_type.default.impl_trait[0].trait_bound.trait.args.angle_bracketed.bindings[0].binding.equality.type.primitive' '"bool"'
+    //@ count '$.index[*][?(@.docs=="type IntoIter")].inner.assoc_type.type.impl_trait[*]' 1
+    //@ is    '$.index[*][?(@.docs=="type IntoIter")].inner.assoc_type.type.impl_trait[0].trait_bound.trait.name' '"Iterator"'
+    //@ count '$.index[*][?(@.docs=="type IntoIter")].inner.assoc_type.type.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[*]' 1
+    //@ is    '$.index[*][?(@.docs=="type IntoIter")].inner.assoc_type.type.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].name' '"Item"'
+    //@ is    '$.index[*][?(@.docs=="type IntoIter")].inner.assoc_type.type.impl_trait[0].trait_bound.trait.args.angle_bracketed.constraints[0].binding.equality.type.primitive' '"bool"'
 
     //@ set IntoIter = '$.index[*][?(@.docs=="type IntoIter")].id'
     /// type IntoIter

--- a/tests/rustdoc-json/impl-trait-precise-capturing.rs
+++ b/tests/rustdoc-json/impl-trait-precise-capturing.rs
@@ -1,4 +1,4 @@
-//@ is "$.index[*][?(@.name=='hello')].inner.function.decl.output.impl_trait[1].use[0]" \"\'a\"
-//@ is "$.index[*][?(@.name=='hello')].inner.function.decl.output.impl_trait[1].use[1]" \"T\"
-//@ is "$.index[*][?(@.name=='hello')].inner.function.decl.output.impl_trait[1].use[2]" \"N\"
+//@ is "$.index[*][?(@.name=='hello')].inner.function.sig.output.impl_trait[1].use[0]" \"\'a\"
+//@ is "$.index[*][?(@.name=='hello')].inner.function.sig.output.impl_trait[1].use[1]" \"T\"
+//@ is "$.index[*][?(@.name=='hello')].inner.function.sig.output.impl_trait[1].use[2]" \"N\"
 pub fn hello<'a, T, const N: usize>() -> impl Sized + use<'a, T, N> {}

--- a/tests/rustdoc-json/impls/auto.rs
+++ b/tests/rustdoc-json/impls/auto.rs
@@ -18,5 +18,5 @@ impl Foo {
 //@ is "$.index[*][?(@.docs=='has span')].span.begin" "[13, 0]"
 //@ is "$.index[*][?(@.docs=='has span')].span.end" "[15, 1]"
 // FIXME: this doesn't work due to https://github.com/freestrings/jsonpath/issues/91
-// is "$.index[*][?(@.inner.impl.synthetic==true)].span" null
+// is "$.index[*][?(@.inner.impl.is_synthetic==true)].span" null
 pub struct Foo;

--- a/tests/rustdoc-json/impls/foreign_for_local.rs
+++ b/tests/rustdoc-json/impls/foreign_for_local.rs
@@ -3,7 +3,7 @@ extern crate foreign_trait;
 
 /// ForeignTrait id hack
 pub use foreign_trait::ForeignTrait as _;
-//@ set ForeignTrait = "$.index[*][?(@.docs=='ForeignTrait id hack')].inner.import.id"
+//@ set ForeignTrait = "$.index[*][?(@.docs=='ForeignTrait id hack')].inner.use.id"
 
 pub struct LocalStruct;
 //@ set LocalStruct = "$.index[*][?(@.name=='LocalStruct')].id"

--- a/tests/rustdoc-json/impls/import_from_private.rs
+++ b/tests/rustdoc-json/impls/import_from_private.rs
@@ -11,10 +11,10 @@ mod bar {
     }
 }
 
-//@ set import = "$.index[*][?(@.inner.import)].id"
+//@ set import = "$.index[*][?(@.inner.use)].id"
 pub use bar::Baz;
 
 //@ is "$.index[*].inner.module.items[*]" $import
-//@ is "$.index[*].inner.import.id" $baz
+//@ is "$.index[*].inner.use.id" $baz
 //@ has "$.index[*][?(@.name == 'Baz')].inner.struct.impls[*]" $impl
 //@ is "$.index[*][?(@.docs=='impl')].inner.impl.items[*]" $doit

--- a/tests/rustdoc-json/impls/local_for_foreign.rs
+++ b/tests/rustdoc-json/impls/local_for_foreign.rs
@@ -3,7 +3,7 @@ extern crate foreign_struct;
 
 /// ForeignStruct id hack
 pub use foreign_struct::ForeignStruct as _;
-//@ set ForeignStruct = "$.index[*][?(@.docs=='ForeignStruct id hack')].inner.import.id"
+//@ set ForeignStruct = "$.index[*][?(@.docs=='ForeignStruct id hack')].inner.use.id"
 
 pub trait LocalTrait {}
 //@ set LocalTrait = "$.index[*][?(@.name=='LocalTrait')].id"

--- a/tests/rustdoc-json/lifetime/longest.rs
+++ b/tests/rustdoc-json/lifetime/longest.rs
@@ -6,21 +6,21 @@
 //@ count "$.index[*][?(@.name=='longest')].inner.function.generics.params[*]" 1
 //@ is "$.index[*][?(@.name=='longest')].inner.function.generics.where_predicates" []
 
-//@ count "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[*]" 2
-//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[0][0]" '"l"'
-//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[1][0]" '"r"'
+//@ count "$.index[*][?(@.name=='longest')].inner.function.sig.inputs[*]" 2
+//@ is "$.index[*][?(@.name=='longest')].inner.function.sig.inputs[0][0]" '"l"'
+//@ is "$.index[*][?(@.name=='longest')].inner.function.sig.inputs[1][0]" '"r"'
 
-//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[0][1].borrowed_ref.lifetime" \"\'a\"
-//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[0][1].borrowed_ref.mutable" false
-//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[0][1].borrowed_ref.type.primitive" \"str\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.sig.inputs[0][1].borrowed_ref.lifetime" \"\'a\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.sig.inputs[0][1].borrowed_ref.is_mutable" false
+//@ is "$.index[*][?(@.name=='longest')].inner.function.sig.inputs[0][1].borrowed_ref.type.primitive" \"str\"
 
-//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[1][1].borrowed_ref.lifetime" \"\'a\"
-//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[1][1].borrowed_ref.mutable" false
-//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.inputs[1][1].borrowed_ref.type.primitive" \"str\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.sig.inputs[1][1].borrowed_ref.lifetime" \"\'a\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.sig.inputs[1][1].borrowed_ref.is_mutable" false
+//@ is "$.index[*][?(@.name=='longest')].inner.function.sig.inputs[1][1].borrowed_ref.type.primitive" \"str\"
 
-//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.output.borrowed_ref.lifetime" \"\'a\"
-//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.output.borrowed_ref.mutable" false
-//@ is "$.index[*][?(@.name=='longest')].inner.function.decl.output.borrowed_ref.type.primitive" \"str\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.sig.output.borrowed_ref.lifetime" \"\'a\"
+//@ is "$.index[*][?(@.name=='longest')].inner.function.sig.output.borrowed_ref.is_mutable" false
+//@ is "$.index[*][?(@.name=='longest')].inner.function.sig.output.borrowed_ref.type.primitive" \"str\"
 
 pub fn longest<'a>(l: &'a str, r: &'a str) -> &'a str {
     if l.len() > r.len() { l } else { r }

--- a/tests/rustdoc-json/lifetime/outlives.rs
+++ b/tests/rustdoc-json/lifetime/outlives.rs
@@ -10,9 +10,9 @@
 //@ is "$.index[*][?(@.name=='foo')].inner.function.generics.params[2].kind.type.default" null
 //@ count "$.index[*][?(@.name=='foo')].inner.function.generics.params[2].kind.type.bounds[*]" 1
 //@ is "$.index[*][?(@.name=='foo')].inner.function.generics.params[2].kind.type.bounds[0].outlives" \"\'b\"
-//@ is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.lifetime" \"\'a\"
-//@ is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.mutable" false
-//@ is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.type.borrowed_ref.lifetime" \"\'b\"
-//@ is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.type.borrowed_ref.mutable" false
-//@ is "$.index[*][?(@.name=='foo')].inner.function.decl.inputs[0][1].borrowed_ref.type.borrowed_ref.type.generic" \"T\"
+//@ is "$.index[*][?(@.name=='foo')].inner.function.sig.inputs[0][1].borrowed_ref.lifetime" \"\'a\"
+//@ is "$.index[*][?(@.name=='foo')].inner.function.sig.inputs[0][1].borrowed_ref.is_mutable" false
+//@ is "$.index[*][?(@.name=='foo')].inner.function.sig.inputs[0][1].borrowed_ref.type.borrowed_ref.lifetime" \"\'b\"
+//@ is "$.index[*][?(@.name=='foo')].inner.function.sig.inputs[0][1].borrowed_ref.type.borrowed_ref.is_mutable" false
+//@ is "$.index[*][?(@.name=='foo')].inner.function.sig.inputs[0][1].borrowed_ref.type.borrowed_ref.type.generic" \"T\"
 pub fn foo<'a, 'b: 'a, T: 'b>(_: &'a &'b T) {}

--- a/tests/rustdoc-json/methods/qualifiers.rs
+++ b/tests/rustdoc-json/methods/qualifiers.rs
@@ -3,34 +3,34 @@
 pub struct Foo;
 
 impl Foo {
-    //@ is "$.index[*][?(@.name=='const_meth')].inner.function.header.async" false
-    //@ is "$.index[*][?(@.name=='const_meth')].inner.function.header.const"  true
-    //@ is "$.index[*][?(@.name=='const_meth')].inner.function.header.unsafe" false
+    //@ is "$.index[*][?(@.name=='const_meth')].inner.function.header.is_async" false
+    //@ is "$.index[*][?(@.name=='const_meth')].inner.function.header.is_const"  true
+    //@ is "$.index[*][?(@.name=='const_meth')].inner.function.header.is_unsafe" false
     pub const fn const_meth() {}
 
-    //@ is "$.index[*][?(@.name=='nothing_meth')].inner.function.header.async"  false
-    //@ is "$.index[*][?(@.name=='nothing_meth')].inner.function.header.const"  false
-    //@ is "$.index[*][?(@.name=='nothing_meth')].inner.function.header.unsafe" false
+    //@ is "$.index[*][?(@.name=='nothing_meth')].inner.function.header.is_async"  false
+    //@ is "$.index[*][?(@.name=='nothing_meth')].inner.function.header.is_const"  false
+    //@ is "$.index[*][?(@.name=='nothing_meth')].inner.function.header.is_unsafe" false
     pub fn nothing_meth() {}
 
-    //@ is "$.index[*][?(@.name=='unsafe_meth')].inner.function.header.async"  false
-    //@ is "$.index[*][?(@.name=='unsafe_meth')].inner.function.header.const"  false
-    //@ is "$.index[*][?(@.name=='unsafe_meth')].inner.function.header.unsafe" true
+    //@ is "$.index[*][?(@.name=='unsafe_meth')].inner.function.header.is_async"  false
+    //@ is "$.index[*][?(@.name=='unsafe_meth')].inner.function.header.is_const"  false
+    //@ is "$.index[*][?(@.name=='unsafe_meth')].inner.function.header.is_unsafe" true
     pub unsafe fn unsafe_meth() {}
 
-    //@ is "$.index[*][?(@.name=='async_meth')].inner.function.header.async"  true
-    //@ is "$.index[*][?(@.name=='async_meth')].inner.function.header.const"  false
-    //@ is "$.index[*][?(@.name=='async_meth')].inner.function.header.unsafe" false
+    //@ is "$.index[*][?(@.name=='async_meth')].inner.function.header.is_async"  true
+    //@ is "$.index[*][?(@.name=='async_meth')].inner.function.header.is_const"  false
+    //@ is "$.index[*][?(@.name=='async_meth')].inner.function.header.is_unsafe" false
     pub async fn async_meth() {}
 
-    //@ is "$.index[*][?(@.name=='async_unsafe_meth')].inner.function.header.async"  true
-    //@ is "$.index[*][?(@.name=='async_unsafe_meth')].inner.function.header.const"  false
-    //@ is "$.index[*][?(@.name=='async_unsafe_meth')].inner.function.header.unsafe" true
+    //@ is "$.index[*][?(@.name=='async_unsafe_meth')].inner.function.header.is_async"  true
+    //@ is "$.index[*][?(@.name=='async_unsafe_meth')].inner.function.header.is_const"  false
+    //@ is "$.index[*][?(@.name=='async_unsafe_meth')].inner.function.header.is_unsafe" true
     pub async unsafe fn async_unsafe_meth() {}
 
-    //@ is "$.index[*][?(@.name=='const_unsafe_meth')].inner.function.header.async"  false
-    //@ is "$.index[*][?(@.name=='const_unsafe_meth')].inner.function.header.const"  true
-    //@ is "$.index[*][?(@.name=='const_unsafe_meth')].inner.function.header.unsafe" true
+    //@ is "$.index[*][?(@.name=='const_unsafe_meth')].inner.function.header.is_async"  false
+    //@ is "$.index[*][?(@.name=='const_unsafe_meth')].inner.function.header.is_const"  true
+    //@ is "$.index[*][?(@.name=='const_unsafe_meth')].inner.function.header.is_unsafe" true
     pub const unsafe fn const_unsafe_meth() {}
 
     // It's impossible for a method to be both const and async, so no test for that

--- a/tests/rustdoc-json/nested.rs
+++ b/tests/rustdoc-json/nested.rs
@@ -22,11 +22,11 @@ pub mod l1 {
         //@ ismany "$.index[*][?(@.name=='l3')].inner.module.items[*]" $l4_id
         pub struct L4;
     }
-    //@ is "$.index[*][?(@.inner.import)].inner.import.glob" false
-    //@ is "$.index[*][?(@.inner.import)].inner.import.source" '"l3::L4"'
-    //@ is "$.index[*][?(@.inner.import)].inner.import.glob" false
-    //@ is "$.index[*][?(@.inner.import)].inner.import.id" $l4_id
-    //@ set l4_use_id = "$.index[*][?(@.inner.import)].id"
+    //@ is "$.index[*][?(@.inner.use)].inner.use.is_glob" false
+    //@ is "$.index[*][?(@.inner.use)].inner.use.source" '"l3::L4"'
+    //@ is "$.index[*][?(@.inner.use)].inner.use.is_glob" false
+    //@ is "$.index[*][?(@.inner.use)].inner.use.id" $l4_id
+    //@ set l4_use_id = "$.index[*][?(@.inner.use)].id"
     pub use l3::L4;
 }
 //@ ismany "$.index[*][?(@.name=='l1')].inner.module.items[*]" $l3_id $l4_use_id

--- a/tests/rustdoc-json/non_lifetime_binders.rs
+++ b/tests/rustdoc-json/non_lifetime_binders.rs
@@ -11,7 +11,7 @@ pub struct Wrapper<T_>(std::marker::PhantomData<T_>);
 //@ is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[0].name" \"\'a\"
 //@ is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[0].kind" '{ "lifetime": { "outlives": [] } }'
 //@ is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[1].name" \"T\"
-//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[1].kind" '{ "type": { "bounds": [], "default": null, "synthetic": false } }'
+//@ is "$.index[*][?(@.name=='foo')].inner.function.generics.where_predicates[0].bound_predicate.generic_params[1].kind" '{ "type": { "bounds": [], "default": null, "is_synthetic": false } }'
 pub fn foo()
 where
     for<'a, T> &'a Wrapper<T>: Trait,

--- a/tests/rustdoc-json/primitives/use_primitive.rs
+++ b/tests/rustdoc-json/primitives/use_primitive.rs
@@ -13,7 +13,7 @@ mod usize {}
 //@ !is "$.index[*][?(@.name=='checked_add')]" $local_crate_id
 //@ !has "$.index[*][?(@.name=='is_ascii_uppercase')]"
 
-//@ is "$.index[*].inner.import[?(@.name=='my_i32')].id" null
+//@ is "$.index[*].inner.use[?(@.name=='my_i32')].id" null
 pub use i32 as my_i32;
-//@ is "$.index[*].inner.import[?(@.name=='u32')].id" null
+//@ is "$.index[*].inner.use[?(@.name=='u32')].id" null
 pub use u32;

--- a/tests/rustdoc-json/reexport/extern_crate_glob.rs
+++ b/tests/rustdoc-json/reexport/extern_crate_glob.rs
@@ -6,6 +6,6 @@ extern crate enum_with_discriminant;
 pub use enum_with_discriminant::*;
 
 //@ !has '$.index[*][?(@.docs == "Should not be inlined")]'
-//@ is '$.index[*][?(@.inner.import)].inner.import.name' \"enum_with_discriminant\"
-//@ set use = '$.index[*][?(@.inner.import)].id'
+//@ is '$.index[*][?(@.inner.use)].inner.use.name' \"enum_with_discriminant\"
+//@ set use = '$.index[*][?(@.inner.use)].id'
 //@ is '$.index[*][?(@.name == "extern_crate_glob")].inner.module.items[*]' $use

--- a/tests/rustdoc-json/reexport/glob_collision.rs
+++ b/tests/rustdoc-json/reexport/glob_collision.rs
@@ -14,13 +14,13 @@ mod m2 {
 }
 
 //@ set m1_use = "$.index[*][?(@.docs=='m1 re-export')].id"
-//@ is "$.index[*].inner.import[?(@.name=='m1')].id" $m1
-//@ is "$.index[*].inner.import[?(@.name=='m1')].glob" true
+//@ is "$.index[*].inner.use[?(@.name=='m1')].id" $m1
+//@ is "$.index[*].inner.use[?(@.name=='m1')].is_glob" true
 /// m1 re-export
 pub use m1::*;
 //@ set m2_use = "$.index[*][?(@.docs=='m2 re-export')].id"
-//@ is "$.index[*].inner.import[?(@.name=='m2')].id" $m2
-//@ is "$.index[*].inner.import[?(@.name=='m2')].glob" true
+//@ is "$.index[*].inner.use[?(@.name=='m2')].id" $m2
+//@ is "$.index[*].inner.use[?(@.name=='m2')].is_glob" true
 /// m2 re-export
 pub use m2::*;
 

--- a/tests/rustdoc-json/reexport/glob_empty_mod.rs
+++ b/tests/rustdoc-json/reexport/glob_empty_mod.rs
@@ -4,5 +4,5 @@
 //@ set m1 = "$.index[*][?(@.name=='m1')].id"
 mod m1 {}
 
-//@ is "$.index[*][?(@.inner.import)].inner.import.id" $m1
+//@ is "$.index[*][?(@.inner.use)].inner.use.id" $m1
 pub use m1::*;

--- a/tests/rustdoc-json/reexport/glob_extern.rs
+++ b/tests/rustdoc-json/reexport/glob_extern.rs
@@ -12,8 +12,8 @@ mod mod1 {
     //@ set mod1_id = "$.index[*][?(@.name=='mod1')].id"
 }
 
-//@ is "$.index[*][?(@.inner.import)].inner.import.glob" true
-//@ is "$.index[*][?(@.inner.import)].inner.import.id" $mod1_id
-//@ set use_id = "$.index[*][?(@.inner.import)].id"
+//@ is "$.index[*][?(@.inner.use)].inner.use.is_glob" true
+//@ is "$.index[*][?(@.inner.use)].inner.use.id" $mod1_id
+//@ set use_id = "$.index[*][?(@.inner.use)].id"
 //@ ismany "$.index[*][?(@.name=='glob_extern')].inner.module.items[*]" $use_id
 pub use mod1::*;

--- a/tests/rustdoc-json/reexport/glob_private.rs
+++ b/tests/rustdoc-json/reexport/glob_private.rs
@@ -12,7 +12,7 @@ mod mod1 {
     }
 
     //@ set mod2_use_id = "$.index[*][?(@.docs=='Mod2 re-export')].id"
-    //@ is "$.index[*][?(@.docs=='Mod2 re-export')].inner.import.name" \"mod2\"
+    //@ is "$.index[*][?(@.docs=='Mod2 re-export')].inner.use.name" \"mod2\"
     /// Mod2 re-export
     pub use self::mod2::*;
 
@@ -23,7 +23,7 @@ mod mod1 {
 }
 
 //@ set mod1_use_id = "$.index[*][?(@.docs=='Mod1 re-export')].id"
-//@ is "$.index[*][?(@.docs=='Mod1 re-export')].inner.import.name" \"mod1\"
+//@ is "$.index[*][?(@.docs=='Mod1 re-export')].inner.use.name" \"mod1\"
 /// Mod1 re-export
 pub use mod1::*;
 

--- a/tests/rustdoc-json/reexport/in_root_and_mod.rs
+++ b/tests/rustdoc-json/reexport/in_root_and_mod.rs
@@ -4,10 +4,10 @@ mod foo {
     pub struct Foo;
 }
 
-//@ has "$.index[*].inner[?(@.import.source=='foo::Foo')]"
+//@ has "$.index[*].inner[?(@.use.source=='foo::Foo')]"
 pub use foo::Foo;
 
 pub mod bar {
-    //@ has "$.index[*].inner[?(@.import.source=='crate::foo::Foo')]"
+    //@ has "$.index[*].inner[?(@.use.source=='crate::foo::Foo')]"
     pub use crate::foo::Foo;
 }

--- a/tests/rustdoc-json/reexport/in_root_and_mod_pub.rs
+++ b/tests/rustdoc-json/reexport/in_root_and_mod_pub.rs
@@ -5,14 +5,14 @@ pub mod foo {
 }
 
 //@ set root_import_id = "$.index[*][?(@.docs=='Outer re-export')].id"
-//@ is "$.index[*].inner[?(@.import.source=='foo::Bar')].import.id" $bar_id
+//@ is "$.index[*].inner[?(@.use.source=='foo::Bar')].use.id" $bar_id
 //@ has "$.index[*][?(@.name=='in_root_and_mod_pub')].inner.module.items[*]" $root_import_id
 /// Outer re-export
 pub use foo::Bar;
 
 pub mod baz {
     //@ set baz_import_id = "$.index[*][?(@.docs=='Inner re-export')].id"
-    //@ is "$.index[*].inner[?(@.import.source=='crate::foo::Bar')].import.id" $bar_id
+    //@ is "$.index[*].inner[?(@.use.source=='crate::foo::Bar')].use.id" $bar_id
     //@ ismany "$.index[*][?(@.name=='baz')].inner.module.items[*]" $baz_import_id
     /// Inner re-export
     pub use crate::foo::Bar;

--- a/tests/rustdoc-json/reexport/mod_not_included.rs
+++ b/tests/rustdoc-json/reexport/mod_not_included.rs
@@ -7,5 +7,5 @@ mod m1 {
 pub use m1::x;
 
 //@ has "$.index[*][?(@.name=='x' && @.inner.function)]"
-//@ has "$.index[*].inner[?(@.import.name=='x')].import.source" '"m1::x"'
+//@ has "$.index[*].inner[?(@.use.name=='x')].use.source" '"m1::x"'
 //@ !has "$.index[*][?(@.name=='m1')]"

--- a/tests/rustdoc-json/reexport/private_twice_one_inline.rs
+++ b/tests/rustdoc-json/reexport/private_twice_one_inline.rs
@@ -7,18 +7,18 @@
 extern crate pub_struct as foo;
 #[doc(inline)]
 //@ set crate_use_id = "$.index[*][?(@.docs=='Hack A')].id"
-//@ set foo_id = "$.index[*][?(@.docs=='Hack A')].inner.import.id"
+//@ set foo_id = "$.index[*][?(@.docs=='Hack A')].inner.use.id"
 /// Hack A
 pub use foo::Foo;
 
 //@ set bar_id = "$.index[*][?(@.name=='bar')].id"
 pub mod bar {
-    //@ is "$.index[*][?(@.docs=='Hack B')].inner.import.id" $foo_id
+    //@ is "$.index[*][?(@.docs=='Hack B')].inner.use.id" $foo_id
     //@ set bar_use_id = "$.index[*][?(@.docs=='Hack B')].id"
     //@ ismany "$.index[*][?(@.name=='bar')].inner.module.items[*]" $bar_use_id
     /// Hack B
     pub use foo::Foo;
 }
 
-//@ ismany "$.index[*][?(@.inner.import)].id" $crate_use_id $bar_use_id
+//@ ismany "$.index[*][?(@.inner.use)].id" $crate_use_id $bar_use_id
 //@ ismany "$.index[*][?(@.name=='private_twice_one_inline')].inner.module.items[*]" $bar_id $crate_use_id

--- a/tests/rustdoc-json/reexport/private_two_names.rs
+++ b/tests/rustdoc-json/reexport/private_two_names.rs
@@ -9,13 +9,13 @@ mod style {
     pub struct Color;
 }
 
-//@ is "$.index[*][?(@.docs=='First re-export')].inner.import.id" $color_struct_id
-//@ is "$.index[*][?(@.docs=='First re-export')].inner.import.name" \"Color\"
+//@ is "$.index[*][?(@.docs=='First re-export')].inner.use.id" $color_struct_id
+//@ is "$.index[*][?(@.docs=='First re-export')].inner.use.name" \"Color\"
 //@ set color_export_id = "$.index[*][?(@.docs=='First re-export')].id"
 /// First re-export
 pub use style::Color;
-//@ is "$.index[*][?(@.docs=='Second re-export')].inner.import.id" $color_struct_id
-//@ is "$.index[*][?(@.docs=='Second re-export')].inner.import.name" \"Colour\"
+//@ is "$.index[*][?(@.docs=='Second re-export')].inner.use.id" $color_struct_id
+//@ is "$.index[*][?(@.docs=='Second re-export')].inner.use.name" \"Colour\"
 //@ set colour_export_id = "$.index[*][?(@.docs=='Second re-export')].id"
 /// Second re-export
 pub use style::Color as Colour;

--- a/tests/rustdoc-json/reexport/reexport_of_hidden.rs
+++ b/tests/rustdoc-json/reexport/reexport_of_hidden.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: --document-hidden-items
 
-//@ has "$.index[*].inner[?(@.import.name=='UsedHidden')]"
+//@ has "$.index[*].inner[?(@.use.name=='UsedHidden')]"
 //@ has "$.index[*][?(@.name=='Hidden')]"
 pub mod submodule {
     #[doc(hidden)]

--- a/tests/rustdoc-json/reexport/rename_private.rs
+++ b/tests/rustdoc-json/reexport/rename_private.rs
@@ -6,5 +6,5 @@ mod inner {
     pub struct Public;
 }
 
-//@ is "$.index[*][?(@.inner.import)].inner.import.name" \"NewName\"
+//@ is "$.index[*][?(@.inner.use)].inner.use.name" \"NewName\"
 pub use inner::Public as NewName;

--- a/tests/rustdoc-json/reexport/rename_public.rs
+++ b/tests/rustdoc-json/reexport/rename_public.rs
@@ -7,8 +7,8 @@ pub mod inner {
     pub struct Public;
 }
 //@ set import_id = "$.index[*][?(@.docs=='Re-export')].id"
-//@ !has "$.index[*].inner[?(@.import.name=='Public')]"
-//@ is "$.index[*].inner[?(@.import.name=='NewName')].import.source" \"inner::Public\"
+//@ !has "$.index[*].inner[?(@.use.name=='Public')]"
+//@ is "$.index[*].inner[?(@.use.name=='NewName')].use.source" \"inner::Public\"
 /// Re-export
 pub use inner::Public as NewName;
 

--- a/tests/rustdoc-json/reexport/same_name_different_types.rs
+++ b/tests/rustdoc-json/reexport/same_name_different_types.rs
@@ -13,10 +13,10 @@ pub mod nested {
     pub fn Foo() {}
 }
 
-//@ ismany "$.index[*].inner[?(@.import.name == 'Foo')].import.id" $foo_fn $foo_struct
-//@ ismany "$.index[*].inner[?(@.import.name == 'Bar')].import.id" $foo_fn $foo_struct
+//@ ismany "$.index[*].inner[?(@.use.name == 'Foo')].use.id" $foo_fn $foo_struct
+//@ ismany "$.index[*].inner[?(@.use.name == 'Bar')].use.id" $foo_fn $foo_struct
 
-//@ count "$.index[*].inner[?(@.import.name == 'Foo')]" 2
+//@ count "$.index[*].inner[?(@.use.name == 'Foo')]" 2
 pub use nested::Foo;
-//@ count "$.index[*].inner[?(@.import.name == 'Bar')]" 2
+//@ count "$.index[*].inner[?(@.use.name == 'Bar')]" 2
 pub use Foo as Bar;

--- a/tests/rustdoc-json/reexport/same_type_reexported_more_than_once.rs
+++ b/tests/rustdoc-json/reexport/same_type_reexported_more_than_once.rs
@@ -10,11 +10,11 @@ mod inner {
 }
 
 //@ set export_id = "$.index[*][?(@.docs=='First re-export')].id"
-//@ is "$.index[*].inner[?(@.import.name=='Trait')].import.id" $trait_id
+//@ is "$.index[*].inner[?(@.use.name=='Trait')].use.id" $trait_id
 /// First re-export
 pub use inner::Trait;
 //@ set reexport_id = "$.index[*][?(@.docs=='Second re-export')].id"
-//@ is "$.index[*].inner[?(@.import.name=='Reexport')].import.id" $trait_id
+//@ is "$.index[*].inner[?(@.use.name=='Reexport')].use.id" $trait_id
 /// Second re-export
 pub use inner::Trait as Reexport;
 

--- a/tests/rustdoc-json/reexport/simple_private.rs
+++ b/tests/rustdoc-json/reexport/simple_private.rs
@@ -6,9 +6,9 @@ mod inner {
     pub struct Public;
 }
 
-//@ is "$.index[*][?(@.inner.import)].inner.import.name" \"Public\"
-//@ is "$.index[*][?(@.inner.import)].inner.import.id" $pub_id
-//@ set use_id = "$.index[*][?(@.inner.import)].id"
+//@ is "$.index[*][?(@.inner.use)].inner.use.name" \"Public\"
+//@ is "$.index[*][?(@.inner.use)].inner.use.id" $pub_id
+//@ set use_id = "$.index[*][?(@.inner.use)].id"
 pub use inner::Public;
 
 //@ ismany "$.index[*][?(@.name=='simple_private')].inner.module.items[*]" $use_id

--- a/tests/rustdoc-json/reexport/simple_public.rs
+++ b/tests/rustdoc-json/reexport/simple_public.rs
@@ -9,7 +9,7 @@ pub mod inner {
 }
 
 //@ set import_id = "$.index[*][?(@.docs=='Outer')].id"
-//@ is "$.index[*][?(@.docs=='Outer')].inner.import.source" \"inner::Public\"
+//@ is "$.index[*][?(@.docs=='Outer')].inner.use.source" \"inner::Public\"
 /// Outer
 pub use inner::Public;
 

--- a/tests/rustdoc-json/return_private.rs
+++ b/tests/rustdoc-json/return_private.rs
@@ -6,7 +6,7 @@ mod secret {
 }
 
 //@ has "$.index[*][?(@.name=='get_secret')].inner.function"
-//@ is "$.index[*][?(@.name=='get_secret')].inner.function.decl.output.resolved_path.name" \"secret::Secret\"
+//@ is "$.index[*][?(@.name=='get_secret')].inner.function.sig.output.resolved_path.name" \"secret::Secret\"
 pub fn get_secret() -> secret::Secret {
     secret::Secret
 }

--- a/tests/rustdoc-json/structs/plain_all_pub.rs
+++ b/tests/rustdoc-json/structs/plain_all_pub.rs
@@ -8,4 +8,4 @@ pub struct Demo {
 //@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[0]" $x
 //@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[1]" $y
 //@ count "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[*]" 2
-//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields_stripped" false
+//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.has_stripped_fields" false

--- a/tests/rustdoc-json/structs/plain_doc_hidden.rs
+++ b/tests/rustdoc-json/structs/plain_doc_hidden.rs
@@ -8,4 +8,4 @@ pub struct Demo {
 //@ !has "$.index[*][?(@.name=='y')].id"
 //@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[0]" $x
 //@ count "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[*]" 1
-//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields_stripped" true
+//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.has_stripped_fields" true

--- a/tests/rustdoc-json/structs/plain_empty.rs
+++ b/tests/rustdoc-json/structs/plain_empty.rs
@@ -1,5 +1,5 @@
 //@ is "$.index[*][?(@.name=='PlainEmpty')].visibility" \"public\"
 //@ has "$.index[*][?(@.name=='PlainEmpty')].inner.struct"
-//@ is "$.index[*][?(@.name=='PlainEmpty')].inner.struct.kind.plain.fields_stripped" false
+//@ is "$.index[*][?(@.name=='PlainEmpty')].inner.struct.kind.plain.has_stripped_fields" false
 //@ is "$.index[*][?(@.name=='PlainEmpty')].inner.struct.kind.plain.fields" []
 pub struct PlainEmpty {}

--- a/tests/rustdoc-json/structs/plain_pub_priv.rs
+++ b/tests/rustdoc-json/structs/plain_pub_priv.rs
@@ -6,4 +6,4 @@ pub struct Demo {
 //@ set x = "$.index[*][?(@.name=='x')].id"
 //@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[0]" $x
 //@ count "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields[*]" 1
-//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.fields_stripped" true
+//@ is "$.index[*][?(@.name=='Demo')].inner.struct.kind.plain.has_stripped_fields" true

--- a/tests/rustdoc-json/structs/with_generics.rs
+++ b/tests/rustdoc-json/structs/with_generics.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 //@ is "$.index[*][?(@.name=='WithGenerics')].inner.struct.generics.params[0].kind.type.bounds" []
 //@ is "$.index[*][?(@.name=='WithGenerics')].inner.struct.generics.params[1].name" \"U\"
 //@ is "$.index[*][?(@.name=='WithGenerics')].inner.struct.generics.params[1].kind.type.bounds" []
-//@ is "$.index[*][?(@.name=='WithGenerics')].inner.struct.kind.plain.fields_stripped" true
+//@ is "$.index[*][?(@.name=='WithGenerics')].inner.struct.kind.plain.has_stripped_fields" true
 //@ is "$.index[*][?(@.name=='WithGenerics')].inner.struct.kind.plain.fields" []
 pub struct WithGenerics<T, U> {
     stuff: Vec<T>,

--- a/tests/rustdoc-json/structs/with_primitives.rs
+++ b/tests/rustdoc-json/structs/with_primitives.rs
@@ -4,7 +4,7 @@
 //@ has "$.index[*][?(@.name=='WithPrimitives')].inner.struct"
 //@ is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.generics.params[0].name" \"\'a\"
 //@ is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.generics.params[0].kind.lifetime.outlives" []
-//@ is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.kind.plain.fields_stripped" true
+//@ is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.kind.plain.has_stripped_fields" true
 //@ is "$.index[*][?(@.name=='WithPrimitives')].inner.struct.kind.plain.fields" []
 pub struct WithPrimitives<'a> {
     num: u32,

--- a/tests/rustdoc-json/trait_alias.rs
+++ b/tests/rustdoc-json/trait_alias.rs
@@ -7,12 +7,12 @@
 //@ is "$.index[*][?(@.name=='StrLike')].span.filename" $FILE
 pub trait StrLike = AsRef<str>;
 
-//@ is "$.index[*][?(@.name=='f')].inner.function.decl.output.impl_trait[0].trait_bound.trait.id" $StrLike
+//@ is "$.index[*][?(@.name=='f')].inner.function.sig.output.impl_trait[0].trait_bound.trait.id" $StrLike
 pub fn f() -> impl StrLike {
     "heya"
 }
 
-//@ !is "$.index[*][?(@.name=='g')].inner.function.decl.output.impl_trait[0].trait_bound.trait.id" $StrLike
+//@ !is "$.index[*][?(@.name=='g')].inner.function.sig.output.impl_trait[0].trait_bound.trait.id" $StrLike
 pub fn g() -> impl AsRef<str> {
     "heya"
 }

--- a/tests/rustdoc-json/traits/self.rs
+++ b/tests/rustdoc-json/traits/self.rs
@@ -9,29 +9,29 @@ pub struct Foo;
 // Each assertion matches 3 times, and should be the same each time.
 
 impl Foo {
-    //@ ismany '$.index[*][?(@.name=="by_ref")].inner.function.decl.inputs[0][0]' '"self"' '"self"' '"self"'
-    //@ ismany '$.index[*][?(@.name=="by_ref")].inner.function.decl.inputs[0][1].borrowed_ref.type.generic' '"Self"' '"Self"' '"Self"'
-    //@ ismany '$.index[*][?(@.name=="by_ref")].inner.function.decl.inputs[0][1].borrowed_ref.lifetime' null null null
-    //@ ismany '$.index[*][?(@.name=="by_ref")].inner.function.decl.inputs[0][1].borrowed_ref.mutable' false false false
+    //@ ismany '$.index[*][?(@.name=="by_ref")].inner.function.sig.inputs[0][0]' '"self"' '"self"' '"self"'
+    //@ ismany '$.index[*][?(@.name=="by_ref")].inner.function.sig.inputs[0][1].borrowed_ref.type.generic' '"Self"' '"Self"' '"Self"'
+    //@ ismany '$.index[*][?(@.name=="by_ref")].inner.function.sig.inputs[0][1].borrowed_ref.lifetime' null null null
+    //@ ismany '$.index[*][?(@.name=="by_ref")].inner.function.sig.inputs[0][1].borrowed_ref.is_mutable' false false false
     pub fn by_ref(&self) {}
 
-    //@ ismany '$.index[*][?(@.name=="by_exclusive_ref")].inner.function.decl.inputs[0][0]' '"self"' '"self"' '"self"'
-    //@ ismany '$.index[*][?(@.name=="by_exclusive_ref")].inner.function.decl.inputs[0][1].borrowed_ref.type.generic' '"Self"' '"Self"' '"Self"'
-    //@ ismany '$.index[*][?(@.name=="by_exclusive_ref")].inner.function.decl.inputs[0][1].borrowed_ref.lifetime' null null null
-    //@ ismany '$.index[*][?(@.name=="by_exclusive_ref")].inner.function.decl.inputs[0][1].borrowed_ref.mutable' true true true
+    //@ ismany '$.index[*][?(@.name=="by_exclusive_ref")].inner.function.sig.inputs[0][0]' '"self"' '"self"' '"self"'
+    //@ ismany '$.index[*][?(@.name=="by_exclusive_ref")].inner.function.sig.inputs[0][1].borrowed_ref.type.generic' '"Self"' '"Self"' '"Self"'
+    //@ ismany '$.index[*][?(@.name=="by_exclusive_ref")].inner.function.sig.inputs[0][1].borrowed_ref.lifetime' null null null
+    //@ ismany '$.index[*][?(@.name=="by_exclusive_ref")].inner.function.sig.inputs[0][1].borrowed_ref.is_mutable' true true true
     pub fn by_exclusive_ref(&mut self) {}
 
-    //@ ismany '$.index[*][?(@.name=="by_value")].inner.function.decl.inputs[0][0]' '"self"' '"self"' '"self"'
-    //@ ismany '$.index[*][?(@.name=="by_value")].inner.function.decl.inputs[0][1].generic' '"Self"' '"Self"' '"Self"'
+    //@ ismany '$.index[*][?(@.name=="by_value")].inner.function.sig.inputs[0][0]' '"self"' '"self"' '"self"'
+    //@ ismany '$.index[*][?(@.name=="by_value")].inner.function.sig.inputs[0][1].generic' '"Self"' '"Self"' '"Self"'
     pub fn by_value(self) {}
 
-    //@ ismany '$.index[*][?(@.name=="with_lifetime")].inner.function.decl.inputs[0][0]' '"self"' '"self"' '"self"'
-    //@ ismany '$.index[*][?(@.name=="with_lifetime")].inner.function.decl.inputs[0][1].borrowed_ref.type.generic' '"Self"' '"Self"' '"Self"'
-    //@ ismany '$.index[*][?(@.name=="with_lifetime")].inner.function.decl.inputs[0][1].borrowed_ref.lifetime' \"\'a\" \"\'a\" \"\'a\"
-    //@ ismany '$.index[*][?(@.name=="with_lifetime")].inner.function.decl.inputs[0][1].borrowed_ref.mutable' false false false
+    //@ ismany '$.index[*][?(@.name=="with_lifetime")].inner.function.sig.inputs[0][0]' '"self"' '"self"' '"self"'
+    //@ ismany '$.index[*][?(@.name=="with_lifetime")].inner.function.sig.inputs[0][1].borrowed_ref.type.generic' '"Self"' '"Self"' '"Self"'
+    //@ ismany '$.index[*][?(@.name=="with_lifetime")].inner.function.sig.inputs[0][1].borrowed_ref.lifetime' \"\'a\" \"\'a\" \"\'a\"
+    //@ ismany '$.index[*][?(@.name=="with_lifetime")].inner.function.sig.inputs[0][1].borrowed_ref.is_mutable' false false false
     pub fn with_lifetime<'a>(&'a self) {}
 
-    //@ ismany '$.index[*][?(@.name=="build")].inner.function.decl.output.generic' '"Self"' '"Self"' '"Self"'
+    //@ ismany '$.index[*][?(@.name=="build")].inner.function.sig.output.generic' '"Self"' '"Self"' '"Self"'
     pub fn build() -> Self {
         Self
     }

--- a/tests/rustdoc-json/traits/trait_alias.rs
+++ b/tests/rustdoc-json/traits/trait_alias.rs
@@ -19,8 +19,8 @@ pub struct Struct;
 
 impl Orig<i32> for Struct {}
 
-//@ has "$.index[*][?(@.name=='takes_alias')].inner.function.decl.inputs[0][1].impl_trait"
-//@ is "$.index[*][?(@.name=='takes_alias')].inner.function.decl.inputs[0][1].impl_trait[0].trait_bound.trait.id" $Alias
+//@ has "$.index[*][?(@.name=='takes_alias')].inner.function.sig.inputs[0][1].impl_trait"
+//@ is "$.index[*][?(@.name=='takes_alias')].inner.function.sig.inputs[0][1].impl_trait[0].trait_bound.trait.id" $Alias
 //@ is "$.index[*][?(@.name=='takes_alias')].inner.function.generics.params[0].kind.type.bounds[0].trait_bound.trait.id" $Alias
 pub fn takes_alias(_: impl Alias) {}
 // FIXME: Should the trait be mentioned in both the decl and generics?

--- a/tests/rustdoc-json/type/dyn.rs
+++ b/tests/rustdoc-json/type/dyn.rs
@@ -11,7 +11,7 @@ use std::fmt::Debug;
 //@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.generics" '{"params": [], "where_predicates": []}'
 //@ has    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path"
 //@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.name" \"Box\"
-//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.bindings" []
+//@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.constraints" []
 //@ count "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args" 1
 //@ has    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait"
 //@ is    "$.index[*][?(@.name=='SyncIntGen')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.dyn_trait.lifetime" \"\'static\"
@@ -28,7 +28,7 @@ pub type SyncIntGen = Box<dyn Fn() -> i32 + Send + Sync + 'static>;
 //@ has "$.index[*][?(@.name=='RefFn')].inner.type_alias"
 //@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.generics" '{"params": [{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"}],"where_predicates": []}'
 //@ has "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref"
-//@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.mutable" 'false'
+//@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.is_mutable" 'false'
 //@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.lifetime" "\"'a\""
 //@ has "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait"
 //@ is "$.index[*][?(@.name=='RefFn')].inner.type_alias.type.borrowed_ref.type.dyn_trait.lifetime" null

--- a/tests/rustdoc-json/type/extern.rs
+++ b/tests/rustdoc-json/type/extern.rs
@@ -6,4 +6,4 @@ extern "C" {
 }
 
 //@ is "$.index[*][?(@.docs=='No inner information')].name" '"Foo"'
-//@ is "$.index[*][?(@.docs=='No inner information')].inner" \"foreign_type\"
+//@ is "$.index[*][?(@.docs=='No inner information')].inner" \"extern_type\"

--- a/tests/rustdoc-json/type/fn_lifetime.rs
+++ b/tests/rustdoc-json/type/fn_lifetime.rs
@@ -7,9 +7,9 @@
 //@ count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.generics.params[*].kind.lifetime.outlives[*]" 0
 //@ count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.generics.where_predicates[*]" 0
 //@ count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.generic_params[*]" 0
-//@ count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.decl.inputs[*]" 1
-//@ is     "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.decl.inputs[*][1].borrowed_ref.lifetime" \"\'a\"
-//@ is     "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.decl.output.borrowed_ref.lifetime" \"\'a\"
+//@ count  "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.sig.inputs[*]" 1
+//@ is     "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.sig.inputs[*][1].borrowed_ref.lifetime" \"\'a\"
+//@ is     "$.index[*][?(@.name=='GenericFn')].inner.type_alias.type.function_pointer.sig.output.borrowed_ref.lifetime" \"\'a\"
 
 pub type GenericFn<'a> = fn(&'a i32) -> &'a i32;
 
@@ -20,7 +20,7 @@ pub type GenericFn<'a> = fn(&'a i32) -> &'a i32;
 //@ is    "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*].name" \"\'a\"
 //@ has   "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*].kind.lifetime"
 //@ count "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.generic_params[*].kind.lifetime.outlives[*]" 0
-//@ count "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.decl.inputs[*]" 1
-//@ is    "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.decl.inputs[*][1].borrowed_ref.lifetime" \"\'a\"
-//@ is    "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.decl.output.borrowed_ref.lifetime" \"\'a\"
+//@ count "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.sig.inputs[*]" 1
+//@ is    "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.sig.inputs[*][1].borrowed_ref.lifetime" \"\'a\"
+//@ is    "$.index[*][?(@.name=='ForAll')].inner.type_alias.type.function_pointer.sig.output.borrowed_ref.lifetime" \"\'a\"
 pub type ForAll = for<'a> fn(&'a i32) -> &'a i32;

--- a/tests/rustdoc-json/type/generic_default.rs
+++ b/tests/rustdoc-json/type/generic_default.rs
@@ -25,7 +25,7 @@ pub struct MyError {}
 //@ has    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path"
 //@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.id" $result
 //@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.name" \"Result\"
-//@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.bindings" []
+//@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.constraints" []
 //@ has    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.generic"
 //@ has    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[1].type.generic"
 //@ is    "$.index[*][?(@.name=='MyResult')].inner.type_alias.type.resolved_path.args.angle_bracketed.args[0].type.generic" \"T\"

--- a/tests/rustdoc-json/type/hrtb.rs
+++ b/tests/rustdoc-json/type/hrtb.rs
@@ -12,10 +12,10 @@ where
 
 //@ is "$.index[*][?(@.name=='dynfn')].inner.function.generics" '{"params": [], "where_predicates": []}'
 //@ is "$.index[*][?(@.name=='dynfn')].inner.function.generics" '{"params": [], "where_predicates": []}'
-//@ is "$.index[*][?(@.name=='dynfn')].inner.function.decl.inputs[0][1].borrowed_ref.type.dyn_trait.lifetime" null
-//@ count "$.index[*][?(@.name=='dynfn')].inner.function.decl.inputs[0][1].borrowed_ref.type.dyn_trait.traits[*]" 1
-//@ is "$.index[*][?(@.name=='dynfn')].inner.function.decl.inputs[0][1].borrowed_ref.type.dyn_trait.traits[0].generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"},{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
-//@ is "$.index[*][?(@.name=='dynfn')].inner.function.decl.inputs[0][1].borrowed_ref.type.dyn_trait.traits[0].trait.name" '"Fn"'
+//@ is "$.index[*][?(@.name=='dynfn')].inner.function.sig.inputs[0][1].borrowed_ref.type.dyn_trait.lifetime" null
+//@ count "$.index[*][?(@.name=='dynfn')].inner.function.sig.inputs[0][1].borrowed_ref.type.dyn_trait.traits[*]" 1
+//@ is "$.index[*][?(@.name=='dynfn')].inner.function.sig.inputs[0][1].borrowed_ref.type.dyn_trait.traits[0].generic_params" '[{"kind": {"lifetime": {"outlives": []}},"name": "'\''a"},{"kind": {"lifetime": {"outlives": []}},"name": "'\''b"}]'
+//@ is "$.index[*][?(@.name=='dynfn')].inner.function.sig.inputs[0][1].borrowed_ref.type.dyn_trait.traits[0].trait.name" '"Fn"'
 pub fn dynfn(f: &dyn for<'a, 'b> Fn(&'a i32, &'b i32)) {
     let zero = 0;
     f(&zero, &zero);

--- a/tests/rustdoc-json/type/inherent_associated_type.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type.rs
@@ -10,9 +10,9 @@ pub struct Owner;
 pub fn create() -> Owner::Metadata {
     OwnerMetadata
 }
-//@ is '$.index[*][?(@.name=="create")].inner.function.decl.output.qualified_path.name' '"Metadata"'
-//@ is '$.index[*][?(@.name=="create")].inner.function.decl.output.qualified_path.trait' null
-//@ is '$.index[*][?(@.name=="create")].inner.function.decl.output.qualified_path.self_type.resolved_path.id' $Owner
+//@ is '$.index[*][?(@.name=="create")].inner.function.sig.output.qualified_path.name' '"Metadata"'
+//@ is '$.index[*][?(@.name=="create")].inner.function.sig.output.qualified_path.trait' null
+//@ is '$.index[*][?(@.name=="create")].inner.function.sig.output.qualified_path.self_type.resolved_path.id' $Owner
 
 /// impl
 impl Owner {
@@ -21,4 +21,4 @@ impl Owner {
 }
 //@ set iat = '$.index[*][?(@.docs=="iat")].id'
 //@ is '$.index[*][?(@.docs=="impl")].inner.impl.items[*]' $iat
-//@ is '$.index[*][?(@.docs=="iat")].inner.assoc_type.default.resolved_path.id' $OwnerMetadata
+//@ is '$.index[*][?(@.docs=="iat")].inner.assoc_type.type.resolved_path.id' $OwnerMetadata

--- a/tests/rustdoc-json/type/inherent_associated_type_bound.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type_bound.rs
@@ -5,14 +5,14 @@
 //@ set Carrier = '$.index[*][?(@.name=="Carrier")].id'
 pub struct Carrier<'a>(&'a ());
 
-//@ count "$.index[*][?(@.name=='user')].inner.function.decl.inputs[*]" 1
-//@ is "$.index[*][?(@.name=='user')].inner.function.decl.inputs[0][0]" '"_"'
-//@ is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.generic_params[*].name' \""'b"\"
-//@ is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.self_type.resolved_path.id' $Carrier
-//@ is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.self_type.resolved_path.args.angle_bracketed.args[0].lifetime' \""'b"\"
-//@ is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.name' '"Focus"'
-//@ is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.trait' null
-//@ is '$.index[*][?(@.name=="user")].inner.function.decl.inputs[0][1].function_pointer.decl.inputs[0][1].qualified_path.args.angle_bracketed.args[0].type.primitive' '"i32"'
+//@ count "$.index[*][?(@.name=='user')].inner.function.sig.inputs[*]" 1
+//@ is "$.index[*][?(@.name=='user')].inner.function.sig.inputs[0][0]" '"_"'
+//@ is '$.index[*][?(@.name=="user")].inner.function.sig.inputs[0][1].function_pointer.generic_params[*].name' \""'b"\"
+//@ is '$.index[*][?(@.name=="user")].inner.function.sig.inputs[0][1].function_pointer.sig.inputs[0][1].qualified_path.self_type.resolved_path.id' $Carrier
+//@ is '$.index[*][?(@.name=="user")].inner.function.sig.inputs[0][1].function_pointer.sig.inputs[0][1].qualified_path.self_type.resolved_path.args.angle_bracketed.args[0].lifetime' \""'b"\"
+//@ is '$.index[*][?(@.name=="user")].inner.function.sig.inputs[0][1].function_pointer.sig.inputs[0][1].qualified_path.name' '"Focus"'
+//@ is '$.index[*][?(@.name=="user")].inner.function.sig.inputs[0][1].function_pointer.sig.inputs[0][1].qualified_path.trait' null
+//@ is '$.index[*][?(@.name=="user")].inner.function.sig.inputs[0][1].function_pointer.sig.inputs[0][1].qualified_path.args.angle_bracketed.args[0].type.primitive' '"i32"'
 pub fn user(_: for<'b> fn(Carrier<'b>::Focus<i32>)) {}
 
 impl<'a> Carrier<'a> {

--- a/tests/rustdoc-json/type/inherent_associated_type_projections.rs
+++ b/tests/rustdoc-json/type/inherent_associated_type_projections.rs
@@ -5,12 +5,12 @@
 //@ set Parametrized = '$.index[*][?(@.name=="Parametrized")].id'
 pub struct Parametrized<T>(T);
 
-//@ count "$.index[*][?(@.name=='test')].inner.function.decl.inputs[*]" 1
-//@ is "$.index[*][?(@.name=='test')].inner.function.decl.inputs[0][0]" '"_"'
-//@ is '$.index[*][?(@.name=="test")].inner.function.decl.inputs[0][1].qualified_path.self_type.resolved_path.id' $Parametrized
-//@ is '$.index[*][?(@.name=="test")].inner.function.decl.inputs[0][1].qualified_path.self_type.resolved_path.args.angle_bracketed.args[0].type.primitive' \"i32\"
-//@ is '$.index[*][?(@.name=="test")].inner.function.decl.inputs[0][1].qualified_path.name' '"Proj"'
-//@ is '$.index[*][?(@.name=="test")].inner.function.decl.inputs[0][1].qualified_path.trait' null
+//@ count "$.index[*][?(@.name=='test')].inner.function.sig.inputs[*]" 1
+//@ is "$.index[*][?(@.name=='test')].inner.function.sig.inputs[0][0]" '"_"'
+//@ is '$.index[*][?(@.name=="test")].inner.function.sig.inputs[0][1].qualified_path.self_type.resolved_path.id' $Parametrized
+//@ is '$.index[*][?(@.name=="test")].inner.function.sig.inputs[0][1].qualified_path.self_type.resolved_path.args.angle_bracketed.args[0].type.primitive' \"i32\"
+//@ is '$.index[*][?(@.name=="test")].inner.function.sig.inputs[0][1].qualified_path.name' '"Proj"'
+//@ is '$.index[*][?(@.name=="test")].inner.function.sig.inputs[0][1].qualified_path.trait' null
 pub fn test(_: Parametrized<i32>::Proj) {}
 
 /// param_bool

--- a/tests/rustdoc-json/type_alias.rs
+++ b/tests/rustdoc-json/type_alias.rs
@@ -4,12 +4,12 @@
 //@ is "$.index[*][?(@.name=='IntVec')].span.filename" $FILE
 pub type IntVec = Vec<u32>;
 
-//@ is "$.index[*][?(@.name=='f')].inner.function.decl.output.resolved_path.id" $IntVec
+//@ is "$.index[*][?(@.name=='f')].inner.function.sig.output.resolved_path.id" $IntVec
 pub fn f() -> IntVec {
     vec![0; 32]
 }
 
-//@ !is "$.index[*][?(@.name=='g')].inner.function.decl.output.resolved_path.id" $IntVec
+//@ !is "$.index[*][?(@.name=='g')].inner.function.sig.output.resolved_path.id" $IntVec
 pub fn g() -> Vec<u32> {
     vec![0; 32]
 }

--- a/tests/rustdoc-json/unions/union.rs
+++ b/tests/rustdoc-json/unions/union.rs
@@ -7,8 +7,8 @@ pub union Union {
     float: f32,
 }
 
-//@ has "$.index[*][?(@.name=='make_int_union')].inner.function.decl.output.resolved_path"
-//@ is "$.index[*][?(@.name=='make_int_union')].inner.function.decl.output.resolved_path.id" $Union
+//@ has "$.index[*][?(@.name=='make_int_union')].inner.function.sig.output.resolved_path"
+//@ is "$.index[*][?(@.name=='make_int_union')].inner.function.sig.output.resolved_path.id" $Union
 pub fn make_int_union(int: i32) -> Union {
     Union { int }
 }


### PR DESCRIPTION
Updates #100961 

- `Import` -> `Use`, to better reflect the terminology of Rust & its syntax
- `TypeBinding` -> `AssocItemConstraint`, to sync up with `clean`
- `FnDecl` -> `FunctionSignature`, because that's what it is
- `Header` -> `FunctionHeader`, because `Header` is a very word that's very heavily loaded with different meanings
- `ItemEnum::AssocType`: `default` -> `type`, because those items appear in `impl` blocks as well, where they're _not_ the "default"
- `ItemEnum::AssocConst`: `default` -> `value`, see the previous point
- `ForeignType` -> `ExternType`, because "foreign" is not the right word there
- boolean fields' names made to consistently be a phrase that can be a yes/no answer, e.g. `async` -> `is_async`

The docs of `ItemEnum::AssocType::type_` & of `ItemEnum::AssocConst::value` are also updated to be up to date with the clarification of the name of the fields