### PR TITLE
fix: missing backtrace when using std::backtrace::Backtrace on Android

### DIFF
--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -58,6 +58,18 @@ fn main() {
         || env::var("RUSTC_BOOTSTRAP_SYNTHETIC_TARGET").is_ok()
     {
         // These platforms don't have any special requirements.
+    } else if target_os == "android" {
+        // Since rust-lang/rust#120593 <https://github.com/rust-lang/rust/pull/120593>,
+        // the minimum Android API level change from 19 to 21. And Android supports
+        // `dl_iterate_phdr` since API level 21. Please see
+        // <https://android.googlesource.com/platform/bionic/+/HEAD/docs/status.md>
+        // for details. So we can enable `dl_iterate_phdr` feature for Android witout
+        // checking the Android API level.
+        //
+        // Note: after <https://github.com/rust-lang/backtrace-rs/pull/656>, backtrace-rs
+        // removed the special build logic for Android. So We can remove the next line,
+        // once backtrace-rs in std is updated to the version that includes the change.
+        println!("cargo:rustc-cfg=feature=\"dl_iterate_phdr\"");
     } else {
         // This is for Cargo's build-std support, to mark std as unstable for
         // typically no_std platforms.

--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -63,7 +63,7 @@ fn main() {
         // the minimum Android API level change from 19 to 21. And Android supports
         // `dl_iterate_phdr` since API level 21. Please see
         // <https://android.googlesource.com/platform/bionic/+/HEAD/docs/status.md>
-        // for details. So we can enable `dl_iterate_phdr` feature for Android witout
+        // for details. So we can enable `dl_iterate_phdr` feature for Android without
         // checking the Android API level.
         //
         // Note: after <https://github.com/rust-lang/backtrace-rs/pull/656>, backtrace-rs
@@ -155,7 +155,7 @@ fn main() {
     // These are currently empty, but will fill up as some platforms move from completely
     // unreliable to reliable basics but unreliable math.
 
-    // LLVM is currenlty adding missing routines, <https://github.com/llvm/llvm-project/issues/93566>
+    // LLVM is currently adding missing routines, <https://github.com/llvm/llvm-project/issues/93566>
     let has_reliable_f16_math = has_reliable_f16
         && match (target_arch.as_str(), target_os.as_str()) {
             // FIXME: Disabled on Miri as the intrinsics are not implemented yet.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

This pr will fix #121033.

## Cause of the problem
`backtrace-rs` is introduced into the std lib in [this way](https://github.com/rust-lang/rust/blob/master/library/std/src/lib.rs#L670), which will cause the [build.rs](https://github.com/rust-lang/backtrace-rs/blob/72265bea210891ae47bbe6d4f17b493ef0606619/build.rs) of backtrace-rs to not be executed, and the `dl_iterate_phdr` feature will not be set. Ultimately, the stack information on android cannot be obtained.

## Solution
Since rust-lang/rust#120593, the minimum Android API level change from 19 to 21. And Android supports `dl_iterate_phdr` since API level 21. Please see <https://android.googlesource.com/platform/bionic/+/HEAD/docs/status.md> for details. So we can enable `dl_iterate_phdr` feature for Android without checking the Android API level.
