### PR TITLE
Fix path to run clippy on rustdoc

### DIFF
--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -313,7 +313,7 @@ lint_any!(
     RemoteTestServer, "src/tools/remote-test-server", "remote-test-server";
     Rls, "src/tools/rls", "rls";
     RustAnalyzer, "src/tools/rust-analyzer", "rust-analyzer";
-    Rustdoc, "src/tools/rustdoc", "clippy";
+    Rustdoc, "src/librustdoc", "clippy";
     Rustfmt, "src/tools/rustfmt", "rustfmt";
     RustInstaller, "src/tools/rust-installer", "rust-installer";
     Tidy, "src/tools/tidy", "tidy";


### PR DESCRIPTION
Took me a while to find out that the path clippy expected was `src/tools/rustdoc` and not `src/librustdoc`. I think it makes more sense this way as most commands rely on source paths.

r? @Kobzol 