### PR TITLE
Build `library/profiler_builtins` from `ci-llvm` if appropriate

### DIFF
--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -84,12 +84,16 @@ fn main() {
     let root = Path::new("../../src/llvm-project/compiler-rt");
 
     let src_root = root.join("lib").join("profile");
+    assert!(src_root.exists(), "profiler runtime source directory not found: {src_root:?}");
+    let mut n_sources_found = 0u32;
     for src in profile_sources {
         let path = src_root.join(src);
         if path.exists() {
             cfg.file(path);
+            n_sources_found += 1;
         }
     }
+    assert!(n_sources_found > 0, "couldn't find any profiler runtime source files in {src_root:?}");
 
     cfg.include(root.join("include"));
     cfg.warnings(false);

--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -3,7 +3,7 @@
 //! See the build.rs for libcompiler_builtins crate for details.
 
 use std::env;
-use std::path::Path;
+use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rerun-if-env-changed=LLVM_PROFILER_RT_LIB");
@@ -79,9 +79,13 @@ fn main() {
         cfg.define("COMPILER_RT_HAS_ATOMICS", Some("1"));
     }
 
-    // Note that this should exist if we're going to run (otherwise we just
-    // don't build profiler builtins at all).
-    let root = Path::new("../../src/llvm-project/compiler-rt");
+    // Get the LLVM `compiler-rt` directory from bootstrap.
+    println!("cargo:rerun-if-env-changed=RUST_COMPILER_RT_FOR_PROFILER");
+    let root = PathBuf::from(env::var("RUST_COMPILER_RT_FOR_PROFILER").unwrap_or_else(|_| {
+        let path = "../../src/llvm-project/compiler-rt";
+        println!("RUST_COMPILER_RT_FOR_PROFILER was not set; falling back to {path:?}");
+        path.to_owned()
+    }));
 
     let src_root = root.join("lib").join("profile");
     assert!(src_root.exists(), "profiler runtime source directory not found: {src_root:?}");

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -230,4 +230,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "./x test --rustc-args was renamed to --compiletest-rustc-args as it only applies there. ./x miri --rustc-args was also removed.",
     },
+    ChangeInfo {
+        change_id: 129295,
+        severity: ChangeSeverity::Info,
+        summary: "The `build.profiler` option now tries to use source code from `download-ci-llvm` if possible, instead of checking out the `src/llvm-project` submodule.",
+    },
 ];


### PR DESCRIPTION
Running all of `tests/coverage` requires the LLVM profiler runtime, which requires setting `build.profiler = true`.

Historically, doing that has required checking out the entire `src/llvm-project` submodule. For compiler contributors who otherwise don't need that submodule (thanks to `download-ci-vm`), that's quite inconvenient.

However, thanks to #129116, the downloaded CI LLVM tarball now contains a copy of LLVM's `compiler-rt` directory, which includes all the files needed to build the profiler runtime. So with a little bit of extra logic in bootstrap, we can have `library/profiler_builtins` look for the `compiler-rt` files in `ci-llvm` instead of the `src/llvm-project` submodule.