### PR TITLE
Rollup of 10 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -86,9 +86,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                                 // Multiple different abi names may actually be the same ABI
                                 // If the specified ABIs are not the same name, alert the user that they resolve to the same ABI
                                 let source_map = self.tcx.sess.source_map();
-                                let equivalent = (source_map.span_to_snippet(*prev_sp)
-                                    != source_map.span_to_snippet(*abi_span))
-                                .then_some(());
+                                let equivalent = source_map.span_to_snippet(*prev_sp)
+                                    != source_map.span_to_snippet(*abi_span);
 
                                 self.dcx().emit_err(AbiSpecifiedMultipleTimes {
                                     abi_span: *abi_span,

--- a/compiler/rustc_ast_lowering/src/errors.rs
+++ b/compiler/rustc_ast_lowering/src/errors.rs
@@ -184,7 +184,7 @@ pub struct AbiSpecifiedMultipleTimes {
     #[label]
     pub prev_span: Span,
     #[note]
-    pub equivalent: Option<()>,
+    pub equivalent: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1421,7 +1421,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         };
         hir::FnHeader {
             safety: self.lower_safety(h.safety, default_safety),
-            asyncness: asyncness,
+            asyncness,
             constness: self.lower_constness(h.constness),
             abi: self.lower_extern(h.ext),
         }

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -963,14 +963,13 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 self_ty,
                 items,
             }) => {
-                let error =
-                    |annotation_span, annotation, only_trait: bool| errors::InherentImplCannot {
-                        span: self_ty.span,
-                        annotation_span,
-                        annotation,
-                        self_ty: self_ty.span,
-                        only_trait: only_trait.then_some(()),
-                    };
+                let error = |annotation_span, annotation, only_trait| errors::InherentImplCannot {
+                    span: self_ty.span,
+                    annotation_span,
+                    annotation,
+                    self_ty: self_ty.span,
+                    only_trait,
+                };
 
                 self.with_in_trait_impl(None, |this| {
                     this.visibility_not_permitted(
@@ -1195,7 +1194,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 } else if where_clauses.after.has_where_token {
                     self.dcx().emit_err(errors::WhereClauseAfterTypeAlias {
                         span: where_clauses.after.span,
-                        help: self.session.is_nightly_build().then_some(()),
+                        help: self.session.is_nightly_build(),
                     });
                 }
             }

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -562,10 +562,8 @@ impl<'a> AstValidator<'a> {
         FnHeader { safety: _, coroutine_kind, constness, ext }: FnHeader,
     ) {
         let report_err = |span| {
-            self.dcx().emit_err(errors::FnQualifierInExtern {
-                span: span,
-                block: self.current_extern_span(),
-            });
+            self.dcx()
+                .emit_err(errors::FnQualifierInExtern { span, block: self.current_extern_span() });
         };
         match coroutine_kind {
             Some(knd) => report_err(knd.span()),

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -484,7 +484,7 @@ pub struct InherentImplCannot<'a> {
     #[label(ast_passes_type)]
     pub self_ty: Span,
     #[note(ast_passes_only_trait)]
-    pub only_trait: Option<()>,
+    pub only_trait: bool,
 }
 
 #[derive(Diagnostic)]
@@ -528,7 +528,7 @@ pub struct WhereClauseAfterTypeAlias {
     #[primary_span]
     pub span: Span,
     #[help]
-    pub help: Option<()>,
+    pub help: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -846,7 +846,7 @@ pub fn find_deprecation(
                                     sess.dcx().emit_err(
                                         session_diagnostics::DeprecatedItemSuggestion {
                                             span: mi.span,
-                                            is_nightly: sess.is_nightly_build().then_some(()),
+                                            is_nightly: sess.is_nightly_build(),
                                             details: (),
                                         },
                                     );

--- a/compiler/rustc_attr/src/session_diagnostics.rs
+++ b/compiler/rustc_attr/src/session_diagnostics.rs
@@ -342,7 +342,7 @@ pub(crate) struct DeprecatedItemSuggestion {
     pub span: Span,
 
     #[help]
-    pub is_nightly: Option<()>,
+    pub is_nightly: bool,
 
     #[note]
     pub details: (),

--- a/compiler/rustc_codegen_llvm/src/allocator.rs
+++ b/compiler/rustc_codegen_llvm/src/allocator.rs
@@ -149,7 +149,7 @@ fn create_wrapper_function(
         }
         llvm::LLVMRustSetVisibility(callee, llvm::Visibility::Hidden);
 
-        let llbb = llvm::LLVMAppendBasicBlockInContext(llcx, llfn, c"entry".as_ptr().cast());
+        let llbb = llvm::LLVMAppendBasicBlockInContext(llcx, llfn, c"entry".as_ptr());
 
         let llbuilder = llvm::LLVMCreateBuilderInContext(llcx);
         llvm::LLVMPositionBuilderAtEnd(llbuilder, llbb);

--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -616,7 +616,7 @@ pub(crate) fn run_pass_manager(
             llvm::LLVMRustAddModuleFlagU32(
                 module.module_llvm.llmod(),
                 llvm::LLVMModFlagBehavior::Error,
-                c"LTOPostLink".as_ptr().cast(),
+                c"LTOPostLink".as_ptr(),
                 1,
             );
         }

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -1031,7 +1031,7 @@ unsafe fn embed_bitcode(
             let llglobal = llvm::LLVMAddGlobal(
                 llmod,
                 common::val_ty(llconst),
-                c"rustc.embedded.module".as_ptr().cast(),
+                c"rustc.embedded.module".as_ptr(),
             );
             llvm::LLVMSetInitializer(llglobal, llconst);
 
@@ -1044,7 +1044,7 @@ unsafe fn embed_bitcode(
             let llglobal = llvm::LLVMAddGlobal(
                 llmod,
                 common::val_ty(llconst),
-                c"rustc.embedded.cmdline".as_ptr().cast(),
+                c"rustc.embedded.cmdline".as_ptr(),
             );
             llvm::LLVMSetInitializer(llglobal, llconst);
             let section = if is_apple {
@@ -1054,7 +1054,7 @@ unsafe fn embed_bitcode(
             } else {
                 c".llvmcmd"
             };
-            llvm::LLVMSetSection(llglobal, section.as_ptr().cast());
+            llvm::LLVMSetSection(llglobal, section.as_ptr());
             llvm::LLVMRustSetLinkage(llglobal, llvm::Linkage::PrivateLinkage);
         } else {
             // We need custom section flags, so emit module-level inline assembly.
@@ -1107,7 +1107,7 @@ fn create_msvc_imps(
             .collect::<Vec<_>>();
 
         for (imp_name, val) in globals {
-            let imp = llvm::LLVMAddGlobal(llmod, ptr_ty, imp_name.as_ptr().cast());
+            let imp = llvm::LLVMAddGlobal(llmod, ptr_ty, imp_name.as_ptr());
             llvm::LLVMSetInitializer(imp, val);
             llvm::LLVMRustSetLinkage(imp, llvm::Linkage::ExternalLinkage);
         }

--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -525,7 +525,7 @@ impl<'ll> CodegenCx<'ll, '_> {
                     let val = llvm::LLVMMetadataAsValue(self.llcx, meta);
                     llvm::LLVMAddNamedMetadataOperand(
                         self.llmod,
-                        c"wasm.custom_sections".as_ptr().cast(),
+                        c"wasm.custom_sections".as_ptr(),
                         val,
                     );
                 }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -207,7 +207,7 @@ pub unsafe fn create_module<'ll>(
     // If skipping the PLT is enabled, we need to add some module metadata
     // to ensure intrinsic calls don't use it.
     if !sess.needs_plt() {
-        let avoid_plt = c"RtLibUseGOT".as_ptr().cast();
+        let avoid_plt = c"RtLibUseGOT".as_ptr();
         unsafe {
             llvm::LLVMRustAddModuleFlagU32(llmod, llvm::LLVMModFlagBehavior::Warning, avoid_plt, 1);
         }
@@ -215,7 +215,7 @@ pub unsafe fn create_module<'ll>(
 
     // Enable canonical jump tables if CFI is enabled. (See https://reviews.llvm.org/D65629.)
     if sess.is_sanitizer_cfi_canonical_jump_tables_enabled() && sess.is_sanitizer_cfi_enabled() {
-        let canonical_jump_tables = c"CFI Canonical Jump Tables".as_ptr().cast();
+        let canonical_jump_tables = c"CFI Canonical Jump Tables".as_ptr();
         unsafe {
             llvm::LLVMRustAddModuleFlagU32(
                 llmod,
@@ -228,7 +228,7 @@ pub unsafe fn create_module<'ll>(
 
     // Enable LTO unit splitting if specified or if CFI is enabled. (See https://reviews.llvm.org/D53891.)
     if sess.is_split_lto_unit_enabled() || sess.is_sanitizer_cfi_enabled() {
-        let enable_split_lto_unit = c"EnableSplitLTOUnit".as_ptr().cast();
+        let enable_split_lto_unit = c"EnableSplitLTOUnit".as_ptr();
         unsafe {
             llvm::LLVMRustAddModuleFlagU32(
                 llmod,
@@ -241,7 +241,7 @@ pub unsafe fn create_module<'ll>(
 
     // Add "kcfi" module flag if KCFI is enabled. (See https://reviews.llvm.org/D119296.)
     if sess.is_sanitizer_kcfi_enabled() {
-        let kcfi = c"kcfi".as_ptr().cast();
+        let kcfi = c"kcfi".as_ptr();
         unsafe {
             llvm::LLVMRustAddModuleFlagU32(llmod, llvm::LLVMModFlagBehavior::Override, kcfi, 1);
         }
@@ -280,26 +280,26 @@ pub unsafe fn create_module<'ll>(
                 llvm::LLVMRustAddModuleFlagU32(
                     llmod,
                     llvm::LLVMModFlagBehavior::Min,
-                    c"branch-target-enforcement".as_ptr().cast(),
+                    c"branch-target-enforcement".as_ptr(),
                     bti.into(),
                 );
                 llvm::LLVMRustAddModuleFlagU32(
                     llmod,
                     llvm::LLVMModFlagBehavior::Min,
-                    c"sign-return-address".as_ptr().cast(),
+                    c"sign-return-address".as_ptr(),
                     pac_ret.is_some().into(),
                 );
                 let pac_opts = pac_ret.unwrap_or(PacRet { leaf: false, key: PAuthKey::A });
                 llvm::LLVMRustAddModuleFlagU32(
                     llmod,
                     llvm::LLVMModFlagBehavior::Min,
-                    c"sign-return-address-all".as_ptr().cast(),
+                    c"sign-return-address-all".as_ptr(),
                     pac_opts.leaf.into(),
                 );
                 llvm::LLVMRustAddModuleFlagU32(
                     llmod,
                     llvm::LLVMModFlagBehavior::Min,
-                    c"sign-return-address-with-bkey".as_ptr().cast(),
+                    c"sign-return-address-with-bkey".as_ptr(),
                     u32::from(pac_opts.key == PAuthKey::B),
                 );
             }
@@ -317,7 +317,7 @@ pub unsafe fn create_module<'ll>(
             llvm::LLVMRustAddModuleFlagU32(
                 llmod,
                 llvm::LLVMModFlagBehavior::Override,
-                c"cf-protection-branch".as_ptr().cast(),
+                c"cf-protection-branch".as_ptr(),
                 1,
             );
         }
@@ -327,7 +327,7 @@ pub unsafe fn create_module<'ll>(
             llvm::LLVMRustAddModuleFlagU32(
                 llmod,
                 llvm::LLVMModFlagBehavior::Override,
-                c"cf-protection-return".as_ptr().cast(),
+                c"cf-protection-return".as_ptr(),
                 1,
             );
         }
@@ -338,7 +338,7 @@ pub unsafe fn create_module<'ll>(
             llvm::LLVMRustAddModuleFlagU32(
                 llmod,
                 llvm::LLVMModFlagBehavior::Error,
-                c"Virtual Function Elim".as_ptr().cast(),
+                c"Virtual Function Elim".as_ptr(),
                 1,
             );
         }

--- a/compiler/rustc_codegen_llvm/src/debuginfo/gdb.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/gdb.rs
@@ -34,8 +34,7 @@ pub fn get_or_insert_gdb_debug_scripts_section_global<'ll>(cx: &CodegenCx<'ll, '
     let c_section_var_name = c"__rustc_debug_gdb_scripts_section__";
     let section_var_name = c_section_var_name.to_str().unwrap();
 
-    let section_var =
-        unsafe { llvm::LLVMGetNamedGlobal(cx.llmod, c_section_var_name.as_ptr().cast()) };
+    let section_var = unsafe { llvm::LLVMGetNamedGlobal(cx.llmod, c_section_var_name.as_ptr()) };
 
     section_var.unwrap_or_else(|| {
         let mut section_contents = Vec::new();
@@ -70,7 +69,7 @@ pub fn get_or_insert_gdb_debug_scripts_section_global<'ll>(cx: &CodegenCx<'ll, '
             let section_var = cx
                 .define_global(section_var_name, llvm_type)
                 .unwrap_or_else(|| bug!("symbol `{}` is already defined", section_var_name));
-            llvm::LLVMSetSection(section_var, c".debug_gdb_scripts".as_ptr().cast());
+            llvm::LLVMSetSection(section_var, c".debug_gdb_scripts".as_ptr());
             llvm::LLVMSetInitializer(section_var, cx.const_bytes(section_contents));
             llvm::LLVMSetGlobalConstant(section_var, llvm::True);
             llvm::LLVMSetUnnamedAddress(section_var, llvm::UnnamedAddr::Global);

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -952,7 +952,7 @@ pub fn build_compile_unit_di_node<'ll, 'tcx>(
             producer.as_ptr().cast(),
             producer.len(),
             tcx.sess.opts.optimize != config::OptLevel::No,
-            c"".as_ptr().cast(),
+            c"".as_ptr(),
             0,
             // NB: this doesn't actually have any perceptible effect, it seems. LLVM will instead
             // put the path supplied to `MCSplitDwarfFile` into the debug info of the final

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -20,7 +20,7 @@ use rustc_session::config::{self, DebugInfo};
 use rustc_session::Session;
 use rustc_span::symbol::Symbol;
 use rustc_span::{
-    BytePos, Pos, SourceFile, SourceFileAndLine, SourceFileHash, Span, StableSourceFileId, DUMMY_SP,
+    BytePos, Pos, SourceFile, SourceFileAndLine, SourceFileHash, Span, StableSourceFileId,
 };
 use rustc_target::abi::Size;
 use smallvec::SmallVec;

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -109,7 +109,7 @@ impl<'ll, 'tcx> CodegenUnitDebugContext<'ll, 'tcx> {
                 llvm::LLVMRustAddModuleFlagU32(
                     self.llmod,
                     llvm::LLVMModFlagBehavior::Warning,
-                    c"Dwarf Version".as_ptr().cast(),
+                    c"Dwarf Version".as_ptr(),
                     dwarf_version,
                 );
             } else {
@@ -117,7 +117,7 @@ impl<'ll, 'tcx> CodegenUnitDebugContext<'ll, 'tcx> {
                 llvm::LLVMRustAddModuleFlagU32(
                     self.llmod,
                     llvm::LLVMModFlagBehavior::Warning,
-                    c"CodeView".as_ptr().cast(),
+                    c"CodeView".as_ptr(),
                     1,
                 )
             }
@@ -126,7 +126,7 @@ impl<'ll, 'tcx> CodegenUnitDebugContext<'ll, 'tcx> {
             llvm::LLVMRustAddModuleFlagU32(
                 self.llmod,
                 llvm::LLVMModFlagBehavior::Warning,
-                c"Debug Info Version".as_ptr().cast(),
+                c"Debug Info Version".as_ptr(),
                 llvm::LLVMRustDebugMetadataVersion(),
             );
         }

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -570,7 +570,7 @@ impl<'ll, 'tcx> DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         inlined_at: Option<&'ll DILocation>,
         span: Span,
     ) -> &'ll DILocation {
-        let (line, col) = if span == DUMMY_SP && !self.sess().target.is_like_msvc {
+        let (line, col) = if span.is_dummy() && !self.sess().target.is_like_msvc {
             (0, 0)
         } else {
             let DebugLoc { line, col, .. } = self.lookup_debug_loc(span.lo());

--- a/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/mod.rs
@@ -570,6 +570,11 @@ impl<'ll, 'tcx> DebugInfoMethods<'tcx> for CodegenCx<'ll, 'tcx> {
         inlined_at: Option<&'ll DILocation>,
         span: Span,
     ) -> &'ll DILocation {
+        // When emitting debugging information, DWARF (i.e. everything but MSVC)
+        // treats line 0 as a magic value meaning that the code could not be
+        // attributed to any line in the source. That's also exactly what dummy
+        // spans are. Make that equivalence here, rather than passing dummy spans
+        // to lookup_debug_loc, which will return line 1 for them.
         let (line, col) = if span.is_dummy() && !self.sess().target.is_like_msvc {
             (0, 0)
         } else {

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1500,7 +1500,7 @@ impl<'a> Linker for L4Bender<'a> {
 
 impl<'a> L4Bender<'a> {
     pub fn new(cmd: Command, sess: &'a Session) -> L4Bender<'a> {
-        L4Bender { cmd, sess: sess, hinted_static: false }
+        L4Bender { cmd, sess, hinted_static: false }
     }
 
     fn hint_static(&mut self) {
@@ -1520,7 +1520,7 @@ pub struct AixLinker<'a> {
 
 impl<'a> AixLinker<'a> {
     pub fn new(cmd: Command, sess: &'a Session) -> AixLinker<'a> {
-        AixLinker { cmd, sess: sess, hinted_static: None }
+        AixLinker { cmd, sess, hinted_static: None }
     }
 
     fn hint_static(&mut self) {

--- a/compiler/rustc_const_eval/src/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/check_consts/ops.rs
@@ -384,7 +384,7 @@ impl<'tcx> NonConstOp<'tcx> for HeapAllocation {
         ccx.dcx().create_err(errors::UnallowedHeapAllocations {
             span,
             kind: ccx.const_kind(),
-            teach: ccx.tcx.sess.teach(E0010).then_some(()),
+            teach: ccx.tcx.sess.teach(E0010),
         })
     }
 }
@@ -444,16 +444,16 @@ impl<'tcx> NonConstOp<'tcx> for CellBorrow {
         if let hir::ConstContext::Static(_) = ccx.const_kind() {
             ccx.dcx().create_err(errors::InteriorMutableDataRefer {
                 span,
-                opt_help: Some(()),
+                opt_help: true,
                 kind: ccx.const_kind(),
-                teach: ccx.tcx.sess.teach(E0492).then_some(()),
+                teach: ccx.tcx.sess.teach(E0492),
             })
         } else {
             ccx.dcx().create_err(errors::InteriorMutableDataRefer {
                 span,
-                opt_help: None,
+                opt_help: false,
                 kind: ccx.const_kind(),
-                teach: ccx.tcx.sess.teach(E0492).then_some(()),
+                teach: ccx.tcx.sess.teach(E0492),
             })
         }
     }
@@ -481,12 +481,12 @@ impl<'tcx> NonConstOp<'tcx> for MutBorrow {
             hir::BorrowKind::Raw => ccx.tcx.dcx().create_err(errors::UnallowedMutableRaw {
                 span,
                 kind: ccx.const_kind(),
-                teach: ccx.tcx.sess.teach(E0764).then_some(()),
+                teach: ccx.tcx.sess.teach(E0764),
             }),
             hir::BorrowKind::Ref => ccx.dcx().create_err(errors::UnallowedMutableRefs {
                 span,
                 kind: ccx.const_kind(),
-                teach: ccx.tcx.sess.teach(E0764).then_some(()),
+                teach: ccx.tcx.sess.teach(E0764),
             }),
         }
     }

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -151,7 +151,7 @@ pub(crate) struct UnallowedMutableRefs {
     pub span: Span,
     pub kind: ConstContext,
     #[note(const_eval_teach_note)]
-    pub teach: Option<()>,
+    pub teach: bool,
 }
 
 #[derive(Diagnostic)]
@@ -161,7 +161,7 @@ pub(crate) struct UnallowedMutableRaw {
     pub span: Span,
     pub kind: ConstContext,
     #[note(const_eval_teach_note)]
-    pub teach: Option<()>,
+    pub teach: bool,
 }
 #[derive(Diagnostic)]
 #[diag(const_eval_non_const_fmt_macro_call, code = E0015)]
@@ -196,7 +196,7 @@ pub(crate) struct UnallowedHeapAllocations {
     pub span: Span,
     pub kind: ConstContext,
     #[note(const_eval_teach_note)]
-    pub teach: Option<()>,
+    pub teach: bool,
 }
 
 #[derive(Diagnostic)]
@@ -214,10 +214,10 @@ pub(crate) struct InteriorMutableDataRefer {
     #[label]
     pub span: Span,
     #[help]
-    pub opt_help: Option<()>,
+    pub opt_help: bool,
     pub kind: ConstContext,
     #[note(const_eval_teach_note)]
-    pub teach: Option<()>,
+    pub teach: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -281,7 +281,7 @@ pub(crate) struct IncompleteParse<'a> {
     pub macro_path: &'a ast::Path,
     pub kind_name: &'a str,
     #[note(expand_macro_expands_to_match_arm)]
-    pub expands_to_match_arm: Option<()>,
+    pub expands_to_match_arm: bool,
 
     #[suggestion(
         expand_suggestion_add_semi,

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -1031,7 +1031,7 @@ pub(crate) fn ensure_complete_parse<'a>(
             label_span: span,
             macro_path,
             kind_name,
-            expands_to_match_arm: expands_to_match_arm.then_some(()),
+            expands_to_match_arm,
             add_semicolon,
         });
     }

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1564,7 +1564,7 @@ fn check_type_alias_type_params_are_used<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalD
             // * compare the param span to the pred span to detect lone user-written `Sized` bounds
             let has_explicit_bounds = bounded_params.is_empty()
                 || (*bounded_params).get(&param.index).is_some_and(|&&pred_sp| pred_sp != span);
-            let const_param_help = (!has_explicit_bounds).then_some(());
+            let const_param_help = !has_explicit_bounds;
 
             let mut diag = tcx.dcx().create_err(errors::UnusedGenericParameter {
                 span,

--- a/compiler/rustc_hir_analysis/src/check/entry.rs
+++ b/compiler/rustc_hir_analysis/src/check/entry.rs
@@ -216,7 +216,7 @@ fn check_start_fn_ty(tcx: TyCtxt<'_>, start_def_id: DefId) {
                     }
                     if sig.header.asyncness.is_async() {
                         let span = tcx.def_span(it.owner_id);
-                        tcx.dcx().emit_err(errors::StartAsync { span: span });
+                        tcx.dcx().emit_err(errors::StartAsync { span });
                         error = true;
                     }
 

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1972,8 +1972,7 @@ fn report_bivariance<'tcx>(
     }
 
     let const_param_help =
-        matches!(param.kind, hir::GenericParamKind::Type { .. } if !has_explicit_bounds)
-            .then_some(());
+        matches!(param.kind, hir::GenericParamKind::Type { .. } if !has_explicit_bounds);
 
     let mut diag = tcx.dcx().create_err(errors::UnusedGenericParameter {
         span: param.span,

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1606,7 +1606,7 @@ pub(crate) struct UnusedGenericParameter {
     #[subdiagnostic]
     pub help: UnusedGenericParameterHelp,
     #[help(hir_analysis_const_param_help)]
-    pub const_param_help: Option<()>,
+    pub const_param_help: bool,
 }
 
 #[derive(Diagnostic)]
@@ -1643,9 +1643,9 @@ pub(crate) struct UnconstrainedGenericParameter {
     pub param_name: Symbol,
     pub param_def_kind: &'static str,
     #[note(hir_analysis_const_param_note)]
-    pub const_param_note: Option<()>,
+    pub const_param_note: bool,
     #[note(hir_analysis_const_param_note2)]
-    pub const_param_note2: Option<()>,
+    pub const_param_note2: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -959,11 +959,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                      \n    where\n        T: {qself_str},\n{}",
                     where_bounds.join(",\n"),
                 ));
-            }
-            let reported = err.emit();
-            if !where_bounds.is_empty() {
+                let reported = err.emit();
                 return Err(reported);
             }
+            err.emit();
         }
 
         Ok(bound)

--- a/compiler/rustc_hir_analysis/src/impl_wf_check.rs
+++ b/compiler/rustc_hir_analysis/src/impl_wf_check.rs
@@ -137,8 +137,7 @@ fn enforce_impl_params_are_constrained(
             }
         };
         if err {
-            let const_param_note =
-                matches!(param.kind, ty::GenericParamDefKind::Const { .. }).then_some(());
+            let const_param_note = matches!(param.kind, ty::GenericParamDefKind::Const { .. });
             let mut diag = tcx.dcx().create_err(UnconstrainedGenericParameter {
                 span: tcx.def_span(param.def_id),
                 param_name: param.name,

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -505,7 +505,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                     span: self.span,
                     expr_ty: self.expr_ty,
                     cast_ty: fcx.ty_to_string(self.cast_ty),
-                    teach: fcx.tcx.sess.teach(E0607).then_some(()),
+                    teach: fcx.tcx.sess.teach(E0607),
                 });
             }
             CastError::IntToFatCast(known_metadata) => {

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -706,7 +706,7 @@ pub(crate) struct CastThinPointerToFatPointer<'tcx> {
     pub expr_ty: Ty<'tcx>,
     pub cast_ty: String,
     #[note(hir_typeck_teach_help)]
-    pub(crate) teach: Option<()>,
+    pub(crate) teach: bool,
 }
 
 #[derive(Diagnostic)]
@@ -720,7 +720,7 @@ pub(crate) struct PassToVariadicFunction<'tcx, 'a> {
     pub sugg_span: Option<Span>,
     pub replace: String,
     #[help]
-    pub help: Option<()>,
+    pub help: bool,
     #[note(hir_typeck_teach_help)]
-    pub(crate) teach: Option<()>,
+    pub(crate) teach: bool,
 }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -406,9 +406,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ) {
                     let (sugg_span, replace, help) =
                         if let Ok(snippet) = sess.source_map().span_to_snippet(span) {
-                            (Some(span), format!("{snippet} as {cast_ty}"), None)
+                            (Some(span), format!("{snippet} as {cast_ty}"), false)
                         } else {
-                            (None, "".to_string(), Some(()))
+                            (None, "".to_string(), true)
                         };
 
                     sess.dcx().emit_err(errors::PassToVariadicFunction {
@@ -418,7 +418,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         help,
                         replace,
                         sugg_span,
-                        teach: sess.teach(E0617).then_some(()),
+                        teach: sess.teach(E0617),
                     });
                 }
 

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -527,7 +527,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 {
                     if self.check_and_add_sugg_binding(LetStmt {
                         ty_hir_id_opt: if let Some(ty) = ty { Some(ty.hir_id) } else { None },
-                        binding_id: binding_id,
+                        binding_id,
                         span: pat.span,
                         init_hir_id: init.hir_id,
                     }) {

--- a/compiler/rustc_incremental/src/errors.rs
+++ b/compiler/rustc_incremental/src/errors.rs
@@ -189,10 +189,10 @@ pub struct CreateLock<'a> {
     pub lock_err: std::io::Error,
     pub session_dir: &'a Path,
     #[note(incremental_lock_unsupported)]
-    pub is_unsupported_lock: Option<()>,
+    pub is_unsupported_lock: bool,
     #[help(incremental_cargo_help_1)]
     #[help(incremental_cargo_help_2)]
-    pub is_cargo: Option<()>,
+    pub is_cargo: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_incremental/src/persist/fs.rs
+++ b/compiler/rustc_incremental/src/persist/fs.rs
@@ -486,12 +486,12 @@ fn lock_directory(
         // the lock should be exclusive
         Ok(lock) => Ok((lock, lock_file_path)),
         Err(lock_err) => {
-            let is_unsupported_lock = flock::Lock::error_unsupported(&lock_err).then_some(());
+            let is_unsupported_lock = flock::Lock::error_unsupported(&lock_err);
             Err(sess.dcx().emit_err(errors::CreateLock {
                 lock_err,
                 session_dir,
                 is_unsupported_lock,
-                is_cargo: rustc_session::utils::was_invoked_from_cargo().then_some(()),
+                is_cargo: rustc_session::utils::was_invoked_from_cargo(),
             }))
         }
     }

--- a/compiler/rustc_incremental/src/persist/fs.rs
+++ b/compiler/rustc_incremental/src/persist/fs.rs
@@ -851,7 +851,7 @@ fn delete_old(sess: &Session, path: &Path) {
     debug!("garbage_collect_session_directories() - deleting `{}`", path.display());
 
     if let Err(err) = safe_remove_dir_all(path) {
-        sess.dcx().emit_warn(errors::SessionGcFailed { path: path, err });
+        sess.dcx().emit_warn(errors::SessionGcFailed { path, err });
     } else {
         delete_session_dir_lock_file(sess, &lock_file_path(path));
     }

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1330,7 +1330,7 @@ impl UnreachablePub {
                 BuiltinUnreachablePub {
                     what,
                     suggestion: (vis_span, applicability),
-                    help: exportable.then_some(()),
+                    help: exportable,
                 },
             );
         }

--- a/compiler/rustc_lint/src/errors.rs
+++ b/compiler/rustc_lint/src/errors.rs
@@ -77,7 +77,7 @@ pub struct UnknownToolInScopedLint {
     pub tool_name: Symbol,
     pub lint_name: String,
     #[help]
-    pub is_nightly_build: Option<()>,
+    pub is_nightly_build: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_lint/src/expect.rs
+++ b/compiler/rustc_lint/src/expect.rs
@@ -24,7 +24,7 @@ fn check_expectations(tcx: TyCtxt<'_>, tool_filter: Option<Symbol>) {
                 && tool_filter.map_or(true, |filter| expectation.lint_tool == Some(filter))
             {
                 let rationale = expectation.reason.map(|rationale| ExpectationNote { rationale });
-                let note = expectation.is_unfulfilled_lint_expectations.then_some(());
+                let note = expectation.is_unfulfilled_lint_expectations;
                 tcx.emit_node_span_lint(
                     UNFULFILLED_LINT_EXPECTATIONS,
                     *hir_id,

--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -936,7 +936,7 @@ impl<'s, P: LintLevelsProvider> LintLevelsBuilder<'s, P> {
                             span: tool_ident.map(|ident| ident.span),
                             tool_name: tool_name.unwrap(),
                             lint_name: pprust::path_to_string(&meta_item.path),
-                            is_nightly_build: sess.is_nightly_build().then_some(()),
+                            is_nightly_build: sess.is_nightly_build(),
                         });
                         continue;
                     }

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -257,7 +257,7 @@ pub struct BuiltinUnreachablePub<'a> {
     #[suggestion(code = "pub(crate)")]
     pub suggestion: (Span, Applicability),
     #[help]
-    pub help: Option<()>,
+    pub help: bool,
 }
 
 #[derive(LintDiagnostic)]
@@ -572,7 +572,7 @@ pub struct Expectation {
     #[subdiagnostic]
     pub rationale: Option<ExpectationNote>,
     #[note]
-    pub note: Option<()>,
+    pub note: bool,
 }
 
 #[derive(Subdiagnostic)]
@@ -756,7 +756,7 @@ pub enum InvalidReferenceCastingDiag<'tcx> {
         #[label]
         orig_cast: Option<Span>,
         #[note(lint_invalid_reference_casting_note_ty_has_interior_mutability)]
-        ty_has_interior_mutability: Option<()>,
+        ty_has_interior_mutability: bool,
     },
     #[diag(lint_invalid_reference_casting_assign_to_ref)]
     #[note(lint_invalid_reference_casting_note_book)]
@@ -764,7 +764,7 @@ pub enum InvalidReferenceCastingDiag<'tcx> {
         #[label]
         orig_cast: Option<Span>,
         #[note(lint_invalid_reference_casting_note_ty_has_interior_mutability)]
-        ty_has_interior_mutability: Option<()>,
+        ty_has_interior_mutability: bool,
     },
     #[diag(lint_invalid_reference_casting_bigger_layout)]
     #[note(lint_layout)]

--- a/compiler/rustc_lint/src/reference_casting.rs
+++ b/compiler/rustc_lint/src/reference_casting.rs
@@ -54,8 +54,6 @@ impl<'tcx> LateLintPass<'tcx> for InvalidReferenceCasting {
                 && let Some(ty_has_interior_mutability) =
                     is_cast_from_ref_to_mut_ptr(cx, init, &mut peel_casts)
             {
-                let ty_has_interior_mutability = ty_has_interior_mutability.then_some(());
-
                 cx.emit_span_lint(
                     INVALID_REFERENCE_CASTING,
                     expr.span,

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -1002,11 +1002,7 @@ impl CrateError {
                 if !locator.crate_rejections.via_filename.is_empty() {
                     let mismatches = locator.crate_rejections.via_filename.iter();
                     for CrateMismatch { path, .. } in mismatches {
-                        dcx.emit_err(errors::CrateLocationUnknownType {
-                            span,
-                            path: path,
-                            crate_name,
-                        });
+                        dcx.emit_err(errors::CrateLocationUnknownType { span, path, crate_name });
                         dcx.emit_err(errors::LibFilenameForm {
                             span,
                             dll_prefix: &locator.dll_prefix,
@@ -1035,7 +1031,7 @@ impl CrateError {
                     }
                     dcx.emit_err(errors::NewerCrateVersion {
                         span,
-                        crate_name: crate_name,
+                        crate_name,
                         add_info,
                         found_crates,
                     });

--- a/compiler/rustc_middle/src/error.rs
+++ b/compiler/rustc_middle/src/error.rs
@@ -160,7 +160,7 @@ pub struct TypeLengthLimit {
     pub span: Span,
     pub shrunk: String,
     #[note(middle_written_to_path)]
-    pub was_written: Option<()>,
+    pub was_written: bool,
     pub path: PathBuf,
     pub type_length: usize,
 }

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -395,7 +395,7 @@ pub enum StatementKind<'tcx> {
     /// `PlaceMention(PLACE)`.
     ///
     /// When executed at runtime, this computes the given place, but then discards
-    /// it without doing a load. It is UB if the place is not pointing to live memory.
+    /// it without doing a load. `let _ = *ptr;` is fine even if the pointer is dangling.
     PlaceMention(Box<Place<'tcx>>),
 
     /// Encodes a user's type ascription. These need to be preserved

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -581,9 +581,9 @@ impl<'tcx> Instance<'tcx> {
                     let mut path = PathBuf::new();
                     let was_written = if let Some(path2) = written_to_path {
                         path = path2;
-                        Some(())
+                        true
                     } else {
-                        None
+                        false
                     };
                     tcx.dcx().emit_fatal(error::TypeLengthLimit {
                         // We don't use `def_span(def_id)` so that diagnostics point

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -330,11 +330,11 @@ mir_build_unreachable_making_this_unreachable = collectively making this unreach
 mir_build_unreachable_matches_same_values = matches some of the same values
 
 mir_build_unreachable_pattern = unreachable pattern
-    .label = unreachable pattern
-    .unreachable_matches_no_values = this pattern matches no values because `{$ty}` is uninhabited
+    .label = no value can reach this
+    .unreachable_matches_no_values = matches no values because `{$ty}` is uninhabited
     .unreachable_covered_by_catchall = matches any value
-    .unreachable_covered_by_one = matches all the values already
-    .unreachable_covered_by_many = these patterns collectively make the last one unreachable
+    .unreachable_covered_by_one = matches all the relevant values
+    .unreachable_covered_by_many = multiple earlier patterns match some of the same values
 
 mir_build_unsafe_fn_safe_body = an unsafe function restricts its caller, but its body is safe by default
 mir_build_unsafe_not_inherited = items do not inherit unsafety from separate enclosing items

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -333,7 +333,7 @@ mir_build_unreachable_matches_same_values = matches some of the same values
 
 mir_build_unreachable_pattern = unreachable pattern
     .label = no value can reach this
-    .unreachable_matches_no_values = matches no values because `{$ty}` is uninhabited
+    .unreachable_matches_no_values = matches no values because `{$matches_no_values_ty}` is uninhabited
     .unreachable_uninhabited_note = to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
     .unreachable_covered_by_catchall = matches any value
     .unreachable_covered_by_one = matches all the relevant values

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -327,6 +327,8 @@ mir_build_union_pattern = cannot use unions in constant patterns
 
 mir_build_unreachable_making_this_unreachable = collectively making this unreachable
 
+mir_build_unreachable_making_this_unreachable_n_more = ...and {$covered_by_many_n_more_count} other patterns collectively make this unreachable
+
 mir_build_unreachable_matches_same_values = matches some of the same values
 
 mir_build_unreachable_pattern = unreachable pattern

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -332,6 +332,7 @@ mir_build_unreachable_matches_same_values = matches some of the same values
 mir_build_unreachable_pattern = unreachable pattern
     .label = no value can reach this
     .unreachable_matches_no_values = matches no values because `{$ty}` is uninhabited
+    .unreachable_uninhabited_note = to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
     .unreachable_covered_by_catchall = matches any value
     .unreachable_covered_by_one = matches all the relevant values
     .unreachable_covered_by_many = multiple earlier patterns match some of the same values

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -793,7 +793,7 @@ impl UnsafeOpKind {
                         missing.iter().map(|feature| Cow::from(feature.to_string())).collect(),
                     ),
                     missing_target_features_count: missing.len(),
-                    note: if build_enabled.is_empty() { None } else { Some(()) },
+                    note: !build_enabled.is_empty(),
                     build_target_features: DiagArgValue::StrListSepByAnd(
                         build_enabled
                             .iter()
@@ -958,7 +958,7 @@ impl UnsafeOpKind {
                         missing.iter().map(|feature| Cow::from(feature.to_string())).collect(),
                     ),
                     missing_target_features_count: missing.len(),
-                    note: if build_enabled.is_empty() { None } else { Some(()) },
+                    note: !build_enabled.is_empty(),
                     build_target_features: DiagArgValue::StrListSepByAnd(
                         build_enabled
                             .iter()
@@ -977,7 +977,7 @@ impl UnsafeOpKind {
                         missing.iter().map(|feature| Cow::from(feature.to_string())).collect(),
                     ),
                     missing_target_features_count: missing.len(),
-                    note: if build_enabled.is_empty() { None } else { Some(()) },
+                    note: !build_enabled.is_empty(),
                     build_target_features: DiagArgValue::StrListSepByAnd(
                         build_enabled
                             .iter()

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -588,6 +588,8 @@ pub(crate) struct UnreachablePattern<'tcx> {
     pub(crate) span: Option<Span>,
     #[subdiagnostic]
     pub(crate) matches_no_values: Option<UnreachableMatchesNoValues<'tcx>>,
+    #[note(mir_build_unreachable_uninhabited_note)]
+    pub(crate) uninhabited_note: Option<()>,
     #[label(mir_build_unreachable_covered_by_catchall)]
     pub(crate) covered_by_catchall: Option<Span>,
     #[label(mir_build_unreachable_covered_by_one)]

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -596,6 +596,7 @@ pub(crate) struct UnreachablePattern<'tcx> {
     pub(crate) covered_by_one: Option<Span>,
     #[note(mir_build_unreachable_covered_by_many)]
     pub(crate) covered_by_many: Option<MultiSpan>,
+    pub(crate) covered_by_many_n_more_count: usize,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -161,7 +161,7 @@ pub(crate) struct UnsafeOpInUnsafeFnCallToFunctionWithRequiresUnsafe {
     pub(crate) missing_target_features: DiagArgValue,
     pub(crate) missing_target_features_count: usize,
     #[note]
-    pub(crate) note: Option<()>,
+    pub(crate) note: bool,
     pub(crate) build_target_features: DiagArgValue,
     pub(crate) build_target_features_count: usize,
     #[subdiagnostic]
@@ -413,7 +413,7 @@ pub(crate) struct CallToFunctionWithRequiresUnsafe {
     pub(crate) missing_target_features: DiagArgValue,
     pub(crate) missing_target_features_count: usize,
     #[note]
-    pub(crate) note: Option<()>,
+    pub(crate) note: bool,
     pub(crate) build_target_features: DiagArgValue,
     pub(crate) build_target_features_count: usize,
     #[subdiagnostic]
@@ -431,7 +431,7 @@ pub(crate) struct CallToFunctionWithRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     pub(crate) missing_target_features: DiagArgValue,
     pub(crate) missing_target_features_count: usize,
     #[note]
-    pub(crate) note: Option<()>,
+    pub(crate) note: bool,
     pub(crate) build_target_features: DiagArgValue,
     pub(crate) build_target_features_count: usize,
     #[subdiagnostic]
@@ -623,7 +623,7 @@ pub(crate) struct LowerRangeBoundMustBeLessThanOrEqualToUpper {
     #[label]
     pub(crate) span: Span,
     #[note(mir_build_teach_note)]
-    pub(crate) teach: Option<()>,
+    pub(crate) teach: bool,
 }
 
 #[derive(Diagnostic)]
@@ -865,7 +865,7 @@ pub(crate) struct PatternNotCovered<'s, 'tcx> {
     #[subdiagnostic]
     pub(crate) adt_defined_here: Option<AdtDefinedHere<'tcx>>,
     #[note(mir_build_privately_uninhabited)]
-    pub(crate) witness_1_is_privately_uninhabited: Option<()>,
+    pub(crate) witness_1_is_privately_uninhabited: bool,
     #[note(mir_build_pattern_ty)]
     pub(crate) _p: (),
     pub(crate) pattern_ty: Ty<'tcx>,

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -586,8 +586,9 @@ pub(crate) struct NonConstPath {
 pub(crate) struct UnreachablePattern<'tcx> {
     #[label]
     pub(crate) span: Option<Span>,
-    #[subdiagnostic]
-    pub(crate) matches_no_values: Option<UnreachableMatchesNoValues<'tcx>>,
+    #[label(mir_build_unreachable_matches_no_values)]
+    pub(crate) matches_no_values: Option<Span>,
+    pub(crate) matches_no_values_ty: Ty<'tcx>,
     #[note(mir_build_unreachable_uninhabited_note)]
     pub(crate) uninhabited_note: Option<()>,
     #[label(mir_build_unreachable_covered_by_catchall)]
@@ -597,12 +598,6 @@ pub(crate) struct UnreachablePattern<'tcx> {
     #[note(mir_build_unreachable_covered_by_many)]
     pub(crate) covered_by_many: Option<MultiSpan>,
     pub(crate) covered_by_many_n_more_count: usize,
-}
-
-#[derive(Subdiagnostic)]
-#[note(mir_build_unreachable_matches_no_values)]
-pub(crate) struct UnreachableMatchesNoValues<'tcx> {
-    pub(crate) ty: Ty<'tcx>,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -218,12 +218,7 @@ impl<'tcx> Cx<'tcx> {
                     let lhs =
                         self.thir.exprs.push(Expr { temp_lifetime, ty: discr_ty, span, kind });
                     let bin = ExprKind::Binary { op: BinOp::Add, lhs, rhs: offset };
-                    self.thir.exprs.push(Expr {
-                        temp_lifetime,
-                        ty: discr_ty,
-                        span: span,
-                        kind: bin,
-                    })
+                    self.thir.exprs.push(Expr { temp_lifetime, ty: discr_ty, span, kind: bin })
                 }
                 None => offset,
             };

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -921,6 +921,7 @@ fn report_unreachable_pattern<'p, 'tcx>(
     let mut lint = UnreachablePattern {
         span: Some(pat_span),
         matches_no_values: None,
+        uninhabited_note: None,
         covered_by_catchall: None,
         covered_by_one: None,
         covered_by_many: None,
@@ -929,6 +930,7 @@ fn report_unreachable_pattern<'p, 'tcx>(
         [] => {
             // Empty pattern; we report the uninhabited type that caused the emptiness.
             lint.span = None; // Don't label the pattern itself
+            lint.uninhabited_note = Some(()); // Give a link about empty types
             pat.walk(&mut |subpat| {
                 let ty = **subpat.ty();
                 if cx.is_uninhabited(ty) {

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -917,6 +917,7 @@ fn report_unreachable_pattern<'p, 'tcx>(
     pat: &DeconstructedPat<'p, 'tcx>,
     explanation: &RedundancyExplanation<'p, 'tcx>,
 ) {
+    static CAP_COVERED_BY_MANY: usize = 4;
     let pat_span = pat.data().span;
     let mut lint = UnreachablePattern {
         span: Some(pat_span),
@@ -925,6 +926,7 @@ fn report_unreachable_pattern<'p, 'tcx>(
         covered_by_catchall: None,
         covered_by_one: None,
         covered_by_many: None,
+        covered_by_many_n_more_count: 0,
     };
     match explanation.covered_by.as_slice() {
         [] => {
@@ -950,15 +952,27 @@ fn report_unreachable_pattern<'p, 'tcx>(
             lint.covered_by_one = Some(covering_pat.data().span);
         }
         covering_pats => {
+            let mut iter = covering_pats.iter();
             let mut multispan = MultiSpan::from_span(pat_span);
-            for p in covering_pats {
+            for p in iter.by_ref().take(CAP_COVERED_BY_MANY) {
                 multispan.push_span_label(
                     p.data().span,
                     fluent::mir_build_unreachable_matches_same_values,
                 );
             }
-            multispan
-                .push_span_label(pat_span, fluent::mir_build_unreachable_making_this_unreachable);
+            let remain = iter.count();
+            if remain == 0 {
+                multispan.push_span_label(
+                    pat_span,
+                    fluent::mir_build_unreachable_making_this_unreachable,
+                );
+            } else {
+                lint.covered_by_many_n_more_count = remain;
+                multispan.push_span_label(
+                    pat_span,
+                    fluent::mir_build_unreachable_making_this_unreachable_n_more,
+                );
+            }
             lint.covered_by_many = Some(multispan);
         }
     }

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -922,6 +922,7 @@ fn report_unreachable_pattern<'p, 'tcx>(
     let mut lint = UnreachablePattern {
         span: Some(pat_span),
         matches_no_values: None,
+        matches_no_values_ty: **pat.ty(),
         uninhabited_note: None,
         covered_by_catchall: None,
         covered_by_one: None,
@@ -933,10 +934,11 @@ fn report_unreachable_pattern<'p, 'tcx>(
             // Empty pattern; we report the uninhabited type that caused the emptiness.
             lint.span = None; // Don't label the pattern itself
             lint.uninhabited_note = Some(()); // Give a link about empty types
+            lint.matches_no_values = Some(pat_span);
             pat.walk(&mut |subpat| {
                 let ty = **subpat.ty();
                 if cx.is_uninhabited(ty) {
-                    lint.matches_no_values = Some(UnreachableMatchesNoValues { ty });
+                    lint.matches_no_values_ty = ty;
                     false // No need to dig further.
                 } else if matches!(subpat.ctor(), Constructor::Ref | Constructor::UnionField) {
                     false // Don't explore further since they are not by-value.

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -718,7 +718,7 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
             uncovered: Uncovered::new(pat.span, &cx, witnesses),
             inform,
             interpreted_as_const,
-            witness_1_is_privately_uninhabited: witness_1_is_privately_uninhabited.then_some(()),
+            witness_1_is_privately_uninhabited,
             _p: (),
             pattern_ty,
             let_suggestion,

--- a/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/const_to_pat.rs
@@ -129,7 +129,7 @@ impl<'tcx> ConstToPat<'tcx> {
                 let err = TypeNotPartialEq { span: self.span, non_peq_ty: ty };
                 let e = self.tcx().dcx().emit_err(err);
                 let kind = PatKind::Error(e);
-                return Box::new(Pat { span: self.span, ty: ty, kind });
+                return Box::new(Pat { span: self.span, ty, kind });
             }
         }
 

--- a/compiler/rustc_mir_build/src/thir/pattern/mod.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/mod.rs
@@ -256,7 +256,7 @@ impl<'a, 'tcx> PatCtxt<'a, 'tcx> {
                     RangeEnd::Included => {
                         self.tcx.dcx().emit_err(LowerRangeBoundMustBeLessThanOrEqualToUpper {
                             span,
-                            teach: self.tcx.sess.teach(E0030).then_some(()),
+                            teach: self.tcx.sess.teach(E0030),
                         })
                     }
                     RangeEnd::Excluded => {

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -931,7 +931,7 @@ fn compute_storage_conflicts<'mir, 'tcx>(
     // Compute the storage conflicts for all eligible locals.
     let mut visitor = StorageConflictVisitor {
         body,
-        saved_locals: saved_locals,
+        saved_locals,
         local_conflicts: BitMatrix::from_row_n(&ineligible_locals, body.local_decls.len()),
         eligible_storage_live: BitSet::new_empty(body.local_decls.len()),
     };

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -338,7 +338,7 @@ impl<'a, 'tcx> ConstAnalysis<'a, 'tcx> {
             tcx,
             local_decls: &body.local_decls,
             ecx: InterpCx::new(tcx, DUMMY_SP, param_env, DummyMachine),
-            param_env: param_env,
+            param_env,
         }
     }
 

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -580,9 +580,9 @@ fn check_recursion_limit<'tcx>(
         let mut path = PathBuf::new();
         let was_written = if let Some(written_to_path) = written_to_path {
             path = written_to_path;
-            Some(())
+            true
         } else {
-            None
+            false
         };
         tcx.dcx().emit_fatal(RecursionLimit {
             span,

--- a/compiler/rustc_monomorphize/src/errors.rs
+++ b/compiler/rustc_monomorphize/src/errors.rs
@@ -16,7 +16,7 @@ pub struct RecursionLimit {
     pub def_span: Span,
     pub def_path_str: String,
     #[note(monomorphize_written_to_path)]
-    pub was_written: Option<()>,
+    pub was_written: bool,
     pub path: PathBuf,
 }
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -913,7 +913,7 @@ pub(crate) struct InvalidLiteralSuffixOnTupleIndex {
     #[help(parse_tuple_exception_line_1)]
     #[help(parse_tuple_exception_line_2)]
     #[help(parse_tuple_exception_line_3)]
-    pub exception: Option<()>,
+    pub exception: bool,
 }
 
 #[derive(Diagnostic)]
@@ -1299,7 +1299,7 @@ pub(crate) struct ComparisonOperatorsCannotBeChained {
     pub suggest_turbofish: Option<Span>,
     #[help(parse_sugg_turbofish_syntax)]
     #[help(parse_sugg_parentheses_for_function_args)]
-    pub help_turbofish: Option<()>,
+    pub help_turbofish: bool,
     #[subdiagnostic]
     pub chaining_sugg: Option<ComparisonOperatorsCannotBeChainedSugg>,
 }
@@ -1578,7 +1578,7 @@ pub(crate) struct PathSingleColon {
     pub suggestion: Span,
 
     #[note(parse_type_ascription_removed)]
-    pub type_ascription: Option<()>,
+    pub type_ascription: bool,
 }
 
 #[derive(Diagnostic)]
@@ -1589,7 +1589,7 @@ pub(crate) struct ColonAsSemi {
     pub span: Span,
 
     #[note(parse_type_ascription_removed)]
-    pub type_ascription: Option<()>,
+    pub type_ascription: bool,
 }
 
 #[derive(Diagnostic)]
@@ -2462,7 +2462,7 @@ pub(crate) struct TrailingVertNotAllowed {
     pub start: Option<Span>,
     pub token: Token,
     #[note(parse_note_pattern_alternatives_use_single_vert)]
-    pub note_double_vert: Option<()>,
+    pub note_double_vert: bool,
 }
 
 #[derive(Diagnostic)]
@@ -2894,7 +2894,7 @@ pub(crate) struct BadItemKind {
     pub descr: &'static str,
     pub ctx: &'static str,
     #[help]
-    pub help: Option<()>,
+    pub help: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1403,7 +1403,7 @@ impl<'a> Parser<'a> {
                 let mut err = ComparisonOperatorsCannotBeChained {
                     span: vec![op.span, self.prev_token.span],
                     suggest_turbofish: None,
-                    help_turbofish: None,
+                    help_turbofish: false,
                     chaining_sugg: None,
                 };
 
@@ -1436,7 +1436,7 @@ impl<'a> Parser<'a> {
                         {
                             err.suggest_turbofish = Some(op.span.shrink_to_lo());
                         } else {
-                            err.help_turbofish = Some(());
+                            err.help_turbofish = true;
                         }
 
                         let snapshot = self.create_snapshot_for_diagnostic();
@@ -1468,7 +1468,7 @@ impl<'a> Parser<'a> {
                         {
                             err.suggest_turbofish = Some(op.span.shrink_to_lo());
                         } else {
-                            err.help_turbofish = Some(());
+                            err.help_turbofish = true;
                         }
                         // Consume the fn call arguments.
                         match self.consume_fn_args() {
@@ -1487,7 +1487,7 @@ impl<'a> Parser<'a> {
                         {
                             // All we know is that this is `foo < bar >` and *nothing* else. Try to
                             // be helpful, but don't attempt to recover.
-                            err.help_turbofish = Some(());
+                            err.help_turbofish = true;
                         }
 
                         // If it looks like a genuine attempt to chain operators (as opposed to a
@@ -1895,7 +1895,7 @@ impl<'a> Parser<'a> {
         {
             self.dcx().emit_err(ColonAsSemi {
                 span: self.token.span,
-                type_ascription: self.psess.unstable_features.is_nightly_build().then_some(()),
+                type_ascription: self.psess.unstable_features.is_nightly_build(),
             });
             self.bump();
             return true;

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -2162,13 +2162,13 @@ impl<'a> Parser<'a> {
             self.dcx().emit_warn(errors::InvalidLiteralSuffixOnTupleIndex {
                 span,
                 suffix,
-                exception: Some(()),
+                exception: true,
             });
         } else {
             self.dcx().emit_err(errors::InvalidLiteralSuffixOnTupleIndex {
                 span,
                 suffix,
-                exception: None,
+                exception: false,
             });
         }
     }

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -1248,8 +1248,8 @@ impl<'a> Parser<'a> {
         let span = self.psess.source_map().guess_head_span(span);
         let descr = kind.descr();
         let help = match kind {
-            ItemKind::DelegationMac(deleg) if deleg.suffixes.is_none() => None,
-            _ => Some(()),
+            ItemKind::DelegationMac(deleg) if deleg.suffixes.is_none() => false,
+            _ => true,
         };
         self.dcx().emit_err(errors::BadItemKind { span, descr, ctx, help });
         None

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -333,7 +333,7 @@ impl<'a> Parser<'a> {
                     span: self.token.span,
                     start: lo,
                     token: self.token.clone(),
-                    note_double_vert: matches!(self.token.kind, token::OrOr).then_some(()),
+                    note_double_vert: matches!(self.token.kind, token::OrOr),
                 });
                 self.bump();
                 true

--- a/compiler/rustc_parse/src/parser/path.rs
+++ b/compiler/rustc_parse/src/parser/path.rs
@@ -261,11 +261,7 @@ impl<'a> Parser<'a> {
                         self.dcx().emit_err(PathSingleColon {
                             span: self.prev_token.span,
                             suggestion: self.prev_token.span.shrink_to_hi(),
-                            type_ascription: self
-                                .psess
-                                .unstable_features
-                                .is_nightly_build()
-                                .then_some(()),
+                            type_ascription: self.psess.unstable_features.is_nightly_build(),
                         });
                     }
                     continue;
@@ -334,11 +330,7 @@ impl<'a> Parser<'a> {
                             err = self.dcx().create_err(PathSingleColon {
                                 span: self.token.span,
                                 suggestion: self.prev_token.span.shrink_to_hi(),
-                                type_ascription: self
-                                    .psess
-                                    .unstable_features
-                                    .is_nightly_build()
-                                    .then_some(()),
+                                type_ascription: self.psess.unstable_features.is_nightly_build(),
                             });
                         }
                         // Attempt to find places where a missing `>` might belong.

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -2619,8 +2619,7 @@ fn check_duplicates(
                             warning: matches!(
                                 duplicates,
                                 FutureWarnFollowing | FutureWarnPreceding
-                            )
-                            .then_some(()),
+                            ),
                         },
                     );
                 }

--- a/compiler/rustc_passes/src/diagnostic_items.rs
+++ b/compiler/rustc_passes/src/diagnostic_items.rs
@@ -49,7 +49,7 @@ fn report_duplicate_item(
         orig_span,
         crate_name: tcx.crate_name(item_def_id.krate),
         orig_crate_name: tcx.crate_name(original_def_id.krate),
-        different_crates: (item_def_id.krate != original_def_id.krate).then_some(()),
+        different_crates: (item_def_id.krate != original_def_id.krate),
         name,
     });
 }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -752,7 +752,7 @@ pub struct UnusedDuplicate {
     #[note]
     pub other: Span,
     #[warning]
-    pub warning: Option<()>,
+    pub warning: bool,
 }
 
 #[derive(Diagnostic)]
@@ -911,7 +911,7 @@ pub struct DuplicateDiagnosticItemInCrate {
     #[note(passes_diagnostic_item_first_defined)]
     pub orig_span: Option<Span>,
     #[note]
-    pub different_crates: Option<()>,
+    pub different_crates: bool,
     pub crate_name: Symbol,
     pub orig_crate_name: Symbol,
     pub name: Symbol,

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -214,7 +214,7 @@ pub fn query_system<'tcx>(
             local_providers,
             extern_providers,
             encode_query_results: encode_all_query_results,
-            try_mark_green: try_mark_green,
+            try_mark_green,
         },
         jobs: AtomicU64::new(1),
     }

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1150,7 +1150,7 @@ impl<'a, 'b, 'tcx> BuildReducedGraphVisitor<'a, 'b, 'tcx> {
     fn contains_macro_use(&mut self, attrs: &[ast::Attribute]) -> bool {
         for attr in attrs {
             if attr.has_name(sym::macro_escape) {
-                let inner_attribute = matches!(attr.style, ast::AttrStyle::Inner).then_some(());
+                let inner_attribute = matches!(attr.style, ast::AttrStyle::Inner);
                 self.r
                     .dcx()
                     .emit_warn(errors::MacroExternDeprecated { span: attr.span, inner_attribute });

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -1456,7 +1456,7 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
             let label_span = ident.span.shrink_to_hi();
             let mut spans = MultiSpan::from_span(label_span);
             spans.push_span_label(label_span, "put a macro name here");
-            err.subdiagnostic(MaybeMissingMacroRulesName { spans: spans });
+            err.subdiagnostic(MaybeMissingMacroRulesName { spans });
             return;
         }
 

--- a/compiler/rustc_resolve/src/errors.rs
+++ b/compiler/rustc_resolve/src/errors.rs
@@ -850,7 +850,7 @@ pub(crate) struct MacroExternDeprecated {
     #[primary_span]
     pub(crate) span: Span,
     #[help]
-    pub inner_attribute: Option<()>,
+    pub inner_attribute: bool,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -146,7 +146,7 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for TransformTy<'tcx> {
                         !is_zst
                     });
                     if let Some(field) = field {
-                        let ty0 = self.tcx.type_of(field.did).instantiate(self.tcx, args);
+                        let ty0 = self.tcx.erase_regions(field.ty(self.tcx, args));
                         // Generalize any repr(transparent) user-defined type that is either a
                         // pointer or reference, and either references itself or any other type that
                         // contains or references itself, to avoid a reference cycle.

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -316,7 +316,7 @@ pub fn transform_instance<'tcx>(
             .drop_trait()
             .unwrap_or_else(|| bug!("typeid_for_instance: couldn't get drop_trait lang item"));
         let predicate = ty::ExistentialPredicate::Trait(ty::ExistentialTraitRef {
-            def_id: def_id,
+            def_id,
             args: List::empty(),
         });
         let predicates = tcx.mk_poly_existential_predicates(&[ty::Binder::dummy(predicate)]);

--- a/compiler/rustc_smir/src/rustc_smir/alloc.rs
+++ b/compiler/rustc_smir/src/rustc_smir/alloc.rs
@@ -132,7 +132,7 @@ pub(super) fn allocation_filter<'tcx>(
         ));
     }
     Allocation {
-        bytes: bytes,
+        bytes,
         provenance: ProvenanceMap { ptrs },
         align: alloc.align.bytes(),
         mutability: alloc.mutability.stable(tables),

--- a/compiler/rustc_target/src/abi/call/powerpc.rs
+++ b/compiler/rustc_target/src/abi/call/powerpc.rs
@@ -16,7 +16,7 @@ fn classify_arg<Ty>(cx: &impl HasTargetSpec, arg: &mut ArgAbi<'_, Ty>) {
             && matches!(&*cx.target_spec().env, "gnu" | "musl" | "uclibc")
             && arg.layout.is_zst()
         {
-            arg.make_indirect_force();
+            arg.make_indirect_from_ignore();
         }
         return;
     }

--- a/compiler/rustc_target/src/abi/call/s390x.rs
+++ b/compiler/rustc_target/src/abi/call/s390x.rs
@@ -28,7 +28,7 @@ where
             && matches!(&*cx.target_spec().env, "gnu" | "musl" | "uclibc")
             && arg.layout.is_zst()
         {
-            arg.make_indirect_force();
+            arg.make_indirect_from_ignore();
         }
         return;
     }

--- a/compiler/rustc_target/src/abi/call/sparc64.rs
+++ b/compiler/rustc_target/src/abi/call/sparc64.rs
@@ -225,7 +225,7 @@ where
                 && matches!(&*cx.target_spec().env, "gnu" | "musl" | "uclibc")
                 && arg.layout.is_zst()
             {
-                arg.make_indirect_force();
+                arg.make_indirect_from_ignore();
             }
             return;
         }

--- a/compiler/rustc_target/src/abi/call/x86_win64.rs
+++ b/compiler/rustc_target/src/abi/call/x86_win64.rs
@@ -43,7 +43,7 @@ pub fn compute_abi_info<Ty>(cx: &impl HasTargetSpec, fn_abi: &mut FnAbi<'_, Ty>)
                 && cx.target_spec().env == "gnu"
                 && arg.layout.is_zst()
             {
-                arg.make_indirect_force();
+                arg.make_indirect_from_ignore();
             }
             continue;
         }

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/need_type_info.rs
@@ -382,7 +382,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 infer_subdiags,
                 multi_suggestions,
                 bad_label,
-                was_written: None,
+                was_written: false,
                 path: Default::default(),
             }),
             TypeAnnotationNeeded::E0283 => self.dcx().create_err(AmbiguousImpl {
@@ -393,7 +393,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 infer_subdiags,
                 multi_suggestions,
                 bad_label,
-                was_written: None,
+                was_written: false,
                 path: Default::default(),
             }),
             TypeAnnotationNeeded::E0284 => self.dcx().create_err(AmbiguousReturn {
@@ -404,7 +404,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 infer_subdiags,
                 multi_suggestions,
                 bad_label,
-                was_written: None,
+                was_written: false,
                 path: Default::default(),
             }),
         }
@@ -586,7 +586,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 infer_subdiags,
                 multi_suggestions,
                 bad_label: None,
-                was_written: path.as_ref().map(|_| ()),
+                was_written: path.is_some(),
                 path: path.unwrap_or_default(),
             }),
             TypeAnnotationNeeded::E0283 => self.dcx().create_err(AmbiguousImpl {
@@ -597,7 +597,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 infer_subdiags,
                 multi_suggestions,
                 bad_label: None,
-                was_written: path.as_ref().map(|_| ()),
+                was_written: path.is_some(),
                 path: path.unwrap_or_default(),
             }),
             TypeAnnotationNeeded::E0284 => self.dcx().create_err(AmbiguousReturn {
@@ -608,7 +608,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 infer_subdiags,
                 multi_suggestions,
                 bad_label: None,
-                was_written: path.as_ref().map(|_| ()),
+                was_written: path.is_some(),
                 path: path.unwrap_or_default(),
             }),
         }

--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -203,7 +203,7 @@ pub struct AnnotationRequired<'a> {
     #[subdiagnostic]
     pub multi_suggestions: Vec<SourceKindMultiSuggestion<'a>>,
     #[note(trait_selection_full_type_written)]
-    pub was_written: Option<()>,
+    pub was_written: bool,
     pub path: PathBuf,
 }
 
@@ -224,7 +224,7 @@ pub struct AmbiguousImpl<'a> {
     #[subdiagnostic]
     pub multi_suggestions: Vec<SourceKindMultiSuggestion<'a>>,
     #[note(trait_selection_full_type_written)]
-    pub was_written: Option<()>,
+    pub was_written: bool,
     pub path: PathBuf,
 }
 
@@ -245,7 +245,7 @@ pub struct AmbiguousReturn<'a> {
     #[subdiagnostic]
     pub multi_suggestions: Vec<SourceKindMultiSuggestion<'a>>,
     #[note(trait_selection_full_type_written)]
-    pub was_written: Option<()>,
+    pub was_written: bool,
     pub path: PathBuf,
 }
 

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -770,7 +770,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                                     let reported =
                                         tcx.dcx().emit_err(UnableToConstructConstantValue {
                                             span: tcx.def_span(unevaluated.def),
-                                            unevaluated: unevaluated,
+                                            unevaluated,
                                         });
                                     Err(ErrorHandled::Reported(reported.into(), tcx.def_span(unevaluated.def)))
                                 }

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -284,7 +284,7 @@ fn error(
 ) -> Result<!, ErrorGuaranteed> {
     let reported = tcx.dcx().emit_err(GenericConstantTooComplex {
         span: root_span,
-        maybe_supported: None,
+        maybe_supported: false,
         sub,
     });
 
@@ -298,7 +298,7 @@ fn maybe_supported_error(
 ) -> Result<!, ErrorGuaranteed> {
     let reported = tcx.dcx().emit_err(GenericConstantTooComplex {
         span: root_span,
-        maybe_supported: Some(()),
+        maybe_supported: true,
         sub,
     });
 

--- a/compiler/rustc_ty_utils/src/errors.rs
+++ b/compiler/rustc_ty_utils/src/errors.rs
@@ -18,7 +18,7 @@ pub struct GenericConstantTooComplex {
     #[primary_span]
     pub span: Span,
     #[note(ty_utils_maybe_supported)]
-    pub maybe_supported: Option<()>,
+    pub maybe_supported: bool,
     #[subdiagnostic]
     pub sub: GenericConstantTooComplexSub,
 }

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2818,5 +2818,5 @@ impl_fn_for_zst! {
 }
 
 // This is required to make `impl From<&str> for Box<dyn Error>` and `impl<E> From<E> for Box<dyn Error>` not overlap.
-#[stable(feature = "rust1", since = "1.0.0")]
+#[stable(feature = "error_in_core_neg_impl", since = "1.65.0")]
 impl !crate::error::Error for &str {}

--- a/library/std/src/sys/pal/unix/mod.rs
+++ b/library/std/src/sys/pal/unix/mod.rs
@@ -116,7 +116,7 @@ pub unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
                 if pfd.revents & libc::POLLNVAL == 0 {
                     continue;
                 }
-                if open64(c"/dev/null".as_ptr().cast(), libc::O_RDWR, 0) == -1 {
+                if open64(c"/dev/null".as_ptr(), libc::O_RDWR, 0) == -1 {
                     // If the stream is closed but we failed to reopen it, abort the
                     // process. Otherwise we wouldn't preserve the safety of
                     // operations on the corresponding Rust object Stdin, Stdout, or
@@ -147,7 +147,7 @@ pub unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
             use crate::sys::os::errno;
             for fd in 0..3 {
                 if libc::fcntl(fd, libc::F_GETFD) == -1 && errno() == libc::EBADF {
-                    if open64(c"/dev/null".as_ptr().cast(), libc::O_RDWR, 0) == -1 {
+                    if open64(c"/dev/null".as_ptr(), libc::O_RDWR, 0) == -1 {
                         // If the stream is closed but we failed to reopen it, abort the
                         // process. Otherwise we wouldn't preserve the safety of
                         // operations on the corresponding Rust object Stdin, Stdout, or

--- a/tests/debuginfo/dummy_span.rs
+++ b/tests/debuginfo/dummy_span.rs
@@ -1,0 +1,45 @@
+//@ min-lldb-version: 310
+
+//@ compile-flags:-g
+
+// === GDB TESTS ===================================================================================
+
+// gdb-command:run 7
+
+// gdb-command:next
+// gdb-command:next
+// gdb-check:[...]#loc1[...]
+// gdb-command:next
+// gdb-check:[...]#loc2[...]
+
+// === LLDB TESTS ==================================================================================
+
+// lldb-command:run 7
+
+// lldb-command:next
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#loc1[...]
+// lldb-command:next
+// lldb-command:frame select
+// lldb-check:[...]#loc2[...]
+
+use std::env;
+use std::num::ParseIntError;
+
+fn main() -> Result<(), ParseIntError> {
+    let args = env::args();
+    let number_str = args.skip(1).next().unwrap();
+    let number = number_str.parse::<i32>()?;
+    zzz(); // #break
+    if number % 7 == 0 {
+        // This generates code with a dummy span for
+        // some reason. If that ever changes this
+        // test will not test what it wants to test.
+        return Ok(()); // #loc1
+    }
+    println!("{}", number);
+    Ok(())
+} // #loc2
+
+fn zzz() { () }

--- a/tests/ui/consts/packed_pattern.stderr
+++ b/tests/ui/consts/packed_pattern.stderr
@@ -2,9 +2,9 @@ warning: unreachable pattern
   --> $DIR/packed_pattern.rs:16:9
    |
 LL |         Foo { field: (5, 6, 7, 8) } => {},
-   |         --------------------------- matches all the values already
+   |         --------------------------- matches all the relevant values
 LL |         FOO => unreachable!(),
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
    |
    = note: `#[warn(unreachable_patterns)]` on by default
 

--- a/tests/ui/consts/packed_pattern2.stderr
+++ b/tests/ui/consts/packed_pattern2.stderr
@@ -2,9 +2,9 @@ warning: unreachable pattern
   --> $DIR/packed_pattern2.rs:24:9
    |
 LL |         Bar { a: Foo { field: (5, 6) } } => {},
-   |         -------------------------------- matches all the values already
+   |         -------------------------------- matches all the relevant values
 LL |         FOO => unreachable!(),
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
    |
    = note: `#[warn(unreachable_patterns)]` on by default
 

--- a/tests/ui/error-codes/E0001.stderr
+++ b/tests/ui/error-codes/E0001.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/E0001.rs:8:9
    |
 LL |         _ => {/* ... */}
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/E0001.rs:8:9
    |
 LL |         Some(_) => {/* ... */}

--- a/tests/ui/lint/issue-30302.stderr
+++ b/tests/ui/lint/issue-30302.stderr
@@ -13,7 +13,7 @@ LL |         Nil => true,
    |         --- matches any value
 LL |
 LL |         _ => false
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/issue-30302.rs:4:9

--- a/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
+++ b/tests/ui/or-patterns/exhaustiveness-unreachable-pattern.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:8:9
    |
 LL |         (1 | 2,) => {}
-   |         -------- matches all the values already
+   |         -------- matches all the relevant values
 LL |         (1,) => {}
-   |         ^^^^ unreachable pattern
+   |         ^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/exhaustiveness-unreachable-pattern.rs:1:9
@@ -16,17 +16,17 @@ error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:13:9
    |
 LL |         (1 | 2,) => {}
-   |         -------- matches all the values already
+   |         -------- matches all the relevant values
 LL |         (2,) => {}
-   |         ^^^^ unreachable pattern
+   |         ^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:19:9
    |
 LL |         (1 | 2,) => {}
-   |         ^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/exhaustiveness-unreachable-pattern.rs:19:9
    |
 LL |         (1,) => {}
@@ -40,44 +40,44 @@ error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:24:9
    |
 LL |         (1 | 2, 3 | 4) => {}
-   |         -------------- matches all the values already
+   |         -------------- matches all the relevant values
 LL |         (1, 3) => {}
-   |         ^^^^^^ unreachable pattern
+   |         ^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:25:9
    |
 LL |         (1 | 2, 3 | 4) => {}
-   |         -------------- matches all the values already
+   |         -------------- matches all the relevant values
 LL |         (1, 3) => {}
 LL |         (1, 4) => {}
-   |         ^^^^^^ unreachable pattern
+   |         ^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:26:9
    |
 LL |         (1 | 2, 3 | 4) => {}
-   |         -------------- matches all the values already
+   |         -------------- matches all the relevant values
 ...
 LL |         (2, 4) => {}
-   |         ^^^^^^ unreachable pattern
+   |         ^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:27:9
    |
 LL |         (1 | 2, 3 | 4) => {}
-   |         -------------- matches all the values already
+   |         -------------- matches all the relevant values
 ...
 LL |         (2 | 1, 4) => {}
-   |         ^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:29:9
    |
 LL |         (1, 4 | 5) => {}
-   |         ^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/exhaustiveness-unreachable-pattern.rs:29:9
    |
 LL |         (1 | 2, 3 | 4) => {}
@@ -92,107 +92,107 @@ error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:34:13
    |
 LL |         (0, 0, 0) => {}
-   |             - matches all the values already
+   |             - matches all the relevant values
 LL |         (0, 0 | 1, 0) => {}
-   |             ^ unreachable pattern
+   |             ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:42:9
    |
 LL |         (None | Some(1 | 2),) => {}
-   |         --------------------- matches all the values already
+   |         --------------------- matches all the relevant values
 LL |         (Some(1),) => {}
-   |         ^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:43:9
    |
 LL |         (None | Some(1 | 2),) => {}
-   |         --------------------- matches all the values already
+   |         --------------------- matches all the relevant values
 LL |         (Some(1),) => {}
 LL |         (None,) => {}
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:48:9
    |
 LL |         ((1 | 2,) | (3 | 4,),) => {}
-   |         ---------------------- matches all the values already
+   |         ---------------------- matches all the relevant values
 LL |         ((1..=4,),) => {}
-   |         ^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:53:14
    |
 LL |         (1 | 1,) => {}
-   |          -   ^ unreachable pattern
+   |          -   ^ no value can reach this
    |          |
-   |          matches all the values already
+   |          matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:57:19
    |
 LL |         (0 | 1) | 1 => {}
-   |              -    ^ unreachable pattern
+   |              -    ^ no value can reach this
    |              |
-   |              matches all the values already
+   |              matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:63:14
    |
 LL |         0 | (0 | 0) => {}
-   |         -    ^ unreachable pattern
+   |         -    ^ no value can reach this
    |         |
-   |         matches all the values already
+   |         matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:63:18
    |
 LL |         0 | (0 | 0) => {}
-   |         -        ^ unreachable pattern
+   |         -        ^ no value can reach this
    |         |
-   |         matches all the values already
+   |         matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:71:13
    |
 LL |           Some(0) |
-   |           ------- matches all the values already
+   |           ------- matches all the relevant values
 LL | /             Some(
 LL | |                 0 | 0) => {}
-   | |______________________^ unreachable pattern
+   | |______________________^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:77:15
    |
 LL |         [0
-   |          - matches all the values already
+   |          - matches all the relevant values
 LL |             | 0
-   |               ^ unreachable pattern
+   |               ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:79:15
    |
 LL |         , 0
-   |           - matches all the values already
+   |           - matches all the relevant values
 LL |             | 0] => {}
-   |               ^ unreachable pattern
+   |               ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:83:20
    |
 LL |         (true, 0 | 0) => {}
-   |                -   ^ unreachable pattern
+   |                -   ^ no value can reach this
    |                |
-   |                matches all the values already
+   |                matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:84:17
    |
 LL |         (_, 0 | 0) => {}
-   |                 ^ unreachable pattern
+   |                 ^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/exhaustiveness-unreachable-pattern.rs:84:17
    |
 LL |         (true, 0 | 0) => {}
@@ -206,25 +206,25 @@ error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:92:10
    |
 LL |         [1, ..] => {}
-   |          - matches all the values already
+   |          - matches all the relevant values
 LL |         [1
-   |          ^ unreachable pattern
+   |          ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:104:10
    |
 LL |         [true, ..] => {}
-   |          ---- matches all the values already
+   |          ---- matches all the relevant values
 LL |         [true
-   |          ^^^^ unreachable pattern
+   |          ^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:111:36
    |
 LL |         (true | false, None | Some(true
-   |                                    ^^^^ unreachable pattern
+   |                                    ^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/exhaustiveness-unreachable-pattern.rs:111:36
    |
 LL |         (true, Some(_)) => {}
@@ -238,12 +238,12 @@ error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:116:14
    |
 LL |             (true
-   |              ^^^^ unreachable pattern
+   |              ^^^^ no value can reach this
 ...
 LL |         (true | false, None | Some(t_or_f!())) => {}
    |                                    --------- in this macro invocation
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/exhaustiveness-unreachable-pattern.rs:116:14
    |
 LL |             (true
@@ -261,26 +261,26 @@ error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:127:14
    |
 LL |         Some(0) => {}
-   |              - matches all the values already
+   |              - matches all the relevant values
 LL |         Some(0
-   |              ^ unreachable pattern
+   |              ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:146:19
    |
 LL |         Some(false) => {}
-   |              ----- matches all the values already
+   |              ----- matches all the relevant values
 LL |         None | Some(true
 LL |                 | false) => {}
-   |                   ^^^^^ unreachable pattern
+   |                   ^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:154:15
    |
 LL |             | true) => {}
-   |               ^^^^ unreachable pattern
+   |               ^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/exhaustiveness-unreachable-pattern.rs:154:15
    |
 LL |         (false, true) => {}
@@ -295,9 +295,9 @@ error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:160:15
    |
 LL |             | true,
-   |               ^^^^ unreachable pattern
+   |               ^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/exhaustiveness-unreachable-pattern.rs:160:15
    |
 LL |         (true, false) => {}
@@ -314,13 +314,13 @@ error: unreachable pattern
 LL |         (x, y)
    |         ------ matches any value
 LL |             | (y, x) => {}
-   |               ^^^^^^ unreachable pattern
+   |               ^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:169:30
    |
 LL | fn unreachable_in_param((_ | (_, _)): (bool, bool)) {}
-   |                          -   ^^^^^^ unreachable pattern
+   |                          -   ^^^^^^ no value can reach this
    |                          |
    |                          matches any value
 
@@ -328,7 +328,7 @@ error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:176:14
    |
 LL |     let (_ | (_, _)) = bool_pair;
-   |          -   ^^^^^^ unreachable pattern
+   |          -   ^^^^^^ no value can reach this
    |          |
    |          matches any value
 
@@ -336,7 +336,7 @@ error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:178:14
    |
 LL |     for (_ | (_, _)) in [bool_pair] {}
-   |          -   ^^^^^^ unreachable pattern
+   |          -   ^^^^^^ no value can reach this
    |          |
    |          matches any value
 
@@ -344,25 +344,25 @@ error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:181:20
    |
 LL |     let (Some(_) | Some(true)) = bool_option else { return };
-   |          -------   ^^^^^^^^^^ unreachable pattern
+   |          -------   ^^^^^^^^^^ no value can reach this
    |          |
-   |          matches all the values already
+   |          matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:183:22
    |
 LL |     if let Some(_) | Some(true) = bool_option {}
-   |            -------   ^^^^^^^^^^ unreachable pattern
+   |            -------   ^^^^^^^^^^ no value can reach this
    |            |
-   |            matches all the values already
+   |            matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/exhaustiveness-unreachable-pattern.rs:185:25
    |
 LL |     while let Some(_) | Some(true) = bool_option {}
-   |               -------   ^^^^^^^^^^ unreachable pattern
+   |               -------   ^^^^^^^^^^ no value can reach this
    |               |
-   |               matches all the values already
+   |               matches all the relevant values
 
 error: aborting due to 36 previous errors
 

--- a/tests/ui/pattern/issue-14221.stderr
+++ b/tests/ui/pattern/issue-14221.stderr
@@ -19,7 +19,7 @@ LL |             A => "A",
    |             - matches any value
 LL |
 LL |             B => "B",
-   |             ^ unreachable pattern
+   |             ^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/issue-14221.rs:1:9

--- a/tests/ui/pattern/usefulness/consts-opaque.stderr
+++ b/tests/ui/pattern/usefulness/consts-opaque.stderr
@@ -52,7 +52,7 @@ error: unreachable pattern
 LL |         Bar => {}
    |         --- matches any value
 LL |         BAR => {}
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/consts-opaque.rs:6:9
@@ -67,7 +67,7 @@ LL |         Bar => {}
    |         --- matches any value
 ...
 LL |         _ => {}
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:56:9
@@ -75,7 +75,7 @@ error: unreachable pattern
 LL |         BAR => {}
    |         --- matches any value
 LL |         Bar => {}
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:58:9
@@ -84,7 +84,7 @@ LL |         BAR => {}
    |         --- matches any value
 ...
 LL |         _ => {}
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:64:9
@@ -92,7 +92,7 @@ error: unreachable pattern
 LL |         BAR => {}
    |         --- matches any value
 LL |         BAR => {} // should not be emitting unreachable warning
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:66:9
@@ -101,31 +101,31 @@ LL |         BAR => {}
    |         --- matches any value
 ...
 LL |         _ => {} // should not be emitting unreachable warning
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:72:9
    |
 LL |         BAZ => {}
-   |         --- matches all the values already
+   |         --- matches all the relevant values
 LL |         Baz::Baz1 => {} // should not be emitting unreachable warning
-   |         ^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:79:9
    |
 LL |         Baz::Baz1 => {}
-   |         --------- matches all the values already
+   |         --------- matches all the relevant values
 LL |         BAZ => {}
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/consts-opaque.rs:87:9
    |
 LL |         _ => {} // should not be emitting unreachable warning
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/consts-opaque.rs:87:9
    |
 LL |         BAZ => {}

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `EmptyEnum` is uninhabited
+   = note: matches no values because `EmptyEnum` is uninhabited
 note: the lint level is defined here
   --> $DIR/empty-match-check-notes.rs:7:9
    |
@@ -17,7 +17,7 @@ error: unreachable pattern
 LL |         _ if false => {}
    |         ^
    |
-   = note: this pattern matches no values because `EmptyEnum` is uninhabited
+   = note: matches no values because `EmptyEnum` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-match-check-notes.rs:29:9
@@ -25,7 +25,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `EmptyForeignEnum` is uninhabited
+   = note: matches no values because `EmptyForeignEnum` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-match-check-notes.rs:33:9
@@ -33,7 +33,7 @@ error: unreachable pattern
 LL |         _ if false => {}
    |         ^
    |
-   = note: this pattern matches no values because `EmptyForeignEnum` is uninhabited
+   = note: matches no values because `EmptyForeignEnum` is uninhabited
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/empty-match-check-notes.rs:39:9

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
@@ -5,6 +5,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `EmptyEnum` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/empty-match-check-notes.rs:7:9
    |
@@ -12,31 +13,34 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:21:9
+  --> $DIR/empty-match-check-notes.rs:22:9
    |
 LL |         _ if false => {}
    |         ^
    |
    = note: matches no values because `EmptyEnum` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:29:9
+  --> $DIR/empty-match-check-notes.rs:31:9
    |
 LL |         _ => {}
    |         ^
    |
    = note: matches no values because `EmptyForeignEnum` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:33:9
+  --> $DIR/empty-match-check-notes.rs:36:9
    |
 LL |         _ if false => {}
    |         ^
    |
    = note: matches no values because `EmptyForeignEnum` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-match-check-notes.rs:39:9
+  --> $DIR/empty-match-check-notes.rs:43:9
    |
 LL |     let None = *x;
    |         ^^^^ pattern `Some(_)` not covered
@@ -51,7 +55,7 @@ LL |     if let None = *x { todo!() };
    |     ++               +++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u8..=u8::MAX` not covered
-  --> $DIR/empty-match-check-notes.rs:49:11
+  --> $DIR/empty-match-check-notes.rs:53:11
    |
 LL |     match 0u8 {
    |           ^^^ pattern `0_u8..=u8::MAX` not covered

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.exhaustive_patterns.stderr
@@ -2,9 +2,8 @@ error: unreachable pattern
   --> $DIR/empty-match-check-notes.rs:17:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `EmptyEnum` is uninhabited
    |
-   = note: matches no values because `EmptyEnum` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/empty-match-check-notes.rs:7:9
@@ -16,27 +15,24 @@ error: unreachable pattern
   --> $DIR/empty-match-check-notes.rs:22:9
    |
 LL |         _ if false => {}
-   |         ^
+   |         ^ matches no values because `EmptyEnum` is uninhabited
    |
-   = note: matches no values because `EmptyEnum` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-match-check-notes.rs:31:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `EmptyForeignEnum` is uninhabited
    |
-   = note: matches no values because `EmptyForeignEnum` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-match-check-notes.rs:36:9
    |
 LL |         _ if false => {}
-   |         ^
+   |         ^ matches no values because `EmptyForeignEnum` is uninhabited
    |
-   = note: matches no values because `EmptyForeignEnum` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0005]: refutable pattern in local binding

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `EmptyEnum` is uninhabited
+   = note: matches no values because `EmptyEnum` is uninhabited
 note: the lint level is defined here
   --> $DIR/empty-match-check-notes.rs:7:9
    |
@@ -17,7 +17,7 @@ error: unreachable pattern
 LL |         _ if false => {}
    |         ^
    |
-   = note: this pattern matches no values because `EmptyEnum` is uninhabited
+   = note: matches no values because `EmptyEnum` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-match-check-notes.rs:29:9
@@ -25,7 +25,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `EmptyForeignEnum` is uninhabited
+   = note: matches no values because `EmptyForeignEnum` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-match-check-notes.rs:33:9
@@ -33,7 +33,7 @@ error: unreachable pattern
 LL |         _ if false => {}
    |         ^
    |
-   = note: this pattern matches no values because `EmptyForeignEnum` is uninhabited
+   = note: matches no values because `EmptyForeignEnum` is uninhabited
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/empty-match-check-notes.rs:39:9

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
@@ -5,6 +5,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `EmptyEnum` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/empty-match-check-notes.rs:7:9
    |
@@ -12,31 +13,34 @@ LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:21:9
+  --> $DIR/empty-match-check-notes.rs:22:9
    |
 LL |         _ if false => {}
    |         ^
    |
    = note: matches no values because `EmptyEnum` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:29:9
+  --> $DIR/empty-match-check-notes.rs:31:9
    |
 LL |         _ => {}
    |         ^
    |
    = note: matches no values because `EmptyForeignEnum` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/empty-match-check-notes.rs:33:9
+  --> $DIR/empty-match-check-notes.rs:36:9
    |
 LL |         _ if false => {}
    |         ^
    |
    = note: matches no values because `EmptyForeignEnum` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0005]: refutable pattern in local binding
-  --> $DIR/empty-match-check-notes.rs:39:9
+  --> $DIR/empty-match-check-notes.rs:43:9
    |
 LL |     let None = *x;
    |         ^^^^ pattern `Some(_)` not covered
@@ -51,7 +55,7 @@ LL |     if let None = *x { todo!() };
    |     ++               +++++++++++
 
 error[E0004]: non-exhaustive patterns: `0_u8..=u8::MAX` not covered
-  --> $DIR/empty-match-check-notes.rs:49:11
+  --> $DIR/empty-match-check-notes.rs:53:11
    |
 LL |     match 0u8 {
    |           ^^^ pattern `0_u8..=u8::MAX` not covered

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.normal.stderr
@@ -2,9 +2,8 @@ error: unreachable pattern
   --> $DIR/empty-match-check-notes.rs:17:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `EmptyEnum` is uninhabited
    |
-   = note: matches no values because `EmptyEnum` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/empty-match-check-notes.rs:7:9
@@ -16,27 +15,24 @@ error: unreachable pattern
   --> $DIR/empty-match-check-notes.rs:22:9
    |
 LL |         _ if false => {}
-   |         ^
+   |         ^ matches no values because `EmptyEnum` is uninhabited
    |
-   = note: matches no values because `EmptyEnum` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-match-check-notes.rs:31:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `EmptyForeignEnum` is uninhabited
    |
-   = note: matches no values because `EmptyForeignEnum` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-match-check-notes.rs:36:9
    |
 LL |         _ if false => {}
-   |         ^
+   |         ^ matches no values because `EmptyForeignEnum` is uninhabited
    |
-   = note: matches no values because `EmptyForeignEnum` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0005]: refutable pattern in local binding

--- a/tests/ui/pattern/usefulness/empty-match-check-notes.rs
+++ b/tests/ui/pattern/usefulness/empty-match-check-notes.rs
@@ -16,10 +16,12 @@ fn empty_enum(x: EmptyEnum) {
     match x {
         _ => {} //~ ERROR unreachable pattern
                 //~^ NOTE matches no values
+                //~| NOTE to learn more about uninhabited types, see
     }
     match x {
         _ if false => {} //~ ERROR unreachable pattern
                          //~^ NOTE matches no values
+                         //~| NOTE to learn more about uninhabited types, see
     }
 }
 
@@ -28,10 +30,12 @@ fn empty_foreign_enum(x: empty::EmptyForeignEnum) {
     match x {
         _ => {} //~ ERROR unreachable pattern
                 //~^ NOTE matches no values
+                //~| NOTE to learn more about uninhabited types, see
     }
     match x {
         _ if false => {} //~ ERROR unreachable pattern
                          //~^ NOTE matches no values
+                         //~| NOTE to learn more about uninhabited types, see
     }
 }
 

--- a/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 note: the lint level is defined here
   --> $DIR/empty-types.rs:15:9
    |
@@ -17,7 +17,7 @@ error: unreachable pattern
 LL |         _x => {}
    |         ^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
   --> $DIR/empty-types.rs:56:11
@@ -40,7 +40,7 @@ error: unreachable pattern
 LL |         (_, _) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `(u32, !)` is uninhabited
+   = note: matches no values because `(u32, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:76:9
@@ -48,7 +48,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `(!, !)` is uninhabited
+   = note: matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:79:9
@@ -56,7 +56,7 @@ error: unreachable pattern
 LL |         (_, _) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `(!, !)` is uninhabited
+   = note: matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
@@ -64,7 +64,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
   --> $DIR/empty-types.rs:87:11
@@ -91,7 +91,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:99:9
@@ -99,7 +99,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
   --> $DIR/empty-types.rs:96:11
@@ -139,7 +139,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:115:9
@@ -147,7 +147,7 @@ error: unreachable pattern
 LL |         Ok(_) => {}
    |         ^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:118:9
@@ -155,7 +155,7 @@ error: unreachable pattern
 LL |         Ok(_) => {}
    |         ^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:119:9
@@ -163,7 +163,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:122:9
@@ -171,7 +171,7 @@ error: unreachable pattern
 LL |         Ok(_) => {}
    |         ^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:123:9
@@ -179,7 +179,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:132:13
@@ -187,7 +187,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:135:13
@@ -195,7 +195,7 @@ error: unreachable pattern
 LL |             _ if false => {}
    |             ^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
@@ -203,15 +203,15 @@ error: unreachable pattern
 LL |             Some(_) => {}
    |             ^^^^^^^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:147:13
    |
 LL |             None => {}
-   |             ---- matches all the values already
+   |             ---- matches all the relevant values
 LL |             _ => {}
-   |             ^ unreachable pattern
+   |             ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:199:13
@@ -219,7 +219,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:204:13
@@ -227,7 +227,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:209:13
@@ -235,7 +235,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:214:13
@@ -243,7 +243,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:220:13
@@ -251,7 +251,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:281:9
@@ -259,7 +259,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:284:9
@@ -267,7 +267,7 @@ error: unreachable pattern
 LL |         (_, _) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `(!, !)` is uninhabited
+   = note: matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:287:9
@@ -275,7 +275,7 @@ error: unreachable pattern
 LL |         Ok(_) => {}
    |         ^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
@@ -283,7 +283,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `&[!]` is non-empty
   --> $DIR/empty-types.rs:327:11
@@ -346,7 +346,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `[!; 3]` is uninhabited
+   = note: matches no values because `[!; 3]` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:371:9
@@ -354,7 +354,7 @@ error: unreachable pattern
 LL |         [_, _, _] => {}
    |         ^^^^^^^^^
    |
-   = note: this pattern matches no values because `[!; 3]` is uninhabited
+   = note: matches no values because `[!; 3]` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:374:9
@@ -362,7 +362,7 @@ error: unreachable pattern
 LL |         [_, ..] => {}
    |         ^^^^^^^
    |
-   = note: this pattern matches no values because `[!; 3]` is uninhabited
+   = note: matches no values because `[!; 3]` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
   --> $DIR/empty-types.rs:388:11
@@ -382,9 +382,9 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:395:9
    |
 LL |         [] => {}
-   |         -- matches all the values already
+   |         -- matches all the relevant values
 LL |         _ => {}
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-types.rs:397:11
@@ -406,7 +406,7 @@ error: unreachable pattern
 LL |         Some(_) => {}
    |         ^^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:421:9
@@ -414,25 +414,25 @@ error: unreachable pattern
 LL |         Some(_a) => {}
    |         ^^^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:426:9
    |
 LL |         None => {}
-   |         ---- matches all the values already
+   |         ---- matches all the relevant values
 LL |         // !useful, !reachable
 LL |         _ => {}
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:431:9
    |
 LL |         None => {}
-   |         ---- matches all the values already
+   |         ---- matches all the relevant values
 LL |         // !useful, !reachable
 LL |         _a => {}
-   |         ^^ unreachable pattern
+   |         ^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:603:9
@@ -440,7 +440,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:606:9
@@ -448,7 +448,7 @@ error: unreachable pattern
 LL |         _x => {}
    |         ^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:609:9
@@ -456,7 +456,7 @@ error: unreachable pattern
 LL |         _ if false => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:612:9
@@ -464,7 +464,7 @@ error: unreachable pattern
 LL |         _x if false => {}
    |         ^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: aborting due to 49 previous errors
 

--- a/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
@@ -2,9 +2,8 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:49:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/empty-types.rs:15:9
@@ -16,9 +15,8 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:52:9
    |
 LL |         _x => {}
-   |         ^^
+   |         ^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
@@ -40,36 +38,32 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:70:9
    |
 LL |         (_, _) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `(u32, !)` is uninhabited
    |
-   = note: matches no values because `(u32, !)` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:76:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `(!, !)` is uninhabited
    |
-   = note: matches no values because `(!, !)` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:79:9
    |
 LL |         (_, _) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `(!, !)` is uninhabited
    |
-   = note: matches no values because `(!, !)` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
@@ -95,18 +89,16 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:94:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:99:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
@@ -145,81 +137,72 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:112:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:115:9
    |
 LL |         Ok(_) => {}
-   |         ^^^^^
+   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:118:9
    |
 LL |         Ok(_) => {}
-   |         ^^^^^
+   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:119:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:122:9
    |
 LL |         Ok(_) => {}
-   |         ^^^^^
+   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:123:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:132:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:135:13
    |
 LL |             _ if false => {}
-   |             ^
+   |             ^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
    |
 LL |             Some(_) => {}
-   |             ^^^^^^^
+   |             ^^^^^^^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
@@ -234,81 +217,72 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:199:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:204:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:209:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:214:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:220:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:281:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:284:9
    |
 LL |         (_, _) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `(!, !)` is uninhabited
    |
-   = note: matches no values because `(!, !)` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:287:9
    |
 LL |         Ok(_) => {}
-   |         ^^^^^
+   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `&[!]` is non-empty
@@ -370,27 +344,24 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:368:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `[!; 3]` is uninhabited
    |
-   = note: matches no values because `[!; 3]` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:371:9
    |
 LL |         [_, _, _] => {}
-   |         ^^^^^^^^^
+   |         ^^^^^^^^^ matches no values because `[!; 3]` is uninhabited
    |
-   = note: matches no values because `[!; 3]` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:374:9
    |
 LL |         [_, ..] => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ matches no values because `[!; 3]` is uninhabited
    |
-   = note: matches no values because `[!; 3]` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
@@ -433,18 +404,16 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:416:9
    |
 LL |         Some(_) => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:421:9
    |
 LL |         Some(_a) => {}
-   |         ^^^^^^^^
+   |         ^^^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
@@ -469,36 +438,32 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:603:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:606:9
    |
 LL |         _x => {}
-   |         ^^
+   |         ^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:609:9
    |
 LL |         _ if false => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:612:9
    |
 LL |         _x if false => {}
-   |         ^^
+   |         ^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: aborting due to 49 previous errors

--- a/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.exhaustive_patterns.stderr
@@ -5,6 +5,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/empty-types.rs:15:9
    |
@@ -18,6 +19,7 @@ LL |         _x => {}
    |         ^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
   --> $DIR/empty-types.rs:56:11
@@ -41,6 +43,7 @@ LL |         (_, _) => {}
    |         ^^^^^^
    |
    = note: matches no values because `(u32, !)` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:76:9
@@ -49,6 +52,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `(!, !)` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:79:9
@@ -57,6 +61,7 @@ LL |         (_, _) => {}
    |         ^^^^^^
    |
    = note: matches no values because `(!, !)` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
@@ -65,6 +70,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
   --> $DIR/empty-types.rs:87:11
@@ -92,6 +98,7 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:99:9
@@ -100,6 +107,7 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
   --> $DIR/empty-types.rs:96:11
@@ -140,6 +148,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:115:9
@@ -148,6 +157,7 @@ LL |         Ok(_) => {}
    |         ^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:118:9
@@ -156,6 +166,7 @@ LL |         Ok(_) => {}
    |         ^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:119:9
@@ -164,6 +175,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:122:9
@@ -172,6 +184,7 @@ LL |         Ok(_) => {}
    |         ^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:123:9
@@ -180,6 +193,7 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:132:13
@@ -188,6 +202,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:135:13
@@ -196,6 +211,7 @@ LL |             _ if false => {}
    |             ^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
@@ -204,6 +220,7 @@ LL |             Some(_) => {}
    |             ^^^^^^^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:147:13
@@ -220,6 +237,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:204:13
@@ -228,6 +246,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:209:13
@@ -236,6 +255,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:214:13
@@ -244,6 +264,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:220:13
@@ -252,6 +273,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:281:9
@@ -260,6 +282,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:284:9
@@ -268,6 +291,7 @@ LL |         (_, _) => {}
    |         ^^^^^^
    |
    = note: matches no values because `(!, !)` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:287:9
@@ -276,6 +300,7 @@ LL |         Ok(_) => {}
    |         ^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
@@ -284,6 +309,7 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `&[!]` is non-empty
   --> $DIR/empty-types.rs:327:11
@@ -347,6 +373,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `[!; 3]` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:371:9
@@ -355,6 +382,7 @@ LL |         [_, _, _] => {}
    |         ^^^^^^^^^
    |
    = note: matches no values because `[!; 3]` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:374:9
@@ -363,6 +391,7 @@ LL |         [_, ..] => {}
    |         ^^^^^^^
    |
    = note: matches no values because `[!; 3]` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
   --> $DIR/empty-types.rs:388:11
@@ -407,6 +436,7 @@ LL |         Some(_) => {}
    |         ^^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:421:9
@@ -415,6 +445,7 @@ LL |         Some(_a) => {}
    |         ^^^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:426:9
@@ -441,6 +472,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:606:9
@@ -449,6 +481,7 @@ LL |         _x => {}
    |         ^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:609:9
@@ -457,6 +490,7 @@ LL |         _ if false => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:612:9
@@ -465,6 +499,7 @@ LL |         _x if false => {}
    |         ^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: aborting due to 49 previous errors
 

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -13,7 +13,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 note: the lint level is defined here
   --> $DIR/empty-types.rs:15:9
    |
@@ -26,7 +26,7 @@ error: unreachable pattern
 LL |         _x => {}
    |         ^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
   --> $DIR/empty-types.rs:56:11
@@ -49,7 +49,7 @@ error: unreachable pattern
 LL |         (_, _) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `(u32, !)` is uninhabited
+   = note: matches no values because `(u32, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:76:9
@@ -57,7 +57,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `(!, !)` is uninhabited
+   = note: matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:79:9
@@ -65,7 +65,7 @@ error: unreachable pattern
 LL |         (_, _) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `(!, !)` is uninhabited
+   = note: matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
@@ -73,7 +73,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
   --> $DIR/empty-types.rs:87:11
@@ -100,7 +100,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:99:9
@@ -108,7 +108,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
   --> $DIR/empty-types.rs:96:11
@@ -162,7 +162,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:115:9
@@ -170,7 +170,7 @@ error: unreachable pattern
 LL |         Ok(_) => {}
    |         ^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:118:9
@@ -178,7 +178,7 @@ error: unreachable pattern
 LL |         Ok(_) => {}
    |         ^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:119:9
@@ -186,7 +186,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:122:9
@@ -194,7 +194,7 @@ error: unreachable pattern
 LL |         Ok(_) => {}
    |         ^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:123:9
@@ -202,7 +202,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:132:13
@@ -210,7 +210,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:135:13
@@ -218,7 +218,7 @@ error: unreachable pattern
 LL |             _ if false => {}
    |             ^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
@@ -226,15 +226,15 @@ error: unreachable pattern
 LL |             Some(_) => {}
    |             ^^^^^^^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:147:13
    |
 LL |             None => {}
-   |             ---- matches all the values already
+   |             ---- matches all the relevant values
 LL |             _ => {}
-   |             ^ unreachable pattern
+   |             ^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `Some(!)` not covered
   --> $DIR/empty-types.rs:156:15
@@ -261,7 +261,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:204:13
@@ -269,7 +269,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:209:13
@@ -277,7 +277,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:214:13
@@ -285,7 +285,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:220:13
@@ -293,7 +293,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:281:9
@@ -301,7 +301,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:284:9
@@ -309,7 +309,7 @@ error: unreachable pattern
 LL |         (_, _) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `(!, !)` is uninhabited
+   = note: matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:287:9
@@ -317,7 +317,7 @@ error: unreachable pattern
 LL |         Ok(_) => {}
    |         ^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
@@ -325,7 +325,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/empty-types.rs:297:13
@@ -480,7 +480,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `[!; 3]` is uninhabited
+   = note: matches no values because `[!; 3]` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:371:9
@@ -488,7 +488,7 @@ error: unreachable pattern
 LL |         [_, _, _] => {}
    |         ^^^^^^^^^
    |
-   = note: this pattern matches no values because `[!; 3]` is uninhabited
+   = note: matches no values because `[!; 3]` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:374:9
@@ -496,7 +496,7 @@ error: unreachable pattern
 LL |         [_, ..] => {}
    |         ^^^^^^^
    |
-   = note: this pattern matches no values because `[!; 3]` is uninhabited
+   = note: matches no values because `[!; 3]` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
   --> $DIR/empty-types.rs:388:11
@@ -516,9 +516,9 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:395:9
    |
 LL |         [] => {}
-   |         -- matches all the values already
+   |         -- matches all the relevant values
 LL |         _ => {}
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-types.rs:397:11
@@ -540,7 +540,7 @@ error: unreachable pattern
 LL |         Some(_) => {}
    |         ^^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:421:9
@@ -548,25 +548,25 @@ error: unreachable pattern
 LL |         Some(_a) => {}
    |         ^^^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:426:9
    |
 LL |         None => {}
-   |         ---- matches all the values already
+   |         ---- matches all the relevant values
 LL |         // !useful, !reachable
 LL |         _ => {}
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:431:9
    |
 LL |         None => {}
-   |         ---- matches all the values already
+   |         ---- matches all the relevant values
 LL |         // !useful, !reachable
 LL |         _a => {}
-   |         ^^ unreachable pattern
+   |         ^^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `&Some(!)` not covered
   --> $DIR/empty-types.rs:451:11
@@ -664,7 +664,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:606:9
@@ -672,7 +672,7 @@ error: unreachable pattern
 LL |         _x => {}
    |         ^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:609:9
@@ -680,7 +680,7 @@ error: unreachable pattern
 LL |         _ if false => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:612:9
@@ -688,7 +688,7 @@ error: unreachable pattern
 LL |         _x if false => {}
    |         ^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `&!` not covered
   --> $DIR/empty-types.rs:637:11

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -14,6 +14,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/empty-types.rs:15:9
    |
@@ -27,6 +28,7 @@ LL |         _x => {}
    |         ^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
   --> $DIR/empty-types.rs:56:11
@@ -50,6 +52,7 @@ LL |         (_, _) => {}
    |         ^^^^^^
    |
    = note: matches no values because `(u32, !)` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:76:9
@@ -58,6 +61,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `(!, !)` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:79:9
@@ -66,6 +70,7 @@ LL |         (_, _) => {}
    |         ^^^^^^
    |
    = note: matches no values because `(!, !)` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
@@ -74,6 +79,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
   --> $DIR/empty-types.rs:87:11
@@ -101,6 +107,7 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:99:9
@@ -109,6 +116,7 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
   --> $DIR/empty-types.rs:96:11
@@ -163,6 +171,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:115:9
@@ -171,6 +180,7 @@ LL |         Ok(_) => {}
    |         ^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:118:9
@@ -179,6 +189,7 @@ LL |         Ok(_) => {}
    |         ^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:119:9
@@ -187,6 +198,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:122:9
@@ -195,6 +207,7 @@ LL |         Ok(_) => {}
    |         ^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:123:9
@@ -203,6 +216,7 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:132:13
@@ -211,6 +225,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:135:13
@@ -219,6 +234,7 @@ LL |             _ if false => {}
    |             ^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
@@ -227,6 +243,7 @@ LL |             Some(_) => {}
    |             ^^^^^^^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:147:13
@@ -262,6 +279,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:204:13
@@ -270,6 +288,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:209:13
@@ -278,6 +297,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:214:13
@@ -286,6 +306,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:220:13
@@ -294,6 +315,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:281:9
@@ -302,6 +324,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:284:9
@@ -310,6 +333,7 @@ LL |         (_, _) => {}
    |         ^^^^^^
    |
    = note: matches no values because `(!, !)` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:287:9
@@ -318,6 +342,7 @@ LL |         Ok(_) => {}
    |         ^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
@@ -326,6 +351,7 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/empty-types.rs:297:13
@@ -481,6 +507,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `[!; 3]` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:371:9
@@ -489,6 +516,7 @@ LL |         [_, _, _] => {}
    |         ^^^^^^^^^
    |
    = note: matches no values because `[!; 3]` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:374:9
@@ -497,6 +525,7 @@ LL |         [_, ..] => {}
    |         ^^^^^^^
    |
    = note: matches no values because `[!; 3]` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
   --> $DIR/empty-types.rs:388:11
@@ -541,6 +570,7 @@ LL |         Some(_) => {}
    |         ^^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:421:9
@@ -549,6 +579,7 @@ LL |         Some(_a) => {}
    |         ^^^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:426:9
@@ -665,6 +696,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:606:9
@@ -673,6 +705,7 @@ LL |         _x => {}
    |         ^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:609:9
@@ -681,6 +714,7 @@ LL |         _ if false => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:612:9
@@ -689,6 +723,7 @@ LL |         _x if false => {}
    |         ^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `&!` not covered
   --> $DIR/empty-types.rs:637:11

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -11,9 +11,8 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:49:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/empty-types.rs:15:9
@@ -25,9 +24,8 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:52:9
    |
 LL |         _x => {}
-   |         ^^
+   |         ^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
@@ -49,36 +47,32 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:70:9
    |
 LL |         (_, _) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `(u32, !)` is uninhabited
    |
-   = note: matches no values because `(u32, !)` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:76:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `(!, !)` is uninhabited
    |
-   = note: matches no values because `(!, !)` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:79:9
    |
 LL |         (_, _) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `(!, !)` is uninhabited
    |
-   = note: matches no values because `(!, !)` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
@@ -104,18 +98,16 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:94:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:99:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
@@ -168,81 +160,72 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:112:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:115:9
    |
 LL |         Ok(_) => {}
-   |         ^^^^^
+   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:118:9
    |
 LL |         Ok(_) => {}
-   |         ^^^^^
+   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:119:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:122:9
    |
 LL |         Ok(_) => {}
-   |         ^^^^^
+   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:123:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:132:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:135:13
    |
 LL |             _ if false => {}
-   |             ^
+   |             ^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
    |
 LL |             Some(_) => {}
-   |             ^^^^^^^
+   |             ^^^^^^^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
@@ -276,81 +259,72 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:199:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:204:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:209:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:214:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:220:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:281:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:284:9
    |
 LL |         (_, _) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `(!, !)` is uninhabited
    |
-   = note: matches no values because `(!, !)` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:287:9
    |
 LL |         Ok(_) => {}
-   |         ^^^^^
+   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0005]: refutable pattern in local binding
@@ -504,27 +478,24 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:368:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `[!; 3]` is uninhabited
    |
-   = note: matches no values because `[!; 3]` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:371:9
    |
 LL |         [_, _, _] => {}
-   |         ^^^^^^^^^
+   |         ^^^^^^^^^ matches no values because `[!; 3]` is uninhabited
    |
-   = note: matches no values because `[!; 3]` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:374:9
    |
 LL |         [_, ..] => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ matches no values because `[!; 3]` is uninhabited
    |
-   = note: matches no values because `[!; 3]` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
@@ -567,18 +538,16 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:416:9
    |
 LL |         Some(_) => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:421:9
    |
 LL |         Some(_a) => {}
-   |         ^^^^^^^^
+   |         ^^^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
@@ -693,36 +662,32 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:603:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:606:9
    |
 LL |         _x => {}
-   |         ^^
+   |         ^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:609:9
    |
 LL |         _ if false => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:612:9
    |
 LL |         _x if false => {}
-   |         ^^
+   |         ^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `&!` not covered

--- a/tests/ui/pattern/usefulness/empty-types.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.normal.stderr
@@ -5,6 +5,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/empty-types.rs:15:9
    |
@@ -18,6 +19,7 @@ LL |         _x => {}
    |         ^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
   --> $DIR/empty-types.rs:56:11
@@ -41,6 +43,7 @@ LL |         (_, _) => {}
    |         ^^^^^^
    |
    = note: matches no values because `(u32, !)` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:76:9
@@ -49,6 +52,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `(!, !)` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:79:9
@@ -57,6 +61,7 @@ LL |         (_, _) => {}
    |         ^^^^^^
    |
    = note: matches no values because `(!, !)` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
@@ -65,6 +70,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
   --> $DIR/empty-types.rs:87:11
@@ -92,6 +98,7 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:99:9
@@ -100,6 +107,7 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
   --> $DIR/empty-types.rs:96:11
@@ -154,6 +162,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:115:9
@@ -162,6 +171,7 @@ LL |         Ok(_) => {}
    |         ^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:118:9
@@ -170,6 +180,7 @@ LL |         Ok(_) => {}
    |         ^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:119:9
@@ -178,6 +189,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:122:9
@@ -186,6 +198,7 @@ LL |         Ok(_) => {}
    |         ^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:123:9
@@ -194,6 +207,7 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:132:13
@@ -202,6 +216,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:135:13
@@ -210,6 +225,7 @@ LL |             _ if false => {}
    |             ^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
@@ -218,6 +234,7 @@ LL |             Some(_) => {}
    |             ^^^^^^^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:147:13
@@ -253,6 +270,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:204:13
@@ -261,6 +279,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:209:13
@@ -269,6 +288,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:214:13
@@ -277,6 +297,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:220:13
@@ -285,6 +306,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:281:9
@@ -293,6 +315,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:284:9
@@ -301,6 +324,7 @@ LL |         (_, _) => {}
    |         ^^^^^^
    |
    = note: matches no values because `(!, !)` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:287:9
@@ -309,6 +333,7 @@ LL |         Ok(_) => {}
    |         ^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
@@ -317,6 +342,7 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `Result<!, !>` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/empty-types.rs:297:13
@@ -472,6 +498,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `[!; 3]` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:371:9
@@ -480,6 +507,7 @@ LL |         [_, _, _] => {}
    |         ^^^^^^^^^
    |
    = note: matches no values because `[!; 3]` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:374:9
@@ -488,6 +516,7 @@ LL |         [_, ..] => {}
    |         ^^^^^^^
    |
    = note: matches no values because `[!; 3]` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
   --> $DIR/empty-types.rs:388:11
@@ -532,6 +561,7 @@ LL |         Some(_) => {}
    |         ^^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:421:9
@@ -540,6 +570,7 @@ LL |         Some(_a) => {}
    |         ^^^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:426:9
@@ -656,6 +687,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:606:9
@@ -664,6 +696,7 @@ LL |         _x => {}
    |         ^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:609:9
@@ -672,6 +705,7 @@ LL |         _ if false => {}
    |         ^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:612:9
@@ -680,6 +714,7 @@ LL |         _x if false => {}
    |         ^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `&_` not covered
   --> $DIR/empty-types.rs:637:11

--- a/tests/ui/pattern/usefulness/empty-types.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.normal.stderr
@@ -2,9 +2,8 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:49:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/empty-types.rs:15:9
@@ -16,9 +15,8 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:52:9
    |
 LL |         _x => {}
-   |         ^^
+   |         ^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
@@ -40,36 +38,32 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:70:9
    |
 LL |         (_, _) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `(u32, !)` is uninhabited
    |
-   = note: matches no values because `(u32, !)` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:76:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `(!, !)` is uninhabited
    |
-   = note: matches no values because `(!, !)` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:79:9
    |
 LL |         (_, _) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `(!, !)` is uninhabited
    |
-   = note: matches no values because `(!, !)` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
@@ -95,18 +89,16 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:94:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:99:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
@@ -159,81 +151,72 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:112:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:115:9
    |
 LL |         Ok(_) => {}
-   |         ^^^^^
+   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:118:9
    |
 LL |         Ok(_) => {}
-   |         ^^^^^
+   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:119:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:122:9
    |
 LL |         Ok(_) => {}
-   |         ^^^^^
+   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:123:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:132:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:135:13
    |
 LL |             _ if false => {}
-   |             ^
+   |             ^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
    |
 LL |             Some(_) => {}
-   |             ^^^^^^^
+   |             ^^^^^^^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
@@ -267,81 +250,72 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:199:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:204:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:209:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:214:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:220:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:281:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:284:9
    |
 LL |         (_, _) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `(!, !)` is uninhabited
    |
-   = note: matches no values because `(!, !)` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:287:9
    |
 LL |         Ok(_) => {}
-   |         ^^^^^
+   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
-   = note: matches no values because `Result<!, !>` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0005]: refutable pattern in local binding
@@ -495,27 +469,24 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:368:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `[!; 3]` is uninhabited
    |
-   = note: matches no values because `[!; 3]` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:371:9
    |
 LL |         [_, _, _] => {}
-   |         ^^^^^^^^^
+   |         ^^^^^^^^^ matches no values because `[!; 3]` is uninhabited
    |
-   = note: matches no values because `[!; 3]` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:374:9
    |
 LL |         [_, ..] => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ matches no values because `[!; 3]` is uninhabited
    |
-   = note: matches no values because `[!; 3]` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
@@ -558,18 +529,16 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:416:9
    |
 LL |         Some(_) => {}
-   |         ^^^^^^^
+   |         ^^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:421:9
    |
 LL |         Some(_a) => {}
-   |         ^^^^^^^^
+   |         ^^^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
@@ -684,36 +653,32 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:603:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:606:9
    |
 LL |         _x => {}
-   |         ^^
+   |         ^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:609:9
    |
 LL |         _ if false => {}
-   |         ^
+   |         ^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:612:9
    |
 LL |         _x if false => {}
-   |         ^^
+   |         ^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `&_` not covered

--- a/tests/ui/pattern/usefulness/empty-types.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.normal.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 note: the lint level is defined here
   --> $DIR/empty-types.rs:15:9
    |
@@ -17,7 +17,7 @@ error: unreachable pattern
 LL |         _x => {}
    |         ^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `&!` is non-empty
   --> $DIR/empty-types.rs:56:11
@@ -40,7 +40,7 @@ error: unreachable pattern
 LL |         (_, _) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `(u32, !)` is uninhabited
+   = note: matches no values because `(u32, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:76:9
@@ -48,7 +48,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `(!, !)` is uninhabited
+   = note: matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:79:9
@@ -56,7 +56,7 @@ error: unreachable pattern
 LL |         (_, _) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `(!, !)` is uninhabited
+   = note: matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
@@ -64,7 +64,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Ok(_)` not covered
   --> $DIR/empty-types.rs:87:11
@@ -91,7 +91,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:99:9
@@ -99,7 +99,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
   --> $DIR/empty-types.rs:96:11
@@ -153,7 +153,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:115:9
@@ -161,7 +161,7 @@ error: unreachable pattern
 LL |         Ok(_) => {}
    |         ^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:118:9
@@ -169,7 +169,7 @@ error: unreachable pattern
 LL |         Ok(_) => {}
    |         ^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:119:9
@@ -177,7 +177,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:122:9
@@ -185,7 +185,7 @@ error: unreachable pattern
 LL |         Ok(_) => {}
    |         ^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:123:9
@@ -193,7 +193,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:132:13
@@ -201,7 +201,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:135:13
@@ -209,7 +209,7 @@ error: unreachable pattern
 LL |             _ if false => {}
    |             ^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:143:13
@@ -217,15 +217,15 @@ error: unreachable pattern
 LL |             Some(_) => {}
    |             ^^^^^^^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:147:13
    |
 LL |             None => {}
-   |             ---- matches all the values already
+   |             ---- matches all the relevant values
 LL |             _ => {}
-   |             ^ unreachable pattern
+   |             ^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
   --> $DIR/empty-types.rs:156:15
@@ -252,7 +252,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:204:13
@@ -260,7 +260,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:209:13
@@ -268,7 +268,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:214:13
@@ -276,7 +276,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:220:13
@@ -284,7 +284,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:281:9
@@ -292,7 +292,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:284:9
@@ -300,7 +300,7 @@ error: unreachable pattern
 LL |         (_, _) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `(!, !)` is uninhabited
+   = note: matches no values because `(!, !)` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:287:9
@@ -308,7 +308,7 @@ error: unreachable pattern
 LL |         Ok(_) => {}
    |         ^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:288:9
@@ -316,7 +316,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `Result<!, !>` is uninhabited
+   = note: matches no values because `Result<!, !>` is uninhabited
 
 error[E0005]: refutable pattern in local binding
   --> $DIR/empty-types.rs:297:13
@@ -471,7 +471,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `[!; 3]` is uninhabited
+   = note: matches no values because `[!; 3]` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:371:9
@@ -479,7 +479,7 @@ error: unreachable pattern
 LL |         [_, _, _] => {}
    |         ^^^^^^^^^
    |
-   = note: this pattern matches no values because `[!; 3]` is uninhabited
+   = note: matches no values because `[!; 3]` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:374:9
@@ -487,7 +487,7 @@ error: unreachable pattern
 LL |         [_, ..] => {}
    |         ^^^^^^^
    |
-   = note: this pattern matches no values because `[!; 3]` is uninhabited
+   = note: matches no values because `[!; 3]` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
   --> $DIR/empty-types.rs:388:11
@@ -507,9 +507,9 @@ error: unreachable pattern
   --> $DIR/empty-types.rs:395:9
    |
 LL |         [] => {}
-   |         -- matches all the values already
+   |         -- matches all the relevant values
 LL |         _ => {}
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `[]` not covered
   --> $DIR/empty-types.rs:397:11
@@ -531,7 +531,7 @@ error: unreachable pattern
 LL |         Some(_) => {}
    |         ^^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:421:9
@@ -539,25 +539,25 @@ error: unreachable pattern
 LL |         Some(_a) => {}
    |         ^^^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:426:9
    |
 LL |         None => {}
-   |         ---- matches all the values already
+   |         ---- matches all the relevant values
 LL |         // !useful, !reachable
 LL |         _ => {}
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:431:9
    |
 LL |         None => {}
-   |         ---- matches all the values already
+   |         ---- matches all the relevant values
 LL |         // !useful, !reachable
 LL |         _a => {}
-   |         ^^ unreachable pattern
+   |         ^^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `&Some(_)` not covered
   --> $DIR/empty-types.rs:451:11
@@ -655,7 +655,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:606:9
@@ -663,7 +663,7 @@ error: unreachable pattern
 LL |         _x => {}
    |         ^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:609:9
@@ -671,7 +671,7 @@ error: unreachable pattern
 LL |         _ if false => {}
    |         ^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/empty-types.rs:612:9
@@ -679,7 +679,7 @@ error: unreachable pattern
 LL |         _x if false => {}
    |         ^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error[E0004]: non-exhaustive patterns: `&_` not covered
   --> $DIR/empty-types.rs:637:11

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.rs
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.rs
@@ -32,6 +32,7 @@ fn main() {
         Err(_) => {}
         //~^ ERROR unreachable pattern
         //~| NOTE matches no values because `!` is uninhabited
+        //~| NOTE to learn more about uninhabited types, see
     }
 
     #[derive(Copy, Clone)]
@@ -45,12 +46,14 @@ fn main() {
         (Err(_), Err(_)) => {}
         //~^ ERROR unreachable pattern
         //~| NOTE matches no values because `Void2` is uninhabited
+        //~| NOTE to learn more about uninhabited types, see
         _ => {}
     }
     match (res1, &res2) {
         (Err(_), Err(_)) => {}
         //~^ ERROR unreachable pattern
         //~| NOTE matches no values because `Void1` is uninhabited
+        //~| NOTE to learn more about uninhabited types, see
         _ => {}
     }
 

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.rs
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.rs
@@ -26,6 +26,25 @@ fn main() {
         _ => {}
     }
 
+    match 0u8 {
+        1 => {}
+        //~^ NOTE matches some of the same values
+        2 => {}
+        //~^ NOTE matches some of the same values
+        3 => {}
+        //~^ NOTE matches some of the same values
+        4 => {}
+        //~^ NOTE matches some of the same values
+        5 => {}
+        6 => {}
+        1 ..= 6 => {}
+        //~^ ERROR unreachable pattern
+        //~| NOTE no value can reach this
+        //~| NOTE multiple earlier patterns match some of the same values
+        //~| NOTE ...and 2 other patterns
+        _ => {}
+    }
+
     let res: Result<(),!> = Ok(());
     match res {
         Ok(_) => {}

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.rs
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.rs
@@ -6,10 +6,10 @@
 fn main() {
     match (0u8,) {
         (1 | 2,) => {}
-        //~^ NOTE matches all the values already
+        //~^ NOTE matches all the relevant values
         (2,) => {}
         //~^ ERROR unreachable pattern
-        //~| NOTE unreachable pattern
+        //~| NOTE no value can reach this
         _ => {}
     }
 
@@ -20,8 +20,8 @@ fn main() {
         //~^ NOTE matches some of the same values
         (1 | 2,) => {}
         //~^ ERROR unreachable pattern
-        //~| NOTE unreachable pattern
-        //~| NOTE these patterns collectively make the last one unreachable
+        //~| NOTE no value can reach this
+        //~| NOTE multiple earlier patterns match some of the same values
         //~| NOTE collectively making this unreachable
         _ => {}
     }
@@ -31,7 +31,7 @@ fn main() {
         Ok(_) => {}
         Err(_) => {}
         //~^ ERROR unreachable pattern
-        //~| NOTE this pattern matches no values because `!` is uninhabited
+        //~| NOTE matches no values because `!` is uninhabited
     }
 
     #[derive(Copy, Clone)]
@@ -44,22 +44,22 @@ fn main() {
     match (&res1, res2) {
         (Err(_), Err(_)) => {}
         //~^ ERROR unreachable pattern
-        //~| NOTE this pattern matches no values because `Void2` is uninhabited
+        //~| NOTE matches no values because `Void2` is uninhabited
         _ => {}
     }
     match (res1, &res2) {
         (Err(_), Err(_)) => {}
         //~^ ERROR unreachable pattern
-        //~| NOTE this pattern matches no values because `Void1` is uninhabited
+        //~| NOTE matches no values because `Void1` is uninhabited
         _ => {}
     }
 
 
     if let (0
-        //~^ NOTE matches all the values already
+        //~^ NOTE matches all the relevant values
         | 0, _) = (0, 0) {}
         //~^ ERROR unreachable pattern
-        //~| NOTE unreachable pattern
+        //~| NOTE no value can reach this
 
     match (true, true) {
         (_, true) if false => {} // Guarded patterns don't cover others
@@ -69,20 +69,20 @@ fn main() {
         //~^ NOTE matches some of the same values
         (_, true) => {}
         //~^ ERROR unreachable pattern
-        //~| NOTE unreachable pattern
-        //~| NOTE these patterns collectively make the last one unreachable
+        //~| NOTE no value can reach this
+        //~| NOTE multiple earlier patterns match some of the same values
         //~| NOTE collectively making this unreachable
     }
 
     match (true, true) {
         (true, _) => {}
-        //~^ NOTE matches all the values already
+        //~^ NOTE matches all the relevant values
         (false, _) => {}
         #[allow(unreachable_patterns)]
         (_, true) => {} // Doesn't cover below because it's already unreachable.
         (true, true) => {}
         //~^ ERROR unreachable pattern
-        //~| NOTE unreachable pattern
+        //~| NOTE no value can reach this
     }
 
     // Despite skipping some irrelevant cases, we still report a set of rows that covers the
@@ -90,11 +90,11 @@ fn main() {
     match (true, true, 0) {
         (true, _, _) => {}
         (_, true, 0..10) => {}
-        //~^ NOTE matches all the values already
+        //~^ NOTE matches all the relevant values
         (_, true, 10..) => {}
         (_, true, 3) => {}
         //~^ ERROR unreachable pattern
-        //~| NOTE unreachable pattern
+        //~| NOTE no value can reach this
         _ => {}
     }
 }

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
@@ -32,7 +32,31 @@ LL |         (1 | 2,) => {}
    |         ^^^^^^^^ collectively making this unreachable
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:32:9
+  --> $DIR/explain-unreachable-pats.rs:40:9
+   |
+LL |         1 ..= 6 => {}
+   |         ^^^^^^^ no value can reach this
+   |
+note: multiple earlier patterns match some of the same values
+  --> $DIR/explain-unreachable-pats.rs:40:9
+   |
+LL |         1 => {}
+   |         - matches some of the same values
+LL |
+LL |         2 => {}
+   |         - matches some of the same values
+LL |
+LL |         3 => {}
+   |         - matches some of the same values
+LL |
+LL |         4 => {}
+   |         - matches some of the same values
+...
+LL |         1 ..= 6 => {}
+   |         ^^^^^^^ ...and 2 other patterns collectively make this unreachable
+
+error: unreachable pattern
+  --> $DIR/explain-unreachable-pats.rs:51:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^
@@ -41,7 +65,7 @@ LL |         Err(_) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:46:9
+  --> $DIR/explain-unreachable-pats.rs:65:9
    |
 LL |         (Err(_), Err(_)) => {}
    |         ^^^^^^^^^^^^^^^^
@@ -50,7 +74,7 @@ LL |         (Err(_), Err(_)) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:53:9
+  --> $DIR/explain-unreachable-pats.rs:72:9
    |
 LL |         (Err(_), Err(_)) => {}
    |         ^^^^^^^^^^^^^^^^
@@ -59,7 +83,7 @@ LL |         (Err(_), Err(_)) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:63:11
+  --> $DIR/explain-unreachable-pats.rs:82:11
    |
 LL |     if let (0
    |             - matches all the relevant values
@@ -68,13 +92,13 @@ LL |         | 0, _) = (0, 0) {}
    |           ^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:73:9
+  --> $DIR/explain-unreachable-pats.rs:92:9
    |
 LL |         (_, true) => {}
    |         ^^^^^^^^^ no value can reach this
    |
 note: multiple earlier patterns match some of the same values
-  --> $DIR/explain-unreachable-pats.rs:73:9
+  --> $DIR/explain-unreachable-pats.rs:92:9
    |
 LL |         (true, _) => {}
    |         --------- matches some of the same values
@@ -86,7 +110,7 @@ LL |         (_, true) => {}
    |         ^^^^^^^^^ collectively making this unreachable
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:86:9
+  --> $DIR/explain-unreachable-pats.rs:105:9
    |
 LL |         (true, _) => {}
    |         --------- matches all the relevant values
@@ -95,7 +119,7 @@ LL |         (true, true) => {}
    |         ^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:98:9
+  --> $DIR/explain-unreachable-pats.rs:117:9
    |
 LL |         (_, true, 0..10) => {}
    |         ---------------- matches all the relevant values
@@ -103,5 +127,5 @@ LL |         (_, true, 0..10) => {}
 LL |         (_, true, 3) => {}
    |         ^^^^^^^^^^^^ no value can reach this
 
-error: aborting due to 9 previous errors
+error: aborting due to 10 previous errors
 

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
@@ -38,25 +38,28 @@ LL |         Err(_) => {}
    |         ^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:45:9
+  --> $DIR/explain-unreachable-pats.rs:46:9
    |
 LL |         (Err(_), Err(_)) => {}
    |         ^^^^^^^^^^^^^^^^
    |
    = note: matches no values because `Void2` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:51:9
+  --> $DIR/explain-unreachable-pats.rs:53:9
    |
 LL |         (Err(_), Err(_)) => {}
    |         ^^^^^^^^^^^^^^^^
    |
    = note: matches no values because `Void1` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:60:11
+  --> $DIR/explain-unreachable-pats.rs:63:11
    |
 LL |     if let (0
    |             - matches all the relevant values
@@ -65,13 +68,13 @@ LL |         | 0, _) = (0, 0) {}
    |           ^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:70:9
+  --> $DIR/explain-unreachable-pats.rs:73:9
    |
 LL |         (_, true) => {}
    |         ^^^^^^^^^ no value can reach this
    |
 note: multiple earlier patterns match some of the same values
-  --> $DIR/explain-unreachable-pats.rs:70:9
+  --> $DIR/explain-unreachable-pats.rs:73:9
    |
 LL |         (true, _) => {}
    |         --------- matches some of the same values
@@ -83,7 +86,7 @@ LL |         (_, true) => {}
    |         ^^^^^^^^^ collectively making this unreachable
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:83:9
+  --> $DIR/explain-unreachable-pats.rs:86:9
    |
 LL |         (true, _) => {}
    |         --------- matches all the relevant values
@@ -92,7 +95,7 @@ LL |         (true, true) => {}
    |         ^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:95:9
+  --> $DIR/explain-unreachable-pats.rs:98:9
    |
 LL |         (_, true, 0..10) => {}
    |         ---------------- matches all the relevant values

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
@@ -59,27 +59,24 @@ error: unreachable pattern
   --> $DIR/explain-unreachable-pats.rs:51:9
    |
 LL |         Err(_) => {}
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/explain-unreachable-pats.rs:65:9
    |
 LL |         (Err(_), Err(_)) => {}
-   |         ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^ matches no values because `Void2` is uninhabited
    |
-   = note: matches no values because `Void2` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/explain-unreachable-pats.rs:72:9
    |
 LL |         (Err(_), Err(_)) => {}
-   |         ^^^^^^^^^^^^^^^^
+   |         ^^^^^^^^^^^^^^^^ matches no values because `Void1` is uninhabited
    |
-   = note: matches no values because `Void1` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
@@ -2,10 +2,10 @@ error: unreachable pattern
   --> $DIR/explain-unreachable-pats.rs:10:9
    |
 LL |         (1 | 2,) => {}
-   |         -------- matches all the values already
+   |         -------- matches all the relevant values
 LL |
 LL |         (2,) => {}
-   |         ^^^^ unreachable pattern
+   |         ^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/explain-unreachable-pats.rs:2:9
@@ -17,9 +17,9 @@ error: unreachable pattern
   --> $DIR/explain-unreachable-pats.rs:21:9
    |
 LL |         (1 | 2,) => {}
-   |         ^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/explain-unreachable-pats.rs:21:9
    |
 LL |         (1,) => {}
@@ -37,7 +37,7 @@ error: unreachable pattern
 LL |         Err(_) => {}
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/explain-unreachable-pats.rs:45:9
@@ -45,7 +45,7 @@ error: unreachable pattern
 LL |         (Err(_), Err(_)) => {}
    |         ^^^^^^^^^^^^^^^^
    |
-   = note: this pattern matches no values because `Void2` is uninhabited
+   = note: matches no values because `Void2` is uninhabited
 
 error: unreachable pattern
   --> $DIR/explain-unreachable-pats.rs:51:9
@@ -53,24 +53,24 @@ error: unreachable pattern
 LL |         (Err(_), Err(_)) => {}
    |         ^^^^^^^^^^^^^^^^
    |
-   = note: this pattern matches no values because `Void1` is uninhabited
+   = note: matches no values because `Void1` is uninhabited
 
 error: unreachable pattern
   --> $DIR/explain-unreachable-pats.rs:60:11
    |
 LL |     if let (0
-   |             - matches all the values already
+   |             - matches all the relevant values
 LL |
 LL |         | 0, _) = (0, 0) {}
-   |           ^ unreachable pattern
+   |           ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/explain-unreachable-pats.rs:70:9
    |
 LL |         (_, true) => {}
-   |         ^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/explain-unreachable-pats.rs:70:9
    |
 LL |         (true, _) => {}
@@ -86,19 +86,19 @@ error: unreachable pattern
   --> $DIR/explain-unreachable-pats.rs:83:9
    |
 LL |         (true, _) => {}
-   |         --------- matches all the values already
+   |         --------- matches all the relevant values
 ...
 LL |         (true, true) => {}
-   |         ^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/explain-unreachable-pats.rs:95:9
    |
 LL |         (_, true, 0..10) => {}
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 ...
 LL |         (_, true, 3) => {}
-   |         ^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^ no value can reach this
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/pattern/usefulness/floats.stderr
+++ b/tests/ui/pattern/usefulness/floats.stderr
@@ -15,9 +15,9 @@ error: unreachable pattern
   --> $DIR/floats.rs:18:9
    |
 LL |         0.01f16..=6.5f16 => {}
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 LL |         0.01f16 => {}
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/floats.rs:1:9
@@ -29,117 +29,117 @@ error: unreachable pattern
   --> $DIR/floats.rs:19:9
    |
 LL |         0.01f16..=6.5f16 => {}
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 LL |         0.01f16 => {}
 LL |         0.02f16 => {}
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/floats.rs:20:9
    |
 LL |         0.01f16..=6.5f16 => {}
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 ...
 LL |         6.5f16 => {}
-   |         ^^^^^^ unreachable pattern
+   |         ^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/floats.rs:31:9
    |
 LL |         0.01f32..=6.5f32 => {}
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 LL |         0.01f32 => {}
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/floats.rs:32:9
    |
 LL |         0.01f32..=6.5f32 => {}
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 LL |         0.01f32 => {}
 LL |         0.02f32 => {}
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/floats.rs:33:9
    |
 LL |         0.01f32..=6.5f32 => {}
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 ...
 LL |         6.5f32 => {}
-   |         ^^^^^^ unreachable pattern
+   |         ^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/floats.rs:45:9
    |
 LL |         0.01f64..=6.5f64 => {}
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 LL |         0.005f64 => {}
 LL |         0.01f64 => {}
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/floats.rs:46:9
    |
 LL |         0.01f64..=6.5f64 => {}
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 ...
 LL |         0.02f64 => {}
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/floats.rs:47:9
    |
 LL |         0.01f64..=6.5f64 => {}
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 ...
 LL |         6.5f64 => {}
-   |         ^^^^^^ unreachable pattern
+   |         ^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/floats.rs:49:9
    |
 LL |         0.01f64..=6.5f64 => {}
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 ...
 LL |         1.0f64..=4.0f64 => {}
-   |         ^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/floats.rs:62:9
    |
 LL |         0.01f128..=6.5f128 => {}
-   |         ------------------ matches all the values already
+   |         ------------------ matches all the relevant values
 LL |         0.005f128 => {}
 LL |         0.01f128 => {}
-   |         ^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/floats.rs:63:9
    |
 LL |         0.01f128..=6.5f128 => {}
-   |         ------------------ matches all the values already
+   |         ------------------ matches all the relevant values
 ...
 LL |         0.02f128 => {}
-   |         ^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/floats.rs:64:9
    |
 LL |         0.01f128..=6.5f128 => {}
-   |         ------------------ matches all the values already
+   |         ------------------ matches all the relevant values
 ...
 LL |         6.5f128 => {}
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/floats.rs:66:9
    |
 LL |         0.01f128..=6.5f128 => {}
-   |         ------------------ matches all the values already
+   |         ------------------ matches all the relevant values
 ...
 LL |         1.0f128..=4.0f128 => {}
-   |         ^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^ no value can reach this
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/pattern/usefulness/impl-trait.stderr
+++ b/tests/ui/pattern/usefulness/impl-trait.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:4:9
    |
@@ -17,7 +17,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:44:13
@@ -25,15 +25,15 @@ error: unreachable pattern
 LL |             Some(_) => {}
    |             ^^^^^^^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:48:13
    |
 LL |             None => {}
-   |             ---- matches all the values already
+   |             ---- matches all the relevant values
 LL |             _ => {}
-   |             ^ unreachable pattern
+   |             ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:58:13
@@ -41,15 +41,15 @@ error: unreachable pattern
 LL |             Some(_) => {}
    |             ^^^^^^^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:62:13
    |
 LL |             None => {}
-   |             ---- matches all the values already
+   |             ---- matches all the relevant values
 LL |             _ => {}
-   |             ^ unreachable pattern
+   |             ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:75:9
@@ -57,7 +57,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:85:9
@@ -65,7 +65,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         - matches any value
 LL |         Some((a, b)) => {}
-   |         ^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:93:13
@@ -73,15 +73,15 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:104:9
    |
 LL |         Some((a, b)) => {}
-   |         ------------ matches all the values already
+   |         ------------ matches all the relevant values
 LL |         Some((mut x, mut y)) => {
-   |         ^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:123:13
@@ -89,7 +89,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             - matches any value
 LL |             Rec { n: 0, w: Some(Rec { n: 0, w: _ }) } => {}
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:137:13
@@ -97,7 +97,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `SecretelyVoid` is uninhabited
+   = note: matches no values because `SecretelyVoid` is uninhabited
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:150:13
@@ -105,7 +105,7 @@ error: unreachable pattern
 LL |             _ => {}
    |             ^
    |
-   = note: this pattern matches no values because `SecretelyDoubleVoid` is uninhabited
+   = note: matches no values because `SecretelyDoubleVoid` is uninhabited
 
 error[E0004]: non-exhaustive patterns: type `impl Copy` is non-empty
   --> $DIR/impl-trait.rs:22:11

--- a/tests/ui/pattern/usefulness/impl-trait.stderr
+++ b/tests/ui/pattern/usefulness/impl-trait.stderr
@@ -5,6 +5,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:4:9
    |
@@ -18,6 +19,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:44:13
@@ -26,6 +28,7 @@ LL |             Some(_) => {}
    |             ^^^^^^^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:48:13
@@ -42,6 +45,7 @@ LL |             Some(_) => {}
    |             ^^^^^^^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:62:13
@@ -58,6 +62,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:85:9
@@ -74,6 +79,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:104:9
@@ -98,6 +104,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `SecretelyVoid` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:150:13
@@ -106,6 +113,7 @@ LL |             _ => {}
    |             ^
    |
    = note: matches no values because `SecretelyDoubleVoid` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `impl Copy` is non-empty
   --> $DIR/impl-trait.rs:22:11

--- a/tests/ui/pattern/usefulness/impl-trait.stderr
+++ b/tests/ui/pattern/usefulness/impl-trait.stderr
@@ -2,9 +2,8 @@ error: unreachable pattern
   --> $DIR/impl-trait.rs:16:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/impl-trait.rs:4:9
@@ -16,18 +15,16 @@ error: unreachable pattern
   --> $DIR/impl-trait.rs:30:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:44:13
    |
 LL |             Some(_) => {}
-   |             ^^^^^^^
+   |             ^^^^^^^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
@@ -42,9 +39,8 @@ error: unreachable pattern
   --> $DIR/impl-trait.rs:58:13
    |
 LL |             Some(_) => {}
-   |             ^^^^^^^
+   |             ^^^^^^^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
@@ -59,9 +55,8 @@ error: unreachable pattern
   --> $DIR/impl-trait.rs:75:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
@@ -76,9 +71,8 @@ error: unreachable pattern
   --> $DIR/impl-trait.rs:93:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
@@ -101,18 +95,16 @@ error: unreachable pattern
   --> $DIR/impl-trait.rs:137:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `SecretelyVoid` is uninhabited
    |
-   = note: matches no values because `SecretelyVoid` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/impl-trait.rs:150:13
    |
 LL |             _ => {}
-   |             ^
+   |             ^ matches no values because `SecretelyDoubleVoid` is uninhabited
    |
-   = note: matches no values because `SecretelyDoubleVoid` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `impl Copy` is non-empty

--- a/tests/ui/pattern/usefulness/integer-ranges/reachability.stderr
+++ b/tests/ui/pattern/usefulness/integer-ranges/reachability.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/reachability.rs:18:17
    |
 LL |     m!(0u8, 42, 42);
-   |             --  ^^ unreachable pattern
+   |             --  ^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
    |
 note: the lint level is defined here
   --> $DIR/reachability.rs:3:9
@@ -16,129 +16,129 @@ error: unreachable pattern
   --> $DIR/reachability.rs:22:22
    |
 LL |     m!(0u8, 20..=30, 20);
-   |             -------  ^^ unreachable pattern
+   |             -------  ^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:23:22
    |
 LL |     m!(0u8, 20..=30, 21);
-   |             -------  ^^ unreachable pattern
+   |             -------  ^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:24:22
    |
 LL |     m!(0u8, 20..=30, 25);
-   |             -------  ^^ unreachable pattern
+   |             -------  ^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:25:22
    |
 LL |     m!(0u8, 20..=30, 29);
-   |             -------  ^^ unreachable pattern
+   |             -------  ^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:26:22
    |
 LL |     m!(0u8, 20..=30, 30);
-   |             -------  ^^ unreachable pattern
+   |             -------  ^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:29:21
    |
 LL |     m!(0u8, 20..30, 20);
-   |             ------  ^^ unreachable pattern
+   |             ------  ^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:30:21
    |
 LL |     m!(0u8, 20..30, 21);
-   |             ------  ^^ unreachable pattern
+   |             ------  ^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:31:21
    |
 LL |     m!(0u8, 20..30, 25);
-   |             ------  ^^ unreachable pattern
+   |             ------  ^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:32:21
    |
 LL |     m!(0u8, 20..30, 29);
-   |             ------  ^^ unreachable pattern
+   |             ------  ^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:36:22
    |
 LL |     m!(0u8, 20..=30, 20..=30);
-   |             -------  ^^^^^^^ unreachable pattern
+   |             -------  ^^^^^^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:37:22
    |
 LL |     m!(0u8, 20.. 30, 20.. 30);
-   |             -------  ^^^^^^^ unreachable pattern
+   |             -------  ^^^^^^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:38:22
    |
 LL |     m!(0u8, 20..=30, 20.. 30);
-   |             -------  ^^^^^^^ unreachable pattern
+   |             -------  ^^^^^^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:40:22
    |
 LL |     m!(0u8, 20..=30, 21..=30);
-   |             -------  ^^^^^^^ unreachable pattern
+   |             -------  ^^^^^^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:41:22
    |
 LL |     m!(0u8, 20..=30, 20..=29);
-   |             -------  ^^^^^^^ unreachable pattern
+   |             -------  ^^^^^^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:43:24
    |
 LL |     m!('a', 'A'..='z', 'a'..='z');
-   |             ---------  ^^^^^^^^^ unreachable pattern
+   |             ---------  ^^^^^^^^^ no value can reach this
    |             |
-   |             matches all the values already
+   |             matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/reachability.rs:50:9
    |
 LL |         5..=8 => {},
-   |         ^^^^^ unreachable pattern
+   |         ^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/reachability.rs:50:9
    |
 LL |         5 => {},
@@ -156,9 +156,9 @@ error: unreachable pattern
   --> $DIR/reachability.rs:56:9
    |
 LL |         5..15 => {},
-   |         ^^^^^ unreachable pattern
+   |         ^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/reachability.rs:56:9
    |
 LL |         0..10 => {},
@@ -172,9 +172,9 @@ error: unreachable pattern
   --> $DIR/reachability.rs:63:9
    |
 LL |         5..25 => {},
-   |         ^^^^^ unreachable pattern
+   |         ^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/reachability.rs:63:9
    |
 LL |         0..10 => {},
@@ -190,9 +190,9 @@ error: unreachable pattern
   --> $DIR/reachability.rs:71:9
    |
 LL |         5..25 => {},
-   |         ^^^^^ unreachable pattern
+   |         ^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/reachability.rs:71:9
    |
 LL |         0..10 => {},
@@ -210,9 +210,9 @@ error: unreachable pattern
   --> $DIR/reachability.rs:77:9
    |
 LL |         5..15 => {},
-   |         ^^^^^ unreachable pattern
+   |         ^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/reachability.rs:77:9
    |
 LL |         0..10 => {},
@@ -228,15 +228,15 @@ error: unreachable pattern
 LL |         _ => {},
    |         - matches any value
 LL |         '\u{D7FF}'..='\u{E000}' => {},
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/reachability.rs:89:9
    |
 LL |         '\u{D7FF}'..='\u{E000}' => {},
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/reachability.rs:89:9
    |
 LL |         '\u{0}'..='\u{D7FF}' => {},
@@ -250,18 +250,18 @@ error: unreachable pattern
   --> $DIR/reachability.rs:105:9
    |
 LL |         &42 => {}
-   |         --- matches all the values already
+   |         --- matches all the relevant values
 LL |         &FOO => {}
-   |         ^^^^ unreachable pattern
+   |         ^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/reachability.rs:106:9
    |
 LL |         &42 => {}
-   |         --- matches all the values already
+   |         --- matches all the relevant values
 LL |         &FOO => {}
 LL |         BAR => {}
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
 
 error: aborting due to 25 previous errors
 

--- a/tests/ui/pattern/usefulness/issue-12116.stderr
+++ b/tests/ui/pattern/usefulness/issue-12116.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/issue-12116.rs:15:9
    |
 LL |         &IntList::Cons(val, box ref next_list) => tail(next_list),
-   |         -------------------------------------- matches all the values already
+   |         -------------------------------------- matches all the relevant values
 LL |         &IntList::Cons(val, box IntList::Nil)  => IntList::Cons(val, Box::new(IntList::Nil)),
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/issue-12116.rs:4:9

--- a/tests/ui/pattern/usefulness/issue-12369.stderr
+++ b/tests/ui/pattern/usefulness/issue-12369.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/issue-12369.rs:9:9
    |
 LL |         &[10,a, ref rest @ ..] => 10
-   |         ^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/issue-12369.rs:9:9
    |
 LL |         &[a,b,c] => 3,

--- a/tests/ui/pattern/usefulness/issue-13727.stderr
+++ b/tests/ui/pattern/usefulness/issue-13727.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/issue-13727.rs:7:5
    |
 LL |     256 => print!("0b1110\n"),
-   |     --- matches all the values already
+   |     --- matches all the relevant values
 LL |     512 => print!("0b1111\n"),
-   |     ^^^ unreachable pattern
+   |     ^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/issue-13727.rs:2:9

--- a/tests/ui/pattern/usefulness/issue-30240-b.stderr
+++ b/tests/ui/pattern/usefulness/issue-30240-b.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/issue-30240-b.rs:12:9
    |
 LL |         "hello" => {}
-   |         ------- matches all the values already
+   |         ------- matches all the relevant values
 LL |         "hello" => {}
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/issue-30240-b.rs:1:9

--- a/tests/ui/pattern/usefulness/issue-31221.stderr
+++ b/tests/ui/pattern/usefulness/issue-31221.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         Var3 => (),
    |         ---- matches any value
 LL |         Var2 => (),
-   |         ^^^^ unreachable pattern
+   |         ^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/issue-31221.rs:4:9
@@ -18,15 +18,15 @@ error: unreachable pattern
 LL |         &Var3 => (),
    |         ----- matches any value
 LL |         &Var2 => (),
-   |         ^^^^^ unreachable pattern
+   |         ^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/issue-31221.rs:31:9
    |
 LL |         anything => ()
-   |         ^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/issue-31221.rs:31:9
    |
 LL |         (Var1, b) => (),

--- a/tests/ui/pattern/usefulness/issue-57472.stderr
+++ b/tests/ui/pattern/usefulness/issue-57472.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/issue-57472.rs:15:13
    |
 LL |             Punned { foo: [_], .. } => println!("foo"),
-   |             ----------------------- matches all the values already
+   |             ----------------------- matches all the relevant values
 LL |             Punned { bar: [_], .. } => println!("bar"),
-   |             ^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |             ^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/issue-57472.rs:2:9
@@ -16,9 +16,9 @@ error: unreachable pattern
   --> $DIR/issue-57472.rs:32:17
    |
 LL |                 Punned { foo: [_] } => println!("foo"),
-   |                 ------------------- matches all the values already
+   |                 ------------------- matches all the relevant values
 LL |                 Punned { bar: [_] } => println!("bar"),
-   |                 ^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |                 ^^^^^^^^^^^^^^^^^^^ no value can reach this
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/pattern/usefulness/match-arm-statics.stderr
+++ b/tests/ui/pattern/usefulness/match-arm-statics.stderr
@@ -2,10 +2,10 @@ error: unreachable pattern
   --> $DIR/match-arm-statics.rs:25:9
    |
 LL |         TRUE_TRUE => (),
-   |         --------- matches all the values already
+   |         --------- matches all the relevant values
 ...
 LL |         (true, true) => ()
-   |         ^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/match-arm-statics.rs:2:9
@@ -17,18 +17,18 @@ error: unreachable pattern
   --> $DIR/match-arm-statics.rs:40:9
    |
 LL |         Some(Some(EAST)) => (),
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 ...
 LL |         Some(Some(East)) => (),
-   |         ^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/match-arm-statics.rs:60:9
    |
 LL |         Foo { bar: Some(EAST), baz: NewBool(false) } => ()
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/match-arm-statics.rs:60:9
    |
 LL |         Foo { bar: _, baz: NEW_FALSE } => (),

--- a/tests/ui/pattern/usefulness/match-byte-array-patterns.stderr
+++ b/tests/ui/pattern/usefulness/match-byte-array-patterns.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:8:9
    |
 LL |         b"AAAA" => {},
-   |         ------- matches all the values already
+   |         ------- matches all the relevant values
 LL |         &[0x41, 0x41, 0x41, 0x41] => {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/match-byte-array-patterns.rs:1:9
@@ -16,57 +16,57 @@ error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:14:9
    |
 LL |         &[0x41, 0x41, 0x41, 0x41] => {}
-   |         ------------------------- matches all the values already
+   |         ------------------------- matches all the relevant values
 LL |         b"AAAA" => {},
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:20:9
    |
 LL |         &[_, 0x41, 0x41, 0x41] => {},
-   |         ---------------------- matches all the values already
+   |         ---------------------- matches all the relevant values
 LL |         b"AAAA" => {},
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:26:9
    |
 LL |         &[0x41, .., 0x41] => {}
-   |         ----------------- matches all the values already
+   |         ----------------- matches all the relevant values
 LL |         b"AAAA" => {},
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:34:9
    |
 LL |         b"AAAA" => {},
-   |         ------- matches all the values already
+   |         ------- matches all the relevant values
 LL |         &[0x41, 0x41, 0x41, 0x41] => {}
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:40:9
    |
 LL |         &[0x41, 0x41, 0x41, 0x41] => {}
-   |         ------------------------- matches all the values already
+   |         ------------------------- matches all the relevant values
 LL |         b"AAAA" => {},
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:46:9
    |
 LL |         &[_, 0x41, 0x41, 0x41] => {},
-   |         ---------------------- matches all the values already
+   |         ---------------------- matches all the relevant values
 LL |         b"AAAA" => {},
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/match-byte-array-patterns.rs:52:9
    |
 LL |         &[0x41, .., 0x41] => {}
-   |         ----------------- matches all the values already
+   |         ----------------- matches all the relevant values
 LL |         b"AAAA" => {},
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/pattern/usefulness/match-ref-ice.stderr
+++ b/tests/ui/pattern/usefulness/match-ref-ice.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/match-ref-ice.rs:13:9
    |
 LL |         [1, ref _madoka, 3] => (),
-   |         ------------------- matches all the values already
+   |         ------------------- matches all the relevant values
 LL |         [1, 2, 3] => (),
-   |         ^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/match-ref-ice.rs:1:9

--- a/tests/ui/pattern/usefulness/match-vec-fixed.stderr
+++ b/tests/ui/pattern/usefulness/match-vec-fixed.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/match-vec-fixed.rs:7:9
    |
 LL |         [_, _, _] => {}
-   |         --------- matches all the values already
+   |         --------- matches all the relevant values
 LL |         [_, _, _] => {}
-   |         ^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/match-vec-fixed.rs:1:9
@@ -16,9 +16,9 @@ error: unreachable pattern
   --> $DIR/match-vec-fixed.rs:11:9
    |
 LL |         [_, 1, _] => {}
-   |         --------- matches all the values already
+   |         --------- matches all the relevant values
 LL |         [_, 1, _] => {}
-   |         ^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^ no value can reach this
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/pattern/usefulness/match-vec-unreachable.stderr
+++ b/tests/ui/pattern/usefulness/match-vec-unreachable.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/match-vec-unreachable.rs:8:9
    |
 LL |         [a, (2, 3), _] => (),
-   |         -------------- matches all the values already
+   |         -------------- matches all the relevant values
 LL |         [(1, 2), (2, 3), b] => (),
-   |         ^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/match-vec-unreachable.rs:1:9
@@ -16,17 +16,17 @@ error: unreachable pattern
   --> $DIR/match-vec-unreachable.rs:18:9
    |
 LL |         [ref a, _, _, ..] => { println!("{}", a); }
-   |         ----------------- matches all the values already
+   |         ----------------- matches all the relevant values
 LL |         [_, _, _, _, _] => { }
-   |         ^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/match-vec-unreachable.rs:26:9
    |
 LL |         ['a', 'b', 'c', ref _tail @ ..] => {}
-   |         ------------------------------- matches all the values already
+   |         ------------------------------- matches all the relevant values
 LL |         ['a', 'b', 'c'] => {}
-   |         ^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^ no value can reach this
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/pattern/usefulness/slice-pattern-const-2.stderr
+++ b/tests/ui/pattern/usefulness/slice-pattern-const-2.stderr
@@ -2,10 +2,10 @@ error: unreachable pattern
   --> $DIR/slice-pattern-const-2.rs:9:9
    |
 LL |         MAGIC_TEST => (),
-   |         ---------- matches all the values already
+   |         ---------- matches all the relevant values
 LL |         [0x00, 0x00, 0x00, 0x00] => (),
 LL |         [4, 5, 6, 7] => (),
-   |         ^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/slice-pattern-const-2.rs:1:9
@@ -17,25 +17,25 @@ error: unreachable pattern
   --> $DIR/slice-pattern-const-2.rs:15:9
    |
 LL |         MAGIC_TEST => (),
-   |         ---------- matches all the values already
+   |         ---------- matches all the relevant values
 LL |         [4, 5, 6, 7] => (),
-   |         ^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const-2.rs:21:9
    |
 LL |         [4, 5, 6, 7] => (),
-   |         ------------ matches all the values already
+   |         ------------ matches all the relevant values
 LL |         MAGIC_TEST => (),
-   |         ^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const-2.rs:28:9
    |
 LL |         [4] => (),
-   |         --- matches all the values already
+   |         --- matches all the relevant values
 LL |         FOO => (),
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/pattern/usefulness/slice-pattern-const-3.stderr
+++ b/tests/ui/pattern/usefulness/slice-pattern-const-3.stderr
@@ -2,10 +2,10 @@ error: unreachable pattern
   --> $DIR/slice-pattern-const-3.rs:9:9
    |
 LL |         MAGIC_TEST => (),
-   |         ---------- matches all the values already
+   |         ---------- matches all the relevant values
 LL |         ["0x00", "0x00", "0x00", "0x00"] => (),
 LL |         ["4", "5", "6", "7"] => (),
-   |         ^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/slice-pattern-const-3.rs:1:9
@@ -17,25 +17,25 @@ error: unreachable pattern
   --> $DIR/slice-pattern-const-3.rs:15:9
    |
 LL |         MAGIC_TEST => (),
-   |         ---------- matches all the values already
+   |         ---------- matches all the relevant values
 LL |         ["4", "5", "6", "7"] => (),
-   |         ^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const-3.rs:21:9
    |
 LL |         ["4", "5", "6", "7"] => (),
-   |         -------------------- matches all the values already
+   |         -------------------- matches all the relevant values
 LL |         MAGIC_TEST => (),
-   |         ^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const-3.rs:28:9
    |
 LL |         ["boo"] => (),
-   |         ------- matches all the values already
+   |         ------- matches all the relevant values
 LL |         FOO => (),
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/pattern/usefulness/slice-pattern-const.stderr
+++ b/tests/ui/pattern/usefulness/slice-pattern-const.stderr
@@ -2,10 +2,10 @@ error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:9:9
    |
 LL |         MAGIC_TEST => (),
-   |         ---------- matches all the values already
+   |         ---------- matches all the relevant values
 LL |         [0x00, 0x00, 0x00, 0x00] => (),
 LL |         [84, 69, 83, 84] => (),
-   |         ^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/slice-pattern-const.rs:1:9
@@ -17,67 +17,67 @@ error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:15:9
    |
 LL |         MAGIC_TEST => (),
-   |         ---------- matches all the values already
+   |         ---------- matches all the relevant values
 LL |         [84, 69, 83, 84] => (),
-   |         ^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:21:9
    |
 LL |         [84, 69, 83, 84] => (),
-   |         ---------------- matches all the values already
+   |         ---------------- matches all the relevant values
 LL |         MAGIC_TEST => (),
-   |         ^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:28:9
    |
 LL |         [4] => (),
-   |         --- matches all the values already
+   |         --- matches all the relevant values
 LL |         FOO => (),
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:35:9
    |
 LL |         [4] => (),
-   |         --- matches all the values already
+   |         --- matches all the relevant values
 LL |         BAR => (),
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:43:9
    |
 LL |         [] => (),
-   |         -- matches all the values already
+   |         -- matches all the relevant values
 LL |         BOO => (),
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:44:9
    |
 LL |         [] => (),
-   |         -- matches all the values already
+   |         -- matches all the relevant values
 LL |         BOO => (),
 LL |         b"" => (),
-   |         ^^^ unreachable pattern
+   |         ^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:45:9
    |
 LL |         [] => (),
-   |         -- matches all the values already
+   |         -- matches all the relevant values
 ...
 LL |         _ => (),
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-pattern-const.rs:51:9
    |
 LL |         CONST1 => {}
-   |         ------ matches all the values already
+   |         ------ matches all the relevant values
 LL |         [true] => {}
-   |         ^^^^^^ unreachable pattern
+   |         ^^^^^^ no value can reach this
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/pattern/usefulness/slice-patterns-reachability.stderr
+++ b/tests/ui/pattern/usefulness/slice-patterns-reachability.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/slice-patterns-reachability.rs:8:9
    |
 LL |         [true, ..] => {}
-   |         ---------- matches all the values already
+   |         ---------- matches all the relevant values
 LL |         [true, ..] => {}
-   |         ^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/slice-patterns-reachability.rs:1:9
@@ -16,44 +16,44 @@ error: unreachable pattern
   --> $DIR/slice-patterns-reachability.rs:9:9
    |
 LL |         [true, ..] => {}
-   |         ---------- matches all the values already
+   |         ---------- matches all the relevant values
 LL |         [true, ..] => {}
 LL |         [true] => {}
-   |         ^^^^^^ unreachable pattern
+   |         ^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-patterns-reachability.rs:14:9
    |
 LL |         [.., true] => {}
-   |         ---------- matches all the values already
+   |         ---------- matches all the relevant values
 LL |         [.., true] => {}
-   |         ^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-patterns-reachability.rs:15:9
    |
 LL |         [.., true] => {}
-   |         ---------- matches all the values already
+   |         ---------- matches all the relevant values
 LL |         [.., true] => {}
 LL |         [true] => {}
-   |         ^^^^^^ unreachable pattern
+   |         ^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-patterns-reachability.rs:20:9
    |
 LL |         [false, .., true] => {}
-   |         ----------------- matches all the values already
+   |         ----------------- matches all the relevant values
 LL |         [false, .., true] => {}
-   |         ^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/slice-patterns-reachability.rs:21:9
    |
 LL |         [false, .., true] => {}
-   |         ----------------- matches all the values already
+   |         ----------------- matches all the relevant values
 LL |         [false, .., true] => {}
 LL |         [false, true] => {}
-   |         ^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^ no value can reach this
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/pattern/usefulness/struct-pattern-match-useless.stderr
+++ b/tests/ui/pattern/usefulness/struct-pattern-match-useless.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         Foo { x: _x, y: _y } => (),
    |         -------------------- matches any value
 LL |         Foo { .. } => ()
-   |         ^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/struct-pattern-match-useless.rs:1:9

--- a/tests/ui/pattern/usefulness/top-level-alternation.stderr
+++ b/tests/ui/pattern/usefulness/top-level-alternation.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/top-level-alternation.rs:4:23
    |
 LL |     while let 0..=2 | 1 = 0 {}
-   |               -----   ^ unreachable pattern
+   |               -----   ^ no value can reach this
    |               |
-   |               matches all the values already
+   |               matches all the relevant values
    |
 note: the lint level is defined here
   --> $DIR/top-level-alternation.rs:1:9
@@ -16,66 +16,66 @@ error: unreachable pattern
   --> $DIR/top-level-alternation.rs:5:20
    |
 LL |     if let 0..=2 | 1 = 0 {}
-   |            -----   ^ unreachable pattern
+   |            -----   ^ no value can reach this
    |            |
-   |            matches all the values already
+   |            matches all the relevant values
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:9:15
    |
 LL |         0
-   |         - matches all the values already
+   |         - matches all the relevant values
 LL |             | 0 => {}
-   |               ^ unreachable pattern
+   |               ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:14:15
    |
 LL |         Some(0)
-   |         ------- matches all the values already
+   |         ------- matches all the relevant values
 LL |             | Some(0) => {}
-   |               ^^^^^^^ unreachable pattern
+   |               ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:19:9
    |
 LL |         (0, _) | (_, 0) => {}
-   |         --------------- matches all the values already
+   |         --------------- matches all the relevant values
 LL |         (0, 0) => {}
-   |         ^^^^^^ unreachable pattern
+   |         ^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:39:9
    |
 LL |         None | Some(_) => {}
-   |         -------------- matches all the values already
+   |         -------------- matches all the relevant values
 LL |         _ => {}
-   |         ^ unreachable pattern
+   |         ^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:43:9
    |
 LL |         None | Some(_) => {}
-   |         -------------- matches all the values already
+   |         -------------- matches all the relevant values
 LL |         Some(_) => {}
-   |         ^^^^^^^ unreachable pattern
+   |         ^^^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:44:9
    |
 LL |         None | Some(_) => {}
-   |         -------------- matches all the values already
+   |         -------------- matches all the relevant values
 LL |         Some(_) => {}
 LL |         None => {}
-   |         ^^^^ unreachable pattern
+   |         ^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:49:9
    |
 LL |         None | Some(_) => {}
-   |         ^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^ no value can reach this
    |
-note: these patterns collectively make the last one unreachable
+note: multiple earlier patterns match some of the same values
   --> $DIR/top-level-alternation.rs:49:9
    |
 LL |         Some(_) => {}
@@ -89,17 +89,17 @@ error: unreachable pattern
   --> $DIR/top-level-alternation.rs:53:9
    |
 LL |         1 | 2 => {},
-   |         ----- matches all the values already
+   |         ----- matches all the relevant values
 LL |         1..=2 => {},
-   |         ^^^^^ unreachable pattern
+   |         ^^^^^ no value can reach this
 
 error: unreachable pattern
   --> $DIR/top-level-alternation.rs:56:14
    |
 LL |     let (0 | 0) = 0 else { return };
-   |          -   ^ unreachable pattern
+   |          -   ^ no value can reach this
    |          |
-   |          matches all the values already
+   |          matches all the relevant values
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/reachable/unreachable-arm.stderr
+++ b/tests/ui/reachable/unreachable-arm.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/unreachable-arm.rs:11:9
    |
 LL |         Foo::B(_) | Foo::A(box _, 1) => { }
-   |         ---------------------------- matches all the values already
+   |         ---------------------------- matches all the relevant values
 LL |         Foo::A(_, 1) => { }
-   |         ^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/unreachable-arm.rs:4:9

--- a/tests/ui/reachable/unreachable-loop-patterns.stderr
+++ b/tests/ui/reachable/unreachable-loop-patterns.stderr
@@ -2,9 +2,8 @@ error: unreachable pattern
   --> $DIR/unreachable-loop-patterns.rs:16:9
    |
 LL |     for _ in unimplemented!() as Void {}
-   |         ^
+   |         ^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/unreachable-loop-patterns.rs:3:9

--- a/tests/ui/reachable/unreachable-loop-patterns.stderr
+++ b/tests/ui/reachable/unreachable-loop-patterns.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |     for _ in unimplemented!() as Void {}
    |         ^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 note: the lint level is defined here
   --> $DIR/unreachable-loop-patterns.rs:3:9
    |

--- a/tests/ui/reachable/unreachable-loop-patterns.stderr
+++ b/tests/ui/reachable/unreachable-loop-patterns.stderr
@@ -5,6 +5,7 @@ LL |     for _ in unimplemented!() as Void {}
    |         ^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/unreachable-loop-patterns.rs:3:9
    |

--- a/tests/ui/reachable/unreachable-try-pattern.stderr
+++ b/tests/ui/reachable/unreachable-try-pattern.stderr
@@ -20,6 +20,7 @@ LL |     let y = (match x { Ok(n) => Ok(n as u32), Err(e) => Err(e) })?;
    |                        ^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/unreachable-try-pattern.rs:4:9
    |
@@ -33,6 +34,7 @@ LL |     let y = (match x { Ok(n) => Ok(n), Err(e) => Err(e) })?;
    |                                        ^^^^^^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 warning: 3 warnings emitted
 

--- a/tests/ui/reachable/unreachable-try-pattern.stderr
+++ b/tests/ui/reachable/unreachable-try-pattern.stderr
@@ -17,9 +17,8 @@ warning: unreachable pattern
   --> $DIR/unreachable-try-pattern.rs:19:24
    |
 LL |     let y = (match x { Ok(n) => Ok(n as u32), Err(e) => Err(e) })?;
-   |                        ^^^^^
+   |                        ^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/unreachable-try-pattern.rs:4:9
@@ -31,9 +30,8 @@ warning: unreachable pattern
   --> $DIR/unreachable-try-pattern.rs:30:40
    |
 LL |     let y = (match x { Ok(n) => Ok(n), Err(e) => Err(e) })?;
-   |                                        ^^^^^^
+   |                                        ^^^^^^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 warning: 3 warnings emitted

--- a/tests/ui/reachable/unreachable-try-pattern.stderr
+++ b/tests/ui/reachable/unreachable-try-pattern.stderr
@@ -19,7 +19,7 @@ warning: unreachable pattern
 LL |     let y = (match x { Ok(n) => Ok(n as u32), Err(e) => Err(e) })?;
    |                        ^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 note: the lint level is defined here
   --> $DIR/unreachable-try-pattern.rs:4:9
    |
@@ -32,7 +32,7 @@ warning: unreachable pattern
 LL |     let y = (match x { Ok(n) => Ok(n), Err(e) => Err(e) })?;
    |                                        ^^^^^^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 warning: 3 warnings emitted
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         Err(!),
    |         ^^^^^^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 note: the lint level is defined here
   --> $DIR/unreachable.rs:4:9
    |
@@ -17,7 +17,7 @@ error: unreachable pattern
 LL |     let (Ok(_x) | Err(!)) = res_void;
    |                   ^^^^^^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:19:12
@@ -25,7 +25,7 @@ error: unreachable pattern
 LL |     if let Err(!) = res_void {}
    |            ^^^^^^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:21:24
@@ -33,7 +33,7 @@ error: unreachable pattern
 LL |     if let (Ok(true) | Err(!)) = res_void {}
    |                        ^^^^^^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:23:23
@@ -41,7 +41,7 @@ error: unreachable pattern
 LL |     for (Ok(mut _x) | Err(!)) in [res_void] {}
    |                       ^^^^^^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:27:18
@@ -49,7 +49,7 @@ error: unreachable pattern
 LL | fn foo((Ok(_x) | Err(!)): Result<bool, Void>) {}
    |                  ^^^^^^
    |
-   = note: this pattern matches no values because `Void` is uninhabited
+   = note: matches no values because `Void` is uninhabited
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.stderr
@@ -5,6 +5,7 @@ LL |         Err(!),
    |         ^^^^^^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/unreachable.rs:4:9
    |
@@ -18,6 +19,7 @@ LL |     let (Ok(_x) | Err(!)) = res_void;
    |                   ^^^^^^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:19:12
@@ -26,6 +28,7 @@ LL |     if let Err(!) = res_void {}
    |            ^^^^^^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:21:24
@@ -34,6 +37,7 @@ LL |     if let (Ok(true) | Err(!)) = res_void {}
    |                        ^^^^^^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:23:23
@@ -42,6 +46,7 @@ LL |     for (Ok(mut _x) | Err(!)) in [res_void] {}
    |                       ^^^^^^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:27:18
@@ -50,6 +55,7 @@ LL | fn foo((Ok(_x) | Err(!)): Result<bool, Void>) {}
    |                  ^^^^^^
    |
    = note: matches no values because `Void` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.stderr
@@ -2,9 +2,8 @@ error: unreachable pattern
   --> $DIR/unreachable.rs:14:9
    |
 LL |         Err(!),
-   |         ^^^^^^
+   |         ^^^^^^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/unreachable.rs:4:9
@@ -16,45 +15,40 @@ error: unreachable pattern
   --> $DIR/unreachable.rs:17:19
    |
 LL |     let (Ok(_x) | Err(!)) = res_void;
-   |                   ^^^^^^
+   |                   ^^^^^^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:19:12
    |
 LL |     if let Err(!) = res_void {}
-   |            ^^^^^^
+   |            ^^^^^^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:21:24
    |
 LL |     if let (Ok(true) | Err(!)) = res_void {}
-   |                        ^^^^^^
+   |                        ^^^^^^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:23:23
    |
 LL |     for (Ok(mut _x) | Err(!)) in [res_void] {}
-   |                       ^^^^^^
+   |                       ^^^^^^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/unreachable.rs:27:18
    |
 LL | fn foo((Ok(_x) | Err(!)): Result<bool, Void>) {}
-   |                  ^^^^^^
+   |                  ^^^^^^ matches no values because `Void` is uninhabited
    |
-   = note: matches no values because `Void` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: aborting due to 6 previous errors

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
@@ -5,6 +5,7 @@ LL |         _ => {}
    |         ^
    |
    = note: matches no values because `EmptyNonExhaustiveEnum` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/enum_same_crate_empty_match.rs:1:9
    |

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         _ => {}
    |         ^
    |
-   = note: this pattern matches no values because `EmptyNonExhaustiveEnum` is uninhabited
+   = note: matches no values because `EmptyNonExhaustiveEnum` is uninhabited
 note: the lint level is defined here
   --> $DIR/enum_same_crate_empty_match.rs:1:9
    |

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/enum_same_crate_empty_match.stderr
@@ -2,9 +2,8 @@ error: unreachable pattern
   --> $DIR/enum_same_crate_empty_match.rs:28:9
    |
 LL |         _ => {}
-   |         ^
+   |         ^ matches no values because `EmptyNonExhaustiveEnum` is uninhabited
    |
-   = note: matches no values because `EmptyNonExhaustiveEnum` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/enum_same_crate_empty_match.rs:1:9

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/issue-65157-repeated-match-arm.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/issue-65157-repeated-match-arm.stderr
@@ -2,9 +2,9 @@ error: unreachable pattern
   --> $DIR/issue-65157-repeated-match-arm.rs:15:9
    |
 LL |         PartiallyInhabitedVariants::Struct { .. } => {},
-   |         ----------------------------------------- matches all the values already
+   |         ----------------------------------------- matches all the relevant values
 LL |         PartiallyInhabitedVariants::Struct { .. } => {},
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unreachable pattern
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
    |
 note: the lint level is defined here
   --> $DIR/issue-65157-repeated-match-arm.rs:2:9

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         Some(_x) => (),
    |         ^^^^^^^^
    |
-   = note: this pattern matches no values because `UninhabitedEnum` is uninhabited
+   = note: matches no values because `UninhabitedEnum` is uninhabited
 note: the lint level is defined here
   --> $DIR/patterns_same_crate.rs:1:9
    |
@@ -17,7 +17,7 @@ error: unreachable pattern
 LL |         Some(_x) => (),
    |         ^^^^^^^^
    |
-   = note: this pattern matches no values because `UninhabitedVariants` is uninhabited
+   = note: matches no values because `UninhabitedVariants` is uninhabited
 
 error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:60:15
@@ -25,7 +25,7 @@ error: unreachable pattern
 LL |     while let PartiallyInhabitedVariants::Struct { x } = partially_inhabited_variant() {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: this pattern matches no values because `!` is uninhabited
+   = note: matches no values because `!` is uninhabited
 
 error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:64:15
@@ -33,7 +33,7 @@ error: unreachable pattern
 LL |     while let Some(_x) = uninhabited_struct() {
    |               ^^^^^^^^
    |
-   = note: this pattern matches no values because `UninhabitedStruct` is uninhabited
+   = note: matches no values because `UninhabitedStruct` is uninhabited
 
 error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:67:15
@@ -41,7 +41,7 @@ error: unreachable pattern
 LL |     while let Some(_x) = uninhabited_tuple_struct() {
    |               ^^^^^^^^
    |
-   = note: this pattern matches no values because `UninhabitedTupleStruct` is uninhabited
+   = note: matches no values because `UninhabitedTupleStruct` is uninhabited
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
@@ -2,9 +2,8 @@ error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:51:9
    |
 LL |         Some(_x) => (),
-   |         ^^^^^^^^
+   |         ^^^^^^^^ matches no values because `UninhabitedEnum` is uninhabited
    |
-   = note: matches no values because `UninhabitedEnum` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/patterns_same_crate.rs:1:9
@@ -16,36 +15,32 @@ error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:56:9
    |
 LL |         Some(_x) => (),
-   |         ^^^^^^^^
+   |         ^^^^^^^^ matches no values because `UninhabitedVariants` is uninhabited
    |
-   = note: matches no values because `UninhabitedVariants` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:60:15
    |
 LL |     while let PartiallyInhabitedVariants::Struct { x } = partially_inhabited_variant() {
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `!` is uninhabited
    |
-   = note: matches no values because `!` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:64:15
    |
 LL |     while let Some(_x) = uninhabited_struct() {
-   |               ^^^^^^^^
+   |               ^^^^^^^^ matches no values because `UninhabitedStruct` is uninhabited
    |
-   = note: matches no values because `UninhabitedStruct` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:67:15
    |
 LL |     while let Some(_x) = uninhabited_tuple_struct() {
-   |               ^^^^^^^^
+   |               ^^^^^^^^ matches no values because `UninhabitedTupleStruct` is uninhabited
    |
-   = note: matches no values because `UninhabitedTupleStruct` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: aborting due to 5 previous errors

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
@@ -5,6 +5,7 @@ LL |         Some(_x) => (),
    |         ^^^^^^^^
    |
    = note: matches no values because `UninhabitedEnum` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/patterns_same_crate.rs:1:9
    |
@@ -18,6 +19,7 @@ LL |         Some(_x) => (),
    |         ^^^^^^^^
    |
    = note: matches no values because `UninhabitedVariants` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:60:15
@@ -26,6 +28,7 @@ LL |     while let PartiallyInhabitedVariants::Struct { x } = partially_inhabite
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: matches no values because `!` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:64:15
@@ -34,6 +37,7 @@ LL |     while let Some(_x) = uninhabited_struct() {
    |               ^^^^^^^^
    |
    = note: matches no values because `UninhabitedStruct` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/patterns_same_crate.rs:67:15
@@ -42,6 +46,7 @@ LL |     while let Some(_x) = uninhabited_tuple_struct() {
    |               ^^^^^^^^
    |
    = note: matches no values because `UninhabitedTupleStruct` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/warns.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/warns.stderr
@@ -16,9 +16,9 @@ error: unreachable pattern
   --> $DIR/warns.rs:15:25
    |
 LL |         x if let None | None = x => {}
-   |                  ----   ^^^^ unreachable pattern
+   |                  ----   ^^^^ no value can reach this
    |                  |
-   |                  matches all the values already
+   |                  matches all the relevant values
    |
 note: the lint level is defined here
   --> $DIR/warns.rs:12:8

--- a/tests/ui/sanitizer/cfi/transparent-has-regions.rs
+++ b/tests/ui/sanitizer/cfi/transparent-has-regions.rs
@@ -1,0 +1,18 @@
+//@ needs-sanitizer-cfi
+//@ compile-flags: -Ccodegen-units=1 -Clto -Ctarget-feature=-crt-static -Zsanitizer=cfi
+//@ no-prefer-dynamic
+//@ only-x86_64-unknown-linux-gnu
+//@ build-pass
+
+pub trait Trait {}
+
+impl Trait for i32 {}
+
+#[repr(transparent)]
+struct BoxedTrait(Box<dyn Trait + 'static>);
+
+fn hello(x: BoxedTrait) {}
+
+fn main() {
+    hello(BoxedTrait(Box::new(1)));
+}

--- a/tests/ui/uninhabited/uninhabited-patterns.stderr
+++ b/tests/ui/uninhabited/uninhabited-patterns.stderr
@@ -2,9 +2,8 @@ error: unreachable pattern
   --> $DIR/uninhabited-patterns.rs:29:9
    |
 LL |         Ok(box _) => (),
-   |         ^^^^^^^^^
+   |         ^^^^^^^^^ matches no values because `NotSoSecretlyEmpty` is uninhabited
    |
-   = note: matches no values because `NotSoSecretlyEmpty` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/uninhabited-patterns.rs:3:9
@@ -16,18 +15,16 @@ error: unreachable pattern
   --> $DIR/uninhabited-patterns.rs:38:9
    |
 LL |         Err(Ok(_y)) => (),
-   |         ^^^^^^^^^^^
+   |         ^^^^^^^^^^^ matches no values because `NotSoSecretlyEmpty` is uninhabited
    |
-   = note: matches no values because `NotSoSecretlyEmpty` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/uninhabited-patterns.rs:41:15
    |
 LL |     while let Some(_y) = foo() {
-   |               ^^^^^^^^
+   |               ^^^^^^^^ matches no values because `NotSoSecretlyEmpty` is uninhabited
    |
-   = note: matches no values because `NotSoSecretlyEmpty` is uninhabited
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: aborting due to 3 previous errors

--- a/tests/ui/uninhabited/uninhabited-patterns.stderr
+++ b/tests/ui/uninhabited/uninhabited-patterns.stderr
@@ -5,6 +5,7 @@ LL |         Ok(box _) => (),
    |         ^^^^^^^^^
    |
    = note: matches no values because `NotSoSecretlyEmpty` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
   --> $DIR/uninhabited-patterns.rs:3:9
    |
@@ -18,6 +19,7 @@ LL |         Err(Ok(_y)) => (),
    |         ^^^^^^^^^^^
    |
    = note: matches no values because `NotSoSecretlyEmpty` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
   --> $DIR/uninhabited-patterns.rs:41:15
@@ -26,6 +28,7 @@ LL |     while let Some(_y) = foo() {
    |               ^^^^^^^^
    |
    = note: matches no values because `NotSoSecretlyEmpty` is uninhabited
+   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/uninhabited/uninhabited-patterns.stderr
+++ b/tests/ui/uninhabited/uninhabited-patterns.stderr
@@ -4,7 +4,7 @@ error: unreachable pattern
 LL |         Ok(box _) => (),
    |         ^^^^^^^^^
    |
-   = note: this pattern matches no values because `NotSoSecretlyEmpty` is uninhabited
+   = note: matches no values because `NotSoSecretlyEmpty` is uninhabited
 note: the lint level is defined here
   --> $DIR/uninhabited-patterns.rs:3:9
    |
@@ -17,7 +17,7 @@ error: unreachable pattern
 LL |         Err(Ok(_y)) => (),
    |         ^^^^^^^^^^^
    |
-   = note: this pattern matches no values because `NotSoSecretlyEmpty` is uninhabited
+   = note: matches no values because `NotSoSecretlyEmpty` is uninhabited
 
 error: unreachable pattern
   --> $DIR/uninhabited-patterns.rs:41:15
@@ -25,7 +25,7 @@ error: unreachable pattern
 LL |     while let Some(_y) = foo() {
    |               ^^^^^^^^
    |
-   = note: this pattern matches no values because `NotSoSecretlyEmpty` is uninhabited
+   = note: matches no values because `NotSoSecretlyEmpty` is uninhabited
 
 error: aborting due to 3 previous errors
 


### PR DESCRIPTION
Successful merges:

 - #128627 (Special case DUMMY_SP to emit line 0/column 0 locations on DWARF platforms.)
 - #128843 (Minor Refactor: Remove a Redundant Conditional Check)
 - #129179 (CFI: Erase regions when projecting ADT to its transparent non-1zst field)
 - #129281 (Tweak unreachable lint wording)
 - #129312 (Fix stability attribute of `impl !Error for &str`)
 - #129332 (Avoid extra `cast()`s after `CStr::as_ptr()`)
 - #129339 (Make `ArgAbi::make_indirect_force` more specific)
 - #129344 (Use `bool` in favor of `Option<()>` for diagnostics)
 - #129345 (Use shorthand field initialization syntax more aggressively in the compiler)
 - #129355 (fix comment on PlaceMention semantics)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=128627,128843,129179,129281,129312,129332,129339,129344,129345,129355)
<!-- homu-ignore:end -->