### PR TITLE
Make `ArgAbi::make_indirect_force` more specific

### DIFF
--- a/compiler/rustc_target/src/abi/call/powerpc.rs
+++ b/compiler/rustc_target/src/abi/call/powerpc.rs
@@ -16,7 +16,7 @@ fn classify_arg<Ty>(cx: &impl HasTargetSpec, arg: &mut ArgAbi<'_, Ty>) {
             && matches!(&*cx.target_spec().env, "gnu" | "musl" | "uclibc")
             && arg.layout.is_zst()
         {
-            arg.make_indirect_force();
+            arg.make_indirect_from_ignore();
         }
         return;
     }

--- a/compiler/rustc_target/src/abi/call/s390x.rs
+++ b/compiler/rustc_target/src/abi/call/s390x.rs
@@ -28,7 +28,7 @@ where
             && matches!(&*cx.target_spec().env, "gnu" | "musl" | "uclibc")
             && arg.layout.is_zst()
         {
-            arg.make_indirect_force();
+            arg.make_indirect_from_ignore();
         }
         return;
     }

--- a/compiler/rustc_target/src/abi/call/sparc64.rs
+++ b/compiler/rustc_target/src/abi/call/sparc64.rs
@@ -225,7 +225,7 @@ where
                 && matches!(&*cx.target_spec().env, "gnu" | "musl" | "uclibc")
                 && arg.layout.is_zst()
             {
-                arg.make_indirect_force();
+                arg.make_indirect_from_ignore();
             }
             return;
         }

--- a/compiler/rustc_target/src/abi/call/x86_win64.rs
+++ b/compiler/rustc_target/src/abi/call/x86_win64.rs
@@ -43,7 +43,7 @@ pub fn compute_abi_info<Ty>(cx: &impl HasTargetSpec, fn_abi: &mut FnAbi<'_, Ty>)
                 && cx.target_spec().env == "gnu"
                 && arg.layout.is_zst()
             {
-                arg.make_indirect_force();
+                arg.make_indirect_from_ignore();
             }
             continue;
         }


### PR DESCRIPTION
As the method is only needed for making ignored ZSTs indirect on some ABIs, rename and add a doc-comment and `self.mode` check to make it harder to accidentally misuse. Addresses review feedback from https://github.com/rust-lang/rust/pull/125854#discussion_r1721047899.

r? @RalfJung