### PR TITLE
doc: std::env::var: Returns None for names with '=' or NUL byte

### DIFF
--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -198,16 +198,12 @@ impl fmt::Debug for VarsOs {
 ///
 /// # Errors
 ///
-/// This function returns [`VarError::NotPresent`] if the environment variable
-/// isn't set.
+/// Returns [`VarError::NotPresent`] if:
+/// - The variable is not set.
+/// - The variable's name contains an equal sign or NUL (`'='` or `'\0'`).
 ///
-/// This function may return [`VarError::NotPresent`] if the
-/// environment variable's name contains the equal sign character (`=`) or the
-/// NUL character.
-///
-/// This function will return [`VarError::NotUnicode`] if the environment
-/// variable's value is not valid Unicode. If this is not desired, consider
-/// using [`var_os`].
+/// Returns [`VarError::NotUnicode`] if the variable's value is not valid
+/// Unicode. If this is not desired, consider using [`var_os`].
 ///
 /// # Examples
 ///

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -198,13 +198,16 @@ impl fmt::Debug for VarsOs {
 ///
 /// # Errors
 ///
-/// This function will return an error if the environment variable isn't set.
+/// This function returns [`VarError::NotPresent`] if the environment variable
+/// isn't set.
 ///
-/// This function may return an error if the environment variable's name contains
-/// the equal sign character (`=`) or the NUL character.
+/// This function may return [`VarError::NotPresent`] if the
+/// environment variable's name contains the equal sign character (`=`) or the
+/// NUL character.
 ///
-/// This function will return an error if the environment variable's value is
-/// not valid Unicode. If this is not desired, consider using [`var_os`].
+/// This function will return [`VarError::NotUnicode`] if the environment
+/// variable's value is not valid Unicode. If this is not desired, consider
+/// using [`var_os`].
 ///
 /// # Examples
 ///


### PR DESCRIPTION
The documentation incorrectly stated that std::env::var could return an error for variable names containing '=' or the NUL byte. Copy the correct documentation from var_os.

var_os was fixed in Commit 8a7a665, Pull Request #109894, which closed Issue #109893.

This documentation was incorrectly added in commit f2c0f292, which replaced a panic in var_os by returning None, but documented the change as "May error if ...".

Reference the specific error values and link to them.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
