### PR TITLE
std::net: adding new option todevice.

### DIFF
--- a/library/std/src/net/tcp.rs
+++ b/library/std/src/net/tcp.rs
@@ -3,6 +3,7 @@
 #[cfg(all(test, not(any(target_os = "emscripten", target_os = "xous"))))]
 mod tests;
 
+use crate::ffi::CString;
 use crate::fmt;
 use crate::io::prelude::*;
 use crate::io::{self, BorrowedCursor, IoSlice, IoSliceMut};
@@ -602,6 +603,47 @@ impl TcpStream {
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.0.set_nonblocking(nonblocking)
+    }
+
+    /// Bind the socket to an interface
+    ///
+    /// ```no_run
+    /// #![feature(unix_set_device)]
+    ///
+    /// use std::net::TcpStream;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let stream = TcpStream::connect("127.0.0.1:8080")
+    ///                        .expect("Couldn't connect to the server...");
+    ///     stream.set_device("eth0")?;
+    ///     Ok(())
+    /// }
+    ///
+    /// ```
+    #[unstable(feature = "unix_set_device", issue = "129182")]
+    pub fn set_device(&self, ifrname: &str) -> io::Result<()> {
+        self.0.set_device(ifrname)
+    }
+
+    /// Get the interface this socket is bound to
+    ///
+    /// ```no_run
+    /// #![feature(unix_set_device)]
+    ///
+    /// use std::net::TcpStream;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let stream = TcpStream::connect("127.0.0.1:8080")
+    ///                        .expect("Couldn't connect to the server...");
+    ///     stream.set_device("eth0")?;
+    ///     let name = stream.device()?;
+    ///     assert_eq!(Ok("eth0"), name.to_str());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "unix_set_device", issue = "129182")]
+    pub fn device(&self) -> io::Result<CString> {
+        self.0.device()
     }
 }
 

--- a/library/std/src/net/udp.rs
+++ b/library/std/src/net/udp.rs
@@ -1,6 +1,7 @@
 #[cfg(all(test, not(any(target_os = "emscripten", target_env = "sgx", target_os = "xous"))))]
 mod tests;
 
+use crate::ffi::CString;
 use crate::fmt;
 use crate::io::{self, ErrorKind};
 use crate::net::{Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
@@ -805,6 +806,45 @@ impl UdpSocket {
     #[stable(feature = "net2_mutators", since = "1.9.0")]
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.0.set_nonblocking(nonblocking)
+    }
+
+    /// Bind the socket to an interface
+    ///
+    /// ```no_run
+    /// #![feature(unix_set_device)]
+    ///
+    /// use std::net::UdpSocket;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let socket = UdpSocket::bind("127.0.0.1:7878").unwrap();
+    ///     socket.set_device("eth0")?;
+    ///     Ok(())
+    /// }
+    ///
+    /// ```
+    #[unstable(feature = "unix_set_device", issue = "129182")]
+    pub fn set_device(&self, ifrname: &str) -> io::Result<()> {
+        self.0.set_device(ifrname)
+    }
+
+    /// Get the interface this socket is bound to
+    ///
+    /// ```no_run
+    /// #![feature(unix_set_device)]
+    ///
+    /// use std::net::UdpSocket;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let socket = UdpSocket::bind("127.0.0.1:7878").unwrap();
+    ///     socket.set_device("eth0")?;
+    ///     let name = socket.device()?;
+    ///     assert_eq!(Ok("eth0"), name.to_str());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[unstable(feature = "unix_set_device", issue = "129182")]
+    pub fn device(&self) -> io::Result<CString> {
+        self.0.device()
     }
 }
 

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -16,7 +16,7 @@ use libc::MSG_NOSIGNAL;
 use super::{recv_vectored_with_ancillary_from, send_vectored_with_ancillary_to, SocketAncillary};
 use super::{sockaddr_un, SocketAddr};
 #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
-use crate::ffi::CStr;
+use crate::ffi::{CStr, CString};
 #[cfg(any(doc, target_os = "android", target_os = "linux"))]
 use crate::io::{IoSlice, IoSliceMut};
 use crate::net::Shutdown;
@@ -886,7 +886,7 @@ impl UnixDatagram {
     /// ```
     #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
     #[unstable(feature = "unix_set_todevice", issue = "129182")]
-    pub fn todevice(&self) -> io::Result<&CStr> {
+    pub fn todevice(&self) -> io::Result<CString> {
         self.0.todevice()
     }
     /// Returns the value of the `SO_ERROR` option.

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -15,7 +15,6 @@ use libc::MSG_NOSIGNAL;
 #[cfg(any(doc, target_os = "android", target_os = "linux"))]
 use super::{recv_vectored_with_ancillary_from, send_vectored_with_ancillary_to, SocketAncillary};
 use super::{sockaddr_un, SocketAddr};
-#[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
 use crate::ffi::CString;
 #[cfg(any(doc, target_os = "android", target_os = "linux"))]
 use crate::io::{IoSlice, IoSliceMut};
@@ -840,14 +839,7 @@ impl UnixDatagram {
 
     /// Bind the socket to an interface
     ///
-    #[cfg_attr(
-        any(target_os = "linux", target_os = "haiku", target_os = "vxworks"),
-        doc = "```no_run"
-    )]
-    #[cfg_attr(
-        not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")),
-        doc = "```ignore"
-    )]
+    /// ```no_run
     /// #![feature(unix_set_device)]
     /// use std::os::unix::net::UnixDatagram;
     ///
@@ -857,7 +849,6 @@ impl UnixDatagram {
     ///     Ok(())
     /// }
     /// ```
-    #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
     #[unstable(feature = "unix_set_device", issue = "129182")]
     pub fn set_device(&self, ifrname: &str) -> io::Result<()> {
         self.0.set_device(ifrname)
@@ -865,14 +856,7 @@ impl UnixDatagram {
 
     /// Get the interface this socket is bound to
     ///
-    #[cfg_attr(
-        any(target_os = "linux", target_os = "haiku", target_os = "vxworks"),
-        doc = "```no_run"
-    )]
-    #[cfg_attr(
-        not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")),
-        doc = "```ignore"
-    )]
+    /// ```no_run
     /// #![feature(unix_set_device)]
     /// use std::os::unix::net::UnixDatagram;
     ///
@@ -884,7 +868,6 @@ impl UnixDatagram {
     ///     Ok(())
     /// }
     /// ```
-    #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
     #[unstable(feature = "unix_set_device", issue = "129182")]
     pub fn device(&self) -> io::Result<CString> {
         self.0.device()

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -15,6 +15,8 @@ use libc::MSG_NOSIGNAL;
 #[cfg(any(doc, target_os = "android", target_os = "linux"))]
 use super::{recv_vectored_with_ancillary_from, send_vectored_with_ancillary_to, SocketAncillary};
 use super::{sockaddr_un, SocketAddr};
+#[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
+use crate::ffi::CStr;
 #[cfg(any(doc, target_os = "android", target_os = "linux"))]
 use crate::io::{IoSlice, IoSliceMut};
 use crate::net::Shutdown;
@@ -836,6 +838,57 @@ impl UnixDatagram {
         self.0.set_mark(mark)
     }
 
+    /// Bind the socket to an interface
+    ///
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "haiku", target_os = "vxworks"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")),
+        doc = "```ignore"
+    )]
+    /// #![feature(unix_set_todevice)]
+    /// use std::os::unix::net::UnixDatagram;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let socket = UnixDatagram::unbound()?;
+    ///     socket.set_todevice(c"eth0")?;
+    ///     Ok(())
+    /// }
+    /// ```
+    #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
+    #[unstable(feature = "unix_set_todevice", issue = "129182")]
+    pub fn set_todevice(&self, ifrname: &CStr) -> io::Result<()> {
+        self.0.set_todevice(ifrname)
+    }
+
+    /// Get the interface this socket is bound to
+    ///
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "haiku", target_os = "vxworks"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")),
+        doc = "```ignore"
+    )]
+    /// #![feature(unix_set_todevice)]
+    /// use std::os::unix::net::UnixDatagram;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let socket = UnixDatagram::unbound()?;
+    ///     socket.set_todevice(c"eth0")?;
+    ///     let name = socket.todevice()?;
+    ///     assert_eq!(Ok("eth0"), name.to_str());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
+    #[unstable(feature = "unix_set_todevice", issue = "129182")]
+    pub fn todevice(&self) -> io::Result<&CStr> {
+        self.0.todevice()
+    }
     /// Returns the value of the `SO_ERROR` option.
     ///
     /// # Examples

--- a/library/std/src/os/unix/net/datagram.rs
+++ b/library/std/src/os/unix/net/datagram.rs
@@ -16,7 +16,7 @@ use libc::MSG_NOSIGNAL;
 use super::{recv_vectored_with_ancillary_from, send_vectored_with_ancillary_to, SocketAncillary};
 use super::{sockaddr_un, SocketAddr};
 #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
-use crate::ffi::{CStr, CString};
+use crate::ffi::CString;
 #[cfg(any(doc, target_os = "android", target_os = "linux"))]
 use crate::io::{IoSlice, IoSliceMut};
 use crate::net::Shutdown;
@@ -848,19 +848,19 @@ impl UnixDatagram {
         not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")),
         doc = "```ignore"
     )]
-    /// #![feature(unix_set_todevice)]
+    /// #![feature(unix_set_device)]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
     ///     let socket = UnixDatagram::unbound()?;
-    ///     socket.set_todevice(c"eth0")?;
+    ///     socket.set_device("eth0")?;
     ///     Ok(())
     /// }
     /// ```
     #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
-    #[unstable(feature = "unix_set_todevice", issue = "129182")]
-    pub fn set_todevice(&self, ifrname: &CStr) -> io::Result<()> {
-        self.0.set_todevice(ifrname)
+    #[unstable(feature = "unix_set_device", issue = "129182")]
+    pub fn set_device(&self, ifrname: &str) -> io::Result<()> {
+        self.0.set_device(ifrname)
     }
 
     /// Get the interface this socket is bound to
@@ -873,21 +873,21 @@ impl UnixDatagram {
         not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")),
         doc = "```ignore"
     )]
-    /// #![feature(unix_set_todevice)]
+    /// #![feature(unix_set_device)]
     /// use std::os::unix::net::UnixDatagram;
     ///
     /// fn main() -> std::io::Result<()> {
     ///     let socket = UnixDatagram::unbound()?;
-    ///     socket.set_todevice(c"eth0")?;
-    ///     let name = socket.todevice()?;
+    ///     socket.set_device("eth0")?;
+    ///     let name = socket.device()?;
     ///     assert_eq!(Ok("eth0"), name.to_str());
     ///     Ok(())
     /// }
     /// ```
     #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
-    #[unstable(feature = "unix_set_todevice", issue = "129182")]
-    pub fn todevice(&self) -> io::Result<CString> {
-        self.0.todevice()
+    #[unstable(feature = "unix_set_device", issue = "129182")]
+    pub fn device(&self) -> io::Result<CString> {
+        self.0.device()
     }
     /// Returns the value of the `SO_ERROR` option.
     ///

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -12,6 +12,8 @@ use super::{peer_cred, UCred};
 #[cfg(any(doc, target_os = "android", target_os = "linux"))]
 use super::{recv_vectored_with_ancillary_from, send_vectored_with_ancillary_to, SocketAncillary};
 use super::{sockaddr_un, SocketAddr};
+#[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
+use crate::ffi::CStr;
 use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::Shutdown;
@@ -403,6 +405,58 @@ impl UnixStream {
     #[unstable(feature = "unix_set_mark", issue = "96467")]
     pub fn set_mark(&self, mark: u32) -> io::Result<()> {
         self.0.set_mark(mark)
+    }
+
+    /// Bind the socket to an interface
+    ///
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "haiku", target_os = "vxworks"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")),
+        doc = "```ignore"
+    )]
+    /// #![feature(unix_set_todevice)]
+    /// use std::os::unix::net::UnixStream;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let socket = UnixStream::connect("/tmp/sock")?;
+    ///     socket.set_todevice(c"eth0")?;
+    ///     Ok(())
+    /// }
+    /// ```
+    #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
+    #[unstable(feature = "unix_set_todevice", issue = "129182")]
+    pub fn set_todevice(&self, ifrname: &CStr) -> io::Result<()> {
+        self.0.set_todevice(ifrname)
+    }
+
+    /// Get the interface this socket is bound to
+    ///
+    #[cfg_attr(
+        any(target_os = "linux", target_os = "haiku", target_os = "vxworks"),
+        doc = "```no_run"
+    )]
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")),
+        doc = "```ignore"
+    )]
+    /// #![feature(unix_set_todevice)]
+    /// use std::os::unix::net::UnixStream;
+    ///
+    /// fn main() -> std::io::Result<()> {
+    ///     let socket = UnixStream::connect("/tmp/sock")?;
+    ///     socket.set_todevice(c"eth0")?;
+    ///     let name = socket.todevice()?;
+    ///     assert_eq!(Ok("eth0"), name.to_str());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
+    #[unstable(feature = "unix_set_todevice", issue = "129182")]
+    pub fn todevice(&self) -> io::Result<&CStr> {
+        self.0.todevice()
     }
 
     /// Returns the value of the `SO_ERROR` option.

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -13,7 +13,7 @@ use super::{peer_cred, UCred};
 use super::{recv_vectored_with_ancillary_from, send_vectored_with_ancillary_to, SocketAncillary};
 use super::{sockaddr_un, SocketAddr};
 #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
-use crate::ffi::{CStr, CString};
+use crate::ffi::CString;
 use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::Shutdown;
@@ -417,19 +417,19 @@ impl UnixStream {
         not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")),
         doc = "```ignore"
     )]
-    /// #![feature(unix_set_todevice)]
+    /// #![feature(unix_set_device)]
     /// use std::os::unix::net::UnixStream;
     ///
     /// fn main() -> std::io::Result<()> {
     ///     let socket = UnixStream::connect("/tmp/sock")?;
-    ///     socket.set_todevice(c"eth0")?;
+    ///     socket.set_device("eth0")?;
     ///     Ok(())
     /// }
     /// ```
     #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
-    #[unstable(feature = "unix_set_todevice", issue = "129182")]
-    pub fn set_todevice(&self, ifrname: &CStr) -> io::Result<()> {
-        self.0.set_todevice(ifrname)
+    #[unstable(feature = "unix_set_device", issue = "129182")]
+    pub fn set_device(&self, ifrname: &str) -> io::Result<()> {
+        self.0.set_device(ifrname)
     }
 
     /// Get the interface this socket is bound to
@@ -442,21 +442,21 @@ impl UnixStream {
         not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")),
         doc = "```ignore"
     )]
-    /// #![feature(unix_set_todevice)]
+    /// #![feature(unix_set_device)]
     /// use std::os::unix::net::UnixStream;
     ///
     /// fn main() -> std::io::Result<()> {
     ///     let socket = UnixStream::connect("/tmp/sock")?;
-    ///     socket.set_todevice(c"eth0")?;
-    ///     let name = socket.todevice()?;
+    ///     socket.set_device("eth0")?;
+    ///     let name = socket.device()?;
     ///     assert_eq!(Ok("eth0"), name.to_str());
     ///     Ok(())
     /// }
     /// ```
     #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
-    #[unstable(feature = "unix_set_todevice", issue = "129182")]
-    pub fn todevice(&self) -> io::Result<CString> {
-        self.0.todevice()
+    #[unstable(feature = "unix_set_device", issue = "129182")]
+    pub fn device(&self) -> io::Result<CString> {
+        self.0.device()
     }
 
     /// Returns the value of the `SO_ERROR` option.

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -12,8 +12,6 @@ use super::{peer_cred, UCred};
 #[cfg(any(doc, target_os = "android", target_os = "linux"))]
 use super::{recv_vectored_with_ancillary_from, send_vectored_with_ancillary_to, SocketAncillary};
 use super::{sockaddr_un, SocketAddr};
-#[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
-use crate::ffi::CString;
 use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::Shutdown;
@@ -405,58 +403,6 @@ impl UnixStream {
     #[unstable(feature = "unix_set_mark", issue = "96467")]
     pub fn set_mark(&self, mark: u32) -> io::Result<()> {
         self.0.set_mark(mark)
-    }
-
-    /// Bind the socket to an interface
-    ///
-    #[cfg_attr(
-        any(target_os = "linux", target_os = "haiku", target_os = "vxworks"),
-        doc = "```no_run"
-    )]
-    #[cfg_attr(
-        not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")),
-        doc = "```ignore"
-    )]
-    /// #![feature(unix_set_device)]
-    /// use std::os::unix::net::UnixStream;
-    ///
-    /// fn main() -> std::io::Result<()> {
-    ///     let socket = UnixStream::connect("/tmp/sock")?;
-    ///     socket.set_device("eth0")?;
-    ///     Ok(())
-    /// }
-    /// ```
-    #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
-    #[unstable(feature = "unix_set_device", issue = "129182")]
-    pub fn set_device(&self, ifrname: &str) -> io::Result<()> {
-        self.0.set_device(ifrname)
-    }
-
-    /// Get the interface this socket is bound to
-    ///
-    #[cfg_attr(
-        any(target_os = "linux", target_os = "haiku", target_os = "vxworks"),
-        doc = "```no_run"
-    )]
-    #[cfg_attr(
-        not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")),
-        doc = "```ignore"
-    )]
-    /// #![feature(unix_set_device)]
-    /// use std::os::unix::net::UnixStream;
-    ///
-    /// fn main() -> std::io::Result<()> {
-    ///     let socket = UnixStream::connect("/tmp/sock")?;
-    ///     socket.set_device("eth0")?;
-    ///     let name = socket.device()?;
-    ///     assert_eq!(Ok("eth0"), name.to_str());
-    ///     Ok(())
-    /// }
-    /// ```
-    #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
-    #[unstable(feature = "unix_set_device", issue = "129182")]
-    pub fn device(&self) -> io::Result<CString> {
-        self.0.device()
     }
 
     /// Returns the value of the `SO_ERROR` option.

--- a/library/std/src/os/unix/net/stream.rs
+++ b/library/std/src/os/unix/net/stream.rs
@@ -13,7 +13,7 @@ use super::{peer_cred, UCred};
 use super::{recv_vectored_with_ancillary_from, send_vectored_with_ancillary_to, SocketAncillary};
 use super::{sockaddr_un, SocketAddr};
 #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
-use crate::ffi::CStr;
+use crate::ffi::{CStr, CString};
 use crate::fmt;
 use crate::io::{self, IoSlice, IoSliceMut};
 use crate::net::Shutdown;
@@ -455,7 +455,7 @@ impl UnixStream {
     /// ```
     #[cfg(any(doc, target_os = "linux", target_os = "haiku", target_os = "vxworks",))]
     #[unstable(feature = "unix_set_todevice", issue = "129182")]
-    pub fn todevice(&self) -> io::Result<&CStr> {
+    pub fn todevice(&self) -> io::Result<CString> {
         self.0.todevice()
     }
 

--- a/library/std/src/sys/pal/hermit/net.rs
+++ b/library/std/src/sys/pal/hermit/net.rs
@@ -312,6 +312,14 @@ impl Socket {
     pub fn as_raw(&self) -> RawFd {
         self.0.as_raw_fd()
     }
+
+    pub fn device(&self) -> io::Result<crate::ffi::CString> {
+        unimplemented!()
+    }
+
+    pub fn set_device(&self, _: &str) -> io::Result<()> {
+        unimplemented!()
+    }
 }
 
 impl AsInner<FileDesc> for Socket {

--- a/library/std/src/sys/pal/sgx/net.rs
+++ b/library/std/src/sys/pal/sgx/net.rs
@@ -207,6 +207,14 @@ impl TcpStream {
     pub fn set_nonblocking(&self, _: bool) -> io::Result<()> {
         sgx_ineffective(())
     }
+
+    pub fn device(&self) -> io::Result<crate::ffi::CString> {
+        unimplemented!()
+    }
+
+    pub fn set_device(&self, _: &str) -> io::Result<()> {
+        unimplemented!()
+    }
 }
 
 impl AsInner<Socket> for TcpStream {

--- a/library/std/src/sys/pal/solid/net.rs
+++ b/library/std/src/sys/pal/solid/net.rs
@@ -380,6 +380,14 @@ impl Socket {
     pub fn as_raw(&self) -> c_int {
         self.as_raw_fd()
     }
+
+    pub fn device(&self) -> io::Result<crate::ffi::CString> {
+        unimplemented!()
+    }
+
+    pub fn set_device(&self, _: &str) -> io::Result<()> {
+        unimplemented!()
+    }
 }
 
 impl FromInner<OwnedFd> for Socket {

--- a/library/std/src/sys/pal/unix/net.rs
+++ b/library/std/src/sys/pal/unix/net.rs
@@ -572,6 +572,11 @@ impl Socket {
         Ok(crate::ffi::CString::new(name.to_bytes()).unwrap())
     }
 
+    #[cfg(not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")))]
+    pub fn device(&self) -> io::Result<crate::ffi::CString> {
+        unimplemented!()
+    }
+
     #[cfg(any(target_os = "linux", target_os = "haiku", target_os = "vxworks"))]
     pub fn set_device(&self, ifrname: &str) -> io::Result<()> {
         let istr = ifrname.as_bytes();
@@ -585,6 +590,11 @@ impl Socket {
             *dst = *src as libc::c_char;
         }
         setsockopt(self, libc::SOL_SOCKET, libc::SO_BINDTODEVICE, buf)
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "haiku", target_os = "vxworks")))]
+    pub fn set_device(&self, _: &str) -> io::Result<()> {
+        unimplemented!()
     }
 
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {

--- a/library/std/src/sys/pal/unix/net.rs
+++ b/library/std/src/sys/pal/unix/net.rs
@@ -564,7 +564,7 @@ impl Socket {
     }
 
     #[cfg(any(target_os = "linux", target_os = "haiku", target_os = "vxworks"))]
-    pub fn todevice(&self) -> io::Result<crate::ffi::CString> {
+    pub fn device(&self) -> io::Result<crate::ffi::CString> {
         let buf: [libc::c_char; libc::IFNAMSIZ] =
             getsockopt(self, libc::SOL_SOCKET, libc::SO_BINDTODEVICE)?;
         let s: &[u8] = unsafe { core::slice::from_raw_parts(buf.as_ptr() as *const u8, buf.len()) };
@@ -573,8 +573,8 @@ impl Socket {
     }
 
     #[cfg(any(target_os = "linux", target_os = "haiku", target_os = "vxworks"))]
-    pub fn set_todevice(&self, ifrname: &CStr) -> io::Result<()> {
-        let istr = ifrname.to_bytes();
+    pub fn set_device(&self, ifrname: &str) -> io::Result<()> {
+        let istr = ifrname.as_bytes();
 
         if istr.len() >= libc::IFNAMSIZ {
             return Err(io::Error::from_raw_os_error(libc::ENAMETOOLONG));

--- a/library/std/src/sys/pal/wasi/net.rs
+++ b/library/std/src/sys/pal/wasi/net.rs
@@ -194,6 +194,14 @@ impl TcpStream {
     pub fn into_socket(self) -> Socket {
         self.inner
     }
+
+    pub fn device(&self) -> io::Result<crate::ffi::CString> {
+        unimplemented!()
+    }
+
+    pub fn set_device(&self, _: &str) -> io::Result<()> {
+        unimplemented!()
+    }
 }
 
 impl FromInner<Socket> for TcpStream {

--- a/library/std/src/sys/pal/windows/net.rs
+++ b/library/std/src/sys/pal/windows/net.rs
@@ -521,6 +521,14 @@ impl Socket {
         debug_assert_eq!(mem::align_of::<c::SOCKET>(), mem::align_of::<RawSocket>());
         unsafe { Self::from_raw_socket(raw as RawSocket) }
     }
+
+    pub fn device(&self) -> io::Result<crate::ffi::CString> {
+        unimplemented!()
+    }
+
+    pub fn set_device(&self, _: &str) -> io::Result<()> {
+        unimplemented!()
+    }
 }
 
 #[unstable(reason = "not public", issue = "none", feature = "fd_read")]

--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::ffi::{c_int, c_void};
+use crate::ffi::{c_int, c_void, CString};
 use crate::io::{self, BorrowedCursor, ErrorKind, IoSlice, IoSliceMut};
 use crate::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr};
 use crate::sys::common::small_c_string::run_with_cstr;
@@ -352,6 +352,14 @@ impl TcpStream {
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.inner.set_nonblocking(nonblocking)
     }
+
+    pub fn device(&self) -> io::Result<CString> {
+        self.inner.device()
+    }
+
+    pub fn set_device(&self, ifrname: &str) -> io::Result<()> {
+        self.inner.set_device(ifrname)
+    }
 }
 
 impl AsInner<Socket> for TcpStream {
@@ -701,6 +709,14 @@ impl UdpSocket {
     pub fn connect(&self, addr: io::Result<&SocketAddr>) -> io::Result<()> {
         let (addr, len) = addr?.into_inner();
         cvt_r(|| unsafe { c::connect(self.inner.as_raw(), addr.as_ptr(), len) }).map(drop)
+    }
+
+    pub fn device(&self) -> io::Result<CString> {
+        self.inner.device()
+    }
+
+    pub fn set_device(&self, ifrname: &str) -> io::Result<()> {
+        self.inner.set_device(ifrname)
     }
 }
 


### PR DESCRIPTION
Allows to bind a socket to an network interface, to exclusively listen from it. For packet sockets, regular bind is more appropriate.

tracking issue: #129182