### PR TITLE
Docs - type guarantees update

### DIFF
--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -1124,7 +1124,7 @@ impl String {
     ///
     /// # Panics
     ///
-    /// Panics if the new capacity overflows [`usize`].
+    /// Panics if the new capacity exceeds [`isize::MAX`] bytes.
     ///
     /// # Examples
     ///
@@ -1174,7 +1174,7 @@ impl String {
     ///
     /// # Panics
     ///
-    /// Panics if the new capacity overflows [`usize`].
+    /// Panics if the new capacity exceeds [`isize::MAX`] bytes.
     ///
     /// # Examples
     ///

--- a/library/core/src/num/saturating.rs
+++ b/library/core/src/num/saturating.rs
@@ -31,6 +31,10 @@ use crate::ops::{
 ///
 /// assert_eq!(u32::MAX, (max + one).0);
 /// ```
+///
+/// # Layout
+///
+/// `Saturating<T>` is guaranteed to have the same layout and ABI as `T`.
 #[stable(feature = "saturating_int_impl", since = "1.74.0")]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default, Hash)]
 #[repr(transparent)]

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1522,8 +1522,7 @@ impl<'a, T: ?Sized> Pin<&'a T> {
     ///
     /// This function is unsafe. You must guarantee that the data you return
     /// will not move so long as the argument value does not move (for example,
-    /// because it is one of the fields of that value), and also that you do
-    /// not move out of the argument you receive to the interior function.
+    /// because it is one of the fields of that value).
     ///
     /// [`pin` module]: self#projections-and-structural-pinning
     #[stable(feature = "pin", since = "1.33.0")]

--- a/library/core/src/str/iter.rs
+++ b/library/core/src/str/iter.rs
@@ -1287,7 +1287,7 @@ pub struct SplitAsciiWhitespace<'a> {
 }
 
 /// An iterator over the substrings of a string,
-/// terminated by a substring matching to a predicate function
+/// terminated by a substring matching to a predicate function.
 /// Unlike `Split`, it contains the matched part as a terminator
 /// of the subslice.
 ///


### PR DESCRIPTION
**Content:**
- Pin::map_unchecked | Safety section update
- String::reserve, String::reserve_exact | Panic section update
- Saturating | Introduce Layout section
- Fix typos

**Questions:**

1. This proposes to update String reserve methods docs:
        
    > Panics if the new capacity overflows [`usize`].
    
    ->
    
    > Panics if the new capacity exceeds [`isize::MAX`] bytes.
    
    There are a few other types that are based on Vec and offer similar reserve API (like BinaryHeap). 
    Should they be updated, too?


ACP: ~~https://github.com/rust-lang/libs-team/issues/482~~ [not required]