### PR TITLE
Support reading thin archives in ArArchiveBuilder

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/archive.rs
+++ b/compiler/rustc_codegen_llvm/src/back/archive.rs
@@ -106,9 +106,7 @@ pub struct LlvmArchiveBuilderBuilder;
 
 impl ArchiveBuilderBuilder for LlvmArchiveBuilderBuilder {
     fn new_archive_builder<'a>(&self, sess: &'a Session) -> Box<dyn ArchiveBuilder + 'a> {
-        // FIXME use ArArchiveBuilder on most targets again once reading thin archives is
-        // implemented
-        if true {
+        if false {
             Box::new(LlvmArchiveBuilder { sess, additions: Vec::new() })
         } else {
             Box::new(ArArchiveBuilder::new(sess, &LLVM_OBJECT_READER))

--- a/compiler/rustc_codegen_llvm/src/back/archive.rs
+++ b/compiler/rustc_codegen_llvm/src/back/archive.rs
@@ -106,6 +106,10 @@ pub struct LlvmArchiveBuilderBuilder;
 
 impl ArchiveBuilderBuilder for LlvmArchiveBuilderBuilder {
     fn new_archive_builder<'a>(&self, sess: &'a Session) -> Box<dyn ArchiveBuilder + 'a> {
+        // Keeping LlvmArchiveBuilder around in case of a regression caused by using
+        // ArArchiveBuilder.
+        // FIXME remove a couple of months after #128936 gets merged in case no
+        // regression is found.
         if false {
             Box::new(LlvmArchiveBuilder { sess, additions: Vec::new() })
         } else {

--- a/compiler/rustc_codegen_llvm/src/back/archive.rs
+++ b/compiler/rustc_codegen_llvm/src/back/archive.rs
@@ -108,8 +108,8 @@ impl ArchiveBuilderBuilder for LlvmArchiveBuilderBuilder {
     fn new_archive_builder<'a>(&self, sess: &'a Session) -> Box<dyn ArchiveBuilder + 'a> {
         // Keeping LlvmArchiveBuilder around in case of a regression caused by using
         // ArArchiveBuilder.
-        // FIXME remove a couple of months after #128936 gets merged in case no
-        // regression is found.
+        // FIXME(#128955) remove a couple of months after #128936 gets merged in case
+        // no regression is found.
         if false {
             Box::new(LlvmArchiveBuilder { sess, additions: Vec::new() })
         } else {

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -307,10 +307,17 @@ impl<'a> ArchiveBuilder for ArArchiveBuilder<'a> {
             let file_name = String::from_utf8(entry.name().to_vec())
                 .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
             if !skip(&file_name) {
-                self.entries.push((
-                    file_name.into_bytes(),
-                    ArchiveEntry::FromArchive { archive_index, file_range: entry.file_range() },
-                ));
+                if entry.is_thin() {
+                    self.entries.push((
+                        file_name.clone().into_bytes(),
+                        ArchiveEntry::File(PathBuf::from(file_name)),
+                    ));
+                } else {
+                    self.entries.push((
+                        file_name.into_bytes(),
+                        ArchiveEntry::FromArchive { archive_index, file_range: entry.file_range() },
+                    ));
+                }
             }
         }
 

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -308,10 +308,8 @@ impl<'a> ArchiveBuilder for ArArchiveBuilder<'a> {
                 .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
             if !skip(&file_name) {
                 if entry.is_thin() {
-                    self.entries.push((
-                        file_name.clone().into_bytes(),
-                        ArchiveEntry::File(PathBuf::from(file_name)),
-                    ));
+                    let member_path = archive_path.parent().unwrap().join(Path::new(&file_name));
+                    self.entries.push((file_name.into_bytes(), ArchiveEntry::File(member_path)));
                 } else {
                     self.entries.push((
                         file_name.into_bytes(),

--- a/compiler/rustc_llvm/llvm-wrapper/SymbolWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/SymbolWrapper.cpp
@@ -80,6 +80,9 @@ LLVMRustGetSymbols(char *BufPtr, size_t BufLen, void *State,
     return ErrorCallback(toString(ObjOrErr.takeError()).c_str());
   }
   std::unique_ptr<object::SymbolicFile> Obj = std::move(*ObjOrErr);
+  if (Obj == nullptr) {
+    return 0;
+  }
 
   for (const object::BasicSymbolRef &S : Obj->symbols()) {
     if (!isArchiveSymbol(S))

--- a/compiler/rustc_llvm/llvm-wrapper/SymbolWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/SymbolWrapper.cpp
@@ -77,11 +77,7 @@ LLVMRustGetSymbols(char *BufPtr, size_t BufLen, void *State,
   Expected<std::unique_ptr<object::SymbolicFile>> ObjOrErr =
       getSymbolicFile(Buf->getMemBufferRef(), Context);
   if (!ObjOrErr) {
-    Error E = ObjOrErr.takeError();
-    SmallString<0> ErrorBuf;
-    auto Error = raw_svector_ostream(ErrorBuf);
-    Error << E << '\0';
-    return ErrorCallback(Error.str().data());
+    return ErrorCallback(toString(ObjOrErr.takeError()).c_str());
   }
   std::unique_ptr<object::SymbolicFile> Obj = std::move(*ObjOrErr);
 
@@ -89,10 +85,7 @@ LLVMRustGetSymbols(char *BufPtr, size_t BufLen, void *State,
     if (!isArchiveSymbol(S))
       continue;
     if (Error E = S.printName(SymName)) {
-      SmallString<0> ErrorBuf;
-      auto Error = raw_svector_ostream(ErrorBuf);
-      Error << E << '\0';
-      return ErrorCallback(Error.str().data());
+      return ErrorCallback(toString(std::move(E)).c_str());
     }
     SymName << '\0';
     if (void *E = Callback(State, SymNameBuf.str().data())) {

--- a/src/tools/run-make-support/src/external_deps/llvm.rs
+++ b/src/tools/run-make-support/src/external_deps/llvm.rs
@@ -271,6 +271,12 @@ impl LlvmAr {
         self
     }
 
+    /// Like `obj_to_ar` except creating a thin archive.
+    pub fn obj_to_thin_ar(&mut self) -> &mut Self {
+        self.cmd.arg("rcus").arg("--thin");
+        self
+    }
+
     /// Extract archive members back to files.
     pub fn extract(&mut self) -> &mut Self {
         self.cmd.arg("x");

--- a/tests/run-make/staticlib-thin-archive/bin.rs
+++ b/tests/run-make/staticlib-thin-archive/bin.rs
@@ -1,0 +1,10 @@
+#[link(name = "rust_archive", kind = "static")]
+extern "C" {
+    fn simple_fn();
+}
+
+fn main() {
+    unsafe {
+        simple_fn();
+    }
+}

--- a/tests/run-make/staticlib-thin-archive/bin.rs
+++ b/tests/run-make/staticlib-thin-archive/bin.rs
@@ -1,10 +1,5 @@
-#[link(name = "rust_archive", kind = "static")]
-extern "C" {
-    fn simple_fn();
-}
-
 fn main() {
     unsafe {
-        simple_fn();
+        rust_lib::simple_fn();
     }
 }

--- a/tests/run-make/staticlib-thin-archive/rmake.rs
+++ b/tests/run-make/staticlib-thin-archive/rmake.rs
@@ -1,0 +1,13 @@
+// Regression test for https://github.com/rust-lang/rust/issues/107407
+
+use run_make_support::{llvm_ar, rustc, static_lib_name};
+
+fn main() {
+    rustc().input("simple_obj.rs").emit("obj").run();
+    llvm_ar().obj_to_thin_ar().output_input(static_lib_name("thin_archive"), "simple_obj.o").run();
+    rustc().input("rust_archive.rs").run();
+    // Disable lld as it ignores the symbol table in the archive file.
+    rustc()
+        .input("bin.rs") /*.arg("-Zlinker-features=-lld")*/
+        .run();
+}

--- a/tests/run-make/staticlib-thin-archive/rmake.rs
+++ b/tests/run-make/staticlib-thin-archive/rmake.rs
@@ -3,21 +3,16 @@
 // archive support rustc would add emit object files to the staticlib and after
 // the object crate added thin archive support it would previously crash the
 // compiler due to a missing special case for thin archive members.
-use std::path::Path;
-
-use run_make_support::{llvm_ar, rust_lib_name, rustc, static_lib_name};
+use run_make_support::{llvm_ar, path, rfs, rust_lib_name, rustc, static_lib_name};
 
 fn main() {
-    std::fs::create_dir("archive").unwrap();
+    rfs::create_dir("archive");
 
     // Build a thin archive
     rustc().input("simple_obj.rs").emit("obj").output("archive/simple_obj.o").run();
     llvm_ar()
         .obj_to_thin_ar()
-        .output_input(
-            Path::new("archive").join(static_lib_name("thin_archive")),
-            "archive/simple_obj.o",
-        )
+        .output_input(path("archive").join(static_lib_name("thin_archive")), "archive/simple_obj.o")
         .run();
 
     // Build an rlib which includes the members of this thin archive

--- a/tests/run-make/staticlib-thin-archive/rust_archive.rs
+++ b/tests/run-make/staticlib-thin-archive/rust_archive.rs
@@ -1,4 +1,0 @@
-#![crate_type = "staticlib"]
-
-#[link(name = "thin_archive", kind = "static")]
-extern "C" {}

--- a/tests/run-make/staticlib-thin-archive/rust_archive.rs
+++ b/tests/run-make/staticlib-thin-archive/rust_archive.rs
@@ -1,0 +1,4 @@
+#![crate_type = "staticlib"]
+
+#[link(name = "thin_archive", kind = "static")]
+extern "C" {}

--- a/tests/run-make/staticlib-thin-archive/rust_lib.rs
+++ b/tests/run-make/staticlib-thin-archive/rust_lib.rs
@@ -1,0 +1,6 @@
+#![crate_type = "rlib"]
+
+#[link(name = "thin_archive", kind = "static")]
+extern "C" {
+    pub fn simple_fn();
+}

--- a/tests/run-make/staticlib-thin-archive/simple_obj.rs
+++ b/tests/run-make/staticlib-thin-archive/simple_obj.rs
@@ -1,0 +1,4 @@
+#![crate_type = "staticlib"]
+
+#[no_mangle]
+extern "C" fn simple_fn() {}


### PR DESCRIPTION
And switch to using ArArchiveBuilder with the LLVM backend too now that all regressions are fixed.

Fixes https://github.com/rust-lang/rust/issues/107407
Fixes https://github.com/rust-lang/rust/issues/107162
https://github.com/rust-lang/rust/issues/107495 has been fixed in a previous PR already.