### PR TITLE
rustdoc-json: Use FxHashMap from rustdoc_json_types

### DIFF
--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use rustc_hash::FxHashMap;
+pub use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 /// The version of JSON output that this crate represents.


### PR DESCRIPTION
Alternative to #110051 and #127456.

This lets us avoid rehashing the json index after building it by using the same hashmap type in construction and in rustdoc_json_types. The above PR's tried to do this by having rustdoc_json_types get the same hashmap that rustdoc has via rustc_data_structures. However, this can be made simpler if we change rustdoc instead.

For the rustdoc-type republish on crates.io, It will filter out the `pub use`, and not change source at all. https://github.com/aDotInTheVoid/rustdoc-types/pull/30. That code [already replaces the hashmap](https://github.com/aDotInTheVoid/rustdoc-types/blob/8d6528669ec64c2af43d1c79a228b7711cefdad7/update.sh#L11) to use the one in `std::collections` (instead of `FxHashMap`)

try-job: dist-arm-linux

r? @GuillaumeGomez 