### PR TITLE
Implement struct_target_features.

### DIFF
--- a/compiler/rustc_codegen_gcc/src/attributes.rs
+++ b/compiler/rustc_codegen_gcc/src/attributes.rs
@@ -6,7 +6,7 @@ use rustc_attr::InlineAttr;
 use rustc_attr::InstructionSetAttr;
 #[cfg(feature = "master")]
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
-use rustc_middle::ty;
+use rustc_middle::ty::{self, ParamEnv};
 
 use crate::context::CodegenCx;
 use crate::gcc_util::to_gcc_features;
@@ -70,8 +70,9 @@ pub fn from_fn_attrs<'gcc, 'tcx>(
         }
     }
 
-    let mut function_features = codegen_fn_attrs
-        .target_features
+    let function_features =
+        codegen_fn_attrs.target_features_for_instance(cx.tcx, ParamEnv::reveal_all(), instance);
+    let mut function_features = function_features
         .iter()
         .map(|features| features.name.as_str())
         .flat_map(|feat| to_gcc_features(cx.tcx.sess, feat).into_iter())

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -4,7 +4,7 @@ use rustc_attr::{InlineAttr, InstructionSetAttr, OptimizeAttr};
 use rustc_codegen_ssa::traits::*;
 use rustc_hir::def_id::DefId;
 use rustc_middle::middle::codegen_fn_attrs::{CodegenFnAttrFlags, PatchableFunctionEntry};
-use rustc_middle::ty::{self, TyCtxt};
+use rustc_middle::ty::{self, ParamEnv, TyCtxt};
 use rustc_session::config::{BranchProtection, FunctionReturn, OptLevel, PAuthKey, PacRet};
 use rustc_target::spec::{FramePointer, SanitizerSet, StackProbeType, StackProtector};
 use smallvec::SmallVec;
@@ -499,7 +499,9 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
     to_add.extend(tune_cpu_attr(cx));
 
     let function_features =
-        codegen_fn_attrs.target_features.iter().map(|f| f.name.as_str()).collect::<Vec<&str>>();
+        codegen_fn_attrs.target_features_for_instance(cx.tcx, ParamEnv::reveal_all(), instance);
+    let function_features =
+        function_features.iter().map(|f| f.name.as_str()).collect::<Vec<&str>>();
 
     let function_features = function_features
         .iter()

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -243,7 +243,7 @@ codegen_ssa_symbol_file_write_failure = failed to write symbols file: {$error}
 codegen_ssa_target_feature_disable_or_enable =
     the target features {$features} must all be either enabled or disabled together
 
-codegen_ssa_target_feature_safe_trait = `#[target_feature(..)]` cannot be applied to safe trait method
+codegen_ssa_target_feature_safe_trait = `#[target_feature(enable = ..)]` cannot be applied to safe trait method
     .label = cannot be applied to safe trait method
     .label_def = not an `unsafe` function
 

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -13,7 +13,7 @@ use rustc_middle::middle::codegen_fn_attrs::{
 };
 use rustc_middle::mir::mono::Linkage;
 use rustc_middle::query::Providers;
-use rustc_middle::ty::{self as ty, Ty, TyCtxt};
+use rustc_middle::ty::{self as ty, TyCtxt};
 use rustc_session::parse::feature_err;
 use rustc_session::{Session, lint};
 use rustc_span::symbol::Ident;
@@ -607,13 +607,6 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
                 tcx.param_env(did.to_def_id()).and(*ty),
                 &mut additional_tf,
             )
-        }
-        // FIXME(struct_target_features): is this really necessary?
-        if !additional_tf.is_empty() && sig.skip_binder().abi() != abi::Abi::Rust {
-            tcx.dcx().span_err(
-                tcx.hir().span(tcx.local_def_id_to_hir_id(did)),
-                "cannot use a struct with target features in a function with non-Rust ABI",
-            );
         }
         if !additional_tf.is_empty() && codegen_fn_attrs.inline == InlineAttr::Always {
             tcx.dcx().span_err(

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -137,7 +137,7 @@ fn asm_target_features(tcx: TyCtxt<'_>, did: DefId) -> &FxIndexSet<Symbol> {
     let mut target_features = tcx.sess.unstable_target_features.clone();
     if tcx.def_kind(did).has_codegen_attrs() {
         let attrs = tcx.codegen_fn_attrs(did);
-        target_features.extend(attrs.target_features.iter().map(|feature| feature.name));
+        target_features.extend(attrs.def_target_features.iter().map(|feature| feature.name));
         match attrs.instruction_set {
             None => {}
             Some(InstructionSetAttr::ArmA32) => {

--- a/compiler/rustc_codegen_ssa/src/target_features.rs
+++ b/compiler/rustc_codegen_ssa/src/target_features.rs
@@ -20,6 +20,7 @@ pub(crate) fn from_target_feature(
     attr: &ast::Attribute,
     supported_target_features: &UnordMap<String, Option<Symbol>>,
     target_features: &mut Vec<TargetFeature>,
+    mut features_from_args: Option<&mut bool>,
 ) {
     let Some(list) = attr.meta_item_list() else { return };
     let bad_item = |span| {
@@ -33,6 +34,14 @@ pub(crate) fn from_target_feature(
     let rust_features = tcx.features();
     let mut added_target_features = Vec::new();
     for item in list {
+        if let Some(ref mut from_args) = features_from_args
+            && item.ident().is_some_and(|x| x.name == sym::from_args)
+            && tcx.features().struct_target_features
+        {
+            **from_args = true;
+            continue;
+        }
+
         // Only `enable = ...` is accepted in the meta-item list.
         if !item.has_name(sym::enable) {
             bad_item(item.span());
@@ -144,7 +153,7 @@ fn asm_target_features(tcx: TyCtxt<'_>, did: DefId) -> &FxIndexSet<Symbol> {
     tcx.arena.alloc(target_features)
 }
 
-/// Checks the function annotated with `#[target_feature]` is not a safe
+/// Checks the function annotated with `#[target_feature(enable = ...)]` is not a safe
 /// trait method implementation, reporting an error if it is.
 pub(crate) fn check_target_feature_trait_unsafe(tcx: TyCtxt<'_>, id: LocalDefId, attr_span: Span) {
     if let DefKind::AssocFn = tcx.def_kind(id) {

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -601,6 +601,8 @@ declare_features! (
     (unstable, strict_provenance, "1.61.0", Some(95228)),
     /// Allows string patterns to dereference values to match them.
     (unstable, string_deref_patterns, "1.67.0", Some(87121)),
+    /// Allows structs to carry target_feature information.
+    (incomplete, struct_target_features, "CURRENT_RUSTC_VERSION", Some(129107)),
     /// Allows the use of `#[target_feature]` on safe functions.
     (unstable, target_feature_11, "1.45.0", Some(69098)),
     /// Allows using `#[thread_local]` on `static` items.

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -329,6 +329,43 @@ impl DefKind {
             | DefKind::ExternCrate => false,
         }
     }
+
+    /// Whether `query struct_target_features` should be used with this definition.
+    pub fn has_struct_target_features(self) -> bool {
+        match self {
+            DefKind::Struct => true,
+            DefKind::Fn
+            | DefKind::Union
+            | DefKind::Enum
+            | DefKind::AssocFn
+            | DefKind::Ctor(..)
+            | DefKind::Closure
+            | DefKind::Static { .. }
+            | DefKind::Mod
+            | DefKind::Variant
+            | DefKind::Trait
+            | DefKind::TyAlias
+            | DefKind::ForeignTy
+            | DefKind::TraitAlias
+            | DefKind::AssocTy
+            | DefKind::Const
+            | DefKind::AssocConst
+            | DefKind::Macro(..)
+            | DefKind::Use
+            | DefKind::ForeignMod
+            | DefKind::OpaqueTy
+            | DefKind::Impl { .. }
+            | DefKind::Field
+            | DefKind::TyParam
+            | DefKind::ConstParam
+            | DefKind::LifetimeParam
+            | DefKind::AnonConst
+            | DefKind::InlineConst
+            | DefKind::SyntheticCoroutineBody
+            | DefKind::GlobalAsm
+            | DefKind::ExternCrate => false,
+        }
+    }
 }
 
 /// The resolution of a path or export.

--- a/compiler/rustc_hir_analysis/src/check/entry.rs
+++ b/compiler/rustc_hir_analysis/src/check/entry.rs
@@ -105,7 +105,7 @@ fn check_main_fn_ty(tcx: TyCtxt<'_>, main_def_id: DefId) {
         error = true;
     }
 
-    if !tcx.codegen_fn_attrs(main_def_id).target_features.is_empty()
+    if !tcx.codegen_fn_attrs(main_def_id).def_target_features.is_empty()
         // Calling functions with `#[target_feature]` is not unsafe on WASM, see #84988
         && !tcx.sess.target.is_like_wasm
         && !tcx.sess.opts.actually_rustdoc

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -920,12 +920,15 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                         return Err(TypeError::IntrinsicCast);
                     }
 
-                    // Safe `#[target_feature]` functions are not assignable to safe fn pointers (RFC 2396).
-                    // FIXME(struct_target_features): should this be true also for functions that inherit
-                    // target features from structs?
-
+                    // Safe functions with explicit `#[target_feature]` attributes are not
+                    // assignable to safe fn pointers (RFC 2396).
                     if b_hdr.safety == hir::Safety::Safe
-                        && !self.tcx.codegen_fn_attrs(def_id).target_features.is_empty()
+                        && self
+                            .tcx
+                            .codegen_fn_attrs(def_id)
+                            .target_features
+                            .iter()
+                            .any(|x| !x.implied)
                     {
                         return Err(TypeError::TargetFeatureCast(def_id));
                     }

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -926,7 +926,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                         && self
                             .tcx
                             .codegen_fn_attrs(def_id)
-                            .target_features
+                            .def_target_features
                             .iter()
                             .any(|x| !x.implied)
                     {

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -921,6 +921,8 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                     }
 
                     // Safe `#[target_feature]` functions are not assignable to safe fn pointers (RFC 2396).
+                    // FIXME(struct_target_features): should this be true also for functions that inherit
+                    // target features from structs?
 
                     if b_hdr.safety == hir::Safety::Safe
                         && !self.tcx.codegen_fn_attrs(def_id).target_features.is_empty()

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -254,6 +254,7 @@ provide! { tcx, def_id, other, cdata,
     variances_of => { table }
     fn_sig => { table }
     codegen_fn_attrs => { table }
+    struct_target_features => { table_defaulted_array }
     impl_trait_header => { table }
     const_param_default => { table }
     object_lifetime_default => { table }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1401,6 +1401,9 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
             if def_kind.has_codegen_attrs() {
                 record!(self.tables.codegen_fn_attrs[def_id] <- self.tcx.codegen_fn_attrs(def_id));
             }
+            if def_kind.has_struct_target_features() {
+                record_defaulted_array!(self.tables.struct_target_features[def_id] <- self.tcx.struct_target_features(def_id));
+            }
             if should_encode_visibility(def_kind) {
                 let vis =
                     self.tcx.local_visibility(local_id).map_id(|def_id| def_id.local_def_index);

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -19,7 +19,7 @@ use rustc_macros::{
     Decodable, Encodable, MetadataDecodable, MetadataEncodable, TyDecodable, TyEncodable,
 };
 use rustc_middle::metadata::ModChild;
-use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrs;
+use rustc_middle::middle::codegen_fn_attrs::{CodegenFnAttrs, TargetFeature};
 use rustc_middle::middle::debugger_visualizer::DebuggerVisualizerFile;
 use rustc_middle::middle::exported_symbols::{ExportedSymbol, SymbolExportInfo};
 use rustc_middle::middle::lib_features::FeatureStability;
@@ -404,6 +404,7 @@ define_tables! {
     // individually instead of `DefId`s.
     module_children_reexports: Table<DefIndex, LazyArray<ModChild>>,
     cross_crate_inlinable: Table<DefIndex, bool>,
+    struct_target_features: Table<DefIndex, LazyArray<TargetFeature>>,
 
 - optional:
     attributes: Table<DefIndex, LazyArray<ast::Attribute>>,

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -26,8 +26,8 @@ pub struct CodegenFnAttrs {
     /// be set when `link_name` is set. This is for foreign items with the
     /// "raw-dylib" kind.
     pub link_ordinal: Option<u16>,
-    /// The `#[target_feature(enable = "...")]` attribute and the enabled
-    /// features (only enabled features are supported right now).
+    /// All the target features that are enabled for this function. Some features might be enabled
+    /// implicitly.
     pub target_features: Vec<TargetFeature>,
     /// The `#[linkage = "..."]` attribute on Rust-defined items and the value we found.
     pub linkage: Option<Linkage>,
@@ -55,8 +55,8 @@ pub struct CodegenFnAttrs {
 pub struct TargetFeature {
     /// The name of the target feature (e.g. "avx")
     pub name: Symbol,
-    /// The feature is implied by another feature, rather than explicitly added by the
-    /// `#[target_feature]` attribute
+    /// The feature is implied by another feature or by an argument, rather than explicitly
+    /// added by the `#[target_feature]` attribute
     pub implied: bool,
 }
 

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -49,6 +49,8 @@ pub struct CodegenFnAttrs {
     /// The `#[patchable_function_entry(...)]` attribute. Indicates how many nops should be around
     /// the function entry.
     pub patchable_function_entry: Option<PatchableFunctionEntry>,
+    /// Whether the target features can be extended through the arguments of the function.
+    pub target_features_from_args: bool,
 }
 
 #[derive(Copy, Clone, Debug, TyEncodable, TyDecodable, HashStable)]
@@ -156,6 +158,7 @@ impl CodegenFnAttrs {
             instruction_set: None,
             alignment: None,
             patchable_function_entry: None,
+            target_features_from_args: false,
         }
     }
 

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -48,7 +48,7 @@ use {rustc_ast as ast, rustc_attr as attr, rustc_hir as hir};
 use crate::infer::canonical::{self, Canonical};
 use crate::lint::LintExpectation;
 use crate::metadata::ModChild;
-use crate::middle::codegen_fn_attrs::CodegenFnAttrs;
+use crate::middle::codegen_fn_attrs::{CodegenFnAttrs, TargetFeature};
 use crate::middle::debugger_visualizer::DebuggerVisualizerFile;
 use crate::middle::exported_symbols::{ExportedSymbol, SymbolExportInfo};
 use crate::middle::lib_features::LibFeatures;
@@ -1254,6 +1254,15 @@ rustc_queries! {
         cache_on_disk_if { def_id.is_local() }
         separate_provide_extern
         feedable
+    }
+
+    query struct_target_features(def_id: DefId) -> &'tcx [TargetFeature] {
+        separate_provide_extern
+        desc { |tcx| "computing target features for struct `{}`", tcx.def_path_str(def_id) }
+    }
+
+    query struct_reachable_target_features(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> &'tcx [TargetFeature] {
+        desc { |tcx| "computing target features reachable from {}", env.value }
     }
 
     query asm_target_features(def_id: DefId) -> &'tcx FxIndexSet<Symbol> {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1261,10 +1261,6 @@ rustc_queries! {
         desc { |tcx| "computing target features for struct `{}`", tcx.def_path_str(def_id) }
     }
 
-    query struct_reachable_target_features(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> &'tcx [TargetFeature] {
-        desc { |tcx| "computing target features reachable from {}", env.value }
-    }
-
     query asm_target_features(def_id: DefId) -> &'tcx FxIndexSet<Symbol> {
         desc { |tcx| "computing target features for inline asm of `{}`", tcx.def_path_str(def_id) }
     }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -364,7 +364,7 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     }
 
     fn has_target_features(self, def_id: DefId) -> bool {
-        !self.codegen_fn_attrs(def_id).target_features.is_empty()
+        !self.codegen_fn_attrs(def_id).def_target_features.is_empty()
     }
 
     fn require_lang_item(self, lang_item: TraitSolverLangItem) -> DefId {

--- a/compiler/rustc_middle/src/ty/parameterized.rs
+++ b/compiler/rustc_middle/src/ty/parameterized.rs
@@ -59,6 +59,7 @@ trivially_parameterized_over_tcx! {
     std::string::String,
     crate::metadata::ModChild,
     crate::middle::codegen_fn_attrs::CodegenFnAttrs,
+    crate::middle::codegen_fn_attrs::TargetFeature,
     crate::middle::debugger_visualizer::DebuggerVisualizerFile,
     crate::middle::exported_symbols::SymbolExportInfo,
     crate::middle::lib_features::FeatureStability,

--- a/compiler/rustc_mir_build/messages.ftl
+++ b/compiler/rustc_mir_build/messages.ftl
@@ -125,6 +125,37 @@ mir_build_initializing_type_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed 
     .note = initializing a layout restricted type's field with a value outside the valid range is undefined behavior
     .label = initializing type with `rustc_layout_scalar_valid_range` attr
 
+mir_build_initializing_type_with_target_feature_requires_unsafe =
+    initializing type `{$adt}` with `#[target_feature]` is unsafe and requires unsafe block
+    .help = in order for the call to be safe, the context requires the following additional target {$missing_target_features_count ->
+        [1] feature
+        *[count] features
+        }: {$missing_target_features}
+    .note = the {$build_target_features} target {$build_target_features_count ->
+        [1] feature
+        *[count] features
+        } being enabled in the build configuration does not remove the requirement to list {$build_target_features_count ->
+        [1] it
+        *[count] them
+        } in `#[target_feature]`
+    .label = call to function with `#[target_feature]`
+
+mir_build_initializing_type_with_target_feature_requires_unsafe_unsafe_op_in_unsafe_fn_allowed =
+    initializing type `{$adt}` with `#[target_feature]` is unsafe and requires unsafe function or block
+    .help = in order for the call to be safe, the context requires the following additional target {$missing_target_features_count ->
+        [1] feature
+        *[count] features
+        }: {$missing_target_features}
+    .note = the {$build_target_features} target {$build_target_features_count ->
+        [1] feature
+        *[count] features
+        } being enabled in the build configuration does not remove the requirement to list {$build_target_features_count ->
+        [1] it
+        *[count] them
+        } in `#[target_feature]`
+    .label = call to function with `#[target_feature]`
+
+
 mir_build_inline_assembly_requires_unsafe =
     use of inline assembly is unsafe and requires unsafe block
     .note = inline assembly is entirely unchecked and can cause undefined behavior
@@ -387,6 +418,21 @@ mir_build_unsafe_op_in_unsafe_fn_initializing_type_with_requires_unsafe =
     initializing type with `rustc_layout_scalar_valid_range` attr is unsafe and requires unsafe block
     .note = initializing a layout restricted type's field with a value outside the valid range is undefined behavior
     .label = initializing type with `rustc_layout_scalar_valid_range` attr
+
+mir_build_unsafe_op_in_unsafe_fn_initializing_type_with_target_feature_requires_unsafe =
+    initializing type `{$adt}` with `#[target_feature]` is unsafe and requires unsafe block
+    .help = in order for the call to be safe, the context requires the following additional target {$missing_target_features_count ->
+        [1] feature
+        *[count] features
+        }: {$missing_target_features}
+    .note = the {$build_target_features} target {$build_target_features_count ->
+        [1] feature
+        *[count] features
+        } being enabled in the build configuration does not remove the requirement to list {$build_target_features_count ->
+        [1] it
+        *[count] them
+        } in `#[target_feature]`
+    .label = call to function with `#[target_feature]`
 
 mir_build_unsafe_op_in_unsafe_fn_inline_assembly_requires_unsafe =
     use of inline assembly is unsafe and requires unsafe block

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -469,14 +469,18 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                     };
                     self.requires_unsafe(expr.span, CallToUnsafeFunction(func_id));
                 } else if let &ty::FnDef(func_did, _) = self.thir[fun].ty.kind() {
-                    // If the called function has target features the calling function hasn't,
+                    // If the called function has explicit target features the calling function hasn't,
                     // the call requires `unsafe`. Don't check this on wasm
                     // targets, though. For more information on wasm see the
                     // is_like_wasm check in hir_analysis/src/collect.rs
+                    // Implicit target features are OK because they are either a consequence of some
+                    // explicit target feature (which is checked to be present in the caller) or
+                    // come from a witness argument.
                     let callee_features = &self.tcx.codegen_fn_attrs(func_did).target_features;
                     if !self.tcx.sess.target.options.is_like_wasm
                         && !callee_features.iter().all(|feature| {
-                            self.body_target_features.iter().any(|f| f.name == feature.name)
+                            feature.implied
+                                || self.body_target_features.iter().any(|f| f.name == feature.name)
                         })
                     {
                         let missing: Vec<_> = callee_features
@@ -551,10 +555,52 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                 user_ty: _,
                 fields: _,
                 base: _,
-            }) => match self.tcx.layout_scalar_valid_range(adt_def.did()) {
-                (Bound::Unbounded, Bound::Unbounded) => {}
-                _ => self.requires_unsafe(expr.span, InitializingTypeWith),
-            },
+            }) => {
+                match self.tcx.layout_scalar_valid_range(adt_def.did()) {
+                    (Bound::Unbounded, Bound::Unbounded) => {}
+                    _ => self.requires_unsafe(expr.span, InitializingTypeWith),
+                }
+                let struct_features = self.tcx.struct_target_features(adt_def.did());
+                if !struct_features.is_empty() {
+                    if !self.tcx.sess.target.options.is_like_wasm
+                        && !struct_features.iter().all(|feature| {
+                            feature.implied
+                                || self.body_target_features.iter().any(|f| f.name == feature.name)
+                        })
+                    {
+                        // Matches the logic for calling non-unsafe `target_feature` functions.
+                        let missing: Vec<_> = struct_features
+                            .iter()
+                            .copied()
+                            .filter(|feature| {
+                                !feature.implied
+                                    && !self
+                                        .body_target_features
+                                        .iter()
+                                        .any(|body_feature| body_feature.name == feature.name)
+                            })
+                            .map(|feature| feature.name)
+                            .collect();
+                        let build_enabled = self
+                            .tcx
+                            .sess
+                            .target_features
+                            .iter()
+                            .copied()
+                            .filter(|feature| missing.contains(feature))
+                            .collect();
+                        self.requires_unsafe(
+                            expr.span,
+                            ConstructingTargetFeaturesTypeWith {
+                                adt: adt_def.did(),
+                                missing,
+                                build_enabled,
+                            },
+                        );
+                    }
+                }
+            }
+
             ExprKind::Closure(box ClosureExpr {
                 closure_id,
                 args: _,
@@ -656,6 +702,15 @@ enum UnsafeOpKind {
     CallToUnsafeFunction(Option<DefId>),
     UseOfInlineAssembly,
     InitializingTypeWith,
+    ConstructingTargetFeaturesTypeWith {
+        adt: DefId,
+        /// Target features enabled in callee's `#[target_feature]` but missing in
+        /// caller's `#[target_feature]`.
+        missing: Vec<Symbol>,
+        /// Target features in `missing` that are enabled at compile time
+        /// (e.g., with `-C target-feature`).
+        build_enabled: Vec<Symbol>,
+    },
     UseOfMutableStatic,
     UseOfExternStatic,
     DerefOfRawPointer,
@@ -737,6 +792,29 @@ impl UnsafeOpKind {
                     unsafe_not_inherited_note,
                 },
             ),
+            ConstructingTargetFeaturesTypeWith { adt, missing, build_enabled } => tcx
+                .emit_node_span_lint(
+                    UNSAFE_OP_IN_UNSAFE_FN,
+                    hir_id,
+                    span,
+                    UnsafeOpInUnsafeFnInitializingTypeWithTargetFeatureRequiresUnsafe {
+                        span,
+                        adt: with_no_trimmed_paths!(tcx.def_path_str(*adt)),
+                        missing_target_features: DiagArgValue::StrListSepByAnd(
+                            missing.iter().map(|feature| Cow::from(feature.to_string())).collect(),
+                        ),
+                        missing_target_features_count: missing.len(),
+                        note: !build_enabled.is_empty(),
+                        build_target_features: DiagArgValue::StrListSepByAnd(
+                            build_enabled
+                                .iter()
+                                .map(|feature| Cow::from(feature.to_string()))
+                                .collect(),
+                        ),
+                        build_target_features_count: build_enabled.len(),
+                        unsafe_not_inherited_note,
+                    },
+                ),
             UseOfMutableStatic => tcx.emit_node_span_lint(
                 UNSAFE_OP_IN_UNSAFE_FN,
                 hir_id,
@@ -891,6 +969,48 @@ impl UnsafeOpKind {
             InitializingTypeWith => {
                 dcx.emit_err(InitializingTypeWithRequiresUnsafe {
                     span,
+                    unsafe_not_inherited_note,
+                });
+            }
+            ConstructingTargetFeaturesTypeWith { adt, missing, build_enabled }
+                if unsafe_op_in_unsafe_fn_allowed =>
+            {
+                dcx.emit_err(
+                    InitializingTypeWithTargetFeatureRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
+                        span,
+                        adt: with_no_trimmed_paths!(tcx.def_path_str(*adt)),
+                        missing_target_features: DiagArgValue::StrListSepByAnd(
+                            missing.iter().map(|feature| Cow::from(feature.to_string())).collect(),
+                        ),
+                        missing_target_features_count: missing.len(),
+                        note: !build_enabled.is_empty(),
+                        build_target_features: DiagArgValue::StrListSepByAnd(
+                            build_enabled
+                                .iter()
+                                .map(|feature| Cow::from(feature.to_string()))
+                                .collect(),
+                        ),
+                        build_target_features_count: build_enabled.len(),
+                        unsafe_not_inherited_note,
+                    },
+                );
+            }
+            ConstructingTargetFeaturesTypeWith { adt, missing, build_enabled } => {
+                dcx.emit_err(InitializingTypeWithTargetFeatureRequiresUnsafe {
+                    span,
+                    adt: with_no_trimmed_paths!(tcx.def_path_str(*adt)),
+                    missing_target_features: DiagArgValue::StrListSepByAnd(
+                        missing.iter().map(|feature| Cow::from(feature.to_string())).collect(),
+                    ),
+                    missing_target_features_count: missing.len(),
+                    note: !build_enabled.is_empty(),
+                    build_target_features: DiagArgValue::StrListSepByAnd(
+                        build_enabled
+                            .iter()
+                            .map(|feature| Cow::from(feature.to_string()))
+                            .collect(),
+                    ),
+                    build_target_features_count: build_enabled.len(),
                     unsafe_not_inherited_note,
                 });
             }

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -476,7 +476,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                     // Implicit target features are OK because they are either a consequence of some
                     // explicit target feature (which is checked to be present in the caller) or
                     // come from a witness argument.
-                    let callee_features = &self.tcx.codegen_fn_attrs(func_did).target_features;
+                    let callee_features = &self.tcx.codegen_fn_attrs(func_did).def_target_features;
                     if !self.tcx.sess.target.options.is_like_wasm
                         && !callee_features.iter().all(|feature| {
                             feature.implied
@@ -1143,7 +1143,7 @@ pub(crate) fn check_unsafety(tcx: TyCtxt<'_>, def: LocalDefId) {
             SafetyContext::Safe
         }
     });
-    let body_target_features = &tcx.body_codegen_attrs(def.to_def_id()).target_features;
+    let body_target_features = &tcx.body_codegen_attrs(def.to_def_id()).def_target_features;
     let mut warnings = Vec::new();
     let mut visitor = UnsafetyVisitor {
         tcx,

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -589,14 +589,11 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
                             .copied()
                             .filter(|feature| missing.contains(feature))
                             .collect();
-                        self.requires_unsafe(
-                            expr.span,
-                            ConstructingTargetFeaturesTypeWith {
-                                adt: adt_def.did(),
-                                missing,
-                                build_enabled,
-                            },
-                        );
+                        self.requires_unsafe(expr.span, ConstructingTargetFeaturesTypeWith {
+                            adt: adt_def.did(),
+                            missing,
+                            build_enabled,
+                        });
                     }
                 }
             }

--- a/compiler/rustc_mir_build/src/errors.rs
+++ b/compiler/rustc_mir_build/src/errors.rs
@@ -87,6 +87,23 @@ pub(crate) struct UnsafeOpInUnsafeFnInitializingTypeWithRequiresUnsafe {
 }
 
 #[derive(LintDiagnostic)]
+#[diag(mir_build_unsafe_op_in_unsafe_fn_initializing_type_with_target_feature_requires_unsafe, code = E0133)]
+#[note]
+pub(crate) struct UnsafeOpInUnsafeFnInitializingTypeWithTargetFeatureRequiresUnsafe {
+    #[label]
+    pub(crate) span: Span,
+    pub(crate) adt: String,
+    pub(crate) missing_target_features: DiagArgValue,
+    pub(crate) missing_target_features_count: usize,
+    #[note]
+    pub(crate) note: bool,
+    pub(crate) build_target_features: DiagArgValue,
+    pub(crate) build_target_features_count: usize,
+    #[subdiagnostic]
+    pub(crate) unsafe_not_inherited_note: Option<UnsafeNotInheritedLintNote>,
+}
+
+#[derive(LintDiagnostic)]
 #[diag(mir_build_unsafe_op_in_unsafe_fn_mutable_static_requires_unsafe, code = E0133)]
 #[note]
 pub(crate) struct UnsafeOpInUnsafeFnUseOfMutableStaticRequiresUnsafe {
@@ -251,6 +268,24 @@ pub(crate) struct InitializingTypeWithRequiresUnsafe {
 }
 
 #[derive(Diagnostic)]
+#[diag(mir_build_initializing_type_with_target_feature_requires_unsafe, code = E0133)]
+#[note]
+pub(crate) struct InitializingTypeWithTargetFeatureRequiresUnsafe {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+    pub(crate) adt: String,
+    pub(crate) missing_target_features: DiagArgValue,
+    pub(crate) missing_target_features_count: usize,
+    #[note]
+    pub(crate) note: bool,
+    pub(crate) build_target_features: DiagArgValue,
+    pub(crate) build_target_features_count: usize,
+    #[subdiagnostic]
+    pub(crate) unsafe_not_inherited_note: Option<UnsafeNotInheritedNote>,
+}
+
+#[derive(Diagnostic)]
 #[diag(
     mir_build_initializing_type_with_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
     code = E0133
@@ -260,6 +295,27 @@ pub(crate) struct InitializingTypeWithRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
     #[primary_span]
     #[label]
     pub(crate) span: Span,
+    #[subdiagnostic]
+    pub(crate) unsafe_not_inherited_note: Option<UnsafeNotInheritedNote>,
+}
+
+#[derive(Diagnostic)]
+#[diag(
+    mir_build_initializing_type_with_target_feature_requires_unsafe_unsafe_op_in_unsafe_fn_allowed,
+    code = E0133
+)]
+#[note]
+pub(crate) struct InitializingTypeWithTargetFeatureRequiresUnsafeUnsafeOpInUnsafeFnAllowed {
+    #[primary_span]
+    #[label]
+    pub(crate) span: Span,
+    pub(crate) adt: String,
+    pub(crate) missing_target_features: DiagArgValue,
+    pub(crate) missing_target_features_count: usize,
+    #[note]
+    pub(crate) note: bool,
+    pub(crate) build_target_features: DiagArgValue,
+    pub(crate) build_target_features_count: usize,
     #[subdiagnostic]
     pub(crate) unsafe_not_inherited_note: Option<UnsafeNotInheritedNote>,
 }

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -669,6 +669,10 @@ passes_should_be_applied_to_fn =
         *[false] not a function definition
     }
 
+passes_should_be_applied_to_fn_or_struct =
+    attribute should be applied to a function definition or struct
+    .label = not a function definition or a struct
+
 passes_should_be_applied_to_static =
     attribute should be applied to a static
     .label = not a static

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -701,6 +701,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                     });
                 }
             }
+            Target::Struct if self.tcx.features().struct_target_features => {}
             Target::Method(MethodKind::Trait { body: true } | MethodKind::Inherent) => {}
             // FIXME: #[target_feature] was previously erroneously allowed on statements and some
             // crates used this, so only emit a warning.
@@ -720,11 +721,18 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 self.inline_attr_str_error_with_macro_def(hir_id, attr, "target_feature");
             }
             _ => {
-                self.dcx().emit_err(errors::AttrShouldBeAppliedToFn {
-                    attr_span: attr.span,
-                    defn_span: span,
-                    on_crate: hir_id == CRATE_HIR_ID,
-                });
+                if self.tcx.features().struct_target_features {
+                    self.dcx().emit_err(errors::AttrShouldBeAppliedToFnOrStruct {
+                        attr_span: attr.span,
+                        defn_span: span,
+                    });
+                } else {
+                    self.dcx().emit_err(errors::AttrShouldBeAppliedToFn {
+                        attr_span: attr.span,
+                        defn_span: span,
+                        on_crate: hir_id == CRATE_HIR_ID,
+                    });
+                }
             }
         }
     }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -83,6 +83,15 @@ pub(crate) struct AttrShouldBeAppliedToFn {
 }
 
 #[derive(Diagnostic)]
+#[diag(passes_should_be_applied_to_fn_or_struct)]
+pub(crate) struct AttrShouldBeAppliedToFnOrStruct {
+    #[primary_span]
+    pub attr_span: Span,
+    #[label]
+    pub defn_span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(passes_should_be_applied_to_fn, code = E0739)]
 pub(crate) struct TrackedCallerWrongLocation {
     #[primary_span]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1919,6 +1919,7 @@ symbols! {
         stringify,
         struct_field_attributes,
         struct_inherit,
+        struct_target_features,
         struct_variant,
         structural_match,
         structural_peq,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -946,6 +946,7 @@ symbols! {
         frem_algebraic,
         frem_fast,
         from,
+        from_args,
         from_desugaring,
         from_fn,
         from_iter,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -464,7 +464,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         let is_target_feature_fn = if let ty::FnDef(def_id, _) =
                             *leaf_trait_ref.skip_binder().self_ty().kind()
                         {
-                            self.tcx.codegen_fn_attrs(def_id).target_features.iter().any(|x| !x.implied)
+                            self.tcx.codegen_fn_attrs(def_id).def_target_features.iter().any(|x| !x.implied)
                         } else {
                             false
                         };

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -464,9 +464,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         let is_target_feature_fn = if let ty::FnDef(def_id, _) =
                             *leaf_trait_ref.skip_binder().self_ty().kind()
                         {
-                            // FIXME(struct_target_features): should a function that inherits
-                            // target_features through arguments implement Fn traits?
-                            !self.tcx.codegen_fn_attrs(def_id).target_features.is_empty()
+                            self.tcx.codegen_fn_attrs(def_id).target_features.iter().any(|x| !x.implied)
                         } else {
                             false
                         };

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -464,6 +464,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         let is_target_feature_fn = if let ty::FnDef(def_id, _) =
                             *leaf_trait_ref.skip_binder().self_ty().kind()
                         {
+                            // FIXME(struct_target_features): should a function that inherits
+                            // target_features through arguments implement Fn traits?
                             !self.tcx.codegen_fn_attrs(def_id).target_features.is_empty()
                         } else {
                             false

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -546,13 +546,12 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         .push(FnPointerCandidate { fn_host_effect: self.tcx().consts.true_ });
                 }
             }
-            // Provide an impl for suitable functions, rejecting `#[target_feature]` functions (RFC 2396).
+            // Provide an impl for suitable functions, rejecting functions with explicit
+            // `#[target_feature]` attributes (RFC 2396).
             ty::FnDef(def_id, args) => {
                 let tcx = self.tcx();
-                // FIXME(struct_target_features): should a function that inherits target_features
-                // through an argument implement Fn traits?
                 if tcx.fn_sig(def_id).skip_binder().is_fn_trait_compatible()
-                    && tcx.codegen_fn_attrs(def_id).target_features.is_empty()
+                    && !tcx.codegen_fn_attrs(def_id).target_features.iter().any(|x| !x.implied)
                 {
                     candidates.vec.push(FnPointerCandidate {
                         fn_host_effect: tcx

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -549,6 +549,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             // Provide an impl for suitable functions, rejecting `#[target_feature]` functions (RFC 2396).
             ty::FnDef(def_id, args) => {
                 let tcx = self.tcx();
+                // FIXME(struct_target_features): should a function that inherits target_features
+                // through an argument implement Fn traits?
                 if tcx.fn_sig(def_id).skip_binder().is_fn_trait_compatible()
                     && tcx.codegen_fn_attrs(def_id).target_features.is_empty()
                 {

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -482,7 +482,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::FnDef(def_id, _) => {
                 let tcx = self.tcx();
                 if tcx.fn_sig(def_id).skip_binder().is_fn_trait_compatible()
-                    && tcx.codegen_fn_attrs(def_id).target_features.is_empty()
+                    && tcx.codegen_fn_attrs(def_id).def_target_features.is_empty()
                 {
                     candidates.vec.push(AsyncClosureCandidate);
                 }
@@ -551,7 +551,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             ty::FnDef(def_id, args) => {
                 let tcx = self.tcx();
                 if tcx.fn_sig(def_id).skip_binder().is_fn_trait_compatible()
-                    && !tcx.codegen_fn_attrs(def_id).target_features.iter().any(|x| !x.implied)
+                    && !tcx.codegen_fn_attrs(def_id).def_target_features.iter().any(|x| !x.implied)
                 {
                     candidates.vec.push(FnPointerCandidate {
                         fn_host_effect: tcx

--- a/src/doc/unstable-book/src/language-features/struct-target-features.md
+++ b/src/doc/unstable-book/src/language-features/struct-target-features.md
@@ -1,0 +1,7 @@
+# `struct_target_features`
+
+The tracking issue for this feature is: [#129107]
+
+[#129107]: https://github.com/rust-lang/rust/issues/129107
+
+------------------------

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -15,7 +15,9 @@ use rustc_data_structures::fx::{FxHashMap, FxHashSet};
 use rustc_data_structures::static_assert_size;
 use rustc_middle::mir;
 use rustc_middle::query::TyCtxtAt;
-use rustc_middle::ty::layout::{HasTyCtxt, LayoutCx, LayoutError, LayoutOf, TyAndLayout};
+use rustc_middle::ty::layout::{
+    HasParamEnv, HasTyCtxt, LayoutCx, LayoutError, LayoutOf, TyAndLayout,
+};
 use rustc_middle::ty::{self, Instance, Ty, TyCtxt};
 use rustc_session::config::InliningThreshold;
 use rustc_span::def_id::{CrateNum, DefId};
@@ -964,12 +966,12 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
     ) -> InterpResult<'tcx> {
         let attrs = ecx.tcx.codegen_fn_attrs(instance.def_id());
         if attrs
-            .target_features
+            .target_features_for_instance(ecx.tcx.tcx, ecx.param_env(), instance)
             .iter()
             .any(|feature| !ecx.tcx.sess.target_features.contains(&feature.name))
         {
             let unavailable = attrs
-                .target_features
+                .target_features_for_instance(ecx.tcx.tcx, ecx.param_env(), instance)
                 .iter()
                 .filter(|&feature| {
                     !feature.implied && !ecx.tcx.sess.target_features.contains(&feature.name)

--- a/tests/assembly/struct-target-features.rs
+++ b/tests/assembly/struct-target-features.rs
@@ -37,3 +37,15 @@ pub fn add_fma_combined(_: &Avx, _: &Fma, v: __m256) -> (__m256, __m256) {
     let r2 = unsafe { _mm256_fmadd_ps(v, v, v) };
     (r1, r2)
 }
+
+#[target_feature(from_args)]
+fn add_generic<S>(_: S, v: __m256) -> __m256 {
+    // CHECK-NOT: call
+    // CHECK: vaddps
+    unsafe { _mm256_add_ps(v, v) }
+}
+
+pub fn add_using_generic(v: __m256) -> __m256 {
+    assert!(is_x86_feature_detected!("avx"));
+    add_generic(unsafe { Avx {} }, v)
+}

--- a/tests/assembly/struct-target-features.rs
+++ b/tests/assembly/struct-target-features.rs
@@ -1,0 +1,31 @@
+//@ compile-flags: -O
+//@ assembly-output: emit-asm
+//@ only-x86_64
+
+#![crate_type = "lib"]
+#![feature(struct_target_features)]
+
+// Check that a struct_target_features type causes the compiler to effectively inline intrinsics.
+
+use std::arch::x86_64::*;
+
+#[target_feature(enable = "avx")]
+struct Avx {}
+
+#[target_feature(enable = "fma")]
+struct Fma {}
+
+pub fn add_simple(_: Avx, v: __m256) -> __m256 {
+    // CHECK-NOT: call
+    // CHECK: vaddps
+    unsafe { _mm256_add_ps(v, v) }
+}
+
+pub fn add_fma_combined(_: &Avx, _: &Fma, v: __m256) -> (__m256, __m256) {
+    // CHECK-NOT: call
+    // CHECK-DAG: vaddps
+    let r1 = unsafe { _mm256_add_ps(v, v) };
+    // CHECK-DAG: vfmadd213ps
+    let r2 = unsafe { _mm256_fmadd_ps(v, v, v) };
+    (r1, r2)
+}

--- a/tests/assembly/struct-target-features.rs
+++ b/tests/assembly/struct-target-features.rs
@@ -15,12 +15,20 @@ struct Avx {}
 #[target_feature(enable = "fma")]
 struct Fma {}
 
+#[target_feature(from_args)]
 pub fn add_simple(_: Avx, v: __m256) -> __m256 {
     // CHECK-NOT: call
     // CHECK: vaddps
     unsafe { _mm256_add_ps(v, v) }
 }
 
+// Test that the features don't get inherited from the arguments without the attribute.
+pub fn add_simple_noattr(_: Avx, v: __m256) -> __m256 {
+    // CHECK: call
+    unsafe { _mm256_add_ps(v, v) }
+}
+
+#[target_feature(from_args)]
 pub fn add_fma_combined(_: &Avx, _: &Fma, v: __m256) -> (__m256, __m256) {
     // CHECK-NOT: call
     // CHECK-DAG: vaddps

--- a/tests/ui/feature-gates/feature-gate-struct-target-features.rs
+++ b/tests/ui/feature-gates/feature-gate-struct-target-features.rs
@@ -1,0 +1,4 @@
+#[target_feature(enable = "avx")] //~ ERROR attribute should be applied to a function definition
+struct Avx {}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-struct-target-features.stderr
+++ b/tests/ui/feature-gates/feature-gate-struct-target-features.stderr
@@ -1,0 +1,10 @@
+error: attribute should be applied to a function definition
+  --> $DIR/feature-gate-struct-target-features.rs:1:1
+   |
+LL | #[target_feature(enable = "avx")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL | struct Avx {}
+   | ------------- not a function definition
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/trait-impl.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/trait-impl.stderr
@@ -1,4 +1,4 @@
-error: `#[target_feature(..)]` cannot be applied to safe trait method
+error: `#[target_feature(enable = ..)]` cannot be applied to safe trait method
   --> $DIR/trait-impl.rs:13:5
    |
 LL |     #[target_feature(enable = "sse2")]
@@ -7,7 +7,7 @@ LL |
 LL |     fn foo(&self) {}
    |     ------------- not an `unsafe` function
 
-error: `#[target_feature(..)]` cannot be applied to safe trait method
+error: `#[target_feature(enable = ..)]` cannot be applied to safe trait method
   --> $DIR/trait-impl.rs:22:5
    |
 LL |     #[target_feature(enable = "sse2")]

--- a/tests/ui/target-feature/auxiliary/struct-target-features-crate-dep.rs
+++ b/tests/ui/target-feature/auxiliary/struct-target-features-crate-dep.rs
@@ -1,0 +1,6 @@
+#![feature(struct_target_features)]
+
+#[target_feature(enable = "avx")]
+pub struct Avx {}
+
+pub struct NoFeatures {}

--- a/tests/ui/target-feature/struct-target-features-crate.rs
+++ b/tests/ui/target-feature/struct-target-features-crate.rs
@@ -1,0 +1,23 @@
+//@ only-x86_64
+//@ aux-build: struct-target-features-crate-dep.rs
+//@ check-pass
+#![feature(target_feature_11)]
+
+extern crate struct_target_features_crate_dep;
+
+#[target_feature(enable = "avx")]
+fn avx() {}
+
+fn f(_: struct_target_features_crate_dep::Avx) {
+    avx();
+}
+
+fn g(_: struct_target_features_crate_dep::NoFeatures) {}
+
+fn main() {
+    if is_x86_feature_detected!("avx") {
+        let avx = unsafe { struct_target_features_crate_dep::Avx {} };
+        f(avx);
+    }
+    g(struct_target_features_crate_dep::NoFeatures {});
+}

--- a/tests/ui/target-feature/struct-target-features-crate.rs
+++ b/tests/ui/target-feature/struct-target-features-crate.rs
@@ -2,12 +2,15 @@
 //@ aux-build: struct-target-features-crate-dep.rs
 //@ check-pass
 #![feature(target_feature_11)]
+#![feature(struct_target_features)]
+//~^ WARNING the feature `struct_target_features` is incomplete and may not be safe to use and/or cause compiler crashes
 
 extern crate struct_target_features_crate_dep;
 
 #[target_feature(enable = "avx")]
 fn avx() {}
 
+#[target_feature(from_args)]
 fn f(_: struct_target_features_crate_dep::Avx) {
     avx();
 }

--- a/tests/ui/target-feature/struct-target-features-crate.stderr
+++ b/tests/ui/target-feature/struct-target-features-crate.stderr
@@ -1,0 +1,11 @@
+warning: the feature `struct_target_features` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/struct-target-features-crate.rs:5:12
+   |
+LL | #![feature(struct_target_features)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #129107 <https://github.com/rust-lang/rust/issues/129107> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/target-feature/struct-target-features.rs
+++ b/tests/ui/target-feature/struct-target-features.rs
@@ -1,0 +1,100 @@
+//@ only-x86_64
+#![feature(struct_target_features)]
+//~^ WARNING the feature `struct_target_features` is incomplete and may not be safe to use and/or cause compiler crashes
+#![feature(target_feature_11)]
+
+use std::arch::x86_64::*;
+
+#[target_feature(enable = "avx")]
+struct Invalid(u32);
+
+#[target_feature(enable = "avx")]
+struct Avx {}
+
+#[target_feature(enable = "sse")]
+struct Sse();
+
+#[target_feature(enable = "avx")]
+fn avx() {}
+
+trait TFAssociatedType {
+    type Assoc;
+}
+
+impl TFAssociatedType for () {
+    type Assoc = Avx;
+}
+
+fn avx_self(_: <() as TFAssociatedType>::Assoc) {
+    avx();
+}
+
+fn avx_avx(_: Avx) {
+    avx();
+}
+
+extern "C" fn bad_fun(_: Avx) {}
+//~^ ERROR cannot use a struct with target features in a function with non-Rust ABI
+
+#[inline(always)]
+//~^ ERROR cannot use `#[inline(always)]` with `#[target_feature]`
+fn inline_fun(_: Avx) {}
+//~^ ERROR cannot use a struct with target features in a #[inline(always)] function
+
+trait Simd {
+    fn do_something(&self);
+}
+
+impl Simd for Avx {
+    fn do_something(&self) {
+        unsafe {
+            println!("{:?}", _mm256_setzero_ps());
+        }
+    }
+}
+
+impl Simd for Sse {
+    fn do_something(&self) {
+        unsafe {
+            println!("{:?}", _mm_setzero_ps());
+        }
+    }
+}
+
+struct WithAvx {
+    #[allow(dead_code)]
+    avx: Avx,
+}
+
+impl Simd for WithAvx {
+    fn do_something(&self) {
+        unsafe {
+            println!("{:?}", _mm256_setzero_ps());
+        }
+    }
+}
+
+#[inline(never)]
+fn dosomething<S: Simd>(simd: &S) {
+    simd.do_something();
+}
+
+fn avxfn(_: &Avx) {
+    // This is not unsafe because we already have the feature at function-level.
+    let _ = Avx {};
+}
+
+fn main() {
+    Avx {};
+    //~^ ERROR initializing type `Avx` with `#[target_feature]` is unsafe and requires unsafe function or block [E0133]
+
+    if is_x86_feature_detected!("avx") {
+        let avx = unsafe { Avx {} };
+        avxfn(&avx);
+        dosomething(&avx);
+        dosomething(&WithAvx { avx });
+    }
+    if is_x86_feature_detected!("sse") {
+        dosomething(&unsafe { Sse {} })
+    }
+}

--- a/tests/ui/target-feature/struct-target-features.stderr
+++ b/tests/ui/target-feature/struct-target-features.stderr
@@ -7,32 +7,26 @@ LL | #![feature(struct_target_features)]
    = note: see issue #129107 <https://github.com/rust-lang/rust/issues/129107> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error: cannot use a struct with target features in a function with non-Rust ABI
-  --> $DIR/struct-target-features.rs:36:1
-   |
-LL | extern "C" fn bad_fun(_: Avx) {}
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: cannot use a struct with target features in a #[inline(always)] function
-  --> $DIR/struct-target-features.rs:41:1
+  --> $DIR/struct-target-features.rs:44:1
    |
 LL | fn inline_fun(_: Avx) {}
    | ^^^^^^^^^^^^^^^^^^^^^
 
 error: cannot use `#[inline(always)]` with `#[target_feature]`
-  --> $DIR/struct-target-features.rs:39:1
+  --> $DIR/struct-target-features.rs:41:1
    |
 LL | #[inline(always)]
    | ^^^^^^^^^^^^^^^^^
 
 error[E0133]: initializing type `Avx` with `#[target_feature]` is unsafe and requires unsafe function or block
-  --> $DIR/struct-target-features.rs:88:5
+  --> $DIR/struct-target-features.rs:76:5
    |
 LL |     Avx {};
    |     ^^^^^^ call to function with `#[target_feature]`
    |
    = note: the  target features being enabled in the build configuration does not remove the requirement to list them in `#[target_feature]`
 
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 3 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0133`.

--- a/tests/ui/target-feature/struct-target-features.stderr
+++ b/tests/ui/target-feature/struct-target-features.stderr
@@ -1,0 +1,38 @@
+warning: the feature `struct_target_features` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/struct-target-features.rs:2:12
+   |
+LL | #![feature(struct_target_features)]
+   |            ^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #129107 <https://github.com/rust-lang/rust/issues/129107> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error: cannot use a struct with target features in a function with non-Rust ABI
+  --> $DIR/struct-target-features.rs:36:1
+   |
+LL | extern "C" fn bad_fun(_: Avx) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot use a struct with target features in a #[inline(always)] function
+  --> $DIR/struct-target-features.rs:41:1
+   |
+LL | fn inline_fun(_: Avx) {}
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot use `#[inline(always)]` with `#[target_feature]`
+  --> $DIR/struct-target-features.rs:39:1
+   |
+LL | #[inline(always)]
+   | ^^^^^^^^^^^^^^^^^
+
+error[E0133]: initializing type `Avx` with `#[target_feature]` is unsafe and requires unsafe function or block
+  --> $DIR/struct-target-features.rs:88:5
+   |
+LL |     Avx {};
+   |     ^^^^^^ call to function with `#[target_feature]`
+   |
+   = note: the  target features being enabled in the build configuration does not remove the requirement to list them in `#[target_feature]`
+
+error: aborting due to 4 previous errors; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0133`.


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/129881)*

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR implements a first version of RFC 3525.

This is a roll-up of rust-lang/rust#129764, rust-lang/rust#129783 and rust-lang/rust#129764, which will hopefully result in a PR that does not introduce perf regressions in the first place.

This PR also includes code to handle generics, unlike the original PR, since doing so influenced the design of the original PR significantly.

r? Kobzol 

Tracking issue: rust-lang/rust#129107
