### PR TITLE
feat: Add explanations of when the IRs (HIR, THIR, MIR) become available

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -176,6 +176,7 @@ pub trait Callbacks {
         Compilation::Continue
     }
     /// Called after analysis. Return value instructs the compiler whether to
+    /// continue the compilation afterwards (defaults to `Compilation::Continue`)
     /// At this point, the MIR (Middle-Level Intermediate Representation) becomes available.
     fn after_analysis<'tcx>(
         &mut self,

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -166,6 +166,8 @@ pub trait Callbacks {
     }
     /// Called after expansion. Return value instructs the compiler whether to
     /// continue the compilation afterwards (defaults to `Compilation::Continue`)
+    /// At this point, the HIR (High-Level Intermediate Representation) becomes available.
+    /// Please call tcx.thir_body(owner_def), if you want to get THIR (Typed HIR).
     fn after_expansion<'tcx>(
         &mut self,
         _compiler: &interface::Compiler,
@@ -174,7 +176,7 @@ pub trait Callbacks {
         Compilation::Continue
     }
     /// Called after analysis. Return value instructs the compiler whether to
-    /// continue the compilation afterwards (defaults to `Compilation::Continue`)
+    /// At this point, the MIR (Middle-Level Intermediate Representation) becomes available.
     fn after_analysis<'tcx>(
         &mut self,
         _compiler: &interface::Compiler,


### PR DESCRIPTION
We couldn't know when the IRs (HIR, THIR, MIR) becomes available from current document.
Please see #129240 for more infomation.
<!-- homu-ignore:start -->
<!--

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
