### PR TITLE
Fix compile error in solid's remove_dir_all

### DIFF
--- a/library/std/src/sys/pal/solid/fs.rs
+++ b/library/std/src/sys/pal/solid/fs.rs
@@ -538,7 +538,7 @@ pub fn remove_dir_all(path: &Path) -> io::Result<()> {
             }
         };
         // ignore internal NotFound errors
-        if let Err(err) = result
+        if let Err(err) = &result
             && err.kind() != io::ErrorKind::NotFound
         {
             return result;


### PR DESCRIPTION
Before this PR, `x check library/std --target=aarch64-kmc-solid_asp3` will fail with:
```
error[E0382]: use of partially moved value: `result`
   --> std/src/sys/pal/solid/fs.rs:544:20
    |
541 |         if let Err(err) = result
    |                    --- value partially moved here
...
544 |             return result;
    |                    ^^^^^^ value used here after partial move
    |
    = note: partial move occurs because value has type `io::error::Error`, which does not implement the `Copy` trait
help: borrow this binding in the pattern to avoid moving the value
    |
541 |         if let Err(ref err) = result
    |                    +++

```

cc @kawadakk I think this will clear up https://solid-rs.github.io/toolstate/ :)