### PR TITLE
CI: rfl: add more tools and steps

### DIFF
--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 LINUX_VERSION=4c7864e81d8bbd51036dacf92fb0a400e13aaeee
 
-# Build rustc, rustdoc, cargo and clippy-driver
-../x.py build --stage 2 library rustdoc clippy
+# Build rustc, rustdoc, cargo, clippy-driver and rustfmt
+../x.py build --stage 2 library rustdoc clippy rustfmt
 ../x.py build --stage 0 cargo
 
 # Install rustup so that we can use the built toolchain easily, and also
@@ -90,3 +90,10 @@ make -C linux LLVM=1 -j$(($(nproc) + 1)) CLIPPY=1 \
     samples/rust/rust_print.o \
     drivers/net/phy/ax88796b_rust.o \
     rust/doctests_kernel_generated.o
+
+# Format the code
+#
+# This returns successfully even if there were changes, i.e. it is not
+# a check.
+make -C linux LLVM=1 -j$(($(nproc) + 1)) \
+    rustfmt

--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -80,6 +80,14 @@ make -C linux LLVM=1 -j$(($(nproc) + 1)) \
 make -C linux LLVM=1 -j$(($(nproc) + 1)) \
     rustdoc
 
+# Build macro expanded source (`-Zunpretty=expanded`)
+#
+# This target also formats the macro expanded code, thus it is also
+# intended to catch ICEs with formatting `-Zunpretty=expanded` output
+# like https://github.com/rust-lang/rustfmt/issues/6105.
+make -C linux LLVM=1 -j$(($(nproc) + 1)) \
+    samples/rust/rust_minimal.rsi
+
 # Re-build with Clippy enabled
 #
 # This should not introduce Clippy errors, since `CONFIG_WERROR` is not

--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -62,11 +62,20 @@ make -C linux LLVM=1 -j$(($(nproc) + 1)) \
     defconfig \
     rfl-for-rust-ci.config
 
+# Build a few Rust targets
+#
+# This does not include building the C side of the kernel nor linking,
+# which can find other issues, but it is much faster.
+#
+# This includes transforming `rustdoc` tests into KUnit ones thanks to
+# `CONFIG_RUST_KERNEL_DOCTESTS=y` above (which, for the moment, uses the
+# unstable `--test-builder` and `--no-run`).
 make -C linux LLVM=1 -j$(($(nproc) + 1)) \
     samples/rust/rust_minimal.o \
     samples/rust/rust_print.o \
     drivers/net/phy/ax88796b_rust.o \
     rust/doctests_kernel_generated.o
 
+# Generate documentation
 make -C linux LLVM=1 -j$(($(nproc) + 1)) \
     rustdoc

--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 LINUX_VERSION=4c7864e81d8bbd51036dacf92fb0a400e13aaeee
 
 # Build rustc, rustdoc and cargo
-../x.py build --stage 1 library rustdoc
+../x.py build --stage 2 library rustdoc
 ../x.py build --stage 0 cargo
 
 # Install rustup so that we can use the built toolchain easily, and also
@@ -16,7 +16,7 @@ sh rustup.sh -y --default-toolchain none
 source /cargo/env
 
 BUILD_DIR=$(realpath ./build)
-rustup toolchain link local "${BUILD_DIR}"/x86_64-unknown-linux-gnu/stage1
+rustup toolchain link local "${BUILD_DIR}"/x86_64-unknown-linux-gnu/stage2
 rustup default local
 
 mkdir -p rfl

--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -62,6 +62,13 @@ make -C linux LLVM=1 -j$(($(nproc) + 1)) \
     defconfig \
     rfl-for-rust-ci.config
 
+BUILD_TARGETS="
+    samples/rust/rust_minimal.o
+    samples/rust/rust_print.o
+    drivers/net/phy/ax88796b_rust.o
+    rust/doctests_kernel_generated.o
+"
+
 # Build a few Rust targets
 #
 # This does not include building the C side of the kernel nor linking,
@@ -71,10 +78,7 @@ make -C linux LLVM=1 -j$(($(nproc) + 1)) \
 # `CONFIG_RUST_KERNEL_DOCTESTS=y` above (which, for the moment, uses the
 # unstable `--test-builder` and `--no-run`).
 make -C linux LLVM=1 -j$(($(nproc) + 1)) \
-    samples/rust/rust_minimal.o \
-    samples/rust/rust_print.o \
-    drivers/net/phy/ax88796b_rust.o \
-    rust/doctests_kernel_generated.o
+    $BUILD_TARGETS
 
 # Generate documentation
 make -C linux LLVM=1 -j$(($(nproc) + 1)) \
@@ -94,10 +98,7 @@ make -C linux LLVM=1 -j$(($(nproc) + 1)) \
 # set (thus no `-Dwarnings`) and the kernel uses `-W` for all Clippy
 # lints, including `clippy::all`. However, it could catch ICEs.
 make -C linux LLVM=1 -j$(($(nproc) + 1)) CLIPPY=1 \
-    samples/rust/rust_minimal.o \
-    samples/rust/rust_print.o \
-    drivers/net/phy/ax88796b_rust.o \
-    rust/doctests_kernel_generated.o
+    $BUILD_TARGETS
 
 # Format the code
 #


### PR DESCRIPTION
This will add some time for the tool building -- the actual steps should be quick, though, and allows us to cover quite a few more tools and unstable features in use.

Please see the individual commits for a few details.

Cc: @GuillaumeGomez @tgross35
r? @Kobzol
try-job: x86_64-rust-for-linux