### PR TITLE
rustc_codegen_ssa: Set architecture for object crate for 32-bit SPARC

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -208,6 +208,7 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
         "powerpc64" => (Architecture::PowerPc64, None),
         "riscv32" => (Architecture::Riscv32, None),
         "riscv64" => (Architecture::Riscv64, None),
+        "sparc" => (Architecture::Sparc32Plus, None),
         "sparc64" => (Architecture::Sparc64, None),
         "avr" => (Architecture::Avr, None),
         "msp430" => (Architecture::Msp430, None),


### PR DESCRIPTION
The `object` crate was recently updated to recognize the 32-bit SPARC ELF targets `EM_SPARC` and `EM_SPARC32PLUS`, so the proper architecture for 32-bit SPARC can now be set in `rustc_codegen_ssa`.

r? nagisa