### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -64,6 +64,10 @@ jobs:
       - name: cargo update
         # Remove first line that always just says "Updating crates.io index"
         run: cargo update 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
+      - name: cargo update library
+        run: |
+          echo -e "\nlibrary dependencies:" >> cargo_update.log
+          cargo update --manifest-path library/Cargo.toml 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
       - name: cargo update rustbook
         run: |
           echo -e "\nrustbook dependencies:" >> cargo_update.log
@@ -74,6 +78,7 @@ jobs:
           name: Cargo-lock
           path: |
             Cargo.lock
+            library/Cargo.lock
             src/tools/rustbook/Cargo.lock
           retention-days: 1
       - name: upload cargo-update log artifact for use in PR
@@ -119,7 +124,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git switch --force-create cargo_update
-          git add ./Cargo.lock ./src/tools/rustbook/Cargo.lock
+          git add ./Cargo.lock ./library/Cargo.lock ./src/tools/rustbook/Cargo.lock
           git commit --no-verify --file=commit.txt
 
       - name: push

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de11a9d32db3327f981143bdf699ade4d637c6887b13b97e6e91a9154666963c"
+checksum = "01667f6f40216b9a0b2945e05fed5f1ad0ab6470e69cb9378001e37b1c0668e4"
 dependencies = [
  "object 0.36.2",
 ]

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -20,7 +20,7 @@ use rustc_session::config::{self, DebugInfo};
 use rustc_session::Session;
 use rustc_span::symbol::Symbol;
 use rustc_span::{
-    BytePos, Pos, SourceFile, SourceFileAndLine, SourceFileHash, Span, StableSourceFileId, DUMMY_SP,
+    BytePos, Pos, SourceFile, SourceFileAndLine, SourceFileHash, Span, StableSourceFileId,
 };
 use rustc_target::abi::Size;
 use smallvec::SmallVec;

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -570,7 +570,7 @@ impl<'ll, 'tcx> DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         inlined_at: Option<&'ll DILocation>,
         span: Span,
     ) -> &'ll DILocation {
-        let (line, col) = if span == DUMMY_SP && !self.sess().target.is_like_msvc {
+        let (line, col) = if span.is_dummy() && !self.sess().target.is_like_msvc {
             (0, 0)
         } else {
             let DebugLoc { line, col, .. } = self.lookup_debug_loc(span.lo());

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -570,6 +570,11 @@ impl<'ll, 'tcx> DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         inlined_at: Option<&'ll DILocation>,
         span: Span,
     ) -> &'ll DILocation {
+        // When emitting debugging information, DWARF (i.e. everything but MSVC)
+        // treats line 0 as a magic value meaning that the code could not be
+        // attributed to any line in the source. That's also exactly what dummy
+        // spans are. Make that equivalence here, rather than passing dummy spans
+        // to lookup_debug_loc, which will return line 1 for them.
         let (line, col) = if span.is_dummy() && !self.sess().target.is_like_msvc {
             (0, 0)
         } else {

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # tidy-alphabetical-start
-ar_archive_writer = "0.4.0"
+ar_archive_writer = "0.4.2"
 arrayvec = { version = "0.7", default-features = false }
 bitflags = "2.4.1"
 cc = "1.0.90"

--- a/compiler/rustc_codegen_ssa/src/back/archive.rs
+++ b/compiler/rustc_codegen_ssa/src/back/archive.rs
@@ -108,7 +108,11 @@ pub trait ArchiveBuilderBuilder {
                 &exports,
                 machine,
                 !sess.target.is_like_msvc,
-                /*comdat=*/ false,
+                // Enable compatibility with MSVC's `/WHOLEARCHIVE` flag.
+                // Without this flag a duplicate symbol error would be emitted
+                // when linking a rust staticlib using `/WHOLEARCHIVE`.
+                // See #129020
+                true,
             ) {
                 sess.dcx()
                     .emit_fatal(ErrorCreatingImportLibrary { lib_name, error: error.to_string() });

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -3498,7 +3498,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                 err,
                                 pick.item.def_id,
                                 rcvr.hir_id,
-                                *rcvr_ty,
+                                Some(*rcvr_ty),
                             );
                         if pick.autoderefs == 0 && !trait_in_other_version_found {
                             err.span_label(
@@ -3689,8 +3689,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         if let SelfSource::QPath(ty) = source
             && !valid_out_of_scope_traits.is_empty()
             && let hir::TyKind::Path(path) = ty.kind
-            && let hir::QPath::Resolved(_, path) = path
-            && let Some(def_id) = path.res.opt_def_id()
+            && let hir::QPath::Resolved(..) = path
             && let Some(assoc) = self
                 .tcx
                 .associated_items(valid_out_of_scope_traits[0])
@@ -3700,7 +3699,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             // See if the `Type::function(val)` where `function` wasn't found corresponds to a
             // `Trait` that is imported directly, but `Type` came from a different version of the
             // same crate.
-            let rcvr_ty = self.tcx.type_of(def_id).instantiate_identity();
+
+            let rcvr_ty = self.node_ty_opt(ty.hir_id);
             trait_in_other_version_found = self.detect_and_explain_multiple_crate_versions(
                 err,
                 assoc.def_id,
@@ -4080,7 +4080,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         err: &mut Diag<'_>,
         item_def_id: DefId,
         hir_id: hir::HirId,
-        rcvr_ty: Ty<'_>,
+        rcvr_ty: Option<Ty<'_>>,
     ) -> bool {
         let hir_id = self.tcx.parent_hir_id(hir_id);
         let Some(traits) = self.tcx.in_scope_traits(hir_id) else { return false };
@@ -4110,8 +4110,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut multi_span: MultiSpan = trait_span.into();
         multi_span.push_span_label(trait_span, format!("this is the trait that is needed"));
         let descr = self.tcx.associated_item(item_def_id).descr();
+        let rcvr_ty =
+            rcvr_ty.map(|t| format!("`{t}`")).unwrap_or_else(|| "the receiver".to_string());
         multi_span
-            .push_span_label(item_span, format!("the {descr} is available for `{rcvr_ty}` here"));
+            .push_span_label(item_span, format!("the {descr} is available for {rcvr_ty} here"));
         for (def_id, import_def_id) in candidates {
             if let Some(import_def_id) = import_def_id {
                 multi_span.push_span_label(

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1230,6 +1230,52 @@ impl Thread {
         self.cname().map(|s| unsafe { str::from_utf8_unchecked(s.to_bytes()) })
     }
 
+    /// Consumes the `Thread`, returning a raw pointer.
+    ///
+    /// To avoid a memory leak the pointer must be converted
+    /// back into a `Thread` using [`Thread::from_raw`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(thread_raw)]
+    ///
+    /// use std::thread::{self, Thread};
+    ///
+    /// let thread = thread::current();
+    /// let id = thread.id();
+    /// let ptr = Thread::into_raw(thread);
+    /// unsafe {
+    ///     assert_eq!(Thread::from_raw(ptr).id(), id);
+    /// }
+    /// ```
+    #[unstable(feature = "thread_raw", issue = "97523")]
+    pub fn into_raw(self) -> *const () {
+        Arc::into_raw(Pin::into_inner(self.inner)) as *const ()
+    }
+
+    /// Constructs a `Thread` from a raw pointer.
+    ///
+    /// The raw pointer must have been previously returned
+    /// by a call to [`Thread::into_raw`].
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because improper use may lead
+    /// to memory unsafety, even if the returned `Thread` is never
+    /// accessed.
+    ///
+    /// Creating a `Thread` from a pointer other than one returned
+    /// from [`Thread::into_raw`] is **undefined behavior**.
+    ///
+    /// Calling this function twice on the same raw pointer can lead
+    /// to a double-free if both `Thread` instances are dropped.
+    #[unstable(feature = "thread_raw", issue = "97523")]
+    pub unsafe fn from_raw(ptr: *const ()) -> Thread {
+        // SAFETY: upheld by caller
+        unsafe { Thread { inner: Pin::new_unchecked(Arc::from_raw(ptr as *const Inner)) } }
+    }
+
     fn cname(&self) -> Option<&CStr> {
         self.inner.name.as_deref()
     }

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1547,10 +1547,23 @@ instead, we check that it's not a "finger" cursor.
 	margin-left: 24px;
 }
 
+@keyframes targetfadein {
+	from {
+		background-color: var(--main-background-color);
+	}
+	10% {
+		background-color: var(--target-border-color);
+	}
+	to {
+		background-color: var(--target-background-color);
+	}
+}
+
 :target {
 	padding-right: 3px;
 	background-color: var(--target-background-color);
 	border-right: 3px solid var(--target-border-color);
+	animation: 0.65s cubic-bezier(0, 0, 0.1, 1.0) 0.1s targetfadein;
 }
 
 .code-header a.tooltip {

--- a/tests/debuginfo/dummy_span.rs
+++ b/tests/debuginfo/dummy_span.rs
@@ -1,0 +1,45 @@
+//@ min-lldb-version: 310
+
+//@ compile-flags:-g
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run 7
+
+// gdb-command:next
+// gdb-command:next
+// gdb-check:[...]#loc1[...]
+// gdb-command:next
+// gdb-check:[...]#loc2[...]
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run 7
+
+// lldb-command:next
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#loc1[...]
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#loc2[...]
+
+use std::env;
+use std::num::ParseIntError;
+
+fn main() -> Result<(), ParseIntError> {
+    let args = env::args();
+    let number_str = args.skip(1).next().unwrap();
+    let number = number_str.parse::<i32>()?;
+    zzz(); // #break
+    if number % 7 == 0 {
+        // This generates code with a dummy span for
+        // some reason. If that ever changes this
+        // test will not test what it wants to test.
+        return Ok(()); // #loc1
+    }
+    println!("{}", number);
+    Ok(())
+} // #loc2
+
+fn zzz() { () }

--- a/tests/run-make/msvc-wholearchive/c.c
+++ b/tests/run-make/msvc-wholearchive/c.c
@@ -1,0 +1,1 @@
+// This page is intentionally left blank

--- a/tests/run-make/msvc-wholearchive/dll.def
+++ b/tests/run-make/msvc-wholearchive/dll.def
@@ -1,0 +1,4 @@
+LIBRARY dll
+EXPORTS
+        hello
+        number

--- a/tests/run-make/msvc-wholearchive/rmake.rs
+++ b/tests/run-make/msvc-wholearchive/rmake.rs
@@ -1,0 +1,52 @@
+//! This is a regression test for #129020
+//! It ensures we can use `/WHOLEARCHIVE` to link a rust staticlib into DLL
+//! using the MSVC linker
+
+//@ only-msvc
+// Reason: this is testing the MSVC linker
+
+use std::path::PathBuf;
+
+use run_make_support::{cc, cmd, env_var, extra_c_flags, rustc};
+
+fn main() {
+    // Build the staticlib
+    rustc().crate_type("staticlib").input("static.rs").output("static.lib").run();
+    // Build an empty object to pass to the linker.
+    cc().input("c.c").output("c.obj").args(["-c"]).run();
+
+    // Find the C toolchain's linker.
+    let mut linker = PathBuf::from(env_var("CC"));
+    let linker_flavour = if linker.file_stem().is_some_and(|s| s == "cl") {
+        linker.set_file_name("link.exe");
+        "msvc"
+    } else if linker.file_stem().is_some_and(|s| s == "clang-cl") {
+        linker.set_file_name("lld-link.exe");
+        "llvm"
+    } else {
+        panic!("unknown C toolchain");
+    };
+
+    // As a sanity check, make sure this works without /WHOLEARCHIVE.
+    // Otherwise the actual test failure may be caused by something else.
+    cmd(&linker)
+        .args(["c.obj", "./static.lib", "-dll", "-def:dll.def", "-out:dll.dll"])
+        .args(extra_c_flags())
+        .run();
+
+    // FIXME(@ChrisDenton): this doesn't currently work with llvm's lld-link for other reasons.
+    // May need LLVM patches.
+    if linker_flavour == "msvc" {
+        // Link in the staticlib using `/WHOLEARCHIVE` and produce a DLL.
+        cmd(&linker)
+            .args([
+                "c.obj",
+                "-WHOLEARCHIVE:./static.lib",
+                "-dll",
+                "-def:dll.def",
+                "-out:dll_whole_archive.dll",
+            ])
+            .args(extra_c_flags())
+            .run();
+    }
+}

--- a/tests/run-make/msvc-wholearchive/static.rs
+++ b/tests/run-make/msvc-wholearchive/static.rs
@@ -1,0 +1,9 @@
+#[no_mangle]
+pub extern "C" fn hello() {
+    println!("Hello world!");
+}
+
+#[no_mangle]
+pub extern "C" fn number() -> u32 {
+    42
+}

--- a/tests/rustdoc-gui/target.goml
+++ b/tests/rustdoc-gui/target.goml
@@ -11,7 +11,7 @@ define-function: (
     [theme, background, border],
     block {
         call-function: ("switch-theme", {"theme": |theme|})
-        assert-css: ("#method\.a_method:target", {
+        wait-for-css: ("#method\.a_method:target", {
             "background-color": |background|,
             "border-right": "3px solid " + |border|,
         })

--- a/tests/ui/consts/const-float-bits-conv.rs
+++ b/tests/ui/consts/const-float-bits-conv.rs
@@ -29,6 +29,7 @@ fn has_broken_floats() -> bool {
     std::env::var("TARGET").is_ok_and(|v| v.contains("i586"))
 }
 
+#[cfg(target_arch = "x86_64")]
 fn f16(){
     const_assert!((1f16).to_bits(), 0x3c00);
     const_assert!(u16::from_be_bytes(1f16.to_be_bytes()), 0x3c00);
@@ -119,6 +120,7 @@ fn f64() {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 fn f128() {
     const_assert!((1f128).to_bits(), 0x3fff0000000000000000000000000000);
     const_assert!(u128::from_be_bytes(1f128.to_be_bytes()), 0x3fff0000000000000000000000000000);
@@ -150,8 +152,11 @@ fn f128() {
 }
 
 fn main() {
-    f16();
+    #[cfg(target_arch = "x86_64")]
+    {
+        f16();
+        f128();
+    }
     f32();
     f64();
-    f128();
 }

--- a/tests/ui/consts/const-float-bits-conv.rs
+++ b/tests/ui/consts/const-float-bits-conv.rs
@@ -3,8 +3,9 @@
 
 #![feature(const_float_bits_conv)]
 #![feature(const_float_classify)]
+#![feature(f16)]
+#![feature(f128)]
 #![allow(unused_macro_rules)]
-
 // Don't promote
 const fn nop<T>(x: T) -> T { x }
 
@@ -26,6 +27,36 @@ macro_rules! const_assert {
 fn has_broken_floats() -> bool {
     // i586 targets are broken due to <https://github.com/rust-lang/rust/issues/114479>.
     std::env::var("TARGET").is_ok_and(|v| v.contains("i586"))
+}
+
+fn f16(){
+    const_assert!((1f16).to_bits(), 0x3c00);
+    const_assert!(u16::from_be_bytes(1f16.to_be_bytes()), 0x3c00);
+    const_assert!((12.5f16).to_bits(), 0x4a40);
+    const_assert!(u16::from_le_bytes(12.5f16.to_le_bytes()), 0x4a40);
+    const_assert!((1337f16).to_bits(), 0x6539);
+    const_assert!(u16::from_ne_bytes(1337f16.to_ne_bytes()), 0x6539);
+    const_assert!((-14.25f16).to_bits(), 0xcb20);
+    const_assert!(f16::from_bits(0x3c00), 1.0);
+    const_assert!(f16::from_be_bytes(0x3c00u16.to_be_bytes()), 1.0);
+    const_assert!(f16::from_bits(0x4a40), 12.5);
+    const_assert!(f16::from_le_bytes(0x4a40u16.to_le_bytes()), 12.5);
+    const_assert!(f16::from_bits(0x5be0), 252.0);
+    const_assert!(f16::from_ne_bytes(0x5be0u16.to_ne_bytes()), 252.0);
+    const_assert!(f16::from_bits(0xcb20), -14.25);
+
+    // Check that NaNs roundtrip their bits regardless of signalingness
+    // 0xA is 0b1010; 0x5 is 0b0101 -- so these two together clobbers all the mantissa bits
+    // NOTE: These names assume `f{BITS}::NAN` is a quiet NAN and IEEE754-2008's NaN rules apply!
+    const QUIET_NAN: u16 = f16::NAN.to_bits() ^ 0x0155;
+    const SIGNALING_NAN: u16 = f16::NAN.to_bits() ^ 0x02AA;
+
+    const_assert!(f16::from_bits(QUIET_NAN).is_nan());
+    const_assert!(f16::from_bits(SIGNALING_NAN).is_nan());
+    const_assert!(f16::from_bits(QUIET_NAN).to_bits(), QUIET_NAN);
+    if !has_broken_floats() {
+        const_assert!(f16::from_bits(SIGNALING_NAN).to_bits(), SIGNALING_NAN);
+    }
 }
 
 fn f32() {
@@ -88,7 +119,39 @@ fn f64() {
     }
 }
 
+fn f128() {
+    const_assert!((1f128).to_bits(), 0x3fff0000000000000000000000000000);
+    const_assert!(u128::from_be_bytes(1f128.to_be_bytes()), 0x3fff0000000000000000000000000000);
+    const_assert!((12.5f128).to_bits(), 0x40029000000000000000000000000000);
+    const_assert!(u128::from_le_bytes(12.5f128.to_le_bytes()), 0x40029000000000000000000000000000);
+    const_assert!((1337f128).to_bits(), 0x40094e40000000000000000000000000);
+    const_assert!(u128::from_ne_bytes(1337f128.to_ne_bytes()), 0x40094e40000000000000000000000000);
+    const_assert!((-14.25f128).to_bits(), 0xc002c800000000000000000000000000);
+    const_assert!(f128::from_bits(0x3fff0000000000000000000000000000), 1.0);
+    const_assert!(f128::from_be_bytes(0x3fff0000000000000000000000000000u128.to_be_bytes()), 1.0);
+    const_assert!(f128::from_bits(0x40029000000000000000000000000000), 12.5);
+    const_assert!(f128::from_le_bytes(0x40029000000000000000000000000000u128.to_le_bytes()), 12.5);
+    const_assert!(f128::from_bits(0x40094e40000000000000000000000000), 1337.0);
+    assert_eq!(f128::from_ne_bytes(0x40094e40000000000000000000000000u128.to_ne_bytes()), 1337.0);
+    const_assert!(f128::from_bits(0xc002c800000000000000000000000000), -14.25);
+
+    // Check that NaNs roundtrip their bits regardless of signalingness
+    // 0xA is 0b1010; 0x5 is 0b0101 -- so these two together clobbers all the mantissa bits
+    // NOTE: These names assume `f{BITS}::NAN` is a quiet NAN and IEEE754-2008's NaN rules apply!
+    const QUIET_NAN: u128 = f128::NAN.to_bits() | 0x0000_AAAA_AAAA_AAAA_AAAA_AAAA_AAAA_AAAA;
+    const SIGNALING_NAN: u128 = f128::NAN.to_bits() ^ 0x0000_5555_5555_5555_5555_5555_5555_5555;
+
+    const_assert!(f128::from_bits(QUIET_NAN).is_nan());
+    const_assert!(f128::from_bits(SIGNALING_NAN).is_nan());
+    const_assert!(f128::from_bits(QUIET_NAN).to_bits(), QUIET_NAN);
+    if !has_broken_floats() {
+        const_assert!(f128::from_bits(SIGNALING_NAN).to_bits(), SIGNALING_NAN);
+    }
+}
+
 fn main() {
+    f16();
     f32();
     f64();
+    f128();
 }

--- a/tests/ui/methods/missing-method-on-type-parameter.rs
+++ b/tests/ui/methods/missing-method-on-type-parameter.rs
@@ -1,0 +1,6 @@
+// Regression test for https://github.com/rust-lang/rust/issues/129205
+fn x<T: Copy>() {
+    T::try_from(); //~ ERROR E0599
+}
+
+fn main() {}

--- a/tests/ui/methods/missing-method-on-type-parameter.stderr
+++ b/tests/ui/methods/missing-method-on-type-parameter.stderr
@@ -1,0 +1,19 @@
+error[E0599]: no function or associated item named `try_from` found for type parameter `T` in the current scope
+  --> $DIR/missing-method-on-type-parameter.rs:3:8
+   |
+LL | fn x<T: Copy>() {
+   |      - function or associated item `try_from` not found for this type parameter
+LL |     T::try_from();
+   |        ^^^^^^^^ function or associated item not found in `T`
+   |
+   = help: items from traits can only be used if the trait is in scope
+help: there is an associated function `from` with a similar name
+  --> $SRC_DIR/core/src/convert/mod.rs:LL:COL
+help: trait `TryFrom` which provides `try_from` is implemented but not in scope; perhaps you want to import it
+   |
+LL + use std::convert::TryFrom;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Successful merges:

 - #97524 (Add `Thread::{into_raw, from_raw}`)
 - #128627 (Special case DUMMY_SP to emit line 0/column 0 locations on DWARF platforms.)
 - #129190 (Added f16 and f128 to tests/ui/consts/const-float-bits-conv.rs)
 - #129250 (Do not ICE on non-ADT rcvr type when looking for crate version collision)
 - #129257 (Allow rust staticlib to work with MSVC's /WHOLEARCHIVE)
 - #129264 (Update `library/Cargo.toml` in weekly job)
 - #129284 (rustdoc: animate the `:target` highlight)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=97524,128627,129190,129250,129257,129264,129284)
<!-- homu-ignore:end -->