### PR TITLE
add crashtests for several old unfixed ICEs

### DIFF
--- a/tests/crashes/117460.rs
+++ b/tests/crashes/117460.rs
@@ -1,0 +1,8 @@
+//@ known-bug: #117460
+#![feature(generic_const_exprs)]
+
+struct Matrix<D = [(); 2 + 2]> {
+    d: D,
+}
+
+impl Matrix {}

--- a/tests/crashes/119095.rs
+++ b/tests/crashes/119095.rs
@@ -1,0 +1,48 @@
+//@ known-bug: #119095
+//@ compile-flags: --edition=2021
+
+fn any<T>() -> T {
+    loop {}
+}
+
+trait Acquire {
+    type Connection;
+}
+
+impl Acquire for &'static () {
+    type Connection = ();
+}
+
+trait Unit {}
+impl Unit for () {}
+
+fn get_connection<T>() -> impl Unit
+where
+    T: Acquire,
+    T::Connection: Unit,
+{
+    any::<T::Connection>()
+}
+
+fn main() {
+    let future = async { async { get_connection::<&'static ()>() }.await };
+
+    future.resolve_me();
+}
+
+trait ResolveMe {
+    fn resolve_me(self);
+}
+
+impl<S> ResolveMe for S
+where
+    (): CheckSend<S>,
+{
+    fn resolve_me(self) {}
+}
+
+trait CheckSend<F> {}
+impl<F> CheckSend<F> for () where F: Send {}
+
+trait NeverImplemented {}
+impl<E, F> CheckSend<F> for E where E: NeverImplemented {}

--- a/tests/crashes/126443.rs
+++ b/tests/crashes/126443.rs
@@ -1,0 +1,15 @@
+//@ known-bug: #126443
+//@ compile-flags: -Copt-level=0
+#![feature(generic_const_exprs)]
+
+fn double_up<const M: usize>() -> [(); M * 2] {
+    todo!()
+}
+
+fn quadruple_up<const N: usize>() -> [(); N * 2 * 2] {
+    double_up()
+}
+
+fn main() {
+    quadruple_up::<0>();
+}

--- a/tests/crashes/128097.rs
+++ b/tests/crashes/128097.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #128097
+#![feature(explicit_tail_calls)]
+fn f(x: &mut ()) {
+    let _y: String;
+    become f(x);
+}


### PR DESCRIPTION
Adds several new crashtests for some older ICEs that did not yet have any.
Tests were added for #128097, #119095, #117460 and #126443.