### PR TITLE
hexagon: fix symbols defined in global namespace

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.123"
+version = "0.1.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47fcbecb558bdad78c7d3a998523c60a50dd6cd046d5fe74163e309e878fff7"
+checksum = "0032e7c369e994d5cdad76088a8413bfe17a1d1da86505cb4cca0a512ec2443a"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",


### PR DESCRIPTION
Update `compiler_builtins` to `0.1.124`:

Some call targets were defined with aliases that could conflict with symbols from a user's program.  These aliases have now been deleted or qualified with two leading underscores.

* Includes https://github.com/rust-lang/compiler-builtins/pull/682
* Should fix #129823

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
