### PR TITLE
Clean up `library/profiler_builtins/build.rs`

### DIFF
--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -85,15 +85,9 @@ fn main() {
     let src_root = root.join("lib").join("profile");
     assert!(src_root.exists(), "profiler runtime source directory not found: {src_root:?}");
     println!("cargo::rerun-if-changed={}", src_root.display());
-    let mut n_sources_found = 0u32;
-    for src in profile_sources {
-        let path = src_root.join(src);
-        if path.exists() {
-            cfg.file(path);
-            n_sources_found += 1;
-        }
+    for file in profile_sources {
+        cfg.file(src_root.join(file));
     }
-    assert!(n_sources_found > 0, "couldn't find any profiler runtime source files in {src_root:?}");
 
     let include = root.join("include");
     println!("cargo::rerun-if-changed={}", include.display());

--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -20,10 +20,12 @@ fn main() {
     // FIXME: `rerun-if-changed` directives are not currently emitted and the build script
     // will not rerun on changes in these source files or headers included into them.
     let mut profile_sources = vec![
+        // tidy-alphabetical-start
         "GCDAProfiling.c",
         "InstrProfiling.c",
         "InstrProfilingBuffer.c",
         "InstrProfilingFile.c",
+        "InstrProfilingInternal.c",
         "InstrProfilingMerge.c",
         "InstrProfilingMergeFile.c",
         "InstrProfilingNameVar.c",
@@ -38,8 +40,7 @@ fn main() {
         "InstrProfilingValue.c",
         "InstrProfilingVersionVar.c",
         "InstrProfilingWriter.c",
-        // These files were added in LLVM 11.
-        "InstrProfilingInternal.c",
+        // tidy-alphabetical-end
     ];
 
     if target_env == "msvc" {

--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -17,8 +17,6 @@ fn main() {
     let target_env = env::var("CARGO_CFG_TARGET_ENV").expect("CARGO_CFG_TARGET_ENV was not set");
     let cfg = &mut cc::Build::new();
 
-    // FIXME: `rerun-if-changed` directives are not currently emitted and the build script
-    // will not rerun on changes in these source files or headers included into them.
     let profile_sources = vec![
         // tidy-alphabetical-start
         "GCDAProfiling.c",
@@ -86,6 +84,7 @@ fn main() {
 
     let src_root = root.join("lib").join("profile");
     assert!(src_root.exists(), "profiler runtime source directory not found: {src_root:?}");
+    println!("cargo::rerun-if-changed={}", src_root.display());
     let mut n_sources_found = 0u32;
     for src in profile_sources {
         let path = src_root.join(src);
@@ -96,7 +95,10 @@ fn main() {
     }
     assert!(n_sources_found > 0, "couldn't find any profiler runtime source files in {src_root:?}");
 
-    cfg.include(root.join("include"));
+    let include = root.join("include");
+    println!("cargo::rerun-if-changed={}", include.display());
+    cfg.include(include);
+
     cfg.warnings(false);
     cfg.compile("profiler-rt");
 }

--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -40,7 +40,6 @@ fn main() {
         "InstrProfilingWriter.c",
         // These files were added in LLVM 11.
         "InstrProfilingInternal.c",
-        "InstrProfilingBiasVar.c",
     ];
 
     if target_env == "msvc" {

--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -19,7 +19,7 @@ fn main() {
 
     // FIXME: `rerun-if-changed` directives are not currently emitted and the build script
     // will not rerun on changes in these source files or headers included into them.
-    let mut profile_sources = vec![
+    let profile_sources = vec![
         // tidy-alphabetical-start
         "GCDAProfiling.c",
         "InstrProfiling.c",
@@ -40,13 +40,13 @@ fn main() {
         "InstrProfilingValue.c",
         "InstrProfilingVersionVar.c",
         "InstrProfilingWriter.c",
+        "WindowsMMap.c",
         // tidy-alphabetical-end
     ];
 
     if target_env == "msvc" {
         // Don't pull in extra libraries on MSVC
         cfg.flag("/Zl");
-        profile_sources.push("WindowsMMap.c");
         cfg.define("strdup", Some("_strdup"));
         cfg.define("open", Some("_open"));
         cfg.define("fdopen", Some("_fdopen"));
@@ -61,8 +61,6 @@ fn main() {
         if target_os != "windows" {
             cfg.flag("-fvisibility=hidden");
             cfg.define("COMPILER_RT_HAS_UNAME", Some("1"));
-        } else {
-            profile_sources.push("WindowsMMap.c");
         }
     }
 

--- a/library/profiler_builtins/build.rs
+++ b/library/profiler_builtins/build.rs
@@ -1,6 +1,8 @@
 //! Compiles the profiler part of the `compiler-rt` library.
 //!
-//! See the build.rs for libcompiler_builtins crate for details.
+//! Loosely based on:
+//! - LLVM's `compiler-rt/lib/profile/CMakeLists.txt`
+//! - <https://github.com/rust-lang/compiler-builtins/blob/master/build.rs>.
 
 use std::env;
 use std::path::PathBuf;


### PR DESCRIPTION
This PR makes a series of improvements to the long-neglected build script for `profiler_builtins`.

Most notably:
- The logic that silently skips missing source files has been removed, since it is currently unnecessary and makes build errors more confusing.
- The script now emits `cargo::rerun-if-changed` directives for the `compiler-rt` source and include directories.


Compiler behaviour and user programs should be unaffected by these changes.