### PR TITLE
inline array::IntoIter::drop fn so it can be eliminated

### DIFF
--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -351,6 +351,7 @@ impl<T, const N: usize> DoubleEndedIterator for IntoIter<T, N> {
 
 #[stable(feature = "array_value_iter_impls", since = "1.40.0")]
 impl<T, const N: usize> Drop for IntoIter<T, N> {
+    #[inline]
     fn drop(&mut self) {
         // SAFETY: This is safe: `as_mut_slice` returns exactly the sub-slice
         // of elements that have not been moved out yet and that remain


### PR DESCRIPTION
I saw `drop_in_place::<IntoIter<usize, 2>>()` showing up in local profiles, which is silly.

r? ghost