### PR TITLE
Don't consider locals to shadow inner items' generics

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -2677,14 +2677,14 @@ impl<'a: 'ast, 'b, 'ast, 'tcx> LateResolutionVisitor<'a, 'b, 'ast, 'tcx> {
             // We also can't shadow bindings from associated parent items.
             for ns in [ValueNS, TypeNS] {
                 for parent_rib in self.ribs[ns].iter().rev() {
-                    seen_bindings
-                        .extend(parent_rib.bindings.keys().map(|ident| (*ident, ident.span)));
-
                     // Break at mod level, to account for nested items which are
                     // allowed to shadow generic param names.
                     if matches!(parent_rib.kind, RibKind::Module(..)) {
                         break;
                     }
+
+                    seen_bindings
+                        .extend(parent_rib.bindings.keys().map(|ident| (*ident, ident.span)));
                 }
             }
 

--- a/tests/ui/resolve/local-shadows-inner-generic.rs
+++ b/tests/ui/resolve/local-shadows-inner-generic.rs
@@ -1,0 +1,8 @@
+//@ check-pass
+
+#![allow(non_camel_case_types)]
+
+pub fn main() {
+    let a = 1;
+    struct Foo<a> { field: a, };
+}


### PR DESCRIPTION
We don't want to consider the bindings from a `RibKind::Module` itself, because for an inner item that module will contain the local bindings from the function body or wherever else the inner item is being defined.

Fixes #129265

r? petrochenkov
