### PR TITLE
chore: Fix typos in 'compiler' (batch 3)

### DIFF
--- a/compiler/rustc_symbol_mangling/src/hashed.rs
+++ b/compiler/rustc_symbol_mangling/src/hashed.rs
@@ -14,7 +14,7 @@ pub(super) fn mangle<'tcx>(
 ) -> String {
     // The symbol of a generic function may be scattered in multiple downstream dylibs.
     // If the symbol of a generic function still contains `crate name`, hash conflicts between the
-    // generic funcion and other symbols of the same `crate` cannot be detected in time during
+    // generic function and other symbols of the same `crate` cannot be detected in time during
     // construction. This symbol conflict is left over until it occurs during run time.
     // In this case, `instantiating-crate name` is used to replace `crate name` can completely
     // eliminate the risk of the preceding potential hash conflict.

--- a/compiler/rustc_target/src/abi/call/xtensa.rs
+++ b/compiler/rustc_target/src/abi/call/xtensa.rs
@@ -26,7 +26,7 @@ where
     // so defer to `classify_arg_ty`.
     let mut arg_gprs_left = NUM_RET_GPRS;
     classify_arg_ty(arg, &mut arg_gprs_left, MAX_RET_IN_REGS_SIZE);
-    // Ret args cannot be passed via stack, we lower to indirect and let the backend handle the invisble reference
+    // Ret args cannot be passed via stack, we lower to indirect and let the backend handle the invisible reference
     match arg.mode {
         super::PassMode::Indirect { attrs: _, meta_attrs: _, ref mut on_stack } => {
             *on_stack = false;

--- a/compiler/rustc_target/src/spec/base/windows_msvc.rs
+++ b/compiler/rustc_target/src/spec/base/windows_msvc.rs
@@ -29,7 +29,7 @@ pub fn opts() -> TargetOptions {
         // they bring in.
         //
         // See also https://learn.microsoft.com/en-us/cpp/preprocessor/comment-c-cpp?view=msvc-170#lib
-        // for documention on including library dependencies in C/C++ code.
+        // for documentation on including library dependencies in C/C++ code.
         no_default_libraries: false,
         has_thread_local: true,
 

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -2148,7 +2148,7 @@ pub struct TargetOptions {
     pub is_like_aix: bool,
     /// Whether the target toolchain is like macOS's. Only useful for compiling against iOS/macOS,
     /// in particular running dsymutil and some other stuff like `-dead_strip`. Defaults to false.
-    /// Also indiates whether to use Apple-specific ABI changes, such as extending function
+    /// Also indicates whether to use Apple-specific ABI changes, such as extending function
     /// parameters to 32-bits.
     pub is_like_osx: bool,
     /// Whether the target toolchain is like Solaris's.

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip2.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip2.rs
@@ -53,7 +53,7 @@ pub fn target() -> Target {
     options.entry_name = "__main_void".into();
 
     // Default to PIC unlike base wasm. This makes precompiled objects such as
-    // the standard library more suitable to be used with shared libaries a la
+    // the standard library more suitable to be used with shared libraries a la
     // emscripten's dynamic linking convention.
     options.relocation_model = RelocModel::Pic;
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -170,7 +170,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         {
                             return guar;
                         }
-                        // Silence redundant errors on binding acccess that are already
+                        // Silence redundant errors on binding access that are already
                         // reported on the binding definition (#56607).
                         if let Err(guar) = self.fn_arg_obligation(&obligation) {
                             return guar;
@@ -900,7 +900,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let mut suggested = false;
         let mut chain = vec![];
 
-        // The following logic is simlar to `point_at_chain`, but that's focused on associated types
+        // The following logic is similar to `point_at_chain`, but that's focused on associated types
         let mut expr = expr;
         while let hir::ExprKind::MethodCall(path_segment, rcvr_expr, args, span) = expr.kind {
             // Point at every method call in the chain with the `Result` type.

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
@@ -878,7 +878,7 @@ impl<'tcx> OnUnimplementedFormatString {
             }
         }
         // we cannot return errors from processing the format string as hard error here
-        // as the diagnostic namespace gurantees that malformed input cannot cause an error
+        // as the diagnostic namespace guarantees that malformed input cannot cause an error
         //
         // if we encounter any error while processing we nevertheless want to show it as warning
         // so that users are aware that something is not correct
@@ -986,10 +986,10 @@ impl<'tcx> OnUnimplementedFormatString {
             })
             .collect();
         // we cannot return errors from processing the format string as hard error here
-        // as the diagnostic namespace gurantees that malformed input cannot cause an error
+        // as the diagnostic namespace guarantees that malformed input cannot cause an error
         //
         // if we encounter any error while processing the format string
-        // we don't want to show the potentially half assembled formated string,
+        // we don't want to show the potentially half assembled formatted string,
         // therefore we fall back to just showing the input string in this case
         //
         // The actual parser errors are emitted earlier

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -4663,7 +4663,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         // because this suggest adding both return type in
         // the `FnSig` and a default return value in the body, so it
         // is not suitable for foreign function without a local body,
-        // and neighter for trait method which may be also implemented
+        // and neither for trait method which may be also implemented
         // in other place, so shouldn't change it's FnSig.
         fn choose_suggest_items<'tcx, 'hir>(
             tcx: TyCtxt<'tcx>,

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -723,7 +723,7 @@ impl<'a, 'tcx> ProofTreeVisitor<'tcx> for AmbiguityCausesVisitor<'a, 'tcx> {
                     // FIXME: While this matches the behavior of the
                     // old solver, it is not the only way in which the unknowable
                     // candidates *weaken* coherence, they can also force otherwise
-                    // sucessful normalization to be ambiguous.
+                    // successful normalization to be ambiguous.
                     Ok(Certainty::Maybe(_) | Certainty::Yes) => {
                         ambiguity_cause = None;
                         break;

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -472,7 +472,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                     };
 
                     match infcx.at(&obligation.cause, obligation.param_env).eq(
-                        // Only really excercised by generic_const_exprs
+                        // Only really exercised by generic_const_exprs
                         DefineOpaqueTypes::Yes,
                         ct_ty,
                         ty,

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -991,7 +991,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     };
 
                     match self.infcx.at(&obligation.cause, obligation.param_env).eq(
-                        // Only really excercised by generic_const_exprs
+                        // Only really exercised by generic_const_exprs
                         DefineOpaqueTypes::Yes,
                         ct_ty,
                         ty,

--- a/compiler/rustc_transmute/src/maybe_transmutable/mod.rs
+++ b/compiler/rustc_transmute/src/maybe_transmutable/mod.rs
@@ -242,7 +242,7 @@ where
                 //   }
                 // ...if `refs_answer` was computed lazily. The below early
                 // returns can be deleted without impacting the correctness of
-                // the algoritm; only its performance.
+                // the algorithm; only its performance.
                 debug!(?bytes_answer);
                 match bytes_answer {
                     Answer::No(_) if !self.assume.validity => return bytes_answer,

--- a/compiler/rustc_type_ir/src/binder.rs
+++ b/compiler/rustc_type_ir/src/binder.rs
@@ -776,7 +776,7 @@ impl<'a, I: Interner> ArgFolder<'a, I> {
     }
 
     /// It is sometimes necessary to adjust the De Bruijn indices during instantiation. This occurs
-    /// when we are instantating a type with escaping bound vars into a context where we have
+    /// when we are instantiating a type with escaping bound vars into a context where we have
     /// passed through binders. That's quite a mouthful. Let's see an example:
     ///
     /// ```

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -162,7 +162,7 @@ pub trait Ty<I: Interner<Ty = Self>>:
 
     /// Returns `true` when the outermost type cannot be further normalized,
     /// resolved, or instantiated. This includes all primitive types, but also
-    /// things like ADTs and trait objects, sice even if their arguments or
+    /// things like ADTs and trait objects, since even if their arguments or
     /// nested types may be further simplified, the outermost [`ty::TyKind`] or
     /// type constructor remains the same.
     fn is_known_rigid(self) -> bool {

--- a/compiler/rustc_type_ir/src/relate.rs
+++ b/compiler/rustc_type_ir/src/relate.rs
@@ -550,7 +550,7 @@ pub fn structurally_relate_tys<I: Interner, R: TypeRelation<I>>(
 /// Any semantic equality, e.g. of unevaluated consts, and inference variables have
 /// to be handled by the caller.
 ///
-/// FIXME: This is not totally structual, which probably should be fixed.
+/// FIXME: This is not totally structural, which probably should be fixed.
 /// See the HACKs below.
 pub fn structurally_relate_consts<I: Interner, R: TypeRelation<I>>(
     relation: &mut R,

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -132,7 +132,7 @@ pub enum GoalSource {
     /// results in better error messages by avoiding spurious errors.
     /// We do not erase overflow constraints in `normalizes-to` goals unless
     /// they are from an impl where-clause. This is necessary due to
-    /// backwards compatability, cc trait-system-refactor-initiatitive#70.
+    /// backwards compatibility, cc trait-system-refactor-initiatitive#70.
     ImplWhereBound,
     /// Instantiating a higher-ranked goal and re-proving it.
     InstantiateHigherRanked,

--- a/compiler/stable_mir/src/abi.rs
+++ b/compiler/stable_mir/src/abi.rs
@@ -70,7 +70,7 @@ pub struct TyAndLayout {
 /// The layout of a type in memory.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize)]
 pub struct LayoutShape {
-    /// The fields location withing the layout
+    /// The fields location within the layout
     pub fields: FieldsShape,
 
     /// Encodes information about multi-variant layouts.

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -267,7 +267,7 @@ impl Span {
         with(|c| c.get_filename(self))
     }
 
-    /// Return lines that corespond to this `Span`
+    /// Return lines that correspond to this `Span`
     pub fn get_lines(&self) -> LineInfo {
         with(|c| c.get_lines(self))
     }


### PR DESCRIPTION
Batch 3/3: Fixes typos in `compiler`

(See [issue](https://github.com/rust-lang/rust/issues/129874) tracking all PRs with typos fixes)