### PR TITLE
Infer async closure args from `Fn` bound even if there is no corresponding `Future` bound on return

### DIFF
--- a/tests/ui/async-await/async-closures/sig-from-bare-fn.rs
+++ b/tests/ui/async-await/async-closures/sig-from-bare-fn.rs
@@ -1,0 +1,49 @@
+//@ check-pass
+//@ edition: 2021
+
+// Make sure that we infer the args of an async closure even if it's passed to
+// a function that requires the async closure implement `Fn*` but does *not* have
+// a `Future` bound on the return type.
+
+#![feature(async_closure)]
+
+use std::future::Future;
+
+trait TryStream {
+    type Ok;
+    type Err;
+}
+
+trait TryFuture {
+    type Ok;
+    type Err;
+}
+
+impl<F, T, E> TryFuture for F where F: Future<Output = Result<T, E>> {
+    type Ok = T;
+    type Err = E;
+}
+
+trait TryStreamExt: TryStream {
+    fn try_for_each<F, Fut>(&self, f: F)
+    where
+        F: FnMut(Self::Ok) -> Fut,
+        Fut: TryFuture<Ok = (), Err = Self::Err>;
+}
+
+impl<S> TryStreamExt for S where S: TryStream {
+    fn try_for_each<F, Fut>(&self, f: F)
+    where
+        F: FnMut(Self::Ok) -> Fut,
+        Fut: TryFuture<Ok = (), Err = Self::Err>,
+    { }
+}
+
+fn test(stream: impl TryStream<Ok = &'static str, Err = ()>) {
+    stream.try_for_each(async |s| {
+        s.trim(); // Make sure we know the type of `s` at this point.
+        Ok(())
+    });
+}
+
+fn main() {}


### PR DESCRIPTION
In #127482, I implemented the functionality to infer an async closure signature when passed into a function that has `Fn` + `Future` where clauses that look like:

```
fn whatever(callback: F)
where
  F: Fn(Arg) -> Fut,
  Fut: Future<Output = Out>,
```

However, #127781 demonstrates that this is still incomplete to address the cases users care about. So let's not bail when we fail to find a `Future` bound, and try our best to just use the args from the `Fn` bound if we find it. This is *fine* since most users of closures only really care about the *argument* types for inference guidance, since we require the receiver of a `.` method call to be known in order to probe methods.

When I experimented with programmatically rewriting `|| async {}` to `async || {}` in #127827, this also seems to have fixed ~5000 regressions (probably all coming from usages `TryFuture`/`TryStream` from futures-rs): the [before](https://github.com/rust-lang/rust/pull/127827#issuecomment-2254061733) and [after](https://github.com/rust-lang/rust/pull/127827#issuecomment-2255470176) crater runs.

Fixes #127781.