### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0517.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0517.md
@@ -25,14 +25,17 @@ impl Foo {
 These attributes do not work on typedefs, since typedefs are just aliases.
 
 Representations like `#[repr(u8)]`, `#[repr(i64)]` are for selecting the
-discriminant size for enums with no data fields on any of the variants, e.g.
-`enum Color {Red, Blue, Green}`, effectively setting the size of the enum to
-the size of the provided type. Such an enum can be cast to a value of the same
-type as well. In short, `#[repr(u8)]` makes the enum behave like an integer
-with a constrained set of allowed values.
+discriminant size for enums. For enums with no data fields on any of the
+variants, e.g. `enum Color {Red, Blue, Green}`, this effectively sets the size
+of the enum to the size of the provided type. Such an enum can be cast to a
+value of the same type as well. In short, `#[repr(u8)]` makes a field-less enum
+behave like an integer with a constrained set of allowed values.
 
-Only field-less enums can be cast to numerical primitives, so this attribute
-will not apply to structs.
+For a description of how `#[repr(C)]` and representations like `#[repr(u8)]`
+affect the layout of enums with data fields, see [RFC 2195][rfc2195].
+
+Only field-less enums can be cast to numerical primitives. Representations like
+`#[repr(u8)]` will not apply to structs.
 
 `#[repr(packed)]` reduces padding to make the struct size smaller. The
 representation of enums isn't strictly defined in Rust, and this attribute
@@ -42,3 +45,5 @@ won't work on enums.
 types (i.e., `u8`, `i32`, etc) a representation that permits vectorization via
 SIMD. This doesn't make much sense for enums since they don't consist of a
 single list of data.
+
+[rfc2195]: https://github.com/rust-lang/rfcs/blob/master/text/2195-really-tagged-unions.md

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -818,6 +818,13 @@ fn run_required_analyses(tcx: TyCtxt<'_>) {
     });
     sess.time("layout_testing", || layout_test::test_layout(tcx));
     sess.time("abi_testing", || abi_test::test_abi(tcx));
+    if tcx.sess.opts.unstable_opts.validate_mir {
+        sess.time("ensuring_optimized_MIR_is_computable", || {
+            tcx.hir().par_body_owners(|def_id| {
+                tcx.instance_mir(ty::InstanceKind::Item(def_id.into()));
+            });
+        });
+    }
 }
 
 /// Runs the type-checking, region checking and other miscellaneous analysis

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -228,9 +228,11 @@ pub fn explain_lint_level_source(
                 err.note_once(format!(
                     "`{flag} {hyphen_case_lint_name}` implied by `{flag} {hyphen_case_flag_val}`"
                 ));
-                err.help_once(format!(
-                    "to override `{flag} {hyphen_case_flag_val}` add `#[allow({name})]`"
-                ));
+                if matches!(orig_level, Level::Warn | Level::Deny) {
+                    err.help_once(format!(
+                        "to override `{flag} {hyphen_case_flag_val}` add `#[allow({name})]`"
+                    ));
+                }
             }
         }
         LintLevelSource::Node { name: lint_attr_name, span, reason, .. } => {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1129,9 +1129,6 @@ pub struct Resolver<'a, 'tcx> {
     /// Also includes of list of each fields visibility
     struct_constructors: LocalDefIdMap<(Res, ty::Visibility<DefId>, Vec<ty::Visibility<DefId>>)>,
 
-    /// Features declared for this crate.
-    declared_features: FxHashSet<Symbol>,
-
     lint_buffer: LintBuffer,
 
     next_node_id: NodeId,
@@ -1402,7 +1399,6 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
 
         let registered_tools = tcx.registered_tools(());
 
-        let features = tcx.features();
         let pub_vis = ty::Visibility::<DefId>::Public;
         let edition = tcx.sess.edition();
 
@@ -1506,7 +1502,6 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             multi_segment_macro_resolutions: Default::default(),
             builtin_attrs: Default::default(),
             containers_deriving_copy: Default::default(),
-            declared_features: features.declared_features.clone(),
             lint_buffer: LintBuffer::default(),
             next_node_id: CRATE_NODE_ID,
             node_id_to_def_id,

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -1001,7 +1001,8 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                 let feature = stability.feature;
 
                 let is_allowed = |feature| {
-                    self.declared_features.contains(&feature) || span.allows_unstable(feature)
+                    self.tcx.features().declared_features.contains(&feature)
+                        || span.allows_unstable(feature)
                 };
                 let allowed_by_implication = implied_by.is_some_and(|feature| is_allowed(feature));
                 if !is_allowed(feature) && !allowed_by_implication {

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1171,15 +1171,22 @@ impl<T: ?Sized> NonNull<T> {
     /// `align`.
     ///
     /// If it is not possible to align the pointer, the implementation returns
-    /// `usize::MAX`. It is permissible for the implementation to *always*
-    /// return `usize::MAX`. Only your algorithm's performance can depend
-    /// on getting a usable offset here, not its correctness.
+    /// `usize::MAX`.
     ///
     /// The offset is expressed in number of `T` elements, and not bytes.
     ///
     /// There are no guarantees whatsoever that offsetting the pointer will not overflow or go
     /// beyond the allocation that the pointer points into. It is up to the caller to ensure that
     /// the returned offset is correct in all terms other than alignment.
+    ///
+    /// When this is called during compile-time evaluation (which is unstable), the implementation
+    /// may return `usize::MAX` in cases where that can never happen at runtime. This is because the
+    /// actual alignment of pointers is not known yet during compile-time, so an offset with
+    /// guaranteed alignment can sometimes not be computed. For example, a buffer declared as `[u8;
+    /// N]` might be allocated at an odd or an even address, but at compile-time this is not yet
+    /// known, so the execution has to be correct for either choice. It is therefore impossible to
+    /// find an offset that is guaranteed to be 2-aligned. (This behavior is subject to change, as usual
+    /// for unstable APIs.)
     ///
     /// # Panics
     ///

--- a/tests/crashes/121127.rs
+++ b/tests/crashes/121127.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #121127
-//@ compile-flags: -Zpolymorphize=on -Zinline-mir=yes -C debuginfo=2
+//@ compile-flags: -Zvalidate-mir -Zinline-mir=yes -C debuginfo=2
 // Note that as of PR#123949 this only crashes with debuginfo enabled
 
 #![feature(specialization)]

--- a/tests/crashes/122909.rs
+++ b/tests/crashes/122909.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zpolymorphize=on -Zinline-mir=yes
+//@ compile-flags: -Zvalidate-mir -Zinline-mir=yes
 //@ known-bug: #122909
 
 

--- a/tests/crashes/126896.rs
+++ b/tests/crashes/126896.rs
@@ -1,5 +1,5 @@
 //@ known-bug: rust-lang/rust#126896
-//@ compile-flags: -Zpolymorphize=on -Zinline-mir=yes
+//@ compile-flags: -Zvalidate-mir -Zinline-mir=yes
 
 #![feature(type_alias_impl_trait)]
 type Two<'a, 'b> = impl std::fmt::Debug;

--- a/tests/ui/async-await/async-closures/fn-exception.rs
+++ b/tests/ui/async-await/async-closures/fn-exception.rs
@@ -1,0 +1,27 @@
+//@ edition: 2021
+
+#![feature(async_closure, target_feature_11)]
+// `target_feature_11` just to test safe functions w/ target features.
+
+use std::pin::Pin;
+use std::future::Future;
+
+unsafe extern "Rust" {
+    pub unsafe fn unsafety() -> Pin<Box<dyn Future<Output = ()> + 'static>>;
+}
+
+unsafe extern "C" {
+    pub safe fn abi() -> Pin<Box<dyn Future<Output = ()> + 'static>>;
+}
+
+
+#[target_feature(enable = "sse2")]
+fn target_feature()  -> Pin<Box<dyn Future<Output = ()> + 'static>> { todo!() }
+
+fn test(f: impl async Fn()) {}
+
+fn main() {
+    test(unsafety); //~ ERROR the trait bound
+    test(abi); //~ ERROR the trait bound
+    test(target_feature); //~ ERROR the trait bound
+}

--- a/tests/ui/async-await/async-closures/fn-exception.stderr
+++ b/tests/ui/async-await/async-closures/fn-exception.stderr
@@ -1,0 +1,45 @@
+error[E0277]: the trait bound `unsafe fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {unsafety}: AsyncFn<()>` is not satisfied
+  --> $DIR/fn-exception.rs:24:10
+   |
+LL |     test(unsafety);
+   |     ---- ^^^^^^^^ the trait `AsyncFn<()>` is not implemented for fn item `unsafe fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {unsafety}`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `test`
+  --> $DIR/fn-exception.rs:21:17
+   |
+LL | fn test(f: impl async Fn()) {}
+   |                 ^^^^^^^^^^ required by this bound in `test`
+
+error[E0277]: the trait bound `extern "C" fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {abi}: AsyncFn<()>` is not satisfied
+  --> $DIR/fn-exception.rs:25:10
+   |
+LL |     test(abi);
+   |     ---- ^^^ the trait `AsyncFn<()>` is not implemented for fn item `extern "C" fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {abi}`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `test`
+  --> $DIR/fn-exception.rs:21:17
+   |
+LL | fn test(f: impl async Fn()) {}
+   |                 ^^^^^^^^^^ required by this bound in `test`
+
+error[E0277]: the trait bound `fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}: AsyncFn<()>` is not satisfied
+  --> $DIR/fn-exception.rs:26:10
+   |
+LL |     test(target_feature);
+   |     ---- ^^^^^^^^^^^^^^ the trait `AsyncFn<()>` is not implemented for fn item `fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `test`
+  --> $DIR/fn-exception.rs:21:17
+   |
+LL | fn test(f: impl async Fn()) {}
+   |                 ^^^^^^^^^^ required by this bound in `test`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/inline-const/using-late-bound-from-closure.rs
+++ b/tests/ui/inline-const/using-late-bound-from-closure.rs
@@ -1,0 +1,16 @@
+// Test for ICE: cannot convert ReLateParam to a region vid
+// https://github.com/rust-lang/rust/issues/125873
+
+#![feature(closure_lifetime_binder)]
+fn foo() {
+    let a = for<'a> |b: &'a ()| -> &'a () {
+        const {
+            let awd = ();
+            let _: &'a () = &awd;
+            //~^ `awd` does not live long enough
+        };
+        b
+    };
+}
+
+fn main() {}

--- a/tests/ui/inline-const/using-late-bound-from-closure.stderr
+++ b/tests/ui/inline-const/using-late-bound-from-closure.stderr
@@ -1,0 +1,19 @@
+error[E0597]: `awd` does not live long enough
+  --> $DIR/using-late-bound-from-closure.rs:9:29
+   |
+LL |     let a = for<'a> |b: &'a ()| -> &'a () {
+   |                 -- lifetime `'a` defined here
+LL |         const {
+LL |             let awd = ();
+   |                 --- binding `awd` declared here
+LL |             let _: &'a () = &awd;
+   |                    ------   ^^^^ borrowed value does not live long enough
+   |                    |
+   |                    type annotation requires that `awd` is borrowed for `'a`
+LL |
+LL |         };
+   |         - `awd` dropped here while still borrowed
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0597`.

--- a/tests/ui/lint/command-line-lint-group-forbid.stderr
+++ b/tests/ui/lint/command-line-lint-group-forbid.stderr
@@ -5,7 +5,6 @@ LL |     let _InappropriateCamelCasing = true;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `_inappropriate_camel_casing`
    |
    = note: `-F non-snake-case` implied by `-F bad-style`
-   = help: to override `-F bad-style` add `#[allow(non_snake_case)]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/force-warn/cap-lints-warn-allowed-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/cap-lints-warn-allowed-warn-by-default-lint.stderr
@@ -7,7 +7,6 @@ LL |         0...100 => true,
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn ellipsis-inclusive-range-patterns` implied by `--force-warn rust-2021-compatibility`
-   = help: to override `--force-warn rust-2021-compatibility` add `#[allow(ellipsis_inclusive_range_patterns)]`
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/force-warn/lint-group-allow-warnings.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allow-warnings.stderr
@@ -5,7 +5,6 @@ LL | pub fn FUNCTION() {}
    |        ^^^^^^^^ help: convert the identifier to snake case: `function`
    |
    = note: `--force-warn non-snake-case` implied by `--force-warn nonstandard-style`
-   = help: to override `--force-warn nonstandard-style` add `#[allow(non_snake_case)]`
 
 warning: 1 warning emitted
 

--- a/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
@@ -7,7 +7,6 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
-   = help: to override `--force-warn rust-2018-idioms` add `#[allow(bare_trait_objects)]`
 help: if this is an object-safe trait, use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}

--- a/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
@@ -7,7 +7,6 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
-   = help: to override `--force-warn rust-2018-idioms` add `#[allow(bare_trait_objects)]`
 help: if this is an object-safe trait, use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}

--- a/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
@@ -7,7 +7,6 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
-   = help: to override `--force-warn rust-2018-idioms` add `#[allow(bare_trait_objects)]`
 help: if this is an object-safe trait, use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}

--- a/tests/ui/lint/group-forbid-always-trumps-cli.stderr
+++ b/tests/ui/lint/group-forbid-always-trumps-cli.stderr
@@ -5,7 +5,6 @@ LL |     let x = 1;
    |         ^ help: if this is intentional, prefix it with an underscore: `_x`
    |
    = note: `-F unused-variables` implied by `-F unused`
-   = help: to override `-F unused` add `#[allow(unused_variables)]`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Successful merges:

 - #128306 (Update NonNull::align_offset quarantees)
 - #128612 (Make `validate_mir` ensure the final MIR for all bodies)
 - #128648 (Add regression test)
 - #128791 (Don't implement `AsyncFn` for `FnDef`/`FnPtr` that wouldnt implement `Fn`)
 - #128795 (Update E0517 message to reflect RFC 2195.)
 - #128825 (rm `declared_features` field in resolver)
 - #128826 (Only suggest `#[allow]` for `--warn` and `--deny` lint level flags)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=128306,128612,128648,128791,128795,128825,128826)
<!-- homu-ignore:end -->