### PR TITLE
Fix tidy to allow `edition = "2024"` in `Cargo.toml`

### DIFF
--- a/src/tools/tidy/src/edition.rs
+++ b/src/tools/tidy/src/edition.rs
@@ -1,4 +1,4 @@
-//! Tidy check to ensure that crate `edition` is '2018' or '2021'.
+//! Tidy check to ensure that crate `edition` is '2021' or '2024'.
 
 use std::path::Path;
 
@@ -12,7 +12,9 @@ pub fn check(path: &Path, bad: &mut bool) {
             return;
         }
 
-        let is_2021 = contents.lines().any(|line| line.trim() == "edition = \"2021\"");
+        let is_current_edition = contents
+            .lines()
+            .any(|line| line.trim() == "edition = \"2021\"" || line.trim() == "edition = \"2024\"");
 
         let is_workspace = contents.lines().any(|line| line.trim() == "[workspace]");
         let is_package = contents.lines().any(|line| line.trim() == "[package]");
@@ -20,10 +22,10 @@ pub fn check(path: &Path, bad: &mut bool) {
 
         // Check that all packages use the 2021 edition. Virtual workspaces don't allow setting an
         // edition, so these shouldn't be checked.
-        if is_package && !is_2021 {
+        if is_package && !is_current_edition {
             tidy_error!(
                 bad,
-                "{} doesn't have `edition = \"2021\"` on a separate line",
+                "{} doesn't have `edition = \"2021\"` or `edition = \"2024\"` on a separate line",
                 file.display()
             );
         }


### PR DESCRIPTION
Needed to upgrade to edition 2024 eventually.