### PR TITLE
skip stage 0 target check if `BOOTSTRAP_SKIP_TARGET_SANITY` is set

### DIFF
--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -8,9 +8,7 @@
 //! In theory if we get past this phase it's a bug if a build fails, but in
 //! practice that's likely not true!
 
-use std::collections::HashMap;
-#[cfg(not(feature = "bootstrap-self-test"))]
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::{env, fs};
@@ -34,7 +32,6 @@ pub struct Finder {
 // it might not yet be included in stage0. In such cases, we handle the targets missing from stage0 in this list.
 //
 // Targets can be removed from this list once they are present in the stage0 compiler (usually by updating the beta compiler of the bootstrap).
-#[cfg(not(feature = "bootstrap-self-test"))]
 const STAGE0_MISSING_TARGETS: &[&str] = &[
     // just a dummy comment so the list doesn't get onelined
 ];
@@ -205,7 +202,6 @@ than building it.
         .map(|p| cmd_finder.must_have(p))
         .or_else(|| cmd_finder.maybe_have("reuse"));
 
-    #[cfg(not(feature = "bootstrap-self-test"))]
     let stage0_supported_target_list: HashSet<String> = crate::utils::helpers::output(
         command(&build.config.initial_rustc).args(["--print", "target-list"]).as_command_mut(),
     )
@@ -234,8 +230,7 @@ than building it.
         }
 
         // Ignore fake targets that are only used for unit tests in bootstrap.
-        #[cfg(not(feature = "bootstrap-self-test"))]
-        {
+        if cfg!(not(feature = "bootstrap-self-test")) && !skip_target_sanity {
             let mut has_target = false;
             let target_str = target.to_string();
 

--- a/src/tools/opt-dist/src/tests.rs
+++ b/src/tools/opt-dist/src/tests.rs
@@ -102,7 +102,13 @@ llvm-config = "{llvm_config}"
     for test_path in env.skipped_tests() {
         args.extend(["--skip", test_path]);
     }
-    cmd(&args).env("COMPILETEST_FORCE_STAGE0", "1").run().context("Cannot execute tests")
+    cmd(&args)
+        .env("COMPILETEST_FORCE_STAGE0", "1")
+        // Above we override the stage 0 compiler with previously compiled compiler,
+        // which can cause confusion in bootstrap's target sanity checks.
+        .env("BOOTSTRAP_SKIP_TARGET_SANITY", "1")
+        .run()
+        .context("Cannot execute tests")
 }
 
 /// Tries to find the version of the dist artifacts (either nightly, beta, or 1.XY.Z).


### PR DESCRIPTION
When adding a new target to `rustc` and extending `STAGE0_MISSING_TARGETS`, there is a chance that in the merge CI bootstrap target sanity check might fail [here](https://github.com/rust-lang/rust/blob/26d27b7c8729fb61fe8321fcd2ce734a79aa695d/src/bootstrap/src/core/sanity.rs#L243-L256) because the stage 0 compiler will assume to already support the new target since `opt-dist` uses the previously compiled compiler as the stage 0 compiler.

This PR skips this check if `BOOTSTRAP_SKIP_TARGET_SANITY` is set, and makes `opt-dist` to set `BOOTSTRAP_SKIP_TARGET_SANITY` so bootstrap doesn't run this logic for opt-dist tests.

Fixes https://github.com/rust-lang/rust/pull/127021#issuecomment-2308782315.

Zulip thread: https://rust-lang.zulipchat.com/#narrow/stream/326414-t-infra.2Fbootstrap/topic/.60STAGE0_MISSING_TARGETS.60.20seems.20to.20check.20stage1

Blocker for https://github.com/rust-lang/rust/pull/127021