### PR TITLE
Fix one usage of target triple in bootstrap

### DIFF
--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -519,7 +519,7 @@ impl Config {
         extra_components: &[&str],
         download_component: fn(&Config, String, &str, &str),
     ) {
-        let host = self.build;
+        let host = self.build.triple;
         let bin_root = self.out.join(host).join(sysroot);
         let rustc_stamp = bin_root.join(".rustc-stamp");
 


### PR DESCRIPTION
This bug was introduced in https://github.com/rust-lang/rust/pull/128983. In this one case, the `TargetSelection` was also used as `Display` (not just as `Path`), which I did not notice in the original PR. If the target contained a custom file, it would be included in its `Display` formatting, even though only the triple should be used.

Found [here](https://github.com/rust-lang/rust/pull/128983#issuecomment-2286601889).

r? @onur-ozkan