### PR TITLE
struct_target_features: cache feature computation.

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1250,6 +1250,10 @@ rustc_queries! {
         desc { |tcx| "computing target features for struct `{}`", tcx.def_path_str(def_id) }
     }
 
+    query struct_reachable_target_features(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> &'tcx [TargetFeature] {
+        desc { |tcx| "computing target features reachable from {}", env.value }
+    }
+
     query asm_target_features(def_id: DefId) -> &'tcx FxIndexSet<Symbol> {
         desc { |tcx| "computing target features for inline asm of `{}`", tcx.def_path_str(def_id) }
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

This commit moves the type-recursion to a query, causing it to be cached and (hopefully!)
fixing the instruction-count regression from https://github.com/rust-lang/rust/pull/127537.

r? compiler-errors

Tracking issue: https://github.com/rust-lang/rust/issues/129107
