### PR TITLE
fix:  #128855 Ensure `Guard`'s `drop` method is removed at `opt-level=s` for `…

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -889,6 +889,7 @@ impl<T> Guard<'_, T> {
 }
 
 impl<T> Drop for Guard<'_, T> {
+    #[inline]
     fn drop(&mut self) {
         debug_assert!(self.initialized <= self.array_mut.len());
 

--- a/tests/codegen/array-from_fn.rs
+++ b/tests/codegen/array-from_fn.rs
@@ -1,0 +1,13 @@
+//@ revisions: NORMAL OPT
+//@ [NORMAL] compile-flags: -C opt-level=0 -C debuginfo=2
+//@ [OPT] compile-flags: -C opt-level=s -C debuginfo=0
+
+#![crate_type = "lib"]
+#![feature(array_from_fn)]
+
+#[no_mangle]
+pub fn iota() -> [u8; 16] {
+    // OPT-NOT: core..array..Guard
+    // NORMAL: core..array..Guard
+    std::array::from_fn(|i| i as _)
+}


### PR DESCRIPTION
fix: #128855

…Copy` types

Added `#[inline]` to the `drop` method in the `Guard` implementation to ensure that the method is removed by the compiler at optimization level `opt-level=s` for `Copy` types. This change aims to align the method's behavior with optimization expectations and ensure it does not affect performance.

r​? @scottmcm
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
