### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -10,7 +10,9 @@ use rustc_middle::middle::resolve_bound_vars::ResolvedArg;
 use rustc_middle::ty::{
     self, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable, TypeVisitableExt, TypeVisitor,
 };
+use rustc_session::lint::FutureIncompatibilityReason;
 use rustc_session::{declare_lint, declare_lint_pass};
+use rustc_span::edition::Edition;
 use rustc_span::Span;
 
 use crate::{fluent_generated as fluent, LateContext, LateLintPass};
@@ -54,10 +56,10 @@ declare_lint! {
     pub IMPL_TRAIT_OVERCAPTURES,
     Allow,
     "`impl Trait` will capture more lifetimes than possibly intended in edition 2024",
-    //@future_incompatible = FutureIncompatibleInfo {
-    //    reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-    //    reference: "<FIXME>",
-    //};
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>",
+    };
 }
 
 declare_lint! {

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -197,8 +197,77 @@ impl<'a, 'tcx> Resolver<'a, 'tcx> {
     pub(crate) fn build_reduced_graph_external(&mut self, module: Module<'a>) {
         for child in self.tcx.module_children(module.def_id()) {
             let parent_scope = ParentScope::module(module, self);
-            BuildReducedGraphVisitor { r: self, parent_scope }
-                .build_reduced_graph_for_external_crate_res(child);
+            self.build_reduced_graph_for_external_crate_res(child, parent_scope)
+        }
+    }
+
+    /// Builds the reduced graph for a single item in an external crate.
+    fn build_reduced_graph_for_external_crate_res(
+        &mut self,
+        child: &ModChild,
+        parent_scope: ParentScope<'a>,
+    ) {
+        let parent = parent_scope.module;
+        let ModChild { ident, res, vis, ref reexport_chain } = *child;
+        let span = self.def_span(
+            reexport_chain
+                .first()
+                .and_then(|reexport| reexport.id())
+                .unwrap_or_else(|| res.def_id()),
+        );
+        let res = res.expect_non_local();
+        let expansion = parent_scope.expansion;
+        // Record primary definitions.
+        match res {
+            Res::Def(DefKind::Mod | DefKind::Enum | DefKind::Trait, def_id) => {
+                let module = self.expect_module(def_id);
+                self.define(parent, ident, TypeNS, (module, vis, span, expansion));
+            }
+            Res::Def(
+                DefKind::Struct
+                | DefKind::Union
+                | DefKind::Variant
+                | DefKind::TyAlias
+                | DefKind::ForeignTy
+                | DefKind::OpaqueTy
+                | DefKind::TraitAlias
+                | DefKind::AssocTy,
+                _,
+            )
+            | Res::PrimTy(..)
+            | Res::ToolMod => self.define(parent, ident, TypeNS, (res, vis, span, expansion)),
+            Res::Def(
+                DefKind::Fn
+                | DefKind::AssocFn
+                | DefKind::Static { .. }
+                | DefKind::Const
+                | DefKind::AssocConst
+                | DefKind::Ctor(..),
+                _,
+            ) => self.define(parent, ident, ValueNS, (res, vis, span, expansion)),
+            Res::Def(DefKind::Macro(..), _) | Res::NonMacroAttr(..) => {
+                self.define(parent, ident, MacroNS, (res, vis, span, expansion))
+            }
+            Res::Def(
+                DefKind::TyParam
+                | DefKind::ConstParam
+                | DefKind::ExternCrate
+                | DefKind::Use
+                | DefKind::ForeignMod
+                | DefKind::AnonConst
+                | DefKind::InlineConst
+                | DefKind::Field
+                | DefKind::LifetimeParam
+                | DefKind::GlobalAsm
+                | DefKind::Closure
+                | DefKind::Impl { .. },
+                _,
+            )
+            | Res::Local(..)
+            | Res::SelfTyParam { .. }
+            | Res::SelfTyAlias { .. }
+            | Res::SelfCtor(..)
+            | Res::Err => bug!("unexpected resolution: {:?}", res),
         }
     }
 }
@@ -964,72 +1033,6 @@ impl<'a, 'b, 'tcx> BuildReducedGraphVisitor<'a, 'b, 'tcx> {
             );
             self.r.block_map.insert(block.id, module);
             self.parent_scope.module = module; // Descend into the block.
-        }
-    }
-
-    /// Builds the reduced graph for a single item in an external crate.
-    fn build_reduced_graph_for_external_crate_res(&mut self, child: &ModChild) {
-        let parent = self.parent_scope.module;
-        let ModChild { ident, res, vis, ref reexport_chain } = *child;
-        let span = self.r.def_span(
-            reexport_chain
-                .first()
-                .and_then(|reexport| reexport.id())
-                .unwrap_or_else(|| res.def_id()),
-        );
-        let res = res.expect_non_local();
-        let expansion = self.parent_scope.expansion;
-        // Record primary definitions.
-        match res {
-            Res::Def(DefKind::Mod | DefKind::Enum | DefKind::Trait, def_id) => {
-                let module = self.r.expect_module(def_id);
-                self.r.define(parent, ident, TypeNS, (module, vis, span, expansion));
-            }
-            Res::Def(
-                DefKind::Struct
-                | DefKind::Union
-                | DefKind::Variant
-                | DefKind::TyAlias
-                | DefKind::ForeignTy
-                | DefKind::OpaqueTy
-                | DefKind::TraitAlias
-                | DefKind::AssocTy,
-                _,
-            )
-            | Res::PrimTy(..)
-            | Res::ToolMod => self.r.define(parent, ident, TypeNS, (res, vis, span, expansion)),
-            Res::Def(
-                DefKind::Fn
-                | DefKind::AssocFn
-                | DefKind::Static { .. }
-                | DefKind::Const
-                | DefKind::AssocConst
-                | DefKind::Ctor(..),
-                _,
-            ) => self.r.define(parent, ident, ValueNS, (res, vis, span, expansion)),
-            Res::Def(DefKind::Macro(..), _) | Res::NonMacroAttr(..) => {
-                self.r.define(parent, ident, MacroNS, (res, vis, span, expansion))
-            }
-            Res::Def(
-                DefKind::TyParam
-                | DefKind::ConstParam
-                | DefKind::ExternCrate
-                | DefKind::Use
-                | DefKind::ForeignMod
-                | DefKind::AnonConst
-                | DefKind::InlineConst
-                | DefKind::Field
-                | DefKind::LifetimeParam
-                | DefKind::GlobalAsm
-                | DefKind::Closure
-                | DefKind::Impl { .. },
-                _,
-            )
-            | Res::Local(..)
-            | Res::SelfTyParam { .. }
-            | Res::SelfTyAlias { .. }
-            | Res::SelfCtor(..)
-            | Res::Err => bug!("unexpected resolution: {:?}", res),
         }
     }
 

--- a/library/core/src/error.rs
+++ b/library/core/src/error.rs
@@ -1,9 +1,6 @@
 #![doc = include_str!("error.md")]
 #![stable(feature = "error_in_core", since = "1.81.0")]
 
-#[cfg(test)]
-mod tests;
-
 use crate::any::TypeId;
 use crate::fmt::{Debug, Display, Formatter, Result};
 

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1321,6 +1321,7 @@ macro_rules! int_impl {
         ///
         /// Basic usage:
         /// ```
+        /// #![feature(unbounded_shifts)]
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(4), 0x10);")]
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(129), 0);")]
         /// ```
@@ -1447,10 +1448,11 @@ macro_rules! int_impl {
         ///
         /// Basic usage:
         /// ```
+        /// #![feature(unbounded_shifts)]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shl(4), 0x1);")]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.unbounded_shr(129), -1);")]
-        /// ```
+        /// ```  
         #[unstable(feature = "unbounded_shifts", issue = "129375")]
         #[rustc_allow_const_fn_unstable(unchecked_shifts)]
         #[must_use = "this returns the result of the operation, \

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1313,12 +1313,12 @@ macro_rules! int_impl {
         }
 
         /// Unbounded shift left. Computes `self << rhs`, without bounding the value of `rhs`
-        /// 
-        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        ///
+        /// If `rhs` is larger or equal to the number of bits in `self`,
         /// the entire value is shifted out, and `0` is returned.
         ///
         /// # Examples
-        /// 
+        ///
         /// Basic usage:
         /// ```
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(4), 0x10);")]
@@ -1438,13 +1438,13 @@ macro_rules! int_impl {
         }
 
         /// Unbounded shift right. Computes `self >> rhs`, without bounding the value of `rhs`
-        /// 
-        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        ///
+        /// If `rhs` is larger or equal to the number of bits in `self`,
         /// the entire value is shifted out, which yields `0` for a positive number,
         /// and `-1` for a negative number.
         ///
         /// # Examples
-        /// 
+        ///
         /// Basic usage:
         /// ```
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shl(4), 0x1);")]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1449,7 +1449,7 @@ macro_rules! int_impl {
         /// Basic usage:
         /// ```
         /// #![feature(unbounded_shifts)]
-        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shl(4), 0x1);")]
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(4), 0x1);")]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.unbounded_shr(129), -1);")]
         /// ```

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1326,7 +1326,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(129), 0);")]
         /// ```
         #[unstable(feature = "unbounded_shifts", issue = "129375")]
-        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[rustc_const_unstable(feature = "const_unbounded_shifts", issue = "129375")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
@@ -1454,7 +1454,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.unbounded_shr(129), -1);")]
         /// ```
         #[unstable(feature = "unbounded_shifts", issue = "129375")]
-        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[rustc_const_unstable(feature = "const_unbounded_shifts", issue = "129375")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1330,11 +1330,11 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline]
         pub const fn unbounded_shl(self, rhs: u32) -> $SelfT{
-            if rhs < Self::BITS{
+            if rhs < Self::BITS {
                 // SAFETY:
                 // rhs is just checked to be in-range above
                 unsafe { self.unchecked_shl(rhs) }
-            }else{
+            } else {
                 0
             }
         }
@@ -1457,11 +1457,11 @@ macro_rules! int_impl {
                       without modifying the original"]
         #[inline]
         pub const fn unbounded_shr(self, rhs: u32) -> $SelfT{
-            if rhs < Self::BITS{
+            if rhs < Self::BITS {
                 // SAFETY:
                 // rhs is just checked to be in-range above
                 unsafe { self.unchecked_shr(rhs) }
-            }else{
+            } else {
                 // A shift by `Self::BITS-1` suffices for signed integers, because the sign bit is copied for each of the shifted bits.
 
                 // SAFETY:

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1452,7 +1452,7 @@ macro_rules! int_impl {
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shl(4), 0x1);")]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
         #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.unbounded_shr(129), -1);")]
-        /// ```  
+        /// ```
         #[unstable(feature = "unbounded_shifts", issue = "129375")]
         #[rustc_allow_const_fn_unstable(unchecked_shifts)]
         #[must_use = "this returns the result of the operation, \

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1312,6 +1312,33 @@ macro_rules! int_impl {
             }
         }
 
+        /// Unbounded shift left. Computes `self << rhs`, without bounding the value of `rhs`
+        /// 
+        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        /// the entire value is shifted out, and `0` is returned.
+        ///
+        /// # Examples
+        /// 
+        /// Basic usage:
+        /// ```
+        #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(4), 0x10);")]
+        #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(129), 0);")]
+        /// ```
+        #[unstable(feature = "unbounded_shifts", issue = "129375")]
+        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn unbounded_shl(self, v: u32) -> $SelfT{
+            if v < Self::BITS{
+                // SAFETY:
+                // v is just checked to be in-range above
+                unsafe{self.unchecked_shl(v)}
+            }else{
+                0
+            }
+        }
+
         /// Checked shift right. Computes `self >> rhs`, returning `None` if `rhs` is
         /// larger than or equal to the number of bits in `self`.
         ///
@@ -1407,6 +1434,39 @@ macro_rules! int_impl {
             // SAFETY: this is guaranteed to be safe by the caller.
             unsafe {
                 intrinsics::unchecked_shr(self, rhs)
+            }
+        }
+
+        /// Unbounded shift right. Computes `self >> rhs`, without bounding the value of `rhs`
+        /// 
+        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        /// the entire value is shifted out, which yields `0` for a positive number,
+        /// and `-1` for a negative number.
+        ///
+        /// # Examples
+        /// 
+        /// Basic usage:
+        /// ```
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shl(4), 0x1);")]
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
+        #[doc = concat!("assert_eq!(", stringify!($SelfT), "::MIN.unbounded_shr(129), -1);")]
+        /// ```
+        #[unstable(feature = "unbounded_shifts", issue = "129375")]
+        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn unbounded_shr(self, v: u32) -> $SelfT{
+            if v < Self::BITS{
+                // SAFETY:
+                // v is just checked to be in-range above
+                unsafe{self.unchecked_shr(v)}
+            }else{
+                // A shift by `Self::BITS-1` suffices for signed integers, because the sign bit is copied for each of the shifted bits.
+
+                // SAFETY:
+                // `Self::BITS-1` is guaranteed to be less than `Self::BITS`
+                unsafe{self.unchecked_shr(Self::BITS - 1)}
             }
         }
 

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1329,11 +1329,11 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn unbounded_shl(self, v: u32) -> $SelfT{
-            if v < Self::BITS{
+        pub const fn unbounded_shl(self, rhs: u32) -> $SelfT{
+            if rhs < Self::BITS{
                 // SAFETY:
-                // v is just checked to be in-range above
-                unsafe{self.unchecked_shl(v)}
+                // rhs is just checked to be in-range above
+                unsafe { self.unchecked_shl(rhs) }
             }else{
                 0
             }
@@ -1456,17 +1456,17 @@ macro_rules! int_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn unbounded_shr(self, v: u32) -> $SelfT{
-            if v < Self::BITS{
+        pub const fn unbounded_shr(self, rhs: u32) -> $SelfT{
+            if rhs < Self::BITS{
                 // SAFETY:
-                // v is just checked to be in-range above
-                unsafe{self.unchecked_shr(v)}
+                // rhs is just checked to be in-range above
+                unsafe { self.unchecked_shr(rhs) }
             }else{
                 // A shift by `Self::BITS-1` suffices for signed integers, because the sign bit is copied for each of the shifted bits.
 
                 // SAFETY:
                 // `Self::BITS-1` is guaranteed to be less than `Self::BITS`
-                unsafe{self.unchecked_shr(Self::BITS - 1)}
+                unsafe { self.unchecked_shr(Self::BITS - 1) }
             }
         }
 

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1515,7 +1515,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(129), 0);")]
         /// ```
         #[unstable(feature = "unbounded_shifts", issue = "129375")]
-        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[rustc_const_unstable(feature = "const_unbounded_shifts", issue = "129375")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
@@ -1641,7 +1641,7 @@ macro_rules! uint_impl {
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
         /// ```
         #[unstable(feature = "unbounded_shifts", issue = "129375")]
-        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[rustc_const_unstable(feature = "const_unbounded_shifts", issue = "129375")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1637,7 +1637,7 @@ macro_rules! uint_impl {
         /// Basic usage:
         /// ```
         /// #![feature(unbounded_shifts)]
-        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(4), 0x10);")]
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(4), 0x1);")]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
         /// ```
         #[unstable(feature = "unbounded_shifts", issue = "129375")]

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1518,11 +1518,11 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn unbounded_shl(self, v: u32) -> $SelfT{
-            if v < Self::BITS{
+        pub const fn unbounded_shl(self, rhs: u32) -> $SelfT{
+            if rhs < Self::BITS{
                 // SAFETY:
-                // v is just checked to be in-range above
-                unsafe{self.unchecked_shl(v)}
+                // rhs is just checked to be in-range above
+                unsafe { self.unchecked_shl(rhs) }
             }else{
                 0
             }
@@ -1643,11 +1643,11 @@ macro_rules! uint_impl {
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
-        pub const fn unbounded_shr(self, v: u32) -> $SelfT{
-            if v < Self::BITS{
+        pub const fn unbounded_shr(self, rhs: u32) -> $SelfT{
+            if rhs < Self::BITS{
                 // SAFETY:
-                // v is just checked to be in-range above
-                unsafe{self.unchecked_shr(v)}
+                // rhs is just checked to be in-range above
+                unsafe { self.unchecked_shr(rhs) }
             }else{
                 0
             }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1501,7 +1501,7 @@ macro_rules! uint_impl {
             }
         }
 
-                /// Unbounded shift left. Computes `self << rhs`, without bounding the value of `rhs`
+        /// Unbounded shift left. Computes `self << rhs`, without bounding the value of `rhs`
         ///
         /// If `rhs` is larger or equal to the number of bits in `self`,
         /// the entire value is shifted out, and `0` is returned.
@@ -1510,6 +1510,7 @@ macro_rules! uint_impl {
         ///
         /// Basic usage:
         /// ```
+        /// #![feature(unbounded_shifts)]
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(4), 0x10);")]
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(129), 0);")]
         /// ```
@@ -1635,6 +1636,7 @@ macro_rules! uint_impl {
         ///
         /// Basic usage:
         /// ```
+        /// #![feature(unbounded_shifts)]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(4), 0x10);")]
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
         /// ```

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1501,6 +1501,33 @@ macro_rules! uint_impl {
             }
         }
 
+                /// Unbounded shift left. Computes `self << rhs`, without bounding the value of `rhs`
+        /// 
+        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        /// the entire value is shifted out, and `0` is returned.
+        ///
+        /// # Examples
+        /// 
+        /// Basic usage:
+        /// ```
+        #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(4), 0x10);")]
+        #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(129), 0);")]
+        /// ```
+        #[unstable(feature = "unbounded_shifts", issue = "129375")]
+        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn unbounded_shl(self, v: u32) -> $SelfT{
+            if v < Self::BITS{
+                // SAFETY:
+                // v is just checked to be in-range above
+                unsafe{self.unchecked_shl(v)}
+            }else{
+                0
+            }
+        }
+
         /// Checked shift right. Computes `self >> rhs`, returning `None`
         /// if `rhs` is larger than or equal to the number of bits in `self`.
         ///
@@ -1596,6 +1623,33 @@ macro_rules! uint_impl {
             // SAFETY: this is guaranteed to be safe by the caller.
             unsafe {
                 intrinsics::unchecked_shr(self, rhs)
+            }
+        }
+
+        /// Unbounded shift right. Computes `self >> rhs`, without bounding the value of `rhs`
+        /// 
+        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        /// the entire value is shifted out, and `0` is returned.
+        ///
+        /// # Examples
+        /// 
+        /// Basic usage:
+        /// ```
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(4), 0x10);")]
+        #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(129), 0);")]
+        /// ```
+        #[unstable(feature = "unbounded_shifts", issue = "129375")]
+        #[rustc_allow_const_fn_unstable(unchecked_shifts)]
+        #[must_use = "this returns the result of the operation, \
+                      without modifying the original"]
+        #[inline]
+        pub const fn unbounded_shr(self, v: u32) -> $SelfT{
+            if v < Self::BITS{
+                // SAFETY:
+                // v is just checked to be in-range above
+                unsafe{self.unchecked_shr(v)}
+            }else{
+                0
             }
         }
 

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1519,11 +1519,11 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         pub const fn unbounded_shl(self, rhs: u32) -> $SelfT{
-            if rhs < Self::BITS{
+            if rhs < Self::BITS {
                 // SAFETY:
                 // rhs is just checked to be in-range above
                 unsafe { self.unchecked_shl(rhs) }
-            }else{
+            } else {
                 0
             }
         }
@@ -1644,11 +1644,11 @@ macro_rules! uint_impl {
                       without modifying the original"]
         #[inline]
         pub const fn unbounded_shr(self, rhs: u32) -> $SelfT{
-            if rhs < Self::BITS{
+            if rhs < Self::BITS {
                 // SAFETY:
                 // rhs is just checked to be in-range above
                 unsafe { self.unchecked_shr(rhs) }
-            }else{
+            } else {
                 0
             }
         }

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1502,12 +1502,12 @@ macro_rules! uint_impl {
         }
 
                 /// Unbounded shift left. Computes `self << rhs`, without bounding the value of `rhs`
-        /// 
-        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        ///
+        /// If `rhs` is larger or equal to the number of bits in `self`,
         /// the entire value is shifted out, and `0` is returned.
         ///
         /// # Examples
-        /// 
+        ///
         /// Basic usage:
         /// ```
         #[doc = concat!("assert_eq!(0x1", stringify!($SelfT), ".unbounded_shl(4), 0x10);")]
@@ -1627,12 +1627,12 @@ macro_rules! uint_impl {
         }
 
         /// Unbounded shift right. Computes `self >> rhs`, without bounding the value of `rhs`
-        /// 
-        /// If `rhs` is larger or equal to the number of bits in `self`, 
+        ///
+        /// If `rhs` is larger or equal to the number of bits in `self`,
         /// the entire value is shifted out, and `0` is returned.
         ///
         /// # Examples
-        /// 
+        ///
         /// Basic usage:
         /// ```
         #[doc = concat!("assert_eq!(0x10", stringify!($SelfT), ".unbounded_shr(4), 0x10);")]

--- a/library/core/src/task/poll.rs
+++ b/library/core/src/task/poll.rs
@@ -5,6 +5,8 @@ use crate::ops::{self, ControlFlow};
 
 /// Indicates whether a value is available or if the current task has been
 /// scheduled to receive a wakeup instead.
+///
+/// This is returned by [`Future::poll`](core::future::Future::poll).
 #[must_use = "this `Poll` may be a `Pending` variant, which should be handled"]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[lang = "Poll"]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -141,7 +141,6 @@ mod intrinsics;
 mod io;
 mod iter;
 mod lazy;
-#[cfg(test)]
 mod macros;
 mod manually_drop;
 mod mem;

--- a/library/core/tests/num/int_macros.rs
+++ b/library/core/tests/num/int_macros.rs
@@ -1,427 +1,424 @@
 macro_rules! int_module {
     ($T:ident) => {
-        #[cfg(test)]
-        mod tests {
-            use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
-            use core::$T::*;
+        use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
+        use core::$T::*;
 
-            use crate::num;
+        use crate::num;
 
-            #[test]
-            fn test_overflows() {
-                assert!(MAX > 0);
-                assert!(MIN <= 0);
-                assert_eq!(MIN + MAX + 1, 0);
+        #[test]
+        fn test_overflows() {
+            assert!(MAX > 0);
+            assert!(MIN <= 0);
+            assert_eq!(MIN + MAX + 1, 0);
+        }
+
+        #[test]
+        fn test_num() {
+            num::test_num(10 as $T, 2 as $T);
+        }
+
+        #[test]
+        fn test_rem_euclid() {
+            assert_eq!((-1 as $T).rem_euclid(MIN), MAX);
+        }
+
+        #[test]
+        pub fn test_abs() {
+            assert_eq!((1 as $T).abs(), 1 as $T);
+            assert_eq!((0 as $T).abs(), 0 as $T);
+            assert_eq!((-1 as $T).abs(), 1 as $T);
+        }
+
+        #[test]
+        fn test_signum() {
+            assert_eq!((1 as $T).signum(), 1 as $T);
+            assert_eq!((0 as $T).signum(), 0 as $T);
+            assert_eq!((-0 as $T).signum(), 0 as $T);
+            assert_eq!((-1 as $T).signum(), -1 as $T);
+        }
+
+        #[test]
+        fn test_is_positive() {
+            assert!((1 as $T).is_positive());
+            assert!(!(0 as $T).is_positive());
+            assert!(!(-0 as $T).is_positive());
+            assert!(!(-1 as $T).is_positive());
+        }
+
+        #[test]
+        fn test_is_negative() {
+            assert!(!(1 as $T).is_negative());
+            assert!(!(0 as $T).is_negative());
+            assert!(!(-0 as $T).is_negative());
+            assert!((-1 as $T).is_negative());
+        }
+
+        #[test]
+        fn test_bitwise_operators() {
+            assert_eq!(0b1110 as $T, (0b1100 as $T).bitor(0b1010 as $T));
+            assert_eq!(0b1000 as $T, (0b1100 as $T).bitand(0b1010 as $T));
+            assert_eq!(0b0110 as $T, (0b1100 as $T).bitxor(0b1010 as $T));
+            assert_eq!(0b1110 as $T, (0b0111 as $T).shl(1));
+            assert_eq!(0b0111 as $T, (0b1110 as $T).shr(1));
+            assert_eq!(-(0b11 as $T) - (1 as $T), (0b11 as $T).not());
+        }
+
+        const A: $T = 0b0101100;
+        const B: $T = 0b0100001;
+        const C: $T = 0b1111001;
+
+        const _0: $T = 0;
+        const _1: $T = !0;
+
+        #[test]
+        fn test_count_ones() {
+            assert_eq!(A.count_ones(), 3);
+            assert_eq!(B.count_ones(), 2);
+            assert_eq!(C.count_ones(), 5);
+        }
+
+        #[test]
+        fn test_count_zeros() {
+            assert_eq!(A.count_zeros(), $T::BITS - 3);
+            assert_eq!(B.count_zeros(), $T::BITS - 2);
+            assert_eq!(C.count_zeros(), $T::BITS - 5);
+        }
+
+        #[test]
+        fn test_leading_trailing_ones() {
+            let a: $T = 0b0101_1111;
+            assert_eq!(a.trailing_ones(), 5);
+            assert_eq!((!a).leading_ones(), $T::BITS - 7);
+
+            assert_eq!(a.reverse_bits().leading_ones(), 5);
+
+            assert_eq!(_1.leading_ones(), $T::BITS);
+            assert_eq!(_1.trailing_ones(), $T::BITS);
+
+            assert_eq!((_1 << 1).trailing_ones(), 0);
+            assert_eq!(MAX.leading_ones(), 0);
+
+            assert_eq!((_1 << 1).leading_ones(), $T::BITS - 1);
+            assert_eq!(MAX.trailing_ones(), $T::BITS - 1);
+
+            assert_eq!(_0.leading_ones(), 0);
+            assert_eq!(_0.trailing_ones(), 0);
+
+            let x: $T = 0b0010_1100;
+            assert_eq!(x.leading_ones(), 0);
+            assert_eq!(x.trailing_ones(), 0);
+        }
+
+        #[test]
+        fn test_rotate() {
+            assert_eq!(A.rotate_left(6).rotate_right(2).rotate_right(4), A);
+            assert_eq!(B.rotate_left(3).rotate_left(2).rotate_right(5), B);
+            assert_eq!(C.rotate_left(6).rotate_right(2).rotate_right(4), C);
+
+            // Rotating these should make no difference
+            //
+            // We test using 124 bits because to ensure that overlong bit shifts do
+            // not cause undefined behaviour. See #10183.
+            assert_eq!(_0.rotate_left(124), _0);
+            assert_eq!(_1.rotate_left(124), _1);
+            assert_eq!(_0.rotate_right(124), _0);
+            assert_eq!(_1.rotate_right(124), _1);
+
+            // Rotating by 0 should have no effect
+            assert_eq!(A.rotate_left(0), A);
+            assert_eq!(B.rotate_left(0), B);
+            assert_eq!(C.rotate_left(0), C);
+            // Rotating by a multiple of word size should also have no effect
+            assert_eq!(A.rotate_left(128), A);
+            assert_eq!(B.rotate_left(128), B);
+            assert_eq!(C.rotate_left(128), C);
+        }
+
+        #[test]
+        fn test_swap_bytes() {
+            assert_eq!(A.swap_bytes().swap_bytes(), A);
+            assert_eq!(B.swap_bytes().swap_bytes(), B);
+            assert_eq!(C.swap_bytes().swap_bytes(), C);
+
+            // Swapping these should make no difference
+            assert_eq!(_0.swap_bytes(), _0);
+            assert_eq!(_1.swap_bytes(), _1);
+        }
+
+        #[test]
+        fn test_le() {
+            assert_eq!($T::from_le(A.to_le()), A);
+            assert_eq!($T::from_le(B.to_le()), B);
+            assert_eq!($T::from_le(C.to_le()), C);
+            assert_eq!($T::from_le(_0), _0);
+            assert_eq!($T::from_le(_1), _1);
+            assert_eq!(_0.to_le(), _0);
+            assert_eq!(_1.to_le(), _1);
+        }
+
+        #[test]
+        fn test_be() {
+            assert_eq!($T::from_be(A.to_be()), A);
+            assert_eq!($T::from_be(B.to_be()), B);
+            assert_eq!($T::from_be(C.to_be()), C);
+            assert_eq!($T::from_be(_0), _0);
+            assert_eq!($T::from_be(_1), _1);
+            assert_eq!(_0.to_be(), _0);
+            assert_eq!(_1.to_be(), _1);
+        }
+
+        #[test]
+        fn test_signed_checked_div() {
+            assert_eq!((10 as $T).checked_div(2), Some(5));
+            assert_eq!((5 as $T).checked_div(0), None);
+            assert_eq!(isize::MIN.checked_div(-1), None);
+        }
+
+        #[test]
+        fn test_saturating_abs() {
+            assert_eq!((0 as $T).saturating_abs(), 0);
+            assert_eq!((123 as $T).saturating_abs(), 123);
+            assert_eq!((-123 as $T).saturating_abs(), 123);
+            assert_eq!((MAX - 2).saturating_abs(), MAX - 2);
+            assert_eq!((MAX - 1).saturating_abs(), MAX - 1);
+            assert_eq!(MAX.saturating_abs(), MAX);
+            assert_eq!((MIN + 2).saturating_abs(), MAX - 1);
+            assert_eq!((MIN + 1).saturating_abs(), MAX);
+            assert_eq!(MIN.saturating_abs(), MAX);
+        }
+
+        #[test]
+        fn test_saturating_neg() {
+            assert_eq!((0 as $T).saturating_neg(), 0);
+            assert_eq!((123 as $T).saturating_neg(), -123);
+            assert_eq!((-123 as $T).saturating_neg(), 123);
+            assert_eq!((MAX - 2).saturating_neg(), MIN + 3);
+            assert_eq!((MAX - 1).saturating_neg(), MIN + 2);
+            assert_eq!(MAX.saturating_neg(), MIN + 1);
+            assert_eq!((MIN + 2).saturating_neg(), MAX - 1);
+            assert_eq!((MIN + 1).saturating_neg(), MAX);
+            assert_eq!(MIN.saturating_neg(), MAX);
+        }
+
+        #[test]
+        fn test_from_str() {
+            fn from_str<T: std::str::FromStr>(t: &str) -> Option<T> {
+                std::str::FromStr::from_str(t).ok()
+            }
+            assert_eq!(from_str::<$T>("0"), Some(0 as $T));
+            assert_eq!(from_str::<$T>("3"), Some(3 as $T));
+            assert_eq!(from_str::<$T>("10"), Some(10 as $T));
+            assert_eq!(from_str::<i32>("123456789"), Some(123456789 as i32));
+            assert_eq!(from_str::<$T>("00100"), Some(100 as $T));
+
+            assert_eq!(from_str::<$T>("-1"), Some(-1 as $T));
+            assert_eq!(from_str::<$T>("-3"), Some(-3 as $T));
+            assert_eq!(from_str::<$T>("-10"), Some(-10 as $T));
+            assert_eq!(from_str::<i32>("-123456789"), Some(-123456789 as i32));
+            assert_eq!(from_str::<$T>("-00100"), Some(-100 as $T));
+
+            assert_eq!(from_str::<$T>(""), None);
+            assert_eq!(from_str::<$T>(" "), None);
+            assert_eq!(from_str::<$T>("x"), None);
+        }
+
+        #[test]
+        fn test_from_str_radix() {
+            assert_eq!($T::from_str_radix("123", 10), Ok(123 as $T));
+            assert_eq!($T::from_str_radix("1001", 2), Ok(9 as $T));
+            assert_eq!($T::from_str_radix("123", 8), Ok(83 as $T));
+            assert_eq!(i32::from_str_radix("123", 16), Ok(291 as i32));
+            assert_eq!(i32::from_str_radix("ffff", 16), Ok(65535 as i32));
+            assert_eq!(i32::from_str_radix("FFFF", 16), Ok(65535 as i32));
+            assert_eq!($T::from_str_radix("z", 36), Ok(35 as $T));
+            assert_eq!($T::from_str_radix("Z", 36), Ok(35 as $T));
+
+            assert_eq!($T::from_str_radix("-123", 10), Ok(-123 as $T));
+            assert_eq!($T::from_str_radix("-1001", 2), Ok(-9 as $T));
+            assert_eq!($T::from_str_radix("-123", 8), Ok(-83 as $T));
+            assert_eq!(i32::from_str_radix("-123", 16), Ok(-291 as i32));
+            assert_eq!(i32::from_str_radix("-ffff", 16), Ok(-65535 as i32));
+            assert_eq!(i32::from_str_radix("-FFFF", 16), Ok(-65535 as i32));
+            assert_eq!($T::from_str_radix("-z", 36), Ok(-35 as $T));
+            assert_eq!($T::from_str_radix("-Z", 36), Ok(-35 as $T));
+
+            assert_eq!($T::from_str_radix("Z", 35).ok(), None::<$T>);
+            assert_eq!($T::from_str_radix("-9", 2).ok(), None::<$T>);
+        }
+
+        #[test]
+        fn test_pow() {
+            let mut r = 2 as $T;
+            assert_eq!(r.pow(2), 4 as $T);
+            assert_eq!(r.pow(0), 1 as $T);
+            assert_eq!(r.wrapping_pow(2), 4 as $T);
+            assert_eq!(r.wrapping_pow(0), 1 as $T);
+            assert_eq!(r.checked_pow(2), Some(4 as $T));
+            assert_eq!(r.checked_pow(0), Some(1 as $T));
+            assert_eq!(r.overflowing_pow(2), (4 as $T, false));
+            assert_eq!(r.overflowing_pow(0), (1 as $T, false));
+            assert_eq!(r.saturating_pow(2), 4 as $T);
+            assert_eq!(r.saturating_pow(0), 1 as $T);
+
+            r = MAX;
+            // use `^` to represent .pow() with no overflow.
+            // if itest::MAX == 2^j-1, then itest is a `j` bit int,
+            // so that `itest::MAX*itest::MAX == 2^(2*j)-2^(j+1)+1`,
+            // thussaturating_pow the overflowing result is exactly 1.
+            assert_eq!(r.wrapping_pow(2), 1 as $T);
+            assert_eq!(r.checked_pow(2), None);
+            assert_eq!(r.overflowing_pow(2), (1 as $T, true));
+            assert_eq!(r.saturating_pow(2), MAX);
+            //test for negative exponent.
+            r = -2 as $T;
+            assert_eq!(r.pow(2), 4 as $T);
+            assert_eq!(r.pow(3), -8 as $T);
+            assert_eq!(r.pow(0), 1 as $T);
+            assert_eq!(r.wrapping_pow(2), 4 as $T);
+            assert_eq!(r.wrapping_pow(3), -8 as $T);
+            assert_eq!(r.wrapping_pow(0), 1 as $T);
+            assert_eq!(r.checked_pow(2), Some(4 as $T));
+            assert_eq!(r.checked_pow(3), Some(-8 as $T));
+            assert_eq!(r.checked_pow(0), Some(1 as $T));
+            assert_eq!(r.overflowing_pow(2), (4 as $T, false));
+            assert_eq!(r.overflowing_pow(3), (-8 as $T, false));
+            assert_eq!(r.overflowing_pow(0), (1 as $T, false));
+            assert_eq!(r.saturating_pow(2), 4 as $T);
+            assert_eq!(r.saturating_pow(3), -8 as $T);
+            assert_eq!(r.saturating_pow(0), 1 as $T);
+        }
+
+        #[test]
+        fn test_isqrt() {
+            assert_eq!($T::MIN.checked_isqrt(), None);
+            assert_eq!((-1 as $T).checked_isqrt(), None);
+            assert_eq!((0 as $T).isqrt(), 0 as $T);
+            assert_eq!((1 as $T).isqrt(), 1 as $T);
+            assert_eq!((2 as $T).isqrt(), 1 as $T);
+            assert_eq!((99 as $T).isqrt(), 9 as $T);
+            assert_eq!((100 as $T).isqrt(), 10 as $T);
+        }
+
+        #[cfg(not(miri))] // Miri is too slow
+        #[test]
+        fn test_lots_of_isqrt() {
+            let n_max: $T = (1024 * 1024).min($T::MAX as u128) as $T;
+            for n in 0..=n_max {
+                let isqrt: $T = n.isqrt();
+
+                assert!(isqrt.pow(2) <= n);
+                let (square, overflow) = (isqrt + 1).overflowing_pow(2);
+                assert!(overflow || square > n);
             }
 
-            #[test]
-            fn test_num() {
-                num::test_num(10 as $T, 2 as $T);
+            for n in ($T::MAX - 127)..=$T::MAX {
+                let isqrt: $T = n.isqrt();
+
+                assert!(isqrt.pow(2) <= n);
+                let (square, overflow) = (isqrt + 1).overflowing_pow(2);
+                assert!(overflow || square > n);
             }
+        }
 
-            #[test]
-            fn test_rem_euclid() {
-                assert_eq!((-1 as $T).rem_euclid(MIN), MAX);
-            }
+        #[test]
+        fn test_div_floor() {
+            let a: $T = 8;
+            let b = 3;
+            assert_eq!(a.div_floor(b), 2);
+            assert_eq!(a.div_floor(-b), -3);
+            assert_eq!((-a).div_floor(b), -3);
+            assert_eq!((-a).div_floor(-b), 2);
+        }
 
-            #[test]
-            pub fn test_abs() {
-                assert_eq!((1 as $T).abs(), 1 as $T);
-                assert_eq!((0 as $T).abs(), 0 as $T);
-                assert_eq!((-1 as $T).abs(), 1 as $T);
-            }
+        #[test]
+        fn test_div_ceil() {
+            let a: $T = 8;
+            let b = 3;
+            assert_eq!(a.div_ceil(b), 3);
+            assert_eq!(a.div_ceil(-b), -2);
+            assert_eq!((-a).div_ceil(b), -2);
+            assert_eq!((-a).div_ceil(-b), 3);
+        }
 
-            #[test]
-            fn test_signum() {
-                assert_eq!((1 as $T).signum(), 1 as $T);
-                assert_eq!((0 as $T).signum(), 0 as $T);
-                assert_eq!((-0 as $T).signum(), 0 as $T);
-                assert_eq!((-1 as $T).signum(), -1 as $T);
-            }
+        #[test]
+        fn test_next_multiple_of() {
+            assert_eq!((16 as $T).next_multiple_of(8), 16);
+            assert_eq!((23 as $T).next_multiple_of(8), 24);
+            assert_eq!((16 as $T).next_multiple_of(-8), 16);
+            assert_eq!((23 as $T).next_multiple_of(-8), 16);
+            assert_eq!((-16 as $T).next_multiple_of(8), -16);
+            assert_eq!((-23 as $T).next_multiple_of(8), -16);
+            assert_eq!((-16 as $T).next_multiple_of(-8), -16);
+            assert_eq!((-23 as $T).next_multiple_of(-8), -24);
+            assert_eq!(MIN.next_multiple_of(-1), MIN);
+        }
 
-            #[test]
-            fn test_is_positive() {
-                assert!((1 as $T).is_positive());
-                assert!(!(0 as $T).is_positive());
-                assert!(!(-0 as $T).is_positive());
-                assert!(!(-1 as $T).is_positive());
-            }
+        #[test]
+        fn test_checked_next_multiple_of() {
+            assert_eq!((16 as $T).checked_next_multiple_of(8), Some(16));
+            assert_eq!((23 as $T).checked_next_multiple_of(8), Some(24));
+            assert_eq!((16 as $T).checked_next_multiple_of(-8), Some(16));
+            assert_eq!((23 as $T).checked_next_multiple_of(-8), Some(16));
+            assert_eq!((-16 as $T).checked_next_multiple_of(8), Some(-16));
+            assert_eq!((-23 as $T).checked_next_multiple_of(8), Some(-16));
+            assert_eq!((-16 as $T).checked_next_multiple_of(-8), Some(-16));
+            assert_eq!((-23 as $T).checked_next_multiple_of(-8), Some(-24));
+            assert_eq!((1 as $T).checked_next_multiple_of(0), None);
+            assert_eq!(MAX.checked_next_multiple_of(2), None);
+            assert_eq!(MIN.checked_next_multiple_of(-3), None);
+            assert_eq!(MIN.checked_next_multiple_of(-1), Some(MIN));
+        }
 
-            #[test]
-            fn test_is_negative() {
-                assert!(!(1 as $T).is_negative());
-                assert!(!(0 as $T).is_negative());
-                assert!(!(-0 as $T).is_negative());
-                assert!((-1 as $T).is_negative());
-            }
+        #[test]
+        fn test_carrying_add() {
+            assert_eq!($T::MAX.carrying_add(1, false), ($T::MIN, true));
+            assert_eq!($T::MAX.carrying_add(0, true), ($T::MIN, true));
+            assert_eq!($T::MAX.carrying_add(1, true), ($T::MIN + 1, true));
+            assert_eq!($T::MAX.carrying_add(-1, false), ($T::MAX - 1, false));
+            assert_eq!($T::MAX.carrying_add(-1, true), ($T::MAX, false)); // no intermediate overflow
+            assert_eq!($T::MIN.carrying_add(-1, false), ($T::MAX, true));
+            assert_eq!($T::MIN.carrying_add(-1, true), ($T::MIN, false)); // no intermediate overflow
+            assert_eq!((0 as $T).carrying_add($T::MAX, true), ($T::MIN, true));
+            assert_eq!((0 as $T).carrying_add($T::MIN, true), ($T::MIN + 1, false));
+        }
 
-            #[test]
-            fn test_bitwise_operators() {
-                assert_eq!(0b1110 as $T, (0b1100 as $T).bitor(0b1010 as $T));
-                assert_eq!(0b1000 as $T, (0b1100 as $T).bitand(0b1010 as $T));
-                assert_eq!(0b0110 as $T, (0b1100 as $T).bitxor(0b1010 as $T));
-                assert_eq!(0b1110 as $T, (0b0111 as $T).shl(1));
-                assert_eq!(0b0111 as $T, (0b1110 as $T).shr(1));
-                assert_eq!(-(0b11 as $T) - (1 as $T), (0b11 as $T).not());
-            }
+        #[test]
+        fn test_borrowing_sub() {
+            assert_eq!($T::MIN.borrowing_sub(1, false), ($T::MAX, true));
+            assert_eq!($T::MIN.borrowing_sub(0, true), ($T::MAX, true));
+            assert_eq!($T::MIN.borrowing_sub(1, true), ($T::MAX - 1, true));
+            assert_eq!($T::MIN.borrowing_sub(-1, false), ($T::MIN + 1, false));
+            assert_eq!($T::MIN.borrowing_sub(-1, true), ($T::MIN, false)); // no intermediate overflow
+            assert_eq!($T::MAX.borrowing_sub(-1, false), ($T::MIN, true));
+            assert_eq!($T::MAX.borrowing_sub(-1, true), ($T::MAX, false)); // no intermediate overflow
+            assert_eq!((0 as $T).borrowing_sub($T::MIN, false), ($T::MIN, true));
+            assert_eq!((0 as $T).borrowing_sub($T::MIN, true), ($T::MAX, false));
+        }
 
-            const A: $T = 0b0101100;
-            const B: $T = 0b0100001;
-            const C: $T = 0b1111001;
+        #[test]
+        fn test_midpoint() {
+            assert_eq!(<$T>::midpoint(1, 3), 2);
+            assert_eq!(<$T>::midpoint(3, 1), 2);
 
-            const _0: $T = 0;
-            const _1: $T = !0;
+            assert_eq!(<$T>::midpoint(0, 0), 0);
+            assert_eq!(<$T>::midpoint(0, 2), 1);
+            assert_eq!(<$T>::midpoint(2, 0), 1);
+            assert_eq!(<$T>::midpoint(2, 2), 2);
 
-            #[test]
-            fn test_count_ones() {
-                assert_eq!(A.count_ones(), 3);
-                assert_eq!(B.count_ones(), 2);
-                assert_eq!(C.count_ones(), 5);
-            }
+            assert_eq!(<$T>::midpoint(1, 4), 2);
+            assert_eq!(<$T>::midpoint(4, 1), 2);
+            assert_eq!(<$T>::midpoint(3, 4), 3);
+            assert_eq!(<$T>::midpoint(4, 3), 3);
 
-            #[test]
-            fn test_count_zeros() {
-                assert_eq!(A.count_zeros(), $T::BITS - 3);
-                assert_eq!(B.count_zeros(), $T::BITS - 2);
-                assert_eq!(C.count_zeros(), $T::BITS - 5);
-            }
+            assert_eq!(<$T>::midpoint(<$T>::MIN, <$T>::MAX), -1);
+            assert_eq!(<$T>::midpoint(<$T>::MAX, <$T>::MIN), -1);
+            assert_eq!(<$T>::midpoint(<$T>::MIN, <$T>::MIN), <$T>::MIN);
+            assert_eq!(<$T>::midpoint(<$T>::MAX, <$T>::MAX), <$T>::MAX);
 
-            #[test]
-            fn test_leading_trailing_ones() {
-                let a: $T = 0b0101_1111;
-                assert_eq!(a.trailing_ones(), 5);
-                assert_eq!((!a).leading_ones(), $T::BITS - 7);
-
-                assert_eq!(a.reverse_bits().leading_ones(), 5);
-
-                assert_eq!(_1.leading_ones(), $T::BITS);
-                assert_eq!(_1.trailing_ones(), $T::BITS);
-
-                assert_eq!((_1 << 1).trailing_ones(), 0);
-                assert_eq!(MAX.leading_ones(), 0);
-
-                assert_eq!((_1 << 1).leading_ones(), $T::BITS - 1);
-                assert_eq!(MAX.trailing_ones(), $T::BITS - 1);
-
-                assert_eq!(_0.leading_ones(), 0);
-                assert_eq!(_0.trailing_ones(), 0);
-
-                let x: $T = 0b0010_1100;
-                assert_eq!(x.leading_ones(), 0);
-                assert_eq!(x.trailing_ones(), 0);
-            }
-
-            #[test]
-            fn test_rotate() {
-                assert_eq!(A.rotate_left(6).rotate_right(2).rotate_right(4), A);
-                assert_eq!(B.rotate_left(3).rotate_left(2).rotate_right(5), B);
-                assert_eq!(C.rotate_left(6).rotate_right(2).rotate_right(4), C);
-
-                // Rotating these should make no difference
-                //
-                // We test using 124 bits because to ensure that overlong bit shifts do
-                // not cause undefined behaviour. See #10183.
-                assert_eq!(_0.rotate_left(124), _0);
-                assert_eq!(_1.rotate_left(124), _1);
-                assert_eq!(_0.rotate_right(124), _0);
-                assert_eq!(_1.rotate_right(124), _1);
-
-                // Rotating by 0 should have no effect
-                assert_eq!(A.rotate_left(0), A);
-                assert_eq!(B.rotate_left(0), B);
-                assert_eq!(C.rotate_left(0), C);
-                // Rotating by a multiple of word size should also have no effect
-                assert_eq!(A.rotate_left(128), A);
-                assert_eq!(B.rotate_left(128), B);
-                assert_eq!(C.rotate_left(128), C);
-            }
-
-            #[test]
-            fn test_swap_bytes() {
-                assert_eq!(A.swap_bytes().swap_bytes(), A);
-                assert_eq!(B.swap_bytes().swap_bytes(), B);
-                assert_eq!(C.swap_bytes().swap_bytes(), C);
-
-                // Swapping these should make no difference
-                assert_eq!(_0.swap_bytes(), _0);
-                assert_eq!(_1.swap_bytes(), _1);
-            }
-
-            #[test]
-            fn test_le() {
-                assert_eq!($T::from_le(A.to_le()), A);
-                assert_eq!($T::from_le(B.to_le()), B);
-                assert_eq!($T::from_le(C.to_le()), C);
-                assert_eq!($T::from_le(_0), _0);
-                assert_eq!($T::from_le(_1), _1);
-                assert_eq!(_0.to_le(), _0);
-                assert_eq!(_1.to_le(), _1);
-            }
-
-            #[test]
-            fn test_be() {
-                assert_eq!($T::from_be(A.to_be()), A);
-                assert_eq!($T::from_be(B.to_be()), B);
-                assert_eq!($T::from_be(C.to_be()), C);
-                assert_eq!($T::from_be(_0), _0);
-                assert_eq!($T::from_be(_1), _1);
-                assert_eq!(_0.to_be(), _0);
-                assert_eq!(_1.to_be(), _1);
-            }
-
-            #[test]
-            fn test_signed_checked_div() {
-                assert_eq!((10 as $T).checked_div(2), Some(5));
-                assert_eq!((5 as $T).checked_div(0), None);
-                assert_eq!(isize::MIN.checked_div(-1), None);
-            }
-
-            #[test]
-            fn test_saturating_abs() {
-                assert_eq!((0 as $T).saturating_abs(), 0);
-                assert_eq!((123 as $T).saturating_abs(), 123);
-                assert_eq!((-123 as $T).saturating_abs(), 123);
-                assert_eq!((MAX - 2).saturating_abs(), MAX - 2);
-                assert_eq!((MAX - 1).saturating_abs(), MAX - 1);
-                assert_eq!(MAX.saturating_abs(), MAX);
-                assert_eq!((MIN + 2).saturating_abs(), MAX - 1);
-                assert_eq!((MIN + 1).saturating_abs(), MAX);
-                assert_eq!(MIN.saturating_abs(), MAX);
-            }
-
-            #[test]
-            fn test_saturating_neg() {
-                assert_eq!((0 as $T).saturating_neg(), 0);
-                assert_eq!((123 as $T).saturating_neg(), -123);
-                assert_eq!((-123 as $T).saturating_neg(), 123);
-                assert_eq!((MAX - 2).saturating_neg(), MIN + 3);
-                assert_eq!((MAX - 1).saturating_neg(), MIN + 2);
-                assert_eq!(MAX.saturating_neg(), MIN + 1);
-                assert_eq!((MIN + 2).saturating_neg(), MAX - 1);
-                assert_eq!((MIN + 1).saturating_neg(), MAX);
-                assert_eq!(MIN.saturating_neg(), MAX);
-            }
-
-            #[test]
-            fn test_from_str() {
-                fn from_str<T: std::str::FromStr>(t: &str) -> Option<T> {
-                    std::str::FromStr::from_str(t).ok()
-                }
-                assert_eq!(from_str::<$T>("0"), Some(0 as $T));
-                assert_eq!(from_str::<$T>("3"), Some(3 as $T));
-                assert_eq!(from_str::<$T>("10"), Some(10 as $T));
-                assert_eq!(from_str::<i32>("123456789"), Some(123456789 as i32));
-                assert_eq!(from_str::<$T>("00100"), Some(100 as $T));
-
-                assert_eq!(from_str::<$T>("-1"), Some(-1 as $T));
-                assert_eq!(from_str::<$T>("-3"), Some(-3 as $T));
-                assert_eq!(from_str::<$T>("-10"), Some(-10 as $T));
-                assert_eq!(from_str::<i32>("-123456789"), Some(-123456789 as i32));
-                assert_eq!(from_str::<$T>("-00100"), Some(-100 as $T));
-
-                assert_eq!(from_str::<$T>(""), None);
-                assert_eq!(from_str::<$T>(" "), None);
-                assert_eq!(from_str::<$T>("x"), None);
-            }
-
-            #[test]
-            fn test_from_str_radix() {
-                assert_eq!($T::from_str_radix("123", 10), Ok(123 as $T));
-                assert_eq!($T::from_str_radix("1001", 2), Ok(9 as $T));
-                assert_eq!($T::from_str_radix("123", 8), Ok(83 as $T));
-                assert_eq!(i32::from_str_radix("123", 16), Ok(291 as i32));
-                assert_eq!(i32::from_str_radix("ffff", 16), Ok(65535 as i32));
-                assert_eq!(i32::from_str_radix("FFFF", 16), Ok(65535 as i32));
-                assert_eq!($T::from_str_radix("z", 36), Ok(35 as $T));
-                assert_eq!($T::from_str_radix("Z", 36), Ok(35 as $T));
-
-                assert_eq!($T::from_str_radix("-123", 10), Ok(-123 as $T));
-                assert_eq!($T::from_str_radix("-1001", 2), Ok(-9 as $T));
-                assert_eq!($T::from_str_radix("-123", 8), Ok(-83 as $T));
-                assert_eq!(i32::from_str_radix("-123", 16), Ok(-291 as i32));
-                assert_eq!(i32::from_str_radix("-ffff", 16), Ok(-65535 as i32));
-                assert_eq!(i32::from_str_radix("-FFFF", 16), Ok(-65535 as i32));
-                assert_eq!($T::from_str_radix("-z", 36), Ok(-35 as $T));
-                assert_eq!($T::from_str_radix("-Z", 36), Ok(-35 as $T));
-
-                assert_eq!($T::from_str_radix("Z", 35).ok(), None::<$T>);
-                assert_eq!($T::from_str_radix("-9", 2).ok(), None::<$T>);
-            }
-
-            #[test]
-            fn test_pow() {
-                let mut r = 2 as $T;
-                assert_eq!(r.pow(2), 4 as $T);
-                assert_eq!(r.pow(0), 1 as $T);
-                assert_eq!(r.wrapping_pow(2), 4 as $T);
-                assert_eq!(r.wrapping_pow(0), 1 as $T);
-                assert_eq!(r.checked_pow(2), Some(4 as $T));
-                assert_eq!(r.checked_pow(0), Some(1 as $T));
-                assert_eq!(r.overflowing_pow(2), (4 as $T, false));
-                assert_eq!(r.overflowing_pow(0), (1 as $T, false));
-                assert_eq!(r.saturating_pow(2), 4 as $T);
-                assert_eq!(r.saturating_pow(0), 1 as $T);
-
-                r = MAX;
-                // use `^` to represent .pow() with no overflow.
-                // if itest::MAX == 2^j-1, then itest is a `j` bit int,
-                // so that `itest::MAX*itest::MAX == 2^(2*j)-2^(j+1)+1`,
-                // thussaturating_pow the overflowing result is exactly 1.
-                assert_eq!(r.wrapping_pow(2), 1 as $T);
-                assert_eq!(r.checked_pow(2), None);
-                assert_eq!(r.overflowing_pow(2), (1 as $T, true));
-                assert_eq!(r.saturating_pow(2), MAX);
-                //test for negative exponent.
-                r = -2 as $T;
-                assert_eq!(r.pow(2), 4 as $T);
-                assert_eq!(r.pow(3), -8 as $T);
-                assert_eq!(r.pow(0), 1 as $T);
-                assert_eq!(r.wrapping_pow(2), 4 as $T);
-                assert_eq!(r.wrapping_pow(3), -8 as $T);
-                assert_eq!(r.wrapping_pow(0), 1 as $T);
-                assert_eq!(r.checked_pow(2), Some(4 as $T));
-                assert_eq!(r.checked_pow(3), Some(-8 as $T));
-                assert_eq!(r.checked_pow(0), Some(1 as $T));
-                assert_eq!(r.overflowing_pow(2), (4 as $T, false));
-                assert_eq!(r.overflowing_pow(3), (-8 as $T, false));
-                assert_eq!(r.overflowing_pow(0), (1 as $T, false));
-                assert_eq!(r.saturating_pow(2), 4 as $T);
-                assert_eq!(r.saturating_pow(3), -8 as $T);
-                assert_eq!(r.saturating_pow(0), 1 as $T);
-            }
-
-            #[test]
-            fn test_isqrt() {
-                assert_eq!($T::MIN.checked_isqrt(), None);
-                assert_eq!((-1 as $T).checked_isqrt(), None);
-                assert_eq!((0 as $T).isqrt(), 0 as $T);
-                assert_eq!((1 as $T).isqrt(), 1 as $T);
-                assert_eq!((2 as $T).isqrt(), 1 as $T);
-                assert_eq!((99 as $T).isqrt(), 9 as $T);
-                assert_eq!((100 as $T).isqrt(), 10 as $T);
-            }
-
-            #[cfg(not(miri))] // Miri is too slow
-            #[test]
-            fn test_lots_of_isqrt() {
-                let n_max: $T = (1024 * 1024).min($T::MAX as u128) as $T;
-                for n in 0..=n_max {
-                    let isqrt: $T = n.isqrt();
-
-                    assert!(isqrt.pow(2) <= n);
-                    let (square, overflow) = (isqrt + 1).overflowing_pow(2);
-                    assert!(overflow || square > n);
-                }
-
-                for n in ($T::MAX - 127)..=$T::MAX {
-                    let isqrt: $T = n.isqrt();
-
-                    assert!(isqrt.pow(2) <= n);
-                    let (square, overflow) = (isqrt + 1).overflowing_pow(2);
-                    assert!(overflow || square > n);
-                }
-            }
-
-            #[test]
-            fn test_div_floor() {
-                let a: $T = 8;
-                let b = 3;
-                assert_eq!(a.div_floor(b), 2);
-                assert_eq!(a.div_floor(-b), -3);
-                assert_eq!((-a).div_floor(b), -3);
-                assert_eq!((-a).div_floor(-b), 2);
-            }
-
-            #[test]
-            fn test_div_ceil() {
-                let a: $T = 8;
-                let b = 3;
-                assert_eq!(a.div_ceil(b), 3);
-                assert_eq!(a.div_ceil(-b), -2);
-                assert_eq!((-a).div_ceil(b), -2);
-                assert_eq!((-a).div_ceil(-b), 3);
-            }
-
-            #[test]
-            fn test_next_multiple_of() {
-                assert_eq!((16 as $T).next_multiple_of(8), 16);
-                assert_eq!((23 as $T).next_multiple_of(8), 24);
-                assert_eq!((16 as $T).next_multiple_of(-8), 16);
-                assert_eq!((23 as $T).next_multiple_of(-8), 16);
-                assert_eq!((-16 as $T).next_multiple_of(8), -16);
-                assert_eq!((-23 as $T).next_multiple_of(8), -16);
-                assert_eq!((-16 as $T).next_multiple_of(-8), -16);
-                assert_eq!((-23 as $T).next_multiple_of(-8), -24);
-                assert_eq!(MIN.next_multiple_of(-1), MIN);
-            }
-
-            #[test]
-            fn test_checked_next_multiple_of() {
-                assert_eq!((16 as $T).checked_next_multiple_of(8), Some(16));
-                assert_eq!((23 as $T).checked_next_multiple_of(8), Some(24));
-                assert_eq!((16 as $T).checked_next_multiple_of(-8), Some(16));
-                assert_eq!((23 as $T).checked_next_multiple_of(-8), Some(16));
-                assert_eq!((-16 as $T).checked_next_multiple_of(8), Some(-16));
-                assert_eq!((-23 as $T).checked_next_multiple_of(8), Some(-16));
-                assert_eq!((-16 as $T).checked_next_multiple_of(-8), Some(-16));
-                assert_eq!((-23 as $T).checked_next_multiple_of(-8), Some(-24));
-                assert_eq!((1 as $T).checked_next_multiple_of(0), None);
-                assert_eq!(MAX.checked_next_multiple_of(2), None);
-                assert_eq!(MIN.checked_next_multiple_of(-3), None);
-                assert_eq!(MIN.checked_next_multiple_of(-1), Some(MIN));
-            }
-
-            #[test]
-            fn test_carrying_add() {
-                assert_eq!($T::MAX.carrying_add(1, false), ($T::MIN, true));
-                assert_eq!($T::MAX.carrying_add(0, true), ($T::MIN, true));
-                assert_eq!($T::MAX.carrying_add(1, true), ($T::MIN + 1, true));
-                assert_eq!($T::MAX.carrying_add(-1, false), ($T::MAX - 1, false));
-                assert_eq!($T::MAX.carrying_add(-1, true), ($T::MAX, false)); // no intermediate overflow
-                assert_eq!($T::MIN.carrying_add(-1, false), ($T::MAX, true));
-                assert_eq!($T::MIN.carrying_add(-1, true), ($T::MIN, false)); // no intermediate overflow
-                assert_eq!((0 as $T).carrying_add($T::MAX, true), ($T::MIN, true));
-                assert_eq!((0 as $T).carrying_add($T::MIN, true), ($T::MIN + 1, false));
-            }
-
-            #[test]
-            fn test_borrowing_sub() {
-                assert_eq!($T::MIN.borrowing_sub(1, false), ($T::MAX, true));
-                assert_eq!($T::MIN.borrowing_sub(0, true), ($T::MAX, true));
-                assert_eq!($T::MIN.borrowing_sub(1, true), ($T::MAX - 1, true));
-                assert_eq!($T::MIN.borrowing_sub(-1, false), ($T::MIN + 1, false));
-                assert_eq!($T::MIN.borrowing_sub(-1, true), ($T::MIN, false)); // no intermediate overflow
-                assert_eq!($T::MAX.borrowing_sub(-1, false), ($T::MIN, true));
-                assert_eq!($T::MAX.borrowing_sub(-1, true), ($T::MAX, false)); // no intermediate overflow
-                assert_eq!((0 as $T).borrowing_sub($T::MIN, false), ($T::MIN, true));
-                assert_eq!((0 as $T).borrowing_sub($T::MIN, true), ($T::MAX, false));
-            }
-
-            #[test]
-            fn test_midpoint() {
-                assert_eq!(<$T>::midpoint(1, 3), 2);
-                assert_eq!(<$T>::midpoint(3, 1), 2);
-
-                assert_eq!(<$T>::midpoint(0, 0), 0);
-                assert_eq!(<$T>::midpoint(0, 2), 1);
-                assert_eq!(<$T>::midpoint(2, 0), 1);
-                assert_eq!(<$T>::midpoint(2, 2), 2);
-
-                assert_eq!(<$T>::midpoint(1, 4), 2);
-                assert_eq!(<$T>::midpoint(4, 1), 2);
-                assert_eq!(<$T>::midpoint(3, 4), 3);
-                assert_eq!(<$T>::midpoint(4, 3), 3);
-
-                assert_eq!(<$T>::midpoint(<$T>::MIN, <$T>::MAX), -1);
-                assert_eq!(<$T>::midpoint(<$T>::MAX, <$T>::MIN), -1);
-                assert_eq!(<$T>::midpoint(<$T>::MIN, <$T>::MIN), <$T>::MIN);
-                assert_eq!(<$T>::midpoint(<$T>::MAX, <$T>::MAX), <$T>::MAX);
-
-                assert_eq!(<$T>::midpoint(<$T>::MIN, 6), <$T>::MIN / 2 + 3);
-                assert_eq!(<$T>::midpoint(6, <$T>::MIN), <$T>::MIN / 2 + 3);
-                assert_eq!(<$T>::midpoint(<$T>::MAX, 6), <$T>::MAX / 2 + 3);
-                assert_eq!(<$T>::midpoint(6, <$T>::MAX), <$T>::MAX / 2 + 3);
-            }
+            assert_eq!(<$T>::midpoint(<$T>::MIN, 6), <$T>::MIN / 2 + 3);
+            assert_eq!(<$T>::midpoint(6, <$T>::MIN), <$T>::MIN / 2 + 3);
+            assert_eq!(<$T>::midpoint(<$T>::MAX, 6), <$T>::MAX / 2 + 3);
+            assert_eq!(<$T>::midpoint(6, <$T>::MAX), <$T>::MAX / 2 + 3);
         }
     };
 }

--- a/library/core/tests/num/mod.rs
+++ b/library/core/tests/num/mod.rs
@@ -178,7 +178,7 @@ fn test_can_not_overflow() {
 
     // Check u128 separately:
     for base in 2..=36 {
-        let num = u128::MAX as u128;
+        let num = <u128>::MAX;
         let max_len_string = format_radix(num, base as u128);
         // base 16 fits perfectly for u128 and won't overflow:
         assert_eq!(can_overflow::<u128>(base, &max_len_string), base != 16);

--- a/library/core/tests/num/uint_macros.rs
+++ b/library/core/tests/num/uint_macros.rs
@@ -1,320 +1,317 @@
 macro_rules! uint_module {
     ($T:ident) => {
-        #[cfg(test)]
-        mod tests {
-            use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
-            use core::$T::*;
-            use std::str::FromStr;
+        use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
+        use core::$T::*;
+        use std::str::FromStr;
 
-            use crate::num;
+        use crate::num;
 
-            #[test]
-            fn test_overflows() {
-                assert!(MAX > 0);
-                assert!(MIN <= 0);
-                assert!((MIN + MAX).wrapping_add(1) == 0);
+        #[test]
+        fn test_overflows() {
+            assert!(MAX > 0);
+            assert!(MIN <= 0);
+            assert!((MIN + MAX).wrapping_add(1) == 0);
+        }
+
+        #[test]
+        fn test_num() {
+            num::test_num(10 as $T, 2 as $T);
+        }
+
+        #[test]
+        fn test_bitwise_operators() {
+            assert!(0b1110 as $T == (0b1100 as $T).bitor(0b1010 as $T));
+            assert!(0b1000 as $T == (0b1100 as $T).bitand(0b1010 as $T));
+            assert!(0b0110 as $T == (0b1100 as $T).bitxor(0b1010 as $T));
+            assert!(0b1110 as $T == (0b0111 as $T).shl(1));
+            assert!(0b0111 as $T == (0b1110 as $T).shr(1));
+            assert!(MAX - (0b1011 as $T) == (0b1011 as $T).not());
+        }
+
+        const A: $T = 0b0101100;
+        const B: $T = 0b0100001;
+        const C: $T = 0b1111001;
+
+        const _0: $T = 0;
+        const _1: $T = !0;
+
+        #[test]
+        fn test_count_ones() {
+            assert!(A.count_ones() == 3);
+            assert!(B.count_ones() == 2);
+            assert!(C.count_ones() == 5);
+        }
+
+        #[test]
+        fn test_count_zeros() {
+            assert!(A.count_zeros() == $T::BITS - 3);
+            assert!(B.count_zeros() == $T::BITS - 2);
+            assert!(C.count_zeros() == $T::BITS - 5);
+        }
+
+        #[test]
+        fn test_leading_trailing_ones() {
+            let a: $T = 0b0101_1111;
+            assert_eq!(a.trailing_ones(), 5);
+            assert_eq!((!a).leading_ones(), $T::BITS - 7);
+
+            assert_eq!(a.reverse_bits().leading_ones(), 5);
+
+            assert_eq!(_1.leading_ones(), $T::BITS);
+            assert_eq!(_1.trailing_ones(), $T::BITS);
+
+            assert_eq!((_1 << 1).trailing_ones(), 0);
+            assert_eq!((_1 >> 1).leading_ones(), 0);
+
+            assert_eq!((_1 << 1).leading_ones(), $T::BITS - 1);
+            assert_eq!((_1 >> 1).trailing_ones(), $T::BITS - 1);
+
+            assert_eq!(_0.leading_ones(), 0);
+            assert_eq!(_0.trailing_ones(), 0);
+
+            let x: $T = 0b0010_1100;
+            assert_eq!(x.leading_ones(), 0);
+            assert_eq!(x.trailing_ones(), 0);
+        }
+
+        #[test]
+        fn test_rotate() {
+            assert_eq!(A.rotate_left(6).rotate_right(2).rotate_right(4), A);
+            assert_eq!(B.rotate_left(3).rotate_left(2).rotate_right(5), B);
+            assert_eq!(C.rotate_left(6).rotate_right(2).rotate_right(4), C);
+
+            // Rotating these should make no difference
+            //
+            // We test using 124 bits because to ensure that overlong bit shifts do
+            // not cause undefined behaviour. See #10183.
+            assert_eq!(_0.rotate_left(124), _0);
+            assert_eq!(_1.rotate_left(124), _1);
+            assert_eq!(_0.rotate_right(124), _0);
+            assert_eq!(_1.rotate_right(124), _1);
+
+            // Rotating by 0 should have no effect
+            assert_eq!(A.rotate_left(0), A);
+            assert_eq!(B.rotate_left(0), B);
+            assert_eq!(C.rotate_left(0), C);
+            // Rotating by a multiple of word size should also have no effect
+            assert_eq!(A.rotate_left(128), A);
+            assert_eq!(B.rotate_left(128), B);
+            assert_eq!(C.rotate_left(128), C);
+        }
+
+        #[test]
+        fn test_swap_bytes() {
+            assert_eq!(A.swap_bytes().swap_bytes(), A);
+            assert_eq!(B.swap_bytes().swap_bytes(), B);
+            assert_eq!(C.swap_bytes().swap_bytes(), C);
+
+            // Swapping these should make no difference
+            assert_eq!(_0.swap_bytes(), _0);
+            assert_eq!(_1.swap_bytes(), _1);
+        }
+
+        #[test]
+        fn test_reverse_bits() {
+            assert_eq!(A.reverse_bits().reverse_bits(), A);
+            assert_eq!(B.reverse_bits().reverse_bits(), B);
+            assert_eq!(C.reverse_bits().reverse_bits(), C);
+
+            // Swapping these should make no difference
+            assert_eq!(_0.reverse_bits(), _0);
+            assert_eq!(_1.reverse_bits(), _1);
+        }
+
+        #[test]
+        fn test_le() {
+            assert_eq!($T::from_le(A.to_le()), A);
+            assert_eq!($T::from_le(B.to_le()), B);
+            assert_eq!($T::from_le(C.to_le()), C);
+            assert_eq!($T::from_le(_0), _0);
+            assert_eq!($T::from_le(_1), _1);
+            assert_eq!(_0.to_le(), _0);
+            assert_eq!(_1.to_le(), _1);
+        }
+
+        #[test]
+        fn test_be() {
+            assert_eq!($T::from_be(A.to_be()), A);
+            assert_eq!($T::from_be(B.to_be()), B);
+            assert_eq!($T::from_be(C.to_be()), C);
+            assert_eq!($T::from_be(_0), _0);
+            assert_eq!($T::from_be(_1), _1);
+            assert_eq!(_0.to_be(), _0);
+            assert_eq!(_1.to_be(), _1);
+        }
+
+        #[test]
+        fn test_unsigned_checked_div() {
+            assert!((10 as $T).checked_div(2) == Some(5));
+            assert!((5 as $T).checked_div(0) == None);
+        }
+
+        fn from_str<T: FromStr>(t: &str) -> Option<T> {
+            FromStr::from_str(t).ok()
+        }
+
+        #[test]
+        pub fn test_from_str() {
+            assert_eq!(from_str::<$T>("0"), Some(0 as $T));
+            assert_eq!(from_str::<$T>("3"), Some(3 as $T));
+            assert_eq!(from_str::<$T>("10"), Some(10 as $T));
+            assert_eq!(from_str::<u32>("123456789"), Some(123456789 as u32));
+            assert_eq!(from_str::<$T>("00100"), Some(100 as $T));
+
+            assert_eq!(from_str::<$T>(""), None);
+            assert_eq!(from_str::<$T>(" "), None);
+            assert_eq!(from_str::<$T>("x"), None);
+        }
+
+        #[test]
+        pub fn test_parse_bytes() {
+            assert_eq!($T::from_str_radix("123", 10), Ok(123 as $T));
+            assert_eq!($T::from_str_radix("1001", 2), Ok(9 as $T));
+            assert_eq!($T::from_str_radix("123", 8), Ok(83 as $T));
+            assert_eq!(u16::from_str_radix("123", 16), Ok(291 as u16));
+            assert_eq!(u16::from_str_radix("ffff", 16), Ok(65535 as u16));
+            assert_eq!($T::from_str_radix("z", 36), Ok(35 as $T));
+
+            assert_eq!($T::from_str_radix("Z", 10).ok(), None::<$T>);
+            assert_eq!($T::from_str_radix("_", 2).ok(), None::<$T>);
+        }
+
+        #[test]
+        fn test_pow() {
+            let mut r = 2 as $T;
+            assert_eq!(r.pow(2), 4 as $T);
+            assert_eq!(r.pow(0), 1 as $T);
+            assert_eq!(r.wrapping_pow(2), 4 as $T);
+            assert_eq!(r.wrapping_pow(0), 1 as $T);
+            assert_eq!(r.checked_pow(2), Some(4 as $T));
+            assert_eq!(r.checked_pow(0), Some(1 as $T));
+            assert_eq!(r.overflowing_pow(2), (4 as $T, false));
+            assert_eq!(r.overflowing_pow(0), (1 as $T, false));
+            assert_eq!(r.saturating_pow(2), 4 as $T);
+            assert_eq!(r.saturating_pow(0), 1 as $T);
+
+            r = MAX;
+            // use `^` to represent .pow() with no overflow.
+            // if itest::MAX == 2^j-1, then itest is a `j` bit int,
+            // so that `itest::MAX*itest::MAX == 2^(2*j)-2^(j+1)+1`,
+            // thussaturating_pow the overflowing result is exactly 1.
+            assert_eq!(r.wrapping_pow(2), 1 as $T);
+            assert_eq!(r.checked_pow(2), None);
+            assert_eq!(r.overflowing_pow(2), (1 as $T, true));
+            assert_eq!(r.saturating_pow(2), MAX);
+        }
+
+        #[test]
+        fn test_isqrt() {
+            assert_eq!((0 as $T).isqrt(), 0 as $T);
+            assert_eq!((1 as $T).isqrt(), 1 as $T);
+            assert_eq!((2 as $T).isqrt(), 1 as $T);
+            assert_eq!((99 as $T).isqrt(), 9 as $T);
+            assert_eq!((100 as $T).isqrt(), 10 as $T);
+            assert_eq!($T::MAX.isqrt(), (1 << ($T::BITS / 2)) - 1);
+        }
+
+        #[cfg(not(miri))] // Miri is too slow
+        #[test]
+        fn test_lots_of_isqrt() {
+            let n_max: $T = (1024 * 1024).min($T::MAX as u128) as $T;
+            for n in 0..=n_max {
+                let isqrt: $T = n.isqrt();
+
+                assert!(isqrt.pow(2) <= n);
+                assert!(isqrt + 1 == (1 as $T) << ($T::BITS / 2) || (isqrt + 1).pow(2) > n);
             }
 
-            #[test]
-            fn test_num() {
-                num::test_num(10 as $T, 2 as $T);
+            for n in ($T::MAX - 255)..=$T::MAX {
+                let isqrt: $T = n.isqrt();
+
+                assert!(isqrt.pow(2) <= n);
+                assert!(isqrt + 1 == (1 as $T) << ($T::BITS / 2) || (isqrt + 1).pow(2) > n);
             }
+        }
 
-            #[test]
-            fn test_bitwise_operators() {
-                assert!(0b1110 as $T == (0b1100 as $T).bitor(0b1010 as $T));
-                assert!(0b1000 as $T == (0b1100 as $T).bitand(0b1010 as $T));
-                assert!(0b0110 as $T == (0b1100 as $T).bitxor(0b1010 as $T));
-                assert!(0b1110 as $T == (0b0111 as $T).shl(1));
-                assert!(0b0111 as $T == (0b1110 as $T).shr(1));
-                assert!(MAX - (0b1011 as $T) == (0b1011 as $T).not());
-            }
+        #[test]
+        fn test_div_floor() {
+            assert_eq!((8 as $T).div_floor(3), 2);
+        }
 
-            const A: $T = 0b0101100;
-            const B: $T = 0b0100001;
-            const C: $T = 0b1111001;
+        #[test]
+        fn test_div_ceil() {
+            assert_eq!((8 as $T).div_ceil(3), 3);
+        }
 
-            const _0: $T = 0;
-            const _1: $T = !0;
+        #[test]
+        fn test_next_multiple_of() {
+            assert_eq!((16 as $T).next_multiple_of(8), 16);
+            assert_eq!((23 as $T).next_multiple_of(8), 24);
+            assert_eq!(MAX.next_multiple_of(1), MAX);
+        }
 
-            #[test]
-            fn test_count_ones() {
-                assert!(A.count_ones() == 3);
-                assert!(B.count_ones() == 2);
-                assert!(C.count_ones() == 5);
-            }
+        #[test]
+        fn test_checked_next_multiple_of() {
+            assert_eq!((16 as $T).checked_next_multiple_of(8), Some(16));
+            assert_eq!((23 as $T).checked_next_multiple_of(8), Some(24));
+            assert_eq!((1 as $T).checked_next_multiple_of(0), None);
+            assert_eq!(MAX.checked_next_multiple_of(2), None);
+        }
 
-            #[test]
-            fn test_count_zeros() {
-                assert!(A.count_zeros() == $T::BITS - 3);
-                assert!(B.count_zeros() == $T::BITS - 2);
-                assert!(C.count_zeros() == $T::BITS - 5);
-            }
+        #[test]
+        fn test_is_next_multiple_of() {
+            assert!((12 as $T).is_multiple_of(4));
+            assert!(!(12 as $T).is_multiple_of(5));
+            assert!((0 as $T).is_multiple_of(0));
+            assert!(!(12 as $T).is_multiple_of(0));
+        }
 
-            #[test]
-            fn test_leading_trailing_ones() {
-                let a: $T = 0b0101_1111;
-                assert_eq!(a.trailing_ones(), 5);
-                assert_eq!((!a).leading_ones(), $T::BITS - 7);
+        #[test]
+        fn test_carrying_add() {
+            assert_eq!($T::MAX.carrying_add(1, false), (0, true));
+            assert_eq!($T::MAX.carrying_add(0, true), (0, true));
+            assert_eq!($T::MAX.carrying_add(1, true), (1, true));
 
-                assert_eq!(a.reverse_bits().leading_ones(), 5);
+            assert_eq!($T::MIN.carrying_add($T::MAX, false), ($T::MAX, false));
+            assert_eq!($T::MIN.carrying_add(0, true), (1, false));
+            assert_eq!($T::MIN.carrying_add($T::MAX, true), (0, true));
+        }
 
-                assert_eq!(_1.leading_ones(), $T::BITS);
-                assert_eq!(_1.trailing_ones(), $T::BITS);
+        #[test]
+        fn test_borrowing_sub() {
+            assert_eq!($T::MIN.borrowing_sub(1, false), ($T::MAX, true));
+            assert_eq!($T::MIN.borrowing_sub(0, true), ($T::MAX, true));
+            assert_eq!($T::MIN.borrowing_sub(1, true), ($T::MAX - 1, true));
 
-                assert_eq!((_1 << 1).trailing_ones(), 0);
-                assert_eq!((_1 >> 1).leading_ones(), 0);
+            assert_eq!($T::MAX.borrowing_sub($T::MAX, false), (0, false));
+            assert_eq!($T::MAX.borrowing_sub(0, true), ($T::MAX - 1, false));
+            assert_eq!($T::MAX.borrowing_sub($T::MAX, true), ($T::MAX, true));
+        }
 
-                assert_eq!((_1 << 1).leading_ones(), $T::BITS - 1);
-                assert_eq!((_1 >> 1).trailing_ones(), $T::BITS - 1);
+        #[test]
+        fn test_midpoint() {
+            assert_eq!(<$T>::midpoint(1, 3), 2);
+            assert_eq!(<$T>::midpoint(3, 1), 2);
 
-                assert_eq!(_0.leading_ones(), 0);
-                assert_eq!(_0.trailing_ones(), 0);
+            assert_eq!(<$T>::midpoint(0, 0), 0);
+            assert_eq!(<$T>::midpoint(0, 2), 1);
+            assert_eq!(<$T>::midpoint(2, 0), 1);
+            assert_eq!(<$T>::midpoint(2, 2), 2);
 
-                let x: $T = 0b0010_1100;
-                assert_eq!(x.leading_ones(), 0);
-                assert_eq!(x.trailing_ones(), 0);
-            }
+            assert_eq!(<$T>::midpoint(1, 4), 2);
+            assert_eq!(<$T>::midpoint(4, 1), 2);
+            assert_eq!(<$T>::midpoint(3, 4), 3);
+            assert_eq!(<$T>::midpoint(4, 3), 3);
 
-            #[test]
-            fn test_rotate() {
-                assert_eq!(A.rotate_left(6).rotate_right(2).rotate_right(4), A);
-                assert_eq!(B.rotate_left(3).rotate_left(2).rotate_right(5), B);
-                assert_eq!(C.rotate_left(6).rotate_right(2).rotate_right(4), C);
+            assert_eq!(<$T>::midpoint(<$T>::MIN, <$T>::MAX), (<$T>::MAX - <$T>::MIN) / 2);
+            assert_eq!(<$T>::midpoint(<$T>::MAX, <$T>::MIN), (<$T>::MAX - <$T>::MIN) / 2);
+            assert_eq!(<$T>::midpoint(<$T>::MIN, <$T>::MIN), <$T>::MIN);
+            assert_eq!(<$T>::midpoint(<$T>::MAX, <$T>::MAX), <$T>::MAX);
 
-                // Rotating these should make no difference
-                //
-                // We test using 124 bits because to ensure that overlong bit shifts do
-                // not cause undefined behaviour. See #10183.
-                assert_eq!(_0.rotate_left(124), _0);
-                assert_eq!(_1.rotate_left(124), _1);
-                assert_eq!(_0.rotate_right(124), _0);
-                assert_eq!(_1.rotate_right(124), _1);
-
-                // Rotating by 0 should have no effect
-                assert_eq!(A.rotate_left(0), A);
-                assert_eq!(B.rotate_left(0), B);
-                assert_eq!(C.rotate_left(0), C);
-                // Rotating by a multiple of word size should also have no effect
-                assert_eq!(A.rotate_left(128), A);
-                assert_eq!(B.rotate_left(128), B);
-                assert_eq!(C.rotate_left(128), C);
-            }
-
-            #[test]
-            fn test_swap_bytes() {
-                assert_eq!(A.swap_bytes().swap_bytes(), A);
-                assert_eq!(B.swap_bytes().swap_bytes(), B);
-                assert_eq!(C.swap_bytes().swap_bytes(), C);
-
-                // Swapping these should make no difference
-                assert_eq!(_0.swap_bytes(), _0);
-                assert_eq!(_1.swap_bytes(), _1);
-            }
-
-            #[test]
-            fn test_reverse_bits() {
-                assert_eq!(A.reverse_bits().reverse_bits(), A);
-                assert_eq!(B.reverse_bits().reverse_bits(), B);
-                assert_eq!(C.reverse_bits().reverse_bits(), C);
-
-                // Swapping these should make no difference
-                assert_eq!(_0.reverse_bits(), _0);
-                assert_eq!(_1.reverse_bits(), _1);
-            }
-
-            #[test]
-            fn test_le() {
-                assert_eq!($T::from_le(A.to_le()), A);
-                assert_eq!($T::from_le(B.to_le()), B);
-                assert_eq!($T::from_le(C.to_le()), C);
-                assert_eq!($T::from_le(_0), _0);
-                assert_eq!($T::from_le(_1), _1);
-                assert_eq!(_0.to_le(), _0);
-                assert_eq!(_1.to_le(), _1);
-            }
-
-            #[test]
-            fn test_be() {
-                assert_eq!($T::from_be(A.to_be()), A);
-                assert_eq!($T::from_be(B.to_be()), B);
-                assert_eq!($T::from_be(C.to_be()), C);
-                assert_eq!($T::from_be(_0), _0);
-                assert_eq!($T::from_be(_1), _1);
-                assert_eq!(_0.to_be(), _0);
-                assert_eq!(_1.to_be(), _1);
-            }
-
-            #[test]
-            fn test_unsigned_checked_div() {
-                assert!((10 as $T).checked_div(2) == Some(5));
-                assert!((5 as $T).checked_div(0) == None);
-            }
-
-            fn from_str<T: FromStr>(t: &str) -> Option<T> {
-                FromStr::from_str(t).ok()
-            }
-
-            #[test]
-            pub fn test_from_str() {
-                assert_eq!(from_str::<$T>("0"), Some(0 as $T));
-                assert_eq!(from_str::<$T>("3"), Some(3 as $T));
-                assert_eq!(from_str::<$T>("10"), Some(10 as $T));
-                assert_eq!(from_str::<u32>("123456789"), Some(123456789 as u32));
-                assert_eq!(from_str::<$T>("00100"), Some(100 as $T));
-
-                assert_eq!(from_str::<$T>(""), None);
-                assert_eq!(from_str::<$T>(" "), None);
-                assert_eq!(from_str::<$T>("x"), None);
-            }
-
-            #[test]
-            pub fn test_parse_bytes() {
-                assert_eq!($T::from_str_radix("123", 10), Ok(123 as $T));
-                assert_eq!($T::from_str_radix("1001", 2), Ok(9 as $T));
-                assert_eq!($T::from_str_radix("123", 8), Ok(83 as $T));
-                assert_eq!(u16::from_str_radix("123", 16), Ok(291 as u16));
-                assert_eq!(u16::from_str_radix("ffff", 16), Ok(65535 as u16));
-                assert_eq!($T::from_str_radix("z", 36), Ok(35 as $T));
-
-                assert_eq!($T::from_str_radix("Z", 10).ok(), None::<$T>);
-                assert_eq!($T::from_str_radix("_", 2).ok(), None::<$T>);
-            }
-
-            #[test]
-            fn test_pow() {
-                let mut r = 2 as $T;
-                assert_eq!(r.pow(2), 4 as $T);
-                assert_eq!(r.pow(0), 1 as $T);
-                assert_eq!(r.wrapping_pow(2), 4 as $T);
-                assert_eq!(r.wrapping_pow(0), 1 as $T);
-                assert_eq!(r.checked_pow(2), Some(4 as $T));
-                assert_eq!(r.checked_pow(0), Some(1 as $T));
-                assert_eq!(r.overflowing_pow(2), (4 as $T, false));
-                assert_eq!(r.overflowing_pow(0), (1 as $T, false));
-                assert_eq!(r.saturating_pow(2), 4 as $T);
-                assert_eq!(r.saturating_pow(0), 1 as $T);
-
-                r = MAX;
-                // use `^` to represent .pow() with no overflow.
-                // if itest::MAX == 2^j-1, then itest is a `j` bit int,
-                // so that `itest::MAX*itest::MAX == 2^(2*j)-2^(j+1)+1`,
-                // thussaturating_pow the overflowing result is exactly 1.
-                assert_eq!(r.wrapping_pow(2), 1 as $T);
-                assert_eq!(r.checked_pow(2), None);
-                assert_eq!(r.overflowing_pow(2), (1 as $T, true));
-                assert_eq!(r.saturating_pow(2), MAX);
-            }
-
-            #[test]
-            fn test_isqrt() {
-                assert_eq!((0 as $T).isqrt(), 0 as $T);
-                assert_eq!((1 as $T).isqrt(), 1 as $T);
-                assert_eq!((2 as $T).isqrt(), 1 as $T);
-                assert_eq!((99 as $T).isqrt(), 9 as $T);
-                assert_eq!((100 as $T).isqrt(), 10 as $T);
-                assert_eq!($T::MAX.isqrt(), (1 << ($T::BITS / 2)) - 1);
-            }
-
-            #[cfg(not(miri))] // Miri is too slow
-            #[test]
-            fn test_lots_of_isqrt() {
-                let n_max: $T = (1024 * 1024).min($T::MAX as u128) as $T;
-                for n in 0..=n_max {
-                    let isqrt: $T = n.isqrt();
-
-                    assert!(isqrt.pow(2) <= n);
-                    assert!(isqrt + 1 == (1 as $T) << ($T::BITS / 2) || (isqrt + 1).pow(2) > n);
-                }
-
-                for n in ($T::MAX - 255)..=$T::MAX {
-                    let isqrt: $T = n.isqrt();
-
-                    assert!(isqrt.pow(2) <= n);
-                    assert!(isqrt + 1 == (1 as $T) << ($T::BITS / 2) || (isqrt + 1).pow(2) > n);
-                }
-            }
-
-            #[test]
-            fn test_div_floor() {
-                assert_eq!((8 as $T).div_floor(3), 2);
-            }
-
-            #[test]
-            fn test_div_ceil() {
-                assert_eq!((8 as $T).div_ceil(3), 3);
-            }
-
-            #[test]
-            fn test_next_multiple_of() {
-                assert_eq!((16 as $T).next_multiple_of(8), 16);
-                assert_eq!((23 as $T).next_multiple_of(8), 24);
-                assert_eq!(MAX.next_multiple_of(1), MAX);
-            }
-
-            #[test]
-            fn test_checked_next_multiple_of() {
-                assert_eq!((16 as $T).checked_next_multiple_of(8), Some(16));
-                assert_eq!((23 as $T).checked_next_multiple_of(8), Some(24));
-                assert_eq!((1 as $T).checked_next_multiple_of(0), None);
-                assert_eq!(MAX.checked_next_multiple_of(2), None);
-            }
-
-            #[test]
-            fn test_is_next_multiple_of() {
-                assert!((12 as $T).is_multiple_of(4));
-                assert!(!(12 as $T).is_multiple_of(5));
-                assert!((0 as $T).is_multiple_of(0));
-                assert!(!(12 as $T).is_multiple_of(0));
-            }
-
-            #[test]
-            fn test_carrying_add() {
-                assert_eq!($T::MAX.carrying_add(1, false), (0, true));
-                assert_eq!($T::MAX.carrying_add(0, true), (0, true));
-                assert_eq!($T::MAX.carrying_add(1, true), (1, true));
-
-                assert_eq!($T::MIN.carrying_add($T::MAX, false), ($T::MAX, false));
-                assert_eq!($T::MIN.carrying_add(0, true), (1, false));
-                assert_eq!($T::MIN.carrying_add($T::MAX, true), (0, true));
-            }
-
-            #[test]
-            fn test_borrowing_sub() {
-                assert_eq!($T::MIN.borrowing_sub(1, false), ($T::MAX, true));
-                assert_eq!($T::MIN.borrowing_sub(0, true), ($T::MAX, true));
-                assert_eq!($T::MIN.borrowing_sub(1, true), ($T::MAX - 1, true));
-
-                assert_eq!($T::MAX.borrowing_sub($T::MAX, false), (0, false));
-                assert_eq!($T::MAX.borrowing_sub(0, true), ($T::MAX - 1, false));
-                assert_eq!($T::MAX.borrowing_sub($T::MAX, true), ($T::MAX, true));
-            }
-
-            #[test]
-            fn test_midpoint() {
-                assert_eq!(<$T>::midpoint(1, 3), 2);
-                assert_eq!(<$T>::midpoint(3, 1), 2);
-
-                assert_eq!(<$T>::midpoint(0, 0), 0);
-                assert_eq!(<$T>::midpoint(0, 2), 1);
-                assert_eq!(<$T>::midpoint(2, 0), 1);
-                assert_eq!(<$T>::midpoint(2, 2), 2);
-
-                assert_eq!(<$T>::midpoint(1, 4), 2);
-                assert_eq!(<$T>::midpoint(4, 1), 2);
-                assert_eq!(<$T>::midpoint(3, 4), 3);
-                assert_eq!(<$T>::midpoint(4, 3), 3);
-
-                assert_eq!(<$T>::midpoint(<$T>::MIN, <$T>::MAX), (<$T>::MAX - <$T>::MIN) / 2);
-                assert_eq!(<$T>::midpoint(<$T>::MAX, <$T>::MIN), (<$T>::MAX - <$T>::MIN) / 2);
-                assert_eq!(<$T>::midpoint(<$T>::MIN, <$T>::MIN), <$T>::MIN);
-                assert_eq!(<$T>::midpoint(<$T>::MAX, <$T>::MAX), <$T>::MAX);
-
-                assert_eq!(<$T>::midpoint(<$T>::MIN, 6), <$T>::MIN / 2 + 3);
-                assert_eq!(<$T>::midpoint(6, <$T>::MIN), <$T>::MIN / 2 + 3);
-                assert_eq!(<$T>::midpoint(<$T>::MAX, 6), (<$T>::MAX - <$T>::MIN) / 2 + 3);
-                assert_eq!(<$T>::midpoint(6, <$T>::MAX), (<$T>::MAX - <$T>::MIN) / 2 + 3);
-            }
+            assert_eq!(<$T>::midpoint(<$T>::MIN, 6), <$T>::MIN / 2 + 3);
+            assert_eq!(<$T>::midpoint(6, <$T>::MIN), <$T>::MIN / 2 + 3);
+            assert_eq!(<$T>::midpoint(<$T>::MAX, 6), (<$T>::MAX - <$T>::MIN) / 2 + 3);
+            assert_eq!(<$T>::midpoint(6, <$T>::MAX), (<$T>::MAX - <$T>::MIN) / 2 + 3);
         }
     };
 }

--- a/library/std/src/sys/pal/hermit/thread.rs
+++ b/library/std/src/sys/pal/hermit/thread.rs
@@ -77,8 +77,10 @@ impl Thread {
 
     #[inline]
     pub fn sleep(dur: Duration) {
+        let micros = dur.as_micros() + if dur.subsec_nanos() % 1_000 > 0 { 1 } else { 0 };
+
         unsafe {
-            hermit_abi::usleep(dur.as_micros() as u64);
+            hermit_abi::usleep(micros as u64);
         }
     }
 

--- a/library/std/src/sys/pal/hermit/thread.rs
+++ b/library/std/src/sys/pal/hermit/thread.rs
@@ -78,9 +78,10 @@ impl Thread {
     #[inline]
     pub fn sleep(dur: Duration) {
         let micros = dur.as_micros() + if dur.subsec_nanos() % 1_000 > 0 { 1 } else { 0 };
+        let micros = u64::try_from(micros).unwrap_or(u64::MAX);
 
         unsafe {
-            hermit_abi::usleep(micros as u64);
+            hermit_abi::usleep(micros);
         }
     }
 

--- a/tests/ui/consts/const-float-bits-conv.rs
+++ b/tests/ui/consts/const-float-bits-conv.rs
@@ -29,6 +29,7 @@ fn has_broken_floats() -> bool {
     std::env::var("TARGET").is_ok_and(|v| v.contains("i586"))
 }
 
+#[cfg(target_arch = "x86_64")]
 fn f16(){
     const_assert!((1f16).to_bits(), 0x3c00);
     const_assert!(u16::from_be_bytes(1f16.to_be_bytes()), 0x3c00);
@@ -119,6 +120,7 @@ fn f64() {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 fn f128() {
     const_assert!((1f128).to_bits(), 0x3fff0000000000000000000000000000);
     const_assert!(u128::from_be_bytes(1f128.to_be_bytes()), 0x3fff0000000000000000000000000000);
@@ -150,8 +152,11 @@ fn f128() {
 }
 
 fn main() {
-    f16();
+    #[cfg(target_arch = "x86_64")]
+    {
+        f16();
+        f128();
+    }
     f32();
     f64();
-    f128();
 }

--- a/tests/ui/consts/const-float-bits-conv.rs
+++ b/tests/ui/consts/const-float-bits-conv.rs
@@ -3,8 +3,9 @@
 
 #![feature(const_float_bits_conv)]
 #![feature(const_float_classify)]
+#![feature(f16)]
+#![feature(f128)]
 #![allow(unused_macro_rules)]
-
 // Don't promote
 const fn nop<T>(x: T) -> T { x }
 
@@ -26,6 +27,36 @@ macro_rules! const_assert {
 fn has_broken_floats() -> bool {
     // i586 targets are broken due to <https://github.com/rust-lang/rust/issues/114479>.
     std::env::var("TARGET").is_ok_and(|v| v.contains("i586"))
+}
+
+fn f16(){
+    const_assert!((1f16).to_bits(), 0x3c00);
+    const_assert!(u16::from_be_bytes(1f16.to_be_bytes()), 0x3c00);
+    const_assert!((12.5f16).to_bits(), 0x4a40);
+    const_assert!(u16::from_le_bytes(12.5f16.to_le_bytes()), 0x4a40);
+    const_assert!((1337f16).to_bits(), 0x6539);
+    const_assert!(u16::from_ne_bytes(1337f16.to_ne_bytes()), 0x6539);
+    const_assert!((-14.25f16).to_bits(), 0xcb20);
+    const_assert!(f16::from_bits(0x3c00), 1.0);
+    const_assert!(f16::from_be_bytes(0x3c00u16.to_be_bytes()), 1.0);
+    const_assert!(f16::from_bits(0x4a40), 12.5);
+    const_assert!(f16::from_le_bytes(0x4a40u16.to_le_bytes()), 12.5);
+    const_assert!(f16::from_bits(0x5be0), 252.0);
+    const_assert!(f16::from_ne_bytes(0x5be0u16.to_ne_bytes()), 252.0);
+    const_assert!(f16::from_bits(0xcb20), -14.25);
+
+    // Check that NaNs roundtrip their bits regardless of signalingness
+    // 0xA is 0b1010; 0x5 is 0b0101 -- so these two together clobbers all the mantissa bits
+    // NOTE: These names assume `f{BITS}::NAN` is a quiet NAN and IEEE754-2008's NaN rules apply!
+    const QUIET_NAN: u16 = f16::NAN.to_bits() ^ 0x0155;
+    const SIGNALING_NAN: u16 = f16::NAN.to_bits() ^ 0x02AA;
+
+    const_assert!(f16::from_bits(QUIET_NAN).is_nan());
+    const_assert!(f16::from_bits(SIGNALING_NAN).is_nan());
+    const_assert!(f16::from_bits(QUIET_NAN).to_bits(), QUIET_NAN);
+    if !has_broken_floats() {
+        const_assert!(f16::from_bits(SIGNALING_NAN).to_bits(), SIGNALING_NAN);
+    }
 }
 
 fn f32() {
@@ -88,7 +119,39 @@ fn f64() {
     }
 }
 
+fn f128() {
+    const_assert!((1f128).to_bits(), 0x3fff0000000000000000000000000000);
+    const_assert!(u128::from_be_bytes(1f128.to_be_bytes()), 0x3fff0000000000000000000000000000);
+    const_assert!((12.5f128).to_bits(), 0x40029000000000000000000000000000);
+    const_assert!(u128::from_le_bytes(12.5f128.to_le_bytes()), 0x40029000000000000000000000000000);
+    const_assert!((1337f128).to_bits(), 0x40094e40000000000000000000000000);
+    const_assert!(u128::from_ne_bytes(1337f128.to_ne_bytes()), 0x40094e40000000000000000000000000);
+    const_assert!((-14.25f128).to_bits(), 0xc002c800000000000000000000000000);
+    const_assert!(f128::from_bits(0x3fff0000000000000000000000000000), 1.0);
+    const_assert!(f128::from_be_bytes(0x3fff0000000000000000000000000000u128.to_be_bytes()), 1.0);
+    const_assert!(f128::from_bits(0x40029000000000000000000000000000), 12.5);
+    const_assert!(f128::from_le_bytes(0x40029000000000000000000000000000u128.to_le_bytes()), 12.5);
+    const_assert!(f128::from_bits(0x40094e40000000000000000000000000), 1337.0);
+    assert_eq!(f128::from_ne_bytes(0x40094e40000000000000000000000000u128.to_ne_bytes()), 1337.0);
+    const_assert!(f128::from_bits(0xc002c800000000000000000000000000), -14.25);
+
+    // Check that NaNs roundtrip their bits regardless of signalingness
+    // 0xA is 0b1010; 0x5 is 0b0101 -- so these two together clobbers all the mantissa bits
+    // NOTE: These names assume `f{BITS}::NAN` is a quiet NAN and IEEE754-2008's NaN rules apply!
+    const QUIET_NAN: u128 = f128::NAN.to_bits() | 0x0000_AAAA_AAAA_AAAA_AAAA_AAAA_AAAA_AAAA;
+    const SIGNALING_NAN: u128 = f128::NAN.to_bits() ^ 0x0000_5555_5555_5555_5555_5555_5555_5555;
+
+    const_assert!(f128::from_bits(QUIET_NAN).is_nan());
+    const_assert!(f128::from_bits(SIGNALING_NAN).is_nan());
+    const_assert!(f128::from_bits(QUIET_NAN).to_bits(), QUIET_NAN);
+    if !has_broken_floats() {
+        const_assert!(f128::from_bits(SIGNALING_NAN).to_bits(), SIGNALING_NAN);
+    }
+}
+
 fn main() {
+    f16();
     f32();
     f64();
+    f128();
 }

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024.fixed
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024.fixed
@@ -5,14 +5,17 @@
 
 fn named<'a>(x: &'a i32) -> impl Sized + use<> { *x }
 //~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
+//~| WARN this changes meaning in Rust 2024
 
 fn implicit(x: &i32) -> impl Sized + use<> { *x }
 //~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
+//~| WARN this changes meaning in Rust 2024
 
 struct W;
 impl W {
     fn hello(&self, x: &i32) -> impl Sized + '_ + use<'_> { self }
     //~^ ERROR `impl Sized + '_` will capture more lifetimes than possibly intended in edition 2024
+    //~| WARN this changes meaning in Rust 2024
 }
 
 trait Higher<'a> {
@@ -24,5 +27,6 @@ impl Higher<'_> for () {
 
 fn hrtb() -> impl for<'a> Higher<'a, Output = impl Sized + use<>> {}
 //~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
+//~| WARN this changes meaning in Rust 2024
 
 fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024.rs
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024.rs
@@ -5,14 +5,17 @@
 
 fn named<'a>(x: &'a i32) -> impl Sized { *x }
 //~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
+//~| WARN this changes meaning in Rust 2024
 
 fn implicit(x: &i32) -> impl Sized { *x }
 //~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
+//~| WARN this changes meaning in Rust 2024
 
 struct W;
 impl W {
     fn hello(&self, x: &i32) -> impl Sized + '_ { self }
     //~^ ERROR `impl Sized + '_` will capture more lifetimes than possibly intended in edition 2024
+    //~| WARN this changes meaning in Rust 2024
 }
 
 trait Higher<'a> {
@@ -24,5 +27,6 @@ impl Higher<'_> for () {
 
 fn hrtb() -> impl for<'a> Higher<'a, Output = impl Sized> {}
 //~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
+//~| WARN this changes meaning in Rust 2024
 
 fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024.stderr
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024.stderr
@@ -4,6 +4,8 @@ error: `impl Sized` will capture more lifetimes than possibly intended in editio
 LL | fn named<'a>(x: &'a i32) -> impl Sized { *x }
    |                             ^^^^^^^^^^
    |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
   --> $DIR/overcaptures-2024.rs:6:10
    |
@@ -21,13 +23,15 @@ LL | fn named<'a>(x: &'a i32) -> impl Sized + use<> { *x }
    |                                        +++++++
 
 error: `impl Sized` will capture more lifetimes than possibly intended in edition 2024
-  --> $DIR/overcaptures-2024.rs:9:25
+  --> $DIR/overcaptures-2024.rs:10:25
    |
 LL | fn implicit(x: &i32) -> impl Sized { *x }
    |                         ^^^^^^^^^^
    |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
-  --> $DIR/overcaptures-2024.rs:9:16
+  --> $DIR/overcaptures-2024.rs:10:16
    |
 LL | fn implicit(x: &i32) -> impl Sized { *x }
    |                ^
@@ -38,13 +42,15 @@ LL | fn implicit(x: &i32) -> impl Sized + use<> { *x }
    |                                    +++++++
 
 error: `impl Sized + '_` will capture more lifetimes than possibly intended in edition 2024
-  --> $DIR/overcaptures-2024.rs:14:33
+  --> $DIR/overcaptures-2024.rs:16:33
    |
 LL |     fn hello(&self, x: &i32) -> impl Sized + '_ { self }
    |                                 ^^^^^^^^^^^^^^^
    |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
-  --> $DIR/overcaptures-2024.rs:14:24
+  --> $DIR/overcaptures-2024.rs:16:24
    |
 LL |     fn hello(&self, x: &i32) -> impl Sized + '_ { self }
    |                        ^
@@ -55,13 +61,15 @@ LL |     fn hello(&self, x: &i32) -> impl Sized + '_ + use<'_> { self }
    |                                                 +++++++++
 
 error: `impl Sized` will capture more lifetimes than possibly intended in edition 2024
-  --> $DIR/overcaptures-2024.rs:25:47
+  --> $DIR/overcaptures-2024.rs:28:47
    |
 LL | fn hrtb() -> impl for<'a> Higher<'a, Output = impl Sized> {}
    |                                               ^^^^^^^^^^
    |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
-  --> $DIR/overcaptures-2024.rs:25:23
+  --> $DIR/overcaptures-2024.rs:28:23
    |
 LL | fn hrtb() -> impl for<'a> Higher<'a, Output = impl Sized> {}
    |                       ^^


### PR DESCRIPTION
Successful merges:

 - #129190 (Add f16 and f128 to tests/ui/consts/const-float-bits-conv.rs)
 - #129377 (Add implementations for `unbounded_shl`/`unbounded_shr`)
 - #129539 (link to Future::poll from the Poll docs)
 - #129588 (pal/hermit: correctly round up microseconds in `Thread::sleep`)
 - #129592 (Remove cfg(test) from library/core)
 - #129597 (mv `build_reduced_graph_for_external_crate_res` into Resolver)
 - #129600 (Tie `impl_trait_overcaptures` lint to Rust 2024)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=129190,129377,129539,129588,129592,129597,129600)
<!-- homu-ignore:end -->