### PR TITLE
Rollup of 9 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -143,6 +143,7 @@ Compatibility Notes
 - [Turn `proc_macro_back_compat` lint into a hard error.](https://github.com/rust-lang/rust/pull/125596/)
 - [Detect unused structs even when implementing private traits](https://github.com/rust-lang/rust/pull/122382/)
 - [`std::sync::ReentrantLockGuard<T>` is no longer `Sync` if `T: !Sync`](https://github.com/rust-lang/rust/pull/125527) which means [`std::io::StdoutLock` and `std::io::StderrLock` are no longer Sync](https://github.com/rust-lang/rust/issues/127340)
+- [alloc: implement FromIterator for Box<str>](https://github.com/rust-lang/rust/pull/99969/)
 
 <a id="1.80-Internal-Changes"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -143,8 +143,8 @@ Compatibility Notes
 - [Turn `proc_macro_back_compat` lint into a hard error.](https://github.com/rust-lang/rust/pull/125596/)
 - [Detect unused structs even when implementing private traits](https://github.com/rust-lang/rust/pull/122382/)
 - [`std::sync::ReentrantLockGuard<T>` is no longer `Sync` if `T: !Sync`](https://github.com/rust-lang/rust/pull/125527) which means [`std::io::StdoutLock` and `std::io::StderrLock` are no longer Sync](https://github.com/rust-lang/rust/issues/127340)
-- [Type inference will fail in some cases due to a new impl of FromIterator for Box<str>](https://github.com/rust-lang/rust/pull/99969/)
-  Notably this breaks versions of the `time` crate before 0.3.36, due to no longer inferring the right impl.
+- [Type inference will fail in some cases due to new implementations of `FromIterator for Box<str>`.](https://github.com/rust-lang/rust/pull/99969/)
+  Notably, this breaks versions of the `time` crate before 0.3.35, due to no longer inferring the implementation for `Box<[_]>`.
 
 <a id="1.80-Internal-Changes"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -143,7 +143,8 @@ Compatibility Notes
 - [Turn `proc_macro_back_compat` lint into a hard error.](https://github.com/rust-lang/rust/pull/125596/)
 - [Detect unused structs even when implementing private traits](https://github.com/rust-lang/rust/pull/122382/)
 - [`std::sync::ReentrantLockGuard<T>` is no longer `Sync` if `T: !Sync`](https://github.com/rust-lang/rust/pull/125527) which means [`std::io::StdoutLock` and `std::io::StderrLock` are no longer Sync](https://github.com/rust-lang/rust/issues/127340)
-- [alloc: implement FromIterator for Box<str>](https://github.com/rust-lang/rust/pull/99969/)
+- [Type inference will fail in some cases due to a new impl of FromIterator for Box<str>](https://github.com/rust-lang/rust/pull/99969/)
+  Notably this breaks versions of the `time` crate before 0.3.55, due to no longer inferring the right impl.
 
 <a id="1.80-Internal-Changes"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -144,7 +144,7 @@ Compatibility Notes
 - [Detect unused structs even when implementing private traits](https://github.com/rust-lang/rust/pull/122382/)
 - [`std::sync::ReentrantLockGuard<T>` is no longer `Sync` if `T: !Sync`](https://github.com/rust-lang/rust/pull/125527) which means [`std::io::StdoutLock` and `std::io::StderrLock` are no longer Sync](https://github.com/rust-lang/rust/issues/127340)
 - [Type inference will fail in some cases due to a new impl of FromIterator for Box<str>](https://github.com/rust-lang/rust/pull/99969/)
-  Notably this breaks versions of the `time` crate before 0.3.55, due to no longer inferring the right impl.
+  Notably this breaks versions of the `time` crate before 0.3.36, due to no longer inferring the right impl.
 
 <a id="1.80-Internal-Changes"></a>
 

--- a/compiler/rustc_lint/src/drop_forget_useless.rs
+++ b/compiler/rustc_lint/src/drop_forget_useless.rs
@@ -151,10 +151,11 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetUseless {
                     && let Node::Stmt(stmt) = node
                     && let StmtKind::Semi(e) = stmt.kind
                     && e.hir_id == expr.hir_id
+                    && let Some(arg_span) = arg.span.find_ancestor_inside(expr.span)
                 {
                     UseLetUnderscoreIgnoreSuggestion::Suggestion {
-                        start_span: expr.span.shrink_to_lo().until(arg.span),
-                        end_span: arg.span.shrink_to_hi().until(expr.span.shrink_to_hi()),
+                        start_span: expr.span.shrink_to_lo().until(arg_span),
+                        end_span: arg_span.shrink_to_hi().until(expr.span.shrink_to_hi()),
                     }
                 } else {
                     UseLetUnderscoreIgnoreSuggestion::Note

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1693,7 +1693,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     StringPart::highlighted("multiple different versions".to_string()),
                     StringPart::normal(" of crate `".to_string()),
                     StringPart::highlighted(format!("{name}")),
-                    StringPart::normal("` the your dependency graph".to_string()),
+                    StringPart::normal("` in the dependency graph".to_string()),
                 ],
             );
             let candidates = if impl_candidates.is_empty() {

--- a/config.example.toml
+++ b/config.example.toml
@@ -337,6 +337,7 @@
 #    "analysis",
 #    "src",
 #    "wasm-component-ld",
+#    "miri", "cargo-miri" # for dev/nightly channels
 #]
 
 # Verbosity level: 0 == not verbose, 1 == verbose, 2 == very verbose, 3 == print environment variables on each rustc invocation

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -110,7 +110,6 @@
 #![cfg_attr(bootstrap, feature(offset_of_nested))]
 #![feature(array_ptr_get)]
 #![feature(asm_experimental_arch)]
-#![feature(char_indices_offset)]
 #![feature(const_align_of_val)]
 #![feature(const_align_of_val_raw)]
 #![feature(const_align_offset)]

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -241,24 +241,35 @@ impl<'a> CharIndices<'a> {
     /// Returns the byte position of the next character, or the length
     /// of the underlying string if there are no more characters.
     ///
+    /// This means that, when the iterator has not been fully consumed,
+    /// the returned value will match the index that will be returned
+    /// by the next call to [`next()`](Self::next).
+    ///
     /// # Examples
     ///
     /// ```
-    /// #![feature(char_indices_offset)]
     /// let mut chars = "a楽".char_indices();
     ///
+    /// // `next()` has not been called yet, so `offset()` returns the byte
+    /// // index of the first character of the string, which is always 0.
     /// assert_eq!(chars.offset(), 0);
+    /// // As expected, the first call to `next()` also returns 0 as index.
     /// assert_eq!(chars.next(), Some((0, 'a')));
     ///
+    /// // `next()` has been called once, so `offset()` returns the byte index
+    /// // of the second character ...
     /// assert_eq!(chars.offset(), 1);
+    /// // ... which matches the index returned by the next call to `next()`.
     /// assert_eq!(chars.next(), Some((1, '楽')));
     ///
+    /// // Once the iterator has been consumed, `offset()` returns the length
+    /// // in bytes of the string.
     /// assert_eq!(chars.offset(), 4);
     /// assert_eq!(chars.next(), None);
     /// ```
     #[inline]
     #[must_use]
-    #[unstable(feature = "char_indices_offset", issue = "83871")]
+    #[stable(feature = "char_indices_offset", since = "CURRENT_RUSTC_VERSION")]
     pub fn offset(&self) -> usize {
         self.front_offset
     }

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -1096,7 +1096,7 @@ tool_extended!((self, builder),
     CargoClippy, "src/tools/clippy", "cargo-clippy", stable=true;
     Clippy, "src/tools/clippy", "clippy-driver", stable=true, add_bins_to_sysroot = ["clippy-driver", "cargo-clippy"];
     Miri, "src/tools/miri", "miri", stable=false, add_bins_to_sysroot = ["miri"];
-    CargoMiri, "src/tools/miri/cargo-miri", "cargo-miri", stable=true, add_bins_to_sysroot = ["cargo-miri"];
+    CargoMiri, "src/tools/miri/cargo-miri", "cargo-miri", stable=false, add_bins_to_sysroot = ["cargo-miri"];
     Rls, "src/tools/rls", "rls", stable=true;
     Rustfmt, "src/tools/rustfmt", "rustfmt", stable=true, add_bins_to_sysroot = ["rustfmt", "cargo-fmt"];
 );

--- a/src/doc/rustc/src/SUMMARY.md
+++ b/src/doc/rustc/src/SUMMARY.md
@@ -78,6 +78,7 @@
     - [wasm32-wasip1](platform-support/wasm32-wasip1.md)
     - [wasm32-wasip1-threads](platform-support/wasm32-wasip1-threads.md)
     - [wasm32-wasip2](platform-support/wasm32-wasip2.md)
+    - [wasm32-unknown-unknown](platform-support/wasm32-unknown-unknown.md)
     - [wasm64-unknown-unknown](platform-support/wasm64-unknown-unknown.md)
     - [\*-win7-windows-msvc](platform-support/win7-windows-msvc.md)
     - [x86_64-fortanix-unknown-sgx](platform-support/x86_64-fortanix-unknown-sgx.md)

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -190,7 +190,7 @@ target | std | notes
 [`thumbv8m.main-none-eabi`](platform-support/thumbv8m.main-none-eabi.md) | * | Bare Armv8-M Mainline
 [`thumbv8m.main-none-eabihf`](platform-support/thumbv8m.main-none-eabi.md) | * | Bare Armv8-M Mainline, hardfloat
 `wasm32-unknown-emscripten` | ✓ | WebAssembly via Emscripten
-`wasm32-unknown-unknown` | ✓ | WebAssembly
+[`wasm32-unknown-unknown`](platform-support/wasm32-unknown-unknown.md) | ✓ | WebAssembly
 `wasm32-wasi` | ✓ | WebAssembly with WASI (undergoing a [rename to `wasm32-wasip1`][wasi-rename])
 [`wasm32-wasip1`](platform-support/wasm32-wasip1.md) | ✓ | WebAssembly with WASI
 [`wasm32-wasip1-threads`](platform-support/wasm32-wasip1-threads.md) | ✓ | WebAssembly with WASI Preview 1 and threads

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
@@ -6,7 +6,7 @@ The `wasm32-unknown-unknown` target is a WebAssembly compilation target which
 does not import any functions from the host for the standard library. This is
 the "minimal" WebAssembly in the sense of making the fewest assumptions about
 the host environment. This target is often used when compiling to the web or
-JavaScript environments as there is not standard for what functions can be
+JavaScript environments as there is no standard for what functions can be
 imported on the web. This target can also be useful for creating minimal or
 bare-bones WebAssembly binaries.
 
@@ -86,13 +86,13 @@ $ file foo.wasm
 
 ## Cross-compilation
 
-This target can be cross-compiled from any hosts.
+This target can be cross-compiled from any host.
 
 ## Testing
 
 This target is not tested in CI for the rust-lang/rust repository. Many tests
 must be disabled to run on this target and failures are non-obvious because
-println doesn't work in the standard library. It's recommended to test the
+`println!` doesn't work in the standard library. It's recommended to test the
 `wasm32-wasip1` target instead for WebAssembly compatibility.
 
 ## Conditionally compiling code
@@ -118,7 +118,7 @@ Changes to WebAssembly go through a [proposals process][proposals] but reaching
 the final stage (stage 5) does not automatically mean that the feature will be
 enabled in LLVM and Rust by default. At this time the general guidance is that
 features must be present in most engines for a "good chunk of time" before
-they're enabled in LLVM by default. There is currently not exact number of
+they're enabled in LLVM by default. There is currently no exact number of
 months or engines that are required to enable features by default.
 
 [proposals]: https://github.com/WebAssembly/proposals
@@ -144,7 +144,8 @@ will produce a binary that uses only the original WebAssembly features by
 default and no proposals since its inception.
 
 To enable individual features it can be done with `-Ctarget-feature=+foo`.
-Available features can be found through:
+Available features for Rust code itself are documented in the [reference] and
+can also be found through:
 
 ```sh
 $ rustc -Ctarget-feature=help --target wasm32-unknown-unknown
@@ -152,3 +153,5 @@ $ rustc -Ctarget-feature=help --target wasm32-unknown-unknown
 
 You'll need to consult your WebAssembly engine's documentation to learn more
 about the supported WebAssembly features the engine has.
+
+[reference]: https://doc.rust-lang.org/reference/attributes/codegen.html#wasm32-or-wasm64

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
@@ -163,7 +163,7 @@ final binary still has SIMD instructions, for example, the function in question
 will need to be found and the crate in question will likely contain something
 like:
 
-```rust
+```rust,ignore
 #[target_feature(enable = "simd128")]
 fn foo() {
     // ...
@@ -176,7 +176,7 @@ at compile time either by default or through a Cargo feature. For crate authors
 it's recommended to avoid `#[target_feature(enable = "...")]` except where
 necessary and instead use:
 
-```rust
+```rust,ignore
 #[cfg(target_feature = "simd128")]
 fn foo() {
     // ...

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
@@ -171,7 +171,7 @@ final binary still has SIMD instructions, for example, the function in question
 will need to be found and the crate in question will likely contain something
 like:
 
-```rust,ignore
+```rust,ignore (not-always-compiled-to-wasm)
 #[target_feature(enable = "simd128")]
 fn foo() {
     // ...
@@ -184,7 +184,7 @@ at compile time either by default or through a Cargo feature. For crate authors
 it's recommended to avoid `#[target_feature(enable = "...")]` except where
 necessary and instead use:
 
-```rust,ignore
+```rust,ignore (not-always-compiled-to-wasm)
 #[cfg(target_feature = "simd128")]
 fn foo() {
     // ...

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
@@ -123,6 +123,14 @@ months or engines that are required to enable features by default.
 
 [proposals]: https://github.com/WebAssembly/proposals
 
+As of the time of this writing the proposals that are enabled by default (the
+`generic` CPU in LLVM terminology) are:
+
+* `multivalue`
+* `mutable-globals`
+* `reference-types`
+* `sign-ext`
+
 If you're compiling WebAssembly code for an engine that does not support a
 feature in LLVM's default feature set then the feature must be disabled at
 compile time. Note, though, that enabled features may be used in the standard

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
@@ -1,0 +1,154 @@
+# `wasm32-unknown-unknown`
+
+**Tier: 2**
+
+The `wasm32-unknown-unknown` target is a WebAssembly compilation target which
+does not import any functions from the host for the standard library. This is
+the "minimal" WebAssembly in the sense of making the fewest assumptions about
+the host environment. This target is often used when compiling to the web or
+JavaScript environments as there is not standard for what functions can be
+imported on the web. This target can also be useful for creating minimal or
+bare-bones WebAssembly binaries.
+
+The `wasm32-unknown-unknown` target has support for the Rust standard library
+but many parts of the standard library do not work and return errors. For
+example `println!` does nothing, `std::fs` always return errors, and
+`std::thread::spawn` will panic. There is no means by which this can be
+overridden. For a WebAssembly target that more fully supports the standard
+library see the [`wasm32-wasip1`](./wasm32-wasip1.md) or
+[`wasm32-wasip2`](./wasm32-wasip2.md) targets.
+
+The `wasm32-unknown-unknown` target has full support for the `core` and `alloc`
+crates. It additionally supports the `HashMap` type in the `std` crate, although
+hash maps are not randomized like they are on other platforms.
+
+One existing user of this target (please feel free to edit and expand this list
+too) is the [`wasm-bindgen` project](https://github.com/rustwasm/wasm-bindgen)
+which facilitates Rust code interoperating with JavaScript code. Note, though,
+that not all uses of `wasm32-unknown-unknown` are using JavaScript and the web.
+
+## Target maintainers
+
+When this target was added to the compiler platform-specific documentation here
+was not maintained at that time. This means that the list below is not
+exhaustive and there are more interested parties in this target. That being
+said since when this document was last updated those interested in maintaining
+this target are:
+
+- Alex Crichton, https://github.com/alexcrichton
+
+## Requirements
+
+This target is cross-compiled. The target includes support for `std` itself,
+but as mentioned above many pieces of functionality that require an operating
+system do not work and will return errors.
+
+This target currently has no equivalent in C/C++. There is no C/C++ toolchain
+for this target. While interop is theoretically possible it's recommended to
+instead use one of:
+
+* `wasm32-unknown-emscripten` - for web-based use cases the Emscripten
+  toolchain is typically chosen for running C/C++.
+* [`wasm32-wasip1`](./wasm32-wasip1.md) - the wasi-sdk toolchain is used to
+  compile C/C++ on this target and can interop with Rust code. WASI works on
+  the web so far as there's no blocker, but an implementation of WASI APIs
+  must be either chosen or reimplemented.
+
+This target has no build requirements beyond what's in-tree in the Rust
+repository. Linking binaries requires LLD to be enabled for the `wasm-ld`
+driver. This target uses the `dlmalloc` crate as the default global allocator.
+
+## Building the target
+
+Building this target can be done by:
+
+* Configure the `wasm32-unknown-unknown` target to get built.
+* Configure LLD to be built.
+* Ensure the `WebAssembly` target backend is not disabled in LLVM.
+
+These are all controlled through `config.toml` options. It should be possible
+to build this target on any platform.
+
+## Building Rust programs
+
+Rust programs can be compiled by adding this target via rustup:
+
+```sh
+$ rustup target add wasm32-unknown-unknown
+```
+
+and then compiling with the target:
+
+```sh
+$ rustc foo.rs --target wasm32-unknown-unknown
+$ file foo.wasm
+```
+
+## Cross-compilation
+
+This target can be cross-compiled from any hosts.
+
+## Testing
+
+This target is not tested in CI for the rust-lang/rust repository. Many tests
+must be disabled to run on this target and failures are non-obvious because
+println doesn't work in the standard library. It's recommended to test the
+`wasm32-wasip1` target instead for WebAssembly compatibility.
+
+## Conditionally compiling code
+
+It's recommended to conditionally compile code for this target with:
+
+```text
+#[cfg(all(target_family = "wasm", target_os = "unknown"))]
+```
+
+Note that there is no way to tell via `#[cfg]` whether code will be running on
+the web or not.
+
+## Enabled WebAssembly features
+
+WebAssembly is an evolving standard which adds new features such as new
+instructions over time. This target's default set of supported WebAssembly
+features will additionally change over time. The `wasm32-unknown-unknown` target
+inherits the default settings of LLVM which typically matches the default
+settings of Emscripten as well.
+
+Changes to WebAssembly go through a [proposals process][proposals] but reaching
+the final stage (stage 5) does not automatically mean that the feature will be
+enabled in LLVM and Rust by default. At this time the general guidance is that
+features must be present in most engines for a "good chunk of time" before
+they're enabled in LLVM by default. There is currently not exact number of
+months or engines that are required to enable features by default.
+
+[proposals]: https://github.com/WebAssembly/proposals
+
+If you're compiling WebAssembly code for an engine that does not support a
+feature in LLVM's default feature set then the feature must be disabled at
+compile time. Note, though, that enabled features may be used in the standard
+library or precompiled libraries shipped via rustup. This means that not only
+does your own code need to be compiled with the correct set of flags but the
+Rust standard library additionally must be recompiled.
+
+Compiling all code for the initial release of WebAssembly looks like:
+
+```sh
+$ export RUSTFLAG=-Ctarget-cpu=mvp
+$ cargo +nightly build -Zbuild-std=panic_abort,std --target wasm32-unknown-unknown
+```
+
+Here the `mvp` "cpu" is a placeholder in LLVM for disabling all supported
+features by default. Cargo's `-Zbuild-std` feature, a Nightly Rust feature, is
+then used to recompile the standard library in addition to your own code. This
+will produce a binary that uses only the original WebAssembly features by
+default and no proposals since its inception.
+
+To enable individual features it can be done with `-Ctarget-feature=+foo`.
+Available features can be found through:
+
+```sh
+$ rustc -Ctarget-feature=help --target wasm32-unknown-unknown
+```
+
+You'll need to consult your WebAssembly engine's documentation to learn more
+about the supported WebAssembly features the engine has.

--- a/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
+++ b/src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
@@ -141,7 +141,7 @@ Rust standard library additionally must be recompiled.
 Compiling all code for the initial release of WebAssembly looks like:
 
 ```sh
-$ export RUSTFLAG=-Ctarget-cpu=mvp
+$ export RUSTFLAGS=-Ctarget-cpu=mvp
 $ cargo +nightly build -Zbuild-std=panic_abort,std --target wasm32-unknown-unknown
 ```
 
@@ -166,7 +166,7 @@ about the supported WebAssembly features the engine has.
 
 Note that it is still possible for Rust crates and libraries to enable
 WebAssembly features on a per-function level. This means that the build
-command above may not be sufficent to disable all WebAssembly features. If the
+command above may not be sufficient to disable all WebAssembly features. If the
 final binary still has SIMD instructions, for example, the function in question
 will need to be found and the crate in question will likely contain something
 like:

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
@@ -165,14 +165,14 @@ necessary to detect this target may change as the target becomes more stable.
 
 ## Enabled WebAssembly features
 
-The default set of WebAssembly features enabled for compilation is similar to
-[`wasm32-unknown-unknokwn`](./wasm32-unknown-unknown.md) but two more features
-are included:
+The default set of WebAssembly features enabled for compilation includes two
+more features in addition to that which
+[`wasm32-unknown-unknown`](./wasm32-unknown-unknown.md) enables:
 
 * `bulk-memory`
 * `atomics`
 
 For more information about features see the documentation for
-[`wasm32-unknown-unknokwn`](./wasm32-unknown-unknown.md), but note that the
+[`wasm32-unknown-unknown`](./wasm32-unknown-unknown.md), but note that the
 `mvp` CPU in LLVM does not support this target as it's required that
 `bulk-memory`, `atomics`, and `mutable-globals` are all enabled.

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1-threads.md
@@ -162,3 +162,17 @@ It's recommended to conditionally compile code for this target with:
 Prior to Rust 1.80 the `target_env = "p1"` key was not set. Currently the
 `target_feature = "atomics"` is Nightly-only. Note that the precise `#[cfg]`
 necessary to detect this target may change as the target becomes more stable.
+
+## Enabled WebAssembly features
+
+The default set of WebAssembly features enabled for compilation is similar to
+[`wasm32-unknown-unknokwn`](./wasm32-unknown-unknown.md) but two more features
+are included:
+
+* `bulk-memory`
+* `atomics`
+
+For more information about features see the documentation for
+[`wasm32-unknown-unknokwn`](./wasm32-unknown-unknown.md), but note that the
+`mvp` CPU in LLVM does not support this target as it's required that
+`bulk-memory`, `atomics`, and `mutable-globals` are all enabled.

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1.md
@@ -136,5 +136,5 @@ to Rust 1.80 the `target_env` condition was not set.
 ## Enabled WebAssembly features
 
 The default set of WebAssembly features enabled for compilation is currently the
-same as [`wasm32-unknown-unknokwn`](./wasm32-unknown-unknown.md). See the
+same as [`wasm32-unknown-unknown`](./wasm32-unknown-unknown.md). See the
 documentation there for more information.

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1.md
@@ -132,3 +132,10 @@ It's recommended to conditionally compile code for this target with:
 
 Note that the `target_env = "p1"` condition first appeared in Rust 1.80. Prior
 to Rust 1.80 the `target_env` condition was not set.
+
+## Enabled WebAssembly features
+
+The default set of WebAssembly features enabled for compilation is currently the
+same across all WebAssembly targets. For more information on WebAssembly
+features see the documentation for
+[`wasm32-unknown-unknokwn`](./wasm32-unknown-unknown.md)

--- a/src/doc/rustc/src/platform-support/wasm32-wasip1.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip1.md
@@ -136,6 +136,5 @@ to Rust 1.80 the `target_env` condition was not set.
 ## Enabled WebAssembly features
 
 The default set of WebAssembly features enabled for compilation is currently the
-same across all WebAssembly targets. For more information on WebAssembly
-features see the documentation for
-[`wasm32-unknown-unknokwn`](./wasm32-unknown-unknown.md)
+same as [`wasm32-unknown-unknokwn`](./wasm32-unknown-unknown.md). See the
+documentation there for more information.

--- a/src/doc/rustc/src/platform-support/wasm32-wasip2.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip2.md
@@ -65,5 +65,5 @@ It's recommended to conditionally compile code for this target with:
 ## Enabled WebAssembly features
 
 The default set of WebAssembly features enabled for compilation is currently the
-same as [`wasm32-unknown-unknokwn`](./wasm32-unknown-unknown.md). See the
+same as [`wasm32-unknown-unknown`](./wasm32-unknown-unknown.md). See the
 documentation there for more information.

--- a/src/doc/rustc/src/platform-support/wasm32-wasip2.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip2.md
@@ -65,6 +65,5 @@ It's recommended to conditionally compile code for this target with:
 ## Enabled WebAssembly features
 
 The default set of WebAssembly features enabled for compilation is currently the
-same across all WebAssembly targets. For more information on WebAssembly
-features see the documentation for
-[`wasm32-unknown-unknokwn`](./wasm32-unknown-unknown.md)
+same as [`wasm32-unknown-unknokwn`](./wasm32-unknown-unknown.md). See the
+documentation there for more information.

--- a/src/doc/rustc/src/platform-support/wasm32-wasip2.md
+++ b/src/doc/rustc/src/platform-support/wasm32-wasip2.md
@@ -61,3 +61,10 @@ It's recommended to conditionally compile code for this target with:
 ```text
 #[cfg(all(target_os = "wasi", target_env = "p2"))]
 ```
+
+## Enabled WebAssembly features
+
+The default set of WebAssembly features enabled for compilation is currently the
+same across all WebAssembly targets. For more information on WebAssembly
+features see the documentation for
+[`wasm32-unknown-unknokwn`](./wasm32-unknown-unknown.md)

--- a/tests/assembly/x86_64-cmp.rs
+++ b/tests/assembly/x86_64-cmp.rs
@@ -1,6 +1,9 @@
-//@ revisions: DEBUG OPTIM
+//@ revisions: DEBUG LLVM-PRE-20-OPTIM LLVM-20-OPTIM
 //@ [DEBUG] compile-flags: -C opt-level=0
-//@ [OPTIM] compile-flags: -C opt-level=3
+//@ [LLVM-PRE-20-OPTIM] compile-flags: -C opt-level=3
+//@ [LLVM-PRE-20-OPTIM] ignore-llvm-version: 20 - 99
+//@ [LLVM-20-OPTIM] compile-flags: -C opt-level=3
+//@ [LLVM-20-OPTIM] min-llvm-version: 20
 //@ assembly-output: emit-asm
 //@ compile-flags: --crate-type=lib -C llvm-args=-x86-asm-syntax=intel
 //@ only-x86_64
@@ -21,12 +24,18 @@ pub fn signed_cmp(a: i16, b: i16) -> std::cmp::Ordering {
     // DEBUG: and
     // DEBUG: sub
 
-    // OPTIM: xor
-    // OPTIM: cmp
-    // OPTIM: setne
-    // OPTIM: mov
-    // OPTIM: cmovge
-    // OPTIM: ret
+    // LLVM-PRE-20-OPTIM: xor
+    // LLVM-PRE-20-OPTIM: cmp
+    // LLVM-PRE-20-OPTIM: setne
+    // LLVM-PRE-20-OPTIM: mov
+    // LLVM-PRE-20-OPTIM: cmovge
+    // LLVM-PRE-20-OPTIM: ret
+    //
+    // LLVM-20-OPTIM: cmp
+    // LLVM-20-OPTIM: setl
+    // LLVM-20-OPTIM: setg
+    // LLVM-20-OPTIM: sub
+    // LLVM-20-OPTIM: ret
     three_way_compare(a, b)
 }
 
@@ -41,11 +50,16 @@ pub fn unsigned_cmp(a: u16, b: u16) -> std::cmp::Ordering {
     // DEBUG: and
     // DEBUG: sub
 
-    // OPTIM: xor
-    // OPTIM: cmp
-    // OPTIM: setne
-    // OPTIM: mov
-    // OPTIM: cmovae
-    // OPTIM: ret
+    // LLVM-PRE-20-OPTIM: xor
+    // LLVM-PRE-20-OPTIM: cmp
+    // LLVM-PRE-20-OPTIM: setne
+    // LLVM-PRE-20-OPTIM: mov
+    // LLVM-PRE-20-OPTIM: cmovae
+    // LLVM-PRE-20-OPTIM: ret
+    //
+    // LLVM-20-OPTIM: cmp
+    // LLVM-20-OPTIM: seta
+    // LLVM-20-OPTIM: sbb
+    // LLVM-20-OPTIM: ret
     three_way_compare(a, b)
 }

--- a/tests/codegen/integer-cmp.rs
+++ b/tests/codegen/integer-cmp.rs
@@ -1,6 +1,9 @@
 // This is test for more optimal Ord implementation for integers.
 // See <https://github.com/rust-lang/rust/issues/63758> for more info.
 
+//@ revisions: llvm-pre-20 llvm-20
+//@ [llvm-20] min-llvm-version: 20
+//@ [llvm-pre-20] ignore-llvm-version: 20 - 99
 //@ compile-flags: -C opt-level=3
 
 #![crate_type = "lib"]
@@ -10,19 +13,21 @@ use std::cmp::Ordering;
 // CHECK-LABEL: @cmp_signed
 #[no_mangle]
 pub fn cmp_signed(a: i64, b: i64) -> Ordering {
-    // CHECK: icmp slt
-    // CHECK: icmp ne
-    // CHECK: zext i1
-    // CHECK: select i1
+    // llvm-20: @llvm.scmp.i8.i64
+    // llvm-pre-20: icmp slt
+    // llvm-pre-20: icmp ne
+    // llvm-pre-20: zext i1
+    // llvm-pre-20: select i1
     a.cmp(&b)
 }
 
 // CHECK-LABEL: @cmp_unsigned
 #[no_mangle]
 pub fn cmp_unsigned(a: u32, b: u32) -> Ordering {
-    // CHECK: icmp ult
-    // CHECK: icmp ne
-    // CHECK: zext i1
-    // CHECK: select i1
+    // llvm-20: @llvm.ucmp.i8.i32
+    // llvm-pre-20: icmp ult
+    // llvm-pre-20: icmp ne
+    // llvm-pre-20: zext i1
+    // llvm-pre-20: select i1
     a.cmp(&b)
 }

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -27,7 +27,7 @@ fn main() {
    |     |
    |     required by a bound introduced by this call
    |
-help: there are multiple different versions of crate `dependency` the your dependency graph
+help: there are multiple different versions of crate `dependency` in the dependency graph
   --> multiple-dep-versions.rs:1:1
    |
 1  | extern crate dep_2_reexport;

--- a/tests/ui/lint/dropping_copy_types-macros.fixed
+++ b/tests/ui/lint/dropping_copy_types-macros.fixed
@@ -1,0 +1,12 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(dropping_copy_types)]
+
+use std::fmt::Write;
+
+fn main() {
+    let mut msg = String::new();
+    let _ = writeln!(&mut msg, "test");
+    //~^ ERROR calls to `std::mem::drop`
+}

--- a/tests/ui/lint/dropping_copy_types-macros.rs
+++ b/tests/ui/lint/dropping_copy_types-macros.rs
@@ -1,0 +1,12 @@
+//@ check-fail
+//@ run-rustfix
+
+#![deny(dropping_copy_types)]
+
+use std::fmt::Write;
+
+fn main() {
+    let mut msg = String::new();
+    drop(writeln!(&mut msg, "test"));
+    //~^ ERROR calls to `std::mem::drop`
+}

--- a/tests/ui/lint/dropping_copy_types-macros.stderr
+++ b/tests/ui/lint/dropping_copy_types-macros.stderr
@@ -1,0 +1,21 @@
+error: calls to `std::mem::drop` with a value that implements `Copy` does nothing
+  --> $DIR/dropping_copy_types-macros.rs:10:5
+   |
+LL |     drop(writeln!(&mut msg, "test"));
+   |     ^^^^^--------------------------^
+   |          |
+   |          argument has type `Result<(), std::fmt::Error>`
+   |
+note: the lint level is defined here
+  --> $DIR/dropping_copy_types-macros.rs:4:9
+   |
+LL | #![deny(dropping_copy_types)]
+   |         ^^^^^^^^^^^^^^^^^^^
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(writeln!(&mut msg, "test"));
+LL +     let _ = writeln!(&mut msg, "test");
+   |
+
+error: aborting due to 1 previous error
+

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -913,7 +913,7 @@ cc = ["@kobzol"]
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
-users_on_vacation = ["jyn514", "jhpratt", "oli-obk"]
+users_on_vacation = ["jyn514", "jhpratt", "oli-obk", "kobzol"]
 
 [assign.adhoc_groups]
 compiler-team = [


### PR DESCRIPTION
Successful merges:

 - #128511 (Document WebAssembly target feature expectations)
 - #129243 (do not build `cargo-miri` by default on stable channel)
 - #129263 (Add a missing compatibility note in the 1.80.0 release notes)
 - #129276 (Stabilize feature `char_indices_offset`)
 - #129350 (adapt integer comparison tests for LLVM 20 IR changes)
 - #129408 (Fix handling of macro arguments within the `dropping_copy_types` lint)
 - #129426 (rustdoc-search: use tighter json for names and parents)
 - #129437 (Fix typo in a help diagnostic)
 - #129457 (kobzol vacation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=128511,129243,129263,129276,129350,129408,129426,129437,129457)
<!-- homu-ignore:end -->