### PR TITLE
[CRATER RUN DO NOT MERGE] crater run to evaluate effectiveness of lint for if_let_rescope

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 	shallow = true
 [submodule "src/tools/cargo"]
 	path = src/tools/cargo
-	url = https://github.com/rust-lang/cargo.git
+	url = https://github.com/dingxiangfei2009/cargo.git
 	shallow = true
 [submodule "src/doc/reference"]
 	path = src/doc/reference

--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -472,7 +472,7 @@ fn resolve_expr<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, expr: &'tcx h
 
         hir::ExprKind::If(cond, then, Some(otherwise)) => {
             let expr_cx = visitor.cx;
-            let data = if expr.span.at_least_rust_2024() && visitor.tcx.features().if_let_rescope {
+            let data = if expr.span.at_least_rust_2024() {
                 ScopeData::IfThenRescope
             } else {
                 ScopeData::IfThen
@@ -487,7 +487,7 @@ fn resolve_expr<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, expr: &'tcx h
 
         hir::ExprKind::If(cond, then, None) => {
             let expr_cx = visitor.cx;
-            let data = if expr.span.at_least_rust_2024() && visitor.tcx.features().if_let_rescope {
+            let data = if expr.span.at_least_rust_2024() {
                 ScopeData::IfThenRescope
             } else {
                 ScopeData::IfThen

--- a/compiler/rustc_lint/src/if_let_rescope.rs
+++ b/compiler/rustc_lint/src/if_let_rescope.rs
@@ -239,7 +239,7 @@ impl_lint_pass!(
 
 impl<'tcx> LateLintPass<'tcx> for IfLetRescope {
     fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx hir::Expr<'tcx>) {
-        if expr.span.edition().at_least_rust_2024() || !cx.tcx.features().if_let_rescope {
+        if expr.span.edition().at_least_rust_2024() {
             return;
         }
         if let (Level::Allow, _) = cx.tcx.lint_level_at_node(IF_LET_RESCOPE, expr.hir_id) {

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -707,7 +707,7 @@ impl<'tcx> Cx<'tcx> {
                 if_then_scope: region::Scope {
                     id: then.hir_id.local_id,
                     data: {
-                        if expr.span.at_least_rust_2024() && tcx.features().if_let_rescope {
+                        if expr.span.at_least_rust_2024() {
                             region::ScopeData::IfThenRescope
                         } else {
                             region::ScopeData::IfThen

--- a/tests/ui/drop/if-let-rescope-suggestions.fixed
+++ b/tests/ui/drop/if-let-rescope-suggestions.fixed
@@ -1,0 +1,26 @@
+//@ edition:2024
+//@ compile-flags: -Z validate-mir -Zunstable-options
+//@ run-rustfix
+
+#![deny(if_let_rescope)]
+#![feature(if_let_rescope)]
+
+struct Droppy;
+impl Drop for Droppy {
+    fn drop(&mut self) {
+        println!("dropped");
+    }
+}
+impl Droppy {
+    fn get_ref(&self) -> Option<&u8> {
+        None
+    }
+}
+
+fn do_something<T>(_: &T) {}
+
+fn main() {
+    let binding = Droppy;
+    do_something(match binding.get_ref()  { Some(value) => { value } _ => { &0 }});
+    //~^ ERROR: temporary value dropped while borrowed
+}

--- a/tests/ui/drop/if-let-rescope-suggestions.rs
+++ b/tests/ui/drop/if-let-rescope-suggestions.rs
@@ -1,0 +1,25 @@
+//@ edition:2024
+//@ compile-flags: -Z validate-mir -Zunstable-options
+//@ run-rustfix
+
+#![deny(if_let_rescope)]
+#![feature(if_let_rescope)]
+
+struct Droppy;
+impl Drop for Droppy {
+    fn drop(&mut self) {
+        println!("dropped");
+    }
+}
+impl Droppy {
+    fn get_ref(&self) -> Option<&u8> {
+        None
+    }
+}
+
+fn do_something<T>(_: &T) {}
+
+fn main() {
+    do_something(if let Some(value) = Droppy.get_ref() { value } else { &0 });
+    //~^ ERROR: temporary value dropped while borrowed
+}

--- a/tests/ui/drop/if-let-rescope-suggestions.stderr
+++ b/tests/ui/drop/if-let-rescope-suggestions.stderr
@@ -1,0 +1,26 @@
+error[E0716]: temporary value dropped while borrowed
+  --> $DIR/if-let-rescope-suggestions.rs:23:39
+   |
+LL |     do_something(if let Some(value) = Droppy.get_ref() { value } else { &0 });
+   |                                       ^^^^^^                   - temporary value is freed at the end of this statement
+   |                                       |
+   |                                       creates a temporary value which is freed while still in use
+   |
+note: lifetime for temporaries generated in `if let`s have been shorted in Edition 2024
+  --> $DIR/if-let-rescope-suggestions.rs:23:65
+   |
+LL |     do_something(if let Some(value) = Droppy.get_ref() { value } else { &0 });
+   |                                                                 ^
+help: consider using a `let` binding to create a longer lived value
+   |
+LL ~     let binding = Droppy;
+LL ~     do_something(if let Some(value) = binding.get_ref() { value } else { &0 });
+   |
+help: consider rewriting the `if` into `match` which preserves the extended lifetime
+   |
+LL |     do_something(match Droppy.get_ref()  { Some(value) => { value } _ => { &0 }});
+   |                  ~~~~~                   ++++++++++++++++           ~~~~       +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0716`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
Tracked by #124085
Related to #107251
cc @jieyouxu for review context
cc @traviscross for edition tracking

There is one unresolved issue that `cargo fix --edition` does not emit `if-let-rescope` lint. Details in rust-lang/cargo#14447.

Note that this patch is assuming that the feature gate `if_let_rescope` is always on just for this crater run.