### PR TITLE
Do not call query to compute coroutine layout for synthetic body of async closure

### DIFF
--- a/tests/ui/async-await/async-closures/validate-synthetic-body.rs
+++ b/tests/ui/async-await/async-closures/validate-synthetic-body.rs
@@ -1,0 +1,19 @@
+//@ check-pass
+//@ edition: 2021
+
+#![feature(async_closure)]
+
+// Make sure that we don't hit a query cycle when validating
+// the by-move coroutine body for an async closure.
+
+use std::future::Future;
+
+async fn test<Fut: Future>(operation: impl Fn() -> Fut) {
+    operation().await;
+}
+
+pub async fn orchestrate_simple_crud() {
+    test(async || async {}.await).await;
+}
+
+fn main() {}


### PR DESCRIPTION
There is code in the MIR validator that attempts to prevent query cycles when inlining a coroutine into itself, and will use the coroutine layout directly from the body when it detects that's the same coroutine as the one that's being validated. After #128506, this logic didn't take into account the fact that the coroutine def id will differ if it's the "by-move body" of an async closure. This PR implements that.

Fixes #129811