### PR TITLE
crater experiment: de-const-stabilize UnsafeCell::get and various as_ptr methods

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -581,7 +581,7 @@ impl<T: ?Sized> Cell<T> {
     /// ```
     #[inline]
     #[stable(feature = "cell_as_ptr", since = "1.12.0")]
-    #[rustc_const_stable(feature = "const_cell_as_ptr", since = "1.32.0")]
+    #[rustc_const_unstable(feature = "const_unsafecell_get", issue = "1")]
     #[rustc_never_returns_null_ptr]
     pub const fn as_ptr(&self) -> *mut T {
         self.value.get()
@@ -2142,7 +2142,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// ```
     #[inline(always)]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_stable(feature = "const_unsafecell_get", since = "1.32.0")]
+    #[rustc_const_unstable(feature = "const_unsafecell_get", issue = "1")]
     #[rustc_never_returns_null_ptr]
     pub const fn get(&self) -> *mut T {
         // We can just cast the pointer from `UnsafeCell<T>` to `T` because of
@@ -2203,7 +2203,7 @@ impl<T: ?Sized> UnsafeCell<T> {
     /// ```
     #[inline(always)]
     #[stable(feature = "unsafe_cell_raw_get", since = "1.56.0")]
-    #[rustc_const_stable(feature = "unsafe_cell_raw_get", since = "1.56.0")]
+    #[rustc_const_unstable(feature = "const_unsafecell_get", issue = "1")]
     #[rustc_diagnostic_item = "unsafe_cell_raw_get"]
     pub const fn raw_get(this: *const Self) -> *mut T {
         // We can just cast the pointer from `UnsafeCell<T>` to `T` because of

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -163,6 +163,7 @@
 #![feature(const_typed_swap)]
 #![feature(const_ub_checks)]
 #![feature(const_unicode_case_lookup)]
+#![feature(const_unsafecell_get)]
 #![feature(const_unsafecell_get_mut)]
 #![feature(coverage_attribute)]
 #![feature(do_not_recommend)]

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -1114,7 +1114,7 @@ impl AtomicBool {
     /// ```
     #[inline]
     #[stable(feature = "atomic_as_ptr", since = "1.70.0")]
-    #[rustc_const_stable(feature = "atomic_as_ptr", since = "1.70.0")]
+    #[rustc_const_unstable(feature = "const_unsafecell_get", issue = "1")]
     #[rustc_never_returns_null_ptr]
     pub const fn as_ptr(&self) -> *mut bool {
         self.v.get().cast()
@@ -2051,7 +2051,7 @@ impl<T> AtomicPtr<T> {
     /// ```
     #[inline]
     #[stable(feature = "atomic_as_ptr", since = "1.70.0")]
-    #[rustc_const_stable(feature = "atomic_as_ptr", since = "1.70.0")]
+    #[rustc_const_unstable(feature = "const_unsafecell_get", issue = "1")]
     #[rustc_never_returns_null_ptr]
     pub const fn as_ptr(&self) -> *mut *mut T {
         self.p.get()
@@ -3015,7 +3015,7 @@ macro_rules! atomic_int {
             /// ```
             #[inline]
             #[stable(feature = "atomic_as_ptr", since = "1.70.0")]
-            #[rustc_const_stable(feature = "atomic_as_ptr", since = "1.70.0")]
+            #[rustc_const_unstable(feature = "const_unsafecell_get", issue = "1")]
             #[rustc_never_returns_null_ptr]
             pub const fn as_ptr(&self) -> *mut $int_type {
                 self.v.get()


### PR DESCRIPTION
These should not have been stabilized before const_refs_to_cell.
For now I mostly want to see whether any code out there actually uses these methods, since it shouldn't be possible to do anything useful with them...
Cc @rust-lang/wg-const-eval 