### PR TITLE
Fix projections when parent capture is by-ref but child capture is by-value in the `ByMoveBody` pass

### DIFF
--- a/tests/ui/async-await/async-closures/move-out-of-ref.rs
+++ b/tests/ui/async-await/async-closures/move-out-of-ref.rs
@@ -1,0 +1,16 @@
+//@ compile-flags: -Zvalidate-mir
+//@ edition: 2021
+
+#![feature(async_closure)]
+
+// NOT copy.
+struct Ty;
+
+fn hello(x: &Ty) {
+    let c = async || {
+        *x;
+        //~^ ERROR cannot move out of `*x` which is behind a shared reference
+    };
+}
+
+fn main() {}

--- a/tests/ui/async-await/async-closures/move-out-of-ref.stderr
+++ b/tests/ui/async-await/async-closures/move-out-of-ref.stderr
@@ -1,0 +1,18 @@
+error[E0507]: cannot move out of `*x` which is behind a shared reference
+  --> $DIR/move-out-of-ref.rs:11:9
+   |
+LL |         *x;
+   |         ^^ move occurs because `*x` has type `Ty`, which does not implement the `Copy` trait
+   |
+note: if `Ty` implemented `Clone`, you could clone the value
+  --> $DIR/move-out-of-ref.rs:7:1
+   |
+LL | struct Ty;
+   | ^^^^^^^^^ consider implementing `Clone` for this type
+...
+LL |         *x;
+   |         -- you could clone this value
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0507`.


### PR DESCRIPTION
This fixes a somewhat strange bug where we build the incorrect MIR in #129074. This one is weird, but I don't expect it to actually matter in practice since it almost certainly results in a move error in borrowck. However, let's not ICE.

Given the code:

```
#![feature(async_closure)]

// NOT copy.
struct Ty;

fn hello(x: &Ty) {
    let c = async || {
        *x;
        //~^ ERROR cannot move out of `*x` which is behind a shared reference
    };
}

fn main() {}
```

The parent coroutine-closure captures `x: &Ty` by-ref, resulting in an upvar of `&&Ty`. The child coroutine captures `x` by-value, resulting in an upvar of `&Ty`. When constructing the by-move body for the coroutine-closure, we weren't applying an additional deref projection to convert the parent capture into the child capture, resulting in an type error in assignment, which is a validation ICE.

As I said above, this only occurs (AFAICT) in code that eventually results in an error, because it is only triggered by HIR that attempts to move a non-copy value out of a ref. This doesn't occur if `Ty` is `Copy`, since we'd instead capture `x` by-ref in the child coroutine.

Fixes #129074