### PR TITLE
Rename `BikeshedIntrinsicFrom` to `TransmuteFrom`

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/normalizes_to/mod.rs
@@ -862,7 +862,7 @@ where
         _ecx: &mut EvalCtxt<'_, D>,
         goal: Goal<I, Self>,
     ) -> Result<Candidate<I>, NoSolution> {
-        panic!("`BikeshedIntrinsicFrom` does not have an associated type: {:?}", goal)
+        panic!("`TransmuteFrom` does not have an associated type: {:?}", goal)
     }
 
     fn consider_builtin_effects_intersection_candidate(

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -19,7 +19,7 @@ pub use maybe_uninit::MaybeUninit;
 
 mod transmutability;
 #[unstable(feature = "transmutability", issue = "99571")]
-pub use transmutability::{Assume, BikeshedIntrinsicFrom};
+pub use transmutability::{Assume, TransmuteFrom};
 
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(inline)]

--- a/tests/crashes/123693.rs
+++ b/tests/crashes/123693.rs
@@ -3,11 +3,11 @@
 #![feature(transmutability)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::NOTHING }>,
+        Dst: TransmuteFrom<Src, { Assume::NOTHING }>,
     {
     }
 }

--- a/tests/crashes/124207.rs
+++ b/tests/crashes/124207.rs
@@ -4,6 +4,6 @@
 trait OpaqueTrait {}
 type OpaqueType = impl OpaqueTrait;
 trait AnotherTrait {}
-impl<T: std::mem::BikeshedIntrinsicFrom<(), ()>> AnotherTrait for T {}
+impl<T: std::mem::TransmuteFrom<(), ()>> AnotherTrait for T {}
 impl AnotherTrait for OpaqueType {}
 pub fn main() {}

--- a/tests/crashes/125881.rs
+++ b/tests/crashes/125881.rs
@@ -3,6 +3,6 @@
 #![feature(transmutability)]
 #![feature(unboxed_closures,effects)]
 
-const fn test() -> impl std::mem::BikeshedIntrinsicFrom() {
+const fn test() -> impl std::mem::TransmuteFrom() {
     || {}
 }

--- a/tests/crashes/126267.rs
+++ b/tests/crashes/126267.rs
@@ -14,11 +14,11 @@ pub enum Error {
 }
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src>, // safety is NOT assumed
+        Dst: TransmuteFrom<Src>, // safety is NOT assumed
     {
     }
 }

--- a/tests/crashes/126377.rs
+++ b/tests/crashes/126377.rs
@@ -4,7 +4,7 @@
 #![feature(generic_const_exprs)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<
         Src,
@@ -15,7 +15,7 @@ mod assert {
         const ASSUME_VALIDITY: bool,
     >()
     where
-        Dst: BikeshedIntrinsicFrom<
+        Dst: TransmuteFrom<
             Src,
             {  }
         >,

--- a/tests/crashes/126966.rs
+++ b/tests/crashes/126966.rs
@@ -1,10 +1,10 @@
 //@ known-bug: rust-lang/rust#126966
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src>,
+        Dst: TransmuteFrom<Src>,
     {
     }
 }

--- a/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.rs
+++ b/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.rs
@@ -4,11 +4,11 @@
 #![allow(incomplete_features, unstable_features)]
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<Src, Dst, Context, const ASSUME: std::mem::Assume>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
+        Dst: TransmuteFrom<Src, Context, ASSUME>,
         //~^ ERROR trait takes at most 2 generic arguments but 3 generic arguments were supplied
     {
     }

--- a/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.stderr
+++ b/tests/ui/const-generics/adt_const_params/transmutable-ice-110969.stderr
@@ -1,8 +1,8 @@
 error[E0107]: trait takes at most 2 generic arguments but 3 generic arguments were supplied
   --> $DIR/transmutable-ice-110969.rs:11:14
    |
-LL |         Dst: BikeshedIntrinsicFrom<Src, Context, ASSUME>,
-   |              ^^^^^^^^^^^^^^^^^^^^^             -------- help: remove the unnecessary generic argument
+LL |         Dst: TransmuteFrom<Src, Context, ASSUME>,
+   |              ^^^^^^^^^^^^^             -------- help: remove the unnecessary generic argument
    |              |
    |              expected at most 2 generic arguments
 

--- a/tests/ui/transmutability/abstraction/abstracted_assume.rs
+++ b/tests/ui/transmutability/abstraction/abstracted_assume.rs
@@ -8,7 +8,7 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<
         Src,
@@ -16,7 +16,7 @@ mod assert {
         const ASSUME: std::mem::Assume,
     >()
     where
-        Dst: BikeshedIntrinsicFrom<
+        Dst: TransmuteFrom<
             Src,
             ASSUME,
         >,

--- a/tests/ui/transmutability/abstraction/const_generic_fn.rs
+++ b/tests/ui/transmutability/abstraction/const_generic_fn.rs
@@ -6,12 +6,12 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn array_like<T, E, const N: usize>()
     where
-        T: BikeshedIntrinsicFrom<[E; N], { Assume::SAFETY }>,
-        [E; N]: BikeshedIntrinsicFrom<T, { Assume::SAFETY }>
+        T: TransmuteFrom<[E; N], { Assume::SAFETY }>,
+        [E; N]: TransmuteFrom<T, { Assume::SAFETY }>
     {}
 }
 

--- a/tests/ui/transmutability/alignment/align-fail.rs
+++ b/tests/ui/transmutability/alignment/align-fail.rs
@@ -2,11 +2,11 @@
 #![feature(transmutability)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: false,
                 lifetimes: true,

--- a/tests/ui/transmutability/alignment/align-fail.stderr
+++ b/tests/ui/transmutability/alignment/align-fail.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: false,

--- a/tests/ui/transmutability/alignment/align-pass.rs
+++ b/tests/ui/transmutability/alignment/align-pass.rs
@@ -2,11 +2,11 @@
 #![feature(transmutability)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: false,
                 lifetimes: false,

--- a/tests/ui/transmutability/arrays/huge-len.rs
+++ b/tests/ui/transmutability/arrays/huge-len.rs
@@ -1,11 +1,11 @@
 #![crate_type = "lib"]
 #![feature(transmutability)]
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src>,
+        Dst: TransmuteFrom<Src>,
     {
     }
 }

--- a/tests/ui/transmutability/arrays/huge-len.stderr
+++ b/tests/ui/transmutability/arrays/huge-len.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_maybe_transmutable`
 LL |     pub fn is_maybe_transmutable<Src, Dst>()
    |            --------------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>,
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
+LL |         Dst: TransmuteFrom<Src>,
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
 
 error[E0277]: `ExplicitlyPadded` cannot be safely transmuted into `()`
   --> $DIR/huge-len.rs:24:55
@@ -25,8 +25,8 @@ note: required by a bound in `is_maybe_transmutable`
 LL |     pub fn is_maybe_transmutable<Src, Dst>()
    |            --------------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>,
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
+LL |         Dst: TransmuteFrom<Src>,
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/transmutability/arrays/issue-103783-array-length.rs
+++ b/tests/ui/transmutability/arrays/issue-103783-array-length.rs
@@ -3,11 +3,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<
+        Dst: TransmuteFrom<
             Src,
             { Assume { alignment: true, lifetimes: true, safety: true, validity: true } },
         >,

--- a/tests/ui/transmutability/arrays/should_have_correct_length.rs
+++ b/tests/ui/transmutability/arrays/should_have_correct_length.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY.and(Assume::VALIDITY) }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY.and(Assume::VALIDITY) }>
     {}
 }
 

--- a/tests/ui/transmutability/arrays/should_inherit_alignment.rs
+++ b/tests/ui/transmutability/arrays/should_inherit_alignment.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume::ALIGNMENT
                 .and(Assume::LIFETIMES)
                 .and(Assume::SAFETY)

--- a/tests/ui/transmutability/arrays/should_require_well_defined_layout.rs
+++ b/tests/ui/transmutability/arrays/should_require_well_defined_layout.rs
@@ -5,11 +5,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume::ALIGNMENT
                 .and(Assume::LIFETIMES)
                 .and(Assume::SAFETY)

--- a/tests/ui/transmutability/arrays/should_require_well_defined_layout.stderr
+++ b/tests/ui/transmutability/arrays/should_require_well_defined_layout.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
 LL | |                 .and(Assume::LIFETIMES)
@@ -31,7 +31,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
 LL | |                 .and(Assume::LIFETIMES)
@@ -52,7 +52,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
 LL | |                 .and(Assume::LIFETIMES)
@@ -73,7 +73,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
 LL | |                 .and(Assume::LIFETIMES)
@@ -94,7 +94,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
 LL | |                 .and(Assume::LIFETIMES)
@@ -115,7 +115,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
 LL | |                 .and(Assume::LIFETIMES)

--- a/tests/ui/transmutability/enums/niche_optimization.rs
+++ b/tests/ui/transmutability/enums/niche_optimization.rs
@@ -5,11 +5,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: false,
                 lifetimes: false,
@@ -21,7 +21,7 @@ mod assert {
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: false,
                 lifetimes: false,

--- a/tests/ui/transmutability/enums/repr/padding_differences.rs
+++ b/tests/ui/transmutability/enums/repr/padding_differences.rs
@@ -7,11 +7,11 @@
 use std::mem::MaybeUninit;
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: false,
                 lifetimes: false,
@@ -23,7 +23,7 @@ mod assert {
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: false,
                 lifetimes: false,

--- a/tests/ui/transmutability/enums/repr/primitive_reprs_should_have_correct_length.rs
+++ b/tests/ui/transmutability/enums/repr/primitive_reprs_should_have_correct_length.rs
@@ -5,11 +5,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: true,

--- a/tests/ui/transmutability/enums/repr/primitive_reprs_should_have_correct_length.stderr
+++ b/tests/ui/transmutability/enums/repr/primitive_reprs_should_have_correct_length.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -32,7 +32,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -54,7 +54,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -76,7 +76,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -98,7 +98,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -120,7 +120,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -142,7 +142,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -164,7 +164,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -186,7 +186,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -208,7 +208,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -230,7 +230,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -252,7 +252,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -274,7 +274,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -296,7 +296,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -318,7 +318,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -340,7 +340,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -362,7 +362,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -384,7 +384,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -406,7 +406,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -428,7 +428,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,

--- a/tests/ui/transmutability/enums/repr/should_handle_all.rs
+++ b/tests/ui/transmutability/enums/repr/should_handle_all.rs
@@ -5,11 +5,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: true,

--- a/tests/ui/transmutability/enums/should_order_correctly.rs
+++ b/tests/ui/transmutability/enums/should_order_correctly.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume::ALIGNMENT
                 .and(Assume::LIFETIMES)
                 .and(Assume::SAFETY)

--- a/tests/ui/transmutability/enums/should_pad_variants.rs
+++ b/tests/ui/transmutability/enums/should_pad_variants.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume::ALIGNMENT
                 .and(Assume::LIFETIMES)
                 .and(Assume::SAFETY)

--- a/tests/ui/transmutability/enums/should_pad_variants.stderr
+++ b/tests/ui/transmutability/enums/should_pad_variants.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
 LL | |                 .and(Assume::LIFETIMES)

--- a/tests/ui/transmutability/enums/should_respect_endianness.rs
+++ b/tests/ui/transmutability/enums/should_respect_endianness.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume::ALIGNMENT
                 .and(Assume::LIFETIMES)
                 .and(Assume::SAFETY)

--- a/tests/ui/transmutability/enums/should_respect_endianness.stderr
+++ b/tests/ui/transmutability/enums/should_respect_endianness.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
 LL | |                 .and(Assume::LIFETIMES)

--- a/tests/ui/transmutability/enums/uninhabited_optimization.rs
+++ b/tests/ui/transmutability/enums/uninhabited_optimization.rs
@@ -4,7 +4,7 @@
 
 fn assert_transmutable<T>()
 where
-    (): std::mem::BikeshedIntrinsicFrom<T>
+    (): std::mem::TransmuteFrom<T>
 {}
 
 enum Uninhabited {}

--- a/tests/ui/transmutability/issue-101739-1.rs
+++ b/tests/ui/transmutability/issue-101739-1.rs
@@ -1,11 +1,11 @@
 #![feature(transmutability)]
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<Src, const ASSUME_ALIGNMENT: bool>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, ASSUME_ALIGNMENT>, //~ ERROR cannot find type `Dst` in this scope
+        Dst: TransmuteFrom<Src, ASSUME_ALIGNMENT>, //~ ERROR cannot find type `Dst` in this scope
                                                            //~| the constant `ASSUME_ALIGNMENT` is not of type `Assume`
                                                            //~| ERROR: mismatched types
     {

--- a/tests/ui/transmutability/issue-101739-1.stderr
+++ b/tests/ui/transmutability/issue-101739-1.stderr
@@ -1,23 +1,23 @@
 error[E0412]: cannot find type `Dst` in this scope
   --> $DIR/issue-101739-1.rs:8:9
    |
-LL |         Dst: BikeshedIntrinsicFrom<Src, ASSUME_ALIGNMENT>,
+LL |         Dst: TransmuteFrom<Src, ASSUME_ALIGNMENT>,
    |         ^^^ not found in this scope
 
 error: the constant `ASSUME_ALIGNMENT` is not of type `Assume`
   --> $DIR/issue-101739-1.rs:8:14
    |
-LL |         Dst: BikeshedIntrinsicFrom<Src, ASSUME_ALIGNMENT>,
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Assume`, found `bool`
+LL |         Dst: TransmuteFrom<Src, ASSUME_ALIGNMENT>,
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Assume`, found `bool`
    |
-note: required by a const generic parameter in `BikeshedIntrinsicFrom`
+note: required by a const generic parameter in `TransmuteFrom`
   --> $SRC_DIR/core/src/mem/transmutability.rs:LL:COL
 
 error[E0308]: mismatched types
-  --> $DIR/issue-101739-1.rs:8:41
+  --> $DIR/issue-101739-1.rs:8:33
    |
-LL |         Dst: BikeshedIntrinsicFrom<Src, ASSUME_ALIGNMENT>,
-   |                                         ^^^^^^^^^^^^^^^^ expected `Assume`, found `bool`
+LL |         Dst: TransmuteFrom<Src, ASSUME_ALIGNMENT>,
+   |                                 ^^^^^^^^^^^^^^^^ expected `Assume`, found `bool`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/transmutability/issue-101739-2.rs
+++ b/tests/ui/transmutability/issue-101739-2.rs
@@ -3,7 +3,7 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<
         Src,
@@ -14,7 +14,7 @@ mod assert {
         const ASSUME_VISIBILITY: bool,
     >()
     where
-        Dst: BikeshedIntrinsicFrom<
+        Dst: TransmuteFrom<
                 //~^ ERROR trait takes at most 2 generic arguments but 5 generic arguments were supplied
                 Src,
                 ASSUME_ALIGNMENT, //~ ERROR: mismatched types

--- a/tests/ui/transmutability/issue-101739-2.stderr
+++ b/tests/ui/transmutability/issue-101739-2.stderr
@@ -1,8 +1,8 @@
 error[E0107]: trait takes at most 2 generic arguments but 5 generic arguments were supplied
   --> $DIR/issue-101739-2.rs:17:14
    |
-LL |           Dst: BikeshedIntrinsicFrom<
-   |                ^^^^^^^^^^^^^^^^^^^^^ expected at most 2 generic arguments
+LL |           Dst: TransmuteFrom<
+   |                ^^^^^^^^^^^^^ expected at most 2 generic arguments
 ...
 LL |                   ASSUME_ALIGNMENT,
    |  _________________________________-

--- a/tests/ui/transmutability/issue-110467.rs
+++ b/tests/ui/transmutability/issue-110467.rs
@@ -1,11 +1,11 @@
 //@ check-pass
 #![crate_type = "lib"]
 #![feature(transmutability)]
-use std::mem::BikeshedIntrinsicFrom;
+use std::mem::TransmuteFrom;
 
 pub fn is_maybe_transmutable<Src, Dst>()
 where
-    Dst: BikeshedIntrinsicFrom<Src>,
+    Dst: TransmuteFrom<Src>,
 {
 }
 

--- a/tests/ui/transmutability/issue-110892.rs
+++ b/tests/ui/transmutability/issue-110892.rs
@@ -3,7 +3,7 @@
 #![allow(incomplete_features)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<
         Src,
@@ -14,7 +14,7 @@ mod assert {
         const ASSUME_VALIDITY: bool,
     >()
     where
-        Dst: BikeshedIntrinsicFrom<
+        Dst: TransmuteFrom<
             Src,
             { from_options(ASSUME_ALIGNMENT, ASSUME_LIFETIMES, ASSUME_SAFETY, ASSUME_VALIDITY) }
         >,

--- a/tests/ui/transmutability/malformed-program-gracefulness/feature-missing.rs
+++ b/tests/ui/transmutability/malformed-program-gracefulness/feature-missing.rs
@@ -2,7 +2,7 @@
 
 #![crate_type = "lib"]
 
-use std::mem::BikeshedIntrinsicFrom;
+use std::mem::TransmuteFrom;
 //~^ ERROR use of unstable library feature 'transmutability' [E0658]
 
 use std::mem::Assume;

--- a/tests/ui/transmutability/malformed-program-gracefulness/feature-missing.stderr
+++ b/tests/ui/transmutability/malformed-program-gracefulness/feature-missing.stderr
@@ -1,8 +1,8 @@
 error[E0658]: use of unstable library feature 'transmutability'
   --> $DIR/feature-missing.rs:5:5
    |
-LL | use std::mem::BikeshedIntrinsicFrom;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | use std::mem::TransmuteFrom;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #99571 <https://github.com/rust-lang/rust/issues/99571> for more information
    = help: add `#![feature(transmutability)]` to the crate attributes to enable

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst.rs
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst.rs
@@ -5,11 +5,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src>
+        Dst: TransmuteFrom<Src>
     {}
 }
 

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst_field.rs
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst_field.rs
@@ -5,11 +5,11 @@
 #![allow(incomplete_features)]
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src>
+        Dst: TransmuteFrom<Src>
     {}
 }
 

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst_field.stderr
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_dst_field.stderr
@@ -22,8 +22,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `should_gracefully_handle_unknown_dst_ref_field::Src` cannot be safely transmuted into `should_gracefully_handle_unknown_dst_ref_field::Dst`
   --> $DIR/unknown_dst_field.rs:25:36
@@ -37,8 +37,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_src.rs
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_src.rs
@@ -5,11 +5,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src>
+        Dst: TransmuteFrom<Src>
     {}
 }
 

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_src_field.rs
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_src_field.rs
@@ -5,11 +5,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src>
+        Dst: TransmuteFrom<Src>
     {}
 }
 

--- a/tests/ui/transmutability/malformed-program-gracefulness/unknown_src_field.stderr
+++ b/tests/ui/transmutability/malformed-program-gracefulness/unknown_src_field.stderr
@@ -22,8 +22,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `should_gracefully_handle_unknown_src_ref_field::Src` cannot be safely transmuted into `should_gracefully_handle_unknown_src_ref_field::Dst`
   --> $DIR/unknown_src_field.rs:25:36
@@ -37,8 +37,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/transmutability/malformed-program-gracefulness/wrong-type-assume.rs
+++ b/tests/ui/transmutability/malformed-program-gracefulness/wrong-type-assume.rs
@@ -8,7 +8,7 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<
         Src,
@@ -19,7 +19,7 @@ mod assert {
         const ASSUME_VALIDITY: bool,
     >()
     where
-        Dst: BikeshedIntrinsicFrom<
+        Dst: TransmuteFrom<
             Src,
             { from_options(ASSUME_ALIGNMENT, ASSUME_LIFETIMES, ASSUME_SAFETY, ASSUME_VALIDITY) }
         >,

--- a/tests/ui/transmutability/maybeuninit.rs
+++ b/tests/ui/transmutability/maybeuninit.rs
@@ -5,11 +5,11 @@
 use std::mem::MaybeUninit;
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY }>
     {}
 }
 

--- a/tests/ui/transmutability/maybeuninit.stderr
+++ b/tests/ui/transmutability/maybeuninit.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_maybe_transmutable`
 LL |     pub fn is_maybe_transmutable<Src, Dst>()
    |            --------------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/transmutability/primitives/bool-mut.rs
+++ b/tests/ui/transmutability/primitives/bool-mut.rs
@@ -2,11 +2,11 @@
 
 #![feature(transmutability)]
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY }>
     {}
 }
 

--- a/tests/ui/transmutability/primitives/bool-mut.stderr
+++ b/tests/ui/transmutability/primitives/bool-mut.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/transmutability/primitives/bool.current.stderr
+++ b/tests/ui/transmutability/primitives/bool.current.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/transmutability/primitives/bool.next.stderr
+++ b/tests/ui/transmutability/primitives/bool.next.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/transmutability/primitives/bool.rs
+++ b/tests/ui/transmutability/primitives/bool.rs
@@ -4,16 +4,16 @@
 
 #![feature(transmutability)]
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY }>
     {}
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY.and(Assume::VALIDITY) }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY.and(Assume::VALIDITY) }>
     {}
 }
 

--- a/tests/ui/transmutability/primitives/numbers.current.stderr
+++ b/tests/ui/transmutability/primitives/numbers.current.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u16`
   --> $DIR/numbers.rs:65:40
@@ -25,8 +25,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:66:40
@@ -40,8 +40,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:67:40
@@ -55,8 +55,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:68:40
@@ -70,8 +70,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:69:40
@@ -85,8 +85,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:70:40
@@ -100,8 +100,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:71:40
@@ -115,8 +115,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:72:39
@@ -130,8 +130,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:73:39
@@ -145,8 +145,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i16`
   --> $DIR/numbers.rs:75:40
@@ -160,8 +160,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u16`
   --> $DIR/numbers.rs:76:40
@@ -175,8 +175,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:77:40
@@ -190,8 +190,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:78:40
@@ -205,8 +205,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:79:40
@@ -220,8 +220,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:80:40
@@ -235,8 +235,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:81:40
@@ -250,8 +250,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:82:40
@@ -265,8 +265,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:83:39
@@ -280,8 +280,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:84:39
@@ -295,8 +295,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:86:40
@@ -310,8 +310,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:87:40
@@ -325,8 +325,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:88:40
@@ -340,8 +340,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:89:40
@@ -355,8 +355,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:90:40
@@ -370,8 +370,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:91:40
@@ -385,8 +385,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:92:39
@@ -400,8 +400,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:93:39
@@ -415,8 +415,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:95:40
@@ -430,8 +430,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:96:40
@@ -445,8 +445,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:97:40
@@ -460,8 +460,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:98:40
@@ -475,8 +475,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:99:40
@@ -490,8 +490,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:100:40
@@ -505,8 +505,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:101:39
@@ -520,8 +520,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:102:39
@@ -535,8 +535,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:104:40
@@ -550,8 +550,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:105:40
@@ -565,8 +565,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:106:40
@@ -580,8 +580,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:107:39
@@ -595,8 +595,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:108:39
@@ -610,8 +610,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:110:40
@@ -625,8 +625,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:111:40
@@ -640,8 +640,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:112:40
@@ -655,8 +655,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:113:39
@@ -670,8 +670,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:114:39
@@ -685,8 +685,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:116:40
@@ -700,8 +700,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:117:40
@@ -715,8 +715,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:118:40
@@ -730,8 +730,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:119:39
@@ -745,8 +745,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:120:39
@@ -760,8 +760,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u64` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:122:39
@@ -775,8 +775,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u64` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:123:39
@@ -790,8 +790,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i64` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:125:39
@@ -805,8 +805,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i64` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:126:39
@@ -820,8 +820,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f64` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:128:39
@@ -835,8 +835,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f64` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:129:39
@@ -850,8 +850,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error: aborting due to 57 previous errors
 

--- a/tests/ui/transmutability/primitives/numbers.next.stderr
+++ b/tests/ui/transmutability/primitives/numbers.next.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u16`
   --> $DIR/numbers.rs:65:40
@@ -25,8 +25,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:66:40
@@ -40,8 +40,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:67:40
@@ -55,8 +55,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:68:40
@@ -70,8 +70,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:69:40
@@ -85,8 +85,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:70:40
@@ -100,8 +100,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:71:40
@@ -115,8 +115,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:72:39
@@ -130,8 +130,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i8` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:73:39
@@ -145,8 +145,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i16`
   --> $DIR/numbers.rs:75:40
@@ -160,8 +160,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u16`
   --> $DIR/numbers.rs:76:40
@@ -175,8 +175,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:77:40
@@ -190,8 +190,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:78:40
@@ -205,8 +205,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:79:40
@@ -220,8 +220,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:80:40
@@ -235,8 +235,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:81:40
@@ -250,8 +250,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:82:40
@@ -265,8 +265,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:83:39
@@ -280,8 +280,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u8` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:84:39
@@ -295,8 +295,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:86:40
@@ -310,8 +310,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:87:40
@@ -325,8 +325,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:88:40
@@ -340,8 +340,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:89:40
@@ -355,8 +355,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:90:40
@@ -370,8 +370,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:91:40
@@ -385,8 +385,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:92:39
@@ -400,8 +400,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i16` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:93:39
@@ -415,8 +415,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `i32`
   --> $DIR/numbers.rs:95:40
@@ -430,8 +430,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `f32`
   --> $DIR/numbers.rs:96:40
@@ -445,8 +445,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `u32`
   --> $DIR/numbers.rs:97:40
@@ -460,8 +460,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:98:40
@@ -475,8 +475,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:99:40
@@ -490,8 +490,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:100:40
@@ -505,8 +505,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:101:39
@@ -520,8 +520,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u16` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:102:39
@@ -535,8 +535,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:104:40
@@ -550,8 +550,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:105:40
@@ -565,8 +565,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:106:40
@@ -580,8 +580,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:107:39
@@ -595,8 +595,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i32` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:108:39
@@ -610,8 +610,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:110:40
@@ -625,8 +625,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:111:40
@@ -640,8 +640,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:112:40
@@ -655,8 +655,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:113:39
@@ -670,8 +670,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f32` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:114:39
@@ -685,8 +685,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `u64`
   --> $DIR/numbers.rs:116:40
@@ -700,8 +700,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `i64`
   --> $DIR/numbers.rs:117:40
@@ -715,8 +715,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `f64`
   --> $DIR/numbers.rs:118:40
@@ -730,8 +730,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:119:39
@@ -745,8 +745,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u32` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:120:39
@@ -760,8 +760,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u64` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:122:39
@@ -775,8 +775,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `u64` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:123:39
@@ -790,8 +790,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i64` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:125:39
@@ -805,8 +805,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `i64` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:126:39
@@ -820,8 +820,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f64` cannot be safely transmuted into `u128`
   --> $DIR/numbers.rs:128:39
@@ -835,8 +835,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `f64` cannot be safely transmuted into `i128`
   --> $DIR/numbers.rs:129:39
@@ -850,8 +850,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src>
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error: aborting due to 57 previous errors
 

--- a/tests/ui/transmutability/primitives/numbers.rs
+++ b/tests/ui/transmutability/primitives/numbers.rs
@@ -7,11 +7,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src>
+        Dst: TransmuteFrom<Src>
     {}
 }
 

--- a/tests/ui/transmutability/primitives/unit.current.stderr
+++ b/tests/ui/transmutability/primitives/unit.current.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
 LL | |                 .and(Assume::LIFETIMES)

--- a/tests/ui/transmutability/primitives/unit.next.stderr
+++ b/tests/ui/transmutability/primitives/unit.next.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
 LL | |                 .and(Assume::LIFETIMES)

--- a/tests/ui/transmutability/primitives/unit.rs
+++ b/tests/ui/transmutability/primitives/unit.rs
@@ -9,11 +9,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume::ALIGNMENT
                 .and(Assume::LIFETIMES)
                 .and(Assume::SAFETY)

--- a/tests/ui/transmutability/references/accept_assume_lifetime_extension.rs
+++ b/tests/ui/transmutability/references/accept_assume_lifetime_extension.rs
@@ -4,11 +4,11 @@
 
 #![feature(transmutability, core_intrinsics)]
 
-use std::mem::{Assume, BikeshedIntrinsicFrom};
+use std::mem::{Assume, TransmuteFrom};
 
 unsafe fn transmute<Src, Dst>(src: Src) -> Dst
 where
-    Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY.and(Assume::LIFETIMES) }>,
+    Dst: TransmuteFrom<Src, { Assume::SAFETY.and(Assume::LIFETIMES) }>,
 {
     core::intrinsics::transmute_unchecked(src)
 }
@@ -82,7 +82,7 @@ mod hrtb {
 
     unsafe fn extend_hrtb<'a>(src: &'a u8) -> &'static u8
     where
-        for<'b> &'b u8: BikeshedIntrinsicFrom<&'a u8, { Assume::LIFETIMES }>,
+        for<'b> &'b u8: TransmuteFrom<&'a u8, { Assume::LIFETIMES }>,
     {
         core::intrinsics::transmute_unchecked(src)
     }

--- a/tests/ui/transmutability/references/accept_unexercised_lifetime_extension.rs
+++ b/tests/ui/transmutability/references/accept_unexercised_lifetime_extension.rs
@@ -4,11 +4,11 @@
 
 #![feature(transmutability, core_intrinsics)]
 
-use std::mem::{Assume, BikeshedIntrinsicFrom};
+use std::mem::{Assume, TransmuteFrom};
 
 unsafe fn transmute<Src, Dst>(src: Src) -> Dst
 where
-    Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>,
+    Dst: TransmuteFrom<Src, { Assume::SAFETY }>,
 {
     core::intrinsics::transmute_unchecked(src)
 }

--- a/tests/ui/transmutability/references/recursive-wrapper-types-bit-compatible-mut.rs
+++ b/tests/ui/transmutability/references/recursive-wrapper-types-bit-compatible-mut.rs
@@ -2,11 +2,11 @@
 #![feature(transmutability)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: false,

--- a/tests/ui/transmutability/references/recursive-wrapper-types-bit-compatible-mut.stderr
+++ b/tests/ui/transmutability/references/recursive-wrapper-types-bit-compatible-mut.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,

--- a/tests/ui/transmutability/references/recursive-wrapper-types-bit-compatible.rs
+++ b/tests/ui/transmutability/references/recursive-wrapper-types-bit-compatible.rs
@@ -2,11 +2,11 @@
 #![feature(transmutability)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: false,

--- a/tests/ui/transmutability/references/recursive-wrapper-types-bit-incompatible.rs
+++ b/tests/ui/transmutability/references/recursive-wrapper-types-bit-incompatible.rs
@@ -2,11 +2,11 @@
 #![feature(transmutability)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: false,

--- a/tests/ui/transmutability/references/recursive-wrapper-types-bit-incompatible.stderr
+++ b/tests/ui/transmutability/references/recursive-wrapper-types-bit-incompatible.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,

--- a/tests/ui/transmutability/references/recursive-wrapper-types.rs
+++ b/tests/ui/transmutability/references/recursive-wrapper-types.rs
@@ -2,11 +2,11 @@
 #![feature(transmutability)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: false,

--- a/tests/ui/transmutability/references/reject_extension.rs
+++ b/tests/ui/transmutability/references/reject_extension.rs
@@ -6,11 +6,11 @@
 #![feature(transmutability)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<
+        Dst: TransmuteFrom<
             Src,
             {
                 Assume {

--- a/tests/ui/transmutability/references/reject_extension.stderr
+++ b/tests/ui/transmutability/references/reject_extension.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<
+LL |           Dst: TransmuteFrom<
    |  ______________^
 LL | |             Src,
 LL | |             {

--- a/tests/ui/transmutability/references/reject_lifetime_extension.rs
+++ b/tests/ui/transmutability/references/reject_lifetime_extension.rs
@@ -4,11 +4,11 @@
 
 #![feature(transmutability, core_intrinsics)]
 
-use std::mem::{Assume, BikeshedIntrinsicFrom};
+use std::mem::{Assume, TransmuteFrom};
 
 unsafe fn transmute<Src, Dst>(src: Src) -> Dst
 where
-    Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>,
+    Dst: TransmuteFrom<Src, { Assume::SAFETY }>,
 {
     core::intrinsics::transmute_unchecked(src)
 }
@@ -82,7 +82,7 @@ mod hrtb {
 
     unsafe fn extend_hrtb<'a>(src: &'a u8) -> &'static u8
     where
-        for<'b> &'b u8: BikeshedIntrinsicFrom<&'a u8>,
+        for<'b> &'b u8: TransmuteFrom<&'a u8>,
     {
         core::intrinsics::transmute_unchecked(src)
     }

--- a/tests/ui/transmutability/references/reject_lifetime_extension.stderr
+++ b/tests/ui/transmutability/references/reject_lifetime_extension.stderr
@@ -70,8 +70,8 @@ LL |         unsafe { extend_hrtb(src) }
 note: due to current limitations in the borrow checker, this implies a `'static` lifetime
   --> $DIR/reject_lifetime_extension.rs:85:25
    |
-LL |         for<'b> &'b u8: BikeshedIntrinsicFrom<&'a u8>,
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         for<'b> &'b u8: TransmuteFrom<&'a u8>,
+   |                         ^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/transmutability/references/u8-to-unit.rs
+++ b/tests/ui/transmutability/references/u8-to-unit.rs
@@ -2,11 +2,11 @@
 #![feature(transmutability)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: false,
                 lifetimes: true,

--- a/tests/ui/transmutability/references/unit-to-itself.rs
+++ b/tests/ui/transmutability/references/unit-to-itself.rs
@@ -2,11 +2,11 @@
 #![feature(transmutability)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: false,

--- a/tests/ui/transmutability/references/unit-to-u8.rs
+++ b/tests/ui/transmutability/references/unit-to-u8.rs
@@ -2,11 +2,11 @@
 #![feature(transmutability)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: true,

--- a/tests/ui/transmutability/references/unit-to-u8.stderr
+++ b/tests/ui/transmutability/references/unit-to-u8.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,

--- a/tests/ui/transmutability/references/unsafecell.rs
+++ b/tests/ui/transmutability/references/unsafecell.rs
@@ -5,11 +5,11 @@
 use std::cell::UnsafeCell;
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY }>
     {}
 }
 

--- a/tests/ui/transmutability/references/unsafecell.stderr
+++ b/tests/ui/transmutability/references/unsafecell.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_maybe_transmutable`
 LL |     pub fn is_maybe_transmutable<Src, Dst>()
    |            --------------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
 
 error[E0277]: `&UnsafeCell<u8>` cannot be safely transmuted into `&UnsafeCell<u8>`
   --> $DIR/unsafecell.rs:29:62
@@ -25,8 +25,8 @@ note: required by a bound in `is_maybe_transmutable`
 LL |     pub fn is_maybe_transmutable<Src, Dst>()
    |            --------------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/transmutability/region-infer.rs
+++ b/tests/ui/transmutability/region-infer.rs
@@ -1,13 +1,13 @@
 #![feature(transmutability)]
 
-use std::mem::{Assume, BikeshedIntrinsicFrom};
+use std::mem::{Assume, TransmuteFrom};
 
 #[repr(C)]
 struct W<'a>(&'a ());
 
 fn test<'a>()
 where
-    W<'a>: BikeshedIntrinsicFrom<
+    W<'a>: TransmuteFrom<
             (),
             { Assume { alignment: true, lifetimes: true, safety: true, validity: true } },
         >,

--- a/tests/ui/transmutability/region-infer.stderr
+++ b/tests/ui/transmutability/region-infer.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `test`
 LL |   fn test<'a>()
    |      ---- required by a bound in this function
 LL |   where
-LL |       W<'a>: BikeshedIntrinsicFrom<
+LL |       W<'a>: TransmuteFrom<
    |  ____________^
 LL | |             (),
 LL | |             { Assume { alignment: true, lifetimes: true, safety: true, validity: true } },

--- a/tests/ui/transmutability/safety/assume/should_accept_if_dst_has_safety_invariant.rs
+++ b/tests/ui/transmutability/safety/assume/should_accept_if_dst_has_safety_invariant.rs
@@ -8,11 +8,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY }>
     {}
 }
 

--- a/tests/ui/transmutability/safety/assume/should_accept_if_ref_src_has_safety_invariant.rs
+++ b/tests/ui/transmutability/safety/assume/should_accept_if_ref_src_has_safety_invariant.rs
@@ -8,11 +8,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY }>
     {}
 }
 

--- a/tests/ui/transmutability/safety/assume/should_accept_if_src_has_safety_invariant.rs
+++ b/tests/ui/transmutability/safety/assume/should_accept_if_src_has_safety_invariant.rs
@@ -8,11 +8,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY }>
     {}
 }
 

--- a/tests/ui/transmutability/safety/should_accept_if_src_has_safety_invariant.rs
+++ b/tests/ui/transmutability/safety/should_accept_if_src_has_safety_invariant.rs
@@ -8,11 +8,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src> // safety is NOT assumed
+        Dst: TransmuteFrom<Src> // safety is NOT assumed
     {}
 }
 

--- a/tests/ui/transmutability/safety/should_reject_if_dst_has_safety_invariant.rs
+++ b/tests/ui/transmutability/safety/should_reject_if_dst_has_safety_invariant.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src> // safety is NOT assumed
+        Dst: TransmuteFrom<Src> // safety is NOT assumed
     {}
 }
 

--- a/tests/ui/transmutability/safety/should_reject_if_dst_has_safety_invariant.stderr
+++ b/tests/ui/transmutability/safety/should_reject_if_dst_has_safety_invariant.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src> // safety is NOT assumed
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src> // safety is NOT assumed
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/transmutability/safety/should_reject_if_ref_src_has_safety_invariant.rs
+++ b/tests/ui/transmutability/safety/should_reject_if_ref_src_has_safety_invariant.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::BikeshedIntrinsicFrom;
+    use std::mem::TransmuteFrom;
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src> // safety is NOT assumed
+        Dst: TransmuteFrom<Src> // safety is NOT assumed
     {}
 }
 

--- a/tests/ui/transmutability/safety/should_reject_if_ref_src_has_safety_invariant.stderr
+++ b/tests/ui/transmutability/safety/should_reject_if_ref_src_has_safety_invariant.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src> // safety is NOT assumed
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src> // safety is NOT assumed
+   |              ^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/transmutability/structs/repr/should_handle_align.rs
+++ b/tests/ui/transmutability/structs/repr/should_handle_align.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: true,

--- a/tests/ui/transmutability/structs/repr/should_handle_all.rs
+++ b/tests/ui/transmutability/structs/repr/should_handle_all.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: true,

--- a/tests/ui/transmutability/structs/repr/should_handle_packed.rs
+++ b/tests/ui/transmutability/structs/repr/should_handle_packed.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: true,

--- a/tests/ui/transmutability/structs/repr/transmute_infinitely_recursive_type.rs
+++ b/tests/ui/transmutability/structs/repr/transmute_infinitely_recursive_type.rs
@@ -7,11 +7,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src>,
+        Dst: TransmuteFrom<Src>,
     {
     }
 }

--- a/tests/ui/transmutability/structs/repr/transmute_infinitely_recursive_type.stderr
+++ b/tests/ui/transmutability/structs/repr/transmute_infinitely_recursive_type.stderr
@@ -12,7 +12,7 @@ LL |     struct ExplicitlyPadded(Box<ExplicitlyPadded>);
 error[E0391]: cycle detected when computing layout of `should_pad_explicitly_packed_field::ExplicitlyPadded`
    |
    = note: ...which immediately requires computing layout of `should_pad_explicitly_packed_field::ExplicitlyPadded` again
-   = note: cycle used when evaluating trait selection obligation `(): core::mem::transmutability::BikeshedIntrinsicFrom<should_pad_explicitly_packed_field::ExplicitlyPadded, core::mem::transmutability::Assume { alignment: false, lifetimes: false, safety: false, validity: false }>`
+   = note: cycle used when evaluating trait selection obligation `(): core::mem::transmutability::TransmuteFrom<should_pad_explicitly_packed_field::ExplicitlyPadded, core::mem::transmutability::Assume { alignment: false, lifetimes: false, safety: false, validity: false }>`
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: aborting due to 2 previous errors

--- a/tests/ui/transmutability/structs/should_order_fields_correctly.rs
+++ b/tests/ui/transmutability/structs/should_order_fields_correctly.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume::ALIGNMENT
                 .and(Assume::LIFETIMES)
                 .and(Assume::SAFETY)

--- a/tests/ui/transmutability/transmute-padding-ice.rs
+++ b/tests/ui/transmutability/transmute-padding-ice.rs
@@ -9,11 +9,11 @@
 use std::mem::size_of;
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<
+        Dst: TransmuteFrom<
             Src,
             { Assume { alignment: true, lifetimes: true, safety: true, validity: true } },
         >,

--- a/tests/ui/transmutability/uninhabited.rs
+++ b/tests/ui/transmutability/uninhabited.rs
@@ -3,11 +3,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: true,

--- a/tests/ui/transmutability/uninhabited.stderr
+++ b/tests/ui/transmutability/uninhabited.stderr
@@ -34,7 +34,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -56,7 +56,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -78,7 +78,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,
@@ -100,7 +100,7 @@ note: required by a bound in `is_maybe_transmutable`
 LL |       pub fn is_maybe_transmutable<Src, Dst>()
    |              --------------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume {
 LL | |                 alignment: true,

--- a/tests/ui/transmutability/unions/boolish.rs
+++ b/tests/ui/transmutability/unions/boolish.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY }>
     {}
 }
 

--- a/tests/ui/transmutability/unions/repr/should_handle_align.rs
+++ b/tests/ui/transmutability/unions/repr/should_handle_align.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: true,

--- a/tests/ui/transmutability/unions/repr/should_handle_all.rs
+++ b/tests/ui/transmutability/unions/repr/should_handle_all.rs
@@ -5,11 +5,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: true,

--- a/tests/ui/transmutability/unions/repr/should_handle_packed.rs
+++ b/tests/ui/transmutability/unions/repr/should_handle_packed.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume {
                 alignment: true,
                 lifetimes: true,

--- a/tests/ui/transmutability/unions/should_pad_variants.rs
+++ b/tests/ui/transmutability/unions/should_pad_variants.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, {
+        Dst: TransmuteFrom<Src, {
             Assume::ALIGNMENT
                 .and(Assume::LIFETIMES)
                 .and(Assume::SAFETY)

--- a/tests/ui/transmutability/unions/should_pad_variants.stderr
+++ b/tests/ui/transmutability/unions/should_pad_variants.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `is_transmutable`
 LL |       pub fn is_transmutable<Src, Dst>()
    |              --------------- required by a bound in this function
 LL |       where
-LL |           Dst: BikeshedIntrinsicFrom<Src, {
+LL |           Dst: TransmuteFrom<Src, {
    |  ______________^
 LL | |             Assume::ALIGNMENT
 LL | |                 .and(Assume::LIFETIMES)

--- a/tests/ui/transmutability/unions/should_permit_intersecting_if_validity_is_assumed.rs
+++ b/tests/ui/transmutability/unions/should_permit_intersecting_if_validity_is_assumed.rs
@@ -7,11 +7,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY.and(Assume::VALIDITY) }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY.and(Assume::VALIDITY) }>
     {}
 }
 

--- a/tests/ui/transmutability/unions/should_reject_contraction.rs
+++ b/tests/ui/transmutability/unions/should_reject_contraction.rs
@@ -5,11 +5,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY }>
     {}
 }
 

--- a/tests/ui/transmutability/unions/should_reject_contraction.stderr
+++ b/tests/ui/transmutability/unions/should_reject_contraction.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/transmutability/unions/should_reject_disjoint.rs
+++ b/tests/ui/transmutability/unions/should_reject_disjoint.rs
@@ -5,11 +5,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_maybe_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY.and(Assume::VALIDITY) }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY.and(Assume::VALIDITY) }>
     {}
 }
 

--- a/tests/ui/transmutability/unions/should_reject_disjoint.stderr
+++ b/tests/ui/transmutability/unions/should_reject_disjoint.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_maybe_transmutable`
 LL |     pub fn is_maybe_transmutable<Src, Dst>()
    |            --------------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY.and(Assume::VALIDITY) }>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY.and(Assume::VALIDITY) }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
 
 error[E0277]: `B` cannot be safely transmuted into `A`
   --> $DIR/should_reject_disjoint.rs:33:40
@@ -25,8 +25,8 @@ note: required by a bound in `is_maybe_transmutable`
 LL |     pub fn is_maybe_transmutable<Src, Dst>()
    |            --------------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY.and(Assume::VALIDITY) }>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY.and(Assume::VALIDITY) }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_maybe_transmutable`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/transmutability/unions/should_reject_intersecting.rs
+++ b/tests/ui/transmutability/unions/should_reject_intersecting.rs
@@ -6,11 +6,11 @@
 #![allow(dead_code, incomplete_features, non_camel_case_types)]
 
 mod assert {
-    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    use std::mem::{Assume, TransmuteFrom};
 
     pub fn is_transmutable<Src, Dst>()
     where
-        Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
+        Dst: TransmuteFrom<Src, { Assume::SAFETY }>
         // validity is NOT assumed -----^^^^^^^^^^^^^^^^^^
     {}
 }

--- a/tests/ui/transmutability/unions/should_reject_intersecting.stderr
+++ b/tests/ui/transmutability/unions/should_reject_intersecting.stderr
@@ -10,8 +10,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error[E0277]: `B` cannot be safely transmuted into `A`
   --> $DIR/should_reject_intersecting.rs:36:34
@@ -25,8 +25,8 @@ note: required by a bound in `is_transmutable`
 LL |     pub fn is_transmutable<Src, Dst>()
    |            --------------- required by a bound in this function
 LL |     where
-LL |         Dst: BikeshedIntrinsicFrom<Src, { Assume::SAFETY }>
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
+LL |         Dst: TransmuteFrom<Src, { Assume::SAFETY }>
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `is_transmutable`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
As our implementation of MCP411 nears completion and we begin to solicit testing, it's no longer reasonable to expect testers to type or remember `BikeshedIntrinsicFrom`. The name degrades the ease-of-reading of documentation, and the overall experience of using compiler safe transmute.

Tentatively, we'll instead adopt `TransmuteFrom`.

This name seems to be the one most likely to be stabilized, after discussion on Zulip [1]. We may want to revisit the ordering of `Src` and `Dst` before stabilization, at which point we'd likely consider `TransmuteInto` or `Transmute`.

[1] https://rust-lang.zulipchat.com/#narrow/stream/216762-project-safe-transmute/topic/What.20should.20.60BikeshedIntrinsicFrom.60.20be.20named.3F

Tracking Issue: https://github.com/rust-lang/rust/issues/99571

r​? @compiler-errors