### PR TITLE
Add a triagebot mention for `library/Cargo.lock`

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -778,6 +778,14 @@ If this was unintentional then you should revert the changes before this PR is m
 Otherwise, you can ignore this comment.
 """
 
+[mentions."library/Cargo.lock"]
+message = """
+These commits modify the `library/Cargo.lock` file. Unintentional changes to `library/Cargo.lock` can be introduced when switching branches and rebasing PRs.
+
+If this was unintentional then you should revert the changes before this PR is merged.
+Otherwise, you can ignore this comment.
+"""
+
 [mentions."src/tools/x"]
 message = "`src/tools/x` was changed. Bump version of Cargo.toml in `src/tools/x` so tidy will suggest installing the new version."
 


### PR DESCRIPTION
Since [1], `Cargo.lock` was split into `Cargo.lock` and `library/Cargo.lock`. Update Triagebot to give the same warning for both.

[1]: https://github.com/rust-lang/rust/pull/128534
