### PR TITLE
Pass end position of span through inline ASM cookie

### DIFF
--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -504,14 +504,13 @@ pub(crate) fn inline_asm_call<'ll>(
             let key = "srcloc";
             let kind = llvm::LLVMGetMDKindIDInContext(
                 bx.llcx,
-                key.as_ptr() as *const c_char,
+                key.as_ptr().cast::<c_char>(),
                 key.len() as c_uint,
             );
 
-            // srcloc contains one integer for each line of assembly code.
-            // Unfortunately this isn't enough to encode a full span so instead
-            // we just encode the start position of each line.
-            // FIXME: Figure out a way to pass the entire line spans.
+            // `srcloc` contains one 64-bit integer for each line of assembly code,
+            // where the lower 32 bits hold the lo byte position and the upper 32 bits
+            // hold the hi byte position.
             let mut srcloc = vec![];
             if dia == llvm::AsmDialect::Intel && line_spans.len() > 1 {
                 // LLVM inserts an extra line to add the ".intel_syntax", so add
@@ -521,13 +520,13 @@ pub(crate) fn inline_asm_call<'ll>(
                 // due to the asm template string coming from a macro. LLVM will
                 // default to the first srcloc for lines that don't have an
                 // associated srcloc.
-                srcloc.push(llvm::LLVMValueAsMetadata(bx.const_i32(0)));
+                srcloc.push(llvm::LLVMValueAsMetadata(bx.const_u64(0)));
             }
-            srcloc.extend(
-                line_spans
-                    .iter()
-                    .map(|span| llvm::LLVMValueAsMetadata(bx.const_i32(span.lo().to_u32() as i32))),
-            );
+            srcloc.extend(line_spans.iter().map(|span| {
+                llvm::LLVMValueAsMetadata(bx.const_u64(
+                    u64::from(span.lo().to_u32()) | (u64::from(span.hi().to_u32()) << 32),
+                ))
+            }));
             let md = llvm::LLVMMDNodeInContext2(bx.llcx, srcloc.as_ptr(), srcloc.len());
             let md = llvm::LLVMMetadataAsValue(&bx.llcx, md);
             llvm::LLVMSetMetadata(call, kind, md);

--- a/compiler/rustc_codegen_llvm/src/llvm/diagnostic.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/diagnostic.rs
@@ -151,7 +151,7 @@ impl InlineAsmDiagnostic {
             unsafe { SrcMgrDiagnostic::unpack(super::LLVMRustGetSMDiagnostic(di, &mut cookie)) };
         InlineAsmDiagnostic {
             level: smdiag.level,
-            cookie: cookie.into(),
+            cookie,
             message: smdiag.message,
             source: smdiag.source,
         }

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2316,7 +2316,7 @@ unsafe extern "C" {
 
     pub fn LLVMRustGetSMDiagnostic<'a>(
         DI: &'a DiagnosticInfo,
-        cookie_out: &mut c_uint,
+        cookie_out: &mut u64,
     ) -> &'a SMDiagnostic;
 
     pub fn LLVMRustUnpackSMDiagnostic(

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -1535,7 +1535,7 @@ extern "C" LLVMTypeKind LLVMRustGetTypeKind(LLVMTypeRef Ty) {
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(SMDiagnostic, LLVMSMDiagnosticRef)
 
 extern "C" LLVMSMDiagnosticRef LLVMRustGetSMDiagnostic(LLVMDiagnosticInfoRef DI,
-                                                       unsigned *Cookie) {
+                                                       uint64_t *Cookie) {
   llvm::DiagnosticInfoSrcMgr *SM =
       static_cast<llvm::DiagnosticInfoSrcMgr *>(unwrap(DI));
   *Cookie = SM->getLocCookie();

--- a/compiler/rustc_span/src/lib.rs
+++ b/compiler/rustc_span/src/lib.rs
@@ -521,6 +521,12 @@ impl SpanData {
     }
 }
 
+impl Default for SpanData {
+    fn default() -> Self {
+        Self { lo: BytePos(0), hi: BytePos(0), ctxt: SyntaxContext::root(), parent: None }
+    }
+}
+
 impl PartialOrd for Span {
     fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
         PartialOrd::partial_cmp(&self.data(), &rhs.data())

--- a/tests/ui/asm/aarch64/srcloc.new.stderr
+++ b/tests/ui/asm/aarch64/srcloc.new.stderr
@@ -1,0 +1,320 @@
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:15:15
+   |
+LL |         asm!("invalid_instruction");
+   |               ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:2
+   |
+LL |     invalid_instruction
+   |     ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:19:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:13
+   |
+LL |             invalid_instruction
+   |             ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:24:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:13
+   |
+LL |             invalid_instruction
+   |             ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:30:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:13
+   |
+LL |             invalid_instruction
+   |             ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:37:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:13
+   |
+LL |             invalid_instruction
+   |             ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:42:14
+   |
+LL |         asm!(concat!("invalid", "_", "instruction"));
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:2
+   |
+LL |     invalid_instruction
+   |     ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:46:14
+   |
+LL |             "invalid_instruction",
+   |              ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:2
+   |
+LL |     invalid_instruction
+   |     ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:52:14
+   |
+LL |             "invalid_instruction",
+   |              ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:1
+   |
+LL | invalid_instruction
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:59:14
+   |
+LL |             "invalid_instruction",
+   |              ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:1
+   |
+LL | invalid_instruction
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:66:13
+   |
+LL |             concat!("invalid", "_", "instruction"),
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:1
+   |
+LL | invalid_instruction
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:73:13
+   |
+LL |             concat!("invalid", "_", "instruction"),
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:1
+   |
+LL | invalid_instruction
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:80:14
+   |
+LL |             "invalid_instruction1",
+   |              ^^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:2
+   |
+LL |     invalid_instruction1
+   |     ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:81:14
+   |
+LL |             "invalid_instruction2",
+   |              ^^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:1
+   |
+LL | invalid_instruction2
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:87:13
+   |
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction1", "\n",
+LL | |                 "invalid", "_", "instruction2",
+LL | |             ),
+   | |_____________^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:2
+   |
+LL |     invalid_instruction1
+   |     ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:87:13
+   |
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction1", "\n",
+LL | |                 "invalid", "_", "instruction2",
+LL | |             ),
+   | |_____________^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:1
+   |
+LL | invalid_instruction2
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:96:13
+   |
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction1", "\n",
+LL | |                 "invalid", "_", "instruction2",
+LL | |             ),
+   | |_____________^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:2
+   |
+LL |     invalid_instruction1
+   |     ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:96:13
+   |
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction1", "\n",
+LL | |                 "invalid", "_", "instruction2",
+LL | |             ),
+   | |_____________^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:1
+   |
+LL | invalid_instruction2
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:100:13
+   |
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction3", "\n",
+LL | |                 "invalid", "_", "instruction4",
+LL | |             ),
+   | |_____________^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:1
+   |
+LL | invalid_instruction3
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:100:13
+   |
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction3", "\n",
+LL | |                 "invalid", "_", "instruction4",
+LL | |             ),
+   | |_____________^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:4:1
+   |
+LL | invalid_instruction4
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:111:13
+   |
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction1", "\n",
+LL | |                 "invalid", "_", "instruction2", "\n",
+LL | |             ),
+   | |_____________^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:2
+   |
+LL |     invalid_instruction1
+   |     ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:111:13
+   |
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction1", "\n",
+LL | |                 "invalid", "_", "instruction2", "\n",
+LL | |             ),
+   | |_____________^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:1
+   |
+LL | invalid_instruction2
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:115:13
+   |
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction3", "\n",
+LL | |                 "invalid", "_", "instruction4", "\n",
+LL | |             ),
+   | |_____________^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:4:1
+   |
+LL | invalid_instruction3
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:115:13
+   |
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction3", "\n",
+LL | |                 "invalid", "_", "instruction4", "\n",
+LL | |             ),
+   | |_____________^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:5:1
+   |
+LL | invalid_instruction4
+   | ^
+
+error: unrecognized instruction mnemonic
+  --> $DIR/srcloc.rs:128:14
+   |
+LL |             "invalid_instruction"
+   |              ^^^^^^^^^^^^^^^^^^^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:4:1
+   |
+LL | invalid_instruction
+   | ^
+
+error: aborting due to 24 previous errors
+

--- a/tests/ui/asm/aarch64/srcloc.old.stderr
+++ b/tests/ui/asm/aarch64/srcloc.old.stderr
@@ -1,5 +1,5 @@
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:12:15
+  --> $DIR/srcloc.rs:15:15
    |
 LL |         asm!("invalid_instruction");
    |               ^
@@ -11,7 +11,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:16:13
+  --> $DIR/srcloc.rs:19:13
    |
 LL |             invalid_instruction
    |             ^
@@ -23,7 +23,7 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:21:13
+  --> $DIR/srcloc.rs:24:13
    |
 LL |             invalid_instruction
    |             ^
@@ -35,7 +35,7 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:27:13
+  --> $DIR/srcloc.rs:30:13
    |
 LL |             invalid_instruction
    |             ^
@@ -47,7 +47,7 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:34:13
+  --> $DIR/srcloc.rs:37:13
    |
 LL |             invalid_instruction
    |             ^
@@ -59,7 +59,7 @@ LL |             invalid_instruction
    |             ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:39:14
+  --> $DIR/srcloc.rs:42:14
    |
 LL |         asm!(concat!("invalid", "_", "instruction"));
    |              ^
@@ -71,7 +71,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:43:14
+  --> $DIR/srcloc.rs:46:14
    |
 LL |             "invalid_instruction",
    |              ^
@@ -83,7 +83,7 @@ LL |     invalid_instruction
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:49:14
+  --> $DIR/srcloc.rs:52:14
    |
 LL |             "invalid_instruction",
    |              ^
@@ -95,7 +95,7 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:56:14
+  --> $DIR/srcloc.rs:59:14
    |
 LL |             "invalid_instruction",
    |              ^
@@ -107,7 +107,7 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:63:13
+  --> $DIR/srcloc.rs:66:13
    |
 LL |             concat!("invalid", "_", "instruction"),
    |             ^
@@ -119,7 +119,7 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:70:13
+  --> $DIR/srcloc.rs:73:13
    |
 LL |             concat!("invalid", "_", "instruction"),
    |             ^
@@ -131,7 +131,7 @@ LL | invalid_instruction
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:77:14
+  --> $DIR/srcloc.rs:80:14
    |
 LL |             "invalid_instruction1",
    |              ^
@@ -143,7 +143,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:78:14
+  --> $DIR/srcloc.rs:81:14
    |
 LL |             "invalid_instruction2",
    |              ^
@@ -155,7 +155,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:84:13
+  --> $DIR/srcloc.rs:87:13
    |
 LL |             concat!(
    |             ^
@@ -167,7 +167,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:84:13
+  --> $DIR/srcloc.rs:87:13
    |
 LL |             concat!(
    |             ^
@@ -179,7 +179,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:93:13
+  --> $DIR/srcloc.rs:96:13
    |
 LL |             concat!(
    |             ^
@@ -191,7 +191,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:93:13
+  --> $DIR/srcloc.rs:96:13
    |
 LL |             concat!(
    |             ^
@@ -203,7 +203,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:97:13
+  --> $DIR/srcloc.rs:100:13
    |
 LL |             concat!(
    |             ^
@@ -215,7 +215,7 @@ LL | invalid_instruction3
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:97:13
+  --> $DIR/srcloc.rs:100:13
    |
 LL |             concat!(
    |             ^
@@ -227,7 +227,7 @@ LL | invalid_instruction4
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:108:13
+  --> $DIR/srcloc.rs:111:13
    |
 LL |             concat!(
    |             ^
@@ -239,7 +239,7 @@ LL |     invalid_instruction1
    |     ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:108:13
+  --> $DIR/srcloc.rs:111:13
    |
 LL |             concat!(
    |             ^
@@ -251,7 +251,7 @@ LL | invalid_instruction2
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:112:13
+  --> $DIR/srcloc.rs:115:13
    |
 LL |             concat!(
    |             ^
@@ -263,7 +263,7 @@ LL | invalid_instruction3
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:112:13
+  --> $DIR/srcloc.rs:115:13
    |
 LL |             concat!(
    |             ^
@@ -275,7 +275,7 @@ LL | invalid_instruction4
    | ^
 
 error: unrecognized instruction mnemonic
-  --> $DIR/srcloc.rs:125:14
+  --> $DIR/srcloc.rs:128:14
    |
 LL |             "invalid_instruction"
    |              ^

--- a/tests/ui/asm/aarch64/srcloc.rs
+++ b/tests/ui/asm/aarch64/srcloc.rs
@@ -1,7 +1,10 @@
+//@ revisions: old new
 //@ only-aarch64
 //@ build-fail
 //@ needs-asm-support
 //@ compile-flags: -Ccodegen-units=1
+//@[old] ignore-llvm-version: 19 - 99
+//@[new] min-llvm-version: 19
 
 use std::arch::asm;
 

--- a/tests/ui/asm/inline-syntax.arm_llvm_18.stderr
+++ b/tests/ui/asm/inline-syntax.arm_llvm_18.stderr
@@ -18,7 +18,7 @@ error: unknown directive
   --> $DIR/inline-syntax.rs:35:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
-   |               ^^^^^^^^^^^^^^^^^^^^^^
+   |               ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:2
@@ -30,7 +30,7 @@ error: unknown directive
   --> $DIR/inline-syntax.rs:39:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:2
@@ -42,7 +42,7 @@ error: unknown directive
   --> $DIR/inline-syntax.rs:43:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
-   |               ^^^^^^^^^^^^^^^^^^^^
+   |               ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:2
@@ -54,7 +54,7 @@ error: unknown directive
   --> $DIR/inline-syntax.rs:47:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:2
@@ -66,7 +66,7 @@ error: unknown directive
   --> $DIR/inline-syntax.rs:51:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:2
@@ -78,7 +78,7 @@ error: unknown directive
   --> $DIR/inline-syntax.rs:58:13
    |
 LL |             .intel_syntax noprefix
-   |             ^^^^^^^^^^^^^^^^^^^^^^
+   |             ^
    |
 note: instantiated into assembly here
   --> <inline asm>:2:13

--- a/tests/ui/asm/inline-syntax.rs
+++ b/tests/ui/asm/inline-syntax.rs
@@ -1,10 +1,16 @@
-//@ revisions: x86_64 arm
+//@ revisions: x86_64 arm_llvm_18 arm
 //@[x86_64] compile-flags: --target x86_64-unknown-linux-gnu
 //@[x86_64] check-pass
 //@[x86_64] needs-llvm-components: x86
+//@[arm_llvm_18] compile-flags: --target armv7-unknown-linux-gnueabihf
+//@[arm_llvm_18] build-fail
+//@[arm_llvm_18] needs-llvm-components: arm
+//@[arm_llvm_18] ignore-llvm-version: 19 - 99
+// LLVM 19+ has full support for 64-bit cookies.
 //@[arm] compile-flags: --target armv7-unknown-linux-gnueabihf
 //@[arm] build-fail
 //@[arm] needs-llvm-components: arm
+//@[arm] min-llvm-version: 19
 //@ needs-asm-support
 
 #![feature(no_core, lang_items, rustc_attrs)]
@@ -29,18 +35,23 @@ pub fn main() {
         asm!(".intel_syntax noprefix", "nop");
         //[x86_64]~^ WARN avoid using `.intel_syntax`
         //[arm]~^^ ERROR unknown directive
+        //[arm_llvm_18]~^^^ ERROR unknown directive
         asm!(".intel_syntax aaa noprefix", "nop");
         //[x86_64]~^ WARN avoid using `.intel_syntax`
         //[arm]~^^ ERROR unknown directive
+        //[arm_llvm_18]~^^^ ERROR unknown directive
         asm!(".att_syntax noprefix", "nop");
         //[x86_64]~^ WARN avoid using `.att_syntax`
         //[arm]~^^ ERROR unknown directive
+        //[arm_llvm_18]~^^^ ERROR unknown directive
         asm!(".att_syntax bbb noprefix", "nop");
         //[x86_64]~^ WARN avoid using `.att_syntax`
         //[arm]~^^ ERROR unknown directive
+        //[arm_llvm_18]~^^^ ERROR unknown directive
         asm!(".intel_syntax noprefix; nop");
         //[x86_64]~^ WARN avoid using `.intel_syntax`
         //[arm]~^^ ERROR unknown directive
+        //[arm_llvm_18]~^^^ ERROR unknown directive
 
         asm!(
             r"
@@ -49,9 +60,10 @@ pub fn main() {
         );
         //[x86_64]~^^^ WARN avoid using `.intel_syntax`
         //[arm]~^^^^ ERROR unknown directive
+        //[arm_llvm_18]~^^^^^ ERROR unknown directive
     }
 }
 
 global_asm!(".intel_syntax noprefix", "nop");
 //[x86_64]~^ WARN avoid using `.intel_syntax`
-// Assembler errors don't have line numbers, so no error on ARM
+// Global assembly errors don't have line numbers, so no error on ARM.

--- a/tests/ui/asm/inline-syntax.x86_64.stderr
+++ b/tests/ui/asm/inline-syntax.x86_64.stderr
@@ -1,5 +1,5 @@
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:55:14
+  --> $DIR/inline-syntax.rs:67:14
    |
 LL | global_asm!(".intel_syntax noprefix", "nop");
    |              ^^^^^^^^^^^^^^^^^^^^^^
@@ -7,37 +7,37 @@ LL | global_asm!(".intel_syntax noprefix", "nop");
    = note: `#[warn(bad_asm_style)]` on by default
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:29:15
+  --> $DIR/inline-syntax.rs:35:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:32:15
+  --> $DIR/inline-syntax.rs:39:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.att_syntax`, prefer using `options(att_syntax)` instead
-  --> $DIR/inline-syntax.rs:35:15
+  --> $DIR/inline-syntax.rs:43:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.att_syntax`, prefer using `options(att_syntax)` instead
-  --> $DIR/inline-syntax.rs:38:15
+  --> $DIR/inline-syntax.rs:47:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:41:15
+  --> $DIR/inline-syntax.rs:51:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:47:13
+  --> $DIR/inline-syntax.rs:58:13
    |
 LL |             .intel_syntax noprefix
    |             ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32e_llvm_18.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32e_llvm_18.stderr
@@ -2,7 +2,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:58:11
    |
 LL |     asm!("li x16, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -14,7 +14,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:61:11
    |
 LL |     asm!("li x17, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -26,7 +26,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:64:11
    |
 LL |     asm!("li x18, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -38,7 +38,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:67:11
    |
 LL |     asm!("li x19, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -50,7 +50,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:70:11
    |
 LL |     asm!("li x20, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -62,7 +62,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:73:11
    |
 LL |     asm!("li x21, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -74,7 +74,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:76:11
    |
 LL |     asm!("li x22, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -86,7 +86,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:79:11
    |
 LL |     asm!("li x23, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -98,7 +98,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:82:11
    |
 LL |     asm!("li x24, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -110,7 +110,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:85:11
    |
 LL |     asm!("li x25, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -122,7 +122,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:88:11
    |
 LL |     asm!("li x26, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -134,7 +134,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:91:11
    |
 LL |     asm!("li x27, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -146,7 +146,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:94:11
    |
 LL |     asm!("li x28, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -158,7 +158,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:97:11
    |
 LL |     asm!("li x29, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -170,7 +170,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:100:11
    |
 LL |     asm!("li x30, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -182,7 +182,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:103:11
    |
 LL |     asm!("li x31, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32em.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32em.stderr
@@ -1,8 +1,8 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:46:11
+  --> $DIR/riscv32e-registers.rs:58:11
    |
 LL |     asm!("li x16, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -11,10 +11,10 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:49:11
+  --> $DIR/riscv32e-registers.rs:61:11
    |
 LL |     asm!("li x17, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -23,10 +23,10 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:52:11
+  --> $DIR/riscv32e-registers.rs:64:11
    |
 LL |     asm!("li x18, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -35,10 +35,10 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:55:11
+  --> $DIR/riscv32e-registers.rs:67:11
    |
 LL |     asm!("li x19, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -47,10 +47,10 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:70:11
    |
 LL |     asm!("li x20, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -59,10 +59,10 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:73:11
    |
 LL |     asm!("li x21, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -71,10 +71,10 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:76:11
    |
 LL |     asm!("li x22, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -83,10 +83,10 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:79:11
    |
 LL |     asm!("li x23, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -95,10 +95,10 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:82:11
    |
 LL |     asm!("li x24, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -107,10 +107,10 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:85:11
    |
 LL |     asm!("li x25, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -119,10 +119,10 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:88:11
    |
 LL |     asm!("li x26, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -131,10 +131,10 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:91:11
    |
 LL |     asm!("li x27, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -143,10 +143,10 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:94:11
    |
 LL |     asm!("li x28, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -155,10 +155,10 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:97:11
    |
 LL |     asm!("li x29, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -167,10 +167,10 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:100:11
    |
 LL |     asm!("li x30, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -179,10 +179,10 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:91:11
+  --> $DIR/riscv32e-registers.rs:103:11
    |
 LL |     asm!("li x31, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32em_llvm_18.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32em_llvm_18.stderr
@@ -2,7 +2,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:58:11
    |
 LL |     asm!("li x16, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -14,7 +14,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:61:11
    |
 LL |     asm!("li x17, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -26,7 +26,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:64:11
    |
 LL |     asm!("li x18, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -38,7 +38,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:67:11
    |
 LL |     asm!("li x19, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -50,7 +50,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:70:11
    |
 LL |     asm!("li x20, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -62,7 +62,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:73:11
    |
 LL |     asm!("li x21, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -74,7 +74,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:76:11
    |
 LL |     asm!("li x22, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -86,7 +86,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:79:11
    |
 LL |     asm!("li x23, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -98,7 +98,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:82:11
    |
 LL |     asm!("li x24, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -110,7 +110,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:85:11
    |
 LL |     asm!("li x25, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -122,7 +122,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:88:11
    |
 LL |     asm!("li x26, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -134,7 +134,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:91:11
    |
 LL |     asm!("li x27, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -146,7 +146,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:94:11
    |
 LL |     asm!("li x28, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -158,7 +158,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:97:11
    |
 LL |     asm!("li x29, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -170,7 +170,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:100:11
    |
 LL |     asm!("li x30, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -182,7 +182,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:103:11
    |
 LL |     asm!("li x31, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32emc.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32emc.stderr
@@ -1,8 +1,8 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:46:11
+  --> $DIR/riscv32e-registers.rs:58:11
    |
 LL |     asm!("li x16, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -11,10 +11,10 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:49:11
+  --> $DIR/riscv32e-registers.rs:61:11
    |
 LL |     asm!("li x17, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -23,10 +23,10 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:52:11
+  --> $DIR/riscv32e-registers.rs:64:11
    |
 LL |     asm!("li x18, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -35,10 +35,10 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:55:11
+  --> $DIR/riscv32e-registers.rs:67:11
    |
 LL |     asm!("li x19, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -47,10 +47,10 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:70:11
    |
 LL |     asm!("li x20, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -59,10 +59,10 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:73:11
    |
 LL |     asm!("li x21, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -71,10 +71,10 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:76:11
    |
 LL |     asm!("li x22, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -83,10 +83,10 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:79:11
    |
 LL |     asm!("li x23, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -95,10 +95,10 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:82:11
    |
 LL |     asm!("li x24, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -107,10 +107,10 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:85:11
    |
 LL |     asm!("li x25, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -119,10 +119,10 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:88:11
    |
 LL |     asm!("li x26, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -131,10 +131,10 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:91:11
    |
 LL |     asm!("li x27, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -143,10 +143,10 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:94:11
    |
 LL |     asm!("li x28, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -155,10 +155,10 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:97:11
    |
 LL |     asm!("li x29, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -167,10 +167,10 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:100:11
    |
 LL |     asm!("li x30, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -179,10 +179,10 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:91:11
+  --> $DIR/riscv32e-registers.rs:103:11
    |
 LL |     asm!("li x31, 0");
-   |           ^
+   |           ^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32emc_llvm_18.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32emc_llvm_18.stderr
@@ -2,7 +2,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:58:11
    |
 LL |     asm!("li x16, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -14,7 +14,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:61:11
    |
 LL |     asm!("li x17, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -26,7 +26,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:64:11
    |
 LL |     asm!("li x18, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -38,7 +38,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:67:11
    |
 LL |     asm!("li x19, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -50,7 +50,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:70:11
    |
 LL |     asm!("li x20, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -62,7 +62,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:73:11
    |
 LL |     asm!("li x21, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -74,7 +74,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:76:11
    |
 LL |     asm!("li x22, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -86,7 +86,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:79:11
    |
 LL |     asm!("li x23, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -98,7 +98,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:82:11
    |
 LL |     asm!("li x24, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -110,7 +110,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:85:11
    |
 LL |     asm!("li x25, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -122,7 +122,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:88:11
    |
 LL |     asm!("li x26, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -134,7 +134,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:91:11
    |
 LL |     asm!("li x27, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -146,7 +146,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:94:11
    |
 LL |     asm!("li x28, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -158,7 +158,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:97:11
    |
 LL |     asm!("li x29, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -170,7 +170,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:100:11
    |
 LL |     asm!("li x30, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5
@@ -182,7 +182,7 @@ error: invalid operand for instruction
   --> $DIR/riscv32e-registers.rs:103:11
    |
 LL |     asm!("li x31, 0");
-   |           ^^^^^^^^^
+   |           ^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:5

--- a/tests/ui/asm/riscv/riscv32e-registers.rs
+++ b/tests/ui/asm/riscv/riscv32e-registers.rs
@@ -1,15 +1,27 @@
 // Test that loads into registers x16..=x31 are never generated for riscv32{e,em,emc} targets
 //
 //@ build-fail
-//@ revisions: riscv32e riscv32em riscv32emc
+//@ revisions: riscv32e riscv32em riscv32emc riscv32e_llvm_18 riscv32em_llvm_18 riscv32emc_llvm_18
 //
 //@ compile-flags: --crate-type=rlib
 //@ [riscv32e] needs-llvm-components: riscv
 //@ [riscv32e] compile-flags: --target=riscv32e-unknown-none-elf
+//@ [riscv32e] min-llvm-version: 19
 //@ [riscv32em] needs-llvm-components: riscv
 //@ [riscv32em] compile-flags: --target=riscv32em-unknown-none-elf
+//@ [riscv32em] min-llvm-version: 19
 //@ [riscv32emc] needs-llvm-components: riscv
 //@ [riscv32emc] compile-flags: --target=riscv32emc-unknown-none-elf
+//@ [riscv32emc] min-llvm-version: 19
+//@ [riscv32e_llvm_18] needs-llvm-components: riscv
+//@ [riscv32e_llvm_18] compile-flags: --target=riscv32e-unknown-none-elf
+//@ [riscv32e_llvm_18] ignore-llvm-version: 19 - 99
+//@ [riscv32em_llvm_18] needs-llvm-components: riscv
+//@ [riscv32em_llvm_18] compile-flags: --target=riscv32em-unknown-none-elf
+//@ [riscv32em_llvm_18] ignore-llvm-version: 19 - 99
+//@ [riscv32emc_llvm_18] needs-llvm-components: riscv
+//@ [riscv32emc_llvm_18] compile-flags: --target=riscv32emc-unknown-none-elf
+//@ [riscv32emc_llvm_18] ignore-llvm-version: 19 - 99
 
 // Unlike bad-reg.rs, this tests if the assembler can reject invalid registers
 // usage in assembly code.

--- a/tests/ui/asm/x86_64/srcloc.new.stderr
+++ b/tests/ui/asm/x86_64/srcloc.new.stderr
@@ -1,8 +1,8 @@
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:11:15
+  --> $DIR/srcloc.rs:14:15
    |
 LL |         asm!("invalid_instruction");
-   |               ^
+   |               ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:2:2
@@ -11,10 +11,10 @@ LL |     invalid_instruction
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:15:13
+  --> $DIR/srcloc.rs:18:13
    |
 LL |             invalid_instruction
-   |             ^
+   |             ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:3:13
@@ -23,10 +23,10 @@ LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:20:13
+  --> $DIR/srcloc.rs:23:13
    |
 LL |             invalid_instruction
-   |             ^
+   |             ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:3:13
@@ -35,10 +35,10 @@ LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:26:13
+  --> $DIR/srcloc.rs:29:13
    |
 LL |             invalid_instruction
-   |             ^
+   |             ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:4:13
@@ -47,10 +47,10 @@ LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:33:13
+  --> $DIR/srcloc.rs:36:13
    |
 LL |             invalid_instruction
-   |             ^
+   |             ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:4:13
@@ -59,10 +59,10 @@ LL |             invalid_instruction
    |             ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:38:14
+  --> $DIR/srcloc.rs:41:14
    |
 LL |         asm!(concat!("invalid", "_", "instruction"));
-   |              ^
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:2:2
@@ -71,10 +71,10 @@ LL |     invalid_instruction
    |     ^^^^^^^^^^^^^^^^^^^
 
 warning: scale factor without index register is ignored
-  --> $DIR/srcloc.rs:41:15
+  --> $DIR/srcloc.rs:44:15
    |
 LL |         asm!("movaps %xmm3, (%esi, 2)", options(att_syntax));
-   |               ^
+   |               ^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:1:23
@@ -83,10 +83,10 @@ LL |     movaps %xmm3, (%esi, 2)
    |                          ^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:45:14
+  --> $DIR/srcloc.rs:48:14
    |
 LL |             "invalid_instruction",
-   |              ^
+   |              ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:2:2
@@ -95,10 +95,10 @@ LL |     invalid_instruction
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:51:14
+  --> $DIR/srcloc.rs:54:14
    |
 LL |             "invalid_instruction",
-   |              ^
+   |              ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:3:1
@@ -107,10 +107,10 @@ LL | invalid_instruction
    | ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:58:14
+  --> $DIR/srcloc.rs:61:14
    |
 LL |             "invalid_instruction",
-   |              ^
+   |              ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:4:1
@@ -119,10 +119,10 @@ LL | invalid_instruction
    | ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:65:13
+  --> $DIR/srcloc.rs:68:13
    |
 LL |             concat!("invalid", "_", "instruction"),
-   |             ^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:3:1
@@ -131,10 +131,10 @@ LL | invalid_instruction
    | ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:72:13
+  --> $DIR/srcloc.rs:75:13
    |
 LL |             concat!("invalid", "_", "instruction"),
-   |             ^
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:3:1
@@ -143,10 +143,10 @@ LL | invalid_instruction
    | ^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction1'
-  --> $DIR/srcloc.rs:79:14
+  --> $DIR/srcloc.rs:82:14
    |
 LL |             "invalid_instruction1",
-   |              ^
+   |              ^^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:2:2
@@ -155,10 +155,10 @@ LL |     invalid_instruction1
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction2'
-  --> $DIR/srcloc.rs:80:14
+  --> $DIR/srcloc.rs:83:14
    |
 LL |             "invalid_instruction2",
-   |              ^
+   |              ^^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:3:1
@@ -167,10 +167,13 @@ LL | invalid_instruction2
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction1'
-  --> $DIR/srcloc.rs:86:13
+  --> $DIR/srcloc.rs:89:13
    |
-LL |             concat!(
-   |             ^
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction1", "\n",
+LL | |                 "invalid", "_", "instruction2",
+LL | |             ),
+   | |_____________^
    |
 note: instantiated into assembly here
   --> <inline asm>:2:2
@@ -179,10 +182,13 @@ LL |     invalid_instruction1
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction2'
-  --> $DIR/srcloc.rs:86:13
+  --> $DIR/srcloc.rs:89:13
    |
-LL |             concat!(
-   |             ^
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction1", "\n",
+LL | |                 "invalid", "_", "instruction2",
+LL | |             ),
+   | |_____________^
    |
 note: instantiated into assembly here
   --> <inline asm>:3:1
@@ -191,10 +197,13 @@ LL | invalid_instruction2
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction1'
-  --> $DIR/srcloc.rs:95:13
+  --> $DIR/srcloc.rs:98:13
    |
-LL |             concat!(
-   |             ^
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction1", "\n",
+LL | |                 "invalid", "_", "instruction2",
+LL | |             ),
+   | |_____________^
    |
 note: instantiated into assembly here
   --> <inline asm>:2:2
@@ -203,10 +212,13 @@ LL |     invalid_instruction1
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction2'
-  --> $DIR/srcloc.rs:95:13
+  --> $DIR/srcloc.rs:98:13
    |
-LL |             concat!(
-   |             ^
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction1", "\n",
+LL | |                 "invalid", "_", "instruction2",
+LL | |             ),
+   | |_____________^
    |
 note: instantiated into assembly here
   --> <inline asm>:3:1
@@ -215,10 +227,13 @@ LL | invalid_instruction2
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction3'
-  --> $DIR/srcloc.rs:99:13
+  --> $DIR/srcloc.rs:102:13
    |
-LL |             concat!(
-   |             ^
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction3", "\n",
+LL | |                 "invalid", "_", "instruction4",
+LL | |             ),
+   | |_____________^
    |
 note: instantiated into assembly here
   --> <inline asm>:4:1
@@ -227,10 +242,13 @@ LL | invalid_instruction3
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction4'
-  --> $DIR/srcloc.rs:99:13
+  --> $DIR/srcloc.rs:102:13
    |
-LL |             concat!(
-   |             ^
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction3", "\n",
+LL | |                 "invalid", "_", "instruction4",
+LL | |             ),
+   | |_____________^
    |
 note: instantiated into assembly here
   --> <inline asm>:5:1
@@ -239,10 +257,13 @@ LL | invalid_instruction4
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction1'
-  --> $DIR/srcloc.rs:110:13
+  --> $DIR/srcloc.rs:113:13
    |
-LL |             concat!(
-   |             ^
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction1", "\n",
+LL | |                 "invalid", "_", "instruction2", "\n",
+LL | |             ),
+   | |_____________^
    |
 note: instantiated into assembly here
   --> <inline asm>:2:2
@@ -251,10 +272,13 @@ LL |     invalid_instruction1
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction2'
-  --> $DIR/srcloc.rs:110:13
+  --> $DIR/srcloc.rs:113:13
    |
-LL |             concat!(
-   |             ^
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction1", "\n",
+LL | |                 "invalid", "_", "instruction2", "\n",
+LL | |             ),
+   | |_____________^
    |
 note: instantiated into assembly here
   --> <inline asm>:3:1
@@ -263,10 +287,13 @@ LL | invalid_instruction2
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction3'
-  --> $DIR/srcloc.rs:114:13
+  --> $DIR/srcloc.rs:117:13
    |
-LL |             concat!(
-   |             ^
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction3", "\n",
+LL | |                 "invalid", "_", "instruction4", "\n",
+LL | |             ),
+   | |_____________^
    |
 note: instantiated into assembly here
   --> <inline asm>:5:1
@@ -275,10 +302,13 @@ LL | invalid_instruction3
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction4'
-  --> $DIR/srcloc.rs:114:13
+  --> $DIR/srcloc.rs:117:13
    |
-LL |             concat!(
-   |             ^
+LL | /             concat!(
+LL | |                 "invalid", "_", "instruction3", "\n",
+LL | |                 "invalid", "_", "instruction4", "\n",
+LL | |             ),
+   | |_____________^
    |
 note: instantiated into assembly here
   --> <inline asm>:6:1
@@ -287,10 +317,10 @@ LL | invalid_instruction4
    | ^^^^^^^^^^^^^^^^^^^^
 
 error: invalid instruction mnemonic 'invalid_instruction'
-  --> $DIR/srcloc.rs:127:14
+  --> $DIR/srcloc.rs:130:14
    |
 LL |             "invalid_instruction"
-   |              ^
+   |              ^^^^^^^^^^^^^^^^^^^
    |
 note: instantiated into assembly here
   --> <inline asm>:5:1

--- a/tests/ui/asm/x86_64/srcloc.old.stderr
+++ b/tests/ui/asm/x86_64/srcloc.old.stderr
@@ -1,0 +1,302 @@
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:14:15
+   |
+LL |         asm!("invalid_instruction");
+   |               ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:2
+   |
+LL |     invalid_instruction
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:18:13
+   |
+LL |             invalid_instruction
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:23:13
+   |
+LL |             invalid_instruction
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:29:13
+   |
+LL |             invalid_instruction
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:4:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:36:13
+   |
+LL |             invalid_instruction
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:4:13
+   |
+LL |             invalid_instruction
+   |             ^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:41:14
+   |
+LL |         asm!(concat!("invalid", "_", "instruction"));
+   |              ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:2
+   |
+LL |     invalid_instruction
+   |     ^^^^^^^^^^^^^^^^^^^
+
+warning: scale factor without index register is ignored
+  --> $DIR/srcloc.rs:44:15
+   |
+LL |         asm!("movaps %xmm3, (%esi, 2)", options(att_syntax));
+   |               ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:1:23
+   |
+LL |     movaps %xmm3, (%esi, 2)
+   |                          ^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:48:14
+   |
+LL |             "invalid_instruction",
+   |              ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:2
+   |
+LL |     invalid_instruction
+   |     ^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:54:14
+   |
+LL |             "invalid_instruction",
+   |              ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:1
+   |
+LL | invalid_instruction
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:61:14
+   |
+LL |             "invalid_instruction",
+   |              ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:4:1
+   |
+LL | invalid_instruction
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:68:13
+   |
+LL |             concat!("invalid", "_", "instruction"),
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:1
+   |
+LL | invalid_instruction
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:75:13
+   |
+LL |             concat!("invalid", "_", "instruction"),
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:1
+   |
+LL | invalid_instruction
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction1'
+  --> $DIR/srcloc.rs:82:14
+   |
+LL |             "invalid_instruction1",
+   |              ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:2
+   |
+LL |     invalid_instruction1
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction2'
+  --> $DIR/srcloc.rs:83:14
+   |
+LL |             "invalid_instruction2",
+   |              ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:1
+   |
+LL | invalid_instruction2
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction1'
+  --> $DIR/srcloc.rs:89:13
+   |
+LL |             concat!(
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:2
+   |
+LL |     invalid_instruction1
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction2'
+  --> $DIR/srcloc.rs:89:13
+   |
+LL |             concat!(
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:1
+   |
+LL | invalid_instruction2
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction1'
+  --> $DIR/srcloc.rs:98:13
+   |
+LL |             concat!(
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:2
+   |
+LL |     invalid_instruction1
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction2'
+  --> $DIR/srcloc.rs:98:13
+   |
+LL |             concat!(
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:1
+   |
+LL | invalid_instruction2
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction3'
+  --> $DIR/srcloc.rs:102:13
+   |
+LL |             concat!(
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:4:1
+   |
+LL | invalid_instruction3
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction4'
+  --> $DIR/srcloc.rs:102:13
+   |
+LL |             concat!(
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:5:1
+   |
+LL | invalid_instruction4
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction1'
+  --> $DIR/srcloc.rs:113:13
+   |
+LL |             concat!(
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:2:2
+   |
+LL |     invalid_instruction1
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction2'
+  --> $DIR/srcloc.rs:113:13
+   |
+LL |             concat!(
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:3:1
+   |
+LL | invalid_instruction2
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction3'
+  --> $DIR/srcloc.rs:117:13
+   |
+LL |             concat!(
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:5:1
+   |
+LL | invalid_instruction3
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction4'
+  --> $DIR/srcloc.rs:117:13
+   |
+LL |             concat!(
+   |             ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:6:1
+   |
+LL | invalid_instruction4
+   | ^^^^^^^^^^^^^^^^^^^^
+
+error: invalid instruction mnemonic 'invalid_instruction'
+  --> $DIR/srcloc.rs:130:14
+   |
+LL |             "invalid_instruction"
+   |              ^
+   |
+note: instantiated into assembly here
+  --> <inline asm>:5:1
+   |
+LL | invalid_instruction
+   | ^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 24 previous errors; 1 warning emitted
+

--- a/tests/ui/asm/x86_64/srcloc.rs
+++ b/tests/ui/asm/x86_64/srcloc.rs
@@ -1,6 +1,9 @@
+//@ revisions: old new
 //@ only-x86_64
 //@ build-fail
 //@ compile-flags: -Ccodegen-units=1
+//@[old] ignore-llvm-version: 19 - 99
+//@[new] min-llvm-version: 19
 
 use std::arch::asm;
 


### PR DESCRIPTION
Before this PR, only the start position of the span was passed though the inline ASM cookie to diagnostics. LLVM 19 has full support for 64-bit inline ASM cookies; this PR uses that to pass the end position of the span in the upper 32 bits, meaning inline ASM diagnostics now point at the entire line the error occurred on, not just the first character of it.