### PR TITLE
Introduce `SolverRelating` type relation to the new solver code

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -134,6 +134,7 @@ impl<'me, 'bccx, 'tcx> NllTypeRelating<'me, 'bccx, 'tcx> {
 
             self.type_checker.infcx.instantiate_ty_var(
                 self,
+                StructurallyRelateAliases::No,
                 opaque_is_expected,
                 ty_vid,
                 variance,
@@ -353,9 +354,14 @@ impl<'bccx, 'tcx> TypeRelation<TyCtxt<'tcx>> for NllTypeRelating<'_, 'bccx, 'tcx
                 );
             }
 
-            (&ty::Infer(ty::TyVar(a_vid)), _) => {
-                infcx.instantiate_ty_var(self, true, a_vid, self.ambient_variance, b)?
-            }
+            (&ty::Infer(ty::TyVar(a_vid)), _) => infcx.instantiate_ty_var(
+                self,
+                StructurallyRelateAliases::No,
+                true,
+                a_vid,
+                self.ambient_variance,
+                b,
+            )?,
 
             (
                 &ty::Alias(ty::Opaque, ty::AliasTy { def_id: a_def_id, .. }),
@@ -522,10 +528,6 @@ impl<'bccx, 'tcx> TypeRelation<TyCtxt<'tcx>> for NllTypeRelating<'_, 'bccx, 'tcx
 impl<'bccx, 'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for NllTypeRelating<'_, 'bccx, 'tcx> {
     fn span(&self) -> Span {
         self.locations.span(self.type_checker.body)
-    }
-
-    fn structurally_relate_aliases(&self) -> StructurallyRelateAliases {
-        StructurallyRelateAliases::No
     }
 
     fn param_env(&self) -> ty::ParamEnv<'tcx> {

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -1,13 +1,12 @@
 ///! Definition of `InferCtxtLike` from the librarified type layer.
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_middle::infer::unify_key::EffectVarValue;
-use rustc_middle::traits::solve::{Goal, NoSolution, SolverMode};
+use rustc_middle::traits::solve::SolverMode;
 use rustc_middle::traits::ObligationCause;
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::{ErrorGuaranteed, DUMMY_SP};
 use rustc_type_ir::relate::combine::PredicateEmittingRelation;
-use rustc_type_ir::relate::Relate;
 use rustc_type_ir::InferCtxtLike;
 
 use super::{BoundRegionConversionTime, InferCtxt, SubregionOrigin};
@@ -132,26 +131,6 @@ impl<'tcx> InferCtxtLike for InferCtxt<'tcx> {
         f: impl FnOnce(T) -> U,
     ) -> U {
         self.enter_forall(value, f)
-    }
-
-    fn relate<T: Relate<TyCtxt<'tcx>>>(
-        &self,
-        param_env: ty::ParamEnv<'tcx>,
-        lhs: T,
-        variance: ty::Variance,
-        rhs: T,
-    ) -> Result<Vec<Goal<'tcx, ty::Predicate<'tcx>>>, NoSolution> {
-        self.at(&ObligationCause::dummy(), param_env).relate_no_trace(lhs, variance, rhs)
-    }
-
-    fn eq_structurally_relating_aliases<T: Relate<TyCtxt<'tcx>>>(
-        &self,
-        param_env: ty::ParamEnv<'tcx>,
-        lhs: T,
-        rhs: T,
-    ) -> Result<Vec<Goal<'tcx, ty::Predicate<'tcx>>>, NoSolution> {
-        self.at(&ObligationCause::dummy(), param_env)
-            .eq_structurally_relating_aliases_no_trace(lhs, rhs)
     }
 
     fn shallow_resolve(&self, ty: Ty<'tcx>) -> Ty<'tcx> {

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -1,14 +1,17 @@
 ///! Definition of `InferCtxtLike` from the librarified type layer.
 use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_middle::infer::unify_key::EffectVarValue;
 use rustc_middle::traits::solve::{Goal, NoSolution, SolverMode};
 use rustc_middle::traits::ObligationCause;
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::{self, Ty, TyCtxt};
-use rustc_span::DUMMY_SP;
+use rustc_span::{ErrorGuaranteed, DUMMY_SP};
+use rustc_type_ir::relate::combine::PredicateEmittingRelation;
 use rustc_type_ir::relate::Relate;
 use rustc_type_ir::InferCtxtLike;
 
 use super::{BoundRegionConversionTime, InferCtxt, SubregionOrigin};
+use crate::infer::RelateResult;
 
 impl<'tcx> InferCtxtLike for InferCtxt<'tcx> {
     type Interner = TyCtxt<'tcx>;
@@ -155,6 +158,10 @@ impl<'tcx> InferCtxtLike for InferCtxt<'tcx> {
         self.shallow_resolve(ty)
     }
 
+    fn shallow_resolve_const(&self, ct: ty::Const<'tcx>) -> ty::Const<'tcx> {
+        self.shallow_resolve_const(ct)
+    }
+
     fn resolve_vars_if_possible<T>(&self, value: T) -> T
     where
         T: TypeFoldable<TyCtxt<'tcx>>,
@@ -167,10 +174,96 @@ impl<'tcx> InferCtxtLike for InferCtxt<'tcx> {
     }
 
     fn sub_regions(&self, sub: ty::Region<'tcx>, sup: ty::Region<'tcx>) {
-        self.sub_regions(SubregionOrigin::RelateRegionParamBound(DUMMY_SP), sub, sup)
+        self.inner.borrow_mut().unwrap_region_constraints().make_subregion(
+            SubregionOrigin::RelateRegionParamBound(DUMMY_SP),
+            sub,
+            sup,
+        );
+    }
+
+    fn equate_regions(&self, a: ty::Region<'tcx>, b: ty::Region<'tcx>) {
+        self.inner.borrow_mut().unwrap_region_constraints().make_eqregion(
+            SubregionOrigin::RelateRegionParamBound(DUMMY_SP),
+            a,
+            b,
+        );
     }
 
     fn register_ty_outlives(&self, ty: Ty<'tcx>, r: ty::Region<'tcx>) {
         self.register_region_obligation_with_cause(ty, r, &ObligationCause::dummy());
+    }
+
+    fn equate_ty_vids_raw(&self, a: rustc_type_ir::TyVid, b: rustc_type_ir::TyVid) {
+        self.inner.borrow_mut().type_variables().equate(a, b);
+    }
+
+    fn equate_int_vids_raw(&self, a: rustc_type_ir::IntVid, b: rustc_type_ir::IntVid) {
+        self.inner.borrow_mut().int_unification_table().union(a, b);
+    }
+
+    fn equate_float_vids_raw(&self, a: rustc_type_ir::FloatVid, b: rustc_type_ir::FloatVid) {
+        self.inner.borrow_mut().float_unification_table().union(a, b);
+    }
+
+    fn equate_const_vids_raw(&self, a: rustc_type_ir::ConstVid, b: rustc_type_ir::ConstVid) {
+        self.inner.borrow_mut().const_unification_table().union(a, b);
+    }
+
+    fn equate_effect_vids_raw(&self, a: rustc_type_ir::EffectVid, b: rustc_type_ir::EffectVid) {
+        self.inner.borrow_mut().effect_unification_table().union(a, b);
+    }
+
+    fn instantiate_ty_var_raw<R: PredicateEmittingRelation<Self>>(
+        &self,
+        relation: &mut R,
+        target_is_expected: bool,
+        target_vid: rustc_type_ir::TyVid,
+        instantiation_variance: rustc_type_ir::Variance,
+        source_ty: Ty<'tcx>,
+    ) -> RelateResult<'tcx, ()> {
+        self.instantiate_ty_var(
+            relation,
+            target_is_expected,
+            target_vid,
+            instantiation_variance,
+            source_ty,
+        )
+    }
+
+    fn instantiate_int_var_raw(
+        &self,
+        vid: rustc_type_ir::IntVid,
+        value: rustc_type_ir::IntVarValue,
+    ) {
+        self.inner.borrow_mut().int_unification_table().union_value(vid, value);
+    }
+
+    fn instantiate_float_var_raw(
+        &self,
+        vid: rustc_type_ir::FloatVid,
+        value: rustc_type_ir::FloatVarValue,
+    ) {
+        self.inner.borrow_mut().float_unification_table().union_value(vid, value);
+    }
+
+    fn instantiate_effect_var_raw(&self, vid: rustc_type_ir::EffectVid, value: ty::Const<'tcx>) {
+        self.inner
+            .borrow_mut()
+            .effect_unification_table()
+            .union_value(vid, EffectVarValue::Known(value));
+    }
+
+    fn instantiate_const_var_raw<R: PredicateEmittingRelation<Self>>(
+        &self,
+        relation: &mut R,
+        target_is_expected: bool,
+        target_vid: rustc_type_ir::ConstVid,
+        source_ct: ty::Const<'tcx>,
+    ) -> RelateResult<'tcx, ()> {
+        self.instantiate_const_var(relation, target_is_expected, target_vid, source_ct)
+    }
+
+    fn set_tainted_by_errors(&self, e: ErrorGuaranteed) {
+        self.set_tainted_by_errors(e)
     }
 }

--- a/compiler/rustc_infer/src/infer/context.rs
+++ b/compiler/rustc_infer/src/infer/context.rs
@@ -7,6 +7,7 @@ use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_span::{ErrorGuaranteed, DUMMY_SP};
 use rustc_type_ir::relate::combine::PredicateEmittingRelation;
+use rustc_type_ir::relate::StructurallyRelateAliases;
 use rustc_type_ir::InferCtxtLike;
 
 use super::{BoundRegionConversionTime, InferCtxt, SubregionOrigin};
@@ -195,6 +196,7 @@ impl<'tcx> InferCtxtLike for InferCtxt<'tcx> {
     fn instantiate_ty_var_raw<R: PredicateEmittingRelation<Self>>(
         &self,
         relation: &mut R,
+        structurally_relate_aliases: StructurallyRelateAliases,
         target_is_expected: bool,
         target_vid: rustc_type_ir::TyVid,
         instantiation_variance: rustc_type_ir::Variance,
@@ -202,6 +204,7 @@ impl<'tcx> InferCtxtLike for InferCtxt<'tcx> {
     ) -> RelateResult<'tcx, ()> {
         self.instantiate_ty_var(
             relation,
+            structurally_relate_aliases,
             target_is_expected,
             target_vid,
             instantiation_variance,
@@ -235,11 +238,18 @@ impl<'tcx> InferCtxtLike for InferCtxt<'tcx> {
     fn instantiate_const_var_raw<R: PredicateEmittingRelation<Self>>(
         &self,
         relation: &mut R,
+        structurally_relate_aliases: StructurallyRelateAliases,
         target_is_expected: bool,
         target_vid: rustc_type_ir::ConstVid,
         source_ct: ty::Const<'tcx>,
     ) -> RelateResult<'tcx, ()> {
-        self.instantiate_const_var(relation, target_is_expected, target_vid, source_ct)
+        self.instantiate_const_var(
+            relation,
+            structurally_relate_aliases,
+            target_is_expected,
+            target_vid,
+            source_ct,
+        )
     }
 
     fn set_tainted_by_errors(&self, e: ErrorGuaranteed) {

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -180,7 +180,7 @@ impl<'tcx> InferCtxt<'tcx> {
     ///
     /// See `tests/ui/const-generics/occurs-check/` for more examples where this is relevant.
     #[instrument(level = "debug", skip(self, relation))]
-    pub(super) fn instantiate_const_var<R: PredicateEmittingRelation<InferCtxt<'tcx>>>(
+    pub(crate) fn instantiate_const_var<R: PredicateEmittingRelation<InferCtxt<'tcx>>>(
         &self,
         relation: &mut R,
         target_is_expected: bool,

--- a/compiler/rustc_infer/src/infer/relate/generalize.rs
+++ b/compiler/rustc_infer/src/infer/relate/generalize.rs
@@ -35,6 +35,7 @@ impl<'tcx> InferCtxt<'tcx> {
     pub fn instantiate_ty_var<R: PredicateEmittingRelation<InferCtxt<'tcx>>>(
         &self,
         relation: &mut R,
+        structurally_relate_aliases: StructurallyRelateAliases,
         target_is_expected: bool,
         target_vid: ty::TyVid,
         instantiation_variance: ty::Variance,
@@ -53,7 +54,7 @@ impl<'tcx> InferCtxt<'tcx> {
         let Generalization { value_may_be_infer: generalized_ty, has_unconstrained_ty_var } = self
             .generalize(
                 relation.span(),
-                relation.structurally_relate_aliases(),
+                structurally_relate_aliases,
                 target_vid,
                 instantiation_variance,
                 source_ty,
@@ -183,6 +184,7 @@ impl<'tcx> InferCtxt<'tcx> {
     pub(crate) fn instantiate_const_var<R: PredicateEmittingRelation<InferCtxt<'tcx>>>(
         &self,
         relation: &mut R,
+        structurally_relate_aliases: StructurallyRelateAliases,
         target_is_expected: bool,
         target_vid: ty::ConstVid,
         source_ct: ty::Const<'tcx>,
@@ -192,7 +194,7 @@ impl<'tcx> InferCtxt<'tcx> {
         let Generalization { value_may_be_infer: generalized_ct, has_unconstrained_ty_var } = self
             .generalize(
                 relation.span(),
-                relation.structurally_relate_aliases(),
+                structurally_relate_aliases,
                 target_vid,
                 ty::Invariant,
                 source_ct,

--- a/compiler/rustc_infer/src/infer/relate/glb.rs
+++ b/compiler/rustc_infer/src/infer/relate/glb.rs
@@ -7,7 +7,6 @@ use rustc_span::Span;
 
 use super::combine::{CombineFields, PredicateEmittingRelation};
 use super::lattice::{self, LatticeDir};
-use super::StructurallyRelateAliases;
 use crate::infer::{DefineOpaqueTypes, InferCtxt, SubregionOrigin};
 use crate::traits::ObligationCause;
 
@@ -35,7 +34,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Glb<'_, '_, 'tcx> {
         b: T,
     ) -> RelateResult<'tcx, T> {
         match variance {
-            ty::Invariant => self.fields.equate(StructurallyRelateAliases::No).relate(a, b),
+            ty::Invariant => self.fields.equate().relate(a, b),
             ty::Covariant => self.relate(a, b),
             // FIXME(#41044) -- not correct, need test
             ty::Bivariant => Ok(a),
@@ -123,10 +122,6 @@ impl<'combine, 'infcx, 'tcx> LatticeDir<'infcx, 'tcx> for Glb<'combine, 'infcx, 
 impl<'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for Glb<'_, '_, 'tcx> {
     fn span(&self) -> Span {
         self.fields.trace.span()
-    }
-
-    fn structurally_relate_aliases(&self) -> StructurallyRelateAliases {
-        StructurallyRelateAliases::No
     }
 
     fn param_env(&self) -> ty::ParamEnv<'tcx> {

--- a/compiler/rustc_infer/src/infer/relate/lub.rs
+++ b/compiler/rustc_infer/src/infer/relate/lub.rs
@@ -7,7 +7,6 @@ use rustc_span::Span;
 
 use super::combine::{CombineFields, PredicateEmittingRelation};
 use super::lattice::{self, LatticeDir};
-use super::StructurallyRelateAliases;
 use crate::infer::{DefineOpaqueTypes, InferCtxt, SubregionOrigin};
 use crate::traits::ObligationCause;
 
@@ -35,7 +34,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for Lub<'_, '_, 'tcx> {
         b: T,
     ) -> RelateResult<'tcx, T> {
         match variance {
-            ty::Invariant => self.fields.equate(StructurallyRelateAliases::No).relate(a, b),
+            ty::Invariant => self.fields.equate().relate(a, b),
             ty::Covariant => self.relate(a, b),
             // FIXME(#41044) -- not correct, need test
             ty::Bivariant => Ok(a),
@@ -122,10 +121,6 @@ impl<'combine, 'infcx, 'tcx> LatticeDir<'infcx, 'tcx> for Lub<'combine, 'infcx, 
 impl<'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for Lub<'_, '_, 'tcx> {
     fn span(&self) -> Span {
         self.fields.trace.span()
-    }
-
-    fn structurally_relate_aliases(&self) -> StructurallyRelateAliases {
-        StructurallyRelateAliases::No
     }
 
     fn param_env(&self) -> ty::ParamEnv<'tcx> {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -703,6 +703,12 @@ impl<'tcx> rustc_type_ir::inherent::Features<TyCtxt<'tcx>> for &'tcx rustc_featu
     }
 }
 
+impl<'tcx> rustc_type_ir::inherent::Span<TyCtxt<'tcx>> for Span {
+    fn dummy() -> Self {
+        DUMMY_SP
+    }
+}
+
 type InternedSet<'tcx, T> = ShardedHashMap<InternedInSet<'tcx, T>, ()>;
 
 pub struct CtxtInterners<'tcx> {

--- a/compiler/rustc_next_trait_solver/src/relate.rs
+++ b/compiler/rustc_next_trait_solver/src/relate.rs
@@ -1,15 +1,428 @@
+use rustc_type_ir::error::{ExpectedFound, TypeError};
+use rustc_type_ir::inherent::*;
 pub use rustc_type_ir::relate::*;
+use rustc_type_ir::solve::Goal;
+use rustc_type_ir::{self as ty, InferCtxtLike, Interner};
+use tracing::{debug, instrument};
 
-pub mod combine;
+use self::combine::PredicateEmittingRelation;
 
-/// Whether aliases should be related structurally or not. Used
-/// to adjust the behavior of generalization and combine.
-///
-/// This should always be `No` unless in a few special-cases when
-/// instantiating canonical responses and in the new solver. Each
-/// such case should have a comment explaining why it is used.
-#[derive(Debug, Copy, Clone)]
-pub enum StructurallyRelateAliases {
-    Yes,
-    No,
+#[allow(unused)]
+/// Enforce that `a` is equal to or a subtype of `b`.
+pub struct SolverRelating<'infcx, Infcx, I: Interner> {
+    infcx: &'infcx Infcx,
+    structurally_relate_aliases: StructurallyRelateAliases,
+    ambient_variance: ty::Variance,
+    param_env: I::ParamEnv,
+    goals: Vec<Goal<I, I::Predicate>>,
+}
+
+impl<'infcx, Infcx, I> SolverRelating<'infcx, Infcx, I>
+where
+    Infcx: InferCtxtLike<Interner = I>,
+    I: Interner,
+{
+}
+
+impl<Infcx, I> TypeRelation<I> for SolverRelating<'_, Infcx, I>
+where
+    Infcx: InferCtxtLike<Interner = I>,
+    I: Interner,
+{
+    fn cx(&self) -> I {
+        self.infcx.cx()
+    }
+
+    fn relate_item_args(
+        &mut self,
+        item_def_id: I::DefId,
+        a_arg: I::GenericArgs,
+        b_arg: I::GenericArgs,
+    ) -> RelateResult<I, I::GenericArgs> {
+        if self.ambient_variance == ty::Invariant {
+            // Avoid fetching the variance if we are in an invariant
+            // context; no need, and it can induce dependency cycles
+            // (e.g., #41849).
+            relate_args_invariantly(self, a_arg, b_arg)
+        } else {
+            let tcx = self.cx();
+            let opt_variances = tcx.variances_of(item_def_id);
+            relate_args_with_variances(self, item_def_id, opt_variances, a_arg, b_arg, false)
+        }
+    }
+
+    fn relate_with_variance<T: Relate<I>>(
+        &mut self,
+        variance: ty::Variance,
+        _info: VarianceDiagInfo<I>,
+        a: T,
+        b: T,
+    ) -> RelateResult<I, T> {
+        let old_ambient_variance = self.ambient_variance;
+        self.ambient_variance = self.ambient_variance.xform(variance);
+        debug!(?self.ambient_variance, "new ambient variance");
+
+        let r = if self.ambient_variance == ty::Bivariant { Ok(a) } else { self.relate(a, b) };
+
+        self.ambient_variance = old_ambient_variance;
+        r
+    }
+
+    #[instrument(skip(self), level = "trace")]
+    fn tys(&mut self, a: I::Ty, b: I::Ty) -> RelateResult<I, I::Ty> {
+        if a == b {
+            return Ok(a);
+        }
+
+        let infcx = self.infcx;
+        let a = infcx.shallow_resolve(a);
+        let b = infcx.shallow_resolve(b);
+
+        match (a.kind(), b.kind()) {
+            (ty::Infer(ty::TyVar(a_id)), ty::Infer(ty::TyVar(b_id))) => {
+                match self.ambient_variance {
+                    ty::Covariant => {
+                        // can't make progress on `A <: B` if both A and B are
+                        // type variables, so record an obligation.
+                        self.goals.push(Goal::new(
+                            self.cx(),
+                            self.param_env,
+                            ty::Binder::dummy(ty::PredicateKind::Subtype(ty::SubtypePredicate {
+                                a_is_expected: true,
+                                a,
+                                b,
+                            })),
+                        ));
+                    }
+                    ty::Contravariant => {
+                        // can't make progress on `B <: A` if both A and B are
+                        // type variables, so record an obligation.
+                        self.goals.push(Goal::new(
+                            self.cx(),
+                            self.param_env,
+                            ty::Binder::dummy(ty::PredicateKind::Subtype(ty::SubtypePredicate {
+                                a_is_expected: false,
+                                a: b,
+                                b: a,
+                            })),
+                        ));
+                    }
+                    ty::Invariant => {
+                        infcx.equate_ty_vids_raw(a_id, b_id);
+                    }
+                    ty::Bivariant => {
+                        unreachable!("Expected bivariance to be handled in relate_with_variance")
+                    }
+                }
+                Ok(a)
+            }
+
+            (ty::Infer(ty::TyVar(a_vid)), _) => {
+                infcx.instantiate_ty_var_raw(self, true, a_vid, self.ambient_variance, b)?;
+                Ok(a)
+            }
+            (_, ty::Infer(ty::TyVar(b_vid))) => {
+                infcx.instantiate_ty_var_raw(
+                    self,
+                    false,
+                    b_vid,
+                    self.ambient_variance.xform(ty::Contravariant),
+                    a,
+                )?;
+                Ok(a)
+            }
+
+            (ty::Error(e), _) | (_, ty::Error(e)) => {
+                infcx.set_tainted_by_errors(e);
+                Ok(Ty::new_error(self.cx(), e))
+            }
+
+            // Relate integral variables to other types
+            (ty::Infer(ty::IntVar(a_id)), ty::Infer(ty::IntVar(b_id))) => {
+                infcx.equate_int_vids_raw(a_id, b_id);
+                Ok(a)
+            }
+            (ty::Infer(ty::IntVar(v_id)), ty::Int(v)) => {
+                infcx.instantiate_int_var_raw(v_id, ty::IntVarValue::IntType(v));
+                Ok(a)
+            }
+            (ty::Int(v), ty::Infer(ty::IntVar(v_id))) => {
+                infcx.instantiate_int_var_raw(v_id, ty::IntVarValue::IntType(v));
+                Ok(a)
+            }
+            (ty::Infer(ty::IntVar(v_id)), ty::Uint(v)) => {
+                infcx.instantiate_int_var_raw(v_id, ty::IntVarValue::UintType(v));
+                Ok(a)
+            }
+            (ty::Uint(v), ty::Infer(ty::IntVar(v_id))) => {
+                infcx.instantiate_int_var_raw(v_id, ty::IntVarValue::UintType(v));
+                Ok(a)
+            }
+
+            // Relate floating-point variables to other types
+            (ty::Infer(ty::FloatVar(a_id)), ty::Infer(ty::FloatVar(b_id))) => {
+                infcx.equate_float_vids_raw(a_id, b_id);
+                Ok(a)
+            }
+            (ty::Infer(ty::FloatVar(v_id)), ty::Float(v)) => {
+                infcx.instantiate_float_var_raw(v_id, ty::FloatVarValue::Known(v));
+                Ok(a)
+            }
+            (ty::Float(v), ty::Infer(ty::FloatVar(v_id))) => {
+                infcx.instantiate_float_var_raw(v_id, ty::FloatVarValue::Known(v));
+                Ok(a)
+            }
+
+            (_, ty::Alias(..)) | (ty::Alias(..), _) => match self.structurally_relate_aliases {
+                StructurallyRelateAliases::Yes => structurally_relate_tys(self, a, b),
+                StructurallyRelateAliases::No => {
+                    self.register_alias_relate_predicate(a, b);
+                    Ok(a)
+                }
+            },
+
+            // All other cases of inference are errors
+            (ty::Infer(_), _) | (_, ty::Infer(_)) => {
+                Err(TypeError::Sorts(ExpectedFound::new(true, a, b)))
+            }
+
+            _ => structurally_relate_tys(self, a, b),
+        }
+    }
+
+    #[instrument(skip(self), level = "trace")]
+    fn regions(&mut self, a: I::Region, b: I::Region) -> RelateResult<I, I::Region> {
+        match self.ambient_variance {
+            // Subtype(&'a u8, &'b u8) => Outlives('a: 'b) => SubRegion('b, 'a)
+            ty::Covariant => {
+                self.infcx.sub_regions(b, a);
+            }
+            // Suptype(&'a u8, &'b u8) => Outlives('b: 'a) => SubRegion('a, 'b)
+            ty::Contravariant => {
+                self.infcx.sub_regions(a, b);
+            }
+            ty::Invariant => {
+                self.infcx.equate_regions(a, b);
+            }
+            ty::Bivariant => {
+                unreachable!("Expected bivariance to be handled in relate_with_variance")
+            }
+        }
+
+        Ok(a)
+    }
+
+    #[instrument(skip(self), level = "trace")]
+    fn consts(&mut self, a: I::Const, b: I::Const) -> RelateResult<I, I::Const> {
+        if a == b {
+            return Ok(a);
+        }
+
+        let infcx = self.infcx;
+        let a = infcx.shallow_resolve_const(a);
+        let b = infcx.shallow_resolve_const(b);
+
+        match (a.kind(), b.kind()) {
+            (
+                ty::ConstKind::Infer(ty::InferConst::Var(a_vid)),
+                ty::ConstKind::Infer(ty::InferConst::Var(b_vid)),
+            ) => {
+                infcx.equate_const_vids_raw(a_vid, b_vid);
+                Ok(a)
+            }
+
+            (
+                ty::ConstKind::Infer(ty::InferConst::EffectVar(a_vid)),
+                ty::ConstKind::Infer(ty::InferConst::EffectVar(b_vid)),
+            ) => {
+                infcx.equate_effect_vids_raw(a_vid, b_vid);
+                Ok(a)
+            }
+
+            // All other cases of inference with other variables are errors.
+            (
+                ty::ConstKind::Infer(ty::InferConst::Var(_) | ty::InferConst::EffectVar(_)),
+                ty::ConstKind::Infer(_),
+            )
+            | (
+                ty::ConstKind::Infer(_),
+                ty::ConstKind::Infer(ty::InferConst::Var(_) | ty::InferConst::EffectVar(_)),
+            ) => {
+                panic!(
+                    "tried to combine ConstKind::Infer/ConstKind::Infer(InferConst::Var): {a:?} and {b:?}"
+                )
+            }
+
+            (ty::ConstKind::Infer(ty::InferConst::Var(vid)), _) => {
+                infcx.instantiate_const_var_raw(self, true, vid, b)?;
+                Ok(b)
+            }
+
+            (_, ty::ConstKind::Infer(ty::InferConst::Var(vid))) => {
+                infcx.instantiate_const_var_raw(self, false, vid, a)?;
+                Ok(a)
+            }
+
+            (ty::ConstKind::Infer(ty::InferConst::EffectVar(vid)), _) => {
+                infcx.instantiate_effect_var_raw(vid, b);
+                Ok(a)
+            }
+
+            (_, ty::ConstKind::Infer(ty::InferConst::EffectVar(vid))) => {
+                infcx.instantiate_effect_var_raw(vid, a);
+                Ok(a)
+            }
+
+            (ty::ConstKind::Unevaluated(..), _) | (_, ty::ConstKind::Unevaluated(..)) => {
+                match self.structurally_relate_aliases {
+                    StructurallyRelateAliases::No => {
+                        self.register_predicates([ty::PredicateKind::AliasRelate(
+                            a.into(),
+                            b.into(),
+                            ty::AliasRelationDirection::Equate,
+                        )]);
+
+                        Ok(b)
+                    }
+                    StructurallyRelateAliases::Yes => structurally_relate_consts(self, a, b),
+                }
+            }
+
+            _ => structurally_relate_consts(self, a, b),
+        }
+    }
+
+    fn binders<T>(
+        &mut self,
+        a: ty::Binder<I, T>,
+        b: ty::Binder<I, T>,
+    ) -> RelateResult<I, ty::Binder<I, T>>
+    where
+        T: Relate<I>,
+    {
+        // If they're equal, then short-circuit.
+        if a == b {
+            return Ok(a);
+        }
+
+        // If they have no bound vars, relate normally.
+        if let Some(a_inner) = a.no_bound_vars() {
+            if let Some(b_inner) = b.no_bound_vars() {
+                self.relate(a_inner, b_inner)?;
+                return Ok(a);
+            }
+        };
+
+        match self.ambient_variance {
+            // Checks whether `for<..> sub <: for<..> sup` holds.
+            //
+            // For this to hold, **all** instantiations of the super type
+            // have to be a super type of **at least one** instantiation of
+            // the subtype.
+            //
+            // This is implemented by first entering a new universe.
+            // We then replace all bound variables in `sup` with placeholders,
+            // and all bound variables in `sub` with inference vars.
+            // We can then just relate the two resulting types as normal.
+            //
+            // Note: this is a subtle algorithm. For a full explanation, please see
+            // the [rustc dev guide][rd]
+            //
+            // [rd]: https://rustc-dev-guide.rust-lang.org/borrow_check/region_inference/placeholders_and_universes.html
+            ty::Covariant => {
+                self.infcx.enter_forall(b, |b| {
+                    let a = self.infcx.instantiate_binder_with_infer(a);
+                    self.relate(a, b)
+                })?;
+            }
+            ty::Contravariant => {
+                self.infcx.enter_forall(a, |a| {
+                    let b = self.infcx.instantiate_binder_with_infer(b);
+                    self.relate(a, b)
+                })?;
+            }
+
+            // When **equating** binders, we check that there is a 1-to-1
+            // correspondence between the bound vars in both types.
+            //
+            // We do so by separately instantiating one of the binders with
+            // placeholders and the other with inference variables and then
+            // equating the instantiated types.
+            //
+            // We want `for<..> A == for<..> B` -- therefore we want
+            // `exists<..> A == for<..> B` and `exists<..> B == for<..> A`.
+            // Check if `exists<..> A == for<..> B`
+            ty::Invariant => {
+                self.infcx.enter_forall(b, |b| {
+                    let a = self.infcx.instantiate_binder_with_infer(a);
+                    self.relate(a, b)
+                })?;
+
+                // Check if `exists<..> B == for<..> A`.
+                self.infcx.enter_forall(a, |a| {
+                    let b = self.infcx.instantiate_binder_with_infer(b);
+                    self.relate(a, b)
+                })?;
+            }
+            ty::Bivariant => {
+                unreachable!("Expected bivariance to be handled in relate_with_variance")
+            }
+        }
+        Ok(a)
+    }
+}
+
+impl<Infcx, I> PredicateEmittingRelation<Infcx> for SolverRelating<'_, Infcx, I>
+where
+    Infcx: InferCtxtLike<Interner = I>,
+    I: Interner,
+{
+    fn span(&self) -> I::Span {
+        Span::dummy()
+    }
+
+    fn param_env(&self) -> I::ParamEnv {
+        self.param_env
+    }
+
+    fn structurally_relate_aliases(&self) -> StructurallyRelateAliases {
+        self.structurally_relate_aliases
+    }
+
+    fn register_predicates(
+        &mut self,
+        obligations: impl IntoIterator<Item: ty::Upcast<I, I::Predicate>>,
+    ) {
+        self.goals.extend(
+            obligations.into_iter().map(|pred| Goal::new(self.infcx.cx(), self.param_env, pred)),
+        );
+    }
+
+    fn register_goals(&mut self, obligations: impl IntoIterator<Item = Goal<I, I::Predicate>>) {
+        self.goals.extend(obligations);
+    }
+
+    fn register_alias_relate_predicate(&mut self, a: I::Ty, b: I::Ty) {
+        self.register_predicates([ty::Binder::dummy(match self.ambient_variance {
+            ty::Covariant => ty::PredicateKind::AliasRelate(
+                a.into(),
+                b.into(),
+                ty::AliasRelationDirection::Subtype,
+            ),
+            // a :> b is b <: a
+            ty::Contravariant => ty::PredicateKind::AliasRelate(
+                b.into(),
+                a.into(),
+                ty::AliasRelationDirection::Subtype,
+            ),
+            ty::Invariant => ty::PredicateKind::AliasRelate(
+                a.into(),
+                b.into(),
+                ty::AliasRelationDirection::Equate,
+            ),
+            ty::Bivariant => {
+                unreachable!("Expected bivariance to be handled in relate_with_variance")
+            }
+        })]);
+    }
 }

--- a/compiler/rustc_next_trait_solver/src/relate.rs
+++ b/compiler/rustc_next_trait_solver/src/relate.rs
@@ -178,12 +178,20 @@ where
             }
 
             (ty::Infer(ty::TyVar(a_vid)), _) => {
-                infcx.instantiate_ty_var_raw(self, true, a_vid, self.ambient_variance, b)?;
+                infcx.instantiate_ty_var_raw(
+                    self,
+                    self.structurally_relate_aliases,
+                    true,
+                    a_vid,
+                    self.ambient_variance,
+                    b,
+                )?;
                 Ok(a)
             }
             (_, ty::Infer(ty::TyVar(b_vid))) => {
                 infcx.instantiate_ty_var_raw(
                     self,
+                    self.structurally_relate_aliases,
                     false,
                     b_vid,
                     self.ambient_variance.xform(ty::Contravariant),
@@ -314,12 +322,24 @@ where
             }
 
             (ty::ConstKind::Infer(ty::InferConst::Var(vid)), _) => {
-                infcx.instantiate_const_var_raw(self, true, vid, b)?;
+                infcx.instantiate_const_var_raw(
+                    self,
+                    self.structurally_relate_aliases,
+                    true,
+                    vid,
+                    b,
+                )?;
                 Ok(b)
             }
 
             (_, ty::ConstKind::Infer(ty::InferConst::Var(vid))) => {
-                infcx.instantiate_const_var_raw(self, false, vid, a)?;
+                infcx.instantiate_const_var_raw(
+                    self,
+                    self.structurally_relate_aliases,
+                    false,
+                    vid,
+                    a,
+                )?;
                 Ok(a)
             }
 
@@ -443,10 +463,6 @@ where
 
     fn param_env(&self) -> I::ParamEnv {
         self.param_env
-    }
-
-    fn structurally_relate_aliases(&self) -> StructurallyRelateAliases {
-        self.structurally_relate_aliases
     }
 
     fn register_predicates(

--- a/compiler/rustc_next_trait_solver/src/relate.rs
+++ b/compiler/rustc_next_trait_solver/src/relate.rs
@@ -1,11 +1,57 @@
 use rustc_type_ir::error::{ExpectedFound, TypeError};
 use rustc_type_ir::inherent::*;
 pub use rustc_type_ir::relate::*;
-use rustc_type_ir::solve::Goal;
+use rustc_type_ir::solve::{Goal, NoSolution};
 use rustc_type_ir::{self as ty, InferCtxtLike, Interner};
 use tracing::{debug, instrument};
 
 use self::combine::PredicateEmittingRelation;
+
+pub trait RelateExt: InferCtxtLike {
+    fn relate<T: Relate<Self::Interner>>(
+        &self,
+        param_env: <Self::Interner as Interner>::ParamEnv,
+        lhs: T,
+        variance: ty::Variance,
+        rhs: T,
+    ) -> Result<Vec<Goal<Self::Interner, <Self::Interner as Interner>::Predicate>>, NoSolution>;
+
+    fn eq_structurally_relating_aliases<T: Relate<Self::Interner>>(
+        &self,
+        param_env: <Self::Interner as Interner>::ParamEnv,
+        lhs: T,
+        rhs: T,
+    ) -> Result<Vec<Goal<Self::Interner, <Self::Interner as Interner>::Predicate>>, NoSolution>;
+}
+
+impl<Infcx: InferCtxtLike> RelateExt for Infcx {
+    fn relate<T: Relate<Self::Interner>>(
+        &self,
+        param_env: <Self::Interner as Interner>::ParamEnv,
+        lhs: T,
+        variance: ty::Variance,
+        rhs: T,
+    ) -> Result<Vec<Goal<Self::Interner, <Self::Interner as Interner>::Predicate>>, NoSolution>
+    {
+        let mut relate =
+            SolverRelating::new(self, StructurallyRelateAliases::No, variance, param_env);
+        relate.relate(lhs, rhs)?;
+        Ok(relate.goals)
+    }
+
+    fn eq_structurally_relating_aliases<T: Relate<Self::Interner>>(
+        &self,
+        param_env: <Self::Interner as Interner>::ParamEnv,
+        lhs: T,
+        rhs: T,
+    ) -> Result<Vec<Goal<Self::Interner, <Self::Interner as Interner>::Predicate>>, NoSolution>
+    {
+        let mut relate =
+            SolverRelating::new(self, StructurallyRelateAliases::Yes, ty::Invariant, param_env);
+        relate.relate(lhs, rhs)?;
+        Ok(relate.goals)
+    }
+}
 
 #[allow(unused)]
 /// Enforce that `a` is equal to or a subtype of `b`.
@@ -22,6 +68,20 @@ where
     Infcx: InferCtxtLike<Interner = I>,
     I: Interner,
 {
+    fn new(
+        infcx: &'infcx Infcx,
+        structurally_relate_aliases: StructurallyRelateAliases,
+        ambient_variance: ty::Variance,
+        param_env: I::ParamEnv,
+    ) -> Self {
+        SolverRelating {
+            infcx,
+            structurally_relate_aliases,
+            ambient_variance,
+            param_env,
+            goals: vec![],
+        }
+    }
 }
 
 impl<Infcx, I> TypeRelation<I> for SolverRelating<'_, Infcx, I>

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/canonical.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/canonical.rs
@@ -19,6 +19,7 @@ use tracing::{instrument, trace};
 
 use crate::canonicalizer::{CanonicalizeMode, Canonicalizer};
 use crate::delegate::SolverDelegate;
+use crate::relate::RelateExt;
 use crate::resolve::EagerResolver;
 use crate::solve::eval_ctxt::NestedGoals;
 use crate::solve::{

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -14,6 +14,7 @@ use tracing::{instrument, trace};
 
 use crate::coherence;
 use crate::delegate::SolverDelegate;
+use crate::relate::RelateExt;
 use crate::solve::inspect::{self, ProofTreeBuilder};
 use crate::solve::search_graph::SearchGraph;
 use crate::solve::{

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -793,7 +793,7 @@ where
             let ctor_term = rigid_ctor.to_term(cx);
             let obligations =
                 self.delegate.eq_structurally_relating_aliases(param_env, term, ctor_term)?;
-            debug_assert!(obligations.is_empty());
+            debug_assert!(obligations.is_empty(), "{obligations:#?}");
             self.relate(param_env, alias, variance, rigid_ctor)
         } else {
             Err(NoSolution)

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -1,7 +1,7 @@
 use crate::fold::TypeFoldable;
 use crate::relate::combine::PredicateEmittingRelation;
-use crate::relate::{Relate, RelateResult};
-use crate::solve::{Goal, NoSolution, SolverMode};
+use crate::relate::RelateResult;
+use crate::solve::SolverMode;
 use crate::{self as ty, Interner};
 
 pub trait InferCtxtLike: Sized {
@@ -89,21 +89,6 @@ pub trait InferCtxtLike: Sized {
     ) -> RelateResult<Self::Interner, ()>;
 
     fn set_tainted_by_errors(&self, e: <Self::Interner as Interner>::ErrorGuaranteed);
-
-    fn relate<T: Relate<Self::Interner>>(
-        &self,
-        param_env: <Self::Interner as Interner>::ParamEnv,
-        lhs: T,
-        variance: ty::Variance,
-        rhs: T,
-    ) -> Result<Vec<Goal<Self::Interner, <Self::Interner as Interner>::Predicate>>, NoSolution>;
-
-    fn eq_structurally_relating_aliases<T: Relate<Self::Interner>>(
-        &self,
-        param_env: <Self::Interner as Interner>::ParamEnv,
-        lhs: T,
-        rhs: T,
-    ) -> Result<Vec<Goal<Self::Interner, <Self::Interner as Interner>::Predicate>>, NoSolution>;
 
     fn shallow_resolve(
         &self,

--- a/compiler/rustc_type_ir/src/infer_ctxt.rs
+++ b/compiler/rustc_type_ir/src/infer_ctxt.rs
@@ -1,6 +1,6 @@
 use crate::fold::TypeFoldable;
 use crate::relate::combine::PredicateEmittingRelation;
-use crate::relate::RelateResult;
+use crate::relate::{RelateResult, StructurallyRelateAliases};
 use crate::solve::SolverMode;
 use crate::{self as ty, Interner};
 
@@ -68,6 +68,7 @@ pub trait InferCtxtLike: Sized {
     fn instantiate_ty_var_raw<R: PredicateEmittingRelation<Self>>(
         &self,
         relation: &mut R,
+        structurally_relate_aliases: StructurallyRelateAliases,
         target_is_expected: bool,
         target_vid: ty::TyVid,
         instantiation_variance: ty::Variance,
@@ -83,6 +84,7 @@ pub trait InferCtxtLike: Sized {
     fn instantiate_const_var_raw<R: PredicateEmittingRelation<Self>>(
         &self,
         relation: &mut R,
+        structurally_relate_aliases: StructurallyRelateAliases,
         target_is_expected: bool,
         target_vid: ty::ConstVid,
         source_ct: <Self::Interner as Interner>::Const,

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -561,6 +561,10 @@ pub trait BoundExistentialPredicates<I: Interner>:
     ) -> impl IntoIterator<Item = ty::Binder<I, ty::ExistentialProjection<I>>>;
 }
 
+pub trait Span<I: Interner>: Copy + Debug + Hash + Eq + TypeFoldable<I> {
+    fn dummy() -> Self;
+}
+
 pub trait SliceLike: Sized + Copy {
     type Item: Copy;
     type IntoIter: Iterator<Item = Self::Item>;

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -37,7 +37,7 @@ pub trait Interner:
 {
     type DefId: DefId<Self>;
     type LocalDefId: Copy + Debug + Hash + Eq + Into<Self::DefId> + TypeFoldable<Self>;
-    type Span: Copy + Debug + Hash + Eq + TypeFoldable<Self>;
+    type Span: Span<Self>;
 
     type GenericArgs: GenericArgs<Self>;
     type GenericArgsSlice: Copy + Debug + Hash + Eq + SliceLike<Item = Self::GenericArg>;

--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -9,6 +9,20 @@ use crate::fold::TypeFoldable;
 use crate::inherent::*;
 use crate::{self as ty, Interner};
 
+pub mod combine;
+
+/// Whether aliases should be related structurally or not. Used
+/// to adjust the behavior of generalization and combine.
+///
+/// This should always be `No` unless in a few special-cases when
+/// instantiating canonical responses and in the new solver. Each
+/// such case should have a comment explaining why it is used.
+#[derive(Debug, Copy, Clone)]
+pub enum StructurallyRelateAliases {
+    Yes,
+    No,
+}
+
 pub type RelateResult<I, T> = Result<T, TypeError<I>>;
 
 /// Extra information about why we ended up with a particular variance.

--- a/compiler/rustc_type_ir/src/relate/combine.rs
+++ b/compiler/rustc_type_ir/src/relate/combine.rs
@@ -1,8 +1,6 @@
-pub use rustc_type_ir::relate::*;
-use rustc_type_ir::solve::Goal;
-use rustc_type_ir::{InferCtxtLike, Interner, Upcast};
-
-use super::StructurallyRelateAliases;
+use super::{StructurallyRelateAliases, TypeRelation};
+use crate::solve::Goal;
+use crate::{InferCtxtLike, Interner, Upcast};
 
 pub trait PredicateEmittingRelation<Infcx, I = <Infcx as InferCtxtLike>::Interner>:
     TypeRelation<I>

--- a/compiler/rustc_type_ir/src/relate/combine.rs
+++ b/compiler/rustc_type_ir/src/relate/combine.rs
@@ -1,4 +1,4 @@
-use super::{StructurallyRelateAliases, TypeRelation};
+use super::TypeRelation;
 use crate::solve::Goal;
 use crate::{InferCtxtLike, Interner, Upcast};
 
@@ -11,11 +11,6 @@ where
     fn span(&self) -> I::Span;
 
     fn param_env(&self) -> I::ParamEnv;
-
-    /// Whether aliases should be related structurally. This is pretty much
-    /// always `No` unless you're equating in some specific locations of the
-    /// new solver. See the comments in these use-cases for more details.
-    fn structurally_relate_aliases(&self) -> StructurallyRelateAliases;
 
     /// Register obligations that must hold in order for this relation to hold
     fn register_goals(&mut self, obligations: impl IntoIterator<Item = Goal<I, I::Predicate>>);


### PR DESCRIPTION
This "uplifts" (i.e. duplicates) the `TypeRelating` delegate into the new solver as a new relation called `SolverRelating`, so we can use that rather than exposing `InferCtxtLike::relate` for implementations to have to implement themselves.

The reason I duplicated rather than fully uplifted `TypeRelating` is because it's so complicated.
* `CombineFields` is a bunch of unnecessary machinery that only exists to track a `Trace` and to make it easy to swap between `Lub`/`Glb`.
* There are a bunch of `next_trait_solver` branches in in the `super_combine_{const,ty}` functions, and in the `TypeRelating` code itself that can be folded away.

This then allows us to remove `StructurallyRelateAliases` from `PredicateEmittingRelation` and move it directly onto the generalizer `instantiate_*_var` functions.

r? @lcnr -- I'm curious what you think of this approach in general.