### PR TITLE
Special-case alias ty during the delayed bug emission in `try_from_lit`

### DIFF
--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -305,6 +305,10 @@ impl<'tcx> Const<'tcx> {
             // mir.
             match tcx.at(expr.span).lit_to_const(lit_input) {
                 Ok(c) => return Some(c),
+                Err(_) if lit_input.ty.has_aliases() => {
+                    // allow the `ty` to be an alias type, though we cannot handle it here
+                    return None;
+                }
                 Err(e) => {
                     tcx.dcx().span_delayed_bug(
                         expr.span,

--- a/tests/ui/const-generics/adt_const_params/116308.rs
+++ b/tests/ui/const-generics/adt_const_params/116308.rs
@@ -1,5 +1,7 @@
-//@ known-bug: #116308
+//@ check-pass
 #![feature(adt_const_params)]
+
+// Regression test for #116308
 
 pub trait Identity {
     type Identity;


### PR DESCRIPTION
This PR tries to fix #116308.

A delayed bug in `try_from_lit` will not be emitted so that the compiler will not ICE when it sees the pair `(ast::LitKind::Int, ty::TyKind::Alias)` in `lit_to_const` (called from `try_from_lit`).

This PR is related to an unstable feature `adt_const_params` (#95174).

r? @BoxyUwU 

