### PR TITLE
Expand std::os::unix::fs::chown() doc with a warning

### DIFF
--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -985,7 +985,7 @@ impl DirBuilderExt for fs::DirBuilder {
 /// Changing the owner typically requires privileges, such as root or a specific capability.
 /// Changing the group typically requires either being the owner and a member of the group, or
 /// having privileges.
-/// 
+///
 /// Be aware that changing owner clears the `suid` and `sgid` permission bits in most cases
 /// according to POSIX, usually even if the user is root. The sgid is not cleared when
 /// the file is non-group-executable. See: <https://www.man7.org/linux/man-pages/man2/chown.2.html>

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -985,6 +985,10 @@ impl DirBuilderExt for fs::DirBuilder {
 /// Changing the owner typically requires privileges, such as root or a specific capability.
 /// Changing the group typically requires either being the owner and a member of the group, or
 /// having privileges.
+/// 
+/// Be aware that changing owner clears the `suid` and `sgid` permission bits in most cases
+/// according to POSIX, usually even if the user is root. The sgid is not cleared when
+/// the file is non-group-executable.
 ///
 /// If called on a symbolic link, this will change the owner and group of the link target. To
 /// change the owner and group of the link itself, see [`lchown`].

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -988,7 +988,8 @@ impl DirBuilderExt for fs::DirBuilder {
 /// 
 /// Be aware that changing owner clears the `suid` and `sgid` permission bits in most cases
 /// according to POSIX, usually even if the user is root. The sgid is not cleared when
-/// the file is non-group-executable.
+/// the file is non-group-executable. See: <https://www.man7.org/linux/man-pages/man2/chown.2.html>
+/// This call may also clear file capabilities, if there was any.
 ///
 /// If called on a symbolic link, this will change the owner and group of the link target. To
 /// change the owner and group of the link itself, see [`lchown`].


### PR DESCRIPTION
Include warning about losing setuid/gid when chowning, per POSIX.

It is about the underlying system call but it is rather useful to mention it in the help in case someone accidentally forgets (don't look at me :)).
