### PR TITLE
Fix handling of macro arguments within the `dropping_copy_types` lint

### DIFF
--- a/compiler/rustc_lint/src/drop_forget_useless.rs
+++ b/compiler/rustc_lint/src/drop_forget_useless.rs
@@ -151,10 +151,11 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetUseless {
                     && let Node::Stmt(stmt) = node
                     && let StmtKind::Semi(e) = stmt.kind
                     && e.hir_id == expr.hir_id
+                    && let Some(arg_span) = arg.span.find_ancestor_inside(expr.span)
                 {
                     UseLetUnderscoreIgnoreSuggestion::Suggestion {
-                        start_span: expr.span.shrink_to_lo().until(arg.span),
-                        end_span: arg.span.shrink_to_hi().until(expr.span.shrink_to_hi()),
+                        start_span: expr.span.shrink_to_lo().until(arg_span),
+                        end_span: arg_span.shrink_to_hi().until(expr.span.shrink_to_hi()),
                     }
                 } else {
                     UseLetUnderscoreIgnoreSuggestion::Note

--- a/tests/ui/lint/dropping_copy_types-macros.fixed
+++ b/tests/ui/lint/dropping_copy_types-macros.fixed
@@ -1,0 +1,12 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(dropping_copy_types)]
+
+use std::fmt::Write;
+
+fn main() {
+    let mut msg = String::new();
+    let _ = writeln!(&mut msg, "test");
+    //~^ ERROR calls to `std::mem::drop`
+}

--- a/tests/ui/lint/dropping_copy_types-macros.rs
+++ b/tests/ui/lint/dropping_copy_types-macros.rs
@@ -1,0 +1,12 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(dropping_copy_types)]
+
+use std::fmt::Write;
+
+fn main() {
+    let mut msg = String::new();
+    drop(writeln!(&mut msg, "test"));
+    //~^ ERROR calls to `std::mem::drop`
+}

--- a/tests/ui/lint/dropping_copy_types-macros.stderr
+++ b/tests/ui/lint/dropping_copy_types-macros.stderr
@@ -1,0 +1,21 @@
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-macros.rs:10:5
+   |
+LL |     drop(writeln!(&mut msg, "test"));
+   |     ^^^^^--------------------------^
+   |          |
+   |          argument has type `Result<(), std::fmt::Error>`
+   |
+note: the lint level is defined here
+  --> $DIR/dropping_copy_types-macros.rs:4:9
+   |
+LL | #![deny(dropping_copy_types)]
+   |         ^^^^^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(writeln!(&mut msg, "test"));
+LL +     let _ = writeln!(&mut msg, "test");
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This PR fixes the handling of spans with different context (aka macro arguments) than the primary expression within the different `{drop,forget}ing_copy_types` and `{drop,forget}ing_references` lints.

<details>
<summary>Before</summary>

```
warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
 --> drop_writeln.rs:5:5
  |
5 |     drop(writeln!(&mut msg, "test"));
  |     ^^^^^--------------------------^
  |          |
  |          argument has type `Result<(), std::fmt::Error>`
  |
  = note: `#[warn(dropping_copy_types)]` on by default
help: use `let _ = ...` to ignore the expression or result
 --> /home/[..]/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/macros/mod.rs:688:9
  |
68|         let _ =
  |         ~~~~~~~
```

</details>

<details>
<summary>With this PR</summary>

```
warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
 --> drop_writeln.rs:5:5
  |
5 |     drop(writeln!(&mut msg, "test"));
  |     ^^^^^--------------------------^
  |          |
  |          argument has type `Result<(), std::fmt::Error>`
  |
  = note: `#[warn(dropping_copy_types)]` on by default
help: use `let _ = ...` to ignore the expression or result
  |
5 -     drop(writeln!(&mut msg, "test"));
5 +     let _ = writeln!(&mut msg, "test");
  |
```

</details>

@rustbot label +L-dropping_copy_types 