### PR TITLE
[stable] Fix CVE-2024-43402

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -50,6 +50,7 @@ Libraries
 - [Replace sort implementations with stable `driftsort` and unstable `ipnsort`.](https://github.com/rust-lang/rust/pull/124032/) All `slice::sort*` and `slice::select_nth*` methods are expected to see significant performance improvements. See the [research project](https://github.com/Voultapher/sort-research-rs) for more details.
 - [Document behavior of `create_dir_all` with respect to empty paths.](https://github.com/rust-lang/rust/pull/125112/)
 - [Fix interleaved output in the default panic hook when multiple threads panic simultaneously.](https://github.com/rust-lang/rust/pull/127397/)
+- Fix `Command`'s batch files argument escaping not working when file name has trailing whitespace or periods (CVE-2024-43402).
 
 <a id="1.81.0-Stabilized-APIs"></a>
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -101,6 +101,9 @@ Compatibility Notes
   The reason is that these types have different roles: `std::panic::PanicHookInfo` is the argument to the [panic hook](https://doc.rust-lang.org/stable/std/panic/fn.set_hook.html) in std context (where panics can have an arbitrary payload), while `core::panic::PanicInfo` is the argument to the [`#[panic_handler]`](https://doc.rust-lang.org/nomicon/panic-handler.html) in no_std context (where panics always carry a formatted *message*). Separating these types allows us to add more useful methods to these types, such as `std::panic::PanicHookInfo::payload_as_str()` and `core::panic::PanicInfo::message()`.
 
 * The new sort implementations may panic if a type's implementation of [`Ord`](https://doc.rust-lang.org/std/cmp/trait.Ord.html) (or the given comparison function) does not implement a [total order](https://en.wikipedia.org/wiki/Total_order) as the trait requires. `Ord`'s supertraits (`PartialOrd`, `Eq`, and `PartialEq`) must also be consistent. The previous implementations would not "notice" any problem, but the new implementations have a good chance of detecting inconsistencies, throwing a panic rather than returning knowingly unsorted data.
+* [In very rare cases, a change in the internal evaluation order of the trait
+  solver may result in new fatal overflow errors.](https://github.com/rust-lang/rust/pull/126128)
+
 
 <a id="1.81.0-Internal-Changes"></a>
 

--- a/library/std/src/sys/pal/windows/mod.rs
+++ b/library/std/src/sys/pal/windows/mod.rs
@@ -14,7 +14,7 @@ pub use self::rand::hashmap_random_keys;
 #[macro_use]
 pub mod compat;
 
-mod api;
+pub mod api;
 
 pub mod alloc;
 pub mod args;

--- a/library/std/src/sys/pal/windows/process.rs
+++ b/library/std/src/sys/pal/windows/process.rs
@@ -279,11 +279,24 @@ impl Command {
             None
         };
         let program = resolve_exe(&self.program, || env::var_os("PATH"), child_paths)?;
-        // Case insensitive "ends_with" of UTF-16 encoded ".bat" or ".cmd"
-        let is_batch_file = matches!(
-            program.len().checked_sub(5).and_then(|i| program.get(i..)),
-            Some([46, 98 | 66, 97 | 65, 116 | 84, 0] | [46, 99 | 67, 109 | 77, 100 | 68, 0])
-        );
+        let has_bat_extension = |program: &[u16]| {
+            matches!(
+                // Case insensitive "ends_with" of UTF-16 encoded ".bat" or ".cmd"
+                program.len().checked_sub(4).and_then(|i| program.get(i..)),
+                Some([46, 98 | 66, 97 | 65, 116 | 84] | [46, 99 | 67, 109 | 77, 100 | 68])
+            )
+        };
+        let is_batch_file = if path::is_verbatim(&program) {
+            has_bat_extension(&program[..program.len() - 1])
+        } else {
+            super::fill_utf16_buf(
+                |buffer, size| unsafe {
+                    // resolve the path so we can test the final file name.
+                    c::GetFullPathNameW(program.as_ptr(), size, buffer, ptr::null_mut())
+                },
+                |program| has_bat_extension(program),
+            )?
+        };
         let (program, mut cmd_str) = if is_batch_file {
             (
                 command_prompt()?,

--- a/library/std/src/sys/path/windows.rs
+++ b/library/std/src/sys/path/windows.rs
@@ -2,6 +2,7 @@ use crate::ffi::{OsStr, OsString};
 use crate::io;
 use crate::path::{Path, PathBuf, Prefix};
 use crate::ptr;
+use crate::sys::api::utf16;
 use crate::sys::pal::{c, fill_utf16_buf, os2path, to_u16s};
 
 #[cfg(test)]
@@ -18,6 +19,10 @@ pub fn is_sep_byte(b: u8) -> bool {
 #[inline]
 pub fn is_verbatim_sep(b: u8) -> bool {
     b == b'\\'
+}
+
+pub fn is_verbatim(path: &[u16]) -> bool {
+    path.starts_with(utf16!(r"\\?\")) || path.starts_with(utf16!(r"\??\"))
 }
 
 /// Returns true if `path` looks like a lone filename.

--- a/tests/ui/std/windows-bat-args.rs
+++ b/tests/ui/std/windows-bat-args.rs
@@ -32,7 +32,9 @@ fn parent() {
     let bat2 = String::from(bat.to_str().unwrap());
     bat.set_file_name("windows-bat-args3.bat");
     let bat3 = String::from(bat.to_str().unwrap());
-    let bat = [bat1.as_str(), bat2.as_str(), bat3.as_str()];
+    bat.set_file_name("windows-bat-args1.bat .. ");
+    let bat4 = String::from(bat.to_str().unwrap());
+    let bat = [bat1.as_str(), bat2.as_str(), bat3.as_str(), bat4.as_str()];
 
     check_args(&bat, &["a", "b"]).unwrap();
     check_args(&bat, &["c is for cat", "d is for dog"]).unwrap();


### PR DESCRIPTION
Backport the fix for CVE-2024-43402 in the upcoming 1.81.0. See https://github.com/rust-lang/rust/security/advisories/GHSA-2xg3-7mm6-98jj for more information about it.

This also includes https://github.com/rust-lang/rust/pull/129944 as a last-minute fix to the relnotes.

cc @boxyuwu as you are driving this release
r? @ghost

