### PR TITLE
Re-enable more debuginfo tests on freebsd

### DIFF
--- a/tests/debuginfo/pretty-huge-vec.rs
+++ b/tests/debuginfo/pretty-huge-vec.rs
@@ -1,5 +1,4 @@
 //@ ignore-windows failing on win32 bot
-//@ ignore-freebsd: gdb package too new
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g
 //@ min-gdb-version: 8.1

--- a/tests/debuginfo/pretty-std-collections.rs
+++ b/tests/debuginfo/pretty-std-collections.rs
@@ -1,5 +1,4 @@
 //@ ignore-windows failing on win32 bot
-//@ ignore-freebsd: gdb package too new
 //@ ignore-android: FIXME(#10381)
 //@ ignore-windows-gnu: #128981
 //@ compile-flags:-g

--- a/tests/debuginfo/pretty-std.rs
+++ b/tests/debuginfo/pretty-std.rs
@@ -1,5 +1,4 @@
 // ignore-tidy-linelength
-//@ ignore-freebsd: gdb package too new
 //@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g

--- a/tests/debuginfo/pretty-uninitialized-vec.rs
+++ b/tests/debuginfo/pretty-uninitialized-vec.rs
@@ -1,5 +1,4 @@
 //@ ignore-windows failing on win32 bot
-//@ ignore-freebsd: gdb package too new
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g
 //@ min-gdb-version: 8.1


### PR DESCRIPTION
These ignores are _ancient_, we don't run freebsd tests in CI, and even if we did they'd probably pass because the test suite passes with the latest gdb release on Linux.