### PR TITLE
Add lint for recursive default impls

### DIFF
--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -265,7 +265,7 @@ mir_build_pointer_pattern = function pointers and raw pointers not derived from 
 
 mir_build_privately_uninhabited = pattern `{$witness_1}` is currently uninhabited, but this variant contains private fields which may become inhabited in the future
 
-mir_build_recursive_default_impl = ..default() in the Default impl does not apply a default for each struct field
+mir_build_recursive_default_impl = calling `..Default::default()` in a `Default` implementation leads to infinite recursion, and does not initialize the fields of a struct or enum
 
 mir_build_rust_2024_incompatible_pat = patterns are not allowed to reset the default binding mode in edition 2024
 

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -265,6 +265,8 @@ mir_build_pointer_pattern = function pointers and raw pointers not derived from 
 
 mir_build_privately_uninhabited = pattern `{$witness_1}` is currently uninhabited, but this variant contains private fields which may become inhabited in the future
 
+mir_build_recursive_default_impl = ..default() in the Default impl does not apply a default for each struct field
+
 mir_build_rust_2024_incompatible_pat = patterns are not allowed to reset the default binding mode in edition 2024
 
 mir_build_rustc_box_attribute_error = `#[rustc_box]` attribute used incorrectly

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -18,15 +18,11 @@ use crate::fluent_generated as fluent;
 pub(crate) struct UnconditionalRecursion {
     #[label]
     pub(crate) span: Span,
-    #[subdiagnostic]
-    pub(crate) default_impl_note: Option<RecursiveDefaultImpl>,
+    #[help(mir_build_recursive_default_impl)]
+    pub(crate) default_impl_note: Option<()>,
     #[label(mir_build_unconditional_recursion_call_site_label)]
     pub(crate) call_sites: Vec<Span>,
 }
-
-#[derive(Subdiagnostic)]
-#[help(mir_build_recursive_default_impl)]
-pub(crate) struct RecursiveDefaultImpl {}
 
 #[derive(LintDiagnostic)]
 #[diag(mir_build_call_to_deprecated_safe_fn_requires_unsafe)]

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -18,9 +18,15 @@ use crate::fluent_generated as fluent;
 pub(crate) struct UnconditionalRecursion {
     #[label]
     pub(crate) span: Span,
+    #[subdiagnostic]
+    pub(crate) default_impl_note: Option<RecursiveDefaultImpl>,
     #[label(mir_build_unconditional_recursion_call_site_label)]
     pub(crate) call_sites: Vec<Span>,
 }
+
+#[derive(Subdiagnostic)]
+#[help(mir_build_recursive_default_impl)]
+pub(crate) struct RecursiveDefaultImpl {}
 
 #[derive(LintDiagnostic)]
 #[diag(mir_build_call_to_deprecated_safe_fn_requires_unsafe)]

--- a/tests/ui/lint/lint-unconditional-recursion.stderr
+++ b/tests/ui/lint/lint-unconditional-recursion.stderr
@@ -122,6 +122,7 @@ LL |         let x = Default::default();
    |                 ------------------ recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
+   = help: ..default() in the Default impl does not apply a default for each struct field
 
 error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:102:5
@@ -196,6 +197,7 @@ LL |             ..Default::default()
    |               ------------------ recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
+   = help: ..default() in the Default impl does not apply a default for each struct field
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/lint/lint-unconditional-recursion.stderr
+++ b/tests/ui/lint/lint-unconditional-recursion.stderr
@@ -122,7 +122,7 @@ LL |         let x = Default::default();
    |                 ------------------ recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
-   = help: ..default() in the Default impl does not apply a default for each struct field
+   = help: calling `..Default::default()` in a `Default` implementation leads to infinite recursion, and does not initialize the fields of a struct or enum
 
 error: function cannot return without recursing
   --> $DIR/lint-unconditional-recursion.rs:102:5
@@ -197,7 +197,7 @@ LL |             ..Default::default()
    |               ------------------ recursive call site
    |
    = help: a `loop` may express intention better if this is on purpose
-   = help: ..default() in the Default impl does not apply a default for each struct field
+   = help: calling `..Default::default()` in a `Default` implementation leads to infinite recursion, and does not initialize the fields of a struct or enum
 
 error: aborting due to 18 previous errors
 


### PR DESCRIPTION
Fixes #128421, where it was pointed out that recursion in default impls can be confusing and always results in failure.
