### PR TITLE
Don't generate functions with the `rustc_intrinsic_must_be_overridden` attribute

### DIFF
--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -888,7 +888,9 @@ fn visit_instance_use<'tcx>(
             if tcx.should_codegen_locally(panic_instance) {
                 output.push(create_fn_mono_item(tcx, panic_instance, source));
             }
-        } else if tcx.has_attr(def_id, sym::rustc_intrinsic) {
+        } else if tcx.has_attr(def_id, sym::rustc_intrinsic)
+            && !tcx.has_attr(def_id, sym::rustc_intrinsic_must_be_overridden)
+        {
             // Codegen the fallback body of intrinsics with fallback bodies
             let instance = ty::Instance::new(def_id, instance.args);
             if tcx.should_codegen_locally(instance) {

--- a/tests/codegen/intrinsics/rustc_intrinsic_must_be_overridden.rs
+++ b/tests/codegen/intrinsics/rustc_intrinsic_must_be_overridden.rs
@@ -1,0 +1,14 @@
+//@ revisions: OPT0 OPT1
+//@ [OPT0] compile-flags: -Copt-level=0
+//@ [OPT1] compile-flags: -Copt-level=1
+//@ compile-flags: -Cno-prepopulate-passes
+
+#![crate_type = "lib"]
+#![feature(core_intrinsics)]
+
+// CHECK-NOT: core::intrinsics::size_of_val
+
+#[no_mangle]
+pub unsafe fn size_of_val(ptr: *const i32) -> usize {
+    core::intrinsics::size_of_val(ptr)
+}


### PR DESCRIPTION
Functions with the attribute `rustc_intrinsic_must_be_overridden` never be called.

r? compiler