### PR TITLE
Fix wrong source location for some incorrect macro definitions

### DIFF
--- a/tests/ui/macros/macro-match-nonterminal.stderr
+++ b/tests/ui/macros/macro-match-nonterminal.stderr
@@ -1,14 +1,14 @@
 error: missing fragment specifier
-  --> $DIR/macro-match-nonterminal.rs:2:8
+  --> $DIR/macro-match-nonterminal.rs:2:6
    |
 LL |     ($a, $b) => {
-   |        ^
+   |      ^^
 
 error: missing fragment specifier
-  --> $DIR/macro-match-nonterminal.rs:2:8
+  --> $DIR/macro-match-nonterminal.rs:2:6
    |
 LL |     ($a, $b) => {
-   |        ^
+   |      ^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #40107 <https://github.com/rust-lang/rust/issues/40107>
@@ -27,10 +27,10 @@ error: aborting due to 3 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
 error: missing fragment specifier
-  --> $DIR/macro-match-nonterminal.rs:2:8
+  --> $DIR/macro-match-nonterminal.rs:2:6
    |
 LL |     ($a, $b) => {
-   |        ^
+   |      ^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #40107 <https://github.com/rust-lang/rust/issues/40107>


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

Fixes #95463 

Currently the code will consume the next token tree after `var` when trying to parse `$var:some_type` even when it's not a `:` (e.g. a `$` when input is `($foo $bar:tt) => {}`). Additionally it will return the wrong span when it's not a `:`.

This PR fixes these problems.