### PR TITLE
Remove `HasLocalDecls`.

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/move_errors.rs
@@ -432,7 +432,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
         // Inspect the type of the content behind the
         // borrow to provide feedback about why this
         // was a move rather than a copy.
-        let ty = deref_target_place.ty(self.body, tcx).ty;
+        let ty = deref_target_place.ty(&self.body.local_decls, tcx).ty;
         let upvar_field = self
             .prefixes(move_place.as_ref(), PrefixSet::All)
             .find_map(|p| self.is_upvar_field_projection(p));
@@ -567,7 +567,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
             GroupedMoveError::MovesFromPlace { mut binds_to, move_from, .. } => {
                 self.add_borrow_suggestions(err, span);
                 if binds_to.is_empty() {
-                    let place_ty = move_from.ty(self.body, self.infcx.tcx).ty;
+                    let place_ty = move_from.ty(&self.body.local_decls, self.infcx.tcx).ty;
                     let place_desc = match self.describe_place(move_from.as_ref()) {
                         Some(desc) => format!("`{desc}`"),
                         None => "value".to_string(),
@@ -599,7 +599,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
             // No binding. Nothing to suggest.
             GroupedMoveError::OtherIllegalMove { ref original_path, use_spans, .. } => {
                 let use_span = use_spans.var_or_use();
-                let place_ty = original_path.ty(self.body, self.infcx.tcx).ty;
+                let place_ty = original_path.ty(&self.body.local_decls, self.infcx.tcx).ty;
                 let place_desc = match self.describe_place(original_path.as_ref()) {
                     Some(desc) => format!("`{desc}`"),
                     None => "value".to_string(),
@@ -757,7 +757,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, '_, 'infcx, 'tcx> {
     /// references to the struct's fields since doing so would be undefined behaviour
     fn add_note_for_packed_struct_derive(&self, err: &mut Diag<'_>, local: Local) {
         let local_place: PlaceRef<'tcx> = local.into();
-        let local_ty = local_place.ty(self.body.local_decls(), self.infcx.tcx).ty.peel_refs();
+        let local_ty = local_place.ty(&self.body.local_decls, self.infcx.tcx).ty.peel_refs();
 
         if let Some(adt) = local_ty.ty_adt_def()
             && adt.repr().packed()

--- a/compiler/rustc_borrowck/src/path_utils.rs
+++ b/compiler/rustc_borrowck/src/path_utils.rs
@@ -158,7 +158,7 @@ pub(crate) fn is_upvar_field_projection<'tcx>(
 
     match place_ref.last_projection() {
         Some((place_base, ProjectionElem::Field(field, _ty))) => {
-            let base_ty = place_base.ty(body, tcx).ty;
+            let base_ty = place_base.ty(&body.local_decls, tcx).ty;
             if (base_ty.is_closure() || base_ty.is_coroutine() || base_ty.is_coroutine_closure())
                 && (!by_ref || upvars[field.index()].is_by_ref())
             {

--- a/compiler/rustc_borrowck/src/place_ext.rs
+++ b/compiler/rustc_borrowck/src/place_ext.rs
@@ -38,7 +38,7 @@ impl<'tcx> Place<'tcx> {
 
         for (i, (proj_base, elem)) in self.iter_projections().enumerate() {
             if elem == ProjectionElem::Deref {
-                let ty = proj_base.ty(body, tcx).ty;
+                let ty = proj_base.ty(&body.local_decls, tcx).ty;
                 match ty.kind() {
                     ty::Ref(_, _, hir::Mutability::Not) if i == 0 => {
                         // For references to thread-local statics, we do need

--- a/compiler/rustc_borrowck/src/places_conflict.rs
+++ b/compiler/rustc_borrowck/src/places_conflict.rs
@@ -199,7 +199,7 @@ fn place_components_conflict<'tcx>(
             // our place. This is a conflict if that is a part our
             // access cares about.
 
-            let base_ty = base.ty(body, tcx).ty;
+            let base_ty = base.ty(&body.local_decls, tcx).ty;
 
             match (elem, base_ty.kind(), access) {
                 (_, _, Shallow(Some(ArtificialField::ArrayLength)))
@@ -311,7 +311,7 @@ fn place_projection_conflict<'tcx>(
                 debug!("place_element_conflict: DISJOINT-OR-EQ-FIELD");
                 Overlap::EqualOrDisjoint
             } else {
-                let ty = pi1.ty(body, tcx).ty;
+                let ty = pi1.ty(&body.local_decls, tcx).ty;
                 if ty.is_union() {
                     // Different fields of a union, we are basically stuck.
                     debug!("place_element_conflict: STUCK-UNION");

--- a/compiler/rustc_codegen_cranelift/src/abi/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/abi/mod.rs
@@ -432,7 +432,9 @@ pub(crate) fn codegen_terminator_call<'tcx>(
 
     let extra_args = &args[fn_sig.inputs().skip_binder().len()..];
     let extra_args = fx.tcx.mk_type_list_from_iter(
-        extra_args.iter().map(|op_arg| fx.monomorphize(op_arg.node.ty(fx.mir, fx.tcx))),
+        extra_args
+            .iter()
+            .map(|op_arg| fx.monomorphize(op_arg.node.ty(&fx.mir.local_decls, fx.tcx))),
     );
     let fn_abi = if let Some(instance) = instance {
         RevealAllLayoutCx(fx.tcx).fn_abi_of_instance(instance, extra_args)

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
@@ -182,7 +182,7 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
 
             // Make sure this is actually an array, since typeck only checks the length-suffixed
             // version of this intrinsic.
-            let idx_ty = fx.monomorphize(idx.node.ty(fx.mir, fx.tcx));
+            let idx_ty = fx.monomorphize(idx.node.ty(&fx.mir.local_decls, fx.tcx));
             let n: u16 = match idx_ty.kind() {
                 ty::Array(ty, len) if matches!(ty.kind(), ty::Uint(ty::UintTy::U32)) => len
                     .try_eval_target_usize(fx.tcx, ty::ParamEnv::reveal_all())

--- a/compiler/rustc_codegen_ssa/src/mir/analyze.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/analyze.rs
@@ -109,7 +109,7 @@ impl<'mir, 'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> LocalAnalyzer<'mir, 'a, 'tcx,
                 )
             );
             if is_consume {
-                let base_ty = place_base.ty(self.fx.mir, cx.tcx());
+                let base_ty = place_base.ty(&self.fx.mir.local_decls, cx.tcx());
                 let base_ty = self.fx.monomorphize(base_ty);
 
                 // ZSTs don't require any actual memory access.

--- a/compiler/rustc_codegen_ssa/src/mir/block.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/block.rs
@@ -504,7 +504,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         unwind: mir::UnwindAction,
         mergeable_succ: bool,
     ) -> MergingSucc {
-        let ty = location.ty(self.mir, bx.tcx()).ty;
+        let ty = location.ty(&self.mir.local_decls, bx.tcx()).ty;
         let ty = self.monomorphize(ty);
         let drop_fn = Instance::resolve_drop_in_place(bx.tcx(), ty);
 
@@ -869,7 +869,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
         let extra_args = &args[sig.inputs().skip_binder().len()..];
         let extra_args = bx.tcx().mk_type_list_from_iter(extra_args.iter().map(|op_arg| {
-            let op_ty = op_arg.node.ty(self.mir, bx.tcx());
+            let op_ty = op_arg.node.ty(&self.mir.local_decls, bx.tcx());
             self.monomorphize(op_ty)
         }));
 

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -538,7 +538,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
 
     pub fn monomorphized_place_ty(&self, place_ref: mir::PlaceRef<'tcx>) -> Ty<'tcx> {
         let tcx = self.cx.tcx();
-        let place_ty = place_ref.ty(self.mir, tcx);
+        let place_ty = place_ref.ty(&self.mir.local_decls, tcx);
         self.monomorphize(place_ty.ty)
     }
 }

--- a/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/rvalue.rs
@@ -678,7 +678,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             }
 
             mir::Rvalue::Discriminant(ref place) => {
-                let discr_ty = rvalue.ty(self.mir, bx.tcx());
+                let discr_ty = rvalue.ty(&self.mir.local_decls, bx.tcx());
                 let discr_ty = self.monomorphize(discr_ty);
                 let discr = self.codegen_place(bx, place.as_ref()).codegen_get_discr(bx, discr_ty);
                 OperandRef {
@@ -746,7 +746,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             mir::Rvalue::Use(ref operand) => self.codegen_operand(bx, operand),
             mir::Rvalue::Repeat(..) => bug!("{rvalue:?} in codegen_rvalue_operand"),
             mir::Rvalue::Aggregate(_, ref fields) => {
-                let ty = rvalue.ty(self.mir, self.cx.tcx());
+                let ty = rvalue.ty(&self.mir.local_decls, self.cx.tcx());
                 let ty = self.monomorphize(ty);
                 let layout = self.cx.layout_of(ty);
 
@@ -1053,7 +1053,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
     pub fn rvalue_creates_operand(&self, rvalue: &mir::Rvalue<'tcx>, span: Span) -> bool {
         match *rvalue {
             mir::Rvalue::Cast(mir::CastKind::Transmute, ref operand, cast_ty) => {
-                let operand_ty = operand.ty(self.mir, self.cx.tcx());
+                let operand_ty = operand.ty(&self.mir.local_decls, self.cx.tcx());
                 let cast_layout = self.cx.layout_of(self.monomorphize(cast_ty));
                 let operand_layout = self.cx.layout_of(self.monomorphize(operand_ty));
 
@@ -1114,7 +1114,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     mir::AggregateKind::Coroutine(..) | mir::AggregateKind::CoroutineClosure(..) => false,
                 };
                 allowed_kind && {
-                let ty = rvalue.ty(self.mir, self.cx.tcx());
+                let ty = rvalue.ty(&self.mir.local_decls, self.cx.tcx());
                 let ty = self.monomorphize(ty);
                     let layout = self.cx.spanned_layout_of(ty, span);
                     !self.cx.is_backend_ref(layout)

--- a/compiler/rustc_const_eval/src/check_consts/post_drop_elaboration.rs
+++ b/compiler/rustc_const_eval/src/check_consts/post_drop_elaboration.rs
@@ -83,7 +83,7 @@ impl<'tcx> Visitor<'tcx> for CheckLiveDrops<'_, 'tcx> {
 
         match &terminator.kind {
             mir::TerminatorKind::Drop { place: dropped_place, .. } => {
-                let dropped_ty = dropped_place.ty(self.body, self.tcx).ty;
+                let dropped_ty = dropped_place.ty(&self.body.local_decls, self.tcx).ty;
 
                 if !NeedsNonConstDrop::in_any_value_of_ty(self.ccx, dropped_ty) {
                     // Instead of throwing a bug, we just return here. This is because we have to

--- a/compiler/rustc_const_eval/src/check_consts/resolver.rs
+++ b/compiler/rustc_const_eval/src/check_consts/resolver.rs
@@ -53,7 +53,7 @@ where
 
         if !value {
             for (base, _elem) in place.iter_projections() {
-                let base_ty = base.ty(self.ccx.body, self.ccx.tcx);
+                let base_ty = base.ty(&self.ccx.body.local_decls, self.ccx.tcx);
                 if base_ty.ty.is_union() && Q::in_any_value_of_ty(self.ccx, base_ty.ty) {
                     value = true;
                     break;
@@ -86,7 +86,7 @@ where
         return_places.for_each(|place| {
             // We cannot reason about another function's internals, so use conservative type-based
             // qualification for the result of a function call.
-            let return_ty = place.ty(self.ccx.body, self.ccx.tcx).ty;
+            let return_ty = place.ty(&self.ccx.body.local_decls, self.ccx.tcx).ty;
             let qualif = Q::in_any_value_of_ty(self.ccx, return_ty);
 
             if !place.is_indirect() {
@@ -120,7 +120,10 @@ where
     ///
     /// [rust-lang/unsafe-code-guidelines#134]: https://github.com/rust-lang/unsafe-code-guidelines/issues/134
     fn shared_borrow_allows_mutation(&self, place: mir::Place<'tcx>) -> bool {
-        !place.ty(self.ccx.body, self.ccx.tcx).ty.is_freeze(self.ccx.tcx, self.ccx.param_env)
+        !place
+            .ty(&self.ccx.body.local_decls, self.ccx.tcx)
+            .ty
+            .is_freeze(self.ccx.tcx, self.ccx.param_env)
     }
 }
 
@@ -172,7 +175,7 @@ where
         match rvalue {
             mir::Rvalue::RawPtr(_mt, borrowed_place) => {
                 if !borrowed_place.is_indirect() && self.address_of_allows_mutation() {
-                    let place_ty = borrowed_place.ty(self.ccx.body, self.ccx.tcx).ty;
+                    let place_ty = borrowed_place.ty(&self.ccx.body.local_decls, self.ccx.tcx).ty;
                     if Q::in_any_value_of_ty(self.ccx, place_ty) {
                         self.state.qualif.insert(borrowed_place.local);
                         self.state.borrow.insert(borrowed_place.local);
@@ -183,7 +186,7 @@ where
             mir::Rvalue::Ref(_, kind, borrowed_place) => {
                 if !borrowed_place.is_indirect() && self.ref_allows_mutation(*kind, *borrowed_place)
                 {
-                    let place_ty = borrowed_place.ty(self.ccx.body, self.ccx.tcx).ty;
+                    let place_ty = borrowed_place.ty(&self.ccx.body.local_decls, self.ccx.tcx).ty;
                     if Q::in_any_value_of_ty(self.ccx, place_ty) {
                         self.state.qualif.insert(borrowed_place.local);
                         self.state.borrow.insert(borrowed_place.local);

--- a/compiler/rustc_const_eval/src/util/alignment.rs
+++ b/compiler/rustc_const_eval/src/util/alignment.rs
@@ -6,15 +6,12 @@ use tracing::debug;
 /// Returns `true` if this place is allowed to be less aligned
 /// than its containing struct (because it is within a packed
 /// struct).
-pub fn is_disaligned<'tcx, L>(
+pub fn is_disaligned<'tcx>(
     tcx: TyCtxt<'tcx>,
-    local_decls: &L,
+    local_decls: &LocalDecls<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     place: Place<'tcx>,
-) -> bool
-where
-    L: HasLocalDecls<'tcx>,
-{
+) -> bool {
     debug!("is_disaligned({:?})", place);
     let Some(pack) = is_within_packed(tcx, local_decls, place) else {
         debug!("is_disaligned({:?}) - not within packed", place);
@@ -50,14 +47,11 @@ where
     }
 }
 
-pub fn is_within_packed<'tcx, L>(
+pub fn is_within_packed<'tcx>(
     tcx: TyCtxt<'tcx>,
-    local_decls: &L,
+    local_decls: &LocalDecls<'tcx>,
     place: Place<'tcx>,
-) -> Option<Align>
-where
-    L: HasLocalDecls<'tcx>,
-{
+) -> Option<Align> {
     place
         .iter_projections()
         .rev()

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -81,31 +81,6 @@ pub use self::pretty::{
 /// Types for locals
 pub type LocalDecls<'tcx> = IndexSlice<Local, LocalDecl<'tcx>>;
 
-pub trait HasLocalDecls<'tcx> {
-    fn local_decls(&self) -> &LocalDecls<'tcx>;
-}
-
-impl<'tcx> HasLocalDecls<'tcx> for IndexVec<Local, LocalDecl<'tcx>> {
-    #[inline]
-    fn local_decls(&self) -> &LocalDecls<'tcx> {
-        self
-    }
-}
-
-impl<'tcx> HasLocalDecls<'tcx> for LocalDecls<'tcx> {
-    #[inline]
-    fn local_decls(&self) -> &LocalDecls<'tcx> {
-        self
-    }
-}
-
-impl<'tcx> HasLocalDecls<'tcx> for Body<'tcx> {
-    #[inline]
-    fn local_decls(&self) -> &LocalDecls<'tcx> {
-        &self.local_decls
-    }
-}
-
 thread_local! {
     static PASS_NAMES: RefCell<FxHashMap<&'static str, &'static str>> = {
         RefCell::new(FxHashMap::default())

--- a/compiler/rustc_middle/src/mir/tcx.rs
+++ b/compiler/rustc_middle/src/mir/tcx.rs
@@ -117,35 +117,24 @@ impl<'tcx> PlaceTy<'tcx> {
 }
 
 impl<'tcx> Place<'tcx> {
-    pub fn ty_from<D: ?Sized>(
+    pub fn ty_from(
         local: Local,
         projection: &[PlaceElem<'tcx>],
-        local_decls: &D,
+        local_decls: &LocalDecls<'tcx>,
         tcx: TyCtxt<'tcx>,
-    ) -> PlaceTy<'tcx>
-    where
-        D: HasLocalDecls<'tcx>,
-    {
-        projection
-            .iter()
-            .fold(PlaceTy::from_ty(local_decls.local_decls()[local].ty), |place_ty, &elem| {
-                place_ty.projection_ty(tcx, elem)
-            })
+    ) -> PlaceTy<'tcx> {
+        projection.iter().fold(PlaceTy::from_ty(local_decls[local].ty), |place_ty, &elem| {
+            place_ty.projection_ty(tcx, elem)
+        })
     }
 
-    pub fn ty<D: ?Sized>(&self, local_decls: &D, tcx: TyCtxt<'tcx>) -> PlaceTy<'tcx>
-    where
-        D: HasLocalDecls<'tcx>,
-    {
+    pub fn ty(&self, local_decls: &LocalDecls<'tcx>, tcx: TyCtxt<'tcx>) -> PlaceTy<'tcx> {
         Place::ty_from(self.local, self.projection, local_decls, tcx)
     }
 }
 
 impl<'tcx> PlaceRef<'tcx> {
-    pub fn ty<D: ?Sized>(&self, local_decls: &D, tcx: TyCtxt<'tcx>) -> PlaceTy<'tcx>
-    where
-        D: HasLocalDecls<'tcx>,
-    {
+    pub fn ty(&self, local_decls: &LocalDecls<'tcx>, tcx: TyCtxt<'tcx>) -> PlaceTy<'tcx> {
         Place::ty_from(self.local, self.projection, local_decls, tcx)
     }
 }
@@ -156,10 +145,7 @@ pub enum RvalueInitializationState {
 }
 
 impl<'tcx> Rvalue<'tcx> {
-    pub fn ty<D: ?Sized>(&self, local_decls: &D, tcx: TyCtxt<'tcx>) -> Ty<'tcx>
-    where
-        D: HasLocalDecls<'tcx>,
-    {
+    pub fn ty(&self, local_decls: &LocalDecls<'tcx>, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
         match *self {
             Rvalue::Use(ref operand) => operand.ty(local_decls, tcx),
             Rvalue::Repeat(ref operand, count) => {
@@ -220,24 +206,16 @@ impl<'tcx> Rvalue<'tcx> {
 }
 
 impl<'tcx> Operand<'tcx> {
-    pub fn ty<D: ?Sized>(&self, local_decls: &D, tcx: TyCtxt<'tcx>) -> Ty<'tcx>
-    where
-        D: HasLocalDecls<'tcx>,
-    {
+    pub fn ty(&self, local_decls: &LocalDecls<'tcx>, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
         match self {
             &Operand::Copy(ref l) | &Operand::Move(ref l) => l.ty(local_decls, tcx).ty,
             Operand::Constant(c) => c.const_.ty(),
         }
     }
 
-    pub fn span<D: ?Sized>(&self, local_decls: &D) -> Span
-    where
-        D: HasLocalDecls<'tcx>,
-    {
+    pub fn span(&self, local_decls: &LocalDecls<'tcx>) -> Span {
         match self {
-            &Operand::Copy(ref l) | &Operand::Move(ref l) => {
-                local_decls.local_decls()[l.local].source_info.span
-            }
+            &Operand::Copy(ref l) | &Operand::Move(ref l) => local_decls[l.local].source_info.span,
             Operand::Constant(c) => c.span,
         }
     }

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -258,7 +258,7 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
             ),
             ExprKind::Cast { source } => {
                 let source = self.parse_operand(*source)?;
-                let source_ty = source.ty(self.body.local_decls(), self.tcx);
+                let source_ty = source.ty(&self.body.local_decls, self.tcx);
                 let cast_kind = mir_cast_kind(source_ty, expr.ty);
                 Ok(Rvalue::Cast(cast_kind, source, expr.ty))
             },

--- a/compiler/rustc_mir_build/src/lints.rs
+++ b/compiler/rustc_mir_build/src/lints.rs
@@ -136,7 +136,7 @@ impl<'tcx> TerminatorClassifier<'tcx> for CallRecursion<'tcx> {
         let caller = body.source.def_id();
         let param_env = tcx.param_env(caller);
 
-        let func_ty = func.ty(body, tcx);
+        let func_ty = func.ty(&body.local_decls, tcx);
         if let ty::FnDef(callee, args) = *func_ty.kind() {
             let Ok(normalized_args) = tcx.try_normalize_erasing_regions(param_env, args) else {
                 return false;
@@ -171,7 +171,7 @@ impl<'tcx> TerminatorClassifier<'tcx> for RecursiveDrop<'tcx> {
     ) -> bool {
         let TerminatorKind::Drop { place, .. } = &terminator.kind else { return false };
 
-        let dropped_ty = place.ty(body, tcx).ty;
+        let dropped_ty = place.ty(&body.local_decls, tcx).ty;
         dropped_ty == self.drop_for
     }
 }

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -199,7 +199,7 @@ where
 {
     #[instrument(level = "trace", skip(self), ret)]
     fn place_ty(&self, place: Place<'tcx>) -> Ty<'tcx> {
-        place.ty(self.elaborator.body(), self.tcx()).ty
+        place.ty(&self.elaborator.body().local_decls, self.tcx()).ty
     }
 
     fn tcx(&self) -> TyCtxt<'tcx> {

--- a/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/borrowed_locals.rs
@@ -26,7 +26,7 @@ impl<'tcx> AnalysisDomain<'tcx> for MaybeBorrowedLocals {
 
     fn bottom_value(&self, body: &Body<'tcx>) -> Self::Domain {
         // bottom = unborrowed
-        BitSet::new_empty(body.local_decls().len())
+        BitSet::new_empty(body.local_decls.len())
     }
 
     fn initialize_start_block(&self, _: &Body<'tcx>, _: &mut Self::Domain) {

--- a/compiler/rustc_mir_dataflow/src/impls/initialized.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/initialized.rs
@@ -760,7 +760,7 @@ fn switch_on_enum_discriminant<'mir, 'tcx>(
             mir::StatementKind::Assign(box (lhs, mir::Rvalue::Discriminant(discriminated)))
                 if *lhs == switch_on =>
             {
-                match discriminated.ty(body, tcx).ty.kind() {
+                match discriminated.ty(&body.local_decls, tcx).ty.kind() {
                     ty::Adt(def, _) => return Some((*discriminated, *def)),
 
                     // `Rvalue::Discriminant` is also used to get the active yield point for a

--- a/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
+++ b/compiler/rustc_mir_dataflow/src/move_paths/builder.rs
@@ -133,7 +133,7 @@ impl<'b, 'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> Gatherer<'b, 'a, 'tcx, F> {
         for (place_ref, elem) in data.rev_lookup.un_derefer.iter_projections(place.as_ref()) {
             let body = self.builder.body;
             let tcx = self.builder.tcx;
-            let place_ty = place_ref.ty(body, tcx).ty;
+            let place_ty = place_ref.ty(&body.local_decls, tcx).ty;
             if place_ty.references_error() {
                 return MovePathResult::Error;
             }
@@ -562,7 +562,7 @@ impl<'b, 'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> Gatherer<'b, 'a, 'tcx, F> {
                     return;
                 }
             };
-            let base_ty = base_place.ty(self.builder.body, self.builder.tcx).ty;
+            let base_ty = base_place.ty(&self.builder.body.local_decls, self.builder.tcx).ty;
             let len: u64 = match base_ty.kind() {
                 ty::Array(_, size) => {
                     size.eval_target_usize(self.builder.tcx, self.builder.param_env)
@@ -604,7 +604,7 @@ impl<'b, 'a, 'tcx, F: Fn(Ty<'tcx>) -> bool> Gatherer<'b, 'a, 'tcx, F> {
         // Check if we are assigning into a field of a union, if so, lookup the place
         // of the union so it is marked as initialized again.
         if let Some((place_base, ProjectionElem::Field(_, _))) = place.last_projection() {
-            if place_base.ty(self.builder.body, self.builder.tcx).ty.is_union() {
+            if place_base.ty(&self.builder.body.local_decls, self.builder.tcx).ty.is_union() {
                 place = place_base;
             }
         }

--- a/compiler/rustc_mir_transform/src/abort_unwinding_calls.rs
+++ b/compiler/rustc_mir_transform/src/abort_unwinding_calls.rs
@@ -61,7 +61,7 @@ impl<'tcx> MirPass<'tcx> for AbortUnwindingCalls {
 
             let call_can_unwind = match &terminator.kind {
                 TerminatorKind::Call { func, .. } => {
-                    let ty = func.ty(body, tcx);
+                    let ty = func.ty(&body.local_decls, tcx);
                     let sig = ty.fn_sig(tcx);
                     let fn_def_id = match ty.kind() {
                         ty::FnPtr(..) => None,

--- a/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
+++ b/compiler/rustc_mir_transform/src/add_moves_for_packed_drops.rs
@@ -59,7 +59,7 @@ fn add_moves_for_packed_drops_patch<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>) 
 
         match terminator.kind {
             TerminatorKind::Drop { place, .. }
-                if util::is_disaligned(tcx, body, param_env, place) =>
+                if util::is_disaligned(tcx, &body.local_decls, param_env, place) =>
             {
                 add_move_for_packed_drop(tcx, body, &mut patch, terminator, loc, data.is_cleanup);
             }
@@ -84,7 +84,7 @@ fn add_move_for_packed_drop<'tcx>(
     };
 
     let source_info = terminator.source_info;
-    let ty = place.ty(body, tcx).ty;
+    let ty = place.ty(&body.local_decls, tcx).ty;
     let temp = patch.new_temp(ty, terminator.source_info.span);
 
     let storage_dead_block = patch.new_block(BasicBlockData {

--- a/compiler/rustc_mir_transform/src/add_subtyping_projections.rs
+++ b/compiler/rustc_mir_transform/src/add_subtyping_projections.rs
@@ -1,4 +1,3 @@
-use rustc_index::IndexVec;
 use rustc_middle::mir::patch::MirPatch;
 use rustc_middle::mir::visit::MutVisitor;
 use rustc_middle::mir::*;
@@ -9,7 +8,7 @@ pub struct Subtyper;
 pub struct SubTypeChecker<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     patcher: MirPatch<'tcx>,
-    local_decls: &'a IndexVec<Local, LocalDecl<'tcx>>,
+    local_decls: &'a LocalDecls<'tcx>,
 }
 
 impl<'a, 'tcx> MutVisitor<'tcx> for SubTypeChecker<'a, 'tcx> {

--- a/compiler/rustc_mir_transform/src/check_packed_ref.rs
+++ b/compiler/rustc_mir_transform/src/check_packed_ref.rs
@@ -38,7 +38,7 @@ impl<'tcx> Visitor<'tcx> for PackedRefChecker<'_, 'tcx> {
 
     fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, _location: Location) {
         if context.is_borrow() {
-            if util::is_disaligned(self.tcx, self.body, self.param_env, *place) {
+            if util::is_disaligned(self.tcx, &self.body.local_decls, self.param_env, *place) {
                 let def_id = self.body.source.instance.def_id();
                 if let Some(impl_def_id) = self.tcx.impl_of_method(def_id)
                     && self.tcx.is_builtin_derived(impl_def_id)

--- a/compiler/rustc_mir_transform/src/coroutine.rs
+++ b/compiler/rustc_mir_transform/src/coroutine.rs
@@ -644,7 +644,7 @@ fn transform_async_context<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
 
         match &bb_data.terminator().kind {
             TerminatorKind::Call { func, .. } => {
-                let func_ty = func.ty(body, tcx);
+                let func_ty = func.ty(&body.local_decls, tcx);
                 if let ty::FnDef(def_id, _) = *func_ty.kind() {
                     if def_id == get_context_def_id {
                         let local = eliminate_get_context_call(&mut body[bb]);

--- a/compiler/rustc_mir_transform/src/cost_checker.rs
+++ b/compiler/rustc_mir_transform/src/cost_checker.rs
@@ -118,7 +118,7 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
         match &terminator.kind {
             TerminatorKind::Drop { place, unwind, .. } => {
                 // If the place doesn't actually need dropping, treat it like a regular goto.
-                let ty = self.instantiate_ty(place.ty(self.callee_body, self.tcx).ty);
+                let ty = self.instantiate_ty(place.ty(&self.callee_body.local_decls, self.tcx).ty);
                 if ty.needs_drop(self.tcx, self.param_env) {
                     self.penalty += CALL_PENALTY;
                     if let UnwindAction::Cleanup(_) = unwind {

--- a/compiler/rustc_mir_transform/src/cross_crate_inline.rs
+++ b/compiler/rustc_mir_transform/src/cross_crate_inline.rs
@@ -109,7 +109,7 @@ impl<'tcx> Visitor<'tcx> for CostChecker<'_, 'tcx> {
         let tcx = self.tcx;
         match terminator.kind {
             TerminatorKind::Drop { ref place, unwind, .. } => {
-                let ty = place.ty(self.callee_body, tcx).ty;
+                let ty = place.ty(&self.callee_body.local_decls, tcx).ty;
                 if !ty.is_trivially_pure_clone_copy() {
                     self.calls += 1;
                     if let UnwindAction::Cleanup(_) = unwind {

--- a/compiler/rustc_mir_transform/src/dead_store_elimination.rs
+++ b/compiler/rustc_mir_transform/src/dead_store_elimination.rs
@@ -65,7 +65,7 @@ pub fn eliminate<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
                     // the move may be codegened as a pointer to that field.
                     // Using that disaligned pointer may trigger UB in the callee,
                     // so do nothing.
-                    && is_within_packed(tcx, body, place).is_none()
+                    && is_within_packed(tcx, &body.local_decls, place).is_none()
                 {
                     call_operands_to_move.push((bb, index));
                 }

--- a/compiler/rustc_mir_transform/src/deref_separator.rs
+++ b/compiler/rustc_mir_transform/src/deref_separator.rs
@@ -1,4 +1,3 @@
-use rustc_index::IndexVec;
 use rustc_middle::mir::patch::MirPatch;
 use rustc_middle::mir::visit::NonUseContext::VarDebugInfo;
 use rustc_middle::mir::visit::{MutVisitor, PlaceContext};
@@ -10,7 +9,7 @@ pub struct Derefer;
 pub struct DerefChecker<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     patcher: MirPatch<'tcx>,
-    local_decls: &'a IndexVec<Local, LocalDecl<'tcx>>,
+    local_decls: &'a LocalDecls<'tcx>,
 }
 
 impl<'a, 'tcx> MutVisitor<'tcx> for DerefChecker<'a, 'tcx> {

--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -137,8 +137,8 @@ use rustc_index::interval::SparseIntervalMatrix;
 use rustc_middle::bug;
 use rustc_middle::mir::visit::{MutVisitor, PlaceContext, Visitor};
 use rustc_middle::mir::{
-    dump_mir, traversal, Body, HasLocalDecls, InlineAsmOperand, Local, LocalKind, Location,
-    Operand, PassWhere, Place, Rvalue, Statement, StatementKind, TerminatorKind,
+    dump_mir, traversal, Body, InlineAsmOperand, Local, LocalKind, Location, Operand, PassWhere,
+    Place, Rvalue, Statement, StatementKind, TerminatorKind,
 };
 use rustc_middle::ty::TyCtxt;
 use rustc_mir_dataflow::impls::MaybeLiveLocals;
@@ -787,15 +787,15 @@ impl<'tcx> Visitor<'tcx> for FindAssignments<'_, '_, 'tcx> {
 
             // As described at the top of this file, we do not touch locals which have
             // different types.
-            let src_ty = self.body.local_decls()[src].ty;
-            let dest_ty = self.body.local_decls()[dest].ty;
+            let src_ty = self.body.local_decls[src].ty;
+            let dest_ty = self.body.local_decls[dest].ty;
             if src_ty != dest_ty {
                 // FIXME(#112651): This can be removed afterwards. Also update the module description.
                 trace!("skipped `{src:?} = {dest:?}` due to subtyping: {src_ty} != {dest_ty}");
                 return;
             }
 
-            // Also, we need to make sure that MIR actually allows the `src` to be removed
+            // Also.local_decls, we need to make sure that MIR actually allows the `src` to be removed
             if is_local_required(src, self.body) {
                 return;
             }

--- a/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
+++ b/compiler/rustc_mir_transform/src/early_otherwise_branch.rs
@@ -126,7 +126,7 @@ impl<'tcx> MirPass<'tcx> for EarlyOtherwiseBranch {
                 Operand::Copy(x) => Operand::Copy(*x),
                 Operand::Constant(x) => Operand::Constant(x.clone()),
             };
-            let parent_ty = parent_op.ty(body.local_decls(), tcx);
+            let parent_ty = parent_op.ty(&body.local_decls, tcx);
             let statements_before = bbs[parent].statements.len();
             let parent_end = Location { block: parent, statement_index: statements_before };
 
@@ -233,7 +233,7 @@ fn evaluate_candidate<'tcx>(
     else {
         return None;
     };
-    let parent_ty = parent_discr.ty(body.local_decls(), tcx);
+    let parent_ty = parent_discr.ty(&body.local_decls, tcx);
     if !bbs[targets.otherwise()].is_empty_unreachable() {
         // Someone could write code like this:
         // ```rust
@@ -275,7 +275,7 @@ fn evaluate_candidate<'tcx>(
     else {
         return None;
     };
-    let child_ty = child_discr.ty(body.local_decls(), tcx);
+    let child_ty = child_discr.ty(&body.local_decls, tcx);
     if child_ty != parent_ty {
         return None;
     }

--- a/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
+++ b/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
@@ -47,7 +47,7 @@ fn has_ffi_unwind_calls(tcx: TyCtxt<'_>, local_def_id: LocalDefId) -> bool {
         let Some(terminator) = &block.terminator else { continue };
         let TerminatorKind::Call { func, .. } = &terminator.kind else { continue };
 
-        let ty = func.ty(body, tcx);
+        let ty = func.ty(&body.local_decls, tcx);
         let sig = ty.fn_sig(tcx);
 
         // Rust calls cannot themselves create foreign unwinds.

--- a/compiler/rustc_mir_transform/src/function_item_references.rs
+++ b/compiler/rustc_mir_transform/src/function_item_references.rs
@@ -41,11 +41,11 @@ impl<'tcx> Visitor<'tcx> for FunctionItemRefChecker<'_, 'tcx> {
         } = &terminator.kind
         {
             let source_info = *self.body.source_info(location);
-            let func_ty = func.ty(self.body, self.tcx);
+            let func_ty = func.ty(&self.body.local_decls, self.tcx);
             if let ty::FnDef(def_id, args_ref) = *func_ty.kind() {
                 // Handle calls to `transmute`
                 if self.tcx.is_diagnostic_item(sym::transmute, def_id) {
-                    let arg_ty = args[0].node.ty(self.body, self.tcx);
+                    let arg_ty = args[0].node.ty(&self.body.local_decls, self.tcx);
                     for inner_ty in arg_ty.walk().filter_map(|arg| arg.as_type()) {
                         if let Some((fn_id, fn_args)) = FunctionItemRefChecker::is_fn_ref(inner_ty)
                         {

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -200,7 +200,7 @@ impl<'tcx, 'a> TOFinder<'tcx, 'a> {
         let discr = discr.place()?;
         debug!(?discr, ?bb);
 
-        let discr_ty = discr.ty(self.body, self.tcx).ty;
+        let discr_ty = discr.ty(&self.body.local_decls, self.tcx).ty;
         let discr_layout = self.ecx.layout_of(discr_ty).ok()?;
 
         let discr = self.map.find(discr.as_ref())?;
@@ -467,7 +467,7 @@ impl<'tcx, 'a> TOFinder<'tcx, 'a> {
             }
             // If we expect `lhs ?= A`, we have an opportunity if we assume `constant == A`.
             Rvalue::Aggregate(box ref kind, ref operands) => {
-                let agg_ty = lhs_place.ty(self.body, self.tcx).ty;
+                let agg_ty = lhs_place.ty(&self.body.local_decls, self.tcx).ty;
                 let lhs = match kind {
                     // Do not support unions.
                     AggregateKind::Adt(.., Some(_)) => return None,
@@ -551,7 +551,7 @@ impl<'tcx, 'a> TOFinder<'tcx, 'a> {
             // we have an opportunity if `variant_index ?= A`.
             StatementKind::SetDiscriminant { box place, variant_index } => {
                 let discr_target = self.map.find_discr(place.as_ref())?;
-                let enum_ty = place.ty(self.body, self.tcx).ty;
+                let enum_ty = place.ty(&self.body.local_decls, self.tcx).ty;
                 // `SetDiscriminant` may be a no-op if the assigned variant is the untagged variant
                 // of a niche encoding. If we cannot ensure that we write to the discriminant, do
                 // nothing.
@@ -643,7 +643,7 @@ impl<'tcx, 'a> TOFinder<'tcx, 'a> {
         debug_assert_eq!(self.body.basic_blocks.predecessors()[target_bb].len(), 1);
 
         let discr = discr.place()?;
-        let discr_ty = discr.ty(self.body, self.tcx).ty;
+        let discr_ty = discr.ty(&self.body.local_decls, self.tcx).ty;
         let discr_layout = self.ecx.layout_of(discr_ty).ok()?;
         let conditions = state.try_get(discr.as_ref(), self.map)?;
 

--- a/compiler/rustc_mir_transform/src/known_panics_lint.rs
+++ b/compiler/rustc_mir_transform/src/known_panics_lint.rs
@@ -545,7 +545,7 @@ impl<'mir, 'tcx> ConstPropagator<'mir, 'tcx> {
             return None;
         }
         use rustc_middle::mir::Rvalue::*;
-        let layout = self.ecx.layout_of(dest.ty(self.body, self.tcx).ty).ok()?;
+        let layout = self.ecx.layout_of(dest.ty(&self.body.local_decls, self.tcx).ty).ok()?;
         trace!(?layout);
 
         let val: Value<'_> = match *rvalue {

--- a/compiler/rustc_mir_transform/src/match_branches.rs
+++ b/compiler/rustc_mir_transform/src/match_branches.rs
@@ -72,7 +72,7 @@ trait SimplifyMatch<'tcx> {
             _ => unreachable!(),
         };
 
-        let discr_ty = discr.ty(body.local_decls(), tcx);
+        let discr_ty = discr.ty(&body.local_decls, tcx);
         self.can_simplify(tcx, targets, param_env, bbs, discr_ty)?;
 
         let mut patch = MirPatch::new(body);

--- a/compiler/rustc_mir_transform/src/remove_uninit_drops.rs
+++ b/compiler/rustc_mir_transform/src/remove_uninit_drops.rs
@@ -48,7 +48,7 @@ impl<'tcx> MirPass<'tcx> for RemoveUninitDrops {
                 param_env,
                 maybe_inits,
                 &move_data,
-                place.ty(body, tcx).ty,
+                place.ty(&body.local_decls, tcx).ty,
                 mpi,
             );
             if !should_keep {

--- a/compiler/rustc_mir_transform/src/shim.rs
+++ b/compiler/rustc_mir_transform/src/shim.rs
@@ -261,7 +261,7 @@ fn build_drop_shim<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, ty: Option<Ty<'tcx>>)
             BorrowKind::Mut { kind: MutBorrowKind::Default },
             tcx.mk_place_deref(dropee_ptr),
         );
-        let ref_ty = reborrow.ty(body.local_decls(), tcx);
+        let ref_ty = reborrow.ty(&body.local_decls, tcx);
         dropee_ptr = body.local_decls.push(LocalDecl::new(ref_ty, span)).into();
         let new_statements = [
             StatementKind::Assign(Box::new((dropee_ptr, reborrow))),

--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -98,7 +98,7 @@ fn escaping_locals<'tcx>(
 
     let mut set = BitSet::new_empty(body.local_decls.len());
     set.insert_range(RETURN_PLACE..=Local::from_usize(body.arg_count));
-    for (local, decl) in body.local_decls().iter_enumerated() {
+    for (local, decl) in body.local_decls.iter_enumerated() {
         if excluded.contains(local) || is_excluded_ty(decl.ty) {
             set.insert(local);
         }

--- a/compiler/rustc_mir_transform/src/ssa.rs
+++ b/compiler/rustc_mir_transform/src/ssa.rs
@@ -335,8 +335,8 @@ fn compute_copy_classes(ssa: &mut SsaLocals, body: &Body<'_>) {
         };
 
         let Some(rhs) = place.as_local() else { continue };
-        let local_ty = body.local_decls()[local].ty;
-        let rhs_ty = body.local_decls()[rhs].ty;
+        let local_ty = body.local_decls[local].ty;
+        let rhs_ty = body.local_decls[rhs].ty;
         if local_ty != rhs_ty {
             // FIXME(#112651): This can be removed afterwards.
             trace!("skipped `{local:?} = {rhs:?}` due to subtyping: {local_ty} != {rhs_ty}");

--- a/compiler/rustc_mir_transform/src/unreachable_enum_branching.rs
+++ b/compiler/rustc_mir_transform/src/unreachable_enum_branching.rs
@@ -40,7 +40,7 @@ fn get_switched_on_type<'tcx>(
     if let StatementKind::Assign(box (l, Rvalue::Discriminant(place))) = stmt_before_term.kind
         && l.as_local() == Some(local)
     {
-        let ty = place.ty(body, tcx).ty;
+        let ty = place.ty(&body.local_decls, tcx).ty;
         if ty.is_enum() {
             return Some(ty);
         }

--- a/compiler/rustc_mir_transform/src/unreachable_prop.rs
+++ b/compiler/rustc_mir_transform/src/unreachable_prop.rs
@@ -91,7 +91,7 @@ fn remove_successors_from_switch<'tcx>(
     // In order to preserve this information, we record reachable and unreachable targets as
     // `Assume` statements in MIR.
 
-    let discr_ty = discr.ty(body, tcx);
+    let discr_ty = discr.ty(&body.local_decls, tcx);
     let discr_size = Size::from_bits(match discr_ty.kind() {
         ty::Uint(uint) => uint.normalize(tcx.sess.target.pointer_width).bit_width().unwrap(),
         ty::Int(int) => int.normalize(tcx.sess.target.pointer_width).bit_width().unwrap(),

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -666,7 +666,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirUsedCollector<'a, 'tcx> {
                 target_ty,
             )
             | mir::Rvalue::Cast(mir::CastKind::DynStar, ref operand, target_ty) => {
-                let source_ty = operand.ty(self.body, self.tcx);
+                let source_ty = operand.ty(&self.body.local_decls, self.tcx);
                 // *Before* monomorphizing, record that we already handled this mention.
                 self.used_mentioned_items
                     .insert(MentionedItem::UnsizeCast { source_ty, target_ty });
@@ -694,7 +694,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirUsedCollector<'a, 'tcx> {
                 ref operand,
                 _,
             ) => {
-                let fn_ty = operand.ty(self.body, self.tcx);
+                let fn_ty = operand.ty(&self.body.local_decls, self.tcx);
                 // *Before* monomorphizing, record that we already handled this mention.
                 self.used_mentioned_items.insert(MentionedItem::Fn(fn_ty));
                 let fn_ty = self.monomorphize(fn_ty);
@@ -705,7 +705,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirUsedCollector<'a, 'tcx> {
                 ref operand,
                 _,
             ) => {
-                let source_ty = operand.ty(self.body, self.tcx);
+                let source_ty = operand.ty(&self.body.local_decls, self.tcx);
                 // *Before* monomorphizing, record that we already handled this mention.
                 self.used_mentioned_items.insert(MentionedItem::Closure(source_ty));
                 let source_ty = self.monomorphize(source_ty);
@@ -757,7 +757,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirUsedCollector<'a, 'tcx> {
         match terminator.kind {
             mir::TerminatorKind::Call { ref func, ref args, ref fn_span, .. }
             | mir::TerminatorKind::TailCall { ref func, ref args, ref fn_span } => {
-                let callee_ty = func.ty(self.body, tcx);
+                let callee_ty = func.ty(&self.body.local_decls, tcx);
                 // *Before* monomorphizing, record that we already handled this mention.
                 self.used_mentioned_items.insert(MentionedItem::Fn(callee_ty));
                 let callee_ty = self.monomorphize(callee_ty);
@@ -765,7 +765,7 @@ impl<'a, 'tcx> MirVisitor<'tcx> for MirUsedCollector<'a, 'tcx> {
                 visit_fn_use(self.tcx, callee_ty, true, source, &mut self.used_items)
             }
             mir::TerminatorKind::Drop { ref place, .. } => {
-                let ty = place.ty(self.body, self.tcx).ty;
+                let ty = place.ty(&self.body.local_decls, self.tcx).ty;
                 // *Before* monomorphizing, record that we already handled this mention.
                 self.used_mentioned_items.insert(MentionedItem::Drop(ty));
                 let ty = self.monomorphize(ty);

--- a/compiler/rustc_monomorphize/src/collector/move_check.rs
+++ b/compiler/rustc_monomorphize/src/collector/move_check.rs
@@ -95,7 +95,7 @@ impl<'a, 'tcx> MirUsedCollector<'a, 'tcx> {
         limit: Limit,
         operand: &mir::Operand<'tcx>,
     ) -> Option<Size> {
-        let ty = operand.ty(self.body, self.tcx);
+        let ty = operand.ty(&self.body.local_decls, self.tcx);
         let ty = self.monomorphize(ty);
         let Ok(layout) = self.tcx.layout_of(ty::ParamEnv::reveal_all().and(ty)) else {
             return None;

--- a/src/tools/clippy/clippy_lints/src/redundant_clone.rs
+++ b/src/tools/clippy/clippy_lints/src/redundant_clone.rs
@@ -258,8 +258,8 @@ fn is_call_with_ref_arg<'tcx>(
     } = kind
         && args.len() == 1
         && let mir::Operand::Move(mir::Place { local, .. }) = &args[0].node
-        && let ty::FnDef(def_id, _) = *func.ty(mir, cx.tcx).kind()
-        && let (inner_ty, 1) = walk_ptrs_ty_depth(args[0].node.ty(mir, cx.tcx))
+        && let ty::FnDef(def_id, _) = *func.ty(&mir.local_decls, cx.tcx).kind()
+        && let (inner_ty, 1) = walk_ptrs_ty_depth(args[0].node.ty(&mir.local_decls, cx.tcx))
         && !is_copy(cx, inner_ty)
     {
         Some((def_id, *local, inner_ty, destination.as_local()?))


### PR DESCRIPTION
It's a trait that lets you pass any of `Body`, `LocalDecls`, or `IndexVec<Local, LocalDecl>` to various functions. A minor convenience, and a minor obfuscation, that not actually needed.

This commit removes the trait and changes those functions to receive `&LocalDecls` instead of `&D where D: HasLocalDecls`. This makes lots of call sites slightly more verbose, but I think it's worth it for the overall simplicity.

r? @scottmcm