### PR TITLE
Rework MIR inlining debuginfo so function parameters show up in debuggers.

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -106,7 +106,7 @@ pub struct FunctionCx<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> {
     locals: locals::Locals<'tcx, Bx::Value>,
 
     /// All `VarDebugInfo` from the MIR body, partitioned by `Local`.
-    /// This is `None` if no var`#[non_exhaustive]`iable debuginfo/names are needed.
+    /// This is `None` if no variable debuginfo/names are needed.
     per_local_var_debug_info:
         Option<IndexVec<mir::Local, Vec<PerLocalVarDebugInfo<'tcx, Bx::DIVariable>>>>,
 

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::hash::Hash;
 
 use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_data_structures::fx::FxIndexMap;
@@ -30,7 +31,7 @@ pub trait BackendTypes {
 
     // FIXME(eddyb) find a common convention for all of the debuginfo-related
     // names (choose between `Dbg`, `Debug`, `DebugInfo`, `DI` etc.).
-    type DIScope: Copy;
+    type DIScope: Copy + Hash + PartialEq + Eq;
     type DILocation: Copy;
     type DIVariable: Copy;
 }

--- a/tests/codegen/debuginfo-inline-callsite-location.rs
+++ b/tests/codegen/debuginfo-inline-callsite-location.rs
@@ -9,13 +9,12 @@
 // CHECK:       tail call void @{{[A-Za-z0-9_]+4core6option13unwrap_failed}}
 // CHECK-SAME:  !dbg ![[#second_dbg:]]
 
-// CHECK-DAG:   ![[#func_dbg:]] = distinct !DISubprogram(name: "unwrap<i32>"
-// CHECK-DAG:   ![[#first_scope:]] = distinct !DILexicalBlock(scope: ![[#func_dbg]],
-// CHECK:       ![[#second_scope:]] = distinct !DILexicalBlock(scope: ![[#func_dbg]],
+// CHECK-DAG:   ![[#func_scope:]] = distinct !DISubprogram(name: "unwrap<i32>"
+// CHECK-DAG:   ![[#]] = !DILocalVariable(name: "self",{{( arg: 1,)?}} scope: ![[#func_scope]]
 // CHECK:       ![[#first_dbg]] = !DILocation(line: [[#]]
-// CHECK-SAME:  scope: ![[#first_scope]], inlinedAt: ![[#]])
+// CHECK-SAME:  scope: ![[#func_scope]], inlinedAt: ![[#]])
 // CHECK:       ![[#second_dbg]] = !DILocation(line: [[#]]
-// CHECK-SAME:  scope: ![[#second_scope]], inlinedAt: ![[#]])
+// CHECK-SAME:  scope: ![[#func_scope]], inlinedAt: ![[#]])
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/inline-function-args-debug-info.rs
+++ b/tests/codegen/inline-function-args-debug-info.rs
@@ -15,6 +15,7 @@ pub fn outer_function(x: usize, y: usize) -> usize {
 fn inner_function(aaaa: usize, bbbb: usize) -> usize {
     // CHECK: !DILocalVariable(name: "aaaa", arg: 1
     // CHECK-SAME: line: 15
+    // CHECK-NOT: !DILexicalBlock(
     // CHECK: !DILocalVariable(name: "bbbb", arg: 2
     // CHECK-SAME: line: 15
     aaaa + bbbb


### PR DESCRIPTION
Line numbers of multiply-inlined functions were fixed in #114643 by using a single DISubprogram. That, however, triggered assertions because parameters weren't deduplicated. The "solution" to that in #115417 was to insert a DILexicalScope below the DISubprogram and parent all of the parameters to that scope. That fixed the assertion, but debuggers (including gdb and lldb) don't recognize variables that are not parented to the subprogram itself as parameters, even if they are emitted with DW_TAG_formal_parameter.

Consider the program:

```rust
use std::env;

#[inline(always)]
fn square(n: i32) -> i32 {
    n * n
}

#[inline(never)]
fn square_no_inline(n: i32) -> i32 {
    n * n
}

fn main() {
    let x = square(env::vars().count() as i32);
    let y = square_no_inline(env::vars().count() as i32);
    println!("{x} == {y}");
}
```

When making a release build with debug=2 and rustc 1.82.0-nightly (8b3870784 2024-08-07)

```
(gdb) r
Starting program: /ephemeral/tmp/target/release/tmp [Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Breakpoint 1, tmp::square () at src/main.rs:5
5	    n * n
(gdb) info args
No arguments.
(gdb) info locals
n = 31
(gdb) c
Continuing.

Breakpoint 2, tmp::square_no_inline (n=31) at src/main.rs:10
10	    n * n
(gdb) info args
n = 31
(gdb) info locals
No locals.
```

This issue is particularly annoying because it removes arguments from stack traces.

The DWARF for the inlined function looks like this:

```
< 2><0x00002132 GOFF=0x00002132>      DW_TAG_subprogram
                                        DW_AT_linkage_name          _ZN3tmp6square17hc507052ff3d2a488E
                                        DW_AT_name                  square
                                        DW_AT_decl_file             0x0000000f /ephemeral/tmp/src/main.rs
                                        DW_AT_decl_line             0x00000004
                                        DW_AT_type                  0x00001a56<.debug_info+0x00001a56>
                                        DW_AT_inline                DW_INL_inlined
< 3><0x00002142 GOFF=0x00002142>        DW_TAG_lexical_block
< 4><0x00002143 GOFF=0x00002143>          DW_TAG_formal_parameter
                                            DW_AT_name                  n
                                            DW_AT_decl_file             0x0000000f /ephemeral/tmp/src/main.rs
                                            DW_AT_decl_line             0x00000004
                                            DW_AT_type                  0x00001a56<.debug_info+0x00001a56>
< 4><0x0000214e GOFF=0x0000214e>          DW_TAG_null
< 3><0x0000214f GOFF=0x0000214f>        DW_TAG_null
```

That DW_TAG_lexical_block inhibits every debugger I've tested from recognizing 'n' as a parameter.

This patch removes the additional lexical scope. Parameters can be easily deduplicated by a tuple of their scope and the argument index, at the trivial cost of taking a Hash + Eq bound on DIScope.