### PR TITLE
[DO NOT MERGE] Tail expr drop order crater run

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -168,11 +168,7 @@ fn resolve_block<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, blk: &'tcx h
             }
         }
         if let Some(tail_expr) = blk.expr {
-            if visitor.tcx.features().shorter_tail_lifetimes
-                && blk.span.edition().at_least_rust_2024()
-            {
-                visitor.terminating_scopes.insert(tail_expr.hir_id.local_id);
-            }
+            visitor.terminating_scopes.insert(tail_expr.hir_id.local_id);
             visitor.visit_expr(tail_expr);
         }
     }

--- a/compiler/rustc_lint/src/tail_expr_drop_order.rs
+++ b/compiler/rustc_lint/src/tail_expr_drop_order.rs
@@ -137,9 +137,7 @@ impl<'tcx> LateLintPass<'tcx> for TailExprDropOrder {
         _: Span,
         def_id: rustc_span::def_id::LocalDefId,
     ) {
-        if cx.tcx.sess.at_least_rust_2024() && cx.tcx.features().shorter_tail_lifetimes {
-            Self::check_fn_or_closure(cx, fn_kind, body, def_id);
-        }
+        Self::check_fn_or_closure(cx, fn_kind, body, def_id);
     }
 }
 
@@ -185,10 +183,6 @@ impl<'tcx, 'a> Visitor<'tcx> for LintVisitor<'tcx, 'a> {
 
 impl<'tcx, 'a> LintVisitor<'tcx, 'a> {
     fn check_block_inner(&mut self, block: &Block<'tcx>) {
-        if !block.span.at_least_rust_2024() {
-            // We only lint for Edition 2024 onwards
-            return;
-        }
         let Some(tail_expr) = block.expr else { return };
         for stmt in block.stmts {
             match stmt.kind {

--- a/tests/ui/async-await/async-fn-size-moved-locals.rs
+++ b/tests/ui/async-await/async-fn-size-moved-locals.rs
@@ -8,7 +8,7 @@
 // See issue #59123 for a full explanation.
 
 //@ needs-unwind Size of Futures change on panic=abort
-//@ run-pass
+//@ ignore-test
 
 //@ edition:2018
 
@@ -70,11 +70,7 @@ async fn joined() {
     let b = BigFut::new();
     let c = BigFut::new();
 
-    let joiner = Joiner {
-        a: Some(a),
-        b: Some(b),
-        c: Some(c),
-    };
+    let joiner = Joiner { a: Some(a), b: Some(b), c: Some(c) };
     joiner.await
 }
 
@@ -83,11 +79,7 @@ async fn joined_with_noop() {
     let b = BigFut::new();
     let c = BigFut::new();
 
-    let joiner = Joiner {
-        a: Some(a),
-        b: Some(b),
-        c: Some(c),
-    };
+    let joiner = Joiner { a: Some(a), b: Some(b), c: Some(c) };
     noop();
     joiner.await
 }
@@ -98,11 +90,7 @@ async fn mixed_sizes() {
     let c = BigFut::new();
     let d = BigFut::new();
     let e = BigFut::new();
-    let joiner = Joiner {
-        a: Some(a),
-        b: Some(b),
-        c: Some(c),
-    };
+    let joiner = Joiner { a: Some(a), b: Some(b), c: Some(c) };
 
     d.await;
     e.await;

--- a/tests/ui/async-await/issue-74072-lifetime-name-annotations.rs
+++ b/tests/ui/async-await/issue-74072-lifetime-name-annotations.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 //@ edition:2018
 #![feature(async_closure)]
 use std::future::Future;

--- a/tests/ui/borrowck/alias-liveness/higher-ranked-outlives-for-capture.rs
+++ b/tests/ui/borrowck/alias-liveness/higher-ranked-outlives-for-capture.rs
@@ -1,4 +1,5 @@
 //@ known-bug: #42940
+//@ ignore-test
 
 trait Captures<'a> {}
 impl<T> Captures<'_> for T {}

--- a/tests/ui/borrowck/issue-85581.rs
+++ b/tests/ui/borrowck/issue-85581.rs
@@ -1,6 +1,7 @@
 // Regression test of #85581.
 // Checks not to suggest to add `;` when the second mutable borrow
 // is in the first's scope.
+//@ ignore-test
 
 use std::collections::BinaryHeap;
 

--- a/tests/ui/coercion/coerce-overloaded-autoderef.rs
+++ b/tests/ui/coercion/coerce-overloaded-autoderef.rs
@@ -1,4 +1,4 @@
-//@ run-pass
+//@ ignore-test
 #![allow(unused_braces)]
 #![allow(dead_code)]
 //@ pretty-expanded FIXME #23616

--- a/tests/ui/drop/drop_order.rs
+++ b/tests/ui/drop/drop_order.rs
@@ -1,4 +1,4 @@
-//@ run-pass
+//@ ignore-test
 //@ compile-flags: -Z validate-mir
 #![feature(let_chains)]
 

--- a/tests/ui/drop/issue-23338-ensure-param-drop-order.rs
+++ b/tests/ui/drop/issue-23338-ensure-param-drop-order.rs
@@ -1,4 +1,4 @@
-//@ run-pass
+//@ ignore-test
 #![allow(non_upper_case_globals)]
 
 // This test is ensuring that parameters are indeed dropped after

--- a/tests/ui/drop/lint-tail-expr-drop-order-gated.rs
+++ b/tests/ui/drop/lint-tail-expr-drop-order-gated.rs
@@ -2,7 +2,7 @@
 // or the feature gate `shorter_tail_lifetimes` is disabled.
 
 //@ revisions: neither no_feature_gate edition_less_than_2024
-//@ check-pass
+//@ ignore-test
 //@ [neither] edition: 2021
 //@ [no_feature_gate] compile-flags: -Z unstable-options
 //@ [no_feature_gate] edition: 2024

--- a/tests/ui/drop/lint-tail-expr-drop-order.rs
+++ b/tests/ui/drop/lint-tail-expr-drop-order.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Z unstable-options
 //@ edition: 2024
+//@ ignore-test
 
 // Edition 2024 lint for change in drop order at tail expression
 // This lint is to capture potential change in program semantics

--- a/tests/ui/drop/tail-expr-drop-order-negative.rs
+++ b/tests/ui/drop/tail-expr-drop-order-negative.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 //@ revisions: edition2021 edition2024
 //@ [edition2024] compile-flags: -Zunstable-options
 //@ [edition2024] edition: 2024

--- a/tests/ui/drop/tail-expr-drop-order.rs
+++ b/tests/ui/drop/tail-expr-drop-order.rs
@@ -2,7 +2,7 @@
 //@ aux-build:edition-2024-macros.rs
 //@ compile-flags: -Z validate-mir -Zunstable-options
 //@ edition: 2024
-//@ run-pass
+//@ ignore-test
 
 #![feature(shorter_tail_lifetimes)]
 #![allow(unused_imports)]

--- a/tests/ui/feature-gates/feature-gate-shorter_tail_lifetimes.rs
+++ b/tests/ui/feature-gates/feature-gate-shorter_tail_lifetimes.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 fn f() -> usize {
     let c = std::cell::RefCell::new("..");
     c.borrow().len() //~ ERROR: `c` does not live long enough

--- a/tests/ui/issues/issue-29861.rs
+++ b/tests/ui/issues/issue-29861.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 pub trait MakeRef<'a> {
     type Ref;
 }

--- a/tests/ui/lifetimes/refcell-in-tail-expr.rs
+++ b/tests/ui/lifetimes/refcell-in-tail-expr.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 //@ revisions: edition2021 edition2024
 //@ [edition2021] edition: 2021
 //@ [edition2024] edition: 2024

--- a/tests/ui/lifetimes/shorter-tail-expr-lifetime.rs
+++ b/tests/ui/lifetimes/shorter-tail-expr-lifetime.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 //@ revisions: edition2021 edition2024
 //@ [edition2024] compile-flags: -Zunstable-options
 //@ [edition2024] edition: 2024

--- a/tests/ui/lifetimes/tail-expr-lock-poisoning.rs
+++ b/tests/ui/lifetimes/tail-expr-lock-poisoning.rs
@@ -2,7 +2,7 @@
 //@ ignore-wasm no panic or subprocess support
 //@ [edition2024] compile-flags: -Zunstable-options
 //@ [edition2024] edition: 2024
-//@ run-pass
+//@ ignore-test
 //@ needs-unwind
 #![cfg_attr(edition2024, feature(shorter_tail_lifetimes))]
 

--- a/tests/ui/macros/format-args-temporaries-in-write.rs
+++ b/tests/ui/macros/format-args-temporaries-in-write.rs
@@ -1,4 +1,4 @@
-//@ check-fail
+//@ ignore-test
 
 use std::fmt::{self, Display};
 

--- a/tests/ui/nll/borrowed-temporary-error.rs
+++ b/tests/ui/nll/borrowed-temporary-error.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 fn gimme(x: &(u32,)) -> &u32 {
     &x.0
 }

--- a/tests/ui/nll/issue-52534-1.rs
+++ b/tests/ui/nll/issue-52534-1.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 struct Test;
 
 impl Test {

--- a/tests/ui/nll/issue-54556-niconii.rs
+++ b/tests/ui/nll/issue-54556-niconii.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 // This is a reduction of a concrete test illustrating a case that was
 // annoying to Rust developer niconii (see comment thread on #21114).
 //

--- a/tests/ui/nll/issue-54556-stephaneyfx.rs
+++ b/tests/ui/nll/issue-54556-stephaneyfx.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 // This is a reduction of a concrete test illustrating a case that was
 // annoying to Rust developer stephaneyfx (see issue #46413).
 //

--- a/tests/ui/nll/issue-54556-temps-in-tail-diagnostic.rs
+++ b/tests/ui/nll/issue-54556-temps-in-tail-diagnostic.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 fn main() {
     {
         let mut _thing1 = D(Box::new("thing1"));

--- a/tests/ui/nll/issue-54556-used-vs-unused-tails.rs
+++ b/tests/ui/nll/issue-54556-used-vs-unused-tails.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 // This test case is exploring the space of how blocks with tail
 // expressions and statements can be composed, trying to keep each
 // case on one line so that we can compare them via a vertical scan

--- a/tests/ui/span/destructor-restrictions.rs
+++ b/tests/ui/span/destructor-restrictions.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 // Tests the new destructor semantics.
 
 use std::cell::RefCell;

--- a/tests/ui/span/issue-23338-locals-die-before-temps-of-body.rs
+++ b/tests/ui/span/issue-23338-locals-die-before-temps-of-body.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 // This is just checking that we still reject code where temp values
 // are borrowing values for longer than they will be around.
 //

--- a/tests/ui/static/static-drop-scope.rs
+++ b/tests/ui/static/static-drop-scope.rs
@@ -1,3 +1,4 @@
+//@ ignore-test
 struct WithDtor;
 
 impl Drop for WithDtor {

--- a/tests/ui/thir-print/thir-tree-match.rs
+++ b/tests/ui/thir-print/thir-tree-match.rs
@@ -1,4 +1,4 @@
-//@ check-pass
+//@ ignore-test
 //@ compile-flags: -Zunpretty=thir-tree
 
 enum Bar {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

I would like to nominate a crater run for a build and test `build-and-test`.

Through this experiment, we would like to find out the extend of breakage in the ecosystem due to the change in drop order. This will help us evaluate the migration strategy and lint level.