### PR TITLE
Fix default/minimum deployment target for Aarch64 simulator targets

### DIFF
--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -323,12 +323,18 @@ fn deployment_target(os: &str, arch: Arch, abi: TargetAbi) -> (u16, u8, u8) {
     };
 
     // On certain targets it makes sense to raise the minimum OS version.
+    //
+    // This matches what LLVM does, see:
+    // <https://github.com/llvm/llvm-project/blob/llvmorg-18.1.8/llvm/lib/TargetParser/Triple.cpp#L1900-L1932>
     let min = match (os, arch, abi) {
-        // Use 11.0 on Aarch64 as that's the earliest version with M1 support.
         ("macos", Arch::Arm64 | Arch::Arm64e, _) => (11, 0, 0),
-        ("ios", Arch::Arm64e, _) => (14, 0, 0),
+        ("ios", Arch::Arm64 | Arch::Arm64e, TargetAbi::MacCatalyst) => (14, 0, 0),
+        ("ios", Arch::Arm64 | Arch::Arm64e, TargetAbi::Simulator) => (14, 0, 0),
+        ("ios", Arch::Arm64e, TargetAbi::Normal) => (14, 0, 0),
         // Mac Catalyst defaults to 13.1 in Clang.
         ("ios", _, TargetAbi::MacCatalyst) => (13, 1, 0),
+        ("tvos", Arch::Arm64 | Arch::Arm64e, TargetAbi::Simulator) => (14, 0, 0),
+        ("watchos", Arch::Arm64 | Arch::Arm64e, TargetAbi::Simulator) => (7, 0, 0),
         _ => os_min,
     };
 

--- a/src/doc/rustc/src/platform-support/apple-ios-macabi.md
+++ b/src/doc/rustc/src/platform-support/apple-ios-macabi.md
@@ -24,7 +24,7 @@ environment variable.
 
 ### OS version
 
-The minimum supported version is iOS 13.1.
+The minimum supported version is iOS 13.1 on x86 and 14.0 on Aarch64.
 
 This can be raised per-binary by changing the deployment target. `rustc`
 respects the common environment variables used by Xcode to do so, in this

--- a/src/doc/rustc/src/platform-support/arm64e-apple-ios.md
+++ b/src/doc/rustc/src/platform-support/arm64e-apple-ios.md
@@ -2,7 +2,7 @@
 
 **Tier: 3**
 
-ARM64e iOS (12.0+)
+ARM64e iOS (14.0+)
 
 ## Target maintainers
 

--- a/tests/run-make/apple-deployment-target/rmake.rs
+++ b/tests/run-make/apple-deployment-target/rmake.rs
@@ -55,11 +55,8 @@ fn main() {
         rustc().env(env_var, example_version).run();
         minos("foo.o", example_version);
 
-        // FIXME(madsmtm): Doesn't work on Mac Catalyst and the simulator.
-        if !target().contains("macabi") && !target().contains("sim") {
-            rustc().env_remove(env_var).run();
-            minos("foo.o", default_version);
-        }
+        rustc().env_remove(env_var).run();
+        minos("foo.o", default_version);
     });
 
     // Test that version makes it to the linker when linking dylibs.
@@ -105,8 +102,18 @@ fn main() {
             rustc
         };
 
-        // FIXME(madsmtm): Doesn't work on watchOS for some reason?
-        if !target().contains("watchos") {
+        // FIXME(madsmtm): Xcode's version of Clang seems to require a minimum
+        // version of 9.0 on aarch64-apple-watchos for some reason? Which is
+        // odd, because the first Aarch64 watch was Apple Watch Series 4,
+        // which runs on as low as watchOS 5.0.
+        //
+        // You can see Clang's behaviour by running:
+        // ```
+        // echo "int main() { return 0; }" > main.c
+        // xcrun --sdk watchos clang --target=aarch64-apple-watchos main.c
+        // vtool -show a.out
+        // ```
+        if target() != "aarch64-apple-watchos" {
             rustc().env(env_var, example_version).run();
             minos("foo", example_version);
 
@@ -148,10 +155,7 @@ fn main() {
         rustc().env(env_var, higher_example_version).run();
         minos("foo.o", higher_example_version);
 
-        // FIXME(madsmtm): Doesn't work on Mac Catalyst and the simulator.
-        if !target().contains("macabi") && !target().contains("sim") {
-            rustc().env_remove(env_var).run();
-            minos("foo.o", default_version);
-        }
+        rustc().env_remove(env_var).run();
+        minos("foo.o", default_version);
     });
 }


### PR DESCRIPTION
The minimum that `rustc` encoded did not match [the version in Clang](https://github.com/llvm/llvm-project/blob/llvmorg-18.1.8/llvm/lib/TargetParser/Triple.cpp#L1900-L1932), and that meant that that when linking, Clang ended up bumping the version. See https://github.com/rust-lang/rust/issues/129432 for more motivation behind this change.

Specifically, this PR sets the correct deployment target of the following targets:
- `aarch64-apple-ios-sim` from 10.0 to 14.0
- `aarch64-apple-tvos-sim` from 10.0 to 14.0
- `aarch64-apple-watchos-sim` from 5.0 to 7.0
- `aarch64-apple-ios-macabi` from 13.1 to 14.0

I have chosen not to document the `-sim` changes in the platform support docs, as it is fundamentally uninteresting; the normal targets (e.g. `aarch64-apple-ios`) still have the same deployment target, and that's what developers should actually target.

r? compiler

CC @BlackHoleFox