### PR TITLE
compiletest: Don't panic on unknown JSON-like output lines

### DIFF
--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -127,11 +127,10 @@ pub fn extract_rendered(output: &str) -> String {
                     // Ignore the notification.
                     None
                 } else {
-                    print!(
-                        "failed to decode compiler output as json: line: {}\noutput: {}",
-                        line, output
-                    );
-                    panic!()
+                    // This function is called for both compiler and non-compiler output,
+                    // so if the line isn't recognized as JSON from the compiler then
+                    // just print it as-is.
+                    Some(format!("{line}\n"))
                 }
             } else {
                 // preserve non-JSON lines, such as ICEs

--- a/src/tools/compiletest/src/json.rs
+++ b/src/tools/compiletest/src/json.rs
@@ -1,5 +1,4 @@
 //! These structs are a subset of the ones found in `rustc_errors::json`.
-//! They are only used for deserialization of JSON output provided by libtest.
 
 use std::path::{Path, PathBuf};
 use std::str::FromStr;


### PR DESCRIPTION
The `json::extract_rendered` function is called for both compiler output and non-compiler output, so it's inappropriate to panic just because a line starting with `{` didn't contain a compiler output message.

It is called from two places: when checking the output of a `ui` test process, and when printing the output of an arbitrary non-passing `ProcRes`. So unfortunately there's currently no easy way to know for sure whether it is seeing compiler output or not. Fortunately, neither call site appears to be relying on this panic; it's just an overzealous internal check.

Fixes #126373.