### PR TITLE
Only suggest `#[allow]` for `--warn` and `--deny` lint level flags

### DIFF
--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -228,9 +228,11 @@ pub fn explain_lint_level_source(
                 err.note_once(format!(
                     "`{flag} {hyphen_case_lint_name}` implied by `{flag} {hyphen_case_flag_val}`"
                 ));
-                err.help_once(format!(
-                    "to override `{flag} {hyphen_case_flag_val}` add `#[allow({name})]`"
-                ));
+                if matches!(orig_level, Level::Warn | Level::Deny) {
+                    err.help_once(format!(
+                        "to override `{flag} {hyphen_case_flag_val}` add `#[allow({name})]`"
+                    ));
+                }
             }
         }
         LintLevelSource::Node { name: lint_attr_name, span, reason, .. } => {

--- a/tests/ui/lint/command-line-lint-group-forbid.stderr
+++ b/tests/ui/lint/command-line-lint-group-forbid.stderr
@@ -5,7 +5,6 @@ LL |     let _InappropriateCamelCasing = true;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `_inappropriate_camel_casing`
    |
    = note: `-F non-snake-case` implied by `-F bad-style`
-   = help: to override `-F bad-style` add `#[allow(non_snake_case)]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/force-warn/cap-lints-warn-allowed-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/cap-lints-warn-allowed-warn-by-default-lint.stderr
@@ -7,7 +7,6 @@ LL |         0...100 => true,
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn ellipsis-inclusive-range-patterns` implied by `--force-warn rust-2021-compatibility`
-   = help: to override `--force-warn rust-2021-compatibility` add `#[allow(ellipsis_inclusive_range_patterns)]`
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/force-warn/lint-group-allow-warnings.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allow-warnings.stderr
@@ -5,7 +5,6 @@ LL | pub fn FUNCTION() {}
    |        ^^^^^^^^ help: convert the identifier to snake case: `function`
    |
    = note: `--force-warn non-snake-case` implied by `--force-warn nonstandard-style`
-   = help: to override `--force-warn nonstandard-style` add `#[allow(non_snake_case)]`
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
@@ -7,7 +7,6 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
-   = help: to override `--force-warn rust-2018-idioms` add `#[allow(bare_trait_objects)]`
 help: if this is an object-safe trait, use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}

--- a/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
@@ -7,7 +7,6 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
-   = help: to override `--force-warn rust-2018-idioms` add `#[allow(bare_trait_objects)]`
 help: if this is an object-safe trait, use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}

--- a/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
@@ -7,7 +7,6 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
-   = help: to override `--force-warn rust-2018-idioms` add `#[allow(bare_trait_objects)]`
 help: if this is an object-safe trait, use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}

--- a/tests/ui/lint/group-forbid-always-trumps-cli.stderr
+++ b/tests/ui/lint/group-forbid-always-trumps-cli.stderr
@@ -5,7 +5,6 @@ LL |     let x = 1;
    |         ^ help: if this is intentional, prefix it with an underscore: `_x`
    |
    = note: `-F unused-variables` implied by `-F unused`
-   = help: to override `-F unused` add `#[allow(unused_variables)]`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
`--force-warn` and `--forbid` cannot be overridden