### PR TITLE
pal/hermit: correctly round up microseconds in `Thread::sleep`

### DIFF
--- a/library/std/src/sys/pal/hermit/thread.rs
+++ b/library/std/src/sys/pal/hermit/thread.rs
@@ -77,8 +77,10 @@ impl Thread {
 
     #[inline]
     pub fn sleep(dur: Duration) {
+        let micros = dur.as_micros() + if dur.subsec_nanos() % 1_000 > 0 { 1 } else { 0 };
+
         unsafe {
-            hermit_abi::usleep(dur.as_micros() as u64);
+            hermit_abi::usleep(micros as u64);
         }
     }
 

--- a/library/std/src/sys/pal/hermit/thread.rs
+++ b/library/std/src/sys/pal/hermit/thread.rs
@@ -78,9 +78,10 @@ impl Thread {
     #[inline]
     pub fn sleep(dur: Duration) {
         let micros = dur.as_micros() + if dur.subsec_nanos() % 1_000 > 0 { 1 } else { 0 };
+        let micros = u64::try_from(micros).unwrap_or(u64::MAX);
 
         unsafe {
-            hermit_abi::usleep(micros as u64);
+            hermit_abi::usleep(micros);
         }
     }
 


### PR DESCRIPTION
This fixes the Hermit-related part of https://github.com/rust-lang/rust/issues/129212 and thus the whole issue, since ESP-IDF is already fixed, as far as I understand.

Fixes https://github.com/rust-lang/rust/issues/129212

r? @workingjubilee

CC: @stlankes