### PR TITLE
Experiment: add unstable RHS type to Ord, impl PartialOrd<[U]> for [T]

### DIFF
--- a/library/core/src/slice/cmp.rs
+++ b/library/core/src/slice/cmp.rs
@@ -1,10 +1,9 @@
 //! Comparison traits for `[T]`.
 
 use super::{from_raw_parts, memchr};
-use crate::cmp::{self, BytewiseEq, Ordering};
+use crate::cmp::{self, AlwaysApplicableOrd, BytewiseEq, Ordering, UnsignedBytewiseOrd};
 use crate::intrinsics::compare_bytes;
-use crate::num::NonZero;
-use crate::{ascii, mem};
+use crate::mem;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, U> PartialEq<[U]> for [T]
@@ -20,51 +19,32 @@ where
     }
 }
 
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Eq> Eq for [T] {}
-
-/// Implements comparison of slices [lexicographically](Ord#lexicographical-comparison).
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<T: Ord> Ord for [T] {
-    fn cmp(&self, other: &[T]) -> Ordering {
-        SliceOrd::compare(self, other)
-    }
-}
-
-/// Implements comparison of slices [lexicographically](Ord#lexicographical-comparison).
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<T: PartialOrd> PartialOrd for [T] {
-    fn partial_cmp(&self, other: &[T]) -> Option<Ordering> {
-        SlicePartialOrd::partial_compare(self, other)
-    }
-}
-
 #[doc(hidden)]
 // intermediate trait for specialization of slice's PartialEq
-trait SlicePartialEq<B> {
-    fn equal(&self, other: &[B]) -> bool;
+trait SlicePartialEq<B>: Sized {
+    fn equal(left: &[Self], right: &[B]) -> bool;
 
-    fn not_equal(&self, other: &[B]) -> bool {
-        !self.equal(other)
+    fn not_equal(left: &[Self], right: &[B]) -> bool {
+        !Self::equal(left, right)
     }
 }
 
 // Generic slice equality
-impl<A, B> SlicePartialEq<B> for [A]
+impl<A, B> SlicePartialEq<B> for A
 where
     A: PartialEq<B>,
 {
-    default fn equal(&self, other: &[B]) -> bool {
-        if self.len() != other.len() {
+    default fn equal(left: &[A], right: &[B]) -> bool {
+        if left.len() != right.len() {
             return false;
         }
 
         // Implemented as explicit indexing rather
         // than zipped iterators for performance reasons.
         // See PR https://github.com/rust-lang/rust/pull/116846
-        for idx in 0..self.len() {
+        for idx in 0..left.len() {
             // bound checks are optimized away
-            if self[idx] != other[idx] {
+            if left[idx] != right[idx] {
                 return false;
             }
         }
@@ -75,32 +55,49 @@ where
 
 // When each element can be compared byte-wise, we can compare all the bytes
 // from the whole size in one call to the intrinsics.
-impl<A, B> SlicePartialEq<B> for [A]
+impl<A, B> SlicePartialEq<B> for A
 where
     A: BytewiseEq<B>,
 {
-    fn equal(&self, other: &[B]) -> bool {
-        if self.len() != other.len() {
+    fn equal(left: &[A], right: &[B]) -> bool {
+        if left.len() != right.len() {
             return false;
         }
 
         // SAFETY: `self` and `other` are references and are thus guaranteed to be valid.
         // The two slices have been checked to have the same size above.
         unsafe {
-            let size = mem::size_of_val(self);
-            compare_bytes(self.as_ptr() as *const u8, other.as_ptr() as *const u8, size) == 0
+            let size = mem::size_of_val(left);
+            compare_bytes(left.as_ptr() as *const u8, right.as_ptr() as *const u8, size) == 0
         }
+    }
+}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T: Eq> Eq for [T] {}
+
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T, U> PartialOrd<[U]> for [T]
+where
+    T: PartialOrd<U>,
+{
+    fn partial_cmp(&self, other: &[U]) -> Option<Ordering> {
+        SlicePartialOrd::partial_compare(self, other)
     }
 }
 
 #[doc(hidden)]
 // intermediate trait for specialization of slice's PartialOrd
-trait SlicePartialOrd: Sized {
-    fn partial_compare(left: &[Self], right: &[Self]) -> Option<Ordering>;
+trait SlicePartialOrd<B>: Sized {
+    fn partial_compare(left: &[Self], right: &[B]) -> Option<Ordering>;
 }
 
-impl<A: PartialOrd> SlicePartialOrd for A {
-    default fn partial_compare(left: &[A], right: &[A]) -> Option<Ordering> {
+/// Implements comparison of slices [lexicographically](Ord#lexicographical-comparison).
+impl<A, B> SlicePartialOrd<B> for A
+where
+    A: PartialOrd<B>,
+{
+    default fn partial_compare(left: &[A], right: &[B]) -> Option<Ordering> {
         let l = cmp::min(left.len(), right.len());
 
         // Slice to the loop iteration range to enable bound check
@@ -119,52 +116,37 @@ impl<A: PartialOrd> SlicePartialOrd for A {
     }
 }
 
-// This is the impl that we would like to have. Unfortunately it's not sound.
-// See `partial_ord_slice.rs`.
-/*
-impl<A> SlicePartialOrd for A
+impl<A, B> SlicePartialOrd<B> for A
 where
-    A: Ord,
+    A: AlwaysApplicableOrd<B>,
 {
-    default fn partial_compare(left: &[A], right: &[A]) -> Option<Ordering> {
-        Some(SliceOrd::compare(left, right))
-    }
-}
-*/
-
-impl<A: AlwaysApplicableOrd> SlicePartialOrd for A {
-    fn partial_compare(left: &[A], right: &[A]) -> Option<Ordering> {
+    fn partial_compare(left: &[A], right: &[B]) -> Option<Ordering> {
         Some(SliceOrd::compare(left, right))
     }
 }
 
-#[rustc_specialization_trait]
-trait AlwaysApplicableOrd: SliceOrd + Ord {}
-
-macro_rules! always_applicable_ord {
-    ($([$($p:tt)*] $t:ty,)*) => {
-        $(impl<$($p)*> AlwaysApplicableOrd for $t {})*
+#[stable(feature = "rust1", since = "1.0.0")]
+impl<T> Ord for [T]
+where
+    T: Ord,
+{
+    fn cmp(&self, other: &[T]) -> Ordering {
+        SliceOrd::compare(self, other)
     }
-}
-
-always_applicable_ord! {
-    [] u8, [] u16, [] u32, [] u64, [] u128, [] usize,
-    [] i8, [] i16, [] i32, [] i64, [] i128, [] isize,
-    [] bool, [] char,
-    [T: ?Sized] *const T, [T: ?Sized] *mut T,
-    [T: AlwaysApplicableOrd] &T,
-    [T: AlwaysApplicableOrd] &mut T,
-    [T: AlwaysApplicableOrd] Option<T>,
 }
 
 #[doc(hidden)]
 // intermediate trait for specialization of slice's Ord
-trait SliceOrd: Sized {
-    fn compare(left: &[Self], right: &[Self]) -> Ordering;
+trait SliceOrd<B>: Sized + Ord<B> {
+    fn compare(left: &[Self], right: &[B]) -> Ordering;
 }
 
-impl<A: Ord> SliceOrd for A {
-    default fn compare(left: &[Self], right: &[Self]) -> Ordering {
+/// Implements comparison of slices [lexicographically](Ord#lexicographical-comparison).
+impl<A, B> SliceOrd<B> for A
+where
+    A: Ord<B>,
+{
+    default fn compare(left: &[A], right: &[B]) -> Ordering {
         let l = cmp::min(left.len(), right.len());
 
         // Slice to the loop iteration range to enable bound check
@@ -183,27 +165,14 @@ impl<A: Ord> SliceOrd for A {
     }
 }
 
-/// Marks that a type should be treated as an unsigned byte for comparisons.
-///
-/// # Safety
-/// * The type must be readable as an `u8`, meaning it has to have the same
-///   layout as `u8` and always be initialized.
-/// * For every `x` and `y` of this type, `Ord(x, y)` must return the same
-///   value as `Ord::cmp(transmute::<_, u8>(x), transmute::<_, u8>(y))`.
-#[rustc_specialization_trait]
-unsafe trait UnsignedBytewiseOrd {}
-
-unsafe impl UnsignedBytewiseOrd for bool {}
-unsafe impl UnsignedBytewiseOrd for u8 {}
-unsafe impl UnsignedBytewiseOrd for NonZero<u8> {}
-unsafe impl UnsignedBytewiseOrd for Option<NonZero<u8>> {}
-unsafe impl UnsignedBytewiseOrd for ascii::Char {}
-
 // `compare_bytes` compares a sequence of unsigned bytes lexicographically, so
 // use it if the requirements for `UnsignedBytewiseOrd` are fulfilled.
-impl<A: Ord + UnsignedBytewiseOrd> SliceOrd for A {
+impl<A, B> SliceOrd<B> for A
+where
+    A: UnsignedBytewiseOrd<B>,
+{
     #[inline]
-    fn compare(left: &[Self], right: &[Self]) -> Ordering {
+    fn compare(left: &[A], right: &[B]) -> Ordering {
         // Since the length of a slice is always less than or equal to
         // isize::MAX, this never underflows.
         let diff = left.len() as isize - right.len() as isize;
@@ -225,6 +194,7 @@ impl<A: Ord + UnsignedBytewiseOrd> SliceOrd for A {
     }
 }
 
+// trait for specialization of `slice::contains`
 pub(super) trait SliceContains: Sized {
     fn slice_contains(&self, x: &[Self]) -> bool;
 }


### PR DESCRIPTION
This PR adds an unstable `Rhs` parameter to `Ord` in an attempt to implement `PartialOrd<[U]> for [T]` without disrupting specialization. Doing so requires reducing the number of types implementing `AlwaysApplicableOrd`, which could disrupt specialization, but this (hopefully) won't affect performance.

In particular, `*const T`, `*mut T`, and `Option<T>` no longer are marked as `AlwaysApplicableOrd` because there is no equivalent implementations of `PartialOrd` for them. In particular, there are not general implementations of the following, and adding them would be a larger API change than the implementation that was accepted by the ACP:

```rust
impl<T, U> PartialOrd<*const U> for *const T {}
impl<T, U> PartialOrd<*mut U> for *mut T {}
impl<T: PartialOrd<U>, U> PartialOrd<Option<U>> for Option<T> {}
```

Closes #129039, which tracks the implementation of the ACP rust-lang/libs-team#285.

This requires an FCP since it technically adds immediately-stable impls, although it's unclear whether these impls can actually affect users. See below for notes.

r? libs-api

## Details

Currently, this expands the following impls:

```rust
impl<T: Ord> Ord for &T {}
impl<T: Ord> Ord for &mut T {}
```

into the following:

```rust
impl<T: Ord<U>, U> Ord<&U> for &T {}
impl<T: Ord<U>, U> Ord<&mut U> for &mut T {}
```

Which is technically a new impl in the sense that `for<'a, 'b> Ord<&'a T> for &'b T` now exists, although it's unclear whether this actually would be observable by users in practice. The reason for this impl is to ensure that `AlwaysApplicableOrd` can apply to references, since a `PartialOrd` implementation exists for them, but it's unclear whether this is truly needed. No matter what, users won't be able to name these specific impls in bounds, but they will be able to use them in functions anonymously by calling `Ord::cmp` directly.

*However*, adding this type parameter helps make specialization possible for using `Ord` on slices whenever possible, since we no longer have to rely on the lifetimes of two parameters being exactly equal to swap in `Ord` in `PartialOrd` impls.

Personally, I think that longer-term, it could be useful to have an `Rhs` type parameter for `Ord` since it actually makes sense logically, even though it doesn't for `Eq` (which just adds reflexivity to `PartialEq`, and thus doesn't depend on the RHS). However, this PR is only adding the type parameter to make `PartialOrd` work as expected, and that would require its own ACP.

