### PR TITLE
Use `FxHasher` on new solver unconditionally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4543,6 +4543,7 @@ dependencies = [
  "bitflags 2.6.0",
  "derive-where",
  "indexmap",
+ "rustc-hash",
  "rustc_ast_ir",
  "rustc_data_structures",
  "rustc_index",

--- a/compiler/rustc_type_ir/Cargo.toml
+++ b/compiler/rustc_type_ir/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 bitflags = "2.4.1"
 derive-where = "1.2.7"
 indexmap = "2.0.0"
+rustc-hash = "1.1.0"
 rustc_ast_ir = { path = "../rustc_ast_ir", default-features = false }
 rustc_data_structures = { path = "../rustc_data_structures", optional = true }
 rustc_index = { path = "../rustc_index", default-features = false }

--- a/compiler/rustc_type_ir/src/data_structures.rs
+++ b/compiler/rustc_type_ir/src/data_structures.rs
@@ -1,8 +1,13 @@
+use std::hash::BuildHasherDefault;
+
+use rustc_hash::FxHasher;
+pub use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+pub type IndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<FxHasher>>;
+pub type IndexSet<V> = indexmap::IndexSet<V, BuildHasherDefault<FxHasher>>;
+
 #[cfg(feature = "nightly")]
 mod impl_ {
-    pub use rustc_data_structures::fx::{
-        FxHashMap as HashMap, FxHashSet as HashSet, FxIndexMap as IndexMap, FxIndexSet as IndexSet,
-    };
     pub use rustc_data_structures::sso::{SsoHashMap, SsoHashSet};
     pub use rustc_data_structures::stack::ensure_sufficient_stack;
     pub use rustc_data_structures::sync::Lrc;
@@ -10,10 +15,8 @@ mod impl_ {
 
 #[cfg(not(feature = "nightly"))]
 mod impl_ {
-    pub use std::collections::{HashMap, HashMap as SsoHashMap, HashSet, HashSet as SsoHashSet};
+    pub use std::collections::{HashMap as SsoHashMap, HashSet as SsoHashSet};
     pub use std::sync::Arc as Lrc;
-
-    pub use indexmap::{IndexMap, IndexSet};
 
     #[inline]
     pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {


### PR DESCRIPTION
r? lqd

This should actually fix the inference problem in ad855fe6db641755c528fb5b1cc0308f3a4bf607, since `HashSet::default` was not inferring the hasher when `HashSet` was coming from the stdlib due to the way that defaulted types/inference vars work. You could cherry-pick this on top of your PR alternatively.