### PR TITLE
Update stacker to 0.1.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4978,15 +4978,15 @@ dependencies = [
 
 [[package]]
 name = "stacker"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+checksum = "799c883d55abdb5e98af1a7b3f23b9b6de8ecada0ecac058672d7635eb48ca7b"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/compiler/rustc_data_structures/Cargo.toml
+++ b/compiler/rustc_data_structures/Cargo.toml
@@ -22,7 +22,7 @@ rustc_index = { path = "../rustc_index", package = "rustc_index" }
 rustc_macros = { path = "../rustc_macros" }
 rustc_serialize = { path = "../rustc_serialize" }
 smallvec = { version = "1.8.1", features = ["const_generics", "union", "may_dangle"] }
-stacker = "0.1.15"
+stacker = "0.1.17"
 tempfile = "3.2"
 thin-vec = "0.2.12"
 tracing = "0.1"


### PR DESCRIPTION
The main new feature is support for detecting the current stack size on illumos. (See [my blog post] for the context which led to this.)

[my blog post]: https://sunshowers.io/posts/rustc-segfault-illumos/

try-job: x86_64-mingw