### PR TITLE
library: bump libc dependency

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 dependencies = [
  "rustc-std-workspace-core",
 ]


### PR DESCRIPTION
This pulls in https://github.com/rust-lang/libc/pull/3723, which hopefully unblocks https://github.com/rust-lang/miri/pull/3748.