### PR TITLE
Suggest the correct pattern syntax on usage of unit variant pattern for a struct variant

### DIFF
--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -45,7 +45,7 @@ pub use coercion::can_coerce;
 use fn_ctxt::FnCtxt;
 use rustc_data_structures::unord::UnordSet;
 use rustc_errors::codes::*;
-use rustc_errors::{struct_span_code_err, Applicability, ErrorGuaranteed};
+use rustc_errors::{pluralize, struct_span_code_err, Applicability, ErrorGuaranteed};
 use rustc_hir as hir;
 use rustc_hir::def::{DefKind, Res};
 use rustc_hir::intravisit::Visitor;
@@ -419,6 +419,36 @@ fn report_unexpected_variant_res(
             }
 
             err.multipart_suggestion_verbose(descr, suggestion, Applicability::MaybeIncorrect);
+            err
+        }
+        Res::Def(DefKind::Variant, _) if expr.is_none() => {
+            err.span_label(span, format!("not a {expected}"));
+
+            let fields = &tcx.expect_variant_res(res).fields.raw;
+            let span = qpath.span().shrink_to_hi().to(span.shrink_to_hi());
+            let (msg, sugg) = if fields.is_empty() {
+                ("use the struct variant pattern syntax".to_string(), " {}".to_string())
+            } else {
+                let msg = format!(
+                    "the struct variant's field{s} {are} being ignored",
+                    s = pluralize!(fields.len()),
+                    are = pluralize!("is", fields.len())
+                );
+                let fields = fields
+                    .iter()
+                    .map(|field| format!("{}: _", field.name.to_ident_string()))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let sugg = format!(" {{ {} }}", fields);
+                (msg, sugg)
+            };
+
+            err.span_suggestion_verbose(
+                qpath.span().shrink_to_hi().to(span.shrink_to_hi()),
+                msg,
+                sugg,
+                Applicability::HasPlaceholders,
+            );
             err
         }
         _ => err.with_span_label(span, format!("not a {expected}")),

--- a/tests/ui/empty/empty-struct-braces-pat-1.stderr
+++ b/tests/ui/empty/empty-struct-braces-pat-1.stderr
@@ -3,12 +3,22 @@ error[E0533]: expected unit struct, unit variant or constant, found struct varia
    |
 LL |         E::Empty3 => ()
    |         ^^^^^^^^^ not a unit struct, unit variant or constant
+   |
+help: use the struct variant pattern syntax
+   |
+LL |         E::Empty3 {} => ()
+   |                   ++
 
 error[E0533]: expected unit struct, unit variant or constant, found struct variant `XE::XEmpty3`
   --> $DIR/empty-struct-braces-pat-1.rs:31:9
    |
 LL |         XE::XEmpty3 => ()
    |         ^^^^^^^^^^^ not a unit struct, unit variant or constant
+   |
+help: use the struct variant pattern syntax
+   |
+LL |         XE::XEmpty3 {} => ()
+   |                     ++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/empty/empty-struct-braces-pat-3.stderr
+++ b/tests/ui/empty/empty-struct-braces-pat-3.stderr
@@ -3,24 +3,44 @@ error[E0164]: expected tuple struct or tuple variant, found struct variant `E::E
    |
 LL |         E::Empty3() => ()
    |         ^^^^^^^^^^^ not a tuple struct or tuple variant
+   |
+help: use the struct variant pattern syntax
+   |
+LL |         E::Empty3 {} => ()
+   |                   ~~
 
 error[E0164]: expected tuple struct or tuple variant, found struct variant `XE::XEmpty3`
   --> $DIR/empty-struct-braces-pat-3.rs:21:9
    |
 LL |         XE::XEmpty3() => ()
    |         ^^^^^^^^^^^^^ not a tuple struct or tuple variant
+   |
+help: use the struct variant pattern syntax
+   |
+LL |         XE::XEmpty3 {} => ()
+   |                     ~~
 
 error[E0164]: expected tuple struct or tuple variant, found struct variant `E::Empty3`
   --> $DIR/empty-struct-braces-pat-3.rs:25:9
    |
 LL |         E::Empty3(..) => ()
    |         ^^^^^^^^^^^^^ not a tuple struct or tuple variant
+   |
+help: use the struct variant pattern syntax
+   |
+LL |         E::Empty3 {} => ()
+   |                   ~~
 
 error[E0164]: expected tuple struct or tuple variant, found struct variant `XE::XEmpty3`
   --> $DIR/empty-struct-braces-pat-3.rs:29:9
    |
 LL |         XE::XEmpty3(..) => ()
    |         ^^^^^^^^^^^^^^^ not a tuple struct or tuple variant
+   |
+help: use the struct variant pattern syntax
+   |
+LL |         XE::XEmpty3 {} => ()
+   |                     ~~
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/issues/issue-63983.stderr
+++ b/tests/ui/issues/issue-63983.stderr
@@ -12,6 +12,11 @@ error[E0533]: expected unit struct, unit variant or constant, found struct varia
    |
 LL |         MyEnum::Struct => "",
    |         ^^^^^^^^^^^^^^ not a unit struct, unit variant or constant
+   |
+help: the struct variant's field is being ignored
+   |
+LL |         MyEnum::Struct { s: _ } => "",
+   |                        ++++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/recover/recover-from-bad-variant.stderr
+++ b/tests/ui/parser/recover/recover-from-bad-variant.stderr
@@ -19,6 +19,11 @@ error[E0164]: expected tuple struct or tuple variant, found struct variant `Enum
    |
 LL |         Enum::Foo(a, b) => {}
    |         ^^^^^^^^^^^^^^^ not a tuple struct or tuple variant
+   |
+help: the struct variant's fields are being ignored
+   |
+LL |         Enum::Foo { a: _, b: _ } => {}
+   |                   ~~~~~~~~~~~~~~
 
 error[E0769]: tuple variant `Enum::Bar` written as struct variant
   --> $DIR/recover-from-bad-variant.rs:12:9

--- a/tests/ui/suggestions/issue-84700.stderr
+++ b/tests/ui/suggestions/issue-84700.stderr
@@ -12,6 +12,11 @@ error[E0164]: expected tuple struct or tuple variant, found struct variant `Farm
    |
 LL |         FarmAnimal::Chicken(_) => "cluck, cluck!".to_string(),
    |         ^^^^^^^^^^^^^^^^^^^^^^ not a tuple struct or tuple variant
+   |
+help: the struct variant's field is being ignored
+   |
+LL |         FarmAnimal::Chicken { num_eggs: _ } => "cluck, cluck!".to_string(),
+   |                             ~~~~~~~~~~~~~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
+++ b/tests/ui/type-alias-enum-variants/incorrect-variant-form-through-alias-caught.stderr
@@ -14,12 +14,22 @@ error[E0533]: expected unit struct, unit variant or constant, found struct varia
    |
 LL |     let Alias::Braced = panic!();
    |         ^^^^^^^^^^^^^ not a unit struct, unit variant or constant
+   |
+help: use the struct variant pattern syntax
+   |
+LL |     let Alias::Braced {} = panic!();
+   |                       ++
 
 error[E0164]: expected tuple struct or tuple variant, found struct variant `Alias::Braced`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:12:9
    |
 LL |     let Alias::Braced(..) = panic!();
    |         ^^^^^^^^^^^^^^^^^ not a tuple struct or tuple variant
+   |
+help: use the struct variant pattern syntax
+   |
+LL |     let Alias::Braced {} = panic!();
+   |                       ~~
 
 error[E0618]: expected function, found enum variant `Alias::Unit`
   --> $DIR/incorrect-variant-form-through-alias-caught.rs:15:5


### PR DESCRIPTION
Closes #126243

I add a suggestion on usage of unit variant pattern for a struct variant.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
