### PR TITLE
Detect more `cfg`d out items in resolution errors

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1399,44 +1399,26 @@ impl InvocationCollectorNode for P<ast::Item> {
     }
 
     fn declared_idents(&self) -> Vec<Ident> {
-        struct ItemNameVisitor(Vec<Ident>, u8);
-        impl Visitor<'_> for ItemNameVisitor {
-            fn visit_item(&mut self, i: &ast::Item) {
-                self.1 += 1;
-                if let ItemKind::Use(ut) = &i.kind {
-                    fn collect_use_tree_leaves(ut: &ast::UseTree, idents: &mut Vec<Ident>) {
-                        match &ut.kind {
-                            ast::UseTreeKind::Glob => {}
-                            ast::UseTreeKind::Simple(_) => idents.push(ut.ident()),
-                            ast::UseTreeKind::Nested { items, .. } => {
-                                for (ut, _) in items {
-                                    collect_use_tree_leaves(ut, idents);
-                                }
-                            }
+        if let ItemKind::Use(ut) = &self.kind {
+            fn collect_use_tree_leaves(ut: &ast::UseTree, idents: &mut Vec<Ident>) {
+                match &ut.kind {
+                    ast::UseTreeKind::Glob => {}
+                    ast::UseTreeKind::Simple(_) => idents.push(ut.ident()),
+                    ast::UseTreeKind::Nested { items, .. } => {
+                        for (ut, _) in items {
+                            collect_use_tree_leaves(ut, idents);
                         }
                     }
-
-                    collect_use_tree_leaves(ut, &mut self.0);
-                } else {
-                    if let Some(ident) = i.kind.ident() {
-                        self.0.push(ident);
-                    }
                 }
-                if self.1 < 4 {
-                    // We only visit up to 3 levels of nesting from this item, like if we were
-                    // looking at `mod a`, we'd find item `a::b::c`. We have this limit to guard
-                    // against deeply nested modules behind `cfg` flags, where we could spend
-                    // significant time collecting this information purely for a potential
-                    // diagnostic improvement.
-                    visit::walk_item(self, i);
-                }
-                self.1 -= 1;
             }
+            let mut idents = vec![];
+            collect_use_tree_leaves(&ut, &mut idents);
+            idents
+        } else if let Some(ident) = self.kind.ident() {
+            vec![ident]
+        } else {
+            vec![]
         }
-
-        let mut v = ItemNameVisitor(vec![], 0);
-        v.visit_item(self);
-        v.0
     }
 }
 

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1411,13 +1411,11 @@ impl InvocationCollectorNode for P<ast::Item> {
                     }
                 }
             }
-            let mut idents = vec![];
+            let mut idents = Vec::new();
             collect_use_tree_leaves(&ut, &mut idents);
             idents
-        } else if let Some(ident) = self.kind.ident() {
-            vec![ident]
         } else {
-            vec![]
+            self.kind.ident().into_iter().collect()
         }
     }
 }

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -803,11 +803,16 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     }
                     err.multipart_suggestion(msg, suggestions, applicability);
                 }
-                if let Some(ModuleOrUniformRoot::Module(module)) = module
-                    && let Some(module) = module.opt_def_id()
-                    && let Some(segment) = segment
-                {
-                    self.find_cfg_stripped(&mut err, &segment, module);
+
+                if let Some(segment) = segment {
+                    if let Some(ModuleOrUniformRoot::Module(module)) = module {
+                        let module =
+                            module.opt_def_id().unwrap_or_else(|| CRATE_DEF_ID.to_def_id());
+                        self.find_cfg_stripped(&mut err, &segment, module);
+                    } else {
+                        let module = CRATE_DEF_ID.to_def_id();
+                        self.find_cfg_stripped(&mut err, &segment, module);
+                    }
                 }
 
                 err

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -2845,16 +2845,13 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 continue;
             }
 
-            let note = errors::FoundItemConfigureOut { span: ident.span };
-            err.subdiagnostic(note);
-
-            if let CfgEntry::NameValue { value: Some((feature, _)), .. } = cfg.0 {
-                let note = errors::ItemWasBehindFeature { feature, span: cfg.1 };
-                err.subdiagnostic(note);
+            let item_was = if let CfgEntry::NameValue { value: Some((feature, _)), .. } = cfg.0 {
+                errors::ItemWas::BehindFeature { feature, span: cfg.1 }
             } else {
-                let note = errors::ItemWasCfgOut { span: cfg.1 };
-                err.subdiagnostic(note);
-            }
+                errors::ItemWas::CfgOut { span: cfg.1 }
+            };
+            let note = errors::FoundItemConfigureOut { span: ident.span, item_was };
+            err.subdiagnostic(note);
         }
     }
 }

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -805,14 +805,11 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 }
 
                 if let Some(segment) = segment {
-                    if let Some(ModuleOrUniformRoot::Module(module)) = module {
-                        let module =
-                            module.opt_def_id().unwrap_or_else(|| CRATE_DEF_ID.to_def_id());
-                        self.find_cfg_stripped(&mut err, &segment, module);
-                    } else {
-                        let module = CRATE_DEF_ID.to_def_id();
-                        self.find_cfg_stripped(&mut err, &segment, module);
-                    }
+                    let module = match module {
+                        Some(ModuleOrUniformRoot::Module(m)) if let Some(id) = m.opt_def_id() => id,
+                        _ => CRATE_DEF_ID.to_def_id(),
+                    };
+                    self.find_cfg_stripped(&mut err, &segment, module);
                 }
 
                 err

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -525,9 +525,8 @@ impl<'ast, 'ra, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
         }
         self.err_code_special_cases(&mut err, source, path, span);
 
-        if let Some(module) = base_error.module {
-            self.r.find_cfg_stripped(&mut err, &path.last().unwrap().ident.name, module);
-        }
+        let module = base_error.module.unwrap_or_else(|| CRATE_DEF_ID.to_def_id());
+        self.r.find_cfg_stripped(&mut err, &path.last().unwrap().ident.name, module);
 
         (err, candidates)
     }

--- a/tests/ui/cfg/both-true-false.stderr
+++ b/tests/ui/cfg/both-true-false.stderr
@@ -3,6 +3,27 @@ error[E0425]: cannot find function `foo` in this scope
    |
 LL |     foo();
    |     ^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/both-true-false.rs:6:4
+   |
+LL | fn foo() {}
+   |    ^^^
+note: the item is gated here
+  --> $DIR/both-true-false.rs:4:7
+   |
+LL | #[cfg(false)]
+   |       ^^^^^
+note: found an item that was configured out
+  --> $DIR/both-true-false.rs:10:4
+   |
+LL | fn foo() {}
+   |    ^^^
+note: the item is gated here
+  --> $DIR/both-true-false.rs:9:7
+   |
+LL | #[cfg(false)]
+   |       ^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cfg/both-true-false.stderr
+++ b/tests/ui/cfg/both-true-false.stderr
@@ -7,23 +7,18 @@ LL |     foo();
 note: found an item that was configured out
   --> $DIR/both-true-false.rs:6:4
    |
+LL | #[cfg(false)]
+   |       ----- the item is gated here
+LL | #[cfg(true)]
 LL | fn foo() {}
    |    ^^^
-note: the item is gated here
-  --> $DIR/both-true-false.rs:4:7
-   |
-LL | #[cfg(false)]
-   |       ^^^^^
 note: found an item that was configured out
   --> $DIR/both-true-false.rs:10:4
    |
+LL | #[cfg(false)]
+   |       ----- the item is gated here
 LL | fn foo() {}
    |    ^^^
-note: the item is gated here
-  --> $DIR/both-true-false.rs:9:7
-   |
-LL | #[cfg(false)]
-   |       ^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cfg/cfg-version/syntax.stderr
+++ b/tests/ui/cfg/cfg-version/syntax.stderr
@@ -132,13 +132,11 @@ LL |     key_value_form();
 note: found an item that was configured out
   --> $DIR/syntax.rs:32:4
    |
+LL | #[cfg(version = "1.43")]
+   |       ---------------- the item is gated behind the `1.43` feature
+LL |
 LL | fn key_value_form() {}
    |    ^^^^^^^^^^^^^^
-note: the item is gated behind the `1.43` feature
-  --> $DIR/syntax.rs:30:7
-   |
-LL | #[cfg(version = "1.43")]
-   |       ^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `not_numbers_or_periods` in this scope
   --> $DIR/syntax.rs:143:5
@@ -149,13 +147,11 @@ LL |     not_numbers_or_periods();
 note: found an item that was configured out
   --> $DIR/syntax.rs:53:4
    |
+LL | #[cfg(version("foo"))]
+   |              ------- the item is gated here
+LL |
 LL | fn not_numbers_or_periods() {}
    |    ^^^^^^^^^^^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/syntax.rs:51:14
-   |
-LL | #[cfg(version("foo"))]
-   |              ^^^^^^^
 
 error[E0425]: cannot find function `complex_semver_with_metadata` in this scope
   --> $DIR/syntax.rs:144:5
@@ -166,13 +162,11 @@ LL |     complex_semver_with_metadata();
 note: found an item that was configured out
   --> $DIR/syntax.rs:57:4
    |
+LL | #[cfg(version("1.20.0-stable"))]
+   |              ----------------- the item is gated here
+LL |
 LL | fn complex_semver_with_metadata() {}
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/syntax.rs:55:14
-   |
-LL | #[cfg(version("1.20.0-stable"))]
-   |              ^^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `invalid_major_only` in this scope
   --> $DIR/syntax.rs:145:5
@@ -183,13 +177,11 @@ LL |     invalid_major_only();
 note: found an item that was configured out
   --> $DIR/syntax.rs:80:4
    |
+LL | #[cfg(version("1"))]
+   |              ----- the item is gated here
+LL |
 LL | fn invalid_major_only() {}
    |    ^^^^^^^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/syntax.rs:78:14
-   |
-LL | #[cfg(version("1"))]
-   |              ^^^^^
 
 error[E0425]: cannot find function `invalid_major_only_zero` in this scope
   --> $DIR/syntax.rs:146:5
@@ -200,13 +192,11 @@ LL |     invalid_major_only_zero();
 note: found an item that was configured out
   --> $DIR/syntax.rs:84:4
    |
+LL | #[cfg(version("0"))]
+   |              ----- the item is gated here
+LL |
 LL | fn invalid_major_only_zero() {}
    |    ^^^^^^^^^^^^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/syntax.rs:82:14
-   |
-LL | #[cfg(version("0"))]
-   |              ^^^^^
 
 error[E0425]: cannot find function `invalid_major_only_negative` in this scope
   --> $DIR/syntax.rs:147:5
@@ -217,13 +207,11 @@ LL |     invalid_major_only_negative();
 note: found an item that was configured out
   --> $DIR/syntax.rs:97:4
    |
+LL | #[cfg(version("-1"))]
+   |              ------ the item is gated here
+LL |
 LL | fn invalid_major_only_negative() {}
    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/syntax.rs:95:14
-   |
-LL | #[cfg(version("-1"))]
-   |              ^^^^^^
 
 error[E0425]: cannot find function `exceed_u16_major` in this scope
   --> $DIR/syntax.rs:148:5
@@ -234,13 +222,11 @@ LL |     exceed_u16_major();
 note: found an item that was configured out
   --> $DIR/syntax.rs:103:4
    |
+LL | #[cfg(version("65536"))]
+   |              --------- the item is gated here
+LL |
 LL | fn exceed_u16_major() {}
    |    ^^^^^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/syntax.rs:101:14
-   |
-LL | #[cfg(version("65536"))]
-   |              ^^^^^^^^^
 
 error[E0425]: cannot find function `exceed_u16_minor` in this scope
   --> $DIR/syntax.rs:149:5
@@ -251,13 +237,11 @@ LL |     exceed_u16_minor();
 note: found an item that was configured out
   --> $DIR/syntax.rs:107:4
    |
+LL | #[cfg(version("1.65536.0"))]
+   |              ------------- the item is gated here
+LL |
 LL | fn exceed_u16_minor() {}
    |    ^^^^^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/syntax.rs:105:14
-   |
-LL | #[cfg(version("1.65536.0"))]
-   |              ^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `exceed_u16_patch` in this scope
   --> $DIR/syntax.rs:150:5
@@ -268,13 +252,11 @@ LL |     exceed_u16_patch();
 note: found an item that was configured out
   --> $DIR/syntax.rs:111:4
    |
+LL | #[cfg(version("1.0.65536"))]
+   |              ------------- the item is gated here
+LL |
 LL | fn exceed_u16_patch() {}
    |    ^^^^^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/syntax.rs:109:14
-   |
-LL | #[cfg(version("1.0.65536"))]
-   |              ^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `exceed_u16_mixed` in this scope
   --> $DIR/syntax.rs:151:5
@@ -285,13 +267,11 @@ LL |     exceed_u16_mixed();
 note: found an item that was configured out
   --> $DIR/syntax.rs:115:4
    |
+LL | #[cfg(version("65536.0.65536"))]
+   |              ----------------- the item is gated here
+LL |
 LL | fn exceed_u16_mixed() {}
    |    ^^^^^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/syntax.rs:113:14
-   |
-LL | #[cfg(version("65536.0.65536"))]
-   |              ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 14 previous errors; 14 warnings emitted
 

--- a/tests/ui/cfg/cfg-version/syntax.stderr
+++ b/tests/ui/cfg/cfg-version/syntax.stderr
@@ -128,60 +128,170 @@ error[E0425]: cannot find function `key_value_form` in this scope
    |
 LL |     key_value_form();
    |     ^^^^^^^^^^^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/syntax.rs:32:4
+   |
+LL | fn key_value_form() {}
+   |    ^^^^^^^^^^^^^^
+note: the item is gated behind the `1.43` feature
+  --> $DIR/syntax.rs:30:7
+   |
+LL | #[cfg(version = "1.43")]
+   |       ^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `not_numbers_or_periods` in this scope
   --> $DIR/syntax.rs:143:5
    |
 LL |     not_numbers_or_periods();
    |     ^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/syntax.rs:53:4
+   |
+LL | fn not_numbers_or_periods() {}
+   |    ^^^^^^^^^^^^^^^^^^^^^^
+note: the item is gated here
+  --> $DIR/syntax.rs:51:14
+   |
+LL | #[cfg(version("foo"))]
+   |              ^^^^^^^
 
 error[E0425]: cannot find function `complex_semver_with_metadata` in this scope
   --> $DIR/syntax.rs:144:5
    |
 LL |     complex_semver_with_metadata();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/syntax.rs:57:4
+   |
+LL | fn complex_semver_with_metadata() {}
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: the item is gated here
+  --> $DIR/syntax.rs:55:14
+   |
+LL | #[cfg(version("1.20.0-stable"))]
+   |              ^^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `invalid_major_only` in this scope
   --> $DIR/syntax.rs:145:5
    |
 LL |     invalid_major_only();
    |     ^^^^^^^^^^^^^^^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/syntax.rs:80:4
+   |
+LL | fn invalid_major_only() {}
+   |    ^^^^^^^^^^^^^^^^^^
+note: the item is gated here
+  --> $DIR/syntax.rs:78:14
+   |
+LL | #[cfg(version("1"))]
+   |              ^^^^^
 
 error[E0425]: cannot find function `invalid_major_only_zero` in this scope
   --> $DIR/syntax.rs:146:5
    |
 LL |     invalid_major_only_zero();
    |     ^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/syntax.rs:84:4
+   |
+LL | fn invalid_major_only_zero() {}
+   |    ^^^^^^^^^^^^^^^^^^^^^^^
+note: the item is gated here
+  --> $DIR/syntax.rs:82:14
+   |
+LL | #[cfg(version("0"))]
+   |              ^^^^^
 
 error[E0425]: cannot find function `invalid_major_only_negative` in this scope
   --> $DIR/syntax.rs:147:5
    |
 LL |     invalid_major_only_negative();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/syntax.rs:97:4
+   |
+LL | fn invalid_major_only_negative() {}
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: the item is gated here
+  --> $DIR/syntax.rs:95:14
+   |
+LL | #[cfg(version("-1"))]
+   |              ^^^^^^
 
 error[E0425]: cannot find function `exceed_u16_major` in this scope
   --> $DIR/syntax.rs:148:5
    |
 LL |     exceed_u16_major();
    |     ^^^^^^^^^^^^^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/syntax.rs:103:4
+   |
+LL | fn exceed_u16_major() {}
+   |    ^^^^^^^^^^^^^^^^
+note: the item is gated here
+  --> $DIR/syntax.rs:101:14
+   |
+LL | #[cfg(version("65536"))]
+   |              ^^^^^^^^^
 
 error[E0425]: cannot find function `exceed_u16_minor` in this scope
   --> $DIR/syntax.rs:149:5
    |
 LL |     exceed_u16_minor();
    |     ^^^^^^^^^^^^^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/syntax.rs:107:4
+   |
+LL | fn exceed_u16_minor() {}
+   |    ^^^^^^^^^^^^^^^^
+note: the item is gated here
+  --> $DIR/syntax.rs:105:14
+   |
+LL | #[cfg(version("1.65536.0"))]
+   |              ^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `exceed_u16_patch` in this scope
   --> $DIR/syntax.rs:150:5
    |
 LL |     exceed_u16_patch();
    |     ^^^^^^^^^^^^^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/syntax.rs:111:4
+   |
+LL | fn exceed_u16_patch() {}
+   |    ^^^^^^^^^^^^^^^^
+note: the item is gated here
+  --> $DIR/syntax.rs:109:14
+   |
+LL | #[cfg(version("1.0.65536"))]
+   |              ^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `exceed_u16_mixed` in this scope
   --> $DIR/syntax.rs:151:5
    |
 LL |     exceed_u16_mixed();
    |     ^^^^^^^^^^^^^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/syntax.rs:115:4
+   |
+LL | fn exceed_u16_mixed() {}
+   |    ^^^^^^^^^^^^^^^^
+note: the item is gated here
+  --> $DIR/syntax.rs:113:14
+   |
+LL | #[cfg(version("65536.0.65536"))]
+   |              ^^^^^^^^^^^^^^^^^
 
 error: aborting due to 14 previous errors; 14 warnings emitted
 

--- a/tests/ui/cfg/cmdline-false.stderr
+++ b/tests/ui/cfg/cmdline-false.stderr
@@ -7,13 +7,10 @@ LL |     foo();
 note: found an item that was configured out
   --> $DIR/cmdline-false.rs:5:4
    |
+LL | #[cfg(false)]
+   |       ----- the item is gated here
 LL | fn foo() {}
    |    ^^^
-note: the item is gated here
-  --> $DIR/cmdline-false.rs:4:7
-   |
-LL | #[cfg(false)]
-   |       ^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cfg/cmdline-false.stderr
+++ b/tests/ui/cfg/cmdline-false.stderr
@@ -3,6 +3,17 @@ error[E0425]: cannot find function `foo` in this scope
    |
 LL |     foo();
    |     ^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/cmdline-false.rs:5:4
+   |
+LL | fn foo() {}
+   |    ^^^
+note: the item is gated here
+  --> $DIR/cmdline-false.rs:4:7
+   |
+LL | #[cfg(false)]
+   |       ^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cfg/diagnostics-cross-crate.rs
+++ b/tests/ui/cfg/diagnostics-cross-crate.rs
@@ -11,24 +11,20 @@ fn main() {
     cfged_out::inner::uwu(); //~ ERROR cannot find function
     //~^ NOTE found an item that was configured out
     //~| NOTE not found in `cfged_out::inner`
-    //~| NOTE the item is gated here
 
     // The module isn't found - we would like to get a diagnostic, but currently don't due to
     // the awkward way the resolver diagnostics are currently implemented.
     cfged_out::inner::doesnt_exist::hello(); //~ ERROR failed to resolve
     //~^ NOTE could not find `doesnt_exist` in `inner`
     //~| NOTE found an item that was configured out
-    //~| NOTE the item is gated here
 
     // It should find the one in the right module, not the wrong one.
     cfged_out::inner::right::meow(); //~ ERROR cannot find function
     //~^ NOTE found an item that was configured out
     //~| NOTE not found in `cfged_out::inner::right
-    //~| NOTE the item is gated behind the `what-a-cool-feature` feature
 
     // Exists in the crate root - diagnostic.
     cfged_out::vanished(); //~ ERROR cannot find function
     //~^ NOTE found an item that was configured out
     //~| NOTE not found in `cfged_out`
-    //~| NOTE the item is gated here
 }

--- a/tests/ui/cfg/diagnostics-cross-crate.stderr
+++ b/tests/ui/cfg/diagnostics-cross-crate.stderr
@@ -1,5 +1,5 @@
 error[E0433]: failed to resolve: could not find `doesnt_exist` in `inner`
-  --> $DIR/diagnostics-cross-crate.rs:18:23
+  --> $DIR/diagnostics-cross-crate.rs:17:23
    |
 LL |     cfged_out::inner::doesnt_exist::hello();
    |                       ^^^^^^^^^^^^ could not find `doesnt_exist` in `inner`
@@ -7,13 +7,10 @@ LL |     cfged_out::inner::doesnt_exist::hello();
 note: found an item that was configured out
   --> $DIR/auxiliary/cfged_out.rs:6:13
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
 LL |     pub mod doesnt_exist {
    |             ^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/auxiliary/cfged_out.rs:5:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error[E0425]: cannot find function `uwu` in crate `cfged_out`
   --> $DIR/diagnostics-cross-crate.rs:7:16
@@ -30,16 +27,13 @@ LL |     cfged_out::inner::uwu();
 note: found an item that was configured out
   --> $DIR/auxiliary/cfged_out.rs:3:12
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
 LL |     pub fn uwu() {}
    |            ^^^
-note: the item is gated here
-  --> $DIR/auxiliary/cfged_out.rs:2:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error[E0425]: cannot find function `meow` in module `cfged_out::inner::right`
-  --> $DIR/diagnostics-cross-crate.rs:24:30
+  --> $DIR/diagnostics-cross-crate.rs:22:30
    |
 LL |     cfged_out::inner::right::meow();
    |                              ^^^^ not found in `cfged_out::inner::right`
@@ -47,16 +41,13 @@ LL |     cfged_out::inner::right::meow();
 note: found an item that was configured out
   --> $DIR/auxiliary/cfged_out.rs:17:16
    |
+LL |         #[cfg(feature = "what-a-cool-feature")]
+   |               ------------------------------- the item is gated behind the `what-a-cool-feature` feature
 LL |         pub fn meow() {}
    |                ^^^^
-note: the item is gated behind the `what-a-cool-feature` feature
-  --> $DIR/auxiliary/cfged_out.rs:16:15
-   |
-LL |         #[cfg(feature = "what-a-cool-feature")]
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `vanished` in crate `cfged_out`
-  --> $DIR/diagnostics-cross-crate.rs:30:16
+  --> $DIR/diagnostics-cross-crate.rs:27:16
    |
 LL |     cfged_out::vanished();
    |                ^^^^^^^^ not found in `cfged_out`
@@ -64,13 +55,10 @@ LL |     cfged_out::vanished();
 note: found an item that was configured out
   --> $DIR/auxiliary/cfged_out.rs:22:8
    |
+LL | #[cfg(i_dont_exist_and_you_can_do_nothing_about_it)]
+   |       -------------------------------------------- the item is gated here
 LL | pub fn vanished() {}
    |        ^^^^^^^^
-note: the item is gated here
-  --> $DIR/auxiliary/cfged_out.rs:21:7
-   |
-LL | #[cfg(i_dont_exist_and_you_can_do_nothing_about_it)]
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/cfg/diagnostics-reexport-2.stderr
+++ b/tests/ui/cfg/diagnostics-reexport-2.stderr
@@ -7,13 +7,11 @@ LL |     reexport::gated::foo();
 note: found an item that was configured out
   --> $DIR/diagnostics-reexport-2.rs:10:13
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
+...
 LL |     pub mod gated {
    |             ^^^^^
-note: the item is gated here
-  --> $DIR/diagnostics-reexport-2.rs:4:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error[E0433]: failed to resolve: could not find `gated` in `reexport2`
   --> $DIR/diagnostics-reexport-2.rs:46:16
@@ -24,13 +22,11 @@ LL |     reexport2::gated::foo();
 note: found an item that was configured out
   --> $DIR/diagnostics-reexport-2.rs:10:13
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
+...
 LL |     pub mod gated {
    |             ^^^^^
-note: the item is gated here
-  --> $DIR/diagnostics-reexport-2.rs:4:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error[E0433]: failed to resolve: could not find `gated` in `reexport30`
   --> $DIR/diagnostics-reexport-2.rs:50:17
@@ -41,13 +37,11 @@ LL |     reexport30::gated::foo();
 note: found an item that was configured out
   --> $DIR/diagnostics-reexport-2.rs:10:13
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
+...
 LL |     pub mod gated {
    |             ^^^^^
-note: the item is gated here
-  --> $DIR/diagnostics-reexport-2.rs:4:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error[E0433]: failed to resolve: could not find `gated` in `reexport31`
   --> $DIR/diagnostics-reexport-2.rs:54:17
@@ -58,13 +52,11 @@ LL |     reexport31::gated::foo();
 note: found an item that was configured out
   --> $DIR/diagnostics-reexport-2.rs:10:13
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
+...
 LL |     pub mod gated {
    |             ^^^^^
-note: the item is gated here
-  --> $DIR/diagnostics-reexport-2.rs:4:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error[E0433]: failed to resolve: could not find `gated` in `reexport32`
   --> $DIR/diagnostics-reexport-2.rs:58:17
@@ -75,13 +67,11 @@ LL |     reexport32::gated::foo();
 note: found an item that was configured out
   --> $DIR/diagnostics-reexport-2.rs:10:13
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
+...
 LL |     pub mod gated {
    |             ^^^^^
-note: the item is gated here
-  --> $DIR/diagnostics-reexport-2.rs:4:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/cfg/diagnostics-reexport.rs
+++ b/tests/ui/cfg/diagnostics-reexport.rs
@@ -1,7 +1,7 @@
 pub mod inner {
-    #[cfg(false)]
+    #[cfg(false)] //~ NOTE the item is gated here
     mod gone {
-        pub fn uwu() {}
+        pub fn uwu() {} //~ NOTE found an item that was configured out
     }
 
     #[cfg(false)] //~ NOTE the item is gated here
@@ -34,7 +34,7 @@ mod b {
 }
 
 fn main() {
-    // There is no uwu at this path - no diagnostic.
+    // There is no uwu at this path, but there's one in a cgfd out sub-module, so we mention it.
     inner::uwu(); //~ ERROR cannot find function
     //~^ NOTE not found in `inner`
 }

--- a/tests/ui/cfg/diagnostics-reexport.rs
+++ b/tests/ui/cfg/diagnostics-reexport.rs
@@ -1,7 +1,7 @@
 pub mod inner {
-    #[cfg(false)] //~ NOTE the item is gated here
+    #[cfg(false)]
     mod gone {
-        pub fn uwu() {} //~ NOTE found an item that was configured out
+        pub fn uwu() {}
     }
 
     #[cfg(false)] //~ NOTE the item is gated here

--- a/tests/ui/cfg/diagnostics-reexport.stderr
+++ b/tests/ui/cfg/diagnostics-reexport.stderr
@@ -7,13 +7,10 @@ LL | pub use a::x;
 note: found an item that was configured out
   --> $DIR/diagnostics-reexport.rs:18:12
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
 LL |     pub fn x() {}
    |            ^
-note: the item is gated here
-  --> $DIR/diagnostics-reexport.rs:17:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error[E0432]: unresolved imports `b::x`, `b::y`
   --> $DIR/diagnostics-reexport.rs:22:13
@@ -26,23 +23,17 @@ LL | pub use b::{x, y};
 note: found an item that was configured out
   --> $DIR/diagnostics-reexport.rs:29:12
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
 LL |     pub fn x() {}
    |            ^
-note: the item is gated here
-  --> $DIR/diagnostics-reexport.rs:28:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 note: found an item that was configured out
   --> $DIR/diagnostics-reexport.rs:32:12
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
 LL |     pub fn y() {}
    |            ^
-note: the item is gated here
-  --> $DIR/diagnostics-reexport.rs:31:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error[E0425]: cannot find function `uwu` in module `inner`
   --> $DIR/diagnostics-reexport.rs:38:12
@@ -53,13 +44,10 @@ LL |     inner::uwu();
 note: found an item that was configured out
   --> $DIR/diagnostics-reexport.rs:8:20
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
 LL |     pub use super::uwu;
    |                    ^^^
-note: the item is gated here
-  --> $DIR/diagnostics-reexport.rs:7:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/cfg/diagnostics-reexport.stderr
+++ b/tests/ui/cfg/diagnostics-reexport.stderr
@@ -51,16 +51,6 @@ LL |     inner::uwu();
    |            ^^^ not found in `inner`
    |
 note: found an item that was configured out
-  --> $DIR/diagnostics-reexport.rs:4:16
-   |
-LL |         pub fn uwu() {}
-   |                ^^^
-note: the item is gated here
-  --> $DIR/diagnostics-reexport.rs:2:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
-note: found an item that was configured out
   --> $DIR/diagnostics-reexport.rs:8:20
    |
 LL |     pub use super::uwu;

--- a/tests/ui/cfg/diagnostics-reexport.stderr
+++ b/tests/ui/cfg/diagnostics-reexport.stderr
@@ -51,6 +51,16 @@ LL |     inner::uwu();
    |            ^^^ not found in `inner`
    |
 note: found an item that was configured out
+  --> $DIR/diagnostics-reexport.rs:4:16
+   |
+LL |         pub fn uwu() {}
+   |                ^^^
+note: the item is gated here
+  --> $DIR/diagnostics-reexport.rs:2:11
+   |
+LL |     #[cfg(false)]
+   |           ^^^^^
+note: found an item that was configured out
   --> $DIR/diagnostics-reexport.rs:8:20
    |
 LL |     pub use super::uwu;

--- a/tests/ui/cfg/diagnostics-same-crate.rs
+++ b/tests/ui/cfg/diagnostics-same-crate.rs
@@ -37,8 +37,8 @@ mod placeholder {
     //~| NOTE could not find `doesnt_exist` in `inner`
 }
 
-#[cfg(i_dont_exist_and_you_can_do_nothing_about_it)]
-pub fn vanished() {}
+#[cfg(i_dont_exist_and_you_can_do_nothing_about_it)] //~ NOTE the item is gated here
+pub fn vanished() {} //~ NOTE found an item that was configured out
 
 fn main() {
     // There is no uwu at this path - no diagnostic.
@@ -49,8 +49,7 @@ fn main() {
     inner::uwu(); //~ ERROR cannot find function
     //~| NOTE not found in `inner`
 
-    // The module isn't found - we would like to get a diagnostic, but currently don't due to
-    // the awkward way the resolver diagnostics are currently implemented.
+    // The module isn't found - we get a diagnostic.
     inner::doesnt_exist::hello(); //~ ERROR failed to resolve
     //~| NOTE could not find `doesnt_exist` in `inner`
 
@@ -58,9 +57,8 @@ fn main() {
     inner::right::meow(); //~ ERROR cannot find function
     //~| NOTE not found in `inner::right
 
-    // Exists in the crate root - we would generally want a diagnostic,
-    // but currently don't have one.
-    // Not that it matters much though, this is highly unlikely to confuse anyone.
+    // Exists in the crate root - we show a diagnostic because we treat "no module DefId" as "crate
+    // root DefId".
     vanished(); //~ ERROR cannot find function
     //~^ NOTE not found in this scope
 }

--- a/tests/ui/cfg/diagnostics-same-crate.stderr
+++ b/tests/ui/cfg/diagnostics-same-crate.stderr
@@ -33,7 +33,7 @@ LL |     #[cfg(false)]
    |           ^^^^^
 
 error[E0433]: failed to resolve: could not find `doesnt_exist` in `inner`
-  --> $DIR/diagnostics-same-crate.rs:54:12
+  --> $DIR/diagnostics-same-crate.rs:53:12
    |
 LL |     inner::doesnt_exist::hello();
    |            ^^^^^^^^^^^^ could not find `doesnt_exist` in `inner`
@@ -67,7 +67,7 @@ LL |     #[cfg(false)]
    |           ^^^^^
 
 error[E0425]: cannot find function `meow` in module `inner::right`
-  --> $DIR/diagnostics-same-crate.rs:58:19
+  --> $DIR/diagnostics-same-crate.rs:57:19
    |
 LL |     inner::right::meow();
    |                   ^^^^ not found in `inner::right`
@@ -90,10 +90,21 @@ LL |     uwu();
    |     ^^^ not found in this scope
 
 error[E0425]: cannot find function `vanished` in this scope
-  --> $DIR/diagnostics-same-crate.rs:64:5
+  --> $DIR/diagnostics-same-crate.rs:62:5
    |
 LL |     vanished();
    |     ^^^^^^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/diagnostics-same-crate.rs:41:8
+   |
+LL | pub fn vanished() {}
+   |        ^^^^^^^^
+note: the item is gated here
+  --> $DIR/diagnostics-same-crate.rs:40:7
+   |
+LL | #[cfg(i_dont_exist_and_you_can_do_nothing_about_it)]
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/cfg/diagnostics-same-crate.stderr
+++ b/tests/ui/cfg/diagnostics-same-crate.stderr
@@ -7,13 +7,11 @@ LL |     use super::inner::doesnt_exist;
 note: found an item that was configured out
   --> $DIR/diagnostics-same-crate.rs:11:13
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
+...
 LL |     pub mod doesnt_exist {
    |             ^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/diagnostics-same-crate.rs:8:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error[E0432]: unresolved import `super::inner::doesnt_exist`
   --> $DIR/diagnostics-same-crate.rs:35:23
@@ -24,13 +22,11 @@ LL |     use super::inner::doesnt_exist::hi;
 note: found an item that was configured out
   --> $DIR/diagnostics-same-crate.rs:11:13
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
+...
 LL |     pub mod doesnt_exist {
    |             ^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/diagnostics-same-crate.rs:8:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error[E0433]: failed to resolve: could not find `doesnt_exist` in `inner`
   --> $DIR/diagnostics-same-crate.rs:53:12
@@ -41,13 +37,11 @@ LL |     inner::doesnt_exist::hello();
 note: found an item that was configured out
   --> $DIR/diagnostics-same-crate.rs:11:13
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
+...
 LL |     pub mod doesnt_exist {
    |             ^^^^^^^^^^^^
-note: the item is gated here
-  --> $DIR/diagnostics-same-crate.rs:8:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error[E0425]: cannot find function `uwu` in module `inner`
   --> $DIR/diagnostics-same-crate.rs:49:12
@@ -58,13 +52,10 @@ LL |     inner::uwu();
 note: found an item that was configured out
   --> $DIR/diagnostics-same-crate.rs:5:12
    |
+LL |     #[cfg(false)]
+   |           ----- the item is gated here
 LL |     pub fn uwu() {}
    |            ^^^
-note: the item is gated here
-  --> $DIR/diagnostics-same-crate.rs:4:11
-   |
-LL |     #[cfg(false)]
-   |           ^^^^^
 
 error[E0425]: cannot find function `meow` in module `inner::right`
   --> $DIR/diagnostics-same-crate.rs:57:19
@@ -75,13 +66,10 @@ LL |     inner::right::meow();
 note: found an item that was configured out
   --> $DIR/diagnostics-same-crate.rs:26:16
    |
+LL |         #[cfg(feature = "what-a-cool-feature")]
+   |               ------------------------------- the item is gated behind the `what-a-cool-feature` feature
 LL |         pub fn meow() {}
    |                ^^^^
-note: the item is gated behind the `what-a-cool-feature` feature
-  --> $DIR/diagnostics-same-crate.rs:25:15
-   |
-LL |         #[cfg(feature = "what-a-cool-feature")]
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find function `uwu` in this scope
   --> $DIR/diagnostics-same-crate.rs:45:5
@@ -98,13 +86,10 @@ LL |     vanished();
 note: found an item that was configured out
   --> $DIR/diagnostics-same-crate.rs:41:8
    |
+LL | #[cfg(i_dont_exist_and_you_can_do_nothing_about_it)]
+   |       -------------------------------------------- the item is gated here
 LL | pub fn vanished() {}
    |        ^^^^^^^^
-note: the item is gated here
-  --> $DIR/diagnostics-same-crate.rs:40:7
-   |
-LL | #[cfg(i_dont_exist_and_you_can_do_nothing_about_it)]
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/cfg/nested-cfg-attr-conditional-compilation.rs
+++ b/tests/ui/cfg/nested-cfg-attr-conditional-compilation.rs
@@ -10,9 +10,10 @@
 //!
 //! Added in <https://github.com/rust-lang/rust/pull/34216>.
 
-#[cfg_attr(all(), cfg_attr(all(), cfg(false)))]
-fn f() {}
+#[cfg_attr(all(), cfg_attr(all(), cfg(false)))] //~ NOTE the item is gated here
+fn f() {} //~ NOTE found an item that was configured out
 
 fn main() {
     f() //~ ERROR cannot find function `f` in this scope
+    //~^ NOTE not found in this scope
 }

--- a/tests/ui/cfg/nested-cfg-attr-conditional-compilation.stderr
+++ b/tests/ui/cfg/nested-cfg-attr-conditional-compilation.stderr
@@ -3,6 +3,17 @@ error[E0425]: cannot find function `f` in this scope
    |
 LL |     f()
    |     ^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/nested-cfg-attr-conditional-compilation.rs:14:4
+   |
+LL | fn f() {}
+   |    ^
+note: the item is gated here
+  --> $DIR/nested-cfg-attr-conditional-compilation.rs:13:39
+   |
+LL | #[cfg_attr(all(), cfg_attr(all(), cfg(false)))]
+   |                                       ^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/cfg/nested-cfg-attr-conditional-compilation.stderr
+++ b/tests/ui/cfg/nested-cfg-attr-conditional-compilation.stderr
@@ -7,13 +7,10 @@ LL |     f()
 note: found an item that was configured out
   --> $DIR/nested-cfg-attr-conditional-compilation.rs:14:4
    |
+LL | #[cfg_attr(all(), cfg_attr(all(), cfg(false)))]
+   |                                       ----- the item is gated here
 LL | fn f() {}
    |    ^
-note: the item is gated here
-  --> $DIR/nested-cfg-attr-conditional-compilation.rs:13:39
-   |
-LL | #[cfg_attr(all(), cfg_attr(all(), cfg(false)))]
-   |                                       ^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/conditional-compilation/test-cfg.rs
+++ b/tests/ui/conditional-compilation/test-cfg.rs
@@ -1,8 +1,10 @@
 //@ compile-flags: --cfg foo --check-cfg=cfg(foo,bar)
 
 #[cfg(all(foo, bar))] // foo AND bar
-fn foo() {}
+//~^ NOTE the item is gated here
+fn foo() {} //~ NOTE found an item that was configured out
 
 fn main() {
     foo(); //~ ERROR cannot find function `foo` in this scope
+    //~^ NOTE not found in this scope
 }

--- a/tests/ui/conditional-compilation/test-cfg.stderr
+++ b/tests/ui/conditional-compilation/test-cfg.stderr
@@ -7,13 +7,11 @@ LL |     foo();
 note: found an item that was configured out
   --> $DIR/test-cfg.rs:5:4
    |
+LL | #[cfg(all(foo, bar))] // foo AND bar
+   |                --- the item is gated here
+LL |
 LL | fn foo() {}
    |    ^^^
-note: the item is gated here
-  --> $DIR/test-cfg.rs:3:16
-   |
-LL | #[cfg(all(foo, bar))] // foo AND bar
-   |                ^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/conditional-compilation/test-cfg.stderr
+++ b/tests/ui/conditional-compilation/test-cfg.stderr
@@ -1,8 +1,19 @@
 error[E0425]: cannot find function `foo` in this scope
-  --> $DIR/test-cfg.rs:7:5
+  --> $DIR/test-cfg.rs:8:5
    |
 LL |     foo();
    |     ^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/test-cfg.rs:5:4
+   |
+LL | fn foo() {}
+   |    ^^^
+note: the item is gated here
+  --> $DIR/test-cfg.rs:3:16
+   |
+LL | #[cfg(all(foo, bar))] // foo AND bar
+   |                ^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/builtin-std-paths-fail.stderr
+++ b/tests/ui/macros/builtin-std-paths-fail.stderr
@@ -104,8 +104,8 @@ LL | #[std::test]
    |
 note: found an item that was configured out
   --> $SRC_DIR/std/src/lib.rs:LL:COL
-note: the item is gated here
-  --> $SRC_DIR/std/src/lib.rs:LL:COL
+   |
+   = note: the item is gated here
 
 error: aborting due to 16 previous errors
 

--- a/tests/ui/macros/macro-inner-attributes.stderr
+++ b/tests/ui/macros/macro-inner-attributes.stderr
@@ -9,11 +9,8 @@ note: found an item that was configured out
    |
 LL | test!(a,
    |       ^
-note: the item is gated here
-  --> $DIR/macro-inner-attributes.rs:8:13
-   |
 LL |       #[cfg(false)],
-   |             ^^^^^
+   |             ----- the item is gated here
 help: there is a crate or module with a similar name
    |
 LL -     a::bar();

--- a/tests/ui/macros/macro-inner-attributes.stderr
+++ b/tests/ui/macros/macro-inner-attributes.stderr
@@ -4,6 +4,16 @@ error[E0433]: failed to resolve: use of unresolved module or unlinked crate `a`
 LL |     a::bar();
    |     ^ use of unresolved module or unlinked crate `a`
    |
+note: found an item that was configured out
+  --> $DIR/macro-inner-attributes.rs:7:7
+   |
+LL | test!(a,
+   |       ^
+note: the item is gated here
+  --> $DIR/macro-inner-attributes.rs:8:13
+   |
+LL |       #[cfg(false)],
+   |             ^^^^^
 help: there is a crate or module with a similar name
    |
 LL -     a::bar();

--- a/tests/ui/macros/macro-outer-attributes.stderr
+++ b/tests/ui/macros/macro-outer-attributes.stderr
@@ -7,13 +7,10 @@ LL |     a::bar();
 note: found an item that was configured out
   --> $DIR/macro-outer-attributes.rs:9:14
    |
+LL |       #[cfg(false)],
+   |             ----- the item is gated here
 LL |       pub fn bar() { });
    |              ^^^
-note: the item is gated here
-  --> $DIR/macro-outer-attributes.rs:8:13
-   |
-LL |       #[cfg(false)],
-   |             ^^^^^
 help: consider importing this function
    |
 LL + use b::bar;

--- a/tests/ui/rustdoc/cfg-rustdoc.rs
+++ b/tests/ui/rustdoc/cfg-rustdoc.rs
@@ -1,6 +1,7 @@
-#[cfg(doc)]
-pub struct Foo;
+#[cfg(doc)] //~ NOTE the item is gated here
+pub struct Foo; //~ NOTE found an item that was configured out
 
 fn main() {
-    let f = Foo; //~ ERROR
+    let f = Foo; //~ ERROR cannot find value `Foo` in this scope
+    //~^ NOTE not found in this scope
 }

--- a/tests/ui/rustdoc/cfg-rustdoc.stderr
+++ b/tests/ui/rustdoc/cfg-rustdoc.stderr
@@ -7,13 +7,10 @@ LL |     let f = Foo;
 note: found an item that was configured out
   --> $DIR/cfg-rustdoc.rs:2:12
    |
+LL | #[cfg(doc)]
+   |       --- the item is gated here
 LL | pub struct Foo;
    |            ^^^
-note: the item is gated here
-  --> $DIR/cfg-rustdoc.rs:1:7
-   |
-LL | #[cfg(doc)]
-   |       ^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rustdoc/cfg-rustdoc.stderr
+++ b/tests/ui/rustdoc/cfg-rustdoc.stderr
@@ -3,6 +3,17 @@ error[E0425]: cannot find value `Foo` in this scope
    |
 LL |     let f = Foo;
    |             ^^^ not found in this scope
+   |
+note: found an item that was configured out
+  --> $DIR/cfg-rustdoc.rs:2:12
+   |
+LL | pub struct Foo;
+   |            ^^^
+note: the item is gated here
+  --> $DIR/cfg-rustdoc.rs:1:7
+   |
+LL | #[cfg(doc)]
+   |       ^^^
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Use a visitor to collect *all* items (including those nested) that were stripped behind a `cfg` condition.

```
error[E0425]: cannot find function `f` in this scope
  --> $DIR/nested-cfg-attrs.rs:4:13
   |
LL | fn main() { f() }
   |             ^ not found in this scope
   |
note: found an item that was configured out
  --> $DIR/nested-cfg-attrs.rs:2:4
   |
LL | fn f() {}
   |    ^
note: the item is gated here
  --> $DIR/nested-cfg-attrs.rs:1:35
   |
LL | #[cfg_attr(all(), cfg_attr(all(), cfg(FALSE)))]
   |                                   ^^^^^^^^^^
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
