### PR TITLE
Pin `cc` to 1.0.105

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,12 +420,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
-dependencies = [
- "shlex",
-]
+checksum = "5208975e568d83b6b05cc0a063c8e7e9acc2b43bee6da15616a5b73e109d7437"
 
 [[package]]
 name = "cfg-if"

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 ar_archive_writer = "0.4.0"
 arrayvec = { version = "0.7", default-features = false }
 bitflags = "2.4.1"
-cc = "1.0.90"
+cc = "=1.0.105" # FIXME(cc): pinned to keep support for VS2013
 either = "1.5.0"
 itertools = "0.12"
 jobserver = "0.1.28"

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -10,5 +10,5 @@ libc = "0.2.73"
 
 [build-dependencies]
 # tidy-alphabetical-start
-cc = "1.0.97"
+cc = "=1.0.105" # FIXME(cc): pinned to keep support for VS2013
 # tidy-alphabetical-end


### PR DESCRIPTION
`cc` 1.0.106 removes support for Visual Studio 12. Pin to 1.0.105 so we don't drop support yet.

Fixes: https://github.com/rust-lang/rust/pull/128722#issuecomment-2297605573

<!-- homu-ignore:start -->
r? @Mark-Simulacrum 
Cc @dpaoliello
<!-- homu-ignore:end -->