### PR TITLE
Re-enable `dump-ice-to-disk` for Windows

### DIFF
--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -14,11 +14,14 @@
 //!       that `RUSTC_ICE_PATH` takes precedence and no ICE dump is emitted under `METRICS_PATH`.
 //!
 //! See <https://github.com/rust-lang/rust/pull/108714>.
-
-//@ ignore-windows
-// FIXME(#128911): @jieyouxu: This test is sometimes for whatever forsaken reason flakey in
-// `i686-mingw`, and I cannot reproduce it locally. The error messages upon assertion failure in
-// this test is intentionally extremely verbose to aid debugging that issue.
+//!
+//! # Test history
+//!
+//! - The previous rmake.rs iteration of this test was flakey for unknown reason on `i686-mingw`
+//!   *specifically*, so assertion failures in this test was made extremely verbose to help
+//!   diagnose why the ICE messages was different *specifically* on `i686-mingw`.
+//! - An attempt is made to re-enable this test on `i686-mingw` (by removing `ignore-windows`). If
+//!   this test is still flakey, please restore the `ignore-windows` directive.
 
 use std::cell::OnceCell;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
This test was previously flakey on `i686-mingw` (reason unknown), but since some modifications (quarantining each ICE test in separate tmp dirs, adding/removing `RUSTC_ICE` env vars as suitable to prevent any kind of environmental influence), I could no longer make it fail on `i686-mingw`.

I tried running this test (without the `ignore-windows` of course) a bunch of times via `i686-mingw` try jobs and it refused to fail (see #128958). I was also never able to reproduce the failure locally.

In any case, if this turns out to be still flakey on `i686-mingw`, we can revert the removal of `ignore-windows` but this time we'll have way more context for why the test failed.

Running the `i686-mingw` alongside some Windows jobs for basic santiy check. But the try jobs succeeding is insufficient to guarantee reproducibility.

cc #129115 for backlink.

try-job: x86_64-msvc
try-job: x86_64-mingw
try-job: i686-msvc
try-job: i686-mingw