### PR TITLE
Update `crosstool-ng` for loongarch64

### DIFF
--- a/src/ci/docker/README.md
+++ b/src/ci/docker/README.md
@@ -266,9 +266,9 @@ For targets: `loongarch64-unknown-linux-gnu`
 - Target options > Bitness = 64-bit
 - Operating System > Target OS = linux
 - Operating System > Linux kernel version = 5.19.16
-- Binary utilities > Version of binutils = 2.40
+- Binary utilities > Version of binutils = 2.42
 - C-library > glibc version = 2.36
-- C compiler > gcc version = 13.2.0
+- C compiler > gcc version = 14.2.0
 - C compiler > C++ = ENABLE -- to cross compile LLVM
 
 ### `loongarch64-linux-musl.defconfig`
@@ -282,9 +282,9 @@ For targets: `loongarch64-unknown-linux-musl`
 - Target options > Bitness = 64-bit
 - Operating System > Target OS = linux
 - Operating System > Linux kernel version = 5.19.16
-- Binary utilities > Version of binutils = 2.41
+- Binary utilities > Version of binutils = 2.42
 - C-library > musl version = 1.2.5
-- C compiler > gcc version = 13.2.0
+- C compiler > gcc version = 14.2.0
 - C compiler > C++ = ENABLE -- to cross compile LLVM
 
 ### `mips-linux-gnu.defconfig`

--- a/src/ci/docker/host-x86_64/dist-loongarch64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-loongarch64-linux/Dockerfile
@@ -3,8 +3,8 @@ FROM ubuntu:22.04
 COPY scripts/cross-apt-packages.sh /scripts/
 RUN sh /scripts/cross-apt-packages.sh
 
-COPY scripts/crosstool-ng.sh /scripts/
-RUN sh /scripts/crosstool-ng.sh
+COPY scripts/crosstool-ng-git.sh /scripts/
+RUN sh /scripts/crosstool-ng-git.sh
 
 COPY scripts/rustbuild-setup.sh /scripts/
 RUN sh /scripts/rustbuild-setup.sh

--- a/src/ci/docker/scripts/crosstool-ng-git.sh
+++ b/src/ci/docker/scripts/crosstool-ng-git.sh
@@ -2,7 +2,7 @@
 set -ex
 
 URL=https://github.com/crosstool-ng/crosstool-ng
-REV=c64500d94be92ed1bcdfdef911048a14e216a5e1
+REV=ed12fa68402f58e171a6f79500f73f4781fdc9e5
 
 mkdir crosstool-ng
 cd crosstool-ng


### PR DESCRIPTION
The current cross-compilation toolchain for the LoongArch64 target consists of GCC 13.2.0, Binutils 2.40, and Glibc 2.36. However, Binutils 2.40 has known issues that in broken binaries without any error reports:

- https://github.com/rust-lang/rust/issues/121289
- https://github.com/cross-rs/cross/issues/1538

This patch upgrades the cross-compilation toolchain for the LoongArch64 target to resolve these issues.

- GCC: 13.2.0 -> 14.2.0
- Binutils: 2.40 -> 2.42

The new binaries remain compatible with the existing GCC 13.2.0/Glibc 2.36 distribution, and no issues have been identified.

try-job: dist-loongarch64-linux