### PR TITLE
Remove useless attributes in merged doctest generated code

### DIFF
--- a/src/librustdoc/doctest/runner.rs
+++ b/src/librustdoc/doctest/runner.rs
@@ -75,7 +75,6 @@ impl DocTestRunner {
 #![allow(internal_features)]
 #![feature(test)]
 #![feature(rustc_attrs)]
-#![feature(coverage_attribute)]
 "
         .to_string();
 
@@ -135,7 +134,6 @@ mod __doctest_mod {{
 }}
 
 #[rustc_main]
-#[coverage(off)]
 fn main() -> std::process::ExitCode {{
 const TESTS: [test::TestDescAndFn; {nb_tests}] = [{ids}];
 let bin_marker = std::ffi::OsStr::new(__doctest_mod::BIN_OPTION);
@@ -235,11 +233,9 @@ fn main() {returns_result} {{
     writeln!(
         output,
         "
-#[rustc_test_marker = {test_name:?}]
 pub const TEST: test::TestDescAndFn = test::TestDescAndFn::new_doctest(
 {test_name:?}, {ignore}, {file:?}, {line}, {no_run}, {should_panic},
 test::StaticTestFn(
-    #[coverage(off)]
     || {{{runner}}},
 ));
 }}",


### PR DESCRIPTION
I took another look at the generated code for merged doctests and it seems like those attributes are only useful when running `rustc --test`, which isn't the case for merged doctests. Less code generated. \o/

r? @notriddle 