### PR TITLE
fix ICE when `asm_const` and `const_refs_to_static` are combined

### DIFF
--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -2522,7 +2522,7 @@ mod diags {
         }
 
         pub(crate) fn emit_errors(&mut self) -> Option<ErrorGuaranteed> {
-            let mut res = None;
+            let mut res = self.infcx.tainted_by_errors();
 
             // Buffer any move errors that we collected and de-duplicated.
             for (_, (_, diag)) in std::mem::take(&mut self.diags.buffered_move_errors) {

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -29,7 +29,8 @@ use rustc_macros::extension;
 use rustc_middle::ty::fold::TypeFoldable;
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{
-    self, GenericArgs, GenericArgsRef, InlineConstArgs, InlineConstArgsParts, RegionVid, Ty, TyCtxt,
+    self, GenericArgs, GenericArgsRef, InlineConstArgs, InlineConstArgsParts, RegionVid, Ty,
+    TyCtxt, TypeVisitableExt,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::symbol::{kw, sym};
@@ -688,7 +689,8 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
         defining_ty: DefiningTy<'tcx>,
     ) -> ty::Binder<'tcx, &'tcx ty::List<Ty<'tcx>>> {
         let tcx = self.infcx.tcx;
-        match defining_ty {
+
+        let inputs_and_output = match defining_ty {
             DefiningTy::Closure(def_id, args) => {
                 assert_eq!(self.mir_def.to_def_id(), def_id);
                 let closure_sig = args.as_closure().sig();
@@ -798,6 +800,7 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
                 // "output" (the type of the constant).
                 assert_eq!(self.mir_def.to_def_id(), def_id);
                 let ty = tcx.type_of(self.mir_def).instantiate_identity();
+
                 let ty = indices.fold_to_region_vids(tcx, ty);
                 ty::Binder::dummy(tcx.mk_type_list(&[ty]))
             }
@@ -807,7 +810,14 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
                 let ty = args.as_inline_const().ty();
                 ty::Binder::dummy(tcx.mk_type_list(&[ty]))
             }
+        };
+
+        // FIXME(#129952): We probably want a more principled approach here.
+        if let Err(terr) = inputs_and_output.skip_binder().error_reported() {
+            self.infcx.set_tainted_by_errors(terr);
         }
+
+        inputs_and_output
     }
 }
 

--- a/tests/ui/asm/const-refs-to-static.rs
+++ b/tests/ui/asm/const-refs-to-static.rs
@@ -1,0 +1,21 @@
+//@ needs-asm-support
+//@ ignore-nvptx64
+//@ ignore-spirv
+
+#![feature(const_refs_to_static)]
+
+use std::arch::{asm, global_asm};
+use std::ptr::addr_of;
+
+static FOO: u8 = 42;
+
+global_asm!("{}", const addr_of!(FOO));
+//~^ ERROR invalid type for `const` operand
+
+#[no_mangle]
+fn inline() {
+    unsafe { asm!("{}", const addr_of!(FOO)) };
+    //~^ ERROR invalid type for `const` operand
+}
+
+fn main() {}

--- a/tests/ui/asm/const-refs-to-static.stderr
+++ b/tests/ui/asm/const-refs-to-static.stderr
@@ -1,0 +1,22 @@
+error: invalid type for `const` operand
+  --> $DIR/const-refs-to-static.rs:12:19
+   |
+LL | global_asm!("{}", const addr_of!(FOO));
+   |                   ^^^^^^-------------
+   |                         |
+   |                         is a `*const u8`
+   |
+   = help: `const` operands must be of an integer type
+
+error: invalid type for `const` operand
+  --> $DIR/const-refs-to-static.rs:17:25
+   |
+LL |     unsafe { asm!("{}", const addr_of!(FOO)) };
+   |                         ^^^^^^-------------
+   |                               |
+   |                               is a `*const u8`
+   |
+   = help: `const` operands must be of an integer type
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/consts/missing_assoc_const_type.rs
+++ b/tests/ui/consts/missing_assoc_const_type.rs
@@ -16,7 +16,7 @@ impl Range for TwoDigits {
 
 const fn digits(x: u8) -> usize {
     match x {
-        TwoDigits::FIRST..=TwoDigits::LAST => 0,
+        TwoDigits::FIRST..=TwoDigits::LAST => 0, //~ ERROR: could not evaluate constant pattern
         0..=9 | 100..=255 => panic!(),
     }
 }

--- a/tests/ui/consts/missing_assoc_const_type.stderr
+++ b/tests/ui/consts/missing_assoc_const_type.stderr
@@ -4,5 +4,11 @@ error: missing type for `const` item
 LL |     const FIRST:  = 10;
    |                 ^ help: provide a type for the associated constant: `u8`
 
-error: aborting due to 1 previous error
+error: could not evaluate constant pattern
+  --> $DIR/missing_assoc_const_type.rs:19:9
+   |
+LL |         TwoDigits::FIRST..=TwoDigits::LAST => 0,
+   |         ^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
 

--- a/tests/ui/static/missing-type.rs
+++ b/tests/ui/static/missing-type.rs
@@ -1,4 +1,5 @@
-//@ known-bug: #124164
+// reported as #124164
 static S_COUNT: = std::sync::atomic::AtomicUsize::new(0);
+//~^ ERROR: missing type for `static` item
 
 fn main() {}

--- a/tests/ui/static/missing-type.stderr
+++ b/tests/ui/static/missing-type.stderr
@@ -1,0 +1,8 @@
+error: missing type for `static` item
+  --> $DIR/missing-type.rs:2:16
+   |
+LL | static S_COUNT: = std::sync::atomic::AtomicUsize::new(0);
+   |                ^ help: provide a type for the static variable: `AtomicUsize`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/type-alias-impl-trait/taint.rs
+++ b/tests/ui/type-alias-impl-trait/taint.rs
@@ -1,5 +1,6 @@
-//@ known-bug: rust-lang/rust#126896
 //@ compile-flags: -Zvalidate-mir -Zinline-mir=yes
+
+// reported as rust-lang/rust#126896
 
 #![feature(type_alias_impl_trait)]
 type Two<'a, 'b> = impl std::fmt::Debug;
@@ -9,9 +10,8 @@ fn set(x: &mut isize) -> isize {
 }
 
 fn d(x: Two) {
-    let c1 = || set(x);
+    let c1 = || set(x); //~ ERROR: expected generic lifetime parameter, found `'_`
     c1;
 }
 
-fn main() {
-}
+fn main() {}

--- a/tests/ui/type-alias-impl-trait/taint.stderr
+++ b/tests/ui/type-alias-impl-trait/taint.stderr
@@ -1,0 +1,12 @@
+error[E0792]: expected generic lifetime parameter, found `'_`
+  --> $DIR/taint.rs:13:17
+   |
+LL | type Two<'a, 'b> = impl std::fmt::Debug;
+   |          -- this generic parameter must be used with a generic lifetime parameter
+...
+LL |     let c1 = || set(x);
+   |                 ^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0792`.


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/129462
fixes #126896
fixes #124164

I think this is a case that was missed in the fix for https://github.com/rust-lang/rust/pull/125558, which inserts a type error in the case of an invalid (that is, non-integer) type being passed to an asm `const` operand.

I'm not 100% sure that `span_mirbug_and_err` is the right macro here, but it is used earlier with `builtin_deref` and seems to do the trick.

r? @lcnr 
