### PR TITLE
rustdoc css: fix border-radius of examples with line numbers

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -748,6 +748,12 @@ ul.block, .block li {
 .rustdoc .example-wrap > pre {
 	border-radius: 6px;
 }
+.rustdoc .example-wrap > pre.example-line-numbers {
+	border-radius: 6px 0 0 6px;
+}
+.rustdoc .example-wrap > pre.example-line-numbers + pre {
+	border-radius: 0 6px 6px 0;
+}
 
 /* For the last child of a div, the margin will be taken care of
 	by the margin-top of the next item. */


### PR DESCRIPTION
No more dents in the example blocks.

before: ![image](https://github.com/user-attachments/assets/f1e98468-49d4-4fd9-b341-6bd2c3669d3c)

after: ![image](https://github.com/user-attachments/assets/c3d2330b-322c-458a-b631-eae0a3a730cc)

without line numbers for comparison: ![image](https://github.com/user-attachments/assets/0af63a80-b891-403a-a167-1c9ad3595ba8)
