### PR TITLE
rustdoc: do not run doctests with invalid langstrings

### DIFF
--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -61,7 +61,7 @@ fn test_lang_string_parse() {
         ..Default::default()
     });
     // error
-    t(LangString { original: "{rust}".into(), rust: true, ..Default::default() });
+    t(LangString { original: "{rust}".into(), rust: false, ..Default::default() });
     t(LangString {
         original: "{.rust}".into(),
         rust: true,
@@ -233,7 +233,7 @@ fn test_lang_string_parse() {
         ..Default::default()
     });
     // error
-    t(LangString { original: "{class=first=second}".into(), rust: true, ..Default::default() });
+    t(LangString { original: "{class=first=second}".into(), rust: false, ..Default::default() });
     // error
     t(LangString {
         original: "{class=first.second}".into(),
@@ -261,7 +261,7 @@ fn test_lang_string_parse() {
         ..Default::default()
     });
     // error
-    t(LangString { original: r#"{class=f"irst"}"#.into(), rust: true, ..Default::default() });
+    t(LangString { original: r#"{class=f"irst"}"#.into(), rust: false, ..Default::default() });
 }
 
 #[test]

--- a/tests/rustdoc-ui/doctest/doctest-no-run-invalid-langstring-124577.rs
+++ b/tests/rustdoc-ui/doctest/doctest-no-run-invalid-langstring-124577.rs
@@ -1,4 +1,5 @@
 //@ compile-flags:--test
+//@ check-pass
 #![allow(rustdoc::invalid_codeblock_attributes)]
 
 // https://github.com/rust-lang/rust/pull/124577#issuecomment-2276034737

--- a/tests/rustdoc-ui/doctest/doctest-no-run-invalid-langstring-124577.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-no-run-invalid-langstring-124577.stdout
@@ -1,0 +1,5 @@
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+

--- a/tests/rustdoc/doctest/doctest-no-run-invalid-langstring-124577.rs
+++ b/tests/rustdoc/doctest/doctest-no-run-invalid-langstring-124577.rs
@@ -1,0 +1,11 @@
+//@ compile-flags:--test
+#![allow(rustdoc::invalid_codeblock_attributes)]
+
+// https://github.com/rust-lang/rust/pull/124577#issuecomment-2276034737
+
+// Test that invalid langstrings don't get run.
+
+/// ```{rust,ignore}
+/// panic!();
+/// ```
+pub struct Foo;


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/124577#issuecomment-2276034737

CC @decathorpe
