### PR TITLE
Use subtyping for `UnsafeFnPointer` coercion, too

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -2043,9 +2043,9 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
                         let ty_fn_ptr_from = tcx.safe_to_unsafe_fn_ty(fn_sig);
 
-                        if let Err(terr) = self.eq_types(
-                            *ty,
+                        if let Err(terr) = self.sub_types(
                             ty_fn_ptr_from,
+                            *ty,
                             location.to_locations(),
                             ConstraintCategory::Cast { unsize_to: None },
                         ) {

--- a/tests/ui/coercion/cast-higher-ranked-unsafe-fn-ptr.rs
+++ b/tests/ui/coercion/cast-higher-ranked-unsafe-fn-ptr.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+
+fn higher_ranked_fndef(ctx: &mut ()) {}
+
+fn test(higher_ranked_fnptr: fn(&mut ())) {
+    fn as_unsafe<T>(_: unsafe fn(T)) {}
+
+    // Make sure that we can cast higher-ranked fn items and pointers to
+    // a non-higher-ranked target.
+    as_unsafe(higher_ranked_fndef);
+    as_unsafe(higher_ranked_fnptr);
+}
+
+fn main() {}


### PR DESCRIPTION
I overlooked this in #129059, which changed MIR typechecking to use subtyping for other fn pointer coercions.

Fixes #129285