### PR TITLE
Fix stability attribute of `impl !Error for &str`

### DIFF
--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2818,5 +2818,5 @@ impl_fn_for_zst! {
 }
 
 // This is required to make `impl From<&str> for Box<dyn Error>` and `impl<E> From<E> for Box<dyn Error>` not overlap.
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "error_in_core_neg_impl", since = "1.65.0")]
 impl !crate::error::Error for &str {}


### PR DESCRIPTION
It was introduced in bf7611d55ee6e24647aefc4d1c82b1dba0164536 (#99917), which was included in Rust 1.65.0.