### PR TITLE
Do not rely on names to find lifetimes.

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -1079,16 +1079,8 @@ fn msg_span_from_named_region<'tcx>(
 ) -> (String, Option<Span>) {
     match *region {
         ty::ReEarlyParam(br) => {
-            let scope = tcx
-                .parent(tcx.generics_of(generic_param_scope).region_param(br, tcx).def_id)
-                .expect_local();
-            let span = if let Some(param) =
-                tcx.hir().get_generics(scope).and_then(|generics| generics.get_named(br.name))
-            {
-                param.span
-            } else {
-                tcx.def_span(scope)
-            };
+            let param_def_id = tcx.generics_of(generic_param_scope).region_param(br, tcx).def_id;
+            let span = tcx.def_span(param_def_id);
             let text = if br.has_name() {
                 format!("the lifetime `{}` as defined here", br.name)
             } else {
@@ -1104,16 +1096,8 @@ fn msg_span_from_named_region<'tcx>(
                 ("the anonymous lifetime defined here".to_string(), Some(ty.span))
             } else {
                 match fr.bound_region {
-                    ty::BoundRegionKind::BrNamed(_, name) => {
-                        let span = if let Some(param) = tcx
-                            .hir()
-                            .get_generics(generic_param_scope)
-                            .and_then(|generics| generics.get_named(name))
-                        {
-                            param.span
-                        } else {
-                            tcx.def_span(generic_param_scope)
-                        };
+                    ty::BoundRegionKind::BrNamed(param_def_id, name) => {
+                        let span = tcx.def_span(param_def_id);
                         let text = if name == kw::UnderscoreLifetime {
                             "the anonymous lifetime as defined here".to_string()
                         } else {

--- a/tests/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
+++ b/tests/ui/borrowck/regions-bound-missing-bound-in-impl.stderr
@@ -30,9 +30,9 @@ note: the lifetime `'c` as defined here...
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |                        ^^
 note: ...does not necessarily outlive the lifetime `'c` as defined here
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:27:24
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:12:24
    |
-LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
+LL |     fn wrong_bound1<'b,'c,'d:'a+'b>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>);
    |                        ^^
 
 error[E0308]: method not compatible with trait
@@ -44,16 +44,15 @@ LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d
    = note: expected signature `fn(&'a _, Inv<'c>, Inv<'c>, Inv<'_>)`
               found signature `fn(&'a _, Inv<'_>, Inv<'c>, Inv<'_>)`
 note: the lifetime `'c` as defined here...
-  --> $DIR/regions-bound-missing-bound-in-impl.rs:27:24
+  --> $DIR/regions-bound-missing-bound-in-impl.rs:12:24
    |
-LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
+LL |     fn wrong_bound1<'b,'c,'d:'a+'b>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>);
    |                        ^^
 note: ...does not necessarily outlive the lifetime `'c` as defined here
   --> $DIR/regions-bound-missing-bound-in-impl.rs:27:24
    |
 LL |     fn wrong_bound1<'b,'c,'d:'a+'c>(self, b: Inv<'b>, c: Inv<'c>, d: Inv<'d>) {
    |                        ^^
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0195]: lifetime parameters or bounds on method `wrong_bound2` do not match the trait declaration
   --> $DIR/regions-bound-missing-bound-in-impl.rs:42:20

--- a/tests/ui/consts/static-default-lifetime/elided-lifetime.stderr
+++ b/tests/ui/consts/static-default-lifetime/elided-lifetime.stderr
@@ -48,10 +48,10 @@ LL |     const STATIC: &str = "";
    = note: expected reference `&'static _`
               found reference `&_`
 note: the anonymous lifetime as defined here...
-  --> $DIR/elided-lifetime.rs:15:18
+  --> $DIR/elided-lifetime.rs:16:19
    |
-LL | impl Bar for Foo<'_> {
-   |                  ^^
+LL |     const STATIC: &str = "";
+   |                   ^
    = note: ...does not necessarily outlive the static lifetime
 
 error: aborting due to 3 previous errors

--- a/tests/ui/consts/static-default-lifetime/static-trait-impl.stderr
+++ b/tests/ui/consts/static-default-lifetime/static-trait-impl.stderr
@@ -30,10 +30,10 @@ LL |     const STATIC: &str = "";
    = note: expected reference `&_`
               found reference `&_`
 note: the anonymous lifetime as defined here...
-  --> $DIR/static-trait-impl.rs:8:10
+  --> $DIR/static-trait-impl.rs:9:19
    |
-LL | impl Bar<'_> for A {
-   |          ^^
+LL |     const STATIC: &str = "";
+   |                   ^
 note: ...does not necessarily outlive the anonymous lifetime as defined here
   --> $DIR/static-trait-impl.rs:8:10
    |

--- a/tests/ui/implied-bounds/impl-implied-bounds-compatibility-unnormalized.stderr
+++ b/tests/ui/implied-bounds/impl-implied-bounds-compatibility-unnormalized.stderr
@@ -5,9 +5,9 @@ LL |     fn get<'s>(s: &'s str, _: <&'static &'s () as Project>::Ty) -> &'static
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the lifetime `'s` as defined here...
-  --> $DIR/impl-implied-bounds-compatibility-unnormalized.rs:11:12
+  --> $DIR/impl-implied-bounds-compatibility-unnormalized.rs:8:12
    |
-LL |     fn get<'s>(s: &'s str, _: <&'static &'s () as Project>::Ty) -> &'static str {
+LL |     fn get<'s>(s: &'s str, _: ()) -> &'static str;
    |            ^^
 note: ...so that the method type is compatible with trait
   --> $DIR/impl-implied-bounds-compatibility-unnormalized.rs:11:5

--- a/tests/ui/issues/issue-20831-debruijn.stderr
+++ b/tests/ui/issues/issue-20831-debruijn.stderr
@@ -5,10 +5,10 @@ LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: first, the lifetime cannot outlive the anonymous lifetime as defined here...
-  --> $DIR/issue-20831-debruijn.rs:28:18
+  --> $DIR/issue-20831-debruijn.rs:28:67
    |
 LL |     fn subscribe(&mut self, t : Box<dyn Subscriber<Input=<Self as Publisher>::Output> + 'a>) {
-   |                  ^
+   |                                                                   ^^^^^^^^^
 note: ...but the lifetime must also be valid for the lifetime `'a` as defined here...
   --> $DIR/issue-20831-debruijn.rs:26:6
    |

--- a/tests/ui/issues/issue-37884.stderr
+++ b/tests/ui/issues/issue-37884.stderr
@@ -7,10 +7,7 @@ LL |     fn next(&'a mut self) -> Option<Self::Item>
    = note: expected signature `fn(&mut RepeatMut<'_, _>) -> Option<_>`
               found signature `fn(&'a mut RepeatMut<'_, _>) -> Option<_>`
 note: the anonymous lifetime as defined here...
-  --> $DIR/issue-37884.rs:6:5
-   |
-LL |     fn next(&'a mut self) -> Option<Self::Item>
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  --> $SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL
 note: ...does not necessarily outlive the lifetime `'a` as defined here
   --> $DIR/issue-37884.rs:3:6
    |


### PR DESCRIPTION
For some reason, we were trying to find the lifetime parameter from its name, instead of using the def_id we have.

This PR uses it instead. This changes some ui tests, I think to be more sensible.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
