### PR TITLE
Don't Suggest Labeling `const` and `unsafe` Blocks 

### DIFF
--- a/tests/ui/inline-const/break-inside-inline-const-issue-128604.rs
+++ b/tests/ui/inline-const/break-inside-inline-const-issue-128604.rs
@@ -15,4 +15,11 @@ fn main() {
         break;
         //~^ ERROR `break` outside of a loop or labeled block
     };
+
+    {
+        const {
+            break;
+            //~^ ERROR `break` outside of a loop or labeled block
+        }
+    }
 }

--- a/tests/ui/inline-const/break-inside-inline-const-issue-128604.rs
+++ b/tests/ui/inline-const/break-inside-inline-const-issue-128604.rs
@@ -1,0 +1,18 @@
+fn main() {
+    let _ = ['a'; { break 2; 1 }];
+    //~^ ERROR `break` outside of a loop or labeled block
+    //~| HELP consider labeling this block to be able to break within it
+
+    const {
+        {
+            //~^ HELP consider labeling this block to be able to break within it
+            break;
+            //~^ ERROR `break` outside of a loop or labeled block
+        }
+    };
+
+    const {
+        break;
+        //~^ ERROR `break` outside of a loop or labeled block
+    };
+}

--- a/tests/ui/inline-const/break-inside-inline-const-issue-128604.stderr
+++ b/tests/ui/inline-const/break-inside-inline-const-issue-128604.stderr
@@ -1,0 +1,39 @@
+error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/break-inside-inline-const-issue-128604.rs:2:21
+   |
+LL |     let _ = ['a'; { break 2; 1 }];
+   |                     ^^^^^^^ cannot `break` outside of a loop or labeled block
+   |
+help: consider labeling this block to be able to break within it
+   |
+LL |     let _ = ['a'; 'block: { break 'block 2; 1 }];
+   |                   +++++++         ++++++
+
+error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/break-inside-inline-const-issue-128604.rs:9:13
+   |
+LL |             break;
+   |             ^^^^^ cannot `break` outside of a loop or labeled block
+   |
+help: consider labeling this block to be able to break within it
+   |
+LL ~         'block: {
+LL |
+LL ~             break 'block;
+   |
+
+error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/break-inside-inline-const-issue-128604.rs:15:9
+   |
+LL |         break;
+   |         ^^^^^ cannot `break` outside of a loop or labeled block
+   |
+help: consider labeling this block to be able to break within it
+   |
+LL ~     const 'block: {
+LL ~         break 'block;
+   |
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0268`.

--- a/tests/ui/inline-const/break-inside-inline-const-issue-128604.stderr
+++ b/tests/ui/inline-const/break-inside-inline-const-issue-128604.stderr
@@ -1,4 +1,16 @@
 error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/break-inside-inline-const-issue-128604.rs:15:9
+   |
+LL |         break;
+   |         ^^^^^ cannot `break` outside of a loop or labeled block
+
+error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/break-inside-inline-const-issue-128604.rs:21:13
+   |
+LL |             break;
+   |             ^^^^^ cannot `break` outside of a loop or labeled block
+
+error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/break-inside-inline-const-issue-128604.rs:2:21
    |
 LL |     let _ = ['a'; { break 2; 1 }];
@@ -22,18 +34,6 @@ LL |
 LL ~             break 'block;
    |
 
-error[E0268]: `break` outside of a loop or labeled block
-  --> $DIR/break-inside-inline-const-issue-128604.rs:15:9
-   |
-LL |         break;
-   |         ^^^^^ cannot `break` outside of a loop or labeled block
-   |
-help: consider labeling this block to be able to break within it
-   |
-LL ~     const 'block: {
-LL ~         break 'block;
-   |
-
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0268`.

--- a/tests/ui/unsafe/break-inside-unsafe-block-issue-128604.rs
+++ b/tests/ui/unsafe/break-inside-unsafe-block-issue-128604.rs
@@ -15,4 +15,20 @@ fn main() {
         //~^ ERROR `break` outside of a loop or labeled block
     }
 
+    {
+        //~^ HELP consider labeling this block to be able to break within it
+        unsafe {
+            break;
+            //~^ ERROR `break` outside of a loop or labeled block
+        }
+    }
+
+    while 2 > 1 {
+        unsafe {
+            if true || false {
+                break;
+            }
+        }
+    }
+
 }

--- a/tests/ui/unsafe/break-inside-unsafe-block-issue-128604.rs
+++ b/tests/ui/unsafe/break-inside-unsafe-block-issue-128604.rs
@@ -1,0 +1,18 @@
+fn main() {
+    let a = ["_"; unsafe { break; 1 + 2 }];
+    //~^ ERROR `break` outside of a loop or labeled block
+
+    unsafe {
+        {
+            //~^ HELP consider labeling this block to be able to break within it
+            break;
+            //~^ ERROR `break` outside of a loop or labeled block
+        }
+    }
+
+    unsafe {
+        break;
+        //~^ ERROR `break` outside of a loop or labeled block
+    }
+
+}

--- a/tests/ui/unsafe/break-inside-unsafe-block-issue-128604.stderr
+++ b/tests/ui/unsafe/break-inside-unsafe-block-issue-128604.stderr
@@ -3,11 +3,12 @@ error[E0268]: `break` outside of a loop or labeled block
    |
 LL |     let a = ["_"; unsafe { break; 1 + 2 }];
    |                            ^^^^^ cannot `break` outside of a loop or labeled block
+
+error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/break-inside-unsafe-block-issue-128604.rs:14:9
    |
-help: consider labeling this block to be able to break within it
-   |
-LL |     let a = ["_"; 'block: unsafe { break 'block; 1 + 2 }];
-   |                   +++++++                ++++++
+LL |         break;
+   |         ^^^^^ cannot `break` outside of a loop or labeled block
 
 error[E0268]: `break` outside of a loop or labeled block
   --> $DIR/break-inside-unsafe-block-issue-128604.rs:8:13
@@ -23,17 +24,19 @@ LL ~             break 'block;
    |
 
 error[E0268]: `break` outside of a loop or labeled block
-  --> $DIR/break-inside-unsafe-block-issue-128604.rs:14:9
+  --> $DIR/break-inside-unsafe-block-issue-128604.rs:21:13
    |
-LL |         break;
-   |         ^^^^^ cannot `break` outside of a loop or labeled block
+LL |             break;
+   |             ^^^^^ cannot `break` outside of a loop or labeled block
    |
 help: consider labeling this block to be able to break within it
    |
-LL ~     'block: unsafe {
-LL ~         break 'block;
+LL ~     'block: {
+LL |
+LL |         unsafe {
+LL ~             break 'block;
    |
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0268`.

--- a/tests/ui/unsafe/break-inside-unsafe-block-issue-128604.stderr
+++ b/tests/ui/unsafe/break-inside-unsafe-block-issue-128604.stderr
@@ -1,0 +1,39 @@
+error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/break-inside-unsafe-block-issue-128604.rs:2:28
+   |
+LL |     let a = ["_"; unsafe { break; 1 + 2 }];
+   |                            ^^^^^ cannot `break` outside of a loop or labeled block
+   |
+help: consider labeling this block to be able to break within it
+   |
+LL |     let a = ["_"; 'block: unsafe { break 'block; 1 + 2 }];
+   |                   +++++++                ++++++
+
+error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/break-inside-unsafe-block-issue-128604.rs:8:13
+   |
+LL |             break;
+   |             ^^^^^ cannot `break` outside of a loop or labeled block
+   |
+help: consider labeling this block to be able to break within it
+   |
+LL ~         'block: {
+LL |
+LL ~             break 'block;
+   |
+
+error[E0268]: `break` outside of a loop or labeled block
+  --> $DIR/break-inside-unsafe-block-issue-128604.rs:14:9
+   |
+LL |         break;
+   |         ^^^^^ cannot `break` outside of a loop or labeled block
+   |
+help: consider labeling this block to be able to break within it
+   |
+LL ~     'block: unsafe {
+LL ~         break 'block;
+   |
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0268`.


### PR DESCRIPTION
Fixes #128604

Previously, both anonymous constant blocks (E.g. The labeled block
inside `['_'; 'block: { break 'block 1 + 2; }]`) and inline const
blocks (E.g. `const { ... }`) were considered to be the same
kind of blocks. This caused the compiler to incorrectly suggest
labeling both the blocks when only anonymous constant blocks can be
labeled.

This PR adds an other enum variant to `Context` so that both the
blocks can be handled appropriately.

Also, adds some doc comments and removes unnecessary `&mut` in a
couple of places.