### PR TITLE
Detect multiple crate versions on method not found

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -4109,8 +4109,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let trait_span = self.tcx.def_span(trait_def_id);
         let mut multi_span: MultiSpan = trait_span.into();
         multi_span.push_span_label(trait_span, format!("this is the trait that is needed"));
+        let descr = self.tcx.associated_item(item_def_id).descr();
         multi_span
-            .push_span_label(item_span, format!("the method is available for `{rcvr_ty}` here"));
+            .push_span_label(item_span, format!("the {descr} is available for `{rcvr_ty}` here"));
         for (def_id, import_def_id) in candidates {
             if let Some(import_def_id) = import_def_id {
                 multi_span.push_span_label(

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -4062,7 +4062,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let name = self.tcx.crate_name(trait_candidate.def_id.krate);
                 if trait_candidate.def_id.krate != item.def_id.krate && name == pick_name {
                     let msg = format!(
-                        "you have multiple different versions of crate `{name}` in your \
+                        "there are multiple different versions of crate `{name}` in the \
                          dependency graph",
                     );
                     let tdid = self.tcx.parent(item.def_id);

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1697,11 +1697,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             err.highlighted_span_help(
                 span,
                 vec![
-                    StringPart::normal("you have ".to_string()),
+                    StringPart::normal("there are ".to_string()),
                     StringPart::highlighted("multiple different versions".to_string()),
                     StringPart::normal(" of crate `".to_string()),
                     StringPart::highlighted(format!("{name}")),
-                    StringPart::normal("` in your dependency graph".to_string()),
+                    StringPart::normal("` the your dependency graph".to_string()),
                 ],
             );
             let candidates = if impl_candidates.is_empty() {

--- a/tests/run-make/crate-loading/multiple-dep-versions-1.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-1.rs
@@ -1,6 +1,10 @@
 #![crate_name = "dependency"]
 #![crate_type = "rlib"]
-pub struct Type;
-pub trait Trait {}
-impl Trait for Type {}
+pub struct Type(pub i32);
+pub trait Trait {
+    fn foo(&self);
+}
+impl Trait for Type {
+    fn foo(&self) {}
+}
 pub fn do_something<X: Trait>(_: X) {}

--- a/tests/run-make/crate-loading/multiple-dep-versions-1.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-1.rs
@@ -3,8 +3,10 @@
 pub struct Type(pub i32);
 pub trait Trait {
     fn foo(&self);
+    fn bar();
 }
 impl Trait for Type {
     fn foo(&self) {}
+    fn bar() {}
 }
 pub fn do_something<X: Trait>(_: X) {}

--- a/tests/run-make/crate-loading/multiple-dep-versions-2.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-2.rs
@@ -1,6 +1,10 @@
 #![crate_name = "dependency"]
 #![crate_type = "rlib"]
-pub struct Type(pub i32);
-pub trait Trait {}
-impl Trait for Type {}
+pub struct Type;
+pub trait Trait {
+    fn foo(&self);
+}
+impl Trait for Type {
+    fn foo(&self) {}
+}
 pub fn do_something<X: Trait>(_: X) {}

--- a/tests/run-make/crate-loading/multiple-dep-versions-2.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-2.rs
@@ -3,8 +3,10 @@
 pub struct Type;
 pub trait Trait {
     fn foo(&self);
+    fn bar();
 }
 impl Trait for Type {
     fn foo(&self) {}
+    fn bar() {}
 }
 pub fn do_something<X: Trait>(_: X) {}

--- a/tests/run-make/crate-loading/multiple-dep-versions-3.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-3.rs
@@ -1,0 +1,5 @@
+#![crate_name = "foo"]
+#![crate_type = "rlib"]
+
+extern crate dependency;
+pub use dependency::Type;

--- a/tests/run-make/crate-loading/multiple-dep-versions.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions.rs
@@ -1,8 +1,9 @@
 extern crate dep_2_reexport;
 extern crate dependency;
-use dep_2_reexport::do_something;
-use dependency::Type;
+use dep_2_reexport::Type;
+use dependency::{do_something, Trait};
 
 fn main() {
     do_something(Type);
+    Type.foo();
 }

--- a/tests/run-make/crate-loading/multiple-dep-versions.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions.rs
@@ -6,4 +6,5 @@ use dependency::{do_something, Trait};
 fn main() {
     do_something(Type);
     Type.foo();
+    Type::bar();
 }

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -7,11 +7,15 @@ use run_make_support::{rust_lib_name, rustc};
 fn main() {
     rustc().input("multiple-dep-versions-1.rs").run();
     rustc().input("multiple-dep-versions-2.rs").extra_filename("2").metadata("2").run();
+    rustc()
+        .input("multiple-dep-versions-3.rs")
+        .extern_("dependency", rust_lib_name("dependency2"))
+        .run();
 
     rustc()
         .input("multiple-dep-versions.rs")
         .extern_("dependency", rust_lib_name("dependency"))
-        .extern_("dep_2_reexport", rust_lib_name("dependency2"))
+        .extern_("dep_2_reexport", rust_lib_name("foo"))
         .run_fail()
         .assert_stderr_contains(
             "you have multiple different versions of crate `dependency` in your dependency graph",
@@ -22,5 +26,11 @@ fn main() {
         )
         .assert_stderr_contains("this type doesn't implement the required trait")
         .assert_stderr_contains("this type implements the required trait")
-        .assert_stderr_contains("this is the required trait");
+        .assert_stderr_contains("this is the required trait")
+        .assert_stderr_contains(
+            "`dependency` imported here doesn't correspond to the right crate version",
+        )
+        .assert_stderr_contains("this is the trait that was imported")
+        .assert_stderr_contains("this is the trait that is needed")
+        .assert_stderr_contains("the method is available for `dep_2_reexport::Type` here");
 }

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -1,6 +1,7 @@
 //@ only-linux
 //@ ignore-wasm32
 //@ ignore-wasm64
+// ignore-tidy-linelength
 
 use run_make_support::{rust_lib_name, rustc};
 
@@ -18,19 +19,82 @@ fn main() {
         .extern_("dep_2_reexport", rust_lib_name("foo"))
         .run_fail()
         .assert_stderr_contains(
-            "there are multiple different versions of crate `dependency` in the dependency graph",
+            r#"error[E0277]: the trait bound `dep_2_reexport::Type: Trait` is not satisfied
+  --> multiple-dep-versions.rs:7:18
+   |
+7  |     do_something(Type);
+   |     ------------ ^^^^ the trait `Trait` is not implemented for `dep_2_reexport::Type`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: there are multiple different versions of crate `dependency` the your dependency graph
+  --> multiple-dep-versions.rs:1:1
+   |
+1  | extern crate dep_2_reexport;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one version of crate `dependency` is used here, as a dependency of crate `foo`
+2  | extern crate dependency;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ one version of crate `dependency` is used here, as a direct dependency of the current crate"#,
         )
         .assert_stderr_contains(
-            "two types coming from two different versions of the same crate are different types \
-             even if they look the same",
+            r#"
+3  | pub struct Type(pub i32);
+   | ^^^^^^^^^^^^^^^ this type implements the required trait
+4  | pub trait Trait {
+   | --------------- this is the required trait"#,
         )
-        .assert_stderr_contains("this type doesn't implement the required trait")
-        .assert_stderr_contains("this type implements the required trait")
-        .assert_stderr_contains("this is the required trait")
         .assert_stderr_contains(
-            "`dependency` imported here doesn't correspond to the right crate version",
+            r#"
+3  | pub struct Type;
+   | ^^^^^^^^^^^^^^^ this type doesn't implement the required trait"#,
         )
-        .assert_stderr_contains("this is the trait that was imported")
-        .assert_stderr_contains("this is the trait that is needed")
-        .assert_stderr_contains("the method is available for `dep_2_reexport::Type` here");
+        .assert_stderr_contains(
+            r#"
+error[E0599]: no method named `foo` found for struct `dep_2_reexport::Type` in the current scope
+ --> multiple-dep-versions.rs:8:10
+  |
+8 |     Type.foo();
+  |          ^^^ method not found in `Type`
+  |
+note: there are multiple different versions of crate `dependency` in the dependency graph"#,
+        )
+        .assert_stderr_contains(
+            r#"
+4 | pub trait Trait {
+  | ^^^^^^^^^^^^^^^ this is the trait that is needed
+5 |     fn foo(&self);
+  |     -------------- the method is available for `dep_2_reexport::Type` here
+  |
+ ::: multiple-dep-versions.rs:4:32
+  |
+4 | use dependency::{do_something, Trait};
+  |                                ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`"#,
+        )
+        .assert_stderr_contains(
+            r#"
+4 | pub trait Trait {
+  | --------------- this is the trait that was imported"#,
+        )
+        .assert_stderr_contains(
+            r#"
+error[E0599]: no function or associated item named `bar` found for struct `dep_2_reexport::Type` in the current scope
+ --> multiple-dep-versions.rs:9:11
+  |
+9 |     Type::bar();
+  |           ^^^ function or associated item not found in `Type`
+  |
+note: there are multiple different versions of crate `dependency` in the dependency graph"#,
+        )
+        .assert_stderr_contains(
+            r#"
+4 | pub trait Trait {
+  | ^^^^^^^^^^^^^^^ this is the trait that is needed
+5 |     fn foo(&self);
+6 |     fn bar();
+  |     --------- the method is available for `dep_2_reexport::Type` here
+  |
+ ::: multiple-dep-versions.rs:4:32
+  |
+4 | use dependency::{do_something, Trait};
+  |                                ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`"#,
+        );
 }

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -90,7 +90,7 @@ note: there are multiple different versions of crate `dependency` in the depende
   | ^^^^^^^^^^^^^^^ this is the trait that is needed
 5 |     fn foo(&self);
 6 |     fn bar();
-  |     --------- the method is available for `dep_2_reexport::Type` here
+  |     --------- the associated function is available for `dep_2_reexport::Type` here
   |
  ::: multiple-dep-versions.rs:4:32
   |

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -18,7 +18,7 @@ fn main() {
         .extern_("dep_2_reexport", rust_lib_name("foo"))
         .run_fail()
         .assert_stderr_contains(
-            "you have multiple different versions of crate `dependency` in your dependency graph",
+            "there are multiple different versions of crate `dependency` in the dependency graph",
         )
         .assert_stderr_contains(
             "two types coming from two different versions of the same crate are different types \


### PR DESCRIPTION
When a type comes indirectly from one crate version but the imported trait comes from a separate crate version, the called method won't be found. We now show additional context:

```
error[E0599]: no method named `foo` found for struct `dep_2_reexport::Type` in the current scope
 --> multiple-dep-versions.rs:8:10
  |
8 |     Type.foo();
  |          ^^^ method not found in `Type`
  |
note: there are multiple different versions of crate `dependency` in the dependency graph
 --> multiple-dep-versions.rs:4:32
  |
4 | use dependency::{do_something, Trait};
  |                                ^^^^^ `dependency` imported here doesn't correspond to the right crate version
  |
 ::: ~/rust/build/x86_64-unknown-linux-gnu/test/run-make/crate-loading/rmake_out/multiple-dep-versions-1.rs:4:1
  |
4 | pub trait Trait {
  | --------------- this is the trait that was imported
  |
 ::: ~/rust/build/x86_64-unknown-linux-gnu/test/run-make/crate-loading/rmake_out/multiple-dep-versions-2.rs:4:1
  |
4 | pub trait Trait {
  | --------------- this is the trait that is needed
5 |     fn foo(&self);
  |        --- the method is available for `dep_2_reexport::Type` here
```

Fix #128569, fix #110926, fix #109161, fix #81659, fix #51458, fix #32611. Follow up to #124944.