### PR TITLE
Implement (part of) ACP 429: add `DerefMut` to `Lazy[Cell/Lock]`

### DIFF
--- a/library/core/src/cell/lazy.rs
+++ b/library/core/src/cell/lazy.rs
@@ -1,6 +1,6 @@
 use super::UnsafeCell;
 use crate::hint::unreachable_unchecked;
-use crate::ops::Deref;
+use crate::ops::{Deref, DerefMut};
 use crate::{fmt, mem};
 
 enum State<T, F> {
@@ -281,6 +281,14 @@ impl<T, F: FnOnce() -> T> Deref for LazyCell<T, F> {
     #[inline]
     fn deref(&self) -> &T {
         LazyCell::force(self)
+    }
+}
+
+#[stable(feature = "lazy_deref_mut", since = "CURRENT_RUSTC_VERSION")]
+impl<T, F: FnOnce() -> T> DerefMut for LazyCell<T, F> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        LazyCell::force_mut(self)
     }
 }
 

--- a/library/std/src/sync/lazy_lock.rs
+++ b/library/std/src/sync/lazy_lock.rs
@@ -1,7 +1,7 @@
 use super::once::ExclusiveState;
 use crate::cell::UnsafeCell;
 use crate::mem::ManuallyDrop;
-use crate::ops::Deref;
+use crate::ops::{Deref, DerefMut};
 use crate::panic::{RefUnwindSafe, UnwindSafe};
 use crate::sync::Once;
 use crate::{fmt, ptr};
@@ -309,6 +309,14 @@ impl<T, F: FnOnce() -> T> Deref for LazyLock<T, F> {
     #[inline]
     fn deref(&self) -> &T {
         LazyLock::force(self)
+    }
+}
+
+#[stable(feature = "lazy_deref_mut", since = "CURRENT_RUSTC_VERSION")]
+impl<T, F: FnOnce() -> T> DerefMut for LazyLock<T, F> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        LazyLock::force_mut(self)
     }
 }
 


### PR DESCRIPTION
`DerefMut` is instantly stable, as a trait impl. That means this needs an FCP.

@rustbot label +needs-fcp

https://github.com/rust-lang/libs-team/issues/429

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

-->
<!-- homu-ignore:end -->
