### PR TITLE
add back test for stable-const-can-only-call-stable-const

### DIFF
--- a/compiler/rustc_const_eval/messages.ftl
+++ b/compiler/rustc_const_eval/messages.ftl
@@ -419,7 +419,7 @@ const_eval_unstable_const_fn = `{$def_path}` is not yet stable as a const fn
 const_eval_unstable_in_stable =
     const-stable function cannot use `#[feature({$gate})]`
     .unstable_sugg = if it is not part of the public API, make this function unstably const
-    .bypass_sugg = otherwise `#[rustc_allow_const_fn_unstable]` can be used to bypass stability checks
+    .bypass_sugg = otherwise `#[rustc_allow_const_fn_unstable]` can be used to bypass stability checks (but requires team approval)
 
 const_eval_unterminated_c_string =
     reading a null-terminated string starting at {$pointer} with no null found before end of allocation

--- a/tests/ui/consts/min_const_fn/allow_const_fn_ptr_run_pass.rs
+++ b/tests/ui/consts/min_const_fn/allow_const_fn_ptr_run_pass.rs
@@ -1,6 +1,4 @@
 //@ run-pass
-#![feature(rustc_allow_const_fn_unstable)]
-
 #![feature(rustc_attrs, staged_api)]
 #![stable(feature = "rust1", since = "1.0.0")]
 

--- a/tests/ui/consts/min_const_fn/min_const_fn_libstd_stability.rs
+++ b/tests/ui/consts/min_const_fn/min_const_fn_libstd_stability.rs
@@ -28,9 +28,11 @@ const fn bar2() -> u32 { foo2() } //~ ERROR not yet stable as a const fn
 // conformity is required
 const fn bar3() -> u32 {
     let x = std::cell::Cell::new(0u32);
-    x.get()
+    x.get();
     //~^ ERROR const-stable function cannot use `#[feature(const_refs_to_cell)]`
     //~| ERROR cannot call non-const fn
+    foo()
+    //~^ ERROR is not yet stable as a const fn
 }
 
 // check whether this function cannot be called even with the feature gate active

--- a/tests/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
+++ b/tests/ui/consts/min_const_fn/min_const_fn_libstd_stability.stderr
@@ -17,7 +17,7 @@ LL | const fn bar2() -> u32 { foo2() }
 error: const-stable function cannot use `#[feature(const_refs_to_cell)]`
   --> $DIR/min_const_fn_libstd_stability.rs:31:5
    |
-LL |     x.get()
+LL |     x.get();
    |     ^
    |
 help: if it is not part of the public API, make this function unstably const
@@ -25,7 +25,7 @@ help: if it is not part of the public API, make this function unstably const
 LL + #[rustc_const_unstable(feature = "...", issue = "...")]
 LL | const fn bar3() -> u32 {
    |
-help: otherwise `#[rustc_allow_const_fn_unstable]` can be used to bypass stability checks
+help: otherwise `#[rustc_allow_const_fn_unstable]` can be used to bypass stability checks (but requires team approval)
    |
 LL + #[rustc_allow_const_fn_unstable(const_refs_to_cell)]
 LL | const fn bar3() -> u32 {
@@ -34,19 +34,27 @@ LL | const fn bar3() -> u32 {
 error[E0015]: cannot call non-const fn `Cell::<u32>::get` in constant functions
   --> $DIR/min_const_fn_libstd_stability.rs:31:7
    |
-LL |     x.get()
+LL |     x.get();
    |       ^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
 
+error: `foo` is not yet stable as a const fn
+  --> $DIR/min_const_fn_libstd_stability.rs:34:5
+   |
+LL |     foo()
+   |     ^^^^^
+   |
+   = help: const-stable functions can only call other const-stable functions
+
 error: `foo2_gated` is not yet stable as a const fn
-  --> $DIR/min_const_fn_libstd_stability.rs:43:32
+  --> $DIR/min_const_fn_libstd_stability.rs:45:32
    |
 LL | const fn bar2_gated() -> u32 { foo2_gated() }
    |                                ^^^^^^^^^^^^
    |
    = help: const-stable functions can only call other const-stable functions
 
-error: aborting due to 5 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0015`.


### PR DESCRIPTION
This got accidentally removed in https://github.com/rust-lang/rust/pull/128596 (file `tests/ui/internal/internal-unstable-const.rs`). The test has little to do with "allow internal unstable" though, so add it in a file that already tests various const stability things.

Also tweak the help that suggests to add `rustc_allow_const_fn_unstable` to make it clear that this needs team approval, since it is a fairly big gun.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
