### PR TITLE
gitignore: Add Zed and Helix editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ Session.vim
 .vscode
 .project
 .vim/
+.helix/
+.zed/
 .favorites.json
 .settings/
 .vs/


### PR DESCRIPTION
Just adding two extra code editors to .gitignore.

Reference:
https://helix-editor.com/
https://zed.dev/

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
