### PR TITLE
Ensure that tail expr receive lifetime extension

### DIFF
--- a/tests/ui/lifetimes/temporary-lifetime-extension.edition2021.run.stdout
+++ b/tests/ui/lifetimes/temporary-lifetime-extension.edition2021.run.stdout
@@ -1,0 +1,1 @@
+("Hello", 1) [(("Hello", 1),)] "Hello" "Hello" "Hello" ("Hello", 1) ("Hello", 1) ("Hello", 1)

--- a/tests/ui/lifetimes/temporary-lifetime-extension.edition2024.run.stdout
+++ b/tests/ui/lifetimes/temporary-lifetime-extension.edition2024.run.stdout
@@ -1,0 +1,1 @@
+("Hello", 1) [(("Hello", 1),)] "Hello" "Hello" "Hello" ("Hello", 1) ("Hello", 1) ("Hello", 1)

--- a/tests/ui/lifetimes/temporary-lifetime-extension.rs
+++ b/tests/ui/lifetimes/temporary-lifetime-extension.rs
@@ -1,4 +1,21 @@
-//@ check-pass
+// This is a test for the new temporary lifetime behaviour as implemented for RFC 3606.
+// In essence, with #3606 we can write the following variable initialisation without
+// a borrow checking error because the temporary lifetime is automatically extended.
+// ```rust
+// let x = if condition() {
+//    &something()
+// } else {
+//    &something_else()
+// };
+// ```
+// More details can be found in https://github.com/rust-lang/rfcs/pull/3606
+
+//@ run-pass
+//@ check-run-results
+//@ revisions: edition2021 edition2024
+//@ [edition2021] edition: 2021
+//@ [edition2024] edition: 2024
+//@ [edition2024] compile-flags: -Z unstable-options
 
 fn temp() -> (String, i32) {
     (String::from("Hello"), 1)
@@ -13,11 +30,7 @@ fn main() {
         let _ = 123;
         &(*temp().0)[..]
     };
-    let f = if true {
-        &temp()
-    } else {
-        &temp()
-    };
+    let f = if true { &temp() } else { &temp() };
     let g = match true {
         true => &temp(),
         false => {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

cc @jieyouxu @traviscross 

It just came to me that we should add a test to make sure that we honor the contract from the temporary lifetime rule #121346. We should continue to implement this rule in Edition 2021 onward and shorter tail expression lifetime should not override it.

This is a small PR to improve our assurance and establish a stronger contract.

Tracked by rust-lang/rust#123739