### PR TITLE
Additional stringy PartialEq implementations for Box<str>

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1553,6 +1553,42 @@ impl Clone for Box<str> {
     }
 }
 
+// This is the same impl as `Cow<'a, str>`, but with a newer stability attribute.
+// It needs to be in this file to refer to the Box as a local struct rather than as a lang-item.
+macro_rules! impl_eq {
+    ($lhs:ty, $rhs: ty) => {
+        #[stable(feature = "box_str_partial_eq", since = "CURRENT_RUSTC_VERSION")]
+        #[allow(unused_lifetimes)]
+        impl<'a, 'b> PartialEq<$rhs> for $lhs {
+            #[inline]
+            fn eq(&self, other: &$rhs) -> bool {
+                PartialEq::eq(&self[..], &other[..])
+            }
+            #[inline]
+            fn ne(&self, other: &$rhs) -> bool {
+                PartialEq::ne(&self[..], &other[..])
+            }
+        }
+
+        #[stable(feature = "box_str_partial_eq", since = "CURRENT_RUSTC_VERSION")]
+        #[allow(unused_lifetimes)]
+        impl<'a, 'b> PartialEq<$lhs> for $rhs {
+            #[inline]
+            fn eq(&self, other: &$lhs) -> bool {
+                PartialEq::eq(&self[..], &other[..])
+            }
+            #[inline]
+            fn ne(&self, other: &$lhs) -> bool {
+                PartialEq::ne(&self[..], &other[..])
+            }
+        }
+    };
+}
+
+impl_eq! { Box<str>, str }
+impl_eq! { Box<str>, &'a str }
+impl_eq! { Box<str>, String }
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized + PartialEq, A: Allocator> PartialEq for Box<T, A> {
     #[inline]
@@ -1564,6 +1600,7 @@ impl<T: ?Sized + PartialEq, A: Allocator> PartialEq for Box<T, A> {
         PartialEq::ne(&**self, &**other)
     }
 }
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized + PartialOrd, A: Allocator> PartialOrd for Box<T, A> {
     #[inline]

--- a/library/alloc/tests/str.rs
+++ b/library/alloc/tests/str.rs
@@ -14,6 +14,29 @@ fn test_le() {
 }
 
 #[test]
+fn test_box_str_eq() {
+    let boxed: Box<str> = Box::from("boxed");
+    assert!(*"boxed" == boxed);
+    assert!(*"other" != boxed);
+    assert!(boxed == *"boxed");
+    assert!(boxed != *"other");
+
+    assert!(&"boxed" == &boxed);
+    assert!(&boxed == &"boxed");
+    assert!(&"BOXED" != &boxed);
+    assert!(&boxed != &"BOXED");
+
+    assert_eq!(Box::from("foo"), "foo");
+    assert_eq!("bar", Box::from("bar"));
+
+    assert_ne!(Box::from("foo"), "bar");
+    assert_ne!("bar", Box::from("foo"));
+
+    assert!("" == Box::from(""));
+    assert!("本" == String::from("本").into_boxed_str());
+}
+
+#[test]
 fn test_find() {
     assert_eq!("hello".find('l'), Some(2));
     assert_eq!("hello".find(|c: char| c == 'o'), Some(4));


### PR DESCRIPTION
`Box<str>` lacks `PartialEq` implementations for comparisons with other string types. It can't even be compared to a string literal:

```text
error[E0277]: can't compare `&str` with `Box<str>`
 --> src/lib.rs:6:21
  |
6 |     assert!("boxed" == boxed);
  |                     ^^ no implementation for `&str == Box<str>`
  |
  = help: the trait `PartialEq<Box<str>>` is not implemented for `&str`
help: consider dereferencing both sides of the expression
  |
6 |     assert!(*"boxed" == *boxed);
```

This PR adds the same `PartialEq` implementations to `Box<str>` as `Cow<str>` has, making it comparable with `str` and `String` in many more cases.

**This is a risky change, as it may affect type inference**. AFAIK `PartialEq` implementations can't be marked as unstable, so this is **insta-stable**. 

[Forum discussion](https://internals.rust-lang.org/t/partialeq-for-box-str/21434).