### PR TITLE
Fix typo in a help diagnostic

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1693,7 +1693,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     StringPart::highlighted("multiple different versions".to_string()),
                     StringPart::normal(" of crate `".to_string()),
                     StringPart::highlighted(format!("{name}")),
-                    StringPart::normal("` the your dependency graph".to_string()),
+                    StringPart::normal("` in the dependency graph".to_string()),
                 ],
             );
             let candidates = if impl_candidates.is_empty() {

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -27,7 +27,7 @@ fn main() {
    |     |
    |     required by a bound introduced by this call
    |
-help: there are multiple different versions of crate `dependency` the your dependency graph
+help: there are multiple different versions of crate `dependency` in the dependency graph
   --> multiple-dep-versions.rs:1:1
    |
 1  | extern crate dep_2_reexport;


### PR DESCRIPTION
Replaced "**the your** dependency graph" with "**in the** dependency graph".