### PR TITLE
Add `position` to `Enumerate`

### DIFF
--- a/library/core/src/iter/adapters/enumerate.rs
+++ b/library/core/src/iter/adapters/enumerate.rs
@@ -23,6 +23,11 @@ impl<I> Enumerate<I> {
     pub(in crate::iter) fn new(iter: I) -> Enumerate<I> {
         Enumerate { iter, count: 0 }
     }
+
+    #[inline]
+    pub fn position(&self) -> usize {
+        self.count
+    }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
In situations where the iterator progresses due to a function call, it may be tedious to determine the current position/count of the iterator.

```rs
fn do_iter(iter: &mut Enumerate<Chars<'a>>) {
    // ...
}

fn main() {
    do_iter(&mut i);

    // An iterator being used for parsing may want to compare the original position to the end position.
}