### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_gcc/build_system/build_sysroot/Cargo.lock
+++ b/compiler/rustc_codegen_gcc/build_system/build_sysroot/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.109"
+version = "0.1.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f11973008a8cf741fe6d22f339eba21fd0ca81e2760a769ba8243ed6c21edd7e"
 dependencies = [

--- a/compiler/rustc_codegen_gcc/build_system/build_sysroot/Cargo.toml
+++ b/compiler/rustc_codegen_gcc/build_system/build_sysroot/Cargo.toml
@@ -6,9 +6,7 @@ resolver = "2"
 
 [dependencies]
 core = { path = "./sysroot_src/library/core" }
-# TODO: after the sync, revert to using version 0.1.
-# compiler_builtins = "0.1"
-compiler_builtins = "=0.1.109"
+compiler_builtins = "0.1"
 alloc = { path = "./sysroot_src/library/alloc" }
 std = { path = "./sysroot_src/library/std", features = ["panic_unwind", "backtrace"] }
 test = { path = "./sysroot_src/library/test" }

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -505,6 +505,10 @@ impl<'tcx> Inliner<'tcx> {
     ) -> Result<(), &'static str> {
         let tcx = self.tcx;
 
+        if let Some(_) = callee_body.tainted_by_errors {
+            return Err("Body is tainted");
+        }
+
         let mut threshold = if self.caller_is_inline_forwarder {
             self.tcx.sess.opts.unstable_opts.inline_mir_forwarder_threshold.unwrap_or(30)
         } else if cross_crate_inlinable {

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.117"
+version = "0.1.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91dae36d82fe12621dfb5b596d7db766187747749b22e33ac068e1bfc356f4a"
+checksum = "92afe7344b64cccf3662ca26d5d1c0828ab826f04206b97d856e3625e390e4b5"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { version = "0.1.117", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "0.1.118", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "0.1.117" }
+compiler_builtins = { version = "0.1.118" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.14", default-features = false, features = [

--- a/tests/run-make/redundant-libs/foo.c
+++ b/tests/run-make/redundant-libs/foo.c
@@ -1,2 +1,8 @@
-void foo1() {}
-void foo2() {}
+#ifdef _MSC_VER
+#define DllExport __declspec(dllexport)
+#else
+#define DllExport
+#endif
+
+DllExport void foo1() {}
+DllExport void foo2() {}

--- a/tests/run-make/redundant-libs/rmake.rs
+++ b/tests/run-make/redundant-libs/rmake.rs
@@ -10,12 +10,6 @@
 
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
-//@ ignore-windows-msvc
-// Reason: this test links libraries via link.exe, which only accepts the import library
-// for the dynamic library, i.e. `foo.dll.lib`. However, build_native_dynamic_lib only
-// produces `foo.dll` - the dynamic library itself. To make this test work on MSVC, one
-// would need to derive the import library from the dynamic library.
-// See https://stackoverflow.com/questions/9360280/
 
 use run_make_support::{
     build_native_dynamic_lib, build_native_static_lib, cwd, is_msvc, rfs, run, rustc,

--- a/tests/ui/polymorphization/inline-tainted-body.rs
+++ b/tests/ui/polymorphization/inline-tainted-body.rs
@@ -1,15 +1,21 @@
 //@ compile-flags: -Zvalidate-mir -Zinline-mir=yes
-//@ known-bug: #122909
 
+#![feature(unboxed_closures)]
 
-use std::sync::{Arc, Context, Weak};
+use std::sync::Arc;
 
 pub struct WeakOnce<T>();
+//~^ ERROR type parameter `T` is never used
+
 impl<T> WeakOnce<T> {
     extern "rust-call" fn try_get(&self) -> Option<Arc<T>> {}
+    //~^ ERROR functions with the "rust-call" ABI must take a single non-self tuple argument
+    //~| ERROR mismatched types
 
     pub fn get(&self) -> Arc<T> {
         self.try_get()
             .unwrap_or_else(|| panic!("Singleton {} not available", std::any::type_name::<T>()))
     }
 }
+
+fn main() {}

--- a/tests/ui/polymorphization/inline-tainted-body.stderr
+++ b/tests/ui/polymorphization/inline-tainted-body.stderr
@@ -1,0 +1,30 @@
+error[E0392]: type parameter `T` is never used
+  --> $DIR/inline-tainted-body.rs:7:21
+   |
+LL | pub struct WeakOnce<T>();
+   |                     ^ unused type parameter
+   |
+   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+   = help: if you intended `T` to be a const parameter, use `const T: /* Type */` instead
+
+error: functions with the "rust-call" ABI must take a single non-self tuple argument
+  --> $DIR/inline-tainted-body.rs:11:35
+   |
+LL |     extern "rust-call" fn try_get(&self) -> Option<Arc<T>> {}
+   |                                   ^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/inline-tainted-body.rs:11:45
+   |
+LL |     extern "rust-call" fn try_get(&self) -> Option<Arc<T>> {}
+   |                           -------           ^^^^^^^^^^^^^^ expected `Option<Arc<T>>`, found `()`
+   |                           |
+   |                           implicitly returns `()` as its body has no tail or `return` expression
+   |
+   = note:   expected enum `Option<Arc<T>>`
+           found unit type `()`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0308, E0392.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #128616 (Don't inline tainted MIR bodies)
 - #128804 (run-make: enable msvc for redundant-libs)
 - #128823 (run-make: enable msvc for staticlib-dylib-linkage)
 - #128824 (Update compiler-builtins version to 0.1.118)

Failed merges:

 - #128410 (Migrate `remap-path-prefix-dwarf` `run-make` test to rmake)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=128616,128804,128823,128824)
<!-- homu-ignore:end -->