### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -4612,6 +4612,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         })
     }
 
+    // For E0277 when use `?` operator, suggest adding
+    // a suitable return type in `FnSig`, and a default
+    // return value at the end of the function's body.
     pub(super) fn suggest_add_result_as_return_type(
         &self,
         obligation: &PredicateObligation<'tcx>,
@@ -4622,19 +4625,47 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             return;
         }
 
+        // Only suggest for local function and associated method,
+        // because this suggest adding both return type in
+        // the `FnSig` and a default return value in the body, so it
+        // is not suitable for foreign function without a local body,
+        // and neighter for trait method which may be also implemented
+        // in other place, so shouldn't change it's FnSig.
+        fn choose_suggest_items<'tcx, 'hir>(
+            tcx: TyCtxt<'tcx>,
+            node: hir::Node<'hir>,
+        ) -> Option<(&'hir hir::FnDecl<'hir>, hir::BodyId)> {
+            match node {
+                hir::Node::Item(item) if let hir::ItemKind::Fn(sig, _, body_id) = item.kind => {
+                    Some((sig.decl, body_id))
+                }
+                hir::Node::ImplItem(item)
+                    if let hir::ImplItemKind::Fn(sig, body_id) = item.kind =>
+                {
+                    let parent = tcx.parent_hir_node(item.hir_id());
+                    if let hir::Node::Item(item) = parent
+                        && let hir::ItemKind::Impl(imp) = item.kind
+                        && imp.of_trait.is_none()
+                    {
+                        return Some((sig.decl, body_id));
+                    }
+                    None
+                }
+                _ => None,
+            }
+        }
+
         let node = self.tcx.hir_node_by_def_id(obligation.cause.body_id);
-        if let hir::Node::Item(item) = node
-            && let hir::ItemKind::Fn(sig, _, body_id) = item.kind
-            && let hir::FnRetTy::DefaultReturn(ret_span) = sig.decl.output
+        if let Some((fn_decl, body_id)) = choose_suggest_items(self.tcx, node)
+            && let hir::FnRetTy::DefaultReturn(ret_span) = fn_decl.output
             && self.tcx.is_diagnostic_item(sym::FromResidual, trait_pred.def_id())
             && trait_pred.skip_binder().trait_ref.args.type_at(0).is_unit()
             && let ty::Adt(def, _) = trait_pred.skip_binder().trait_ref.args.type_at(1).kind()
             && self.tcx.is_diagnostic_item(sym::Result, def.did())
         {
-            let body = self.tcx.hir().body(body_id);
             let mut sugg_spans =
                 vec![(ret_span, " -> Result<(), Box<dyn std::error::Error>>".to_string())];
-
+            let body = self.tcx.hir().body(body_id);
             if let hir::ExprKind::Block(b, _) = body.value.kind
                 && b.expr.is_none()
             {

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -333,14 +333,14 @@ impl<'cx, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for QueryNormalizer<'cx, 'tcx> 
             return Ok(constant);
         }
 
-        let constant = constant.try_super_fold_with(self)?;
-        debug!(?constant, ?self.param_env);
-        Ok(crate::traits::with_replaced_escaping_bound_vars(
+        let constant = crate::traits::with_replaced_escaping_bound_vars(
             self.infcx,
             &mut self.universes,
             constant,
             |constant| constant.normalize(self.infcx.tcx, self.param_env),
-        ))
+        );
+        debug!(?constant, ?self.param_env);
+        constant.try_super_fold_with(self)
     }
 
     #[inline]

--- a/tests/crashes/129150.rs
+++ b/tests/crashes/129150.rs
@@ -1,0 +1,7 @@
+//@ known-bug: rust-lang/rust#129150
+//@ only-x86_64
+use std::arch::x86_64::_mm_blend_ps;
+
+pub fn main() {
+     _mm_blend_ps(1, 2, &const {} );
+}

--- a/tests/crashes/129166.rs
+++ b/tests/crashes/129166.rs
@@ -1,0 +1,7 @@
+//@ known-bug: rust-lang/rust#129166
+
+fn main() {
+    #[cfg_eval]
+    #[cfg]
+    0
+}

--- a/tests/crashes/129205.rs
+++ b/tests/crashes/129205.rs
@@ -1,0 +1,5 @@
+//@ known-bug: rust-lang/rust#129205
+
+fn x<T: Copy>() {
+    T::try_from();
+}

--- a/tests/crashes/129209.rs
+++ b/tests/crashes/129209.rs
@@ -1,0 +1,11 @@
+//@ known-bug: rust-lang/rust#129209
+
+impl<
+        const N: usize = {
+            static || {
+                Foo([0; X]);
+            }
+        },
+    > PartialEq for True
+{
+}

--- a/tests/crashes/129214.rs
+++ b/tests/crashes/129214.rs
@@ -1,0 +1,30 @@
+//@ known-bug: rust-lang/rust#129214
+//@ compile-flags: -Zvalidate-mir -Copt-level=3 --crate-type=lib
+
+trait to_str {}
+
+trait map<T> {
+    fn map<U, F>(&self, f: F) -> Vec<U>
+    where
+        F: FnMut(&Box<usize>) -> U;
+}
+impl<T> map<T> for Vec<T> {
+    fn map<U, F>(&self, mut f: F) -> Vec<U>
+    where
+        F: FnMut(&T) -> U,
+    {
+        let mut r = Vec::new();
+        for i in self {
+            r.push(f(i));
+        }
+        r
+    }
+}
+
+fn foo<U, T: map<U>>(x: T) -> Vec<String> {
+    x.map(|_e| "hi".to_string())
+}
+
+pub fn main() {
+    assert_eq!(foo(vec![1]), ["hi".to_string()]);
+}

--- a/tests/crashes/129216.rs
+++ b/tests/crashes/129216.rs
@@ -1,0 +1,11 @@
+//@ known-bug: rust-lang/rust#129216
+
+trait Mirror {
+    type Assoc;
+}
+
+struct Foo;
+
+fn main() {
+    <Foo as Mirror>::Assoc::new();
+}

--- a/tests/crashes/129219.rs
+++ b/tests/crashes/129219.rs
@@ -1,0 +1,26 @@
+//@ known-bug: rust-lang/rust#129219
+//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir --edition=2018
+
+use core::marker::Unsize;
+
+pub trait CastTo<T: ?Sized>: Unsize<T> {}
+
+impl<T: ?Sized, U: ?Sized> CastTo<T> for U {}
+
+impl<T: ?Sized> Cast for T {}
+pub trait Cast {
+    fn cast<T: ?Sized>(&self) -> &T
+    where
+        Self: CastTo<T>,
+    {
+        self
+    }
+}
+
+pub trait Foo {}
+impl Foo for [i32; 0] {}
+
+fn main() {
+    let x: &dyn Foo = &[];
+    let x = x.cast::<[i32]>();
+}

--- a/tests/ui/const-generics/const-ty-is-normalized.rs
+++ b/tests/ui/const-generics/const-ty-is-normalized.rs
@@ -1,0 +1,25 @@
+//@ compile-flags: -Cdebuginfo=2 --crate-type=lib
+//@ build-pass
+#![feature(adt_const_params)]
+
+const N_ISLANDS: usize = 4;
+
+pub type Matrix = [[usize; N_ISLANDS]; N_ISLANDS];
+
+const EMPTY_MATRIX: Matrix = [[0; N_ISLANDS]; N_ISLANDS];
+
+const fn to_matrix() -> Matrix {
+    EMPTY_MATRIX
+}
+
+const BRIDGE_MATRIX: [[usize; N_ISLANDS]; N_ISLANDS] = to_matrix();
+
+pub struct Walk<const CURRENT: usize, const REMAINING: Matrix> {
+    _p: (),
+}
+
+impl Walk<0, BRIDGE_MATRIX> {
+    pub const fn new() -> Self {
+        Self { _p: () }
+    }
+}

--- a/tests/ui/return/return-from-residual-sugg-issue-125997.fixed
+++ b/tests/ui/return/return-from-residual-sugg-issue-125997.fixed
@@ -33,6 +33,25 @@ macro_rules! mac {
     };
 }
 
+struct A;
+
+impl A {
+    fn test4(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let mut _file = File::create("foo.txt")?;
+        //~^ ERROR the `?` operator can only be used in a method
+    
+    Ok(())
+}
+
+    fn test5(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let mut _file = File::create("foo.txt")?;
+        //~^ ERROR the `?` operator can only be used in a method
+        println!();
+    
+    Ok(())
+}
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut _file = File::create("foo.txt")?;
     //~^ ERROR the `?` operator can only be used in a function

--- a/tests/ui/return/return-from-residual-sugg-issue-125997.rs
+++ b/tests/ui/return/return-from-residual-sugg-issue-125997.rs
@@ -27,6 +27,21 @@ macro_rules! mac {
     };
 }
 
+struct A;
+
+impl A {
+    fn test4(&self) {
+        let mut _file = File::create("foo.txt")?;
+        //~^ ERROR the `?` operator can only be used in a method
+    }
+
+    fn test5(&self) {
+        let mut _file = File::create("foo.txt")?;
+        //~^ ERROR the `?` operator can only be used in a method
+        println!();
+    }
+}
+
 fn main() {
     let mut _file = File::create("foo.txt")?;
     //~^ ERROR the `?` operator can only be used in a function

--- a/tests/ui/return/return-from-residual-sugg-issue-125997.stderr
+++ b/tests/ui/return/return-from-residual-sugg-issue-125997.stderr
@@ -37,8 +37,47 @@ LL +     Ok(())
 LL + }
    |
 
+error[E0277]: the `?` operator can only be used in a method that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> $DIR/return-from-residual-sugg-issue-125997.rs:34:48
+   |
+LL |     fn test4(&self) {
+   |     --------------- this function should return `Result` or `Option` to accept `?`
+LL |         let mut _file = File::create("foo.txt")?;
+   |                                                ^ cannot use the `?` operator in a method that returns `()`
+   |
+   = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
+help: consider adding return type
+   |
+LL ~     fn test4(&self) -> Result<(), Box<dyn std::error::Error>> {
+LL |         let mut _file = File::create("foo.txt")?;
+LL |
+LL ~     
+LL +     Ok(())
+LL + }
+   |
+
+error[E0277]: the `?` operator can only be used in a method that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> $DIR/return-from-residual-sugg-issue-125997.rs:39:48
+   |
+LL |     fn test5(&self) {
+   |     --------------- this function should return `Result` or `Option` to accept `?`
+LL |         let mut _file = File::create("foo.txt")?;
+   |                                                ^ cannot use the `?` operator in a method that returns `()`
+   |
+   = help: the trait `FromResidual<Result<Infallible, std::io::Error>>` is not implemented for `()`
+help: consider adding return type
+   |
+LL ~     fn test5(&self) -> Result<(), Box<dyn std::error::Error>> {
+LL |         let mut _file = File::create("foo.txt")?;
+LL |
+LL |         println!();
+LL ~     
+LL +     Ok(())
+LL + }
+   |
+
 error[E0277]: the `?` operator can only be used in a function that returns `Result` or `Option` (or another type that implements `FromResidual`)
-  --> $DIR/return-from-residual-sugg-issue-125997.rs:31:44
+  --> $DIR/return-from-residual-sugg-issue-125997.rs:46:44
    |
 LL | fn main() {
    | --------- this function should return `Result` or `Option` to accept `?`
@@ -81,6 +120,6 @@ LL +     Ok(())
 LL + }
    |
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Successful merges:

 - #128084 (Suggest adding Result return type for associated method in E0277.)
 - #129187 (bootstrap: fix clean's remove_dir_all implementation)
 - #129208 (Fix order of normalization and recursion in const folding.)
 - #129228 (crashes: more tests)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=128084,129187,129208,129228)
<!-- homu-ignore:end -->