### PR TITLE
Add a test for trait solver overflow in MIR inliner cycle detection

### DIFF
--- a/tests/mir-opt/inline/type_overflow.rs
+++ b/tests/mir-opt/inline/type_overflow.rs
@@ -1,0 +1,32 @@
+// This is a regression test for one of the problems in #128887; it checks that the
+// strategy in #129714 avoids trait solver overflows in this specific case.
+
+// skip-filecheck
+//@ compile-flags: -Zinline-mir
+
+pub trait Foo {
+    type Associated;
+    type Chain: Foo<Associated = Self::Associated>;
+}
+
+trait FooExt {
+    fn do_ext() {}
+}
+impl<T: Foo<Associated = f64>> FooExt for T {}
+
+#[allow(unconditional_recursion)]
+fn recurse<T: Foo<Associated = f64>>() {
+    T::do_ext();
+    recurse::<T::Chain>();
+}
+
+macro_rules! emit {
+    ($($m:ident)*) => {$(
+        pub fn $m<T: Foo<Associated = f64>>() {
+            recurse::<T>();
+        }
+    )*}
+}
+
+// Increase the chance of triggering the bug
+emit!(m00 m01 m02 m03 m04 m05 m06 m07 m08 m09 m10 m11 m12 m13 m14 m15 m16 m17 m18 m19);


### PR DESCRIPTION
This test is a combination of the reproducer posted here: https://github.com/rust-lang/rust/issues/128887#issuecomment-2314198229 and the existing test for polymorphic recursion: https://github.com/rust-lang/rust/blob/784d444733d65c3d305ce5edcbb41e3d0d0aee2e/tests/mir-opt/inline/polymorphic_recursion.rs

r? @compiler-errors 