### PR TITLE
Don't build by-move body when async closure is tainted

### DIFF
--- a/tests/ui/async-await/async-closures/tainted-body-2.rs
+++ b/tests/ui/async-await/async-closures/tainted-body-2.rs
@@ -1,0 +1,18 @@
+//@ edition: 2021
+
+#![feature(async_closure)]
+
+// Ensure that building a by-ref async closure body doesn't ICE when the parent
+// body is tainted.
+
+fn main() {
+    missing;
+    //~^ ERROR cannot find value `missing` in this scope
+
+    // We don't do numerical inference fallback when the body is tainted.
+    // This leads to writeback folding the type of the coroutine-closure
+    // into an error type, since its signature contains that numerical
+    // infer var.
+    let c = async |_| {};
+    c(1);
+}

--- a/tests/ui/async-await/async-closures/tainted-body-2.stderr
+++ b/tests/ui/async-await/async-closures/tainted-body-2.stderr
@@ -1,0 +1,9 @@
+error[E0425]: cannot find value `missing` in this scope
+  --> $DIR/tainted-body-2.rs:9:5
+   |
+LL |     missing;
+   |     ^^^^^^^ not found in this scope
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes #129676 

See explanation in the ui test.