### PR TITLE
Deny imports of `rustc_type_ir::inherent` outside of type ir + new trait solver

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -783,6 +783,9 @@ lint_tykind = usage of `ty::TyKind`
 lint_tykind_kind = usage of `ty::TyKind::<kind>`
     .suggestion = try using `ty::<kind>` directly
 
+lint_type_ir_inherent_usage = do not use `rustc_type_ir::inherent` unless you're inside of the trait solver
+    .note = the method or struct you're looking for is likely defined somewhere else downstream in the compiler
+
 lint_undropped_manually_drops = calls to `std::mem::drop` with `std::mem::ManuallyDrop` instead of the inner value does nothing
     .label = argument has type `{$arg_ty}`
     .suggestion = use `std::mem::ManuallyDrop::into_inner` to get the inner value

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -919,6 +919,11 @@ pub(crate) struct TyQualified {
 }
 
 #[derive(LintDiagnostic)]
+#[diag(lint_type_ir_inherent_usage)]
+#[note]
+pub(crate) struct TypeIrInherentUsage;
+
+#[derive(LintDiagnostic)]
 #[diag(lint_non_glob_import_type_ir_inherent)]
 pub(crate) struct NonGlobImportTypeIrInherent {
     #[suggestion(code = "{snippet}", applicability = "maybe-incorrect")]

--- a/compiler/rustc_next_trait_solver/src/lib.rs
+++ b/compiler/rustc_next_trait_solver/src/lib.rs
@@ -5,6 +5,7 @@
 //! So if you got to this crate from the old solver, it's totally normal.
 
 // tidy-alphabetical-start
+#![cfg_attr(not(bootstrap), allow(rustc::usage_of_type_ir_inherent))]
 #![warn(unreachable_pub)]
 // tidy-alphabetical-end
 

--- a/compiler/rustc_type_ir/src/lib.rs
+++ b/compiler/rustc_type_ir/src/lib.rs
@@ -5,6 +5,7 @@
     feature(associated_type_defaults, never_type, rustc_attrs, negative_impls)
 )]
 #![cfg_attr(feature = "nightly", allow(internal_features))]
+#![cfg_attr(not(bootstrap), allow(rustc::usage_of_type_ir_inherent))]
 // tidy-alphabetical-end
 
 extern crate self as rustc_type_ir;

--- a/tests/ui-fulldeps/internal-lints/import-of-type-ir-inherent.rs
+++ b/tests/ui-fulldeps/internal-lints/import-of-type-ir-inherent.rs
@@ -1,0 +1,18 @@
+//@ compile-flags: -Z unstable-options
+
+// #[cfg(bootstrap)]: We can stop ignoring next beta bump; afterward this ALWAYS should run.
+//@ ignore-stage1
+
+#![feature(rustc_private)]
+#![deny(rustc::usage_of_type_ir_inherent)]
+
+extern crate rustc_type_ir;
+
+use rustc_type_ir::inherent::*;
+//~^ ERROR do not use `rustc_type_ir::inherent` unless you're inside of the trait solver
+use rustc_type_ir::inherent;
+//~^ ERROR do not use `rustc_type_ir::inherent` unless you're inside of the trait solver
+use rustc_type_ir::inherent::Predicate;
+//~^ ERROR do not use `rustc_type_ir::inherent` unless you're inside of the trait solver
+
+fn main() {}

--- a/tests/ui-fulldeps/internal-lints/import-of-type-ir-inherent.stderr
+++ b/tests/ui-fulldeps/internal-lints/import-of-type-ir-inherent.stderr
@@ -1,0 +1,31 @@
+error: do not use `rustc_type_ir::inherent` unless you're inside of the trait solver
+  --> $DIR/import-of-type-ir-inherent.rs:11:20
+   |
+LL | use rustc_type_ir::inherent::*;
+   |                    ^^^^^^^^
+   |
+   = note: the method or struct you're looking for is likely defined somewhere else downstream in the compiler
+note: the lint level is defined here
+  --> $DIR/import-of-type-ir-inherent.rs:7:9
+   |
+LL | #![deny(rustc::usage_of_type_ir_inherent)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: do not use `rustc_type_ir::inherent` unless you're inside of the trait solver
+  --> $DIR/import-of-type-ir-inherent.rs:13:20
+   |
+LL | use rustc_type_ir::inherent;
+   |                    ^^^^^^^^
+   |
+   = note: the method or struct you're looking for is likely defined somewhere else downstream in the compiler
+
+error: do not use `rustc_type_ir::inherent` unless you're inside of the trait solver
+  --> $DIR/import-of-type-ir-inherent.rs:15:20
+   |
+LL | use rustc_type_ir::inherent::Predicate;
+   |                    ^^^^^^^^
+   |
+   = note: the method or struct you're looking for is likely defined somewhere else downstream in the compiler
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
We shouldn't encourage using `rustc_type_ir::inherent` outside of the new solver[^1], though this can happen by accident due to rust-analyzer, for example. See https://github.com/rust-lang/rust/pull/127537#discussion_r1733813842 for an example in practice.

r? fmease

[^1]: Unless we go the fully radical approach of always using these inherent methods everywhere in favor of inherent methods, which would be a major overhaul of the compiler, IMO. I don't really want to consider that possibility right now, tho.