### PR TITLE
Port `run-make/sysroot-crates-are-unstable` to rmake

### DIFF
--- a/src/tools/tidy/src/allowed_run_make_makefiles.txt
+++ b/src/tools/tidy/src/allowed_run_make_makefiles.txt
@@ -21,6 +21,5 @@ run-make/reproducible-build/Makefile
 run-make/rlib-format-packed-bundled-libs/Makefile
 run-make/split-debuginfo/Makefile
 run-make/symbol-mangling-hashed/Makefile
-run-make/sysroot-crates-are-unstable/Makefile
 run-make/translation/Makefile
 run-make/x86_64-fortanix-unknown-sgx-lvi/Makefile

--- a/tests/run-make/sysroot-crates-are-unstable/Makefile
+++ b/tests/run-make/sysroot-crates-are-unstable/Makefile
@@ -1,2 +1,0 @@
-all:
-	'$(PYTHON)' test.py

--- a/tests/run-make/sysroot-crates-are-unstable/rmake.rs
+++ b/tests/run-make/sysroot-crates-are-unstable/rmake.rs
@@ -1,0 +1,5 @@
+use run_make_support::python_command;
+
+fn main() {
+    python_command().arg("test.py").run();
+}


### PR DESCRIPTION
I already have a more elaborate draft at #126231 that tries to port the underlying Python script to rmake, but there's no need for the removal of Makefiles to be held up on complex tasks like that, so this PR simply takes the trivial Makefile and converts it into a trivial rmake recipe.

Part of #121876.

r? @jieyouxu 