### PR TITLE
rustdoc search: add new `crate:` syntax to search a single crate

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -4448,7 +4448,6 @@ function updateSearchHistory(url) {
 async function search(forced) {
     const query = DocSearch.parseQuery(searchState.input.value.trim());
     let filterCrates = getFilterCrates();
-
     if (!forced && query.userQuery === currentResults) {
         if (query.userQuery.length > 0) {
             putBackSearch();
@@ -4648,8 +4647,19 @@ function registerSearchEvents() {
 function updateCrate(ev) {
     if (ev.target.value === "all crates") {
         // If we don't remove it from the URL, it'll be picked up again by the search.
-        const query = searchState.input.value.trim();
+        const query = searchState.input.value.trim()
+            .replace(/crate:[a-zA-Z_0-9]+/, "");
         updateSearchHistory(buildUrl(query, null));
+        searchState.input.value = query;
+    } else {
+        const crate = ev.target.value;
+        // add/update the `crate:` syntax in the search bar
+        let newquery = searchState.input.value
+            .replace(/crate:[a-zA-Z_0-9]+/, "crate:" + crate);
+        if (!newquery.includes("crate:")) {
+            newquery = "crate:" + crate + " " + searchState.input.value;
+        }
+        searchState.input.value = newquery;
     }
     // In case you "cut" the entry from the search input, then change the crate filter
     // before paste back the previous search, you get the old search results without


### PR DESCRIPTION
alternative to https://github.com/rust-lang/rust/pull/129769

fixes https://github.com/rust-lang/rust/issues/129537

~~limitations: currently, the crate filter has to be followed by a comma, so it's `crate:std, vec`.~~

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
r? @notriddle 