### PR TITLE
[rustdoc] Generate source link on impl associated types

### DIFF
--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -1730,6 +1730,7 @@ fn render_impl(
                 let source_id = format!("{item_type}.{name}");
                 let id = cx.derive_id(&source_id);
                 write!(w, "<section id=\"{id}\" class=\"{item_type}{in_trait_class}\">");
+                render_rightside(w, cx, item, render_mode);
                 if trait_.is_some() {
                     // Anchors are only used on trait impls.
                     write!(w, "<a href=\"#{id}\" class=\"anchor\">§</a>");
@@ -1751,6 +1752,7 @@ fn render_impl(
                 let source_id = format!("{item_type}.{name}");
                 let id = cx.derive_id(&source_id);
                 write!(w, "<section id=\"{id}\" class=\"{item_type}{in_trait_class}\">");
+                render_rightside(w, cx, item, render_mode);
                 if trait_.is_some() {
                     // Anchors are only used on trait impls.
                     write!(w, "<a href=\"#{id}\" class=\"anchor\">§</a>");

--- a/tests/rustdoc/anchors.no_type_anchor2.html
+++ b/tests/rustdoc/anchors.no_type_anchor2.html
@@ -1,1 +1,1 @@
-<section id="associatedtype.Y" class="associatedtype"><h4 class="code-header">pub type <a href="#associatedtype.Y" class="associatedtype">Y</a> = <a class="primitive" href="{{channel}}/std/primitive.u32.html">u32</a></h4></section>
+<section id="associatedtype.Y" class="associatedtype"><a class="src rightside" href="../src/foo/anchors.rs.html#45">source</a><h4 class="code-header">pub type <a href="#associatedtype.Y" class="associatedtype">Y</a> = <a class="primitive" href="{{channel}}/std/primitive.u32.html">u32</a></h4></section>

--- a/tests/rustdoc/assoc-type-source-link.rs
+++ b/tests/rustdoc/assoc-type-source-link.rs
@@ -1,0 +1,26 @@
+// This test ensures that the source links are generated for impl associated types.
+
+#![crate_name = "foo"]
+#![feature(inherent_associated_types)]
+#![allow(incomplete_features)]
+
+//@ has 'foo/struct.Bar.html'
+pub struct Bar;
+
+impl Bar {
+    //@ has - '//*[@id="implementations-list"]//*[@id="associatedtype.Y"]/a' 'source'
+    //@ has - '//*[@id="implementations-list"]//*[@id="associatedtype.Y"]/a/@href' \
+    // '../src/foo/assoc-type-source-link.rs.html#14'
+    pub type Y = u8;
+}
+
+pub trait Foo {
+    type Z;
+}
+
+impl Foo for Bar {
+    //@ has - '//*[@id="trait-implementations-list"]//*[@id="associatedtype.Z"]/a' 'source'
+    //@ has - '//*[@id="trait-implementations-list"]//*[@id="associatedtype.Z"]/a/@href' \
+    // '../src/foo/assoc-type-source-link.rs.html#25'
+    type Z = u8;
+}


### PR DESCRIPTION
Currently, impl associated types are generated but don't get a source link. This PR fixes that.

Before:

![image](https://github.com/user-attachments/assets/3a22adb5-8b66-4124-9267-7c26eed1aa5e)

After:

![Screenshot from 2024-08-25 16-31-36](https://github.com/user-attachments/assets/6e9b35e7-4357-4ecf-8c49-1d8294051283)

r? @notriddle 