### PR TITLE
doc: core::cell::UnsafeCell: clarify concurrent access requirements

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -1922,7 +1922,8 @@ impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
 ///
 /// - At all times, you must avoid data races. If multiple threads have access to
 /// the same `UnsafeCell`, then any writes must have a proper happens-before relation to all other
-/// accesses (or use atomics).
+/// accesses, or all accesses must use atomic operations that establish a memory barrier (e.g.,
+/// operations in [core::sync::atomic] or compiler intrinsics).
 ///
 /// To assist with proper design, the following scenarios are explicitly declared legal
 /// for single-threaded code:


### PR DESCRIPTION
## Overview / Background

This commit clarifies an imprecise comment in the documentation of `UnsafeCell` around its requirements for multi-threaded accesses. Accesses to an `UnsafeCell` must be free of data races. Prior to this change, the documentation for this requirement read as follows:

> If multiple threads have access to the same UnsafeCell, then any writes must have a proper happens-before relation to all other accesses (or use atomics).

This phrasing is unfortunate in two regards:

- When using atomics for concurrent access to an UnsafeCell, atomic operations must be used for _all_ accesses to this object.

  The current text can be read as to require atomics only for write operations. Under that (wrong) interpretation Rust should admit, e.g., an AtomicUsize implementation that uses atomics for writes and instructions that happen to read back a consistent value on the target for reads, such as proposed in [1].

- The accesses need not only be atomic in the ISA / hardware, but the Rust compiler must recognize these operations to be atomics, and thus assume them to be able to synchronize between threads.

  For instance, the example of [1] _does_ read the shared `UnsafeCell`'s contents using a `mov` instruction that as far as I know, on AMD64 for a naturally aligned QWORD happens to be atomic, and is further guaranteed to be atomic in the presence of the concurrent `lock; xchg` instruction.

  However, because the Rust compiler does not explicitly treat this operation as atomic, it annotates the generated LLVM IR symbols with `nosync`, and both rustc and LLVM perform optimizations that rely on the assumption that the value is not shared.

  While working through this, I [wrote a blog post](https://leon.schuermann.io/blog/2024-08-07_rust-mutex-atomics-unsafecell_spooky-action-at-a-distance.html) [2] that steps through this "Atomics From Scratch" example and tries to reason through the interactions of UnsafeCell with Rust's memory barriers and synchronization primitives.

I looked through the [Unsafe Code Guidelines](https://github.com/rust-lang/unsafe-code-guidelines) repository but could not find any issue related to this.

## Proposed Change

With this commit, I propose to change this part of `UnsafeCell`'s documentation to explicitly call out these requirements. The documentation should explicitly mention that the atomicity requirement pertains to _all_ accesses, and that the Rust compiler must be aware that these operations can be used to synchronize between threads.

I believe that this second requirement effectively boils down to these operations generating some (weak or strong) memory barrier.

Hence, this commit updates the documented requirement to:

> If multiple threads have access to the same UnsafeCell, all accesses must use atomic operations that establish a memory barrier (e.g., operations in [core::sync::atomic] or compiler intrinsics).

[1]: https://whenderson.dev/blog/implementing-atomics-in-rust/
[2]: https://leon.schuermann.io/blog/2024-08-07_rust-mutex-atomics-unsafecell_spooky-action-at-a-distance.html

## Open Questions

- [ ] I'm not certain whether the requirement for atomics / intrinsics to establish a memory barrier is correct or accurate. I used this phrasing after reading through the `core::sync::atomic` module documentation, and in particular following this statement:
  > Each method takes an [Ordering](https://doc.rust-lang.org/stable/std/sync/atomic/enum.Ordering.html) which represents the strength of the memory barrier for that operation.
  
  Is there a better way to phrase this?

- [ ] Should Rust more explicitly state which operations are suitable for such inter-thread synchronization? It is still quite nebulous which _particular_ intrinsics and operations cause the compiler to assume that a function may synchronize with a different thread.

  For instance, I [tried to reason through how Rust's standard library implements `Mutex` using the `UnsafeCell` primitive](https://leon.schuermann.io/blog/2024-08-07_rust-mutex-atomics-unsafecell_spooky-action-at-a-distance.html#spooky-action-at-a-distance). After working through this code it becomes clear that the `atomic_cxchg_*` intrinsics establish the happens-before relation that is required for synchronized accesses to the `UnsafeCell<T>`'s contents, but I don't think that this is clearly documented anywhere right now.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
