### PR TITLE
Minor Refactor: Remove a Redundant Conditional Check

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -959,11 +959,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                      \n    where\n        T: {qself_str},\n{}",
                     where_bounds.join(",\n"),
                 ));
-            }
-            let reported = err.emit();
-            if !where_bounds.is_empty() {
+                let reported = err.emit();
                 return Err(reported);
             }
+            err.emit();
         }
 
         Ok(bound)


### PR DESCRIPTION
The existing code checks `where_bounds.is_empty()` twice when
it can be combined into one. Now, after combining, the refactored code reads
better and feels straightforward.

The diff doesn't make it clear. So, the current code looks like this:
``` rust
    if !where_bounds.is_empty() {
        err.help(format!(
            "consider introducing a new type parameter `T` and adding `where` constraints:\
             \n    where\n        T: {qself_str},\n{}",
            where_bounds.join(",\n"),
        ));
    }
    let reported = err.emit();
    if !where_bounds.is_empty() {
        return Err(reported);
    }
```
The proposed changes:
``` rust
    if !where_bounds.is_empty() {
        err.help(format!(
            "consider introducing a new type parameter `T` and adding `where` constraints:\
             \n    where\n        T: {qself_str},\n{}",
            where_bounds.join(",\n"),
        ));
        let reported = err.emit();
        return Err(reported);
    }
    err.emit();

```
