### PR TITLE
Add implementations for `unbounded_shl`/`unbounded_shr`

### DIFF
--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1321,6 +1321,7 @@ macro_rules! int_impl {
         ///
         /// Basic usage:
         /// ```
+        /// #![feature(unbounded_shifts)]
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(4), 0x10);")]
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(129), 0);")]
         /// ```
@@ -1447,10 +1448,11 @@ macro_rules! int_impl {
         ///
         /// Basic usage:
         /// ```
+        /// #![feature(unbounded_shifts)]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shl(4), 0x1);")]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.unbounded_shr(129), -1);")]
-        /// ```
+        /// ```  
         #[unstable(feature = "unbounded_shifts", issue = "129375")]
         #[rustc_allow_const_fn_unstable(unchecked_shifts)]
         #[must_use = "this returns the result of the operation, \

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1313,12 +1313,12 @@ macro_rules! int_impl {
         }
 
         /// Unbounded shift left. Computes `self << rhs`, without bounding the value of `rhs`
-        /// 
-        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        ///
+        /// If `rhs` is larger or equal to the number of bits in `self`,
         /// the entire value is shifted out, and `0` is returned.
         ///
         /// # Examples
-        /// 
+        ///
         /// Basic usage:
         /// ```
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(4), 0x10);")]
@@ -1438,13 +1438,13 @@ macro_rules! int_impl {
         }
 
         /// Unbounded shift right. Computes `self >> rhs`, without bounding the value of `rhs`
-        /// 
-        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        ///
+        /// If `rhs` is larger or equal to the number of bits in `self`,
         /// the entire value is shifted out, which yields `0` for a positive number,
         /// and `-1` for a negative number.
         ///
         /// # Examples
-        /// 
+        ///
         /// Basic usage:
         /// ```
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shl(4), 0x1);")]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1449,7 +1449,7 @@ macro_rules! int_impl {
         /// Basic usage:
         /// ```
         /// #![feature(unbounded_shifts)]
-        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shl(4), 0x1);")]
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(4), 0x1);")]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.unbounded_shr(129), -1);")]
         /// ```

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1326,7 +1326,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(129), 0);")]
         /// ```
         #[unstable(feature = "unbounded_shifts", issue = "129375")]
-        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[rustc_const_unstable(feature = "const_unbounded_shifts", issue = "129375")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
@@ -1454,7 +1454,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.unbounded_shr(129), -1);")]
         /// ```
         #[unstable(feature = "unbounded_shifts", issue = "129375")]
-        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[rustc_const_unstable(feature = "const_unbounded_shifts", issue = "129375")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1330,11 +1330,11 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline]
         pub const fn unbounded_shl(self, rhs: u32) -> $SelfT{
-            if rhs < Self::BITS{
+            if rhs < Self::BITS {
                 // SAFETY:
                 // rhs is just checked to be in-range above
                 unsafe { self.unchecked_shl(rhs) }
-            }else{
+            } else {
                 0
             }
         }
@@ -1457,11 +1457,11 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline]
         pub const fn unbounded_shr(self, rhs: u32) -> $SelfT{
-            if rhs < Self::BITS{
+            if rhs < Self::BITS {
                 // SAFETY:
                 // rhs is just checked to be in-range above
                 unsafe { self.unchecked_shr(rhs) }
-            }else{
+            } else {
                 // A shift by `Self::BITS-1` suffices for signed integers, because the sign bit is copied for each of the shifted bits.
 
                 // SAFETY:

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1452,7 +1452,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shl(4), 0x1);")]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.unbounded_shr(129), -1);")]
-        /// ```  
+        /// ```
         #[unstable(feature = "unbounded_shifts", issue = "129375")]
         #[rustc_allow_const_fn_unstable(unchecked_shifts)]
         #[must_use = "this returns the result of the operation, \

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1312,6 +1312,33 @@ macro_rules! int_impl {
             }
         }
 
+        /// Unbounded shift left. Computes `self << rhs`, without bounding the value of `rhs`
+        /// 
+        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        /// the entire value is shifted out, and `0` is returned.
+        ///
+        /// # Examples
+        /// 
+        /// Basic usage:
+        /// ```
+        #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(4), 0x10);")]
+        #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(129), 0);")]
+        /// ```
+        #[unstable(feature = "unbounded_shifts", issue = "129375")]
+        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn unbounded_shl(self, v: u32) -> $SelfT{
+            if v < Self::BITS{
+                // SAFETY:
+                // v is just checked to be in-range above
+                unsafe{self.unchecked_shl(v)}
+            }else{
+                0
+            }
+        }
+
         /// Checked shift right. Computes `self >> rhs`, returning `None` if `rhs` is
         /// larger than or equal to the number of bits in `self`.
         ///
@@ -1407,6 +1434,39 @@ macro_rules! int_impl {
             // SAFETY: this is guaranteed to be safe by the caller.
             unsafe {
                 intrinsics::unchecked_shr(self, rhs)
+            }
+        }
+
+        /// Unbounded shift right. Computes `self >> rhs`, without bounding the value of `rhs`
+        /// 
+        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        /// the entire value is shifted out, which yields `0` for a positive number,
+        /// and `-1` for a negative number.
+        ///
+        /// # Examples
+        /// 
+        /// Basic usage:
+        /// ```
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shl(4), 0x1);")]
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.unbounded_shr(129), -1);")]
+        /// ```
+        #[unstable(feature = "unbounded_shifts", issue = "129375")]
+        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn unbounded_shr(self, v: u32) -> $SelfT{
+            if v < Self::BITS{
+                // SAFETY:
+                // v is just checked to be in-range above
+                unsafe{self.unchecked_shr(v)}
+            }else{
+                // A shift by `Self::BITS-1` suffices for signed integers, because the sign bit is copied for each of the shifted bits.
+
+                // SAFETY:
+                // `Self::BITS-1` is guaranteed to be less than `Self::BITS`
+                unsafe{self.unchecked_shr(Self::BITS - 1)}
             }
         }
 

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1329,11 +1329,11 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn unbounded_shl(self, v: u32) -> $SelfT{
-            if v < Self::BITS{
+        pub const fn unbounded_shl(self, rhs: u32) -> $SelfT{
+            if rhs < Self::BITS{
                 // SAFETY:
-                // v is just checked to be in-range above
-                unsafe{self.unchecked_shl(v)}
+                // rhs is just checked to be in-range above
+                unsafe { self.unchecked_shl(rhs) }
             }else{
                 0
             }
@@ -1456,17 +1456,17 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn unbounded_shr(self, v: u32) -> $SelfT{
-            if v < Self::BITS{
+        pub const fn unbounded_shr(self, rhs: u32) -> $SelfT{
+            if rhs < Self::BITS{
                 // SAFETY:
-                // v is just checked to be in-range above
-                unsafe{self.unchecked_shr(v)}
+                // rhs is just checked to be in-range above
+                unsafe { self.unchecked_shr(rhs) }
             }else{
                 // A shift by `Self::BITS-1` suffices for signed integers, because the sign bit is copied for each of the shifted bits.
 
                 // SAFETY:
                 // `Self::BITS-1` is guaranteed to be less than `Self::BITS`
-                unsafe{self.unchecked_shr(Self::BITS - 1)}
+                unsafe { self.unchecked_shr(Self::BITS - 1) }
             }
         }
 

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1515,7 +1515,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(129), 0);")]
         /// ```
         #[unstable(feature = "unbounded_shifts", issue = "129375")]
-        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[rustc_const_unstable(feature = "const_unbounded_shifts", issue = "129375")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
@@ -1641,7 +1641,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
         /// ```
         #[unstable(feature = "unbounded_shifts", issue = "129375")]
-        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[rustc_const_unstable(feature = "const_unbounded_shifts", issue = "129375")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1637,7 +1637,7 @@ macro_rules! uint_impl {
         /// Basic usage:
         /// ```
         /// #![feature(unbounded_shifts)]
-        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(4), 0x10);")]
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(4), 0x1);")]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
         /// ```
         #[unstable(feature = "unbounded_shifts", issue = "129375")]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1518,11 +1518,11 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn unbounded_shl(self, v: u32) -> $SelfT{
-            if v < Self::BITS{
+        pub const fn unbounded_shl(self, rhs: u32) -> $SelfT{
+            if rhs < Self::BITS{
                 // SAFETY:
-                // v is just checked to be in-range above
-                unsafe{self.unchecked_shl(v)}
+                // rhs is just checked to be in-range above
+                unsafe { self.unchecked_shl(rhs) }
             }else{
                 0
             }
@@ -1643,11 +1643,11 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn unbounded_shr(self, v: u32) -> $SelfT{
-            if v < Self::BITS{
+        pub const fn unbounded_shr(self, rhs: u32) -> $SelfT{
+            if rhs < Self::BITS{
                 // SAFETY:
-                // v is just checked to be in-range above
-                unsafe{self.unchecked_shr(v)}
+                // rhs is just checked to be in-range above
+                unsafe { self.unchecked_shr(rhs) }
             }else{
                 0
             }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1501,7 +1501,7 @@ macro_rules! uint_impl {
             }
         }
 
-                /// Unbounded shift left. Computes `self << rhs`, without bounding the value of `rhs`
+        /// Unbounded shift left. Computes `self << rhs`, without bounding the value of `rhs`
         ///
         /// If `rhs` is larger or equal to the number of bits in `self`,
         /// the entire value is shifted out, and `0` is returned.
@@ -1510,6 +1510,7 @@ macro_rules! uint_impl {
         ///
         /// Basic usage:
         /// ```
+        /// #![feature(unbounded_shifts)]
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(4), 0x10);")]
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(129), 0);")]
         /// ```
@@ -1635,6 +1636,7 @@ macro_rules! uint_impl {
         ///
         /// Basic usage:
         /// ```
+        /// #![feature(unbounded_shifts)]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(4), 0x10);")]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
         /// ```

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1501,6 +1501,33 @@ macro_rules! uint_impl {
             }
         }
 
+                /// Unbounded shift left. Computes `self << rhs`, without bounding the value of `rhs`
+        /// 
+        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        /// the entire value is shifted out, and `0` is returned.
+        ///
+        /// # Examples
+        /// 
+        /// Basic usage:
+        /// ```
+        #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(4), 0x10);")]
+        #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(129), 0);")]
+        /// ```
+        #[unstable(feature = "unbounded_shifts", issue = "129375")]
+        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn unbounded_shl(self, v: u32) -> $SelfT{
+            if v < Self::BITS{
+                // SAFETY:
+                // v is just checked to be in-range above
+                unsafe{self.unchecked_shl(v)}
+            }else{
+                0
+            }
+        }
+
         /// Checked shift right. Computes `self >> rhs`, returning `None`
         /// if `rhs` is larger than or equal to the number of bits in `self`.
         ///
@@ -1596,6 +1623,33 @@ macro_rules! uint_impl {
             // SAFETY: this is guaranteed to be safe by the caller.
             unsafe {
                 intrinsics::unchecked_shr(self, rhs)
+            }
+        }
+
+        /// Unbounded shift right. Computes `self >> rhs`, without bounding the value of `rhs`
+        /// 
+        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        /// the entire value is shifted out, and `0` is returned.
+        ///
+        /// # Examples
+        /// 
+        /// Basic usage:
+        /// ```
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(4), 0x10);")]
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
+        /// ```
+        #[unstable(feature = "unbounded_shifts", issue = "129375")]
+        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn unbounded_shr(self, v: u32) -> $SelfT{
+            if v < Self::BITS{
+                // SAFETY:
+                // v is just checked to be in-range above
+                unsafe{self.unchecked_shr(v)}
+            }else{
+                0
             }
         }
 

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1519,11 +1519,11 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         pub const fn unbounded_shl(self, rhs: u32) -> $SelfT{
-            if rhs < Self::BITS{
+            if rhs < Self::BITS {
                 // SAFETY:
                 // rhs is just checked to be in-range above
                 unsafe { self.unchecked_shl(rhs) }
-            }else{
+            } else {
                 0
             }
         }
@@ -1644,11 +1644,11 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         pub const fn unbounded_shr(self, rhs: u32) -> $SelfT{
-            if rhs < Self::BITS{
+            if rhs < Self::BITS {
                 // SAFETY:
                 // rhs is just checked to be in-range above
                 unsafe { self.unchecked_shr(rhs) }
-            }else{
+            } else {
                 0
             }
         }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1502,12 +1502,12 @@ macro_rules! uint_impl {
         }
 
                 /// Unbounded shift left. Computes `self << rhs`, without bounding the value of `rhs`
-        /// 
-        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        ///
+        /// If `rhs` is larger or equal to the number of bits in `self`,
         /// the entire value is shifted out, and `0` is returned.
         ///
         /// # Examples
-        /// 
+        ///
         /// Basic usage:
         /// ```
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(4), 0x10);")]
@@ -1627,12 +1627,12 @@ macro_rules! uint_impl {
         }
 
         /// Unbounded shift right. Computes `self >> rhs`, without bounding the value of `rhs`
-        /// 
-        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        ///
+        /// If `rhs` is larger or equal to the number of bits in `self`,
         /// the entire value is shifted out, and `0` is returned.
         ///
         /// # Examples
-        /// 
+        ///
         /// Basic usage:
         /// ```
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(4), 0x10);")]


### PR DESCRIPTION
Tracking Issue: https://github.com/rust-lang/rust/issues/129375

This implements `unbounded_shl` and `unbounded_shr` under the feature gate `unbounded_shifts`