### PR TITLE
Try to shrink `Alignment`-related MIR in `Layout`

### DIFF
--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -94,7 +94,12 @@ impl Alignment {
     #[rustc_const_unstable(feature = "ptr_alignment_type", issue = "102070")]
     #[inline]
     pub const fn as_usize(self) -> usize {
-        self.0 as usize
+        // It would be possible to do this with `self.0 as _`, but that results
+        // in way more MIR -- mostly because of the assume -- which ends up
+        // impacting compilation time for things using `Layout`.
+
+        // SAFETY: this type is a subset of the possible values of usize.
+        unsafe { mem::transmute::<Alignment, usize>(self) }
     }
 
     /// Returns the alignment as a <code>[NonZero]<[usize]></code>.


### PR DESCRIPTION
Noticed all this in <https://rust.godbolt.org/z/55Tx65v4e>:
```rust
        _22 = (_11.0: std::ptr::alignment::AlignmentEnum);
        _23 = discriminant(_22);
        _24 = Ge(_23, const 1_u64);
        _25 = Le(_23, const 9223372036854775808_u64);
        _26 = BitAnd(move _24, move _25);
        assume(move _26);
        _20 = _23 as usize (IntToInt);
```

So let's see if a non-`as` here works better.