### PR TITLE
interpret: add missing alignment check in raw_eq

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -684,19 +684,19 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         assert!(layout.is_sized());
 
         let get_bytes = |this: &InterpCx<'tcx, M>,
-                         op: &OpTy<'tcx, <M as Machine<'tcx>>::Provenance>,
-                         size|
+                         op: &OpTy<'tcx, <M as Machine<'tcx>>::Provenance>|
          -> InterpResult<'tcx, &[u8]> {
             let ptr = this.read_pointer(op)?;
-            let Some(alloc_ref) = self.get_ptr_alloc(ptr, size)? else {
+            this.check_ptr_align(ptr, layout.align.abi)?;
+            let Some(alloc_ref) = self.get_ptr_alloc(ptr, layout.size)? else {
                 // zero-sized access
                 return Ok(&[]);
             };
             alloc_ref.get_bytes_strip_provenance()
         };
 
-        let lhs_bytes = get_bytes(self, lhs, layout.size)?;
-        let rhs_bytes = get_bytes(self, rhs, layout.size)?;
+        let lhs_bytes = get_bytes(self, lhs)?;
+        let rhs_bytes = get_bytes(self, rhs)?;
         Ok(Scalar::from_bool(lhs_bytes == rhs_bytes))
     }
 }

--- a/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.rs
+++ b/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.rs
@@ -13,5 +13,13 @@ const RAW_EQ_PTR: bool = unsafe {
 //~| unable to turn pointer into integer
 };
 
+const RAW_EQ_NOT_ALIGNED: bool = unsafe {
+    let arr = [0u8; 4];
+    let aref = &*arr.as_ptr().cast::<i32>();
+    std::intrinsics::raw_eq(aref, aref)
+//~^ ERROR evaluation of constant value failed
+//~| alignment
+};
+
 pub fn main() {
 }

--- a/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.stderr
+++ b/tests/ui/intrinsics/intrinsic-raw_eq-const-bad.stderr
@@ -13,6 +13,12 @@ LL |     std::intrinsics::raw_eq(&(&0), &(&1))
    = help: this code performed an operation that depends on the underlying bytes representing a pointer
    = help: the absolute address of a pointer is not known at compile-time, so such operations are not supported
 
-error: aborting due to 2 previous errors
+error[E0080]: evaluation of constant value failed
+  --> $DIR/intrinsic-raw_eq-const-bad.rs:19:5
+   |
+LL |     std::intrinsics::raw_eq(aref, aref)
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ accessing memory with alignment 1, but alignment 4 is required
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
The intrinsic requires alignment, but we forgot to check for that in Miri and const-eval.