### PR TITLE
Add `nneg` to non-negative when using `zext` at discriminant

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -1034,6 +1034,11 @@ impl WrappingRange {
         }
     }
 
+    #[inline(always)]
+    pub fn must_be_non_negative(&self, size: Size) -> bool {
+        self.start <= self.end && self.end <= size.signed_int_max() as u128
+    }
+
     /// Returns `self` with replaced `start`
     #[inline(always)]
     fn with_start(mut self, start: u128) -> Self {

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -1263,12 +1263,13 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
 
     fn intcast(
         &mut self,
-        value: RValue<'gcc>,
-        dest_typ: Type<'gcc>,
-        _is_signed: bool,
+        val: RValue<'gcc>,
+        dest_ty: Type<'gcc>,
+        _val_is_signed: bool,
+        _val_valid_range: Option<WrappingRange>,
     ) -> RValue<'gcc> {
         // NOTE: is_signed is for value, not dest_typ.
-        self.gcc_int_cast(value, dest_typ)
+        self.gcc_int_cast(val, dest_ty)
     }
 
     fn pointercast(&mut self, value: RValue<'gcc>, dest_ty: Type<'gcc>) -> RValue<'gcc> {

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -356,26 +356,26 @@ impl<'ll, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                                 &[args[0].immediate(), y],
                             );
 
-                            self.intcast(ret, llret_ty, false)
+                            self.intcast(ret, llret_ty, false, None)
                         }
                         sym::ctlz_nonzero => {
                             let y = self.const_bool(true);
                             let llvm_name = &format!("llvm.ctlz.i{width}");
                             let ret = self.call_intrinsic(llvm_name, &[args[0].immediate(), y]);
-                            self.intcast(ret, llret_ty, false)
+                            self.intcast(ret, llret_ty, false, None)
                         }
                         sym::cttz_nonzero => {
                             let y = self.const_bool(true);
                             let llvm_name = &format!("llvm.cttz.i{width}");
                             let ret = self.call_intrinsic(llvm_name, &[args[0].immediate(), y]);
-                            self.intcast(ret, llret_ty, false)
+                            self.intcast(ret, llret_ty, false, None)
                         }
                         sym::ctpop => {
                             let ret = self.call_intrinsic(
                                 &format!("llvm.ctpop.i{width}"),
                                 &[args[0].immediate()],
                             );
-                            self.intcast(ret, llret_ty, false)
+                            self.intcast(ret, llret_ty, false, None)
                         }
                         sym::bswap => {
                             if width == 8 {
@@ -400,7 +400,7 @@ impl<'ll, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'_, 'll, 'tcx> {
                                 &format!("llvm.fsh{}.i{}", if is_left { 'l' } else { 'r' }, width);
 
                             // llvm expects shift to be the same type as the values, but rust always uses `u32`
-                            let raw_shift = self.intcast(raw_shift, self.val_ty(val), false);
+                            let raw_shift = self.intcast(raw_shift, self.val_ty(val), false, None);
 
                             self.call_intrinsic(llvm_name, &[val, val, raw_shift])
                         }

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1632,6 +1632,7 @@ extern "C" {
     ) -> &'a Value;
 
     pub fn LLVMRustSetFastMath(Instr: &Value);
+    pub fn LLVMRustSetNonNeg(Instr: &Value, nonNeg: bool);
     pub fn LLVMRustSetAlgebraicMath(Instr: &Value);
     pub fn LLVMRustSetAllowReassoc(Instr: &Value);
 

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -488,7 +488,7 @@ pub fn maybe_create_entry_wrapper<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         if cx.sess().target.os.contains("uefi") {
             bx.ret(result);
         } else {
-            let cast = bx.intcast(result, cx.type_int(), true);
+            let cast = bx.intcast(result, cx.type_int(), true, None);
             bx.ret(cast);
         }
 
@@ -517,7 +517,7 @@ fn get_argc_argv<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         // Params from native `main()` used as args for rust start function
         let param_argc = bx.get_param(0);
         let param_argv = bx.get_param(1);
-        let arg_argc = bx.intcast(param_argc, cx.type_isize(), true);
+        let arg_argc = bx.intcast(param_argc, cx.type_isize(), true, None);
         let arg_argv = param_argv;
         (arg_argc, arg_argv)
     } else {

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -272,7 +272,7 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
                     Int(_, signed) => !tag_scalar.is_bool() && signed,
                     _ => false,
                 };
-                bx.intcast(tag_imm, cast_to, signed)
+                bx.intcast(tag_imm, cast_to, signed, Some(tag_scalar.valid_range(bx)))
             }
             TagEncoding::Niche { untagged_variant, ref niche_variants, niche_start } => {
                 // Cast to an integer so we don't have to treat a pointer as a
@@ -322,7 +322,7 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
                     // The special cases don't apply, so we'll have to go with
                     // the general algorithm.
                     let relative_discr = bx.sub(tag, bx.cx().const_uint_big(tag_llty, niche_start));
-                    let cast_tag = bx.intcast(relative_discr, cast_to, false);
+                    let cast_tag = bx.intcast(relative_discr, cast_to, false, None);
                     let is_niche = bx.icmp(
                         IntPredicate::IntULE,
                         relative_discr,

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -301,7 +301,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         self.assume_scalar_range(bx, imm, from_scalar, from_backend_ty);
 
         imm = match (from_scalar.primitive(), to_scalar.primitive()) {
-            (Int(_, is_signed), Int(..)) => bx.intcast(imm, to_backend_ty, is_signed),
+            (Int(_, is_signed), Int(..)) => bx.intcast(imm, to_backend_ty, is_signed, None),
             (Float(_), Float(_)) => {
                 let srcsz = bx.cx().float_width(from_backend_ty);
                 let dstsz = bx.cx().float_width(to_backend_ty);
@@ -322,7 +322,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
             (Pointer(..), Pointer(..)) => bx.pointercast(imm, to_backend_ty),
             (Int(_, is_signed), Pointer(..)) => {
-                let usize_imm = bx.intcast(imm, bx.cx().type_isize(), is_signed);
+                let usize_imm = bx.intcast(imm, bx.cx().type_isize(), is_signed, None);
                 bx.inttoptr(usize_imm, to_backend_ty)
             }
             (Float(_), Int(_, is_signed)) => bx.cast_float_to_int(is_signed, imm, to_backend_ty),

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -239,7 +239,13 @@ pub trait BuilderMethods<'a, 'tcx>:
     fn ptrtoint(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value;
     fn inttoptr(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value;
     fn bitcast(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value;
-    fn intcast(&mut self, val: Self::Value, dest_ty: Self::Type, is_signed: bool) -> Self::Value;
+    fn intcast(
+        &mut self,
+        val: Self::Value,
+        dest_ty: Self::Type,
+        val_is_signed: bool,
+        val_valid_range: Option<WrappingRange>,
+    ) -> Self::Value;
     fn pointercast(&mut self, val: Self::Value, dest_ty: Self::Type) -> Self::Value;
 
     fn cast_float_to_int(

--- a/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/RustWrapper.cpp
@@ -505,6 +505,14 @@ extern "C" void LLVMRustSetFastMath(LLVMValueRef V) {
   }
 }
 
+extern "C" void LLVMRustSetNonNeg(LLVMValueRef V, bool b) {
+  if (auto I = dyn_cast<Instruction>(unwrap<Value>(V))) {
+#if LLVM_VERSION_GE(17, 0)
+    I->setNonNeg(b);
+#endif
+  }
+}
+
 // Enable fast-math flags which permit algebraic transformations that are not
 // allowed by IEEE floating point. For example: a + (b + c) = (a + b) + c and a
 // / b = a * (1 / b) Note that this does NOT enable any flags which can cause a

--- a/tests/codegen/enum/enum-discriminant-value-zext.rs
+++ b/tests/codegen/enum/enum-discriminant-value-zext.rs
@@ -1,0 +1,42 @@
+//@ compile-flags: -Cno-prepopulate-passes -O
+//@ min-llvm-version: 18
+
+// Test for adding `nneg` to non-negative when using `zext`.
+
+#![crate_type = "lib"]
+
+pub enum Enum0 {
+    A = 0,
+    B = 127, // 127i8
+}
+
+pub enum Enum1 {
+    A = 0,
+    B = 128, // -128i8
+}
+
+pub enum Enum2 {
+    A = 0,
+    B = 255, // -1i8
+}
+
+// CHECK-LABEL: @discriminant_0
+#[no_mangle]
+pub fn discriminant_0(e: Enum0) -> isize {
+    // CHECK: zext nneg i8
+    e as isize
+}
+
+// CHECK-LABEL: @discriminant_1
+#[no_mangle]
+pub fn discriminant_1(e: Enum1) -> isize {
+    // CHECK: zext i8
+    e as isize
+}
+
+// CHECK-LABEL: @discriminant_2
+#[no_mangle]
+pub fn discriminant_2(e: Enum2) -> isize {
+    // CHECK: zext i8
+    e as isize
+}


### PR DESCRIPTION
r? @ghost