### PR TITLE
Fix double handling in `collect_tokens`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4172,6 +4172,7 @@ dependencies = [
  "rustc_errors",
  "rustc_feature",
  "rustc_fluent_macro",
+ "rustc_index",
  "rustc_lexer",
  "rustc_macros",
  "rustc_session",

--- a/compiler/rustc_index/src/interval.rs
+++ b/compiler/rustc_index/src/interval.rs
@@ -18,7 +18,7 @@ mod tests;
 #[derive(Debug, Clone)]
 pub struct IntervalSet<I> {
     // Start, end
-    map: SmallVec<[(u32, u32); 4]>,
+    map: SmallVec<[(u32, u32); 2]>,
     domain: usize,
     _data: PhantomData<I>,
 }

--- a/compiler/rustc_parse/Cargo.toml
+++ b/compiler/rustc_parse/Cargo.toml
@@ -12,6 +12,7 @@ rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }
 rustc_feature = { path = "../rustc_feature" }
 rustc_fluent_macro = { path = "../rustc_fluent_macro" }
+rustc_index = { path = "../rustc_index" }
 rustc_lexer = { path = "../rustc_lexer" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_session = { path = "../rustc_session" }

--- a/compiler/rustc_parse/src/parser/attr_wrapper.rs
+++ b/compiler/rustc_parse/src/parser/attr_wrapper.rs
@@ -363,7 +363,7 @@ impl<'a> Parser<'a> {
                 [parser_replacements_start..parser_replacements_end]
                 .iter()
                 .cloned()
-                .chain(inner_attr_parser_replacements.iter().cloned())
+                .chain(inner_attr_parser_replacements.into_iter())
                 .map(|(parser_range, data)| {
                     (NodeRange::new(parser_range, collect_pos.start_pos), data)
                 })

--- a/compiler/rustc_parse/src/parser/attr_wrapper.rs
+++ b/compiler/rustc_parse/src/parser/attr_wrapper.rs
@@ -510,9 +510,11 @@ fn make_attr_token_stream(
 }
 
 /// Tokens are needed if:
-/// - any non-single-segment attributes (other than doc comments) are present; or
-/// - any `cfg_attr` attributes are present;
-/// - any single-segment, non-builtin attributes are present.
+/// - any non-single-segment attributes (other than doc comments) are present,
+///   e.g. `rustfmt::skip`; or
+/// - any `cfg_attr` attributes are present; or
+/// - any single-segment, non-builtin attributes are present, e.g. `derive`,
+///   `test`, `global_allocator`.
 fn needs_tokens(attrs: &[ast::Attribute]) -> bool {
     attrs.iter().any(|attr| match attr.ident() {
         None => !attr.is_doc_comment(),

--- a/compiler/rustc_parse/src/parser/attr_wrapper.rs
+++ b/compiler/rustc_parse/src/parser/attr_wrapper.rs
@@ -134,9 +134,8 @@ impl ToAttrTokenStream for LazyAttrTokenStreamImpl {
                 node_replacements.array_windows()
             {
                 assert!(
-                    node_range.0.end <= next_node_range.0.start
-                        || node_range.0.end >= next_node_range.0.end,
-                    "Node ranges should be disjoint or nested: ({:?}, {:?}) ({:?}, {:?})",
+                    node_range.0.end <= next_node_range.0.start,
+                    "Node ranges should be disjoint: ({:?}, {:?}) ({:?}, {:?})",
                     node_range,
                     tokens,
                     next_node_range,
@@ -144,20 +143,8 @@ impl ToAttrTokenStream for LazyAttrTokenStreamImpl {
                 );
             }
 
-            // Process the replace ranges, starting from the highest start
-            // position and working our way back. If have tokens like:
-            //
-            // `#[cfg(FALSE)] struct Foo { #[cfg(FALSE)] field: bool }`
-            //
-            // Then we will generate replace ranges for both
-            // the `#[cfg(FALSE)] field: bool` and the entire
-            // `#[cfg(FALSE)] struct Foo { #[cfg(FALSE)] field: bool }`
-            //
-            // By starting processing from the replace range with the greatest
-            // start position, we ensure that any (outer) replace range which
-            // encloses another (inner) replace range will fully overwrite the
-            // inner range's replacement.
-            for (node_range, target) in node_replacements.into_iter().rev() {
+            // Process the replace ranges.
+            for (node_range, target) in node_replacements.into_iter() {
                 assert!(
                     !node_range.0.is_empty(),
                     "Cannot replace an empty node range: {:?}",
@@ -364,10 +351,9 @@ impl<'a> Parser<'a> {
             // from `ParserRange` form to `NodeRange` form. We will perform the actual
             // replacement only when we convert the `LazyAttrTokenStream` to an
             // `AttrTokenStream`.
-            self.capture_state.parser_replacements
-                [parser_replacements_start..parser_replacements_end]
-                .iter()
-                .cloned()
+            self.capture_state
+                .parser_replacements
+                .drain(parser_replacements_start..parser_replacements_end)
                 .chain(inner_attr_parser_replacements.into_iter())
                 .map(|(parser_range, data)| {
                     (NodeRange::new(parser_range, collect_pos.start_pos), data)

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -238,7 +238,8 @@ impl NodeRange {
     // is the position of the function's start token. This gives
     // `NodeRange(10..15)`.
     fn new(ParserRange(parser_range): ParserRange, start_pos: u32) -> NodeRange {
-        assert!(parser_range.start >= start_pos && parser_range.end >= start_pos);
+        assert!(!parser_range.is_empty());
+        assert!(parser_range.start >= start_pos);
         NodeRange((parser_range.start - start_pos)..(parser_range.end - start_pos))
     }
 }

--- a/tests/crashes/129166.rs
+++ b/tests/crashes/129166.rs
@@ -1,7 +1,0 @@
-//@ known-bug: rust-lang/rust#129166
-
-fn main() {
-    #[cfg_eval]
-    #[cfg]
-    0
-}

--- a/tests/ui/conditional-compilation/invalid-node-range-issue-129166.rs
+++ b/tests/ui/conditional-compilation/invalid-node-range-issue-129166.rs
@@ -1,0 +1,11 @@
+// This was triggering an assertion failure in `NodeRange::new`.
+
+#![feature(cfg_eval)]
+#![feature(stmt_expr_attributes)]
+
+fn f() -> u32 {
+    #[cfg_eval] #[cfg(not(FALSE))] 0
+    //~^ ERROR removing an expression is not supported in this position
+}
+
+fn main() {}

--- a/tests/ui/conditional-compilation/invalid-node-range-issue-129166.stderr
+++ b/tests/ui/conditional-compilation/invalid-node-range-issue-129166.stderr
@@ -1,0 +1,8 @@
+error: removing an expression is not supported in this position
+  --> $DIR/invalid-node-range-issue-129166.rs:7:17
+   |
+LL |     #[cfg_eval] #[cfg(not(FALSE))] 0
+   |                 ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/proc-macro/macro-rules-derive-cfg.rs
+++ b/tests/ui/proc-macro/macro-rules-derive-cfg.rs
@@ -14,17 +14,15 @@ extern crate test_macros;
 macro_rules! produce_it {
     ($expr:expr) => {
         #[derive(Print)]
-        struct Foo {
-            val: [bool; {
-                let a = #[cfg_attr(not(FALSE), rustc_dummy(first))] $expr;
-                0
-            }]
-        }
+        struct Foo(
+            [bool; #[cfg_attr(not(FALSE), rustc_dummy(first))] $expr]
+        );
     }
 }
 
 produce_it!(#[cfg_attr(not(FALSE), rustc_dummy(second))] {
-    #![cfg_attr(not(FALSE), allow(unused))]
+    #![cfg_attr(not(FALSE), rustc_dummy(third))]
+    #[cfg_attr(not(FALSE), rustc_dummy(fourth))]
     30
 });
 

--- a/tests/ui/proc-macro/macro-rules-derive-cfg.stdout
+++ b/tests/ui/proc-macro/macro-rules-derive-cfg.stdout
@@ -1,21 +1,11 @@
-PRINT-DERIVE INPUT (DISPLAY): struct Foo
+PRINT-DERIVE INPUT (DISPLAY): struct
+Foo([bool; #[rustc_dummy(first)] #[rustc_dummy(second)]
+{ #![rustc_dummy(third)] #[rustc_dummy(fourth)] #[rustc_dummy(fourth)] 30 }]);
+PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): struct
+Foo([bool; #[rustc_dummy(first)] #[rustc_dummy(second)]
 {
-    val :
-    [bool;
-    {
-        let a = #[rustc_dummy(first)] #[rustc_dummy(second)]
-        { #![allow(unused)] 30 }; 0
-    }]
-}
-PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): struct Foo
-{
-    val :
-    [bool;
-    {
-        let a = #[rustc_dummy(first)] #[rustc_dummy(second)]
-        { #! [allow(unused)] 30 }; 0
-    }]
-}
+    #! [rustc_dummy(third)] #[rustc_dummy(fourth)] #[rustc_dummy(fourth)] 30
+}]);
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -26,155 +16,171 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
         span: $DIR/macro-rules-derive-cfg.rs:17:16: 17:19 (#3),
     },
     Group {
-        delimiter: Brace,
+        delimiter: Parenthesis,
         stream: TokenStream [
-            Ident {
-                ident: "val",
-                span: $DIR/macro-rules-derive-cfg.rs:18:13: 18:16 (#3),
-            },
-            Punct {
-                ch: ':',
-                spacing: Alone,
-                span: $DIR/macro-rules-derive-cfg.rs:18:16: 18:17 (#3),
-            },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "bool",
-                        span: $DIR/macro-rules-derive-cfg.rs:18:19: 18:23 (#3),
+                        span: $DIR/macro-rules-derive-cfg.rs:18:14: 18:18 (#3),
                     },
                     Punct {
                         ch: ';',
                         spacing: Alone,
-                        span: $DIR/macro-rules-derive-cfg.rs:18:23: 18:24 (#3),
+                        span: $DIR/macro-rules-derive-cfg.rs:18:18: 18:19 (#3),
+                    },
+                    Punct {
+                        ch: '#',
+                        spacing: Alone,
+                        span: $DIR/macro-rules-derive-cfg.rs:18:20: 18:21 (#3),
+                    },
+                    Group {
+                        delimiter: Bracket,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "rustc_dummy",
+                                span: $DIR/macro-rules-derive-cfg.rs:18:43: 18:54 (#3),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "first",
+                                        span: $DIR/macro-rules-derive-cfg.rs:18:55: 18:60 (#3),
+                                    },
+                                ],
+                                span: $DIR/macro-rules-derive-cfg.rs:18:54: 18:61 (#3),
+                            },
+                        ],
+                        span: $DIR/macro-rules-derive-cfg.rs:18:21: 18:63 (#3),
+                    },
+                    Punct {
+                        ch: '#',
+                        spacing: Alone,
+                        span: $DIR/macro-rules-derive-cfg.rs:23:13: 23:14 (#0),
+                    },
+                    Group {
+                        delimiter: Bracket,
+                        stream: TokenStream [
+                            Ident {
+                                ident: "rustc_dummy",
+                                span: $DIR/macro-rules-derive-cfg.rs:23:36: 23:47 (#0),
+                            },
+                            Group {
+                                delimiter: Parenthesis,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "second",
+                                        span: $DIR/macro-rules-derive-cfg.rs:23:48: 23:54 (#0),
+                                    },
+                                ],
+                                span: $DIR/macro-rules-derive-cfg.rs:23:47: 23:55 (#0),
+                            },
+                        ],
+                        span: $DIR/macro-rules-derive-cfg.rs:23:14: 23:57 (#0),
                     },
                     Group {
                         delimiter: Brace,
                         stream: TokenStream [
-                            Ident {
-                                ident: "let",
-                                span: $DIR/macro-rules-derive-cfg.rs:19:17: 19:20 (#3),
-                            },
-                            Ident {
-                                ident: "a",
-                                span: $DIR/macro-rules-derive-cfg.rs:19:21: 19:22 (#3),
-                            },
-                            Punct {
-                                ch: '=',
-                                spacing: Alone,
-                                span: $DIR/macro-rules-derive-cfg.rs:19:23: 19:24 (#3),
-                            },
                             Punct {
                                 ch: '#',
+                                spacing: Joint,
+                                span: $DIR/macro-rules-derive-cfg.rs:24:5: 24:6 (#0),
+                            },
+                            Punct {
+                                ch: '!',
                                 spacing: Alone,
-                                span: $DIR/macro-rules-derive-cfg.rs:19:25: 19:26 (#3),
+                                span: $DIR/macro-rules-derive-cfg.rs:24:6: 24:7 (#0),
                             },
                             Group {
                                 delimiter: Bracket,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "rustc_dummy",
-                                        span: $DIR/macro-rules-derive-cfg.rs:19:48: 19:59 (#3),
+                                        span: $DIR/macro-rules-derive-cfg.rs:24:29: 24:40 (#0),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
                                             Ident {
-                                                ident: "first",
-                                                span: $DIR/macro-rules-derive-cfg.rs:19:60: 19:65 (#3),
+                                                ident: "third",
+                                                span: $DIR/macro-rules-derive-cfg.rs:24:41: 24:46 (#0),
                                             },
                                         ],
-                                        span: $DIR/macro-rules-derive-cfg.rs:19:59: 19:66 (#3),
+                                        span: $DIR/macro-rules-derive-cfg.rs:24:40: 24:47 (#0),
                                     },
                                 ],
-                                span: $DIR/macro-rules-derive-cfg.rs:19:26: 19:68 (#3),
+                                span: $DIR/macro-rules-derive-cfg.rs:24:7: 24:49 (#0),
                             },
                             Punct {
                                 ch: '#',
                                 spacing: Alone,
-                                span: $DIR/macro-rules-derive-cfg.rs:26:13: 26:14 (#0),
+                                span: $DIR/macro-rules-derive-cfg.rs:25:5: 25:6 (#0),
                             },
                             Group {
                                 delimiter: Bracket,
                                 stream: TokenStream [
                                     Ident {
                                         ident: "rustc_dummy",
-                                        span: $DIR/macro-rules-derive-cfg.rs:26:36: 26:47 (#0),
+                                        span: $DIR/macro-rules-derive-cfg.rs:25:28: 25:39 (#0),
                                     },
                                     Group {
                                         delimiter: Parenthesis,
                                         stream: TokenStream [
                                             Ident {
-                                                ident: "second",
-                                                span: $DIR/macro-rules-derive-cfg.rs:26:48: 26:54 (#0),
+                                                ident: "fourth",
+                                                span: $DIR/macro-rules-derive-cfg.rs:25:40: 25:46 (#0),
                                             },
                                         ],
-                                        span: $DIR/macro-rules-derive-cfg.rs:26:47: 26:55 (#0),
+                                        span: $DIR/macro-rules-derive-cfg.rs:25:39: 25:47 (#0),
                                     },
                                 ],
-                                span: $DIR/macro-rules-derive-cfg.rs:26:14: 26:57 (#0),
-                            },
-                            Group {
-                                delimiter: Brace,
-                                stream: TokenStream [
-                                    Punct {
-                                        ch: '#',
-                                        spacing: Joint,
-                                        span: $DIR/macro-rules-derive-cfg.rs:27:5: 27:6 (#0),
-                                    },
-                                    Punct {
-                                        ch: '!',
-                                        spacing: Alone,
-                                        span: $DIR/macro-rules-derive-cfg.rs:27:6: 27:7 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Bracket,
-                                        stream: TokenStream [
-                                            Ident {
-                                                ident: "allow",
-                                                span: $DIR/macro-rules-derive-cfg.rs:27:29: 27:34 (#0),
-                                            },
-                                            Group {
-                                                delimiter: Parenthesis,
-                                                stream: TokenStream [
-                                                    Ident {
-                                                        ident: "unused",
-                                                        span: $DIR/macro-rules-derive-cfg.rs:27:35: 27:41 (#0),
-                                                    },
-                                                ],
-                                                span: $DIR/macro-rules-derive-cfg.rs:27:34: 27:42 (#0),
-                                            },
-                                        ],
-                                        span: $DIR/macro-rules-derive-cfg.rs:27:7: 27:44 (#0),
-                                    },
-                                    Literal {
-                                        kind: Integer,
-                                        symbol: "30",
-                                        suffix: None,
-                                        span: $DIR/macro-rules-derive-cfg.rs:28:5: 28:7 (#0),
-                                    },
-                                ],
-                                span: $DIR/macro-rules-derive-cfg.rs:26:58: 29:2 (#0),
+                                span: $DIR/macro-rules-derive-cfg.rs:25:6: 25:49 (#0),
                             },
                             Punct {
-                                ch: ';',
+                                ch: '#',
                                 spacing: Alone,
-                                span: $DIR/macro-rules-derive-cfg.rs:19:74: 19:75 (#3),
+                                span: $DIR/macro-rules-derive-cfg.rs:25:5: 25:6 (#0),
+                            },
+                            Group {
+                                delimiter: Bracket,
+                                stream: TokenStream [
+                                    Ident {
+                                        ident: "rustc_dummy",
+                                        span: $DIR/macro-rules-derive-cfg.rs:25:28: 25:39 (#0),
+                                    },
+                                    Group {
+                                        delimiter: Parenthesis,
+                                        stream: TokenStream [
+                                            Ident {
+                                                ident: "fourth",
+                                                span: $DIR/macro-rules-derive-cfg.rs:25:40: 25:46 (#0),
+                                            },
+                                        ],
+                                        span: $DIR/macro-rules-derive-cfg.rs:25:39: 25:47 (#0),
+                                    },
+                                ],
+                                span: $DIR/macro-rules-derive-cfg.rs:25:6: 25:49 (#0),
                             },
                             Literal {
                                 kind: Integer,
-                                symbol: "0",
+                                symbol: "30",
                                 suffix: None,
-                                span: $DIR/macro-rules-derive-cfg.rs:20:17: 20:18 (#3),
+                                span: $DIR/macro-rules-derive-cfg.rs:26:5: 26:7 (#0),
                             },
                         ],
-                        span: $DIR/macro-rules-derive-cfg.rs:18:25: 21:14 (#3),
+                        span: $DIR/macro-rules-derive-cfg.rs:23:58: 27:2 (#0),
                     },
                 ],
-                span: $DIR/macro-rules-derive-cfg.rs:18:18: 21:15 (#3),
+                span: $DIR/macro-rules-derive-cfg.rs:18:13: 18:70 (#3),
             },
         ],
-        span: $DIR/macro-rules-derive-cfg.rs:17:20: 22:10 (#3),
+        span: $DIR/macro-rules-derive-cfg.rs:17:19: 19:10 (#3),
+    },
+    Punct {
+        ch: ';',
+        spacing: Alone,
+        span: $DIR/macro-rules-derive-cfg.rs:19:10: 19:11 (#3),
     },
 ]

--- a/tests/ui/proc-macro/macro-rules-derive-cfg.stdout
+++ b/tests/ui/proc-macro/macro-rules-derive-cfg.stdout
@@ -1,11 +1,9 @@
 PRINT-DERIVE INPUT (DISPLAY): struct
 Foo([bool; #[rustc_dummy(first)] #[rustc_dummy(second)]
-{ #![rustc_dummy(third)] #[rustc_dummy(fourth)] #[rustc_dummy(fourth)] 30 }]);
+{ #![rustc_dummy(third)] #[rustc_dummy(fourth)] 30 }]);
 PRINT-DERIVE DEEP-RE-COLLECTED (DISPLAY): struct
 Foo([bool; #[rustc_dummy(first)] #[rustc_dummy(second)]
-{
-    #! [rustc_dummy(third)] #[rustc_dummy(fourth)] #[rustc_dummy(fourth)] 30
-}]);
+{ #! [rustc_dummy(third)] #[rustc_dummy(fourth)] 30 }]);
 PRINT-DERIVE INPUT (DEBUG): TokenStream [
     Ident {
         ident: "struct",
@@ -112,31 +110,6 @@ PRINT-DERIVE INPUT (DEBUG): TokenStream [
                                     },
                                 ],
                                 span: $DIR/macro-rules-derive-cfg.rs:24:7: 24:49 (#0),
-                            },
-                            Punct {
-                                ch: '#',
-                                spacing: Alone,
-                                span: $DIR/macro-rules-derive-cfg.rs:25:5: 25:6 (#0),
-                            },
-                            Group {
-                                delimiter: Bracket,
-                                stream: TokenStream [
-                                    Ident {
-                                        ident: "rustc_dummy",
-                                        span: $DIR/macro-rules-derive-cfg.rs:25:28: 25:39 (#0),
-                                    },
-                                    Group {
-                                        delimiter: Parenthesis,
-                                        stream: TokenStream [
-                                            Ident {
-                                                ident: "fourth",
-                                                span: $DIR/macro-rules-derive-cfg.rs:25:40: 25:46 (#0),
-                                            },
-                                        ],
-                                        span: $DIR/macro-rules-derive-cfg.rs:25:39: 25:47 (#0),
-                                    },
-                                ],
-                                span: $DIR/macro-rules-derive-cfg.rs:25:6: 25:49 (#0),
                             },
                             Punct {
                                 ch: '#',


### PR DESCRIPTION
Double handling of AST nodes can occur in `collect_tokens`. This is when an inner call to `collect_tokens` produces an AST node, and then an outer call to `collect_tokens` produces the same AST node. This can happen in a few places, e.g. expression statements where the statement delegates `HasTokens` and `HasAttrs` to the expression. It will also happen more after #124141.

This PR fixes some double handling cases that cause problems, including #129166.

r? @petrochenkov 