### PR TITLE
rustdoc-json: Add test for `Self` type

### DIFF
--- a/tests/rustdoc-json/traits/self.rs
+++ b/tests/rustdoc-json/traits/self.rs
@@ -1,0 +1,58 @@
+// ignore-tidy-linelength
+
+pub struct Foo;
+
+// Check that Self is represented uniformly between inherent impls, trait impls,
+// and trait definitions, even though it uses both SelfTyParam and SelfTyAlias
+// internally.
+//
+// Each assertion matches 3 times, and should be the same each time.
+
+impl Foo {
+    //@ ismany '$.index[*][?(@.name=="by_ref")].inner.function.decl.inputs[0][0]' '"self"' '"self"' '"self"'
+    //@ ismany '$.index[*][?(@.name=="by_ref")].inner.function.decl.inputs[0][1].borrowed_ref.type.generic' '"Self"' '"Self"' '"Self"'
+    //@ ismany '$.index[*][?(@.name=="by_ref")].inner.function.decl.inputs[0][1].borrowed_ref.lifetime' null null null
+    //@ ismany '$.index[*][?(@.name=="by_ref")].inner.function.decl.inputs[0][1].borrowed_ref.mutable' false false false
+    pub fn by_ref(&self) {}
+
+    //@ ismany '$.index[*][?(@.name=="by_exclusive_ref")].inner.function.decl.inputs[0][0]' '"self"' '"self"' '"self"'
+    //@ ismany '$.index[*][?(@.name=="by_exclusive_ref")].inner.function.decl.inputs[0][1].borrowed_ref.type.generic' '"Self"' '"Self"' '"Self"'
+    //@ ismany '$.index[*][?(@.name=="by_exclusive_ref")].inner.function.decl.inputs[0][1].borrowed_ref.lifetime' null null null
+    //@ ismany '$.index[*][?(@.name=="by_exclusive_ref")].inner.function.decl.inputs[0][1].borrowed_ref.mutable' true true true
+    pub fn by_exclusive_ref(&mut self) {}
+
+    //@ ismany '$.index[*][?(@.name=="by_value")].inner.function.decl.inputs[0][0]' '"self"' '"self"' '"self"'
+    //@ ismany '$.index[*][?(@.name=="by_value")].inner.function.decl.inputs[0][1].generic' '"Self"' '"Self"' '"Self"'
+    pub fn by_value(self) {}
+
+    //@ ismany '$.index[*][?(@.name=="with_lifetime")].inner.function.decl.inputs[0][0]' '"self"' '"self"' '"self"'
+    //@ ismany '$.index[*][?(@.name=="with_lifetime")].inner.function.decl.inputs[0][1].borrowed_ref.type.generic' '"Self"' '"Self"' '"Self"'
+    //@ ismany '$.index[*][?(@.name=="with_lifetime")].inner.function.decl.inputs[0][1].borrowed_ref.lifetime' \"\'a\" \"\'a\" \"\'a\"
+    //@ ismany '$.index[*][?(@.name=="with_lifetime")].inner.function.decl.inputs[0][1].borrowed_ref.mutable' false false false
+    pub fn with_lifetime<'a>(&'a self) {}
+
+    //@ ismany '$.index[*][?(@.name=="build")].inner.function.decl.output.generic' '"Self"' '"Self"' '"Self"'
+    pub fn build() -> Self {
+        Self
+    }
+}
+
+pub struct Bar;
+
+pub trait SelfParams {
+    fn by_ref(&self);
+    fn by_exclusive_ref(&mut self);
+    fn by_value(self);
+    fn with_lifetime<'a>(&'a self);
+    fn build() -> Self;
+}
+
+impl SelfParams for Bar {
+    fn by_ref(&self) {}
+    fn by_exclusive_ref(&mut self) {}
+    fn by_value(self) {}
+    fn with_lifetime<'a>(&'a self) {}
+    fn build() -> Self {
+        Self
+    }
+}


### PR DESCRIPTION
Inspired by #128471, the rustdoc-json suite had no tests in place for the `Self` type. This PR adds one.

I've also manually checked locally that this test passes on 29e924841f06bb181d87494eba2783761bc1ddec, confirming that adding `clean::Type::SelfTy` didn't change the JSON output. (potentially adding a self type to json (insead of (ab)using generic) is tracked in #128522)

Updates #81359

r? @fmease 