### PR TITLE
Fix order of normalization and recursion in const folding.

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -333,14 +333,14 @@ impl<'cx, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for QueryNormalizer<'cx, 'tcx> 
             return Ok(constant);
         }
 
-        let constant = constant.try_super_fold_with(self)?;
-        debug!(?constant, ?self.param_env);
-        Ok(crate::traits::with_replaced_escaping_bound_vars(
+        let constant = crate::traits::with_replaced_escaping_bound_vars(
             self.infcx,
             &mut self.universes,
             constant,
             |constant| constant.normalize(self.infcx.tcx, self.param_env),
-        ))
+        );
+        debug!(?constant, ?self.param_env);
+        constant.try_super_fold_with(self)
     }
 
     #[inline]

--- a/tests/ui/const-generics/const-ty-is-normalized.rs
+++ b/tests/ui/const-generics/const-ty-is-normalized.rs
@@ -1,0 +1,25 @@
+//@ compile-flags: -Cdebuginfo=2 --crate-type=lib
+//@ build-pass
+#![feature(adt_const_params)]
+
+const N_ISLANDS: usize = 4;
+
+pub type Matrix = [[usize; N_ISLANDS]; N_ISLANDS];
+
+const EMPTY_MATRIX: Matrix = [[0; N_ISLANDS]; N_ISLANDS];
+
+const fn to_matrix() -> Matrix {
+    EMPTY_MATRIX
+}
+
+const BRIDGE_MATRIX: [[usize; N_ISLANDS]; N_ISLANDS] = to_matrix();
+
+pub struct Walk<const CURRENT: usize, const REMAINING: Matrix> {
+    _p: (),
+}
+
+impl Walk<0, BRIDGE_MATRIX> {
+    pub const fn new() -> Self {
+        Self { _p: () }
+    }
+}


### PR DESCRIPTION
Fixes #126831.

Without this patch, type normalization is not always idempotent, which leads to all sorts of bugs in places that assume that normalizing a normalized type does nothing.

Tracking issue: https://github.com/rust-lang/rust/issues/95174

r? BoxyUwU

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
