### PR TITLE
Remove Duplicate E0381 Label

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -678,14 +678,15 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
         let inits = &self.move_data.init_path_map[mpi];
         let move_path = &self.move_data.move_paths[mpi];
         let decl_span = self.body.local_decls[move_path.place.local].source_info.span;
-        let mut spans = vec![];
+        let mut spans_set = FxIndexSet::default();
         for init_idx in inits {
             let init = &self.move_data.inits[*init_idx];
             let span = init.span(self.body);
             if !span.is_dummy() {
-                spans.push(span);
+                spans_set.insert(span);
             }
         }
+        let spans: Vec<_> = spans_set.into_iter().collect();
 
         let (name, desc) = match self.describe_place_with_options(
             moved_place,

--- a/tests/ui/duplicate-label-E0381-issue-129274.rs
+++ b/tests/ui/duplicate-label-E0381-issue-129274.rs
@@ -1,0 +1,13 @@
+fn main() {
+    fn test() {
+        loop {
+            let blah: Option<String>;
+            if true {
+                blah = Some("".to_string());
+            }
+            if let Some(blah) = blah.as_ref() { //~ ERROR E0381
+            }
+        }
+    }
+    println!("{:?}", test())
+}

--- a/tests/ui/duplicate-label-E0381-issue-129274.stderr
+++ b/tests/ui/duplicate-label-E0381-issue-129274.stderr
@@ -1,0 +1,15 @@
+error[E0381]: used binding `blah` is possibly-uninitialized
+  --> $DIR/duplicate-label-E0381-issue-129274.rs:8:33
+   |
+LL |             let blah: Option<String>;
+   |                 ---- binding declared here but left uninitialized
+LL |             if true {
+LL |                 blah = Some("".to_string());
+   |                 ---- binding initialized here in some conditions
+LL |             }
+LL |             if let Some(blah) = blah.as_ref() {
+   |                                 ^^^^ `blah` used here but it is possibly-uninitialized
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0381`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
Aims to resolve https://github.com/rust-lang/rust/issues/129274, and adds a test for the case.

Essentially, we are duplicating this span for some reason. For now, I'm just using a set to collect the spans rather than the vec. I imagine there's probably no real reason to inspect duplicates in this area, but if I'm wrong I can adjust to collect "seen spans" in just the point where this label is applied.

I'm not sure why it's producing duplicate spans. Looks like this has been this way for a while? I think it gives the duplicate label on 1.75.0 for example.