### PR TITLE
clarify that addr_of creates read-only pointers

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -2285,9 +2285,13 @@ impl<F: FnPtr> fmt::Debug for F {
 /// `addr_of!(expr)` is equivalent to `&raw const expr`. The macro is *soft-deprecated*;
 /// use `&raw const` instead.
 ///
-/// It is still an open question whether writing through an `addr_of!`-created pointer is permitted
-/// or not. Until that is decided, the same rules as for shared references apply: it is UB to write
-/// through a pointer created with this operation, except for bytes located inside an `UnsafeCell`.
+/// It is still an open question under which conditions writing through an `addr_of!`-created
+/// pointer is permitted. If the place `expr` evaluates to is based on a raw pointer, then the
+/// result of `addr_of!` inherits all permissions from that raw pointer. However, if the place is
+/// based on a reference, local variable, or `static`, then until all details are decided, the same
+/// rules as for shared references apply: it is UB to write through a pointer created with this
+/// operation, except for bytes located inside an `UnsafeCell`. Use `&raw mut` (or [`addr_of_mut`])
+/// to create a raw pointer that definitely permits mutation.
 ///
 /// Creating a reference with `&`/`&mut` is only allowed if the pointer is properly aligned
 /// and points to initialized data. For cases where those requirements do not hold,

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -2285,6 +2285,10 @@ impl<F: FnPtr> fmt::Debug for F {
 /// `addr_of!(expr)` is equivalent to `&raw const expr`. The macro is *soft-deprecated*;
 /// use `&raw const` instead.
 ///
+/// It is still an open question whether writing through an `addr_of!`-created pointer is permitted
+/// or not. Until that is decided, the same rules as for shared references apply: it is UB to write
+/// through a pointer created with this operation, except for bytes located inside an `UnsafeCell`.
+///
 /// Creating a reference with `&`/`&mut` is only allowed if the pointer is properly aligned
 /// and points to initialized data. For cases where those requirements do not hold,
 /// raw pointers should be used instead. However, `&expr as *const _` creates a reference


### PR DESCRIPTION
Stacked Borrows does make this UB, but Tree Borrows does not. This is tied up with https://github.com/rust-lang/rust/issues/56604 and other UCG discussions. Also see [this collection of links](https://github.com/Rust-for-Linux/linux/pull/950#discussion_r1104759431) where rustc treats `addr_of!` as a "non-mutating use".

So, let's better be careful for now.