### PR TITLE
Differentiate between methods and associated functions in diagnostics

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1117,7 +1117,7 @@ fn check_region_bounds_on_impl_item<'tcx>(
             .dcx()
             .create_err(LifetimesOrBoundsMismatchOnTrait {
                 span,
-                item_kind: assoc_item_kind_str(&impl_m),
+                item_kind: impl_m.descr(),
                 ident: impl_m.ident(tcx),
                 generics_span,
                 bounds_span,
@@ -1294,7 +1294,7 @@ fn compare_number_of_generics<'tcx>(
         ("const", trait_own_counts.consts, impl_own_counts.consts),
     ];
 
-    let item_kind = assoc_item_kind_str(&impl_);
+    let item_kind = impl_.descr();
 
     let mut err_occurred = None;
     for (kind, trait_count, impl_count) in matchings {
@@ -1676,7 +1676,7 @@ fn compare_generic_param_kinds<'tcx>(
                 param_impl_span,
                 E0053,
                 "{} `{}` has an incompatible generic parameter for trait `{}`",
-                assoc_item_kind_str(&impl_item),
+                impl_item.descr(),
                 trait_item.name,
                 &tcx.def_path_str(tcx.parent(trait_item.def_id))
             );
@@ -2247,14 +2247,6 @@ fn param_env_with_gat_bounds<'tcx>(
     }
 
     ty::ParamEnv::new(tcx.mk_clauses(&predicates), Reveal::UserFacing)
-}
-
-fn assoc_item_kind_str(impl_item: &ty::AssocItem) -> &'static str {
-    match impl_item.kind {
-        ty::AssocKind::Const => "const",
-        ty::AssocKind::Fn => "method",
-        ty::AssocKind::Type => "type",
-    }
 }
 
 /// Manually check here that `async fn foo()` wasn't matched against `fn foo()`,

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -1165,17 +1165,23 @@ fn hir_id_to_string(map: Map<'_>, id: HirId) -> String {
         }
         Node::ImplItem(ii) => {
             let kind = match ii.kind {
-                ImplItemKind::Const(..) => "assoc const",
-                ImplItemKind::Fn(..) => "method",
-                ImplItemKind::Type(_) => "assoc type",
+                ImplItemKind::Const(..) => "associated constant",
+                ImplItemKind::Fn(fn_sig, _) => match fn_sig.decl.implicit_self {
+                    ImplicitSelfKind::None => "associated function",
+                    _ => "method",
+                },
+                ImplItemKind::Type(_) => "associated type",
             };
             format!("{id} ({kind} `{}` in {})", ii.ident, path_str(ii.owner_id.def_id))
         }
         Node::TraitItem(ti) => {
             let kind = match ti.kind {
-                TraitItemKind::Const(..) => "assoc constant",
-                TraitItemKind::Fn(..) => "trait method",
-                TraitItemKind::Type(..) => "assoc type",
+                TraitItemKind::Const(..) => "associated constant",
+                TraitItemKind::Fn(fn_sig, _) => match fn_sig.decl.implicit_self {
+                    ImplicitSelfKind::None => "associated function",
+                    _ => "trait method",
+                },
+                TraitItemKind::Type(..) => "associated type",
             };
 
             format!("{id} ({kind} `{}` in {})", ti.ident, path_str(ti.owner_id.def_id))

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -98,6 +98,15 @@ impl AssocItem {
         }
     }
 
+    pub fn descr(&self) -> &'static str {
+        match self.kind {
+            ty::AssocKind::Const => "const",
+            ty::AssocKind::Fn if self.fn_has_self_parameter => "method",
+            ty::AssocKind::Fn => "associated function",
+            ty::AssocKind::Type => "type",
+        }
+    }
+
     pub fn is_impl_trait_in_trait(&self) -> bool {
         self.opt_rpitit_info.is_some()
     }

--- a/tests/ui/async-await/in-trait/generics-mismatch.rs
+++ b/tests/ui/async-await/in-trait/generics-mismatch.rs
@@ -6,7 +6,7 @@ trait Foo {
 
 impl Foo for () {
     async fn foo<const N: usize>() {}
-    //~^ ERROR: method `foo` has an incompatible generic parameter for trait `Foo` [E0053]
+    //~^ ERROR: associated function `foo` has an incompatible generic parameter for trait `Foo` [E0053]
 }
 
 fn main() {}

--- a/tests/ui/async-await/in-trait/generics-mismatch.stderr
+++ b/tests/ui/async-await/in-trait/generics-mismatch.stderr
@@ -1,4 +1,4 @@
-error[E0053]: method `foo` has an incompatible generic parameter for trait `Foo`
+error[E0053]: associated function `foo` has an incompatible generic parameter for trait `Foo`
   --> $DIR/generics-mismatch.rs:8:18
    |
 LL | trait Foo {

--- a/tests/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.rs
+++ b/tests/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.rs
@@ -3,7 +3,7 @@ trait Trait {
 }
 impl Trait for () {
     fn foo<const M: u64>() {}
-    //~^ error: method `foo` has an incompatible generic parameter for trait
+    //~^ error: associated function `foo` has an incompatible generic parameter for trait
 }
 
 trait Other {
@@ -11,7 +11,7 @@ trait Other {
 }
 impl Other for () {
     fn bar<T>() {}
-    //~^ error: method `bar` has an incompatible generic parameter for trait
+    //~^ error: associated function `bar` has an incompatible generic parameter for trait
 }
 
 trait Uwu {
@@ -19,7 +19,7 @@ trait Uwu {
 }
 impl Uwu for () {
     fn baz<const N: i32>() {}
-    //~^ error: method `baz` has an incompatible generic parameter for trait
+    //~^ error: associated function `baz` has an incompatible generic parameter for trait
 }
 
 trait Aaaaaa {
@@ -27,7 +27,7 @@ trait Aaaaaa {
 }
 impl Aaaaaa for () {
     fn bbbb<T, const N: u32>() {}
-    //~^ error: method `bbbb` has an incompatible generic parameter for trait
+    //~^ error: associated function `bbbb` has an incompatible generic parameter for trait
 }
 
 trait Names {
@@ -35,7 +35,7 @@ trait Names {
 }
 impl Names for () {
     fn abcd<const N: u32, T>() {}
-    //~^ error: method `abcd` has an incompatible generic parameter for trait
+    //~^ error: associated function `abcd` has an incompatible generic parameter for trait
 }
 
 fn main() {}

--- a/tests/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.stderr
+++ b/tests/ui/const-generics/defaults/mismatched_ty_const_in_trait_impl.stderr
@@ -1,4 +1,4 @@
-error[E0053]: method `foo` has an incompatible generic parameter for trait `Trait`
+error[E0053]: associated function `foo` has an incompatible generic parameter for trait `Trait`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:5:12
    |
 LL | trait Trait {
@@ -11,7 +11,7 @@ LL | impl Trait for () {
 LL |     fn foo<const M: u64>() {}
    |            ^^^^^^^^^^^^ found const parameter of type `u64`
 
-error[E0053]: method `bar` has an incompatible generic parameter for trait `Other`
+error[E0053]: associated function `bar` has an incompatible generic parameter for trait `Other`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:13:12
    |
 LL | trait Other {
@@ -24,7 +24,7 @@ LL | impl Other for () {
 LL |     fn bar<T>() {}
    |            ^ found type parameter
 
-error[E0053]: method `baz` has an incompatible generic parameter for trait `Uwu`
+error[E0053]: associated function `baz` has an incompatible generic parameter for trait `Uwu`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:21:12
    |
 LL | trait Uwu {
@@ -37,7 +37,7 @@ LL | impl Uwu for () {
 LL |     fn baz<const N: i32>() {}
    |            ^^^^^^^^^^^^ found const parameter of type `i32`
 
-error[E0053]: method `bbbb` has an incompatible generic parameter for trait `Aaaaaa`
+error[E0053]: associated function `bbbb` has an incompatible generic parameter for trait `Aaaaaa`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:29:13
    |
 LL | trait Aaaaaa {
@@ -50,7 +50,7 @@ LL | impl Aaaaaa for () {
 LL |     fn bbbb<T, const N: u32>() {}
    |             ^ found type parameter
 
-error[E0053]: method `abcd` has an incompatible generic parameter for trait `Names`
+error[E0053]: associated function `abcd` has an incompatible generic parameter for trait `Names`
   --> $DIR/mismatched_ty_const_in_trait_impl.rs:37:13
    |
 LL | trait Names {

--- a/tests/ui/delegation/not-supported.rs
+++ b/tests/ui/delegation/not-supported.rs
@@ -53,7 +53,7 @@ mod generics {
         //~| ERROR method `foo2` has 0 type parameters but its trait declaration has 1 type parameter
         reuse <F as Trait>::foo3;
         //~^ ERROR early bound generics are not supported for associated delegation items
-        //~| ERROR lifetime parameters or bounds on method `foo3` do not match the trait declaration
+        //~| ERROR lifetime parameters or bounds on associated function `foo3` do not match the trait declaration
     }
 
     struct GenericS<T>(T);

--- a/tests/ui/delegation/not-supported.stderr
+++ b/tests/ui/delegation/not-supported.stderr
@@ -84,14 +84,14 @@ LL |         fn foo3<'a: 'a>(_: &'a u32) {}
 LL |         reuse <F as Trait>::foo3;
    |                             ^^^^
 
-error[E0195]: lifetime parameters or bounds on method `foo3` do not match the trait declaration
+error[E0195]: lifetime parameters or bounds on associated function `foo3` do not match the trait declaration
   --> $DIR/not-supported.rs:54:29
    |
 LL |         fn foo3<'a: 'a>(_: &'a u32) {}
-   |                -------- lifetimes in impl do not match this method in trait
+   |                -------- lifetimes in impl do not match this associated function in trait
 ...
 LL |         reuse <F as Trait>::foo3;
-   |                             ^^^^ lifetimes do not match method in trait
+   |                             ^^^^ lifetimes do not match associated function in trait
 
 error: delegation to a function with effect parameter is not supported yet
   --> $DIR/not-supported.rs:112:18

--- a/tests/ui/error-codes/E0049.stderr
+++ b/tests/ui/error-codes/E0049.stderr
@@ -1,4 +1,4 @@
-error[E0049]: method `foo` has 0 type parameters but its trait declaration has 1 type parameter
+error[E0049]: associated function `foo` has 0 type parameters but its trait declaration has 1 type parameter
   --> $DIR/E0049.rs:8:11
    |
 LL |     fn foo<T: Default>(x: T) -> Self;
@@ -7,7 +7,7 @@ LL |     fn foo<T: Default>(x: T) -> Self;
 LL |     fn foo(x: bool) -> Self { Bar }
    |           ^ found 0 type parameters
 
-error[E0049]: method `fuzz` has 0 type parameters but its trait declaration has 2 type parameters
+error[E0049]: associated function `fuzz` has 0 type parameters but its trait declaration has 2 type parameters
   --> $DIR/E0049.rs:18:12
    |
 LL |     fn fuzz<A: Default, B>(x: A, y: B) -> Self;

--- a/tests/ui/error-codes/E0195.rs
+++ b/tests/ui/error-codes/E0195.rs
@@ -1,13 +1,13 @@
 trait Trait {
     fn bar<'a,'b:'a>(x: &'a str, y: &'b str);
-    //~^ NOTE lifetimes in impl do not match this method in trait
+    //~^ NOTE lifetimes in impl do not match this associated function in trait
 }
 
 struct Foo;
 
 impl Trait for Foo {
     fn bar<'a,'b>(x: &'a str, y: &'b str) { //~ ERROR E0195
-    //~^ NOTE lifetimes do not match method in trait
+    //~^ NOTE lifetimes do not match associated function in trait
     }
 }
 

--- a/tests/ui/error-codes/E0195.stderr
+++ b/tests/ui/error-codes/E0195.stderr
@@ -1,11 +1,11 @@
-error[E0195]: lifetime parameters or bounds on method `bar` do not match the trait declaration
+error[E0195]: lifetime parameters or bounds on associated function `bar` do not match the trait declaration
   --> $DIR/E0195.rs:9:11
    |
 LL |     fn bar<'a,'b:'a>(x: &'a str, y: &'b str);
-   |           ---------- lifetimes in impl do not match this method in trait
+   |           ---------- lifetimes in impl do not match this associated function in trait
 ...
 LL |     fn bar<'a,'b>(x: &'a str, y: &'b str) {
-   |           ^^^^^^^ lifetimes do not match method in trait
+   |           ^^^^^^^ lifetimes do not match associated function in trait
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.rs
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.rs
@@ -8,7 +8,7 @@ impl<T> X for T { //~ ERROR: not all trait items implemented
   fn foo<'a, T1: X<Y = T1>>(t : T1) -> T1::Y<'a> {
     //~^ ERROR missing generics for associated type
     //~^^ ERROR missing generics for associated type
-    //~| ERROR method `foo` has 1 type parameter but its trait declaration has 0 type parameters
+    //~| ERROR associated function `foo` has 1 type parameter but its trait declaration has 0 type parameters
     t
   }
 }

--- a/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-missing-lifetime.stderr
@@ -1,4 +1,4 @@
-error[E0049]: method `foo` has 1 type parameter but its trait declaration has 0 type parameters
+error[E0049]: associated function `foo` has 1 type parameter but its trait declaration has 0 type parameters
   --> $DIR/gat-trait-path-missing-lifetime.rs:8:10
    |
 LL |   fn foo<'a>(t : Self::Y<'a>) -> Self::Y<'a> { t }

--- a/tests/ui/impl-trait/in-trait/trait-more-generics-than-impl.rs
+++ b/tests/ui/impl-trait/in-trait/trait-more-generics-than-impl.rs
@@ -6,7 +6,7 @@ trait Foo {
 
 impl Foo for S {
     fn bar() -> impl Sized {}
-    //~^ ERROR method `bar` has 0 type parameters but its trait declaration has 1 type parameter
+    //~^ ERROR associated function `bar` has 0 type parameters but its trait declaration has 1 type parameter
 }
 
 fn main() {

--- a/tests/ui/impl-trait/in-trait/trait-more-generics-than-impl.stderr
+++ b/tests/ui/impl-trait/in-trait/trait-more-generics-than-impl.stderr
@@ -1,4 +1,4 @@
-error[E0049]: method `bar` has 0 type parameters but its trait declaration has 1 type parameter
+error[E0049]: associated function `bar` has 0 type parameters but its trait declaration has 1 type parameter
   --> $DIR/trait-more-generics-than-impl.rs:8:11
    |
 LL |     fn bar<T>() -> impl Sized;

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.precise.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.precise.stderr
@@ -40,7 +40,7 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | const fn a<T: ~const Destruct>(_: T) {}
    |                      ^^^^^^^^
 
-error[E0049]: method `foo` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `foo` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const-drop.rs:54:5
    |
 LL |     #[const_trait]
@@ -49,7 +49,7 @@ LL |     pub trait SomeTrait {
 LL |         fn foo();
    |               - expected 0 const parameters
 
-error[E0049]: method `foo` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `foo` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const-drop.rs:54:5
    |
 LL |     #[const_trait]

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.stock.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/const-drop.stock.stderr
@@ -40,7 +40,7 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | const fn a<T: ~const Destruct>(_: T) {}
    |                      ^^^^^^^^
 
-error[E0049]: method `foo` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `foo` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const-drop.rs:54:5
    |
 LL |     #[const_trait]
@@ -49,7 +49,7 @@ LL |     pub trait SomeTrait {
 LL |         fn foo();
    |               - expected 0 const parameters
 
-error[E0049]: method `foo` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `foo` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const-drop.rs:54:5
    |
 LL |     #[const_trait]

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/specialization/const-default-bound-non-const-specialized-bound.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/specialization/const-default-bound-non-const-specialized-bound.stderr
@@ -1,4 +1,4 @@
-error[E0049]: method `bar` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `bar` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const-default-bound-non-const-specialized-bound.rs:16:1
    |
 LL | #[const_trait]
@@ -16,7 +16,7 @@ LL | |     T: Foo, //FIXME ~ ERROR missing `~const` qualifier
 LL | |     T: Specialize,
    | |__________________^
 
-error[E0049]: method `baz` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `baz` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const-default-bound-non-const-specialized-bound.rs:36:1
    |
 LL | #[const_trait]
@@ -25,7 +25,7 @@ LL | trait Baz {
 LL |     fn baz();
    |           - expected 0 const parameters
 
-error[E0049]: method `baz` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `baz` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const-default-bound-non-const-specialized-bound.rs:36:1
    |
 LL | #[const_trait]

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/specialization/const-default-const-specialized.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/specialization/const-default-const-specialized.stderr
@@ -1,4 +1,4 @@
-error[E0049]: method `value` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `value` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const-default-const-specialized.rs:10:1
    |
 LL | #[const_trait]
@@ -7,7 +7,7 @@ LL | trait Value {
 LL |     fn value() -> u32;
    |             - expected 0 const parameters
 
-error[E0049]: method `value` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `value` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const-default-const-specialized.rs:10:1
    |
 LL | #[const_trait]

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/specialization/default-keyword.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/specialization/default-keyword.stderr
@@ -1,4 +1,4 @@
-error[E0049]: method `foo` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `foo` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/default-keyword.rs:7:1
    |
 LL | #[const_trait]

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/specialization/issue-95186-specialize-on-tilde-const.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/specialization/issue-95186-specialize-on-tilde-const.stderr
@@ -1,4 +1,4 @@
-error[E0049]: method `foo` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `foo` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/issue-95186-specialize-on-tilde-const.rs:14:1
    |
 LL | #[const_trait]
@@ -7,7 +7,7 @@ LL | trait Foo {
 LL |     fn foo();
    |           - expected 0 const parameters
 
-error[E0049]: method `foo` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `foo` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/issue-95186-specialize-on-tilde-const.rs:14:1
    |
 LL | #[const_trait]
@@ -18,7 +18,7 @@ LL |     fn foo();
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0049]: method `bar` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `bar` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/issue-95186-specialize-on-tilde-const.rs:30:1
    |
 LL | #[const_trait]
@@ -27,7 +27,7 @@ LL | trait Bar {
 LL |     fn bar() {}
    |           - expected 0 const parameters
 
-error[E0049]: method `bar` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `bar` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/issue-95186-specialize-on-tilde-const.rs:30:1
    |
 LL | #[const_trait]

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/specialization/issue-95187-same-trait-bound-different-constness.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/specialization/issue-95187-same-trait-bound-different-constness.stderr
@@ -1,4 +1,4 @@
-error[E0049]: method `bar` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `bar` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/issue-95187-same-trait-bound-different-constness.rs:18:1
    |
 LL | #[const_trait]
@@ -7,7 +7,7 @@ LL | trait Bar {
 LL |     fn bar();
    |           - expected 0 const parameters
 
-error[E0049]: method `bar` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `bar` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/issue-95187-same-trait-bound-different-constness.rs:18:1
    |
 LL | #[const_trait]
@@ -18,7 +18,7 @@ LL |     fn bar();
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0049]: method `baz` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `baz` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/issue-95187-same-trait-bound-different-constness.rs:38:1
    |
 LL | #[const_trait]
@@ -27,7 +27,7 @@ LL | trait Baz {
 LL |     fn baz();
    |           - expected 0 const parameters
 
-error[E0049]: method `baz` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `baz` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/issue-95187-same-trait-bound-different-constness.rs:38:1
    |
 LL | #[const_trait]

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/specialization/non-const-default-const-specialized.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/specialization/non-const-default-const-specialized.stderr
@@ -1,4 +1,4 @@
-error[E0049]: method `value` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `value` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/non-const-default-const-specialized.rs:9:1
    |
 LL | #[const_trait]
@@ -7,7 +7,7 @@ LL | trait Value {
 LL |     fn value() -> u32;
    |             - expected 0 const parameters
 
-error[E0049]: method `value` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `value` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/non-const-default-const-specialized.rs:9:1
    |
 LL | #[const_trait]

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/specializing-constness-2.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/specializing-constness-2.stderr
@@ -1,4 +1,4 @@
-error[E0049]: method `a` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `a` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/specializing-constness-2.rs:9:1
    |
 LL | #[const_trait]
@@ -7,7 +7,7 @@ LL | pub trait A {
 LL |     fn a() -> u32;
    |         - expected 0 const parameters
 
-error[E0049]: method `a` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `a` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/specializing-constness-2.rs:9:1
    |
 LL | #[const_trait]

--- a/tests/ui/specialization/const_trait_impl.stderr
+++ b/tests/ui/specialization/const_trait_impl.stderr
@@ -1,4 +1,4 @@
-error[E0049]: method `foo` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `foo` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const_trait_impl.rs:6:1
    |
 LL | #[const_trait]
@@ -7,7 +7,7 @@ LL | pub unsafe trait Sup {
 LL |     fn foo() -> u32;
    |           - expected 0 const parameters
 
-error[E0049]: method `foo` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `foo` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const_trait_impl.rs:6:1
    |
 LL | #[const_trait]
@@ -36,7 +36,7 @@ error: `~const` can only be applied to `#[const_trait]` traits
 LL | impl<T: ~const Default + ~const Sub> const A for T {
    |                ^^^^^^^
 
-error[E0049]: method `a` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `a` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const_trait_impl.rs:29:1
    |
 LL | #[const_trait]
@@ -45,7 +45,7 @@ LL | pub trait A {
 LL |     fn a() -> u32;
    |         - expected 0 const parameters
 
-error[E0049]: method `a` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `a` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const_trait_impl.rs:29:1
    |
 LL | #[const_trait]
@@ -56,7 +56,7 @@ LL |     fn a() -> u32;
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0049]: method `a` has 1 const parameter but its trait declaration has 0 const parameters
+error[E0049]: associated function `a` has 1 const parameter but its trait declaration has 0 const parameters
   --> $DIR/const_trait_impl.rs:29:1
    |
 LL | #[const_trait]

--- a/tests/ui/typeck/issue-36708.stderr
+++ b/tests/ui/typeck/issue-36708.stderr
@@ -1,4 +1,4 @@
-error[E0049]: method `foo` has 1 type parameter but its trait declaration has 0 type parameters
+error[E0049]: associated function `foo` has 1 type parameter but its trait declaration has 0 type parameters
   --> $DIR/issue-36708.rs:8:12
    |
 LL |     fn foo<T>() {}


### PR DESCRIPTION
Accurately refer to assoc fn without receiver as assoc fn instead of methods. Add `AssocItem::descr` method to centralize where we call methods and associated functions.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
