### PR TITLE
Fuchsia Test Runner: enable ffx repository server

### DIFF
--- a/src/ci/docker/scripts/fuchsia-test-runner.py
+++ b/src/ci/docker/scripts/fuchsia-test-runner.py
@@ -571,6 +571,19 @@ class TestEnvironment:
         )
 
         # Start repository server
+        # Note that we must first enable the repository server daemon.
+        check_call_with_logging(
+            [
+                ffx_path,
+                "config",
+                "set",
+                "repository.server.enabled",
+                "true",
+            ],
+            env=ffx_env,
+            stdout_handler=self.subprocess_logger.debug,
+            stderr_handler=self.subprocess_logger.debug,
+        )
         check_call_with_logging(
             [
                 ffx_path,


### PR DESCRIPTION
The default repository server setting has changed on Fuchsia (default is newly "false"). Now, in order to start the repository server, the config `repository.server.enabled` must be set to true.

