### PR TITLE
Change cross_crate_inlinable to use InstanceKind not DefId

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -20,7 +20,7 @@ use rustc_middle::query::Providers;
 use rustc_middle::traits::specialization_graph;
 use rustc_middle::ty::codec::TyEncoder;
 use rustc_middle::ty::fast_reject::{self, TreatParams};
-use rustc_middle::ty::{AssocItemContainer, SymbolName};
+use rustc_middle::ty::{AssocItemContainer, InstanceKind, SymbolName};
 use rustc_middle::util::common::to_readable_str;
 use rustc_middle::{bug, span_bug};
 use rustc_serialize::{opaque, Decodable, Decoder, Encodable, Encoder};
@@ -1068,7 +1068,7 @@ fn should_encode_mir(
                 || (tcx.sess.opts.output_types.should_codegen()
                     && reachable_set.contains(&def_id)
                     && (generics.requires_monomorphization(tcx)
-                        || tcx.cross_crate_inlinable(def_id)));
+                        || tcx.cross_crate_inlinable(InstanceKind::Item(def_id.into()))));
             // The function has a `const` modifier or is in a `#[const_trait]`.
             let is_const_fn = tcx.is_const_fn_raw(def_id.to_def_id())
                 || tcx.is_const_default_method(def_id.to_def_id());
@@ -1667,9 +1667,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             debug!("EntryBuilder::encode_mir({:?})", def_id);
             if encode_opt {
                 record!(self.tables.optimized_mir[def_id.to_def_id()] <- tcx.optimized_mir(def_id));
-                self.tables
-                    .cross_crate_inlinable
-                    .set(def_id.to_def_id().index, self.tcx.cross_crate_inlinable(def_id));
+                self.tables.cross_crate_inlinable.set(
+                    def_id.to_def_id().index,
+                    self.tcx.cross_crate_inlinable(InstanceKind::Item(def_id.into())),
+                );
                 record!(self.tables.closure_saved_names_of_captured_variables[def_id.to_def_id()]
                     <- tcx.closure_saved_names_of_captured_variables(def_id));
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -2270,7 +2270,7 @@ rustc_queries! {
         desc { "check whether the item has a `where Self: Sized` bound" }
     }
 
-    query cross_crate_inlinable(def_id: DefId) -> bool {
+    query cross_crate_inlinable(instance: ty::InstanceKind<'tcx>) -> bool {
         desc { "whether the item should be made inlinable across crates" }
         separate_provide_extern
     }

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -342,13 +342,16 @@ impl<'tcx> InstanceKind<'tcx> {
                     }
                     _ => unreachable!(),
                 }
-                .map_or_else(|| adt_def.is_enum(), |did| tcx.cross_crate_inlinable(did))
+                .map_or_else(
+                    || adt_def.is_enum(),
+                    |did| tcx.cross_crate_inlinable(InstanceKind::Item(did)),
+                )
             });
         }
         if let ty::InstanceKind::ThreadLocalShim(..) = *self {
             return false;
         }
-        tcx.cross_crate_inlinable(self.def_id())
+        tcx.cross_crate_inlinable(*self)
     }
 
     pub fn requires_caller_location(&self, tcx: TyCtxt<'_>) -> bool {

--- a/compiler/rustc_mir_transform/src/cross_crate_inline.rs
+++ b/compiler/rustc_mir_transform/src/cross_crate_inline.rs
@@ -1,10 +1,9 @@
 use rustc_attr::InlineAttr;
 use rustc_hir::def::DefKind;
-use rustc_hir::def_id::LocalDefId;
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::*;
 use rustc_middle::query::Providers;
-use rustc_middle::ty::TyCtxt;
+use rustc_middle::ty::{InstanceKind, TyCtxt};
 use rustc_session::config::{InliningThreshold, OptLevel};
 use rustc_span::sym;
 
@@ -14,7 +13,9 @@ pub fn provide(providers: &mut Providers) {
     providers.cross_crate_inlinable = cross_crate_inlinable;
 }
 
-fn cross_crate_inlinable(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
+fn cross_crate_inlinable<'tcx>(tcx: TyCtxt<'tcx>, instance: InstanceKind<'tcx>) -> bool {
+    let def_id = instance.def_id();
+
     let codegen_fn_attrs = tcx.codegen_fn_attrs(def_id);
     // If this has an extern indicator, then this function is globally shared and thus will not
     // generate cgu-internal copies which would make it cross-crate inlinable.

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -186,7 +186,7 @@ impl<'tcx> Inliner<'tcx> {
         self.check_mir_is_available(caller_body, callsite.callee)?;
 
         let callee_attrs = self.tcx.codegen_fn_attrs(callsite.callee.def_id());
-        let cross_crate_inlinable = self.tcx.cross_crate_inlinable(callsite.callee.def_id());
+        let cross_crate_inlinable = self.tcx.cross_crate_inlinable(callsite.callee.def);
         self.check_codegen_attributes(callsite, callee_attrs, cross_crate_inlinable)?;
 
         // Intrinsic fallback bodies are automatically made cross-crate inlineable,

--- a/compiler/rustc_passes/src/reachable.rs
+++ b/compiler/rustc_passes/src/reachable.rs
@@ -34,7 +34,7 @@ use rustc_middle::middle::codegen_fn_attrs::{CodegenFnAttrFlags, CodegenFnAttrs}
 use rustc_middle::middle::privacy::{self, Level};
 use rustc_middle::mir::interpret::{ConstAllocation, ErrorHandled, GlobalAlloc};
 use rustc_middle::query::Providers;
-use rustc_middle::ty::{self, ExistentialTraitRef, TyCtxt};
+use rustc_middle::ty::{self, ExistentialTraitRef, InstanceKind, TyCtxt};
 use rustc_privacy::DefIdVisitor;
 use rustc_session::config::CrateType;
 use tracing::debug;
@@ -43,7 +43,7 @@ use tracing::debug;
 /// below for details.
 fn recursively_reachable(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
     tcx.generics_of(def_id).requires_monomorphization(tcx)
-        || tcx.cross_crate_inlinable(def_id)
+        || tcx.cross_crate_inlinable(InstanceKind::Item(def_id.into()))
         || tcx.is_const_fn(def_id)
 }
 


### PR DESCRIPTION
@compiler-errors suggested I do this so that we can use `tcx.instance_mir` inside `cross_crate_inlinable`.

I know that at least the incremental suite fails right now because we don't reuse some CGUs anymore. That seems bad.