### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/float-minmax-pass.rs
+++ b/compiler/rustc_codegen_cranelift/example/float-minmax-pass.rs
@@ -9,13 +9,13 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct f32x4(pub f32, pub f32, pub f32, pub f32);
+struct f32x4(pub [f32; 4]);
 
 use std::intrinsics::simd::*;
 
 fn main() {
-    let x = f32x4(1.0, 2.0, 3.0, 4.0);
-    let y = f32x4(2.0, 1.0, 4.0, 3.0);
+    let x = f32x4([1.0, 2.0, 3.0, 4.0]);
+    let y = f32x4([2.0, 1.0, 4.0, 3.0]);
 
     #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
     let nan = f32::NAN;
@@ -24,13 +24,13 @@ fn main() {
     #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
     let nan = f32::from_bits(f32::NAN.to_bits() - 1);
 
-    let n = f32x4(nan, nan, nan, nan);
+    let n = f32x4([nan, nan, nan, nan]);
 
     unsafe {
         let min0 = simd_fmin(x, y);
         let min1 = simd_fmin(y, x);
         assert_eq!(min0, min1);
-        let e = f32x4(1.0, 1.0, 3.0, 3.0);
+        let e = f32x4([1.0, 1.0, 3.0, 3.0]);
         assert_eq!(min0, e);
         let minn = simd_fmin(x, n);
         assert_eq!(minn, x);
@@ -40,7 +40,7 @@ fn main() {
         let max0 = simd_fmax(x, y);
         let max1 = simd_fmax(y, x);
         assert_eq!(max0, max1);
-        let e = f32x4(2.0, 2.0, 4.0, 4.0);
+        let e = f32x4([2.0, 2.0, 4.0, 4.0]);
         assert_eq!(max0, e);
         let maxn = simd_fmax(x, n);
         assert_eq!(maxn, x);

--- a/compiler/rustc_codegen_cranelift/example/std_example.rs
+++ b/compiler/rustc_codegen_cranelift/example/std_example.rs
@@ -166,7 +166,7 @@ fn main() {
         enum Never {}
     }
 
-    foo(I64X2(0, 0));
+    foo(I64X2([0, 0]));
 
     transmute_fat_pointer();
 
@@ -204,7 +204,7 @@ fn rust_call_abi() {
 }
 
 #[repr(simd)]
-struct I64X2(i64, i64);
+struct I64X2([i64; 2]);
 
 #[allow(improper_ctypes_definitions)]
 extern "C" fn foo(_a: I64X2) {}

--- a/compiler/rustc_error_codes/src/error_codes/E0074.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0074.md
@@ -11,7 +11,7 @@ This will cause an error:
 #![feature(repr_simd)]
 
 #[repr(simd)]
-struct Bad<T>(T, T, T, T);
+struct Bad<T>([T; 4]);
 ```
 
 This will not:
@@ -20,5 +20,5 @@ This will not:
 #![feature(repr_simd)]
 
 #[repr(simd)]
-struct Good(u32, u32, u32, u32);
+struct Good([u32; 4]);
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0075.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0075.md
@@ -1,6 +1,6 @@
-A `#[simd]` attribute was applied to an empty tuple struct.
+A `#[simd]` attribute was applied to an empty or multi-field struct.
 
-Erroneous code example:
+Erroneous code examples:
 
 ```compile_fail,E0075
 #![feature(repr_simd)]
@@ -9,9 +9,15 @@ Erroneous code example:
 struct Bad; // error!
 ```
 
-The `#[simd]` attribute can only be applied to non empty tuple structs, because
-it doesn't make sense to try to use SIMD operations when there are no values to
-operate on.
+```compile_fail,E0075
+#![feature(repr_simd)]
+
+#[repr(simd)]
+struct Bad([u32; 1], [u32; 1]); // error!
+```
+
+The `#[simd]` attribute can only be applied to a single-field struct, because
+the one field must be the array of values in the vector.
 
 Fixed example:
 
@@ -19,5 +25,5 @@ Fixed example:
 #![feature(repr_simd)]
 
 #[repr(simd)]
-struct Good(u32); // ok!
+struct Good([u32; 2]); // ok!
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0076.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0076.md
@@ -1,4 +1,4 @@
-All types in a tuple struct aren't the same when using the `#[simd]`
+The type of the field in a tuple struct isn't an array when using the `#[simd]`
 attribute.
 
 Erroneous code example:
@@ -7,12 +7,12 @@ Erroneous code example:
 #![feature(repr_simd)]
 
 #[repr(simd)]
-struct Bad(u16, u32, u32 u32); // error!
+struct Bad(u16); // error!
 ```
 
 When using the `#[simd]` attribute to automatically use SIMD operations in tuple
-struct, the types in the struct must all be of the same type, or the compiler
-will trigger this error.
+structs, if you want a single-lane vector then the field must be a 1-element
+array, or the compiler will trigger this error.
 
 Fixed example:
 
@@ -20,5 +20,5 @@ Fixed example:
 #![feature(repr_simd)]
 
 #[repr(simd)]
-struct Good(u32, u32, u32, u32); // ok!
+struct Good([u16; 1]); // ok!
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0077.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0077.md
@@ -7,7 +7,7 @@ Erroneous code example:
 #![feature(repr_simd)]
 
 #[repr(simd)]
-struct Bad(String); // error!
+struct Bad([String; 2]); // error!
 ```
 
 When using the `#[simd]` attribute on a tuple struct, the elements in the tuple
@@ -19,5 +19,5 @@ Fixed example:
 #![feature(repr_simd)]
 
 #[repr(simd)]
-struct Good(u32, u32, u32, u32); // ok!
+struct Good([u32; 4]); // ok!
 ```

--- a/compiler/rustc_error_codes/src/error_codes/E0511.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0511.md
@@ -23,11 +23,11 @@ The generic type has to be a SIMD type. Example:
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct i32x2(i32, i32);
+struct i32x2([i32; 2]);
 
 extern "rust-intrinsic" {
     fn simd_add<T>(a: T, b: T) -> T;
 }
 
-unsafe { simd_add(i32x2(0, 0), i32x2(1, 2)); } // ok!
+unsafe { simd_add(i32x2([0, 0]), i32x2([1, 2])); } // ok!
 ```

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1063,20 +1063,29 @@ fn check_simd(tcx: TyCtxt<'_>, sp: Span, def_id: LocalDefId) {
             struct_span_code_err!(tcx.dcx(), sp, E0075, "SIMD vector cannot be empty").emit();
             return;
         }
-        let e = fields[FieldIdx::ZERO].ty(tcx, args);
-        if !fields.iter().all(|f| f.ty(tcx, args) == e) {
-            struct_span_code_err!(tcx.dcx(), sp, E0076, "SIMD vector should be homogeneous")
-                .with_span_label(sp, "SIMD elements must have the same type")
+
+        let array_field = &fields[FieldIdx::ZERO];
+        let array_ty = array_field.ty(tcx, args);
+        let ty::Array(element_ty, len_const) = array_ty.kind() else {
+            struct_span_code_err!(
+                tcx.dcx(),
+                sp,
+                E0076,
+                "SIMD vector's only field must be an array"
+            )
+            .with_span_label(tcx.def_span(array_field.did), "not an array")
+            .emit();
+            return;
+        };
+
+        if let Some(second_field) = fields.get(FieldIdx::from_u32(1)) {
+            struct_span_code_err!(tcx.dcx(), sp, E0075, "SIMD vector cannot have multiple fields")
+                .with_span_label(tcx.def_span(second_field.did), "excess field")
                 .emit();
             return;
         }
 
-        let len = if let ty::Array(_ty, c) = e.kind() {
-            c.try_eval_target_usize(tcx, tcx.param_env(def.did()))
-        } else {
-            Some(fields.len() as u64)
-        };
-        if let Some(len) = len {
+        if let Some(len) = len_const.try_eval_target_usize(tcx, tcx.param_env(def.did())) {
             if len == 0 {
                 struct_span_code_err!(tcx.dcx(), sp, E0075, "SIMD vector cannot be empty").emit();
                 return;
@@ -1096,16 +1105,9 @@ fn check_simd(tcx: TyCtxt<'_>, sp: Span, def_id: LocalDefId) {
         // These are scalar types which directly match a "machine" type
         // Yes: Integers, floats, "thin" pointers
         // No: char, "fat" pointers, compound types
-        match e.kind() {
-            ty::Param(_) => (), // pass struct<T>(T, T, T, T) through, let monomorphization catch errors
-            ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::RawPtr(_, _) => (), // struct(u8, u8, u8, u8) is ok
-            ty::Array(t, _) if matches!(t.kind(), ty::Param(_)) => (), // pass struct<T>([T; N]) through, let monomorphization catch errors
-            ty::Array(t, _clen)
-                if matches!(
-                    t.kind(),
-                    ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::RawPtr(_, _)
-                ) =>
-            { /* struct([f32; 4]) is ok */ }
+        match element_ty.kind() {
+            ty::Param(_) => (), // pass struct<T>([T; 4]) through, let monomorphization catch errors
+            ty::Int(_) | ty::Uint(_) | ty::Float(_) | ty::RawPtr(_, _) => (), // struct([u8; 4]) is ok
             _ => {
                 struct_span_code_err!(
                     tcx.dcx(),

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4806,7 +4806,7 @@ declare_lint! {
     /// version of Rust this will be fixed and therefore dependencies relying
     /// on the non-spec-compliant C ABI will stop functioning.
     pub WASM_C_ABI,
-    Warn,
+    Deny,
     "detects dependencies that are incompatible with the Wasm C ABI",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseErrorReportInDeps,

--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(rustc::potential_query_instability)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
+#![feature(control_flow_enum)]
 #![feature(coroutines)]
 #![feature(decl_macro)]
 #![feature(error_iter)]
@@ -34,7 +35,9 @@ pub mod locator;
 
 pub use creader::{load_symbol_from_dylib, DylibError};
 pub use fs::{emit_wrapper_file, METADATA_FILENAME};
-pub use native_libs::find_native_static_library;
+pub use native_libs::{
+    find_native_static_library, try_find_native_static_library, walk_native_lib_search_dirs,
+};
 pub use rmeta::{encode_metadata, rendered_const, EncodedMetadata, METADATA_HEADER};
 
 rustc_fluent_macro::fluent_messages! { "../messages.ftl" }

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::ops::ControlFlow;
+use std::path::{Path, PathBuf};
 
 use rustc_ast::{NestedMetaItem, CRATE_NODE_ID};
 use rustc_attr as attr;
@@ -16,10 +17,68 @@ use rustc_session::Session;
 use rustc_span::def_id::{DefId, LOCAL_CRATE};
 use rustc_span::symbol::{sym, Symbol};
 use rustc_target::spec::abi::Abi;
+use rustc_target::spec::LinkSelfContainedComponents;
 
 use crate::{errors, fluent_generated};
 
-pub fn find_native_static_library(name: &str, verbatim: bool, sess: &Session) -> PathBuf {
+pub fn walk_native_lib_search_dirs<R>(
+    sess: &Session,
+    self_contained_components: LinkSelfContainedComponents,
+    apple_sdk_root: Option<&Path>,
+    mut f: impl FnMut(&Path, bool /*is_framework*/) -> ControlFlow<R>,
+) -> ControlFlow<R> {
+    // Library search paths explicitly supplied by user (`-L` on the command line).
+    for search_path in sess.target_filesearch(PathKind::Native).cli_search_paths() {
+        f(&search_path.dir, false)?;
+    }
+    for search_path in sess.target_filesearch(PathKind::Framework).cli_search_paths() {
+        // Frameworks are looked up strictly in framework-specific paths.
+        if search_path.kind != PathKind::All {
+            f(&search_path.dir, true)?;
+        }
+    }
+
+    // The toolchain ships some native library components and self-contained linking was enabled.
+    // Add the self-contained library directory to search paths.
+    if self_contained_components.intersects(
+        LinkSelfContainedComponents::LIBC
+            | LinkSelfContainedComponents::UNWIND
+            | LinkSelfContainedComponents::MINGW,
+    ) {
+        f(&sess.target_tlib_path.dir.join("self-contained"), false)?;
+    }
+
+    // Toolchains for some targets may ship `libunwind.a`, but place it into the main sysroot
+    // library directory instead of the self-contained directories.
+    // Sanitizer libraries have the same issue and are also linked by name on Apple targets.
+    // The targets here should be in sync with `copy_third_party_objects` in bootstrap.
+    // FIXME: implement `-Clink-self-contained=+/-unwind,+/-sanitizers`, move the shipped libunwind
+    // and sanitizers to self-contained directory, and stop adding this search path.
+    if sess.target.vendor == "fortanix"
+        || sess.target.os == "linux"
+        || sess.target.os == "fuchsia"
+        || sess.target.is_like_osx && !sess.opts.unstable_opts.sanitizer.is_empty()
+    {
+        f(&sess.target_tlib_path.dir, false)?;
+    }
+
+    // Mac Catalyst uses the macOS SDK, but to link to iOS-specific frameworks
+    // we must have the support library stubs in the library search path (#121430).
+    if let Some(sdk_root) = apple_sdk_root
+        && sess.target.llvm_target.contains("macabi")
+    {
+        f(&sdk_root.join("System/iOSSupport/usr/lib"), false)?;
+        f(&sdk_root.join("System/iOSSupport/System/Library/Frameworks"), true)?;
+    }
+
+    ControlFlow::Continue(())
+}
+
+pub fn try_find_native_static_library(
+    sess: &Session,
+    name: &str,
+    verbatim: bool,
+) -> Option<PathBuf> {
     let formats = if verbatim {
         vec![("".into(), "".into())]
     } else {
@@ -30,16 +89,29 @@ pub fn find_native_static_library(name: &str, verbatim: bool, sess: &Session) ->
         if os == unix { vec![os] } else { vec![os, unix] }
     };
 
-    for path in sess.target_filesearch(PathKind::Native).search_paths() {
-        for (prefix, suffix) in &formats {
-            let test = path.dir.join(format!("{prefix}{name}{suffix}"));
-            if test.exists() {
-                return test;
+    // FIXME: Account for self-contained linking settings and Apple SDK.
+    walk_native_lib_search_dirs(
+        sess,
+        LinkSelfContainedComponents::empty(),
+        None,
+        |dir, is_framework| {
+            if !is_framework {
+                for (prefix, suffix) in &formats {
+                    let test = dir.join(format!("{prefix}{name}{suffix}"));
+                    if test.exists() {
+                        return ControlFlow::Break(test);
+                    }
+                }
             }
-        }
-    }
+            ControlFlow::Continue(())
+        },
+    )
+    .break_value()
+}
 
-    sess.dcx().emit_fatal(errors::MissingNativeLibrary::new(name, verbatim));
+pub fn find_native_static_library(name: &str, verbatim: bool, sess: &Session) -> PathBuf {
+    try_find_native_static_library(sess, name, verbatim)
+        .unwrap_or_else(|| sess.dcx().emit_fatal(errors::MissingNativeLibrary::new(name, verbatim)))
 }
 
 fn find_bundled_library(

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1091,29 +1091,21 @@ impl<'tcx> Ty<'tcx> {
     }
 
     pub fn simd_size_and_type(self, tcx: TyCtxt<'tcx>) -> (u64, Ty<'tcx>) {
-        match self.kind() {
-            Adt(def, args) => {
-                assert!(def.repr().simd(), "`simd_size_and_type` called on non-SIMD type");
-                let variant = def.non_enum_variant();
-                let f0_ty = variant.fields[FieldIdx::ZERO].ty(tcx, args);
-
-                match f0_ty.kind() {
-                    // If the first field is an array, we assume it is the only field and its
-                    // elements are the SIMD components.
-                    Array(f0_elem_ty, f0_len) => {
-                        // FIXME(repr_simd): https://github.com/rust-lang/rust/pull/78863#discussion_r522784112
-                        // The way we evaluate the `N` in `[T; N]` here only works since we use
-                        // `simd_size_and_type` post-monomorphization. It will probably start to ICE
-                        // if we use it in generic code. See the `simd-array-trait` ui test.
-                        (f0_len.eval_target_usize(tcx, ParamEnv::empty()), *f0_elem_ty)
-                    }
-                    // Otherwise, the fields of this Adt are the SIMD components (and we assume they
-                    // all have the same type).
-                    _ => (variant.fields.len() as u64, f0_ty),
-                }
-            }
-            _ => bug!("`simd_size_and_type` called on invalid type"),
-        }
+        let Adt(def, args) = self.kind() else {
+            bug!("`simd_size_and_type` called on invalid type")
+        };
+        assert!(def.repr().simd(), "`simd_size_and_type` called on non-SIMD type");
+        let variant = def.non_enum_variant();
+        assert_eq!(variant.fields.len(), 1);
+        let field_ty = variant.fields[FieldIdx::ZERO].ty(tcx, args);
+        let Array(f0_elem_ty, f0_len) = field_ty.kind() else {
+            bug!("Simd type has non-array field type {field_ty:?}")
+        };
+        // FIXME(repr_simd): https://github.com/rust-lang/rust/pull/78863#discussion_r522784112
+        // The way we evaluate the `N` in `[T; N]` here only works since we use
+        // `simd_size_and_type` post-monomorphization. It will probably start to ICE
+        // if we use it in generic code. See the `simd-array-trait` ui test.
+        (f0_len.eval_target_usize(tcx, ParamEnv::empty()), *f0_elem_ty)
     }
 
     #[inline]

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1000,7 +1000,7 @@ impl<'tcx> Ty<'tcx> {
 
     #[inline]
     pub fn is_primitive(self) -> bool {
-        self.kind().is_primitive()
+        matches!(self.kind(), Bool | Char | Int(_) | Uint(_) | Float(_))
     }
 
     #[inline]

--- a/compiler/rustc_type_ir/src/ty_kind.rs
+++ b/compiler/rustc_type_ir/src/ty_kind.rs
@@ -254,13 +254,6 @@ pub enum TyKind<I: Interner> {
     Error(I::ErrorGuaranteed),
 }
 
-impl<I: Interner> TyKind<I> {
-    #[inline]
-    pub fn is_primitive(&self) -> bool {
-        matches!(self, Bool | Char | Int(_) | Uint(_) | Float(_))
-    }
-}
-
 // This is manually implemented because a derive would require `I: Debug`
 impl<I: Interner> fmt::Debug for TyKind<I> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/alloc/benches/lib.rs
+++ b/library/alloc/benches/lib.rs
@@ -1,6 +1,3 @@
-// Disabling on android for the time being
-// See https://github.com/rust-lang/rust/issues/73535#event-3477699747
-#![cfg(not(target_os = "android"))]
 // Disabling in Miri as these would take too long.
 #![cfg(not(miri))]
 #![feature(btree_extract_if)]

--- a/library/alloc/benches/slice.rs
+++ b/library/alloc/benches/slice.rs
@@ -336,10 +336,10 @@ reverse!(reverse_u32, u32, |x| x as u32);
 reverse!(reverse_u64, u64, |x| x as u64);
 reverse!(reverse_u128, u128, |x| x as u128);
 #[repr(simd)]
-struct F64x4(f64, f64, f64, f64);
+struct F64x4([f64; 4]);
 reverse!(reverse_simd_f64x4, F64x4, |x| {
     let x = x as f64;
-    F64x4(x, x, x, x)
+    F64x4([x, x, x, x])
 });
 
 macro_rules! rotate {

--- a/library/alloc/tests/string.rs
+++ b/library/alloc/tests/string.rs
@@ -723,7 +723,6 @@ fn test_reserve_exact() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Miri does not support signalling OOM
-#[cfg_attr(target_os = "android", ignore)] // Android used in CI has a broken dlmalloc
 fn test_try_with_capacity() {
     let string = String::try_with_capacity(1000).unwrap();
     assert_eq!(0, string.len());
@@ -734,7 +733,6 @@ fn test_try_with_capacity() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Miri does not support signalling OOM
-#[cfg_attr(target_os = "android", ignore)] // Android used in CI has a broken dlmalloc
 fn test_try_reserve() {
     // These are the interesting cases:
     // * exactly isize::MAX should never trigger a CapacityOverflow (can be OOM)
@@ -803,7 +801,6 @@ fn test_try_reserve() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Miri does not support signalling OOM
-#[cfg_attr(target_os = "android", ignore)] // Android used in CI has a broken dlmalloc
 fn test_try_reserve_exact() {
     // This is exactly the same as test_try_reserve with the method changed.
     // See that test for comments.

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -1695,7 +1695,6 @@ fn test_reserve_exact() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Miri does not support signalling OOM
-#[cfg_attr(target_os = "android", ignore)] // Android used in CI has a broken dlmalloc
 fn test_try_with_capacity() {
     let mut vec: Vec<u32> = Vec::try_with_capacity(5).unwrap();
     assert_eq!(0, vec.len());
@@ -1707,7 +1706,6 @@ fn test_try_with_capacity() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Miri does not support signalling OOM
-#[cfg_attr(target_os = "android", ignore)] // Android used in CI has a broken dlmalloc
 fn test_try_reserve() {
     // These are the interesting cases:
     // * exactly isize::MAX should never trigger a CapacityOverflow (can be OOM)
@@ -1803,7 +1801,6 @@ fn test_try_reserve() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Miri does not support signalling OOM
-#[cfg_attr(target_os = "android", ignore)] // Android used in CI has a broken dlmalloc
 fn test_try_reserve_exact() {
     // This is exactly the same as test_try_reserve with the method changed.
     // See that test for comments.

--- a/library/alloc/tests/vec_deque.rs
+++ b/library/alloc/tests/vec_deque.rs
@@ -1185,7 +1185,6 @@ fn test_reserve_exact_2() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Miri does not support signalling OOM
-#[cfg_attr(target_os = "android", ignore)] // Android used in CI has a broken dlmalloc
 fn test_try_with_capacity() {
     let vec: VecDeque<u32> = VecDeque::try_with_capacity(5).unwrap();
     assert_eq!(0, vec.len());
@@ -1196,7 +1195,6 @@ fn test_try_with_capacity() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Miri does not support signalling OOM
-#[cfg_attr(target_os = "android", ignore)] // Android used in CI has a broken dlmalloc
 fn test_try_reserve() {
     // These are the interesting cases:
     // * exactly isize::MAX should never trigger a CapacityOverflow (can be OOM)
@@ -1292,7 +1290,6 @@ fn test_try_reserve() {
 
 #[test]
 #[cfg_attr(miri, ignore)] // Miri does not support signalling OOM
-#[cfg_attr(target_os = "android", ignore)] // Android used in CI has a broken dlmalloc
 fn test_try_reserve_exact() {
     // This is exactly the same as test_try_reserve with the method changed.
     // See that test for comments.

--- a/library/core/tests/num/int_log.rs
+++ b/library/core/tests/num/int_log.rs
@@ -1,7 +1,4 @@
-//! This tests the `Integer::{ilog,log2,log10}` methods. These tests are in a
-//! separate file because there's both a large number of them, and not all tests
-//! can be run on Android. This is because in Android `ilog2` uses an imprecise
-//! approximation:https://github.com/rust-lang/rust/blob/4825e12fc9c79954aa0fe18f5521efa6c19c7539/src/libstd/sys/unix/android.rs#L27-L53
+//! Tests for the `Integer::{ilog,log2,log10}` methods.
 
 #[test]
 fn checked_ilog() {
@@ -48,6 +45,10 @@ fn checked_ilog2() {
     assert_eq!(0i8.checked_ilog2(), None);
     assert_eq!(0i16.checked_ilog2(), None);
 
+    assert_eq!(8192u16.checked_ilog2(), Some((8192f32).log2() as u32));
+    assert_eq!(32768u16.checked_ilog2(), Some((32768f32).log2() as u32));
+    assert_eq!(8192i16.checked_ilog2(), Some((8192f32).log2() as u32));
+
     for i in 1..=u8::MAX {
         assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32), "checking {i}");
     }
@@ -75,15 +76,6 @@ fn checked_ilog2() {
             assert_eq!(i.checked_ilog2(), Some((i as f32).log2() as u32), "checking {i}");
         }
     }
-}
-
-// Validate cases that fail on Android's imprecise float ilog2 implementation.
-#[test]
-#[cfg(not(target_os = "android"))]
-fn checked_ilog2_not_android() {
-    assert_eq!(8192u16.checked_ilog2(), Some((8192f32).log2() as u32));
-    assert_eq!(32768u16.checked_ilog2(), Some((32768f32).log2() as u32));
-    assert_eq!(8192i16.checked_ilog2(), Some((8192f32).log2() as u32));
 }
 
 #[test]

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -14,9 +14,8 @@ use crate::core::build_steps::synthetic_targets::MirOptPanicAbortSyntheticTarget
 use crate::core::build_steps::tool::{self, SourceType, Tool};
 use crate::core::build_steps::toolstate::ToolState;
 use crate::core::build_steps::{compile, dist, llvm};
-use crate::core::builder;
 use crate::core::builder::{
-    crate_description, Builder, Compiler, Kind, RunConfig, ShouldRun, Step,
+    self, crate_description, Alias, Builder, Compiler, Kind, RunConfig, ShouldRun, Step,
 };
 use crate::core::config::flags::{get_completion, Subcommand};
 use crate::core::config::TargetSelection;
@@ -2435,18 +2434,14 @@ impl Step for CrateLibrustc {
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.crate_or_deps("rustc-main")
+        run.crate_or_deps("rustc-main").path("compiler")
     }
 
     fn make_run(run: RunConfig<'_>) {
         let builder = run.builder;
         let host = run.build_triple();
         let compiler = builder.compiler_for(builder.top_stage, host, host);
-        let crates = run
-            .paths
-            .iter()
-            .map(|p| builder.crate_paths[&p.assert_single_path().path].clone())
-            .collect();
+        let crates = run.make_run_crates(Alias::Compiler);
 
         builder.ensure(CrateLibrustc { compiler, target: run.target, crates });
     }

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -47,7 +47,7 @@ KIND=PATH` where `KIND` may be one of:
   directory.
 - `native` — Only search for native libraries in this directory.
 - `framework` — Only search for macOS frameworks in this directory.
-- `all` — Search for all library kinds in this directory. This is the default
+- `all` — Search for all library kinds in this directory, except frameworks. This is the default
   if `KIND` is not specified.
 
 <a id="option-l-link-lib"></a>

--- a/src/tools/miri/tests/fail/intrinsics/simd-div-by-zero.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-div-by-zero.rs
@@ -4,12 +4,12 @@ use std::intrinsics::simd::simd_div;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
-struct i32x2(i32, i32);
+struct i32x2([i32; 2]);
 
 fn main() {
     unsafe {
-        let x = i32x2(1, 1);
-        let y = i32x2(1, 0);
+        let x = i32x2([1, 1]);
+        let y = i32x2([1, 0]);
         simd_div(x, y); //~ERROR: Undefined Behavior: dividing by zero
     }
 }

--- a/src/tools/miri/tests/fail/intrinsics/simd-div-overflow.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-div-overflow.rs
@@ -4,12 +4,12 @@ use std::intrinsics::simd::simd_div;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
-struct i32x2(i32, i32);
+struct i32x2([i32; 2]);
 
 fn main() {
     unsafe {
-        let x = i32x2(1, i32::MIN);
-        let y = i32x2(1, -1);
+        let x = i32x2([1, i32::MIN]);
+        let y = i32x2([1, -1]);
         simd_div(x, y); //~ERROR: Undefined Behavior: overflow in signed division
     }
 }

--- a/src/tools/miri/tests/fail/intrinsics/simd-reduce-invalid-bool.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-reduce-invalid-bool.rs
@@ -4,11 +4,11 @@ use std::intrinsics::simd::simd_reduce_any;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
-struct i32x2(i32, i32);
+struct i32x2([i32; 2]);
 
 fn main() {
     unsafe {
-        let x = i32x2(0, 1);
+        let x = i32x2([0, 1]);
         simd_reduce_any(x); //~ERROR: must be all-0-bits or all-1-bits
     }
 }

--- a/src/tools/miri/tests/fail/intrinsics/simd-rem-by-zero.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-rem-by-zero.rs
@@ -4,12 +4,12 @@ use std::intrinsics::simd::simd_rem;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
-struct i32x2(i32, i32);
+struct i32x2([i32; 2]);
 
 fn main() {
     unsafe {
-        let x = i32x2(1, 1);
-        let y = i32x2(1, 0);
+        let x = i32x2([1, 1]);
+        let y = i32x2([1, 0]);
         simd_rem(x, y); //~ERROR: Undefined Behavior: calculating the remainder with a divisor of zero
     }
 }

--- a/src/tools/miri/tests/fail/intrinsics/simd-select-bitmask-invalid.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-select-bitmask-invalid.rs
@@ -5,11 +5,11 @@ use std::intrinsics::simd::simd_select_bitmask;
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone)]
-struct i32x2(i32, i32);
+struct i32x2([i32; 2]);
 
 fn main() {
     unsafe {
-        let x = i32x2(0, 1);
+        let x = i32x2([0, 1]);
         simd_select_bitmask(0b11111111u8, x, x); //~ERROR: bitmask less than 8 bits long must be filled with 0s for the remaining bits
     }
 }

--- a/src/tools/miri/tests/fail/intrinsics/simd-select-invalid-bool.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-select-invalid-bool.rs
@@ -5,11 +5,11 @@ use std::intrinsics::simd::simd_select;
 #[repr(simd)]
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone)]
-struct i32x2(i32, i32);
+struct i32x2([i32; 2]);
 
 fn main() {
     unsafe {
-        let x = i32x2(0, 1);
+        let x = i32x2([0, 1]);
         simd_select(x, x, x); //~ERROR: must be all-0-bits or all-1-bits
     }
 }

--- a/src/tools/miri/tests/fail/intrinsics/simd-shl-too-far.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-shl-too-far.rs
@@ -4,12 +4,12 @@ use std::intrinsics::simd::simd_shl;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
-struct i32x2(i32, i32);
+struct i32x2([i32; 2]);
 
 fn main() {
     unsafe {
-        let x = i32x2(1, 1);
-        let y = i32x2(100, 0);
+        let x = i32x2([1, 1]);
+        let y = i32x2([100, 0]);
         simd_shl(x, y); //~ERROR: overflowing shift by 100 in `simd_shl` in lane 0
     }
 }

--- a/src/tools/miri/tests/fail/intrinsics/simd-shr-too-far.rs
+++ b/src/tools/miri/tests/fail/intrinsics/simd-shr-too-far.rs
@@ -4,12 +4,12 @@ use std::intrinsics::simd::simd_shr;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
-struct i32x2(i32, i32);
+struct i32x2([i32; 2]);
 
 fn main() {
     unsafe {
-        let x = i32x2(1, 1);
-        let y = i32x2(20, 40);
+        let x = i32x2([1, 1]);
+        let y = i32x2([20, 40]);
         simd_shr(x, y); //~ERROR: overflowing shift by 40 in `simd_shr` in lane 1
     }
 }

--- a/src/tools/miri/tests/pass/simd-intrinsic-generic-elements.rs
+++ b/src/tools/miri/tests/pass/simd-intrinsic-generic-elements.rs
@@ -3,22 +3,22 @@
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
-struct i32x2(i32, i32);
+struct i32x2([i32; 2]);
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
-struct i32x4(i32, i32, i32, i32);
+struct i32x4([i32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
-struct i32x8(i32, i32, i32, i32, i32, i32, i32, i32);
+struct i32x8([i32; 8]);
 
 fn main() {
-    let _x2 = i32x2(20, 21);
-    let _x4 = i32x4(40, 41, 42, 43);
-    let _x8 = i32x8(80, 81, 82, 83, 84, 85, 86, 87);
+    let _x2 = i32x2([20, 21]);
+    let _x4 = i32x4([40, 41, 42, 43]);
+    let _x8 = i32x8([80, 81, 82, 83, 84, 85, 86, 87]);
 
-    let _y2 = i32x2(120, 121);
-    let _y4 = i32x4(140, 141, 142, 143);
-    let _y8 = i32x8(180, 181, 182, 183, 184, 185, 186, 187);
+    let _y2 = i32x2([120, 121]);
+    let _y4 = i32x4([140, 141, 142, 143]);
+    let _y8 = i32x8([180, 181, 182, 183, 184, 185, 186, 187]);
 }

--- a/src/tools/rustdoc-js/tester.js
+++ b/src/tools/rustdoc-js/tester.js
@@ -427,7 +427,6 @@ function loadSearchJS(doc_folder, resource_suffix) {
             return list[descIndex];
         },
         loadedDescShard: function(crate, shard, data) {
-            //console.log(this.descShards);
             this.descShards.get(crate)[shard].resolve(data.split("\n"));
         },
     };
@@ -436,15 +435,15 @@ function loadSearchJS(doc_folder, resource_suffix) {
     const searchJs = fs.readdirSync(staticFiles).find(f => f.match(/search.*\.js$/));
     const searchModule = require(path.join(staticFiles, searchJs));
     searchModule.initSearch(searchIndex.searchIndex);
-
+    const docSearch = searchModule.docSearch;
     return {
         doSearch: function(queryStr, filterCrate, currentCrate) {
-            return searchModule.execQuery(searchModule.parseQuery(queryStr),
+            return docSearch.execQuery(searchModule.parseQuery(queryStr),
                 filterCrate, currentCrate);
         },
         getCorrections: function(queryStr, filterCrate, currentCrate) {
             const parsedQuery = searchModule.parseQuery(queryStr);
-            searchModule.execQuery(parsedQuery, filterCrate, currentCrate);
+            docSearch.execQuery(parsedQuery, filterCrate, currentCrate);
             return parsedQuery.correction;
         },
         parseQuery: searchModule.parseQuery,

--- a/tests/assembly/asm/aarch64-types.rs
+++ b/tests/assembly/asm/aarch64-types.rs
@@ -30,36 +30,39 @@ trait Sized {}
 #[lang = "copy"]
 trait Copy {}
 
+// Do we really need to use no_core for this?!?
+impl<T: Copy, const N: usize> Copy for [T; N] {}
+
 type ptr = *mut u8;
 
 #[repr(simd)]
-pub struct i8x8(i8, i8, i8, i8, i8, i8, i8, i8);
+pub struct i8x8([i8; 8]);
 #[repr(simd)]
-pub struct i16x4(i16, i16, i16, i16);
+pub struct i16x4([i16; 4]);
 #[repr(simd)]
-pub struct i32x2(i32, i32);
+pub struct i32x2([i32; 2]);
 #[repr(simd)]
-pub struct i64x1(i64);
+pub struct i64x1([i64; 1]);
 #[repr(simd)]
-pub struct f16x4(f16, f16, f16, f16);
+pub struct f16x4([f16; 4]);
 #[repr(simd)]
-pub struct f32x2(f32, f32);
+pub struct f32x2([f32; 2]);
 #[repr(simd)]
-pub struct f64x1(f64);
+pub struct f64x1([f64; 1]);
 #[repr(simd)]
-pub struct i8x16(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8);
+pub struct i8x16([i8; 16]);
 #[repr(simd)]
-pub struct i16x8(i16, i16, i16, i16, i16, i16, i16, i16);
+pub struct i16x8([i16; 8]);
 #[repr(simd)]
-pub struct i32x4(i32, i32, i32, i32);
+pub struct i32x4([i32; 4]);
 #[repr(simd)]
-pub struct i64x2(i64, i64);
+pub struct i64x2([i64; 2]);
 #[repr(simd)]
-pub struct f16x8(f16, f16, f16, f16, f16, f16, f16, f16);
+pub struct f16x8([f16; 8]);
 #[repr(simd)]
-pub struct f32x4(f32, f32, f32, f32);
+pub struct f32x4([f32; 4]);
 #[repr(simd)]
-pub struct f64x2(f64, f64);
+pub struct f64x2([f64; 2]);
 
 impl Copy for i8 {}
 impl Copy for i16 {}

--- a/tests/assembly/asm/arm-modifiers.rs
+++ b/tests/assembly/asm/arm-modifiers.rs
@@ -27,8 +27,11 @@ trait Sized {}
 #[lang = "copy"]
 trait Copy {}
 
+// Do we really need to use no_core for this?!?
+impl<T: Copy, const N: usize> Copy for [T; N] {}
+
 #[repr(simd)]
-pub struct f32x4(f32, f32, f32, f32);
+pub struct f32x4([f32; 4]);
 
 impl Copy for i32 {}
 impl Copy for f32 {}

--- a/tests/assembly/asm/arm-types.rs
+++ b/tests/assembly/asm/arm-types.rs
@@ -30,32 +30,35 @@ trait Sized {}
 #[lang = "copy"]
 trait Copy {}
 
+// Do we really need to use no_core for this?!?
+impl<T: Copy, const N: usize> Copy for [T; N] {}
+
 type ptr = *mut u8;
 
 #[repr(simd)]
-pub struct i8x8(i8, i8, i8, i8, i8, i8, i8, i8);
+pub struct i8x8([i8; 8]);
 #[repr(simd)]
-pub struct i16x4(i16, i16, i16, i16);
+pub struct i16x4([i16; 4]);
 #[repr(simd)]
-pub struct i32x2(i32, i32);
+pub struct i32x2([i32; 2]);
 #[repr(simd)]
-pub struct i64x1(i64);
+pub struct i64x1([i64; 1]);
 #[repr(simd)]
-pub struct f16x4(f16, f16, f16, f16);
+pub struct f16x4([f16; 4]);
 #[repr(simd)]
-pub struct f32x2(f32, f32);
+pub struct f32x2([f32; 2]);
 #[repr(simd)]
-pub struct i8x16(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8);
+pub struct i8x16([i8; 16]);
 #[repr(simd)]
-pub struct i16x8(i16, i16, i16, i16, i16, i16, i16, i16);
+pub struct i16x8([i16; 8]);
 #[repr(simd)]
-pub struct i32x4(i32, i32, i32, i32);
+pub struct i32x4([i32; 4]);
 #[repr(simd)]
-pub struct i64x2(i64, i64);
+pub struct i64x2([i64; 2]);
 #[repr(simd)]
-pub struct f16x8(f16, f16, f16, f16, f16, f16, f16, f16);
+pub struct f16x8([f16; 8]);
 #[repr(simd)]
-pub struct f32x4(f32, f32, f32, f32);
+pub struct f32x4([f32; 4]);
 
 impl Copy for i8 {}
 impl Copy for i16 {}

--- a/tests/assembly/asm/x86-types.rs
+++ b/tests/assembly/asm/x86-types.rs
@@ -30,216 +30,55 @@ trait Sized {}
 #[lang = "copy"]
 trait Copy {}
 
+// Do we really need to use no_core for this?!?
+impl<T: Copy, const N: usize> Copy for [T; N] {}
+
 type ptr = *mut u8;
 
 #[repr(simd)]
-pub struct i8x16(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8);
+pub struct i8x16([i8; 16]);
 #[repr(simd)]
-pub struct i16x8(i16, i16, i16, i16, i16, i16, i16, i16);
+pub struct i16x8([i16; 8]);
 #[repr(simd)]
-pub struct i32x4(i32, i32, i32, i32);
+pub struct i32x4([i32; 4]);
 #[repr(simd)]
-pub struct i64x2(i64, i64);
+pub struct i64x2([i64; 2]);
 #[repr(simd)]
-pub struct f16x8(f16, f16, f16, f16, f16, f16, f16, f16);
+pub struct f16x8([f16; 8]);
 #[repr(simd)]
-pub struct f32x4(f32, f32, f32, f32);
+pub struct f32x4([f32; 4]);
 #[repr(simd)]
-pub struct f64x2(f64, f64);
+pub struct f64x2([f64; 2]);
 
 #[repr(simd)]
-pub struct i8x32(
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-);
+pub struct i8x32([i8; 32]);
 #[repr(simd)]
-pub struct i16x16(i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16);
+pub struct i16x16([i16; 16]);
 #[repr(simd)]
-pub struct i32x8(i32, i32, i32, i32, i32, i32, i32, i32);
+pub struct i32x8([i32; 8]);
 #[repr(simd)]
-pub struct i64x4(i64, i64, i64, i64);
+pub struct i64x4([i64; 4]);
 #[repr(simd)]
-pub struct f16x16(f16, f16, f16, f16, f16, f16, f16, f16, f16, f16, f16, f16, f16, f16, f16, f16);
+pub struct f16x16([f16; 16]);
 #[repr(simd)]
-pub struct f32x8(f32, f32, f32, f32, f32, f32, f32, f32);
+pub struct f32x8([f32; 8]);
 #[repr(simd)]
-pub struct f64x4(f64, f64, f64, f64);
+pub struct f64x4([f64; 4]);
 
 #[repr(simd)]
-pub struct i8x64(
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-    i8,
-);
+pub struct i8x64([i8; 64]);
 #[repr(simd)]
-pub struct i16x32(
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-    i16,
-);
+pub struct i16x32([i16; 32]);
 #[repr(simd)]
-pub struct i32x16(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32);
+pub struct i32x16([i32; 16]);
 #[repr(simd)]
-pub struct i64x8(i64, i64, i64, i64, i64, i64, i64, i64);
+pub struct i64x8([i64; 8]);
 #[repr(simd)]
-pub struct f16x32(
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-    f16,
-);
+pub struct f16x32([f16; 32]);
 #[repr(simd)]
-pub struct f32x16(f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32);
+pub struct f32x16([f32; 16]);
 #[repr(simd)]
-pub struct f64x8(f64, f64, f64, f64, f64, f64, f64, f64);
+pub struct f64x8([f64; 8]);
 
 macro_rules! impl_copy {
     ($($ty:ident)*) => {

--- a/tests/codegen/align-byval-vector.rs
+++ b/tests/codegen/align-byval-vector.rs
@@ -21,7 +21,7 @@ trait Freeze {}
 trait Copy {}
 
 #[repr(simd)]
-pub struct i32x4(i32, i32, i32, i32);
+pub struct i32x4([i32; 4]);
 
 #[repr(C)]
 pub struct Foo {
@@ -47,12 +47,12 @@ extern "C" {
 }
 
 pub fn main() {
-    unsafe { f(Foo { a: i32x4(1, 2, 3, 4), b: 0 }) }
+    unsafe { f(Foo { a: i32x4([1, 2, 3, 4]), b: 0 }) }
 
     unsafe {
         g(DoubleFoo {
-            one: Foo { a: i32x4(1, 2, 3, 4), b: 0 },
-            two: Foo { a: i32x4(1, 2, 3, 4), b: 0 },
+            one: Foo { a: i32x4([1, 2, 3, 4]), b: 0 },
+            two: Foo { a: i32x4([1, 2, 3, 4]), b: 0 },
         })
     }
 }

--- a/tests/codegen/const-vector.rs
+++ b/tests/codegen/const-vector.rs
@@ -13,19 +13,11 @@
 // Setting up structs that can be used as const vectors
 #[repr(simd)]
 #[derive(Clone)]
-pub struct i8x2(i8, i8);
+pub struct i8x2([i8; 2]);
 
 #[repr(simd)]
 #[derive(Clone)]
-pub struct i8x2_arr([i8; 2]);
-
-#[repr(simd)]
-#[derive(Clone)]
-pub struct f32x2(f32, f32);
-
-#[repr(simd)]
-#[derive(Clone)]
-pub struct f32x2_arr([f32; 2]);
+pub struct f32x2([f32; 2]);
 
 #[repr(simd, packed)]
 #[derive(Copy, Clone)]
@@ -35,42 +27,34 @@ pub struct Simd<T, const N: usize>([T; N]);
 // that they are called with a const vector
 
 extern "unadjusted" {
-    #[no_mangle]
     fn test_i8x2(a: i8x2);
 }
 
 extern "unadjusted" {
-    #[no_mangle]
     fn test_i8x2_two_args(a: i8x2, b: i8x2);
 }
 
 extern "unadjusted" {
-    #[no_mangle]
     fn test_i8x2_mixed_args(a: i8x2, c: i32, b: i8x2);
 }
 
 extern "unadjusted" {
-    #[no_mangle]
-    fn test_i8x2_arr(a: i8x2_arr);
+    fn test_i8x2_arr(a: i8x2);
 }
 
 extern "unadjusted" {
-    #[no_mangle]
     fn test_f32x2(a: f32x2);
 }
 
 extern "unadjusted" {
-    #[no_mangle]
-    fn test_f32x2_arr(a: f32x2_arr);
+    fn test_f32x2_arr(a: f32x2);
 }
 
 extern "unadjusted" {
-    #[no_mangle]
     fn test_simd(a: Simd<i32, 4>);
 }
 
 extern "unadjusted" {
-    #[no_mangle]
     fn test_simd_unaligned(a: Simd<i32, 3>);
 }
 
@@ -81,22 +65,22 @@ extern "unadjusted" {
 pub fn do_call() {
     unsafe {
         // CHECK: call void @test_i8x2(<2 x i8> <i8 32, i8 64>
-        test_i8x2(const { i8x2(32, 64) });
+        test_i8x2(const { i8x2([32, 64]) });
 
         // CHECK: call void @test_i8x2_two_args(<2 x i8> <i8 32, i8 64>, <2 x i8> <i8 8, i8 16>
-        test_i8x2_two_args(const { i8x2(32, 64) }, const { i8x2(8, 16) });
+        test_i8x2_two_args(const { i8x2([32, 64]) }, const { i8x2([8, 16]) });
 
         // CHECK: call void @test_i8x2_mixed_args(<2 x i8> <i8 32, i8 64>, i32 43, <2 x i8> <i8 8, i8 16>
-        test_i8x2_mixed_args(const { i8x2(32, 64) }, 43, const { i8x2(8, 16) });
+        test_i8x2_mixed_args(const { i8x2([32, 64]) }, 43, const { i8x2([8, 16]) });
 
         // CHECK: call void @test_i8x2_arr(<2 x i8> <i8 32, i8 64>
-        test_i8x2_arr(const { i8x2_arr([32, 64]) });
+        test_i8x2_arr(const { i8x2([32, 64]) });
 
         // CHECK: call void @test_f32x2(<2 x float> <float 0x3FD47AE140000000, float 0x3FE47AE140000000>
-        test_f32x2(const { f32x2(0.32, 0.64) });
+        test_f32x2(const { f32x2([0.32, 0.64]) });
 
         // CHECK: void @test_f32x2_arr(<2 x float> <float 0x3FD47AE140000000, float 0x3FE47AE140000000>
-        test_f32x2_arr(const { f32x2_arr([0.32, 0.64]) });
+        test_f32x2_arr(const { f32x2([0.32, 0.64]) });
 
         // CHECK: call void @test_simd(<4 x i32> <i32 2, i32 4, i32 6, i32 8>
         test_simd(const { Simd::<i32, 4>([2, 4, 6, 8]) });

--- a/tests/codegen/repr/transparent.rs
+++ b/tests/codegen/repr/transparent.rs
@@ -132,7 +132,7 @@ pub extern "C" fn test_Nested2(_: Nested2) -> Nested2 {
 }
 
 #[repr(simd)]
-struct f32x4(f32, f32, f32, f32);
+struct f32x4([f32; 4]);
 
 #[repr(transparent)]
 pub struct Vector(f32x4);

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-abs.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-abs.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_fabs<T>(x: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn fabs_32x16(a: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @fabs_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-ceil.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-ceil.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_ceil<T>(x: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn ceil_32x16(a: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @ceil_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-cos.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-cos.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_fcos<T>(x: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn fcos_32x16(a: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @fcos_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-exp.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-exp.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_fexp<T>(x: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn exp_32x16(a: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @exp_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-exp2.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-exp2.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_fexp2<T>(x: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn exp2_32x16(a: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @exp2_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-floor.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-floor.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_floor<T>(x: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn floor_32x16(a: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @floor_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-fma.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-fma.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_fma<T>(x: T, b: T, c: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn fma_32x16(a: f32x16, b: f32x16, c: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @fma_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-fsqrt.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-fsqrt.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_fsqrt<T>(x: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn fsqrt_32x16(a: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @fsqrt_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-log.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-log.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_flog<T>(x: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn log_32x16(a: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @log_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-log10.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-log10.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_flog10<T>(x: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn log10_32x16(a: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @log10_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-log2.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-log2.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_flog2<T>(x: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn log2_32x16(a: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @log2_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-minmax.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-minmax.rs
@@ -7,7 +7,7 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 extern "rust-intrinsic" {
     fn simd_fmin<T>(x: T, y: T) -> T;

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-pow.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-pow.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_fpow<T>(x: T, b: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn fpow_32x16(a: f32x16, b: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @fpow_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-powi.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-powi.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_fpowi<T>(x: T, b: i32) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn fpowi_32x16(a: f32x16, b: i32) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @fpowi_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-float-sin.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-float-sin.rs
@@ -7,23 +7,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x2(pub f32, pub f32);
+pub struct f32x2(pub [f32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(pub f32, pub f32, pub f32, pub f32,
-                 pub f32, pub f32, pub f32, pub f32);
+pub struct f32x8(pub [f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x16(pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32,
-                  pub f32, pub f32, pub f32, pub f32);
+pub struct f32x16(pub [f32; 16]);
 
 extern "rust-intrinsic" {
     fn simd_fsin<T>(x: T) -> T;
@@ -59,16 +55,15 @@ pub unsafe fn fsin_32x16(a: f32x16) -> f32x16 {
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x2(pub f64, pub f64);
+pub struct f64x2(pub [f64; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x4(pub f64, pub f64, pub f64, pub f64);
+pub struct f64x4(pub [f64; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f64x8(pub f64, pub f64, pub f64, pub f64,
-                 pub f64, pub f64, pub f64, pub f64);
+pub struct f64x8(pub [f64; 8]);
 
 // CHECK-LABEL: @fsin_64x4
 #[no_mangle]

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-arithmetic-saturating.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-arithmetic-saturating.rs
@@ -9,107 +9,57 @@
 
 // signed integer types
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x2(i8, i8);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x4(i8, i8, i8, i8);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x8(
-    i8, i8, i8, i8, i8, i8, i8, i8,
-);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x16(
-    i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8,
-);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x32(
-    i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8,
-    i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8,
-);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x64(
-    i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8,
-    i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8,
-    i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8,
-    i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8,
-);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x2([i8; 2]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x4([i8; 4]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x8([i8; 8]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x16([i8; 16]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x32([i8; 32]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i8x64([i8; 64]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x2(i16, i16);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x4(i16, i16, i16, i16);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x8(
-    i16, i16, i16, i16, i16, i16, i16, i16,
-);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x16(
-    i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16,
-);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x32(
-    i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16,
-    i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16, i16,
-);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x2([i16; 2]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x4([i16; 4]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x8([i16; 8]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x16([i16; 16]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i16x32([i16; 32]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i32x2(i32, i32);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i32x4(i32, i32, i32, i32);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i32x8(
-    i32, i32, i32, i32, i32, i32, i32, i32,
-);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i32x16(
-    i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32,
-);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i32x2([i32; 2]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i32x4([i32; 4]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i32x8([i32; 8]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i32x16([i32; 16]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i64x2(i64, i64);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i64x4(i64, i64, i64, i64);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i64x8(
-    i64, i64, i64, i64, i64, i64, i64, i64,
-);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i64x2([i64; 2]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i64x4([i64; 4]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i64x8([i64; 8]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i128x2(i128, i128);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct i128x4(i128, i128, i128, i128);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i128x2([i128; 2]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct i128x4([i128; 4]);
 
 // unsigned integer types
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x2(u8, u8);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x4(u8, u8, u8, u8);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x8(
-    u8, u8, u8, u8, u8, u8, u8, u8,
-);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x16(
-    u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8,
-);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x32(
-    u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8,
-    u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8,
-);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x64(
-    u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8,
-    u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8,
-    u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8,
-    u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8,
-);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x2([u8; 2]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x4([u8; 4]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x8([u8; 8]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x16([u8; 16]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x32([u8; 32]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u8x64([u8; 64]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x2(u16, u16);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x4(u16, u16, u16, u16);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x8(
-    u16, u16, u16, u16, u16, u16, u16, u16,
-);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x16(
-    u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16,
-);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x32(
-    u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16,
-    u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16, u16,
-);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x2([u16; 2]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x4([u16; 4]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x8([u16; 8]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x16([u16; 16]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u16x32([u16; 32]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u32x2(u32, u32);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u32x4(u32, u32, u32, u32);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u32x8(
-    u32, u32, u32, u32, u32, u32, u32, u32,
-);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u32x16(
-    u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32, u32,
-);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u32x2([u32; 2]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u32x4([u32; 4]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u32x8([u32; 8]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u32x16([u32; 16]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u64x2(u64, u64);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u64x4(u64, u64, u64, u64);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u64x8(
-    u64, u64, u64, u64, u64, u64, u64, u64,
-);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u64x2([u64; 2]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u64x4([u64; 4]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u64x8([u64; 8]);
 
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u128x2(u128, u128);
-#[repr(simd)] #[derive(Copy, Clone)] pub struct u128x4(u128, u128, u128, u128);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u128x2([u128; 2]);
+#[repr(simd)] #[derive(Copy, Clone)] pub struct u128x4([u128; 4]);
 
 extern "rust-intrinsic" {
     fn simd_saturating_add<T>(x: T, y: T) -> T;

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-bitmask.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-bitmask.rs
@@ -8,19 +8,15 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct u32x2(u32, u32);
+pub struct u32x2([u32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct i32x2(i32, i32);
+pub struct i32x2([i32; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct i8x16(
-    i8, i8, i8, i8, i8, i8, i8, i8,
-    i8, i8, i8, i8, i8, i8, i8, i8,
-);
-
+pub struct i8x16([i8; 16]);
 
 extern "rust-intrinsic" {
     fn simd_bitmask<T, U>(x: T) -> U;

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-gather.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-gather.rs
@@ -9,11 +9,11 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct Vec2<T>(pub T, pub T);
+pub struct Vec2<T>(pub [T; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct Vec4<T>(pub T, pub T, pub T, pub T);
+pub struct Vec4<T>(pub [T; 4]);
 
 extern "rust-intrinsic" {
     fn simd_gather<T, P, M>(value: T, pointers: P, mask: M) -> T;

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-load.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-load.rs
@@ -7,11 +7,11 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct Vec2<T>(pub T, pub T);
+pub struct Vec2<T>(pub [T; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct Vec4<T>(pub T, pub T, pub T, pub T);
+pub struct Vec4<T>(pub [T; 4]);
 
 extern "rust-intrinsic" {
     fn simd_masked_load<M, P, T>(mask: M, pointer: P, values: T) -> T;

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-store.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-masked-store.rs
@@ -7,11 +7,11 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct Vec2<T>(pub T, pub T);
+pub struct Vec2<T>(pub [T; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct Vec4<T>(pub T, pub T, pub T, pub T);
+pub struct Vec4<T>(pub [T; 4]);
 
 extern "rust-intrinsic" {
     fn simd_masked_store<M, P, T>(mask: M, pointer: P, values: T) -> ();

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-scatter.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-scatter.rs
@@ -9,11 +9,11 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct Vec2<T>(pub T, pub T);
+pub struct Vec2<T>(pub [T; 2]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct Vec4<T>(pub T, pub T, pub T, pub T);
+pub struct Vec4<T>(pub [T; 4]);
 
 extern "rust-intrinsic" {
     fn simd_scatter<T, P, M>(value: T, pointers: P, mask: M);

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-generic-select.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-generic-select.rs
@@ -7,15 +7,15 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct f32x8(f32, f32, f32, f32, f32, f32, f32, f32);
+pub struct f32x8([f32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-pub struct b8x4(pub i8, pub i8, pub i8, pub i8);
+pub struct b8x4(pub [i8; 4]);
 
 extern "rust-intrinsic" {
     fn simd_select<T, U>(x: T, a: U, b: U) -> U;

--- a/tests/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
+++ b/tests/codegen/simd-intrinsic/simd-intrinsic-transmute-array.rs
@@ -13,10 +13,6 @@ pub struct S<const N: usize>([f32; N]);
 #[derive(Copy, Clone)]
 pub struct T([f32; 4]);
 
-#[repr(simd)]
-#[derive(Copy, Clone)]
-pub struct U(f32, f32, f32, f32);
-
 // CHECK-LABEL: @array_align(
 #[no_mangle]
 pub fn array_align() -> usize {
@@ -28,7 +24,7 @@ pub fn array_align() -> usize {
 #[no_mangle]
 pub fn vector_align() -> usize {
     // CHECK: ret [[USIZE]] [[VECTOR_ALIGN:[0-9]+]]
-    const { std::mem::align_of::<U>() }
+    const { std::mem::align_of::<T>() }
 }
 
 // CHECK-LABEL: @build_array_s
@@ -56,25 +52,6 @@ pub fn build_array_t(x: [f32; 4]) -> T {
 // CHECK-LABEL: @build_array_transmute_t
 #[no_mangle]
 pub fn build_array_transmute_t(x: [f32; 4]) -> T {
-    // CHECK: %[[VAL:.+]] = load <4 x float>, ptr %x, align [[ARRAY_ALIGN]]
-    // CHECK: store <4 x float> %[[VAL:.+]], ptr %_0, align [[VECTOR_ALIGN]]
-    unsafe { std::mem::transmute(x) }
-}
-
-// CHECK-LABEL: @build_array_u
-#[no_mangle]
-pub fn build_array_u(x: [f32; 4]) -> U {
-    // CHECK: store float %a, {{.+}}, align [[VECTOR_ALIGN]]
-    // CHECK: store float %b, {{.+}}, align [[ARRAY_ALIGN]]
-    // CHECK: store float %c, {{.+}}, align
-    // CHECK: store float %d, {{.+}}, align [[ARRAY_ALIGN]]
-    let [a, b, c, d] = x;
-    U(a, b, c, d)
-}
-
-// CHECK-LABEL: @build_array_transmute_u
-#[no_mangle]
-pub fn build_array_transmute_u(x: [f32; 4]) -> U {
     // CHECK: %[[VAL:.+]] = load <4 x float>, ptr %x, align [[ARRAY_ALIGN]]
     // CHECK: store <4 x float> %[[VAL:.+]], ptr %_0, align [[VECTOR_ALIGN]]
     unsafe { std::mem::transmute(x) }

--- a/tests/codegen/simd/unpadded-simd.rs
+++ b/tests/codegen/simd/unpadded-simd.rs
@@ -7,7 +7,7 @@
 
 #[derive(Copy, Clone)]
 #[repr(simd)]
-pub struct int16x4_t(pub i16, pub i16, pub i16, pub i16);
+pub struct int16x4_t(pub [i16; 4]);
 
 #[derive(Copy, Clone)]
 pub struct int16x4x2_t(pub int16x4_t, pub int16x4_t);

--- a/tests/codegen/union-abi.rs
+++ b/tests/codegen/union-abi.rs
@@ -16,7 +16,7 @@ pub enum Unhab {}
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct i64x4(i64, i64, i64, i64);
+pub struct i64x4([i64; 4]);
 
 #[derive(Copy, Clone)]
 pub union UnionI64x4 {

--- a/tests/codegen/zst-offset.rs
+++ b/tests/codegen/zst-offset.rs
@@ -27,7 +27,7 @@ pub fn scalarpair_layout(s: &(u64, u32, ())) {
 }
 
 #[repr(simd)]
-pub struct U64x4(u64, u64, u64, u64);
+pub struct U64x4([u64; 4]);
 
 // Check that we correctly generate a GEP for a ZST that is not included in Vector layout
 // CHECK-LABEL: @vector_layout

--- a/tests/debuginfo/simd.rs
+++ b/tests/debuginfo/simd.rs
@@ -10,27 +10,27 @@
 // gdb-command:run
 
 // gdb-command:print vi8x16
-// gdb-check:$1 = simd::i8x16 (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+// gdb-check:$1 = simd::i8x16 ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
 // gdb-command:print vi16x8
-// gdb-check:$2 = simd::i16x8 (16, 17, 18, 19, 20, 21, 22, 23)
+// gdb-check:$2 = simd::i16x8 ([16, 17, 18, 19, 20, 21, 22, 23])
 // gdb-command:print vi32x4
-// gdb-check:$3 = simd::i32x4 (24, 25, 26, 27)
+// gdb-check:$3 = simd::i32x4 ([24, 25, 26, 27])
 // gdb-command:print vi64x2
-// gdb-check:$4 = simd::i64x2 (28, 29)
+// gdb-check:$4 = simd::i64x2 ([28, 29])
 
 // gdb-command:print vu8x16
-// gdb-check:$5 = simd::u8x16 (30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45)
+// gdb-check:$5 = simd::u8x16 ([30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45])
 // gdb-command:print vu16x8
-// gdb-check:$6 = simd::u16x8 (46, 47, 48, 49, 50, 51, 52, 53)
+// gdb-check:$6 = simd::u16x8 ([46, 47, 48, 49, 50, 51, 52, 53])
 // gdb-command:print vu32x4
-// gdb-check:$7 = simd::u32x4 (54, 55, 56, 57)
+// gdb-check:$7 = simd::u32x4 ([54, 55, 56, 57])
 // gdb-command:print vu64x2
-// gdb-check:$8 = simd::u64x2 (58, 59)
+// gdb-check:$8 = simd::u64x2 ([58, 59])
 
 // gdb-command:print vf32x4
-// gdb-check:$9 = simd::f32x4 (60.5, 61.5, 62.5, 63.5)
+// gdb-check:$9 = simd::f32x4 ([60.5, 61.5, 62.5, 63.5])
 // gdb-command:print vf64x2
-// gdb-check:$10 = simd::f64x2 (64.5, 65.5)
+// gdb-check:$10 = simd::f64x2 ([64.5, 65.5])
 
 // gdb-command:continue
 
@@ -40,43 +40,43 @@
 #![feature(repr_simd)]
 
 #[repr(simd)]
-struct i8x16(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8);
+struct i8x16([i8; 16]);
 #[repr(simd)]
-struct i16x8(i16, i16, i16, i16, i16, i16, i16, i16);
+struct i16x8([i16; 8]);
 #[repr(simd)]
-struct i32x4(i32, i32, i32, i32);
+struct i32x4([i32; 4]);
 #[repr(simd)]
-struct i64x2(i64, i64);
+struct i64x2([i64; 2]);
 #[repr(simd)]
-struct u8x16(u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8);
+struct u8x16([u8; 16]);
 #[repr(simd)]
-struct u16x8(u16, u16, u16, u16, u16, u16, u16, u16);
+struct u16x8([u16; 8]);
 #[repr(simd)]
-struct u32x4(u32, u32, u32, u32);
+struct u32x4([u32; 4]);
 #[repr(simd)]
-struct u64x2(u64, u64);
+struct u64x2([u64; 2]);
 #[repr(simd)]
-struct f32x4(f32, f32, f32, f32);
+struct f32x4([f32; 4]);
 #[repr(simd)]
-struct f64x2(f64, f64);
+struct f64x2([f64; 2]);
 
 fn main() {
 
-    let vi8x16 = i8x16(0, 1, 2, 3, 4, 5, 6, 7,
-                      8, 9, 10, 11, 12, 13, 14, 15);
+    let vi8x16 = i8x16([0, 1, 2, 3, 4, 5, 6, 7,
+                      8, 9, 10, 11, 12, 13, 14, 15]);
 
-    let vi16x8 = i16x8(16, 17, 18, 19, 20, 21, 22, 23);
-    let vi32x4 = i32x4(24, 25, 26, 27);
-    let vi64x2 = i64x2(28, 29);
+    let vi16x8 = i16x8([16, 17, 18, 19, 20, 21, 22, 23]);
+    let vi32x4 = i32x4([24, 25, 26, 27]);
+    let vi64x2 = i64x2([28, 29]);
 
-    let vu8x16 = u8x16(30, 31, 32, 33, 34, 35, 36, 37,
-                      38, 39, 40, 41, 42, 43, 44, 45);
-    let vu16x8 = u16x8(46, 47, 48, 49, 50, 51, 52, 53);
-    let vu32x4 = u32x4(54, 55, 56, 57);
-    let vu64x2 = u64x2(58, 59);
+    let vu8x16 = u8x16([30, 31, 32, 33, 34, 35, 36, 37,
+                      38, 39, 40, 41, 42, 43, 44, 45]);
+    let vu16x8 = u16x8([46, 47, 48, 49, 50, 51, 52, 53]);
+    let vu32x4 = u32x4([54, 55, 56, 57]);
+    let vu64x2 = u64x2([58, 59]);
 
-    let vf32x4 = f32x4(60.5f32, 61.5f32, 62.5f32, 63.5f32);
-    let vf64x2 = f64x2(64.5f64, 65.5f64);
+    let vf32x4 = f32x4([60.5f32, 61.5f32, 62.5f32, 63.5f32]);
+    let vf64x2 = f64x2([64.5f64, 65.5f64]);
 
     zzz(); // #break
 }

--- a/tests/incremental/issue-61530.rs
+++ b/tests/incremental/issue-61530.rs
@@ -3,7 +3,7 @@
 //@ revisions:rpass1 rpass2
 
 #[repr(simd)]
-struct I32x2(i32, i32);
+struct I32x2([i32; 2]);
 
 extern "rust-intrinsic" {
     fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
@@ -12,7 +12,7 @@ extern "rust-intrinsic" {
 fn main() {
     unsafe {
         const IDX: [u32; 2] = [0, 0];
-        let _: I32x2 = simd_shuffle(I32x2(1, 2), I32x2(3, 4), IDX);
-        let _: I32x2 = simd_shuffle(I32x2(1, 2), I32x2(3, 4), IDX);
+        let _: I32x2 = simd_shuffle(I32x2([1, 2]), I32x2([3, 4]), IDX);
+        let _: I32x2 = simd_shuffle(I32x2([1, 2]), I32x2([3, 4]), IDX);
     }
 }

--- a/tests/run-make/native-lib-alt-naming/native.rs
+++ b/tests/run-make/native-lib-alt-naming/native.rs
@@ -1,0 +1,2 @@
+#[no_mangle]
+pub extern "C" fn native_lib_alt_naming() {}

--- a/tests/run-make/native-lib-alt-naming/rmake.rs
+++ b/tests/run-make/native-lib-alt-naming/rmake.rs
@@ -1,0 +1,15 @@
+// On MSVC the alternative naming format for static libraries (`libfoo.a`) is accepted in addition
+// to the default format (`foo.lib`).
+
+//REMOVE@ only-msvc
+
+use run_make_support::rustc;
+
+fn main() {
+    // Prepare the native library.
+    rustc().input("native.rs").crate_type("staticlib").output("libnative.a").run();
+
+    // Try to link to it from both a rlib and a bin.
+    rustc().input("rust.rs").crate_type("rlib").arg("-lstatic=native").run();
+    rustc().input("rust.rs").crate_type("bin").arg("-lstatic=native").run();
+}

--- a/tests/run-make/native-lib-alt-naming/rust.rs
+++ b/tests/run-make/native-lib-alt-naming/rust.rs
@@ -1,0 +1,1 @@
+pub fn main() {}

--- a/tests/run-make/simd-ffi/simd.rs
+++ b/tests/run-make/simd-ffi/simd.rs
@@ -8,7 +8,7 @@
 
 #[derive(Copy)]
 #[repr(simd)]
-pub struct f32x4(f32, f32, f32, f32);
+pub struct f32x4([f32; 4]);
 
 extern "C" {
     #[link_name = "llvm.sqrt.v4f32"]
@@ -21,7 +21,7 @@ pub fn foo(x: f32x4) -> f32x4 {
 
 #[derive(Copy)]
 #[repr(simd)]
-pub struct i32x4(i32, i32, i32, i32);
+pub struct i32x4([i32; 4]);
 
 extern "C" {
     // _mm_sll_epi32
@@ -62,6 +62,8 @@ pub trait Copy {}
 
 impl Copy for f32 {}
 impl Copy for i32 {}
+impl Copy for [f32; 4] {}
+impl Copy for [i32; 4] {}
 
 pub mod marker {
     pub use Copy;

--- a/tests/rustdoc/inline_cross/auxiliary/repr.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/repr.rs
@@ -6,7 +6,7 @@ pub struct ReprC {
 }
 #[repr(simd, packed(2))]
 pub struct ReprSimd {
-    field: u8,
+    field: [u8; 1],
 }
 #[repr(transparent)]
 pub struct ReprTransparent {

--- a/tests/ui/abi/arm-unadjusted-intrinsic.rs
+++ b/tests/ui/abi/arm-unadjusted-intrinsic.rs
@@ -25,16 +25,13 @@ impl Copy for i8 {}
 impl<T: ?Sized> Copy for *const T {}
 impl<T: ?Sized> Copy for *mut T {}
 
+// I hate no_core tests!
+impl<T: Copy, const N: usize> Copy for [T; N] {}
 
 // Regression test for https://github.com/rust-lang/rust/issues/118124.
 
 #[repr(simd)]
-pub struct int8x16_t(
-    pub(crate) i8, pub(crate) i8, pub(crate) i8, pub(crate) i8,
-    pub(crate) i8, pub(crate) i8, pub(crate) i8, pub(crate) i8,
-    pub(crate) i8, pub(crate) i8, pub(crate) i8, pub(crate) i8,
-    pub(crate) i8, pub(crate) i8, pub(crate) i8, pub(crate) i8,
-);
+pub struct int8x16_t(pub(crate) [i8; 16]);
 impl Copy for int8x16_t {}
 
 #[repr(C)]

--- a/tests/ui/abi/homogenous-floats-target-feature-mixup.rs
+++ b/tests/ui/abi/homogenous-floats-target-feature-mixup.rs
@@ -65,13 +65,13 @@ fn is_sigill(status: ExitStatus) -> bool {
 #[allow(nonstandard_style)]
 mod test {
     #[derive(PartialEq, Debug, Clone, Copy)]
-    struct f32x2(f32, f32);
+    struct f32x2([f32; 2]);
 
     #[derive(PartialEq, Debug, Clone, Copy)]
-    struct f32x4(f32, f32, f32, f32);
+    struct f32x4([f32; 4]);
 
     #[derive(PartialEq, Debug, Clone, Copy)]
-    struct f32x8(f32, f32, f32, f32, f32, f32, f32, f32);
+    struct f32x8([f32; 8]);
 
     pub fn main(level: &str) {
         unsafe {
@@ -97,9 +97,9 @@ mod test {
         )*) => ($(
             $(#[$attr])*
             unsafe fn $main(level: &str) {
-                let m128 = f32x2(1., 2.);
-                let m256 = f32x4(3., 4., 5., 6.);
-                let m512 = f32x8(7., 8., 9., 10., 11., 12., 13., 14.);
+                let m128 = f32x2([1., 2.]);
+                let m256 = f32x4([3., 4., 5., 6.]);
+                let m512 = f32x8([7., 8., 9., 10., 11., 12., 13., 14.]);
                 assert_eq!(id_sse_128(m128), m128);
                 assert_eq!(id_sse_256(m256), m256);
                 assert_eq!(id_sse_512(m512), m512);
@@ -133,55 +133,55 @@ mod test {
 
     #[target_feature(enable = "sse2")]
     unsafe fn id_sse_128(a: f32x2) -> f32x2 {
-        assert_eq!(a, f32x2(1., 2.));
+        assert_eq!(a, f32x2([1., 2.]));
         a.clone()
     }
 
     #[target_feature(enable = "sse2")]
     unsafe fn id_sse_256(a: f32x4) -> f32x4 {
-        assert_eq!(a, f32x4(3., 4., 5., 6.));
+        assert_eq!(a, f32x4([3., 4., 5., 6.]));
         a.clone()
     }
 
     #[target_feature(enable = "sse2")]
     unsafe fn id_sse_512(a: f32x8) -> f32x8 {
-        assert_eq!(a, f32x8(7., 8., 9., 10., 11., 12., 13., 14.));
+        assert_eq!(a, f32x8([7., 8., 9., 10., 11., 12., 13., 14.]));
         a.clone()
     }
 
     #[target_feature(enable = "avx")]
     unsafe fn id_avx_128(a: f32x2) -> f32x2 {
-        assert_eq!(a, f32x2(1., 2.));
+        assert_eq!(a, f32x2([1., 2.]));
         a.clone()
     }
 
     #[target_feature(enable = "avx")]
     unsafe fn id_avx_256(a: f32x4) -> f32x4 {
-        assert_eq!(a, f32x4(3., 4., 5., 6.));
+        assert_eq!(a, f32x4([3., 4., 5., 6.]));
         a.clone()
     }
 
     #[target_feature(enable = "avx")]
     unsafe fn id_avx_512(a: f32x8) -> f32x8 {
-        assert_eq!(a, f32x8(7., 8., 9., 10., 11., 12., 13., 14.));
+        assert_eq!(a, f32x8([7., 8., 9., 10., 11., 12., 13., 14.]));
         a.clone()
     }
 
     #[target_feature(enable = "avx512bw")]
     unsafe fn id_avx512_128(a: f32x2) -> f32x2 {
-        assert_eq!(a, f32x2(1., 2.));
+        assert_eq!(a, f32x2([1., 2.]));
         a.clone()
     }
 
     #[target_feature(enable = "avx512bw")]
     unsafe fn id_avx512_256(a: f32x4) -> f32x4 {
-        assert_eq!(a, f32x4(3., 4., 5., 6.));
+        assert_eq!(a, f32x4([3., 4., 5., 6.]));
         a.clone()
     }
 
     #[target_feature(enable = "avx512bw")]
     unsafe fn id_avx512_512(a: f32x8) -> f32x8 {
-        assert_eq!(a, f32x8(7., 8., 9., 10., 11., 12., 13., 14.));
+        assert_eq!(a, f32x8([7., 8., 9., 10., 11., 12., 13., 14.]));
         a.clone()
     }
 }

--- a/tests/ui/asm/aarch64/type-check-2-2.rs
+++ b/tests/ui/asm/aarch64/type-check-2-2.rs
@@ -6,10 +6,10 @@ use std::arch::{asm, global_asm};
 
 #[repr(simd)]
 #[derive(Clone, Copy)]
-struct SimdType(f32, f32, f32, f32);
+struct SimdType([f32; 4]);
 
 #[repr(simd)]
-struct SimdNonCopy(f32, f32, f32, f32);
+struct SimdNonCopy([f32; 4]);
 
 fn main() {
     unsafe {

--- a/tests/ui/asm/aarch64/type-check-2.rs
+++ b/tests/ui/asm/aarch64/type-check-2.rs
@@ -6,10 +6,10 @@ use std::arch::{asm, global_asm};
 
 #[repr(simd)]
 #[derive(Clone, Copy)]
-struct SimdType(f32, f32, f32, f32);
+struct SimdType([f32; 4]);
 
 #[repr(simd)]
-struct SimdNonCopy(f32, f32, f32, f32);
+struct SimdNonCopy([f32; 4]);
 
 fn main() {
     unsafe {
@@ -17,7 +17,7 @@ fn main() {
 
         // Register operands must be Copy
 
-        asm!("{:v}", in(vreg) SimdNonCopy(0.0, 0.0, 0.0, 0.0));
+        asm!("{:v}", in(vreg) SimdNonCopy([0.0, 0.0, 0.0, 0.0]));
         //~^ ERROR arguments for inline assembly must be copyable
 
         // Register operands must be integers, floats, SIMD vectors, pointers or
@@ -25,7 +25,7 @@ fn main() {
 
         asm!("{}", in(reg) 0i64);
         asm!("{}", in(reg) 0f64);
-        asm!("{:v}", in(vreg) SimdType(0.0, 0.0, 0.0, 0.0));
+        asm!("{:v}", in(vreg) SimdType([0.0, 0.0, 0.0, 0.0]));
         asm!("{}", in(reg) 0 as *const u8);
         asm!("{}", in(reg) 0 as *mut u8);
         asm!("{}", in(reg) main as fn());

--- a/tests/ui/asm/aarch64/type-check-2.stderr
+++ b/tests/ui/asm/aarch64/type-check-2.stderr
@@ -1,8 +1,8 @@
 error: arguments for inline assembly must be copyable
   --> $DIR/type-check-2.rs:20:31
    |
-LL |         asm!("{:v}", in(vreg) SimdNonCopy(0.0, 0.0, 0.0, 0.0));
-   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         asm!("{:v}", in(vreg) SimdNonCopy([0.0, 0.0, 0.0, 0.0]));
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `SimdNonCopy` does not implement the Copy trait
 

--- a/tests/ui/asm/aarch64/type-check-3.rs
+++ b/tests/ui/asm/aarch64/type-check-3.rs
@@ -8,11 +8,11 @@ use std::arch::{asm, global_asm};
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct Simd256bit(f64, f64, f64, f64);
+struct Simd256bit([f64; 4]);
 
 fn main() {
     let f64x2: float64x2_t = unsafe { std::mem::transmute(0i128) };
-    let f64x4 = Simd256bit(0.0, 0.0, 0.0, 0.0);
+    let f64x4 = Simd256bit([0.0, 0.0, 0.0, 0.0]);
 
     unsafe {
         // Types must be listed in the register class.

--- a/tests/ui/asm/aarch64/type-check-4.rs
+++ b/tests/ui/asm/aarch64/type-check-4.rs
@@ -8,7 +8,7 @@ use std::arch::{asm, global_asm};
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct Simd256bit(f64, f64, f64, f64);
+struct Simd256bit([f64; 4]);
 
 fn main() {}
 

--- a/tests/ui/asm/x86_64/type-check-2.rs
+++ b/tests/ui/asm/x86_64/type-check-2.rs
@@ -5,7 +5,7 @@
 use std::arch::{asm, global_asm};
 
 #[repr(simd)]
-struct SimdNonCopy(f32, f32, f32, f32);
+struct SimdNonCopy([f32; 4]);
 
 fn main() {
     unsafe {
@@ -29,7 +29,7 @@ fn main() {
 
         // Register operands must be Copy
 
-        asm!("{}", in(xmm_reg) SimdNonCopy(0.0, 0.0, 0.0, 0.0));
+        asm!("{}", in(xmm_reg) SimdNonCopy([0.0, 0.0, 0.0, 0.0]));
         //~^ ERROR arguments for inline assembly must be copyable
 
         // Register operands must be integers, floats, SIMD vectors, pointers or

--- a/tests/ui/asm/x86_64/type-check-2.stderr
+++ b/tests/ui/asm/x86_64/type-check-2.stderr
@@ -1,8 +1,8 @@
 error: arguments for inline assembly must be copyable
   --> $DIR/type-check-2.rs:32:32
    |
-LL |         asm!("{}", in(xmm_reg) SimdNonCopy(0.0, 0.0, 0.0, 0.0));
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         asm!("{}", in(xmm_reg) SimdNonCopy([0.0, 0.0, 0.0, 0.0]));
+   |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `SimdNonCopy` does not implement the Copy trait
 

--- a/tests/ui/asm/x86_64/type-check-5.rs
+++ b/tests/ui/asm/x86_64/type-check-5.rs
@@ -1,11 +1,8 @@
 //@ only-x86_64
 
-#![feature(repr_simd, never_type)]
+#![feature(never_type)]
 
 use std::arch::asm;
-
-#[repr(simd)]
-struct SimdNonCopy(f32, f32, f32, f32);
 
 fn main() {
     unsafe {

--- a/tests/ui/asm/x86_64/type-check-5.stderr
+++ b/tests/ui/asm/x86_64/type-check-5.stderr
@@ -1,5 +1,5 @@
 error[E0381]: used binding `x` isn't initialized
-  --> $DIR/type-check-5.rs:15:28
+  --> $DIR/type-check-5.rs:12:28
    |
 LL |         let x: u64;
    |             - binding declared here but left uninitialized
@@ -12,7 +12,7 @@ LL |         let x: u64 = 42;
    |                    ++++
 
 error[E0381]: used binding `y` isn't initialized
-  --> $DIR/type-check-5.rs:18:9
+  --> $DIR/type-check-5.rs:15:9
    |
 LL |         let mut y: u64;
    |             ----- binding declared here but left uninitialized
@@ -25,7 +25,7 @@ LL |         let mut y: u64 = 42;
    |                        ++++
 
 error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
-  --> $DIR/type-check-5.rs:24:13
+  --> $DIR/type-check-5.rs:21:13
    |
 LL |         let v: Vec<u64> = vec![0, 1, 2];
    |             ^ not mutable

--- a/tests/ui/consts/const-eval/simd/insert_extract.rs
+++ b/tests/ui/consts/const-eval/simd/insert_extract.rs
@@ -5,10 +5,9 @@
 #![stable(feature = "foo", since = "1.3.37")]
 #![allow(non_camel_case_types)]
 
-#[repr(simd)] struct i8x1(i8);
-#[repr(simd)] struct u16x2(u16, u16);
-// Make some of them array types to ensure those also work.
-#[repr(simd)] struct i8x1_arr([i8; 1]);
+// repr(simd) now only supports array types
+#[repr(simd)] struct i8x1([i8; 1]);
+#[repr(simd)] struct u16x2([u16; 2]);
 #[repr(simd)] struct f32x4([f32; 4]);
 
 extern "rust-intrinsic" {
@@ -20,26 +19,18 @@ extern "rust-intrinsic" {
 
 fn main() {
     {
-        const U: i8x1 = i8x1(13);
+        const U: i8x1 = i8x1([13]);
         const V: i8x1 = unsafe { simd_insert(U, 0_u32, 42_i8) };
-        const X0: i8 = V.0;
-        const Y0: i8 = unsafe { simd_extract(V, 0) };
-        assert_eq!(X0, 42);
-        assert_eq!(Y0, 42);
-    }
-    {
-        const U: i8x1_arr = i8x1_arr([13]);
-        const V: i8x1_arr = unsafe { simd_insert(U, 0_u32, 42_i8) };
         const X0: i8 = V.0[0];
         const Y0: i8 = unsafe { simd_extract(V, 0) };
         assert_eq!(X0, 42);
         assert_eq!(Y0, 42);
     }
     {
-        const U: u16x2 = u16x2(13, 14);
+        const U: u16x2 = u16x2([13, 14]);
         const V: u16x2 = unsafe { simd_insert(U, 1_u32, 42_u16) };
-        const X0: u16 = V.0;
-        const X1: u16 = V.1;
+        const X0: u16 = V.0[0];
+        const X1: u16 = V.0[1];
         const Y0: u16 = unsafe { simd_extract(V, 0) };
         const Y1: u16 = unsafe { simd_extract(V, 1) };
         assert_eq!(X0, 13);

--- a/tests/ui/error-codes/E0075.rs
+++ b/tests/ui/error-codes/E0075.rs
@@ -3,5 +3,8 @@
 #[repr(simd)]
 struct Bad; //~ ERROR E0075
 
+#[repr(simd)]
+struct AlsoBad([i32; 1], [i32; 1]); //~ ERROR E0075
+
 fn main() {
 }

--- a/tests/ui/error-codes/E0075.stderr
+++ b/tests/ui/error-codes/E0075.stderr
@@ -4,6 +4,12 @@ error[E0075]: SIMD vector cannot be empty
 LL | struct Bad;
    | ^^^^^^^^^^
 
-error: aborting due to 1 previous error
+error[E0075]: SIMD vector cannot have multiple fields
+  --> $DIR/E0075.rs:7:1
+   |
+LL | struct AlsoBad([i32; 1], [i32; 1]);
+   | ^^^^^^^^^^^^^^           -------- excess field
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0075`.

--- a/tests/ui/error-codes/E0076.rs
+++ b/tests/ui/error-codes/E0076.rs
@@ -1,7 +1,7 @@
 #![feature(repr_simd)]
 
 #[repr(simd)]
-struct Bad(u16, u32, u32);
+struct Bad(u32);
 //~^ ERROR E0076
 
 fn main() {

--- a/tests/ui/error-codes/E0076.stderr
+++ b/tests/ui/error-codes/E0076.stderr
@@ -1,8 +1,8 @@
-error[E0076]: SIMD vector should be homogeneous
+error[E0076]: SIMD vector's only field must be an array
   --> $DIR/E0076.rs:4:1
    |
-LL | struct Bad(u16, u32, u32);
-   | ^^^^^^^^^^ SIMD elements must have the same type
+LL | struct Bad(u32);
+   | ^^^^^^^^^^ --- not an array
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/error-codes/E0077.rs
+++ b/tests/ui/error-codes/E0077.rs
@@ -1,7 +1,7 @@
 #![feature(repr_simd)]
 
 #[repr(simd)]
-struct Bad(String); //~ ERROR E0077
+struct Bad([String; 2]); //~ ERROR E0077
 
 fn main() {
 }

--- a/tests/ui/error-codes/E0077.stderr
+++ b/tests/ui/error-codes/E0077.stderr
@@ -1,7 +1,7 @@
 error[E0077]: SIMD vector element type should be a primitive scalar (integer/float/pointer) type
   --> $DIR/E0077.rs:4:1
    |
-LL | struct Bad(String);
+LL | struct Bad([String; 2]);
    | ^^^^^^^^^^
 
 error: aborting due to 1 previous error

--- a/tests/ui/feature-gates/feature-gate-repr-simd.rs
+++ b/tests/ui/feature-gates/feature-gate-repr-simd.rs
@@ -1,9 +1,9 @@
 #[repr(simd)] //~ error: SIMD types are experimental
-struct Foo(u64, u64);
+struct Foo([u64; 2]);
 
 #[repr(C)] //~ ERROR conflicting representation hints
 //~^ WARN this was previously accepted
 #[repr(simd)] //~ error: SIMD types are experimental
-struct Bar(u64, u64);
+struct Bar([u64; 2]);
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-simd-ffi.rs
+++ b/tests/ui/feature-gates/feature-gate-simd-ffi.rs
@@ -3,7 +3,7 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct LocalSimd(u8, u8);
+struct LocalSimd([u8; 2]);
 
 extern "C" {
     fn baz() -> LocalSimd; //~ ERROR use of SIMD type

--- a/tests/ui/feature-gates/feature-gate-simd.rs
+++ b/tests/ui/feature-gates/feature-gate-simd.rs
@@ -2,10 +2,7 @@
 
 #[repr(simd)] //~ ERROR SIMD types are experimental
 struct RGBA {
-    r: f32,
-    g: f32,
-    b: f32,
-    a: f32
+    rgba: [f32; 4],
 }
 
 pub fn main() {}

--- a/tests/ui/layout/debug.rs
+++ b/tests/ui/layout/debug.rs
@@ -49,7 +49,7 @@ union P2 { x: (u32, u32) } //~ ERROR: layout_of
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct F32x4(f32, f32, f32, f32);
+struct F32x4([f32; 4]);
 
 #[rustc_layout(debug)]
 #[repr(packed(1))]

--- a/tests/ui/repr/attr-usage-repr.rs
+++ b/tests/ui/repr/attr-usage-repr.rs
@@ -10,7 +10,7 @@ struct SExtern(f64, f64);
 struct SPacked(f64, f64);
 
 #[repr(simd)]
-struct SSimd(f64, f64);
+struct SSimd([f64; 2]);
 
 #[repr(i8)] //~ ERROR: attribute should be applied to an enum
 struct SInt(f64, f64);

--- a/tests/ui/repr/explicit-rust-repr-conflicts.rs
+++ b/tests/ui/repr/explicit-rust-repr-conflicts.rs
@@ -18,6 +18,6 @@ enum U {
 #[repr(Rust, simd)]
 //~^ ERROR conflicting representation hints
 //~| ERROR SIMD types are experimental and possibly buggy
-struct F32x4(f32, f32, f32, f32);
+struct F32x4([f32; 4]);
 
 fn main() {}

--- a/tests/ui/simd/const-err-trumps-simd-err.rs
+++ b/tests/ui/simd/const-err-trumps-simd-err.rs
@@ -10,7 +10,7 @@ use std::intrinsics::simd::*;
 
 #[repr(simd)]
 #[allow(non_camel_case_types)]
-struct int8x4_t(u8,u8,u8,u8);
+struct int8x4_t([u8; 4]);
 
 fn get_elem<const LANE: u32>(a: int8x4_t) -> u8 {
     const { assert!(LANE < 4); } // the error should be here...
@@ -20,5 +20,5 @@ fn get_elem<const LANE: u32>(a: int8x4_t) -> u8 {
 }
 
 fn main() {
-    get_elem::<4>(int8x4_t(0,0,0,0));
+    get_elem::<4>(int8x4_t([0, 0, 0, 0]));
 }

--- a/tests/ui/simd/const-err-trumps-simd-err.stderr
+++ b/tests/ui/simd/const-err-trumps-simd-err.stderr
@@ -15,8 +15,8 @@ LL |     const { assert!(LANE < 4); } // the error should be here...
 note: the above error was encountered while instantiating `fn get_elem::<4>`
   --> $DIR/const-err-trumps-simd-err.rs:23:5
    |
-LL |     get_elem::<4>(int8x4_t(0,0,0,0));
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     get_elem::<4>(int8x4_t([0, 0, 0, 0]));
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/simd/generics.rs
+++ b/tests/ui/simd/generics.rs
@@ -6,7 +6,7 @@ use std::ops;
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct f32x4(f32, f32, f32, f32);
+struct f32x4([f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -67,8 +67,8 @@ pub fn main() {
     let y = [2.0f32, 4.0f32, 6.0f32, 8.0f32];
 
     // lame-o
-    let a = f32x4(1.0f32, 2.0f32, 3.0f32, 4.0f32);
-    let f32x4(a0, a1, a2, a3) = add(a, a);
+    let a = f32x4([1.0f32, 2.0f32, 3.0f32, 4.0f32]);
+    let f32x4([a0, a1, a2, a3]) = add(a, a);
     assert_eq!(a0, 2.0f32);
     assert_eq!(a1, 4.0f32);
     assert_eq!(a2, 6.0f32);

--- a/tests/ui/simd/intrinsic/float-math-pass.rs
+++ b/tests/ui/simd/intrinsic/float-math-pass.rs
@@ -13,7 +13,7 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct f32x4(pub f32, pub f32, pub f32, pub f32);
+struct f32x4(pub [f32; 4]);
 
 extern "rust-intrinsic" {
     fn simd_fsqrt<T>(x: T) -> T;
@@ -47,19 +47,19 @@ macro_rules! assert_approx_eq {
     ($a:expr, $b:expr) => ({
         let a = $a;
         let b = $b;
-        assert_approx_eq_f32!(a.0, b.0);
-        assert_approx_eq_f32!(a.1, b.1);
-        assert_approx_eq_f32!(a.2, b.2);
-        assert_approx_eq_f32!(a.3, b.3);
+        assert_approx_eq_f32!(a.0[0], b.0[0]);
+        assert_approx_eq_f32!(a.0[1], b.0[1]);
+        assert_approx_eq_f32!(a.0[2], b.0[2]);
+        assert_approx_eq_f32!(a.0[3], b.0[3]);
     })
 }
 
 fn main() {
-    let x = f32x4(1.0, 1.0, 1.0, 1.0);
-    let y = f32x4(-1.0, -1.0, -1.0, -1.0);
-    let z = f32x4(0.0, 0.0, 0.0, 0.0);
+    let x = f32x4([1.0, 1.0, 1.0, 1.0]);
+    let y = f32x4([-1.0, -1.0, -1.0, -1.0]);
+    let z = f32x4([0.0, 0.0, 0.0, 0.0]);
 
-    let h = f32x4(0.5, 0.5, 0.5, 0.5);
+    let h = f32x4([0.5, 0.5, 0.5, 0.5]);
 
     unsafe {
         let r = simd_fabs(y);

--- a/tests/ui/simd/intrinsic/float-minmax-pass.rs
+++ b/tests/ui/simd/intrinsic/float-minmax-pass.rs
@@ -8,13 +8,13 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct f32x4(pub f32, pub f32, pub f32, pub f32);
+struct f32x4(pub [f32; 4]);
 
 use std::intrinsics::simd::*;
 
 fn main() {
-    let x = f32x4(1.0, 2.0, 3.0, 4.0);
-    let y = f32x4(2.0, 1.0, 4.0, 3.0);
+    let x = f32x4([1.0, 2.0, 3.0, 4.0]);
+    let y = f32x4([2.0, 1.0, 4.0, 3.0]);
 
     #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
     let nan = f32::NAN;
@@ -23,13 +23,13 @@ fn main() {
     #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
     let nan = f32::from_bits(f32::NAN.to_bits() - 1);
 
-    let n = f32x4(nan, nan, nan, nan);
+    let n = f32x4([nan, nan, nan, nan]);
 
     unsafe {
         let min0 = simd_fmin(x, y);
         let min1 = simd_fmin(y, x);
         assert_eq!(min0, min1);
-        let e = f32x4(1.0, 1.0, 3.0, 3.0);
+        let e = f32x4([1.0, 1.0, 3.0, 3.0]);
         assert_eq!(min0, e);
         let minn = simd_fmin(x, n);
         assert_eq!(minn, x);
@@ -39,7 +39,7 @@ fn main() {
         let max0 = simd_fmax(x, y);
         let max1 = simd_fmax(y, x);
         assert_eq!(max0, max1);
-        let e = f32x4(2.0, 2.0, 4.0, 4.0);
+        let e = f32x4([2.0, 2.0, 4.0, 4.0]);
         assert_eq!(max0, e);
         let maxn = simd_fmax(x, n);
         assert_eq!(maxn, x);

--- a/tests/ui/simd/intrinsic/generic-arithmetic-2.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-2.rs
@@ -4,15 +4,15 @@
 #![allow(non_camel_case_types)]
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct i32x4(pub i32, pub i32, pub i32, pub i32);
+pub struct i32x4(pub [i32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct u32x4(pub u32, pub u32, pub u32, pub u32);
+pub struct u32x4(pub [u32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 extern "rust-intrinsic" {
     fn simd_add<T>(x: T, y: T) -> T;
@@ -35,9 +35,9 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    let x = i32x4(0, 0, 0, 0);
-    let y = u32x4(0, 0, 0, 0);
-    let z = f32x4(0.0, 0.0, 0.0, 0.0);
+    let x = i32x4([0, 0, 0, 0]);
+    let y = u32x4([0, 0, 0, 0]);
+    let z = f32x4([0.0, 0.0, 0.0, 0.0]);
 
     unsafe {
         simd_add(x, x);

--- a/tests/ui/simd/intrinsic/generic-arithmetic-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-pass.rs
@@ -5,7 +5,7 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct i32x4(pub i32, pub i32, pub i32, pub i32);
+struct i32x4(pub [i32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -13,17 +13,9 @@ struct U32<const N: usize>([u32; N]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct f32x4(pub f32, pub f32, pub f32, pub f32);
+struct f32x4(pub [f32; 4]);
 
 macro_rules! all_eq {
-    ($a: expr, $b: expr) => {{
-        let a = $a;
-        let b = $b;
-        assert!(a.0 == b.0 && a.1 == b.1 && a.2 == b.2 && a.3 == b.3);
-    }};
-}
-
-macro_rules! all_eq_ {
     ($a: expr, $b: expr) => {{
         let a = $a;
         let b = $b;
@@ -52,112 +44,112 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    let x1 = i32x4(1, 2, 3, 4);
+    let x1 = i32x4([1, 2, 3, 4]);
     let y1 = U32::<4>([1, 2, 3, 4]);
-    let z1 = f32x4(1.0, 2.0, 3.0, 4.0);
-    let x2 = i32x4(2, 3, 4, 5);
+    let z1 = f32x4([1.0, 2.0, 3.0, 4.0]);
+    let x2 = i32x4([2, 3, 4, 5]);
     let y2 = U32::<4>([2, 3, 4, 5]);
-    let z2 = f32x4(2.0, 3.0, 4.0, 5.0);
-    let x3 = i32x4(0, i32::MAX, i32::MIN, -1_i32);
+    let z2 = f32x4([2.0, 3.0, 4.0, 5.0]);
+    let x3 = i32x4([0, i32::MAX, i32::MIN, -1_i32]);
     let y3 = U32::<4>([0, i32::MAX as _, i32::MIN as _, -1_i32 as _]);
 
     unsafe {
-        all_eq!(simd_add(x1, x2), i32x4(3, 5, 7, 9));
-        all_eq!(simd_add(x2, x1), i32x4(3, 5, 7, 9));
-        all_eq_!(simd_add(y1, y2), U32::<4>([3, 5, 7, 9]));
-        all_eq_!(simd_add(y2, y1), U32::<4>([3, 5, 7, 9]));
-        all_eq!(simd_add(z1, z2), f32x4(3.0, 5.0, 7.0, 9.0));
-        all_eq!(simd_add(z2, z1), f32x4(3.0, 5.0, 7.0, 9.0));
+        all_eq!(simd_add(x1, x2), i32x4([3, 5, 7, 9]));
+        all_eq!(simd_add(x2, x1), i32x4([3, 5, 7, 9]));
+        all_eq!(simd_add(y1, y2), U32::<4>([3, 5, 7, 9]));
+        all_eq!(simd_add(y2, y1), U32::<4>([3, 5, 7, 9]));
+        all_eq!(simd_add(z1, z2), f32x4([3.0, 5.0, 7.0, 9.0]));
+        all_eq!(simd_add(z2, z1), f32x4([3.0, 5.0, 7.0, 9.0]));
 
-        all_eq!(simd_mul(x1, x2), i32x4(2, 6, 12, 20));
-        all_eq!(simd_mul(x2, x1), i32x4(2, 6, 12, 20));
-        all_eq_!(simd_mul(y1, y2), U32::<4>([2, 6, 12, 20]));
-        all_eq_!(simd_mul(y2, y1), U32::<4>([2, 6, 12, 20]));
-        all_eq!(simd_mul(z1, z2), f32x4(2.0, 6.0, 12.0, 20.0));
-        all_eq!(simd_mul(z2, z1), f32x4(2.0, 6.0, 12.0, 20.0));
+        all_eq!(simd_mul(x1, x2), i32x4([2, 6, 12, 20]));
+        all_eq!(simd_mul(x2, x1), i32x4([2, 6, 12, 20]));
+        all_eq!(simd_mul(y1, y2), U32::<4>([2, 6, 12, 20]));
+        all_eq!(simd_mul(y2, y1), U32::<4>([2, 6, 12, 20]));
+        all_eq!(simd_mul(z1, z2), f32x4([2.0, 6.0, 12.0, 20.0]));
+        all_eq!(simd_mul(z2, z1), f32x4([2.0, 6.0, 12.0, 20.0]));
 
-        all_eq!(simd_sub(x2, x1), i32x4(1, 1, 1, 1));
-        all_eq!(simd_sub(x1, x2), i32x4(-1, -1, -1, -1));
-        all_eq_!(simd_sub(y2, y1), U32::<4>([1, 1, 1, 1]));
-        all_eq_!(simd_sub(y1, y2), U32::<4>([!0, !0, !0, !0]));
-        all_eq!(simd_sub(z2, z1), f32x4(1.0, 1.0, 1.0, 1.0));
-        all_eq!(simd_sub(z1, z2), f32x4(-1.0, -1.0, -1.0, -1.0));
+        all_eq!(simd_sub(x2, x1), i32x4([1, 1, 1, 1]));
+        all_eq!(simd_sub(x1, x2), i32x4([-1, -1, -1, -1]));
+        all_eq!(simd_sub(y2, y1), U32::<4>([1, 1, 1, 1]));
+        all_eq!(simd_sub(y1, y2), U32::<4>([!0, !0, !0, !0]));
+        all_eq!(simd_sub(z2, z1), f32x4([1.0, 1.0, 1.0, 1.0]));
+        all_eq!(simd_sub(z1, z2), f32x4([-1.0, -1.0, -1.0, -1.0]));
 
-        all_eq!(simd_div(x1, x1), i32x4(1, 1, 1, 1));
-        all_eq!(simd_div(i32x4(2, 4, 6, 8), i32x4(2, 2, 2, 2)), x1);
-        all_eq_!(simd_div(y1, y1), U32::<4>([1, 1, 1, 1]));
-        all_eq_!(simd_div(U32::<4>([2, 4, 6, 8]), U32::<4>([2, 2, 2, 2])), y1);
-        all_eq!(simd_div(z1, z1), f32x4(1.0, 1.0, 1.0, 1.0));
-        all_eq!(simd_div(z1, z2), f32x4(1.0 / 2.0, 2.0 / 3.0, 3.0 / 4.0, 4.0 / 5.0));
-        all_eq!(simd_div(z2, z1), f32x4(2.0 / 1.0, 3.0 / 2.0, 4.0 / 3.0, 5.0 / 4.0));
+        all_eq!(simd_div(x1, x1), i32x4([1, 1, 1, 1]));
+        all_eq!(simd_div(i32x4([2, 4, 6, 8]), i32x4([2, 2, 2, 2])), x1);
+        all_eq!(simd_div(y1, y1), U32::<4>([1, 1, 1, 1]));
+        all_eq!(simd_div(U32::<4>([2, 4, 6, 8]), U32::<4>([2, 2, 2, 2])), y1);
+        all_eq!(simd_div(z1, z1), f32x4([1.0, 1.0, 1.0, 1.0]));
+        all_eq!(simd_div(z1, z2), f32x4([1.0 / 2.0, 2.0 / 3.0, 3.0 / 4.0, 4.0 / 5.0]));
+        all_eq!(simd_div(z2, z1), f32x4([2.0 / 1.0, 3.0 / 2.0, 4.0 / 3.0, 5.0 / 4.0]));
 
-        all_eq!(simd_rem(x1, x1), i32x4(0, 0, 0, 0));
-        all_eq!(simd_rem(x2, x1), i32x4(0, 1, 1, 1));
-        all_eq_!(simd_rem(y1, y1), U32::<4>([0, 0, 0, 0]));
-        all_eq_!(simd_rem(y2, y1), U32::<4>([0, 1, 1, 1]));
-        all_eq!(simd_rem(z1, z1), f32x4(0.0, 0.0, 0.0, 0.0));
+        all_eq!(simd_rem(x1, x1), i32x4([0, 0, 0, 0]));
+        all_eq!(simd_rem(x2, x1), i32x4([0, 1, 1, 1]));
+        all_eq!(simd_rem(y1, y1), U32::<4>([0, 0, 0, 0]));
+        all_eq!(simd_rem(y2, y1), U32::<4>([0, 1, 1, 1]));
+        all_eq!(simd_rem(z1, z1), f32x4([0.0, 0.0, 0.0, 0.0]));
         all_eq!(simd_rem(z1, z2), z1);
-        all_eq!(simd_rem(z2, z1), f32x4(0.0, 1.0, 1.0, 1.0));
+        all_eq!(simd_rem(z2, z1), f32x4([0.0, 1.0, 1.0, 1.0]));
 
-        all_eq!(simd_shl(x1, x2), i32x4(1 << 2, 2 << 3, 3 << 4, 4 << 5));
-        all_eq!(simd_shl(x2, x1), i32x4(2 << 1, 3 << 2, 4 << 3, 5 << 4));
-        all_eq_!(simd_shl(y1, y2), U32::<4>([1 << 2, 2 << 3, 3 << 4, 4 << 5]));
-        all_eq_!(simd_shl(y2, y1), U32::<4>([2 << 1, 3 << 2, 4 << 3, 5 << 4]));
+        all_eq!(simd_shl(x1, x2), i32x4([1 << 2, 2 << 3, 3 << 4, 4 << 5]));
+        all_eq!(simd_shl(x2, x1), i32x4([2 << 1, 3 << 2, 4 << 3, 5 << 4]));
+        all_eq!(simd_shl(y1, y2), U32::<4>([1 << 2, 2 << 3, 3 << 4, 4 << 5]));
+        all_eq!(simd_shl(y2, y1), U32::<4>([2 << 1, 3 << 2, 4 << 3, 5 << 4]));
 
         // test right-shift by assuming left-shift is correct
         all_eq!(simd_shr(simd_shl(x1, x2), x2), x1);
         all_eq!(simd_shr(simd_shl(x2, x1), x1), x2);
-        all_eq_!(simd_shr(simd_shl(y1, y2), y2), y1);
-        all_eq_!(simd_shr(simd_shl(y2, y1), y1), y2);
+        all_eq!(simd_shr(simd_shl(y1, y2), y2), y1);
+        all_eq!(simd_shr(simd_shl(y2, y1), y1), y2);
 
         // ensure we get logical vs. arithmetic shifts correct
         let (a, b, c, d) = (-12, -123, -1234, -12345);
-        all_eq!(simd_shr(i32x4(a, b, c, d), x1), i32x4(a >> 1, b >> 2, c >> 3, d >> 4));
-        all_eq_!(
+        all_eq!(simd_shr(i32x4([a, b, c, d]), x1), i32x4([a >> 1, b >> 2, c >> 3, d >> 4]));
+        all_eq!(
             simd_shr(U32::<4>([a as u32, b as u32, c as u32, d as u32]), y1),
             U32::<4>([(a as u32) >> 1, (b as u32) >> 2, (c as u32) >> 3, (d as u32) >> 4])
         );
 
-        all_eq!(simd_and(x1, x2), i32x4(0, 2, 0, 4));
-        all_eq!(simd_and(x2, x1), i32x4(0, 2, 0, 4));
-        all_eq_!(simd_and(y1, y2), U32::<4>([0, 2, 0, 4]));
-        all_eq_!(simd_and(y2, y1), U32::<4>([0, 2, 0, 4]));
+        all_eq!(simd_and(x1, x2), i32x4([0, 2, 0, 4]));
+        all_eq!(simd_and(x2, x1), i32x4([0, 2, 0, 4]));
+        all_eq!(simd_and(y1, y2), U32::<4>([0, 2, 0, 4]));
+        all_eq!(simd_and(y2, y1), U32::<4>([0, 2, 0, 4]));
 
-        all_eq!(simd_or(x1, x2), i32x4(3, 3, 7, 5));
-        all_eq!(simd_or(x2, x1), i32x4(3, 3, 7, 5));
-        all_eq_!(simd_or(y1, y2), U32::<4>([3, 3, 7, 5]));
-        all_eq_!(simd_or(y2, y1), U32::<4>([3, 3, 7, 5]));
+        all_eq!(simd_or(x1, x2), i32x4([3, 3, 7, 5]));
+        all_eq!(simd_or(x2, x1), i32x4([3, 3, 7, 5]));
+        all_eq!(simd_or(y1, y2), U32::<4>([3, 3, 7, 5]));
+        all_eq!(simd_or(y2, y1), U32::<4>([3, 3, 7, 5]));
 
-        all_eq!(simd_xor(x1, x2), i32x4(3, 1, 7, 1));
-        all_eq!(simd_xor(x2, x1), i32x4(3, 1, 7, 1));
-        all_eq_!(simd_xor(y1, y2), U32::<4>([3, 1, 7, 1]));
-        all_eq_!(simd_xor(y2, y1), U32::<4>([3, 1, 7, 1]));
+        all_eq!(simd_xor(x1, x2), i32x4([3, 1, 7, 1]));
+        all_eq!(simd_xor(x2, x1), i32x4([3, 1, 7, 1]));
+        all_eq!(simd_xor(y1, y2), U32::<4>([3, 1, 7, 1]));
+        all_eq!(simd_xor(y2, y1), U32::<4>([3, 1, 7, 1]));
 
-        all_eq!(simd_neg(x1), i32x4(-1, -2, -3, -4));
-        all_eq!(simd_neg(x2), i32x4(-2, -3, -4, -5));
-        all_eq!(simd_neg(z1), f32x4(-1.0, -2.0, -3.0, -4.0));
-        all_eq!(simd_neg(z2), f32x4(-2.0, -3.0, -4.0, -5.0));
+        all_eq!(simd_neg(x1), i32x4([-1, -2, -3, -4]));
+        all_eq!(simd_neg(x2), i32x4([-2, -3, -4, -5]));
+        all_eq!(simd_neg(z1), f32x4([-1.0, -2.0, -3.0, -4.0]));
+        all_eq!(simd_neg(z2), f32x4([-2.0, -3.0, -4.0, -5.0]));
 
-        all_eq!(simd_bswap(x1), i32x4(0x01000000, 0x02000000, 0x03000000, 0x04000000));
-        all_eq_!(simd_bswap(y1), U32::<4>([0x01000000, 0x02000000, 0x03000000, 0x04000000]));
+        all_eq!(simd_bswap(x1), i32x4([0x01000000, 0x02000000, 0x03000000, 0x04000000]));
+        all_eq!(simd_bswap(y1), U32::<4>([0x01000000, 0x02000000, 0x03000000, 0x04000000]));
 
         all_eq!(
             simd_bitreverse(x1),
-            i32x4(0x80000000u32 as i32, 0x40000000, 0xc0000000u32 as i32, 0x20000000)
+            i32x4([0x80000000u32 as i32, 0x40000000, 0xc0000000u32 as i32, 0x20000000])
         );
-        all_eq_!(simd_bitreverse(y1), U32::<4>([0x80000000, 0x40000000, 0xc0000000, 0x20000000]));
+        all_eq!(simd_bitreverse(y1), U32::<4>([0x80000000, 0x40000000, 0xc0000000, 0x20000000]));
 
-        all_eq!(simd_ctlz(x1), i32x4(31, 30, 30, 29));
-        all_eq_!(simd_ctlz(y1), U32::<4>([31, 30, 30, 29]));
+        all_eq!(simd_ctlz(x1), i32x4([31, 30, 30, 29]));
+        all_eq!(simd_ctlz(y1), U32::<4>([31, 30, 30, 29]));
 
-        all_eq!(simd_ctpop(x1), i32x4(1, 1, 2, 1));
-        all_eq_!(simd_ctpop(y1), U32::<4>([1, 1, 2, 1]));
-        all_eq!(simd_ctpop(x2), i32x4(1, 2, 1, 2));
-        all_eq_!(simd_ctpop(y2), U32::<4>([1, 2, 1, 2]));
-        all_eq!(simd_ctpop(x3), i32x4(0, 31, 1, 32));
-        all_eq_!(simd_ctpop(y3), U32::<4>([0, 31, 1, 32]));
+        all_eq!(simd_ctpop(x1), i32x4([1, 1, 2, 1]));
+        all_eq!(simd_ctpop(y1), U32::<4>([1, 1, 2, 1]));
+        all_eq!(simd_ctpop(x2), i32x4([1, 2, 1, 2]));
+        all_eq!(simd_ctpop(y2), U32::<4>([1, 2, 1, 2]));
+        all_eq!(simd_ctpop(x3), i32x4([0, 31, 1, 32]));
+        all_eq!(simd_ctpop(y3), U32::<4>([0, 31, 1, 32]));
 
-        all_eq!(simd_cttz(x1), i32x4(0, 1, 0, 2));
-        all_eq_!(simd_cttz(y1), U32::<4>([0, 1, 0, 2]));
+        all_eq!(simd_cttz(x1), i32x4([0, 1, 0, 2]));
+        all_eq!(simd_cttz(y1), U32::<4>([0, 1, 0, 2]));
     }
 }

--- a/tests/ui/simd/intrinsic/generic-arithmetic-saturating-2.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-saturating-2.rs
@@ -4,15 +4,15 @@
 #![allow(non_camel_case_types)]
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct i32x4(pub i32, pub i32, pub i32, pub i32);
+pub struct i32x4(pub [i32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct x4<T>(pub T, pub T, pub T, pub T);
+pub struct x4<T>(pub [T; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 extern "rust-intrinsic" {
     fn simd_saturating_add<T>(x: T, y: T) -> T;
@@ -20,9 +20,9 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    let x = i32x4(0, 0, 0, 0);
-    let y = x4(0_usize, 0, 0, 0);
-    let z = f32x4(0.0, 0.0, 0.0, 0.0);
+    let x = i32x4([0, 0, 0, 0]);
+    let y = x4([0_usize, 0, 0, 0]);
+    let z = f32x4([0.0, 0.0, 0.0, 0.0]);
 
     unsafe {
         simd_saturating_add(x, x);

--- a/tests/ui/simd/intrinsic/generic-arithmetic-saturating-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-arithmetic-saturating-pass.rs
@@ -6,7 +6,7 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct u32x4(pub u32, pub u32, pub u32, pub u32);
+struct u32x4(pub [u32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
@@ -22,11 +22,11 @@ fn main() {
     {
         const M: u32 = u32::MAX;
 
-        let a = u32x4(1, 2, 3, 4);
-        let b = u32x4(2, 4, 6, 8);
-        let m = u32x4(M, M, M, M);
-        let m1 = u32x4(M - 1, M - 1, M - 1, M - 1);
-        let z = u32x4(0, 0, 0, 0);
+        let a = u32x4([1, 2, 3, 4]);
+        let b = u32x4([2, 4, 6, 8]);
+        let m = u32x4([M, M, M, M]);
+        let m1 = u32x4([M - 1, M - 1, M - 1, M - 1]);
+        let z = u32x4([0, 0, 0, 0]);
 
         unsafe {
             assert_eq!(simd_saturating_add(z, z), z);

--- a/tests/ui/simd/intrinsic/generic-bitmask-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-bitmask-pass.rs
@@ -11,36 +11,36 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct u32x4(pub u32, pub u32, pub u32, pub u32);
+struct u32x4(pub [u32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct u8x4(pub u8, pub u8, pub u8, pub u8);
+struct u8x4(pub [u8; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct Tx4<T>(pub T, pub T, pub T, pub T);
+struct Tx4<T>(pub [T; 4]);
 
 extern "rust-intrinsic" {
     fn simd_bitmask<T, U>(x: T) -> U;
 }
 
 fn main() {
-    let z = u32x4(0, 0, 0, 0);
+    let z = u32x4([0, 0, 0, 0]);
     let ez = 0_u8;
 
-    let o = u32x4(!0, !0, !0, !0);
+    let o = u32x4([!0, !0, !0, !0]);
     let eo = 0b_1111_u8;
 
-    let m0 = u32x4(!0, 0, !0, 0);
+    let m0 = u32x4([!0, 0, !0, 0]);
     let e0 = 0b_0000_0101_u8;
 
     // Check that the MSB is extracted:
-    let m = u8x4(0b_1000_0000, 0b_0100_0001, 0b_1100_0001, 0b_1111_1111);
+    let m = u8x4([0b_1000_0000, 0b_0100_0001, 0b_1100_0001, 0b_1111_1111]);
     let e = 0b_1101;
 
     // Check usize / isize
-    let msize: Tx4<usize> = Tx4(usize::MAX, 0, usize::MAX, usize::MAX);
+    let msize: Tx4<usize> = Tx4([usize::MAX, 0, usize::MAX, usize::MAX]);
 
     unsafe {
         let r: u8 = simd_bitmask(z);

--- a/tests/ui/simd/intrinsic/generic-cast.rs
+++ b/tests/ui/simd/intrinsic/generic-cast.rs
@@ -5,22 +5,20 @@
 #[repr(simd)]
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
-struct i32x4(i32, i32, i32, i32);
+struct i32x4([i32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
-struct i32x8(i32, i32, i32, i32,
-             i32, i32, i32, i32);
+struct i32x8([i32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
-struct f32x4(f32, f32, f32, f32);
+struct f32x4([f32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
-struct f32x8(f32, f32, f32, f32,
-             f32, f32, f32, f32);
+struct f32x8([f32; 8]);
 
 
 extern "rust-intrinsic" {
@@ -28,7 +26,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    let x = i32x4(0, 0, 0, 0);
+    let x = i32x4([0, 0, 0, 0]);
 
     unsafe {
         simd_cast::<i32, i32>(0);

--- a/tests/ui/simd/intrinsic/generic-cast.stderr
+++ b/tests/ui/simd/intrinsic/generic-cast.stderr
@@ -1,23 +1,23 @@
 error[E0511]: invalid monomorphization of `simd_cast` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-cast.rs:34:9
+  --> $DIR/generic-cast.rs:32:9
    |
 LL |         simd_cast::<i32, i32>(0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_cast` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-cast.rs:36:9
+  --> $DIR/generic-cast.rs:34:9
    |
 LL |         simd_cast::<i32, i32x4>(0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_cast` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-cast.rs:38:9
+  --> $DIR/generic-cast.rs:36:9
    |
 LL |         simd_cast::<i32x4, i32>(x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_cast` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i32x8` with length 8
-  --> $DIR/generic-cast.rs:40:9
+  --> $DIR/generic-cast.rs:38:9
    |
 LL |         simd_cast::<_, i32x8>(x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/generic-comparison-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-comparison-pass.rs
@@ -6,13 +6,13 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct i32x4(i32, i32, i32, i32);
+struct i32x4([i32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct u32x4(pub u32, pub u32, pub u32, pub u32);
+struct u32x4(pub [u32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct f32x4(pub f32, pub f32, pub f32, pub f32);
+struct f32x4(pub [f32; 4]);
 
 extern "rust-intrinsic" {
     fn simd_eq<T, U>(x: T, y: T) -> U;
@@ -29,10 +29,10 @@ macro_rules! cmp {
         let rhs = $rhs;
         let e: u32x4 = concat_idents!(simd_, $method)($lhs, $rhs);
         // assume the scalar version is correct/the behaviour we want.
-        assert!((e.0 != 0) == lhs.0 .$method(&rhs.0));
-        assert!((e.1 != 0) == lhs.1 .$method(&rhs.1));
-        assert!((e.2 != 0) == lhs.2 .$method(&rhs.2));
-        assert!((e.3 != 0) == lhs.3 .$method(&rhs.3));
+        assert!((e.0[0] != 0) == lhs.0[0] .$method(&rhs.0[0]));
+        assert!((e.0[1] != 0) == lhs.0[1] .$method(&rhs.0[1]));
+        assert!((e.0[2] != 0) == lhs.0[2] .$method(&rhs.0[2]));
+        assert!((e.0[3] != 0) == lhs.0[3] .$method(&rhs.0[3]));
     }}
 }
 macro_rules! tests {
@@ -61,17 +61,17 @@ macro_rules! tests {
 fn main() {
     // 13 vs. -100 tests that we get signed vs. unsigned comparisons
     // correct (i32: 13 > -100, u32: 13 < -100).    let i1 = i32x4(10, -11, 12, 13);
-    let i1 = i32x4(10, -11, 12, 13);
-    let i2 = i32x4(5, -5, 20, -100);
-    let i3 = i32x4(10, -11, 20, -100);
+    let i1 = i32x4([10, -11, 12, 13]);
+    let i2 = i32x4([5, -5, 20, -100]);
+    let i3 = i32x4([10, -11, 20, -100]);
 
-    let u1 = u32x4(10, !11+1, 12, 13);
-    let u2 = u32x4(5, !5+1, 20, !100+1);
-    let u3 = u32x4(10, !11+1, 20, !100+1);
+    let u1 = u32x4([10, !11+1, 12, 13]);
+    let u2 = u32x4([5, !5+1, 20, !100+1]);
+    let u3 = u32x4([10, !11+1, 20, !100+1]);
 
-    let f1 = f32x4(10.0, -11.0, 12.0, 13.0);
-    let f2 = f32x4(5.0, -5.0, 20.0, -100.0);
-    let f3 = f32x4(10.0, -11.0, 20.0, -100.0);
+    let f1 = f32x4([10.0, -11.0, 12.0, 13.0]);
+    let f2 = f32x4([5.0, -5.0, 20.0, -100.0]);
+    let f3 = f32x4([10.0, -11.0, 20.0, -100.0]);
 
     unsafe {
         tests! {
@@ -92,7 +92,7 @@ fn main() {
     // NAN comparisons are special:
     // -11 (*)    13
     // -5        -100 (*)
-    let f4 = f32x4(f32::NAN, f1.1, f32::NAN, f2.3);
+    let f4 = f32x4([f32::NAN, f1.0[1], f32::NAN, f2.0[3]]);
 
     unsafe {
         tests! {

--- a/tests/ui/simd/intrinsic/generic-comparison.rs
+++ b/tests/ui/simd/intrinsic/generic-comparison.rs
@@ -5,12 +5,11 @@
 #[repr(simd)]
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
-struct i32x4(i32, i32, i32, i32);
+struct i32x4([i32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
-struct i16x8(i16, i16, i16, i16,
-             i16, i16, i16, i16);
+struct i16x8([i16; 8]);
 
 extern "rust-intrinsic" {
     fn simd_eq<T, U>(x: T, y: T) -> U;
@@ -22,7 +21,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    let x = i32x4(0, 0, 0, 0);
+    let x = i32x4([0, 0, 0, 0]);
 
     unsafe {
         simd_eq::<i32, i32>(0, 0);

--- a/tests/ui/simd/intrinsic/generic-comparison.stderr
+++ b/tests/ui/simd/intrinsic/generic-comparison.stderr
@@ -1,107 +1,107 @@
 error[E0511]: invalid monomorphization of `simd_eq` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:28:9
+  --> $DIR/generic-comparison.rs:27:9
    |
 LL |         simd_eq::<i32, i32>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ne` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:30:9
+  --> $DIR/generic-comparison.rs:29:9
    |
 LL |         simd_ne::<i32, i32>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_lt` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:32:9
+  --> $DIR/generic-comparison.rs:31:9
    |
 LL |         simd_lt::<i32, i32>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_le` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:34:9
+  --> $DIR/generic-comparison.rs:33:9
    |
 LL |         simd_le::<i32, i32>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_gt` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:36:9
+  --> $DIR/generic-comparison.rs:35:9
    |
 LL |         simd_gt::<i32, i32>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ge` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:38:9
+  --> $DIR/generic-comparison.rs:37:9
    |
 LL |         simd_ge::<i32, i32>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_eq` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:41:9
+  --> $DIR/generic-comparison.rs:40:9
    |
 LL |         simd_eq::<_, i32>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ne` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:43:9
+  --> $DIR/generic-comparison.rs:42:9
    |
 LL |         simd_ne::<_, i32>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_lt` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:45:9
+  --> $DIR/generic-comparison.rs:44:9
    |
 LL |         simd_lt::<_, i32>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_le` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:47:9
+  --> $DIR/generic-comparison.rs:46:9
    |
 LL |         simd_le::<_, i32>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_gt` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:49:9
+  --> $DIR/generic-comparison.rs:48:9
    |
 LL |         simd_gt::<_, i32>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ge` intrinsic: expected SIMD return type, found non-SIMD `i32`
-  --> $DIR/generic-comparison.rs:51:9
+  --> $DIR/generic-comparison.rs:50:9
    |
 LL |         simd_ge::<_, i32>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_eq` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
-  --> $DIR/generic-comparison.rs:54:9
+  --> $DIR/generic-comparison.rs:53:9
    |
 LL |         simd_eq::<_, i16x8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ne` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
-  --> $DIR/generic-comparison.rs:56:9
+  --> $DIR/generic-comparison.rs:55:9
    |
 LL |         simd_ne::<_, i16x8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_lt` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
-  --> $DIR/generic-comparison.rs:58:9
+  --> $DIR/generic-comparison.rs:57:9
    |
 LL |         simd_lt::<_, i16x8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_le` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
-  --> $DIR/generic-comparison.rs:60:9
+  --> $DIR/generic-comparison.rs:59:9
    |
 LL |         simd_le::<_, i16x8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_gt` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
-  --> $DIR/generic-comparison.rs:62:9
+  --> $DIR/generic-comparison.rs:61:9
    |
 LL |         simd_gt::<_, i16x8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_ge` intrinsic: expected return type with length 4 (same as input type `i32x4`), found `i16x8` with length 8
-  --> $DIR/generic-comparison.rs:64:9
+  --> $DIR/generic-comparison.rs:63:9
    |
 LL |         simd_ge::<_, i16x8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/generic-elements-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-elements-pass.rs
@@ -6,16 +6,15 @@
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
-struct i32x2(i32, i32);
+struct i32x2([i32; 2]);
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
-struct i32x4(i32, i32, i32, i32);
+struct i32x4([i32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
-struct i32x8(i32, i32, i32, i32,
-             i32, i32, i32, i32);
+struct i32x8([i32; 8]);
 
 extern "rust-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
@@ -37,26 +36,26 @@ macro_rules! all_eq {
 }
 
 fn main() {
-    let x2 = i32x2(20, 21);
-    let x4 = i32x4(40, 41, 42, 43);
-    let x8 = i32x8(80, 81, 82, 83, 84, 85, 86, 87);
+    let x2 = i32x2([20, 21]);
+    let x4 = i32x4([40, 41, 42, 43]);
+    let x8 = i32x8([80, 81, 82, 83, 84, 85, 86, 87]);
     unsafe {
-        all_eq!(simd_insert(x2, 0, 100), i32x2(100, 21));
-        all_eq!(simd_insert(x2, 1, 100), i32x2(20, 100));
+        all_eq!(simd_insert(x2, 0, 100), i32x2([100, 21]));
+        all_eq!(simd_insert(x2, 1, 100), i32x2([20, 100]));
 
-        all_eq!(simd_insert(x4, 0, 100), i32x4(100, 41, 42, 43));
-        all_eq!(simd_insert(x4, 1, 100), i32x4(40, 100, 42, 43));
-        all_eq!(simd_insert(x4, 2, 100), i32x4(40, 41, 100, 43));
-        all_eq!(simd_insert(x4, 3, 100), i32x4(40, 41, 42, 100));
+        all_eq!(simd_insert(x4, 0, 100), i32x4([100, 41, 42, 43]));
+        all_eq!(simd_insert(x4, 1, 100), i32x4([40, 100, 42, 43]));
+        all_eq!(simd_insert(x4, 2, 100), i32x4([40, 41, 100, 43]));
+        all_eq!(simd_insert(x4, 3, 100), i32x4([40, 41, 42, 100]));
 
-        all_eq!(simd_insert(x8, 0, 100), i32x8(100, 81, 82, 83, 84, 85, 86, 87));
-        all_eq!(simd_insert(x8, 1, 100), i32x8(80, 100, 82, 83, 84, 85, 86, 87));
-        all_eq!(simd_insert(x8, 2, 100), i32x8(80, 81, 100, 83, 84, 85, 86, 87));
-        all_eq!(simd_insert(x8, 3, 100), i32x8(80, 81, 82, 100, 84, 85, 86, 87));
-        all_eq!(simd_insert(x8, 4, 100), i32x8(80, 81, 82, 83, 100, 85, 86, 87));
-        all_eq!(simd_insert(x8, 5, 100), i32x8(80, 81, 82, 83, 84, 100, 86, 87));
-        all_eq!(simd_insert(x8, 6, 100), i32x8(80, 81, 82, 83, 84, 85, 100, 87));
-        all_eq!(simd_insert(x8, 7, 100), i32x8(80, 81, 82, 83, 84, 85, 86, 100));
+        all_eq!(simd_insert(x8, 0, 100), i32x8([100, 81, 82, 83, 84, 85, 86, 87]));
+        all_eq!(simd_insert(x8, 1, 100), i32x8([80, 100, 82, 83, 84, 85, 86, 87]));
+        all_eq!(simd_insert(x8, 2, 100), i32x8([80, 81, 100, 83, 84, 85, 86, 87]));
+        all_eq!(simd_insert(x8, 3, 100), i32x8([80, 81, 82, 100, 84, 85, 86, 87]));
+        all_eq!(simd_insert(x8, 4, 100), i32x8([80, 81, 82, 83, 100, 85, 86, 87]));
+        all_eq!(simd_insert(x8, 5, 100), i32x8([80, 81, 82, 83, 84, 100, 86, 87]));
+        all_eq!(simd_insert(x8, 6, 100), i32x8([80, 81, 82, 83, 84, 85, 100, 87]));
+        all_eq!(simd_insert(x8, 7, 100), i32x8([80, 81, 82, 83, 84, 85, 86, 100]));
 
         all_eq!(simd_extract(x2, 0), 20);
         all_eq!(simd_extract(x2, 1), 21);
@@ -76,24 +75,24 @@ fn main() {
         all_eq!(simd_extract(x8, 7), 87);
     }
 
-    let y2 = i32x2(120, 121);
-    let y4 = i32x4(140, 141, 142, 143);
-    let y8 = i32x8(180, 181, 182, 183, 184, 185, 186, 187);
+    let y2 = i32x2([120, 121]);
+    let y4 = i32x4([140, 141, 142, 143]);
+    let y8 = i32x8([180, 181, 182, 183, 184, 185, 186, 187]);
     unsafe {
-        all_eq!(simd_shuffle(x2, y2, const { [3u32, 0] }), i32x2(121, 20));
-        all_eq!(simd_shuffle(x2, y2, const { [3u32, 0, 1, 2] }), i32x4(121, 20, 21, 120));
+        all_eq!(simd_shuffle(x2, y2, const { [3u32, 0] }), i32x2([121, 20]));
+        all_eq!(simd_shuffle(x2, y2, const { [3u32, 0, 1, 2] }), i32x4([121, 20, 21, 120]));
         all_eq!(simd_shuffle(x2, y2, const { [3u32, 0, 1, 2, 1, 2, 3, 0] }),
-                i32x8(121, 20, 21, 120, 21, 120, 121, 20));
+                i32x8([121, 20, 21, 120, 21, 120, 121, 20]));
 
-        all_eq!(simd_shuffle(x4, y4, const { [7u32, 2] }), i32x2(143, 42));
-        all_eq!(simd_shuffle(x4, y4, const { [7u32, 2, 5, 0] }), i32x4(143, 42, 141, 40));
+        all_eq!(simd_shuffle(x4, y4, const { [7u32, 2] }), i32x2([143, 42]));
+        all_eq!(simd_shuffle(x4, y4, const { [7u32, 2, 5, 0] }), i32x4([143, 42, 141, 40]));
         all_eq!(simd_shuffle(x4, y4, const { [7u32, 2, 5, 0, 3, 6, 4, 1] }),
-                i32x8(143, 42, 141, 40, 43, 142, 140, 41));
+                i32x8([143, 42, 141, 40, 43, 142, 140, 41]));
 
-        all_eq!(simd_shuffle(x8, y8, const { [11u32, 5] }), i32x2(183, 85));
-        all_eq!(simd_shuffle(x8, y8, const { [11u32, 5, 15, 0] }), i32x4(183, 85, 187, 80));
+        all_eq!(simd_shuffle(x8, y8, const { [11u32, 5] }), i32x2([183, 85]));
+        all_eq!(simd_shuffle(x8, y8, const { [11u32, 5, 15, 0] }), i32x4([183, 85, 187, 80]));
         all_eq!(simd_shuffle(x8, y8, const { [11u32, 5, 15, 0, 3, 8, 12, 1] }),
-                i32x8(183, 85, 187, 80, 83, 180, 184, 81));
+                i32x8([183, 85, 187, 80, 83, 180, 184, 81]));
     }
 
 }

--- a/tests/ui/simd/intrinsic/generic-elements.rs
+++ b/tests/ui/simd/intrinsic/generic-elements.rs
@@ -6,28 +6,28 @@
 #[repr(simd)]
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
-struct i32x2(i32, i32);
+struct i32x2([i32; 2]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
-struct i32x4(i32, i32, i32, i32);
+struct i32x4([i32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
-struct i32x8(i32, i32, i32, i32, i32, i32, i32, i32);
+struct i32x8([i32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
-struct f32x2(f32, f32);
+struct f32x2([f32; 2]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
-struct f32x4(f32, f32, f32, f32);
+struct f32x4([f32; 4]);
 #[repr(simd)]
 #[derive(Copy, Clone)]
 #[allow(non_camel_case_types)]
-struct f32x8(f32, f32, f32, f32, f32, f32, f32, f32);
+struct f32x8([f32; 8]);
 
 extern "rust-intrinsic" {
     fn simd_insert<T, E>(x: T, idx: u32, y: E) -> T;
@@ -38,7 +38,7 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    let x = i32x4(0, 0, 0, 0);
+    let x = i32x4([0, 0, 0, 0]);
 
     unsafe {
         simd_insert(0, 0, 0);

--- a/tests/ui/simd/intrinsic/generic-gather-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-gather-pass.rs
@@ -8,7 +8,7 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct x4<T>(pub T, pub T, pub T, pub T);
+struct x4<T>(pub [T; 4]);
 
 extern "rust-intrinsic" {
     fn simd_gather<T, U, V>(x: T, y: U, z: V) -> T;
@@ -18,19 +18,19 @@ extern "rust-intrinsic" {
 fn main() {
     let mut x = [0_f32, 1., 2., 3., 4., 5., 6., 7.];
 
-    let default = x4(-3_f32, -3., -3., -3.);
-    let s_strided = x4(0_f32, 2., -3., 6.);
-    let mask = x4(-1_i32, -1, 0, -1);
+    let default = x4([-3_f32, -3., -3., -3.]);
+    let s_strided = x4([0_f32, 2., -3., 6.]);
+    let mask = x4([-1_i32, -1, 0, -1]);
 
     // reading from *const
     unsafe {
         let pointer = x.as_ptr();
-        let pointers =  x4(
+        let pointers =  x4([
             pointer.offset(0),
             pointer.offset(2),
             pointer.offset(4),
             pointer.offset(6)
-        );
+        ]);
 
         let r_strided = simd_gather(default, pointers, mask);
 
@@ -40,12 +40,12 @@ fn main() {
     // reading from *mut
     unsafe {
         let pointer = x.as_mut_ptr();
-        let pointers = x4(
+        let pointers = x4([
             pointer.offset(0),
             pointer.offset(2),
             pointer.offset(4),
             pointer.offset(6)
-        );
+        ]);
 
         let r_strided = simd_gather(default, pointers, mask);
 
@@ -55,14 +55,14 @@ fn main() {
     // writing to *mut
     unsafe {
         let pointer = x.as_mut_ptr();
-        let pointers = x4(
+        let pointers = x4([
             pointer.offset(0),
             pointer.offset(2),
             pointer.offset(4),
             pointer.offset(6)
-        );
+        ]);
 
-        let values = x4(42_f32, 43_f32, 44_f32, 45_f32);
+        let values = x4([42_f32, 43_f32, 44_f32, 45_f32]);
         simd_scatter(values, pointers, mask);
 
         assert_eq!(x, [42., 1., 43., 3., 4., 5., 45., 7.]);
@@ -80,18 +80,18 @@ fn main() {
         &x[7] as *const f32
     ];
 
-    let default = x4(y[0], y[0], y[0], y[0]);
-    let s_strided = x4(y[0], y[2], y[0], y[6]);
+    let default = x4([y[0], y[0], y[0], y[0]]);
+    let s_strided = x4([y[0], y[2], y[0], y[6]]);
 
     // reading from *const
     unsafe {
         let pointer = y.as_ptr();
-        let pointers = x4(
+        let pointers = x4([
             pointer.offset(0),
             pointer.offset(2),
             pointer.offset(4),
             pointer.offset(6)
-        );
+        ]);
 
         let r_strided = simd_gather(default, pointers, mask);
 
@@ -101,12 +101,12 @@ fn main() {
     // reading from *mut
     unsafe {
         let pointer = y.as_mut_ptr();
-        let pointers = x4(
+        let pointers = x4([
             pointer.offset(0),
             pointer.offset(2),
             pointer.offset(4),
             pointer.offset(6)
-        );
+        ]);
 
         let r_strided = simd_gather(default, pointers, mask);
 
@@ -116,14 +116,14 @@ fn main() {
     // writing to *mut
     unsafe {
         let pointer = y.as_mut_ptr();
-        let pointers = x4(
+        let pointers = x4([
             pointer.offset(0),
             pointer.offset(2),
             pointer.offset(4),
             pointer.offset(6)
-        );
+        ]);
 
-        let values = x4(y[7], y[6], y[5], y[1]);
+        let values = x4([y[7], y[6], y[5], y[1]]);
         simd_scatter(values, pointers, mask);
 
         let s = [

--- a/tests/ui/simd/intrinsic/generic-reduction-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-reduction-pass.rs
@@ -10,19 +10,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct i32x4(pub i32, pub i32, pub i32, pub i32);
+struct i32x4(pub [i32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct u32x4(pub u32, pub u32, pub u32, pub u32);
+struct u32x4(pub [u32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct f32x4(pub f32, pub f32, pub f32, pub f32);
+struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-struct b8x4(pub i8, pub i8, pub i8, pub i8);
+struct b8x4(pub [i8; 4]);
 
 extern "rust-intrinsic" {
     fn simd_reduce_add_unordered<T, U>(x: T) -> U;
@@ -40,7 +40,7 @@ extern "rust-intrinsic" {
 
 fn main() {
     unsafe {
-        let x = i32x4(1, -2, 3, 4);
+        let x = i32x4([1, -2, 3, 4]);
         let r: i32 = simd_reduce_add_unordered(x);
         assert_eq!(r, 6_i32);
         let r: i32 = simd_reduce_mul_unordered(x);
@@ -55,7 +55,7 @@ fn main() {
         let r: i32 = simd_reduce_max(x);
         assert_eq!(r, 4_i32);
 
-        let x = i32x4(-1, -1, -1, -1);
+        let x = i32x4([-1, -1, -1, -1]);
         let r: i32 = simd_reduce_and(x);
         assert_eq!(r, -1_i32);
         let r: i32 = simd_reduce_or(x);
@@ -63,7 +63,7 @@ fn main() {
         let r: i32 = simd_reduce_xor(x);
         assert_eq!(r, 0_i32);
 
-        let x = i32x4(-1, -1, 0, -1);
+        let x = i32x4([-1, -1, 0, -1]);
         let r: i32 = simd_reduce_and(x);
         assert_eq!(r, 0_i32);
         let r: i32 = simd_reduce_or(x);
@@ -73,7 +73,7 @@ fn main() {
     }
 
     unsafe {
-        let x = u32x4(1, 2, 3, 4);
+        let x = u32x4([1, 2, 3, 4]);
         let r: u32 = simd_reduce_add_unordered(x);
         assert_eq!(r, 10_u32);
         let r: u32 = simd_reduce_mul_unordered(x);
@@ -89,7 +89,7 @@ fn main() {
         assert_eq!(r, 4_u32);
 
         let t = u32::MAX;
-        let x = u32x4(t, t, t, t);
+        let x = u32x4([t, t, t, t]);
         let r: u32 = simd_reduce_and(x);
         assert_eq!(r, t);
         let r: u32 = simd_reduce_or(x);
@@ -97,7 +97,7 @@ fn main() {
         let r: u32 = simd_reduce_xor(x);
         assert_eq!(r, 0_u32);
 
-        let x = u32x4(t, t, 0, t);
+        let x = u32x4([t, t, 0, t]);
         let r: u32 = simd_reduce_and(x);
         assert_eq!(r, 0_u32);
         let r: u32 = simd_reduce_or(x);
@@ -107,7 +107,7 @@ fn main() {
     }
 
     unsafe {
-        let x = f32x4(1., -2., 3., 4.);
+        let x = f32x4([1., -2., 3., 4.]);
         let r: f32 = simd_reduce_add_unordered(x);
         assert_eq!(r, 6_f32);
         let r: f32 = simd_reduce_mul_unordered(x);
@@ -128,19 +128,19 @@ fn main() {
     }
 
     unsafe {
-        let x = b8x4(!0, !0, !0, !0);
+        let x = b8x4([!0, !0, !0, !0]);
         let r: bool = simd_reduce_all(x);
         assert_eq!(r, true);
         let r: bool = simd_reduce_any(x);
         assert_eq!(r, true);
 
-        let x = b8x4(!0, !0, 0, !0);
+        let x = b8x4([!0, !0, 0, !0]);
         let r: bool = simd_reduce_all(x);
         assert_eq!(r, false);
         let r: bool = simd_reduce_any(x);
         assert_eq!(r, true);
 
-        let x = b8x4(0, 0, 0, 0);
+        let x = b8x4([0, 0, 0, 0]);
         let r: bool = simd_reduce_all(x);
         assert_eq!(r, false);
         let r: bool = simd_reduce_any(x);

--- a/tests/ui/simd/intrinsic/generic-reduction.rs
+++ b/tests/ui/simd/intrinsic/generic-reduction.rs
@@ -9,11 +9,11 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct u32x4(pub u32, pub u32, pub u32, pub u32);
+pub struct u32x4(pub [u32; 4]);
 
 
 extern "rust-intrinsic" {
@@ -27,8 +27,8 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    let x = u32x4(0, 0, 0, 0);
-    let z = f32x4(0.0, 0.0, 0.0, 0.0);
+    let x = u32x4([0, 0, 0, 0]);
+    let z = f32x4([0.0, 0.0, 0.0, 0.0]);
 
     unsafe {
         simd_reduce_add_ordered(z, 0);

--- a/tests/ui/simd/intrinsic/generic-select-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-select-pass.rs
@@ -11,23 +11,23 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct i32x4(pub i32, pub i32, pub i32, pub i32);
+struct i32x4(pub [i32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct u32x4(pub u32, pub u32, pub u32, pub u32);
+struct u32x4(pub [u32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct u32x8(u32, u32, u32, u32, u32, u32, u32, u32);
+struct u32x8([u32; 8]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct f32x4(pub f32, pub f32, pub f32, pub f32);
+struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct b8x4(pub i8, pub i8, pub i8, pub i8);
+struct b8x4(pub [i8; 4]);
 
 extern "rust-intrinsic" {
     fn simd_select<T, U>(x: T, a: U, b: U) -> U;
@@ -35,15 +35,15 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    let m0 = b8x4(!0, !0, !0, !0);
-    let m1 = b8x4(0, 0, 0, 0);
-    let m2 = b8x4(!0, !0, 0, 0);
-    let m3 = b8x4(0, 0, !0, !0);
-    let m4 = b8x4(!0, 0, !0, 0);
+    let m0 = b8x4([!0, !0, !0, !0]);
+    let m1 = b8x4([0, 0, 0, 0]);
+    let m2 = b8x4([!0, !0, 0, 0]);
+    let m3 = b8x4([0, 0, !0, !0]);
+    let m4 = b8x4([!0, 0, !0, 0]);
 
     unsafe {
-        let a = i32x4(1, -2, 3, 4);
-        let b = i32x4(5, 6, -7, 8);
+        let a = i32x4([1, -2, 3, 4]);
+        let b = i32x4([5, 6, -7, 8]);
 
         let r: i32x4 = simd_select(m0, a, b);
         let e = a;
@@ -54,21 +54,21 @@ fn main() {
         assert_eq!(r, e);
 
         let r: i32x4 = simd_select(m2, a, b);
-        let e = i32x4(1, -2, -7, 8);
+        let e = i32x4([1, -2, -7, 8]);
         assert_eq!(r, e);
 
         let r: i32x4 = simd_select(m3, a, b);
-        let e = i32x4(5, 6, 3, 4);
+        let e = i32x4([5, 6, 3, 4]);
         assert_eq!(r, e);
 
         let r: i32x4 = simd_select(m4, a, b);
-        let e = i32x4(1, 6, 3, 8);
+        let e = i32x4([1, 6, 3, 8]);
         assert_eq!(r, e);
     }
 
     unsafe {
-        let a = u32x4(1, 2, 3, 4);
-        let b = u32x4(5, 6, 7, 8);
+        let a = u32x4([1, 2, 3, 4]);
+        let b = u32x4([5, 6, 7, 8]);
 
         let r: u32x4 = simd_select(m0, a, b);
         let e = a;
@@ -79,21 +79,21 @@ fn main() {
         assert_eq!(r, e);
 
         let r: u32x4 = simd_select(m2, a, b);
-        let e = u32x4(1, 2, 7, 8);
+        let e = u32x4([1, 2, 7, 8]);
         assert_eq!(r, e);
 
         let r: u32x4 = simd_select(m3, a, b);
-        let e = u32x4(5, 6, 3, 4);
+        let e = u32x4([5, 6, 3, 4]);
         assert_eq!(r, e);
 
         let r: u32x4 = simd_select(m4, a, b);
-        let e = u32x4(1, 6, 3, 8);
+        let e = u32x4([1, 6, 3, 8]);
         assert_eq!(r, e);
     }
 
     unsafe {
-        let a = f32x4(1., 2., 3., 4.);
-        let b = f32x4(5., 6., 7., 8.);
+        let a = f32x4([1., 2., 3., 4.]);
+        let b = f32x4([5., 6., 7., 8.]);
 
         let r: f32x4 = simd_select(m0, a, b);
         let e = a;
@@ -104,23 +104,23 @@ fn main() {
         assert_eq!(r, e);
 
         let r: f32x4 = simd_select(m2, a, b);
-        let e = f32x4(1., 2., 7., 8.);
+        let e = f32x4([1., 2., 7., 8.]);
         assert_eq!(r, e);
 
         let r: f32x4 = simd_select(m3, a, b);
-        let e = f32x4(5., 6., 3., 4.);
+        let e = f32x4([5., 6., 3., 4.]);
         assert_eq!(r, e);
 
         let r: f32x4 = simd_select(m4, a, b);
-        let e = f32x4(1., 6., 3., 8.);
+        let e = f32x4([1., 6., 3., 8.]);
         assert_eq!(r, e);
     }
 
     unsafe {
         let t = !0 as i8;
         let f = 0 as i8;
-        let a = b8x4(t, f, t, f);
-        let b = b8x4(f, f, f, t);
+        let a = b8x4([t, f, t, f]);
+        let b = b8x4([f, f, f, t]);
 
         let r: b8x4 = simd_select(m0, a, b);
         let e = a;
@@ -131,21 +131,21 @@ fn main() {
         assert_eq!(r, e);
 
         let r: b8x4 = simd_select(m2, a, b);
-        let e = b8x4(t, f, f, t);
+        let e = b8x4([t, f, f, t]);
         assert_eq!(r, e);
 
         let r: b8x4 = simd_select(m3, a, b);
-        let e = b8x4(f, f, t, f);
+        let e = b8x4([f, f, t, f]);
         assert_eq!(r, e);
 
         let r: b8x4 = simd_select(m4, a, b);
-        let e = b8x4(t, f, t, t);
+        let e = b8x4([t, f, t, t]);
         assert_eq!(r, e);
     }
 
     unsafe {
-        let a = u32x8(0, 1, 2, 3, 4, 5, 6, 7);
-        let b = u32x8(8, 9, 10, 11, 12, 13, 14, 15);
+        let a = u32x8([0, 1, 2, 3, 4, 5, 6, 7]);
+        let b = u32x8([8, 9, 10, 11, 12, 13, 14, 15]);
 
         let r: u32x8 = simd_select_bitmask(0u8, a, b);
         let e = b;
@@ -156,21 +156,21 @@ fn main() {
         assert_eq!(r, e);
 
         let r: u32x8 = simd_select_bitmask(0b01010101u8, a, b);
-        let e = u32x8(0, 9, 2, 11, 4, 13, 6, 15);
+        let e = u32x8([0, 9, 2, 11, 4, 13, 6, 15]);
         assert_eq!(r, e);
 
         let r: u32x8 = simd_select_bitmask(0b10101010u8, a, b);
-        let e = u32x8(8, 1, 10, 3, 12, 5, 14, 7);
+        let e = u32x8([8, 1, 10, 3, 12, 5, 14, 7]);
         assert_eq!(r, e);
 
         let r: u32x8 = simd_select_bitmask(0b11110000u8, a, b);
-        let e = u32x8(8, 9, 10, 11, 4, 5, 6, 7);
+        let e = u32x8([8, 9, 10, 11, 4, 5, 6, 7]);
         assert_eq!(r, e);
     }
 
     unsafe {
-        let a = u32x4(0, 1, 2, 3);
-        let b = u32x4(4, 5, 6, 7);
+        let a = u32x4([0, 1, 2, 3]);
+        let b = u32x4([4, 5, 6, 7]);
 
         let r: u32x4 = simd_select_bitmask(0u8, a, b);
         let e = b;
@@ -181,15 +181,15 @@ fn main() {
         assert_eq!(r, e);
 
         let r: u32x4 = simd_select_bitmask(0b0101u8, a, b);
-        let e = u32x4(0, 5, 2, 7);
+        let e = u32x4([0, 5, 2, 7]);
         assert_eq!(r, e);
 
         let r: u32x4 = simd_select_bitmask(0b1010u8, a, b);
-        let e = u32x4(4, 1, 6, 3);
+        let e = u32x4([4, 1, 6, 3]);
         assert_eq!(r, e);
 
         let r: u32x4 = simd_select_bitmask(0b1100u8, a, b);
-        let e = u32x4(4, 5, 2, 3);
+        let e = u32x4([4, 5, 2, 3]);
         assert_eq!(r, e);
     }
 }

--- a/tests/ui/simd/intrinsic/generic-select.rs
+++ b/tests/ui/simd/intrinsic/generic-select.rs
@@ -8,19 +8,19 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct f32x4(pub f32, pub f32, pub f32, pub f32);
+pub struct f32x4(pub [f32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone)]
-pub struct u32x4(pub u32, pub u32, pub u32, pub u32);
+pub struct u32x4(pub [u32; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq)]
-struct b8x4(pub i8, pub i8, pub i8, pub i8);
+struct b8x4(pub [i8; 4]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq)]
-struct b8x8(pub i8, pub i8, pub i8, pub i8, pub i8, pub i8, pub i8, pub i8);
+struct b8x8(pub [i8; 8]);
 
 extern "rust-intrinsic" {
     fn simd_select<T, U>(x: T, a: U, b: U) -> U;
@@ -28,10 +28,10 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    let m4 = b8x4(0, 0, 0, 0);
-    let m8 = b8x8(0, 0, 0, 0, 0, 0, 0, 0);
-    let x = u32x4(0, 0, 0, 0);
-    let z = f32x4(0.0, 0.0, 0.0, 0.0);
+    let m4 = b8x4([0, 0, 0, 0]);
+    let m8 = b8x8([0, 0, 0, 0, 0, 0, 0, 0]);
+    let x = u32x4([0, 0, 0, 0]);
+    let z = f32x4([0.0, 0.0, 0.0, 0.0]);
 
     unsafe {
         simd_select(m4, x, x);

--- a/tests/ui/simd/intrinsic/inlining-issue67557-ice.rs
+++ b/tests/ui/simd/intrinsic/inlining-issue67557-ice.rs
@@ -11,7 +11,7 @@ extern "rust-intrinsic" {
 
 #[repr(simd)]
 #[derive(Debug, PartialEq)]
-struct Simd2(u8, u8);
+struct Simd2([u8; 2]);
 
 fn main() {
     unsafe {
@@ -22,5 +22,5 @@ fn main() {
 #[inline(always)]
 unsafe fn inline_me() -> Simd2 {
     const IDX: [u32; 2] = [0, 3];
-    simd_shuffle(Simd2(10, 11), Simd2(12, 13), IDX)
+    simd_shuffle(Simd2([10, 11]), Simd2([12, 13]), IDX)
 }

--- a/tests/ui/simd/intrinsic/inlining-issue67557.rs
+++ b/tests/ui/simd/intrinsic/inlining-issue67557.rs
@@ -11,12 +11,12 @@ extern "rust-intrinsic" {
 
 #[repr(simd)]
 #[derive(Debug, PartialEq)]
-struct Simd2(u8, u8);
+struct Simd2([u8; 2]);
 
 fn main() {
     unsafe {
         const IDX: [u32; 2] = [0, 1];
-        let p_res: Simd2 = simd_shuffle(Simd2(10, 11), Simd2(12, 13), IDX);
+        let p_res: Simd2 = simd_shuffle(Simd2([10, 11]), Simd2([12, 13]), IDX);
         let a_res: Simd2 = inline_me();
 
         assert_10_11(p_res);
@@ -26,17 +26,17 @@ fn main() {
 
 #[inline(never)]
 fn assert_10_11(x: Simd2) {
-    assert_eq!(x, Simd2(10, 11));
+    assert_eq!(x, Simd2([10, 11]));
 }
 
 #[inline(never)]
 fn assert_10_13(x: Simd2) {
-    assert_eq!(x, Simd2(10, 13));
+    assert_eq!(x, Simd2([10, 13]));
 }
 
 
 #[inline(always)]
 unsafe fn inline_me() -> Simd2 {
     const IDX: [u32; 2] = [0, 3];
-    simd_shuffle(Simd2(10, 11), Simd2(12, 13), IDX)
+    simd_shuffle(Simd2([10, 11]), Simd2([12, 13]), IDX)
 }

--- a/tests/ui/simd/issue-17170.rs
+++ b/tests/ui/simd/issue-17170.rs
@@ -2,9 +2,9 @@
 #![feature(repr_simd)]
 
 #[repr(simd)]
-struct T(f64, f64, f64);
+struct T([f64; 3]);
 
-static X: T = T(0.0, 0.0, 0.0);
+static X: T = T([0.0, 0.0, 0.0]);
 
 fn main() {
     let _ = X;

--- a/tests/ui/simd/issue-32947.rs
+++ b/tests/ui/simd/issue-32947.rs
@@ -6,7 +6,7 @@
 extern crate test;
 
 #[repr(simd)]
-pub struct Mu64(pub u64, pub u64, pub u64, pub u64);
+pub struct Mu64(pub [u64; 4]);
 
 fn main() {
     // This ensures an unaligned pointer even in optimized builds, though LLVM
@@ -18,7 +18,7 @@ fn main() {
         let misaligned_ptr: &mut [u8; 32] = {
             std::mem::transmute(memory.offset(1))
         };
-        *misaligned_ptr = std::mem::transmute(Mu64(1, 1, 1, 1));
+        *misaligned_ptr = std::mem::transmute(Mu64([1, 1, 1, 1]));
         test::black_box(memory);
     }
 }

--- a/tests/ui/simd/issue-39720.rs
+++ b/tests/ui/simd/issue-39720.rs
@@ -5,18 +5,18 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, Debug)]
-pub struct Char3(pub i8, pub i8, pub i8);
+pub struct Char3(pub [i8; 3]);
 
 #[repr(simd)]
 #[derive(Copy, Clone, Debug)]
-pub struct Short3(pub i16, pub i16, pub i16);
+pub struct Short3(pub [i16; 3]);
 
 extern "rust-intrinsic" {
     fn simd_cast<T, U>(x: T) -> U;
 }
 
 fn main() {
-    let cast: Short3 = unsafe { simd_cast(Char3(10, -3, -9)) };
+    let cast: Short3 = unsafe { simd_cast(Char3([10, -3, -9])) };
 
     println!("{:?}", cast);
 }

--- a/tests/ui/simd/issue-89193.rs
+++ b/tests/ui/simd/issue-89193.rs
@@ -8,7 +8,7 @@
 
 #[repr(simd)]
 #[derive(Copy, Clone, PartialEq, Debug)]
-struct x4<T>(pub T, pub T, pub T, pub T);
+struct x4<T>(pub [T; 4]);
 
 extern "rust-intrinsic" {
     fn simd_gather<T, U, V>(x: T, y: U, z: V) -> T;
@@ -16,36 +16,36 @@ extern "rust-intrinsic" {
 
 fn main() {
     let x: [usize; 4] = [10, 11, 12, 13];
-    let default = x4(0_usize, 1, 2, 3);
+    let default = x4([0_usize, 1, 2, 3]);
     let all_set = u8::MAX as i8; // aka -1
-    let mask = x4(all_set, all_set, all_set, all_set);
-    let expected = x4(10_usize, 11, 12, 13);
+    let mask = x4([all_set, all_set, all_set, all_set]);
+    let expected = x4([10_usize, 11, 12, 13]);
 
     unsafe {
         let pointer = x.as_ptr();
-        let pointers =  x4(
+        let pointers =  x4([
             pointer.offset(0),
             pointer.offset(1),
             pointer.offset(2),
             pointer.offset(3)
-        );
+        ]);
         let result = simd_gather(default, pointers, mask);
         assert_eq!(result, expected);
     }
 
     // and again for isize
     let x: [isize; 4] = [10, 11, 12, 13];
-    let default = x4(0_isize, 1, 2, 3);
-    let expected = x4(10_isize, 11, 12, 13);
+    let default = x4([0_isize, 1, 2, 3]);
+    let expected = x4([10_isize, 11, 12, 13]);
 
     unsafe {
         let pointer = x.as_ptr();
-        let pointers =  x4(
+        let pointers =  x4([
             pointer.offset(0),
             pointer.offset(1),
             pointer.offset(2),
             pointer.offset(3)
-        );
+        ]);
         let result = simd_gather(default, pointers, mask);
         assert_eq!(result, expected);
     }

--- a/tests/ui/simd/monomorphize-heterogeneous.rs
+++ b/tests/ui/simd/monomorphize-heterogeneous.rs
@@ -2,7 +2,11 @@
 
 #[repr(simd)]
 struct I64F64(i64, f64);
-//~^ ERROR SIMD vector should be homogeneous
+//~^ ERROR SIMD vector's only field must be an array
+
+#[repr(simd)]
+struct I64x4F64x0([i64; 4], [f64; 0]);
+//~^ ERROR SIMD vector cannot have multiple fields
 
 static X: I64F64 = I64F64(1, 2.0);
 

--- a/tests/ui/simd/monomorphize-heterogeneous.stderr
+++ b/tests/ui/simd/monomorphize-heterogeneous.stderr
@@ -1,9 +1,16 @@
-error[E0076]: SIMD vector should be homogeneous
+error[E0076]: SIMD vector's only field must be an array
   --> $DIR/monomorphize-heterogeneous.rs:4:1
    |
 LL | struct I64F64(i64, f64);
-   | ^^^^^^^^^^^^^ SIMD elements must have the same type
+   | ^^^^^^^^^^^^^ --- not an array
 
-error: aborting due to 1 previous error
+error[E0075]: SIMD vector cannot have multiple fields
+  --> $DIR/monomorphize-heterogeneous.rs:8:1
+   |
+LL | struct I64x4F64x0([i64; 4], [f64; 0]);
+   | ^^^^^^^^^^^^^^^^^           -------- excess field
 
-For more information about this error, try `rustc --explain E0076`.
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0075, E0076.
+For more information about an error, try `rustc --explain E0075`.

--- a/tests/ui/simd/monomorphize-too-long.rs
+++ b/tests/ui/simd/monomorphize-too-long.rs
@@ -1,0 +1,11 @@
+//@ build-fail
+//@ error-pattern: monomorphising SIMD type `Simd<u16, 54321>` of length greater than 32768
+
+#![feature(repr_simd)]
+
+#[repr(simd)]
+struct Simd<T, const N: usize>([T; N]);
+
+fn main() {
+    let _too_big = Simd([1_u16; 54321]);
+}

--- a/tests/ui/simd/monomorphize-too-long.stderr
+++ b/tests/ui/simd/monomorphize-too-long.stderr
@@ -1,0 +1,4 @@
+error: monomorphising SIMD type `Simd<u16, 54321>` of length greater than 32768
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/simd/monomorphize-zero-length.rs
+++ b/tests/ui/simd/monomorphize-zero-length.rs
@@ -1,0 +1,11 @@
+//@ build-fail
+//@ error-pattern: monomorphising SIMD type `Simd<f64, 0>` of zero length
+
+#![feature(repr_simd)]
+
+#[repr(simd)]
+struct Simd<T, const N: usize>([T; N]);
+
+fn main() {
+    let _empty = Simd([1.0; 0]);
+}

--- a/tests/ui/simd/monomorphize-zero-length.stderr
+++ b/tests/ui/simd/monomorphize-zero-length.stderr
@@ -1,0 +1,4 @@
+error: monomorphising SIMD type `Simd<f64, 0>` of zero length
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/simd/target-feature-mixup.rs
+++ b/tests/ui/simd/target-feature-mixup.rs
@@ -54,17 +54,17 @@ mod test {
     // An SSE type
     #[repr(simd)]
     #[derive(PartialEq, Debug, Clone, Copy)]
-    struct __m128i(u64, u64);
+    struct __m128i([u64; 2]);
 
     // An AVX type
     #[repr(simd)]
     #[derive(PartialEq, Debug, Clone, Copy)]
-    struct __m256i(u64, u64, u64, u64);
+    struct __m256i([u64; 4]);
 
     // An AVX-512 type
     #[repr(simd)]
     #[derive(PartialEq, Debug, Clone, Copy)]
-    struct __m512i(u64, u64, u64, u64, u64, u64, u64, u64);
+    struct __m512i([u64; 8]);
 
     pub fn main(level: &str) {
         unsafe {
@@ -90,9 +90,9 @@ mod test {
         )*) => ($(
             $(#[$attr])*
             unsafe fn $main(level: &str) {
-                let m128 = __m128i(1, 2);
-                let m256 = __m256i(3, 4, 5, 6);
-                let m512 = __m512i(7, 8, 9, 10, 11, 12, 13, 14);
+                let m128 = __m128i([1, 2]);
+                let m256 = __m256i([3, 4, 5, 6]);
+                let m512 = __m512i([7, 8, 9, 10, 11, 12, 13, 14]);
                 assert_eq!(id_sse_128(m128), m128);
                 assert_eq!(id_sse_256(m256), m256);
                 assert_eq!(id_sse_512(m512), m512);
@@ -127,55 +127,55 @@ mod test {
 
     #[target_feature(enable = "sse2")]
     unsafe fn id_sse_128(a: __m128i) -> __m128i {
-        assert_eq!(a, __m128i(1, 2));
+        assert_eq!(a, __m128i([1, 2]));
         a.clone()
     }
 
     #[target_feature(enable = "sse2")]
     unsafe fn id_sse_256(a: __m256i) -> __m256i {
-        assert_eq!(a, __m256i(3, 4, 5, 6));
+        assert_eq!(a, __m256i([3, 4, 5, 6]));
         a.clone()
     }
 
     #[target_feature(enable = "sse2")]
     unsafe fn id_sse_512(a: __m512i) -> __m512i {
-        assert_eq!(a, __m512i(7, 8, 9, 10, 11, 12, 13, 14));
+        assert_eq!(a, __m512i([7, 8, 9, 10, 11, 12, 13, 14]));
         a.clone()
     }
 
     #[target_feature(enable = "avx")]
     unsafe fn id_avx_128(a: __m128i) -> __m128i {
-        assert_eq!(a, __m128i(1, 2));
+        assert_eq!(a, __m128i([1, 2]));
         a.clone()
     }
 
     #[target_feature(enable = "avx")]
     unsafe fn id_avx_256(a: __m256i) -> __m256i {
-        assert_eq!(a, __m256i(3, 4, 5, 6));
+        assert_eq!(a, __m256i([3, 4, 5, 6]));
         a.clone()
     }
 
     #[target_feature(enable = "avx")]
     unsafe fn id_avx_512(a: __m512i) -> __m512i {
-        assert_eq!(a, __m512i(7, 8, 9, 10, 11, 12, 13, 14));
+        assert_eq!(a, __m512i([7, 8, 9, 10, 11, 12, 13, 14]));
         a.clone()
     }
 
     #[target_feature(enable = "avx512bw")]
     unsafe fn id_avx512_128(a: __m128i) -> __m128i {
-        assert_eq!(a, __m128i(1, 2));
+        assert_eq!(a, __m128i([1, 2]));
         a.clone()
     }
 
     #[target_feature(enable = "avx512bw")]
     unsafe fn id_avx512_256(a: __m256i) -> __m256i {
-        assert_eq!(a, __m256i(3, 4, 5, 6));
+        assert_eq!(a, __m256i([3, 4, 5, 6]));
         a.clone()
     }
 
     #[target_feature(enable = "avx512bw")]
     unsafe fn id_avx512_512(a: __m512i) -> __m512i {
-        assert_eq!(a, __m512i(7, 8, 9, 10, 11, 12, 13, 14));
+        assert_eq!(a, __m512i([7, 8, 9, 10, 11, 12, 13, 14]));
         a.clone()
     }
 }

--- a/tests/ui/simd/type-generic-monomorphisation-extern-nonnull-ptr.rs
+++ b/tests/ui/simd/type-generic-monomorphisation-extern-nonnull-ptr.rs
@@ -11,7 +11,7 @@ extern {
 }
 
 #[repr(simd)]
-struct S<T>(T);
+struct S<T>([T; 4]);
 
 #[inline(never)]
 fn identity<T>(v: T) -> T {
@@ -19,5 +19,5 @@ fn identity<T>(v: T) -> T {
 }
 
 fn main() {
-    let _v: S<[Option<NonNull<Extern>>; 4]> = identity(S([None; 4]));
+    let _v: S<Option<NonNull<Extern>>> = identity(S([None; 4]));
 }

--- a/tests/ui/simd/type-generic-monomorphisation-wide-ptr.rs
+++ b/tests/ui/simd/type-generic-monomorphisation-wide-ptr.rs
@@ -2,11 +2,11 @@
 
 #![feature(repr_simd)]
 
-//@ error-pattern:monomorphising SIMD type `S<[*mut [u8]; 4]>` with a non-primitive-scalar (integer/float/pointer) element type `*mut [u8]`
+//@ error-pattern:monomorphising SIMD type `S<*mut [u8]>` with a non-primitive-scalar (integer/float/pointer) element type `*mut [u8]`
 
 #[repr(simd)]
-struct S<T>(T);
+struct S<T>([T; 4]);
 
 fn main() {
-    let _v: Option<S<[*mut [u8]; 4]>> = None;
+    let _v: Option<S<*mut [u8]>> = None;
 }

--- a/tests/ui/simd/type-generic-monomorphisation-wide-ptr.stderr
+++ b/tests/ui/simd/type-generic-monomorphisation-wide-ptr.stderr
@@ -1,4 +1,4 @@
-error: monomorphising SIMD type `S<[*mut [u8]; 4]>` with a non-primitive-scalar (integer/float/pointer) element type `*mut [u8]`
+error: monomorphising SIMD type `S<*mut [u8]>` with a non-primitive-scalar (integer/float/pointer) element type `*mut [u8]`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/simd/type-generic-monomorphisation.rs
+++ b/tests/ui/simd/type-generic-monomorphisation.rs
@@ -7,8 +7,8 @@
 
 struct X(Vec<i32>);
 #[repr(simd)]
-struct Simd2<T>(T, T);
+struct Simd2<T>([T; 2]);
 
 fn main() {
-    let _ = Simd2(X(vec![]), X(vec![]));
+    let _ = Simd2([X(vec![]), X(vec![])]);
 }

--- a/tests/ui/simd/type-len.rs
+++ b/tests/ui/simd/type-len.rs
@@ -1,7 +1,6 @@
 #![feature(repr_simd)]
 #![allow(non_camel_case_types)]
 
-
 #[repr(simd)]
 struct empty; //~ ERROR SIMD vector cannot be empty
 
@@ -12,12 +11,12 @@ struct empty2([f32; 0]); //~ ERROR SIMD vector cannot be empty
 struct pow2([f32; 7]);
 
 #[repr(simd)]
-struct i64f64(i64, f64); //~ ERROR SIMD vector should be homogeneous
+struct i64f64(i64, f64); //~ ERROR SIMD vector's only field must be an array
 
 struct Foo;
 
 #[repr(simd)]
-struct FooV(Foo, Foo); //~ ERROR SIMD vector element type should be a primitive scalar (integer/float/pointer) type
+struct FooV(Foo, Foo); //~ ERROR SIMD vector's only field must be an array
 
 #[repr(simd)]
 struct FooV2([Foo; 2]); //~ ERROR SIMD vector element type should be a primitive scalar (integer/float/pointer) type
@@ -29,11 +28,11 @@ struct TooBig([f32; 65536]); //~ ERROR SIMD vector cannot have more than 32768 e
 struct JustRight([u128; 32768]);
 
 #[repr(simd)]
-struct RGBA {
+struct RGBA { //~ ERROR SIMD vector's only field must be an array
     r: f32,
     g: f32,
     b: f32,
-    a: f32
+    a: f32,
 }
 
 fn main() {}

--- a/tests/ui/simd/type-len.stderr
+++ b/tests/ui/simd/type-len.stderr
@@ -1,40 +1,48 @@
 error[E0075]: SIMD vector cannot be empty
-  --> $DIR/type-len.rs:6:1
+  --> $DIR/type-len.rs:5:1
    |
 LL | struct empty;
    | ^^^^^^^^^^^^
 
 error[E0075]: SIMD vector cannot be empty
-  --> $DIR/type-len.rs:9:1
+  --> $DIR/type-len.rs:8:1
    |
 LL | struct empty2([f32; 0]);
    | ^^^^^^^^^^^^^
 
-error[E0076]: SIMD vector should be homogeneous
-  --> $DIR/type-len.rs:15:1
+error[E0076]: SIMD vector's only field must be an array
+  --> $DIR/type-len.rs:14:1
    |
 LL | struct i64f64(i64, f64);
-   | ^^^^^^^^^^^^^ SIMD elements must have the same type
+   | ^^^^^^^^^^^^^ --- not an array
 
-error[E0077]: SIMD vector element type should be a primitive scalar (integer/float/pointer) type
-  --> $DIR/type-len.rs:20:1
+error[E0076]: SIMD vector's only field must be an array
+  --> $DIR/type-len.rs:19:1
    |
 LL | struct FooV(Foo, Foo);
-   | ^^^^^^^^^^^
+   | ^^^^^^^^^^^ --- not an array
 
 error[E0077]: SIMD vector element type should be a primitive scalar (integer/float/pointer) type
-  --> $DIR/type-len.rs:23:1
+  --> $DIR/type-len.rs:22:1
    |
 LL | struct FooV2([Foo; 2]);
    | ^^^^^^^^^^^^
 
 error[E0075]: SIMD vector cannot have more than 32768 elements
-  --> $DIR/type-len.rs:26:1
+  --> $DIR/type-len.rs:25:1
    |
 LL | struct TooBig([f32; 65536]);
    | ^^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error[E0076]: SIMD vector's only field must be an array
+  --> $DIR/type-len.rs:31:1
+   |
+LL | struct RGBA {
+   | ^^^^^^^^^^^
+LL |     r: f32,
+   |     ------ not an array
+
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0075, E0076, E0077.
 For more information about an error, try `rustc --explain E0075`.

--- a/tests/ui/span/gated-features-attr-spans.rs
+++ b/tests/ui/span/gated-features-attr-spans.rs
@@ -1,7 +1,6 @@
 #[repr(simd)] //~ ERROR are experimental
 struct Coord {
-    x: u32,
-    y: u32,
+    v: [u32; 2],
 }
 
 fn main() {}


### PR DESCRIPTION
Successful merges:

 - #126183 (Separate core search logic with search ui)
 - #129366 (linker: Synchronize native library search in rustc and linker)
 - #129403 (Ban non-array SIMD)
 - #129527 (Don't use `TyKind` in a lint)
 - #129534 (Deny `wasm_c_abi` lint to nudge the last 25%)
 - #129640 (Re-enable android tests/benches in alloc/core)
 - #129731 (Allow running `./x.py test compiler`)
 - #129754 (wasi: Fix sleeping for `Duration::MAX`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=126183,129366,129403,129527,129534,129640,129731,129754)
<!-- homu-ignore:end -->