### PR TITLE
Add Suggestions for Misspelled Keywords

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -381,6 +381,7 @@ parse_invalid_char_in_escape_msg = invalid character in {$is_hex ->
     *[false] unicode
     } escape
 
+
 parse_invalid_comparison_operator = invalid comparison operator `{$invalid}`
     .use_instead = `{$invalid}` is not a valid comparison operator, use `{$correct}`
     .spaceship_operator_invalid = `<=>` is not a valid comparison operator, use `std::cmp::Ordering`
@@ -580,6 +581,11 @@ parse_missing_struct_for_struct_definition = missing `struct` for struct definit
 parse_missing_trait_in_trait_impl = missing trait in a trait impl
     .suggestion_add_trait = add a trait here
     .suggestion_remove_for = for an inherent impl, drop this `for`
+
+parse_misspelled_kw = {$is_incorrect_case ->
+                    [true] write keyword `{$similar_kw}` in lowercase
+                    *[false] there is a keyword `{$similar_kw}` with a similar name
+}
 
 parse_modifier_lifetime = `{$modifier}` may only modify trait bounds, not lifetime bounds
     .suggestion = remove the `{$modifier}`

--- a/tests/ui/parser/extern-crate-unexpected-token.stderr
+++ b/tests/ui/parser/extern-crate-unexpected-token.stderr
@@ -3,6 +3,11 @@ error: expected one of `crate` or `{`, found `crte`
    |
 LL | extern crte foo;
    |        ^^^^ expected one of `crate` or `{`
+   |
+help: there is a keyword `crate` with a similar name
+   |
+LL | extern crate foo;
+   |        ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-70549-resolve-after-recovered-self-ctor.stderr
+++ b/tests/ui/parser/issues/issue-70549-resolve-after-recovered-self-ctor.stderr
@@ -8,10 +8,16 @@ error: expected one of `:`, `@`, or `|`, found keyword `Self`
   --> $DIR/issue-70549-resolve-after-recovered-self-ctor.rs:4:17
    |
 LL |     fn foo(&mur Self) {}
-   |            -----^^^^
-   |            |    |
-   |            |    expected one of `:`, `@`, or `|`
-   |            help: declare the type after the parameter binding: `<identifier>: <type>`
+   |                 ^^^^ expected one of `:`, `@`, or `|`
+   |
+help: there is a keyword `mut` with a similar name
+   |
+LL |     fn foo(&mut Self) {}
+   |             ~~~
+help: declare the type after the parameter binding
+   |
+LL |     fn foo(<identifier>: <type>) {}
+   |            ~~~~~~~~~~~~~~~~~~~~
 
 error: unexpected lifetime `'static` in pattern
   --> $DIR/issue-70549-resolve-after-recovered-self-ctor.rs:8:13
@@ -35,16 +41,27 @@ error: expected one of `:`, `@`, or `|`, found keyword `Self`
   --> $DIR/issue-70549-resolve-after-recovered-self-ctor.rs:8:25
    |
 LL |     fn bar(&'static mur Self) {}
-   |            -------------^^^^
-   |            |            |
-   |            |            expected one of `:`, `@`, or `|`
-   |            help: declare the type after the parameter binding: `<identifier>: <type>`
+   |                         ^^^^ expected one of `:`, `@`, or `|`
+   |
+help: there is a keyword `mut` with a similar name
+   |
+LL |     fn bar(&'static mut Self) {}
+   |                     ~~~
+help: declare the type after the parameter binding
+   |
+LL |     fn bar(<identifier>: <type>) {}
+   |            ~~~~~~~~~~~~~~~~~~~~
 
 error: expected one of `:`, `@`, or `|`, found keyword `Self`
   --> $DIR/issue-70549-resolve-after-recovered-self-ctor.rs:14:17
    |
 LL |     fn baz(&mur Self @ _) {}
    |                 ^^^^ expected one of `:`, `@`, or `|`
+   |
+help: there is a keyword `mut` with a similar name
+   |
+LL |     fn baz(&mut Self @ _) {}
+   |             ~~~
 
 error[E0533]: expected unit struct, found self constructor `Self`
   --> $DIR/issue-70549-resolve-after-recovered-self-ctor.rs:4:17

--- a/tests/ui/parser/misspelled-keywords/assoc-type.rs
+++ b/tests/ui/parser/misspelled-keywords/assoc-type.rs
@@ -1,0 +1,6 @@
+trait Animal {
+    Type Result = u8;
+    //~^ ERROR expected one of
+}
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/assoc-type.stderr
+++ b/tests/ui/parser/misspelled-keywords/assoc-type.stderr
@@ -8,6 +8,11 @@ LL |     Type Result = u8;
 LL |
 LL | }
    | - the item list ends here
+   |
+help: write keyword `type` in lowercase
+   |
+LL |     type Result = u8;
+   |     ~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/assoc-type.stderr
+++ b/tests/ui/parser/misspelled-keywords/assoc-type.stderr
@@ -1,0 +1,13 @@
+error: expected one of `!` or `::`, found `Result`
+  --> $DIR/assoc-type.rs:2:10
+   |
+LL | trait Animal {
+   |              - while parsing this item list starting here
+LL |     Type Result = u8;
+   |          ^^^^^^ expected one of `!` or `::`
+LL |
+LL | }
+   | - the item list ends here
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/async-move.rs
+++ b/tests/ui/parser/misspelled-keywords/async-move.rs
@@ -1,0 +1,6 @@
+//@ edition: 2018
+
+fn main() {
+    async Move {}
+    //~^ ERROR expected one of
+}

--- a/tests/ui/parser/misspelled-keywords/async-move.stderr
+++ b/tests/ui/parser/misspelled-keywords/async-move.stderr
@@ -3,6 +3,11 @@ error: expected one of `move`, `|`, or `||`, found `Move`
    |
 LL |     async Move {}
    |           ^^^^ expected one of `move`, `|`, or `||`
+   |
+help: write keyword `move` in lowercase
+   |
+LL |     async move {}
+   |           ~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/async-move.stderr
+++ b/tests/ui/parser/misspelled-keywords/async-move.stderr
@@ -1,0 +1,8 @@
+error: expected one of `move`, `|`, or `||`, found `Move`
+  --> $DIR/async-move.rs:4:11
+   |
+LL |     async Move {}
+   |           ^^^^ expected one of `move`, `|`, or `||`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/const-fn.rs
+++ b/tests/ui/parser/misspelled-keywords/const-fn.rs
@@ -1,0 +1,5 @@
+cnst fn code() {}
+//~^ ERROR expected one of
+
+fn main() {
+}

--- a/tests/ui/parser/misspelled-keywords/const-fn.stderr
+++ b/tests/ui/parser/misspelled-keywords/const-fn.stderr
@@ -3,6 +3,11 @@ error: expected one of `!` or `::`, found keyword `fn`
    |
 LL | cnst fn code() {}
    |      ^^ expected one of `!` or `::`
+   |
+help: there is a keyword `const` with a similar name
+   |
+LL | const fn code() {}
+   | ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/const-fn.stderr
+++ b/tests/ui/parser/misspelled-keywords/const-fn.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found keyword `fn`
+  --> $DIR/const-fn.rs:1:6
+   |
+LL | cnst fn code() {}
+   |      ^^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/const-generics.rs
+++ b/tests/ui/parser/misspelled-keywords/const-generics.rs
@@ -1,0 +1,4 @@
+fn foo<consta N: usize>(_arr: [i32; N]) {}
+//~^ ERROR expected one of
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/const-generics.stderr
+++ b/tests/ui/parser/misspelled-keywords/const-generics.stderr
@@ -3,6 +3,11 @@ error: expected one of `,`, `:`, `=`, or `>`, found `N`
    |
 LL | fn foo<consta N: usize>(_arr: [i32; N]) {}
    |               ^ expected one of `,`, `:`, `=`, or `>`
+   |
+help: there is a keyword `const` with a similar name
+   |
+LL | fn foo<const N: usize>(_arr: [i32; N]) {}
+   |        ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/const-generics.stderr
+++ b/tests/ui/parser/misspelled-keywords/const-generics.stderr
@@ -1,0 +1,8 @@
+error: expected one of `,`, `:`, `=`, or `>`, found `N`
+  --> $DIR/const-generics.rs:1:15
+   |
+LL | fn foo<consta N: usize>(_arr: [i32; N]) {}
+   |               ^ expected one of `,`, `:`, `=`, or `>`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/const.rs
+++ b/tests/ui/parser/misspelled-keywords/const.rs
@@ -1,0 +1,4 @@
+cons A: u8 = 10;
+//~^ ERROR expected one of
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/const.stderr
+++ b/tests/ui/parser/misspelled-keywords/const.stderr
@@ -3,6 +3,11 @@ error: expected one of `!` or `::`, found `A`
    |
 LL | cons A: u8 = 10;
    |      ^ expected one of `!` or `::`
+   |
+help: there is a keyword `const` with a similar name
+   |
+LL | const A: u8 = 10;
+   | ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/const.stderr
+++ b/tests/ui/parser/misspelled-keywords/const.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found `A`
+  --> $DIR/const.rs:1:6
+   |
+LL | cons A: u8 = 10;
+   |      ^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/for-loop.rs
+++ b/tests/ui/parser/misspelled-keywords/for-loop.rs
@@ -1,0 +1,4 @@
+fn main() {
+    form i in 1..10 {}
+    //~^ ERROR expected one of
+}

--- a/tests/ui/parser/misspelled-keywords/for-loop.stderr
+++ b/tests/ui/parser/misspelled-keywords/for-loop.stderr
@@ -3,6 +3,11 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
    |
 LL |     form i in 1..10 {}
    |          ^ expected one of 8 possible tokens
+   |
+help: there is a keyword `for` with a similar name
+   |
+LL |     for i in 1..10 {}
+   |     ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/for-loop.stderr
+++ b/tests/ui/parser/misspelled-keywords/for-loop.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `i`
+  --> $DIR/for-loop.rs:2:10
+   |
+LL |     form i in 1..10 {}
+   |          ^ expected one of 8 possible tokens
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/hrdt.rs
+++ b/tests/ui/parser/misspelled-keywords/hrdt.rs
@@ -1,0 +1,16 @@
+struct Closure<F> {
+    data: (u8, u16),
+    func: F,
+}
+
+impl<F> Closure<F>
+    Where for<'a> F: Fn(&'a (u8, u16)) -> &'a u8,
+//~^ ERROR expected one of
+{
+    fn call(&self) -> &u8 {
+        (self.func)(&self.data)
+    }
+}
+
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/hrdt.stderr
+++ b/tests/ui/parser/misspelled-keywords/hrdt.stderr
@@ -3,6 +3,11 @@ error: expected one of `!`, `(`, `+`, `::`, `<`, `where`, or `{`, found keyword 
    |
 LL |     Where for<'a> F: Fn(&'a (u8, u16)) -> &'a u8,
    |           ^^^ expected one of 7 possible tokens
+   |
+help: write keyword `where` in lowercase (notice the capitalization difference)
+   |
+LL |     where for<'a> F: Fn(&'a (u8, u16)) -> &'a u8,
+   |     ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/hrdt.stderr
+++ b/tests/ui/parser/misspelled-keywords/hrdt.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!`, `(`, `+`, `::`, `<`, `where`, or `{`, found keyword `for`
+  --> $DIR/hrdt.rs:7:11
+   |
+LL |     Where for<'a> F: Fn(&'a (u8, u16)) -> &'a u8,
+   |           ^^^ expected one of 7 possible tokens
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/impl-block.rs
+++ b/tests/ui/parser/misspelled-keywords/impl-block.rs
@@ -1,0 +1,6 @@
+struct Human;
+
+ipml Human {}
+//~^ ERROR expected one of
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/impl-block.stderr
+++ b/tests/ui/parser/misspelled-keywords/impl-block.stderr
@@ -3,6 +3,11 @@ error: expected one of `!` or `::`, found `Human`
    |
 LL | ipml Human {}
    |      ^^^^^ expected one of `!` or `::`
+   |
+help: there is a keyword `impl` with a similar name
+   |
+LL | impl Human {}
+   | ~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/impl-block.stderr
+++ b/tests/ui/parser/misspelled-keywords/impl-block.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found `Human`
+  --> $DIR/impl-block.rs:3:6
+   |
+LL | ipml Human {}
+   |      ^^^^^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/impl-return.rs
+++ b/tests/ui/parser/misspelled-keywords/impl-return.rs
@@ -1,0 +1,4 @@
+fn code() -> Impl Display {}
+//~^ ERROR expected one of
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/impl-return.stderr
+++ b/tests/ui/parser/misspelled-keywords/impl-return.stderr
@@ -3,6 +3,11 @@ error: expected one of `!`, `(`, `+`, `::`, `<`, `where`, or `{`, found `Display
    |
 LL | fn code() -> Impl Display {}
    |                   ^^^^^^^ expected one of 7 possible tokens
+   |
+help: write keyword `impl` in lowercase (notice the capitalization difference)
+   |
+LL | fn code() -> impl Display {}
+   |              ~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/impl-return.stderr
+++ b/tests/ui/parser/misspelled-keywords/impl-return.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!`, `(`, `+`, `::`, `<`, `where`, or `{`, found `Display`
+  --> $DIR/impl-return.rs:1:19
+   |
+LL | fn code() -> Impl Display {}
+   |                   ^^^^^^^ expected one of 7 possible tokens
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/impl-trait-for.rs
+++ b/tests/ui/parser/misspelled-keywords/impl-trait-for.rs
@@ -1,0 +1,6 @@
+struct Human;
+
+impl Debug form Human {}
+//~^ ERROR expected one of
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/impl-trait-for.stderr
+++ b/tests/ui/parser/misspelled-keywords/impl-trait-for.stderr
@@ -3,6 +3,11 @@ error: expected one of `!`, `(`, `+`, `::`, `<`, `where`, or `{`, found `Human`
    |
 LL | impl Debug form Human {}
    |                 ^^^^^ expected one of 7 possible tokens
+   |
+help: there is a keyword `for` with a similar name
+   |
+LL | impl Debug for Human {}
+   |            ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/impl-trait-for.stderr
+++ b/tests/ui/parser/misspelled-keywords/impl-trait-for.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!`, `(`, `+`, `::`, `<`, `where`, or `{`, found `Human`
+  --> $DIR/impl-trait-for.rs:3:17
+   |
+LL | impl Debug form Human {}
+   |                 ^^^^^ expected one of 7 possible tokens
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/impl-trait.rs
+++ b/tests/ui/parser/misspelled-keywords/impl-trait.rs
@@ -1,0 +1,4 @@
+fn code<T: impll Debug>() -> u8 {}
+//~^ ERROR expected one of
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/impl-trait.stderr
+++ b/tests/ui/parser/misspelled-keywords/impl-trait.stderr
@@ -4,6 +4,10 @@ error: expected one of `(`, `+`, `,`, `::`, `<`, `=`, or `>`, found `Debug`
 LL | fn code<T: impll Debug>() -> u8 {}
    |                  ^^^^^ expected one of 7 possible tokens
    |
+help: there is a keyword `impl` with a similar name
+   |
+LL | fn code<T: impl Debug>() -> u8 {}
+   |            ~~~~
 help: you might have meant to end the type parameters here
    |
 LL | fn code<T: impll> Debug>() -> u8 {}

--- a/tests/ui/parser/misspelled-keywords/impl-trait.stderr
+++ b/tests/ui/parser/misspelled-keywords/impl-trait.stderr
@@ -1,0 +1,13 @@
+error: expected one of `(`, `+`, `,`, `::`, `<`, `=`, or `>`, found `Debug`
+  --> $DIR/impl-trait.rs:1:18
+   |
+LL | fn code<T: impll Debug>() -> u8 {}
+   |                  ^^^^^ expected one of 7 possible tokens
+   |
+help: you might have meant to end the type parameters here
+   |
+LL | fn code<T: impll> Debug>() -> u8 {}
+   |                 +
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/let-else.rs
+++ b/tests/ui/parser/misspelled-keywords/let-else.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let Some(a) = Some(10) elze {}
+    //~^ ERROR expected one of
+}

--- a/tests/ui/parser/misspelled-keywords/let-else.stderr
+++ b/tests/ui/parser/misspelled-keywords/let-else.stderr
@@ -3,6 +3,11 @@ error: expected one of `.`, `;`, `?`, `else`, or an operator, found `elze`
    |
 LL |     let Some(a) = Some(10) elze {}
    |                            ^^^^ expected one of `.`, `;`, `?`, `else`, or an operator
+   |
+help: there is a keyword `else` with a similar name
+   |
+LL |     let Some(a) = Some(10) else {}
+   |                            ~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/let-else.stderr
+++ b/tests/ui/parser/misspelled-keywords/let-else.stderr
@@ -1,0 +1,8 @@
+error: expected one of `.`, `;`, `?`, `else`, or an operator, found `elze`
+  --> $DIR/let-else.rs:2:28
+   |
+LL |     let Some(a) = Some(10) elze {}
+   |                            ^^^^ expected one of `.`, `;`, `?`, `else`, or an operator
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/let-mut.rs
+++ b/tests/ui/parser/misspelled-keywords/let-mut.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let muta a = 10;
+    //~^ ERROR expected one of
+}

--- a/tests/ui/parser/misspelled-keywords/let-mut.stderr
+++ b/tests/ui/parser/misspelled-keywords/let-mut.stderr
@@ -3,6 +3,11 @@ error: expected one of `:`, `;`, `=`, `@`, or `|`, found `a`
    |
 LL |     let muta a = 10;
    |              ^ expected one of `:`, `;`, `=`, `@`, or `|`
+   |
+help: there is a keyword `mut` with a similar name
+   |
+LL |     let mut a = 10;
+   |         ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/let-mut.stderr
+++ b/tests/ui/parser/misspelled-keywords/let-mut.stderr
@@ -1,0 +1,8 @@
+error: expected one of `:`, `;`, `=`, `@`, or `|`, found `a`
+  --> $DIR/let-mut.rs:2:14
+   |
+LL |     let muta a = 10;
+   |              ^ expected one of `:`, `;`, `=`, `@`, or `|`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/let.rs
+++ b/tests/ui/parser/misspelled-keywords/let.rs
@@ -1,0 +1,9 @@
+fn main() {
+    Let a = 10;
+    //~^ ERROR expected one of
+}
+
+fn code() {
+    lett a = 10;
+    //~^ ERROR expected one of
+}

--- a/tests/ui/parser/misspelled-keywords/let.stderr
+++ b/tests/ui/parser/misspelled-keywords/let.stderr
@@ -3,12 +3,22 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
    |
 LL |     Let a = 10;
    |         ^ expected one of 8 possible tokens
+   |
+help: write keyword `let` in lowercase
+   |
+LL |     let a = 10;
+   |     ~~~
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `a`
   --> $DIR/let.rs:7:10
    |
 LL |     lett a = 10;
    |          ^ expected one of 8 possible tokens
+   |
+help: there is a keyword `let` with a similar name
+   |
+LL |     let a = 10;
+   |     ~~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/misspelled-keywords/let.stderr
+++ b/tests/ui/parser/misspelled-keywords/let.stderr
@@ -1,0 +1,14 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `a`
+  --> $DIR/let.rs:2:9
+   |
+LL |     Let a = 10;
+   |         ^ expected one of 8 possible tokens
+
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `a`
+  --> $DIR/let.rs:7:10
+   |
+LL |     lett a = 10;
+   |          ^ expected one of 8 possible tokens
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/parser/misspelled-keywords/match.rs
+++ b/tests/ui/parser/misspelled-keywords/match.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let a = 10;
+    matche a {}
+    //~^ ERROR expected one of
+}

--- a/tests/ui/parser/misspelled-keywords/match.stderr
+++ b/tests/ui/parser/misspelled-keywords/match.stderr
@@ -3,6 +3,11 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
    |
 LL |     matche a {}
    |            ^ expected one of 8 possible tokens
+   |
+help: there is a keyword `match` with a similar name
+   |
+LL |     match a {}
+   |     ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/match.stderr
+++ b/tests/ui/parser/misspelled-keywords/match.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `a`
+  --> $DIR/match.rs:3:12
+   |
+LL |     matche a {}
+   |            ^ expected one of 8 possible tokens
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/mod.rs
+++ b/tests/ui/parser/misspelled-keywords/mod.rs
@@ -1,0 +1,4 @@
+mode parser;
+//~^ ERROR expected one of
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/mod.stderr
+++ b/tests/ui/parser/misspelled-keywords/mod.stderr
@@ -3,6 +3,11 @@ error: expected one of `!` or `::`, found `parser`
    |
 LL | mode parser;
    |      ^^^^^^ expected one of `!` or `::`
+   |
+help: there is a keyword `mod` with a similar name
+   |
+LL | mod parser;
+   | ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/mod.stderr
+++ b/tests/ui/parser/misspelled-keywords/mod.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found `parser`
+  --> $DIR/mod.rs:1:6
+   |
+LL | mode parser;
+   |      ^^^^^^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/pub-fn.rs
+++ b/tests/ui/parser/misspelled-keywords/pub-fn.rs
@@ -1,0 +1,5 @@
+puB fn code() {}
+//~^ ERROR expected one of
+
+fn main() {
+}

--- a/tests/ui/parser/misspelled-keywords/pub-fn.stderr
+++ b/tests/ui/parser/misspelled-keywords/pub-fn.stderr
@@ -3,6 +3,11 @@ error: expected one of `#`, `async`, `auto`, `const`, `default`, `enum`, `extern
    |
 LL | puB fn code() {}
    | ^^^ expected one of 21 possible tokens
+   |
+help: write keyword `pub` in lowercase
+   |
+LL | pub fn code() {}
+   | ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/pub-fn.stderr
+++ b/tests/ui/parser/misspelled-keywords/pub-fn.stderr
@@ -1,0 +1,8 @@
+error: expected one of `#`, `async`, `auto`, `const`, `default`, `enum`, `extern`, `fn`, `gen`, `impl`, `macro_rules`, `macro`, `mod`, `pub`, `safe`, `static`, `struct`, `trait`, `type`, `unsafe`, or `use`, found `puB`
+  --> $DIR/pub-fn.rs:1:1
+   |
+LL | puB fn code() {}
+   | ^^^ expected one of 21 possible tokens
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/ref.rs
+++ b/tests/ui/parser/misspelled-keywords/ref.rs
@@ -1,0 +1,9 @@
+fn main() {
+    let a = Some(vec![1, 2]);
+    match a {
+        Some(refe list) => println!("{list:?}"),
+        //~^ ERROR expected one of
+        //~| ERROR this pattern has 2 fields,
+        _ => println!("none"),
+    }
+}

--- a/tests/ui/parser/misspelled-keywords/ref.stderr
+++ b/tests/ui/parser/misspelled-keywords/ref.stderr
@@ -2,9 +2,16 @@ error: expected one of `)`, `,`, `@`, or `|`, found `list`
   --> $DIR/ref.rs:4:19
    |
 LL |         Some(refe list) => println!("{list:?}"),
-   |                  -^^^^ expected one of `)`, `,`, `@`, or `|`
-   |                  |
-   |                  help: missing `,`
+   |                   ^^^^ expected one of `)`, `,`, `@`, or `|`
+   |
+help: there is a keyword `ref` with a similar name
+   |
+LL |         Some(ref list) => println!("{list:?}"),
+   |              ~~~
+help: missing `,`
+   |
+LL |         Some(refe, list) => println!("{list:?}"),
+   |                  +
 
 error[E0023]: this pattern has 2 fields, but the corresponding tuple variant has 1 field
   --> $DIR/ref.rs:4:14

--- a/tests/ui/parser/misspelled-keywords/ref.stderr
+++ b/tests/ui/parser/misspelled-keywords/ref.stderr
@@ -1,0 +1,20 @@
+error: expected one of `)`, `,`, `@`, or `|`, found `list`
+  --> $DIR/ref.rs:4:19
+   |
+LL |         Some(refe list) => println!("{list:?}"),
+   |                  -^^^^ expected one of `)`, `,`, `@`, or `|`
+   |                  |
+   |                  help: missing `,`
+
+error[E0023]: this pattern has 2 fields, but the corresponding tuple variant has 1 field
+  --> $DIR/ref.rs:4:14
+   |
+LL |         Some(refe list) => println!("{list:?}"),
+   |              ^^^^ ^^^^ expected 1 field, found 2
+  --> $SRC_DIR/core/src/option.rs:LL:COL
+   |
+   = note: tuple variant has 1 field
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0023`.

--- a/tests/ui/parser/misspelled-keywords/return.rs
+++ b/tests/ui/parser/misspelled-keywords/return.rs
@@ -1,0 +1,7 @@
+fn code() -> u8 {
+    let a = 10;
+    returnn a;
+    //~^ ERROR expected one of
+}
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/return.stderr
+++ b/tests/ui/parser/misspelled-keywords/return.stderr
@@ -3,6 +3,11 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
    |
 LL |     returnn a;
    |             ^ expected one of 8 possible tokens
+   |
+help: there is a keyword `return` with a similar name
+   |
+LL |     return a;
+   |     ~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/return.stderr
+++ b/tests/ui/parser/misspelled-keywords/return.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `a`
+  --> $DIR/return.rs:3:13
+   |
+LL |     returnn a;
+   |             ^ expected one of 8 possible tokens
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/static-mut.rs
+++ b/tests/ui/parser/misspelled-keywords/static-mut.rs
@@ -1,0 +1,5 @@
+static muta a: u8 = 0;
+//~^ ERROR expected one of
+//~| ERROR missing type for
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/static-mut.stderr
+++ b/tests/ui/parser/misspelled-keywords/static-mut.stderr
@@ -3,6 +3,11 @@ error: expected one of `:`, `;`, or `=`, found `a`
    |
 LL | static muta a: u8 = 0;
    |             ^ expected one of `:`, `;`, or `=`
+   |
+help: there is a keyword `mut` with a similar name
+   |
+LL | static mut a: u8 = 0;
+   |        ~~~
 
 error: missing type for `static` item
   --> $DIR/static-mut.rs:1:12

--- a/tests/ui/parser/misspelled-keywords/static-mut.stderr
+++ b/tests/ui/parser/misspelled-keywords/static-mut.stderr
@@ -1,0 +1,19 @@
+error: expected one of `:`, `;`, or `=`, found `a`
+  --> $DIR/static-mut.rs:1:13
+   |
+LL | static muta a: u8 = 0;
+   |             ^ expected one of `:`, `;`, or `=`
+
+error: missing type for `static` item
+  --> $DIR/static-mut.rs:1:12
+   |
+LL | static muta a: u8 = 0;
+   |            ^
+   |
+help: provide a type for the item
+   |
+LL | static muta: <type> a: u8 = 0;
+   |            ++++++++
+
+error: aborting due to 2 previous errors
+

--- a/tests/ui/parser/misspelled-keywords/static.rs
+++ b/tests/ui/parser/misspelled-keywords/static.rs
@@ -1,0 +1,4 @@
+Static a = 0;
+//~^ ERROR expected one of
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/static.stderr
+++ b/tests/ui/parser/misspelled-keywords/static.stderr
@@ -3,6 +3,11 @@ error: expected one of `!` or `::`, found `a`
    |
 LL | Static a = 0;
    |        ^ expected one of `!` or `::`
+   |
+help: write keyword `static` in lowercase (notice the capitalization difference)
+   |
+LL | static a = 0;
+   | ~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/static.stderr
+++ b/tests/ui/parser/misspelled-keywords/static.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found `a`
+  --> $DIR/static.rs:1:8
+   |
+LL | Static a = 0;
+   |        ^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/struct.rs
+++ b/tests/ui/parser/misspelled-keywords/struct.rs
@@ -1,0 +1,4 @@
+Struct Foor {
+//~^ ERROR expected one of
+    hello: String,
+}

--- a/tests/ui/parser/misspelled-keywords/struct.stderr
+++ b/tests/ui/parser/misspelled-keywords/struct.stderr
@@ -3,6 +3,11 @@ error: expected one of `!` or `::`, found `Foor`
    |
 LL | Struct Foor {
    |        ^^^^ expected one of `!` or `::`
+   |
+help: write keyword `struct` in lowercase (notice the capitalization difference)
+   |
+LL | struct Foor {
+   | ~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/struct.stderr
+++ b/tests/ui/parser/misspelled-keywords/struct.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found `Foor`
+  --> $DIR/struct.rs:1:8
+   |
+LL | Struct Foor {
+   |        ^^^^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/unsafe-fn.rs
+++ b/tests/ui/parser/misspelled-keywords/unsafe-fn.rs
@@ -1,0 +1,4 @@
+unsafee fn code() {}
+//~^ ERROR expected one of
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/unsafe-fn.stderr
+++ b/tests/ui/parser/misspelled-keywords/unsafe-fn.stderr
@@ -3,6 +3,11 @@ error: expected one of `!` or `::`, found keyword `fn`
    |
 LL | unsafee fn code() {}
    |         ^^ expected one of `!` or `::`
+   |
+help: there is a keyword `unsafe` with a similar name
+   |
+LL | unsafe fn code() {}
+   | ~~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/unsafe-fn.stderr
+++ b/tests/ui/parser/misspelled-keywords/unsafe-fn.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found keyword `fn`
+  --> $DIR/unsafe-fn.rs:1:9
+   |
+LL | unsafee fn code() {}
+   |         ^^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/use.rs
+++ b/tests/ui/parser/misspelled-keywords/use.rs
@@ -1,0 +1,4 @@
+usee a::b;
+//~^ ERROR expected one of
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/use.stderr
+++ b/tests/ui/parser/misspelled-keywords/use.stderr
@@ -3,6 +3,11 @@ error: expected one of `!` or `::`, found `a`
    |
 LL | usee a::b;
    |      ^ expected one of `!` or `::`
+   |
+help: there is a keyword `use` with a similar name
+   |
+LL | use a::b;
+   | ~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/use.stderr
+++ b/tests/ui/parser/misspelled-keywords/use.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!` or `::`, found `a`
+  --> $DIR/use.rs:1:6
+   |
+LL | usee a::b;
+   |      ^ expected one of `!` or `::`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/where-clause.rs
+++ b/tests/ui/parser/misspelled-keywords/where-clause.rs
@@ -1,0 +1,8 @@
+fn code<T>() -> u8
+wheree
+//~^ ERROR expected one of
+    T: Debug,
+{
+}
+
+fn main() {}

--- a/tests/ui/parser/misspelled-keywords/where-clause.stderr
+++ b/tests/ui/parser/misspelled-keywords/where-clause.stderr
@@ -5,6 +5,11 @@ LL | fn code<T>() -> u8
    |                   - expected one of 7 possible tokens
 LL | wheree
    | ^^^^^^ unexpected token
+   |
+help: there is a keyword `where` with a similar name
+   |
+LL | where
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/where-clause.stderr
+++ b/tests/ui/parser/misspelled-keywords/where-clause.stderr
@@ -1,0 +1,10 @@
+error: expected one of `!`, `(`, `+`, `::`, `<`, `where`, or `{`, found `wheree`
+  --> $DIR/where-clause.rs:2:1
+   |
+LL | fn code<T>() -> u8
+   |                   - expected one of 7 possible tokens
+LL | wheree
+   | ^^^^^^ unexpected token
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/while-loop.rs
+++ b/tests/ui/parser/misspelled-keywords/while-loop.rs
@@ -1,7 +1,5 @@
 fn main() {
     whilee a < b {
     //~^ ERROR expected one of
-
     }
 }
-

--- a/tests/ui/parser/misspelled-keywords/while-loop.rs
+++ b/tests/ui/parser/misspelled-keywords/while-loop.rs
@@ -1,0 +1,7 @@
+fn main() {
+    whilee a < b {
+    //~^ ERROR expected one of
+
+    }
+}
+

--- a/tests/ui/parser/misspelled-keywords/while-loop.stderr
+++ b/tests/ui/parser/misspelled-keywords/while-loop.stderr
@@ -3,6 +3,11 @@ error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found
    |
 LL |     whilee a < b {
    |            ^ expected one of 8 possible tokens
+   |
+help: there is a keyword `while` with a similar name
+   |
+LL |     while a < b {
+   |     ~~~~~
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/while-loop.stderr
+++ b/tests/ui/parser/misspelled-keywords/while-loop.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `a`
+  --> $DIR/while-loop.rs:2:12
+   |
+LL |     whilee a < b {
+   |            ^ expected one of 8 possible tokens
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/misspelled-keywords/while-without-identifiers.rs
+++ b/tests/ui/parser/misspelled-keywords/while-without-identifiers.rs
@@ -1,0 +1,4 @@
+fn main() {
+    whilee 2 > 1 {}
+    //~^ ERROR expected one of
+}

--- a/tests/ui/parser/misspelled-keywords/while-without-identifiers.stderr
+++ b/tests/ui/parser/misspelled-keywords/while-without-identifiers.stderr
@@ -1,0 +1,8 @@
+error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `2`
+  --> $DIR/while-without-identifiers.rs:2:12
+   |
+LL |     whilee 2 > 1 {}
+   |            ^ expected one of 8 possible tokens
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #97793 

This PR detects misspelled keywords using two heuristics:

1. Lowercasing the unexpected identifier.
2. Using edit distance to find a keyword similar to the unexpected identifier.

However, it does not detect each and every misspelled keyword to
minimize false positives and ambiguities. More details about the
implementation can be found in the comments.