### PR TITLE
Replace walk with visit so we dont skip outermost expr kind in def collector

### DIFF
--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -223,7 +223,7 @@ impl<'a, 'b, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'b, 'tcx> {
                 // we must create two defs.
                 let coroutine_def =
                     self.create_def(coroutine_kind.closure_id(), kw::Empty, DefKind::Closure, span);
-                self.with_parent(coroutine_def, |this| visit::walk_expr(this, body));
+                self.with_parent(coroutine_def, |this| this.visit_expr(body));
             }
             _ => visit::walk_fn(self, fn_kind),
         }

--- a/tests/ui/async-await/async-closures/mac-body.rs
+++ b/tests/ui/async-await/async-closures/mac-body.rs
@@ -1,0 +1,12 @@
+//@ edition: 2021
+//@ check-pass
+
+#![feature(async_closure)]
+
+// Make sure we don't ICE if an async closure has a macro body.
+// This happened because we were calling walk instead of visit
+// in the def collector, oops!
+
+fn main() {
+    let _ = async || println!();
+}


### PR DESCRIPTION
This affects async closures with macros as their body expr. Fixes #129855.

r? @cjgillot or anyone else