### PR TITLE
Tidy up `dump-ice-to-disk` and make assertion failures dump ICE messages

### DIFF
--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -1,137 +1,196 @@
-// This test checks if internal compilation error (ICE) log files work as expected.
-// - Get the number of lines from the log files without any configuration options,
-// then check that the line count doesn't change if the backtrace gets configured to be short
-// or full.
-// - Check that disabling ICE logging results in zero files created.
-// - Check that the ICE files contain some of the expected strings.
-// - exercise the -Zmetrics-dir nightly flag
-// - verify what happens when both the nightly flag and env variable are set
-// - test the RUST_BACKTRACE=0 behavior against the file creation
+//! This test checks if Internal Compilation Error (ICE) dump files `rustc-ice*.txt` work as
+//! expected.
+//!
+//! - Basic sanity checks on a default ICE dump.
+//! - Get the number of lines from the dump files without any `RUST_BACKTRACE` options, then check
+//!   ICE dump file (line count) is not affected by `RUSTC_BACKTRACE` settings.
+//! - Check that disabling ICE dumping results in zero dump files created.
+//! - Check that the ICE dump contain some of the expected strings.
+//! - Check that `RUST_BACKTRACE=0` prevents ICE dump from created.
+//! - Exercise the `-Zmetrics-dir` nightly flag (#128914):
+//!     - When `-Zmetrics=dir=PATH` is present but `RUSTC_ICE` is not set, check that the ICE dump
+//!       is placed under `PATH`.
+//!     - When `RUSTC_ICE=RUSTC_ICE_PATH` and `-Zmetrics-dir=METRICS_PATH` are both provided, check
+//!       that `RUSTC_ICE_PATH` takes precedence and no ICE dump is emitted under `METRICS_PATH`.
+//!
+//! See <https://github.com/rust-lang/rust/pull/108714>.
 
-// See https://github.com/rust-lang/rust/pull/108714
+// FIXME(#128911): @jieyouxu: This test is sometimes for whatever forsaken reason flakey in CI, and
+// I cannot reproduce it locally. The error messages upon assertion failure in this test is
+// intentionally extremely verbose to aid debugging that issue.
 
-use run_make_support::{cwd, has_extension, has_prefix, rfs, rustc, shallow_find_files};
+use std::cell::OnceCell;
+use std::path::{Path, PathBuf};
 
-fn main() {
-    rustc().env("RUSTC_ICE", cwd()).input("lib.rs").arg("-Ztreat-err-as-bug=1").run_fail();
-    let default = get_text_from_ice(".").lines().count();
+use run_make_support::{
+    cwd, filename_contains, has_extension, has_prefix, rfs, run_in_tmpdir, rustc,
+    shallow_find_files,
+};
 
-    clear_ice_files();
-    rustc().env("RUSTC_ICE", cwd()).input("lib.rs").arg("-Ztreat-err-as-bug=1").run_fail();
-    let ice_text = get_text_from_ice(cwd());
-    let default_set = ice_text.lines().count();
-    let content = ice_text;
-    let ice_files = shallow_find_files(cwd(), |path| {
-        has_prefix(path, "rustc-ice") && has_extension(path, "txt")
-    });
-    assert_eq!(ice_files.len(), 1); // There should only be 1 ICE file.
-    let ice_file_name =
-        ice_files.first().and_then(|f| f.file_name()).and_then(|n| n.to_str()).unwrap();
-    // Ensure that the ICE dump path doesn't contain `:`, because they cause problems on Windows.
-    assert!(!ice_file_name.contains(":"), "{ice_file_name}");
-    assert_eq!(default, default_set);
-    assert!(default > 0);
-    // Some of the expected strings in an ICE file should appear.
-    assert!(content.contains("thread 'rustc' panicked at"));
-    assert!(content.contains("stack backtrace:"));
-
-    test_backtrace_short(default);
-    test_backtrace_full(default);
-    test_backtrace_disabled(default);
-
-    clear_ice_files();
-    // The ICE dump is explicitly disabled. Therefore, this should produce no files.
-    rustc().env("RUSTC_ICE", "0").input("lib.rs").arg("-Ztreat-err-as-bug=1").run_fail();
-    let ice_files = shallow_find_files(cwd(), |path| {
-        has_prefix(path, "rustc-ice") && has_extension(path, "txt")
-    });
-    assert!(ice_files.is_empty()); // There should be 0 ICE files.
-
-    metrics_dir(default);
+#[derive(Debug)]
+struct IceDump {
+    name: &'static str,
+    path: PathBuf,
+    message: String,
 }
 
-fn test_backtrace_short(baseline: usize) {
-    clear_ice_files();
-    rustc()
-        .env("RUSTC_ICE", cwd())
-        .input("lib.rs")
-        .env("RUST_BACKTRACE", "short")
-        .arg("-Ztreat-err-as-bug=1")
-        .run_fail();
-    let short = get_text_from_ice(cwd()).lines().count();
-    // backtrace length in dump shouldn't be changed by RUST_BACKTRACE
-    assert_eq!(short, baseline);
-}
-
-fn test_backtrace_full(baseline: usize) {
-    clear_ice_files();
-    rustc()
-        .env("RUSTC_ICE", cwd())
-        .input("lib.rs")
-        .env("RUST_BACKTRACE", "full")
-        .arg("-Ztreat-err-as-bug=1")
-        .run_fail();
-    let full = get_text_from_ice(cwd()).lines().count();
-    // backtrace length in dump shouldn't be changed by RUST_BACKTRACE
-    assert_eq!(full, baseline);
-}
-
-fn test_backtrace_disabled(baseline: usize) {
-    clear_ice_files();
-    rustc()
-        .env("RUSTC_ICE", cwd())
-        .input("lib.rs")
-        .env("RUST_BACKTRACE", "0")
-        .arg("-Ztreat-err-as-bug=1")
-        .run_fail();
-    let disabled = get_text_from_ice(cwd()).lines().count();
-    // backtrace length in dump shouldn't be changed by RUST_BACKTRACE
-    assert_eq!(disabled, baseline);
-}
-
-fn metrics_dir(baseline: usize) {
-    test_flag_only(baseline);
-    test_flag_and_env(baseline);
-}
-
-fn test_flag_only(baseline: usize) {
-    clear_ice_files();
-    let metrics_arg = format!("-Zmetrics-dir={}", cwd().display());
-    rustc().input("lib.rs").arg("-Ztreat-err-as-bug=1").arg(metrics_arg).run_fail();
-    let output = get_text_from_ice(cwd()).lines().count();
-    assert_eq!(output, baseline);
-}
-
-fn test_flag_and_env(baseline: usize) {
-    clear_ice_files();
-    let metrics_arg = format!("-Zmetrics-dir={}", cwd().display());
-    let real_dir = cwd().join("actually_put_ice_here");
-    rfs::create_dir(real_dir.clone());
-    rustc()
-        .input("lib.rs")
-        .env("RUSTC_ICE", real_dir.clone())
-        .arg("-Ztreat-err-as-bug=1")
-        .arg(metrics_arg)
-        .run_fail();
-    let output = get_text_from_ice(real_dir).lines().count();
-    assert_eq!(output, baseline);
-}
-
-fn clear_ice_files() {
-    let ice_files = shallow_find_files(cwd(), |path| {
-        has_prefix(path, "rustc-ice") && has_extension(path, "txt")
-    });
-    for file in ice_files {
-        rfs::remove_file(file);
+impl IceDump {
+    fn lines_count(&self) -> usize {
+        self.message.lines().count()
     }
 }
 
 #[track_caller]
-fn get_text_from_ice(dir: impl AsRef<std::path::Path>) -> String {
-    let ice_files =
-        shallow_find_files(dir, |path| has_prefix(path, "rustc-ice") && has_extension(path, "txt"));
+fn assert_ice_len_equals(left: &IceDump, right: &IceDump) {
+    let left_len = left.lines_count();
+    let right_len = right.lines_count();
+
+    if left_len != right_len {
+        eprintln!("=== {} ICE MESSAGE ({} lines) ====", left.name, left_len);
+        eprintln!("{}", left.message);
+
+        eprintln!("=== {} ICE MESSAGE ({} lines) ====", right.name, right_len);
+        eprintln!("{}", right.message);
+
+        eprintln!("====================================");
+        panic!(
+            "ICE message length mismatch: {} has {} lines but {} has {} lines",
+            left.name, left_len, right.name, right_len
+        );
+    }
+}
+
+fn find_ice_dumps_in_dir<P: AsRef<Path>>(dir: P) -> Vec<PathBuf> {
+    shallow_find_files(dir, |path| has_prefix(path, "rustc-ice") && has_extension(path, "txt"))
+}
+
+// Assert only one `rustc-ice*.txt` ICE file exists, and extract the ICE message from the ICE file.
+#[track_caller]
+fn extract_exactly_one_ice_file<P: AsRef<Path>>(name: &'static str, dir: P) -> IceDump {
+    let ice_files = find_ice_dumps_in_dir(dir);
     assert_eq!(ice_files.len(), 1); // There should only be 1 ICE file.
-    let ice_file = ice_files.get(0).unwrap();
-    let output = rfs::read_to_string(ice_file);
-    output
+    let path = ice_files.get(0).unwrap();
+    let message = rfs::read_to_string(path);
+    IceDump { name, path: path.to_path_buf(), message }
+}
+
+fn main() {
+    // Establish baseline ICE message.
+    let mut default_ice_dump = OnceCell::new();
+    run_in_tmpdir(|| {
+        rustc().env("RUSTC_ICE", cwd()).input("lib.rs").arg("-Ztreat-err-as-bug=1").run_fail();
+        let dump = extract_exactly_one_ice_file("baseline", cwd());
+        // Ensure that the ICE dump path doesn't contain `:`, because they cause problems on
+        // Windows.
+        assert!(!filename_contains(&dump.path, ":"), "{} contains `:`", dump.path.display());
+        // Some of the expected strings in an ICE file should appear.
+        assert!(dump.message.contains("thread 'rustc' panicked at"));
+        assert!(dump.message.contains("stack backtrace:"));
+        default_ice_dump.set(dump).unwrap();
+    });
+    let default_ice_dump = default_ice_dump.get().unwrap();
+
+    test_backtrace_short(default_ice_dump);
+    test_backtrace_full(default_ice_dump);
+    test_backtrace_disabled(default_ice_dump);
+    test_ice_dump_disabled();
+
+    test_metrics_dir(default_ice_dump);
+}
+
+#[track_caller]
+fn test_backtrace_short(baseline: &IceDump) {
+    run_in_tmpdir(|| {
+        rustc()
+            .env("RUSTC_ICE", cwd())
+            .input("lib.rs")
+            .env("RUST_BACKTRACE", "short")
+            .arg("-Ztreat-err-as-bug=1")
+            .run_fail();
+        let dump = extract_exactly_one_ice_file("RUST_BACKTRACE=short", cwd());
+        // Backtrace length in dump shouldn't be changed by `RUST_BACKTRACE`.
+        assert_ice_len_equals(baseline, &dump);
+    });
+}
+
+#[track_caller]
+fn test_backtrace_full(baseline: &IceDump) {
+    run_in_tmpdir(|| {
+        rustc()
+            .env("RUSTC_ICE", cwd())
+            .input("lib.rs")
+            .env("RUST_BACKTRACE", "full")
+            .arg("-Ztreat-err-as-bug=1")
+            .run_fail();
+        let dump = extract_exactly_one_ice_file("RUST_BACKTRACE=full", cwd());
+        // Backtrace length in dump shouldn't be changed by `RUST_BACKTRACE`.
+        assert_ice_len_equals(baseline, &dump);
+    });
+}
+
+#[track_caller]
+fn test_backtrace_disabled(baseline: &IceDump) {
+    run_in_tmpdir(|| {
+        rustc()
+            .env("RUSTC_ICE", cwd())
+            .input("lib.rs")
+            .env("RUST_BACKTRACE", "0")
+            .arg("-Ztreat-err-as-bug=1")
+            .run_fail();
+        let dump = extract_exactly_one_ice_file("RUST_BACKTRACE=disabled", cwd());
+        // Backtrace length in dump shouldn't be changed by `RUST_BACKTRACE`.
+        assert_ice_len_equals(baseline, &dump);
+    });
+}
+
+#[track_caller]
+fn test_ice_dump_disabled() {
+    // The ICE dump is explicitly disabled. Therefore, this should produce no files.
+    run_in_tmpdir(|| {
+        rustc().env("RUSTC_ICE", "0").input("lib.rs").arg("-Ztreat-err-as-bug=1").run_fail();
+        let ice_files = find_ice_dumps_in_dir(cwd());
+        assert!(ice_files.is_empty(), "there should be no ICE files if `RUSTC_ICE=0` is set");
+    });
+}
+
+#[track_caller]
+fn test_metrics_dir(baseline: &IceDump) {
+    test_flag_only(baseline);
+    test_flag_and_env(baseline);
+}
+
+#[track_caller]
+fn test_flag_only(baseline: &IceDump) {
+    run_in_tmpdir(|| {
+        let metrics_arg = format!("-Zmetrics-dir={}", cwd().display());
+        rustc()
+            .env_remove("RUSTC_ICE") // prevent interference from environment
+            .input("lib.rs")
+            .arg("-Ztreat-err-as-bug=1")
+            .arg(metrics_arg)
+            .run_fail();
+        let dump = extract_exactly_one_ice_file("-Zmetrics-dir only", cwd());
+        assert_ice_len_equals(baseline, &dump);
+    });
+}
+
+#[track_caller]
+fn test_flag_and_env(baseline: &IceDump) {
+    run_in_tmpdir(|| {
+        let metrics_arg = format!("-Zmetrics-dir={}", cwd().display());
+        let real_dir = cwd().join("actually_put_ice_here");
+        rfs::create_dir(&real_dir);
+        rustc()
+            .input("lib.rs")
+            .env("RUSTC_ICE", &real_dir)
+            .arg("-Ztreat-err-as-bug=1")
+            .arg(metrics_arg)
+            .run_fail();
+
+        let cwd_ice_files = find_ice_dumps_in_dir(cwd());
+        assert!(cwd_ice_files.is_empty(), "RUSTC_ICE should override -Zmetrics-dir");
+
+        let dump = extract_exactly_one_ice_file("RUSTC_ICE overrides -Zmetrics-dir", real_dir);
+        assert_ice_len_equals(baseline, &dump);
+    });
 }

--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -15,9 +15,10 @@
 //!
 //! See <https://github.com/rust-lang/rust/pull/108714>.
 
-// FIXME(#128911): @jieyouxu: This test is sometimes for whatever forsaken reason flakey in CI, and
-// I cannot reproduce it locally. The error messages upon assertion failure in this test is
-// intentionally extremely verbose to aid debugging that issue.
+//@ ignore-windows
+// FIXME(#128911): @jieyouxu: This test is sometimes for whatever forsaken reason flakey in
+// `i686-mingw`, and I cannot reproduce it locally. The error messages upon assertion failure in
+// this test is intentionally extremely verbose to aid debugging that issue.
 
 use std::cell::OnceCell;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
For the future traveler: **if you did a `git blame` and found this PR that last modified `dump-ice-to-disk` because the test failed in a completely unrelated PR, then I'm afraid our ICE dump may have regressed or somehow behaves differently on `i686-mingw`.**

A bit of clean up to the `dump-ice-to-disk` test.

- Fixes/updates the top-level comment.
- Add a FIXME pointing to #128911 for flakiness.
- Instead of trying to manually cleanup `rustc-ice*.txt` dumps, run each test instance in a separate temp directory.
- Explicitly make `RUSTC_ICE` unavailable in one of the `-Zmetrics-dir` test case to not have interference from environment.
- Make assertion failures (on ICE dump line count mismatch) extremely verbose to help debug why this test is flakey in CI (#128911).

Contains a fix by @saethlin in #128909, should wait until that is merged then rebase on top.

try-job: aarch64-gnu
try-job: aarch64-apple
try-job: x86_64-msvc
try-job: i686-mingw
try-job: test-various