### PR TITLE
Don't allow the `#[pointee]` attribute where it doesn't belong

### DIFF
--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -235,6 +235,8 @@ builtin_macros_non_exhaustive_default = default variant must be exhaustive
     .label = declared `#[non_exhaustive]` here
     .help = consider a manual implementation of `Default`
 
+builtin_macros_non_generic_pointee = the `#[pointee]` attribute may only be used on generic parameters
+
 builtin_macros_non_unit_default = the `#[default]` attribute may only be used on unit enum variants
     .help = consider a manual implementation of `Default`
 

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -937,3 +937,10 @@ pub(crate) struct NakedFunctionTestingAttribute {
     #[label]
     pub testing_span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(builtin_macros_non_generic_pointee)]
+pub(crate) struct NonGenericPointee {
+    #[primary_span]
+    pub span: Span,
+}

--- a/tests/ui/deriving/deriving-smart-pointer-neg.rs
+++ b/tests/ui/deriving/deriving-smart-pointer-neg.rs
@@ -53,6 +53,39 @@ struct NoMaybeSized<'a, #[pointee] T> {
     ptr: &'a T,
 }
 
+#[derive(SmartPointer)]
+#[repr(transparent)]
+struct PointeeOnField<'a, #[pointee] T: ?Sized> {
+    #[pointee]
+    //~^ ERROR: the `#[pointee]` attribute may only be used on generic parameters
+    ptr: &'a T
+}
+
+#[derive(SmartPointer)]
+#[repr(transparent)]
+struct PointeeInTypeConstBlock<'a, T: ?Sized = [u32; const { struct UhOh<#[pointee] T>(T); 10 }]> {
+    //~^ ERROR: the `#[pointee]` attribute may only be used on generic parameters
+    ptr: &'a T,
+}
+
+#[derive(SmartPointer)]
+#[repr(transparent)]
+struct PointeeInConstConstBlock<
+    'a,
+    T: ?Sized,
+    const V: u32 = { struct UhOh<#[pointee] T>(T); 10 }>
+    //~^ ERROR: the `#[pointee]` attribute may only be used on generic parameters
+{
+    ptr: &'a T,
+}
+
+#[derive(SmartPointer)]
+#[repr(transparent)]
+struct PointeeInAnotherTypeConstBlock<'a, #[pointee] T: ?Sized> {
+    ptr: PointeeInConstConstBlock<'a, T, { struct UhOh<#[pointee] T>(T); 0 }>
+    //~^ ERROR: the `#[pointee]` attribute may only be used on generic parameters
+}
+
 // However, reordering attributes should work nevertheless.
 #[repr(transparent)]
 #[derive(SmartPointer)]

--- a/tests/ui/deriving/deriving-smart-pointer-neg.stderr
+++ b/tests/ui/deriving/deriving-smart-pointer-neg.stderr
@@ -58,6 +58,30 @@ error: `derive(SmartPointer)` requires T to be marked `?Sized`
 LL | struct NoMaybeSized<'a, #[pointee] T> {
    |                                    ^
 
+error: the `#[pointee]` attribute may only be used on generic parameters
+  --> $DIR/deriving-smart-pointer-neg.rs:59:5
+   |
+LL |     #[pointee]
+   |     ^^^^^^^^^^
+
+error: the `#[pointee]` attribute may only be used on generic parameters
+  --> $DIR/deriving-smart-pointer-neg.rs:66:74
+   |
+LL | struct PointeeInTypeConstBlock<'a, T: ?Sized = [u32; const { struct UhOh<#[pointee] T>(T); 10 }]> {
+   |                                                                          ^^^^^^^^^^
+
+error: the `#[pointee]` attribute may only be used on generic parameters
+  --> $DIR/deriving-smart-pointer-neg.rs:76:34
+   |
+LL |     const V: u32 = { struct UhOh<#[pointee] T>(T); 10 }>
+   |                                  ^^^^^^^^^^
+
+error: the `#[pointee]` attribute may only be used on generic parameters
+  --> $DIR/deriving-smart-pointer-neg.rs:85:56
+   |
+LL |     ptr: PointeeInConstConstBlock<'a, T, { struct UhOh<#[pointee] T>(T); 0 }>
+   |                                                        ^^^^^^^^^^
+
 error[E0392]: lifetime parameter `'a` is never used
   --> $DIR/deriving-smart-pointer-neg.rs:15:16
    |
@@ -90,6 +114,6 @@ LL | struct NoFieldUnit<'a, #[pointee] T: ?Sized>();
    |
    = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
 
-error: aborting due to 12 previous errors
+error: aborting due to 16 previous errors
 
 For more information about this error, try `rustc --explain E0392`.


### PR DESCRIPTION
Error if the `#[pointee]` attribute is applied to anything but generic type parameters.

Closes #128485
Related to #123430