### PR TITLE
Add `needs-unwind` compiletest directive to `libtest-thread-limit` and replace some `Path` with `path` in `run-make`

### DIFF
--- a/tests/run-make/dos-device-input/rmake.rs
+++ b/tests/run-make/dos-device-input/rmake.rs
@@ -1,13 +1,11 @@
 //@ only-windows
 // Reason: dos devices are a Windows thing
 
-use std::path::Path;
-
-use run_make_support::{rustc, static_lib_name};
+use run_make_support::{path, rustc, static_lib_name};
 
 fn main() {
     rustc().input(r"\\.\NUL").crate_type("staticlib").run();
     rustc().input(r"\\?\NUL").crate_type("staticlib").run();
 
-    assert!(Path::new(&static_lib_name("rust_out")).exists());
+    assert!(path(&static_lib_name("rust_out")).exists());
 }

--- a/tests/run-make/emit-shared-files/rmake.rs
+++ b/tests/run-make/emit-shared-files/rmake.rs
@@ -5,9 +5,7 @@
 // `all-shared` should only emit files that can be shared between crates.
 // See https://github.com/rust-lang/rust/pull/83478
 
-use std::path::Path;
-
-use run_make_support::{has_extension, has_prefix, rustdoc, shallow_find_files};
+use run_make_support::{has_extension, has_prefix, path, rustdoc, shallow_find_files};
 
 fn main() {
     rustdoc()
@@ -19,18 +17,18 @@ fn main() {
         .args(&["--extend-css", "z.css"])
         .input("x.rs")
         .run();
-    assert!(Path::new("invocation-only/search-index-xxx.js").exists());
-    assert!(Path::new("invocation-only/crates-xxx.js").exists());
-    assert!(Path::new("invocation-only/settings.html").exists());
-    assert!(Path::new("invocation-only/x/all.html").exists());
-    assert!(Path::new("invocation-only/x/index.html").exists());
-    assert!(Path::new("invocation-only/theme-xxx.css").exists()); // generated from z.css
-    assert!(!Path::new("invocation-only/storage-xxx.js").exists());
-    assert!(!Path::new("invocation-only/SourceSerif4-It.ttf.woff2").exists());
+    assert!(path("invocation-only/search-index-xxx.js").exists());
+    assert!(path("invocation-only/crates-xxx.js").exists());
+    assert!(path("invocation-only/settings.html").exists());
+    assert!(path("invocation-only/x/all.html").exists());
+    assert!(path("invocation-only/x/index.html").exists());
+    assert!(path("invocation-only/theme-xxx.css").exists()); // generated from z.css
+    assert!(!path("invocation-only/storage-xxx.js").exists());
+    assert!(!path("invocation-only/SourceSerif4-It.ttf.woff2").exists());
     // FIXME: this probably shouldn't have a suffix
-    assert!(Path::new("invocation-only/y-xxx.css").exists());
+    assert!(path("invocation-only/y-xxx.css").exists());
     // FIXME: this is technically incorrect (see `write_shared`)
-    assert!(!Path::new("invocation-only/main-xxx.js").exists());
+    assert!(!path("invocation-only/main-xxx.js").exists());
 
     rustdoc()
         .arg("-Zunstable-options")
@@ -61,10 +59,10 @@ fn main() {
         .len(),
         1
     );
-    assert!(!Path::new("toolchain-only/search-index-xxx.js").exists());
-    assert!(!Path::new("toolchain-only/x/index.html").exists());
-    assert!(!Path::new("toolchain-only/theme.css").exists());
-    assert!(!Path::new("toolchain-only/y-xxx.css").exists());
+    assert!(!path("toolchain-only/search-index-xxx.js").exists());
+    assert!(!path("toolchain-only/x/index.html").exists());
+    assert!(!path("toolchain-only/theme.css").exists());
+    assert!(!path("toolchain-only/y-xxx.css").exists());
 
     rustdoc()
         .arg("-Zunstable-options")
@@ -88,11 +86,11 @@ fn main() {
         .len(),
         1
     );
-    assert!(!Path::new("all-shared/search-index-xxx.js").exists());
-    assert!(!Path::new("all-shared/settings.html").exists());
-    assert!(!Path::new("all-shared/x").exists());
-    assert!(!Path::new("all-shared/src").exists());
-    assert!(!Path::new("all-shared/theme.css").exists());
+    assert!(!path("all-shared/search-index-xxx.js").exists());
+    assert!(!path("all-shared/settings.html").exists());
+    assert!(!path("all-shared/x").exists());
+    assert!(!path("all-shared/src").exists());
+    assert!(!path("all-shared/theme.css").exists());
     assert_eq!(
         shallow_find_files("all-shared/static.files", |path| {
             has_prefix(path, "main-") && has_extension(path, "js")
@@ -100,5 +98,5 @@ fn main() {
         .len(),
         1
     );
-    assert!(!Path::new("all-shared/y-xxx.css").exists());
+    assert!(!path("all-shared/y-xxx.css").exists());
 }

--- a/tests/run-make/libtest-thread-limit/rmake.rs
+++ b/tests/run-make/libtest-thread-limit/rmake.rs
@@ -11,6 +11,9 @@
 // Reason: thread limit modification
 //@ ignore-cross-compile
 // Reason: this test fails armhf-gnu, reasons unknown
+//@ needs-unwind
+// Reason: this should be ignored in cg_clif (Cranelift) CI and anywhere
+// else that uses panic=abort.
 
 use std::ffi::{self, CStr, CString};
 use std::path::PathBuf;

--- a/tests/run-make/manual-crate-name/rmake.rs
+++ b/tests/run-make/manual-crate-name/rmake.rs
@@ -1,8 +1,6 @@
-use std::path::Path;
-
-use run_make_support::rustc;
+use run_make_support::{path, rustc};
 
 fn main() {
     rustc().input("bar.rs").crate_name("foo").run();
-    assert!(Path::new("libfoo.rlib").is_file());
+    assert!(path("libfoo.rlib").is_file());
 }

--- a/tests/run-make/pretty-print-with-dep-file/rmake.rs
+++ b/tests/run-make/pretty-print-with-dep-file/rmake.rs
@@ -5,14 +5,12 @@
 // does not get an unexpected dep-info file.
 // See https://github.com/rust-lang/rust/issues/112898
 
-use std::path::Path;
-
-use run_make_support::{invalid_utf8_contains, rfs, rustc};
+use run_make_support::{invalid_utf8_contains, path, rfs, rustc};
 
 fn main() {
     rustc().emit("dep-info").arg("-Zunpretty=expanded").input("with-dep.rs").run();
     invalid_utf8_contains("with-dep.d", "with-dep.rs");
     rfs::remove_file("with-dep.d");
     rustc().emit("dep-info").arg("-Zunpretty=normal").input("with-dep.rs").run();
-    assert!(!Path::new("with-dep.d").exists());
+    assert!(!path("with-dep.d").exists());
 }

--- a/tests/run-make/profile/rmake.rs
+++ b/tests/run-make/profile/rmake.rs
@@ -8,16 +8,14 @@
 //@ ignore-cross-compile
 //@ needs-profiler-support
 
-use std::path::Path;
-
-use run_make_support::{run, rustc};
+use run_make_support::{path, run, rustc};
 
 fn main() {
     rustc().arg("-g").arg("-Zprofile").input("test.rs").run();
     run("test");
-    assert!(Path::new("test.gcno").exists(), "no .gcno file");
-    assert!(Path::new("test.gcda").exists(), "no .gcda file");
+    assert!(path("test.gcno").exists(), "no .gcno file");
+    assert!(path("test.gcda").exists(), "no .gcda file");
     rustc().arg("-g").arg("-Zprofile").arg("-Zprofile-emit=abc/abc.gcda").input("test.rs").run();
     run("test");
-    assert!(Path::new("abc/abc.gcda").exists(), "gcda file not emitted to defined path");
+    assert!(path("abc/abc.gcda").exists(), "gcda file not emitted to defined path");
 }

--- a/tests/run-make/reset-codegen-1/rmake.rs
+++ b/tests/run-make/reset-codegen-1/rmake.rs
@@ -7,9 +7,7 @@
 
 //@ ignore-cross-compile
 
-use std::path::Path;
-
-use run_make_support::{bin_name, rustc};
+use run_make_support::{bin_name, path, rustc};
 
 fn compile(output_file: &str, emit: Option<&str>) {
     let mut rustc = rustc();
@@ -34,10 +32,10 @@ fn main() {
         // In the None case, bin_name is required for successful Windows compilation.
         let output_file = &bin_name(output_file);
         compile(output_file, emit);
-        assert!(Path::new(output_file).is_file());
+        assert!(path(output_file).is_file());
     }
 
     compile("multi-output", Some("asm,obj"));
-    assert!(Path::new("multi-output.s").is_file());
-    assert!(Path::new("multi-output.o").is_file());
+    assert!(path("multi-output.s").is_file());
+    assert!(path("multi-output.o").is_file());
 }

--- a/tests/run-make/rustdoc-determinism/rmake.rs
+++ b/tests/run-make/rustdoc-determinism/rmake.rs
@@ -1,16 +1,14 @@
 // Assert that the search index is generated deterministically, regardless of the
 // order that crates are documented in.
 
-use std::path::Path;
-
-use run_make_support::{diff, rustdoc};
+use run_make_support::{diff, path, rustdoc};
 
 fn main() {
-    let foo_first = Path::new("foo_first");
+    let foo_first = path("foo_first");
     rustdoc().input("foo.rs").out_dir(&foo_first).run();
     rustdoc().input("bar.rs").out_dir(&foo_first).run();
 
-    let bar_first = Path::new("bar_first");
+    let bar_first = path("bar_first");
     rustdoc().input("bar.rs").out_dir(&bar_first).run();
     rustdoc().input("foo.rs").out_dir(&bar_first).run();
 

--- a/tests/run-make/rustdoc-output-path/rmake.rs
+++ b/tests/run-make/rustdoc-output-path/rmake.rs
@@ -1,11 +1,9 @@
 // Checks that if the output folder doesn't exist, rustdoc will create it.
 
-use std::path::Path;
-
-use run_make_support::rustdoc;
+use run_make_support::{path, rustdoc};
 
 fn main() {
-    let out_dir = Path::new("foo/bar/doc");
+    let out_dir = path("foo/bar/doc");
     rustdoc().input("foo.rs").out_dir(&out_dir).run();
     assert!(out_dir.exists());
 }


### PR DESCRIPTION
Part of #121876 and the associated [Google Summer of Code project](https://blog.rust-lang.org/2024/05/01/gsoc-2024-selected-projects.html).

This PR does two things:

1. Add this to `libtest-thread-limit` ([Why?](https://github.com/rust-lang/rust/pull/128507#issuecomment-2315158014))
```
//@ needs-unwind
// Reason: this should be ignored in cg_clif (Cranelift) CI and anywhere
// else that uses panic=abort.
```

2. Use `path` instead of `Path` to simplify multiple run-make tests.