### PR TITLE
warn the user if the upstream master branch is old

### DIFF
--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::SyncSender;
 use std::sync::Mutex;
 
 use build_helper::ci::CiEnv;
-use build_helper::git::get_git_modified_files;
+use build_helper::git::{get_git_modified_files, warn_old_master_branch};
 use ignore::WalkBuilder;
 
 use crate::core::builder::Builder;
@@ -93,7 +93,8 @@ fn get_modified_rs_files(build: &Builder<'_>) -> Result<Option<Vec<String>>, Str
     if !verify_rustfmt_version(build) {
         return Ok(None);
     }
-
+    warn_old_master_branch(&build.config.git_config(), &build.config.src)
+        .map_err(|e| e.to_string())?;
     get_git_modified_files(&build.config.git_config(), Some(&build.config.src), &["rs"])
 }
 

--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::SyncSender;
 use std::sync::Mutex;
 
 use build_helper::ci::CiEnv;
-use build_helper::git::{get_git_modified_files, warn_old_master_branch};
+use build_helper::git::get_git_modified_files;
 use ignore::WalkBuilder;
 
 use crate::core::builder::Builder;
@@ -93,8 +93,6 @@ fn get_modified_rs_files(build: &Builder<'_>) -> Result<Option<Vec<String>>, Str
     if !verify_rustfmt_version(build) {
         return Ok(None);
     }
-    warn_old_master_branch(&build.config.git_config(), &build.config.src)
-        .map_err(|e| e.to_string())?;
     get_git_modified_files(&build.config.git_config(), Some(&build.config.src), &["rs"])
 }
 

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -15,6 +15,8 @@ use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::{env, fs};
 
+use build_helper::git::warn_old_master_branch;
+
 #[cfg(not(feature = "bootstrap-self-test"))]
 use crate::builder::Builder;
 use crate::builder::Kind;
@@ -379,4 +381,8 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
     if let Some(ref s) = build.config.ccache {
         cmd_finder.must_have(s);
     }
+
+    warn_old_master_branch(&build.config.git_config(), &build.config.src)
+        .map_err(|e| e.to_string())
+        .unwrap();
 }

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -382,7 +382,13 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
         cmd_finder.must_have(s);
     }
 
-    warn_old_master_branch(&build.config.git_config(), &build.config.src)
-        .map_err(|e| e.to_string())
-        .unwrap();
+    // this warning is useless in CI,
+    // and CI probably won't have the right branches anyway.
+    if !build_helper::ci::CiEnv::is_ci() {
+        if let Err(e) = warn_old_master_branch(&build.config.git_config(), &build.config.src)
+            .map_err(|e| e.to_string())
+        {
+            eprintln!("unable to check if upstream branch is old: {e}");
+        }
+    }
 }


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/129528

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
