### PR TITLE
Rub come caching on caller_location

### DIFF
--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -66,7 +66,7 @@ use crate::metadata::ModChild;
 use crate::middle::codegen_fn_attrs::CodegenFnAttrs;
 use crate::middle::{resolve_bound_vars, stability};
 use crate::mir::interpret::{self, Allocation, ConstAllocation};
-use crate::mir::{Body, Local, Place, PlaceElem, ProjectionKind, Promoted};
+use crate::mir::{Body, ConstValue, Local, Place, PlaceElem, ProjectionKind, Promoted};
 use crate::query::plumbing::QuerySystem;
 use crate::query::{IntoQueryParam, LocalCrate, Providers, TyCtxtAt};
 use crate::thir::Thir;
@@ -1297,6 +1297,8 @@ pub struct GlobalCtxt<'tcx> {
     /// Stores memory for globals (statics/consts).
     pub(crate) alloc_map: Lock<interpret::AllocMap<'tcx>>,
 
+    pub caller_location_cache: Lock<FxHashMap<(Symbol, u32, u32), ConstValue<'tcx>>>,
+
     current_gcx: CurrentGcx,
 }
 
@@ -1527,6 +1529,7 @@ impl<'tcx> TyCtxt<'tcx> {
             canonical_param_env_cache: Default::default(),
             data_layout,
             alloc_map: Lock::new(interpret::AllocMap::new()),
+            caller_location_cache: Default::default(),
             current_gcx,
         }
     }


### PR DESCRIPTION
Inspired by the huge perf wins from making track_caller a no-op: https://github.com/rust-lang/rust/pull/129704, I started poking around and it looks like we have no deduplication of identical `panic::Location` allocations.

Nora says I can use a query here, but I'm scared of query overhead so I'm going to perf something very crude first.

r? @ghost