### PR TITLE
Add tracking issue to core-pattern-type

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -391,7 +391,7 @@ pub mod net;
 pub mod option;
 pub mod panic;
 pub mod panicking;
-#[unstable(feature = "core_pattern_types", issue = "none")]
+#[unstable(feature = "core_pattern_types", issue = "123646")]
 pub mod pat;
 pub mod pin;
 #[unstable(feature = "new_range_api", issue = "125687")]

--- a/library/core/src/pat.rs
+++ b/library/core/src/pat.rs
@@ -6,7 +6,7 @@
 /// ```
 #[macro_export]
 #[rustc_builtin_macro(pattern_type)]
-#[unstable(feature = "core_pattern_type", issue = "none")]
+#[unstable(feature = "core_pattern_type", issue = "123646")]
 macro_rules! pattern_type {
     ($($arg:tt)*) => {
         /* compiler built-in */

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -586,7 +586,7 @@ pub mod net;
 pub mod num;
 pub mod os;
 pub mod panic;
-#[unstable(feature = "core_pattern_types", issue = "none")]
+#[unstable(feature = "core_pattern_types", issue = "123646")]
 pub mod pat;
 pub mod path;
 #[unstable(feature = "anonymous_pipe", issue = "127154")]

--- a/tests/ui/type/pattern_types/feature-gate-pattern_types.stderr
+++ b/tests/ui/type/pattern_types/feature-gate-pattern_types.stderr
@@ -4,6 +4,7 @@ error[E0658]: use of unstable library feature 'core_pattern_type'
 LL | type NonNullU32 = pattern_type!(u32 is 1..);
    |                   ^^^^^^^^^^^^
    |
+   = note: see issue #123646 <https://github.com/rust-lang/rust/issues/123646> for more information
    = help: add `#![feature(core_pattern_type)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -13,6 +14,7 @@ error[E0658]: use of unstable library feature 'core_pattern_type'
 LL | type Percent = pattern_type!(u32 is 0..=100);
    |                ^^^^^^^^^^^^
    |
+   = note: see issue #123646 <https://github.com/rust-lang/rust/issues/123646> for more information
    = help: add `#![feature(core_pattern_type)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -22,6 +24,7 @@ error[E0658]: use of unstable library feature 'core_pattern_type'
 LL | type Negative = pattern_type!(i32 is ..=0);
    |                 ^^^^^^^^^^^^
    |
+   = note: see issue #123646 <https://github.com/rust-lang/rust/issues/123646> for more information
    = help: add `#![feature(core_pattern_type)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -31,6 +34,7 @@ error[E0658]: use of unstable library feature 'core_pattern_type'
 LL | type Positive = pattern_type!(i32 is 0..);
    |                 ^^^^^^^^^^^^
    |
+   = note: see issue #123646 <https://github.com/rust-lang/rust/issues/123646> for more information
    = help: add `#![feature(core_pattern_type)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -40,6 +44,7 @@ error[E0658]: use of unstable library feature 'core_pattern_type'
 LL | type Always = pattern_type!(Option<u32> is Some(_));
    |               ^^^^^^^^^^^^
    |
+   = note: see issue #123646 <https://github.com/rust-lang/rust/issues/123646> for more information
    = help: add `#![feature(core_pattern_type)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 


### PR DESCRIPTION
While the actual `pattern_types` feature flag has an issue assigned, the exported macro and its module do not.

cc #123646 