### PR TITLE
Stabilize `Pin::as_deref_mut()`

### DIFF
--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1422,7 +1422,7 @@ impl<Ptr: DerefMut> Pin<Ptr> {
     /// move in the future, and this method does not enable the pointee to move. "Malicious"
     /// implementations of `Ptr::DerefMut` are likewise ruled out by the contract of
     /// `Pin::new_unchecked`.
-    #[unstable(feature = "pin_deref_mut", issue = "86918")]
+    #[stable(feature = "pin_deref_mut", since = "CURRENT_RUSTC_VERSION")]
     #[must_use = "`self` will be dropped if the result is not used"]
     #[inline(always)]
     pub fn as_deref_mut(self: Pin<&mut Pin<Ptr>>) -> Pin<&mut Ptr::Target> {


### PR DESCRIPTION
Tracking issue: closes #86918

Stabilizing the following API:

```rust
impl<Ptr: DerefMut> Pin<Ptr> {
    pub fn as_deref_mut(self: Pin<&mut Pin<Ptr>>) -> Pin<&mut Ptr::Target>;
}
```

I know that an FCP has not been started yet, but this isn't a very complex stabilization, and I'm hoping this can motivate an FCP to *get* started - this has been pending for a while and it's a very useful function when writing Future impls.

r? @jonhoo