### PR TITLE
Fix extern crates not being hidden with `doc(hidden)`

### DIFF
--- a/src/librustdoc/passes/strip_hidden.rs
+++ b/src/librustdoc/passes/strip_hidden.rs
@@ -2,7 +2,7 @@
 
 use std::mem;
 
-use rustc_hir::def_id::LocalDefId;
+use rustc_hir::def_id::{LocalDefId, CRATE_DEF_ID};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::symbol::sym;
 
@@ -145,8 +145,9 @@ impl<'a, 'tcx> DocFolder for Stripper<'a, 'tcx> {
                 let old = mem::replace(&mut self.update_retained, false);
                 let ret = self.set_is_in_hidden_item_and_fold(true, i);
                 self.update_retained = old;
-                if ret.is_crate() {
-                    // We don't strip the crate, even if it has `#[doc(hidden)]`.
+                if ret.item_id == clean::ItemId::DefId(CRATE_DEF_ID.into()) {
+                    // We don't strip the current crate, even if it has `#[doc(hidden)]`.
+                    debug!("strip_hidden: Not strippping local crate");
                     Some(ret)
                 } else {
                     Some(strip_item(ret))

--- a/tests/rustdoc/doc-hidden-crate.rs
+++ b/tests/rustdoc/doc-hidden-crate.rs
@@ -1,0 +1,27 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/126796>.
+// `doc(hidden)` should still be able to hide extern crates, only the local crates
+// cannot be hidden because we still need to generate its `index.html` file.
+
+#![crate_name = "foo"]
+#![doc(hidden)]
+
+//@ has 'foo/index.html'
+// First we check that the page contains the crate name (`foo`).
+//@ has - '//*' 'foo'
+// But doesn't contain any of the other items.
+//@ !has - '//*' 'other'
+//@ !has - '//*' 'marker'
+//@ !has - '//*' 'PhantomData'
+
+#[doc(inline)]
+pub use std as other;
+
+#[doc(inline)]
+pub use std::marker;
+
+#[doc(inline)]
+pub use std::marker::PhantomData;
+
+//@ !has - '//*' 'myself'
+#[doc(inline)]
+pub use crate as myself;


### PR DESCRIPTION
Fixes #126796.

Only the current crate should never be stripped, any other crate should be strippable.

r? @notriddle 