### PR TITLE
Stabilize `tcp_quickack`

### DIFF
--- a/library/std/src/os/android/net.rs
+++ b/library/std/src/os/android/net.rs
@@ -6,5 +6,5 @@
 pub use crate::os::net::linux_ext::addr::SocketAddrExt;
 #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
 pub use crate::os::net::linux_ext::socket::UnixSocketExt;
-#[unstable(feature = "tcp_quickack", issue = "96256")]
+#[stable(feature = "tcp_quickack", since = "CURRENT_RUSTC_VERSION")]
 pub use crate::os::net::linux_ext::tcp::TcpStreamExt;

--- a/library/std/src/os/linux/net.rs
+++ b/library/std/src/os/linux/net.rs
@@ -6,5 +6,5 @@
 pub use crate::os::net::linux_ext::addr::SocketAddrExt;
 #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
 pub use crate::os::net::linux_ext::socket::UnixSocketExt;
-#[unstable(feature = "tcp_quickack", issue = "96256")]
+#[stable(feature = "tcp_quickack", since = "CURRENT_RUSTC_VERSION")]
 pub use crate::os::net::linux_ext::tcp::TcpStreamExt;

--- a/library/std/src/os/net/linux_ext/mod.rs
+++ b/library/std/src/os/net/linux_ext/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod addr;
 #[unstable(feature = "unix_socket_ancillary_data", issue = "76915")]
 pub(crate) mod socket;
 
-#[unstable(feature = "tcp_quickack", issue = "96256")]
+#[stable(feature = "tcp_quickack", since = "CURRENT_RUSTC_VERSION")]
 pub(crate) mod tcp;
 
 #[cfg(test)]

--- a/library/std/src/os/net/linux_ext/tcp.rs
+++ b/library/std/src/os/net/linux_ext/tcp.rs
@@ -9,7 +9,7 @@ use crate::{io, net};
 /// Os-specific extensions for [`TcpStream`]
 ///
 /// [`TcpStream`]: net::TcpStream
-#[unstable(feature = "tcp_quickack", issue = "96256")]
+#[stable(feature = "tcp_quickack", since = "CURRENT_RUSTC_VERSION")]
 pub trait TcpStreamExt: Sealed {
     /// Enable or disable `TCP_QUICKACK`.
     ///
@@ -23,7 +23,6 @@ pub trait TcpStreamExt: Sealed {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(tcp_quickack)]
     /// use std::net::TcpStream;
     /// use std::os::linux::net::TcpStreamExt;
     ///
@@ -31,7 +30,7 @@ pub trait TcpStreamExt: Sealed {
     ///         .expect("Couldn't connect to the server...");
     /// stream.set_quickack(true).expect("set_quickack call failed");
     /// ```
-    #[unstable(feature = "tcp_quickack", issue = "96256")]
+    #[stable(feature = "tcp_quickack", since = "CURRENT_RUSTC_VERSION")]
     fn set_quickack(&self, quickack: bool) -> io::Result<()>;
 
     /// Gets the value of the `TCP_QUICKACK` option on this socket.
@@ -41,7 +40,6 @@ pub trait TcpStreamExt: Sealed {
     /// # Examples
     ///
     /// ```no_run
-    /// #![feature(tcp_quickack)]
     /// use std::net::TcpStream;
     /// use std::os::linux::net::TcpStreamExt;
     ///
@@ -50,7 +48,7 @@ pub trait TcpStreamExt: Sealed {
     /// stream.set_quickack(true).expect("set_quickack call failed");
     /// assert_eq!(stream.quickack().unwrap_or(false), true);
     /// ```
-    #[unstable(feature = "tcp_quickack", issue = "96256")]
+    #[stable(feature = "tcp_quickack", since = "CURRENT_RUSTC_VERSION")]
     fn quickack(&self) -> io::Result<bool>;
 
     /// A socket listener will be awakened solely when data arrives.
@@ -99,10 +97,10 @@ pub trait TcpStreamExt: Sealed {
     fn deferaccept(&self) -> io::Result<u32>;
 }
 
-#[unstable(feature = "tcp_quickack", issue = "96256")]
+#[stable(feature = "tcp_quickack", since = "CURRENT_RUSTC_VERSION")]
 impl Sealed for net::TcpStream {}
 
-#[unstable(feature = "tcp_quickack", issue = "96256")]
+#[stable(feature = "tcp_quickack", since = "CURRENT_RUSTC_VERSION")]
 impl TcpStreamExt for net::TcpStream {
     fn set_quickack(&self, quickack: bool) -> io::Result<()> {
         self.as_inner().as_inner().set_quickack(quickack)


### PR DESCRIPTION
to stabilise the quickack part for now, tcp_deferaccept had been added at a later stage.

The related API calls are the following

```rust
// std::os::linux::net

// sealed trait, implemented for std::net::TcpStream
pub trait TcpStreamExt: Sealed{
  fn quickack(&self) -> io::Result<bool>;
  fn set_quickack(&self, quickack: bool) -> io::Result<()>;
}
```

Closes: https://github.com/rust-lang/rust/issues/96256