### PR TITLE
Revert "alloc: implement FromIterator for Box<str>"

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -2254,54 +2254,6 @@ impl<'a, I, A: Allocator> IntoIterator for &'a mut Box<[I], A> {
 }
 
 #[cfg(not(no_global_oom_handling))]
-#[stable(feature = "boxed_str_from_iter", since = "1.80.0")]
-impl FromIterator<char> for Box<str> {
-    fn from_iter<T: IntoIterator<Item = char>>(iter: T) -> Self {
-        String::from_iter(iter).into_boxed_str()
-    }
-}
-
-#[cfg(not(no_global_oom_handling))]
-#[stable(feature = "boxed_str_from_iter", since = "1.80.0")]
-impl<'a> FromIterator<&'a char> for Box<str> {
-    fn from_iter<T: IntoIterator<Item = &'a char>>(iter: T) -> Self {
-        String::from_iter(iter).into_boxed_str()
-    }
-}
-
-#[cfg(not(no_global_oom_handling))]
-#[stable(feature = "boxed_str_from_iter", since = "1.80.0")]
-impl<'a> FromIterator<&'a str> for Box<str> {
-    fn from_iter<T: IntoIterator<Item = &'a str>>(iter: T) -> Self {
-        String::from_iter(iter).into_boxed_str()
-    }
-}
-
-#[cfg(not(no_global_oom_handling))]
-#[stable(feature = "boxed_str_from_iter", since = "1.80.0")]
-impl FromIterator<String> for Box<str> {
-    fn from_iter<T: IntoIterator<Item = String>>(iter: T) -> Self {
-        String::from_iter(iter).into_boxed_str()
-    }
-}
-
-#[cfg(not(no_global_oom_handling))]
-#[stable(feature = "boxed_str_from_iter", since = "1.80.0")]
-impl<A: Allocator> FromIterator<Box<str, A>> for Box<str> {
-    fn from_iter<T: IntoIterator<Item = Box<str, A>>>(iter: T) -> Self {
-        String::from_iter(iter).into_boxed_str()
-    }
-}
-
-#[cfg(not(no_global_oom_handling))]
-#[stable(feature = "boxed_str_from_iter", since = "1.80.0")]
-impl<'a> FromIterator<Cow<'a, str>> for Box<str> {
-    fn from_iter<T: IntoIterator<Item = Cow<'a, str>>>(iter: T) -> Self {
-        String::from_iter(iter).into_boxed_str()
-    }
-}
-
-#[cfg(not(no_global_oom_handling))]
 #[stable(feature = "box_slice_clone", since = "1.3.0")]
 impl<T: Clone, A: Allocator + Clone> Clone for Box<[T], A> {
     fn clone(&self) -> Self {

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -57,8 +57,6 @@ use core::str::pattern::Pattern;
 use core::{fmt, hash, ptr, slice};
 
 #[cfg(not(no_global_oom_handling))]
-use crate::alloc::Allocator;
-#[cfg(not(no_global_oom_handling))]
 use crate::borrow::{Cow, ToOwned};
 use crate::boxed::Box;
 use crate::collections::TryReserveError;
@@ -2156,8 +2154,8 @@ impl FromIterator<String> for String {
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "box_str2", since = "1.45.0")]
-impl<A: Allocator> FromIterator<Box<str, A>> for String {
-    fn from_iter<I: IntoIterator<Item = Box<str, A>>>(iter: I) -> String {
+impl FromIterator<Box<str>> for String {
+    fn from_iter<I: IntoIterator<Item = Box<str>>>(iter: I) -> String {
         let mut buf = String::new();
         buf.extend(iter);
         buf
@@ -2238,8 +2236,8 @@ impl<'a> Extend<&'a str> for String {
 
 #[cfg(not(no_global_oom_handling))]
 #[stable(feature = "box_str2", since = "1.45.0")]
-impl<A: Allocator> Extend<Box<str, A>> for String {
-    fn extend<I: IntoIterator<Item = Box<str, A>>>(&mut self, iter: I) {
+impl Extend<Box<str>> for String {
+    fn extend<I: IntoIterator<Item = Box<str>>>(&mut self, iter: I) {
         iter.into_iter().for_each(move |s| self.push_str(&s));
     }
 }


### PR DESCRIPTION
This reverts commit c92c22826015168581f82e8b0f870a8cef9209b9 from #99969.

Given the regressions caused by #127343, I believe we need to seriously consider reverting the change. I'm opening this PR in order to have a focal point for the appropriate teams to have that conversation.

This revert can be temporary, while we find a less disruptive way for landing this change. If we were to merge this, it should be backported to 1.81, and I would argue it would warrant a 1.80.2 dot-release.

@rust-lang/libs-api @rust-lang/libs @rust-lang/compiler @rust-lang/lang @rust-lang/release 