### PR TITLE
Implement Return Type Notation (RTN)'s path form in where clauses

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -20,8 +20,8 @@ use super::errors::{
 };
 use super::LoweringContext;
 use crate::{
-    fluent_generated as fluent, ImplTraitContext, ImplTraitPosition, ParamMode,
-    ResolverAstLoweringExt,
+    fluent_generated as fluent, AllowReturnTypeNotation, ImplTraitContext, ImplTraitPosition,
+    ParamMode, ResolverAstLoweringExt,
 };
 
 impl<'a, 'hir> LoweringContext<'a, 'hir> {
@@ -201,6 +201,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                                 &sym.qself,
                                 &sym.path,
                                 ParamMode::Optional,
+                                AllowReturnTypeNotation::No,
                                 ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                                 None,
                             );

--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -52,7 +52,7 @@ use rustc_target::spec::abi;
 use {rustc_ast as ast, rustc_hir as hir};
 
 use super::{GenericArgsMode, ImplTraitContext, LoweringContext, ParamMode};
-use crate::{ImplTraitPosition, ResolverAstLoweringExt};
+use crate::{AllowReturnTypeNotation, ImplTraitPosition, ResolverAstLoweringExt};
 
 pub(crate) struct DelegationResults<'hir> {
     pub body_id: hir::BodyId,
@@ -340,6 +340,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 &delegation.qself,
                 &delegation.path,
                 ParamMode::Optional,
+                AllowReturnTypeNotation::No,
                 ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                 None,
             );

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -23,7 +23,7 @@ use super::{
     GenericArgsMode, ImplTraitContext, LoweringContext, ParamMode, ResolverAstLoweringExt,
 };
 use crate::errors::YieldInClosure;
-use crate::{fluent_generated, FnDeclKind, ImplTraitPosition};
+use crate::{fluent_generated, AllowReturnTypeNotation, FnDeclKind, ImplTraitPosition};
 
 impl<'hir> LoweringContext<'_, 'hir> {
     fn lower_exprs(&mut self, exprs: &[AstP<Expr>]) -> &'hir [hir::Expr<'hir>] {
@@ -281,6 +281,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         qself,
                         path,
                         ParamMode::Optional,
+                        AllowReturnTypeNotation::No,
                         ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                         None,
                     );
@@ -328,6 +329,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                             &se.qself,
                             &se.path,
                             ParamMode::Optional,
+                            AllowReturnTypeNotation::No,
                             ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                             None,
                         )),
@@ -1291,6 +1293,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         qself,
                         path,
                         ParamMode::Optional,
+                        AllowReturnTypeNotation::No,
                         ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                         None,
                     );
@@ -1311,6 +1314,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         qself,
                         path,
                         ParamMode::Optional,
+                        AllowReturnTypeNotation::No,
                         ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                         None,
                     );
@@ -1336,6 +1340,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     &se.qself,
                     &se.path,
                     ParamMode::Optional,
+                    AllowReturnTypeNotation::No,
                     ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                     None,
                 );

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -487,11 +487,12 @@ enum ParamMode {
 
 #[derive(Copy, Clone, Debug)]
 enum AllowReturnTypeNotation {
+    /// Only in types, since RTN is denied later during HIR lowering.
     Yes,
+    /// All other positions (path expr, method, use tree).
     No,
 }
 
-#[derive(Copy, Clone, Debug)]
 enum GenericArgsMode {
     ParenSugar,
     ReturnTypeNotation,
@@ -1239,7 +1240,6 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             qself,
             path,
             param_mode,
-            // We deny these after the fact in HIR->middle type lowering.
             AllowReturnTypeNotation::Yes,
             itctx,
             None,

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -494,9 +494,14 @@ enum AllowReturnTypeNotation {
 }
 
 enum GenericArgsMode {
+    /// Allow paren sugar, don't allow RTN.
     ParenSugar,
+    /// Allow RTN, don't allow paren sugar.
     ReturnTypeNotation,
+    // Error if parenthesized generics or RTN are encountered.
     Err,
+    /// Silence errors when lowering generics. Only used with `Res::Err`.
+    Silence,
 }
 
 impl<'a, 'hir> LoweringContext<'a, 'hir> {

--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -485,8 +485,16 @@ enum ParamMode {
     Optional,
 }
 
+#[derive(Copy, Clone, Debug)]
+enum AllowReturnTypeNotation {
+    Yes,
+    No,
+}
+
+#[derive(Copy, Clone, Debug)]
 enum GenericArgsMode {
     ParenSugar,
+    ReturnTypeNotation,
     Err,
 }
 
@@ -1226,7 +1234,16 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
         }
 
         let id = self.lower_node_id(t.id);
-        let qpath = self.lower_qpath(t.id, qself, path, param_mode, itctx, None);
+        let qpath = self.lower_qpath(
+            t.id,
+            qself,
+            path,
+            param_mode,
+            // We deny these after the fact in HIR->middle type lowering.
+            AllowReturnTypeNotation::Yes,
+            itctx,
+            None,
+        );
         self.ty_path(id, t.span, qpath)
     }
 
@@ -2203,6 +2220,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             &None,
             &p.path,
             ParamMode::Explicit,
+            AllowReturnTypeNotation::No,
             itctx,
             Some(modifiers),
         ) {
@@ -2341,6 +2359,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     &None,
                     path,
                     ParamMode::Optional,
+                    AllowReturnTypeNotation::No,
                     ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                     None,
                 );
@@ -2419,6 +2438,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 qself,
                 path,
                 ParamMode::Optional,
+                AllowReturnTypeNotation::No,
                 ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                 None,
             );

--- a/compiler/rustc_ast_lowering/src/pat.rs
+++ b/compiler/rustc_ast_lowering/src/pat.rs
@@ -11,7 +11,7 @@ use super::errors::{
     ArbitraryExpressionInPattern, ExtraDoubleDot, MisplacedDoubleDot, SubTupleBinding,
 };
 use super::{ImplTraitContext, LoweringContext, ParamMode, ResolverAstLoweringExt};
-use crate::ImplTraitPosition;
+use crate::{AllowReturnTypeNotation, ImplTraitPosition};
 
 impl<'a, 'hir> LoweringContext<'a, 'hir> {
     pub(crate) fn lower_pat(&mut self, pattern: &Pat) -> &'hir hir::Pat<'hir> {
@@ -38,6 +38,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             qself,
                             path,
                             ParamMode::Optional,
+                            AllowReturnTypeNotation::No,
                             ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                             None,
                         );
@@ -55,6 +56,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             qself,
                             path,
                             ParamMode::Optional,
+                            AllowReturnTypeNotation::No,
                             ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                             None,
                         );
@@ -66,6 +68,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             qself,
                             path,
                             ParamMode::Optional,
+                            AllowReturnTypeNotation::No,
                             ImplTraitContext::Disallowed(ImplTraitPosition::Path),
                             None,
                         );

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -16,10 +16,9 @@ use super::errors::{
     GenericTypeWithParentheses, UseAngleBrackets,
 };
 use super::{
-    AllowReturnTypeNotation, GenericArgsCtor, GenericArgsMode, ImplTraitContext, LifetimeRes,
-    LoweringContext, ParamMode, ResolverAstLoweringExt,
+    AllowReturnTypeNotation, GenericArgsCtor, GenericArgsMode, ImplTraitContext, ImplTraitPosition,
+    LifetimeRes, LoweringContext, ParamMode, ResolverAstLoweringExt,
 };
-use crate::ImplTraitPosition;
 
 impl<'a, 'hir> LoweringContext<'a, 'hir> {
     #[instrument(level = "trace", skip(self))]

--- a/compiler/rustc_ast_lowering/src/path.rs
+++ b/compiler/rustc_ast_lowering/src/path.rs
@@ -111,7 +111,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             }
                         }
                         // Avoid duplicated errors.
-                        Res::Err => GenericArgsMode::ParenSugar,
+                        Res::Err => GenericArgsMode::Silence,
                         // An error
                         _ => GenericArgsMode::Err,
                     };
@@ -288,11 +288,12 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             false,
                         )
                     }
-                    GenericArgsMode::ParenSugar => self.lower_parenthesized_parameter_data(
-                        data,
-                        itctx,
-                        bound_modifier_allowed_features,
-                    ),
+                    GenericArgsMode::ParenSugar | GenericArgsMode::Silence => self
+                        .lower_parenthesized_parameter_data(
+                            data,
+                            itctx,
+                            bound_modifier_allowed_features,
+                        ),
                     GenericArgsMode::Err => {
                         // Suggest replacing parentheses with angle brackets `Trait(params...)` to `Trait<params...>`
                         let sub = if !data.inputs.is_empty() {
@@ -330,7 +331,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                 },
                 GenericArgs::ParenthesizedElided(span) => {
                     match generic_args_mode {
-                        GenericArgsMode::ReturnTypeNotation => {
+                        GenericArgsMode::ReturnTypeNotation | GenericArgsMode::Silence => {
                             // Ok
                         }
                         GenericArgsMode::ParenSugar | GenericArgsMode::Err => {

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -48,6 +48,8 @@ hir_analysis_auto_deref_reached_recursion_limit = reached the recursion limit wh
 
 hir_analysis_bad_precise_capture = expected {$kind} parameter in `use<...>` precise captures list, found {$found}
 
+hir_analysis_bad_return_type_notation_position = return type notation not allowed in this position yet
+
 hir_analysis_cannot_capture_late_bound_const =
     cannot capture late-bound const parameter in {$what}
     .label = parameter defined here

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -37,7 +37,7 @@ hir_analysis_assoc_kind_mismatch = expected {$expected}, found {$got}
 
 hir_analysis_assoc_kind_mismatch_wrap_in_braces_sugg = consider adding braces here
 
-hir_analysis_associated_type_trait_uninferred_generic_params = cannot use the associated type of a trait with uninferred generic parameters
+hir_analysis_associated_type_trait_uninferred_generic_params = cannot use the associated {$what} of a trait with uninferred generic parameters
     .suggestion = use a fully qualified path with inferred lifetimes
 
 hir_analysis_associated_type_trait_uninferred_generic_params_multipart_suggestion = use a fully qualified path with explicit lifetimes

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -460,7 +460,7 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
                                 [] => (generics.span, format!("<{lt_name}>")),
                                 [bound, ..] => (bound.span.shrink_to_lo(), format!("{lt_name}, ")),
                             };
-                            mpart_sugg = Some(errors::AssociatedTypeTraitUninferredGenericParamsMultipartSuggestion {
+                            mpart_sugg = Some(errors::AssociatedItemTraitUninferredGenericParamsMultipartSuggestion {
                                 fspan: lt_sp,
                                 first: sugg,
                                 sspan: span.with_hi(item_segment.ident.span.lo()),
@@ -502,7 +502,7 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
             }
             Ty::new_error(
                 self.tcx(),
-                self.tcx().dcx().emit_err(errors::AssociatedTypeTraitUninferredGenericParams {
+                self.tcx().dcx().emit_err(errors::AssociatedItemTraitUninferredGenericParams {
                     span,
                     inferred_sugg,
                     bound,

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -507,6 +507,7 @@ impl<'tcx> HirTyLowerer<'tcx> for ItemCtxt<'tcx> {
                     inferred_sugg,
                     bound,
                     mpart_sugg,
+                    what: "type",
                 }),
             )
         }

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -1886,10 +1886,11 @@ impl<'a, 'tcx> BoundVarContext<'a, 'tcx> {
                         )
                     }) =>
             {
-                let Res::Def(DefKind::AssocFn, item_def_id) = path.res else {
-                    bug!();
-                };
-                (vec![], item_def_id, item_segment)
+                match path.res {
+                    Res::Err => return,
+                    Res::Def(DefKind::AssocFn, item_def_id) => (vec![], item_def_id, item_segment),
+                    _ => bug!("only expected method resolution for fully qualified RTN"),
+                }
             }
 
             // If we have a type-dependent path, then we do need to do some lookup.

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -787,7 +787,8 @@ pub(crate) struct AssociatedTypeTraitUninferredGenericParams {
     pub inferred_sugg: Option<Span>,
     pub bound: String,
     #[subdiagnostic]
-    pub mpart_sugg: Option<AssociatedTypeTraitUninferredGenericParamsMultipartSuggestion>,
+    pub mpart_sugg: Option<AssociatedItemTraitUninferredGenericParamsMultipartSuggestion>,
+    pub what: &'static str,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -780,7 +780,7 @@ pub(crate) struct PlaceholderNotAllowedItemSignatures {
 
 #[derive(Diagnostic)]
 #[diag(hir_analysis_associated_type_trait_uninferred_generic_params, code = E0212)]
-pub(crate) struct AssociatedTypeTraitUninferredGenericParams {
+pub(crate) struct AssociatedItemTraitUninferredGenericParams {
     #[primary_span]
     pub span: Span,
     #[suggestion(style = "verbose", applicability = "maybe-incorrect", code = "{bound}")]
@@ -796,7 +796,7 @@ pub(crate) struct AssociatedTypeTraitUninferredGenericParams {
     hir_analysis_associated_type_trait_uninferred_generic_params_multipart_suggestion,
     applicability = "maybe-incorrect"
 )]
-pub(crate) struct AssociatedTypeTraitUninferredGenericParamsMultipartSuggestion {
+pub(crate) struct AssociatedItemTraitUninferredGenericParamsMultipartSuggestion {
     #[suggestion_part(code = "{first}")]
     pub fspan: Span,
     pub first: String,

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1693,3 +1693,10 @@ pub(crate) struct CmseCallGeneric {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag(hir_analysis_bad_return_type_notation_position)]
+pub(crate) struct BadReturnTypeNotation {
+    #[primary_span]
+    pub span: Span,
+}

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -813,7 +813,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         }
     }
 
-    /// Search for a trait bound on a type parameter whose trait defines the associated type given by `assoc_name`.
+    /// Search for a trait bound on a type parameter whose trait defines the associated item
+    /// given by `assoc_name` and `kind`.
     ///
     /// This fails if there is no such bound in the list of candidates or if there are multiple
     /// candidates in which case it reports ambiguity.

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -820,10 +820,11 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     ///
     /// `ty_param_def_id` is the `LocalDefId` of the type parameter.
     #[instrument(level = "debug", skip_all, ret)]
-    fn probe_single_ty_param_bound_for_assoc_ty(
+    fn probe_single_ty_param_bound_for_assoc_item(
         &self,
         ty_param_def_id: LocalDefId,
         ty_param_span: Span,
+        kind: ty::AssocKind,
         assoc_name: Ident,
         span: Span,
     ) -> Result<ty::PolyTraitRef<'tcx>, ErrorGuaranteed> {
@@ -841,7 +842,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 traits::transitive_bounds_that_define_assoc_item(tcx, trait_refs, assoc_name)
             },
             AssocItemQSelf::TyParam(ty_param_def_id, ty_param_span),
-            ty::AssocKind::Type,
+            kind,
             assoc_name,
             span,
             None,
@@ -1081,9 +1082,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             (
                 &ty::Param(_),
                 Res::SelfTyParam { trait_: param_did } | Res::Def(DefKind::TyParam, param_did),
-            ) => self.probe_single_ty_param_bound_for_assoc_ty(
+            ) => self.probe_single_ty_param_bound_for_assoc_item(
                 param_did.expect_local(),
                 qself.span,
+                ty::AssocKind::Type,
                 assoc_ident,
                 span,
             )?,
@@ -1545,48 +1547,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         debug!(?trait_def_id);
 
         let Some(self_ty) = opt_self_ty else {
-            let path_str = tcx.def_path_str(trait_def_id);
-
-            let def_id = self.item_def_id();
-            debug!(item_def_id = ?def_id);
-
-            // FIXME: document why/how this is different from `tcx.local_parent(def_id)`
-            let parent_def_id =
-                tcx.hir().get_parent_item(tcx.local_def_id_to_hir_id(def_id)).to_def_id();
-            debug!(?parent_def_id);
-
-            // If the trait in segment is the same as the trait defining the item,
-            // use the `<Self as ..>` syntax in the error.
-            let is_part_of_self_trait_constraints = def_id.to_def_id() == trait_def_id;
-            let is_part_of_fn_in_self_trait = parent_def_id == trait_def_id;
-
-            let type_names = if is_part_of_self_trait_constraints || is_part_of_fn_in_self_trait {
-                vec!["Self".to_string()]
-            } else {
-                // Find all the types that have an `impl` for the trait.
-                tcx.all_impls(trait_def_id)
-                    .filter_map(|impl_def_id| tcx.impl_trait_header(impl_def_id))
-                    .filter(|header| {
-                        // Consider only accessible traits
-                        tcx.visibility(trait_def_id).is_accessible_from(self.item_def_id(), tcx)
-                            && header.polarity != ty::ImplPolarity::Negative
-                    })
-                    .map(|header| header.trait_ref.instantiate_identity().self_ty())
-                    // We don't care about blanket impls.
-                    .filter(|self_ty| !self_ty.has_non_region_param())
-                    .map(|self_ty| tcx.erase_regions(self_ty).to_string())
-                    .collect()
-            };
-            // FIXME: also look at `tcx.generics_of(self.item_def_id()).params` any that
-            // references the trait. Relevant for the first case in
-            // `src/test/ui/associated-types/associated-types-in-ambiguous-context.rs`
-            let reported = self.report_ambiguous_assoc_ty(
-                span,
-                &type_names,
-                &[path_str],
-                item_segment.ident.name,
-            );
-            return Ty::new_error(tcx, reported);
+            return self.error_missing_qpath_self_ty(trait_def_id, span, item_segment);
         };
         debug!(?self_ty);
 
@@ -1598,6 +1559,53 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             self.lower_generic_args_of_assoc_item(span, item_def_id, item_segment, trait_ref.args);
 
         Ty::new_projection_from_args(tcx, item_def_id, item_args)
+    }
+
+    fn error_missing_qpath_self_ty(
+        &self,
+        trait_def_id: DefId,
+        span: Span,
+        item_segment: &hir::PathSegment<'tcx>,
+    ) -> Ty<'tcx> {
+        let tcx = self.tcx();
+        let path_str = tcx.def_path_str(trait_def_id);
+
+        let def_id = self.item_def_id();
+        debug!(item_def_id = ?def_id);
+
+        // FIXME: document why/how this is different from `tcx.local_parent(def_id)`
+        let parent_def_id =
+            tcx.hir().get_parent_item(tcx.local_def_id_to_hir_id(def_id)).to_def_id();
+        debug!(?parent_def_id);
+
+        // If the trait in segment is the same as the trait defining the item,
+        // use the `<Self as ..>` syntax in the error.
+        let is_part_of_self_trait_constraints = def_id.to_def_id() == trait_def_id;
+        let is_part_of_fn_in_self_trait = parent_def_id == trait_def_id;
+
+        let type_names = if is_part_of_self_trait_constraints || is_part_of_fn_in_self_trait {
+            vec!["Self".to_string()]
+        } else {
+            // Find all the types that have an `impl` for the trait.
+            tcx.all_impls(trait_def_id)
+                .filter_map(|impl_def_id| tcx.impl_trait_header(impl_def_id))
+                .filter(|header| {
+                    // Consider only accessible traits
+                    tcx.visibility(trait_def_id).is_accessible_from(self.item_def_id(), tcx)
+                        && header.polarity != ty::ImplPolarity::Negative
+                })
+                .map(|header| header.trait_ref.instantiate_identity().self_ty())
+                // We don't care about blanket impls.
+                .filter(|self_ty| !self_ty.has_non_region_param())
+                .map(|self_ty| tcx.erase_regions(self_ty).to_string())
+                .collect()
+        };
+        // FIXME: also look at `tcx.generics_of(self.item_def_id()).params` any that
+        // references the trait. Relevant for the first case in
+        // `src/test/ui/associated-types/associated-types-in-ambiguous-context.rs`
+        let reported =
+            self.report_ambiguous_assoc_ty(span, &type_names, &[path_str], item_segment.ident.name);
+        Ty::new_error(tcx, reported)
     }
 
     pub fn prohibit_generic_args<'a>(
@@ -1910,19 +1918,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     ty::BoundConstness::NotConst,
                 )
             }
-            // Deny any qpath types that were successfully lowered in AST lowering.
-            Res::Def(DefKind::AssocFn, _)
-                if let [.., _trait_segment, item_segment] = &path.segments[..]
-                    && item_segment.args.is_some_and(|args| {
-                        matches!(
-                            args.parenthesized,
-                            hir::GenericArgsParentheses::ReturnTypeNotation
-                        )
-                    }) =>
-            {
-                let guar = self.dcx().emit_err(BadReturnTypeNotation { span: path.span });
-                Ty::new_error(tcx, guar)
-            }
             Res::PrimTy(prim_ty) => {
                 assert_eq!(opt_self_ty, None);
                 let _ = self.prohibit_generic_args(
@@ -1943,7 +1938,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     .tcx()
                     .dcx()
                     .span_delayed_bug(path.span, "path with `Res::Err` but no error emitted");
-                Ty::new_error(self.tcx(), e)
+                Ty::new_error(tcx, e)
             }
             Res::Def(..) => {
                 assert_eq!(
@@ -2097,6 +2092,15 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     }
                     ref i => bug!("`impl Trait` pointed to non-opaque type?? {:#?}", i),
                 }
+            }
+            // TODO:
+            hir::TyKind::Path(hir::QPath::TypeRelative(_, segment))
+                if segment.args.is_some_and(|args| {
+                    matches!(args.parenthesized, hir::GenericArgsParentheses::ReturnTypeNotation)
+                }) =>
+            {
+                let guar = self.dcx().emit_err(BadReturnTypeNotation { span: hir_ty.span });
+                Ty::new_error(tcx, guar)
             }
             hir::TyKind::Path(hir::QPath::TypeRelative(qself, segment)) => {
                 debug!(?qself, ?segment);

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -790,7 +790,9 @@ impl<'ra: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'r
             TyKind::Path(qself, path) => {
                 self.diag_metadata.current_type_path = Some(ty);
 
-                // TODO:
+                // If we have a path that ends with `(..)`, then it must be
+                // return type notation. Resolve that path in the *value*
+                // namespace.
                 let source = if let Some(seg) = path.segments.last()
                     && let Some(args) = &seg.args
                     && matches!(**args, GenericArgs::ParenthesizedElided(..))

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -790,6 +790,7 @@ impl<'ra: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'r
             TyKind::Path(qself, path) => {
                 self.diag_metadata.current_type_path = Some(ty);
 
+                // TODO:
                 let source = if let Some(seg) = path.segments.last()
                     && let Some(args) = &seg.args
                     && matches!(**args, GenericArgs::ParenthesizedElided(..))

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -404,6 +404,8 @@ pub(crate) enum PathSource<'a> {
     Delegation,
     /// An arg in a `use<'a, N>` precise-capturing bound.
     PreciseCapturingArg(Namespace),
+    // Paths that end with `(..)`, for return type notation.
+    ReturnTypeNotation,
 }
 
 impl<'a> PathSource<'a> {
@@ -413,7 +415,8 @@ impl<'a> PathSource<'a> {
             PathSource::Expr(..)
             | PathSource::Pat
             | PathSource::TupleStruct(..)
-            | PathSource::Delegation => ValueNS,
+            | PathSource::Delegation
+            | PathSource::ReturnTypeNotation => ValueNS,
             PathSource::TraitItem(ns) => ns,
             PathSource::PreciseCapturingArg(ns) => ns,
         }
@@ -425,7 +428,8 @@ impl<'a> PathSource<'a> {
             | PathSource::Expr(..)
             | PathSource::Pat
             | PathSource::Struct
-            | PathSource::TupleStruct(..) => true,
+            | PathSource::TupleStruct(..)
+            | PathSource::ReturnTypeNotation => true,
             PathSource::Trait(_)
             | PathSource::TraitItem(..)
             | PathSource::Delegation
@@ -471,7 +475,7 @@ impl<'a> PathSource<'a> {
                 },
                 _ => "value",
             },
-            PathSource::Delegation => "function",
+            PathSource::ReturnTypeNotation | PathSource::Delegation => "function",
             PathSource::PreciseCapturingArg(..) => "type or const parameter",
         }
     }
@@ -540,6 +544,10 @@ impl<'a> PathSource<'a> {
                 Res::Def(DefKind::AssocTy, _) if ns == TypeNS => true,
                 _ => false,
             },
+            PathSource::ReturnTypeNotation => match res {
+                Res::Def(DefKind::AssocFn, _) => true,
+                _ => false,
+            },
             PathSource::Delegation => matches!(res, Res::Def(DefKind::Fn | DefKind::AssocFn, _)),
             PathSource::PreciseCapturingArg(ValueNS) => {
                 matches!(res, Res::Def(DefKind::ConstParam, _))
@@ -565,8 +573,8 @@ impl<'a> PathSource<'a> {
             (PathSource::Expr(..), false) | (PathSource::Delegation, false) => E0425,
             (PathSource::Pat | PathSource::TupleStruct(..), true) => E0532,
             (PathSource::Pat | PathSource::TupleStruct(..), false) => E0531,
-            (PathSource::TraitItem(..), true) => E0575,
-            (PathSource::TraitItem(..), false) => E0576,
+            (PathSource::TraitItem(..), true) | (PathSource::ReturnTypeNotation, true) => E0575,
+            (PathSource::TraitItem(..), false) | (PathSource::ReturnTypeNotation, false) => E0576,
             (PathSource::PreciseCapturingArg(..), true) => E0799,
             (PathSource::PreciseCapturingArg(..), false) => E0800,
         }
@@ -781,7 +789,17 @@ impl<'ra: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'r
             }
             TyKind::Path(qself, path) => {
                 self.diag_metadata.current_type_path = Some(ty);
-                self.smart_resolve_path(ty.id, qself, path, PathSource::Type);
+
+                let source = if let Some(seg) = path.segments.last()
+                    && let Some(args) = &seg.args
+                    && matches!(**args, GenericArgs::ParenthesizedElided(..))
+                {
+                    PathSource::ReturnTypeNotation
+                } else {
+                    PathSource::Type
+                };
+
+                self.smart_resolve_path(ty.id, qself, path, source);
 
                 // Check whether we should interpret this as a bare trait object.
                 if qself.is_none()
@@ -1920,7 +1938,8 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 PathSource::Trait(..)
                 | PathSource::TraitItem(..)
                 | PathSource::Type
-                | PathSource::PreciseCapturingArg(..) => false,
+                | PathSource::PreciseCapturingArg(..)
+                | PathSource::ReturnTypeNotation => false,
                 PathSource::Expr(..)
                 | PathSource::Pat
                 | PathSource::Struct

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.rs
@@ -16,4 +16,22 @@ fn bar<T: Trait<method() -> (): Send>>() {}
 fn baz<T: Trait<method(): Send>>() {}
 //~^ ERROR return type notation arguments must be elided with `..`
 
+fn foo_path<T: Trait>() where T::method(i32): Send {}
+//~^ ERROR argument types not allowed with return type notation
+
+fn bar_path<T: Trait>() where T::method() -> (): Send {}
+//~^ ERROR return type not allowed with return type notation
+
+fn baz_path<T: Trait>() where T::method(): Send {}
+//~^ ERROR return type notation arguments must be elided with `..`
+
+fn foo_qualified<T: Trait>() where <T as Trait>::method(i32): Send {}
+//~^ ERROR expected associated type
+
+fn bar_qualified<T: Trait>() where <T as Trait>::method() -> (): Send {}
+//~^ ERROR expected associated type
+
+fn baz_qualified<T: Trait>() where <T as Trait>::method(): Send {}
+//~^ ERROR expected associated type
+
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bad-inputs-and-output.stderr
@@ -1,3 +1,21 @@
+error[E0575]: expected associated type, found associated function `Trait::method`
+  --> $DIR/bad-inputs-and-output.rs:28:36
+   |
+LL | fn foo_qualified<T: Trait>() where <T as Trait>::method(i32): Send {}
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ not a associated type
+
+error[E0575]: expected associated type, found associated function `Trait::method`
+  --> $DIR/bad-inputs-and-output.rs:31:36
+   |
+LL | fn bar_qualified<T: Trait>() where <T as Trait>::method() -> (): Send {}
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ not a associated type
+
+error[E0575]: expected associated type, found associated function `Trait::method`
+  --> $DIR/bad-inputs-and-output.rs:34:36
+   |
+LL | fn baz_qualified<T: Trait>() where <T as Trait>::method(): Send {}
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^ not a associated type
+
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/bad-inputs-and-output.rs:3:12
    |
@@ -25,5 +43,24 @@ error: return type notation arguments must be elided with `..`
 LL | fn baz<T: Trait<method(): Send>>() {}
    |                       ^^ help: add `..`: `(..)`
 
-error: aborting due to 3 previous errors; 1 warning emitted
+error: argument types not allowed with return type notation
+  --> $DIR/bad-inputs-and-output.rs:19:40
+   |
+LL | fn foo_path<T: Trait>() where T::method(i32): Send {}
+   |                                        ^^^^^ help: remove the input types: `()`
 
+error: return type not allowed with return type notation
+  --> $DIR/bad-inputs-and-output.rs:22:42
+   |
+LL | fn bar_path<T: Trait>() where T::method() -> (): Send {}
+   |                                          ^^^^^^ help: remove the return type
+
+error: return type notation arguments must be elided with `..`
+  --> $DIR/bad-inputs-and-output.rs:25:40
+   |
+LL | fn baz_path<T: Trait>() where T::method(): Send {}
+   |                                        ^^ help: add `..`: `(..)`
+
+error: aborting due to 9 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0575`.

--- a/tests/ui/associated-type-bounds/return-type-notation/bare-path.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/bare-path.rs
@@ -10,17 +10,14 @@ trait Tr {
 fn foo<T: Tr>()
 where
     T::method(..): Send,
-    //~^ ERROR return type notation not allowed in this position yet
-    //~| ERROR expected type, found function
+    //~^ ERROR expected type, found function
     <T as Tr>::method(..): Send,
     //~^ ERROR return type notation not allowed in this position yet
-    //~| ERROR expected associated type, found associated function `Tr::method`
 {
     let _ = T::CONST::(..);
     //~^ ERROR return type notation not allowed in this position yet
     let _: T::method(..);
-    //~^ ERROR return type notation not allowed in this position yet
-    //~| ERROR expected type, found function
+    //~^ ERROR expected type, found function
 }
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/bare-path.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/bare-path.rs
@@ -10,14 +10,12 @@ trait Tr {
 fn foo<T: Tr>()
 where
     T::method(..): Send,
-    //~^ ERROR expected type, found function
     <T as Tr>::method(..): Send,
-    //~^ ERROR return type notation not allowed in this position yet
 {
     let _ = T::CONST::(..);
     //~^ ERROR return type notation not allowed in this position yet
     let _: T::method(..);
-    //~^ ERROR expected type, found function
+    //~^ ERROR return type notation not allowed in this position yet
 }
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/bare-path.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bare-path.stderr
@@ -8,40 +8,16 @@ LL | #![feature(return_type_notation)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: return type notation not allowed in this position yet
-  --> $DIR/bare-path.rs:17:23
+  --> $DIR/bare-path.rs:15:23
    |
 LL |     let _ = T::CONST::(..);
    |                       ^^^^
 
-error: expected type, found function
-  --> $DIR/bare-path.rs:12:8
-   |
-LL |     T::method(..): Send,
-   |        ^^^^^^ unexpected function
-   |
-note: the associated function is defined here
-  --> $DIR/bare-path.rs:7:5
-   |
-LL |     fn method() -> impl Sized;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: return type notation not allowed in this position yet
-  --> $DIR/bare-path.rs:14:5
-   |
-LL |     <T as Tr>::method(..): Send,
-   |     ^^^^^^^^^^^^^^^^^^^^^
-
-error: expected type, found function
-  --> $DIR/bare-path.rs:19:15
+  --> $DIR/bare-path.rs:17:12
    |
 LL |     let _: T::method(..);
-   |               ^^^^^^ unexpected function
-   |
-note: the associated function is defined here
-  --> $DIR/bare-path.rs:7:5
-   |
-LL |     fn method() -> impl Sized;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^
 
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/associated-type-bounds/return-type-notation/bare-path.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/bare-path.stderr
@@ -1,9 +1,3 @@
-error[E0575]: expected associated type, found associated function `Tr::method`
-  --> $DIR/bare-path.rs:15:5
-   |
-LL |     <T as Tr>::method(..): Send,
-   |     ^^^^^^^^^^^^^^^^^^^^^ not a associated type
-
 warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
   --> $DIR/bare-path.rs:1:12
    |
@@ -14,28 +8,10 @@ LL | #![feature(return_type_notation)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: return type notation not allowed in this position yet
-  --> $DIR/bare-path.rs:19:23
+  --> $DIR/bare-path.rs:17:23
    |
 LL |     let _ = T::CONST::(..);
    |                       ^^^^
-
-error: return type notation not allowed in this position yet
-  --> $DIR/bare-path.rs:21:21
-   |
-LL |     let _: T::method(..);
-   |                     ^^^^
-
-error: return type notation not allowed in this position yet
-  --> $DIR/bare-path.rs:12:14
-   |
-LL |     T::method(..): Send,
-   |              ^^^^
-
-error: return type notation not allowed in this position yet
-  --> $DIR/bare-path.rs:15:22
-   |
-LL |     <T as Tr>::method(..): Send,
-   |                      ^^^^
 
 error: expected type, found function
   --> $DIR/bare-path.rs:12:8
@@ -49,8 +25,14 @@ note: the associated function is defined here
 LL |     fn method() -> impl Sized;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error: return type notation not allowed in this position yet
+  --> $DIR/bare-path.rs:14:5
+   |
+LL |     <T as Tr>::method(..): Send,
+   |     ^^^^^^^^^^^^^^^^^^^^^
+
 error: expected type, found function
-  --> $DIR/bare-path.rs:21:15
+  --> $DIR/bare-path.rs:19:15
    |
 LL |     let _: T::method(..);
    |               ^^^^^^ unexpected function
@@ -61,6 +43,5 @@ note: the associated function is defined here
 LL |     fn method() -> impl Sized;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 7 previous errors; 1 warning emitted
+error: aborting due to 4 previous errors; 1 warning emitted
 
-For more information about this error, try `rustc --explain E0575`.

--- a/tests/ui/associated-type-bounds/return-type-notation/higher-ranked-bound-works.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/higher-ranked-bound-works.rs
@@ -1,0 +1,52 @@
+//@ check-pass
+
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Trait<'a> {
+    fn late<'b>(&'b self, _: &'a ()) -> impl Sized;
+    fn early<'b: 'b>(&'b self, _: &'a ()) -> impl Sized;
+}
+
+#[allow(refining_impl_trait_internal)]
+impl<'a> Trait<'a> for () {
+    fn late<'b>(&'b self, _: &'a ()) -> i32 { 1 }
+    fn early<'b: 'b>(&'b self, _: &'a ()) -> i32 { 1 }
+}
+
+trait Other<'c> {}
+impl Other<'_> for i32 {}
+
+fn test<T>(t: &T)
+where
+    T: for<'a, 'c> Trait<'a, late(..): Other<'c>>,
+    // which is basically:
+    // for<'a, 'c> Trait<'a, for<'b> method<'b>: Other<'c>>,
+    T: for<'a, 'c> Trait<'a, early(..): Other<'c>>,
+    // which is basically:
+    // for<'a, 'c> Trait<'a, for<'b> method<'b>: Other<'c>>,
+{
+    is_other_impl(t.late(&()));
+    is_other_impl(t.early(&()));
+}
+
+fn test_path<T>(t: &T)
+where
+T: for<'a> Trait<'a>,
+    for<'a, 'c> <T as Trait<'a>>::late(..): Other<'c>,
+    // which is basically:
+    // for<'a, 'b, 'c> <T as Trait<'a>>::method::<'b>: Other<'c>
+    for<'a, 'c> <T as Trait<'a>>::early(..): Other<'c>,
+    // which is basically:
+    // for<'a, 'b, 'c> <T as Trait<'a>>::method::<'b>: Other<'c>
+{
+    is_other_impl(t.late(&()));
+    is_other_impl(t.early(&()));
+}
+
+fn is_other_impl(_: impl for<'c> Other<'c>) {}
+
+fn main() {
+    test(&());
+    test(&());
+}

--- a/tests/ui/associated-type-bounds/return-type-notation/higher-ranked-bound-works.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/higher-ranked-bound-works.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/higher-ranked-bound-works.rs:3:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/namespace-conflict.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/namespace-conflict.rs
@@ -1,0 +1,42 @@
+//@ check-pass
+
+#![allow(non_camel_case_types)]
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Foo {
+    type test;
+
+    fn test() -> impl Bar;
+}
+
+fn call_path<T: Foo>()
+where
+    T::test(..): Bar,
+{
+}
+
+fn call_bound<T: Foo<test(..): Bar>>() {}
+
+trait Bar {}
+struct NotBar;
+struct YesBar;
+impl Bar for YesBar {}
+
+impl Foo for () {
+    type test = NotBar;
+
+    // Use refinement here so we can observe `YesBar: Bar`.
+    #[allow(refining_impl_trait_internal)]
+    fn test() -> YesBar {
+        YesBar
+    }
+}
+
+fn main() {
+    // If `T::test(..)` resolved to the GAT (erroneously), then this would be
+    // an error since `<() as Foo>::bar` -- the associated type -- does not
+    // implement `Bar`, but the return type of the method does.
+    call_path::<()>();
+    call_bound::<()>();
+}

--- a/tests/ui/associated-type-bounds/return-type-notation/namespace-conflict.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/namespace-conflict.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/namespace-conflict.rs:4:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/non-rpitit.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/non-rpitit.rs
@@ -5,7 +5,10 @@ trait Trait {
     fn method() {}
 }
 
-fn test<T: Trait<method(..): Send>>() {}
-//~^ ERROR  return type notation used on function that is not `async` and does not return `impl Trait`
+fn bound<T: Trait<method(..): Send>>() {}
+//~^ ERROR return type notation used on function that is not `async` and does not return `impl Trait`
+
+fn path<T>() where T: Trait, T::method(..): Send {}
+//~^ ERROR return type notation used on function that is not `async` and does not return `impl Trait`
 
 fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/non-rpitit.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/non-rpitit.stderr
@@ -8,15 +8,26 @@ LL | #![feature(return_type_notation)]
    = note: `#[warn(incomplete_features)]` on by default
 
 error: return type notation used on function that is not `async` and does not return `impl Trait`
-  --> $DIR/non-rpitit.rs:8:18
+  --> $DIR/non-rpitit.rs:8:19
    |
 LL |     fn method() {}
    |     ----------- this function must be `async` or return `impl Trait`
 ...
-LL | fn test<T: Trait<method(..): Send>>() {}
-   |                  ^^^^^^^^^^^^^^^^
+LL | fn bound<T: Trait<method(..): Send>>() {}
+   |                   ^^^^^^^^^^^^^^^^
    |
    = note: function returns `()`, which is not compatible with associated type return bounds
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: return type notation used on function that is not `async` and does not return `impl Trait`
+  --> $DIR/non-rpitit.rs:11:30
+   |
+LL |     fn method() {}
+   |     ----------- this function must be `async` or return `impl Trait`
+...
+LL | fn path<T>() where T: Trait, T::method(..): Send {}
+   |                              ^^^^^^^^^^^^^
+   |
+   = note: function returns `()`, which is not compatible with associated type return bounds
+
+error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/associated-type-bounds/return-type-notation/not-a-method.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/not-a-method.rs
@@ -1,0 +1,42 @@
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+fn function() {}
+
+fn not_a_method()
+where
+    function(..): Send,
+    //~^ ERROR expected function, found function `function`
+    //~| ERROR return type notation not allowed in this position yet
+{
+}
+
+fn not_a_method_and_typoed()
+where
+    function(): Send,
+    //~^ ERROR expected type, found function `function`
+{
+}
+
+trait Tr {
+    fn method();
+}
+
+// Forgot the `T::`
+fn maybe_method_overlaps<T: Tr>()
+where
+    method(..): Send,
+    //~^ ERROR cannot find function `method` in this scope
+    //~| ERROR return type notation not allowed in this position yet
+{
+}
+
+// Forgot the `T::`, AND typoed `(..)` to `()`
+fn maybe_method_overlaps_and_typoed<T: Tr>()
+where
+    method(): Send,
+    //~^ ERROR cannot find type `method` in this scope
+{
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/not-a-method.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/not-a-method.stderr
@@ -1,0 +1,49 @@
+error[E0575]: expected function, found function `function`
+  --> $DIR/not-a-method.rs:8:5
+   |
+LL |     function(..): Send,
+   |     ^^^^^^^^^^^^ not a function
+
+error[E0573]: expected type, found function `function`
+  --> $DIR/not-a-method.rs:16:5
+   |
+LL |     function(): Send,
+   |     ^^^^^^^^^^ not a type
+
+error[E0576]: cannot find function `method` in this scope
+  --> $DIR/not-a-method.rs:28:5
+   |
+LL |     method(..): Send,
+   |     ^^^^^^ not found in this scope
+
+error[E0412]: cannot find type `method` in this scope
+  --> $DIR/not-a-method.rs:37:5
+   |
+LL |     method(): Send,
+   |     ^^^^^^ not found in this scope
+
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/not-a-method.rs:1:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: return type notation not allowed in this position yet
+  --> $DIR/not-a-method.rs:8:5
+   |
+LL |     function(..): Send,
+   |     ^^^^^^^^^^^^
+
+error: return type notation not allowed in this position yet
+  --> $DIR/not-a-method.rs:28:5
+   |
+LL |     method(..): Send,
+   |     ^^^^^^^^^^
+
+error: aborting due to 6 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0412, E0573, E0575, E0576.
+For more information about an error, try `rustc --explain E0412`.

--- a/tests/ui/associated-type-bounds/return-type-notation/path-ambiguous.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-ambiguous.rs
@@ -1,0 +1,27 @@
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait A {
+    fn method() -> impl Sized;
+}
+trait B {
+    fn method() -> impl Sized;
+}
+
+fn ambiguous<T: A + B>()
+where
+    T::method(..): Send,
+    //~^ ERROR ambiguous associated function `method` in bounds of `T`
+{
+}
+
+trait Sub: A + B {}
+
+fn ambiguous_via_supertrait<T: Sub>()
+where
+    T::method(..): Send,
+    //~^ ERROR ambiguous associated function `method` in bounds of `T`
+{
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/path-ambiguous.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-ambiguous.stderr
@@ -1,0 +1,54 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/path-ambiguous.rs:1:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0221]: ambiguous associated function `method` in bounds of `T`
+  --> $DIR/path-ambiguous.rs:13:5
+   |
+LL |     fn method() -> impl Sized;
+   |     -------------------------- ambiguous `method` from `A`
+...
+LL |     fn method() -> impl Sized;
+   |     -------------------------- ambiguous `method` from `B`
+...
+LL |     T::method(..): Send,
+   |     ^^^^^^^^^^^^^ ambiguous associated function `method`
+   |
+help: use fully-qualified syntax to disambiguate
+   |
+LL |     <T as B>::method(..): Send,
+   |     ~~~~~~~~~~
+help: use fully-qualified syntax to disambiguate
+   |
+LL |     <T as A>::method(..): Send,
+   |     ~~~~~~~~~~
+
+error[E0221]: ambiguous associated function `method` in bounds of `T`
+  --> $DIR/path-ambiguous.rs:22:5
+   |
+LL |     fn method() -> impl Sized;
+   |     -------------------------- ambiguous `method` from `A`
+...
+LL |     fn method() -> impl Sized;
+   |     -------------------------- ambiguous `method` from `B`
+...
+LL |     T::method(..): Send,
+   |     ^^^^^^^^^^^^^ ambiguous associated function `method`
+   |
+help: use fully-qualified syntax to disambiguate
+   |
+LL |     <T as B>::method(..): Send,
+   |     ~~~~~~~~~~
+help: use fully-qualified syntax to disambiguate
+   |
+LL |     <T as A>::method(..): Send,
+   |     ~~~~~~~~~~
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0221`.

--- a/tests/ui/associated-type-bounds/return-type-notation/path-constrained-in-method.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-constrained-in-method.rs
@@ -3,24 +3,21 @@
 #![feature(return_type_notation)]
 //~^ WARN the feature `return_type_notation` is incomplete
 
-trait Foo {
+trait Trait {
     fn method() -> impl Sized;
-}
-
-trait Bar: Foo {
-    fn other()
-    where
-        Self::method(..): Send;
 }
 
 fn is_send(_: impl Send) {}
 
-impl<T: Foo> Bar for T {
-    fn other()
+struct W<T>(T);
+
+impl<T> W<T> {
+    fn test()
     where
-        Self::method(..): Send,
+        T: Trait,
+        T::method(..): Send,
     {
-        is_send(Self::method());
+        is_send(T::method());
     }
 }
 

--- a/tests/ui/associated-type-bounds/return-type-notation/path-constrained-in-method.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-constrained-in-method.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/path-constrained-in-method.rs:3:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/path-higher-ranked.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-higher-ranked.rs
@@ -1,0 +1,25 @@
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait A<'a> {
+    fn method() -> impl Sized;
+}
+trait B: for<'a> A<'a> {}
+
+fn higher_ranked<T>()
+where
+    T: for<'a> A<'a>,
+    T::method(..): Send,
+    //~^ ERROR cannot use the associated function of a trait with uninferred generic parameters
+{
+}
+
+fn higher_ranked_via_supertrait<T>()
+where
+    T: B,
+    T::method(..): Send,
+    //~^ ERROR cannot use the associated function of a trait with uninferred generic parameters
+{
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/path-higher-ranked.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-higher-ranked.stderr
@@ -1,0 +1,34 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/path-higher-ranked.rs:1:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0212]: cannot use the associated function of a trait with uninferred generic parameters
+  --> $DIR/path-higher-ranked.rs:12:5
+   |
+LL |     T::method(..): Send,
+   |     ^^^^^^^^^^^^^
+   |
+help: use a fully qualified path with inferred lifetimes
+   |
+LL |     <T as A<'_>>::method(..): Send,
+   |     ~~~~~~~~~~~~~~
+
+error[E0212]: cannot use the associated function of a trait with uninferred generic parameters
+  --> $DIR/path-higher-ranked.rs:20:5
+   |
+LL |     T::method(..): Send,
+   |     ^^^^^^^^^^^^^
+   |
+help: use a fully qualified path with inferred lifetimes
+   |
+LL |     <T as A<'_>>::method(..): Send,
+   |     ~~~~~~~~~~~~~~
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0212`.

--- a/tests/ui/associated-type-bounds/return-type-notation/path-missing.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-missing.rs
@@ -1,0 +1,25 @@
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait A {
+    #[allow(non_camel_case_types)]
+    type bad;
+}
+
+fn fully_qualified<T: A>()
+where
+    <T as A>::method(..): Send,
+    //~^ ERROR cannot find method or associated constant `method` in trait `A`
+    <T as A>::bad(..): Send,
+    //~^ ERROR expected method or associated constant, found associated type `A::bad`
+{
+}
+
+fn type_dependent<T: A>()
+where
+    T::method(..): Send,
+    //~^ associated function `method` not found for `T`
+{
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/path-missing.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-missing.stderr
@@ -1,0 +1,33 @@
+error[E0576]: cannot find method or associated constant `method` in trait `A`
+  --> $DIR/path-missing.rs:11:15
+   |
+LL |     <T as A>::method(..): Send,
+   |               ^^^^^^ not found in `A`
+
+error[E0575]: expected method or associated constant, found associated type `A::bad`
+  --> $DIR/path-missing.rs:13:5
+   |
+LL |     <T as A>::bad(..): Send,
+   |     ^^^^^^^^^^^^^^^^^
+   |
+   = note: can't use a type alias as a constructor
+
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/path-missing.rs:1:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0220]: associated function `method` not found for `T`
+  --> $DIR/path-missing.rs:20:8
+   |
+LL |     T::method(..): Send,
+   |        ^^^^^^ associated function `method` not found
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0220, E0575, E0576.
+For more information about an error, try `rustc --explain E0220`.

--- a/tests/ui/associated-type-bounds/return-type-notation/path-no-qself.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-no-qself.rs
@@ -1,0 +1,15 @@
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Trait {
+    fn method() -> impl Sized;
+}
+
+fn test()
+where
+    Trait::method(..): Send,
+    //~^ ERROR ambiguous associated type
+{
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/path-no-qself.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-no-qself.stderr
@@ -1,0 +1,23 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/path-no-qself.rs:1:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0223]: ambiguous associated type
+  --> $DIR/path-no-qself.rs:10:5
+   |
+LL |     Trait::method(..): Send,
+   |     ^^^^^^^^^^^^^^^^^
+   |
+help: if there were a type named `Example` that implemented `Trait`, you could use the fully-qualified path
+   |
+LL |     <Example as Trait>::method: Send,
+   |     ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0223`.

--- a/tests/ui/associated-type-bounds/return-type-notation/path-non-param-qself.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-non-param-qself.rs
@@ -1,0 +1,21 @@
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Trait {
+    fn method() -> impl Sized;
+}
+
+struct Adt;
+
+fn non_param_qself()
+where
+    <()>::method(..): Send,
+    //~^ ERROR ambiguous associated function
+    i32::method(..): Send,
+    //~^ ERROR ambiguous associated function
+    Adt::method(..): Send,
+    //~^ ERROR ambiguous associated function
+{
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/path-non-param-qself.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-non-param-qself.stderr
@@ -1,0 +1,30 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/path-non-param-qself.rs:1:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0223]: ambiguous associated function
+  --> $DIR/path-non-param-qself.rs:12:5
+   |
+LL |     <()>::method(..): Send,
+   |     ^^^^^^^^^^^^^^^^
+
+error[E0223]: ambiguous associated function
+  --> $DIR/path-non-param-qself.rs:14:5
+   |
+LL |     i32::method(..): Send,
+   |     ^^^^^^^^^^^^^^^
+
+error[E0223]: ambiguous associated function
+  --> $DIR/path-non-param-qself.rs:16:5
+   |
+LL |     Adt::method(..): Send,
+   |     ^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0223`.

--- a/tests/ui/associated-type-bounds/return-type-notation/path-self-qself.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-self-qself.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Foo {
+    fn method() -> impl Sized;
+}
+
+trait Bar: Foo {
+    fn other()
+    where
+        Self::method(..): Send;
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/path-self-qself.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-self-qself.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/path-self-qself.rs:3:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/path-type-param.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-type-param.rs
@@ -1,0 +1,22 @@
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Foo {
+    fn method<T>() -> impl Sized;
+}
+
+fn test<T: Foo>()
+where
+    <T as Foo>::method(..): Send,
+    //~^ ERROR return type notation is not allowed for functions that have type parameters
+{
+}
+
+fn test_type_dependent<T: Foo>()
+where
+    <T as Foo>::method(..): Send,
+    //~^ ERROR return type notation is not allowed for functions that have type parameters
+{
+}
+
+fn main() {}

--- a/tests/ui/associated-type-bounds/return-type-notation/path-type-param.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-type-param.stderr
@@ -1,0 +1,29 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/path-type-param.rs:1:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: return type notation is not allowed for functions that have type parameters
+  --> $DIR/path-type-param.rs:10:5
+   |
+LL |     fn method<T>() -> impl Sized;
+   |               - type parameter declared here
+...
+LL |     <T as Foo>::method(..): Send,
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: return type notation is not allowed for functions that have type parameters
+  --> $DIR/path-type-param.rs:17:5
+   |
+LL |     fn method<T>() -> impl Sized;
+   |               - type parameter declared here
+...
+LL |     <T as Foo>::method(..): Send,
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors; 1 warning emitted
+

--- a/tests/ui/associated-type-bounds/return-type-notation/path-unsatisfied.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-unsatisfied.rs
@@ -1,0 +1,25 @@
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Trait {
+    fn method() -> impl Sized;
+}
+
+struct DoesntWork;
+impl Trait for DoesntWork {
+    fn method() -> impl Sized {
+        std::ptr::null_mut::<()>()
+        // This isn't `Send`.
+    }
+}
+
+fn test<T: Trait>()
+where
+    T::method(..): Send,
+{
+}
+
+fn main() {
+    test::<DoesntWork>();
+    //~^ ERROR `*mut ()` cannot be sent between threads safely
+}

--- a/tests/ui/associated-type-bounds/return-type-notation/path-unsatisfied.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-unsatisfied.stderr
@@ -1,0 +1,36 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/path-unsatisfied.rs:1:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0277]: `*mut ()` cannot be sent between threads safely
+  --> $DIR/path-unsatisfied.rs:23:12
+   |
+LL |     fn method() -> impl Sized {
+   |                    ---------- within this `impl Sized`
+...
+LL |     test::<DoesntWork>();
+   |            ^^^^^^^^^^ `*mut ()` cannot be sent between threads safely
+   |
+   = help: within `impl Sized`, the trait `Send` is not implemented for `*mut ()`, which is required by `impl Sized: Send`
+note: required because it appears within the type `impl Sized`
+  --> $DIR/path-unsatisfied.rs:10:20
+   |
+LL |     fn method() -> impl Sized {
+   |                    ^^^^^^^^^^
+note: required by a bound in `test`
+  --> $DIR/path-unsatisfied.rs:18:20
+   |
+LL | fn test<T: Trait>()
+   |    ---- required by a bound in this function
+LL | where
+LL |     T::method(..): Send,
+   |                    ^^^^ required by this bound in `test`
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/associated-type-bounds/return-type-notation/path-works.rs
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-works.rs
@@ -1,0 +1,23 @@
+//@ check-pass
+
+#![feature(return_type_notation)]
+//~^ WARN the feature `return_type_notation` is incomplete
+
+trait Trait {
+    fn method() -> impl Sized;
+}
+
+struct Works;
+impl Trait for Works {
+    fn method() -> impl Sized {}
+}
+
+fn test<T: Trait>()
+where
+    T::method(..): Send,
+{
+}
+
+fn main() {
+    test::<Works>();
+}

--- a/tests/ui/associated-type-bounds/return-type-notation/path-works.stderr
+++ b/tests/ui/associated-type-bounds/return-type-notation/path-works.stderr
@@ -1,0 +1,11 @@
+warning: the feature `return_type_notation` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/path-works.rs:3:12
+   |
+LL | #![feature(return_type_notation)]
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.rs
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.rs
@@ -2,7 +2,7 @@ pub fn foo(num: i32) -> i32 {
     let foo: i32::from_be(num);
     //~^ ERROR expected type, found local variable `num`
     //~| ERROR argument types not allowed with return type notation
-    //~| ERROR ambiguous associated type
+    //~| ERROR return type notation not allowed in this position yet
     foo
 }
 

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.rs
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.rs
@@ -1,7 +1,7 @@
 pub fn foo(num: i32) -> i32 {
     let foo: i32::from_be(num);
     //~^ ERROR expected type, found local variable `num`
-    //~| ERROR parenthesized type parameters may only be used with a `Fn` trait
+    //~| ERROR argument types not allowed with return type notation
     //~| ERROR ambiguous associated type
     foo
 }

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
@@ -6,16 +6,15 @@ LL |     let foo: i32::from_be(num);
    |            |
    |            help: use `=` if you meant to assign
 
-error[E0214]: parenthesized type parameters may only be used with a `Fn` trait
-  --> $DIR/let-binding-init-expr-as-ty.rs:2:19
+error: argument types not allowed with return type notation
+  --> $DIR/let-binding-init-expr-as-ty.rs:2:26
    |
 LL |     let foo: i32::from_be(num);
-   |                   ^^^^^^^^^^^^ only `Fn` traits may use parentheses
+   |                          ^^^^^ help: remove the input types: `()`
    |
-help: use angle brackets instead
-   |
-LL |     let foo: i32::from_be<num>;
-   |                          ~   ~
+   = note: see issue #109417 <https://github.com/rust-lang/rust/issues/109417> for more information
+   = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0223]: ambiguous associated type
   --> $DIR/let-binding-init-expr-as-ty.rs:2:14
@@ -30,5 +29,5 @@ LL |     let foo: <i32 as Example>::from_be;
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0214, E0223, E0573.
-For more information about an error, try `rustc --explain E0214`.
+Some errors have detailed explanations: E0223, E0573.
+For more information about an error, try `rustc --explain E0223`.

--- a/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
+++ b/tests/ui/suggestions/let-binding-init-expr-as-ty.stderr
@@ -16,18 +16,12 @@ LL |     let foo: i32::from_be(num);
    = help: add `#![feature(return_type_notation)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0223]: ambiguous associated type
+error: return type notation not allowed in this position yet
   --> $DIR/let-binding-init-expr-as-ty.rs:2:14
    |
 LL |     let foo: i32::from_be(num);
    |              ^^^^^^^^^^^^^^^^^
-   |
-help: if there were a trait named `Example` with associated type `from_be` implemented for `i32`, you could use the fully-qualified path
-   |
-LL |     let foo: <i32 as Example>::from_be;
-   |              ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0223, E0573.
-For more information about an error, try `rustc --explain E0223`.
+For more information about this error, try `rustc --explain E0573`.


### PR DESCRIPTION
Implement return type notation (RTN) in path position for where clauses. We already had RTN in associated type position ([e.g.](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=627a4fb8e2cb334863fbd08ed3722c09)), but per [the RFC](https://rust-lang.github.io/rfcs/3654-return-type-notation.html#where-rtn-can-be-used-for-now):

> As a standalone type, RTN can only be used as the Self type of a where-clause [...]

Specifically, in order to enable code like:

```rust
trait Foo {
    fn bar() -> impl Sized;
}

fn is_send(_: impl Send) {}

fn test<T>()
where
    T: Foo,
    T::bar(..): Send,
{
    is_send(T::bar());
}
```

* In the resolver, when we see a `TyKind::Path` whose final segment is `GenericArgs::ParenthesizedElided` (i.e. `(..)`), resolve that path in the *value* namespace, since we're looking for a method.
* When lowering where clauses in HIR lowering, we first try to intercept an RTN self type via `lower_ty_maybe_return_type_notation`. If we find an RTN type, we lower it manually in a way that respects its higher-ranked-ness (see below) and resolves to the corresponding RPITIT. Anywhere else, we'll emit the same "return type notation not allowed in this position yet" error we do when writing RTN in every other position.
* In `resolve_bound_vars`, we add some special treatment for RTN types in where clauses. Specifically, we need to add new lifetime variables to our binders for the early- and late-bound vars we encounter on the method. This implements the higher-ranked desugaring [laid out in the RFC](https://rust-lang.github.io/rfcs/3654-return-type-notation.html#converting-to-higher-ranked-trait-bounds).

This PR also adds a bunch of tests, mostly negative ones (testing error messages).

In a follow-up PR, I'm going to mark RTN as no longer incomplete, since this PR basically finishes the impl surface that we should initially stabilize, and the RFC was accepted.

cc [RFC 3654](https://github.com/rust-lang/rfcs/pull/3654) and https://github.com/rust-lang/rust/issues/109417