### PR TITLE
Remove `try_from_lit` from `from_anon_const`

### DIFF
--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -238,18 +238,13 @@ impl<'tcx> Const<'tcx> {
         let expr = &tcx.hir().body(body_id).value;
         debug!(?expr);
 
-        let ty = tcx.type_of(def).no_bound_vars().expect("const parameter types cannot be generic");
-
-        match Self::try_from_lit(tcx, ty, expr) {
-            Some(v) => v,
-            None => ty::Const::new_unevaluated(
-                tcx,
-                ty::UnevaluatedConst {
-                    def: def.to_def_id(),
-                    args: GenericArgs::identity_for_item(tcx, def.to_def_id()),
-                },
-            ),
-        }
+        ty::Const::new_unevaluated(
+            tcx,
+            ty::UnevaluatedConst {
+                def: def.to_def_id(),
+                args: GenericArgs::identity_for_item(tcx, def.to_def_id()),
+            },
+        )
     }
 
     /// Lower a const param to a [`Const`].
@@ -303,6 +298,7 @@ impl<'tcx> Const<'tcx> {
         if let Some(lit_input) = lit_input {
             // If an error occurred, ignore that it's a literal and leave reporting the error up to
             // mir.
+            // try_from_lit
             match tcx.at(expr.span).lit_to_const(lit_input) {
                 Ok(c) => return Some(c),
                 Err(e) => {

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -298,7 +298,6 @@ impl<'tcx> Const<'tcx> {
         if let Some(lit_input) = lit_input {
             // If an error occurred, ignore that it's a literal and leave reporting the error up to
             // mir.
-            // try_from_lit
             match tcx.at(expr.span).lit_to_const(lit_input) {
                 Ok(c) => return Some(c),
                 Err(e) => {

--- a/tests/ui/associated-type-bounds/const-projection-err.gce.stderr
+++ b/tests/ui/associated-type-bounds/const-projection-err.gce.stderr
@@ -7,12 +7,14 @@ LL | #![cfg_attr(gce, feature(generic_const_exprs))]
    = note: see issue #76560 <https://github.com/rust-lang/rust/issues/76560> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0271]: type mismatch resolving `<T as TraitWAssocConst>::A == 1`
+error[E0308]: mismatched types
   --> $DIR/const-projection-err.rs:14:11
    |
 LL |     foo::<T>();
    |           ^ expected `0`, found `1`
    |
+   = note: expected constant `0`
+              found constant `1`
 note: required by a bound in `foo`
   --> $DIR/const-projection-err.rs:11:28
    |
@@ -21,4 +23,4 @@ LL | fn foo<T: TraitWAssocConst<A = 1>>() {}
 
 error: aborting due to 1 previous error; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0271`.
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/defaults/mismatch.rs
+++ b/tests/ui/const-generics/defaults/mismatch.rs
@@ -6,17 +6,17 @@ pub struct Example4<const N: usize = 13, const M: usize = 4>;
 fn main() {
     let e: Example<13> = ();
     //~^ Error: mismatched types
-    //~| expected struct `Example`
+    //~| expected struct `Example<13>`
     let e: Example2<u32, 13> = ();
     //~^ Error: mismatched types
-    //~| expected struct `Example2`
+    //~| expected struct `Example2<u32, 13>`
     let e: Example3<13, u32> = ();
     //~^ Error: mismatched types
-    //~| expected struct `Example3`
+    //~| expected struct `Example3<13>`
     let e: Example3<7> = ();
     //~^ Error: mismatched types
     //~| expected struct `Example3<7>`
     let e: Example4<7> = ();
     //~^ Error: mismatched types
-    //~| expected struct `Example4<7>`
+    //~| expected struct `Example4<7, 4>`
 }

--- a/tests/ui/const-generics/defaults/mismatch.stderr
+++ b/tests/ui/const-generics/defaults/mismatch.stderr
@@ -2,33 +2,33 @@ error[E0308]: mismatched types
   --> $DIR/mismatch.rs:7:26
    |
 LL |     let e: Example<13> = ();
-   |            -----------   ^^ expected `Example`, found `()`
+   |            -----------   ^^ expected `Example<13>`, found `()`
    |            |
    |            expected due to this
    |
-   = note: expected struct `Example`
+   = note: expected struct `Example<13>`
            found unit type `()`
 
 error[E0308]: mismatched types
   --> $DIR/mismatch.rs:10:32
    |
 LL |     let e: Example2<u32, 13> = ();
-   |            -----------------   ^^ expected `Example2`, found `()`
+   |            -----------------   ^^ expected `Example2<u32, 13>`, found `()`
    |            |
    |            expected due to this
    |
-   = note: expected struct `Example2`
+   = note: expected struct `Example2<u32, 13>`
            found unit type `()`
 
 error[E0308]: mismatched types
   --> $DIR/mismatch.rs:13:32
    |
 LL |     let e: Example3<13, u32> = ();
-   |            -----------------   ^^ expected `Example3`, found `()`
+   |            -----------------   ^^ expected `Example3<13>`, found `()`
    |            |
    |            expected due to this
    |
-   = note: expected struct `Example3`
+   = note: expected struct `Example3<13>`
            found unit type `()`
 
 error[E0308]: mismatched types
@@ -46,11 +46,11 @@ error[E0308]: mismatched types
   --> $DIR/mismatch.rs:19:26
    |
 LL |     let e: Example4<7> = ();
-   |            -----------   ^^ expected `Example4<7>`, found `()`
+   |            -----------   ^^ expected `Example4<7, 4>`, found `()`
    |            |
    |            expected due to this
    |
-   = note: expected struct `Example4<7>`
+   = note: expected struct `Example4<7, 4>`
            found unit type `()`
 
 error: aborting due to 5 previous errors

--- a/tests/ui/const-generics/defaults/rp_impl_trait_fail.rs
+++ b/tests/ui/const-generics/defaults/rp_impl_trait_fail.rs
@@ -19,7 +19,7 @@ fn uwu<const N: u8>() -> impl Traitor<N> {
 }
 
 fn owo() -> impl Traitor {
-    //~^ error: the trait bound `u64: Traitor` is not satisfied
+    //~^ error: the trait bound `u64: Traitor<1>` is not satisfied
     1_u64
 }
 

--- a/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -20,11 +20,11 @@ LL |     1_u32
    |
    = help: the trait `Traitor<N, 2>` is implemented for `u32`
 
-error[E0277]: the trait bound `u64: Traitor` is not satisfied
+error[E0277]: the trait bound `u64: Traitor<1>` is not satisfied
   --> $DIR/rp_impl_trait_fail.rs:21:13
    |
 LL | fn owo() -> impl Traitor {
-   |             ^^^^^^^^^^^^ the trait `Traitor` is not implemented for `u64`
+   |             ^^^^^^^^^^^^ the trait `Traitor<1>` is not implemented for `u64`
 LL |
 LL |     1_u64
    |     ----- return type was inferred to be `u64` here

--- a/tests/ui/const-generics/defaults/trait_objects_fail.rs
+++ b/tests/ui/const-generics/defaults/trait_objects_fail.rs
@@ -24,7 +24,7 @@ fn bar<const N: u8>(arg: &dyn Traitor<N>) -> u8 {
 
 fn main() {
     foo(&10_u32);
-    //~^ error: the trait bound `u32: Trait` is not satisfied
+    //~^ error: the trait bound `u32: Trait<12>` is not satisfied
     bar(&true);
     //~^ error: the trait bound `bool: Traitor<_>` is not satisfied
 }

--- a/tests/ui/const-generics/defaults/trait_objects_fail.stderr
+++ b/tests/ui/const-generics/defaults/trait_objects_fail.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `u32: Trait` is not satisfied
+error[E0277]: the trait bound `u32: Trait<12>` is not satisfied
   --> $DIR/trait_objects_fail.rs:26:9
    |
 LL |     foo(&10_u32);
-   |         ^^^^^^^ the trait `Trait` is not implemented for `u32`
+   |         ^^^^^^^ the trait `Trait<12>` is not implemented for `u32`
    |
    = help: the trait `Trait<2>` is implemented for `u32`
-   = note: required for the cast from `&u32` to `&dyn Trait`
+   = note: required for the cast from `&u32` to `&dyn Trait<12>`
 
 error[E0277]: the trait bound `bool: Traitor<_>` is not satisfied
   --> $DIR/trait_objects_fail.rs:28:9

--- a/tests/ui/const-generics/different_generic_args.full.stderr
+++ b/tests/ui/const-generics/different_generic_args.full.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     u = ConstUsize::<4> {};
    |         ^^^^^^^^^^^^^^^^^^ expected `3`, found `4`
    |
-   = note: expected struct `ConstUsize<3>`
-              found struct `ConstUsize<4>`
+   = note: expected constant `3`
+              found constant `4`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-3.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/abstract-const-as-cast-3.stderr
@@ -68,6 +68,27 @@ note: required by a bound in `use_trait_impl::assert_impl`
 LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
 
+error: unconstrained generic constant
+  --> $DIR/abstract-const-as-cast-3.rs:23:19
+   |
+LL |     assert_impl::<HasCastInTraitImpl<13, { 12 as u128 }>>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: required for `HasCastInTraitImpl<13, { 12 as u128 }>` to implement `Trait`
+  --> $DIR/abstract-const-as-cast-3.rs:8:22
+   |
+LL | impl<const O: usize> Trait for HasCastInTraitImpl<O, { O as u128 }> {}
+   |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `use_trait_impl::assert_impl`
+  --> $DIR/abstract-const-as-cast-3.rs:14:23
+   |
+LL |     fn assert_impl<T: Trait>() {}
+   |                       ^^^^^ required by this bound in `assert_impl`
+help: try adding a `where` bound
+   |
+LL |     EvaluatableU128<{N as u128}>:, [(); { O as u128 } as usize]: {
+   |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:23:5
    |
@@ -81,6 +102,27 @@ note: required by a bound in `use_trait_impl::assert_impl`
    |
 LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
+
+error: unconstrained generic constant
+  --> $DIR/abstract-const-as-cast-3.rs:25:19
+   |
+LL |     assert_impl::<HasCastInTraitImpl<14, 13>>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: required for `HasCastInTraitImpl<14, 13>` to implement `Trait`
+  --> $DIR/abstract-const-as-cast-3.rs:8:22
+   |
+LL | impl<const O: usize> Trait for HasCastInTraitImpl<O, { O as u128 }> {}
+   |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `use_trait_impl::assert_impl`
+  --> $DIR/abstract-const-as-cast-3.rs:14:23
+   |
+LL |     fn assert_impl<T: Trait>() {}
+   |                       ^^^^^ required by this bound in `assert_impl`
+help: try adding a `where` bound
+   |
+LL |     EvaluatableU128<{N as u128}>:, [(); { O as u128 } as usize]: {
+   |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:25:5
@@ -166,6 +208,27 @@ note: required by a bound in `use_trait_impl_2::assert_impl`
 LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
 
+error: unconstrained generic constant
+  --> $DIR/abstract-const-as-cast-3.rs:41:19
+   |
+LL |     assert_impl::<HasCastInTraitImpl<13, { 12 as u128 }>>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: required for `HasCastInTraitImpl<13, { 12 as u128 }>` to implement `Trait`
+  --> $DIR/abstract-const-as-cast-3.rs:8:22
+   |
+LL | impl<const O: usize> Trait for HasCastInTraitImpl<O, { O as u128 }> {}
+   |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `use_trait_impl_2::assert_impl`
+  --> $DIR/abstract-const-as-cast-3.rs:32:23
+   |
+LL |     fn assert_impl<T: Trait>() {}
+   |                       ^^^^^ required by this bound in `assert_impl`
+help: try adding a `where` bound
+   |
+LL |     EvaluatableU128<{N as _}>:, [(); { O as u128 } as usize]: {
+   |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:41:5
    |
@@ -179,6 +242,27 @@ note: required by a bound in `use_trait_impl_2::assert_impl`
    |
 LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
+
+error: unconstrained generic constant
+  --> $DIR/abstract-const-as-cast-3.rs:43:19
+   |
+LL |     assert_impl::<HasCastInTraitImpl<14, 13>>();
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: required for `HasCastInTraitImpl<14, 13>` to implement `Trait`
+  --> $DIR/abstract-const-as-cast-3.rs:8:22
+   |
+LL | impl<const O: usize> Trait for HasCastInTraitImpl<O, { O as u128 }> {}
+   |                      ^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `use_trait_impl_2::assert_impl`
+  --> $DIR/abstract-const-as-cast-3.rs:32:23
+   |
+LL |     fn assert_impl<T: Trait>() {}
+   |                       ^^^^^ required by this bound in `assert_impl`
+help: try adding a `where` bound
+   |
+LL |     EvaluatableU128<{N as _}>:, [(); { O as u128 } as usize]: {
+   |                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error[E0308]: mismatched types
   --> $DIR/abstract-const-as-cast-3.rs:43:5
@@ -194,6 +278,6 @@ note: required by a bound in `use_trait_impl_2::assert_impl`
 LL |     fn assert_impl<T: Trait>() {}
    |                       ^^^^^ required by this bound in `assert_impl`
 
-error: aborting due to 12 previous errors
+error: aborting due to 16 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
@@ -13,29 +13,31 @@ LL |     const ASSOC: usize;
 LL | impl<const N: u64> Q for [u8; N] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `ASSOC` in implementation
 
-error: the constant `13` is not of type `u64`
-  --> $DIR/type_mismatch.rs:12:26
+error[E0391]: cycle detected when building an abstract representation for `q_user::{constant#0}`
+  --> $DIR/type_mismatch.rs:12:25
    |
 LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
-   |                          ^^^^^^^^ expected `u64`, found `usize`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^
    |
-note: required for `[u8; 13]` to implement `Q`
-  --> $DIR/type_mismatch.rs:8:20
-   |
-LL | impl<const N: u64> Q for [u8; N] {}
-   |      ------------  ^     ^^^^^^^
-   |      |
-   |      unsatisfied trait bound introduced here
-
-error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:12:20
+note: ...which requires building THIR for `q_user::{constant#0}`...
+  --> $DIR/type_mismatch.rs:12:25
    |
 LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
-   |        ------      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `[u8; <[u8; 13] as Q>::ASSOC]`, found `()`
-   |        |
-   |        implicitly returns `()` as its body has no tail or `return` expression
+   |                         ^^^^^^^^^^^^^^^^^^^^^^
+note: ...which requires type-checking `q_user::{constant#0}`...
+  --> $DIR/type_mismatch.rs:12:25
+   |
+LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
+   |                         ^^^^^^^^^^^^^^^^^^^^^^
+   = note: ...which again requires building an abstract representation for `q_user::{constant#0}`, completing the cycle
+note: cycle used when checking that `q_user` is well-formed
+  --> $DIR/type_mismatch.rs:12:1
+   |
+LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0046, E0308.
+Some errors have detailed explanations: E0046, E0391.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/const-generics/issues/issue-90318.stderr
+++ b/tests/ui/const-generics/issues/issue-90318.stderr
@@ -9,17 +9,6 @@ LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
    = help: consider moving this anonymous constant into a `const` function
    = note: this operation may be supported in the future
 
-error: overly complex generic constant
-  --> $DIR/issue-90318.rs:22:8
-   |
-LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
-   |        ^^-----------------^^^^^^^^^^^^^^^^^^^^^^^^
-   |          |
-   |          borrowing is not supported in generic constants
-   |
-   = help: consider moving this anonymous constant into a `const` function
-   = note: this operation may be supported in the future
-
 error[E0015]: cannot call non-const operator in constants
   --> $DIR/issue-90318.rs:14:10
    |
@@ -33,6 +22,17 @@ help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
    |
 LL + #![feature(const_trait_impl)]
    |
+
+error: overly complex generic constant
+  --> $DIR/issue-90318.rs:22:8
+   |
+LL |     If<{ TypeId::of::<T>() != TypeId::of::<()>() }>: True,
+   |        ^^-----------------^^^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          borrowing is not supported in generic constants
+   |
+   = help: consider moving this anonymous constant into a `const` function
+   = note: this operation may be supported in the future
 
 error[E0015]: cannot call non-const operator in constants
   --> $DIR/issue-90318.rs:22:10

--- a/tests/ui/const-generics/types-mismatch-const-args.full.stderr
+++ b/tests/ui/const-generics/types-mismatch-const-args.full.stderr
@@ -11,23 +11,23 @@ error[E0308]: mismatched types
   --> $DIR/types-mismatch-const-args.rs:16:41
    |
 LL |     let _: A<'a, u16, {2u32}, {3u32}> = A::<'b, u32, {2u32}, {3u32}> { data: PhantomData };
-   |            --------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `A<'_, u16, 2, 3>`, found `A<'_, u32, 2, 3>`
+   |            --------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `A<'_, u16, {2u32}, {3u32}>`, found `A<'_, u32, {2u32}, {3u32}>`
    |            |
    |            expected due to this
    |
-   = note: expected struct `A<'a, u16, _, _>`
-              found struct `A<'b, u32, _, _>`
+   = note: expected struct `A<'a, u16, {2u32}, {3u32}>`
+              found struct `A<'b, u32, {2u32}, {3u32}>`
 
 error[E0308]: mismatched types
   --> $DIR/types-mismatch-const-args.rs:18:41
    |
 LL |     let _: A<'a, u16, {4u32}, {3u32}> = A::<'b, u32, {2u32}, {3u32}> { data: PhantomData };
-   |            --------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `A<'_, u16, 4, 3>`, found `A<'_, u32, 2, 3>`
+   |            --------------------------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `A<'_, u16, {4u32}, {3u32}>`, found `A<'_, u32, {2u32}, {3u32}>`
    |            |
    |            expected due to this
    |
-   = note: expected struct `A<'a, u16, 4, _>`
-              found struct `A<'b, u32, 2, _>`
+   = note: expected struct `A<'a, u16, {4u32}, {3u32}>`
+              found struct `A<'b, u32, {2u32}, {3u32}>`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/repeat-expr/repeat_count.stderr
+++ b/tests/ui/repeat-expr/repeat_count.stderr
@@ -34,12 +34,6 @@ LL |     let e = [0; "foo"];
    |                 ^^^^^ expected `usize`, found `&str`
 
 error[E0308]: mismatched types
-  --> $DIR/repeat_count.rs:31:17
-   |
-LL |     let g = [0; G { g: () }];
-   |                 ^^^^^^^^^^^ expected `usize`, found `G`
-
-error[E0308]: mismatched types
   --> $DIR/repeat_count.rs:19:17
    |
 LL |     let f = [0; -4_isize];
@@ -65,6 +59,12 @@ help: change the type of the numeric literal from `u8` to `usize`
    |
 LL |     let f = [0; 4usize];
    |                  ~~~~~
+
+error[E0308]: mismatched types
+  --> $DIR/repeat_count.rs:31:17
+   |
+LL |     let g = [0; G { g: () }];
+   |                 ^^^^^^^^^^^ expected `usize`, found `G`
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/symbol-names/const-generics-demangling.legacy.stderr
+++ b/tests/ui/symbol-names/const-generics-demangling.legacy.stderr
@@ -1,34 +1,34 @@
-error: symbol-name(_ZN1c21Unsigned$LT$11_u8$GT$1f17h[HASH]E)
+error: symbol-name(_ZN1c17Unsigned$LT$_$GT$1f17h[HASH]E)
   --> $DIR/const-generics-demangling.rs:13:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(c::Unsigned<11_u8>::f::h[HASH])
+error: demangling(c::Unsigned<_>::f::h[HASH])
   --> $DIR/const-generics-demangling.rs:13:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(c::Unsigned<11_u8>::f)
+error: demangling-alt(c::Unsigned<_>::f)
   --> $DIR/const-generics-demangling.rs:13:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1c22Signed$LT$.152_i16$GT$1f17h[HASH]E)
+error: symbol-name(_ZN1c15Signed$LT$_$GT$1f17h[HASH]E)
   --> $DIR/const-generics-demangling.rs:26:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(c::Signed<.152_i16>::f::h[HASH])
+error: demangling(c::Signed<_>::f::h[HASH])
   --> $DIR/const-generics-demangling.rs:26:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(c::Signed<.152_i16>::f)
+error: demangling-alt(c::Signed<_>::f)
   --> $DIR/const-generics-demangling.rs:26:5
    |
 LL |     #[rustc_symbol_name]

--- a/tests/ui/symbol-names/const-generics-demangling.rs
+++ b/tests/ui/symbol-names/const-generics-demangling.rs
@@ -14,9 +14,9 @@ impl Unsigned<11> {
     //[v0]~^ ERROR symbol-name(_RNvMCs
     //[v0]~| ERROR demangling(<c[
     //[v0]~| ERROR demangling-alt(<c::Unsigned<11>>::f)
-    //[legacy]~^^^^ ERROR symbol-name(_ZN1c21Unsigned$LT$11_u8$GT$
-    //[legacy]~|    ERROR demangling(c::Unsigned<11_u8>::f::
-    //[legacy]~|    ERROR demangling-alt(c::Unsigned<11_u8>::f)
+    //[legacy]~^^^^ ERROR symbol-name(_ZN1c17Unsigned$LT$_$GT$
+    //[legacy]~|    ERROR demangling(c::Unsigned<_>::f::
+    //[legacy]~|    ERROR demangling-alt(c::Unsigned<_>::f)
     fn f() {}
 }
 
@@ -27,9 +27,9 @@ impl Signed<-152> {
     //[v0]~^ ERROR symbol-name(_RNvMs_Cs
     //[v0]~| ERROR demangling(<c[
     //[v0]~| ERROR demangling-alt(<c::Signed<-152>>::f)
-    //[legacy]~^^^^ ERROR symbol-name(_ZN1c22Signed$LT$.152_i16$GT$
-    //[legacy]~|    ERROR demangling(c::Signed<.152_i16>::f::
-    //[legacy]~|    ERROR demangling-alt(c::Signed<.152_i16>::f)
+    //[legacy]~^^^^ ERROR symbol-name(_ZN1c15Signed$LT$_$GT$
+    //[legacy]~|    ERROR demangling(c::Signed<_>::f::
+    //[legacy]~|    ERROR demangling-alt(c::Signed<_>::f)
     fn f() {}
 }
 

--- a/tests/ui/symbol-names/impl1.legacy.stderr
+++ b/tests/ui/symbol-names/impl1.legacy.stderr
@@ -46,19 +46,19 @@ error: def-path(bar::<impl foo::Foo>::baz)
 LL |         #[rustc_def_path]
    |         ^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN209_$LT$$u5b$$RF$dyn$u20$impl1..Foo$u2b$Assoc$u20$$u3d$$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RF$u8$C$$u20$...$RP$$u2b$impl1..AutoTrait$u3b$$u20$3$u5d$$u20$as$u20$impl1..main..$u7b$$u7b$closure$u7d$$u7d$..Bar$GT$6method17<SYMBOL_HASH>)
+error: symbol-name(_ZN209_$LT$$u5b$$RF$dyn$u20$impl1..Foo$u2b$Assoc$u20$$u3d$$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RF$u8$C$$u20$...$RP$$u2b$impl1..AutoTrait$u3b$$u20$_$u5d$$u20$as$u20$impl1..main..$u7b$$u7b$closure$u7d$$u7d$..Bar$GT$6method17<SYMBOL_HASH>)
   --> $DIR/impl1.rs:62:13
    |
 LL |             #[rustc_symbol_name]
    |             ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; 3] as impl1::main::{{closure}}::Bar>::method::<SYMBOL_HASH>)
+error: demangling(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method::<SYMBOL_HASH>)
   --> $DIR/impl1.rs:62:13
    |
 LL |             #[rustc_symbol_name]
    |             ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; 3] as impl1::main::{{closure}}::Bar>::method)
+error: demangling-alt(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method)
   --> $DIR/impl1.rs:62:13
    |
 LL |             #[rustc_symbol_name]

--- a/tests/ui/symbol-names/impl1.rs
+++ b/tests/ui/symbol-names/impl1.rs
@@ -60,9 +60,9 @@ fn main() {
         // Test type mangling, by putting them in an `impl` header.
         impl Bar for [&'_ (dyn Foo<Assoc = extern "C" fn(&u8, ...)> + AutoTrait); 3] {
             #[rustc_symbol_name]
-            //[legacy]~^ ERROR symbol-name(_ZN209_$LT$$u5b$$RF$dyn$u20$impl1..Foo$u2b$Assoc$u20$$u3d$$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RF$u8$C$$u20$...$RP$$u2b$impl1..AutoTrait$u3b$$u20$3$u5d$$u20$as$u20$impl1..main..$u7b$$u7b$closure$u7d$$u7d$..Bar$GT$6method
-            //[legacy]~| ERROR demangling(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; 3] as impl1::main::{{closure}}::Bar>::method
-            //[legacy]~| ERROR demangling-alt(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; 3] as impl1::main::{{closure}}::Bar>::method)
+            //[legacy]~^ ERROR symbol-name(_ZN209_$LT$$u5b$$RF$dyn$u20$impl1..Foo$u2b$Assoc$u20$$u3d$$u20$extern$u20$$u22$C$u22$$u20$fn$LP$$RF$u8$C$$u20$...$RP$$u2b$impl1..AutoTrait$u3b$$u20$_$u5d$$u20$as$u20$impl1..main..$u7b$$u7b$closure$u7d$$u7d$..Bar$GT$6method
+            //[legacy]~| ERROR demangling(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method
+            //[legacy]~| ERROR demangling-alt(<[&dyn impl1::Foo+Assoc = extern "C" fn(&u8, ::.)+impl1::AutoTrait; _] as impl1::main::{{closure}}::Bar>::method)
              //[v0]~^^^^ ERROR symbol-name(_RNvXNCNvCs
                 //[v0]~| ERROR demangling(<[&dyn
                 //[v0]~| ERROR demangling-alt(<[&dyn impl1::Foo<Assoc = for<'a> extern "C" fn(&'a u8, ...)> + impl1::AutoTrait; 3] as impl1::main::{closure#1}::Bar>::method)

--- a/tests/ui/symbol-names/types.legacy.stderr
+++ b/tests/ui/symbol-names/types.legacy.stderr
@@ -430,19 +430,19 @@ error: demangling-alt(a::b::Type<&mut str>)
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b35Type$LT$$u5b$u8$u3b$$u20$0$u5d$$GT$17h[HASH]E)
+error: symbol-name(_ZN1a1b35Type$LT$$u5b$u8$u3b$$u20$_$u5d$$GT$17h[HASH]E)
   --> $DIR/types.rs:234:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<[u8; 0]>::h[HASH])
+error: demangling(a::b::Type<[u8; _]>::h[HASH])
   --> $DIR/types.rs:234:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<[u8; 0]>)
+error: demangling-alt(a::b::Type<[u8; _]>)
   --> $DIR/types.rs:234:5
    |
 LL |     #[rustc_symbol_name]

--- a/tests/ui/symbol-names/types.rs
+++ b/tests/ui/symbol-names/types.rs
@@ -232,9 +232,9 @@ pub fn b() {
     impl Type<&mut str> {}
 
     #[rustc_symbol_name]
-    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b35Type$LT$$u5b$u8$u3b$$u20$0$u5d$$GT$
-    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<[u8; 0]>::
-    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<[u8; 0]>)
+    //[legacy,verbose-legacy]~^ ERROR symbol-name(_ZN1a1b35Type$LT$$u5b$u8$u3b$$u20$_$u5d$$GT$
+    //[legacy,verbose-legacy]~| ERROR demangling(a::b::Type<[u8; _]>::
+    //[legacy,verbose-legacy]~| ERROR demangling-alt(a::b::Type<[u8; _]>)
     //[v0]~^^^^ ERROR symbol-name(_RMsm_NvCsCRATE_HASH_1a1bINtB<REF>_4TypeAhj0_E)
     //[v0]~| ERROR ::b::Type<[u8; 0usize]>>)
     //[v0]~| ERROR demangling-alt(<a::b::Type<[u8; 0]>>)

--- a/tests/ui/symbol-names/types.verbose-legacy.stderr
+++ b/tests/ui/symbol-names/types.verbose-legacy.stderr
@@ -430,19 +430,19 @@ error: demangling-alt(a::b::Type<&mut str>)
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: symbol-name(_ZN1a1b35Type$LT$$u5b$u8$u3b$$u20$0$u5d$$GT$17h[HASH]E)
+error: symbol-name(_ZN1a1b35Type$LT$$u5b$u8$u3b$$u20$_$u5d$$GT$17h[HASH]E)
   --> $DIR/types.rs:234:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling(a::b::Type<[u8; 0]>::h[HASH])
+error: demangling(a::b::Type<[u8; _]>::h[HASH])
   --> $DIR/types.rs:234:5
    |
 LL |     #[rustc_symbol_name]
    |     ^^^^^^^^^^^^^^^^^^^^
 
-error: demangling-alt(a::b::Type<[u8; 0]>)
+error: demangling-alt(a::b::Type<[u8; _]>)
   --> $DIR/types.rs:234:5
    |
 LL |     #[rustc_symbol_name]

--- a/tests/ui/type-alias-impl-trait/generic_nondefining_use.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_nondefining_use.stderr
@@ -35,7 +35,7 @@ error[E0792]: non-defining opaque type use in defining scope
   --> $DIR/generic_nondefining_use.rs:27:24
    |
 LL | fn concrete_const() -> OneConst<{ 123 }> {
-   |                        ^^^^^^^^^^^^^^^^^ argument `123` is not a generic parameter
+   |                        ^^^^^^^^^^^^^^^^^ argument `{ 123 }` is not a generic parameter
    |
 note: for this opaque type
   --> $DIR/generic_nondefining_use.rs:11:33


### PR DESCRIPTION
This PR tries to fix #116308.

TODO:
- [ ] write up the reason why `try_from_lit` should be removed from `from_anon_const`
- [ ] write up the reason why it is safe to do this
- [ ] do a perf run and see if doing this affect performance

ui tests changes:
- [ ] failed run-pass/check-pass (`const-arg-in-const-arg.rs#full`, `abstract-const-as-cast-4.rs`, `no_dependence.rs`, `issue-94293.rs`)
- [ ] symbol mangling affected (`symbol-names/*`)
- [ ] different error report (`const-projection-err.rs#gce`, `abstract-const-as-cast-3.rs`, `type_mismatch.rs`)
- [x] misc
    - error report reordering
    - same error, but different const type reprs

This PR is related to two unstable features (`adt_const_params`: #95174, `generic_const_exprs`: #76560). r? @BoxyUwU 

