### PR TITLE
[DO NOT MERGE] crater run on the tail expression drop order lint

### DIFF
--- a/compiler/rustc_lint/src/tail_expr_drop_order.rs
+++ b/compiler/rustc_lint/src/tail_expr_drop_order.rs
@@ -137,9 +137,7 @@ impl<'tcx> LateLintPass<'tcx> for TailExprDropOrder {
         _: Span,
         def_id: rustc_span::def_id::LocalDefId,
     ) {
-        if cx.tcx.sess.at_least_rust_2024() && cx.tcx.features().shorter_tail_lifetimes {
-            Self::check_fn_or_closure(cx, fn_kind, body, def_id);
-        }
+        Self::check_fn_or_closure(cx, fn_kind, body, def_id);
     }
 }
 
@@ -185,10 +183,6 @@ impl<'tcx, 'a> Visitor<'tcx> for LintVisitor<'tcx, 'a> {
 
 impl<'tcx, 'a> LintVisitor<'tcx, 'a> {
     fn check_block_inner(&mut self, block: &Block<'tcx>) {
-        if !block.span.at_least_rust_2024() {
-            // We only lint for Edition 2024 onwards
-            return;
-        }
         let Some(tail_expr) = block.expr else { return };
         for stmt in block.stmts {
             match stmt.kind {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR is intended for a crater run *for the lint tail-expr-drop-order*.

This need another patch on `src/tools/cargo` which is still in progress.