### PR TITLE
Add `?Sized` bound on `T` to `impl<T: Error> Error for Box<T>`

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -2707,7 +2707,7 @@ impl<'a, 'b> From<Cow<'b, str>> for Box<dyn Error + 'a> {
 }
 
 #[stable(feature = "box_error", since = "1.8.0")]
-impl<T: core::error::Error> core::error::Error for Box<T> {
+impl<T: core::error::Error + ?Sized> core::error::Error for Box<T> {
     #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
         core::error::Error::description(&**self)


### PR DESCRIPTION
Add `?Sized` bound on `T` to `impl<T: Error> Error for Box<T>`, this caused `Box<dyn Error>` to not implement `Error`, which in my opinion should implement `Error`.

I brought this up in the rust programming language community discord, I thought making a pull request was the best way to get it fixed.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
