### PR TITLE
Provide a more convinient way of developing rustc on NixOS

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,0 @@
-if nix flake show path:./src/tools/nix-dev-shell &> /dev/null; then
-  use flake path:./src/tools/nix-dev-shell
-fi

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+if nix flake show path:./src/tools/nix-dev-shell &> /dev/null; then
+  use flake path:./src/tools/nix-dev-shell
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ build/
 /src/tools/x/target
 # Created by default with `src/ci/docker/run.sh`
 /obj/
+# Created by nix dev shell / .envrc
+src/tools/nix-dev-shell/flake.lock
 
 ## ICE reports
 rustc-ice-*.txt

--- a/src/tools/nix-dev-shell/envrc-flake
+++ b/src/tools/nix-dev-shell/envrc-flake
@@ -1,0 +1,8 @@
+# If you want to use this as an .envrc file to create a shell with necessery components 
+# to develop rustc, use the following command in the root of the rusr checkout:
+#	
+# ln -s ./src/tools/nix-dev-shell/envrc-flake ./.envrc && echo .envrc >> .git/info/exclude
+
+if nix flake show path:./src/tools/nix-dev-shell &> /dev/null; then
+  use flake path:./src/tools/nix-dev-shell
+fi

--- a/src/tools/nix-dev-shell/envrc-shell
+++ b/src/tools/nix-dev-shell/envrc-shell
@@ -1,0 +1,7 @@
+# If you want to use this as an .envrc file to create a shell with necessery components 
+# to develop rustc, use the following command in the root of the rusr checkout:
+#	
+# ln -s ./src/tools/nix-dev-shell/envrc-shell ./.envrc && echo .envrc >> .git/info/exclude
+
+use nix ./src/tools/nix-dev-shell/shell.nix
+  

--- a/src/tools/nix-dev-shell/flake.nix
+++ b/src/tools/nix-dev-shell/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "rustc dev shell";
+
+  inputs = {
+    nixpkgs.url      = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url  = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+	flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        x = import ./x { inherit pkgs; };
+      in
+      {
+        devShells.default = with pkgs; mkShell {
+          name = "rustc-dev-shell";
+          nativeBuildInputs = with pkgs; [
+            binutils cmake ninja pkg-config python3 git curl cacert patchelf nix
+          ];
+          buildInputs = with pkgs; [
+            openssl glibc.out glibc.static x
+          ];
+          # Avoid creating text files for ICEs.
+          RUSTC_ICE = "0";
+          # Provide `libstdc++.so.6` for the self-contained lld.
+          LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [
+            stdenv.cc.cc.lib
+          ]}";
+        };
+      }
+    );
+}

--- a/src/tools/nix-dev-shell/shell.nix
+++ b/src/tools/nix-dev-shell/shell.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import <nixpkgs> {} }:
+let 
+  x = import ./x { inherit pkgs; };
+in
+pkgs.mkShell {
+  name = "rustc";
+  nativeBuildInputs = with pkgs; [
+    binutils cmake ninja pkg-config python3 git curl cacert patchelf nix
+  ];
+  buildInputs = with pkgs; [
+    openssl glibc.out glibc.static x
+  ];
+  # Avoid creating text files for ICEs.
+  RUSTC_ICE = "0";
+  # Provide `libstdc++.so.6` for the self-contained lld.
+  LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [
+    stdenv.cc.cc.lib
+  ]}";
+}

--- a/src/tools/nix-dev-shell/x/default.nix
+++ b/src/tools/nix-dev-shell/x/default.nix
@@ -1,0 +1,22 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+pkgs.stdenv.mkDerivation {
+  name = "x";
+
+  src = ./x.rs;
+  dontUnpack = true;
+
+  nativeBuildInputs = with pkgs; [ rustc ];
+
+  buildPhase = ''
+    PYTHON=${pkgs.lib.getExe pkgs.python3} rustc -Copt-level=3 --crate-name x $src --out-dir $out/bin
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Helper for rust-lang/rust x.py";
+    homepage = "https://github.com/rust-lang/rust/blob/master/src/tools/x";
+    license = licenses.mit;
+    mainProgram = "x";
+  };
+}

--- a/src/tools/nix-dev-shell/x/x.rs
+++ b/src/tools/nix-dev-shell/x/x.rs
@@ -1,0 +1,50 @@
+// git clone https://github.com/rust-lang/rust/blob/0ea7ddcc35a2fcaa5da8a7dcfc118c9fb4a63b95/src/tools/x/src/main.rs
+// patched to stop doing python probing, stop the probe, please dont, i have a python
+//! Run bootstrap from any subdirectory of a rust compiler checkout.
+//!
+//! We prefer `exec`, to avoid adding an extra process in the process tree.
+//! However, since `exec` isn't available on Windows, we indirect through
+//! `exec_or_status`, which will call `exec` on unix and `status` on Windows.
+//!
+//! We use `powershell.exe x.ps1` on Windows, and `sh -c x` on Unix, those are
+//! the ones that call `x.py`. We use `sh -c` on Unix, because it is a standard.
+//! We also don't use `pwsh` on Windows, because it is not installed by default;
+
+use std::env;
+use std::os::unix::process::CommandExt;
+use std::process::{self, Command};
+
+fn main() {
+    match env::args().skip(1).next().as_deref() {
+        Some("--wrapper-version") => {
+            println!("0.1.0");
+            return;
+        }
+        _ => {}
+    }
+    let current = match env::current_dir() {
+        Ok(dir) => dir,
+        Err(err) => {
+            eprintln!("Failed to get current directory: {err}");
+            process::exit(1);
+        }
+    };
+
+    for dir in current.ancestors() {
+        let candidate = dir.join("x.py");
+        if candidate.exists() {
+            let mut cmd = Command::new(env!("PYTHON"));
+            cmd.arg(dir.join("x.py"));
+            cmd.args(env::args().skip(1)).current_dir(dir);
+
+            let error = cmd.exec();
+            eprintln!("Failed to invoke `{:?}`: {}", cmd, error);
+        }
+    }
+
+    eprintln!(
+        "x.py not found. Please run inside of a checkout of `https://github.com/rust-lang/rust`."
+    );
+
+    process::exit(1);
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR adds envrc files which, once symlinked as  `.envrc` will activates a dev shell from `src/tools/nix-dev-shell/flake.nix` or `src/tools/nix-dev-shell/shell.nix`.

This is based on
- [Current rustc dev guide recommendation for NixOS](https://rustc-dev-guide.rust-lang.org/building/suggested.html?highlight=nix#using-nix-shell)
- https://github.com/oxalica/rust-overlay?tab=readme-ov-file#use-in-devshell-for-nix-develop
- [Nora's `x` nix package](https://github.com/Noratrieb/nixos/tree/26ea68e1a0aadaab313c1b5a8c1033a9770bd138/custom-pkgs/x)
- https://github.com/rust-lang/rustup/pull/2891
- [Direnv: use flake/nix according to availability](https://discourse.nixos.org/t/direnv-use-flake-nix-according-to-availability/29825)

This is something that I plan to use personally, but I thought it might be worth upstreaming :)

r? Noratrieb