### PR TITLE
Add `optimize_for_size` variants for stable and unstable sort as well as select_nth_unstable

### DIFF
--- a/library/core/src/slice/sort/mod.rs
+++ b/library/core/src/slice/sort/mod.rs
@@ -5,5 +5,4 @@ pub mod stable;
 pub mod unstable;
 
 pub(crate) mod select;
-#[cfg(not(feature = "optimize_for_size"))]
 pub(crate) mod shared;

--- a/library/core/src/slice/sort/mod.rs
+++ b/library/core/src/slice/sort/mod.rs
@@ -5,4 +5,5 @@ pub mod stable;
 pub mod unstable;
 
 pub(crate) mod select;
+#[cfg(not(feature = "optimize_for_size"))]
 pub(crate) mod shared;

--- a/library/core/src/slice/sort/select.rs
+++ b/library/core/src/slice/sort/select.rs
@@ -42,14 +42,12 @@ where
         let min_idx = min_index(v, &mut is_less).unwrap();
         v.swap(min_idx, index);
     } else {
-        #[cfg(not(feature = "optimize_for_size"))]
-        {
-            partition_at_index_loop(v, index, None, &mut is_less);
-        }
-
-        #[cfg(feature = "optimize_for_size")]
-        {
-            median_of_medians(v, &mut is_less, index);
+        cfg_if! {
+            if #[cfg(feature = "optimize_for_size")] {
+                median_of_medians(v, &mut is_less, index);
+            } else {
+                partition_at_index_loop(v, index, None, &mut is_less);
+            }
         }
     }
 
@@ -178,14 +176,12 @@ fn median_of_medians<T, F: FnMut(&T, &T) -> bool>(mut v: &mut [T], is_less: &mut
     loop {
         if v.len() <= INSERTION_SORT_THRESHOLD {
             if v.len() >= 2 {
-                #[cfg(not(feature = "optimize_for_size"))]
-                {
-                    insertion_sort_shift_left(v, 1, is_less);
-                }
-
-                #[cfg(feature = "optimize_for_size")]
-                {
-                    bubble_sort(v, is_less);
+                cfg_if! {
+                    if #[cfg(feature = "optimize_for_size")] {
+                        bubble_sort(v, is_less);
+                    } else {
+                        insertion_sort_shift_left(v, 1, is_less);
+                    }
                 }
             }
 

--- a/library/core/src/slice/sort/shared/mod.rs
+++ b/library/core/src/slice/sort/shared/mod.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "optimize_for_size", allow(dead_code))]
+
 use crate::marker::Freeze;
 
 pub(crate) mod pivot;

--- a/library/core/src/slice/sort/shared/smallsort.rs
+++ b/library/core/src/slice/sort/shared/smallsort.rs
@@ -378,7 +378,7 @@ where
 
 /// Swap two values in the slice pointed to by `v_base` at the position `a_pos` and `b_pos` if the
 /// value at position `b_pos` is less than the one at position `a_pos`.
-pub unsafe fn swap_if_less<T, F>(v_base: *mut T, a_pos: usize, b_pos: usize, is_less: &mut F)
+unsafe fn swap_if_less<T, F>(v_base: *mut T, a_pos: usize, b_pos: usize, is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,
 {

--- a/library/core/src/slice/sort/shared/smallsort.rs
+++ b/library/core/src/slice/sort/shared/smallsort.rs
@@ -378,6 +378,11 @@ where
 
 /// Swap two values in the slice pointed to by `v_base` at the position `a_pos` and `b_pos` if the
 /// value at position `b_pos` is less than the one at position `a_pos`.
+///
+/// Purposefully not marked `#[inline]`, despite us wanting it to be inlined for integers like
+/// types. `is_less` could be a huge function and we want to give the compiler an option to
+/// not inline this function. For the same reasons that this function is very perf critical
+/// it should be in the same module as the functions that use it.
 unsafe fn swap_if_less<T, F>(v_base: *mut T, a_pos: usize, b_pos: usize, is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,

--- a/library/core/src/slice/sort/stable/mod.rs
+++ b/library/core/src/slice/sort/stable/mod.rs
@@ -1,14 +1,23 @@
 //! This module contains the entry points for `slice::sort`.
 
+#[cfg(not(feature = "optimize_for_size"))]
+use crate::cmp;
+use crate::intrinsics;
 use crate::mem::{self, MaybeUninit, SizedTypeProperties};
+#[cfg(not(feature = "optimize_for_size"))]
 use crate::slice::sort::shared::smallsort::{
     insertion_sort_shift_left, StableSmallSortTypeImpl, SMALL_SORT_GENERAL_SCRATCH_LEN,
 };
-use crate::{cmp, intrinsics};
 
-pub(crate) mod drift;
 pub(crate) mod merge;
+
+#[cfg(not(feature = "optimize_for_size"))]
+pub(crate) mod drift;
+#[cfg(not(feature = "optimize_for_size"))]
 pub(crate) mod quicksort;
+
+#[cfg(feature = "optimize_for_size")]
+pub(crate) mod tiny;
 
 /// Stable sort called driftsort by Orson Peters and Lukas Bergdoll.
 /// Design document:
@@ -30,25 +39,48 @@ pub fn sort<T, F: FnMut(&T, &T) -> bool, BufT: BufGuard<T>>(v: &mut [T], is_less
         return;
     }
 
-    // More advanced sorting methods than insertion sort are faster if called in
-    // a hot loop for small inputs, but for general-purpose code the small
-    // binary size of insertion sort is more important. The instruction cache in
-    // modern processors is very valuable, and for a single sort call in general
-    // purpose code any gains from an advanced method are cancelled by i-cache
-    // misses during the sort, and thrashing the i-cache for surrounding code.
-    const MAX_LEN_ALWAYS_INSERTION_SORT: usize = 20;
-    if intrinsics::likely(len <= MAX_LEN_ALWAYS_INSERTION_SORT) {
-        insertion_sort_shift_left(v, 1, is_less);
-        return;
+    #[cfg(not(feature = "optimize_for_size"))]
+    {
+        // More advanced sorting methods than insertion sort are faster if called in
+        // a hot loop for small inputs, but for general-purpose code the small
+        // binary size of insertion sort is more important. The instruction cache in
+        // modern processors is very valuable, and for a single sort call in general
+        // purpose code any gains from an advanced method are cancelled by i-cache
+        // misses during the sort, and thrashing the i-cache for surrounding code.
+        const MAX_LEN_ALWAYS_INSERTION_SORT: usize = 20;
+        if intrinsics::likely(len <= MAX_LEN_ALWAYS_INSERTION_SORT) {
+            insertion_sort_shift_left(v, 1, is_less);
+            return;
+        }
+
+        driftsort_main::<T, F, BufT>(v, is_less);
     }
 
-    driftsort_main::<T, F, BufT>(v, is_less);
+    #[cfg(feature = "optimize_for_size")]
+    {
+        let alloc_len = len / 2;
+
+        // For small inputs 4KiB of stack storage suffices, which allows us to avoid
+        // calling the (de-)allocator. Benchmarks showed this was quite beneficial.
+        let mut stack_buf = AlignedStorage::<T, 4096>::new();
+        let stack_scratch = stack_buf.as_uninit_slice_mut();
+        let mut heap_buf;
+        let scratch = if stack_scratch.len() >= alloc_len {
+            stack_scratch
+        } else {
+            heap_buf = BufT::with_capacity(alloc_len);
+            heap_buf.as_uninit_slice_mut()
+        };
+
+        tiny::mergesort(v, scratch, is_less);
+    }
 }
 
 /// See [`sort`]
 ///
 /// Deliberately don't inline the main sorting routine entrypoint to ensure the
 /// inlined insertion sort i-cache footprint remains minimal.
+#[cfg(not(feature = "optimize_for_size"))]
 #[inline(never)]
 fn driftsort_main<T, F: FnMut(&T, &T) -> bool, BufT: BufGuard<T>>(v: &mut [T], is_less: &mut F) {
     // By allocating n elements of memory we can ensure the entire input can

--- a/library/core/src/slice/sort/stable/mod.rs
+++ b/library/core/src/slice/sort/stable/mod.rs
@@ -39,40 +39,38 @@ pub fn sort<T, F: FnMut(&T, &T) -> bool, BufT: BufGuard<T>>(v: &mut [T], is_less
         return;
     }
 
-    #[cfg(not(feature = "optimize_for_size"))]
-    {
-        // More advanced sorting methods than insertion sort are faster if called in
-        // a hot loop for small inputs, but for general-purpose code the small
-        // binary size of insertion sort is more important. The instruction cache in
-        // modern processors is very valuable, and for a single sort call in general
-        // purpose code any gains from an advanced method are cancelled by i-cache
-        // misses during the sort, and thrashing the i-cache for surrounding code.
-        const MAX_LEN_ALWAYS_INSERTION_SORT: usize = 20;
-        if intrinsics::likely(len <= MAX_LEN_ALWAYS_INSERTION_SORT) {
-            insertion_sort_shift_left(v, 1, is_less);
-            return;
-        }
+    cfg_if! {
+        if #[cfg(feature = "optimize_for_size")] {
+            let alloc_len = len / 2;
 
-        driftsort_main::<T, F, BufT>(v, is_less);
-    }
+            // For small inputs 4KiB of stack storage suffices, which allows us to avoid
+            // calling the (de-)allocator. Benchmarks showed this was quite beneficial.
+            let mut stack_buf = AlignedStorage::<T, 4096>::new();
+            let stack_scratch = stack_buf.as_uninit_slice_mut();
+            let mut heap_buf;
+            let scratch = if stack_scratch.len() >= alloc_len {
+                stack_scratch
+            } else {
+                heap_buf = BufT::with_capacity(alloc_len);
+                heap_buf.as_uninit_slice_mut()
+            };
 
-    #[cfg(feature = "optimize_for_size")]
-    {
-        let alloc_len = len / 2;
-
-        // For small inputs 4KiB of stack storage suffices, which allows us to avoid
-        // calling the (de-)allocator. Benchmarks showed this was quite beneficial.
-        let mut stack_buf = AlignedStorage::<T, 4096>::new();
-        let stack_scratch = stack_buf.as_uninit_slice_mut();
-        let mut heap_buf;
-        let scratch = if stack_scratch.len() >= alloc_len {
-            stack_scratch
+            tiny::mergesort(v, scratch, is_less);
         } else {
-            heap_buf = BufT::with_capacity(alloc_len);
-            heap_buf.as_uninit_slice_mut()
-        };
+            // More advanced sorting methods than insertion sort are faster if called in
+            // a hot loop for small inputs, but for general-purpose code the small
+            // binary size of insertion sort is more important. The instruction cache in
+            // modern processors is very valuable, and for a single sort call in general
+            // purpose code any gains from an advanced method are cancelled by i-cache
+            // misses during the sort, and thrashing the i-cache for surrounding code.
+            const MAX_LEN_ALWAYS_INSERTION_SORT: usize = 20;
+            if intrinsics::likely(len <= MAX_LEN_ALWAYS_INSERTION_SORT) {
+                insertion_sort_shift_left(v, 1, is_less);
+                return;
+            }
 
-        tiny::mergesort(v, scratch, is_less);
+            driftsort_main::<T, F, BufT>(v, is_less);
+        }
     }
 }
 

--- a/library/core/src/slice/sort/stable/tiny.rs
+++ b/library/core/src/slice/sort/stable/tiny.rs
@@ -1,0 +1,75 @@
+//! Binary-size optimized mergesort inspired by https://github.com/voultapher/tiny-sort-rs.
+
+use crate::mem::{ManuallyDrop, MaybeUninit};
+use crate::ptr;
+use crate::slice::sort::stable::merge;
+
+/// Tiny recursive top-down merge sort optimized for binary size. It has no adaptiveness whatsoever,
+/// no run detection, etc.
+#[inline(always)]
+pub fn mergesort<T, F: FnMut(&T, &T) -> bool>(
+    v: &mut [T],
+    scratch: &mut [MaybeUninit<T>],
+    is_less: &mut F,
+) {
+    let len = v.len();
+
+    if len > 2 {
+        let mid = len / 2;
+
+        // SAFETY: mid is in-bounds.
+        unsafe {
+            // Sort the left half recursively.
+            mergesort(v.get_unchecked_mut(..mid), scratch, is_less);
+            // Sort the right half recursively.
+            mergesort(v.get_unchecked_mut(mid..), scratch, is_less);
+        }
+
+        merge::merge(v, scratch, mid, is_less);
+    } else if len == 2 {
+        // Branchless swap the two elements. This reduces the recursion depth and improves
+        // perf significantly at a small binary-size cost. Trades ~10% perf boost for integers
+        // for ~50 bytes in the binary.
+
+        // SAFETY: We checked the len, the pointers we create are valid and don't overlap.
+        unsafe {
+            swap_if_less(v.as_mut_ptr(), 0, 1, is_less);
+        }
+    }
+}
+
+/// Swap two values in the slice pointed to by `v_base` at the position `a_pos` and `b_pos` if the
+/// value at position `b_pos` is less than the one at position `a_pos`.
+unsafe fn swap_if_less<T, F>(v_base: *mut T, a_pos: usize, b_pos: usize, is_less: &mut F)
+where
+    F: FnMut(&T, &T) -> bool,
+{
+    // SAFETY: the caller must guarantee that `a` and `b` each added to `v_base` yield valid
+    // pointers into `v_base`, and are properly aligned, and part of the same allocation.
+    unsafe {
+        let v_a = v_base.add(a_pos);
+        let v_b = v_base.add(b_pos);
+
+        // PANIC SAFETY: if is_less panics, no scratch memory was created and the slice should still be
+        // in a well defined state, without duplicates.
+
+        // Important to only swap if it is more and not if it is equal. is_less should return false for
+        // equal, so we don't swap.
+        let should_swap = is_less(&*v_b, &*v_a);
+
+        // This is a branchless version of swap if.
+        // The equivalent code with a branch would be:
+        //
+        // if should_swap {
+        //     ptr::swap(left, right, 1);
+        // }
+
+        // The goal is to generate cmov instructions here.
+        let left_swap = if should_swap { v_b } else { v_a };
+        let right_swap = if should_swap { v_a } else { v_b };
+
+        let right_swap_tmp = ManuallyDrop::new(ptr::read(right_swap));
+        ptr::copy(left_swap, v_a, 1);
+        ptr::copy_nonoverlapping(&*right_swap_tmp, v_b, 1);
+    }
+}

--- a/library/core/src/slice/sort/stable/tiny.rs
+++ b/library/core/src/slice/sort/stable/tiny.rs
@@ -1,6 +1,6 @@
 //! Binary-size optimized mergesort inspired by https://github.com/voultapher/tiny-sort-rs.
 
-use crate::mem::{ManuallyDrop, MaybeUninit};
+use crate::mem::MaybeUninit;
 use crate::ptr;
 use crate::slice::sort::stable::merge;
 
@@ -27,49 +27,15 @@ pub fn mergesort<T, F: FnMut(&T, &T) -> bool>(
 
         merge::merge(v, scratch, mid, is_less);
     } else if len == 2 {
-        // Branchless swap the two elements. This reduces the recursion depth and improves
-        // perf significantly at a small binary-size cost. Trades ~10% perf boost for integers
-        // for ~50 bytes in the binary.
-
         // SAFETY: We checked the len, the pointers we create are valid and don't overlap.
         unsafe {
-            swap_if_less(v.as_mut_ptr(), 0, 1, is_less);
+            let v_base = v.as_mut_ptr();
+            let v_a = v_base;
+            let v_b = v_base.add(1);
+
+            if is_less(&*v_b, &*v_a) {
+                ptr::swap_nonoverlapping(v_a, v_b, 1);
+            }
         }
-    }
-}
-
-/// Swap two values in the slice pointed to by `v_base` at the position `a_pos` and `b_pos` if the
-/// value at position `b_pos` is less than the one at position `a_pos`.
-unsafe fn swap_if_less<T, F>(v_base: *mut T, a_pos: usize, b_pos: usize, is_less: &mut F)
-where
-    F: FnMut(&T, &T) -> bool,
-{
-    // SAFETY: the caller must guarantee that `a` and `b` each added to `v_base` yield valid
-    // pointers into `v_base`, and are properly aligned, and part of the same allocation.
-    unsafe {
-        let v_a = v_base.add(a_pos);
-        let v_b = v_base.add(b_pos);
-
-        // PANIC SAFETY: if is_less panics, no scratch memory was created and the slice should still be
-        // in a well defined state, without duplicates.
-
-        // Important to only swap if it is more and not if it is equal. is_less should return false for
-        // equal, so we don't swap.
-        let should_swap = is_less(&*v_b, &*v_a);
-
-        // This is a branchless version of swap if.
-        // The equivalent code with a branch would be:
-        //
-        // if should_swap {
-        //     ptr::swap(left, right, 1);
-        // }
-
-        // The goal is to generate cmov instructions here.
-        let left_swap = if should_swap { v_b } else { v_a };
-        let right_swap = if should_swap { v_a } else { v_b };
-
-        let right_swap_tmp = ManuallyDrop::new(ptr::read(right_swap));
-        ptr::copy(left_swap, v_a, 1);
-        ptr::copy_nonoverlapping(&*right_swap_tmp, v_b, 1);
     }
 }

--- a/library/core/src/slice/sort/unstable/heapsort.rs
+++ b/library/core/src/slice/sort/unstable/heapsort.rs
@@ -1,46 +1,46 @@
 //! This module contains a branchless heapsort as fallback for unstable quicksort.
 
-use crate::{intrinsics, ptr};
+use crate::{cmp, intrinsics, ptr};
 
 /// Sorts `v` using heapsort, which guarantees *O*(*n* \* log(*n*)) worst-case.
 ///
 /// Never inline this, it sits the main hot-loop in `recurse` and is meant as unlikely algorithmic
 /// fallback.
-///
-/// SAFETY: The caller has to guarantee that `v.len()` >= 2.
 #[inline(never)]
-pub(crate) unsafe fn heapsort<T, F>(v: &mut [T], is_less: &mut F)
+pub(crate) fn heapsort<T, F>(v: &mut [T], is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,
 {
-    // SAFETY: See function safety.
-    unsafe {
-        intrinsics::assume(v.len() >= 2);
+    let len = v.len();
 
-        // Build the heap in linear time.
-        for i in (0..v.len() / 2).rev() {
-            sift_down(v, i, is_less);
-        }
-
-        // Pop maximal elements from the heap.
-        for i in (1..v.len()).rev() {
+    for i in (0..len + len / 2).rev() {
+        let sift_idx = if i >= len {
+            i - len
+        } else {
             v.swap(0, i);
-            sift_down(&mut v[..i], 0, is_less);
+            0
+        };
+
+        // SAFETY: The above calculation ensures that `sift_idx` is either 0 or
+        // `(len..(len + (len / 2))) - len`, which simplifies to `0..(len / 2)`.
+        // This guarantees the required `sift_idx <= len`.
+        unsafe {
+            sift_down(&mut v[..cmp::min(i, len)], sift_idx, is_less);
         }
     }
 }
 
 // This binary heap respects the invariant `parent >= child`.
 //
-// SAFETY: The caller has to guarantee that node < `v.len()`.
-#[inline(never)]
+// SAFETY: The caller has to guarantee that `node <= v.len()`.
+#[inline(always)]
 unsafe fn sift_down<T, F>(v: &mut [T], mut node: usize, is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,
 {
     // SAFETY: See function safety.
     unsafe {
-        intrinsics::assume(node < v.len());
+        intrinsics::assume(node <= v.len());
     }
 
     let len = v.len();

--- a/library/core/src/slice/sort/unstable/heapsort.rs
+++ b/library/core/src/slice/sort/unstable/heapsort.rs
@@ -69,9 +69,7 @@ where
                 break;
             }
 
-            // Swap `node` with the greater child, move one step down, and continue sifting. This
-            // could be ptr::swap_nonoverlapping but that adds a significant amount of binary-size.
-            ptr::swap(v_base.add(node), v_base.add(child));
+            ptr::swap_nonoverlapping(v_base.add(node), v_base.add(child), 1);
         }
 
         node = child;

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -32,10 +32,7 @@ pub fn sort<T, F: FnMut(&T, &T) -> bool>(v: &mut [T], is_less: &mut F) {
 
     cfg_if! {
         if #[cfg(feature = "optimize_for_size")] {
-            // SAFETY: We checked that `len >= 2`.
-            unsafe {
-                heapsort::heapsort(v, is_less);
-            }
+            heapsort::heapsort(v, is_less);
         } else {
             // More advanced sorting methods than insertion sort are faster if called in
             // a hot loop for small inputs, but for general-purpose code the small

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -31,7 +31,7 @@ pub fn sort<T, F: FnMut(&T, &T) -> bool>(v: &mut [T], is_less: &mut F) {
     }
 
     cfg_if! {
-        if #[cfg(feature = "optimize_for_size")] {
+        if #[cfg(any(feature = "optimize_for_size", target_pointer_width = "16"))] {
             heapsort::heapsort(v, is_less);
         } else {
             // More advanced sorting methods than insertion sort are faster if called in

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -30,28 +30,26 @@ pub fn sort<T, F: FnMut(&T, &T) -> bool>(v: &mut [T], is_less: &mut F) {
         return;
     }
 
-    #[cfg(not(feature = "optimize_for_size"))]
-    {
-        // More advanced sorting methods than insertion sort are faster if called in
-        // a hot loop for small inputs, but for general-purpose code the small
-        // binary size of insertion sort is more important. The instruction cache in
-        // modern processors is very valuable, and for a single sort call in general
-        // purpose code any gains from an advanced method are cancelled by i-cache
-        // misses during the sort, and thrashing the i-cache for surrounding code.
-        const MAX_LEN_ALWAYS_INSERTION_SORT: usize = 20;
-        if intrinsics::likely(len <= MAX_LEN_ALWAYS_INSERTION_SORT) {
-            insertion_sort_shift_left(v, 1, is_less);
-            return;
-        }
+    cfg_if! {
+        if #[cfg(feature = "optimize_for_size")] {
+            // SAFETY: We checked that `len >= 2`.
+            unsafe {
+                heapsort::heapsort(v, is_less);
+            }
+        } else {
+            // More advanced sorting methods than insertion sort are faster if called in
+            // a hot loop for small inputs, but for general-purpose code the small
+            // binary size of insertion sort is more important. The instruction cache in
+            // modern processors is very valuable, and for a single sort call in general
+            // purpose code any gains from an advanced method are cancelled by i-cache
+            // misses during the sort, and thrashing the i-cache for surrounding code.
+            const MAX_LEN_ALWAYS_INSERTION_SORT: usize = 20;
+            if intrinsics::likely(len <= MAX_LEN_ALWAYS_INSERTION_SORT) {
+                insertion_sort_shift_left(v, 1, is_less);
+                return;
+            }
 
-        ipnsort(v, is_less);
-    }
-
-    #[cfg(feature = "optimize_for_size")]
-    {
-        // SAFETY: We checked that `len >= 2`.
-        unsafe {
-            heapsort::heapsort(v, is_less);
+            ipnsort(v, is_less);
         }
     }
 }

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -2,10 +2,13 @@
 
 use crate::intrinsics;
 use crate::mem::SizedTypeProperties;
+#[cfg(not(feature = "optimize_for_size"))]
 use crate::slice::sort::shared::find_existing_run;
+#[cfg(not(feature = "optimize_for_size"))]
 use crate::slice::sort::shared::smallsort::insertion_sort_shift_left;
 
 pub(crate) mod heapsort;
+#[cfg(not(feature = "optimize_for_size"))]
 pub(crate) mod quicksort;
 
 /// Unstable sort called ipnsort by Lukas Bergdoll and Orson Peters.
@@ -28,25 +31,37 @@ pub fn sort<T, F: FnMut(&T, &T) -> bool>(v: &mut [T], is_less: &mut F) {
         return;
     }
 
-    // More advanced sorting methods than insertion sort are faster if called in
-    // a hot loop for small inputs, but for general-purpose code the small
-    // binary size of insertion sort is more important. The instruction cache in
-    // modern processors is very valuable, and for a single sort call in general
-    // purpose code any gains from an advanced method are cancelled by i-cache
-    // misses during the sort, and thrashing the i-cache for surrounding code.
-    const MAX_LEN_ALWAYS_INSERTION_SORT: usize = 20;
-    if intrinsics::likely(len <= MAX_LEN_ALWAYS_INSERTION_SORT) {
-        insertion_sort_shift_left(v, 1, is_less);
-        return;
+    #[cfg(not(feature = "optimize_for_size"))]
+    {
+        // More advanced sorting methods than insertion sort are faster if called in
+        // a hot loop for small inputs, but for general-purpose code the small
+        // binary size of insertion sort is more important. The instruction cache in
+        // modern processors is very valuable, and for a single sort call in general
+        // purpose code any gains from an advanced method are cancelled by i-cache
+        // misses during the sort, and thrashing the i-cache for surrounding code.
+        const MAX_LEN_ALWAYS_INSERTION_SORT: usize = 20;
+        if intrinsics::likely(len <= MAX_LEN_ALWAYS_INSERTION_SORT) {
+            insertion_sort_shift_left(v, 1, is_less);
+            return;
+        }
+
+        ipnsort(v, is_less);
     }
 
-    ipnsort(v, is_less);
+    #[cfg(feature = "optimize_for_size")]
+    {
+        // SAFETY: We checked that `len >= 2`.
+        unsafe {
+            heapsort::heapsort(v, is_less);
+        }
+    }
 }
 
 /// See [`sort`]
 ///
 /// Deliberately don't inline the main sorting routine entrypoint to ensure the
 /// inlined insertion sort i-cache footprint remains minimal.
+#[cfg(not(feature = "optimize_for_size"))]
 #[inline(never)]
 fn ipnsort<T, F>(v: &mut [T], is_less: &mut F)
 where

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -8,7 +8,6 @@ use crate::slice::sort::shared::find_existing_run;
 use crate::slice::sort::shared::smallsort::insertion_sort_shift_left;
 
 pub(crate) mod heapsort;
-#[cfg(not(feature = "optimize_for_size"))]
 pub(crate) mod quicksort;
 
 /// Unstable sort called ipnsort by Lukas Bergdoll and Orson Peters.

--- a/library/core/src/slice/sort/unstable/quicksort.rs
+++ b/library/core/src/slice/sort/unstable/quicksort.rs
@@ -141,15 +141,12 @@ const fn inst_partition<T, F: FnMut(&T, &T) -> bool>() -> fn(&mut [T], &T, &mut 
     if mem::size_of::<T>() <= MAX_BRANCHLESS_PARTITION_SIZE {
         // Specialize for types that are relatively cheap to copy, where branchless optimizations
         // have large leverage e.g. `u64` and `String`.
-
-        #[cfg(not(feature = "optimize_for_size"))]
-        {
-            partition_lomuto_branchless_cyclic::<T, F>
-        }
-
-        #[cfg(feature = "optimize_for_size")]
-        {
-            partition_lomuto_branchless_simple::<T, F>
+        cfg_if! {
+            if #[cfg(feature = "optimize_for_size")] {
+                partition_lomuto_branchless_simple::<T, F>
+            } else {
+                partition_lomuto_branchless_cyclic::<T, F>
+            }
         }
     } else {
         partition_hoare_branchy_cyclic::<T, F>

--- a/library/core/src/slice/sort/unstable/quicksort.rs
+++ b/library/core/src/slice/sort/unstable/quicksort.rs
@@ -5,6 +5,8 @@ use crate::mem::{self, ManuallyDrop};
 use crate::slice::sort::shared::pivot::choose_pivot;
 #[cfg(not(feature = "optimize_for_size"))]
 use crate::slice::sort::shared::smallsort::UnstableSmallSortTypeImpl;
+#[cfg(not(feature = "optimize_for_size"))]
+use crate::slice::sort::unstable::heapsort;
 use crate::{intrinsics, ptr};
 
 /// Sorts `v` recursively.
@@ -31,10 +33,7 @@ pub(crate) fn quicksort<'a, T, F>(
         // If too many bad pivot choices were made, simply fall back to heapsort in order to
         // guarantee `O(N x log(N))` worst-case.
         if limit == 0 {
-            // SAFETY: We assume the `small_sort` threshold is at least 1.
-            unsafe {
-                crate::slice::sort::unstable::heapsort::heapsort(v, is_less);
-            }
+            heapsort::heapsort(v, is_less);
             return;
         }
 


### PR DESCRIPTION
- Stable sort uses a simple merge-sort that re-uses the existing - rather gnarly - merge function.
- Unstable sort jumps directly to the branchless heapsort fallback.
- select_nth_unstable jumps directly to the median_of_medians fallback, which is augmented with a custom tiny smallsort and partition impl.

Some code is duplicated but de-duplication would bring it's own problems. For example `swap_if_less` is critical for performance, if the sorting networks don't inline it perf drops drastically, however `#[inline(always)]` is also a poor fit, if the provided comparison function is huge, it gives the compiler an out to only instantiate `swap_if_less` once and call it. Another aspect that would suffer when making `swap_if_less` pub, is having to cfg out dozens of functions in in smallsort module.

Part of https://github.com/rust-lang/rust/issues/125612

r​? @Kobzol 

