### PR TITLE
Enable `nonstandard_style` for `use x as y`

### DIFF
--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -201,6 +201,7 @@ late_lint_methods!(
             // Depends on referenced function signatures in expressions
             UnusedResults: UnusedResults,
             UnitBindings: UnitBindings,
+            NonCamelCaseTypes: NonCamelCaseTypes,
             NonUpperCaseGlobals: NonUpperCaseGlobals,
             NonShorthandFieldPatterns: NonShorthandFieldPatterns,
             UnusedAllocation: UnusedAllocation,

--- a/compiler/rustc_lint/src/passes.rs
+++ b/compiler/rustc_lint/src/passes.rs
@@ -73,8 +73,11 @@ impl LateLintPass<'_> for HardwiredLints {}
 #[macro_export]
 macro_rules! expand_combined_late_lint_pass_method {
     ([$($pass:ident),*], $self: ident, $name: ident, $params:tt) => ({
-        $($self.$pass.$name $params;)*
-    })
+        $($crate::expand_combined_late_lint_pass_method!($pass, $self, $name, $params);)*
+    });
+    ($pass:ident, $self: ident, $name: ident, ($ctx:ident, $($param:expr),*)) => ({
+        $crate::LateLintPass::$name(&mut $self.$pass, $ctx, $($param),*);
+    });
 }
 
 #[macro_export]
@@ -183,8 +186,11 @@ early_lint_methods!(declare_early_lint_pass, []);
 #[macro_export]
 macro_rules! expand_combined_early_lint_pass_method {
     ([$($pass:ident),*], $self: ident, $name: ident, $params:tt) => ({
-        $($self.$pass.$name $params;)*
-    })
+        $($crate::expand_combined_early_lint_pass_method!($pass, $self, $name, $params);)*
+    });
+    ($pass:ident, $self: ident, $name: ident, ($($param:expr),*)) => ({
+        $crate::EarlyLintPass::$name(&mut $self.$pass, $($param),*);
+    });
 }
 
 #[macro_export]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2452,6 +2452,9 @@ pub mod kw {
 /// For example `sym::rustfmt` or `sym::u8`.
 pub mod sym {
     // Used from a macro in `librustc_feature/accepted.rs`
+    // FIXME: `useless_attribute` should be removed after #129204 is merged into beta.
+    #[allow(clippy::useless_attribute)]
+    #[allow(non_upper_case_globals)]
     pub use super::kw::MacroRules as macro_rules;
     #[doc(inline)]
     pub use super::sym_generated::*;

--- a/library/core/src/unicode/mod.rs
+++ b/library/core/src/unicode/mod.rs
@@ -1,19 +1,30 @@
 #![unstable(feature = "unicode_internals", issue = "none")]
 #![allow(missing_docs)]
+// FIXME: This should be removed after #129204 is merged into beta.
+#![allow(clippy::useless_attribute)]
 
 // for use in alloc, not re-exported in std.
 #[rustfmt::skip]
+#[allow(non_snake_case)]
 pub use unicode_data::case_ignorable::lookup as Case_Ignorable;
+#[allow(non_snake_case)]
 pub use unicode_data::cased::lookup as Cased;
 pub use unicode_data::conversions;
 
 #[rustfmt::skip]
+#[allow(non_snake_case)]
 pub(crate) use unicode_data::alphabetic::lookup as Alphabetic;
+#[allow(non_snake_case)]
 pub(crate) use unicode_data::cc::lookup as Cc;
+#[allow(non_snake_case)]
 pub(crate) use unicode_data::grapheme_extend::lookup as Grapheme_Extend;
+#[allow(non_snake_case)]
 pub(crate) use unicode_data::lowercase::lookup as Lowercase;
+#[allow(non_snake_case)]
 pub(crate) use unicode_data::n::lookup as N;
+#[allow(non_snake_case)]
 pub(crate) use unicode_data::uppercase::lookup as Uppercase;
+#[allow(non_snake_case)]
 pub(crate) use unicode_data::white_space::lookup as White_Space;
 
 pub(crate) mod printable;

--- a/src/tools/clippy/tests/ui/mem_forget.rs
+++ b/src/tools/clippy/tests/ui/mem_forget.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use std::rc::Rc;
 use std::sync::Arc;
 

--- a/src/tools/clippy/tests/ui/mem_forget.stderr
+++ b/src/tools/clippy/tests/ui/mem_forget.stderr
@@ -1,5 +1,5 @@
 error: usage of `mem::forget` on `Drop` type
-  --> tests/ui/mem_forget.rs:14:5
+  --> tests/ui/mem_forget.rs:16:5
    |
 LL |     memstuff::forget(six);
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL |     memstuff::forget(six);
    = help: to override `-D warnings` add `#[allow(clippy::mem_forget)]`
 
 error: usage of `mem::forget` on `Drop` type
-  --> tests/ui/mem_forget.rs:19:5
+  --> tests/ui/mem_forget.rs:21:5
    |
 LL |     std::mem::forget(seven);
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -17,7 +17,7 @@ LL |     std::mem::forget(seven);
    = note: argument has type `std::rc::Rc<i32>`
 
 error: usage of `mem::forget` on `Drop` type
-  --> tests/ui/mem_forget.rs:24:5
+  --> tests/ui/mem_forget.rs:26:5
    |
 LL |     forgetSomething(eight);
    |     ^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     forgetSomething(eight);
    = note: argument has type `std::vec::Vec<i32>`
 
 error: usage of `mem::forget` on type with `Drop` fields
-  --> tests/ui/mem_forget.rs:29:5
+  --> tests/ui/mem_forget.rs:31:5
    |
 LL |     std::mem::forget(string);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/tools/clippy/tests/ui/single_component_path_imports_self_after.rs
+++ b/src/tools/clippy/tests/ui/single_component_path_imports_self_after.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::single_component_path_imports)]
 #![allow(unused_imports)]
+#![allow(non_camel_case_types)]
 
 use self::regex::{Regex as xeger, RegexSet as tesxeger};
 #[rustfmt::skip]

--- a/src/tools/clippy/tests/ui/single_component_path_imports_self_before.rs
+++ b/src/tools/clippy/tests/ui/single_component_path_imports_self_before.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::single_component_path_imports)]
 #![allow(unused_imports)]
+#![allow(non_camel_case_types)]
 
 use regex;
 

--- a/tests/ui/lint/lint-lowercase-static-const-pattern.rs
+++ b/tests/ui/lint/lint-lowercase-static-const-pattern.rs
@@ -4,10 +4,10 @@
 #![deny(non_upper_case_globals)]
 
 #[allow(non_upper_case_globals)]
-pub const a : isize = 97;
+pub const a: isize = 97;
 
 fn f() {
-    let r = match (0,0) {
+    let r = match (0, 0) {
         (0, a) => 0,
         //~^ ERROR constant in pattern `a` should have an upper case name
         (x, y) => 1 + x + y,
@@ -17,34 +17,35 @@ fn f() {
 
 mod m {
     #[allow(non_upper_case_globals)]
-    pub const aha : isize = 7;
+    pub const aha: isize = 7;
 }
 
 fn g() {
     use self::m::aha;
-    let r = match (0,0) {
+    let r = match (0, 0) {
         (0, aha) => 0,
         //~^ ERROR constant in pattern `aha` should have an upper case name
-        (x, y)   => 1 + x + y,
+        (x, y) => 1 + x + y,
     };
     assert_eq!(r, 1);
 }
 
 mod n {
-    pub const OKAY : isize = 8;
+    pub const OKAY: isize = 8;
 }
 
 fn h() {
     use self::n::OKAY as not_okay;
-    let r = match (0,0) {
+    //~^ ERROR renamed constant `not_okay` should have an upper case name
+    let r = match (0, 0) {
         (0, not_okay) => 0,
-//~^ ERROR constant in pattern `not_okay` should have an upper case name
-        (x, y)   => 1 + x + y,
+        //~^ ERROR constant in pattern `not_okay` should have an upper case name
+        (x, y) => 1 + x + y,
     };
     assert_eq!(r, 1);
 }
 
-fn main () {
+fn main() {
     f();
     g();
     h();

--- a/tests/ui/lint/lint-lowercase-static-const-pattern.stderr
+++ b/tests/ui/lint/lint-lowercase-static-const-pattern.stderr
@@ -16,11 +16,17 @@ error: constant in pattern `aha` should have an upper case name
 LL |         (0, aha) => 0,
    |             ^^^ help: convert the identifier to upper case: `AHA`
 
+error: renamed constant `not_okay` should have an upper case name
+  --> $DIR/lint-lowercase-static-const-pattern.rs:38:26
+   |
+LL |     use self::n::OKAY as not_okay;
+   |                          ^^^^^^^^ help: convert the identifier to upper case: `NOT_OKAY`
+
 error: constant in pattern `not_okay` should have an upper case name
-  --> $DIR/lint-lowercase-static-const-pattern.rs:40:13
+  --> $DIR/lint-lowercase-static-const-pattern.rs:41:13
    |
 LL |         (0, not_okay) => 0,
    |             ^^^^^^^^ help: convert the identifier to upper case: `NOT_OKAY`
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/lint/lint-non-camel-case-types.rs
+++ b/tests/ui/lint/lint-non-camel-case-types.rs
@@ -4,27 +4,31 @@
 struct ONE_TWO_THREE;
 //~^ ERROR type `ONE_TWO_THREE` should have an upper camel case name
 
-struct foo { //~ ERROR type `foo` should have an upper camel case name
+struct foo {
+    //~^ ERROR type `foo` should have an upper camel case name
     bar: isize,
 }
 
-enum foo2 { //~ ERROR type `foo2` should have an upper camel case name
-    Bar
+enum foo2 {
+    //~^ ERROR type `foo2` should have an upper camel case name
+    Bar,
 }
 
-struct foo3 { //~ ERROR type `foo3` should have an upper camel case name
-    bar: isize
+struct foo3 {
+    //~^ ERROR type `foo3` should have an upper camel case name
+    bar: isize,
 }
 
 type foo4 = isize; //~ ERROR type `foo4` should have an upper camel case name
 
 enum Foo5 {
-    bar //~ ERROR variant `bar` should have an upper camel case name
+    bar, //~ ERROR variant `bar` should have an upper camel case name
 }
 
-trait foo6 { //~ ERROR trait `foo6` should have an upper camel case name
+trait foo6 {
+    //~^ ERROR trait `foo6` should have an upper camel case name
     type foo7; //~ ERROR associated type `foo7` should have an upper camel case name
-    fn dummy(&self) { }
+    fn dummy(&self) {}
 }
 
 fn f<ty>(_: ty) {} //~ ERROR type parameter `ty` should have an upper camel case name
@@ -34,4 +38,18 @@ struct foo7 {
     bar: isize,
 }
 
-fn main() { }
+struct StructRenamed;
+use StructRenamed as struct_renamed; //~ ERROR renamed type `struct_renamed` should have an upper camel case name
+
+enum EnumRenamed {
+    VariantRenamed,
+}
+use EnumRenamed as enum_renamed; //~ ERROR renamed type `enum_renamed` should have an upper camel case name
+use EnumRenamed::VariantRenamed as variant_renamed; //~ ERROR renamed variant `variant_renamed` should have an upper camel case name
+
+type TyAliasRenamed = isize;
+use TyAliasRenamed as ty_alias_renamed; //~ ERROR renamed type `ty_alias_renamed` should have an upper camel case name
+
+use std::fmt::Display as display; //~ERROR renamed trait `display` should have an upper camel case name
+
+fn main() {}

--- a/tests/ui/lint/lint-non-camel-case-types.stderr
+++ b/tests/ui/lint/lint-non-camel-case-types.stderr
@@ -17,46 +17,76 @@ LL | struct foo {
    |        ^^^ help: convert the identifier to upper camel case (notice the capitalization): `Foo`
 
 error: type `foo2` should have an upper camel case name
-  --> $DIR/lint-non-camel-case-types.rs:11:6
+  --> $DIR/lint-non-camel-case-types.rs:12:6
    |
 LL | enum foo2 {
    |      ^^^^ help: convert the identifier to upper camel case (notice the capitalization): `Foo2`
 
 error: type `foo3` should have an upper camel case name
-  --> $DIR/lint-non-camel-case-types.rs:15:8
+  --> $DIR/lint-non-camel-case-types.rs:17:8
    |
 LL | struct foo3 {
    |        ^^^^ help: convert the identifier to upper camel case (notice the capitalization): `Foo3`
 
 error: type `foo4` should have an upper camel case name
-  --> $DIR/lint-non-camel-case-types.rs:19:6
+  --> $DIR/lint-non-camel-case-types.rs:22:6
    |
 LL | type foo4 = isize;
    |      ^^^^ help: convert the identifier to upper camel case (notice the capitalization): `Foo4`
 
 error: variant `bar` should have an upper camel case name
-  --> $DIR/lint-non-camel-case-types.rs:22:5
+  --> $DIR/lint-non-camel-case-types.rs:25:5
    |
-LL |     bar
+LL |     bar,
    |     ^^^ help: convert the identifier to upper camel case: `Bar`
 
 error: trait `foo6` should have an upper camel case name
-  --> $DIR/lint-non-camel-case-types.rs:25:7
+  --> $DIR/lint-non-camel-case-types.rs:28:7
    |
 LL | trait foo6 {
    |       ^^^^ help: convert the identifier to upper camel case (notice the capitalization): `Foo6`
 
 error: associated type `foo7` should have an upper camel case name
-  --> $DIR/lint-non-camel-case-types.rs:26:10
+  --> $DIR/lint-non-camel-case-types.rs:30:10
    |
 LL |     type foo7;
    |          ^^^^ help: convert the identifier to upper camel case (notice the capitalization): `Foo7`
 
 error: type parameter `ty` should have an upper camel case name
-  --> $DIR/lint-non-camel-case-types.rs:30:6
+  --> $DIR/lint-non-camel-case-types.rs:34:6
    |
 LL | fn f<ty>(_: ty) {}
    |      ^^ help: convert the identifier to upper camel case: `Ty`
 
-error: aborting due to 9 previous errors
+error: renamed type `struct_renamed` should have an upper camel case name
+  --> $DIR/lint-non-camel-case-types.rs:42:22
+   |
+LL | use StructRenamed as struct_renamed;
+   |                      ^^^^^^^^^^^^^^ help: convert the identifier to upper camel case: `StructRenamed`
+
+error: renamed type `enum_renamed` should have an upper camel case name
+  --> $DIR/lint-non-camel-case-types.rs:47:20
+   |
+LL | use EnumRenamed as enum_renamed;
+   |                    ^^^^^^^^^^^^ help: convert the identifier to upper camel case: `EnumRenamed`
+
+error: renamed variant `variant_renamed` should have an upper camel case name
+  --> $DIR/lint-non-camel-case-types.rs:48:36
+   |
+LL | use EnumRenamed::VariantRenamed as variant_renamed;
+   |                                    ^^^^^^^^^^^^^^^ help: convert the identifier to upper camel case: `VariantRenamed`
+
+error: renamed type `ty_alias_renamed` should have an upper camel case name
+  --> $DIR/lint-non-camel-case-types.rs:51:23
+   |
+LL | use TyAliasRenamed as ty_alias_renamed;
+   |                       ^^^^^^^^^^^^^^^^ help: convert the identifier to upper camel case: `TyAliasRenamed`
+
+error: renamed trait `display` should have an upper camel case name
+  --> $DIR/lint-non-camel-case-types.rs:53:26
+   |
+LL | use std::fmt::Display as display;
+   |                          ^^^^^^^ help: convert the identifier to upper camel case: `Display`
+
+error: aborting due to 14 previous errors
 

--- a/tests/ui/lint/lint-non-camel-case-variant.rs
+++ b/tests/ui/lint/lint-non-camel-case-variant.rs
@@ -2,9 +2,15 @@
 
 #![deny(non_camel_case_types)]
 
-pub enum Foo {
+pub enum Foo1 {
     #[allow(non_camel_case_types)]
-    bar
+    bar,
 }
+
+pub enum Foo2 {
+    Bar,
+}
+#[allow(non_camel_case_types)]
+use Foo2::Bar as bar;
 
 fn main() {}

--- a/tests/ui/lint/lint-non-uppercase-statics.rs
+++ b/tests/ui/lint/lint-non-uppercase-statics.rs
@@ -1,11 +1,17 @@
 #![forbid(non_upper_case_globals)]
 #![allow(dead_code)]
 
-static foo: isize = 1; //~ ERROR static variable `foo` should have an upper case name
+static foo1: isize = 1; //~ ERROR static variable `foo1` should have an upper case name
 
-static mut bar: isize = 1; //~ ERROR static variable `bar` should have an upper case name
+static mut foo2: isize = 1; //~ ERROR static variable `foo2` should have an upper case name
 
 #[no_mangle]
 pub static extern_foo: isize = 1; // OK, because #[no_mangle] supersedes the warning
 
-fn main() { }
+static BAR_ONE: isize = 1;
+use BAR_ONE as Bar1; //~ ERROR renamed static variable `Bar1` should have an upper case name
+
+static mut BAR_TWO: isize = 1;
+use BAR_TWO as Bar2; //~ ERROR renamed static variable `Bar2` should have an upper case name
+
+fn main() {}

--- a/tests/ui/lint/lint-non-uppercase-statics.stderr
+++ b/tests/ui/lint/lint-non-uppercase-statics.stderr
@@ -1,8 +1,8 @@
-error: static variable `foo` should have an upper case name
+error: static variable `foo1` should have an upper case name
   --> $DIR/lint-non-uppercase-statics.rs:4:8
    |
-LL | static foo: isize = 1;
-   |        ^^^ help: convert the identifier to upper case (notice the capitalization): `FOO`
+LL | static foo1: isize = 1;
+   |        ^^^^ help: convert the identifier to upper case (notice the capitalization): `FOO1`
    |
 note: the lint level is defined here
   --> $DIR/lint-non-uppercase-statics.rs:1:11
@@ -10,11 +10,23 @@ note: the lint level is defined here
 LL | #![forbid(non_upper_case_globals)]
    |           ^^^^^^^^^^^^^^^^^^^^^^
 
-error: static variable `bar` should have an upper case name
+error: static variable `foo2` should have an upper case name
   --> $DIR/lint-non-uppercase-statics.rs:6:12
    |
-LL | static mut bar: isize = 1;
-   |            ^^^ help: convert the identifier to upper case: `BAR`
+LL | static mut foo2: isize = 1;
+   |            ^^^^ help: convert the identifier to upper case (notice the capitalization): `FOO2`
 
-error: aborting due to 2 previous errors
+error: renamed static variable `Bar1` should have an upper case name
+  --> $DIR/lint-non-uppercase-statics.rs:12:16
+   |
+LL | use BAR_ONE as Bar1;
+   |                ^^^^ help: convert the identifier to upper case: `BAR1`
+
+error: renamed static variable `Bar2` should have an upper case name
+  --> $DIR/lint-non-uppercase-statics.rs:15:16
+   |
+LL | use BAR_TWO as Bar2;
+   |                ^^^^ help: convert the identifier to upper case: `BAR2`
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-functions.rs
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-functions.rs
@@ -41,4 +41,8 @@ fn Cookie() {}
 pub fn bi_S_Cuit() {}
 //~^ ERROR function `bi_S_Cuit` should have a snake case name
 
-fn main() { }
+fn foo_renamed() {}
+use foo_renamed as FOO_RENAMED;
+//~^ ERROR renamed function `FOO_RENAMED` should have a snake case name
+
+fn main() {}

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-functions.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-functions.stderr
@@ -58,5 +58,11 @@ error: function `bi_S_Cuit` should have a snake case name
 LL | pub fn bi_S_Cuit() {}
    |        ^^^^^^^^^ help: convert the identifier to snake case (notice the capitalization): `bi_s_cuit`
 
-error: aborting due to 9 previous errors
+error: renamed function `FOO_RENAMED` should have a snake case name
+  --> $DIR/lint-non-snake-case-functions.rs:45:20
+   |
+LL | use foo_renamed as FOO_RENAMED;
+   |                    ^^^^^^^^^^^ help: convert the identifier to snake case: `foo_renamed`
+
+error: aborting due to 10 previous errors
 

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-modules.rs
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-modules.rs
@@ -1,10 +1,16 @@
 #![deny(non_snake_case)]
 #![allow(dead_code)]
 
-mod FooBar { //~ ERROR module `FooBar` should have a snake case name
+mod FooBar1 {
+    //~^ ERROR module `FooBar1` should have a snake case name
     pub struct S;
 }
 
-fn f(_: FooBar::S) { }
+fn f(_: FooBar1::S) {}
 
-fn main() { }
+mod foo_bar2 {
+    pub struct S;
+}
+use foo_bar2 as FooBar2; //~ ERROR renamed module `FooBar2` should have a snake case name
+
+fn main() {}

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-modules.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-modules.stderr
@@ -1,8 +1,8 @@
-error: module `FooBar` should have a snake case name
+error: module `FooBar1` should have a snake case name
   --> $DIR/lint-non-snake-case-modules.rs:4:5
    |
-LL | mod FooBar {
-   |     ^^^^^^ help: convert the identifier to snake case: `foo_bar`
+LL | mod FooBar1 {
+   |     ^^^^^^^ help: convert the identifier to snake case: `foo_bar1`
    |
 note: the lint level is defined here
   --> $DIR/lint-non-snake-case-modules.rs:1:9
@@ -10,5 +10,11 @@ note: the lint level is defined here
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error: renamed module `FooBar2` should have a snake case name
+  --> $DIR/lint-non-snake-case-modules.rs:14:17
+   |
+LL | use foo_bar2 as FooBar2;
+   |                 ^^^^^^^ help: convert the identifier to snake case: `foo_bar2`
+
+error: aborting due to 2 previous errors
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

Fix #126902

I fixed the issue that `non_camel_case_types` , `non_snake_case`, and `non_upper_case_globals` lints were not applied to renamed items.

I used `LateLintPass` for these lints, which runs over the HIR. The `DefKind` (an argument of `ItemKind::Use` from the HIR) helps determine the appropriate naming convention to be applied. (`EarlyLintPass` does not providethis information, correct?)

Since `non_camel_case_types` has already implemented `EarlyLintPass`, I modified `expand_combined_late_lint_pass_method!` and `expand_combined_early_lint_pass_method!` to avoid name conflict when a lint pass has both `EarlyLintPass` and `LateLintPass`. For now, `non_camel_case_types` implements both `EarlyLint` and `LateLint`.

`non_camel_case_types` , `non_snake_case`, and `non_upper_case_globals` do not run when each resolution of `ItemKind` has different naming convention. For example, you can define an enum and a const with the same name, but the former should use camel case, while the later should be upper case.
