### PR TITLE
make it possible to enable const_precise_live_drops per-function

### DIFF
--- a/tests/ui/consts/precise-drop-allow-const-fn-unstable.not_allow.stderr
+++ b/tests/ui/consts/precise-drop-allow-const-fn-unstable.not_allow.stderr
@@ -1,0 +1,12 @@
+error[E0493]: destructor of `Option<T>` cannot be evaluated at compile-time
+  --> $DIR/precise-drop-allow-const-fn-unstable.rs:11:24
+   |
+LL | pub const fn unwrap<T>(this: Option<T>) -> T {
+   |                        ^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL | }
+   | - value is dropped here
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/consts/precise-drop-allow-const-fn-unstable.rs
+++ b/tests/ui/consts/precise-drop-allow-const-fn-unstable.rs
@@ -1,0 +1,17 @@
+//@ revisions: allow not_allow
+//@ compile-flags: --crate-type=lib -Cinstrument-coverage  -Zno-profiler-runtime
+//@[allow] check-pass
+
+#![feature(staged_api, rustc_allow_const_fn_unstable)]
+#![stable(feature = "rust_test", since = "1.0.0")]
+
+#[stable(feature = "rust_test", since = "1.0.0")]
+#[rustc_const_stable(feature = "rust_test", since = "1.0.0")]
+#[cfg_attr(allow, rustc_allow_const_fn_unstable(const_precise_live_drops))]
+pub const fn unwrap<T>(this: Option<T>) -> T {
+//[not_allow]~^ ERROR: cannot be evaluated
+    match this {
+        Some(x) => x,
+        None => panic!(),
+    }
+}


### PR DESCRIPTION
This makes const_precise_live_drops work with rustc_allow_const_fn_unstable so that we can stabilize individual functions that rely on const_precise_live_drops.

The goal is that we can use that to stabilize some of https://github.com/rust-lang/rust/issues/67441 without having to stabilize const_precise_live_drops.