### PR TITLE
Don't ICE when getting an input file name's stem fails

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -838,10 +838,14 @@ pub enum Input {
 
 impl Input {
     pub fn filestem(&self) -> &str {
-        match *self {
-            Input::File(ref ifile) => ifile.file_stem().unwrap().to_str().unwrap(),
-            Input::Str { .. } => "rust_out",
+        if let Input::File(ifile) = self {
+            // If for some reason getting the file stem as a UTF-8 string fails,
+            // then fallback to a fixed name.
+            if let Some(name) = ifile.file_stem().and_then(OsStr::to_str) {
+                return name;
+            }
         }
+        "rust_out"
     }
 
     pub fn source_name(&self) -> FileName {

--- a/tests/run-make/dos-device-input/rmake.rs
+++ b/tests/run-make/dos-device-input/rmake.rs
@@ -1,9 +1,13 @@
 //@ only-windows
 // Reason: dos devices are a Windows thing
 
-use run_make_support::rustc;
+use std::path::Path;
+
+use run_make_support::{rustc, static_lib_name};
 
 fn main() {
     rustc().input(r"\\.\NUL").crate_type("staticlib").run();
     rustc().input(r"\\?\NUL").crate_type("staticlib").run();
+
+    assert!(Path::new(&static_lib_name("rust_out")).exists());
 }

--- a/tests/run-make/dos-device-input/rmake.rs
+++ b/tests/run-make/dos-device-input/rmake.rs
@@ -1,0 +1,9 @@
+//@ only-windows
+// Reason: dos devices are a Windows thing
+
+use run_make_support::rustc;
+
+fn main() {
+    rustc().input(r"\\.\NUL").crate_type("staticlib").run();
+    rustc().input(r"\\?\NUL").crate_type("staticlib").run();
+}


### PR DESCRIPTION
Fixes #128681

The file stem is only used as a user-friendly prefix on intermediary files. While nice to have, it's not the end of the world if it fails so there's no real reason to emit an error here. We can continue with a fixed name as we do when an anonymous string is used.