### PR TITLE
run-make: enable msvc for redundant-libs

### DIFF
--- a/tests/run-make/redundant-libs/foo.c
+++ b/tests/run-make/redundant-libs/foo.c
@@ -1,2 +1,8 @@
-void foo1() {}
-void foo2() {}
+#ifdef _MSC_VER
+#define DllExport __declspec(dllexport)
+#else
+#define DllExport
+#endif
+
+DllExport void foo1() {}
+DllExport void foo2() {}

--- a/tests/run-make/redundant-libs/rmake.rs
+++ b/tests/run-make/redundant-libs/rmake.rs
@@ -10,12 +10,6 @@
 
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
-//@ ignore-windows-msvc
-// Reason: this test links libraries via link.exe, which only accepts the import library
-// for the dynamic library, i.e. `foo.dll.lib`. However, build_native_dynamic_lib only
-// produces `foo.dll` - the dynamic library itself. To make this test work on MSVC, one
-// would need to derive the import library from the dynamic library.
-// See https://stackoverflow.com/questions/9360280/
 
 use run_make_support::{
     build_native_dynamic_lib, build_native_static_lib, cwd, is_msvc, rfs, run, rustc,


### PR DESCRIPTION
The issue here was that `foo` was not exporting any functions therefore creating an import library was unnecessary and elided by the linker. 

I fixed it by exporting the functions.

try-job: x86_64-msvc
try-job: i686-msvc