### PR TITLE
Clean up cfg-gating of ProcessPrng extern

### DIFF
--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -112,16 +112,9 @@ if #[cfg(not(target_vendor = "uwp"))] {
 #[cfg(not(target_vendor = "win7"))]
 #[cfg_attr(
     target_arch = "x86",
-    link(
-        name = "bcryptprimitives",
-        kind = "raw-dylib",
-        import_name_type = "undecorated"
-    )
+    link(name = "bcryptprimitives", kind = "raw-dylib", import_name_type = "undecorated")
 )]
-#[cfg_attr(
-    not(target_arch = "x86"),
-    link(name = "bcryptprimitives", kind = "raw-dylib")
-)]
+#[cfg_attr(not(target_arch = "x86"), link(name = "bcryptprimitives", kind = "raw-dylib"))]
 extern "system" {
     pub fn ProcessPrng(pbdata: *mut u8, cbdata: usize) -> BOOL;
 }

--- a/library/std/src/sys/pal/windows/c.rs
+++ b/library/std/src/sys/pal/windows/c.rs
@@ -109,19 +109,22 @@ if #[cfg(not(target_vendor = "uwp"))] {
 }
 
 // Use raw-dylib to import ProcessPrng as we can't rely on there being an import library.
-cfg_if::cfg_if! {
-if #[cfg(not(target_vendor = "win7"))] {
-    #[cfg(target_arch = "x86")]
-    #[link(name = "bcryptprimitives", kind = "raw-dylib", import_name_type = "undecorated")]
-    extern "system" {
-        pub fn ProcessPrng(pbdata: *mut u8, cbdata: usize) -> BOOL;
-    }
-    #[cfg(not(target_arch = "x86"))]
-    #[link(name = "bcryptprimitives", kind = "raw-dylib")]
-    extern "system" {
-        pub fn ProcessPrng(pbdata: *mut u8, cbdata: usize) -> BOOL;
-    }
-}}
+#[cfg(not(target_vendor = "win7"))]
+#[cfg_attr(
+    target_arch = "x86",
+    link(
+        name = "bcryptprimitives",
+        kind = "raw-dylib",
+        import_name_type = "undecorated"
+    )
+)]
+#[cfg_attr(
+    not(target_arch = "x86"),
+    link(name = "bcryptprimitives", kind = "raw-dylib")
+)]
+extern "system" {
+    pub fn ProcessPrng(pbdata: *mut u8, cbdata: usize) -> BOOL;
+}
 
 // Functions that aren't available on every version of Windows that we support,
 // but we still use them and just provide some form of a fallback implementation.


### PR DESCRIPTION
This removes a bit of duplication and is consistent with how `api-ms-win-core-synch-l1-2-0` externs are imported.