### PR TITLE
explain the options bootstrap passes to curl

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -106,9 +106,9 @@ def _download(path, url, probably_big, verbose, exception):
 
     try:
         if (probably_big or verbose) and "GITHUB_ACTIONS" not in os.environ:
-            option = "-#"
+            option = "--progress-bar"
         else:
-            option = "-s"
+            option = "--silent"
         # If curl is not present on Win32, we should not sys.exit
         #   but raise `CalledProcessError` or `OSError` instead
         require(["curl", "--version"], exception=platform_is_win32())
@@ -120,12 +120,15 @@ def _download(path, url, probably_big, verbose, exception):
         # for consistency.
         # they are also more compreprensivly explained in that file.
         run(["curl", option] + extra_flags + [
-            "-L", # Follow redirect.
-            "-y", "30", "-Y", "10",    # timeout if speed is < 10 bytes/sec for > 30 seconds
-            "--connect-timeout", "30",  # timeout if cannot connect within 30 seconds
-            "-o", path,
+            # Follow redirect.
+            "--location",
+            # timeout if speed is < 10 bytes/sec for > 30 seconds
+            "--speed-time", "30", "--speed-limit", "10",
+            # timeout if cannot connect within 30 seconds
+            "--connect-timeout", "30",
+            "--output", path,
             "--continue-at", "-",
-            "--retry", "3", "-SRf", url],
+            "--retry", "3", "--show-error", "--remote-time", "--fail", url],
             verbose=verbose,
             exception=True, # Will raise RuntimeError on failure
         )

--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -115,6 +115,10 @@ def _download(path, url, probably_big, verbose, exception):
         extra_flags = []
         if curl_version() > (7, 70):
             extra_flags = [ "--retry-all-errors" ]
+        # options should be kept in sync with
+        # src/bootstrap/src/core/download.rs
+        # for consistency.
+        # they are also more compreprensivly explained in that file.
         run(["curl", option] + extra_flags + [
             "-L", # Follow redirect.
             "-y", "30", "-Y", "10",    # timeout if speed is < 10 bytes/sec for > 30 seconds

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -233,17 +233,17 @@ impl Config {
         let mut curl = command("curl");
         curl.args([
             // follow redirect
-            "-L",
+            "--location",
             // timeout if speed is < 10 bytes/sec for > 30 seconds
-            "-y",
+            "--speed-time",
             "30",
-            "-Y",
+            "--speed-limit",
             "10",
             // timeout if cannot connect within 30 seconds
             "--connect-timeout",
             "30",
             // output file
-            "-o",
+            "--output",
             tempfile.to_str().unwrap(),
             // if there is an error, don't restart the download,
             // instead continue where it left off.
@@ -253,14 +253,16 @@ impl Config {
             // attempts will be made, since the first attempt isn't a *re*try.
             "--retry",
             "3",
-            // -S: show errors, even if -s is specified
-            // -R: set timestamp of downloaded file to that of the server
-            // -f: fail on non-ok http status
-            "-SRf",
+            // show errors, even if --silent is specified
+            "--show-error",
+            // set timestamp of downloaded file to that of the server
+            "--remote-time",
+            // fail on non-ok http status
+            "--fail",
         ]);
         // Don't print progress in CI; the \r wrapping looks bad and downloads don't take long enough for progress to be useful.
         if CiEnv::is_ci() {
-            curl.arg("-s");
+            curl.arg("--silent");
         } else {
             curl.arg("--progress-bar");
         }


### PR DESCRIPTION
also fixes a discrepancy where the rust side doesn't use -L

docs are only on the rust side, since duplicated prose has a tendancy to get out-of-sync, and also because there are talks of removing the python script all together eventually.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
