### PR TITLE
split out `ExpandResolver`

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -981,6 +981,16 @@ impl MacroData {
     }
 }
 
+pub struct ExpandResolver<'a, 'tcx> {
+    pub r: Resolver<'a, 'tcx>,
+}
+
+impl<'a, 'tcx> ExpandResolver<'a, 'tcx> {
+    pub fn new(r: Resolver<'a, 'tcx>) -> Self {
+        ExpandResolver { r }
+    }
+}
+
 /// The main resolver class.
 ///
 /// This is the visitor that walks the whole crate.

--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -370,7 +370,7 @@ impl<'a, 'tcx> ResolverExpand for ExpandResolver<'a, 'tcx> {
     }
 
     fn has_derive_copy(&self, expn_id: LocalExpnId) -> bool {
-        self.r.containers_deriving_copy.contains(&expn_id)
+        self.containers_deriving_copy.contains(&expn_id)
     }
 
     fn resolve_derives(
@@ -443,7 +443,7 @@ impl<'a, 'tcx> ResolverExpand for ExpandResolver<'a, 'tcx> {
         // Mark this derive as having `Copy` either if it has `Copy` itself or if its parent derive
         // has `Copy`, to support cases like `#[derive(Clone, Copy)] #[derive(Debug)]`.
         if entry.has_derive_copy || self.has_derive_copy(parent_scope.expansion) {
-            self.r.containers_deriving_copy.insert(expn_id);
+            self.containers_deriving_copy.insert(expn_id);
         }
         assert!(self.r.derive_data.is_empty());
         self.r.derive_data = derive_data;


### PR DESCRIPTION
Split `ExpandResolver` from `Resolver` and try to move some fields that are only used during the graph building process.


r? @petrochenkov 