### PR TITLE
Stabilize `option_get_or_insert_default`

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -9,7 +9,6 @@
 #![feature(let_chains)]
 #![feature(map_try_insert)]
 #![feature(never_type)]
-#![feature(option_get_or_insert_default)]
 #![feature(round_char_boundary)]
 #![feature(try_blocks)]
 #![feature(yeet_expr)]

--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
 #![feature(map_many_mut)]
-#![feature(option_get_or_insert_default)]
 #![feature(rustc_attrs)]
 // tidy-alphabetical-end
 

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1650,8 +1650,6 @@ impl<T> Option<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(option_get_or_insert_default)]
-    ///
     /// let mut x = None;
     ///
     /// {
@@ -1664,7 +1662,7 @@ impl<T> Option<T> {
     /// assert_eq!(x, Some(7));
     /// ```
     #[inline]
-    #[unstable(feature = "option_get_or_insert_default", issue = "82901")]
+    #[stable(feature = "option_get_or_insert_default", since = "CURRENT_RUSTC_VERSION")]
     pub fn get_or_insert_default(&mut self) -> &mut T
     where
         T: Default,


### PR DESCRIPTION
Closes: https://github.com/rust-lang/rust/issues/82901.

@rustbot label: +T-libs-api

r? libs-api