### PR TITLE
Make traits_in_crate and impls_in_crate proper queries.

### DIFF
--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -149,6 +149,28 @@ pub fn provide(providers: &mut Providers) {
     outlives::provide(providers);
     hir_wf_check::provide(providers);
     *providers = Providers {
+        impls_in_crate: |tcx, cnum| {
+            assert_eq!(cnum , LOCAL_CRATE);
+            let mut impls = Vec::new();
+            for id in tcx.hir().items() {
+                if let Defkind::Impl = tcx.def_kind(id.owner_id){
+                    let def_id = id.owner_id.to_def_id();
+                    let simplified_self_ty = if let Some(trait_ref) = tcx.impl_trait_ref(def_id) {
+                        Some(fast_reject::simplify_type(
+                            tcx,
+                            trait_ref.self_ty(),
+                            TreatParams::AsInfer,
+                          ))
+                    } else {
+                        None
+                    };
+                    impls.push((def_id, simplified_self_ty));
+                }
+            }
+            // Keeping the sorting here for now to maintain existing behaviour
+            impls.sort_by_cached_Key(|&(def_id, _)| tcx.def_path_hash(def_id));
+            tcx.arena.alloc_slice(&impls)
+        },
         inherit_sig_for_delegation_item: delegation::inherit_sig_for_delegation_item,
         ..*providers
     };

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -2002,6 +2002,16 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         let mut trait_impls: FxIndexMap<DefId, Vec<(DefIndex, Option<SimplifiedType>)>> =
             FxIndexMap::default();
 
+        for (impl_def_id, simplified_self_ty) in tcx.impls_in_crate(LOCAL_CRATE) {
+            if let Some(trait_ref) = tcx.impl_trait_ref(impl_def_id) {
+                let trait_ref = trait_ref.subst_identity();
+                fx_hash_map
+                    .entry(trait_ref.def_id)
+                    .or_default()
+                    .push((impl_def_id.index, simplified_self_ty));
+            }
+        }
+    
         for id in tcx.hir().items() {
             let DefKind::Impl { of_trait } = tcx.def_kind(id.owner_id) else {
                 continue;

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1809,6 +1809,9 @@ rustc_queries! {
         separate_provide_extern
         arena_cache
     }
+    query impls_in_crate(_:CrateNum) -> &'tcx [(DefId, Option<SimplifiedType>)] {
+        desc { "fetching impls in a crate" }
+    }
     query stability_implications(_: CrateNum) -> &'tcx UnordMap<Symbol, Symbol> {
         arena_cache
         desc { "calculating the implications between `#[unstable]` features defined in a crate" }


### PR DESCRIPTION
Issue -: #95092.

This PR introduces impls_in_crate as a query, maintaining current sorting behavior while setting the stage for future optimizations.

Benefits -: 
  1)  Centralized impl collection.
  2)  Potential for better caching and incremental compilation.
  3)  Groundwork for future performance improvements.

Sorting is kept within the query for now to minimize changes. It Maintains existing behaviour while introducing the new query.