### PR TITLE
Correct trusty targets to be tier 3

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_trusty.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_trusty.rs
@@ -7,7 +7,7 @@ pub fn target() -> Target {
         llvm_target: "aarch64-unknown-unknown-musl".into(),
         metadata: crate::spec::TargetMetadata {
             description: Some("ARM64 Trusty".into()),
-            tier: Some(2),
+            tier: Some(3),
             host_tools: Some(false),
             std: Some(false),
         },

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_trusty.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_trusty.rs
@@ -8,7 +8,7 @@ pub fn target() -> Target {
         llvm_target: "armv7-unknown-unknown-gnueabi".into(),
         metadata: crate::spec::TargetMetadata {
             description: Some("Armv7-A Trusty".into()),
-            tier: Some(2),
+            tier: Some(3),
             host_tools: Some(false),
             std: Some(false),
         },


### PR DESCRIPTION
The Trusty targets were added in https://github.com/rust-lang/rust/pull/129490, but in that PR I accidentally marked them as tier 2. This PR corrects the target metadata to mark them as tier 3.
