### PR TITLE
dont clone old syntax context

### DIFF
--- a/compiler/rustc_span/src/hygiene.rs
+++ b/compiler/rustc_span/src/hygiene.rs
@@ -1420,7 +1420,8 @@ pub fn decode_syntax_context<D: Decoder, F: FnOnce(&mut D, u32) -> SyntaxContext
             && old.outer_transparency == ctxt_data.outer_transparency
             && old.parent == ctxt_data.parent
         {
-            ctxt_data = old.clone();
+            ctxt_data.opaque = old.opaque;
+            ctxt_data.opaque_and_semitransparent = old.opaque_and_semitransparent;
         }
 
         let dummy = std::mem::replace(


### PR DESCRIPTION
I guess this regression was caused by too many clones, so this is an attempt to use the old value rather than cloning it. Perhaps a better approach would be to ensure that only the substantial fields mentioned in this [comment](https://github.com/rust-lang/rust/pull/127279#issuecomment-2210376603) are cacheable.

Anyway, let's run a perf test to see if this can solve the problem.

r? @pnkfelix or @petrochenkov 