### PR TITLE
make writes_through_immutable_pointer a hard error

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -12,7 +12,6 @@ use rustc_middle::query::TyCtxtAt;
 use rustc_middle::ty::layout::{FnAbiOf, TyAndLayout};
 use rustc_middle::ty::{self, TyCtxt};
 use rustc_middle::{bug, mir};
-use rustc_session::lint::builtin::WRITES_THROUGH_IMMUTABLE_POINTER;
 use rustc_span::symbol::{sym, Symbol};
 use rustc_span::Span;
 use rustc_target::abi::{Align, Size};
@@ -729,8 +728,8 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
     }
 
     fn before_memory_write(
-        tcx: TyCtxtAt<'tcx>,
-        machine: &mut Self,
+        _tcx: TyCtxtAt<'tcx>,
+        _machine: &mut Self,
         _alloc_extra: &mut Self::AllocExtra,
         (_alloc_id, immutable): (AllocId, bool),
         range: AllocRange,
@@ -741,9 +740,7 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
         }
         // Reject writes through immutable pointers.
         if immutable {
-            super::lint(tcx, machine, WRITES_THROUGH_IMMUTABLE_POINTER, |frames| {
-                crate::errors::WriteThroughImmutablePointer { frames }
-            });
+            return Err(ConstEvalErrKind::WriteThroughImmutablePointer.into());
         }
         // Everything else is fine.
         Ok(())

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -407,13 +407,6 @@ pub struct ConstEvalError {
     pub frame_notes: Vec<FrameNote>,
 }
 
-#[derive(LintDiagnostic)]
-#[diag(const_eval_write_through_immutable_pointer)]
-pub struct WriteThroughImmutablePointer {
-    #[subdiagnostic]
-    pub frames: Vec<FrameNote>,
-}
-
 #[derive(Diagnostic)]
 #[diag(const_eval_nullary_intrinsic_fail)]
 pub struct NullaryIntrinsicError {

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -569,7 +569,8 @@ fn register_builtins(store: &mut LintStore) {
         "byte_slice_in_packed_struct_with_derive",
         "converted into hard error, see issue #107457 \
          <https://github.com/rust-lang/rust/issues/107457> for more information",
-    )
+    );
+    store.register_removed("writes_through_immutable_pointer", "converted into hard error");
 }
 
 fn register_internals(store: &mut LintStore) {

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -142,7 +142,6 @@ declare_lint_pass! {
         USELESS_DEPRECATED,
         WARNINGS,
         WASM_C_ABI,
-        WRITES_THROUGH_IMMUTABLE_POINTER,
         // tidy-alphabetical-end
     ]
 }
@@ -4693,40 +4692,6 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps,
         reference: "issue #115010 <https://github.com/rust-lang/rust/issues/115010>",
-    };
-}
-
-declare_lint! {
-    /// The `writes_through_immutable_pointer` lint detects writes through pointers derived from
-    /// shared references.
-    ///
-    /// ### Example
-    ///
-    /// ```rust,compile_fail
-    /// #![feature(const_mut_refs)]
-    /// const WRITE_AFTER_CAST: () = unsafe {
-    ///     let mut x = 0;
-    ///     let ptr = &x as *const i32 as *mut i32;
-    ///     *ptr = 0;
-    /// };
-    /// ```
-    ///
-    /// {{produces}}
-    ///
-    /// ### Explanation
-    ///
-    /// Shared references are immutable (when there is no `UnsafeCell` involved),
-    /// and writing through them or through pointers derived from them is Undefined Behavior.
-    /// The compiler recently learned to detect such Undefined Behavior during compile-time
-    /// evaluation, and in the future this will raise a hard error.
-    ///
-    /// [future-incompatible]: ../index.md#future-incompatible-lints
-    pub WRITES_THROUGH_IMMUTABLE_POINTER,
-    Warn,
-    "shared references are immutable, and pointers derived from them must not be written to",
-    @future_incompatible = FutureIncompatibleInfo {
-        reason: FutureIncompatibilityReason::FutureReleaseErrorReportInDeps,
-        reference: "issue #X <https://github.com/rust-lang/rust/issues/X>",
     };
 }
 

--- a/tests/ui/consts/const-eval/ub-write-through-immutable.rs
+++ b/tests/ui/consts/const-eval/ub-write-through-immutable.rs
@@ -1,6 +1,5 @@
 //! Ensure we catch UB due to writing through a shared reference.
 #![feature(const_mut_refs, const_refs_to_cell)]
-#![deny(writes_through_immutable_pointer)]
 #![allow(invalid_reference_casting)]
 
 use std::mem;
@@ -9,15 +8,15 @@ use std::cell::UnsafeCell;
 const WRITE_AFTER_CAST: () = unsafe {
     let mut x = 0;
     let ptr = &x as *const i32 as *mut i32;
-    *ptr = 0; //~ERROR: writes_through_immutable_pointer
-    //~^ previously accepted
+    *ptr = 0; //~ERROR: evaluation of constant value failed
+    //~| immutable
 };
 
 const WRITE_AFTER_TRANSMUTE: () = unsafe {
     let mut x = 0;
     let ptr: *mut i32 = mem::transmute(&x);
-    *ptr = 0; //~ERROR: writes_through_immutable_pointer
-    //~^ previously accepted
+    *ptr = 0; //~ERROR: evaluation of constant value failed
+    //~| immutable
 };
 
 // it's okay when there is interior mutability;

--- a/tests/ui/consts/const-eval/ub-write-through-immutable.stderr
+++ b/tests/ui/consts/const-eval/ub-write-through-immutable.stderr
@@ -1,55 +1,15 @@
-error: writing through a pointer that was derived from a shared (immutable) reference
-  --> $DIR/ub-write-through-immutable.rs:12:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-write-through-immutable.rs:11:5
    |
 LL |     *ptr = 0;
-   |     ^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #X <https://github.com/rust-lang/rust/issues/X>
-note: the lint level is defined here
-  --> $DIR/ub-write-through-immutable.rs:3:9
-   |
-LL | #![deny(writes_through_immutable_pointer)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^ writing through a pointer that was derived from a shared (immutable) reference
 
-error: writing through a pointer that was derived from a shared (immutable) reference
-  --> $DIR/ub-write-through-immutable.rs:19:5
+error[E0080]: evaluation of constant value failed
+  --> $DIR/ub-write-through-immutable.rs:18:5
    |
 LL |     *ptr = 0;
-   |     ^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #X <https://github.com/rust-lang/rust/issues/X>
+   |     ^^^^^^^^ writing through a pointer that was derived from a shared (immutable) reference
 
 error: aborting due to 2 previous errors
 
-Future incompatibility report: Future breakage diagnostic:
-error: writing through a pointer that was derived from a shared (immutable) reference
-  --> $DIR/ub-write-through-immutable.rs:12:5
-   |
-LL |     *ptr = 0;
-   |     ^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #X <https://github.com/rust-lang/rust/issues/X>
-note: the lint level is defined here
-  --> $DIR/ub-write-through-immutable.rs:3:9
-   |
-LL | #![deny(writes_through_immutable_pointer)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-error: writing through a pointer that was derived from a shared (immutable) reference
-  --> $DIR/ub-write-through-immutable.rs:19:5
-   |
-LL |     *ptr = 0;
-   |     ^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #X <https://github.com/rust-lang/rust/issues/X>
-note: the lint level is defined here
-  --> $DIR/ub-write-through-immutable.rs:3:9
-   |
-LL | #![deny(writes_through_immutable_pointer)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
+For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
This turns the lint added in https://github.com/rust-lang/rust/pull/118324 into a hard error. This has been reported in cargo's future-compat reports since Rust 1.76 (released in February). Given that const_mut_refs is still unstable, it should be impossible to even hit this error on stable: we did accidentally stabilize some functions that can cause this error, but that got reverted in https://github.com/rust-lang/rust/pull/117905. Still, let's do a crater run just to be sure.

Given that this should only affect unstable code, I don't think it needs an FCP, but let's Cc @rust-lang/lang anyway -- any objection to making this unambiguous UB into a hard error during const-eval? This can be viewed as part of https://github.com/rust-lang/rust/pull/129195 which is already nominated for discussion.