### PR TITLE
mir-opt: Ignore the dead store statements in MatchBranchSimplification

### DIFF
--- a/compiler/rustc_mir_transform/src/dead_store_elimination.rs
+++ b/compiler/rustc_mir_transform/src/dead_store_elimination.rs
@@ -55,6 +55,7 @@ pub(super) fn eliminate<'tcx>(
     mut modify_basic_blocks: ModifyBasicBlocks<'tcx, '_>,
     ignore_debuginfo: bool,
     arg_copy_to_move: bool,
+    may_live_in_other_bbs: bool,
 ) {
     let body = modify_basic_blocks.body();
     let borrowed_locals = borrowed_locals(body);
@@ -69,7 +70,7 @@ pub(super) fn eliminate<'tcx>(
         always_live
     };
 
-    let mut live = MaybeTransitiveLiveLocals::new(&always_live)
+    let mut live = MaybeTransitiveLiveLocals::new(&always_live, may_live_in_other_bbs, tcx, body)
         .iterate_to_fixpoint(tcx, body, None)
         .into_results_cursor(body);
 
@@ -179,7 +180,7 @@ impl<'tcx> crate::MirPass<'tcx> for DeadStoreElimination {
     }
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
-        eliminate(tcx, ModifyBasicBlocks::Direct(body), false, true);
+        eliminate(tcx, ModifyBasicBlocks::Direct(body), false, true, false);
     }
 
     fn is_required(&self) -> bool {

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -700,8 +700,6 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             // Now, we need to shrink the generated MIR.
             &ref_prop::ReferencePropagation,
             &sroa::ScalarReplacementOfAggregates,
-            &match_branches::MatchBranchSimplification,
-            // inst combine is after MatchBranchSimplification to clean up Ne(_1, false)
             &multiple_return_terminators::MultipleReturnTerminators,
             // After simplifycfg, it allows us to discover new opportunities for peephole
             // optimizations.
@@ -710,6 +708,7 @@ fn run_optimization_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
             &dead_store_elimination::DeadStoreElimination::Initial,
             &gvn::GVN,
             &simplify::SimplifyLocals::AfterGVN,
+            &match_branches::MatchBranchSimplification,
             &dataflow_const_prop::DataflowConstProp,
             &single_use_consts::SingleUseConsts,
             &o1(simplify_branches::SimplifyConstCondition::AfterConstProp),

--- a/compiler/rustc_mir_transform/src/match_branches.rs
+++ b/compiler/rustc_mir_transform/src/match_branches.rs
@@ -31,6 +31,7 @@ impl<'tcx> crate::MirPass<'tcx> for MatchBranchSimplification {
             ModifyBasicBlocks::BasicBlocks(body, bbs),
             true,
             false,
+            true,
         );
         eliminate_unused_storage_mark(body, bbs);
         strip_nops(bbs.as_mut_slice());

--- a/compiler/rustc_mir_transform/src/match_branches.rs
+++ b/compiler/rustc_mir_transform/src/match_branches.rs
@@ -19,32 +19,32 @@ impl<'tcx> crate::MirPass<'tcx> for MatchBranchSimplification {
 
     fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         let typing_env = body.typing_env(tcx);
-        let mut should_cleanup = false;
-        for i in 0..body.basic_blocks.len() {
-            let bbs = &*body.basic_blocks;
-            let bb_idx = BasicBlock::from_usize(i);
-            match bbs[bb_idx].terminator().kind {
+        let mut apply_patch = false;
+        let mut patch = MirPatch::new(body);
+        for (bb, data) in body.basic_blocks.iter_enumerated() {
+            match data.terminator().kind {
                 TerminatorKind::SwitchInt {
                     discr: ref _discr @ (Operand::Copy(_) | Operand::Move(_)),
                     ref targets,
                     ..
                     // We require that the possible target blocks don't contain this block.
-                } if !targets.all_targets().contains(&bb_idx) => {}
+                } if !targets.all_targets().contains(&bb) => {}
                 // Only optimize switch int statements
                 _ => continue,
             };
 
-            if SimplifyToIf.simplify(tcx, body, bb_idx, typing_env).is_some() {
-                should_cleanup = true;
+            if SimplifyToIf.simplify(tcx, body, &mut patch, bb, typing_env).is_some() {
+                apply_patch = true;
                 continue;
             }
-            if SimplifyToExp::default().simplify(tcx, body, bb_idx, typing_env).is_some() {
-                should_cleanup = true;
+            if SimplifyToExp::default().simplify(tcx, body, &mut patch, bb, typing_env).is_some() {
+                apply_patch = true;
                 continue;
             }
         }
 
-        if should_cleanup {
+        if apply_patch {
+            patch.apply(body);
             simplify_cfg(body);
         }
     }
@@ -61,7 +61,8 @@ trait SimplifyMatch<'tcx> {
     fn simplify(
         &mut self,
         tcx: TyCtxt<'tcx>,
-        body: &mut Body<'tcx>,
+        body: &Body<'tcx>,
+        patch: &mut MirPatch<'tcx>,
         switch_bb_idx: BasicBlock,
         typing_env: ty::TypingEnv<'tcx>,
     ) -> Option<()> {
@@ -73,8 +74,6 @@ trait SimplifyMatch<'tcx> {
 
         let discr_ty = discr.ty(body.local_decls(), tcx);
         self.can_simplify(tcx, targets, typing_env, bbs, discr_ty)?;
-
-        let mut patch = MirPatch::new(body);
 
         // Take ownership of items now that we know we can optimize.
         let discr = discr.clone();
@@ -88,19 +87,9 @@ trait SimplifyMatch<'tcx> {
         let parent_end = Location { block: switch_bb_idx, statement_index };
         patch.add_statement(parent_end, StatementKind::StorageLive(discr_local));
         patch.add_assign(parent_end, Place::from(discr_local), Rvalue::Use(discr));
-        self.new_stmts(
-            tcx,
-            targets,
-            typing_env,
-            &mut patch,
-            parent_end,
-            bbs,
-            discr_local,
-            discr_ty,
-        );
+        self.new_stmts(tcx, targets, typing_env, patch, parent_end, bbs, discr_local, discr_ty);
         patch.add_statement(parent_end, StatementKind::StorageDead(discr_local));
         patch.patch_terminator(switch_bb_idx, bbs[first].terminator().kind.clone());
-        patch.apply(body);
         Some(())
     }
 

--- a/compiler/rustc_mir_transform/src/simplify.rs
+++ b/compiler/rustc_mir_transform/src/simplify.rs
@@ -116,7 +116,7 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
     }
 
     fn simplify(mut self) {
-        self.strip_nops();
+        strip_nops(self.basic_blocks);
 
         // Vec of the blocks that should be merged. We store the indices here, instead of the
         // statements itself to avoid moving the (relatively) large statements twice.
@@ -276,11 +276,11 @@ impl<'a, 'tcx> CfgSimplifier<'a, 'tcx> {
         terminator.kind = TerminatorKind::Goto { target: first_succ };
         true
     }
+}
 
-    fn strip_nops(&mut self) {
-        for blk in self.basic_blocks.iter_mut() {
-            blk.statements.retain(|stmt| !matches!(stmt.kind, StatementKind::Nop))
-        }
+pub(super) fn strip_nops(basic_blocks: &mut IndexSlice<BasicBlock, BasicBlockData<'_>>) {
+    for blk in basic_blocks.iter_mut() {
+        blk.statements.retain(|stmt| !matches!(stmt.kind, StatementKind::Nop))
     }
 }
 

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-abort.diff
@@ -8,9 +8,9 @@
       let mut _3: u16;
       let mut _4: u32;
 +     scope 1 (inlined core::num::<impl u16>::unchecked_shl) {
-+         let mut _5: bool;
-+         let _6: ();
++         let _5: ();
 +         scope 2 (inlined core::ub_checks::check_language_ub) {
++             let mut _6: bool;
 +             scope 3 (inlined core::ub_checks::check_language_ub::runtime) {
 +             }
 +         }
@@ -22,20 +22,20 @@
           StorageLive(_4);
           _4 = copy _2;
 -         _0 = core::num::<impl u16>::unchecked_shl(move _3, move _4) -> [return: bb1, unwind unreachable];
-+         StorageLive(_6);
 +         StorageLive(_5);
-+         _5 = UbChecks();
-+         switchInt(move _5) -> [0: bb2, otherwise: bb1];
++         StorageLive(_6);
++         _6 = UbChecks();
++         switchInt(copy _6) -> [0: bb2, otherwise: bb1];
       }
   
       bb1: {
-+         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(copy _4) -> [return: bb2, unwind unreachable];
++         _5 = core::num::<impl u16>::unchecked_shl::precondition_check(copy _4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {
-+         StorageDead(_5);
 +         _0 = ShlUnchecked(copy _3, copy _4);
 +         StorageDead(_6);
++         StorageDead(_5);
           StorageDead(_4);
           StorageDead(_3);
           return;

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shl_unsigned_smaller.Inline.panic-unwind.diff
@@ -8,9 +8,9 @@
       let mut _3: u16;
       let mut _4: u32;
 +     scope 1 (inlined core::num::<impl u16>::unchecked_shl) {
-+         let mut _5: bool;
-+         let _6: ();
++         let _5: ();
 +         scope 2 (inlined core::ub_checks::check_language_ub) {
++             let mut _6: bool;
 +             scope 3 (inlined core::ub_checks::check_language_ub::runtime) {
 +             }
 +         }
@@ -22,20 +22,20 @@
           StorageLive(_4);
           _4 = copy _2;
 -         _0 = core::num::<impl u16>::unchecked_shl(move _3, move _4) -> [return: bb1, unwind continue];
-+         StorageLive(_6);
 +         StorageLive(_5);
-+         _5 = UbChecks();
-+         switchInt(move _5) -> [0: bb2, otherwise: bb1];
++         StorageLive(_6);
++         _6 = UbChecks();
++         switchInt(copy _6) -> [0: bb2, otherwise: bb1];
       }
   
       bb1: {
-+         _6 = core::num::<impl u16>::unchecked_shl::precondition_check(copy _4) -> [return: bb2, unwind unreachable];
++         _5 = core::num::<impl u16>::unchecked_shl::precondition_check(copy _4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {
-+         StorageDead(_5);
 +         _0 = ShlUnchecked(copy _3, copy _4);
 +         StorageDead(_6);
++         StorageDead(_5);
           StorageDead(_4);
           StorageDead(_3);
           return;

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-abort.diff
@@ -8,9 +8,9 @@
       let mut _3: i64;
       let mut _4: u32;
 +     scope 1 (inlined core::num::<impl i64>::unchecked_shr) {
-+         let mut _5: bool;
-+         let _6: ();
++         let _5: ();
 +         scope 2 (inlined core::ub_checks::check_language_ub) {
++             let mut _6: bool;
 +             scope 3 (inlined core::ub_checks::check_language_ub::runtime) {
 +             }
 +         }
@@ -22,20 +22,20 @@
           StorageLive(_4);
           _4 = copy _2;
 -         _0 = core::num::<impl i64>::unchecked_shr(move _3, move _4) -> [return: bb1, unwind unreachable];
-+         StorageLive(_6);
 +         StorageLive(_5);
-+         _5 = UbChecks();
-+         switchInt(move _5) -> [0: bb2, otherwise: bb1];
++         StorageLive(_6);
++         _6 = UbChecks();
++         switchInt(copy _6) -> [0: bb2, otherwise: bb1];
       }
   
       bb1: {
-+         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(copy _4) -> [return: bb2, unwind unreachable];
++         _5 = core::num::<impl i64>::unchecked_shr::precondition_check(copy _4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {
-+         StorageDead(_5);
 +         _0 = ShrUnchecked(copy _3, copy _4);
 +         StorageDead(_6);
++         StorageDead(_5);
           StorageDead(_4);
           StorageDead(_3);
           return;

--- a/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unchecked_shifts.unchecked_shr_signed_bigger.Inline.panic-unwind.diff
@@ -8,9 +8,9 @@
       let mut _3: i64;
       let mut _4: u32;
 +     scope 1 (inlined core::num::<impl i64>::unchecked_shr) {
-+         let mut _5: bool;
-+         let _6: ();
++         let _5: ();
 +         scope 2 (inlined core::ub_checks::check_language_ub) {
++             let mut _6: bool;
 +             scope 3 (inlined core::ub_checks::check_language_ub::runtime) {
 +             }
 +         }
@@ -22,20 +22,20 @@
           StorageLive(_4);
           _4 = copy _2;
 -         _0 = core::num::<impl i64>::unchecked_shr(move _3, move _4) -> [return: bb1, unwind continue];
-+         StorageLive(_6);
 +         StorageLive(_5);
-+         _5 = UbChecks();
-+         switchInt(move _5) -> [0: bb2, otherwise: bb1];
++         StorageLive(_6);
++         _6 = UbChecks();
++         switchInt(copy _6) -> [0: bb2, otherwise: bb1];
       }
   
       bb1: {
-+         _6 = core::num::<impl i64>::unchecked_shr::precondition_check(copy _4) -> [return: bb2, unwind unreachable];
++         _5 = core::num::<impl i64>::unchecked_shr::precondition_check(copy _4) -> [return: bb2, unwind unreachable];
 +     }
 + 
 +     bb2: {
-+         StorageDead(_5);
 +         _0 = ShrUnchecked(copy _3, copy _4);
 +         StorageDead(_6);
++         StorageDead(_5);
           StorageDead(_4);
           StorageDead(_3);
           return;

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-abort.diff
@@ -10,9 +10,9 @@
 +         scope 2 {
 +         }
 +         scope 3 (inlined unreachable_unchecked) {
-+             let mut _4: bool;
-+             let _5: ();
++             let _4: ();
 +             scope 4 (inlined core::ub_checks::check_language_ub) {
++                 let mut _5: bool;
 +                 scope 5 (inlined core::ub_checks::check_language_ub::runtime) {
 +                 }
 +             }
@@ -24,7 +24,7 @@
           _2 = move _1;
 -         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind unreachable];
 +         StorageLive(_3);
-+         StorageLive(_5);
++         StorageLive(_4);
 +         _3 = discriminant(_2);
 +         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
       }
@@ -34,15 +34,15 @@
 +     }
 + 
 +     bb2: {
-+         StorageLive(_4);
-+         _4 = UbChecks();
-+         assume(copy _4);
-+         _5 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
++         StorageLive(_5);
++         _5 = UbChecks();
++         assume(copy _5);
++         _4 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
 +     }
 + 
 +     bb3: {
 +         _0 = move ((_2 as Some).0: T);
-+         StorageDead(_5);
++         StorageDead(_4);
 +         StorageDead(_3);
           StorageDead(_2);
           return;

--- a/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/unwrap_unchecked.unwrap_unchecked.Inline.panic-unwind.diff
@@ -10,9 +10,9 @@
 +         scope 2 {
 +         }
 +         scope 3 (inlined unreachable_unchecked) {
-+             let mut _4: bool;
-+             let _5: ();
++             let _4: ();
 +             scope 4 (inlined core::ub_checks::check_language_ub) {
++                 let mut _5: bool;
 +                 scope 5 (inlined core::ub_checks::check_language_ub::runtime) {
 +                 }
 +             }
@@ -24,7 +24,7 @@
           _2 = move _1;
 -         _0 = Option::<T>::unwrap_unchecked(move _2) -> [return: bb1, unwind: bb2];
 +         StorageLive(_3);
-+         StorageLive(_5);
++         StorageLive(_4);
 +         _3 = discriminant(_2);
 +         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
       }
@@ -38,15 +38,15 @@
 -     bb2 (cleanup): {
 -         resume;
 +     bb2: {
-+         StorageLive(_4);
-+         _4 = UbChecks();
-+         assume(copy _4);
-+         _5 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
++         StorageLive(_5);
++         _5 = UbChecks();
++         assume(copy _5);
++         _4 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
 +     }
 + 
 +     bb3: {
 +         _0 = move ((_2 as Some).0: T);
-+         StorageDead(_5);
++         StorageDead(_4);
 +         StorageDead(_3);
 +         StorageDead(_2);
 +         return;

--- a/tests/mir-opt/instsimplify/ub_check.unwrap_unchecked.InstSimplify-after-simplifycfg.diff
+++ b/tests/mir-opt/instsimplify/ub_check.unwrap_unchecked.InstSimplify-after-simplifycfg.diff
@@ -10,9 +10,9 @@
           scope 2 {
           }
           scope 3 (inlined unreachable_unchecked) {
-              let mut _4: bool;
-              let _5: ();
+              let _4: ();
               scope 4 (inlined core::ub_checks::check_language_ub) {
+                  let mut _5: bool;
                   scope 5 (inlined core::ub_checks::check_language_ub::runtime) {
                   }
               }
@@ -23,7 +23,7 @@
           StorageLive(_2);
           _2 = copy _1;
           StorageLive(_3);
-          StorageLive(_5);
+          StorageLive(_4);
           _3 = discriminant(_2);
           switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
       }
@@ -33,16 +33,16 @@
       }
   
       bb2: {
-          StorageLive(_4);
--         _4 = UbChecks();
-+         _4 = const false;
-          assume(copy _4);
-          _5 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
+          StorageLive(_5);
+-         _5 = UbChecks();
++         _5 = const false;
+          assume(copy _5);
+          _4 = unreachable_unchecked::precondition_check() -> [return: bb1, unwind unreachable];
       }
   
       bb3: {
           _0 = move ((_2 as Some).0: i32);
-          StorageDead(_5);
+          StorageDead(_4);
           StorageDead(_3);
           StorageDead(_2);
           return;

--- a/tests/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
+++ b/tests/mir-opt/issues/issue_75439.foo.MatchBranchSimplification.diff
@@ -5,23 +5,18 @@
       debug bytes => _1;
       let mut _0: std::option::Option<[u8; 4]>;
       let _2: [u32; 4];
-      let mut _3: [u8; 16];
-      let mut _5: [u8; 4];
-      let mut _6: u32;
+      let mut _4: [u8; 4];
       scope 1 {
           debug dwords => _2;
           scope 2 {
-              debug ip => _4;
-              let _4: u32;
+              debug ip => _3;
+              let _3: u32;
           }
       }
   
       bb0: {
           StorageLive(_2);
-          StorageLive(_3);
-          _3 = copy _1;
-          _2 = move _3 as [u32; 4] (Transmute);
-          StorageDead(_3);
+          _2 = copy _1 as [u32; 4] (Transmute);
           switchInt(copy _2[0 of 4]) -> [0: bb1, otherwise: bb4];
       }
   
@@ -34,15 +29,10 @@
       }
   
       bb3: {
+          _3 = copy _2[3 of 4];
           StorageLive(_4);
-          _4 = copy _2[3 of 4];
-          StorageLive(_5);
-          StorageLive(_6);
-          _6 = copy _4;
-          _5 = move _6 as [u8; 4] (Transmute);
-          StorageDead(_6);
-          _0 = Option::<[u8; 4]>::Some(move _5);
-          StorageDead(_5);
+          _4 = copy _3 as [u8; 4] (Transmute);
+          _0 = Option::<[u8; 4]>::Some(move _4);
           StorageDead(_4);
           goto -> bb5;
       }

--- a/tests/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.bar.MatchBranchSimplification.diff
@@ -45,7 +45,7 @@
 +         _3 = Eq(copy _11, const 7_i32);
           _4 = const false;
           _5 = const true;
-          _6 = ();
+-         _6 = ();
 -         goto -> bb3;
 -     }
 - 

--- a/tests/mir-opt/matches_reduce_branches.match_dead_store_failed.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_dead_store_failed.MatchBranchSimplification.diff
@@ -1,0 +1,45 @@
+- // MIR for `match_dead_store_failed` before MatchBranchSimplification
++ // MIR for `match_dead_store_failed` after MatchBranchSimplification
+  
+  fn match_dead_store_failed(_1: bool) -> () {
+      debug b => _1;
+      let mut _0: ();
+      let _2: (&str,);
+      let mut _3: &str;
+      let mut _4: bool;
+      let _5: &str;
+      scope 1 {
+          debug _b => _2;
+      }
+  
+      bb0: {
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = copy _1;
+          switchInt(move _4) -> [0: bb2, otherwise: bb1];
+      }
+  
+      bb1: {
+          _3 = const " ";
+          goto -> bb3;
+      }
+  
+      bb2: {
+          StorageLive(_5);
+          _5 = const "";
+          _3 = &(*_5);
+          StorageDead(_5);
+          goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_4);
+          _2 = (move _3,);
+          StorageDead(_3);
+          _0 = const ();
+          StorageDead(_2);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.match_u8_i8_2.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_i8_2.MatchBranchSimplification.diff
@@ -33,11 +33,7 @@
 -     bb2: {
 -         _2 = const -1_i8;
 -         _3 = const -1_i8;
-+         StorageLive(_8);
-+         _8 = move _5;
-+         _2 = copy _8 as i8 (IntToInt);
-+         _3 = copy _8 as i8 (IntToInt);
-          _4 = ();
+-         _4 = ();
 -         goto -> bb6;
 -     }
 - 
@@ -63,6 +59,10 @@
 -     }
 - 
 -     bb6: {
++         StorageLive(_8);
++         _8 = move _5;
++         _2 = copy _8 as i8 (IntToInt);
++         _3 = copy _8 as i8 (IntToInt);
 +         StorageDead(_8);
           StorageDead(_4);
           StorageLive(_6);

--- a/tests/mir-opt/matches_reduce_branches.match_u8_i8_dead_store.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_i8_dead_store.MatchBranchSimplification.diff
@@ -1,0 +1,47 @@
+- // MIR for `match_u8_i8_dead_store` before MatchBranchSimplification
++ // MIR for `match_u8_i8_dead_store` after MatchBranchSimplification
+  
+  fn match_u8_i8_dead_store(_1: EnumAu8) -> i8 {
+      let mut _0: i8;
+      let mut _2: u8;
++     let mut _3: u8;
+  
+      bb0: {
+          _2 = discriminant(_1);
+-         switchInt(copy _2) -> [0: bb1, 127: bb2, 128: bb3, 255: bb4, otherwise: bb5];
+-     }
+- 
+-     bb1: {
+-         _0 = const 0_i8;
+-         goto -> bb6;
+-     }
+- 
+-     bb2: {
+-         _0 = const 1_i8;
+-         _0 = const i8::MAX;
+-         goto -> bb6;
+-     }
+- 
+-     bb3: {
+-         _0 = const i8::MIN;
+-         goto -> bb6;
+-     }
+- 
+-     bb4: {
+-         _0 = const -1_i8;
+-         goto -> bb6;
+-     }
+- 
+-     bb5: {
+-         unreachable;
+-     }
+- 
+-     bb6: {
++         StorageLive(_3);
++         _3 = copy _2;
++         _0 = copy _3 as i8 (IntToInt);
++         StorageDead(_3);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/matches_reduce_branches.match_u8_i8_failed_len_1.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_i8_failed_len_1.MatchBranchSimplification.diff
@@ -17,7 +17,7 @@
   
       bb2: {
           _0 = const i8::MAX;
-          _0 = const i8::MAX;
+          _0 = Add(copy _0, const 0_i8);
           goto -> bb6;
       }
   

--- a/tests/mir-opt/matches_reduce_branches.match_u8_i8_failed_len_2.MatchBranchSimplification.diff
+++ b/tests/mir-opt/matches_reduce_branches.match_u8_i8_failed_len_2.MatchBranchSimplification.diff
@@ -27,7 +27,7 @@
   
       bb4: {
           _0 = const -1_i8;
-          _0 = const -1_i8;
+          _0 = Add(copy _0, const 0_i8);
           goto -> bb6;
       }
   

--- a/tests/mir-opt/matches_reduce_branches.rs
+++ b/tests/mir-opt/matches_reduce_branches.rs
@@ -672,6 +672,15 @@ fn match_i128_u128(i: EnumAi128) -> u128 {
     }
 }
 
+// We cannot merge these branches unless all the dead statements are eliminated.
+// EMIT_MIR matches_reduce_branches.match_dead_store_failed.MatchBranchSimplification.diff
+pub fn match_dead_store_failed(b: bool) {
+    // CHECK-LABEL: fn match_dead_store_failed(
+    // CHECK: switchInt
+    // CHECK: return
+    let _b = (if b { " " } else { "" },);
+}
+
 fn main() {
     let _ = foo(None);
     let _ = foo(Some(()));

--- a/tests/mir-opt/matches_reduce_branches.rs
+++ b/tests/mir-opt/matches_reduce_branches.rs
@@ -237,7 +237,7 @@ fn match_u8_i8_failed_len_1(i: EnumAu8) -> i8 {
         }
         bb2 = {
             RET = 127;
-            RET = 127;
+            RET = RET + 0;
             Goto(ret)
         }
         bb3 = {
@@ -289,6 +289,50 @@ fn match_u8_i8_failed_len_2(i: EnumAu8) -> i8 {
         }
         bb4 = {
             RET = -1;
+            RET = RET + 0;
+            Goto(ret)
+        }
+        unreachable_bb = {
+            Unreachable()
+        }
+        ret = {
+            Return()
+        }
+    }
+}
+
+// EMIT_MIR matches_reduce_branches.match_u8_i8_dead_store.MatchBranchSimplification.diff
+#[custom_mir(dialect = "built")]
+fn match_u8_i8_dead_store(i: EnumAu8) -> i8 {
+    // CHECK-LABEL: fn match_u8_i8_dead_store(
+    // CHECK-NOT: switchInt
+    // CHECK: IntToInt
+    // CHECK: return
+    mir! {
+        {
+            let a = Discriminant(i);
+            match a {
+                0 => bb1,
+                127 => bb2,
+                128 => bb3,
+                255 => bb4,
+                _ => unreachable_bb,
+            }
+        }
+        bb1 = {
+            RET = 0;
+            Goto(ret)
+        }
+        bb2 = {
+            RET = 1; // This a dead store statement.
+            RET = 127;
+            Goto(ret)
+        }
+        bb3 = {
+            RET = -128;
+            Goto(ret)
+        }
+        bb4 = {
             RET = -1;
             Goto(ret)
         }

--- a/tests/mir-opt/pre-codegen/clone_as_copy.enum_clone_as_copy.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/clone_as_copy.enum_clone_as_copy.PreCodegen.after.mir
@@ -5,11 +5,12 @@ fn enum_clone_as_copy(_1: &Enum1) -> Enum1 {
     let mut _0: Enum1;
     scope 1 (inlined <Enum1 as Clone>::clone) {
         debug self => _1;
-        let mut _2: isize;
+        let _2: &AllCopy;
         let mut _3: &AllCopy;
-        let mut _4: &NestCopy;
+        let _4: &NestCopy;
+        let mut _5: &NestCopy;
         scope 2 {
-            debug __self_0 => _3;
+            debug __self_0 => _2;
             scope 6 (inlined <AllCopy as Clone>::clone) {
                 debug self => _3;
             }
@@ -17,10 +18,10 @@ fn enum_clone_as_copy(_1: &Enum1) -> Enum1 {
         scope 3 {
             debug __self_0 => _4;
             scope 4 (inlined <NestCopy as Clone>::clone) {
-                debug self => _4;
-                let _5: &AllCopy;
+                debug self => _5;
+                let _6: &AllCopy;
                 scope 5 (inlined <AllCopy as Clone>::clone) {
-                    debug self => _5;
+                    debug self => _6;
                 }
             }
         }
@@ -30,33 +31,14 @@ fn enum_clone_as_copy(_1: &Enum1) -> Enum1 {
         StorageLive(_2);
         StorageLive(_3);
         StorageLive(_4);
-        _2 = discriminant((*_1));
-        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
-    }
-
-    bb1: {
-        _3 = &(((*_1) as A).0: AllCopy);
-        _0 = copy (*_1);
-        goto -> bb3;
-    }
-
-    bb2: {
-        _4 = &(((*_1) as B).0: NestCopy);
         StorageLive(_5);
-        _5 = &((((*_1) as B).0: NestCopy).1: AllCopy);
-        StorageDead(_5);
+        StorageLive(_6);
         _0 = copy (*_1);
-        goto -> bb3;
-    }
-
-    bb3: {
+        StorageDead(_6);
+        StorageDead(_5);
         StorageDead(_4);
         StorageDead(_3);
         StorageDead(_2);
         return;
-    }
-
-    bb4: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/pre-codegen/clone_as_copy.rs
+++ b/tests/mir-opt/pre-codegen/clone_as_copy.rs
@@ -32,12 +32,12 @@ fn clone_as_copy(v: &NestCopy) -> NestCopy {
     v.clone()
 }
 
-// FIXME: We can merge into exactly one assignment statement.
+// We can merge into exactly one assignment statement.
 // EMIT_MIR clone_as_copy.enum_clone_as_copy.PreCodegen.after.mir
 fn enum_clone_as_copy(v: &Enum1) -> Enum1 {
     // CHECK-LABEL: fn enum_clone_as_copy(
     // CHECK-NOT: = Enum1::
     // CHECK: _0 = copy (*_1);
-    // CHECK: _0 = copy (*_1);
+    // CHECK-NOT: _0 = copy (*_1);
     v.clone()
 }

--- a/tests/mir-opt/pre-codegen/try_identity.old.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/try_identity.old.PreCodegen.after.mir
@@ -3,38 +3,17 @@
 fn old(_1: Result<T, E>) -> Result<T, E> {
     debug x => _1;
     let mut _0: std::result::Result<T, E>;
-    let mut _2: isize;
-    let _3: T;
-    let _4: E;
+    let _2: T;
+    let _3: E;
     scope 1 {
-        debug v => _3;
+        debug v => _2;
     }
     scope 2 {
-        debug e => _4;
+        debug e => _3;
     }
 
     bb0: {
-        _2 = discriminant(_1);
-        switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
-    }
-
-    bb1: {
-        _3 = copy ((_1 as Ok).0: T);
         _0 = copy _1;
-        goto -> bb3;
-    }
-
-    bb2: {
-        _4 = copy ((_1 as Err).0: E);
-        _0 = copy _1;
-        goto -> bb3;
-    }
-
-    bb3: {
         return;
-    }
-
-    bb4: {
-        unreachable;
     }
 }

--- a/tests/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals-final.panic-abort.diff
+++ b/tests/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals-final.panic-abort.diff
@@ -8,6 +8,9 @@
       let mut _3: std::option::Option<T>;
       let mut _4: isize;
       let mut _5: isize;
+-     let mut _7: bool;
+-     let mut _8: u8;
+-     let mut _9: bool;
       scope 1 {
           debug a => _6;
           let _6: u8;
@@ -32,9 +35,7 @@
       }
   
       bb2: {
-          StorageLive(_6);
           _6 = copy (((_1.0: std::option::Option<u8>) as Some).0: u8);
-          StorageDead(_6);
           goto -> bb3;
       }
   

--- a/tests/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals-final.panic-unwind.diff
+++ b/tests/mir-opt/simplify_locals_fixedpoint.foo.SimplifyLocals-final.panic-unwind.diff
@@ -8,6 +8,9 @@
       let mut _3: std::option::Option<T>;
       let mut _4: isize;
       let mut _5: isize;
+-     let mut _7: bool;
+-     let mut _8: u8;
+-     let mut _9: bool;
       scope 1 {
           debug a => _6;
           let _6: u8;
@@ -32,9 +35,7 @@
       }
   
       bb2: {
-          StorageLive(_6);
           _6 = copy (((_1.0: std::option::Option<u8>) as Some).0: u8);
-          StorageDead(_6);
           goto -> bb3;
       }
   


### PR DESCRIPTION
#128299 simplified

```rust
bb0: {
    _2 = discriminant((*_1));
    switchInt(move _2) -> [0: bb4, 1: bb3, otherwise: bb2];
}
bb3: {
    _5 = &(((*_1) as B).0: NestCopy);
    _7 = copy ((((*_1) as B).0: NestCopy).0: i32);
    _9 = &((((*_1) as B).0: NestCopy).1: AllCopy);
    _11 = copy (((((*_1) as B).0: NestCopy).1: AllCopy).0: i32);
    _12 = copy (((((*_1) as B).0: NestCopy).1: AllCopy).1: u64);
    _13 = copy (((((*_1) as B).0: NestCopy).1: AllCopy).2: [i8; 3]);
    _8 = AllCopy { a: move _11, b: move _12, c: move _13 };
    _10 = copy ((((*_1) as B).0: NestCopy).2: [i8; 3]);
    _6 = NestCopy { a: move _7, b: move _8, c: move _10 };
    _0 = Enum1::B(move _6);
    goto -> bb1;
}
bb4: {
    _3 = &(((*_1) as A).0: AllCopy);
    _14 = copy ((((*_1) as A).0: AllCopy).0: i32);
    _15 = copy ((((*_1) as A).0: AllCopy).1: u64);
    _16 = copy ((((*_1) as A).0: AllCopy).2: [i8; 3]);
    _4 = AllCopy { a: move _14, b: move _15, c: move _16 };
    _0 = Enum1::A(move _4);
    StorageDead(_4);
    goto -> bb1;
}
```
to
```rust
bb0: {
    _2 = discriminant((*_1));
    switchInt(move _2) -> [0: bb1, 1: bb2, otherwise: bb4];
}
bb1: {
    _3 = &(((*_1) as A).0: AllCopy);
    _0 = copy (*_1);
    goto -> bb3;
}
bb2: {
    _4 = &(((*_1) as B).0: NestCopy);
    StorageLive(_5);
    _5 = &((((*_1) as B).0: NestCopy).1: AllCopy);
    StorageDead(_5);
    _0 = copy (*_1);
    goto -> bb3;
}
```

Since all of these are dead store statements, we can simplify and merge them into a single copy statement.