### PR TITLE
Add missing `needs-llvm-components` directives for run-make tests that need target-specific codegen

### DIFF
--- a/tests/run-make/print-cfg/rmake.rs
+++ b/tests/run-make/print-cfg/rmake.rs
@@ -5,6 +5,11 @@
 //!
 //! It also checks that some targets have the correct set cfgs.
 
+// ignore-tidy-linelength
+//@ needs-llvm-components: arm x86
+// Note: without the needs-llvm-components it will fail on LLVM built without the required
+// components listed above.
+
 use std::collections::HashSet;
 use std::iter::FromIterator;
 use std::path::PathBuf;

--- a/tests/run-make/print-target-list/rmake.rs
+++ b/tests/run-make/print-target-list/rmake.rs
@@ -1,10 +1,15 @@
-// Checks that all the targets returned by `rustc --print target-list` are valid
-// target specifications
+// Checks that all the targets returned by `rustc --print target-list` are valid target
+// specifications.
+
+// ignore-tidy-linelength
+//@ needs-llvm-components: aarch64 arm avr bpf csky hexagon loongarch m68k mips msp430 nvptx powerpc riscv sparc systemz webassembly x86
+// FIXME(jieyouxu): there has to be a better way to do this, without the needs-llvm-components it
+// will fail on LLVM built without all of the components listed above.
 
 use run_make_support::bare_rustc;
 
-// FIXME(127877): certain experimental targets fail with creating a 'LLVM TargetMachine'
-// in CI, so we skip them
+// FIXME(#127877): certain experimental targets fail with creating a 'LLVM TargetMachine' in CI, so
+// we skip them.
 const EXPERIMENTAL_TARGETS: &[&str] = &["avr", "m68k", "csky", "xtensa"];
 
 fn main() {

--- a/tests/run-make/print-to-output/rmake.rs
+++ b/tests/run-make/print-to-output/rmake.rs
@@ -1,5 +1,11 @@
-//! This checks the output of some `--print` options when
-//! output to a file (instead of stdout)
+//! This checks the output of some `--print` options when output to a file (instead of stdout)
+
+// ignore-tidy-linelength
+//@ needs-llvm-components: aarch64 arm avr bpf csky hexagon loongarch m68k mips msp430 nvptx powerpc riscv sparc systemz webassembly x86
+// FIXME(jieyouxu): there has to be a better way to do this, without the needs-llvm-components it
+// will fail on LLVM built without all of the components listed above. If adding a new target that
+// relies on a llvm component not listed above, it will need to be added to the required llvm
+// components above.
 
 use std::path::PathBuf;
 

--- a/tests/run-make/target-without-atomic-cas/rmake.rs
+++ b/tests/run-make/target-without-atomic-cas/rmake.rs
@@ -1,8 +1,13 @@
-// ARM Cortex-M are a class of processors supported by the rust compiler. However,
-// they cannot support any atomic features, such as Arc. This test simply prints
-// the configuration details of one Cortex target, and checks that the compiler
-// does not falsely list atomic support.
-// See https://github.com/rust-lang/rust/pull/36874
+// ARM Cortex-M are a class of processors supported by the rust compiler. However, they cannot
+// support any atomic features, such as Arc. This test simply prints the configuration details of
+// one Cortex target, and checks that the compiler does not falsely list atomic support.
+// See <https://github.com/rust-lang/rust/pull/36874>.
+
+// ignore-tidy-linelength
+//@ needs-llvm-components: arm
+// Note: without the needs-llvm-components it will fail on LLVM built without all of the components
+// listed above. If any new targets are added, please double-check their respective llvm components
+// are specified above.
 
 use run_make_support::rustc;
 


### PR DESCRIPTION
Without suitable `needs-llvm-components` directives, some run-make tests exercising target-specific codegen can fail if the LLVM used is built without the necessary components. Currently, the list is:

```
tests\run-make\print-target-list
tests\run-make\print-to-output
tests\run-make\print-cfg
tests\run-make\target-without-atomic-cas
```

This PR also skips tidy checks for revisions and `needs-llvm-components` for run-make tests since revisions are not supported.

Fixes #129390.
Fixes #127895.

cc @petrochenkov who noticed this, thanks! Would be great if you could confirm that this fixes the test errors for you locally.