### PR TITLE
Show paths relative to the source root for diagnostics in sub-workspaces

### DIFF
--- a/src/bootstrap/src/bin/rustc.rs
+++ b/src/bootstrap/src/bin/rustc.rs
@@ -99,6 +99,17 @@ fn main() {
     };
     cmd.args(&args).env(dylib_path_var(), env::join_paths(&dylib_path).unwrap());
 
+    let rustc_source_dir = env::var_os("RUSTC_SOURCE_DIR").unwrap();
+    let workspace_prefix =
+        if let Ok(prefix) = env::current_dir().unwrap().strip_prefix(&rustc_source_dir) {
+            prefix.to_owned()
+        } else {
+            PathBuf::from(".")
+        };
+
+    cmd.arg("--remap-path-prefix");
+    cmd.arg(format!("={}", workspace_prefix.display()));
+
     // Get the name of the crate we're compiling, if any.
     let crate_name = parse_value_from_args(&orig_args, "--crate-name");
 

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1794,7 +1794,8 @@ impl<'a> Builder<'a> {
             .env("RUSTDOC", self.bootstrap_out.join("rustdoc"))
             .env("RUSTDOC_REAL", rustdoc_path)
             .env("RUSTC_ERROR_METADATA_DST", self.extended_error_dir())
-            .env("RUSTC_BREAK_ON_ICE", "1");
+            .env("RUSTC_BREAK_ON_ICE", "1")
+            .env("RUSTC_SOURCE_DIR", &self.src);
 
         // Set RUSTC_WRAPPER to the bootstrap shim, which switches between beta and in-tree
         // sysroot depending on whether we're building build scripts.


### PR DESCRIPTION
This allows rust-analyzer to show inline errors for the library workspace. Clippy recently started doing something similar.

Fixes https://github.com/rust-lang/rust/issues/128726 which is a regression from https://github.com/rust-lang/rust/pull/128534