### PR TITLE
rustc_skip_during_method_dispatch: decouple receiver & edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3745,6 +3745,7 @@ dependencies = [
  "rustc_trait_selection",
  "rustc_type_ir",
  "smallvec",
+ "thin-vec",
  "tracing",
 ]
 

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -969,11 +969,12 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         "the `#[rustc_main]` attribute is used internally to specify test entry point function",
     ),
     rustc_attr!(
-        rustc_skip_during_method_dispatch, Normal, template!(List: "array, boxed_slice"), WarnFollowing,
-        EncodeCrossCrate::No,
+        rustc_skip_during_method_dispatch, Normal,
+        template!(List: r#"receiver = "name", before_edition = "N""#),
+        DuplicatesOk, EncodeCrossCrate::No,
         "the `#[rustc_skip_during_method_dispatch]` attribute is used to exclude a trait \
-        from method dispatch when the receiver is of the following type, for compatibility in \
-        editions < 2021 (array) or editions < 2024 (boxed_slice)."
+        from method dispatch when the receiver is of the type `receiver`, \
+        for compatibility in editions < `before_edition`."
     ),
     rustc_attr!(
         rustc_must_implement_one_of, Normal, template!(List: "function1, function2, ..."),

--- a/compiler/rustc_hir_analysis/Cargo.toml
+++ b/compiler/rustc_hir_analysis/Cargo.toml
@@ -30,5 +30,6 @@ rustc_target = { path = "../rustc_target" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }
 rustc_type_ir = { path = "../rustc_type_ir" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
+thin-vec = "0.2.12"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/stable_mir/src/edition.rs
+++ b/compiler/stable_mir/src/edition.rs
@@ -1,0 +1,10 @@
+use serde::Serialize;
+
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub enum Edition {
+    Edition2015,
+    Edition2018,
+    Edition2021,
+    Edition2024,
+}

--- a/compiler/stable_mir/src/lib.rs
+++ b/compiler/stable_mir/src/lib.rs
@@ -32,6 +32,7 @@ pub mod abi;
 #[macro_use]
 pub mod crate_def;
 pub mod compiler_interface;
+pub mod edition;
 #[macro_use]
 pub mod error;
 pub mod mir;

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -7,6 +7,7 @@ use super::mir::{Body, Mutability, Safety};
 use super::{with, DefId, Error, Symbol};
 use crate::abi::{FnAbi, Layout};
 use crate::crate_def::{CrateDef, CrateDefType};
+use crate::edition::Edition;
 use crate::mir::alloc::{read_target_int, read_target_uint, AllocId};
 use crate::mir::mono::StaticDef;
 use crate::target::MachineInfo;
@@ -1317,6 +1318,13 @@ pub enum TraitSpecializationKind {
     AlwaysApplicable,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
+pub enum GatedReceiver {
+    Array,
+    BoxedSlice,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct TraitDecl {
     pub def_id: TraitDef,
@@ -1325,8 +1333,7 @@ pub struct TraitDecl {
     pub has_auto_impl: bool,
     pub is_marker: bool,
     pub is_coinductive: bool,
-    pub skip_array_during_method_dispatch: bool,
-    pub skip_boxed_slice_during_method_dispatch: bool,
+    pub skip_during_method_dispatch: Vec<(GatedReceiver, Edition)>,
     pub specialization_kind: TraitSpecializationKind,
     pub must_implement_one_of: Option<Vec<Ident>>,
     pub implement_via_object: bool,

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -2304,7 +2304,7 @@ impl<'a, I, A: Allocator> !Iterator for &'a Box<[I], A> {}
 #[stable(feature = "boxed_slice_into_iter", since = "1.80.0")]
 impl<'a, I, A: Allocator> !Iterator for &'a mut Box<[I], A> {}
 
-// Note: the `#[rustc_skip_during_method_dispatch(boxed_slice)]` on `trait IntoIterator`
+// Note: the `rustc_skip_during_method_dispatch` attribute on `trait IntoIterator`
 // hides this implementation from explicit `.into_iter()` calls on editions < 2024,
 // so those calls will still resolve to the slice implementation, by reference.
 #[stable(feature = "boxed_slice_into_iter", since = "1.80.0")]

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -35,7 +35,7 @@ pub struct IntoIter<T, const N: usize> {
     alive: IndexRange,
 }
 
-// Note: the `#[rustc_skip_during_method_dispatch(array)]` on `trait IntoIterator`
+// Note: the `rustc_skip_during_method_dispatch` attribute on `trait IntoIterator`
 // hides this implementation from explicit `.into_iter()` calls on editions < 2021,
 // so those calls will still resolve to the slice implementation, by reference.
 #[stable(feature = "array_into_iter_impl", since = "1.53.0")]

--- a/library/core/src/iter/traits/collect.rs
+++ b/library/core/src/iter/traits/collect.rs
@@ -313,7 +313,12 @@ where
     label = "`{Self}` is not an iterator",
     message = "`{Self}` is not an iterator"
 )]
-#[rustc_skip_during_method_dispatch(array, boxed_slice)]
+#[cfg_attr(bootstrap, rustc_skip_during_method_dispatch(array, boxed_slice))]
+#[cfg_attr(not(bootstrap), rustc_skip_during_method_dispatch(receiver = "array", before = "2021"))]
+#[cfg_attr(
+    not(bootstrap),
+    rustc_skip_during_method_dispatch(receiver = "boxed_slice", before = "2024")
+)]
 #[stable(feature = "rust1", since = "1.0.0")]
 pub trait IntoIterator {
     /// The type of the elements being iterated over.


### PR DESCRIPTION
- Removes the implicit assumption that arrays are gated behind edition 2021, and boxed slices behind 2024.
- Addresses `// FIXME: We could probably do way better attribute validation here.`
- Abstracts `array` and `boxed_slice` away to a `GatedReceiver` enum, offering a more convenient extension point for when we run into the "add this impl now, but gate the method call syntax behind an edition" situation again.
- Instead of having a bool field for each possible receiver store a vec[^hash] of all `Receiver` + `Edition` pairs.
- Stable MIR now has a `#[non_exhaustive]` enum for Editions.

Would be cool if this attribute could be applied inside of an impl instead of to the entire trait declaration. This would eliminate the need for the `receiver` in the first place. But that's either something that had already been tried and failed, or a story for another day.

[^hash]: An alternative would be to use a HashMap from receivers to editions, but 99.999% of the time it would be empty (currently `IntoIterator` is the only trait in existence to have this attribute) and the remaining 0.001% it has like two elements, so any asymptotic improvements would probably be crushed by the constant multiplier. Also `ThinVec` is just 1 pointer wide, while `FxHashMap` is 4, IIRC. A bit wasteful.