### PR TITLE
sanitizers: Fix tests/ui/sanitize/leak.rs fails on

### DIFF
--- a/compiler/rustc_session/messages.ftl
+++ b/compiler/rustc_session/messages.ftl
@@ -98,6 +98,8 @@ session_sanitizer_cfi_requires_single_codegen_unit = `-Zsanitizer=cfi` with `-Cl
 
 session_sanitizer_kcfi_requires_panic_abort = `-Z sanitizer=kcfi` requires `-C panic=abort`
 
+session_sanitizer_leak_requires_export_executable_symbols = `-Zsanitizer=leak` requires `-Zexport-executable-symbols`
+
 session_sanitizer_not_supported = {$us} sanitizer is not supported for this target
 
 session_sanitizers_not_supported = {$us} sanitizers are not supported for this target

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -128,6 +128,10 @@ pub(crate) struct CannotMixAndMatchSanitizers {
 pub(crate) struct CannotEnableCrtStaticLinux;
 
 #[derive(Diagnostic)]
+#[diag(session_sanitizer_leak_requires_export_executable_symbols)]
+pub(crate) struct SanitizerLeakRequiresExportExecutableSymbols;
+
+#[derive(Diagnostic)]
 #[diag(session_sanitizer_cfi_requires_lto)]
 pub(crate) struct SanitizerCfiRequiresLto;
 

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -390,6 +390,10 @@ impl Session {
         self.opts.unstable_opts.sanitizer.contains(SanitizerSet::KCFI)
     }
 
+    pub fn is_sanitizer_leak_enabled(&self) -> bool {
+        self.opts.unstable_opts.sanitizer.contains(SanitizerSet::LEAK)
+    }
+
     pub fn is_split_lto_unit_enabled(&self) -> bool {
         self.opts.unstable_opts.split_lto_unit == Some(true)
     }
@@ -1221,6 +1225,11 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
         && !sess.target.is_like_msvc
     {
         sess.dcx().emit_err(errors::CannotEnableCrtStaticLinux);
+    }
+
+    // LeakSanitizer requires export_executable_symbols.
+    if sess.is_sanitizer_leak_enabled() && !sess.opts.unstable_opts.export_executable_symbols {
+        sess.dcx().emit_err(errors::SanitizerLeakRequiresExportExecutableSymbols);
     }
 
     // LLVM CFI requires LTO.

--- a/tests/codegen/sanitizer/no-sanitize-inlining.rs
+++ b/tests/codegen/sanitizer/no-sanitize-inlining.rs
@@ -6,7 +6,7 @@
 //@ revisions: ASAN LSAN
 //@       compile-flags: -Copt-level=3 -Zmir-opt-level=4 -Ctarget-feature=-crt-static
 //@[ASAN] compile-flags: -Zsanitizer=address
-//@[LSAN] compile-flags: -Zsanitizer=leak
+//@[LSAN] compile-flags: -Zsanitizer=leak -Zexport-executable-symbols
 
 #![crate_type = "lib"]
 #![feature(no_sanitize)]

--- a/tests/ui/sanitizer/cfg.rs
+++ b/tests/ui/sanitizer/cfg.rs
@@ -13,7 +13,7 @@
 //@[kcfi]compile-flags:    -Zsanitizer=kcfi    --cfg kcfi --target x86_64-unknown-none
 //@[kcfi]compile-flags:    -C panic=abort
 //@[leak]needs-sanitizer-leak
-//@[leak]compile-flags:    -Zsanitizer=leak    --cfg leak
+//@[leak]compile-flags:    -Zsanitizer=leak    --cfg leak -Zexport-executable-symbols
 //@[memory]needs-sanitizer-memory
 //@[memory]compile-flags:  -Zsanitizer=memory  --cfg memory
 //@[thread]needs-sanitizer-thread

--- a/tests/ui/sanitizer/leak-requires-export-executable-symbols.rs
+++ b/tests/ui/sanitizer/leak-requires-export-executable-symbols.rs
@@ -1,0 +1,8 @@
+// Verifies that `-Zsanitizer=leak` requires `-Zexport-executable-symbols`.
+//
+//@ needs-sanitizer-leak
+//@ compile-flags: -Zsanitizer=leak
+
+#![feature(no_core)]
+#![no_core]
+#![no_main]

--- a/tests/ui/sanitizer/leak-requires-export-executable-symbols.stderr
+++ b/tests/ui/sanitizer/leak-requires-export-executable-symbols.stderr
@@ -1,0 +1,4 @@
+error: `-Zsanitizer=leak` requires `-Zexport-executable-symbols`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/sanitizer/unsupported-target.rs
+++ b/tests/ui/sanitizer/unsupported-target.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z sanitizer=leak --target i686-unknown-linux-gnu
+//@ compile-flags: -Z sanitizer=leak -Zexport-executable-symbols --target i686-unknown-linux-gnu
 //@ needs-llvm-components: x86
 //@ error-pattern: error: leak sanitizer is not supported for this target
 #![feature(no_core)]


### PR DESCRIPTION
Fix #111073 by checking if `-Zexport-executable-symbols` is passed when LeakSanitizer is enabled.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
