### PR TITLE
Remove `print::Pat` from the printing of `WitnessPat`

### DIFF
--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -832,7 +832,7 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
             Struct if pat.ty().is_box() => {
                 // Outside of the `alloc` crate, the only way to create a struct pattern
                 // of type `Box` is to use a `box` pattern via #[feature(box_patterns)].
-                PatKind::Box { subpattern: hoist(&pat.fields[0]) }
+                PatKind::Print(format!("box {}", hoist(&pat.fields[0])))
             }
             Struct | Variant(_) | UnionField => {
                 let enum_info = match *pat.ty().kind() {

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -784,7 +784,7 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
         } else if range.is_singleton() {
             let lo = cx.hoist_pat_range_bdy(range.lo, ty);
             let value = lo.as_finite().unwrap();
-            PatKind::Constant { value }
+            PatKind::Print(value.to_string())
         } else {
             // We convert to an inclusive range for diagnostics.
             let mut end = rustc_hir::RangeEnd::Included;
@@ -827,7 +827,8 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
         let cx = self;
         let hoist = |p| Box::new(cx.hoist_witness_pat(p));
         let kind = match pat.ctor() {
-            Bool(b) => PatKind::Constant { value: mir::Const::from_bool(cx.tcx, *b) },
+            Bool(b) => PatKind::Print(b.to_string()),
+            Str(s) => PatKind::Print(s.to_string()),
             IntRange(range) => return self.hoist_pat_range(range, *pat.ty()),
             Struct if pat.ty().is_box() => {
                 // Outside of the `alloc` crate, the only way to create a struct pattern
@@ -901,7 +902,6 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
 
                 PatKind::Slice { prefix, has_dot_dot, suffix }
             }
-            &Str(value) => PatKind::Constant { value },
             Never if self.tcx.features().never_patterns => PatKind::Never,
             Never | Wildcard | NonExhaustive | Hidden | PrivateUninhabited => {
                 PatKind::Print("_".to_string())

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -904,7 +904,7 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                 print::write_slice_like(&mut s, &prefix, has_dot_dot, &suffix).unwrap();
                 PatKind::Print(s)
             }
-            Never if self.tcx.features().never_patterns => PatKind::Never,
+            Never if self.tcx.features().never_patterns => PatKind::Print("!".to_string()),
             Never | Wildcard | NonExhaustive | Hidden | PrivateUninhabited => {
                 PatKind::Print("_".to_string())
             }

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -780,7 +780,7 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
         use MaybeInfiniteInt::*;
         let cx = self;
         let kind = if matches!((range.lo, range.hi), (NegInfinity, PosInfinity)) {
-            PatKind::Wild
+            PatKind::Print("_".to_string())
         } else if range.is_singleton() {
             let lo = cx.hoist_pat_range_bdy(range.lo, ty);
             let value = lo.as_finite().unwrap();
@@ -890,7 +890,9 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
             }
             &Str(value) => PatKind::Constant { value },
             Never if self.tcx.features().never_patterns => PatKind::Never,
-            Never | Wildcard | NonExhaustive | Hidden | PrivateUninhabited => PatKind::Wild,
+            Never | Wildcard | NonExhaustive | Hidden | PrivateUninhabited => {
+                PatKind::Print("_".to_string())
+            }
             Missing { .. } => bug!(
                 "trying to convert a `Missing` constructor into a `Pat`; this is probably a bug,
                 `Missing` should have been processed in `apply_constructors`"

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -807,7 +807,7 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                 range.hi
             };
             let hi = cx.hoist_pat_range_bdy(hi, ty);
-            PatKind::Range(Box::new(PatRange { lo, hi, end, ty: ty.inner() }))
+            PatKind::Print(PatRange { lo, hi, end, ty: ty.inner() }.to_string())
         };
 
         Pat { ty: ty.inner(), kind }

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -897,10 +897,12 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                     }
                 }
 
-                let prefix = prefix.iter().map(hoist).collect();
-                let suffix = suffix.iter().map(hoist).collect();
+                let prefix = prefix.iter().map(hoist).collect::<Vec<_>>();
+                let suffix = suffix.iter().map(hoist).collect::<Vec<_>>();
 
-                PatKind::Slice { prefix, has_dot_dot, suffix }
+                let mut s = String::new();
+                print::write_slice_like(&mut s, &prefix, has_dot_dot, &suffix).unwrap();
+                PatKind::Print(s)
             }
             Never if self.tcx.features().never_patterns => PatKind::Never,
             Never | Wildcard | NonExhaustive | Hidden | PrivateUninhabited => {

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -847,7 +847,11 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                 let subpatterns = pat
                     .iter_fields()
                     .enumerate()
-                    .map(|(i, pat)| FieldPat { field: FieldIdx::new(i), pattern: hoist(pat) })
+                    .map(|(i, pat)| FieldPat {
+                        field: FieldIdx::new(i),
+                        pattern: hoist(pat),
+                        is_wildcard: would_print_as_wildcard(cx.tcx, pat),
+                    })
                     .collect::<Vec<_>>();
 
                 PatKind::StructLike { enum_info, subpatterns }

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -854,7 +854,16 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                     })
                     .collect::<Vec<_>>();
 
-                PatKind::StructLike { enum_info, subpatterns }
+                let mut s = String::new();
+                print::write_struct_like(
+                    &mut s,
+                    self.tcx,
+                    pat.ty().inner(),
+                    &enum_info,
+                    &subpatterns,
+                )
+                .unwrap();
+                PatKind::Print(s)
             }
             Ref => PatKind::Deref { subpattern: hoist(&pat.fields[0]) },
             Slice(slice) => {

--- a/compiler/rustc_pattern_analysis/src/rustc.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc.rs
@@ -865,7 +865,11 @@ impl<'p, 'tcx: 'p> RustcPatCtxt<'p, 'tcx> {
                 .unwrap();
                 PatKind::Print(s)
             }
-            Ref => PatKind::Deref { subpattern: hoist(&pat.fields[0]) },
+            Ref => {
+                let mut s = String::new();
+                print::write_ref_like(&mut s, pat.ty().inner(), &hoist(&pat.fields[0])).unwrap();
+                PatKind::Print(s)
+            }
             Slice(slice) => {
                 let (prefix_len, has_dot_dot) = match slice.kind {
                     SliceKind::FixedLen(len) => (len, false),

--- a/compiler/rustc_pattern_analysis/src/rustc/print.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc/print.rs
@@ -11,9 +11,9 @@
 
 use std::fmt;
 
+use rustc_middle::bug;
 use rustc_middle::thir::PatRange;
 use rustc_middle::ty::{self, AdtDef, Ty, TyCtxt};
-use rustc_middle::{bug, mir};
 use rustc_span::sym;
 use rustc_target::abi::{FieldIdx, VariantIdx};
 
@@ -33,10 +33,6 @@ pub(crate) struct Pat<'tcx> {
 
 #[derive(Clone, Debug)]
 pub(crate) enum PatKind<'tcx> {
-    Constant {
-        value: mir::Const<'tcx>,
-    },
-
     Range(Box<PatRange<'tcx>>),
 
     Slice {
@@ -56,7 +52,6 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
             PatKind::Never => write!(f, "!"),
-            PatKind::Constant { value } => write!(f, "{value}"),
             PatKind::Range(ref range) => write!(f, "{range}"),
             PatKind::Slice { ref prefix, has_dot_dot, ref suffix } => {
                 write_slice_like(f, prefix, has_dot_dot, suffix)

--- a/compiler/rustc_pattern_analysis/src/rustc/print.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc/print.rs
@@ -27,19 +27,11 @@ pub(crate) struct FieldPat<'tcx> {
 pub(crate) struct Pat<'tcx> {
     #[allow(dead_code)]
     pub(crate) ty: Ty<'tcx>,
-    pub(crate) kind: PatKind<'tcx>,
+    pub(crate) kind: PatKind,
 }
 
 #[derive(Clone, Debug)]
-pub(crate) enum PatKind<'tcx> {
-    Slice {
-        prefix: Box<[Box<Pat<'tcx>>]>,
-        /// True if this slice-like pattern should include a `..` between the
-        /// prefix and suffix.
-        has_dot_dot: bool,
-        suffix: Box<[Box<Pat<'tcx>>]>,
-    },
-
+pub(crate) enum PatKind {
     Never,
 
     Print(String),
@@ -49,9 +41,6 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
             PatKind::Never => write!(f, "!"),
-            PatKind::Slice { ref prefix, has_dot_dot, ref suffix } => {
-                write_slice_like(f, prefix, has_dot_dot, suffix)
-            }
             PatKind::Print(ref string) => write!(f, "{string}"),
         }
     }
@@ -173,7 +162,7 @@ pub(crate) fn write_ref_like<'tcx>(
     write!(f, "{subpattern}")
 }
 
-fn write_slice_like<'tcx>(
+pub(crate) fn write_slice_like<'tcx>(
     f: &mut impl fmt::Write,
     prefix: &[Box<Pat<'tcx>>],
     has_dot_dot: bool,

--- a/compiler/rustc_pattern_analysis/src/rustc/print.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc/print.rs
@@ -26,16 +26,13 @@ pub(crate) struct FieldPat<'tcx> {
 
 #[derive(Clone, Debug)]
 pub(crate) struct Pat<'tcx> {
+    #[allow(dead_code)]
     pub(crate) ty: Ty<'tcx>,
     pub(crate) kind: PatKind<'tcx>,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) enum PatKind<'tcx> {
-    Deref {
-        subpattern: Box<Pat<'tcx>>,
-    },
-
     Constant {
         value: mir::Const<'tcx>,
     },
@@ -59,7 +56,6 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
             PatKind::Never => write!(f, "!"),
-            PatKind::Deref { ref subpattern } => write_ref_like(f, self.ty, subpattern),
             PatKind::Constant { value } => write!(f, "{value}"),
             PatKind::Range(ref range) => write!(f, "{range}"),
             PatKind::Slice { ref prefix, has_dot_dot, ref suffix } => {
@@ -172,7 +168,7 @@ pub(crate) fn write_struct_like<'tcx>(
     Ok(())
 }
 
-fn write_ref_like<'tcx>(
+pub(crate) fn write_ref_like<'tcx>(
     f: &mut impl fmt::Write,
     ty: Ty<'tcx>,
     subpattern: &Pat<'tcx>,

--- a/compiler/rustc_pattern_analysis/src/rustc/print.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc/print.rs
@@ -17,30 +17,10 @@ use rustc_span::sym;
 use rustc_target::abi::{FieldIdx, VariantIdx};
 
 #[derive(Clone, Debug)]
-pub(crate) struct FieldPat<'tcx> {
+pub(crate) struct FieldPat {
     pub(crate) field: FieldIdx,
-    pub(crate) pattern: Box<Pat<'tcx>>,
+    pub(crate) pattern: String,
     pub(crate) is_wildcard: bool,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct Pat<'tcx> {
-    #[allow(dead_code)]
-    pub(crate) ty: Ty<'tcx>,
-    pub(crate) kind: PatKind,
-}
-
-#[derive(Clone, Debug)]
-pub(crate) enum PatKind {
-    Print(String),
-}
-
-impl<'tcx> fmt::Display for Pat<'tcx> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.kind {
-            PatKind::Print(ref string) => write!(f, "{string}"),
-        }
-    }
 }
 
 /// Returns a closure that will return `""` when called the first time,
@@ -69,7 +49,7 @@ pub(crate) fn write_struct_like<'tcx>(
     tcx: TyCtxt<'_>,
     ty: Ty<'tcx>,
     enum_info: &EnumInfo<'tcx>,
-    subpatterns: &[FieldPat<'tcx>],
+    subpatterns: &[FieldPat],
 ) -> fmt::Result {
     let variant_and_name = match *enum_info {
         EnumInfo::Enum { adt_def, variant_index } => {
@@ -148,7 +128,7 @@ pub(crate) fn write_struct_like<'tcx>(
 pub(crate) fn write_ref_like<'tcx>(
     f: &mut impl fmt::Write,
     ty: Ty<'tcx>,
-    subpattern: &Pat<'tcx>,
+    subpattern: &str,
 ) -> fmt::Result {
     match ty.kind() {
         ty::Ref(_, _, mutbl) => {
@@ -159,11 +139,11 @@ pub(crate) fn write_ref_like<'tcx>(
     write!(f, "{subpattern}")
 }
 
-pub(crate) fn write_slice_like<'tcx>(
+pub(crate) fn write_slice_like(
     f: &mut impl fmt::Write,
-    prefix: &[Box<Pat<'tcx>>],
+    prefix: &[String],
     has_dot_dot: bool,
-    suffix: &[Box<Pat<'tcx>>],
+    suffix: &[String],
 ) -> fmt::Result {
     let mut start_or_comma = start_or_comma();
     write!(f, "[")?;

--- a/compiler/rustc_pattern_analysis/src/rustc/print.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc/print.rs
@@ -32,11 +32,6 @@ pub(crate) struct Pat<'tcx> {
 
 #[derive(Clone, Debug)]
 pub(crate) enum PatKind<'tcx> {
-    StructLike {
-        enum_info: EnumInfo<'tcx>,
-        subpatterns: Vec<FieldPat<'tcx>>,
-    },
-
     Box {
         subpattern: Box<Pat<'tcx>>,
     },
@@ -69,9 +64,6 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
         match self.kind {
             PatKind::Never => write!(f, "!"),
             PatKind::Box { ref subpattern } => write!(f, "box {subpattern}"),
-            PatKind::StructLike { ref enum_info, ref subpatterns } => {
-                ty::tls::with(|tcx| write_struct_like(f, tcx, self.ty, enum_info, subpatterns))
-            }
             PatKind::Deref { ref subpattern } => write_ref_like(f, self.ty, subpattern),
             PatKind::Constant { value } => write!(f, "{value}"),
             PatKind::Range(ref range) => write!(f, "{range}"),
@@ -104,7 +96,7 @@ pub(crate) enum EnumInfo<'tcx> {
     NotEnum,
 }
 
-fn write_struct_like<'tcx>(
+pub(crate) fn write_struct_like<'tcx>(
     f: &mut impl fmt::Write,
     tcx: TyCtxt<'_>,
     ty: Ty<'tcx>,

--- a/compiler/rustc_pattern_analysis/src/rustc/print.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc/print.rs
@@ -32,8 +32,6 @@ pub(crate) struct Pat<'tcx> {
 
 #[derive(Clone, Debug)]
 pub(crate) enum PatKind<'tcx> {
-    Wild,
-
     StructLike {
         enum_info: EnumInfo<'tcx>,
         subpatterns: Vec<FieldPat<'tcx>>,
@@ -69,7 +67,6 @@ pub(crate) enum PatKind<'tcx> {
 impl<'tcx> fmt::Display for Pat<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
-            PatKind::Wild => write!(f, "_"),
             PatKind::Never => write!(f, "!"),
             PatKind::Box { ref subpattern } => write!(f, "box {subpattern}"),
             PatKind::StructLike { ref enum_info, ref subpatterns } => {

--- a/compiler/rustc_pattern_analysis/src/rustc/print.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc/print.rs
@@ -12,7 +12,6 @@
 use std::fmt;
 
 use rustc_middle::bug;
-use rustc_middle::thir::PatRange;
 use rustc_middle::ty::{self, AdtDef, Ty, TyCtxt};
 use rustc_span::sym;
 use rustc_target::abi::{FieldIdx, VariantIdx};
@@ -33,8 +32,6 @@ pub(crate) struct Pat<'tcx> {
 
 #[derive(Clone, Debug)]
 pub(crate) enum PatKind<'tcx> {
-    Range(Box<PatRange<'tcx>>),
-
     Slice {
         prefix: Box<[Box<Pat<'tcx>>]>,
         /// True if this slice-like pattern should include a `..` between the
@@ -52,7 +49,6 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
             PatKind::Never => write!(f, "!"),
-            PatKind::Range(ref range) => write!(f, "{range}"),
             PatKind::Slice { ref prefix, has_dot_dot, ref suffix } => {
                 write_slice_like(f, prefix, has_dot_dot, suffix)
             }

--- a/compiler/rustc_pattern_analysis/src/rustc/print.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc/print.rs
@@ -32,15 +32,12 @@ pub(crate) struct Pat<'tcx> {
 
 #[derive(Clone, Debug)]
 pub(crate) enum PatKind {
-    Never,
-
     Print(String),
 }
 
 impl<'tcx> fmt::Display for Pat<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
-            PatKind::Never => write!(f, "!"),
             PatKind::Print(ref string) => write!(f, "{string}"),
         }
     }

--- a/compiler/rustc_pattern_analysis/src/rustc/print.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc/print.rs
@@ -32,10 +32,6 @@ pub(crate) struct Pat<'tcx> {
 
 #[derive(Clone, Debug)]
 pub(crate) enum PatKind<'tcx> {
-    Box {
-        subpattern: Box<Pat<'tcx>>,
-    },
-
     Deref {
         subpattern: Box<Pat<'tcx>>,
     },
@@ -63,7 +59,6 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.kind {
             PatKind::Never => write!(f, "!"),
-            PatKind::Box { ref subpattern } => write!(f, "box {subpattern}"),
             PatKind::Deref { ref subpattern } => write_ref_like(f, self.ty, subpattern),
             PatKind::Constant { value } => write!(f, "{value}"),
             PatKind::Range(ref range) => write!(f, "{range}"),

--- a/compiler/rustc_pattern_analysis/src/rustc/print.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc/print.rs
@@ -21,6 +21,7 @@ use rustc_target::abi::{FieldIdx, VariantIdx};
 pub(crate) struct FieldPat<'tcx> {
     pub(crate) field: FieldIdx,
     pub(crate) pattern: Box<Pat<'tcx>>,
+    pub(crate) is_wildcard: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -139,12 +140,12 @@ fn write_struct_like<'tcx>(
             write!(f, " {{ ")?;
 
             let mut printed = 0;
-            for p in subpatterns {
-                if let PatKind::Wild = p.pattern.kind {
+            for &FieldPat { field, ref pattern, is_wildcard } in subpatterns {
+                if is_wildcard {
                     continue;
                 }
-                let name = variant.fields[p.field].name;
-                write!(f, "{}{}: {}", start_or_comma(), name, p.pattern)?;
+                let field_name = variant.fields[field].name;
+                write!(f, "{}{field_name}: {pattern}", start_or_comma())?;
                 printed += 1;
             }
 

--- a/compiler/rustc_pattern_analysis/src/rustc/print.rs
+++ b/compiler/rustc_pattern_analysis/src/rustc/print.rs
@@ -62,6 +62,8 @@ pub(crate) enum PatKind<'tcx> {
     },
 
     Never,
+
+    Print(String),
 }
 
 impl<'tcx> fmt::Display for Pat<'tcx> {
@@ -79,6 +81,7 @@ impl<'tcx> fmt::Display for Pat<'tcx> {
             PatKind::Slice { ref prefix, has_dot_dot, ref suffix } => {
                 write_slice_like(f, prefix, has_dot_dot, suffix)
             }
+            PatKind::Print(ref string) => write!(f, "{string}"),
         }
     }
 }


### PR DESCRIPTION
After the preliminary work done in #128536, we can now get rid of `print::Pat` entirely.

- First, we introduce a variant `PatKind::Print(String)`.
- Then we incrementally remove each other variant of `PatKind`, by having the relevant code produce `PatKind::Print` instead.
- Once `PatKind::Print` is the only remaining variant, it becomes easy to remove `print::Pat` and replace it with `String`.

There is more cleanup that I have in mind, but this seemed like a natural stopping point for one PR.

r? @Nadrieril 