### PR TITLE
Add `#[must_use]` attribute to `Coroutine` trait

### DIFF
--- a/library/core/src/ops/coroutine.rs
+++ b/library/core/src/ops/coroutine.rs
@@ -69,6 +69,7 @@ pub enum CoroutineState<Y, R> {
 #[lang = "coroutine"]
 #[unstable(feature = "coroutine_trait", issue = "43122")]
 #[fundamental]
+#[must_use = "coroutines are lazy and do nothing unless resumed"]
 pub trait Coroutine<R = ()> {
     /// The type of value this coroutine yields.
     ///

--- a/tests/ui/coroutine/issue-58888.rs
+++ b/tests/ui/coroutine/issue-58888.rs
@@ -13,7 +13,8 @@ impl Database {
     }
 
     fn check_connection(&self) -> impl Coroutine<Yield = (), Return = ()> + '_ {
-        #[coroutine] move || {
+        #[coroutine]
+        move || {
             let iter = self.get_connection();
             for i in iter {
                 yield i
@@ -23,5 +24,5 @@ impl Database {
 }
 
 fn main() {
-    Database.check_connection();
+    let _ = Database.check_connection();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

[Coroutines tracking issue](https://github.com/rust-lang/rust/issues/43122)

Like closures (`FnOnce`, `AsyncFn`, etc.), coroutines are lazy and do nothing unless called (resumed). Closure traits like `FnOnce` have `#[must_use = "closures are lazy and do nothing unless called"]` to catch likely bugs for users of APIs that produce them. This PR adds such a `#[must_use]` attribute to `trait Coroutine`.