### PR TITLE
Fix rustdoc missing handling of remap-path-prefix option

### DIFF
--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -195,6 +195,7 @@ pub(crate) fn create_config(
         lint_cap,
         scrape_examples_options,
         expanded_args,
+        remap_path_prefix,
         ..
     }: RustdocOptions,
     RenderOptions { document_private, .. }: &RenderOptions,
@@ -247,6 +248,7 @@ pub(crate) fn create_config(
         describe_lints,
         crate_name,
         test,
+        remap_path_prefix,
         ..Options::default()
     };
 

--- a/tests/rustdoc-ui/remap-path-prefix-lint.rs
+++ b/tests/rustdoc-ui/remap-path-prefix-lint.rs
@@ -1,0 +1,10 @@
+// Regression test for remapped paths in rustdoc errors
+// <https://github.com/rust-lang/rust/issues/69264>.
+
+//@ compile-flags:-Z unstable-options --remap-path-prefix={{src-base}}=remapped_path
+//@ rustc-env:RUST_BACKTRACE=0
+
+#![deny(rustdoc::invalid_html_tags)]
+
+/// </script>
+pub struct Bar;

--- a/tests/rustdoc-ui/remap-path-prefix-lint.stderr
+++ b/tests/rustdoc-ui/remap-path-prefix-lint.stderr
@@ -1,0 +1,14 @@
+error: unopened HTML tag `script`
+  --> remapped_path/remap-path-prefix-lint.rs:9:5
+   |
+LL | /// </script>
+   |     ^^^^^^^^^
+   |
+note: the lint level is defined here
+  --> remapped_path/remap-path-prefix-lint.rs:7:9
+   |
+LL | #![deny(rustdoc::invalid_html_tags)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/69264.

cc @weihanglo 
r? @notriddle 