### PR TITLE
add clarifying statement about std::sync::mpsc panics

### DIFF
--- a/library/std/src/sync/mpmc/mod.rs
+++ b/library/std/src/sync/mpmc/mod.rs
@@ -64,7 +64,7 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 /// receive operations must appear at the same time in order to pair up and pass the message over.
 ///
 /// # Panics
-/// Panics if `cap` exceeds [`iszie::MAX`] *bytes*.
+/// Panics if `cap` exceeds [`isize::MAX`] *bytes*.
 pub fn sync_channel<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
     if cap == 0 {
         let (s, r) = counter::new(zero::Channel::new());

--- a/library/std/src/sync/mpmc/mod.rs
+++ b/library/std/src/sync/mpmc/mod.rs
@@ -62,6 +62,9 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 ///
 /// A special case is zero-capacity channel, which cannot hold any messages. Instead, send and
 /// receive operations must appear at the same time in order to pair up and pass the message over.
+///
+/// # Panics
+/// Panics if `cap` exceeds [`iszie::MAX`] *bytes*.
 pub fn sync_channel<T>(cap: usize) -> (Sender<T>, Receiver<T>) {
     if cap == 0 {
         let (s, r) = counter::new(zero::Channel::new());

--- a/library/std/src/sync/mpsc/mod.rs
+++ b/library/std/src/sync/mpsc/mod.rs
@@ -549,6 +549,9 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 /// [`send`]: SyncSender::send
 /// [`recv`]: Receiver::recv
 ///
+/// # Panics
+/// Panics if `bound` exceeds [`isize::MAX`] *bytes*.
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
This PR adds a clarifying statement to the [`std::sync::mpsc`](https://doc.rust-lang.org/std/sync/mpsc/index.html) docs that when calling [`sync_channel`](https://doc.rust-lang.org/std/sync/mpsc/fn.sync_channel.html), if the `bound`, which is `usize`, is greater than `isize::MAX` bytes then the call will panic. I ran into this "in the wild" just now and it took me a while to track down the cause. 