### PR TITLE
copysign with sign being a NaN can have non-portable results

### DIFF
--- a/library/std/src/f128.rs
+++ b/library/std/src/f128.rs
@@ -250,9 +250,14 @@ impl f128 {
     ///
     /// Equal to `self` if the sign of `self` and `sign` are the same, otherwise equal to `-self`.
     /// If `self` is a NaN, then a NaN with the same payload as `self` and the sign bit of `sign` is
-    /// returned. Note, however, that conserving the sign bit on NaN across arithmetical operations
-    /// is not generally guaranteed. See [specification of NaN bit
-    /// patterns](primitive@f32#nan-bit-patterns) for more info.
+    /// returned.
+    ///
+    /// If `sign` is a NaN, then this operation will still carry over its sign into the result. Note
+    /// that IEEE 754 doesn't assign any meaning to the sign bit in case of a NaN, and as Rust
+    /// doesn't guarantee that the bit pattern of NaNs are conserved over arithmetic operations, the
+    /// result of `copysign` with `sign` being a NaN might produce an unexpected or non-portable
+    /// result. See the [specification of NaN bit patterns](primitive@f32#nan-bit-patterns) for more
+    /// info.
     ///
     /// # Examples
     ///

--- a/library/std/src/f16.rs
+++ b/library/std/src/f16.rs
@@ -249,9 +249,14 @@ impl f16 {
     ///
     /// Equal to `self` if the sign of `self` and `sign` are the same, otherwise equal to `-self`.
     /// If `self` is a NaN, then a NaN with the same payload as `self` and the sign bit of `sign` is
-    /// returned. Note, however, that conserving the sign bit on NaN across arithmetical operations
-    /// is not generally guaranteed. See [specification of NaN bit
-    /// patterns](primitive@f32#nan-bit-patterns) for more info.
+    /// returned.
+    ///
+    /// If `sign` is a NaN, then this operation will still carry over its sign into the result. Note
+    /// that IEEE 754 doesn't assign any meaning to the sign bit in case of a NaN, and as Rust
+    /// doesn't guarantee that the bit pattern of NaNs are conserved over arithmetic operations, the
+    /// result of `copysign` with `sign` being a NaN might produce an unexpected or non-portable
+    /// result. See the [specification of NaN bit patterns](primitive@f32#nan-bit-patterns) for more
+    /// info.
     ///
     /// # Examples
     ///

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -228,9 +228,14 @@ impl f32 {
     ///
     /// Equal to `self` if the sign of `self` and `sign` are the same, otherwise equal to `-self`.
     /// If `self` is a NaN, then a NaN with the same payload as `self` and the sign bit of `sign` is
-    /// returned. Note, however, that conserving the sign bit on NaN across arithmetical operations
-    /// is not generally guaranteed. See [specification of NaN bit
-    /// patterns](primitive@f32#nan-bit-patterns) for more info.
+    /// returned.
+    ///
+    /// If `sign` is a NaN, then this operation will still carry over its sign into the result. Note
+    /// that IEEE 754 doesn't assign any meaning to the sign bit in case of a NaN, and as Rust
+    /// doesn't guarantee that the bit pattern of NaNs are conserved over arithmetic operations, the
+    /// result of `copysign` with `sign` being a NaN might produce an unexpected or non-portable
+    /// result. See the [specification of NaN bit patterns](primitive@f32#nan-bit-patterns) for more
+    /// info.
     ///
     /// # Examples
     ///

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -228,9 +228,14 @@ impl f64 {
     ///
     /// Equal to `self` if the sign of `self` and `sign` are the same, otherwise equal to `-self`.
     /// If `self` is a NaN, then a NaN with the same payload as `self` and the sign bit of `sign` is
-    /// returned. Note, however, that conserving the sign bit on NaN across arithmetical operations
-    /// is not generally guaranteed. See [specification of NaN bit
-    /// patterns](primitive@f32#nan-bit-patterns) for more info.
+    /// returned.
+    ///
+    /// If `sign` is a NaN, then this operation will still carry over its sign into the result. Note
+    /// that IEEE 754 doesn't assign any meaning to the sign bit in case of a NaN, and as Rust
+    /// doesn't guarantee that the bit pattern of NaNs are conserved over arithmetic operations, the
+    /// result of `copysign` with `sign` being a NaN might produce an unexpected or non-portable
+    /// result. See the [specification of NaN bit patterns](primitive@f32#nan-bit-patterns) for more
+    /// info.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/129559.
Cc @tgross35 @beetrees 

There's no portable variant we can recommend instead here, is there? Something with a semantics like "if `sign` is a NaN, then return `self` unaltered, otherwise return `self` with the sign changed to that of `sign`"?