### PR TITLE
Pretty-print own args of existential projections (dyn-Trait w/ GAT constraints)

### DIFF
--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -3119,7 +3119,10 @@ define_print! {
 
     ty::ExistentialProjection<'tcx> {
         let name = cx.tcx().associated_item(self.def_id).name;
-        p!(write("{} = ", name), print(self.term))
+        // The args don't contain the self ty (as it has been erased) but the corresp.
+        // generics do as the trait always has a self ty param. We need to offset.
+        let args = &self.args[cx.tcx().generics_of(self.def_id).parent_count - 1..];
+        p!(path_generic_args(|cx| write!(cx, "{name}"), args), " = ", print(self.term))
     }
 
     ty::ProjectionPredicate<'tcx> {

--- a/tests/ui/generic-associated-types/gat-in-trait-path.base.stderr
+++ b/tests/ui/generic-associated-types/gat-in-trait-path.base.stderr
@@ -51,7 +51,7 @@ LL |     type A<'a> where Self: 'a;
    = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `Foo` for this new enum and using it instead:
              Fooy
              Fooer<T>
-   = note: required for the cast from `Box<Fooer<{integer}>>` to `Box<(dyn Foo<A = &'a ()> + 'static)>`
+   = note: required for the cast from `Box<Fooer<{integer}>>` to `Box<(dyn Foo<A<'a> = &'a ()> + 'static)>`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/generic-associated-types/issue-76535.base.stderr
+++ b/tests/ui/generic-associated-types/issue-76535.base.stderr
@@ -47,7 +47,7 @@ LL |     type SubType<'a>: SubTrait where Self: 'a;
    = help: consider moving `SubType` to another trait
    = help: only type `SuperStruct` is seen to implement the trait in this crate, consider using it directly instead
    = note: `SuperTrait` can be implemented in other crates; if you want to support your users passing their own types here, you can't refer to a specific type
-   = note: required for the cast from `Box<SuperStruct>` to `Box<dyn SuperTrait<SubType = SubStruct<'_>>>`
+   = note: required for the cast from `Box<SuperStruct>` to `Box<dyn SuperTrait<SubType<'_> = SubStruct<'_>>>`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/generic-associated-types/issue-79422.base.stderr
+++ b/tests/ui/generic-associated-types/issue-79422.base.stderr
@@ -49,7 +49,7 @@ LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
    = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `MapLike` for this new enum and using it instead:
              std::collections::BTreeMap<K, V>
              Source
-   = note: required for the cast from `Box<BTreeMap<u8, u8>>` to `Box<dyn MapLike<u8, u8, VRefCont = (dyn RefCont<'_, u8> + 'static)>>`
+   = note: required for the cast from `Box<BTreeMap<u8, u8>>` to `Box<dyn MapLike<u8, u8, VRefCont<'_> = (dyn RefCont<'_, u8> + 'static)>>`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/generic-associated-types/issue-79422.extended.stderr
+++ b/tests/ui/generic-associated-types/issue-79422.extended.stderr
@@ -28,7 +28,7 @@ LL |     type VRefCont<'a> = &'a V where Self: 'a;
    = note: expected trait object `(dyn RefCont<'_, u8> + 'static)`
                  found reference `&u8`
    = help: `&u8` implements `RefCont` so you could box the found value and coerce it to the trait object `Box<dyn RefCont>`, you will have to change the expected type as well
-   = note: required for the cast from `Box<BTreeMap<u8, u8>>` to `Box<dyn MapLike<u8, u8, VRefCont = (dyn RefCont<'_, u8> + 'static)>>`
+   = note: required for the cast from `Box<BTreeMap<u8, u8>>` to `Box<dyn MapLike<u8, u8, VRefCont<'_> = (dyn RefCont<'_, u8> + 'static)>>`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/object/pretty.rs
+++ b/tests/ui/traits/object/pretty.rs
@@ -18,6 +18,10 @@ trait FixedHrtb: for<'a> SuperGeneric<'a, Assoc2 = &'a u8> {}
 trait AnyDifferentBinders: for<'a> SuperGeneric<'a, Assoc2 = &'a u8> + Super {}
 trait FixedDifferentBinders: for<'a> SuperGeneric<'a, Assoc2 = &'a u8> + Super<Assoc = u8> {}
 
+trait HasGat<Outer> {
+    type Assoc<Inner> where Self: Sized;
+}
+
 fn dyn_super(x: &dyn Super<Assoc = u8>) { x } //~ERROR mismatched types
 fn dyn_any(x: &dyn Any<Assoc = u8>) { x } //~ERROR mismatched types
 fn dyn_fixed(x: &dyn Fixed) { x } //~ERROR mismatched types
@@ -33,5 +37,8 @@ fn dyn_fixed_generic_multi(x: &dyn for<'a> FixedGeneric1<'a, Assoc2 = &u8>) { x 
 fn dyn_fixed_hrtb(x: &dyn FixedHrtb) { x } //~ERROR mismatched types
 fn dyn_any_different_binders(x: &dyn AnyDifferentBinders<Assoc = u8>) { x } //~ERROR mismatched types
 fn dyn_fixed_different_binders(x: &dyn FixedDifferentBinders) { x } //~ERROR mismatched types
+
+fn dyn_has_gat(x: &dyn HasGat<u8, Assoc<bool> = ()>) { x } //~ERROR mismatched types
+//~^ WARN unnecessary associated type bound
 
 fn main() {}

--- a/tests/ui/traits/object/pretty.stderr
+++ b/tests/ui/traits/object/pretty.stderr
@@ -1,5 +1,14 @@
+warning: unnecessary associated type bound for not object safe associated type
+  --> $DIR/pretty.rs:41:35
+   |
+LL | fn dyn_has_gat(x: &dyn HasGat<u8, Assoc<bool> = ()>) { x }
+   |                                   ^^^^^^^^^^^^^^^^ help: remove this bound
+   |
+   = note: this associated type has a `where Self: Sized` bound, and while the associated type can be specified, it cannot be used because trait objects are never `Sized`
+   = note: `#[warn(unused_associated_type_bounds)]` on by default
+
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:21:43
+  --> $DIR/pretty.rs:25:43
    |
 LL | fn dyn_super(x: &dyn Super<Assoc = u8>) { x }
    |                                        -  ^ expected `()`, found `&dyn Super<Assoc = u8>`
@@ -10,7 +19,7 @@ LL | fn dyn_super(x: &dyn Super<Assoc = u8>) { x }
               found reference `&dyn Super<Assoc = u8>`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:22:39
+  --> $DIR/pretty.rs:26:39
    |
 LL | fn dyn_any(x: &dyn Any<Assoc = u8>) { x }
    |                                    -  ^ expected `()`, found `&dyn Any<Assoc = u8>`
@@ -21,7 +30,7 @@ LL | fn dyn_any(x: &dyn Any<Assoc = u8>) { x }
               found reference `&dyn Any<Assoc = u8>`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:23:31
+  --> $DIR/pretty.rs:27:31
    |
 LL | fn dyn_fixed(x: &dyn Fixed) { x }
    |                            -  ^ expected `()`, found `&dyn Fixed`
@@ -32,7 +41,7 @@ LL | fn dyn_fixed(x: &dyn Fixed) { x }
               found reference `&dyn Fixed`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:24:50
+  --> $DIR/pretty.rs:28:50
    |
 LL | fn dyn_fixed_multi(x: &dyn Fixed<Assoc = u16>) { x }
    |                                               -  ^ expected `()`, found `&dyn Fixed<Assoc = u16>`
@@ -43,7 +52,7 @@ LL | fn dyn_fixed_multi(x: &dyn Fixed<Assoc = u16>) { x }
               found reference `&dyn Fixed<Assoc = u16>`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:25:38
+  --> $DIR/pretty.rs:29:38
    |
 LL | fn dyn_fixed_sub(x: &dyn FixedSub) { x }
    |                                   -  ^ expected `()`, found `&dyn FixedSub`
@@ -54,7 +63,7 @@ LL | fn dyn_fixed_sub(x: &dyn FixedSub) { x }
               found reference `&dyn FixedSub`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:26:44
+  --> $DIR/pretty.rs:30:44
    |
 LL | fn dyn_fixed_static(x: &dyn FixedStatic) { x }
    |                                         -  ^ expected `()`, found `&dyn FixedStatic`
@@ -65,7 +74,7 @@ LL | fn dyn_fixed_static(x: &dyn FixedStatic) { x }
               found reference `&dyn FixedStatic`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:28:75
+  --> $DIR/pretty.rs:32:75
    |
 LL | fn dyn_super_generic(x: &dyn for<'a> SuperGeneric<'a, Assoc2 = &'a u8>) { x }
    |                                                                        -  ^ expected `()`, found `&dyn SuperGeneric<'a, Assoc2 = &u8>`
@@ -76,7 +85,7 @@ LL | fn dyn_super_generic(x: &dyn for<'a> SuperGeneric<'a, Assoc2 = &'a u8>) { x
               found reference `&dyn for<'a> SuperGeneric<'a, Assoc2 = &'a u8>`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:29:71
+  --> $DIR/pretty.rs:33:71
    |
 LL | fn dyn_any_generic(x: &dyn for<'a> AnyGeneric<'a, Assoc2 = &'a u8>) { x }
    |                                                                    -  ^ expected `()`, found `&dyn AnyGeneric<'a, Assoc2 = &u8>`
@@ -87,7 +96,7 @@ LL | fn dyn_any_generic(x: &dyn for<'a> AnyGeneric<'a, Assoc2 = &'a u8>) { x }
               found reference `&dyn for<'a> AnyGeneric<'a, Assoc2 = &'a u8>`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:30:60
+  --> $DIR/pretty.rs:34:60
    |
 LL | fn dyn_fixed_generic1(x: &dyn for<'a> FixedGeneric1<'a>) { x }
    |                                                         -  ^ expected `()`, found `&dyn FixedGeneric1<'a>`
@@ -98,7 +107,7 @@ LL | fn dyn_fixed_generic1(x: &dyn for<'a> FixedGeneric1<'a>) { x }
               found reference `&dyn for<'a> FixedGeneric1<'a>`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:31:60
+  --> $DIR/pretty.rs:35:60
    |
 LL | fn dyn_fixed_generic2(x: &dyn for<'a> FixedGeneric2<'a>) { x }
    |                                                         -  ^ expected `()`, found `&dyn FixedGeneric2<'a>`
@@ -109,7 +118,7 @@ LL | fn dyn_fixed_generic2(x: &dyn for<'a> FixedGeneric2<'a>) { x }
               found reference `&dyn for<'a> FixedGeneric2<'a>`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:32:79
+  --> $DIR/pretty.rs:36:79
    |
 LL | fn dyn_fixed_generic_multi(x: &dyn for<'a> FixedGeneric1<'a, Assoc2 = &u8>) { x }
    |                                                                            -  ^ expected `()`, found `&dyn FixedGeneric1<'a, Assoc2 = ...>`
@@ -120,7 +129,7 @@ LL | fn dyn_fixed_generic_multi(x: &dyn for<'a> FixedGeneric1<'a, Assoc2 = &u8>)
               found reference `&dyn for<'a> FixedGeneric1<'a, Assoc2 = &u8>`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:33:40
+  --> $DIR/pretty.rs:37:40
    |
 LL | fn dyn_fixed_hrtb(x: &dyn FixedHrtb) { x }
    |                                     -  ^ expected `()`, found `&dyn FixedHrtb`
@@ -131,7 +140,7 @@ LL | fn dyn_fixed_hrtb(x: &dyn FixedHrtb) { x }
               found reference `&dyn FixedHrtb`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:34:73
+  --> $DIR/pretty.rs:38:73
    |
 LL | fn dyn_any_different_binders(x: &dyn AnyDifferentBinders<Assoc = u8>) { x }
    |                                                                      -  ^ expected `()`, found `&dyn AnyDifferentBinders<Assoc = ...>`
@@ -142,7 +151,7 @@ LL | fn dyn_any_different_binders(x: &dyn AnyDifferentBinders<Assoc = u8>) { x }
               found reference `&dyn AnyDifferentBinders<Assoc = u8>`
 
 error[E0308]: mismatched types
-  --> $DIR/pretty.rs:35:65
+  --> $DIR/pretty.rs:39:65
    |
 LL | fn dyn_fixed_different_binders(x: &dyn FixedDifferentBinders) { x }
    |                                                              -  ^ expected `()`, found `&dyn FixedDifferentBinders`
@@ -152,6 +161,17 @@ LL | fn dyn_fixed_different_binders(x: &dyn FixedDifferentBinders) { x }
    = note: expected unit type `()`
               found reference `&dyn FixedDifferentBinders`
 
-error: aborting due to 14 previous errors
+error[E0308]: mismatched types
+  --> $DIR/pretty.rs:41:56
+   |
+LL | fn dyn_has_gat(x: &dyn HasGat<u8, Assoc<bool> = ()>) { x }
+   |                                                     -  ^ expected `()`, found `&dyn HasGat<u8, Assoc<bool> = ()>`
+   |                                                     |
+   |                                                     help: try adding a return type: `-> &dyn HasGat<u8, Assoc<bool> = ()>`
+   |
+   = note: expected unit type `()`
+              found reference `&dyn HasGat<u8, Assoc<bool> = ()>`
+
+error: aborting due to 15 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Previously we would just drop them. This bug isn't that significant as it can only be triggered by user code that constrains GATs inside trait object types which is currently gated under the interim feature `generic_associated_types_extended` (whose future is questionable) or on stable if the GATs are 'disabled' in dyn-Trait via `where Self: Sized` (in which case the assoc type bindings get ignored anyway (and trigger the warn-by-default lint `unused_associated_type_bounds`)), so yeah.

Affects diagnostics and output of `std::any::type_name{,_of_val}`.