### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "std_detect",
  "unwind",
  "wasi",
+ "windows-targets 0.0.0",
 ]
 
 [[package]]
@@ -421,8 +422,12 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.5",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.0.0"
 
 [[package]]
 name = "windows-targets"

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 exclude = [
   # stdarch has its own Cargo workspace
   "stdarch",
+  "windows_targets"
 ]
 
 [profile.release.package.compiler_builtins]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -57,6 +57,9 @@ object = { version = "0.36.0", default-features = false, optional = true, featur
     'archive',
 ] }
 
+[target.'cfg(windows)'.dependencies.windows-targets]
+path = "../windows_targets"
+
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }
 rand_xorshift = "0.3.0"
@@ -116,7 +119,7 @@ std_detect_env_override = ["std_detect/std_detect_env_override"]
 
 # Enable using raw-dylib for Windows imports.
 # This will eventually be the default.
-windows_raw_dylib = []
+windows_raw_dylib = ["windows-targets/windows_raw_dylib"]
 
 [package.metadata.fortanix-sgx]
 # Maximum possible number of threads when testing

--- a/library/std/src/sys/pal/windows/alloc.rs
+++ b/library/std/src/sys/pal/windows/alloc.rs
@@ -4,7 +4,7 @@ use crate::alloc::{GlobalAlloc, Layout, System};
 use crate::ffi::c_void;
 use crate::ptr;
 use crate::sync::atomic::{AtomicPtr, Ordering};
-use crate::sys::c::{self, windows_targets};
+use crate::sys::c;
 use crate::sys::common::alloc::{realloc_fallback, MIN_ALIGN};
 
 #[cfg(test)]

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -8,8 +8,6 @@
 use core::ffi::{c_uint, c_ulong, c_ushort, c_void, CStr};
 use core::{mem, ptr};
 
-pub(super) mod windows_targets;
-
 mod windows_sys;
 pub use windows_sys::*;
 

--- a/library/std/src/sys/pal/windows/c/windows_sys.rs
+++ b/library/std/src/sys/pal/windows/c/windows_sys.rs
@@ -3317,4 +3317,3 @@ pub struct WSADATA {
 #[cfg(target_arch = "arm")]
 pub enum CONTEXT {}
 // ignore-tidy-filelength
-use super::windows_targets;

--- a/library/windows_targets/Cargo.toml
+++ b/library/windows_targets/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "windows-targets"
+description = "A drop-in replacement for the real windows-targets crate for use in std only."
+version = "0.0.0"
+edition = "2021"
+
+[features]
+# Enable using raw-dylib for Windows imports.
+# This will eventually be the default.
+windows_raw_dylib = []

--- a/library/windows_targets/src/lib.rs
+++ b/library/windows_targets/src/lib.rs
@@ -2,6 +2,10 @@
 //!
 //! This is a simple wrapper around an `extern` block with a `#[link]` attribute.
 //! It's very roughly equivalent to the windows-targets crate.
+#![no_std]
+#![no_core]
+#![feature(decl_macro)]
+#![feature(no_core)]
 
 #[cfg(feature = "windows_raw_dylib")]
 pub macro link {

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -3027,11 +3027,17 @@ impl<'test> TestCx<'test> {
         const PREFIX: &str = "MONO_ITEM ";
         const CGU_MARKER: &str = "@@";
 
+        // Some MonoItems can contain {closure@/path/to/checkout/tests/codgen-units/test.rs}
+        // To prevent the current dir from leaking, we just replace the entire path to the test
+        // file with TEST_PATH.
         let actual: Vec<MonoItem> = proc_res
             .stdout
             .lines()
             .filter(|line| line.starts_with(PREFIX))
-            .map(|line| str_to_mono_item(line, true))
+            .map(|line| {
+                line.replace(&self.testpaths.file.display().to_string(), "TEST_PATH").to_string()
+            })
+            .map(|line| str_to_mono_item(&line, true))
             .collect();
 
         let expected: Vec<MonoItem> = errors::load_errors(&self.testpaths.file, None)

--- a/src/tools/generate-windows-sys/src/main.rs
+++ b/src/tools/generate-windows-sys/src/main.rs
@@ -35,7 +35,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut f = std::fs::File::options().append(true).open("windows_sys.rs")?;
     f.write_all(ARM32_SHIM.as_bytes())?;
     writeln!(&mut f, "// ignore-tidy-filelength")?;
-    writeln!(&mut f, "use super::windows_targets;")?;
 
     Ok(())
 }

--- a/src/tools/tidy/src/pal.rs
+++ b/src/tools/tidy/src/pal.rs
@@ -36,6 +36,7 @@ use crate::walk::{filter_dirs, walk};
 
 // Paths that may contain platform-specific code.
 const EXCEPTION_PATHS: &[&str] = &[
+    "library/windows_targets",
     "library/panic_abort",
     "library/panic_unwind",
     "library/unwind",

--- a/tests/assembly/powerpc64-struct-abi.rs
+++ b/tests/assembly/powerpc64-struct-abi.rs
@@ -1,0 +1,131 @@
+//@ revisions: elfv1-be elfv2-be elfv2-le
+//@ assembly-output: emit-asm
+//@[elfv1-be] compile-flags: --target powerpc64-unknown-linux-gnu
+//@[elfv1-be] needs-llvm-components: powerpc
+//@[elfv2-be] compile-flags: --target powerpc64-unknown-linux-musl
+//@[elfv2-be] needs-llvm-components: powerpc
+//@[elfv2-le] compile-flags: --target powerpc64le-unknown-linux-gnu
+//@[elfv2-le] needs-llvm-components: powerpc
+//@[elfv1-be] filecheck-flags: --check-prefix be
+//@[elfv2-be] filecheck-flags: --check-prefix be
+
+#![feature(no_core, lang_items)]
+#![no_std]
+#![no_core]
+#![crate_type = "lib"]
+
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "copy"]
+trait Copy {}
+
+#[lang = "freeze"]
+trait Freeze {}
+
+#[lang = "unpin"]
+trait Unpin {}
+
+impl Copy for u8 {}
+impl Copy for u16 {}
+impl Copy for u32 {}
+impl Copy for FiveU32s {}
+impl Copy for FiveU16s {}
+impl Copy for ThreeU8s {}
+
+#[repr(C)]
+struct FiveU32s(u32, u32, u32, u32, u32);
+
+#[repr(C)]
+struct FiveU16s(u16, u16, u16, u16, u16);
+
+#[repr(C)]
+struct ThreeU8s(u8, u8, u8);
+
+// CHECK-LABEL: read_large
+// be: lwz [[REG1:.*]], 16(4)
+// be-NEXT: stw [[REG1]], 16(3)
+// be-NEXT: ld [[REG2:.*]], 8(4)
+// be-NEXT: ld [[REG3:.*]], 0(4)
+// be-NEXT: std [[REG2]], 8(3)
+// be-NEXT: std [[REG3]], 0(3)
+// elfv2-le: lxvd2x [[REG1:.*]], 0, 4
+// elfv2-le-NEXT: lwz [[REG2:.*]], 16(4)
+// elfv2-le-NEXT: stw [[REG2]], 16(3)
+// elfv2-le-NEXT: stxvd2x [[REG1]], 0, 3
+// CHECK-NEXT: blr
+#[no_mangle]
+extern "C" fn read_large(x: &FiveU32s) -> FiveU32s {
+    *x
+}
+
+// CHECK-LABEL: read_medium
+// elfv1-be: lhz [[REG1:.*]], 8(4)
+// elfv1-be-NEXT: ld [[REG2:.*]], 0(4)
+// elfv1-be-NEXT: sth [[REG1]], 8(3)
+// elfv1-be-NEXT: std [[REG2]], 0(3)
+// elfv2-be: lhz [[REG1:.*]], 8(3)
+// elfv2-be-NEXT: ld 3, 0(3)
+// elfv2-be-NEXT: sldi 4, [[REG1]], 48
+// elfv2-le: ld [[REG1:.*]], 0(3)
+// elfv2-le-NEXT: lhz 4, 8(3)
+// elfv2-le-NEXT: mr 3, [[REG1]]
+// CHECK-NEXT: blr
+#[no_mangle]
+extern "C" fn read_medium(x: &FiveU16s) -> FiveU16s {
+    *x
+}
+
+// CHECK-LABEL: read_small
+// elfv1-be: lbz [[REG1:.*]], 2(4)
+// elfv1-be-NEXT: lhz [[REG2:.*]], 0(4)
+// elfv1-be-NEXT: stb [[REG1]], 2(3)
+// elfv1-be-NEXT: sth [[REG2]], 0(3)
+// elfv2-be: lhz [[REG1:.*]], 0(3)
+// elfv2-be-NEXT: lbz 3, 2(3)
+// elfv2-be-NEXT: rldimi 3, [[REG1]], 8, 0
+// elfv2-le: lbz [[REG1:.*]], 2(3)
+// elfv2-le-NEXT: lhz 3, 0(3)
+// elfv2-le-NEXT: rldimi 3, [[REG1]], 16, 0
+// CHECK-NEXT: blr
+#[no_mangle]
+extern "C" fn read_small(x: &ThreeU8s) -> ThreeU8s {
+    *x
+}
+
+// CHECK-LABEL: write_large
+// CHECK: std 3, 0(6)
+// be-NEXT: rldicl [[REG1:.*]], 5, 32, 32
+// CHECK-NEXT: std 4, 8(6)
+// be-NEXT: stw [[REG1]], 16(6)
+// elfv2-le-NEXT: stw 5, 16(6)
+// CHECK-NEXT: blr
+#[no_mangle]
+extern "C" fn write_large(x: FiveU32s, dest: &mut FiveU32s) {
+    *dest = x;
+}
+
+// CHECK-LABEL: write_medium
+// CHECK: std 3, 0(5)
+// be-NEXT: rldicl [[REG1:.*]], 4, 16, 48
+// be-NEXT: sth [[REG1]], 8(5)
+// elfv2-le-NEXT: sth 4, 8(5)
+// CHECK-NEXT: blr
+#[no_mangle]
+extern "C" fn write_medium(x: FiveU16s, dest: &mut FiveU16s) {
+    *dest = x;
+}
+
+// CHECK-LABEL: write_small
+// be: stb 3, 2(4)
+// be-NEXT: srwi [[REG1:.*]], 3, 8
+// be-NEXT: sth [[REG1]], 0(4)
+// The order these instructions are emitted in changed in LLVM 18.
+// elfv2-le-DAG: sth 3, 0(4)
+// elfv2-le-DAG: srwi [[REG1:.*]], 3, 16
+// elfv2-le-NEXT: stb [[REG1]], 2(4)
+// CHECK-NEXT: blr
+#[no_mangle]
+extern "C" fn write_small(x: ThreeU8s, dest: &mut ThreeU8s) {
+    *dest = x;
+}

--- a/tests/codegen-units/item-collection/auxiliary/cgu_extern_closures.rs
+++ b/tests/codegen-units/item-collection/auxiliary/cgu_extern_closures.rs
@@ -1,3 +1,5 @@
+//@ compile-flags: -Zinline-mir=no
+
 #![crate_type = "lib"]
 
 #[inline]

--- a/tests/codegen-units/item-collection/cross-crate-closures.rs
+++ b/tests/codegen-units/item-collection/cross-crate-closures.rs
@@ -1,9 +1,6 @@
-// In the current version of the collector that still has to support
-// legacy-codegen, closures do not generate their own MonoItems, so we are
-// ignoring this test until MIR codegen has taken over completely
-//@ ignore-test
-
-//@ compile-flags:-Zprint-mono-items=eager
+// We need to disable MIR inlining in both this and its aux-build crate. The MIR inliner
+// will just inline everything into our start function if we let it. As it should.
+//@ compile-flags:-Zprint-mono-items=eager -Zinline-mir=no
 
 #![deny(dead_code)]
 #![feature(start)]
@@ -11,15 +8,15 @@
 //@ aux-build:cgu_extern_closures.rs
 extern crate cgu_extern_closures;
 
-//~ MONO_ITEM fn cross_crate_closures::start[0]
+//~ MONO_ITEM fn start @@ cross_crate_closures-cgu.0[Internal]
 #[start]
 fn start(_: isize, _: *const *const u8) -> isize {
-    //~ MONO_ITEM fn cgu_extern_closures::inlined_fn[0]
-    //~ MONO_ITEM fn cgu_extern_closures::inlined_fn[0]::{{closure}}[0]
+    //~ MONO_ITEM fn cgu_extern_closures::inlined_fn @@ cross_crate_closures-cgu.0[Internal]
+    //~ MONO_ITEM fn cgu_extern_closures::inlined_fn::{closure#0} @@ cross_crate_closures-cgu.0[Internal]
     let _ = cgu_extern_closures::inlined_fn(1, 2);
 
-    //~ MONO_ITEM fn cgu_extern_closures::inlined_fn_generic[0]<i32>
-    //~ MONO_ITEM fn cgu_extern_closures::inlined_fn_generic[0]::{{closure}}[0]<i32>
+    //~ MONO_ITEM fn cgu_extern_closures::inlined_fn_generic::<i32> @@ cross_crate_closures-cgu.0[Internal]
+    //~ MONO_ITEM fn cgu_extern_closures::inlined_fn_generic::<i32>::{closure#0} @@ cross_crate_closures-cgu.0[Internal]
     let _ = cgu_extern_closures::inlined_fn_generic(3, 4, 5i32);
 
     // Nothing should be generated for this call, we just link to the instance
@@ -28,5 +25,3 @@ fn start(_: isize, _: *const *const u8) -> isize {
 
     0
 }
-
-//~ MONO_ITEM drop-glue i8

--- a/tests/codegen-units/item-collection/non-generic-closures.rs
+++ b/tests/codegen-units/item-collection/non-generic-closures.rs
@@ -1,49 +1,45 @@
-// In the current version of the collector that still has to support
-// legacy-codegen, closures do not generate their own MonoItems, so we are
-// ignoring this test until MIR codegen has taken over completely
-//@ ignore-test
-
-//
-//@ compile-flags:-Zprint-mono-items=eager
+//@ compile-flags:-Zprint-mono-items=eager -Zinline-mir=no
 
 #![deny(dead_code)]
 #![feature(start)]
 
-//~ MONO_ITEM fn non_generic_closures::temporary[0]
+//~ MONO_ITEM fn temporary @@ non_generic_closures-cgu.0[Internal]
 fn temporary() {
-    //~ MONO_ITEM fn non_generic_closures::temporary[0]::{{closure}}[0]
+    //~ MONO_ITEM fn temporary::{closure#0} @@ non_generic_closures-cgu.0[Internal]
     (|a: u32| {
         let _ = a;
     })(4);
 }
 
-//~ MONO_ITEM fn non_generic_closures::assigned_to_variable_but_not_executed[0]
+//~ MONO_ITEM fn assigned_to_variable_but_not_executed @@ non_generic_closures-cgu.0[Internal]
 fn assigned_to_variable_but_not_executed() {
-    //~ MONO_ITEM fn non_generic_closures::assigned_to_variable_but_not_executed[0]::{{closure}}[0]
     let _x = |a: i16| {
         let _ = a + 1;
     };
 }
 
-//~ MONO_ITEM fn non_generic_closures::assigned_to_variable_executed_directly[0]
+//~ MONO_ITEM fn assigned_to_variable_executed_indirectly @@ non_generic_closures-cgu.0[Internal]
 fn assigned_to_variable_executed_indirectly() {
-    //~ MONO_ITEM fn non_generic_closures::assigned_to_variable_executed_directly[0]::{{closure}}[0]
+    //~ MONO_ITEM fn assigned_to_variable_executed_indirectly::{closure#0} @@ non_generic_closures-cgu.0[Internal]
+    //~ MONO_ITEM fn <{closure@TEST_PATH:27:13: 27:21} as std::ops::FnOnce<(i32,)>>::call_once - shim @@ non_generic_closures-cgu.0[Internal]
+    //~ MONO_ITEM fn <{closure@TEST_PATH:27:13: 27:21} as std::ops::FnOnce<(i32,)>>::call_once - shim(vtable) @@ non_generic_closures-cgu.0[Internal]
+    //~ MONO_ITEM fn std::ptr::drop_in_place::<{closure@TEST_PATH:27:13: 27:21}> - shim(None) @@ non_generic_closures-cgu.0[Internal]
     let f = |a: i32| {
         let _ = a + 2;
     };
     run_closure(&f);
 }
 
-//~ MONO_ITEM fn non_generic_closures::assigned_to_variable_executed_indirectly[0]
+//~ MONO_ITEM fn assigned_to_variable_executed_directly @@ non_generic_closures-cgu.0[Internal]
 fn assigned_to_variable_executed_directly() {
-    //~ MONO_ITEM fn non_generic_closures::assigned_to_variable_executed_indirectly[0]::{{closure}}[0]
+    //~ MONO_ITEM fn assigned_to_variable_executed_directly::{closure#0} @@ non_generic_closures-cgu.0[Internal]
     let f = |a: i64| {
         let _ = a + 3;
     };
     f(4);
 }
 
-//~ MONO_ITEM fn non_generic_closures::start[0]
+//~ MONO_ITEM fn start @@ non_generic_closures-cgu.0[Internal]
 #[start]
 fn start(_: isize, _: *const *const u8) -> isize {
     temporary();
@@ -54,7 +50,7 @@ fn start(_: isize, _: *const *const u8) -> isize {
     0
 }
 
-//~ MONO_ITEM fn non_generic_closures::run_closure[0]
+//~ MONO_ITEM fn run_closure @@ non_generic_closures-cgu.0[Internal]
 fn run_closure(f: &Fn(i32)) {
     f(3);
 }

--- a/tests/codegen-units/partitioning/methods-are-with-self-type.rs
+++ b/tests/codegen-units/partitioning/methods-are-with-self-type.rs
@@ -1,30 +1,23 @@
-// Currently, all generic functions are instantiated in each codegen unit that
-// uses them, even those not marked with #[inline], so this test does not make
-// much sense at the moment.
-//@ ignore-test
-
 // We specify incremental here because we want to test the partitioning for incremental compilation
 //@ incremental
 //@ compile-flags:-Zprint-mono-items=lazy
 
-#![allow(dead_code)]
-#![feature(start)]
+#![crate_type = "lib"]
 
-struct SomeType;
+pub struct SomeType;
 
 struct SomeGenericType<T1, T2>(T1, T2);
 
-mod mod1 {
+pub mod mod1 {
     use super::{SomeGenericType, SomeType};
 
     // Even though the impl is in `mod1`, the methods should end up in the
     // parent module, since that is where their self-type is.
     impl SomeType {
-        //~ MONO_ITEM fn methods_are_with_self_type::mod1[0]::{{impl}}[0]::method[0] @@ methods_are_with_self_type[External]
-        fn method(&self) {}
-
-        //~ MONO_ITEM fn methods_are_with_self_type::mod1[0]::{{impl}}[0]::associated_fn[0] @@ methods_are_with_self_type[External]
-        fn associated_fn() {}
+        //~ MONO_ITEM fn mod1::<impl SomeType>::method @@ methods_are_with_self_type[External]
+        pub fn method(&self) {}
+        //~ MONO_ITEM fn mod1::<impl SomeType>::associated_fn @@ methods_are_with_self_type[External]
+        pub fn associated_fn() {}
     }
 
     impl<T1, T2> SomeGenericType<T1, T2> {
@@ -52,25 +45,20 @@ mod type2 {
     pub struct Struct;
 }
 
-//~ MONO_ITEM fn methods_are_with_self_type::start[0]
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-    //~ MONO_ITEM fn methods_are_with_self_type::mod1[0]::{{impl}}[1]::method[0]<u32, u64> @@ methods_are_with_self_type.volatile[WeakODR]
+//~ MONO_ITEM fn start @@ methods_are_with_self_type[External]
+pub fn start() {
+    //~ MONO_ITEM fn mod1::<impl SomeGenericType<u32, u64>>::method @@ methods_are_with_self_type.volatile[External]
     SomeGenericType(0u32, 0u64).method();
-    //~ MONO_ITEM fn methods_are_with_self_type::mod1[0]::{{impl}}[1]::associated_fn[0]<char, &str> @@ methods_are_with_self_type.volatile[WeakODR]
+    //~ MONO_ITEM fn mod1::<impl SomeGenericType<char, &str>>::associated_fn @@ methods_are_with_self_type.volatile[External]
     SomeGenericType::associated_fn('c', "&str");
 
-    //~ MONO_ITEM fn methods_are_with_self_type::{{impl}}[0]::foo[0]<methods_are_with_self_type::type1[0]::Struct[0]> @@ methods_are_with_self_type-type1.volatile[WeakODR]
+    //~ MONO_ITEM fn <type1::Struct as Trait>::foo @@ methods_are_with_self_type-type1.volatile[External]
     type1::Struct.foo();
-    //~ MONO_ITEM fn methods_are_with_self_type::{{impl}}[0]::foo[0]<methods_are_with_self_type::type2[0]::Struct[0]> @@ methods_are_with_self_type-type2.volatile[WeakODR]
+    //~ MONO_ITEM fn <type2::Struct as Trait>::foo @@ methods_are_with_self_type-type2.volatile[External]
     type2::Struct.foo();
 
-    //~ MONO_ITEM fn methods_are_with_self_type::Trait[0]::default[0]<methods_are_with_self_type::type1[0]::Struct[0]> @@ methods_are_with_self_type-type1.volatile[WeakODR]
+    //~ MONO_ITEM fn <type1::Struct as Trait>::default @@ methods_are_with_self_type-type1.volatile[External]
     type1::Struct.default();
-    //~ MONO_ITEM fn methods_are_with_self_type::Trait[0]::default[0]<methods_are_with_self_type::type2[0]::Struct[0]> @@ methods_are_with_self_type-type2.volatile[WeakODR]
+    //~ MONO_ITEM fn <type2::Struct as Trait>::default @@ methods_are_with_self_type-type2.volatile[External]
     type2::Struct.default();
-
-    0
 }
-
-//~ MONO_ITEM drop-glue i8

--- a/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
+++ b/tests/run-make/CURRENT_RUSTC_VERSION/rmake.rs
@@ -3,8 +3,6 @@
 // Check that the `CURRENT_RUSTC_VERSION` placeholder is correctly replaced by the current
 // `rustc` version and the `since` property in feature stability gating is properly respected.
 
-use std::path::PathBuf;
-
 use run_make_support::{aux_build, rfs, rustc, source_root};
 
 fn main() {

--- a/tests/run-make/arguments-non-c-like-enum/rmake.rs
+++ b/tests/run-make/arguments-non-c-like-enum/rmake.rs
@@ -4,8 +4,6 @@
 use run_make_support::{cc, extra_c_flags, extra_cxx_flags, run, rustc, static_lib_name};
 
 pub fn main() {
-    use std::path::Path;
-
     rustc().input("nonclike.rs").crate_type("staticlib").run();
     cc().input("test.c")
         .input(static_lib_name("nonclike"))

--- a/tests/run-make/c-link-to-rust-staticlib/rmake.rs
+++ b/tests/run-make/c-link-to-rust-staticlib/rmake.rs
@@ -3,8 +3,6 @@
 
 //@ ignore-cross-compile
 
-use std::fs;
-
 use run_make_support::rfs::remove_file;
 use run_make_support::{cc, extra_c_flags, run, rustc, static_lib_name};
 

--- a/tests/run-make/comment-section/rmake.rs
+++ b/tests/run-make/comment-section/rmake.rs
@@ -7,9 +7,7 @@
 // FIXME(jieyouxu): check cross-compile setup
 //@ ignore-cross-compile
 
-use std::path::PathBuf;
-
-use run_make_support::{cwd, env_var, llvm_readobj, rfs, run_in_tmpdir, rustc};
+use run_make_support::{cwd, env_var, llvm_readobj, rfs, rustc};
 
 fn main() {
     let target = env_var("TARGET");

--- a/tests/run-make/compressed-debuginfo/rmake.rs
+++ b/tests/run-make/compressed-debuginfo/rmake.rs
@@ -5,7 +5,7 @@
 
 // FIXME: This test isn't comprehensive and isn't covering all possible combinations.
 
-use run_make_support::{assert_contains, cmd, llvm_readobj, run_in_tmpdir, rustc};
+use run_make_support::{assert_contains, llvm_readobj, run_in_tmpdir, rustc};
 
 fn check_compression(compression: &str, to_find: &str) {
     run_in_tmpdir(|| {

--- a/tests/run-make/const_fn_mir/rmake.rs
+++ b/tests/run-make/const_fn_mir/rmake.rs
@@ -2,7 +2,7 @@
 
 //@ needs-unwind
 
-use run_make_support::{cwd, diff, rustc};
+use run_make_support::{diff, rustc};
 
 fn main() {
     rustc().input("main.rs").emit("mir").output("dump-actual.mir").run();

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -8,7 +8,7 @@ fn main() {
     rustc().input("multiple-dep-versions-1.rs").run();
     rustc().input("multiple-dep-versions-2.rs").extra_filename("2").metadata("2").run();
 
-    let out = rustc()
+    rustc()
         .input("multiple-dep-versions.rs")
         .extern_("dependency", rust_lib_name("dependency"))
         .extern_("dep_2_reexport", rust_lib_name("dependency2"))

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -2,8 +2,7 @@
 //@ ignore-wasm32
 //@ ignore-wasm64
 
-use run_make_support::rfs::copy;
-use run_make_support::{assert_contains, rust_lib_name, rustc};
+use run_make_support::{rust_lib_name, rustc};
 
 fn main() {
     rustc().input("multiple-dep-versions-1.rs").run();

--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -1,137 +1,196 @@
-// This test checks if internal compilation error (ICE) log files work as expected.
-// - Get the number of lines from the log files without any configuration options,
-// then check that the line count doesn't change if the backtrace gets configured to be short
-// or full.
-// - Check that disabling ICE logging results in zero files created.
-// - Check that the ICE files contain some of the expected strings.
-// - exercise the -Zmetrics-dir nightly flag
-// - verify what happens when both the nightly flag and env variable are set
-// - test the RUST_BACKTRACE=0 behavior against the file creation
+//! This test checks if Internal Compilation Error (ICE) dump files `rustc-ice*.txt` work as
+//! expected.
+//!
+//! - Basic sanity checks on a default ICE dump.
+//! - Get the number of lines from the dump files without any `RUST_BACKTRACE` options, then check
+//!   ICE dump file (line count) is not affected by `RUSTC_BACKTRACE` settings.
+//! - Check that disabling ICE dumping results in zero dump files created.
+//! - Check that the ICE dump contain some of the expected strings.
+//! - Check that `RUST_BACKTRACE=0` prevents ICE dump from created.
+//! - Exercise the `-Zmetrics-dir` nightly flag (#128914):
+//!     - When `-Zmetrics=dir=PATH` is present but `RUSTC_ICE` is not set, check that the ICE dump
+//!       is placed under `PATH`.
+//!     - When `RUSTC_ICE=RUSTC_ICE_PATH` and `-Zmetrics-dir=METRICS_PATH` are both provided, check
+//!       that `RUSTC_ICE_PATH` takes precedence and no ICE dump is emitted under `METRICS_PATH`.
+//!
+//! See <https://github.com/rust-lang/rust/pull/108714>.
 
-// See https://github.com/rust-lang/rust/pull/108714
+// FIXME(#128911): @jieyouxu: This test is sometimes for whatever forsaken reason flakey in CI, and
+// I cannot reproduce it locally. The error messages upon assertion failure in this test is
+// intentionally extremely verbose to aid debugging that issue.
 
-use run_make_support::{cwd, has_extension, has_prefix, rfs, rustc, shallow_find_files};
+use std::cell::OnceCell;
+use std::path::{Path, PathBuf};
 
-fn main() {
-    rustc().env("RUSTC_ICE", cwd()).input("lib.rs").arg("-Ztreat-err-as-bug=1").run_fail();
-    let default = get_text_from_ice(".").lines().count();
+use run_make_support::{
+    cwd, filename_contains, has_extension, has_prefix, rfs, run_in_tmpdir, rustc,
+    shallow_find_files,
+};
 
-    clear_ice_files();
-    rustc().env("RUSTC_ICE", cwd()).input("lib.rs").arg("-Ztreat-err-as-bug=1").run_fail();
-    let ice_text = get_text_from_ice(cwd());
-    let default_set = ice_text.lines().count();
-    let content = ice_text;
-    let ice_files = shallow_find_files(cwd(), |path| {
-        has_prefix(path, "rustc-ice") && has_extension(path, "txt")
-    });
-    assert_eq!(ice_files.len(), 1); // There should only be 1 ICE file.
-    let ice_file_name =
-        ice_files.first().and_then(|f| f.file_name()).and_then(|n| n.to_str()).unwrap();
-    // Ensure that the ICE dump path doesn't contain `:`, because they cause problems on Windows.
-    assert!(!ice_file_name.contains(":"), "{ice_file_name}");
-    assert_eq!(default, default_set);
-    assert!(default > 0);
-    // Some of the expected strings in an ICE file should appear.
-    assert!(content.contains("thread 'rustc' panicked at"));
-    assert!(content.contains("stack backtrace:"));
-
-    test_backtrace_short(default);
-    test_backtrace_full(default);
-    test_backtrace_disabled(default);
-
-    clear_ice_files();
-    // The ICE dump is explicitly disabled. Therefore, this should produce no files.
-    rustc().env("RUSTC_ICE", "0").input("lib.rs").arg("-Ztreat-err-as-bug=1").run_fail();
-    let ice_files = shallow_find_files(cwd(), |path| {
-        has_prefix(path, "rustc-ice") && has_extension(path, "txt")
-    });
-    assert!(ice_files.is_empty()); // There should be 0 ICE files.
-
-    metrics_dir(default);
+#[derive(Debug)]
+struct IceDump {
+    name: &'static str,
+    path: PathBuf,
+    message: String,
 }
 
-fn test_backtrace_short(baseline: usize) {
-    clear_ice_files();
-    rustc()
-        .env("RUSTC_ICE", cwd())
-        .input("lib.rs")
-        .env("RUST_BACKTRACE", "short")
-        .arg("-Ztreat-err-as-bug=1")
-        .run_fail();
-    let short = get_text_from_ice(cwd()).lines().count();
-    // backtrace length in dump shouldn't be changed by RUST_BACKTRACE
-    assert_eq!(short, baseline);
-}
-
-fn test_backtrace_full(baseline: usize) {
-    clear_ice_files();
-    rustc()
-        .env("RUSTC_ICE", cwd())
-        .input("lib.rs")
-        .env("RUST_BACKTRACE", "full")
-        .arg("-Ztreat-err-as-bug=1")
-        .run_fail();
-    let full = get_text_from_ice(cwd()).lines().count();
-    // backtrace length in dump shouldn't be changed by RUST_BACKTRACE
-    assert_eq!(full, baseline);
-}
-
-fn test_backtrace_disabled(baseline: usize) {
-    clear_ice_files();
-    rustc()
-        .env("RUSTC_ICE", cwd())
-        .input("lib.rs")
-        .env("RUST_BACKTRACE", "0")
-        .arg("-Ztreat-err-as-bug=1")
-        .run_fail();
-    let disabled = get_text_from_ice(cwd()).lines().count();
-    // backtrace length in dump shouldn't be changed by RUST_BACKTRACE
-    assert_eq!(disabled, baseline);
-}
-
-fn metrics_dir(baseline: usize) {
-    test_flag_only(baseline);
-    test_flag_and_env(baseline);
-}
-
-fn test_flag_only(baseline: usize) {
-    clear_ice_files();
-    let metrics_arg = format!("-Zmetrics-dir={}", cwd().display());
-    rustc().input("lib.rs").arg("-Ztreat-err-as-bug=1").arg(metrics_arg).run_fail();
-    let output = get_text_from_ice(cwd()).lines().count();
-    assert_eq!(output, baseline);
-}
-
-fn test_flag_and_env(baseline: usize) {
-    clear_ice_files();
-    let metrics_arg = format!("-Zmetrics-dir={}", cwd().display());
-    let real_dir = cwd().join("actually_put_ice_here");
-    rfs::create_dir(real_dir.clone());
-    rustc()
-        .input("lib.rs")
-        .env("RUSTC_ICE", real_dir.clone())
-        .arg("-Ztreat-err-as-bug=1")
-        .arg(metrics_arg)
-        .run_fail();
-    let output = get_text_from_ice(real_dir).lines().count();
-    assert_eq!(output, baseline);
-}
-
-fn clear_ice_files() {
-    let ice_files = shallow_find_files(cwd(), |path| {
-        has_prefix(path, "rustc-ice") && has_extension(path, "txt")
-    });
-    for file in ice_files {
-        rfs::remove_file(file);
+impl IceDump {
+    fn lines_count(&self) -> usize {
+        self.message.lines().count()
     }
 }
 
 #[track_caller]
-fn get_text_from_ice(dir: impl AsRef<std::path::Path>) -> String {
-    let ice_files =
-        shallow_find_files(dir, |path| has_prefix(path, "rustc-ice") && has_extension(path, "txt"));
+fn assert_ice_len_equals(left: &IceDump, right: &IceDump) {
+    let left_len = left.lines_count();
+    let right_len = right.lines_count();
+
+    if left_len != right_len {
+        eprintln!("=== {} ICE MESSAGE ({} lines) ====", left.name, left_len);
+        eprintln!("{}", left.message);
+
+        eprintln!("=== {} ICE MESSAGE ({} lines) ====", right.name, right_len);
+        eprintln!("{}", right.message);
+
+        eprintln!("====================================");
+        panic!(
+            "ICE message length mismatch: {} has {} lines but {} has {} lines",
+            left.name, left_len, right.name, right_len
+        );
+    }
+}
+
+fn find_ice_dumps_in_dir<P: AsRef<Path>>(dir: P) -> Vec<PathBuf> {
+    shallow_find_files(dir, |path| has_prefix(path, "rustc-ice") && has_extension(path, "txt"))
+}
+
+// Assert only one `rustc-ice*.txt` ICE file exists, and extract the ICE message from the ICE file.
+#[track_caller]
+fn extract_exactly_one_ice_file<P: AsRef<Path>>(name: &'static str, dir: P) -> IceDump {
+    let ice_files = find_ice_dumps_in_dir(dir);
     assert_eq!(ice_files.len(), 1); // There should only be 1 ICE file.
-    let ice_file = ice_files.get(0).unwrap();
-    let output = rfs::read_to_string(ice_file);
-    output
+    let path = ice_files.get(0).unwrap();
+    let message = rfs::read_to_string(path);
+    IceDump { name, path: path.to_path_buf(), message }
+}
+
+fn main() {
+    // Establish baseline ICE message.
+    let mut default_ice_dump = OnceCell::new();
+    run_in_tmpdir(|| {
+        rustc().env("RUSTC_ICE", cwd()).input("lib.rs").arg("-Ztreat-err-as-bug=1").run_fail();
+        let dump = extract_exactly_one_ice_file("baseline", cwd());
+        // Ensure that the ICE dump path doesn't contain `:`, because they cause problems on
+        // Windows.
+        assert!(!filename_contains(&dump.path, ":"), "{} contains `:`", dump.path.display());
+        // Some of the expected strings in an ICE file should appear.
+        assert!(dump.message.contains("thread 'rustc' panicked at"));
+        assert!(dump.message.contains("stack backtrace:"));
+        default_ice_dump.set(dump).unwrap();
+    });
+    let default_ice_dump = default_ice_dump.get().unwrap();
+
+    test_backtrace_short(default_ice_dump);
+    test_backtrace_full(default_ice_dump);
+    test_backtrace_disabled(default_ice_dump);
+    test_ice_dump_disabled();
+
+    test_metrics_dir(default_ice_dump);
+}
+
+#[track_caller]
+fn test_backtrace_short(baseline: &IceDump) {
+    run_in_tmpdir(|| {
+        rustc()
+            .env("RUSTC_ICE", cwd())
+            .input("lib.rs")
+            .env("RUST_BACKTRACE", "short")
+            .arg("-Ztreat-err-as-bug=1")
+            .run_fail();
+        let dump = extract_exactly_one_ice_file("RUST_BACKTRACE=short", cwd());
+        // Backtrace length in dump shouldn't be changed by `RUST_BACKTRACE`.
+        assert_ice_len_equals(baseline, &dump);
+    });
+}
+
+#[track_caller]
+fn test_backtrace_full(baseline: &IceDump) {
+    run_in_tmpdir(|| {
+        rustc()
+            .env("RUSTC_ICE", cwd())
+            .input("lib.rs")
+            .env("RUST_BACKTRACE", "full")
+            .arg("-Ztreat-err-as-bug=1")
+            .run_fail();
+        let dump = extract_exactly_one_ice_file("RUST_BACKTRACE=full", cwd());
+        // Backtrace length in dump shouldn't be changed by `RUST_BACKTRACE`.
+        assert_ice_len_equals(baseline, &dump);
+    });
+}
+
+#[track_caller]
+fn test_backtrace_disabled(baseline: &IceDump) {
+    run_in_tmpdir(|| {
+        rustc()
+            .env("RUSTC_ICE", cwd())
+            .input("lib.rs")
+            .env("RUST_BACKTRACE", "0")
+            .arg("-Ztreat-err-as-bug=1")
+            .run_fail();
+        let dump = extract_exactly_one_ice_file("RUST_BACKTRACE=disabled", cwd());
+        // Backtrace length in dump shouldn't be changed by `RUST_BACKTRACE`.
+        assert_ice_len_equals(baseline, &dump);
+    });
+}
+
+#[track_caller]
+fn test_ice_dump_disabled() {
+    // The ICE dump is explicitly disabled. Therefore, this should produce no files.
+    run_in_tmpdir(|| {
+        rustc().env("RUSTC_ICE", "0").input("lib.rs").arg("-Ztreat-err-as-bug=1").run_fail();
+        let ice_files = find_ice_dumps_in_dir(cwd());
+        assert!(ice_files.is_empty(), "there should be no ICE files if `RUSTC_ICE=0` is set");
+    });
+}
+
+#[track_caller]
+fn test_metrics_dir(baseline: &IceDump) {
+    test_flag_only(baseline);
+    test_flag_and_env(baseline);
+}
+
+#[track_caller]
+fn test_flag_only(baseline: &IceDump) {
+    run_in_tmpdir(|| {
+        let metrics_arg = format!("-Zmetrics-dir={}", cwd().display());
+        rustc()
+            .env_remove("RUSTC_ICE") // prevent interference from environment
+            .input("lib.rs")
+            .arg("-Ztreat-err-as-bug=1")
+            .arg(metrics_arg)
+            .run_fail();
+        let dump = extract_exactly_one_ice_file("-Zmetrics-dir only", cwd());
+        assert_ice_len_equals(baseline, &dump);
+    });
+}
+
+#[track_caller]
+fn test_flag_and_env(baseline: &IceDump) {
+    run_in_tmpdir(|| {
+        let metrics_arg = format!("-Zmetrics-dir={}", cwd().display());
+        let real_dir = cwd().join("actually_put_ice_here");
+        rfs::create_dir(&real_dir);
+        rustc()
+            .input("lib.rs")
+            .env("RUSTC_ICE", &real_dir)
+            .arg("-Ztreat-err-as-bug=1")
+            .arg(metrics_arg)
+            .run_fail();
+
+        let cwd_ice_files = find_ice_dumps_in_dir(cwd());
+        assert!(cwd_ice_files.is_empty(), "RUSTC_ICE should override -Zmetrics-dir");
+
+        let dump = extract_exactly_one_ice_file("RUSTC_ICE overrides -Zmetrics-dir", real_dir);
+        assert_ice_len_equals(baseline, &dump);
+    });
 }

--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -15,9 +15,10 @@
 //!
 //! See <https://github.com/rust-lang/rust/pull/108714>.
 
-// FIXME(#128911): @jieyouxu: This test is sometimes for whatever forsaken reason flakey in CI, and
-// I cannot reproduce it locally. The error messages upon assertion failure in this test is
-// intentionally extremely verbose to aid debugging that issue.
+//@ ignore-windows
+// FIXME(#128911): @jieyouxu: This test is sometimes for whatever forsaken reason flakey in
+// `i686-mingw`, and I cannot reproduce it locally. The error messages upon assertion failure in
+// this test is intentionally extremely verbose to aid debugging that issue.
 
 use std::cell::OnceCell;
 use std::path::{Path, PathBuf};

--- a/tests/run-make/dylib-soname/rmake.rs
+++ b/tests/run-make/dylib-soname/rmake.rs
@@ -4,7 +4,6 @@
 //@ only-linux
 //@ ignore-cross-compile
 
-use run_make_support::regex::Regex;
 use run_make_support::{cmd, run_in_tmpdir, rustc};
 
 fn main() {

--- a/tests/run-make/extern-flag-disambiguates/rmake.rs
+++ b/tests/run-make/extern-flag-disambiguates/rmake.rs
@@ -1,6 +1,6 @@
 //@ ignore-cross-compile
 
-use run_make_support::{cwd, run, rustc};
+use run_make_support::{run, rustc};
 
 // Attempt to build this dependency tree:
 //

--- a/tests/run-make/ice-dep-cannot-find-dep/rmake.rs
+++ b/tests/run-make/ice-dep-cannot-find-dep/rmake.rs
@@ -16,7 +16,7 @@
 //       If we used `rustc` the additional '-L rmake_out' option would allow rustc to
 //       actually find the crate.
 
-use run_make_support::{bare_rustc, rfs, rust_lib_name, rustc};
+use run_make_support::{bare_rustc, rust_lib_name, rustc};
 
 fn main() {
     rustc().crate_name("a").crate_type("rlib").input("a.rs").arg("--verbose").run();

--- a/tests/run-make/incr-test-moved-file/rmake.rs
+++ b/tests/run-make/incr-test-moved-file/rmake.rs
@@ -14,7 +14,7 @@
 //@ ignore-nvptx64-nvidia-cuda
 // FIXME: can't find crate for 'std'
 
-use run_make_support::{rfs, rust_lib_name, rustc};
+use run_make_support::{rfs, rustc};
 
 fn main() {
     rfs::create_dir("incr");

--- a/tests/run-make/incremental-debugger-visualizer/rmake.rs
+++ b/tests/run-make/incremental-debugger-visualizer/rmake.rs
@@ -2,8 +2,6 @@
 // (in this case, foo.py and foo.natvis) are picked up when compiling incrementally.
 // See https://github.com/rust-lang/rust/pull/111641
 
-use std::io::Read;
-
 use run_make_support::{invalid_utf8_contains, invalid_utf8_not_contains, rfs, rustc};
 
 fn main() {

--- a/tests/run-make/lto-readonly-lib/rmake.rs
+++ b/tests/run-make/lto-readonly-lib/rmake.rs
@@ -7,7 +7,7 @@
 
 //@ ignore-cross-compile
 
-use run_make_support::{rfs, run, rust_lib_name, rustc, test_while_readonly};
+use run_make_support::{run, rust_lib_name, rustc, test_while_readonly};
 
 fn main() {
     rustc().input("lib.rs").run();

--- a/tests/run-make/multiple-emits/rmake.rs
+++ b/tests/run-make/multiple-emits/rmake.rs
@@ -1,4 +1,4 @@
-use run_make_support::{cwd, path, rustc};
+use run_make_support::{path, rustc};
 
 fn main() {
     rustc().input("foo.rs").emit("asm,llvm-ir").output("out").run();

--- a/tests/run-make/naked-symbol-visibility/rmake.rs
+++ b/tests/run-make/naked-symbol-visibility/rmake.rs
@@ -3,7 +3,7 @@
 use run_make_support::object::read::{File, Object, Symbol};
 use run_make_support::object::ObjectSymbol;
 use run_make_support::targets::is_windows;
-use run_make_support::{dynamic_lib_name, env_var, rfs, rustc};
+use run_make_support::{dynamic_lib_name, rfs, rustc};
 
 fn main() {
     let rdylib_name = dynamic_lib_name("a_rust_dylib");

--- a/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
+++ b/tests/run-make/non-unicode-in-incremental-dir/rmake.rs
@@ -8,7 +8,7 @@ fn main() {
     match std::fs::create_dir(&non_unicode) {
         // If an error occurs, check if creating a directory with a valid Unicode name would
         // succeed.
-        Err(e) if std::fs::create_dir("valid_unicode").is_ok() => {
+        Err(_) if std::fs::create_dir("valid_unicode").is_ok() => {
             // Filesystem doesn't appear support non-Unicode paths.
             return;
         }

--- a/tests/run-make/output-type-permutations/rmake.rs
+++ b/tests/run-make/output-type-permutations/rmake.rs
@@ -113,7 +113,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "asm-emit".to_string(),
         },
         || {
@@ -123,7 +123,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "asm-emit2".to_string(),
         },
         || {
@@ -133,7 +133,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "asm-emit3".to_string(),
         },
         || {
@@ -144,7 +144,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "llvm-ir-emit".to_string(),
         },
         || {
@@ -154,7 +154,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "llvm-ir-emit2".to_string(),
         },
         || {
@@ -164,7 +164,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "llvm-ir-emit3".to_string(),
         },
         || {
@@ -175,7 +175,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "llvm-bc-emit".to_string(),
         },
         || {
@@ -185,7 +185,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "llvm-bc-emit2".to_string(),
         },
         || {
@@ -195,7 +195,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "llvm-bc-emit3".to_string(),
         },
         || {
@@ -206,7 +206,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "obj-emit".to_string(),
         },
         || {
@@ -216,7 +216,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "obj-emit2".to_string(),
         },
         || {
@@ -226,7 +226,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "obj-emit3".to_string(),
         },
         || {
@@ -268,7 +268,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "rlib".to_string(),
         },
         || {
@@ -278,7 +278,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "rlib2".to_string(),
         },
         || {
@@ -288,7 +288,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "rlib3".to_string(),
         },
         || {
@@ -375,7 +375,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "staticlib".to_string(),
         },
         || {
@@ -385,7 +385,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "staticlib2".to_string(),
         },
         || {
@@ -395,7 +395,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["foo"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "staticlib3".to_string(),
         },
         || {
@@ -449,7 +449,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["ir", rust_lib_name("bar")],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "rlib-ir".to_string(),
         },
         || {
@@ -466,7 +466,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["ir", "asm", "bc", "obj", "link"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "staticlib-all".to_string(),
         },
         || {
@@ -484,7 +484,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["ir", "asm", "bc", "obj", "link"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "staticlib-all2".to_string(),
         },
         || {
@@ -523,7 +523,7 @@ fn main() {
     assert_expected_output_files(
         Expectations {
             expected_files: s!["bar.bc", rust_lib_name("bar"), "foo.bc"],
-            allowed_files: s![],
+            allowed_files: vec![],
             test_dir: "rlib-emits".to_string(),
         },
         || {

--- a/tests/run-make/print-check-cfg/rmake.rs
+++ b/tests/run-make/print-check-cfg/rmake.rs
@@ -4,7 +4,6 @@ extern crate run_make_support;
 
 use std::collections::HashSet;
 use std::iter::FromIterator;
-use std::ops::Deref;
 
 use run_make_support::rustc;
 

--- a/tests/run-make/print-native-static-libs/rmake.rs
+++ b/tests/run-make/print-native-static-libs/rmake.rs
@@ -12,8 +12,6 @@
 //@ ignore-cross-compile
 //@ ignore-wasm
 
-use std::io::BufRead;
-
 use run_make_support::{is_msvc, rustc};
 
 fn main() {

--- a/tests/run-make/redundant-libs/rmake.rs
+++ b/tests/run-make/redundant-libs/rmake.rs
@@ -11,9 +11,7 @@
 //@ ignore-cross-compile
 // Reason: the compiled binary is executed
 
-use run_make_support::{
-    build_native_dynamic_lib, build_native_static_lib, cwd, is_msvc, rfs, run, rustc,
-};
+use run_make_support::{build_native_dynamic_lib, build_native_static_lib, run, rustc};
 
 fn main() {
     build_native_dynamic_lib("foo");

--- a/tests/run-make/reproducible-build-2/rmake.rs
+++ b/tests/run-make/reproducible-build-2/rmake.rs
@@ -13,7 +13,7 @@
 // 2. When the sysroot gets copied, some symlinks must be re-created,
 // which is a privileged action on Windows.
 
-use run_make_support::{bin_name, rfs, rust_lib_name, rustc};
+use run_make_support::{rfs, rust_lib_name, rustc};
 
 fn main() {
     // test 1: fat lto

--- a/tests/run-make/reset-codegen-1/rmake.rs
+++ b/tests/run-make/reset-codegen-1/rmake.rs
@@ -9,7 +9,7 @@
 
 use std::path::Path;
 
-use run_make_support::{bin_name, rfs, rustc};
+use run_make_support::{bin_name, rustc};
 
 fn compile(output_file: &str, emit: Option<&str>) {
     let mut rustc = rustc();

--- a/tests/run-make/rlib-format-packed-bundled-libs-3/rmake.rs
+++ b/tests/run-make/rlib-format-packed-bundled-libs-3/rmake.rs
@@ -6,7 +6,7 @@
 // See https://github.com/rust-lang/rust/pull/105601
 
 use run_make_support::{
-    build_native_static_lib, is_msvc, llvm_ar, regex, rfs, rust_lib_name, rustc, static_lib_name,
+    build_native_static_lib, llvm_ar, regex, rfs, rust_lib_name, rustc, static_lib_name,
 };
 
 //@ ignore-cross-compile

--- a/tests/run-make/run-in-tmpdir-self-test/rmake.rs
+++ b/tests/run-make/run-in-tmpdir-self-test/rmake.rs
@@ -3,7 +3,7 @@
 //! when returning from the closure.
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use run_make_support::{cwd, run_in_tmpdir};
 

--- a/tests/run-make/rust-lld-by-default-nightly/rmake.rs
+++ b/tests/run-make/rust-lld-by-default-nightly/rmake.rs
@@ -6,8 +6,6 @@
 //@ ignore-stable
 //@ only-x86_64-unknown-linux-gnu
 
-use std::process::Output;
-
 use run_make_support::regex::Regex;
 use run_make_support::rustc;
 

--- a/tests/run-make/rust-lld-compress-debug-sections/rmake.rs
+++ b/tests/run-make/rust-lld-compress-debug-sections/rmake.rs
@@ -6,7 +6,7 @@
 
 // FIXME: This test isn't comprehensive and isn't covering all possible combinations.
 
-use run_make_support::{assert_contains, cmd, llvm_readobj, run_in_tmpdir, rustc};
+use run_make_support::{assert_contains, llvm_readobj, run_in_tmpdir, rustc};
 
 fn check_compression(compression: &str, to_find: &str) {
     run_in_tmpdir(|| {

--- a/tests/run-make/rust-lld-custom-target/rmake.rs
+++ b/tests/run-make/rust-lld-custom-target/rmake.rs
@@ -8,8 +8,6 @@
 //@ needs-rust-lld
 //@ only-x86_64-unknown-linux-gnu
 
-use std::process::Output;
-
 use run_make_support::regex::Regex;
 use run_make_support::rustc;
 

--- a/tests/run-make/rust-lld/rmake.rs
+++ b/tests/run-make/rust-lld/rmake.rs
@@ -4,8 +4,6 @@
 //@ needs-rust-lld
 //@ ignore-s390x lld does not yet support s390x as target
 
-use std::process::Output;
-
 use run_make_support::regex::Regex;
 use run_make_support::{is_msvc, rustc};
 

--- a/tests/run-make/rustdoc-io-error/rmake.rs
+++ b/tests/run-make/rustdoc-io-error/rmake.rs
@@ -20,7 +20,7 @@ use run_make_support::{path, rustdoc};
 
 fn main() {
     let out_dir = path("rustdoc-io-error");
-    let output = fs::create_dir(&out_dir).unwrap();
+    fs::create_dir(&out_dir).unwrap();
     let mut permissions = fs::metadata(&out_dir).unwrap().permissions();
     let original_permissions = permissions.clone();
 

--- a/tests/run-make/rustdoc-io-error/rmake.rs
+++ b/tests/run-make/rustdoc-io-error/rmake.rs
@@ -14,22 +14,20 @@
 // `mkfs.ext4 -d`, as well as mounting a loop device for the rootfs.
 //@ ignore-windows - the `set_readonly` functions doesn't work on folders.
 
-use std::fs;
-
-use run_make_support::{path, rustdoc};
+use run_make_support::{path, rfs, rustdoc};
 
 fn main() {
     let out_dir = path("rustdoc-io-error");
-    fs::create_dir(&out_dir).unwrap();
-    let mut permissions = fs::metadata(&out_dir).unwrap().permissions();
+    rfs::create_dir(&out_dir);
+    let mut permissions = rfs::metadata(&out_dir).permissions();
     let original_permissions = permissions.clone();
 
     permissions.set_readonly(true);
-    fs::set_permissions(&out_dir, permissions).unwrap();
+    rfs::set_permissions(&out_dir, permissions);
 
     let output = rustdoc().input("foo.rs").output(&out_dir).env("RUST_BACKTRACE", "1").run_fail();
 
-    fs::set_permissions(&out_dir, original_permissions).unwrap();
+    rfs::set_permissions(&out_dir, original_permissions);
 
     output
         .assert_exit_code(1)

--- a/tests/run-make/rustdoc-scrape-examples-remap/scrape.rs
+++ b/tests/run-make/rustdoc-scrape-examples-remap/scrape.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use run_make_support::{htmldocck, rfs, rustc, rustdoc, source_root};
+use run_make_support::{htmldocck, rfs, rustc, rustdoc};
 
 pub fn scrape(extra_args: &[&str]) {
     let out_dir = Path::new("rustdoc");

--- a/tests/run-make/sepcomp-cci-copies/rmake.rs
+++ b/tests/run-make/sepcomp-cci-copies/rmake.rs
@@ -4,10 +4,7 @@
 // created for each source module (see `rustc_const_eval::monomorphize::partitioning`).
 // See https://github.com/rust-lang/rust/pull/16367
 
-use run_make_support::{
-    count_regex_matches_in_files_with_extension, cwd, has_extension, regex, rfs, rustc,
-    shallow_find_files,
-};
+use run_make_support::{count_regex_matches_in_files_with_extension, regex, rustc};
 
 fn main() {
     rustc().input("cci_lib.rs").run();

--- a/tests/run-make/sepcomp-inlining/rmake.rs
+++ b/tests/run-make/sepcomp-inlining/rmake.rs
@@ -5,10 +5,7 @@
 // in only one compilation unit.
 // See https://github.com/rust-lang/rust/pull/16367
 
-use run_make_support::{
-    count_regex_matches_in_files_with_extension, cwd, has_extension, regex, rfs, rustc,
-    shallow_find_files,
-};
+use run_make_support::{count_regex_matches_in_files_with_extension, regex, rustc};
 
 fn main() {
     rustc().input("foo.rs").emit("llvm-ir").codegen_units(3).arg("-Zinline-in-all-cgus").run();

--- a/tests/run-make/sepcomp-separate/rmake.rs
+++ b/tests/run-make/sepcomp-separate/rmake.rs
@@ -3,10 +3,7 @@
 // wind up in three different compilation units.
 // See https://github.com/rust-lang/rust/pull/16367
 
-use run_make_support::{
-    count_regex_matches_in_files_with_extension, cwd, has_extension, regex, rfs, rustc,
-    shallow_find_files,
-};
+use run_make_support::{count_regex_matches_in_files_with_extension, regex, rustc};
 
 fn main() {
     rustc().input("foo.rs").emit("llvm-ir").codegen_units(3).run();


### PR DESCRIPTION
Successful merges:

 - #128643 (Refactor `powerpc64` call ABI handling)
 - #128873 (Add windows-targets crate to std's sysroot)
 - #128916 (Tidy up `dump-ice-to-disk` and make assertion failures dump ICE messages)
 - #128929 (Fix codegen-units tests that were disabled 8 years ago)
 - #128937 (Fix warnings in rmake tests on `x86_64-unknown-linux-gnu`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=128643,128873,128916,128929,128937)
<!-- homu-ignore:end -->