### PR TITLE
Port `run-make/libtest-json/validate_json.py` to Rust

### DIFF
--- a/tests/run-make/libtest-json/validate_json.py
+++ b/tests/run-make/libtest-json/validate_json.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-
-import sys
-import json
-
-# Try to decode line in order to ensure it is a valid JSON document
-for line in sys.stdin:
-    json.loads(line)


### PR DESCRIPTION
This is a trivial Python script that simply tries to parse each line of stdin (i.e. the test process output) as JSON, to verify that the overall output is JSON Lines.

We can perform the same check directly in `rmake.rs` using `serde_json`.

r? @jieyouxu