### PR TITLE
Change neutral element of <fNN as iter::Sum> to neg_zero

### DIFF
--- a/library/core/src/iter/traits/accum.rs
+++ b/library/core/src/iter/traits/accum.rs
@@ -104,7 +104,7 @@ macro_rules! float_sum_product {
         impl Sum for $a {
             fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
                 iter.fold(
-                    0.0,
+                    -0.0,
                     #[rustc_inherit_overflow_checks]
                     |a, b| a + b,
                 )
@@ -126,7 +126,7 @@ macro_rules! float_sum_product {
         impl<'a> Sum<&'a $a> for $a {
             fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
                 iter.fold(
-                    0.0,
+                    -0.0,
                     #[rustc_inherit_overflow_checks]
                     |a, b| a + b,
                 )

--- a/library/core/tests/num/float_iter_sum_identity.rs
+++ b/library/core/tests/num/float_iter_sum_identity.rs
@@ -1,0 +1,27 @@
+#[test]
+fn f32_ref() {
+    let x: f32 = -0.0;
+    let still_x: f32 = [x].iter().sum();
+    assert_eq!(1. / x, 1. / still_x)
+}
+
+#[test]
+fn f32_own() {
+    let x: f32 = -0.0;
+    let still_x: f32 = [x].into_iter().sum();
+    assert_eq!(1. / x, 1. / still_x)
+}
+
+#[test]
+fn f64_ref() {
+    let x: f64 = -0.0;
+    let still_x: f64 = [x].iter().sum();
+    assert_eq!(1. / x, 1. / still_x)
+}
+
+#[test]
+fn f64_own() {
+    let x: f64 = -0.0;
+    let still_x: f64 = [x].into_iter().sum();
+    assert_eq!(1. / x, 1. / still_x)
+}

--- a/library/core/tests/num/mod.rs
+++ b/library/core/tests/num/mod.rs
@@ -30,6 +30,7 @@ mod int_log;
 mod ops;
 mod wrapping;
 
+mod float_iter_sum_identity;
 mod ieee754;
 mod nan;
 


### PR DESCRIPTION
The neutral element used to be positive zero, but +0 + -0 = +0 so -0 seems better indicated.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
