### PR TITLE
Emit a warning instead of an error if `--generate-link-to-definition` is used with other output formats than HTML

### DIFF
--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -733,9 +733,11 @@ impl Options {
         let html_no_source = matches.opt_present("html-no-source");
 
         if generate_link_to_definition && (show_coverage || output_format != OutputFormat::Html) {
-            dcx.fatal(
-                "--generate-link-to-definition option can only be used with HTML output format",
-            );
+            dcx.struct_warn(
+                "`--generate-link-to-definition` option can only be used with HTML output format",
+            )
+            .with_note("`--generate-link-to-definition` option will be ignored")
+            .emit();
         }
 
         let scrape_examples_options = ScrapeExamplesOptions::new(matches, dcx);

--- a/tests/rustdoc-ui/generate-link-to-definition/generate-link-to-definition-opt.rs
+++ b/tests/rustdoc-ui/generate-link-to-definition/generate-link-to-definition-opt.rs
@@ -2,5 +2,6 @@
 // option can only be used with HTML generation.
 
 //@ compile-flags: -Zunstable-options --generate-link-to-definition --output-format json
+//@ check-pass
 
 pub fn f() {}

--- a/tests/rustdoc-ui/generate-link-to-definition/generate-link-to-definition-opt.stderr
+++ b/tests/rustdoc-ui/generate-link-to-definition/generate-link-to-definition-opt.stderr
@@ -1,2 +1,4 @@
-error: --generate-link-to-definition option can only be used with HTML output format
+warning: `--generate-link-to-definition` option can only be used with HTML output format
+   |
+   = note: `--generate-link-to-definition` option will be ignored
 

--- a/tests/rustdoc-ui/generate-link-to-definition/generate-link-to-definition-opt2.rs
+++ b/tests/rustdoc-ui/generate-link-to-definition/generate-link-to-definition-opt2.rs
@@ -1,6 +1,0 @@
-// This test purpose is to check that the "--generate-link-to-definition"
-// option can only be used with HTML generation.
-
-//@ compile-flags: -Zunstable-options --generate-link-to-definition --show-coverage
-
-pub fn f() {}

--- a/tests/rustdoc-ui/generate-link-to-definition/generate-link-to-definition-opt2.stderr
+++ b/tests/rustdoc-ui/generate-link-to-definition/generate-link-to-definition-opt2.stderr
@@ -1,2 +1,0 @@
-error: --generate-link-to-definition option can only be used with HTML output format
-


### PR DESCRIPTION
Fixes https://github.com/rust-lang/docs.rs/issues/2581.

It's a bit weird to emit an error in this case anyway, a warning is more than enough.

r? @notriddle 