### PR TITLE
Remove duplicated usage of `-Zunstable-options` in bootstrap

### DIFF
--- a/src/bootstrap/src/bin/rustdoc.rs
+++ b/src/bootstrap/src/bin/rustdoc.rs
@@ -59,8 +59,6 @@ fn main() {
     if stage == "0" {
         cmd.arg("--cfg=bootstrap");
     }
-    cmd.arg("-Zunstable-options");
-    cmd.arg("--check-cfg=cfg(bootstrap)");
 
     maybe_dump(format!("stage{stage}-rustdoc"), &cmd);
 

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -303,10 +303,11 @@ fn invoke_rustdoc(
         .arg(&out)
         .arg(&path)
         .arg("--markdown-css")
-        .arg("../rust.css");
+        .arg("../rust.css")
+        .arg("-Zunstable-options");
 
     if !builder.config.docs_minification {
-        cmd.arg("-Z").arg("unstable-options").arg("--disable-minification");
+        cmd.arg("--disable-minification");
     }
 
     cmd.run(builder);
@@ -376,8 +377,6 @@ impl Step for Standalone {
             }
 
             let mut cmd = builder.rustdoc_cmd(compiler);
-            // Needed for --index-page flag
-            cmd.arg("-Z").arg("unstable-options");
 
             cmd.arg("--html-after-content")
                 .arg(&footer)
@@ -386,6 +385,7 @@ impl Step for Standalone {
                 .arg("--html-in-header")
                 .arg(&favicon)
                 .arg("--markdown-no-toc")
+                .arg("-Zunstable-options")
                 .arg("--index-page")
                 .arg(builder.src.join("src/doc/index.md"))
                 .arg("--markdown-playground-url")
@@ -478,9 +478,6 @@ impl Step for Releases {
             mem::drop(tmpfile);
             let mut cmd = builder.rustdoc_cmd(compiler);
 
-            // Needed for --index-page flag
-            cmd.arg("-Z").arg("unstable-options");
-
             cmd.arg("--html-after-content")
                 .arg(&footer)
                 .arg("--html-before-content")
@@ -490,6 +487,7 @@ impl Step for Releases {
                 .arg("--markdown-no-toc")
                 .arg("--markdown-css")
                 .arg("rust.css")
+                .arg("-Zunstable-options")
                 .arg("--index-page")
                 .arg(builder.src.join("src/doc/index.md"))
                 .arg("--markdown-playground-url")
@@ -636,6 +634,8 @@ impl Step for Std {
         if !builder.config.docs_minification {
             extra_args.push("--disable-minification");
         }
+        // For `--index-page` and `--output-format=json`.
+        extra_args.push("-Zunstable-options");
 
         doc_std(builder, self.format, stage, target, &out, &extra_args, &crates);
 
@@ -715,8 +715,6 @@ fn doc_std(
         .arg("--target-dir")
         .arg(&*target_dir.to_string_lossy())
         .arg("-Zskip-rustdoc-fingerprint")
-        .rustdocflag("-Z")
-        .rustdocflag("unstable-options")
         .rustdocflag("--resource-suffix")
         .rustdocflag(&builder.version);
     for arg in extra_args {
@@ -822,7 +820,6 @@ impl Step for Rustc {
         // Since we always pass --document-private-items, there's no need to warn about linking to private items.
         cargo.rustdocflag("-Arustdoc::private-intra-doc-links");
         cargo.rustdocflag("--enable-index-page");
-        cargo.rustdocflag("-Zunstable-options");
         cargo.rustdocflag("-Znormalize-docs");
         cargo.rustdocflag("--show-type-layout");
         // FIXME: `--generate-link-to-definition` tries to resolve cfged out code
@@ -830,7 +827,6 @@ impl Step for Rustc {
         // cargo.rustdocflag("--generate-link-to-definition");
 
         compile::rustc_cargo(builder, &mut cargo, target, &compiler);
-        cargo.arg("-Zunstable-options");
         cargo.arg("-Zskip-rustdoc-fingerprint");
 
         // Only include compiler crates, no dependencies of those, such as `libc`.
@@ -986,7 +982,6 @@ macro_rules! tool_doc {
                 cargo.rustdocflag("-Arustdoc::private-intra-doc-links");
                 cargo.rustdocflag("--enable-index-page");
                 cargo.rustdocflag("--show-type-layout");
-                cargo.rustdocflag("-Zunstable-options");
                 // FIXME: `--generate-link-to-definition` tries to resolve cfged out code
                 // see https://github.com/rust-lang/rust/pull/122066#issuecomment-1983049222
                 // cargo.rustdocflag("--generate-link-to-definition");

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1616,7 +1616,6 @@ impl<'a> Builder<'a> {
             rustflags.arg("-Csymbol-mangling-version=v0");
         } else {
             rustflags.arg("-Csymbol-mangling-version=legacy");
-            rustflags.arg("-Zunstable-options");
         }
 
         // Enable compile-time checking of `cfg` names, values and Cargo `features`.
@@ -1864,16 +1863,7 @@ impl<'a> Builder<'a> {
             },
         );
 
-        let split_debuginfo = self.config.split_debuginfo(target);
-        let split_debuginfo_is_stable = target.contains("linux")
-            || target.contains("apple")
-            || (target.is_msvc() && split_debuginfo == SplitDebuginfo::Packed)
-            || (target.is_windows() && split_debuginfo == SplitDebuginfo::Off);
-
-        if !split_debuginfo_is_stable {
-            rustflags.arg("-Zunstable-options");
-        }
-        match split_debuginfo {
+        match self.config.split_debuginfo(target) {
             SplitDebuginfo::Packed => rustflags.arg("-Csplit-debuginfo=packed"),
             SplitDebuginfo::Unpacked => rustflags.arg("-Csplit-debuginfo=unpacked"),
             SplitDebuginfo::Off => rustflags.arg("-Csplit-debuginfo=off"),
@@ -2050,7 +2040,6 @@ impl<'a> Builder<'a> {
         }
 
         if mode == Mode::Rustc {
-            rustflags.arg("-Zunstable-options");
             rustflags.arg("-Wrustc::internal");
             // FIXME(edition_2024): Change this to `-Wrust_2024_idioms` when all
             // of the individual lints are satisfied.


### PR DESCRIPTION
Surprisingly, sometimes it is in the same function.

r? @Kobzol 