### PR TITLE
s390x: Fix a regression related to backchain feature

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -353,9 +353,7 @@ pub fn target_features(sess: &Session, allow_unstable: bool) -> Vec<Symbol> {
                 None
             }
         })
-        .filter(|feature| {
-            RUSTC_SPECIAL_FEATURES.contains(feature) || features.contains(&Symbol::intern(feature))
-        })
+        .filter(|feature| features.contains(&Symbol::intern(feature)))
         .map(|feature| Symbol::intern(feature))
         .collect()
 }

--- a/tests/assembly/s390x-backchain-toggle.rs
+++ b/tests/assembly/s390x-backchain-toggle.rs
@@ -1,0 +1,46 @@
+//@ revisions: enable-backchain disable-backchain
+//@ assembly-output: emit-asm
+//@ compile-flags: -O --crate-type=lib --target=s390x-unknown-linux-gnu
+//@ needs-llvm-components: systemz
+//@[enable-backchain] compile-flags: -Ctarget-feature=+backchain
+//@[disable-backchain] compile-flags: -Ctarget-feature=-backchain
+#![feature(no_core, lang_items)]
+#![no_std]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+
+extern "C" {
+    fn extern_func();
+}
+
+// CHECK-LABEL: test_backchain
+#[no_mangle]
+extern "C" fn test_backchain() -> i32 {
+    // Here we try to match if backchain register is saved to the parameter area (stored in r15/sp)
+    // And also if a new parameter area (160 bytes) is allocated for the upcoming function call
+    // enable-backchain: lgr [[REG1:.*]], %r15
+    // enable-backchain-NEXT: aghi %r15, -160
+    // enable-backchain: stg [[REG1]], 0(%r15)
+    // disable-backchain: aghi %r15, -160
+    // disable-backchain-NOT: stg %r{{.*}}, 0(%r15)
+    unsafe {
+        extern_func();
+    }
+    // enable-backchain-NEXT: brasl %r{{.*}}, extern_func@PLT
+    // disable-backchain: brasl %r{{.*}}, extern_func@PLT
+
+    // Make sure that the expected return value is written into %r2 (return register):
+    // enable-backchain-NEXT: lghi %r2, 1
+    // disable-backchain: lghi %r2, 0
+    #[cfg(target_feature = "backchain")]
+    {
+        1
+    }
+    #[cfg(not(target_feature = "backchain"))]
+    {
+        0
+    }
+    // CHECK: br %r{{.*}}
+}


### PR DESCRIPTION
In #127506, we introduced a new IBM Z-specific target feature, `backchain`.

This particular `target-feature` was available as a function-level attribute in LLVM 17 and below, so some hacks were used to avoid blowing up LLVM when querying the supported LLVM features.

This led to an unfortunate regression where `cfg!(target-feature = "backchain")` will always return true.

This pull request aims to fix this issue, and a test has been introduced to ensure it will never happen again.

Fixes #129927.

r? @RalfJung
