### PR TITLE
Use `Param` in desugaring method `~const` bounds as effects

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -410,6 +410,7 @@ language_item_table! {
     EffectsRuntime,          sym::EffectsRuntime,      effects_runtime,            Target::Struct,         GenericRequirement::None;
     EffectsNoRuntime,        sym::EffectsNoRuntime,    effects_no_runtime,         Target::Struct,         GenericRequirement::None;
     EffectsMaybe,            sym::EffectsMaybe,        effects_maybe,              Target::Struct,         GenericRequirement::None;
+    EffectsParam,            sym::EffectsParam,        effects_param,              Target::Struct,         GenericRequirement::Exact(1);
     EffectsIntersection,     sym::EffectsIntersection, effects_intersection,       Target::Trait,          GenericRequirement::None;
     EffectsIntersectionOutput, sym::EffectsIntersectionOutput, effects_intersection_output, Target::AssocTy, GenericRequirement::None;
     EffectsCompat,           sym::EffectsCompat,       effects_compat,             Target::Trait,          GenericRequirement::Exact(1);

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -199,6 +199,7 @@ symbols! {
         EffectsIntersectionOutput,
         EffectsMaybe,
         EffectsNoRuntime,
+        EffectsParam,
         EffectsRuntime,
         EffectsTyCompat,
         Effects__,

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1085,6 +1085,9 @@ pub mod effects {
     #[lang = "EffectsRuntime"]
     pub struct Runtime;
 
+    #[cfg_attr(not(bootstrap), lang = "EffectsParam")]
+    pub struct Param<const RUNTIME: bool>;
+
     #[lang = "EffectsCompat"]
     pub trait Compat<#[rustc_runtime] const RUNTIME: bool> {}
 
@@ -1097,8 +1100,11 @@ pub mod effects {
     pub trait TyCompat<T: ?Sized> {}
 
     impl<T: ?Sized> TyCompat<T> for T {}
-    impl<T: ?Sized> TyCompat<T> for Maybe {}
     impl<T: ?Sized> TyCompat<Maybe> for T {}
+    impl TyCompat<Param<true>> for Runtime {}
+    impl TyCompat<Runtime> for Param<true> {}
+    impl TyCompat<Param<false>> for NoRuntime {}
+    impl TyCompat<NoRuntime> for Param<false> {}
 
     #[lang = "EffectsIntersection"]
     pub trait Intersection {

--- a/tests/ui/delegation/not-supported.rs
+++ b/tests/ui/delegation/not-supported.rs
@@ -111,6 +111,7 @@ mod effects {
 
     reuse Trait::foo;
     //~^ ERROR delegation to a function with effect parameter is not supported yet
+    //~| ERROR mismatched types
 }
 
 fn main() {}

--- a/tests/ui/delegation/not-supported.stderr
+++ b/tests/ui/delegation/not-supported.stderr
@@ -198,7 +198,16 @@ LL |         pub reuse to_reuse2::foo;
 LL |     reuse to_reuse1::foo;
    |                      ^^^
 
-error: aborting due to 17 previous errors; 2 warnings emitted
+error[E0308]: mismatched types
+  --> $DIR/not-supported.rs:112:18
+   |
+LL |     reuse Trait::foo;
+   |                  ^^^ expected `true`, found `host`
+   |
+   = note: expected constant `true`
+              found constant `host`
 
-Some errors have detailed explanations: E0049, E0195, E0391.
+error: aborting due to 18 previous errors; 2 warnings emitted
+
+Some errors have detailed explanations: E0049, E0195, E0308, E0391.
 For more information about an error, try `rustc --explain E0049`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/assoc-type-const-bound-usage-0.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/assoc-type-const-bound-usage-0.stderr
@@ -3,12 +3,15 @@ error: using `#![feature(effects)]` without enabling next trait solver globally
    = note: the next trait solver must be enabled globally for the effects feature to work correctly
    = help: use `-Znext-solver` to enable
 
-error[E0277]: the trait bound `Trait::{synthetic#0}: Compat` is not satisfied
+error[E0277]: the trait bound `Param<_>: TyCompat<Trait::{synthetic#0}>` is not satisfied
   --> $DIR/assoc-type-const-bound-usage-0.rs:13:5
    |
 LL |     T::Assoc::func()
-   |     ^^^^^^^^ the trait `Compat` is not implemented for `Trait::{synthetic#0}`
+   |     ^^^^^^^^ the trait `TyCompat<Trait::{synthetic#0}>` is not implemented for `Param<_>`
    |
+   = help: the following other types implement trait `TyCompat<T>`:
+             `Param<false>` implements `TyCompat<NoRuntime>`
+             `Param<true>` implements `TyCompat<Runtime>`
 note: required by a bound in `Trait::func`
   --> $DIR/assoc-type-const-bound-usage-0.rs:6:1
    |
@@ -18,12 +21,15 @@ LL | #[const_trait]
 LL |     fn func() -> i32;
    |        ---- required by a bound in this associated function
 
-error[E0277]: the trait bound `Trait::{synthetic#0}: Compat` is not satisfied
+error[E0277]: the trait bound `Param<_>: TyCompat<Trait::{synthetic#0}>` is not satisfied
   --> $DIR/assoc-type-const-bound-usage-0.rs:17:5
    |
 LL |     <T as Trait>::Assoc::func()
-   |     ^^^^^^^^^^^^^^^^^^^ the trait `Compat` is not implemented for `Trait::{synthetic#0}`
+   |     ^^^^^^^^^^^^^^^^^^^ the trait `TyCompat<Trait::{synthetic#0}>` is not implemented for `Param<_>`
    |
+   = help: the following other types implement trait `TyCompat<T>`:
+             `Param<false>` implements `TyCompat<NoRuntime>`
+             `Param<true>` implements `TyCompat<Runtime>`
 note: required by a bound in `Trait::func`
   --> $DIR/assoc-type-const-bound-usage-0.rs:6:1
    |

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/assoc-type-const-bound-usage-1.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/assoc-type-const-bound-usage-1.stderr
@@ -3,12 +3,15 @@ error: using `#![feature(effects)]` without enabling next trait solver globally
    = note: the next trait solver must be enabled globally for the effects feature to work correctly
    = help: use `-Znext-solver` to enable
 
-error[E0277]: the trait bound `Trait::{synthetic#0}: Compat` is not satisfied
+error[E0277]: the trait bound `Param<_>: TyCompat<Trait::{synthetic#0}>` is not satisfied
   --> $DIR/assoc-type-const-bound-usage-1.rs:15:44
    |
 LL | fn unqualified<T: const Trait>() -> Type<{ T::Assoc::func() }> {
-   |                                            ^^^^^^^^ the trait `Compat` is not implemented for `Trait::{synthetic#0}`
+   |                                            ^^^^^^^^ the trait `TyCompat<Trait::{synthetic#0}>` is not implemented for `Param<_>`
    |
+   = help: the following other types implement trait `TyCompat<T>`:
+             `Param<false>` implements `TyCompat<NoRuntime>`
+             `Param<true>` implements `TyCompat<Runtime>`
 note: required by a bound in `Trait::func`
   --> $DIR/assoc-type-const-bound-usage-1.rs:7:1
    |
@@ -18,12 +21,15 @@ LL | #[const_trait]
 LL |     fn func() -> i32;
    |        ---- required by a bound in this associated function
 
-error[E0277]: the trait bound `Trait::{synthetic#0}: Compat` is not satisfied
+error[E0277]: the trait bound `Param<_>: TyCompat<Trait::{synthetic#0}>` is not satisfied
   --> $DIR/assoc-type-const-bound-usage-1.rs:19:42
    |
 LL | fn qualified<T: const Trait>() -> Type<{ <T as Trait>::Assoc::func() }> {
-   |                                          ^^^^^^^^^^^^^^^^^^^ the trait `Compat` is not implemented for `Trait::{synthetic#0}`
+   |                                          ^^^^^^^^^^^^^^^^^^^ the trait `TyCompat<Trait::{synthetic#0}>` is not implemented for `Param<_>`
    |
+   = help: the following other types implement trait `TyCompat<T>`:
+             `Param<false>` implements `TyCompat<NoRuntime>`
+             `Param<true>` implements `TyCompat<Runtime>`
 note: required by a bound in `Trait::func`
   --> $DIR/assoc-type-const-bound-usage-1.rs:7:1
    |

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/assoc-type.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/assoc-type.stderr
@@ -12,16 +12,16 @@ error: using `#![feature(effects)]` without enabling next trait solver globally
    = note: the next trait solver must be enabled globally for the effects feature to work correctly
    = help: use `-Znext-solver` to enable
 
-error[E0277]: the trait bound `Add::{synthetic#0}: Compat` is not satisfied
+error[E0277]: the trait bound `Param<true>: TyCompat<Add::{synthetic#0}>` is not satisfied
   --> $DIR/assoc-type.rs:41:15
    |
 LL |     type Qux: Add;
-   |               ^^^ the trait `Compat` is not implemented for `Add::{synthetic#0}`
+   |               ^^^ the trait `TyCompat<Add::{synthetic#0}>` is not implemented for `Param<true>`
    |
-help: consider further restricting the associated type
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
    |
-LL | trait Baz where Add::{synthetic#0}: Compat {
-   |           ++++++++++++++++++++++++++++++++
+LL | trait Baz where Param<true>: TyCompat<Add::{synthetic#0}> {
+   |           +++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/call-const-trait-method-fail.stderr
@@ -12,13 +12,15 @@ error: using `#![feature(effects)]` without enabling next trait solver globally
    = note: the next trait solver must be enabled globally for the effects feature to work correctly
    = help: use `-Znext-solver` to enable
 
-error[E0277]: the trait bound `Runtime: ~const Compat` is not satisfied
+error[E0277]: the trait bound `Param<host>: TyCompat<Runtime>` is not satisfied
   --> $DIR/call-const-trait-method-fail.rs:25:5
    |
 LL |     a.plus(b)
-   |     ^ the trait `~const Compat` is not implemented for `Runtime`
+   |     ^ the trait `TyCompat<Runtime>` is not implemented for `Param<host>`
    |
-   = help: the trait `Compat` is implemented for `Runtime`
+   = help: the following other types implement trait `TyCompat<T>`:
+             `Param<false>` implements `TyCompat<NoRuntime>`
+             `Param<true>` implements `TyCompat<Runtime>`
 note: required by a bound in `Plus::plus`
   --> $DIR/call-const-trait-method-fail.rs:3:1
    |

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/call-generic-method-nonconst.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/call-generic-method-nonconst.rs
@@ -21,7 +21,7 @@ const fn equals_self<T: ~const Foo>(t: &T) -> bool {
 // it not using the impl.
 
 pub const EQ: bool = equals_self(&S);
-//~^ ERROR: the trait bound `Runtime: const Compat` is not satisfied
+//~^ ERROR: the trait bound
 // FIXME(effects) diagnostic
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/call-generic-method-nonconst.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/call-generic-method-nonconst.stderr
@@ -12,15 +12,14 @@ error: using `#![feature(effects)]` without enabling next trait solver globally
    = note: the next trait solver must be enabled globally for the effects feature to work correctly
    = help: use `-Znext-solver` to enable
 
-error[E0277]: the trait bound `Runtime: const Compat` is not satisfied
-  --> $DIR/call-generic-method-nonconst.rs:23:34
+error[E0277]: the trait bound `Param<false>: TyCompat<Runtime>` is not satisfied
+  --> $DIR/call-generic-method-nonconst.rs:23:22
    |
 LL | pub const EQ: bool = equals_self(&S);
-   |                      ----------- ^^ the trait `const Compat` is not implemented for `Runtime`
-   |                      |
-   |                      required by a bound introduced by this call
+   |                      ^^^^^^^^^^^^^^^ the trait `TyCompat<Runtime>` is not implemented for `Param<false>`
    |
-   = help: the trait `Compat` is implemented for `Runtime`
+   = help: the trait `TyCompat<NoRuntime>` is implemented for `Param<false>`
+   = help: for that trait implementation, expected `NoRuntime`, found `Runtime`
 note: required by a bound in `equals_self`
   --> $DIR/call-generic-method-nonconst.rs:16:25
    |

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-default-method-bodies.stderr
@@ -12,13 +12,15 @@ error: using `#![feature(effects)]` without enabling next trait solver globally
    = note: the next trait solver must be enabled globally for the effects feature to work correctly
    = help: use `-Znext-solver` to enable
 
-error[E0277]: the trait bound `Runtime: ~const Compat` is not satisfied
+error[E0277]: the trait bound `Param<host>: TyCompat<Runtime>` is not satisfied
   --> $DIR/const-default-method-bodies.rs:24:18
    |
 LL |     NonConstImpl.a();
-   |                  ^ the trait `~const Compat` is not implemented for `Runtime`
+   |                  ^ the trait `TyCompat<Runtime>` is not implemented for `Param<host>`
    |
-   = help: the trait `Compat` is implemented for `Runtime`
+   = help: the following other types implement trait `TyCompat<T>`:
+             `Param<false>` implements `TyCompat<NoRuntime>`
+             `Param<true>` implements `TyCompat<Runtime>`
 note: required by a bound in `ConstDefaultFn::a`
   --> $DIR/const-default-method-bodies.rs:3:1
    |

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-fns-are-early-bound.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-fns-are-early-bound.rs
@@ -102,6 +102,9 @@ pub mod effects {
     #[lang = "EffectsRuntime"]
     #[stable(feature = "minicore", since = "1.0.0")]
     pub struct Runtime;
+    #[lang = "EffectsParam"]
+    #[stable(feature = "minicore", since = "1.0.0")]
+    pub struct Param<const RUNTIME: bool>;
 
     #[lang = "EffectsCompat"]
     #[stable(feature = "minicore", since = "1.0.0")]
@@ -122,9 +125,15 @@ pub mod effects {
     #[stable(feature = "minicore", since = "1.0.0")]
     impl<T: ?Sized> TyCompat<T> for T {}
     #[stable(feature = "minicore", since = "1.0.0")]
-    impl<T: ?Sized> TyCompat<T> for Maybe {}
-    #[stable(feature = "minicore", since = "1.0.0")]
     impl<T: ?Sized> TyCompat<Maybe> for T {}
+    #[stable(feature = "minicore", since = "1.0.0")]
+    impl TyCompat<Param<true>> for Runtime {}
+    #[stable(feature = "minicore", since = "1.0.0")]
+    impl TyCompat<Runtime> for Param<true> {}
+    #[stable(feature = "minicore", since = "1.0.0")]
+    impl TyCompat<Param<false>> for NoRuntime {}
+    #[stable(feature = "minicore", since = "1.0.0")]
+    impl TyCompat<NoRuntime> for Param<false> {}
 
     #[lang = "EffectsIntersection"]
     #[stable(feature = "minicore", since = "1.0.0")]

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-fns-are-early-bound.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-fns-are-early-bound.stderr
@@ -1,11 +1,12 @@
-error[E0277]: the trait bound `FnOnce<()>::{synthetic#0}: const Compat` is not satisfied
+error[E0277]: the trait bound `Param<false>: TyCompat<FnOnce<()>::{synthetic#0}>` is not satisfied
   --> $DIR/const-fns-are-early-bound.rs:31:17
    |
 LL |     is_const_fn(foo);
-   |     ----------- ^^^ the trait `const Compat` is not implemented for `FnOnce<()>::{synthetic#0}`
+   |     ----------- ^^^ the trait `TyCompat<FnOnce<()>::{synthetic#0}>` is not implemented for `Param<false>`
    |     |
    |     required by a bound introduced by this call
    |
+   = help: the trait `TyCompat<NoRuntime>` is implemented for `Param<false>`
 note: required by a bound in `is_const_fn`
   --> $DIR/const-fns-are-early-bound.rs:25:12
    |

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/cross-crate.gatednc.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/cross-crate.gatednc.stderr
@@ -1,9 +1,12 @@
-error[E0277]: the trait bound `cross_crate::MyTrait::{synthetic#0}: ~const Compat` is not satisfied
+error[E0277]: the trait bound `Param<host>: TyCompat<cross_crate::MyTrait::{synthetic#0}>` is not satisfied
   --> $DIR/cross-crate.rs:19:14
    |
 LL |     NonConst.func();
-   |              ^^^^ the trait `~const Compat` is not implemented for `cross_crate::MyTrait::{synthetic#0}`
+   |              ^^^^ the trait `TyCompat<cross_crate::MyTrait::{synthetic#0}>` is not implemented for `Param<host>`
    |
+   = help: the following other types implement trait `TyCompat<T>`:
+             `Param<false>` implements `TyCompat<NoRuntime>`
+             `Param<true>` implements `TyCompat<Runtime>`
 note: required by a bound in `func`
   --> $DIR/auxiliary/cross-crate.rs:5:1
    |

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/default-method-body-is-const-same-trait-ck.stderr
@@ -12,13 +12,15 @@ error: using `#![feature(effects)]` without enabling next trait solver globally
    = note: the next trait solver must be enabled globally for the effects feature to work correctly
    = help: use `-Znext-solver` to enable
 
-error[E0277]: the trait bound `Runtime: ~const Compat` is not satisfied
+error[E0277]: the trait bound `Param<host>: TyCompat<Runtime>` is not satisfied
   --> $DIR/default-method-body-is-const-same-trait-ck.rs:8:12
    |
 LL |         ().a()
-   |            ^ the trait `~const Compat` is not implemented for `Runtime`
+   |            ^ the trait `TyCompat<Runtime>` is not implemented for `Param<host>`
    |
-   = help: the trait `Compat` is implemented for `Runtime`
+   = help: the following other types implement trait `TyCompat<T>`:
+             `Param<false>` implements `TyCompat<NoRuntime>`
+             `Param<true>` implements `TyCompat<Runtime>`
 note: required by a bound in `Tr::a`
   --> $DIR/default-method-body-is-const-same-trait-ck.rs:3:1
    |

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/minicore.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/minicore.rs
@@ -546,6 +546,8 @@ mod effects {
     pub struct Maybe;
     #[lang = "EffectsRuntime"]
     pub struct Runtime;
+    #[lang = "EffectsParam"]
+    pub struct Param<const RUNTIME: bool>;
 
     #[lang = "EffectsCompat"]
     pub trait Compat<#[rustc_runtime] const RUNTIME: bool> {}
@@ -559,8 +561,12 @@ mod effects {
     pub trait TyCompat<T: ?Sized> {}
 
     impl<T: ?Sized> TyCompat<T> for T {}
-    impl<T: ?Sized> TyCompat<T> for Maybe {}
     impl<T: ?Sized> TyCompat<Maybe> for T {}
+    impl TyCompat<Param<true>> for Runtime {}
+    impl TyCompat<Runtime> for Param<true> {}
+    impl TyCompat<Param<false>> for NoRuntime {}
+    impl TyCompat<NoRuntime> for Param<false> {}
+
 
     #[lang = "EffectsIntersection"]
     pub trait Intersection {

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/specializing-constness.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/specializing-constness.stderr
@@ -18,13 +18,13 @@ error: cannot specialize on const impl with non-const impl
 LL | impl<T: Spec + Sup> A for T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: cannot specialize on trait `Compat`
+error: cannot specialize on trait `TyCompat`
   --> $DIR/specializing-constness.rs:23:16
    |
 LL | impl<T: Spec + Sup> A for T {
    |                ^^^
 
-error: cannot specialize on trait `Compat`
+error: cannot specialize on trait `TyCompat`
   --> $DIR/specializing-constness.rs:23:9
    |
 LL | impl<T: Spec + Sup> A for T {

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yn.stderr
@@ -10,11 +10,11 @@ note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bou
 LL | trait Bar: ~const Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `Foo::{synthetic#0}: ~const Compat` is not satisfied
+error[E0277]: the trait bound `Param<host>: TyCompat<Foo::{synthetic#0}>` is not satisfied
   --> $DIR/super-traits-fail-2.rs:19:7
    |
 LL |     x.a();
-   |       ^ the trait `~const Compat` is not implemented for `Foo::{synthetic#0}`
+   |       ^ the trait `TyCompat<Foo::{synthetic#0}>` is not implemented for `Param<host>`
    |
 note: required by a bound in `Foo::a`
   --> $DIR/super-traits-fail-2.rs:6:25
@@ -24,10 +24,10 @@ LL | #[cfg_attr(any(yy, yn), const_trait)]
 LL | trait Foo {
 LL |     fn a(&self);
    |        - required by a bound in this associated function
-help: consider further restricting the associated type
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
    |
-LL | const fn foo<T: Bar>(x: &T) where Foo::{synthetic#0}: ~const Compat {
-   |                             +++++++++++++++++++++++++++++++++++++++
+LL | const fn foo<T: Bar>(x: &T) where Param<host>: TyCompat<Foo::{synthetic#0}> {
+   |                             +++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yy.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-2.yy.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `Foo::{synthetic#0}: ~const Compat` is not satisfied
+error[E0277]: the trait bound `Param<host>: TyCompat<Foo::{synthetic#0}>` is not satisfied
   --> $DIR/super-traits-fail-2.rs:19:7
    |
 LL |     x.a();
-   |       ^ the trait `~const Compat` is not implemented for `Foo::{synthetic#0}`
+   |       ^ the trait `TyCompat<Foo::{synthetic#0}>` is not implemented for `Param<host>`
    |
 note: required by a bound in `Foo::a`
   --> $DIR/super-traits-fail-2.rs:6:25
@@ -12,10 +12,10 @@ LL | #[cfg_attr(any(yy, yn), const_trait)]
 LL | trait Foo {
 LL |     fn a(&self);
    |        - required by a bound in this associated function
-help: consider further restricting the associated type
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
    |
-LL | const fn foo<T: Bar>(x: &T) where Foo::{synthetic#0}: ~const Compat {
-   |                             +++++++++++++++++++++++++++++++++++++++
+LL | const fn foo<T: Bar>(x: &T) where Param<host>: TyCompat<Foo::{synthetic#0}> {
+   |                             +++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.nn.stderr
@@ -1,31 +1,23 @@
 error: `~const` is not allowed here
-  --> $DIR/super-traits-fail-3.rs:14:12
+  --> $DIR/super-traits-fail-3.rs:13:12
    |
 LL | trait Bar: ~const Foo {}
    |            ^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bounds
-  --> $DIR/super-traits-fail-3.rs:14:1
+  --> $DIR/super-traits-fail-3.rs:13:1
    |
 LL | trait Bar: ~const Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:13:19
    |
 LL | trait Bar: ~const Foo {}
    |                   ^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
-   |
-LL | trait Bar: ~const Foo {}
-   |                   ^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:13:19
    |
 LL | trait Bar: ~const Foo {}
    |                   ^^^
@@ -33,7 +25,15 @@ LL | trait Bar: ~const Foo {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:20:24
+  --> $DIR/super-traits-fail-3.rs:13:19
+   |
+LL | trait Bar: ~const Foo {}
+   |                   ^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: `~const` can only be applied to `#[const_trait]` traits
+  --> $DIR/super-traits-fail-3.rs:19:24
    |
 LL | const fn foo<T: ~const Bar>(x: &T) {
    |                        ^^^

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.ny.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.ny.stderr
@@ -1,11 +1,11 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:13:19
    |
 LL | trait Bar: ~const Foo {}
    |                   ^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:13:19
    |
 LL | trait Bar: ~const Foo {}
    |                   ^^^
@@ -13,7 +13,7 @@ LL | trait Bar: ~const Foo {}
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:13:19
    |
 LL | trait Bar: ~const Foo {}
    |                   ^^^

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.rs
@@ -3,7 +3,6 @@
 #![feature(const_trait_impl, effects)]
 
 //@ revisions: yy yn ny nn
-//@[yy] known-bug: #110395
 
 #[cfg_attr(any(yy, yn), const_trait)]
 trait Foo {
@@ -20,7 +19,7 @@ trait Bar: ~const Foo {}
 const fn foo<T: ~const Bar>(x: &T) {
     //[yn,nn]~^ ERROR: `~const` can only be applied to `#[const_trait]`
     x.a();
-    //[yn]~^ ERROR: the trait bound
+    //[yn,yy]~^ ERROR: the trait bound
 }
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yn.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yn.stderr
@@ -1,39 +1,39 @@
 error: `~const` is not allowed here
-  --> $DIR/super-traits-fail-3.rs:14:12
+  --> $DIR/super-traits-fail-3.rs:13:12
    |
 LL | trait Bar: ~const Foo {}
    |            ^^^^^^
    |
 note: this trait is not a `#[const_trait]`, so it cannot have `~const` trait bounds
-  --> $DIR/super-traits-fail-3.rs:14:1
+  --> $DIR/super-traits-fail-3.rs:13:1
    |
 LL | trait Bar: ~const Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:20:24
+  --> $DIR/super-traits-fail-3.rs:19:24
    |
 LL | const fn foo<T: ~const Bar>(x: &T) {
    |                        ^^^
 
-error[E0277]: the trait bound `Foo::{synthetic#0}: ~const Compat` is not satisfied
-  --> $DIR/super-traits-fail-3.rs:22:7
+error[E0277]: the trait bound `Param<host>: TyCompat<Foo::{synthetic#0}>` is not satisfied
+  --> $DIR/super-traits-fail-3.rs:21:7
    |
 LL |     x.a();
-   |       ^ the trait `~const Compat` is not implemented for `Foo::{synthetic#0}`
+   |       ^ the trait `TyCompat<Foo::{synthetic#0}>` is not implemented for `Param<host>`
    |
 note: required by a bound in `Foo::a`
-  --> $DIR/super-traits-fail-3.rs:8:25
+  --> $DIR/super-traits-fail-3.rs:7:25
    |
 LL | #[cfg_attr(any(yy, yn), const_trait)]
    |                         ^^^^^^^^^^^ required by this bound in `Foo::a`
 LL | trait Foo {
 LL |     fn a(&self);
    |        - required by a bound in this associated function
-help: consider further restricting the associated type
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
    |
-LL | const fn foo<T: ~const Bar>(x: &T) where Foo::{synthetic#0}: ~const Compat {
-   |                                    +++++++++++++++++++++++++++++++++++++++
+LL | const fn foo<T: ~const Bar>(x: &T) where Param<host>: TyCompat<Foo::{synthetic#0}> {
+   |                                    +++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yy.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail-3.yy.stderr
@@ -1,21 +1,21 @@
-error[E0277]: the trait bound `Foo::{synthetic#0}: ~const Compat` is not satisfied
-  --> $DIR/super-traits-fail-3.rs:22:7
+error[E0277]: the trait bound `Param<host>: TyCompat<Foo::{synthetic#0}>` is not satisfied
+  --> $DIR/super-traits-fail-3.rs:21:7
    |
 LL |     x.a();
-   |       ^ the trait `~const Compat` is not implemented for `Foo::{synthetic#0}`
+   |       ^ the trait `TyCompat<Foo::{synthetic#0}>` is not implemented for `Param<host>`
    |
 note: required by a bound in `Foo::a`
-  --> $DIR/super-traits-fail-3.rs:8:25
+  --> $DIR/super-traits-fail-3.rs:7:25
    |
 LL | #[cfg_attr(any(yy, yn), const_trait)]
    |                         ^^^^^^^^^^^ required by this bound in `Foo::a`
 LL | trait Foo {
 LL |     fn a(&self);
    |        - required by a bound in this associated function
-help: consider further restricting the associated type
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
    |
-LL | const fn foo<T: ~const Bar>(x: &T) where Foo::{synthetic#0}: ~const Compat {
-   |                                    +++++++++++++++++++++++++++++++++++++++
+LL | const fn foo<T: ~const Bar>(x: &T) where Param<host>: TyCompat<Foo::{synthetic#0}> {
+   |                                    +++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail.rs
@@ -1,4 +1,4 @@
-//@ check-pass
+//~ ERROR the trait bound
 //@ compile-flags: -Znext-solver
 
 #![allow(incomplete_features)]
@@ -17,6 +17,6 @@ impl Foo for S {
 }
 
 impl const Bar for S {}
-//FIXME ~^ ERROR the trait bound
+// FIXME(effects) span bad
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail.stderr
@@ -1,0 +1,11 @@
+error[E0277]: the trait bound `Maybe: TyCompat<<(Foo::{synthetic#0},) as std::marker::effects::Intersection>::Output>` is not satisfied
+   |
+note: required by a bound in `Bar::{synthetic#0}`
+  --> $DIR/super-traits-fail.rs:11:1
+   |
+LL | #[const_trait]
+   | ^^^^^^^^^^^^^^ required by this bound in `Bar::{synthetic#0}`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `Foo::{synthetic#0}: ~const Compat` is not satisfied
+error[E0277]: the trait bound `Param<host>: TyCompat<Foo::{synthetic#0}>` is not satisfied
   --> $DIR/super-traits.rs:23:7
    |
 LL |     t.a();
-   |       ^ the trait `~const Compat` is not implemented for `Foo::{synthetic#0}`
+   |       ^ the trait `TyCompat<Foo::{synthetic#0}>` is not implemented for `Param<host>`
    |
 note: required by a bound in `Foo::a`
   --> $DIR/super-traits.rs:7:1
@@ -12,10 +12,10 @@ LL | #[const_trait]
 LL | trait Foo {
 LL |     fn a(&self);
    |        - required by a bound in this associated function
-help: consider further restricting the associated type
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
    |
-LL | const fn foo<T: ~const Bar>(t: &T) where Foo::{synthetic#0}: ~const Compat {
-   |                                    +++++++++++++++++++++++++++++++++++++++
+LL | const fn foo<T: ~const Bar>(t: &T) where Param<host>: TyCompat<Foo::{synthetic#0}> {
+   |                                    +++++++++++++++++++++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/trait-where-clause-const.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/trait-where-clause-const.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `Foo::{synthetic#0}: Compat` is not satisfied
+error[E0277]: the trait bound `Param<true>: TyCompat<Foo::{synthetic#0}>` is not satisfied
   --> $DIR/trait-where-clause-const.rs:22:5
    |
 LL |     T::b();
-   |     ^ the trait `Compat` is not implemented for `Foo::{synthetic#0}`
+   |     ^ the trait `TyCompat<Foo::{synthetic#0}>` is not implemented for `Param<true>`
    |
 note: required by a bound in `Foo::b`
   --> $DIR/trait-where-clause-const.rs:13:1
@@ -12,10 +12,10 @@ LL | #[const_trait]
 ...
 LL |     fn b() where Self: ~const Bar;
    |        - required by a bound in this associated function
-help: consider further restricting the associated type
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
    |
-LL | const fn test1<T: ~const Foo + Bar>() where Foo::{synthetic#0}: Compat {
-   |                                       ++++++++++++++++++++++++++++++++
+LL | const fn test1<T: ~const Foo + Bar>() where Param<true>: TyCompat<Foo::{synthetic#0}> {
+   |                                       +++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/trait-where-clause-const.rs:22:5
@@ -26,11 +26,11 @@ LL |     T::b();
    = note: expected constant `host`
               found constant `true`
 
-error[E0277]: the trait bound `Foo::{synthetic#0}: Compat` is not satisfied
+error[E0277]: the trait bound `Param<true>: TyCompat<Foo::{synthetic#0}>` is not satisfied
   --> $DIR/trait-where-clause-const.rs:25:5
    |
 LL |     T::c::<T>();
-   |     ^ the trait `Compat` is not implemented for `Foo::{synthetic#0}`
+   |     ^ the trait `TyCompat<Foo::{synthetic#0}>` is not implemented for `Param<true>`
    |
 note: required by a bound in `Foo::c`
   --> $DIR/trait-where-clause-const.rs:13:1
@@ -40,10 +40,10 @@ LL | #[const_trait]
 ...
 LL |     fn c<T: ~const Bar>();
    |        - required by a bound in this associated function
-help: consider further restricting the associated type
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
    |
-LL | const fn test1<T: ~const Foo + Bar>() where Foo::{synthetic#0}: Compat {
-   |                                       ++++++++++++++++++++++++++++++++
+LL | const fn test1<T: ~const Foo + Bar>() where Param<true>: TyCompat<Foo::{synthetic#0}> {
+   |                                       +++++++++++++++++++++++++++++++++++++++++++++++
 
 error[E0308]: mismatched types
   --> $DIR/trait-where-clause-const.rs:25:5

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/unsatisfied-const-trait-bound.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/unsatisfied-const-trait-bound.rs
@@ -19,7 +19,7 @@ impl Trait for Ty {
 
 fn main() {
     // FIXME(effects): improve diagnostics on this
-    require::<Ty>(); //~ ERROR the trait bound `Trait::{synthetic#0}: const Compat` is not satisfied
+    require::<Ty>(); //~ ERROR the trait bound
 }
 
 struct Container<const N: u32>;

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/unsatisfied-const-trait-bound.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/unsatisfied-const-trait-bound.stderr
@@ -16,12 +16,13 @@ LL | const fn accept1<T: ~const Trait>(_: Container<{ T::make() }>) {}
    = note: expected constant `false`
               found constant `host`
 
-error[E0277]: the trait bound `Trait::{synthetic#0}: const Compat` is not satisfied
+error[E0277]: the trait bound `Param<false>: TyCompat<Trait::{synthetic#0}>` is not satisfied
   --> $DIR/unsatisfied-const-trait-bound.rs:22:15
    |
 LL |     require::<Ty>();
-   |               ^^ the trait `const Compat` is not implemented for `Trait::{synthetic#0}`
+   |               ^^ the trait `TyCompat<Trait::{synthetic#0}>` is not implemented for `Param<false>`
    |
+   = help: the trait `TyCompat<NoRuntime>` is implemented for `Param<false>`
 note: required by a bound in `require`
   --> $DIR/unsatisfied-const-trait-bound.rs:7:15
    |


### PR DESCRIPTION
still a bit WIP. This should help with the interaction of super trait implied bounds and using those in const fn.

r? project-const-traits