### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0517.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0517.md
@@ -25,14 +25,17 @@ impl Foo {
 These attributes do not work on typedefs, since typedefs are just aliases.
 
 Representations like `#[repr(u8)]`, `#[repr(i64)]` are for selecting the
-discriminant size for enums with no data fields on any of the variants, e.g.
-`enum Color {Red, Blue, Green}`, effectively setting the size of the enum to
-the size of the provided type. Such an enum can be cast to a value of the same
-type as well. In short, `#[repr(u8)]` makes the enum behave like an integer
-with a constrained set of allowed values.
+discriminant size for enums. For enums with no data fields on any of the
+variants, e.g. `enum Color {Red, Blue, Green}`, this effectively sets the size
+of the enum to the size of the provided type. Such an enum can be cast to a
+value of the same type as well. In short, `#[repr(u8)]` makes a field-less enum
+behave like an integer with a constrained set of allowed values.
 
-Only field-less enums can be cast to numerical primitives, so this attribute
-will not apply to structs.
+For a description of how `#[repr(C)]` and representations like `#[repr(u8)]`
+affect the layout of enums with data fields, see [RFC 2195][rfc2195].
+
+Only field-less enums can be cast to numerical primitives. Representations like
+`#[repr(u8)]` will not apply to structs.
 
 `#[repr(packed)]` reduces padding to make the struct size smaller. The
 representation of enums isn't strictly defined in Rust, and this attribute
@@ -42,3 +45,5 @@ won't work on enums.
 types (i.e., `u8`, `i32`, etc) a representation that permits vectorization via
 SIMD. This doesn't make much sense for enums since they don't consist of a
 single list of data.
+
+[rfc2195]: https://github.com/rust-lang/rfcs/blob/master/text/2195-really-tagged-unions.md

--- a/tests/run-make/fmt-write-bloat/main.rs
+++ b/tests/run-make/fmt-write-bloat/main.rs
@@ -5,7 +5,8 @@
 use core::fmt;
 use core::fmt::Write;
 
-#[link(name = "c")]
+#[cfg_attr(not(target_env = "msvc"), link(name = "c"))]
+#[cfg_attr(target_env = "msvc", link(name = "libcmt"))]
 extern "C" {}
 
 struct Dummy;

--- a/tests/run-make/fmt-write-bloat/main.rs
+++ b/tests/run-make/fmt-write-bloat/main.rs
@@ -6,7 +6,8 @@ use core::fmt;
 use core::fmt::Write;
 
 #[cfg_attr(not(target_env = "msvc"), link(name = "c"))]
-#[cfg_attr(target_env = "msvc", link(name = "libcmt"))]
+#[cfg_attr(all(target_env = "msvc", target_feature = "crt-static"), link(name = "libcmt"))]
+#[cfg_attr(all(target_env = "msvc", not(target_feature = "crt-static")), link(name = "msvcrt"))]
 extern "C" {}
 
 struct Dummy;

--- a/tests/run-make/fmt-write-bloat/rmake.rs
+++ b/tests/run-make/fmt-write-bloat/rmake.rs
@@ -15,14 +15,11 @@
 //! `NO_DEBUG_ASSERTIONS=1`). If debug assertions are disabled, then we can check for the absence of
 //! additional `usize` formatting and padding related symbols.
 
-// Reason: This test is `ignore-windows` because the `no_std` test (using `#[link(name = "c")])`
-// doesn't link on windows.
-//@ ignore-windows
 //@ ignore-cross-compile
 
 use run_make_support::env::no_debug_assertions;
-use run_make_support::rustc;
 use run_make_support::symbols::any_symbol_contains;
+use run_make_support::{bin_name, rustc};
 
 fn main() {
     rustc().input("main.rs").opt().run();
@@ -33,5 +30,5 @@ fn main() {
         // otherwise, add them to the list of symbols to deny.
         panic_syms.extend_from_slice(&["panicking", "panic_fmt", "pad_integral", "Display"]);
     }
-    assert!(!any_symbol_contains("main", &panic_syms));
+    assert!(!any_symbol_contains(&bin_name("main"), &panic_syms));
 }

--- a/tests/run-make/redundant-libs/foo.c
+++ b/tests/run-make/redundant-libs/foo.c
@@ -1,2 +1,8 @@
-void foo1() {}
-void foo2() {}
+#ifdef _MSC_VER
+#define DllExport __declspec(dllexport)
+#else
+#define DllExport
+#endif
+
+DllExport void foo1() {}
+DllExport void foo2() {}

--- a/tests/run-make/redundant-libs/rmake.rs
+++ b/tests/run-make/redundant-libs/rmake.rs
@@ -10,12 +10,6 @@
 
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
-//@ ignore-windows-msvc
-// Reason: this test links libraries via link.exe, which only accepts the import library
-// for the dynamic library, i.e. `foo.dll.lib`. However, build_native_dynamic_lib only
-// produces `foo.dll` - the dynamic library itself. To make this test work on MSVC, one
-// would need to derive the import library from the dynamic library.
-// See https://stackoverflow.com/questions/9360280/
 
 use run_make_support::{
     build_native_dynamic_lib, build_native_static_lib, cwd, is_msvc, rfs, run, rustc,


### PR DESCRIPTION
Successful merges:

 - #128795 (Update E0517 message to reflect RFC 2195.)
 - #128804 (run-make: enable msvc for redundant-libs)
 - #128807 (run-make: run fmt-write-bloat on Windows)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=128795,128804,128807)
<!-- homu-ignore:end -->