### PR TITLE
[DO NOT MERGE] Try `indexmap` with its own `RawTable`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,12 +1764,10 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
+version = "2.5.0"
+source = "git+https://github.com/cuviper/indexmap?branch=raw#4db206673c970d65e35cecebf9d26acd85b15a30"
 dependencies = [
  "equivalent",
- "hashbrown",
  "rustc-rayon",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,7 @@ codegen-units = 1
 # FIXME: LTO cannot be enabled for binaries in a workspace
 # <https://github.com/rust-lang/cargo/issues/9330>
 # lto = true
+
+[patch.crates-io.indexmap]
+git = "https://github.com/cuviper/indexmap"
+branch = "raw"


### PR DESCRIPTION
I want to see whether there's any noticeable performance difference in `rustc` if `indexmap` embeds its own copy of `hashbrown::raw::RawTable<usize>`, specialized for its own use. The generic parameters are removed, as well as a lot of unused code, and some of the raw API is further tweaked for dealing with always-copyable `usize` data.

* Full `indexmap` comparison: https://github.com/indexmap-rs/indexmap/compare/master...cuviper:raw
* Changes after the initial import: https://github.com/indexmap-rs/indexmap/compare/cfb8d042a59c4532550f634364495795fab61fbe...cuviper:raw

r? ghost