### PR TITLE
Fix anon const def-creation when macros are involved

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1188,14 +1188,7 @@ impl Expr {
     ///
     /// Does not ensure that the path resolves to a const param, the caller should check this.
     pub fn is_potential_trivial_const_arg(&self) -> bool {
-        let this = if let ExprKind::Block(block, None) = &self.kind
-            && let [stmt] = block.stmts.as_slice()
-            && let StmtKind::Expr(expr) = &stmt.kind
-        {
-            expr
-        } else {
-            self
-        };
+        let this = self.maybe_unwrap_block();
 
         if let ExprKind::Path(None, path) = &this.kind
             && path.is_potential_trivial_const_arg()
@@ -1203,6 +1196,17 @@ impl Expr {
             true
         } else {
             false
+        }
+    }
+
+    pub fn maybe_unwrap_block(&self) -> &Expr {
+        if let ExprKind::Block(block, None) = &self.kind
+            && let [stmt] = block.stmts.as_slice()
+            && let StmtKind::Expr(expr) = &stmt.kind
+        {
+            expr
+        } else {
+            self
         }
     }
 

--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -220,9 +220,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             let parent_def_id = self.current_def_id_parent;
                             let node_id = self.next_node_id();
                             // HACK(min_generic_const_args): see lower_anon_const
-                            if !self.tcx.features().const_arg_path
-                                || !expr.is_potential_trivial_const_arg()
-                            {
+                            if !expr.is_potential_trivial_const_arg() {
                                 self.create_def(
                                     parent_def_id,
                                     node_id,

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -387,7 +387,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 let node_id = self.next_node_id();
 
                 // HACK(min_generic_const_args): see lower_anon_const
-                if !self.tcx.features().const_arg_path || !arg.is_potential_trivial_const_arg() {
+                if !arg.is_potential_trivial_const_arg() {
                     // Add a definition for the in-band const def.
                     self.create_def(parent_def_id, node_id, kw::Empty, DefKind::AnonConst, f.span);
                 }

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2335,7 +2335,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         span: Span,
     ) -> &'hir hir::ConstArg<'hir> {
         let ct_kind = match res {
-            Res::Def(DefKind::ConstParam, _) if self.tcx.features().const_arg_path => {
+            Res::Def(DefKind::ConstParam, _) => {
                 let qpath = self.lower_qpath(
                     ty_id,
                     &None,
@@ -2410,8 +2410,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             self.resolver.get_partial_res(expr.id).and_then(|partial_res| partial_res.full_res());
         debug!("res={:?}", maybe_res);
         // FIXME(min_generic_const_args): for now we only lower params to ConstArgKind::Path
-        if self.tcx.features().const_arg_path
-            && let Some(res) = maybe_res
+        if let Some(res) = maybe_res
             && let Res::Def(DefKind::ConstParam, _) = res
             && let ExprKind::Path(qself, path) = &expr.kind
         {
@@ -2442,7 +2441,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
     /// See [`hir::ConstArg`] for when to use this function vs
     /// [`Self::lower_anon_const_to_const_arg`].
     fn lower_anon_const_to_anon_const(&mut self, c: &AnonConst) -> &'hir hir::AnonConst {
-        if self.tcx.features().const_arg_path && c.value.is_potential_trivial_const_arg() {
+        if c.value.is_potential_trivial_const_arg() {
             // HACK(min_generic_const_args): see DefCollector::visit_anon_const
             // Over there, we guess if this is a bare param and only create a def if
             // we think it's not. However we may can guess wrong (see there for example)

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -193,8 +193,6 @@ declare_features! (
     (unstable, anonymous_lifetime_in_impl_trait, "1.63.0", None),
     /// Allows identifying the `compiler_builtins` crate.
     (internal, compiler_builtins, "1.13.0", None),
-    /// Gating for a new desugaring of const arguments of usages of const parameters
-    (internal, const_arg_path, "1.81.0", None),
     /// Allows writing custom MIR
     (internal, custom_mir, "1.65.0", None),
     /// Outputs useful `assert!` messages

--- a/compiler/rustc_middle/src/ty/consts.rs
+++ b/compiler/rustc_middle/src/ty/consts.rs
@@ -295,20 +295,12 @@ impl<'tcx> Const<'tcx> {
             _ => expr,
         };
 
-        if let hir::ExprKind::Path(
-            qpath @ hir::QPath::Resolved(
-                _,
-                &hir::Path { res: Res::Def(DefKind::ConstParam, _), .. },
-            ),
-        ) = expr.kind
+        if let hir::ExprKind::Path(hir::QPath::Resolved(
+            _,
+            &hir::Path { res: Res::Def(DefKind::ConstParam, _), .. },
+        )) = expr.kind
         {
-            if tcx.features().const_arg_path {
-                span_bug!(
-                    expr.span,
-                    "try_from_lit: received const param which shouldn't be possible"
-                );
-            }
-            return Some(Const::from_param(tcx, qpath, expr.hir_id));
+            span_bug!(expr.span, "try_from_lit: received const param which shouldn't be possible");
         };
 
         let lit_input = match expr.kind {

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -347,22 +347,20 @@ impl<'a, 'b, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'b, 'tcx> {
     }
 
     fn visit_anon_const(&mut self, constant: &'a AnonConst) {
-        if self.resolver.tcx.features().const_arg_path {
-            // HACK(min_generic_const_args): don't create defs for anon consts if we think they will
-            // later be turned into ConstArgKind::Path's. because this is before resolve is done, we
-            // may accidentally identify a construction of a unit struct as a param and not create a
-            // def. we'll then create a def later in ast lowering in this case. the parent of nested
-            // items will be messed up, but that's ok because there can't be any if we're just looking
-            // for bare idents.
+        // HACK(min_generic_const_args): don't create defs for anon consts if we think they will
+        // later be turned into ConstArgKind::Path's. because this is before resolve is done, we
+        // may accidentally identify a construction of a unit struct as a param and not create a
+        // def. we'll then create a def later in ast lowering in this case. the parent of nested
+        // items will be messed up, but that's ok because there can't be any if we're just looking
+        // for bare idents.
 
-            if matches!(constant.value.maybe_unwrap_block().kind, ExprKind::MacCall(..)) {
-                // See self.pending_anon_const_info for explanation
-                self.pending_anon_const_info =
-                    Some(PendingAnonConstInfo { id: constant.id, span: constant.value.span });
-                return visit::walk_anon_const(self, constant);
-            } else if constant.value.is_potential_trivial_const_arg() {
-                return visit::walk_anon_const(self, constant);
-            }
+        if matches!(constant.value.maybe_unwrap_block().kind, ExprKind::MacCall(..)) {
+            // See self.pending_anon_const_info for explanation
+            self.pending_anon_const_info =
+                Some(PendingAnonConstInfo { id: constant.id, span: constant.value.span });
+            return visit::walk_anon_const(self, constant);
+        } else if constant.value.is_potential_trivial_const_arg() {
+            return visit::walk_anon_const(self, constant);
         }
 
         let def = self.create_def(constant.id, kw::Empty, DefKind::AnonConst, constant.value.span);

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -12,15 +12,23 @@ use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::Span;
 use tracing::debug;
 
-use crate::{ImplTraitContext, Resolver};
+use crate::{ImplTraitContext, InvocationParent, PendingAnonConstInfo, Resolver};
 
 pub(crate) fn collect_definitions(
     resolver: &mut Resolver<'_, '_>,
     fragment: &AstFragment,
     expansion: LocalExpnId,
 ) {
-    let (parent_def, impl_trait_context, in_attr) = resolver.invocation_parents[&expansion];
-    let mut visitor = DefCollector { resolver, parent_def, expansion, impl_trait_context, in_attr };
+    let InvocationParent { parent_def, pending_anon_const_info, impl_trait_context, in_attr } =
+        resolver.invocation_parents[&expansion];
+    let mut visitor = DefCollector {
+        resolver,
+        parent_def,
+        pending_anon_const_info,
+        expansion,
+        impl_trait_context,
+        in_attr,
+    };
     fragment.visit_with(&mut visitor);
 }
 
@@ -28,6 +36,13 @@ pub(crate) fn collect_definitions(
 struct DefCollector<'a, 'b, 'tcx> {
     resolver: &'a mut Resolver<'b, 'tcx>,
     parent_def: LocalDefId,
+    /// If we have an anon const that consists of a macro invocation, e.g. `Foo<{ m!() }>`,
+    /// we need to wait until we know what the macro expands to before we create the def for
+    /// the anon const. That's because we lower some anon consts into `hir::ConstArgKind::Path`,
+    /// which don't have defs.
+    ///
+    /// See `Self::visit_anon_const()`.
+    pending_anon_const_info: Option<PendingAnonConstInfo>,
     impl_trait_context: ImplTraitContext,
     in_attr: bool,
     expansion: LocalExpnId,
@@ -111,10 +126,16 @@ impl<'a, 'b, 'tcx> DefCollector<'a, 'b, 'tcx> {
 
     fn visit_macro_invoc(&mut self, id: NodeId) {
         let id = id.placeholder_to_expn_id();
-        let old_parent = self
-            .resolver
-            .invocation_parents
-            .insert(id, (self.parent_def, self.impl_trait_context, self.in_attr));
+        let pending_anon_const_info = self.pending_anon_const_info.take();
+        let old_parent = self.resolver.invocation_parents.insert(
+            id,
+            InvocationParent {
+                parent_def: self.parent_def,
+                pending_anon_const_info,
+                impl_trait_context: self.impl_trait_context,
+                in_attr: self.in_attr,
+            },
+        );
         assert!(old_parent.is_none(), "parent `LocalDefId` is reset for an invocation");
     }
 }
@@ -326,46 +347,67 @@ impl<'a, 'b, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'b, 'tcx> {
     }
 
     fn visit_anon_const(&mut self, constant: &'a AnonConst) {
-        if self.resolver.tcx.features().const_arg_path
-            && constant.value.is_potential_trivial_const_arg()
-        {
+        if self.resolver.tcx.features().const_arg_path {
             // HACK(min_generic_const_args): don't create defs for anon consts if we think they will
             // later be turned into ConstArgKind::Path's. because this is before resolve is done, we
             // may accidentally identify a construction of a unit struct as a param and not create a
             // def. we'll then create a def later in ast lowering in this case. the parent of nested
             // items will be messed up, but that's ok because there can't be any if we're just looking
             // for bare idents.
-            visit::walk_anon_const(self, constant)
-        } else {
-            let def =
-                self.create_def(constant.id, kw::Empty, DefKind::AnonConst, constant.value.span);
-            self.with_parent(def, |this| visit::walk_anon_const(this, constant));
+
+            if matches!(constant.value.maybe_unwrap_block().kind, ExprKind::MacCall(..)) {
+                // See self.pending_anon_const_info for explanation
+                self.pending_anon_const_info =
+                    Some(PendingAnonConstInfo { id: constant.id, span: constant.value.span });
+                return visit::walk_anon_const(self, constant);
+            } else if constant.value.is_potential_trivial_const_arg() {
+                return visit::walk_anon_const(self, constant);
+            }
         }
+
+        let def = self.create_def(constant.id, kw::Empty, DefKind::AnonConst, constant.value.span);
+        self.with_parent(def, |this| visit::walk_anon_const(this, constant));
     }
 
     fn visit_expr(&mut self, expr: &'a Expr) {
-        let parent_def = match expr.kind {
-            ExprKind::MacCall(..) => return self.visit_macro_invoc(expr.id),
-            ExprKind::Closure(..) | ExprKind::Gen(..) => {
-                self.create_def(expr.id, kw::Empty, DefKind::Closure, expr.span)
+        if matches!(expr.kind, ExprKind::MacCall(..)) {
+            return self.visit_macro_invoc(expr.id);
+        }
+
+        let grandparent_def = if let Some(pending_anon) = self.pending_anon_const_info.take() {
+            // See self.pending_anon_const_info for explanation
+            if !expr.is_potential_trivial_const_arg() {
+                self.create_def(pending_anon.id, kw::Empty, DefKind::AnonConst, pending_anon.span)
+            } else {
+                self.parent_def
             }
-            ExprKind::ConstBlock(ref constant) => {
-                for attr in &expr.attrs {
-                    visit::walk_attribute(self, attr);
-                }
-                let def = self.create_def(
-                    constant.id,
-                    kw::Empty,
-                    DefKind::InlineConst,
-                    constant.value.span,
-                );
-                self.with_parent(def, |this| visit::walk_anon_const(this, constant));
-                return;
-            }
-            _ => self.parent_def,
+        } else {
+            self.parent_def
         };
 
-        self.with_parent(parent_def, |this| visit::walk_expr(this, expr));
+        self.with_parent(grandparent_def, |this| {
+            let parent_def = match expr.kind {
+                ExprKind::Closure(..) | ExprKind::Gen(..) => {
+                    this.create_def(expr.id, kw::Empty, DefKind::Closure, expr.span)
+                }
+                ExprKind::ConstBlock(ref constant) => {
+                    for attr in &expr.attrs {
+                        visit::walk_attribute(this, attr);
+                    }
+                    let def = this.create_def(
+                        constant.id,
+                        kw::Empty,
+                        DefKind::InlineConst,
+                        constant.value.span,
+                    );
+                    this.with_parent(def, |this| visit::walk_anon_const(this, constant));
+                    return;
+                }
+                _ => this.parent_def,
+            };
+
+            this.with_parent(parent_def, |this| visit::walk_expr(this, expr))
+        })
     }
 
     fn visit_ty(&mut self, ty: &'a Ty) {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -172,6 +172,29 @@ impl<'a> ParentScope<'a> {
 }
 
 #[derive(Copy, Debug, Clone)]
+struct InvocationParent {
+    parent_def: LocalDefId,
+    pending_anon_const_info: Option<PendingAnonConstInfo>,
+    impl_trait_context: ImplTraitContext,
+    in_attr: bool,
+}
+
+impl InvocationParent {
+    const ROOT: Self = Self {
+        parent_def: CRATE_DEF_ID,
+        pending_anon_const_info: None,
+        impl_trait_context: ImplTraitContext::Existential,
+        in_attr: false,
+    };
+}
+
+#[derive(Copy, Debug, Clone)]
+struct PendingAnonConstInfo {
+    id: NodeId,
+    span: Span,
+}
+
+#[derive(Copy, Debug, Clone)]
 enum ImplTraitContext {
     Existential,
     Universal,
@@ -1144,7 +1167,7 @@ pub struct Resolver<'a, 'tcx> {
     /// When collecting definitions from an AST fragment produced by a macro invocation `ExpnId`
     /// we know what parent node that fragment should be attached to thanks to this table,
     /// and how the `impl Trait` fragments were introduced.
-    invocation_parents: FxHashMap<LocalExpnId, (LocalDefId, ImplTraitContext, bool /*in_attr*/)>,
+    invocation_parents: FxHashMap<LocalExpnId, InvocationParent>,
 
     /// Some way to know that we are in a *trait* impl in `visit_assoc_item`.
     /// FIXME: Replace with a more general AST map (together with some other fields).
@@ -1381,8 +1404,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
         node_id_to_def_id.insert(CRATE_NODE_ID, crate_feed);
 
         let mut invocation_parents = FxHashMap::default();
-        invocation_parents
-            .insert(LocalExpnId::ROOT, (CRATE_DEF_ID, ImplTraitContext::Existential, false));
+        invocation_parents.insert(LocalExpnId::ROOT, InvocationParent::ROOT);
 
         let mut extern_prelude: FxHashMap<Ident, ExternPreludeEntry<'_>> = tcx
             .sess

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -42,9 +42,9 @@ use crate::errors::{
 use crate::imports::Import;
 use crate::Namespace::*;
 use crate::{
-    BindingKey, BuiltinMacroState, DeriveData, Determinacy, Finalize, MacroData, ModuleKind,
-    ModuleOrUniformRoot, NameBinding, NameBindingKind, ParentScope, PathResult, ResolutionError,
-    Resolver, ScopeSet, Segment, ToNameBinding, Used,
+    BindingKey, BuiltinMacroState, DeriveData, Determinacy, Finalize, InvocationParent, MacroData,
+    ModuleKind, ModuleOrUniformRoot, NameBinding, NameBindingKind, ParentScope, PathResult,
+    ResolutionError, Resolver, ScopeSet, Segment, ToNameBinding, Used,
 };
 
 type Res = def::Res<NodeId>;
@@ -183,7 +183,7 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
     }
 
     fn invocation_parent(&self, id: LocalExpnId) -> LocalDefId {
-        self.invocation_parents[&id].0
+        self.invocation_parents[&id].parent_def
     }
 
     fn resolve_dollar_crates(&mut self) {
@@ -303,12 +303,12 @@ impl<'a, 'tcx> ResolverExpand for Resolver<'a, 'tcx> {
             .invocation_parents
             .get(&invoc_id)
             .or_else(|| self.invocation_parents.get(&eager_expansion_root))
-            .filter(|&&(mod_def_id, _, in_attr)| {
+            .filter(|&&InvocationParent { parent_def: mod_def_id, in_attr, .. }| {
                 in_attr
                     && invoc.fragment_kind == AstFragmentKind::Expr
                     && self.tcx.def_kind(mod_def_id) == DefKind::Mod
             })
-            .map(|&(mod_def_id, ..)| mod_def_id);
+            .map(|&InvocationParent { parent_def: mod_def_id, .. }| mod_def_id);
         let (ext, res) = self.smart_resolve_macro_path(
             path,
             kind,
@@ -951,7 +951,9 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
                         let node_id = self
                             .invocation_parents
                             .get(&parent_scope.expansion)
-                            .map_or(ast::CRATE_NODE_ID, |id| self.def_id_to_node_id[id.0]);
+                            .map_or(ast::CRATE_NODE_ID, |parent| {
+                                self.def_id_to_node_id[parent.parent_def]
+                            });
                         self.lint_buffer.buffer_lint(
                             LEGACY_DERIVE_HELPERS,
                             node_id,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -599,7 +599,6 @@ symbols! {
         conservative_impl_trait,
         console,
         const_allocate,
-        const_arg_path,
         const_async_blocks,
         const_closures,
         const_compare_raw_pointers,

--- a/tests/ui-fulldeps/stable-mir/check_instance.rs
+++ b/tests/ui-fulldeps/stable-mir/check_instance.rs
@@ -35,7 +35,7 @@ fn test_stable_mir() -> ControlFlow<()> {
     // Get all items and split generic vs monomorphic items.
     let (generic, mono): (Vec<_>, Vec<_>) =
         items.into_iter().partition(|item| item.requires_monomorphization());
-    assert_eq!(mono.len(), 4, "Expected 3 mono functions");
+    assert_eq!(mono.len(), 3, "Expected 3 mono functions");
     assert_eq!(generic.len(), 2, "Expected 2 generic functions");
 
     // For all monomorphic items, get the correspondent instances.

--- a/tests/ui/coherence/negative-coherence/generic_const_type_mismatch.rs
+++ b/tests/ui/coherence/negative-coherence/generic_const_type_mismatch.rs
@@ -5,9 +5,7 @@
 #![feature(with_negative_coherence)]
 trait Trait {}
 impl<const N: u8> Trait for [(); N] {}
-//~^ ERROR: mismatched types
 impl<const N: i8> Trait for [(); N] {}
 //~^ ERROR: conflicting implementations of trait `Trait`
-//~| ERROR: mismatched types
 
 fn main() {}

--- a/tests/ui/coherence/negative-coherence/generic_const_type_mismatch.stderr
+++ b/tests/ui/coherence/negative-coherence/generic_const_type_mismatch.stderr
@@ -1,25 +1,11 @@
 error[E0119]: conflicting implementations of trait `Trait` for type `[(); _]`
-  --> $DIR/generic_const_type_mismatch.rs:9:1
+  --> $DIR/generic_const_type_mismatch.rs:8:1
    |
 LL | impl<const N: u8> Trait for [(); N] {}
    | ----------------------------------- first implementation here
-LL |
 LL | impl<const N: i8> Trait for [(); N] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `[(); _]`
 
-error[E0308]: mismatched types
-  --> $DIR/generic_const_type_mismatch.rs:7:34
-   |
-LL | impl<const N: u8> Trait for [(); N] {}
-   |                                  ^ expected `usize`, found `u8`
+error: aborting due to 1 previous error
 
-error[E0308]: mismatched types
-  --> $DIR/generic_const_type_mismatch.rs:9:34
-   |
-LL | impl<const N: i8> Trait for [(); N] {}
-   |                                  ^ expected `usize`, found `i8`
-
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0119, E0308.
-For more information about an error, try `rustc --explain E0119`.
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/const-generics/bad-subst-const-kind.rs
+++ b/tests/ui/const-generics/bad-subst-const-kind.rs
@@ -7,7 +7,6 @@ trait Q {
 
 impl<const N: u64> Q for [u8; N] {
     //~^ ERROR: the constant `N` is not of type `usize`
-    //~| ERROR: mismatched types
     const ASSOC: usize = 1;
 }
 

--- a/tests/ui/const-generics/bad-subst-const-kind.stderr
+++ b/tests/ui/const-generics/bad-subst-const-kind.stderr
@@ -5,7 +5,7 @@ LL | impl<const N: u64> Q for [u8; N] {
    |                          ^^^^^^^ expected `usize`, found `u64`
 
 error: the constant `13` is not of type `u64`
-  --> $DIR/bad-subst-const-kind.rs:14:24
+  --> $DIR/bad-subst-const-kind.rs:13:24
    |
 LL | pub fn test() -> [u8; <[u8; 13] as Q>::ASSOC] {
    |                        ^^^^^^^^ expected `u64`, found `usize`
@@ -18,12 +18,5 @@ LL | impl<const N: u64> Q for [u8; N] {
    |      |
    |      unsatisfied trait bound introduced here
 
-error[E0308]: mismatched types
-  --> $DIR/bad-subst-const-kind.rs:8:31
-   |
-LL | impl<const N: u64> Q for [u8; N] {
-   |                               ^ expected `usize`, found `u64`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.rs
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.rs
@@ -8,7 +8,6 @@ trait Q {
 impl<const N: u64> Q for [u8; N] {}
 //~^ ERROR not all trait items implemented
 //~| ERROR the constant `N` is not of type `usize`
-//~| ERROR mismatched types
 
 pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
 //~^ ERROR the constant `13` is not of type `u64`

--- a/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/type_mismatch.stderr
@@ -14,7 +14,7 @@ LL | impl<const N: u64> Q for [u8; N] {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `ASSOC` in implementation
 
 error: the constant `13` is not of type `u64`
-  --> $DIR/type_mismatch.rs:13:26
+  --> $DIR/type_mismatch.rs:12:26
    |
 LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
    |                          ^^^^^^^^ expected `u64`, found `usize`
@@ -28,20 +28,14 @@ LL | impl<const N: u64> Q for [u8; N] {}
    |      unsatisfied trait bound introduced here
 
 error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:13:20
+  --> $DIR/type_mismatch.rs:12:20
    |
 LL | pub fn q_user() -> [u8; <[u8; 13] as Q>::ASSOC] {}
    |        ------      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `[u8; <[u8; 13] as Q>::ASSOC]`, found `()`
    |        |
    |        implicitly returns `()` as its body has no tail or `return` expression
 
-error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:8:31
-   |
-LL | impl<const N: u64> Q for [u8; N] {}
-   |                               ^ expected `usize`, found `u64`
-
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0046, E0308.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.rs
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.rs
@@ -25,8 +25,8 @@ mod v20 {
     }
 
     impl<const v10: usize> v17<v10, v2> {
-        //~^ ERROR maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#1}
-        //~| ERROR maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#1}
+        //~^ ERROR maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#0}
+        //~| ERROR maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#0}
         pub const fn v21() -> v18 {
             //~^ ERROR cannot find type `v18` in this scope
             v18 { _p: () }

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
@@ -72,13 +72,13 @@ help: add `#![feature(adt_const_params)]` to the crate attributes to enable more
 LL + #![feature(adt_const_params)]
    |
 
-error: maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#1}
+error: maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#0}
   --> $DIR/unevaluated-const-ice-119731.rs:27:37
    |
 LL |     impl<const v10: usize> v17<v10, v2> {
    |                                     ^^
 
-error: maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#1}
+error: maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#0}
   --> $DIR/unevaluated-const-ice-119731.rs:27:37
    |
 LL |     impl<const v10: usize> v17<v10, v2> {

--- a/tests/ui/const-generics/transmute-fail.rs
+++ b/tests/ui/const-generics/transmute-fail.rs
@@ -11,8 +11,6 @@ fn foo<const W: usize, const H: usize>(v: [[u32; H + 1]; W]) -> [[u32; W + 1]; H
 
 fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
     //~^ ERROR: the constant `W` is not of type `usize`
-    //~| ERROR: mismatched types
-    //~| ERROR: mismatched types
     unsafe {
         std::mem::transmute(v)
         //~^ ERROR: the constant `W` is not of type `usize`

--- a/tests/ui/const-generics/transmute-fail.stderr
+++ b/tests/ui/const-generics/transmute-fail.stderr
@@ -14,13 +14,13 @@ LL |         std::mem::transmute(v)
    = note: target type: `[[u32; W + 1]; H]` (size can vary because of [u32; W + 1])
 
 error: the constant `W` is not of type `usize`
-  --> $DIR/transmute-fail.rs:17:9
+  --> $DIR/transmute-fail.rs:15:9
    |
 LL |         std::mem::transmute(v)
    |         ^^^^^^^^^^^^^^^^^^^ expected `usize`, found `bool`
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:24:9
+  --> $DIR/transmute-fail.rs:22:9
    |
 LL |         std::mem::transmute(v)
    |         ^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL |         std::mem::transmute(v)
    = note: target type: `[u32; W * H * H]` (this type does not have a fixed size)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:31:9
+  --> $DIR/transmute-fail.rs:29:9
    |
 LL |         std::mem::transmute(v)
    |         ^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL |         std::mem::transmute(v)
    = note: target type: `[[[u32; 9999999]; 777777777]; 8888888]` (values of the type `[[u32; 9999999]; 777777777]` are too big for the current architecture)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:38:9
+  --> $DIR/transmute-fail.rs:36:9
    |
 LL |         std::mem::transmute(v)
    |         ^^^^^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL |         std::mem::transmute(v)
    = note: target type: `[[u32; W]; H]` (size can vary because of [u32; W])
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:49:9
+  --> $DIR/transmute-fail.rs:47:9
    |
 LL |         std::mem::transmute(v)
    |         ^^^^^^^^^^^^^^^^^^^
@@ -56,7 +56,7 @@ LL |         std::mem::transmute(v)
    = note: target type: `[u32; W * H]` (this type does not have a fixed size)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:56:9
+  --> $DIR/transmute-fail.rs:54:9
    |
 LL |         std::mem::transmute(v)
    |         ^^^^^^^^^^^^^^^^^^^
@@ -65,7 +65,7 @@ LL |         std::mem::transmute(v)
    = note: target type: `[[u32; W]; H]` (size can vary because of [u32; W])
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:65:9
+  --> $DIR/transmute-fail.rs:63:9
    |
 LL |         std::mem::transmute(v)
    |         ^^^^^^^^^^^^^^^^^^^
@@ -74,7 +74,7 @@ LL |         std::mem::transmute(v)
    = note: target type: `[u32; D * W * H]` (this type does not have a fixed size)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:74:9
+  --> $DIR/transmute-fail.rs:72:9
    |
 LL |         std::mem::transmute(v)
    |         ^^^^^^^^^^^^^^^^^^^
@@ -83,7 +83,7 @@ LL |         std::mem::transmute(v)
    = note: target type: `[[u32; D * W]; H]` (size can vary because of [u32; D * W])
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:81:9
+  --> $DIR/transmute-fail.rs:79:9
    |
 LL |         std::mem::transmute(v)
    |         ^^^^^^^^^^^^^^^^^^^
@@ -92,7 +92,7 @@ LL |         std::mem::transmute(v)
    = note: target type: `[u8; L * 2]` (this type does not have a fixed size)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:88:9
+  --> $DIR/transmute-fail.rs:86:9
    |
 LL |         std::mem::transmute(v)
    |         ^^^^^^^^^^^^^^^^^^^
@@ -101,7 +101,7 @@ LL |         std::mem::transmute(v)
    = note: target type: `[u16; L]` (this type does not have a fixed size)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:95:9
+  --> $DIR/transmute-fail.rs:93:9
    |
 LL |         std::mem::transmute(v)
    |         ^^^^^^^^^^^^^^^^^^^
@@ -110,7 +110,7 @@ LL |         std::mem::transmute(v)
    = note: target type: `[[u8; 1]; L]` (this type does not have a fixed size)
 
 error[E0512]: cannot transmute between types of different sizes, or dependently-sized types
-  --> $DIR/transmute-fail.rs:104:9
+  --> $DIR/transmute-fail.rs:102:9
    |
 LL |         std::mem::transmute(v)
    |         ^^^^^^^^^^^^^^^^^^^
@@ -118,19 +118,6 @@ LL |         std::mem::transmute(v)
    = note: source type: `[[u32; 2 * H]; W + W]` (size can vary because of [u32; 2 * H])
    = note: target type: `[[u32; W + W]; 2 * H]` (size can vary because of [u32; W + W])
 
-error[E0308]: mismatched types
-  --> $DIR/transmute-fail.rs:12:53
-   |
-LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
-   |                                                     ^ expected `usize`, found `bool`
+error: aborting due to 14 previous errors
 
-error[E0308]: mismatched types
-  --> $DIR/transmute-fail.rs:12:67
-   |
-LL | fn bar<const W: bool, const H: usize>(v: [[u32; H]; W]) -> [[u32; W]; H] {
-   |                                                                   ^ expected `usize`, found `bool`
-
-error: aborting due to 16 previous errors
-
-Some errors have detailed explanations: E0308, E0512.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0512`.

--- a/tests/ui/const-generics/type_mismatch.rs
+++ b/tests/ui/const-generics/type_mismatch.rs
@@ -1,12 +1,10 @@
 fn foo<const N: usize>() -> [u8; N] {
     bar::<N>()
     //~^ ERROR the constant `N` is not of type `u8`
-    //~| ERROR: mismatched types
 }
 
 fn bar<const N: u8>() -> [u8; N] {}
 //~^ ERROR the constant `N` is not of type `usize`
-//~| ERROR: mismatched types
 //~| ERROR mismatched types
 
 fn main() {}

--- a/tests/ui/const-generics/type_mismatch.stderr
+++ b/tests/ui/const-generics/type_mismatch.stderr
@@ -1,5 +1,5 @@
 error: the constant `N` is not of type `usize`
-  --> $DIR/type_mismatch.rs:7:26
+  --> $DIR/type_mismatch.rs:6:26
    |
 LL | fn bar<const N: u8>() -> [u8; N] {}
    |                          ^^^^^^^ expected `usize`, found `u8`
@@ -11,31 +11,19 @@ LL |     bar::<N>()
    |           ^ expected `u8`, found `usize`
    |
 note: required by a const generic parameter in `bar`
-  --> $DIR/type_mismatch.rs:7:8
+  --> $DIR/type_mismatch.rs:6:8
    |
 LL | fn bar<const N: u8>() -> [u8; N] {}
    |        ^^^^^^^^^^^ required by this const generic parameter in `bar`
 
 error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:7:26
+  --> $DIR/type_mismatch.rs:6:26
    |
 LL | fn bar<const N: u8>() -> [u8; N] {}
    |    ---                   ^^^^^^^ expected `[u8; N]`, found `()`
    |    |
    |    implicitly returns `()` as its body has no tail or `return` expression
 
-error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:2:11
-   |
-LL |     bar::<N>()
-   |           ^ expected `u8`, found `usize`
-
-error[E0308]: mismatched types
-  --> $DIR/type_mismatch.rs:7:31
-   |
-LL | fn bar<const N: u8>() -> [u8; N] {}
-   |                               ^ expected `usize`, found `u8`
-
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/consts/issue-36163.stderr
+++ b/tests/ui/consts/issue-36163.stderr
@@ -1,10 +1,10 @@
-error[E0391]: cycle detected when simplifying constant for the type system `Foo::B::{constant#0}`
+error[E0391]: cycle detected when simplifying constant for the type system `Foo::{constant#0}`
   --> $DIR/issue-36163.rs:4:9
    |
 LL |     B = A,
    |         ^
    |
-note: ...which requires const-evaluating + checking `Foo::B::{constant#0}`...
+note: ...which requires const-evaluating + checking `Foo::{constant#0}`...
   --> $DIR/issue-36163.rs:4:9
    |
 LL |     B = A,
@@ -19,7 +19,7 @@ note: ...which requires const-evaluating + checking `A`...
    |
 LL | const A: isize = Foo::B as isize;
    |                  ^^^^^^^^^^^^^^^
-   = note: ...which again requires simplifying constant for the type system `Foo::B::{constant#0}`, completing the cycle
+   = note: ...which again requires simplifying constant for the type system `Foo::{constant#0}`, completing the cycle
 note: cycle used when checking that `Foo` is well-formed
   --> $DIR/issue-36163.rs:3:1
    |

--- a/tests/ui/feature-gates/feature-gate-const-arg-path.rs
+++ b/tests/ui/feature-gates/feature-gate-const-arg-path.rs
@@ -1,5 +1,0 @@
-//@ check-pass
-
-// this doesn't really have any user facing impact....
-
-fn main() {}

--- a/tests/ui/lifetimes/issue-95023.rs
+++ b/tests/ui/lifetimes/issue-95023.rs
@@ -9,6 +9,5 @@ impl Fn(&isize) for Error {
     //~^ ERROR associated function in `impl` without body
     //~| ERROR method `foo` is not a member of trait `Fn` [E0407]
     //~| ERROR associated type `B` not found for `Self` [E0220]
-    //~| ERROR: associated type `B` not found for `Self`
 }
 fn main() {}

--- a/tests/ui/lifetimes/issue-95023.stderr
+++ b/tests/ui/lifetimes/issue-95023.stderr
@@ -56,15 +56,7 @@ error[E0220]: associated type `B` not found for `Self`
 LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
    |                                            ^ help: `Self` has the following associated type: `Output`
 
-error[E0220]: associated type `B` not found for `Self`
-  --> $DIR/issue-95023.rs:8:44
-   |
-LL |     fn foo<const N: usize>(&self) -> Self::B<{ N }>;
-   |                                            ^ help: `Self` has the following associated type: `Output`
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 8 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0046, E0183, E0220, E0229, E0277, E0407.
 For more information about an error, try `rustc --explain E0046`.

--- a/tests/ui/specialization/default-proj-ty-as-type-of-const-issue-125757.rs
+++ b/tests/ui/specialization/default-proj-ty-as-type-of-const-issue-125757.rs
@@ -14,6 +14,5 @@ struct Wrapper<const C: <i32 as Trait>::Type> {}
 
 impl<const C: usize> Wrapper<C> {}
 //~^ ERROR the constant `C` is not of type `<i32 as Trait>::Type`
-//~| ERROR: mismatched types
 
 fn main() {}

--- a/tests/ui/specialization/default-proj-ty-as-type-of-const-issue-125757.stderr
+++ b/tests/ui/specialization/default-proj-ty-as-type-of-const-issue-125757.stderr
@@ -20,17 +20,5 @@ note: required by a const generic parameter in `Wrapper`
 LL | struct Wrapper<const C: <i32 as Trait>::Type> {}
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this const generic parameter in `Wrapper`
 
-error[E0308]: mismatched types
-  --> $DIR/default-proj-ty-as-type-of-const-issue-125757.rs:15:30
-   |
-LL | impl<const C: usize> Wrapper<C> {}
-   |                              ^ expected associated type, found `usize`
-   |
-   = note: expected associated type `<i32 as Trait>::Type`
-                         found type `usize`
-   = help: consider constraining the associated type `<i32 as Trait>::Type` to `usize`
-   = note: for more information, visit https://doc.rust-lang.org/book/ch19-03-advanced-traits.html
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.rs
+++ b/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.rs
@@ -6,7 +6,6 @@
 struct S<const L: usize>;
 
 impl<const N: i32> Copy for S<N> {}
-//~^ ERROR: mismatched types
 impl<const M: usize> Copy for S<M> {}
 //~^ ERROR: conflicting implementations of trait `Copy` for type `S<_>`
 

--- a/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.stderr
+++ b/tests/ui/specialization/min_specialization/bad-const-wf-doesnt-specialize.stderr
@@ -1,19 +1,11 @@
 error[E0119]: conflicting implementations of trait `Copy` for type `S<_>`
-  --> $DIR/bad-const-wf-doesnt-specialize.rs:10:1
+  --> $DIR/bad-const-wf-doesnt-specialize.rs:9:1
    |
 LL | impl<const N: i32> Copy for S<N> {}
    | -------------------------------- first implementation here
-LL |
 LL | impl<const M: usize> Copy for S<M> {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `S<_>`
 
-error[E0308]: mismatched types
-  --> $DIR/bad-const-wf-doesnt-specialize.rs:8:31
-   |
-LL | impl<const N: i32> Copy for S<N> {}
-   |                               ^ expected `usize`, found `i32`
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0119, E0308.
-For more information about an error, try `rustc --explain E0119`.
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/transmutability/issue-101739-1.rs
+++ b/tests/ui/transmutability/issue-101739-1.rs
@@ -7,7 +7,6 @@ mod assert {
     where
         Dst: TransmuteFrom<Src, ASSUME_ALIGNMENT>, //~ ERROR cannot find type `Dst` in this scope
                                                            //~| the constant `ASSUME_ALIGNMENT` is not of type `Assume`
-                                                           //~| ERROR: mismatched types
     {
     }
 }

--- a/tests/ui/transmutability/issue-101739-1.stderr
+++ b/tests/ui/transmutability/issue-101739-1.stderr
@@ -13,13 +13,6 @@ LL |         Dst: TransmuteFrom<Src, ASSUME_ALIGNMENT>,
 note: required by a const generic parameter in `TransmuteFrom`
   --> $SRC_DIR/core/src/mem/transmutability.rs:LL:COL
 
-error[E0308]: mismatched types
-  --> $DIR/issue-101739-1.rs:8:33
-   |
-LL |         Dst: TransmuteFrom<Src, ASSUME_ALIGNMENT>,
-   |                                 ^^^^^^^^^^^^^^^^ expected `Assume`, found `bool`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0308, E0412.
-For more information about an error, try `rustc --explain E0308`.
+For more information about this error, try `rustc --explain E0412`.

--- a/tests/ui/transmutability/issue-101739-2.rs
+++ b/tests/ui/transmutability/issue-101739-2.rs
@@ -17,7 +17,7 @@ mod assert {
         Dst: TransmuteFrom<
                 //~^ ERROR trait takes at most 2 generic arguments but 5 generic arguments were supplied
                 Src,
-                ASSUME_ALIGNMENT, //~ ERROR: mismatched types
+                ASSUME_ALIGNMENT,
                 ASSUME_LIFETIMES,
                 ASSUME_VALIDITY,
                 ASSUME_VISIBILITY,

--- a/tests/ui/transmutability/issue-101739-2.stderr
+++ b/tests/ui/transmutability/issue-101739-2.stderr
@@ -11,13 +11,6 @@ LL | |                 ASSUME_VALIDITY,
 LL | |                 ASSUME_VISIBILITY,
    | |_________________________________- help: remove the unnecessary generic arguments
 
-error[E0308]: mismatched types
-  --> $DIR/issue-101739-2.rs:20:17
-   |
-LL |                 ASSUME_ALIGNMENT,
-   |                 ^^^^^^^^^^^^^^^^ expected `Assume`, found `bool`
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0107, E0308.
-For more information about an error, try `rustc --explain E0107`.
+For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.rs
+++ b/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.rs
@@ -6,7 +6,6 @@
 trait Trait {
     fn func<const N: u32>() -> [(); N];
     //~^ ERROR: the constant `N` is not of type `usize`
-    //~| ERROR: mismatched types
 }
 
 struct S {}

--- a/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.stderr
+++ b/tests/ui/typeck/issue-114918/const-in-impl-fn-return-type.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/const-in-impl-fn-return-type.rs:16:39
+  --> $DIR/const-in-impl-fn-return-type.rs:15:39
    |
 LL |     fn func<const N: u32>() -> [(); { () }] {
    |                                       ^^ expected `usize`, found `()`
@@ -10,12 +10,6 @@ error: the constant `N` is not of type `usize`
 LL |     fn func<const N: u32>() -> [(); N];
    |                                ^^^^^^^ expected `usize`, found `u32`
 
-error[E0308]: mismatched types
-  --> $DIR/const-in-impl-fn-return-type.rs:7:37
-   |
-LL |     fn func<const N: u32>() -> [(); N];
-   |                                     ^ expected `usize`, found `u32`
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION

Fixes #128016.

Ever since #125915, some `ast::AnonConst`s turn into `hir::ConstArgKind::Path`s,
which don't have associated `DefId`s. To deal with the fact that we don't have
resolution information in `DefCollector`, we decided to implement a process
where if the anon const *appeared* to be trivial (i.e., `N` or `{ N }`), we
would avoid creating a def for it in `DefCollector`. If later, in AST lowering,
we realized it turned out to be a unit struct literal, or we were lowering it
to something that didn't use `hir::ConstArg`, we'd create its def there.

However, let's say we have a macro `m!()` that expands to a reference to a free
constant `FOO`. If we use `m!()` in the body of an anon const (e.g., `Foo<{ m!() }>`),
then in def collection, it appears to be a nontrivial anon const and we create
a def. But the macro expands to something that looks like a trivial const arg,
but is not, so in AST lowering we "fix" the mistake we assumed def collection
made and create a def for it. This causes a duplicate definition ICE.

The long-term fix for this is to delay the creation of defs for all expression-like
nodes until AST lowering (see #128844 for an incomplete attempt at this). This
would avoid issues like this one that are caused by hacky workarounds. However,
doing this uncovers a pre-existing bug with opaque types that is quite involved
to fix (see #129023).

In the meantime, this PR fixes the bug by delaying def creation for anon consts
whose bodies are macro invocations until after we expand the macro and know
what is inside it. This is accomplished by adding information to create the
anon const's def to the data in `Resolver.invocation_parents`.

r? @BoxyUwU
