### PR TITLE
Re-enable more debuginfo tests on Windows

### DIFF
--- a/tests/debuginfo/drop-locations.rs
+++ b/tests/debuginfo/drop-locations.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows
 //@ ignore-android
 //@ min-lldb-version: 310
 //@ ignore-test: #128971

--- a/tests/debuginfo/embedded-visualizer.rs
+++ b/tests/debuginfo/embedded-visualizer.rs
@@ -1,7 +1,7 @@
 //@ compile-flags:-g
 //@ min-gdb-version: 8.1
 //@ ignore-lldb
-//@ ignore-windows-gnu // emit_debug_gdb_scripts is disabled on Windows
+//@ ignore-windows-gnu: #128981
 
 // === CDB TESTS ==================================================================================
 

--- a/tests/debuginfo/empty-string.rs
+++ b/tests/debuginfo/empty-string.rs
@@ -1,4 +1,4 @@
-//@ ignore-windows failing on win32 bot
+//@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g
 //@ min-gdb-version: 8.1

--- a/tests/debuginfo/issue-12886.rs
+++ b/tests/debuginfo/issue-12886.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows failing on 64-bit bots FIXME #17638
 //@ ignore-lldb
 //@ ignore-aarch64
 
@@ -6,7 +5,7 @@
 
 // gdb-command:run
 // gdb-command:next
-// gdb-check:[...]24[...]let s = Some(5).unwrap(); // #break
+// gdb-check:[...]23[...]let s = Some(5).unwrap(); // #break
 // gdb-command:continue
 
 #![feature(omit_gdb_pretty_printer_section)]

--- a/tests/debuginfo/macro-stepping.rs
+++ b/tests/debuginfo/macro-stepping.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows
 //@ ignore-android
 //@ ignore-aarch64
 //@ min-lldb-version: 1800

--- a/tests/debuginfo/numeric-types.rs
+++ b/tests/debuginfo/numeric-types.rs
@@ -1,7 +1,7 @@
 //@ compile-flags:-g
 
 //@ min-gdb-version: 8.1
-//@ ignore-windows-gnu // emit_debug_gdb_scripts is disabled on Windows
+//@ ignore-windows-gnu: #128981
 
 // Tests the visualizations for `NonZero<T>`, `Wrapping<T>` and
 // `Atomic{Bool,I8,I16,I32,I64,Isize,U8,U16,U32,U64,Usize}` located in `libcore.natvis`.

--- a/tests/debuginfo/pretty-huge-vec.rs
+++ b/tests/debuginfo/pretty-huge-vec.rs
@@ -1,4 +1,4 @@
-//@ ignore-windows failing on win32 bot
+//@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g
 //@ min-gdb-version: 8.1

--- a/tests/debuginfo/pretty-slices.rs
+++ b/tests/debuginfo/pretty-slices.rs
@@ -1,5 +1,5 @@
 //@ ignore-android: FIXME(#10381)
-//@ ignore-windows
+//@ ignore-windows-gnu: #128981
 //@ compile-flags:-g
 
 // gdb-command: run

--- a/tests/debuginfo/pretty-std-collections.rs
+++ b/tests/debuginfo/pretty-std-collections.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows failing on win32 bot
 //@ ignore-android: FIXME(#10381)
 //@ ignore-windows-gnu: #128981
 //@ compile-flags:-g

--- a/tests/debuginfo/pretty-uninitialized-vec.rs
+++ b/tests/debuginfo/pretty-uninitialized-vec.rs
@@ -1,4 +1,4 @@
-//@ ignore-windows failing on win32 bot
+//@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g
 //@ min-gdb-version: 8.1

--- a/tests/debuginfo/thread-names.rs
+++ b/tests/debuginfo/thread-names.rs
@@ -4,7 +4,7 @@
 //@[macos] only-macos
 //@[win] only-windows
 //@ ignore-sgx
-//@ ignore-windows-gnu
+//@ ignore-windows-gnu: gdb on windows-gnu does not print thread names
 
 // === GDB TESTS ==================================================================================
 //


### PR DESCRIPTION
These tests used to be disabled on all Windows hosts. Now they're fully enabled or just disabled on windows-gnu with an issue citation that clearly explains why.

The changes in this PR are not tested by PR CI, but I've tested it using try-jobs below.

try-job: i686-msvc
try-job: i686-mingw
try-job: x86_64-mingw
try-job: x86_64-msvc