### PR TITLE
Remove JohnTitor from review rotation

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -970,7 +970,6 @@ rustdoc = [
 docs = [
     "@ehuss",
     "@GuillaumeGomez",
-    "@JohnTitor",
 ]
 query-system = [
     "@cjgillot",


### PR DESCRIPTION
This removes @JohnTitor from the review rotation. I haven't seen any comments from them in this repository since February, and PRs that get assigned to them tend to sit a few weeks until someone notices. I see that they are still semi-active with libc, but I haven't been able to reach them on Zulip. If @JohnTitor wants to get back on the rotation in the future, they are welcome (I don't want to pressure them, their support in the past was much appreciated).
