### PR TITLE
rustdoc: strip unreachable modules

### DIFF
--- a/src/librustdoc/passes/stripper.rs
+++ b/src/librustdoc/passes/stripper.rs
@@ -95,7 +95,14 @@ impl<'a, 'tcx> DocFolder for Stripper<'a, 'tcx> {
             }
 
             clean::ModuleItem(..) => {
-                if i.item_id.is_local() && i.visibility(self.tcx) != Some(Visibility::Public) {
+                if i.item_id.is_local()
+                    && !is_item_reachable(
+                        self.tcx,
+                        self.is_json_output,
+                        self.effective_visibilities,
+                        i.item_id,
+                    )
+                {
                     debug!("Stripper: stripping module {:?}", i.name);
                     let old = mem::replace(&mut self.update_retained, false);
                     let ret = strip_item(self.fold_item_recur(i));

--- a/tests/rustdoc-json/pub_mod_in_private_mod.rs
+++ b/tests/rustdoc-json/pub_mod_in_private_mod.rs
@@ -1,0 +1,6 @@
+// See https://github.com/rust-lang/rust/issues/101105
+
+//@ !has "$.index[*][?(@.name=='nucleus')]"
+mod corpus {
+    pub mod nucleus {}
+}


### PR DESCRIPTION
Modules are now stripped based on the same logic that's used to strip other item kinds
Fixes #101105 
