### PR TITLE
struct_target_features: reduce serialized rmeta

### DIFF
--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -330,8 +330,10 @@ impl DefKind {
     /// Whether `query struct_target_features` should be used with this definition.
     pub fn has_struct_target_features(self) -> bool {
         match self {
-            DefKind::Struct | DefKind::Union | DefKind::Enum => true,
+            DefKind::Struct => true,
             DefKind::Fn
+            | DefKind::Union
+            | DefKind::Enum
             | DefKind::AssocFn
             | DefKind::Ctor(..)
             | DefKind::Closure

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -224,7 +224,7 @@ provide! { tcx, def_id, other, cdata,
     variances_of => { table }
     fn_sig => { table }
     codegen_fn_attrs => { table }
-    struct_target_features => { table }
+    struct_target_features => { table_defaulted_array }
     impl_trait_header => { table }
     const_param_default => { table }
     object_lifetime_default => { table }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1393,7 +1393,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 record!(self.tables.codegen_fn_attrs[def_id] <- self.tcx.codegen_fn_attrs(def_id));
             }
             if def_kind.has_struct_target_features() {
-                record_array!(self.tables.struct_target_features[def_id] <- self.tcx.struct_target_features(def_id));
+                record_defaulted_array!(self.tables.struct_target_features[def_id] <- self.tcx.struct_target_features(def_id));
             }
             if should_encode_visibility(def_kind) {
                 let vis =

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -402,6 +402,7 @@ define_tables! {
     // individually instead of `DefId`s.
     module_children_reexports: Table<DefIndex, LazyArray<ModChild>>,
     cross_crate_inlinable: Table<DefIndex, bool>,
+    struct_target_features: Table<DefIndex, LazyArray<TargetFeature>>,
 
 - optional:
     attributes: Table<DefIndex, LazyArray<ast::Attribute>>,
@@ -427,7 +428,6 @@ define_tables! {
     variances_of: Table<DefIndex, LazyArray<ty::Variance>>,
     fn_sig: Table<DefIndex, LazyValue<ty::EarlyBinder<'static, ty::PolyFnSig<'static>>>>,
     codegen_fn_attrs: Table<DefIndex, LazyValue<CodegenFnAttrs>>,
-    struct_target_features: Table<DefIndex, LazyArray<TargetFeature>>,
     impl_trait_header: Table<DefIndex, LazyValue<ty::ImplTraitHeader<'static>>>,
     const_param_default: Table<DefIndex, LazyValue<ty::EarlyBinder<'static, rustc_middle::ty::Const<'static>>>>,
     object_lifetime_default: Table<DefIndex, LazyValue<ObjectLifetimeDefault>>,

--- a/tests/ui/target-feature/auxiliary/struct-target-features-crate-dep.rs
+++ b/tests/ui/target-feature/auxiliary/struct-target-features-crate-dep.rs
@@ -1,0 +1,6 @@
+#![feature(struct_target_features)]
+
+#[target_feature(enable = "avx")]
+pub struct Avx {}
+
+pub struct NoFeatures {}

--- a/tests/ui/target-feature/struct-target-features-crate.rs
+++ b/tests/ui/target-feature/struct-target-features-crate.rs
@@ -1,0 +1,23 @@
+//@ only-x86_64
+//@ aux-build: struct-target-features-crate-dep.rs
+//@ check-pass
+#![feature(target_feature_11)]
+
+extern crate struct_target_features_crate_dep;
+
+#[target_feature(enable = "avx")]
+fn avx() {}
+
+fn f(_: struct_target_features_crate_dep::Avx) {
+    avx();
+}
+
+fn g(_: struct_target_features_crate_dep::NoFeatures) {}
+
+fn main() {
+    if is_x86_feature_detected!("avx") {
+        let avx = unsafe { struct_target_features_crate_dep::Avx {} };
+        f(avx);
+    }
+    g(struct_target_features_crate_dep::NoFeatures {});
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

Reduce the amount of serialized information in rmeta. This should fix the binary size regression in #127537 and *may* also fix the speed regression.

r? compiler-errors

Tracking issue: #129107