### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -1000,8 +1000,10 @@ impl<'ll> CodegenCx<'ll, '_> {
         ifn!("llvm.is.constant.i64", fn(t_i64) -> i1);
         ifn!("llvm.is.constant.i128", fn(t_i128) -> i1);
         ifn!("llvm.is.constant.isize", fn(t_isize) -> i1);
+        ifn!("llvm.is.constant.f16", fn(t_f16) -> i1);
         ifn!("llvm.is.constant.f32", fn(t_f32) -> i1);
         ifn!("llvm.is.constant.f64", fn(t_f64) -> i1);
+        ifn!("llvm.is.constant.f128", fn(t_f128) -> i1);
         ifn!("llvm.is.constant.ptr", fn(ptr) -> i1);
 
         ifn!("llvm.expect.i1", fn(i1, i1) -> i1);

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -4109,8 +4109,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let trait_span = self.tcx.def_span(trait_def_id);
         let mut multi_span: MultiSpan = trait_span.into();
         multi_span.push_span_label(trait_span, format!("this is the trait that is needed"));
+        let descr = self.tcx.associated_item(item_def_id).descr();
         multi_span
-            .push_span_label(item_span, format!("the method is available for `{rcvr_ty}` here"));
+            .push_span_label(item_span, format!("the {descr} is available for `{rcvr_ty}` here"));
         for (def_id, import_def_id) in candidates {
             if let Some(import_def_id) = import_def_id {
                 multi_span.push_span_label(

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -4062,7 +4062,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let name = self.tcx.crate_name(trait_candidate.def_id.krate);
                 if trait_candidate.def_id.krate != item.def_id.krate && name == pick_name {
                     let msg = format!(
-                        "you have multiple different versions of crate `{name}` in your \
+                        "there are multiple different versions of crate `{name}` in the \
                          dependency graph",
                     );
                     let tdid = self.tcx.parent(item.def_id);

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1697,11 +1697,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             err.highlighted_span_help(
                 span,
                 vec![
-                    StringPart::normal("you have ".to_string()),
+                    StringPart::normal("there are ".to_string()),
                     StringPart::highlighted("multiple different versions".to_string()),
                     StringPart::normal(" of crate `".to_string()),
                     StringPart::highlighted(format!("{name}")),
-                    StringPart::normal("` in your dependency graph".to_string()),
+                    StringPart::normal("` the your dependency graph".to_string()),
                 ],
             );
             let candidates = if impl_candidates.is_empty() {

--- a/tests/codegen/is_val_statically_known.rs
+++ b/tests/codegen/is_val_statically_known.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: --crate-type=lib -Zmerge-functions=disabled -O
 
 #![feature(core_intrinsics)]
+#![feature(f16, f128)]
 
 use std::intrinsics::is_val_statically_known;
 
@@ -49,7 +50,7 @@ pub fn _bool_false(b: bool) -> i32 {
 
 #[inline]
 pub fn _iref(a: &u8) -> i32 {
-    if unsafe { is_val_statically_known(a) } { 5 } else { 4 }
+    if is_val_statically_known(a) { 5 } else { 4 }
 }
 
 // CHECK-LABEL: @_iref_borrow(
@@ -68,7 +69,7 @@ pub fn _iref_arg(a: &u8) -> i32 {
 
 #[inline]
 pub fn _slice_ref(a: &[u8]) -> i32 {
-    if unsafe { is_val_statically_known(a) } { 7 } else { 6 }
+    if is_val_statically_known(a) { 7 } else { 6 }
 }
 
 // CHECK-LABEL: @_slice_ref_borrow(
@@ -83,4 +84,80 @@ pub fn _slice_ref_borrow() -> i32 {
 pub fn _slice_ref_arg(a: &[u8]) -> i32 {
     // CHECK: ret i32 6
     _slice_ref(a)
+}
+
+#[inline]
+pub fn _f16(a: f16) -> i32 {
+    if is_val_statically_known(a) { 1 } else { 0 }
+}
+
+// CHECK-LABEL: @_f16_true(
+#[no_mangle]
+pub fn _f16_true() -> i32 {
+    // CHECK: ret i32 1
+    _f16(1.0)
+}
+
+// CHECK-LABEL: @_f16_false(
+#[no_mangle]
+pub fn _f16_false(a: f16) -> i32 {
+    // CHECK: ret i32 0
+    _f16(a)
+}
+
+#[inline]
+pub fn _f32(a: f32) -> i32 {
+    if is_val_statically_known(a) { 1 } else { 0 }
+}
+
+// CHECK-LABEL: @_f32_true(
+#[no_mangle]
+pub fn _f32_true() -> i32 {
+    // CHECK: ret i32 1
+    _f32(1.0)
+}
+
+// CHECK-LABEL: @_f32_false(
+#[no_mangle]
+pub fn _f32_false(a: f32) -> i32 {
+    // CHECK: ret i32 0
+    _f32(a)
+}
+
+#[inline]
+pub fn _f64(a: f64) -> i32 {
+    if is_val_statically_known(a) { 1 } else { 0 }
+}
+
+// CHECK-LABEL: @_f64_true(
+#[no_mangle]
+pub fn _f64_true() -> i32 {
+    // CHECK: ret i32 1
+    _f64(1.0)
+}
+
+// CHECK-LABEL: @_f64_false(
+#[no_mangle]
+pub fn _f64_false(a: f64) -> i32 {
+    // CHECK: ret i32 0
+    _f64(a)
+}
+
+#[inline]
+pub fn _f128(a: f128) -> i32 {
+    if is_val_statically_known(a) { 1 } else { 0 }
+}
+
+// CHECK-LABEL: @_f128_true(
+#[no_mangle]
+pub fn _f128_true() -> i32 {
+    // CHECK: ret i32 1
+    _f128(1.0)
+}
+
+// CHECK-LABEL: @_f128_false(
+#[no_mangle]
+pub fn _f128_false(a: f128) -> i32 {
+    // CHECK: ret i32 0
+    _f128(a)
 }

--- a/tests/debuginfo/drop-locations.rs
+++ b/tests/debuginfo/drop-locations.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows
 //@ ignore-android
 //@ min-lldb-version: 310
 //@ ignore-test: #128971

--- a/tests/debuginfo/embedded-visualizer.rs
+++ b/tests/debuginfo/embedded-visualizer.rs
@@ -1,7 +1,7 @@
 //@ compile-flags:-g
 //@ min-gdb-version: 8.1
 //@ ignore-lldb
-//@ ignore-windows-gnu // emit_debug_gdb_scripts is disabled on Windows
+//@ ignore-windows-gnu: #128981
 
 // === CDB TESTS ==================================================================================
 

--- a/tests/debuginfo/empty-string.rs
+++ b/tests/debuginfo/empty-string.rs
@@ -1,4 +1,4 @@
-//@ ignore-windows failing on win32 bot
+//@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g
 //@ min-gdb-version: 8.1

--- a/tests/debuginfo/issue-12886.rs
+++ b/tests/debuginfo/issue-12886.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows failing on 64-bit bots FIXME #17638
 //@ ignore-lldb
 //@ ignore-aarch64
 
@@ -6,7 +5,7 @@
 
 // gdb-command:run
 // gdb-command:next
-// gdb-check:[...]24[...]let s = Some(5).unwrap(); // #break
+// gdb-check:[...]23[...]let s = Some(5).unwrap(); // #break
 // gdb-command:continue
 
 #![feature(omit_gdb_pretty_printer_section)]

--- a/tests/debuginfo/macro-stepping.rs
+++ b/tests/debuginfo/macro-stepping.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows
 //@ ignore-android
 //@ ignore-aarch64
 //@ min-lldb-version: 1800

--- a/tests/debuginfo/numeric-types.rs
+++ b/tests/debuginfo/numeric-types.rs
@@ -1,7 +1,7 @@
 //@ compile-flags:-g
 
 //@ min-gdb-version: 8.1
-//@ ignore-windows-gnu // emit_debug_gdb_scripts is disabled on Windows
+//@ ignore-windows-gnu: #128981
 
 // Tests the visualizations for `NonZero<T>`, `Wrapping<T>` and
 // `Atomic{Bool,I8,I16,I32,I64,Isize,U8,U16,U32,U64,Usize}` located in `libcore.natvis`.

--- a/tests/debuginfo/pretty-huge-vec.rs
+++ b/tests/debuginfo/pretty-huge-vec.rs
@@ -1,4 +1,4 @@
-//@ ignore-windows failing on win32 bot
+//@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g
 //@ min-gdb-version: 8.1

--- a/tests/debuginfo/pretty-slices.rs
+++ b/tests/debuginfo/pretty-slices.rs
@@ -1,5 +1,5 @@
 //@ ignore-android: FIXME(#10381)
-//@ ignore-windows
+//@ ignore-windows-gnu: #128981
 //@ compile-flags:-g
 
 // gdb-command: run

--- a/tests/debuginfo/pretty-std-collections.rs
+++ b/tests/debuginfo/pretty-std-collections.rs
@@ -1,4 +1,3 @@
-//@ ignore-windows failing on win32 bot
 //@ ignore-android: FIXME(#10381)
 //@ ignore-windows-gnu: #128981
 //@ compile-flags:-g

--- a/tests/debuginfo/pretty-uninitialized-vec.rs
+++ b/tests/debuginfo/pretty-uninitialized-vec.rs
@@ -1,4 +1,4 @@
-//@ ignore-windows failing on win32 bot
+//@ ignore-windows-gnu: #128981
 //@ ignore-android: FIXME(#10381)
 //@ compile-flags:-g
 //@ min-gdb-version: 8.1

--- a/tests/debuginfo/thread-names.rs
+++ b/tests/debuginfo/thread-names.rs
@@ -4,7 +4,7 @@
 //@[macos] only-macos
 //@[win] only-windows
 //@ ignore-sgx
-//@ ignore-windows-gnu
+//@ ignore-windows-gnu: gdb on windows-gnu does not print thread names
 
 // === GDB TESTS ==================================================================================
 //

--- a/tests/run-make/crate-loading/multiple-dep-versions-1.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-1.rs
@@ -1,6 +1,10 @@
 #![crate_name = "dependency"]
 #![crate_type = "rlib"]
-pub struct Type;
-pub trait Trait {}
-impl Trait for Type {}
+pub struct Type(pub i32);
+pub trait Trait {
+    fn foo(&self);
+}
+impl Trait for Type {
+    fn foo(&self) {}
+}
 pub fn do_something<X: Trait>(_: X) {}

--- a/tests/run-make/crate-loading/multiple-dep-versions-1.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-1.rs
@@ -3,8 +3,10 @@
 pub struct Type(pub i32);
 pub trait Trait {
     fn foo(&self);
+    fn bar();
 }
 impl Trait for Type {
     fn foo(&self) {}
+    fn bar() {}
 }
 pub fn do_something<X: Trait>(_: X) {}

--- a/tests/run-make/crate-loading/multiple-dep-versions-2.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-2.rs
@@ -1,6 +1,10 @@
 #![crate_name = "dependency"]
 #![crate_type = "rlib"]
-pub struct Type(pub i32);
-pub trait Trait {}
-impl Trait for Type {}
+pub struct Type;
+pub trait Trait {
+    fn foo(&self);
+}
+impl Trait for Type {
+    fn foo(&self) {}
+}
 pub fn do_something<X: Trait>(_: X) {}

--- a/tests/run-make/crate-loading/multiple-dep-versions-2.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-2.rs
@@ -3,8 +3,10 @@
 pub struct Type;
 pub trait Trait {
     fn foo(&self);
+    fn bar();
 }
 impl Trait for Type {
     fn foo(&self) {}
+    fn bar() {}
 }
 pub fn do_something<X: Trait>(_: X) {}

--- a/tests/run-make/crate-loading/multiple-dep-versions-3.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-3.rs
@@ -1,0 +1,5 @@
+#![crate_name = "foo"]
+#![crate_type = "rlib"]
+
+extern crate dependency;
+pub use dependency::Type;

--- a/tests/run-make/crate-loading/multiple-dep-versions.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions.rs
@@ -1,8 +1,9 @@
 extern crate dep_2_reexport;
 extern crate dependency;
-use dep_2_reexport::do_something;
-use dependency::Type;
+use dep_2_reexport::Type;
+use dependency::{do_something, Trait};
 
 fn main() {
     do_something(Type);
+    Type.foo();
 }

--- a/tests/run-make/crate-loading/multiple-dep-versions.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions.rs
@@ -6,4 +6,5 @@ use dependency::{do_something, Trait};
 fn main() {
     do_something(Type);
     Type.foo();
+    Type::bar();
 }

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -7,11 +7,15 @@ use run_make_support::{rust_lib_name, rustc};
 fn main() {
     rustc().input("multiple-dep-versions-1.rs").run();
     rustc().input("multiple-dep-versions-2.rs").extra_filename("2").metadata("2").run();
+    rustc()
+        .input("multiple-dep-versions-3.rs")
+        .extern_("dependency", rust_lib_name("dependency2"))
+        .run();
 
     rustc()
         .input("multiple-dep-versions.rs")
         .extern_("dependency", rust_lib_name("dependency"))
-        .extern_("dep_2_reexport", rust_lib_name("dependency2"))
+        .extern_("dep_2_reexport", rust_lib_name("foo"))
         .run_fail()
         .assert_stderr_contains(
             "you have multiple different versions of crate `dependency` in your dependency graph",
@@ -22,5 +26,11 @@ fn main() {
         )
         .assert_stderr_contains("this type doesn't implement the required trait")
         .assert_stderr_contains("this type implements the required trait")
-        .assert_stderr_contains("this is the required trait");
+        .assert_stderr_contains("this is the required trait")
+        .assert_stderr_contains(
+            "`dependency` imported here doesn't correspond to the right crate version",
+        )
+        .assert_stderr_contains("this is the trait that was imported")
+        .assert_stderr_contains("this is the trait that is needed")
+        .assert_stderr_contains("the method is available for `dep_2_reexport::Type` here");
 }

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -1,6 +1,7 @@
 //@ only-linux
 //@ ignore-wasm32
 //@ ignore-wasm64
+// ignore-tidy-linelength
 
 use run_make_support::{rust_lib_name, rustc};
 
@@ -18,19 +19,82 @@ fn main() {
         .extern_("dep_2_reexport", rust_lib_name("foo"))
         .run_fail()
         .assert_stderr_contains(
-            "there are multiple different versions of crate `dependency` in the dependency graph",
+            r#"error[E0277]: the trait bound `dep_2_reexport::Type: Trait` is not satisfied
+  --> multiple-dep-versions.rs:7:18
+   |
+7  |     do_something(Type);
+   |     ------------ ^^^^ the trait `Trait` is not implemented for `dep_2_reexport::Type`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: there are multiple different versions of crate `dependency` the your dependency graph
+  --> multiple-dep-versions.rs:1:1
+   |
+1  | extern crate dep_2_reexport;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one version of crate `dependency` is used here, as a dependency of crate `foo`
+2  | extern crate dependency;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ one version of crate `dependency` is used here, as a direct dependency of the current crate"#,
         )
         .assert_stderr_contains(
-            "two types coming from two different versions of the same crate are different types \
-             even if they look the same",
+            r#"
+3  | pub struct Type(pub i32);
+   | ^^^^^^^^^^^^^^^ this type implements the required trait
+4  | pub trait Trait {
+   | --------------- this is the required trait"#,
         )
-        .assert_stderr_contains("this type doesn't implement the required trait")
-        .assert_stderr_contains("this type implements the required trait")
-        .assert_stderr_contains("this is the required trait")
         .assert_stderr_contains(
-            "`dependency` imported here doesn't correspond to the right crate version",
+            r#"
+3  | pub struct Type;
+   | ^^^^^^^^^^^^^^^ this type doesn't implement the required trait"#,
         )
-        .assert_stderr_contains("this is the trait that was imported")
-        .assert_stderr_contains("this is the trait that is needed")
-        .assert_stderr_contains("the method is available for `dep_2_reexport::Type` here");
+        .assert_stderr_contains(
+            r#"
+error[E0599]: no method named `foo` found for struct `dep_2_reexport::Type` in the current scope
+ --> multiple-dep-versions.rs:8:10
+  |
+8 |     Type.foo();
+  |          ^^^ method not found in `Type`
+  |
+note: there are multiple different versions of crate `dependency` in the dependency graph"#,
+        )
+        .assert_stderr_contains(
+            r#"
+4 | pub trait Trait {
+  | ^^^^^^^^^^^^^^^ this is the trait that is needed
+5 |     fn foo(&self);
+  |     -------------- the method is available for `dep_2_reexport::Type` here
+  |
+ ::: multiple-dep-versions.rs:4:32
+  |
+4 | use dependency::{do_something, Trait};
+  |                                ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`"#,
+        )
+        .assert_stderr_contains(
+            r#"
+4 | pub trait Trait {
+  | --------------- this is the trait that was imported"#,
+        )
+        .assert_stderr_contains(
+            r#"
+error[E0599]: no function or associated item named `bar` found for struct `dep_2_reexport::Type` in the current scope
+ --> multiple-dep-versions.rs:9:11
+  |
+9 |     Type::bar();
+  |           ^^^ function or associated item not found in `Type`
+  |
+note: there are multiple different versions of crate `dependency` in the dependency graph"#,
+        )
+        .assert_stderr_contains(
+            r#"
+4 | pub trait Trait {
+  | ^^^^^^^^^^^^^^^ this is the trait that is needed
+5 |     fn foo(&self);
+6 |     fn bar();
+  |     --------- the method is available for `dep_2_reexport::Type` here
+  |
+ ::: multiple-dep-versions.rs:4:32
+  |
+4 | use dependency::{do_something, Trait};
+  |                                ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`"#,
+        );
 }

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -90,7 +90,7 @@ note: there are multiple different versions of crate `dependency` in the depende
   | ^^^^^^^^^^^^^^^ this is the trait that is needed
 5 |     fn foo(&self);
 6 |     fn bar();
-  |     --------- the method is available for `dep_2_reexport::Type` here
+  |     --------- the associated function is available for `dep_2_reexport::Type` here
   |
  ::: multiple-dep-versions.rs:4:32
   |

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -18,7 +18,7 @@ fn main() {
         .extern_("dep_2_reexport", rust_lib_name("foo"))
         .run_fail()
         .assert_stderr_contains(
-            "you have multiple different versions of crate `dependency` in your dependency graph",
+            "there are multiple different versions of crate `dependency` in the dependency graph",
         )
         .assert_stderr_contains(
             "two types coming from two different versions of the same crate are different types \

--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -14,11 +14,14 @@
 //!       that `RUSTC_ICE_PATH` takes precedence and no ICE dump is emitted under `METRICS_PATH`.
 //!
 //! See <https://github.com/rust-lang/rust/pull/108714>.
-
-//@ ignore-windows
-// FIXME(#128911): @jieyouxu: This test is sometimes for whatever forsaken reason flakey in
-// `i686-mingw`, and I cannot reproduce it locally. The error messages upon assertion failure in
-// this test is intentionally extremely verbose to aid debugging that issue.
+//!
+//! # Test history
+//!
+//! - The previous rmake.rs iteration of this test was flakey for unknown reason on `i686-mingw`
+//!   *specifically*, so assertion failures in this test was made extremely verbose to help
+//!   diagnose why the ICE messages was different *specifically* on `i686-mingw`.
+//! - An attempt is made to re-enable this test on `i686-mingw` (by removing `ignore-windows`). If
+//!   this test is still flakey, please restore the `ignore-windows` directive.
 
 use std::cell::OnceCell;
 use std::path::{Path, PathBuf};

--- a/tests/run-make/libtest-json/validate_json.py
+++ b/tests/run-make/libtest-json/validate_json.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-
-import sys
-import json
-
-# Try to decode line in order to ensure it is a valid JSON document
-for line in sys.stdin:
-    json.loads(line)


### PR DESCRIPTION
Successful merges:

 - #128786 (Detect multiple crate versions on method not found)
 - #128982 (Re-enable more debuginfo tests on Windows)
 - #128990 (Re-enable more debuginfo tests on freebsd)
 - #129115 (Re-enable `dump-ice-to-disk` for Windows)
 - #129149 (Migrate `validate_json.py` script to rust in `run-make/rustdoc-map-file` test)
 - #129167 (mir/pretty: use `Option` instead of `Either<Once, Empty>`)
 - #129173 (Fix `is_val_statically_known` for floats)
 - #129185 (Port `run-make/libtest-json/validate_json.py` to Rust)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=128786,128982,128990,129115,129149,129167,129173,129185)
<!-- homu-ignore:end -->