### PR TITLE
Update `compiler-builtins` to 0.1.117

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.114"
+version = "0.1.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb58b199190fcfe0846f55a3b545cd6b07a34bdd5930a476ff856f3ebcc5558a"
+checksum = "a91dae36d82fe12621dfb5b596d7db766187747749b22e33ac068e1bfc356f4a"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -10,10 +10,7 @@ edition = "2021"
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { version = "0.1.114", features = ['rustc-dep-of-std'] }
-
-[target.'cfg(not(any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))'.dependencies]
-compiler_builtins = { version = "0.1.114", features = ["no-f16-f128"] }
+compiler_builtins = { version = "0.1.117", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "0.1.114" }
+compiler_builtins = { version = "0.1.117" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.14", default-features = false, features = [


### PR DESCRIPTION
This includes [1] which means we can remove the (nonworking) configuration of `no-f16-f128`.

Fixes https://github.com/rust-lang/rust/issues/128401.

[1]: https://github.com/rust-lang/compiler-builtins/pull/652


try-job: dist-various-1

<!-- homu-ignore:start -->
r? @Amanieu 
<!-- homu-ignore:end -->
