### PR TITLE
Hint on unknown escape of Unicode quotation marks in string literal

### DIFF
--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -158,6 +158,12 @@ pub(crate) fn emit_unescape_error(
                     "this is an isolated carriage return; consider checking your editor and \
                      version control settings",
                 );
+            } else if looks_like_quote(c) {
+                diag.help(
+                    format!("{ec} is not an ascii quote, \
+                             but may look like one in some fonts.\n\
+                             consider writing it in its \
+                             escaped form for clarity."));
             } else {
                 if mode == Mode::Str || mode == Mode::Char {
                     diag.span_suggestion(
@@ -293,5 +299,25 @@ pub(crate) fn escaped_char(c: char) -> String {
             c.to_string()
         }
         _ => c.escape_default().to_string(),
+    }
+}
+
+/// Returns true if `c` may look identical to `"` in some fonts.
+fn looks_like_quote(c: char) -> bool {
+    // list of homoglyphs generated using the following wikidata query:
+    // SELECT ?u WHERE {
+    //   wd:Q87495536 wdt:P2444+ ?c.
+    //   ?c wdt:P4213 ?u.
+    // }
+    match c {
+        '\u{2033}' | 
+        '\u{02BA}' |
+        '\u{02DD}' |
+        '\u{030B}' |
+        '\u{030E}' |
+        '\u{05F4}' |
+        '\u{201C}' |
+        '\u{201D}' => true,
+        _ => false,
     }
 }

--- a/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
+++ b/compiler/rustc_parse/src/lexer/unescape_error_reporting.rs
@@ -159,11 +159,12 @@ pub(crate) fn emit_unescape_error(
                      version control settings",
                 );
             } else if looks_like_quote(c) {
-                diag.help(
-                    format!("{ec} is not an ascii quote, \
+                diag.help(format!(
+                    "{ec} is not an ascii quote, \
                              but may look like one in some fonts.\n\
                              consider writing it in its \
-                             escaped form for clarity."));
+                             escaped form for clarity."
+                ));
             } else {
                 if mode == Mode::Str || mode == Mode::Char {
                     diag.span_suggestion(
@@ -310,14 +311,8 @@ fn looks_like_quote(c: char) -> bool {
     //   ?c wdt:P4213 ?u.
     // }
     match c {
-        '\u{2033}' | 
-        '\u{02BA}' |
-        '\u{02DD}' |
-        '\u{030B}' |
-        '\u{030E}' |
-        '\u{05F4}' |
-        '\u{201C}' |
-        '\u{201D}' => true,
+        '\u{2033}' | '\u{02BA}' | '\u{02DD}' | '\u{030B}' | '\u{030E}' | '\u{05F4}'
+        | '\u{201C}' | '\u{201D}' => true,
         _ => false,
     }
 }

--- a/tests/ui/unicode-quote.rs
+++ b/tests/ui/unicode-quote.rs
@@ -1,0 +1,3 @@
+fn main() {
+    dbg!("since when is \“THIS\” not allowed in a string literal");
+}

--- a/tests/ui/unicode-quote.stderr
+++ b/tests/ui/unicode-quote.stderr
@@ -1,0 +1,20 @@
+error: unknown character escape: `\u{201c}`
+  --> $DIR/unicode-quote.rs:2:26
+   |
+LL |     dbg!("since when is \“THIS\” not allowed in a string literal");
+   |                          ^ unknown character escape
+   |
+   = help: \u{201c} is not an ascii quote, but may look like one in some fonts.
+           consider writing it in its escaped form for clarity.
+
+error: unknown character escape: `\u{201d}`
+  --> $DIR/unicode-quote.rs:2:32
+   |
+LL |     dbg!("since when is \“THIS\” not allowed in a string literal");
+   |                                ^ unknown character escape
+   |
+   = help: \u{201d} is not an ascii quote, but may look like one in some fonts.
+           consider writing it in its escaped form for clarity.
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Fixes #128858

I opted not to produce a suggestion, since it's not obvious what the user meant to do.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
