### PR TITLE
rustdoc: show exact case-sensitive matches first

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1393,6 +1393,7 @@ function initSearch(rawSearchIndex) {
          */
         async function sortResults(results, isType, preferredCrate) {
             const userQuery = parsedQuery.userQuery;
+            const casedUserQuery = parsedQuery.original;
             const result_list = [];
             for (const result of results.values()) {
                 result.item = searchIndex[result.id];
@@ -1402,6 +1403,13 @@ function initSearch(rawSearchIndex) {
 
             result_list.sort((aaa, bbb) => {
                 let a, b;
+
+                // sort by exact case-sensitive match
+                a = (aaa.item.name !== casedUserQuery);
+                b = (bbb.item.name !== casedUserQuery);
+                if (a !== b) {
+                    return a - b;
+                }
 
                 // sort by exact match with regard to the last word (mismatch goes later)
                 a = (aaa.word !== userQuery);

--- a/tests/rustdoc-js-std/exact-case.js
+++ b/tests/rustdoc-js-std/exact-case.js
@@ -1,0 +1,7 @@
+const EXPECTED = {
+    'query': 'Copy',
+    'others': [
+        { 'path': 'std::marker', 'name': 'Copy' },
+        { 'path': 'std::fs', 'name': 'copy' },
+    ],
+}


### PR DESCRIPTION
fixes #119480

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
