### PR TITLE
[Experimental] what if we use symlink_metadata

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,8 @@
 	shallow = true
 [submodule "src/tools/cargo"]
 	path = src/tools/cargo
-	url = https://github.com/rust-lang/cargo.git
+	url = https://github.com/jieyouxu/cargo.git
+    branch = exp-msvc-ci-cargo
 	shallow = true
 [submodule "src/doc/reference"]
 	path = src/doc/reference


### PR DESCRIPTION
r? ghost

Follow up to information revealed in #129431.

The cargo branch contains a change:

```diff
diff --git a/crates/cargo-util/src/paths.rs b/crates/cargo-util/src/paths.rs
index 59e812f3aea..d2f023da3ce 100644
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -571,7 +571,9 @@ where
 }
 
 fn set_not_readonly(p: &Path) -> io::Result<bool> {
-    let mut perms = p.metadata()?.permissions();
+    // Note that `p` is possibly a symlink. What if this is
+    // `symlink_metadata`?
+    let mut perms = p.symlink_metadata()?.permissions();
     if !perms.readonly() {
         return Ok(false);
     }
```

try-job: x86_64-msvc-ext