### PR TITLE
Disable `dump-ice-to-disk` for i686-mingw (again)

### DIFF
--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -23,6 +23,9 @@
 //! - An attempt is made to re-enable this test on `i686-mingw` (by removing `ignore-windows`). If
 //!   this test is still flakey, please restore the `ignore-windows` directive.
 
+//@ ignore-windows
+//FIXME(#128911): still flakey on i686-mingw.
+
 use std::cell::OnceCell;
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
To avoid blocking full CI or `i686-mingw` try jobs (failed in https://github.com/rust-lang/rust/pull/127679#issuecomment-2295184771).

At least we now have some context for why the assertion failed.

Anyone with r+ can approve this.
