### PR TITLE
Actually parse stdout json, instead of using hacky contains logic.

### DIFF
--- a/tests/run-make/rustdoc-output-stdout/rmake.rs
+++ b/tests/run-make/rustdoc-output-stdout/rmake.rs
@@ -4,17 +4,28 @@
 use std::path::PathBuf;
 
 use run_make_support::path_helpers::{cwd, has_extension, read_dir_entries_recursive};
-use run_make_support::rustdoc;
+use run_make_support::{rustdoc, serde_json};
 
 fn main() {
-    // First we check that we generate the JSON in the stdout.
-    rustdoc()
+    let json_string = rustdoc()
         .input("foo.rs")
         .out_dir("-")
         .arg("-Zunstable-options")
         .output_format("json")
         .run()
-        .assert_stdout_contains("{\"");
+        .stdout_utf8();
+
+    // First we check that we generate the JSON in the stdout.
+    let json_value: serde_json::Value =
+        serde_json::from_str(&json_string).expect("stdout should be valid json");
+
+    // We don't care to test the specifics of the JSON, as that's done
+    // elsewhere, just check that it has a format_version (as all JSON output
+    // should).
+    let format_version = json_value["format_version"]
+        .as_i64()
+        .expect("json output should contain format_version field");
+    assert!(format_version > 30);
 
     // Then we check it didn't generate any JSON file.
     read_dir_entries_recursive(cwd(), |path| {


### PR DESCRIPTION
Fixes up the test added in #128963, to actually parse the stdout to JSON, instead of just checking that it contains `{"`.

CC @GuillaumeGomez 

r? @jieyouxu