### PR TITLE
Additional NonZero conversions

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1,6 +1,6 @@
 //! Definitions of integer that is known not to equal zero.
 
-use super::{IntErrorKind, ParseIntError};
+use super::{IntErrorKind, ParseIntError, TryFromIntError};
 use crate::clone::{TrivialClone, UseCloned};
 use crate::cmp::Ordering;
 use crate::hash::{Hash, Hasher};
@@ -8,7 +8,7 @@ use crate::marker::{Destruct, Freeze, StructuralPartialEq};
 use crate::ops::{BitOr, BitOrAssign, Div, DivAssign, Neg, Rem, RemAssign};
 use crate::panic::{RefUnwindSafe, UnwindSafe};
 use crate::str::FromStr;
-use crate::{fmt, intrinsics, ptr, ub_checks};
+use crate::{fmt, intrinsics, ptr, slice, ub_checks};
 
 /// A marker trait for primitive types which can be zero.
 ///
@@ -318,6 +318,114 @@ where
     }
 }
 
+#[stable(feature = "more_from_nonzero", since = "CURRENT_RUSTC_VERSION")]
+impl<'a, T> From<&'a NonZero<T>> for &'a T
+where
+    T: ZeroablePrimitive,
+{
+    #[inline]
+    fn from(nonzero: &'a NonZero<T>) -> &'a T {
+        nonzero.as_ref()
+    }
+}
+
+// FIXME: see library/std/tests/slice-from-array-issue-113238.rs
+/*
+#[stable(feature = "more_from_nonzero", since = "CURRENT_RUSTC_VERSION")]
+impl<'a, T> From<&'a [NonZero<T>]> for &'a [T]
+where
+    T: ZeroablePrimitive,
+{
+    #[inline]
+    fn from(nonzero: &'a [NonZero<T>]) -> &'a [T] {
+        nonzero.as_zeroable()
+    }
+}
+impl<T> [NonZero<T>]
+where
+    T: ZeroablePrimitive,
+{
+    /// Implementation of `From<&[NonZero<T>]> for &[T]`.
+    #[must_use]
+    #[inline]
+    fn as_zeroable(&self) -> &[T] {
+        // SAFETY: `repr(transparent)` ensures that `NonZero<T>` has same layout as `T`, and thus
+        //   `[NonZero<T>]` has same layout as `[T]`
+        unsafe { &*(slice::from_raw_parts(self.as_ptr().cast::<T>(), self.len())) }
+    }
+}
+*/
+
+#[stable(feature = "more_from_nonzero", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> From<[NonZero<T>; N]> for [T; N]
+where
+    T: ZeroablePrimitive,
+{
+    #[inline]
+    fn from(nonzero: [NonZero<T>; N]) -> [T; N] {
+        nonzero.into_zeroable()
+    }
+}
+
+// FIXME: can't detect that ZeroablePrimitive is a sealed trait
+macro_rules! impl_ref_try_from {
+    ($($t:ty),* $(,)?) => {
+        $(
+            #[stable(feature = "more_from_nonzero", since = "CURRENT_RUSTC_VERSION")]
+            impl<'a> TryFrom<&'a $t> for &'a NonZero<$t> {
+                type Error = TryFromIntError;
+
+                #[inline]
+                fn try_from(zeroable: &'a $t) -> Result<&'a NonZero<$t>, TryFromIntError> {
+                    NonZero::from_ref(zeroable).ok_or(TryFromIntError(()))
+                }
+            }
+        )*
+    }
+}
+
+impl_ref_try_from! {
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    char,
+}
+
+#[stable(feature = "more_from_nonzero", since = "CURRENT_RUSTC_VERSION")]
+impl<'a, T> TryFrom<&'a [T]> for &'a [NonZero<T>]
+where
+    T: ZeroablePrimitive,
+{
+    type Error = TryFromIntError;
+
+    #[inline]
+    fn try_from(zeroable: &'a [T]) -> Result<&'a [NonZero<T>], TryFromIntError> {
+        NonZero::from_slice(zeroable).ok_or(TryFromIntError(()))
+    }
+}
+
+#[stable(feature = "more_from_nonzero", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> TryFrom<[T; N]> for [NonZero<T>; N]
+where
+    T: ZeroablePrimitive,
+{
+    type Error = TryFromIntError;
+
+    #[inline]
+    fn try_from(zeroable: [T; N]) -> Result<[NonZero<T>; N], TryFromIntError> {
+        NonZero::from_array(zeroable).ok_or(TryFromIntError(()))
+    }
+}
+
 #[stable(feature = "nonzero_bitor", since = "1.45.0")]
 #[rustc_const_unstable(feature = "const_ops", issue = "143802")]
 impl<T> const BitOr for NonZero<T>
@@ -473,6 +581,45 @@ where
         }
     }
 
+    /// Implementation of `From<&NonZero<T>> for &T`.
+    #[must_use]
+    #[inline]
+    fn as_ref(&self) -> &T {
+        // SAFETY: `repr(transparent)` ensures that `NonZero<T>` has same layout as `T`
+        unsafe { &*(ptr::from_ref(self).cast::<T>()) }
+    }
+
+    /// Implementation of `TryFrom<&T> for &NonZero<T>`.
+    #[must_use]
+    #[inline]
+    fn from_ref(n: &T) -> Option<&Self> {
+        // SAFETY: Memory layout optimization guarantees that `Option<NonZero<T>>` has
+        //         the same layout and size as `T`, with `0` representing `None`.
+        let opt_n = unsafe { &*(ptr::from_ref(n).cast::<Option<Self>>()) };
+
+        opt_n.as_ref()
+    }
+
+    /// Implementation of `TryFrom<&[T]> for &[NonZero<T>]`.
+    #[must_use]
+    #[inline]
+    fn from_slice(n: &[T]) -> Option<&[Self]> {
+        if n.iter().all(|x| NonZero::new(*x).is_some()) {
+            // SAFETY: We explicitly checked that all elements are nonzero, and because of `repr(transparent)`
+            //   the layout remains unchanged
+            Some(unsafe { &*(slice::from_raw_parts(n.as_ptr().cast::<NonZero<T>>(), n.len())) })
+        } else {
+            None
+        }
+    }
+
+    /// Implementation of `TryFrom<[T; N]> for [NonZero<T>; N]`.
+    #[must_use]
+    #[inline]
+    fn from_array<const N: usize>(n: [T; N]) -> Option<[Self; N]> {
+        n.try_map(NonZero::new)
+    }
+
     /// Returns the contained value as a primitive type.
     #[stable(feature = "nonzero", since = "1.28.0")]
     #[rustc_const_stable(feature = "const_nonzero_get", since = "1.34.0")]
@@ -497,6 +644,18 @@ where
         // SAFETY: `ZeroablePrimitive` guarantees that the size and bit validity
         // of `.0` is such that this transmute is sound.
         unsafe { intrinsics::transmute_unchecked(self) }
+    }
+}
+
+impl<T, const N: usize> [NonZero<T>; N]
+where
+    T: ZeroablePrimitive,
+{
+    /// Implementation of `From<[NonZero<T>; N]> for [T; N]`.
+    #[must_use]
+    #[inline]
+    fn into_zeroable(self) -> [T; N] {
+        self.map(NonZero::get)
     }
 }
 

--- a/tests/ui/suggestions/issue-71394-no-from-impl.stderr
+++ b/tests/ui/suggestions/issue-71394-no-from-impl.stderr
@@ -13,7 +13,7 @@ LL |     let _: &[i8] = data.into();
              `[T; 6]` implements `From<(T, T, T, T, T, T)>`
              `[T; 7]` implements `From<(T, T, T, T, T, T, T)>`
              `[T; 8]` implements `From<(T, T, T, T, T, T, T, T)>`
-           and 7 others
+           and 8 others
    = note: required for `&[u8]` to implement `Into<&[i8]>`
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/129036)*
<!-- homu-ignore:end -->

ACP: rust-lang/libs-team#145

Requires FCP due to insta-stable APIs added:

```rust
// can't be done generically; compiler can't infer that ZeroablePrimitive is sealed for coherence reasons
impl From<&NonZero<uN>> for &uN;
impl From<&NonZero<iN>> for &iN;
impl From<&NonZero<usize>> for &usize;
impl From<&NonZero<isize>> for &isize;
impl From<&NonZero<char>> for &char;

// excluded due to typechecking bug, but left commented out in code
// impl<T> From<&[NonZero<T>]> for &[T] where T: ZeroablePrimitive;

// rest are generic
impl<T, const N: usize> From<[NonZero<T>; N]> for [T; N] where T: ZeroablePrimitive;
impl<T> TryFrom<&T> for &NonZero<T> where T: ZeroablePrimitive;
impl<T> TryFrom<&[T]> for &[NonZero<T>] where T: ZeroablePrimitive;
impl<T, const N: usize> TryFrom<[T; N]> for [NonZero<T>; N] where T: ZeroablePrimitive;
```

Note that the `Error` for the `TryFrom` implementations is `TryFromIntError` to match the similar impls.

r? rust-lang/libs-api