### PR TITLE
remove unnecessary tidy ignore

### DIFF
--- a/tests/rustdoc-ui/intra-doc/warning-crlf.rs
+++ b/tests/rustdoc-ui/intra-doc/warning-crlf.rs
@@ -1,4 +1,3 @@
-// ignore-tidy-cr
 //@ check-pass
 
 // This file checks the spans of intra-link warnings in a file with CRLF line endings. The


### PR DESCRIPTION
~~Right now when I run `x test` on master I get an error about an unnecessary ignore directive for CR characters from a rustdoc file.~~

~~Removing the ignore directive resolves the issue~~
```
❯ x test
Building bootstrap
    Finished `dev` profile [unoptimized] target(s) in 0.07s
WARNING: build directory locked by process 70531, waiting for lock
Building stage0 tool tidy (x86_64-unknown-linux-gnu)
    Finished `release` profile [optimized + debuginfo] target(s) in 0.09s
fmt check
fmt: checked 5427 modified files
tidy check
tidy error: ~/git/rust-lang/rust/tests/rustdoc-ui/intra-doc/warning-crlf.rs: ignoring CR characters unnecessarily
some tidy checks failed
```

This seems to be an interaction between .gitattributes and `jj` which I'm using to manage my git repo locally

https://github.com/martinvonz/jj/issues/53