### PR TITLE
rustdoc: fix missing resource suffix on `crates.js`

### DIFF
--- a/src/librustdoc/html/render/write_shared/tests.rs
+++ b/src/librustdoc/html/render/write_shared/tests.rs
@@ -6,10 +6,10 @@ use crate::html::render::write_shared::*;
 fn hack_external_crate_names() {
     let path = tempfile::TempDir::new().unwrap();
     let path = path.path();
-    let crates = hack_get_external_crate_names(&path).unwrap();
+    let crates = hack_get_external_crate_names(&path, "").unwrap();
     assert!(crates.is_empty());
     fs::write(path.join("crates.js"), r#"window.ALL_CRATES = ["a","b","c"];"#).unwrap();
-    let crates = hack_get_external_crate_names(&path).unwrap();
+    let crates = hack_get_external_crate_names(&path, "").unwrap();
     assert_eq!(crates, ["a".to_string(), "b".to_string(), "c".to_string()]);
 }
 
@@ -60,7 +60,7 @@ fn all_crates_template() {
 
 #[test]
 fn all_crates_parts() {
-    let parts = AllCratesPart::get(OrderedJson::serialize("crate").unwrap()).unwrap();
+    let parts = AllCratesPart::get(OrderedJson::serialize("crate").unwrap(), "").unwrap();
     assert_eq!(&parts.parts[0].0, Path::new("crates.js"));
     assert_eq!(&parts.parts[0].1.to_string(), r#""crate""#);
 }

--- a/tests/run-make/emit-shared-files/rmake.rs
+++ b/tests/run-make/emit-shared-files/rmake.rs
@@ -20,6 +20,7 @@ fn main() {
         .input("x.rs")
         .run();
     assert!(Path::new("invocation-only/search-index-xxx.js").exists());
+    assert!(Path::new("invocation-only/crates-xxx.js").exists());
     assert!(Path::new("invocation-only/settings.html").exists());
     assert!(Path::new("invocation-only/x/all.html").exists());
     assert!(Path::new("invocation-only/x/index.html").exists());


### PR DESCRIPTION
Fixes a regression introduced in #128252.
