### PR TITLE
Add missing read_buf stub for x86_64-unknown-l4re-uclibc

### DIFF
--- a/library/std/src/sys/pal/unix/l4re.rs
+++ b/library/std/src/sys/pal/unix/l4re.rs
@@ -54,6 +54,10 @@ pub mod net {
             unimpl!();
         }
 
+        pub fn read_buf(&self, _: BorrowedCursor<'_>) -> io::Result<()> {
+            unimpl!();
+        }
+
         pub fn read_vectored(&self, _: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
             unimpl!();
         }


### PR DESCRIPTION
Before this PR, `x check library/std --target x86_64-unknown-l4re-uclibc` will fail with
```
error[E0599]: no method named `read_buf` found for struct `Socket` in the current scope
   --> std/src/os/unix/net/stream.rs:598:16
    |
598 |         self.0.read_buf(buf)
    |                ^^^^^^^^
    |
   ::: std/src/sys/pal/unix/l4re.rs:23:5
    |
23  |     pub struct Socket(FileDesc);
    |     ----------------- method `read_buf` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
```

This target doesn't have a maintainer to cc.