### PR TITLE
Check ABI target compatibility for function pointers

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -8,7 +8,9 @@ use rustc_hir::Node;
 use rustc_hir::def::{CtorKind, DefKind};
 use rustc_infer::infer::{RegionVariableOrigin, TyCtxtInferExt};
 use rustc_infer::traits::Obligation;
-use rustc_lint_defs::builtin::REPR_TRANSPARENT_EXTERNAL_PRIVATE_FIELDS;
+use rustc_lint_defs::builtin::{
+    REPR_TRANSPARENT_EXTERNAL_PRIVATE_FIELDS, UNSUPPORTED_FN_PTR_CALLING_CONVENTIONS,
+};
 use rustc_middle::middle::resolve_bound_vars::ResolvedArg;
 use rustc_middle::middle::stability::EvalResult;
 use rustc_middle::span_bug;
@@ -52,16 +54,18 @@ pub fn check_abi(tcx: TyCtxt<'_>, hir_id: hir::HirId, span: Span, abi: Abi) {
             });
         }
     }
+}
 
-    // This ABI is only allowed on function pointers
-    if abi == Abi::CCmseNonSecureCall {
-        struct_span_code_err!(
-            tcx.dcx(),
-            span,
-            E0781,
-            "the `\"C-cmse-nonsecure-call\"` ABI is only allowed on function pointers"
-        )
-        .emit();
+pub fn check_abi_fn_ptr(tcx: TyCtxt<'_>, hir_id: hir::HirId, span: Span, abi: Abi) {
+    match tcx.sess.target.is_abi_supported(abi) {
+        Some(true) => (),
+        Some(false) | None => {
+            tcx.node_span_lint(UNSUPPORTED_FN_PTR_CALLING_CONVENTIONS, hir_id, span, |lint| {
+                lint.primary_message(
+                    "use of calling convention not supported on this target on function pointer",
+                );
+            });
+        }
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -73,7 +73,7 @@ pub mod wfcheck;
 
 use std::num::NonZero;
 
-pub use check::check_abi;
+pub use check::{check_abi, check_abi_fn_ptr};
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};
 use rustc_errors::{Diag, ErrorGuaranteed, pluralize, struct_span_code_err};
 use rustc_hir::def_id::{DefId, LocalDefId};

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -53,6 +53,7 @@ use rustc_trait_selection::traits::{self, ObligationCtxt};
 use tracing::{debug, debug_span, instrument};
 
 use crate::bounds::Bounds;
+use crate::check::check_abi_fn_ptr;
 use crate::errors::{AmbiguousLifetimeBound, BadReturnTypeNotation, WildPatTy};
 use crate::hir_ty_lowering::errors::{GenericsArgsErrExtend, prohibit_assoc_item_constraint};
 use crate::hir_ty_lowering::generics::{check_generic_arg_count, lower_generic_args};
@@ -2323,6 +2324,12 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
         let fn_ty = tcx.mk_fn_sig(input_tys, output_ty, decl.c_variadic, safety, abi);
         let bare_fn_ty = ty::Binder::bind_with_vars(fn_ty, bound_vars);
+
+        if let hir::Node::Ty(hir::Ty { kind: hir::TyKind::BareFn(bare_fn_ty), span, .. }) =
+            tcx.hir_node(hir_id)
+        {
+            check_abi_fn_ptr(tcx, hir_id, *span, bare_fn_ty.abi);
+        }
 
         // reject function types that violate cmse ABI requirements
         cmse::validate_cmse_abi(self.tcx(), self.dcx(), hir_id, abi, bare_fn_ty);

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -123,6 +123,7 @@ declare_lint_pass! {
         UNSTABLE_NAME_COLLISIONS,
         UNSTABLE_SYNTAX_PRE_EXPANSION,
         UNSUPPORTED_CALLING_CONVENTIONS,
+        UNSUPPORTED_FN_PTR_CALLING_CONVENTIONS,
         UNUSED_ASSIGNMENTS,
         UNUSED_ASSOCIATED_TYPE_BOUNDS,
         UNUSED_ATTRIBUTES,
@@ -3871,6 +3872,50 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps,
         reference: "issue #87678 <https://github.com/rust-lang/rust/issues/87678>",
+    };
+}
+
+declare_lint! {
+    /// The `unsupported_fn_ptr_calling_conventions` lint is output whenever there is a use of
+    /// a target dependent calling convention on a target that does not support this calling
+    /// convention on a function pointer.
+    ///
+    /// For example `stdcall` does not make much sense for a x86_64 or, more apparently, powerpc
+    /// code, because this calling convention was never specified for those targets.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore (needs specific targets)
+    /// fn stdcall_ptr(f: extern "stdcall" fn ()) {
+    ///     f()
+    /// }
+    /// ```
+    ///
+    /// This will produce:
+    ///
+    /// ```text
+    /// warning: use of calling convention not supported on this target on function pointer
+    ///   --> $DIR/unsupported.rs:34:15
+    ///    |
+    /// LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
+    ///    |               ^^^^^^^^^^^^^^^^^^^^^^^^
+    ///    |
+    ///    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    ///    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+    ///    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
+    /// ```
+    ///
+    /// ### Explanation
+    ///
+    /// On most of the targets the behaviour of `stdcall` and similar calling conventions is not
+    /// defined at all, but was previously accepted due to a bug in the implementation of the
+    /// compiler.
+    pub UNSUPPORTED_FN_PTR_CALLING_CONVENTIONS,
+    Warn,
+    "use of unsupported calling convention for function pointer",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps,
+        reference: "issue #130260 <https://github.com/rust-lang/rust/issues/130260>",
     };
 }
 

--- a/tests/debuginfo/type-names.rs
+++ b/tests/debuginfo/type-names.rs
@@ -17,7 +17,7 @@
 // gdb-check:type = type_names::GenericStruct<type_names::mod1::Struct2, type_names::mod1::mod2::Struct3>
 
 // gdb-command:whatis generic_struct2
-// gdb-check:type = type_names::GenericStruct<type_names::Struct1, extern "fastcall" fn(isize) -> usize>
+// gdb-check:type = type_names::GenericStruct<type_names::Struct1, extern "system" fn(isize) -> usize>
 
 // gdb-command:whatis mod_struct
 // gdb-check:type = type_names::mod1::Struct2
@@ -372,7 +372,7 @@ fn main() {
     let simple_struct = Struct1;
     let generic_struct1: GenericStruct<mod1::Struct2, mod1::mod2::Struct3> =
         GenericStruct(PhantomData);
-    let generic_struct2: GenericStruct<Struct1, extern "fastcall" fn(isize) -> usize> =
+    let generic_struct2: GenericStruct<Struct1, extern "system" fn(isize) -> usize> =
         GenericStruct(PhantomData);
     let mod_struct = mod1::Struct2;
 

--- a/tests/ui/abi/unsupported.aarch64.stderr
+++ b/tests/ui/abi/unsupported.aarch64.stderr
@@ -1,5 +1,5 @@
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:34:15
+  --> $DIR/unsupported.rs:35:15
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:1
+  --> $DIR/unsupported.rs:40:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:48:17
+  --> $DIR/unsupported.rs:49:17
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -24,13 +24,13 @@ LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:61:1
+  --> $DIR/unsupported.rs:62:1
    |
 LL | extern "aapcs" {}
    | ^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:70:18
+  --> $DIR/unsupported.rs:71:18
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:1
+  --> $DIR/unsupported.rs:76:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:80:15
+  --> $DIR/unsupported.rs:81:15
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:85:1
+  --> $DIR/unsupported.rs:86:1
    |
 LL | extern "avr-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:93:17
+  --> $DIR/unsupported.rs:94:17
    |
 LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +69,13 @@ LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:104:1
+  --> $DIR/unsupported.rs:105:1
    |
 LL | extern "riscv-interrupt-m" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:115:15
+  --> $DIR/unsupported.rs:116:15
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:126:1
+  --> $DIR/unsupported.rs:127:1
    |
 LL | extern "x86-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:138:20
+  --> $DIR/unsupported.rs:139:20
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                    ^^^^^^^^^^^^^^^^^^^^^^
@@ -99,13 +99,13 @@ LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:151:1
+  --> $DIR/unsupported.rs:152:1
    |
 LL | extern "thiscall" {}
    | ^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:169:19
+  --> $DIR/unsupported.rs:170:19
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                   ^^^^^^^^^^^^^^^^^^^^^
@@ -114,7 +114,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:182:1
+  --> $DIR/unsupported.rs:183:1
    |
 LL | extern "stdcall" {}
    | ^^^^^^^^^^^^^^^^^^^
@@ -124,58 +124,73 @@ LL | extern "stdcall" {}
    = note: `#[warn(unsupported_calling_conventions)]` on by default
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:194:16
+  --> $DIR/unsupported.rs:195:21
    |
-LL | fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:203:22
+   |
+LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:208:1
+   |
+LL | extern "C-cmse-nonsecure-entry" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:32:1
+  --> $DIR/unsupported.rs:33:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:42:1
+  --> $DIR/unsupported.rs:43:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:68:1
+  --> $DIR/unsupported.rs:69:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:78:1
+  --> $DIR/unsupported.rs:79:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:88:1
+  --> $DIR/unsupported.rs:89:1
    |
 LL | extern "riscv-interrupt-m" fn riscv() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:110:1
+  --> $DIR/unsupported.rs:111:1
    |
 LL | extern "x86-interrupt" fn x86() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:1
+  --> $DIR/unsupported.rs:133:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:158:1
+  --> $DIR/unsupported.rs:159:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -183,6 +198,12 @@ LL | extern "stdcall" fn stdcall() {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
 
-error: aborting due to 14 previous errors; 11 warnings emitted
+error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:201:1
+   |
+LL | extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 16 previous errors; 12 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.aarch64.stderr
+++ b/tests/ui/abi/unsupported.aarch64.stderr
@@ -1,55 +1,188 @@
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:34:15
+   |
+LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+   = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
+
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:28:1
+  --> $DIR/unsupported.rs:39:1
+   |
+LL | extern "ptx-kernel" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:48:17
+   |
+LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
+   |                 ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"aapcs"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:61:1
+   |
+LL | extern "aapcs" {}
+   | ^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:70:18
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:75:1
+   |
+LL | extern "msp430-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:80:15
+   |
+LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:85:1
+   |
+LL | extern "avr-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:93:17
+   |
+LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:104:1
+   |
+LL | extern "riscv-interrupt-m" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:115:15
+   |
+LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:126:1
+   |
+LL | extern "x86-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:138:20
+   |
+LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
+   |                    ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"thiscall"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:151:1
+   |
+LL | extern "thiscall" {}
+   | ^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:169:19
+   |
+LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
+   |                   ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+warning: use of calling convention not supported on this target
+  --> $DIR/unsupported.rs:182:1
+   |
+LL | extern "stdcall" {}
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
+   = note: `#[warn(unsupported_calling_conventions)]` on by default
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:194:16
+   |
+LL | fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:32:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:30:1
+  --> $DIR/unsupported.rs:42:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:36:1
+  --> $DIR/unsupported.rs:68:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:38:1
+  --> $DIR/unsupported.rs:78:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:40:1
+  --> $DIR/unsupported.rs:88:1
    |
 LL | extern "riscv-interrupt-m" fn riscv() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:45:1
+  --> $DIR/unsupported.rs:110:1
    |
 LL | extern "x86-interrupt" fn x86() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:50:1
+  --> $DIR/unsupported.rs:132:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:56:1
+  --> $DIR/unsupported.rs:158:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
-   = note: `#[warn(unsupported_calling_conventions)]` on by default
 
-error: aborting due to 7 previous errors; 1 warning emitted
+error: aborting due to 14 previous errors; 11 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.arm.stderr
+++ b/tests/ui/abi/unsupported.arm.stderr
@@ -1,5 +1,5 @@
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:34:15
+  --> $DIR/unsupported.rs:35:15
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:1
+  --> $DIR/unsupported.rs:40:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:70:18
+  --> $DIR/unsupported.rs:71:18
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -24,13 +24,13 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:1
+  --> $DIR/unsupported.rs:76:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:80:15
+  --> $DIR/unsupported.rs:81:15
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:85:1
+  --> $DIR/unsupported.rs:86:1
    |
 LL | extern "avr-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:93:17
+  --> $DIR/unsupported.rs:94:17
    |
 LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:104:1
+  --> $DIR/unsupported.rs:105:1
    |
 LL | extern "riscv-interrupt-m" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:115:15
+  --> $DIR/unsupported.rs:116:15
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +69,13 @@ LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:126:1
+  --> $DIR/unsupported.rs:127:1
    |
 LL | extern "x86-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:138:20
+  --> $DIR/unsupported.rs:139:20
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                    ^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:151:1
+  --> $DIR/unsupported.rs:152:1
    |
 LL | extern "thiscall" {}
    | ^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:169:19
+  --> $DIR/unsupported.rs:170:19
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                   ^^^^^^^^^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:182:1
+  --> $DIR/unsupported.rs:183:1
    |
 LL | extern "stdcall" {}
    | ^^^^^^^^^^^^^^^^^^^
@@ -109,52 +109,67 @@ LL | extern "stdcall" {}
    = note: `#[warn(unsupported_calling_conventions)]` on by default
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:194:16
+  --> $DIR/unsupported.rs:195:21
    |
-LL | fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:203:22
+   |
+LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:208:1
+   |
+LL | extern "C-cmse-nonsecure-entry" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:32:1
+  --> $DIR/unsupported.rs:33:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:68:1
+  --> $DIR/unsupported.rs:69:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:78:1
+  --> $DIR/unsupported.rs:79:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:88:1
+  --> $DIR/unsupported.rs:89:1
    |
 LL | extern "riscv-interrupt-m" fn riscv() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:110:1
+  --> $DIR/unsupported.rs:111:1
    |
 LL | extern "x86-interrupt" fn x86() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:1
+  --> $DIR/unsupported.rs:133:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:158:1
+  --> $DIR/unsupported.rs:159:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -162,6 +177,12 @@ LL | extern "stdcall" fn stdcall() {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
 
-error: aborting due to 12 previous errors; 10 warnings emitted
+error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:201:1
+   |
+LL | extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 14 previous errors; 11 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.arm.stderr
+++ b/tests/ui/abi/unsupported.arm.stderr
@@ -1,49 +1,167 @@
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:34:15
+   |
+LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+   = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
+
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:28:1
+  --> $DIR/unsupported.rs:39:1
+   |
+LL | extern "ptx-kernel" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:70:18
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:75:1
+   |
+LL | extern "msp430-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:80:15
+   |
+LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:85:1
+   |
+LL | extern "avr-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:93:17
+   |
+LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:104:1
+   |
+LL | extern "riscv-interrupt-m" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:115:15
+   |
+LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:126:1
+   |
+LL | extern "x86-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:138:20
+   |
+LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
+   |                    ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"thiscall"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:151:1
+   |
+LL | extern "thiscall" {}
+   | ^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:169:19
+   |
+LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
+   |                   ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+warning: use of calling convention not supported on this target
+  --> $DIR/unsupported.rs:182:1
+   |
+LL | extern "stdcall" {}
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
+   = note: `#[warn(unsupported_calling_conventions)]` on by default
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:194:16
+   |
+LL | fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:32:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:36:1
+  --> $DIR/unsupported.rs:68:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:38:1
+  --> $DIR/unsupported.rs:78:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:40:1
+  --> $DIR/unsupported.rs:88:1
    |
 LL | extern "riscv-interrupt-m" fn riscv() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:45:1
+  --> $DIR/unsupported.rs:110:1
    |
 LL | extern "x86-interrupt" fn x86() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:50:1
+  --> $DIR/unsupported.rs:132:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:56:1
+  --> $DIR/unsupported.rs:158:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
-   = note: `#[warn(unsupported_calling_conventions)]` on by default
 
-error: aborting due to 6 previous errors; 1 warning emitted
+error: aborting due to 12 previous errors; 10 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.i686.stderr
+++ b/tests/ui/abi/unsupported.i686.stderr
@@ -1,5 +1,5 @@
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:34:15
+  --> $DIR/unsupported.rs:35:15
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:1
+  --> $DIR/unsupported.rs:40:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:48:17
+  --> $DIR/unsupported.rs:49:17
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -24,13 +24,13 @@ LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:61:1
+  --> $DIR/unsupported.rs:62:1
    |
 LL | extern "aapcs" {}
    | ^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:70:18
+  --> $DIR/unsupported.rs:71:18
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:1
+  --> $DIR/unsupported.rs:76:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:80:15
+  --> $DIR/unsupported.rs:81:15
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:85:1
+  --> $DIR/unsupported.rs:86:1
    |
 LL | extern "avr-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:93:17
+  --> $DIR/unsupported.rs:94:17
    |
 LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,50 +69,71 @@ LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:104:1
+  --> $DIR/unsupported.rs:105:1
    |
 LL | extern "riscv-interrupt-m" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:194:16
+  --> $DIR/unsupported.rs:195:21
    |
-LL | fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:203:22
+   |
+LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:208:1
+   |
+LL | extern "C-cmse-nonsecure-entry" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:32:1
+  --> $DIR/unsupported.rs:33:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:42:1
+  --> $DIR/unsupported.rs:43:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:68:1
+  --> $DIR/unsupported.rs:69:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:78:1
+  --> $DIR/unsupported.rs:79:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:88:1
+  --> $DIR/unsupported.rs:89:1
    |
 LL | extern "riscv-interrupt-m" fn riscv() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 10 previous errors; 6 warnings emitted
+error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:201:1
+   |
+LL | extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors; 7 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.i686.stderr
+++ b/tests/ui/abi/unsupported.i686.stderr
@@ -1,33 +1,118 @@
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:34:15
+   |
+LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+   = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
+
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:28:1
+  --> $DIR/unsupported.rs:39:1
+   |
+LL | extern "ptx-kernel" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:48:17
+   |
+LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
+   |                 ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"aapcs"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:61:1
+   |
+LL | extern "aapcs" {}
+   | ^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:70:18
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:75:1
+   |
+LL | extern "msp430-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:80:15
+   |
+LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:85:1
+   |
+LL | extern "avr-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:93:17
+   |
+LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:104:1
+   |
+LL | extern "riscv-interrupt-m" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:194:16
+   |
+LL | fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:32:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:30:1
+  --> $DIR/unsupported.rs:42:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:36:1
+  --> $DIR/unsupported.rs:68:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:38:1
+  --> $DIR/unsupported.rs:78:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:40:1
+  --> $DIR/unsupported.rs:88:1
    |
 LL | extern "riscv-interrupt-m" fn riscv() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 5 previous errors
+error: aborting due to 10 previous errors; 6 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.riscv32.stderr
+++ b/tests/ui/abi/unsupported.riscv32.stderr
@@ -1,5 +1,5 @@
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:34:15
+  --> $DIR/unsupported.rs:35:15
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:1
+  --> $DIR/unsupported.rs:40:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:48:17
+  --> $DIR/unsupported.rs:49:17
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -24,13 +24,13 @@ LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:61:1
+  --> $DIR/unsupported.rs:62:1
    |
 LL | extern "aapcs" {}
    | ^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:70:18
+  --> $DIR/unsupported.rs:71:18
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:1
+  --> $DIR/unsupported.rs:76:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:80:15
+  --> $DIR/unsupported.rs:81:15
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:85:1
+  --> $DIR/unsupported.rs:86:1
    |
 LL | extern "avr-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:115:15
+  --> $DIR/unsupported.rs:116:15
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +69,13 @@ LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:126:1
+  --> $DIR/unsupported.rs:127:1
    |
 LL | extern "x86-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:138:20
+  --> $DIR/unsupported.rs:139:20
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                    ^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:151:1
+  --> $DIR/unsupported.rs:152:1
    |
 LL | extern "thiscall" {}
    | ^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:169:19
+  --> $DIR/unsupported.rs:170:19
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                   ^^^^^^^^^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:182:1
+  --> $DIR/unsupported.rs:183:1
    |
 LL | extern "stdcall" {}
    | ^^^^^^^^^^^^^^^^^^^
@@ -109,52 +109,67 @@ LL | extern "stdcall" {}
    = note: `#[warn(unsupported_calling_conventions)]` on by default
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:194:16
+  --> $DIR/unsupported.rs:195:21
    |
-LL | fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:203:22
+   |
+LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:208:1
+   |
+LL | extern "C-cmse-nonsecure-entry" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:32:1
+  --> $DIR/unsupported.rs:33:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:42:1
+  --> $DIR/unsupported.rs:43:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:68:1
+  --> $DIR/unsupported.rs:69:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:78:1
+  --> $DIR/unsupported.rs:79:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:110:1
+  --> $DIR/unsupported.rs:111:1
    |
 LL | extern "x86-interrupt" fn x86() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:1
+  --> $DIR/unsupported.rs:133:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:158:1
+  --> $DIR/unsupported.rs:159:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -162,6 +177,12 @@ LL | extern "stdcall" fn stdcall() {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
 
-error: aborting due to 12 previous errors; 10 warnings emitted
+error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:201:1
+   |
+LL | extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 14 previous errors; 11 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.riscv32.stderr
+++ b/tests/ui/abi/unsupported.riscv32.stderr
@@ -1,49 +1,167 @@
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:34:15
+   |
+LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+   = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
+
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:28:1
+  --> $DIR/unsupported.rs:39:1
+   |
+LL | extern "ptx-kernel" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:48:17
+   |
+LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
+   |                 ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"aapcs"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:61:1
+   |
+LL | extern "aapcs" {}
+   | ^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:70:18
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:75:1
+   |
+LL | extern "msp430-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:80:15
+   |
+LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:85:1
+   |
+LL | extern "avr-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:115:15
+   |
+LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:126:1
+   |
+LL | extern "x86-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:138:20
+   |
+LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
+   |                    ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"thiscall"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:151:1
+   |
+LL | extern "thiscall" {}
+   | ^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:169:19
+   |
+LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
+   |                   ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+warning: use of calling convention not supported on this target
+  --> $DIR/unsupported.rs:182:1
+   |
+LL | extern "stdcall" {}
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
+   = note: `#[warn(unsupported_calling_conventions)]` on by default
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:194:16
+   |
+LL | fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:32:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:30:1
+  --> $DIR/unsupported.rs:42:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:36:1
+  --> $DIR/unsupported.rs:68:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:38:1
+  --> $DIR/unsupported.rs:78:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:45:1
+  --> $DIR/unsupported.rs:110:1
    |
 LL | extern "x86-interrupt" fn x86() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:50:1
+  --> $DIR/unsupported.rs:132:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:56:1
+  --> $DIR/unsupported.rs:158:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
-   = note: `#[warn(unsupported_calling_conventions)]` on by default
 
-error: aborting due to 6 previous errors; 1 warning emitted
+error: aborting due to 12 previous errors; 10 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.riscv64.stderr
+++ b/tests/ui/abi/unsupported.riscv64.stderr
@@ -1,5 +1,5 @@
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:34:15
+  --> $DIR/unsupported.rs:35:15
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:1
+  --> $DIR/unsupported.rs:40:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:48:17
+  --> $DIR/unsupported.rs:49:17
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -24,13 +24,13 @@ LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:61:1
+  --> $DIR/unsupported.rs:62:1
    |
 LL | extern "aapcs" {}
    | ^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:70:18
+  --> $DIR/unsupported.rs:71:18
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:1
+  --> $DIR/unsupported.rs:76:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:80:15
+  --> $DIR/unsupported.rs:81:15
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:85:1
+  --> $DIR/unsupported.rs:86:1
    |
 LL | extern "avr-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:115:15
+  --> $DIR/unsupported.rs:116:15
    |
 LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +69,13 @@ LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:126:1
+  --> $DIR/unsupported.rs:127:1
    |
 LL | extern "x86-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:138:20
+  --> $DIR/unsupported.rs:139:20
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                    ^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:151:1
+  --> $DIR/unsupported.rs:152:1
    |
 LL | extern "thiscall" {}
    | ^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:169:19
+  --> $DIR/unsupported.rs:170:19
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                   ^^^^^^^^^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:182:1
+  --> $DIR/unsupported.rs:183:1
    |
 LL | extern "stdcall" {}
    | ^^^^^^^^^^^^^^^^^^^
@@ -109,52 +109,67 @@ LL | extern "stdcall" {}
    = note: `#[warn(unsupported_calling_conventions)]` on by default
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:194:16
+  --> $DIR/unsupported.rs:195:21
    |
-LL | fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:203:22
+   |
+LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:208:1
+   |
+LL | extern "C-cmse-nonsecure-entry" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:32:1
+  --> $DIR/unsupported.rs:33:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:42:1
+  --> $DIR/unsupported.rs:43:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:68:1
+  --> $DIR/unsupported.rs:69:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:78:1
+  --> $DIR/unsupported.rs:79:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:110:1
+  --> $DIR/unsupported.rs:111:1
    |
 LL | extern "x86-interrupt" fn x86() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:1
+  --> $DIR/unsupported.rs:133:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:158:1
+  --> $DIR/unsupported.rs:159:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -162,6 +177,12 @@ LL | extern "stdcall" fn stdcall() {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
 
-error: aborting due to 12 previous errors; 10 warnings emitted
+error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:201:1
+   |
+LL | extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 14 previous errors; 11 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.riscv64.stderr
+++ b/tests/ui/abi/unsupported.riscv64.stderr
@@ -1,49 +1,167 @@
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:34:15
+   |
+LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+   = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
+
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:28:1
+  --> $DIR/unsupported.rs:39:1
+   |
+LL | extern "ptx-kernel" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:48:17
+   |
+LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
+   |                 ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"aapcs"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:61:1
+   |
+LL | extern "aapcs" {}
+   | ^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:70:18
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:75:1
+   |
+LL | extern "msp430-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:80:15
+   |
+LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:85:1
+   |
+LL | extern "avr-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:115:15
+   |
+LL | fn x86_ptr(f: extern "x86-interrupt" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:126:1
+   |
+LL | extern "x86-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:138:20
+   |
+LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
+   |                    ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"thiscall"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:151:1
+   |
+LL | extern "thiscall" {}
+   | ^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:169:19
+   |
+LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
+   |                   ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+warning: use of calling convention not supported on this target
+  --> $DIR/unsupported.rs:182:1
+   |
+LL | extern "stdcall" {}
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
+   = note: `#[warn(unsupported_calling_conventions)]` on by default
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:194:16
+   |
+LL | fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:32:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:30:1
+  --> $DIR/unsupported.rs:42:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:36:1
+  --> $DIR/unsupported.rs:68:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:38:1
+  --> $DIR/unsupported.rs:78:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"x86-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:45:1
+  --> $DIR/unsupported.rs:110:1
    |
 LL | extern "x86-interrupt" fn x86() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:50:1
+  --> $DIR/unsupported.rs:132:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:56:1
+  --> $DIR/unsupported.rs:158:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
-   = note: `#[warn(unsupported_calling_conventions)]` on by default
 
-error: aborting due to 6 previous errors; 1 warning emitted
+error: aborting due to 12 previous errors; 10 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.rs
+++ b/tests/ui/abi/unsupported.rs
@@ -21,7 +21,8 @@
     abi_avr_interrupt,
     abi_x86_interrupt,
     abi_riscv_interrupt,
-    abi_c_cmse_nonsecure_call
+    abi_c_cmse_nonsecure_call,
+    cmse_nonsecure_entry
 )]
 #[lang = "sized"]
 trait Sized {}
@@ -191,8 +192,18 @@ extern "stdcall" {}
 //[riscv64]~^^^^^^^^^ WARN use of calling convention not supported
 //[riscv64]~^^^^^^^^^^ WARN this was previously accepted
 
-fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
     //~^ WARN unsupported_fn_ptr_calling_conventions
     //~^^ WARN this was previously accepted
     f()
 }
+
+extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
+//~^ ERROR is not a supported ABI
+fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
+    //~^ WARN unsupported_fn_ptr_calling_conventions
+    //~^^ WARN this was previously accepted
+    f()
+}
+extern "C-cmse-nonsecure-entry" {}
+//~^ ERROR is not a supported ABI

--- a/tests/ui/abi/unsupported.rs
+++ b/tests/ui/abi/unsupported.rs
@@ -20,39 +20,141 @@
     abi_msp430_interrupt,
     abi_avr_interrupt,
     abi_x86_interrupt,
-    abi_riscv_interrupt
+    abi_riscv_interrupt,
+    abi_c_cmse_nonsecure_call
 )]
 #[lang = "sized"]
 trait Sized {}
 
+#[lang = "copy"]
+trait Copy {}
+
 extern "ptx-kernel" fn ptx() {}
 //~^ ERROR is not a supported ABI
+fn ptx_ptr(f: extern "ptx-kernel" fn()) {
+    //~^ WARN unsupported_fn_ptr_calling_conventions
+    //~^^ WARN this was previously accepted
+    f()
+}
+extern "ptx-kernel" {}
+//~^ ERROR is not a supported ABI
+
 extern "aapcs" fn aapcs() {}
 //[x64]~^ ERROR is not a supported ABI
 //[i686]~^^ ERROR is not a supported ABI
 //[aarch64]~^^^ ERROR is not a supported ABI
 //[riscv32]~^^^^ ERROR is not a supported ABI
 //[riscv64]~^^^^^ ERROR is not a supported ABI
+fn aapcs_ptr(f: extern "aapcs" fn()) {
+    //[x64]~^ WARN unsupported_fn_ptr_calling_conventions
+    //[x64]~^^ WARN this was previously accepted
+    //[i686]~^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[i686]~^^^^ WARN this was previously accepted
+    //[aarch64]~^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[aarch64]~^^^^^^ WARN this was previously accepted
+    //[riscv32]~^^^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[riscv32]~^^^^^^^^ WARN this was previously accepted
+    //[riscv64]~^^^^^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[riscv64]~^^^^^^^^^^ WARN this was previously accepted
+    f()
+}
+extern "aapcs" {}
+//[x64]~^ ERROR is not a supported ABI
+//[i686]~^^ ERROR is not a supported ABI
+//[aarch64]~^^^ ERROR is not a supported ABI
+//[riscv32]~^^^^ ERROR is not a supported ABI
+//[riscv64]~^^^^^ ERROR is not a supported ABI
+
 extern "msp430-interrupt" fn msp430() {}
 //~^ ERROR is not a supported ABI
+fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+    //~^ WARN unsupported_fn_ptr_calling_conventions
+    //~^^ WARN this was previously accepted
+    f()
+}
+extern "msp430-interrupt" {}
+//~^ ERROR is not a supported ABI
+
 extern "avr-interrupt" fn avr() {}
 //~^ ERROR is not a supported ABI
+fn avr_ptr(f: extern "avr-interrupt" fn()) {
+    //~^ WARN unsupported_fn_ptr_calling_conventions
+    //~^^ WARN this was previously accepted
+    f()
+}
+extern "avr-interrupt" {}
+//~^ ERROR is not a supported ABI
+
 extern "riscv-interrupt-m" fn riscv() {}
 //[arm]~^ ERROR is not a supported ABI
 //[x64]~^^ ERROR is not a supported ABI
 //[i686]~^^^ ERROR is not a supported ABI
 //[aarch64]~^^^^ ERROR is not a supported ABI
+fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
+    //[arm]~^ WARN unsupported_fn_ptr_calling_conventions
+    //[arm]~^^ WARN this was previously accepted
+    //[x64]~^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[x64]~^^^^ WARN this was previously accepted
+    //[i686]~^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[i686]~^^^^^^ WARN this was previously accepted
+    //[aarch64]~^^^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[aarch64]~^^^^^^^^ WARN this was previously accepted
+    f()
+}
+extern "riscv-interrupt-m" {}
+//[arm]~^ ERROR is not a supported ABI
+//[x64]~^^ ERROR is not a supported ABI
+//[i686]~^^^ ERROR is not a supported ABI
+//[aarch64]~^^^^ ERROR is not a supported ABI
+
 extern "x86-interrupt" fn x86() {}
 //[aarch64]~^ ERROR is not a supported ABI
 //[arm]~^^ ERROR is not a supported ABI
 //[riscv32]~^^^ ERROR is not a supported ABI
 //[riscv64]~^^^^ ERROR is not a supported ABI
+fn x86_ptr(f: extern "x86-interrupt" fn()) {
+    //[aarch64]~^ WARN unsupported_fn_ptr_calling_conventions
+    //[aarch64]~^^ WARN this was previously accepted
+    //[arm]~^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[arm]~^^^^ WARN this was previously accepted
+    //[riscv32]~^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[riscv32]~^^^^^^ WARN this was previously accepted
+    //[riscv64]~^^^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[riscv64]~^^^^^^^^ WARN this was previously accepted
+    f()
+}
+extern "x86-interrupt" {}
+//[aarch64]~^ ERROR is not a supported ABI
+//[arm]~^^ ERROR is not a supported ABI
+//[riscv32]~^^^ ERROR is not a supported ABI
+//[riscv64]~^^^^ ERROR is not a supported ABI
+
 extern "thiscall" fn thiscall() {}
 //[x64]~^ ERROR is not a supported ABI
 //[arm]~^^ ERROR is not a supported ABI
 //[aarch64]~^^^ ERROR is not a supported ABI
 //[riscv32]~^^^^ ERROR is not a supported ABI
 //[riscv64]~^^^^^ ERROR is not a supported ABI
+fn thiscall_ptr(f: extern "thiscall" fn()) {
+    //[x64]~^ WARN unsupported_fn_ptr_calling_conventions
+    //[x64]~^^ WARN this was previously accepted
+    //[arm]~^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[arm]~^^^^ WARN this was previously accepted
+    //[aarch64]~^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[aarch64]~^^^^^^ WARN this was previously accepted
+    //[riscv32]~^^^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[riscv32]~^^^^^^^^ WARN this was previously accepted
+    //[riscv64]~^^^^^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[riscv64]~^^^^^^^^^^ WARN this was previously accepted
+    f()
+}
+extern "thiscall" {}
+//[x64]~^ ERROR is not a supported ABI
+//[arm]~^^ ERROR is not a supported ABI
+//[aarch64]~^^^ ERROR is not a supported ABI
+//[riscv32]~^^^^ ERROR is not a supported ABI
+//[riscv64]~^^^^^ ERROR is not a supported ABI
+
 extern "stdcall" fn stdcall() {}
 //[x64]~^ WARN use of calling convention not supported
 //[x64]~^^ WARN this was previously accepted
@@ -64,3 +166,33 @@ extern "stdcall" fn stdcall() {}
 //[riscv32]~^^^^^^^^ WARN this was previously accepted
 //[riscv64]~^^^^^^^^^ WARN use of calling convention not supported
 //[riscv64]~^^^^^^^^^^ WARN this was previously accepted
+fn stdcall_ptr(f: extern "stdcall" fn()) {
+    //[x64]~^ WARN unsupported_fn_ptr_calling_conventions
+    //[x64]~^^ WARN this was previously accepted
+    //[arm]~^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[arm]~^^^^ WARN this was previously accepted
+    //[aarch64]~^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[aarch64]~^^^^^^ WARN this was previously accepted
+    //[riscv32]~^^^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[riscv32]~^^^^^^^^ WARN this was previously accepted
+    //[riscv64]~^^^^^^^^^ WARN unsupported_fn_ptr_calling_conventions
+    //[riscv64]~^^^^^^^^^^ WARN this was previously accepted
+    f()
+}
+extern "stdcall" {}
+//[x64]~^ WARN use of calling convention not supported
+//[x64]~^^ WARN this was previously accepted
+//[arm]~^^^ WARN use of calling convention not supported
+//[arm]~^^^^ WARN this was previously accepted
+//[aarch64]~^^^^^ WARN use of calling convention not supported
+//[aarch64]~^^^^^^ WARN this was previously accepted
+//[riscv32]~^^^^^^^ WARN use of calling convention not supported
+//[riscv32]~^^^^^^^^ WARN this was previously accepted
+//[riscv64]~^^^^^^^^^ WARN use of calling convention not supported
+//[riscv64]~^^^^^^^^^^ WARN this was previously accepted
+
+fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+    //~^ WARN unsupported_fn_ptr_calling_conventions
+    //~^^ WARN this was previously accepted
+    f()
+}

--- a/tests/ui/abi/unsupported.x64.stderr
+++ b/tests/ui/abi/unsupported.x64.stderr
@@ -1,5 +1,5 @@
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:34:15
+  --> $DIR/unsupported.rs:35:15
    |
 LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
    = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
 
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:39:1
+  --> $DIR/unsupported.rs:40:1
    |
 LL | extern "ptx-kernel" {}
    | ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:48:17
+  --> $DIR/unsupported.rs:49:17
    |
 LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^
@@ -24,13 +24,13 @@ LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:61:1
+  --> $DIR/unsupported.rs:62:1
    |
 LL | extern "aapcs" {}
    | ^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:70:18
+  --> $DIR/unsupported.rs:71:18
    |
 LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,13 +39,13 @@ LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:75:1
+  --> $DIR/unsupported.rs:76:1
    |
 LL | extern "msp430-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:80:15
+  --> $DIR/unsupported.rs:81:15
    |
 LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -54,13 +54,13 @@ LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:85:1
+  --> $DIR/unsupported.rs:86:1
    |
 LL | extern "avr-interrupt" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:93:17
+  --> $DIR/unsupported.rs:94:17
    |
 LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,13 +69,13 @@ LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:104:1
+  --> $DIR/unsupported.rs:105:1
    |
 LL | extern "riscv-interrupt-m" {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:138:20
+  --> $DIR/unsupported.rs:139:20
    |
 LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    |                    ^^^^^^^^^^^^^^^^^^^^^^
@@ -84,13 +84,13 @@ LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:151:1
+  --> $DIR/unsupported.rs:152:1
    |
 LL | extern "thiscall" {}
    | ^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:169:19
+  --> $DIR/unsupported.rs:170:19
    |
 LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    |                   ^^^^^^^^^^^^^^^^^^^^^
@@ -99,7 +99,7 @@ LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:182:1
+  --> $DIR/unsupported.rs:183:1
    |
 LL | extern "stdcall" {}
    | ^^^^^^^^^^^^^^^^^^^
@@ -109,52 +109,67 @@ LL | extern "stdcall" {}
    = note: `#[warn(unsupported_calling_conventions)]` on by default
 
 warning: use of calling convention not supported on this target on function pointer
-  --> $DIR/unsupported.rs:194:16
+  --> $DIR/unsupported.rs:195:21
    |
-LL | fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | fn cmse_call_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
 
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:203:22
+   |
+LL | fn cmse_entry_ptr(f: extern "C-cmse-nonsecure-entry" fn()) {
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:208:1
+   |
+LL | extern "C-cmse-nonsecure-entry" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:32:1
+  --> $DIR/unsupported.rs:33:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:42:1
+  --> $DIR/unsupported.rs:43:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:68:1
+  --> $DIR/unsupported.rs:69:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:78:1
+  --> $DIR/unsupported.rs:79:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:88:1
+  --> $DIR/unsupported.rs:89:1
    |
 LL | extern "riscv-interrupt-m" fn riscv() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:132:1
+  --> $DIR/unsupported.rs:133:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:158:1
+  --> $DIR/unsupported.rs:159:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -162,6 +177,12 @@ LL | extern "stdcall" fn stdcall() {}
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
 
-error: aborting due to 12 previous errors; 10 warnings emitted
+error[E0570]: `"C-cmse-nonsecure-entry"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:201:1
+   |
+LL | extern "C-cmse-nonsecure-entry" fn cmse_entry() {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 14 previous errors; 11 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/abi/unsupported.x64.stderr
+++ b/tests/ui/abi/unsupported.x64.stderr
@@ -1,49 +1,167 @@
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:34:15
+   |
+LL | fn ptx_ptr(f: extern "ptx-kernel" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+   = note: `#[warn(unsupported_fn_ptr_calling_conventions)]` on by default
+
 error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:28:1
+  --> $DIR/unsupported.rs:39:1
+   |
+LL | extern "ptx-kernel" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:48:17
+   |
+LL | fn aapcs_ptr(f: extern "aapcs" fn()) {
+   |                 ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"aapcs"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:61:1
+   |
+LL | extern "aapcs" {}
+   | ^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:70:18
+   |
+LL | fn msp430_ptr(f: extern "msp430-interrupt" fn()) {
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:75:1
+   |
+LL | extern "msp430-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:80:15
+   |
+LL | fn avr_ptr(f: extern "avr-interrupt" fn()) {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:85:1
+   |
+LL | extern "avr-interrupt" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:93:17
+   |
+LL | fn riscv_ptr(f: extern "riscv-interrupt-m" fn()) {
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:104:1
+   |
+LL | extern "riscv-interrupt-m" {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:138:20
+   |
+LL | fn thiscall_ptr(f: extern "thiscall" fn()) {
+   |                    ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"thiscall"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:151:1
+   |
+LL | extern "thiscall" {}
+   | ^^^^^^^^^^^^^^^^^^^^
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:169:19
+   |
+LL | fn stdcall_ptr(f: extern "stdcall" fn()) {
+   |                   ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+warning: use of calling convention not supported on this target
+  --> $DIR/unsupported.rs:182:1
+   |
+LL | extern "stdcall" {}
+   | ^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
+   = note: `#[warn(unsupported_calling_conventions)]` on by default
+
+warning: use of calling convention not supported on this target on function pointer
+  --> $DIR/unsupported.rs:194:16
+   |
+LL | fn cmse_ptr(f: extern "C-cmse-nonsecure-call" fn()) {
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #130260 <https://github.com/rust-lang/rust/issues/130260>
+
+error[E0570]: `"ptx-kernel"` is not a supported ABI for the current target
+  --> $DIR/unsupported.rs:32:1
    |
 LL | extern "ptx-kernel" fn ptx() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"aapcs"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:30:1
+  --> $DIR/unsupported.rs:42:1
    |
 LL | extern "aapcs" fn aapcs() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"msp430-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:36:1
+  --> $DIR/unsupported.rs:68:1
    |
 LL | extern "msp430-interrupt" fn msp430() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"avr-interrupt"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:38:1
+  --> $DIR/unsupported.rs:78:1
    |
 LL | extern "avr-interrupt" fn avr() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"riscv-interrupt-m"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:40:1
+  --> $DIR/unsupported.rs:88:1
    |
 LL | extern "riscv-interrupt-m" fn riscv() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0570]: `"thiscall"` is not a supported ABI for the current target
-  --> $DIR/unsupported.rs:50:1
+  --> $DIR/unsupported.rs:132:1
    |
 LL | extern "thiscall" fn thiscall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: use of calling convention not supported on this target
-  --> $DIR/unsupported.rs:56:1
+  --> $DIR/unsupported.rs:158:1
    |
 LL | extern "stdcall" fn stdcall() {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #87678 <https://github.com/rust-lang/rust/issues/87678>
-   = note: `#[warn(unsupported_calling_conventions)]` on by default
 
-error: aborting due to 6 previous errors; 1 warning emitted
+error: aborting due to 12 previous errors; 10 warnings emitted
 
 For more information about this error, try `rustc --explain E0570`.

--- a/tests/ui/c-variadic/feature-gate-extended_varargs_abi_support.rs
+++ b/tests/ui/c-variadic/feature-gate-extended_varargs_abi_support.rs
@@ -1,3 +1,5 @@
+//@ only-x86_64
+
 fn efiapi(f: extern "efiapi" fn(usize, ...)) {
     //~^ ERROR: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
     //~^^ ERROR: using calling conventions other than `C` or `cdecl` for varargs functions is unstable

--- a/tests/ui/c-variadic/feature-gate-extended_varargs_abi_support.stderr
+++ b/tests/ui/c-variadic/feature-gate-extended_varargs_abi_support.stderr
@@ -1,5 +1,5 @@
 error[E0658]: using calling conventions other than `C` or `cdecl` for varargs functions is unstable
-  --> $DIR/feature-gate-extended_varargs_abi_support.rs:1:14
+  --> $DIR/feature-gate-extended_varargs_abi_support.rs:3:14
    |
 LL | fn efiapi(f: extern "efiapi" fn(usize, ...)) {
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,13 +9,13 @@ LL | fn efiapi(f: extern "efiapi" fn(usize, ...)) {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0045]: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
-  --> $DIR/feature-gate-extended_varargs_abi_support.rs:1:14
+  --> $DIR/feature-gate-extended_varargs_abi_support.rs:3:14
    |
 LL | fn efiapi(f: extern "efiapi" fn(usize, ...)) {
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadic function must have a compatible calling convention
 
 error[E0658]: using calling conventions other than `C` or `cdecl` for varargs functions is unstable
-  --> $DIR/feature-gate-extended_varargs_abi_support.rs:6:12
+  --> $DIR/feature-gate-extended_varargs_abi_support.rs:8:12
    |
 LL | fn sysv(f: extern "sysv64" fn(usize, ...)) {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,13 +25,13 @@ LL | fn sysv(f: extern "sysv64" fn(usize, ...)) {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0045]: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
-  --> $DIR/feature-gate-extended_varargs_abi_support.rs:6:12
+  --> $DIR/feature-gate-extended_varargs_abi_support.rs:8:12
    |
 LL | fn sysv(f: extern "sysv64" fn(usize, ...)) {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadic function must have a compatible calling convention
 
 error[E0658]: using calling conventions other than `C` or `cdecl` for varargs functions is unstable
-  --> $DIR/feature-gate-extended_varargs_abi_support.rs:11:11
+  --> $DIR/feature-gate-extended_varargs_abi_support.rs:13:11
    |
 LL | fn win(f: extern "win64" fn(usize, ...)) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,7 +41,7 @@ LL | fn win(f: extern "win64" fn(usize, ...)) {
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0045]: C-variadic function must have a compatible calling convention, like `C` or `cdecl`
-  --> $DIR/feature-gate-extended_varargs_abi_support.rs:11:11
+  --> $DIR/feature-gate-extended_varargs_abi_support.rs:13:11
    |
 LL | fn win(f: extern "win64" fn(usize, ...)) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadic function must have a compatible calling convention

--- a/tests/ui/c-variadic/variadic-ffi-2-arm.rs
+++ b/tests/ui/c-variadic/variadic-ffi-2-arm.rs
@@ -1,0 +1,9 @@
+//@ only-arm
+//@ build-pass
+#![feature(extended_varargs_abi_support)]
+
+fn aapcs(f: extern "aapcs" fn(usize, ...)) {
+    f(22, 44);
+}
+
+fn main() {}

--- a/tests/ui/c-variadic/variadic-ffi-2.rs
+++ b/tests/ui/c-variadic/variadic-ffi-2.rs
@@ -1,6 +1,7 @@
 //@ ignore-arm stdcall isn't supported
 #![feature(extended_varargs_abi_support)]
 
+#[allow(unsupported_fn_ptr_calling_conventions)]
 fn baz(f: extern "stdcall" fn(usize, ...)) {
     //~^ ERROR: C-variadic function must have a compatible calling convention,
     // like C, cdecl, system, aapcs, win64, sysv64 or efiapi
@@ -10,15 +11,22 @@ fn baz(f: extern "stdcall" fn(usize, ...)) {
 fn system(f: extern "system" fn(usize, ...)) {
     f(22, 44);
 }
-fn aapcs(f: extern "aapcs" fn(usize, ...)) {
-    f(22, 44);
-}
+#[cfg(target_arch = "x86_64")]
 fn sysv(f: extern "sysv64" fn(usize, ...)) {
     f(22, 44);
 }
+#[cfg(target_arch = "x86_64")]
 fn win(f: extern "win64" fn(usize, ...)) {
     f(22, 44);
 }
+#[cfg(any(
+    target_arch = "arm",
+    target_arch = "aarch64",
+    target_arch = "riscv32",
+    target_arch = "riscv64",
+    target_arch = "x86",
+    target_arch = "x86_64"
+))]
 fn efiapi(f: extern "efiapi" fn(usize, ...)) {
     f(22, 44);
 }

--- a/tests/ui/c-variadic/variadic-ffi-2.stderr
+++ b/tests/ui/c-variadic/variadic-ffi-2.stderr
@@ -1,5 +1,5 @@
 error[E0045]: C-variadic function must have a compatible calling convention, like `C`, `cdecl`, `system`, `aapcs`, `win64`, `sysv64` or `efiapi`
-  --> $DIR/variadic-ffi-2.rs:4:11
+  --> $DIR/variadic-ffi-2.rs:5:11
    |
 LL | fn baz(f: extern "stdcall" fn(usize, ...)) {
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ C-variadic function must have a compatible calling convention

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/gate_test.rs
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/gate_test.rs
@@ -1,8 +1,9 @@
 // gate-test-abi_c_cmse_nonsecure_call
+#[allow(unsupported_fn_ptr_calling_conventions)]
 fn main() {
     let non_secure_function = unsafe {
         core::mem::transmute::<usize, extern "C-cmse-nonsecure-call" fn(i32, i32, i32, i32) -> i32>(
-        //~^ ERROR [E0658]
+            //~^ ERROR [E0658]
             0x10000004,
         )
     };

--- a/tests/ui/cmse-nonsecure/cmse-nonsecure-call/gate_test.stderr
+++ b/tests/ui/cmse-nonsecure/cmse-nonsecure-call/gate_test.stderr
@@ -1,5 +1,5 @@
 error[E0658]: C-cmse-nonsecure-call ABI is experimental and subject to change
-  --> $DIR/gate_test.rs:4:46
+  --> $DIR/gate_test.rs:5:46
    |
 LL |         core::mem::transmute::<usize, extern "C-cmse-nonsecure-call" fn(i32, i32, i32, i32) -> i32>(
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/130260
Related tracking issue: #87678

Compatibility of an ABI for a target was previously only performed on function definitions and `extern` blocks. This PR adds it also to function pointers to be consistent.

This might have broken some of the `tests/ui/` depending on the platform, so a try run seems like a good idea.

Also this might break existing code, because we now emit extra errors. Does this require a crater run?

# Example
```rust
// build with: --target=x86_64-unknown-linux-gnu 

// These raise E0570
extern "thiscall" fn foo() {}
extern "thiscall" { fn bar() }

// This did not raise any error
fn baz(f: extern "thiscall" fn()) { f() }
```

# Open Questions
* [x] Should this report a future incompatibility warning like #87678 ?
* [ ] Is this the best place to perform the check?

