### PR TITLE
Special-case raw ref op for diverging check in HIR typeck

### DIFF
--- a/tests/ui/never_type/diverging-place-match.rs
+++ b/tests/ui/never_type/diverging-place-match.rs
@@ -1,0 +1,15 @@
+//@ known-bug: #117288
+//@ check-pass
+
+#![feature(never_type)]
+
+fn make_up_a_value<T>() -> T {
+    unsafe {
+        let x: *const ! = 0 as _;
+        let _: ! = *x;
+        // Since `*x` "diverges" in HIR, but doesn't count as a read in MIR, this
+        // is unsound since we act as if it diverges but it doesn't.
+    }
+}
+
+fn main() {}

--- a/tests/ui/raw-ref-op/never-place-isnt-diverging.rs
+++ b/tests/ui/raw-ref-op/never-place-isnt-diverging.rs
@@ -1,0 +1,13 @@
+#![feature(never_type)]
+
+fn make_up_a_value<T>() -> T {
+    unsafe {
+    //~^ ERROR mismatched types
+        let x: *const ! = 0 as _;
+        &raw const *x;
+        // Since `*x` is `!`, HIR typeck used to think that it diverges
+        // and allowed the block to coerce to any value, leading to UB.
+    }
+}
+
+fn main() {}

--- a/tests/ui/raw-ref-op/never-place-isnt-diverging.stderr
+++ b/tests/ui/raw-ref-op/never-place-isnt-diverging.stderr
@@ -1,0 +1,20 @@
+error[E0308]: mismatched types
+  --> $DIR/never-place-isnt-diverging.rs:4:5
+   |
+LL |   fn make_up_a_value<T>() -> T {
+   |                      - expected this type parameter
+LL | /     unsafe {
+LL | |
+LL | |         let x: *const ! = 0 as _;
+LL | |         &raw const *x;
+LL | |         // Since `*x` is `!`, HIR typeck used to think that it diverges
+LL | |         // and allowed the block to coerce to any value, leading to UB.
+LL | |     }
+   | |_____^ expected type parameter `T`, found `()`
+   |
+   = note: expected type parameter `T`
+                   found unit type `()`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/117288.

`&raw const EXPR` does not constitute a read of `EXPR`, so if `EXPR`'s type is `!`, then we don't want to consider that expression diverging. This was unsound when paired with #129248.

This remains unsound for things like matches `let _: ! = *x;`, but I wanted to add a test for it.