### PR TITLE
Add a missing compatibility note in the 1.80.0 release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -143,6 +143,7 @@ Compatibility Notes
 - [Turn `proc_macro_back_compat` lint into a hard error.](https://github.com/rust-lang/rust/pull/125596/)
 - [Detect unused structs even when implementing private traits](https://github.com/rust-lang/rust/pull/122382/)
 - [`std::sync::ReentrantLockGuard<T>` is no longer `Sync` if `T: !Sync`](https://github.com/rust-lang/rust/pull/125527) which means [`std::io::StdoutLock` and `std::io::StderrLock` are no longer Sync](https://github.com/rust-lang/rust/issues/127340)
+- [alloc: implement FromIterator for Box<str>](https://github.com/rust-lang/rust/pull/99969/)
 
 <a id="1.80-Internal-Changes"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -143,8 +143,8 @@ Compatibility Notes
 - [Turn `proc_macro_back_compat` lint into a hard error.](https://github.com/rust-lang/rust/pull/125596/)
 - [Detect unused structs even when implementing private traits](https://github.com/rust-lang/rust/pull/122382/)
 - [`std::sync::ReentrantLockGuard<T>` is no longer `Sync` if `T: !Sync`](https://github.com/rust-lang/rust/pull/125527) which means [`std::io::StdoutLock` and `std::io::StderrLock` are no longer Sync](https://github.com/rust-lang/rust/issues/127340)
-- [Type inference will fail in some cases due to a new impl of FromIterator for Box<str>](https://github.com/rust-lang/rust/pull/99969/)
-  Notably this breaks versions of the `time` crate before 0.3.36, due to no longer inferring the right impl.
+- [Type inference will fail in some cases due to new implementations of `FromIterator for Box<str>`.](https://github.com/rust-lang/rust/pull/99969/)
+  Notably, this breaks versions of the `time` crate before 0.3.35, due to no longer inferring the implementation for `Box<[_]>`.
 
 <a id="1.80-Internal-Changes"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -143,7 +143,8 @@ Compatibility Notes
 - [Turn `proc_macro_back_compat` lint into a hard error.](https://github.com/rust-lang/rust/pull/125596/)
 - [Detect unused structs even when implementing private traits](https://github.com/rust-lang/rust/pull/122382/)
 - [`std::sync::ReentrantLockGuard<T>` is no longer `Sync` if `T: !Sync`](https://github.com/rust-lang/rust/pull/125527) which means [`std::io::StdoutLock` and `std::io::StderrLock` are no longer Sync](https://github.com/rust-lang/rust/issues/127340)
-- [alloc: implement FromIterator for Box<str>](https://github.com/rust-lang/rust/pull/99969/)
+- [Type inference will fail in some cases due to a new impl of FromIterator for Box<str>](https://github.com/rust-lang/rust/pull/99969/)
+  Notably this breaks versions of the `time` crate before 0.3.55, due to no longer inferring the right impl.
 
 <a id="1.80-Internal-Changes"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -144,7 +144,7 @@ Compatibility Notes
 - [Detect unused structs even when implementing private traits](https://github.com/rust-lang/rust/pull/122382/)
 - [`std::sync::ReentrantLockGuard<T>` is no longer `Sync` if `T: !Sync`](https://github.com/rust-lang/rust/pull/125527) which means [`std::io::StdoutLock` and `std::io::StderrLock` are no longer Sync](https://github.com/rust-lang/rust/issues/127340)
 - [Type inference will fail in some cases due to a new impl of FromIterator for Box<str>](https://github.com/rust-lang/rust/pull/99969/)
-  Notably this breaks versions of the `time` crate before 0.3.55, due to no longer inferring the right impl.
+  Notably this breaks versions of the `time` crate before 0.3.36, due to no longer inferring the right impl.
 
 <a id="1.80-Internal-Changes"></a>
 


### PR DESCRIPTION
#99969 missed being included in the release notes. As discussed [on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/241545-t-release/topic/.2399969.20missed.20the.20release.20notes/near/463002451).

(the discussion about the _a posteriori_ breakage the ecosystem is experiencing is another topic)

Thanks

r? @rust-lang/release 