### PR TITLE
link to Future::poll from the Poll docs

### DIFF
--- a/library/core/src/task/poll.rs
+++ b/library/core/src/task/poll.rs
@@ -5,6 +5,8 @@ use crate::ops::{self, ControlFlow};
 
 /// Indicates whether a value is available or if the current task has been
 /// scheduled to receive a wakeup instead.
+///
+/// This is returned by [`Future::poll`](core::future::Future::poll).
 #[must_use = "this `Poll` may be a `Pending` variant, which should be handled"]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[lang = "Poll"]


### PR DESCRIPTION
The most important thing about Poll is that Future::poll returns it, but previously the docs didn't emphasize this.