### PR TITLE
impl `AsRef<[T; N]>` and `AsMut<[T; N]>` for `[T; N]`

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -850,6 +850,24 @@ impl AsMut<str> for str {
     }
 }
 
+#[cfg(not(bootstrap))]
+#[stable(feature = "array_as_ref_impl", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsRef<[T; N]> for [T; N] {
+    #[inline(always)]
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+#[cfg(not(bootstrap))]
+#[stable(feature = "array_as_ref_impl", since = "CURRENT_RUSTC_VERSION")]
+impl<T, const N: usize> AsMut<[T; N]> for [T; N] {
+    #[inline(always)]
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // THE NO-ERROR ERROR TYPE
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #129849.

Apparently `.as_ref()` is widely used on arrays to mean `.as_slice()`, so some Edition sorcery similar to #84147 or #124097 is required.

## TODO
- [x] Add the impl.
- [ ] Wait for #129871 to land and add `#[rustc_skip_during_method_dispatch(..)]`
- [ ] Implement an edition lint (probably suggesting `.as_slice()`)
- [ ] Add some tests similar to #84147.
- [ ] Fix any existing problems (do we have any edition 2024 crates internally yet?) and bless the tests.
- [ ] The bitter tip of a cucumber: write some docs.
