### PR TITLE
Make the "detect-old-time" UI test more representative

### DIFF
--- a/tests/ui/inference/detect-old-time-version-format_description-parse.rs
+++ b/tests/ui/inference/detect-old-time-version-format_description-parse.rs
@@ -1,8 +1,13 @@
 #![crate_name = "time"]
+#![crate_type = "lib"]
 
-fn main() {
-    let items = Box::new(vec![]); //~ ERROR E0282
+// This code compiled without error in Rust 1.79, but started failing in 1.80
+// after the addition of several `impl FromIterator<_> for Box<str>`.
+
+pub fn parse() -> Option<Vec<()>> {
+    let iter = std::iter::once(Some(())).map(|o| o.map(Into::into));
+    let items = iter.collect::<Option<Box<_>>>()?; //~ ERROR E0282
+    //~^ NOTE this is an inference error on crate `time` caused by an API change in Rust 1.80.0; update `time` to version `>=0.3.35`
+    Some(items.into())
     //~^ NOTE type must be known at this point
-    //~| NOTE this is an inference error on crate `time` caused by an API change in Rust 1.80.0; update `time` to version `>=0.3.35`
-    items.into();
 }

--- a/tests/ui/inference/detect-old-time-version-format_description-parse.stderr
+++ b/tests/ui/inference/detect-old-time-version-format_description-parse.stderr
@@ -1,8 +1,11 @@
-error[E0282]: type annotations needed for `Box<Vec<_>>`
-  --> $DIR/detect-old-time-version-format_description-parse.rs:4:9
+error[E0282]: type annotations needed for `Box<_>`
+  --> $DIR/detect-old-time-version-format_description-parse.rs:9:9
    |
-LL |     let items = Box::new(vec![]);
-   |         ^^^^^   ---------------- type must be known at this point
+LL |     let items = iter.collect::<Option<Box<_>>>()?;
+   |         ^^^^^
+LL |
+LL |     Some(items.into())
+   |                ---- type must be known at this point
    |
    = note: this is an inference error on crate `time` caused by an API change in Rust 1.80.0; update `time` to version `>=0.3.35` by calling `cargo update`
 


### PR DESCRIPTION
The test code did have an inference failure, but that would have failed
on Rust 1.79 and earlier too. Now it is rewritten to be specifically
affected by 1.80's `impl FromIterator<_> for Box<str>`.
