### PR TITLE
rustdoc: clean up tuple <-> primitive conversion docs

### DIFF
--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -951,6 +951,16 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         bare_fn_ty.decl.inputs.len() == 1
                     } else {
                         false
+                    }
+                    || if let Some(&[hir::GenericArg::Type(ty)]) = i
+                        .of_trait
+                        .as_ref()
+                        .and_then(|trait_ref| trait_ref.path.segments.last())
+                        .map(|last_segment| last_segment.args().args)
+                    {
+                        matches!(&ty.kind, hir::TyKind::Tup([_]))
+                    } else {
+                        false
                     };
                 if !is_valid {
                     self.dcx().emit_err(errors::DocFakeVariadicNotValid { span: meta.span() });

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -122,23 +122,29 @@ macro_rules! tuple_impls {
             }
         }
 
-        #[stable(feature = "array_tuple_conv", since = "1.71.0")]
-        impl<T> From<[T; ${count($T)}]> for ($(${ignore($T)} T,)+) {
-            #[inline]
-            #[allow(non_snake_case)]
-            fn from(array: [T; ${count($T)}]) -> Self {
-                let [$($T,)+] = array;
-                ($($T,)+)
+        maybe_tuple_doc! {
+            $($T)+ @
+            #[stable(feature = "array_tuple_conv", since = "1.71.0")]
+            impl<T> From<[T; ${count($T)}]> for ($(${ignore($T)} T,)+) {
+                #[inline]
+                #[allow(non_snake_case)]
+                fn from(array: [T; ${count($T)}]) -> Self {
+                    let [$($T,)+] = array;
+                    ($($T,)+)
+                }
             }
         }
 
-        #[stable(feature = "array_tuple_conv", since = "1.71.0")]
-        impl<T> From<($(${ignore($T)} T,)+)> for [T; ${count($T)}] {
-            #[inline]
-            #[allow(non_snake_case)]
-            fn from(tuple: ($(${ignore($T)} T,)+)) -> Self {
-                let ($($T,)+) = tuple;
-                [$($T,)+]
+        maybe_tuple_doc! {
+            $($T)+ @
+            #[stable(feature = "array_tuple_conv", since = "1.71.0")]
+            impl<T> From<($(${ignore($T)} T,)+)> for [T; ${count($T)}] {
+                #[inline]
+                #[allow(non_snake_case)]
+                fn from(tuple: ($(${ignore($T)} T,)+)) -> Self {
+                    let ($($T,)+) = tuple;
+                    [$($T,)+]
+                }
             }
         }
     }
@@ -148,7 +154,7 @@ macro_rules! tuple_impls {
 // Otherwise, it hides the docs entirely.
 macro_rules! maybe_tuple_doc {
     ($a:ident @ #[$meta:meta] $item:item) => {
-        #[doc(fake_variadic)]
+        #[cfg_attr(not(bootstrap), doc(fake_variadic))]
         #[doc = "This trait is implemented for tuples up to twelve items long."]
         #[$meta]
         $item

--- a/tests/rustdoc/primitive-tuple-variadic.rs
+++ b/tests/rustdoc/primitive-tuple-variadic.rs
@@ -16,3 +16,20 @@ pub trait Bar {}
 //@ has - '//section[@id="impl-Bar-for-(U,)"]/h3' 'impl<U: Foo> Bar for (U₁, U₂, …, Uₙ)'
 #[doc(fake_variadic)]
 impl<U: Foo> Bar for (U,) {}
+
+pub trait Baz<T> { fn baz(&self) -> T { todo!() } }
+
+//@ has foo/trait.Baz.html
+//@ has - '//section[@id="impl-Baz%3C(T,)%3E-for-%5BT;+1%5D"]/h3' 'impl<T> Baz<(T₁, T₂, …, Tₙ)> for [T; N]'
+#[doc(fake_variadic)]
+impl<T> Baz<(T,)> for [T; 1] {}
+
+//@ has foo/trait.Baz.html
+//@ has - '//section[@id="impl-Baz%3C%5BT;+1%5D%3E-for-(T,)"]/h3' 'impl<T> Baz<[T; N]> for (T₁, T₂, …, Tₙ)'
+#[doc(fake_variadic)]
+impl<T> Baz<[T; 1]> for (T,) {}
+
+//@ has foo/trait.Baz.html
+//@ has - '//section[@id="impl-Baz%3CT%3E-for-(T,)"]/h3' 'impl<T> Baz<T> for (T₁, T₂, …, Tₙ)'
+#[doc(fake_variadic)]
+impl<T> Baz<T> for (T,) {}


### PR DESCRIPTION
This adds a minor missing feature to `fake_variadic`, so that it can render `impl From<(T,)> for [T; 1]` correctly.
