### PR TITLE
gitignore: ignore ICE reports regardless of directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,9 @@ build/
 /src/tools/x/target
 # Created by default with `src/ci/docker/run.sh`
 /obj/
-/rustc-ice*
+
+## ICE reports
+rustc-ice-*.txt
 
 ## Temporary files
 *~


### PR DESCRIPTION
Quite often when working on compiler I end up running into ICEs during the standard library compilation.

These ICEs generate reports in `/library/` and not at the root of the repo, so they aren't `gitignore`d.

I finally ended up committing one today, by accident: https://github.com/rust-lang/rust/pull/129487#event-14002067843
