### PR TITLE
Tweak detection of multiple crate versions to be more encompassing

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1796,6 +1796,24 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 StringPart::highlighted("cargo tree".to_string()),
                 StringPart::normal("` to explore your dependency tree".to_string()),
             ]);
+
+            // FIXME: this is a giant hack for the benefit of this specific diagnostic. Because
+            // we're so nested in method calls before the error gets emitted, bubbling a single bit
+            // flag informing the top level caller to stop adding extra detail to the diagnostic,
+            // would actually be harder to follow. So we do something naughty here: we consume the
+            // diagnostic, emit it and leave in its place a "delayed bug" that will continue being
+            // modified but won't actually be printed to end users. This *is not ideal*, but allows
+            // us to reduce the verbosity of an error that is already quite verbose and increase its
+            // specificity. Below we modify the main message as well, in a way that *could* break if
+            // the implementation of Diagnostics change significantly, but that would be caught with
+            // a make test failure when this diagnostic is tested.
+            err.primary_message(format!(
+                "{} because the trait comes from a different crate version",
+                err.messages[0].0.as_str().unwrap(),
+            ));
+            let diag = err.clone();
+            err.downgrade_to_delayed_bug();
+            self.tcx.dcx().emit_diagnostic(diag);
             return true;
         }
 

--- a/tests/run-make/crate-loading/multiple-dep-versions-3.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-3.rs
@@ -3,3 +3,8 @@
 
 extern crate dependency;
 pub use dependency::Type;
+pub struct OtherType;
+impl dependency::Trait for OtherType {
+    fn foo(&self) {}
+    fn bar() {}
+}

--- a/tests/run-make/crate-loading/multiple-dep-versions.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions.rs
@@ -1,10 +1,11 @@
 extern crate dep_2_reexport;
 extern crate dependency;
-use dep_2_reexport::Type;
+use dep_2_reexport::{OtherType, Type};
 use dependency::{Trait, do_something};
 
 fn main() {
     do_something(Type);
     Type.foo();
     Type::bar();
+    do_something(OtherType);
 }

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -18,37 +18,31 @@ fn main() {
         .extern_("dependency", rust_lib_name("dependency"))
         .extern_("dep_2_reexport", rust_lib_name("foo"))
         .run_fail()
-        .assert_stderr_contains(r#"error[E0277]: the trait bound `dep_2_reexport::Type: Trait` is not satisfied
-  --> multiple-dep-versions.rs:7:18
-   |
-7  |     do_something(Type);
-   |     ------------ ^^^^ the trait `Trait` is not implemented for `dep_2_reexport::Type`
-   |     |
-   |     required by a bound introduced by this call
-   |
+        .assert_stderr_contains(r#"error[E0277]: the trait bound `dep_2_reexport::Type: Trait` is not satisfied because the trait comes from a different crate version
+ --> multiple-dep-versions.rs:7:18
+  |
+7 |     do_something(Type);
+  |                  ^^^^ the trait `Trait` is not implemented for `dep_2_reexport::Type`
+  |
 note: there are multiple different versions of crate `dependency` in the dependency graph"#)
         .assert_stderr_contains(r#"
-3  | pub struct Type(pub i32);
-   | --------------- this type implements the required trait
-4  | pub trait Trait {
-   | ^^^^^^^^^^^^^^^ this is the required trait
+3 | pub struct Type(pub i32);
+  | --------------- this type implements the required trait
+4 | pub trait Trait {
+  | ^^^^^^^^^^^^^^^ this is the required trait
 "#)
         .assert_stderr_contains(r#"
-1  | extern crate dep_2_reexport;
-   | ---------------------------- one version of crate `dependency` is used here, as a dependency of crate `foo`
-2  | extern crate dependency;
-   | ------------------------ one version of crate `dependency` is used here, as a direct dependency of the current crate"#)
+1 | extern crate dep_2_reexport;
+  | ---------------------------- one version of crate `dependency` is used here, as a dependency of crate `foo`
+2 | extern crate dependency;
+  | ------------------------ one version of crate `dependency` is used here, as a direct dependency of the current crate"#)
         .assert_stderr_contains(r#"
-3  | pub struct Type;
-   | --------------- this type doesn't implement the required trait
-4  | pub trait Trait {
-   | --------------- this is the found trait
-   = note: two types coming from two different versions of the same crate are different types even if they look the same
-   = help: you can use `cargo tree` to explore your dependency tree"#)
-        .assert_stderr_contains(r#"note: required by a bound in `do_something`"#)
-        .assert_stderr_contains(r#"
-12 | pub fn do_something<X: Trait>(_: X) {}
-   |                        ^^^^^ required by this bound in `do_something`"#)
+3 | pub struct Type;
+  | --------------- this type doesn't implement the required trait
+4 | pub trait Trait {
+  | --------------- this is the found trait
+  = note: two types coming from two different versions of the same crate are different types even if they look the same
+  = help: you can use `cargo tree` to explore your dependency tree"#)
         .assert_stderr_contains(r#"error[E0599]: no method named `foo` found for struct `dep_2_reexport::Type` in the current scope
  --> multiple-dep-versions.rs:8:10
   |

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -18,8 +18,7 @@ fn main() {
         .extern_("dependency", rust_lib_name("dependency"))
         .extern_("dep_2_reexport", rust_lib_name("foo"))
         .run_fail()
-        .assert_stderr_contains(
-            r#"error[E0277]: the trait bound `dep_2_reexport::Type: Trait` is not satisfied
+        .assert_stderr_contains(r#"error[E0277]: the trait bound `dep_2_reexport::Type: Trait` is not satisfied
   --> multiple-dep-versions.rs:7:18
    |
 7  |     do_something(Type);
@@ -27,41 +26,37 @@ fn main() {
    |     |
    |     required by a bound introduced by this call
    |
-help: there are multiple different versions of crate `dependency` in the dependency graph
-  --> multiple-dep-versions.rs:1:1
-   |
-1  | extern crate dep_2_reexport;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one version of crate `dependency` is used here, as a dependency of crate `foo`
-2  | extern crate dependency;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^ one version of crate `dependency` is used here, as a direct dependency of the current crate"#,
-        )
-        .assert_stderr_contains(
-            r#"
+note: there are multiple different versions of crate `dependency` in the dependency graph"#)
+        .assert_stderr_contains(r#"
 3  | pub struct Type(pub i32);
    | --------------- this type implements the required trait
 4  | pub trait Trait {
-   | ^^^^^^^^^^^^^^^ this is the required trait"#,
-        )
-        .assert_stderr_contains(
-            r#"
+   | ^^^^^^^^^^^^^^^ this is the required trait
+"#)
+        .assert_stderr_contains(r#"
+1  | extern crate dep_2_reexport;
+   | ---------------------------- one version of crate `dependency` is used here, as a dependency of crate `foo`
+2  | extern crate dependency;
+   | ------------------------ one version of crate `dependency` is used here, as a direct dependency of the current crate"#)
+        .assert_stderr_contains(r#"
 3  | pub struct Type;
    | --------------- this type doesn't implement the required trait
 4  | pub trait Trait {
    | --------------- this is the found trait
-   = help: you can use `cargo tree` to explore your dependency tree"#,
-        )
-        .assert_stderr_contains(
-            r#"
-error[E0599]: no method named `foo` found for struct `dep_2_reexport::Type` in the current scope
+   = note: two types coming from two different versions of the same crate are different types even if they look the same
+   = help: you can use `cargo tree` to explore your dependency tree"#)
+        .assert_stderr_contains(r#"note: required by a bound in `do_something`"#)
+        .assert_stderr_contains(r#"
+12 | pub fn do_something<X: Trait>(_: X) {}
+   |                        ^^^^^ required by this bound in `do_something`"#)
+        .assert_stderr_contains(r#"error[E0599]: no method named `foo` found for struct `dep_2_reexport::Type` in the current scope
  --> multiple-dep-versions.rs:8:10
   |
 8 |     Type.foo();
   |          ^^^ method not found in `Type`
   |
-note: there are multiple different versions of crate `dependency` in the dependency graph"#,
-        )
-        .assert_stderr_contains(
-            r#"
+note: there are multiple different versions of crate `dependency` in the dependency graph"#)
+        .assert_stderr_contains(r#"
 4 | pub trait Trait {
   | ^^^^^^^^^^^^^^^ this is the trait that is needed
 5 |     fn foo(&self);
@@ -70,25 +65,19 @@ note: there are multiple different versions of crate `dependency` in the depende
  ::: multiple-dep-versions.rs:4:18
   |
 4 | use dependency::{Trait, do_something};
-  |                  ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`"#,
-        )
-        .assert_stderr_contains(
-            r#"
+  |                  ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`"#)
+        .assert_stderr_contains(r#"
 4 | pub trait Trait {
-  | --------------- this is the trait that was imported"#,
-        )
-        .assert_stderr_contains(
-            r#"
+  | --------------- this is the trait that was imported"#)
+        .assert_stderr_contains(r#"
 error[E0599]: no function or associated item named `bar` found for struct `dep_2_reexport::Type` in the current scope
  --> multiple-dep-versions.rs:9:11
   |
 9 |     Type::bar();
   |           ^^^ function or associated item not found in `Type`
   |
-note: there are multiple different versions of crate `dependency` in the dependency graph"#,
-        )
-        .assert_stderr_contains(
-            r#"
+note: there are multiple different versions of crate `dependency` in the dependency graph"#)
+        .assert_stderr_contains(r#"
 4 | pub trait Trait {
   | ^^^^^^^^^^^^^^^ this is the trait that is needed
 5 |     fn foo(&self);
@@ -98,8 +87,7 @@ note: there are multiple different versions of crate `dependency` in the depende
  ::: multiple-dep-versions.rs:4:18
   |
 4 | use dependency::{Trait, do_something};
-  |                  ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`"#,
-        )
+  |                  ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`"#)
         .assert_stderr_contains(
           r#"
 6  | pub struct OtherType;

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -38,14 +38,17 @@ help: there are multiple different versions of crate `dependency` in the depende
         .assert_stderr_contains(
             r#"
 3  | pub struct Type(pub i32);
-   | ^^^^^^^^^^^^^^^ this type implements the required trait
+   | --------------- this type implements the required trait
 4  | pub trait Trait {
-   | --------------- this is the required trait"#,
+   | ^^^^^^^^^^^^^^^ this is the required trait"#,
         )
         .assert_stderr_contains(
             r#"
 3  | pub struct Type;
-   | ^^^^^^^^^^^^^^^ this type doesn't implement the required trait"#,
+   | --------------- this type doesn't implement the required trait
+4  | pub trait Trait {
+   | --------------- this is the found trait
+   = help: you can use `cargo tree` to explore your dependency tree"#,
         )
         .assert_stderr_contains(
             r#"
@@ -96,5 +99,9 @@ note: there are multiple different versions of crate `dependency` in the depende
   |
 4 | use dependency::{Trait, do_something};
   |                  ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`"#,
-        );
+        )
+        .assert_stderr_contains(
+          r#"
+6  | pub struct OtherType;
+   | -------------------- this type doesn't implement the required trait"#);
 }

--- a/tests/ui/typeck/foreign_struct_trait_unimplemented.stderr
+++ b/tests/ui/typeck/foreign_struct_trait_unimplemented.stderr
@@ -6,12 +6,7 @@ LL |     needs_test(foreign_struct_trait_unimplemented::B);
    |     |
    |     required by a bound introduced by this call
    |
-help: there are multiple different versions of crate `foreign_struct_trait_unimplemented` in the dependency graph
-  --> $DIR/foreign_struct_trait_unimplemented.rs:3:1
-   |
-LL | extern crate foreign_struct_trait_unimplemented;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one version of crate `foreign_struct_trait_unimplemented` is used here, as a direct dependency of the current crate
-   = help: you can use `cargo tree` to explore your dependency tree
+   = help: the trait `Test` is implemented for `A`
 note: required by a bound in `needs_test`
   --> $DIR/foreign_struct_trait_unimplemented.rs:10:23
    |


### PR DESCRIPTION
Previously, we only emitted the additional context if the type was in the same crate as the trait that appeared multiple times in the dependency tree. Now, we look at all traits looking for two with the same name in different crates with the same crate number, and we are more flexible looking for the types involved. This will work even if the type that implements the wrong trait version is from a different crate entirely.

```
error[E0277]: the trait bound `CustomErrorHandler: ErrorHandler` is not satisfied because the trait comes from a different crate version
 --> src/main.rs:5:17
  |
5 |     cnb_runtime(CustomErrorHandler {});
  |                 ^^^^^^^^^^^^^^^^^^^^^ the trait `ErrorHandler` is not implemented for `CustomErrorHandler`
  |
note: there are multiple different versions of crate `c` in the dependency graph
 --> /home/gh-estebank/testcase-rustc-crate-version-mismatch/c-v0.2/src/lib.rs:1:1
  |
1 | pub trait ErrorHandler {}
  | ^^^^^^^^^^^^^^^^^^^^^^ this is the required trait
  |
 ::: src/main.rs:1:5
  |
1 | use b::CustomErrorHandler;
  |     - one version of crate `c` is used here, as a dependency of crate `b`
2 | use c::cnb_runtime;
  |     - one version of crate `c` is used here, as a direct dependency of the current crate
  |
 ::: /home/gh-estebank/testcase-rustc-crate-version-mismatch/b/src/lib.rs:1:1
  |
1 | pub struct CustomErrorHandler {}
  | ----------------------------- this type doesn't implement the required trait
  |
 ::: /home/gh-estebank/testcase-rustc-crate-version-mismatch/c-v0.1/src/lib.rs:1:1
  |
1 | pub trait ErrorHandler {}
  | ---------------------- this is the found trait
  = note: two types coming from two different versions of the same crate are different types even if they look the same
  = help: you can use `cargo tree` to explore your dependency tree
```

Fix #89143.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
