### PR TITLE
Enable debuginfo tests that have been "temporarily disabled" for the past 6 years

### DIFF
--- a/tests/debuginfo/basic-types-globals-metadata.rs
+++ b/tests/debuginfo/basic-types-globals-metadata.rs
@@ -1,5 +1,4 @@
 //@ min-lldb-version: 310
-//@ ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 //@ compile-flags:-g
 // gdb-command:run

--- a/tests/debuginfo/basic-types-metadata.rs
+++ b/tests/debuginfo/basic-types-metadata.rs
@@ -1,5 +1,4 @@
 //@ min-lldb-version: 310
-//@ ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 //@ compile-flags:-g
 // gdb-command:run
@@ -36,12 +35,12 @@
 // gdb-command:whatis f64
 // gdb-check:type = f64
 // gdb-command:whatis fnptr
-// gdb-check:type = [...] (*)([...])
+// gdb-check:type = *mut fn ()
 // gdb-command:info functions _yyy
 // gdbg-check:[...]![...]_yyy([...]);
-// gdbr-check:static fn basic_types_metadata::_yyy() -> !;
+// gdbr-check:static fn basic_types_metadata::_yyy();
 // gdb-command:ptype closure_0
-// gdbr-check: type = struct closure
+// gdbr-check: type = struct basic_types_metadata::main::{closure_env#0}
 // gdbg-check: type = struct closure {
 // gdbg-check:     <no data fields>
 // gdbg-check: }
@@ -49,18 +48,18 @@
 // gdbg-check: type = struct closure {
 // gdbg-check:     bool *__0;
 // gdbg-check: }
-// gdbr-check: type = struct closure (
-// gdbr-check:     bool *,
-// gdbr-check: )
+// gdbr-check: type = struct basic_types_metadata::main::{closure_env#1} {
+// gdbr-check:     *mut bool,
+// gdbr-check: }
 // gdb-command:ptype closure_2
 // gdbg-check: type = struct closure {
 // gdbg-check:     bool *__0;
 // gdbg-check:     isize *__1;
 // gdbg-check: }
-// gdbr-check: type = struct closure (
-// gdbr-check:     bool *,
-// gdbr-check:     isize *,
-// gdbr-check: )
+// gdbr-check: type = struct basic_types_metadata::main::{closure_env#2} {
+// gdbr-check:     *mut bool,
+// gdbr-check:     *mut isize,
+// gdbr-check: }
 
 //
 // gdb-command:continue

--- a/tests/debuginfo/basic-types.rs
+++ b/tests/debuginfo/basic-types.rs
@@ -6,9 +6,6 @@
 
 //@ min-lldb-version: 310
 
-// This fails on lldb 6.0.1 on x86-64 Fedora 28; so ignore Linux for now.
-//@ ignore-linux
-
 //@ compile-flags:-g
 
 // === GDB TESTS ===================================================================================

--- a/tests/debuginfo/by-value-non-immediate-argument.rs
+++ b/tests/debuginfo/by-value-non-immediate-argument.rs
@@ -1,6 +1,11 @@
-//@ ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
-//@ min-lldb-version: 310
+// The gdb that we use in CI for aarch64-unknown-linux-gnu and x86_64-pc-windows-gnu seems unable
+// to handle by-value non-immediate arguments, which is the whole point of this test.
+// gdb on those platforms (or the version we test) just prints <optimized out> for structs/tuples
+// and attempts to read memory at 0x0 for enums.
+//@ ignore-aarch64: #128973
+//@ ignore-windows-gnu
 
+//@ min-lldb-version: 1800
 //@ compile-flags:-g
 
 // === GDB TESTS ===================================================================================
@@ -42,11 +47,11 @@
 // lldb-command:run
 
 // lldb-command:v s
-// lldb-check:[...] Struct { a: 1, b: 2.5 }
+// lldb-check:[...] Struct { a = 1 b = 2.5 }
 // lldb-command:continue
 
 // lldb-command:v x
-// lldb-check:[...] Struct { a: 3, b: 4.5 }
+// lldb-check:[...] Struct { a = 3 b = 4.5 }
 // lldb-command:v y
 // lldb-check:[...] 5
 // lldb-command:v z

--- a/tests/debuginfo/by-value-non-immediate-argument.rs
+++ b/tests/debuginfo/by-value-non-immediate-argument.rs
@@ -1,11 +1,5 @@
-// The gdb that we use in CI for aarch64-unknown-linux-gnu and x86_64-pc-windows-gnu seems unable
-// to handle by-value non-immediate arguments, which is the whole point of this test.
-// gdb on those platforms (or the version we test) just prints <optimized out> for structs/tuples
-// and attempts to read memory at 0x0 for enums.
-//@ ignore-aarch64: #128973
-//@ ignore-windows-gnu
-
 //@ min-lldb-version: 1800
+//@ min-gdb-version: 13.0
 //@ compile-flags:-g
 
 // === GDB TESTS ===================================================================================

--- a/tests/debuginfo/c-style-enum.rs
+++ b/tests/debuginfo/c-style-enum.rs
@@ -1,5 +1,4 @@
 //@ ignore-aarch64
-//@ ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 //@ min-lldb-version: 310
 
 //@ compile-flags:-g

--- a/tests/debuginfo/cross-crate-spans.rs
+++ b/tests/debuginfo/cross-crate-spans.rs
@@ -3,10 +3,6 @@
 
 //@ min-lldb-version: 310
 
-// This fails on lldb 6.0.1 on x86-64 Fedora 28; so mark it macOS-only
-// for now.
-//@ only-macos
-
 //@ aux-build:cross_crate_spans.rs
 extern crate cross_crate_spans;
 

--- a/tests/debuginfo/destructured-for-loop-variable.rs
+++ b/tests/debuginfo/destructured-for-loop-variable.rs
@@ -1,9 +1,5 @@
 //@ min-lldb-version: 310
 
-// This fails on lldb 6.0.1 on x86-64 Fedora 28; so mark it macOS-only
-// for now.
-//@ only-macos
-
 //@ compile-flags:-g
 
 // === GDB TESTS ===================================================================================

--- a/tests/debuginfo/drop-locations.rs
+++ b/tests/debuginfo/drop-locations.rs
@@ -1,12 +1,11 @@
 //@ ignore-windows
 //@ ignore-android
-//@ ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 //@ min-lldb-version: 310
+//@ ignore-test: #128971
 
 #![allow(unused)]
 
-//@ compile-flags:-g -O -C no-prepopulate-passes
-// -O -C no-prepopulate-passes added to work around https://bugs.llvm.org/show_bug.cgi?id=32123
+//@ compile-flags:-g
 
 // This test checks that drop glue code gets attributed to scope's closing brace,
 // and function epilogues - to function's closing brace.

--- a/tests/debuginfo/function-arg-initialization.rs
+++ b/tests/debuginfo/function-arg-initialization.rs
@@ -1,6 +1,3 @@
-//@ ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
-//@ min-lldb-version: 310
-
 // This test case checks if function arguments already have the correct value
 // when breaking at the first line of the function, that is if the function
 // prologue has already been executed at the first line. Note that because of
@@ -8,7 +5,9 @@
 // arguments have been properly loaded when setting the breakpoint via the
 // function name.
 
-//@ compile-flags:-g
+//@ min-lldb-version: 1800
+//@ compile-flags:-g -Zmir-enable-passes=-SingleUseConsts
+// SingleUseConsts shouldn't need to be disabled, see #128945
 
 // === GDB TESTS ===================================================================================
 

--- a/tests/debuginfo/function-prologue-stepping-regular.rs
+++ b/tests/debuginfo/function-prologue-stepping-regular.rs
@@ -1,9 +1,8 @@
 // This test case checks if function arguments already have the correct value when breaking at the
 // beginning of a function.
 
-//@ min-lldb-version: 310
+//@ min-lldb-version: 1800
 //@ ignore-gdb
-//@ ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 //@ compile-flags:-g
 
 // lldb-command:breakpoint set --name immediate_args

--- a/tests/debuginfo/lexical-scopes-in-block-expression.rs
+++ b/tests/debuginfo/lexical-scopes-in-block-expression.rs
@@ -1,5 +1,4 @@
 //@ min-lldb-version: 310
-//@ ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 //@ compile-flags:-g
 

--- a/tests/debuginfo/limited-debuginfo.rs
+++ b/tests/debuginfo/limited-debuginfo.rs
@@ -1,5 +1,4 @@
 //@ ignore-lldb
-//@ ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 //@ compile-flags:-C debuginfo=1
 

--- a/tests/debuginfo/macro-stepping.rs
+++ b/tests/debuginfo/macro-stepping.rs
@@ -2,6 +2,7 @@
 //@ ignore-android
 //@ ignore-aarch64
 //@ min-lldb-version: 310
+//@ min-gdb-version: 13.0
 
 //@ aux-build:macro-stepping.rs
 

--- a/tests/debuginfo/macro-stepping.rs
+++ b/tests/debuginfo/macro-stepping.rs
@@ -2,7 +2,6 @@
 //@ ignore-android
 //@ ignore-aarch64
 //@ min-lldb-version: 310
-//@ ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 //@ aux-build:macro-stepping.rs
 
@@ -11,7 +10,7 @@
 #[macro_use]
 extern crate macro_stepping; // exports new_scope!()
 
-//@ compile-flags:-g
+//@ compile-flags:-g -Zmir-enable-passes=-SingleUseConsts
 
 // === GDB TESTS ===================================================================================
 

--- a/tests/debuginfo/macro-stepping.rs
+++ b/tests/debuginfo/macro-stepping.rs
@@ -1,7 +1,7 @@
 //@ ignore-windows
 //@ ignore-android
 //@ ignore-aarch64
-//@ min-lldb-version: 310
+//@ min-lldb-version: 1800
 //@ min-gdb-version: 13.0
 
 //@ aux-build:macro-stepping.rs
@@ -12,6 +12,7 @@
 extern crate macro_stepping; // exports new_scope!()
 
 //@ compile-flags:-g -Zmir-enable-passes=-SingleUseConsts
+// SingleUseConsts shouldn't need to be disabled, see #128945
 
 // === GDB TESTS ===================================================================================
 

--- a/tests/debuginfo/method-on-enum.rs
+++ b/tests/debuginfo/method-on-enum.rs
@@ -1,5 +1,5 @@
-//@ min-lldb-version: 310
-//@ ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
+//@ min-lldb-version: 1800
+//@ ignore-i686-pc-windows-gnu
 
 //@ compile-flags:-g
 

--- a/tests/debuginfo/method-on-enum.rs
+++ b/tests/debuginfo/method-on-enum.rs
@@ -1,5 +1,5 @@
 //@ min-lldb-version: 1800
-//@ ignore-i686-pc-windows-gnu
+//@ min-gdb-version: 13.0
 
 //@ compile-flags:-g
 

--- a/tests/debuginfo/option-like-enum.rs
+++ b/tests/debuginfo/option-like-enum.rs
@@ -1,5 +1,5 @@
 //@ min-lldb-version: 1800
-//@ ignore-i686-pc-windows-gnu
+//@ min-gdb-version: 13.0
 
 //@ compile-flags:-g
 

--- a/tests/debuginfo/option-like-enum.rs
+++ b/tests/debuginfo/option-like-enum.rs
@@ -1,6 +1,5 @@
-//@ ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
-
-//@ min-lldb-version: 310
+//@ min-lldb-version: 1800
+//@ ignore-i686-pc-windows-gnu
 
 //@ compile-flags:-g
 
@@ -22,7 +21,7 @@
 
 // gdbg-command:print empty_gdb->discr
 // gdbr-command:print empty_gdb.discr
-// gdb-check:$4 = (isize *) 0x0
+// gdb-check:$4 = (*mut isize) 0x1
 
 // gdb-command:print droid
 // gdbg-check:$5 = {RUST$ENCODED$ENUM$2$Void = {id = 675675, range = 10000001, internals = 0x43218765}}
@@ -30,11 +29,11 @@
 
 // gdbg-command:print void_droid_gdb->internals
 // gdbr-command:print void_droid_gdb.internals
-// gdb-check:$6 = (isize *) 0x0
+// gdb-check:$6 = (*mut isize) 0x1
 
 // gdb-command:print nested_non_zero_yep
 // gdbg-check:$7 = {RUST$ENCODED$ENUM$1$2$Nope = {__0 = 10.5, __1 = {a = 10, b = 20, c = [...]}}}
-// gdbr-check:$7 = option_like_enum::NestedNonZero::Yep(10.5, option_like_enum::NestedNonZeroField {a: 10, b: 20, c: 0x[...] "x[...]"})
+// gdbr-check:$7 = option_like_enum::NestedNonZero::Yep(10.5, option_like_enum::NestedNonZeroField {a: 10, b: 20, c: 0x[...]})
 
 // gdb-command:print nested_non_zero_nope
 // gdbg-check:$8 = {RUST$ENCODED$ENUM$1$2$Nope = {__0 = [...], __1 = {a = [...], b = [...], c = 0x0}}}

--- a/tests/debuginfo/pretty-std-collections.rs
+++ b/tests/debuginfo/pretty-std-collections.rs
@@ -1,6 +1,7 @@
 //@ ignore-windows failing on win32 bot
 //@ ignore-freebsd: gdb package too new
 //@ ignore-android: FIXME(#10381)
+//@ ignore-windows-gnu: #128981
 //@ compile-flags:-g
 
 // The pretty printers being tested here require the patch from

--- a/tests/debuginfo/pretty-std.rs
+++ b/tests/debuginfo/pretty-std.rs
@@ -1,10 +1,10 @@
 // ignore-tidy-linelength
 //@ ignore-freebsd: gdb package too new
-//@ only-cdb // "Temporarily" ignored on GDB/LLDB due to debuginfo tests being disabled, see PR 47155
+//@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g
 //@ min-gdb-version: 7.7
-//@ min-lldb-version: 310
+//@ min-lldb-version: 1800
 //@ min-cdb-version: 10.0.18317.1001
 
 // === GDB TESTS ===================================================================================
@@ -12,10 +12,10 @@
 // gdb-command: run
 
 // gdb-command: print slice
-// gdb-check:$1 = &[i32](len: 4) = {0, 1, 2, 3}
+// gdb-check:$1 = &[i32](size=4) = {0, 1, 2, 3}
 
 // gdb-command: print vec
-// gdb-check:$2 = Vec<u64, alloc::alloc::Global>(len: 4, cap: [...]) = {4, 5, 6, 7}
+// gdb-check:$2 = Vec(size=4) = {4, 5, 6, 7}
 
 // gdb-command: print str_slice
 // gdb-check:$3 = "IAMA string slice!"
@@ -24,37 +24,37 @@
 // gdb-check:$4 = "IAMA string!"
 
 // gdb-command: print some
-// gdb-check:$5 = Some = {8}
+// gdb-check:$5 = core::option::Option<i16>::Some(8)
 
 // gdb-command: print none
 // gdbg-check:$6 = None
-// gdbr-check:$6 = core::option::Option::None
+// gdbr-check:$6 = core::option::Option<i64>::None
 
 // gdb-command: print os_string
 // gdb-check:$7 = "IAMA OS string 😃"
 
 // gdb-command: print some_string
-// gdb-check:$8 = Some = {"IAMA optional string!"}
+// gdb-check:$8 = core::option::Option<alloc::string::String>::Some("IAMA optional string!")
 
-// gdb-command: set print length 5
+// gdb-command: set print elements 5
 // gdb-command: print some_string
-// gdb-check:$8 = Some = {"IAMA "...}
+// gdb-check:$9 = core::option::Option<alloc::string::String>::Some("IAMA "...)
 
 // === LLDB TESTS ==================================================================================
 
 // lldb-command:run
 
 // lldb-command:v slice
-// lldb-check:[...] slice = &[0, 1, 2, 3]
+// lldb-check:[...] slice = size=4 { [0] = 0 [1] = 1 [2] = 2 [3] = 3 }
 
 // lldb-command:v vec
-// lldb-check:[...] vec = vec![4, 5, 6, 7]
+// lldb-check:[...] vec = size=4 { [0] = 4 [1] = 5 [2] = 6 [3] = 7 }
 
 // lldb-command:v str_slice
-// lldb-check:[...] str_slice = "IAMA string slice!"
+// lldb-check:[...] str_slice = "IAMA string slice!" { [0] = 'I' [1] = 'A' [2] = 'M' [3] = 'A' [4] = ' ' [5] = 's' [6] = 't' [7] = 'r' [8] = 'i' [9] = 'n' [10] = 'g' [11] = ' ' [12] = 's' [13] = 'l' [14] = 'i' [15] = 'c' [16] = 'e' [17] = '!' }
 
 // lldb-command:v string
-// lldb-check:[...] string = "IAMA string!"
+// lldb-check:[...] string = "IAMA string!" { vec = size=12 { [0] = 'I' [1] = 'A' [2] = 'M' [3] = 'A' [4] = ' ' [5] = 's' [6] = 't' [7] = 'r' [8] = 'i' [9] = 'n' [10] = 'g' [11] = '!' } }
 
 // lldb-command:v some
 // lldb-check:[...] some = Some(8)
@@ -63,7 +63,7 @@
 // lldb-check:[...] none = None
 
 // lldb-command:v os_string
-// lldb-check:[...] os_string = "IAMA OS string 😃"[...]
+// lldb-check:[...] os_string = "IAMA OS string 😃" { inner = { inner = size=19 { [0] = 'I' [1] = 'A' [2] = 'M' [3] = 'A' [4] = ' ' [5] = 'O' [6] = 'S' [7] = ' ' [8] = 's' [9] = 't' [10] = 'r' [11] = 'i' [12] = 'n' [13] = 'g' [14] = ' ' [15] = '\xf0' [16] = '\x9f' [17] = '\x98' [18] = '\x83' } } }
 
 // === CDB TESTS ==================================================================================
 

--- a/tests/debuginfo/rc_arc.rs
+++ b/tests/debuginfo/rc_arc.rs
@@ -1,4 +1,4 @@
-//@ ignore-windows-gnu: pretty-printers are not loaded
+//@ ignore-windows-gnu: #128981
 //@ compile-flags:-g
 
 //@ min-gdb-version: 8.1

--- a/tests/debuginfo/simple-struct.rs
+++ b/tests/debuginfo/simple-struct.rs
@@ -1,5 +1,4 @@
 //@ min-lldb-version: 310
-//@ ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 //@ compile-flags: -g -Zmir-enable-passes=-CheckAlignment
 

--- a/tests/debuginfo/simple-tuple.rs
+++ b/tests/debuginfo/simple-tuple.rs
@@ -1,5 +1,4 @@
 //@ min-lldb-version: 310
-//@ ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 //@ compile-flags:-g
 

--- a/tests/debuginfo/struct-in-enum.rs
+++ b/tests/debuginfo/struct-in-enum.rs
@@ -1,6 +1,5 @@
-//@ min-lldb-version: 310
+//@ min-lldb-version: 1800
 //@ ignore-gdb-version: 7.11.90 - 7.12.9
-//@ ignore-test // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 //@ compile-flags:-g
 

--- a/tests/debuginfo/union-smoke.rs
+++ b/tests/debuginfo/union-smoke.rs
@@ -1,5 +1,4 @@
 //@ min-lldb-version: 310
-//@ ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 //@ ignore-gdb-version: 7.11.90 - 7.12.9
 

--- a/tests/debuginfo/vec.rs
+++ b/tests/debuginfo/vec.rs
@@ -1,5 +1,4 @@
 //@ min-lldb-version: 310
-//@ ignore-gdb // Test temporarily ignored due to debuginfo tests being disabled, see PR 47155
 
 //@ compile-flags:-g
 


### PR DESCRIPTION
The PR history is a bit of a mess because I had to test this a lot with try-jobs, so I'll try to summarize the non-obvious changes here.

A number of tests now have `min-lldb-version: 1800`. Those tests should have gotten an lldb version jump either in https://github.com/rust-lang/rust/pull/124781 or long ago. Note that all such tests with that lldb version requirement do not run in Apple CI.

`tests/debuginfo/drop-locations.rs` is staying disabled for now because gdb doesn't know to stop on the drop calls produced by a `}`: https://github.com/rust-lang/rust/issues/128971

`tests/debuginfo/function-arg-initialization.rs` now has `-Zmir-enable-passes=-SingleUseConsts`; without that we initialize the const before the function prelude: https://github.com/rust-lang/rust/issues/128945

`tests/debuginfo/by-value-non-immediate-argument.rs` fails because we don't generate a function prelude for unused non-immediate arguments, even with all optimizations disabled, and this seems to confuse debuggers on aarch64: https://github.com/rust-lang/rust/issues/128973

`tests/debuginfo/pretty-std.rs` is staying disabled on windows-gnu because our test harness doesn't know how to load our pretty-printers on that target: https://github.com/rust-lang/rust/issues/128981

`tests/debuginfo/method-on-enum.rs` and `tests/debuginfo/option-like-enum.rs` encounter some kind of gdb bug on i686-pc-windows-gnu. I don't know enough about that situation to write a good issue.

I plan on doing more work on this test suite. There's clearly a lot more basic cleanup work to do here.