### PR TITLE
Flip the `grow_one` inlining

### DIFF
--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -344,7 +344,7 @@ impl<T, A: Allocator> RawVec<T, A> {
     /// A specialized version of `self.reserve(len, 1)` which requires the
     /// caller to ensure `len == self.capacity()`.
     #[cfg(not(no_global_oom_handling))]
-    #[inline(never)]
+    #[inline]
     pub fn grow_one(&mut self) {
         self.inner.grow_one(T::LAYOUT)
     }
@@ -562,7 +562,7 @@ impl<A: Allocator> RawVecInner<A> {
     }
 
     #[cfg(not(no_global_oom_handling))]
-    #[inline]
+    #[inline(never)]
     fn grow_one(&mut self, elem_layout: Layout) {
         if let Err(err) = self.grow_amortized(self.cap.0, 1, elem_layout) {
             handle_error(err);


### PR DESCRIPTION
Right now `RawVec<T>::grow_one` is `inline(never)` but `RawVecInner::grow_one` is `inline`.

This tries flipping them, in hopes that the `Vec<T>` methods that call `RawVec<T>::grow_one` will MIR-inline that call and thus end up calling `RawVecInner::grow_one` directly, hopefully meaning we never monomorphize `RawVec<T>::grow_one` ever.

(I had this idea in https://github.com/rust-lang/rust/pull/126793/files#r1709966778 ; let's see if it even matters)

r? saethlin 