### PR TITLE
remove invalid `TyCompat` relation for effects

### DIFF
--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -1097,7 +1097,6 @@ pub mod effects {
     pub trait TyCompat<T: ?Sized> {}
 
     impl<T: ?Sized> TyCompat<T> for T {}
-    impl<T: ?Sized> TyCompat<T> for Maybe {}
     impl<T: ?Sized> TyCompat<Maybe> for T {}
 
     #[lang = "EffectsIntersection"]

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail.rs
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail.rs
@@ -1,4 +1,4 @@
-//@ check-pass
+//~ ERROR the trait bound
 //@ compile-flags: -Znext-solver
 
 #![allow(incomplete_features)]
@@ -17,6 +17,6 @@ impl Foo for S {
 }
 
 impl const Bar for S {}
-//FIXME ~^ ERROR the trait bound
+// FIXME(effects) bad span
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/super-traits-fail.stderr
@@ -1,0 +1,11 @@
+error[E0277]: the trait bound `Maybe: TyCompat<<(Foo::{synthetic#0},) as std::marker::effects::Intersection>::Output>` is not satisfied
+   |
+note: required by a bound in `Bar::{synthetic#0}`
+  --> $DIR/super-traits-fail.rs:11:1
+   |
+LL | #[const_trait]
+   | ^^^^^^^^^^^^^^ required by this bound in `Bar::{synthetic#0}`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
if the current impl uses `Maybe` (`impl const`), the parent impl must use `Maybe` (`impl const`) as well.

I'd like to rename `TyCompat` to `Sub` which is probably clearer. But it would conflict with my other PR.

r? @rust-lang/project-const-traits 