### PR TITLE
Cleanup `NonZero<T>::get`

### DIFF
--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -426,7 +426,7 @@ where
     #[rustc_const_stable(feature = "const_nonzero_get", since = "1.34.0")]
     #[inline]
     pub const fn get(self) -> T {
-        self.0
+        self.0.0
     }
 }
 

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -426,19 +426,7 @@ where
     #[rustc_const_stable(feature = "const_nonzero_get", since = "1.34.0")]
     #[inline]
     pub const fn get(self) -> T {
-        // FIXME: This can be changed to simply `self.0` once LLVM supports `!range` metadata
-        // for function arguments: https://github.com/llvm/llvm-project/issues/76628
-        //
-        // Rustc can set range metadata only if it loads `self` from
-        // memory somewhere. If the value of `self` was from by-value argument
-        // of some not-inlined function, LLVM don't have range metadata
-        // to understand that the value cannot be zero.
-        //
-        // For now, using the transmute `assume`s the range at runtime.
-        //
-        // SAFETY: `ZeroablePrimitive` guarantees that the size and bit validity
-        // of `.0` is such that this transmute is sound.
-        unsafe { intrinsics::transmute_unchecked(self) }
+        self.0
     }
 }
 


### PR DESCRIPTION
After https://github.com/rust-lang/rust/pull/128371, we may be able to remove this complexity.

Codegen test was introduced in https://github.com/rust-lang/rust/pull/119452/.

r? libs
