### PR TITLE
Arbitrary self types: diagnostics for mismatched self types

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -15,6 +15,7 @@ use rustc_middle::ty::{
 };
 use rustc_span::Span;
 use rustc_trait_selection::error_reporting::infer::nice_region_error::NiceRegionError;
+use rustc_trait_selection::error_reporting::infer::TypeErrorRole;
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::traits::query::type_op;
 use rustc_trait_selection::traits::ObligationCtxt;
@@ -482,12 +483,11 @@ fn try_extract_error_from_region_constraints<'a, 'tcx>(
         .try_report_from_nll()
         .or_else(|| {
             if let SubregionOrigin::Subtype(trace) = cause {
-                Some(
-                    infcx.err_ctxt().report_and_explain_type_error(
-                        *trace,
-                        TypeError::RegionsPlaceholderMismatch,
-                    ),
-                )
+                Some(infcx.err_ctxt().report_and_explain_type_error(
+                    *trace,
+                    TypeError::RegionsPlaceholderMismatch,
+                    TypeErrorRole::Elsewhere,
+                ))
             } else {
                 None
             }

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -21,6 +21,7 @@ use rustc_middle::ty::{
 };
 use rustc_middle::{bug, span_bug};
 use rustc_span::Span;
+use rustc_trait_selection::error_reporting::infer::TypeErrorRole;
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::regions::InferCtxtRegionExt;
@@ -612,6 +613,7 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
                 terr,
                 false,
                 false,
+                TypeErrorRole::Elsewhere,
             );
             return Err(diag.emit());
         }
@@ -1036,6 +1038,7 @@ fn report_trait_method_mismatch<'tcx>(
         terr,
         false,
         false,
+        TypeErrorRole::Elsewhere,
     );
 
     return diag.emit();
@@ -1843,6 +1846,7 @@ fn compare_const_predicate_entailment<'tcx>(
             terr,
             false,
             false,
+            TypeErrorRole::Elsewhere,
         );
         return Err(diag.emit());
     };

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -93,7 +93,7 @@ use rustc_span::symbol::{kw, sym, Ident};
 use rustc_span::{BytePos, Span, Symbol, DUMMY_SP};
 use rustc_target::abi::VariantIdx;
 use rustc_target::spec::abi::Abi;
-use rustc_trait_selection::error_reporting::infer::ObligationCauseExt as _;
+use rustc_trait_selection::error_reporting::infer::{ObligationCauseExt as _, TypeErrorRole};
 use rustc_trait_selection::error_reporting::traits::suggestions::ReturnsVisitor;
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::traits::ObligationCtxt;
@@ -656,6 +656,7 @@ pub fn check_function_signature<'tcx>(
                 err,
                 false,
                 false,
+                TypeErrorRole::Elsewhere,
             );
             return Err(diag.emit());
         }

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -521,7 +521,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                 // to the feature, like the self type can't reference method args.
                 if self.tcx.features().arbitrary_self_types {
                     self.err_ctxt()
-                        .report_mismatched_types(&cause, method_self_ty, self_ty, terr)
+                        .report_mismatched_self_types(&cause, method_self_ty, self_ty, terr)
                         .emit();
                 } else {
                     // This has/will have errored in wfcheck, which we cannot depend on from here, as typeck on functions

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -35,6 +35,7 @@ use rustc_session::parse::feature_err;
 use rustc_span::symbol::{kw, sym, Symbol};
 use rustc_span::{BytePos, Span, DUMMY_SP};
 use rustc_target::spec::abi::Abi;
+use rustc_trait_selection::error_reporting::infer::TypeErrorRole;
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
 use rustc_trait_selection::infer::{TyCtxtInferExt, ValuePairs};
 use rustc_trait_selection::traits::ObligationCtxt;
@@ -2336,6 +2337,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 terr,
                 false,
                 false,
+                TypeErrorRole::Elsewhere,
             );
             diag.emit();
             self.abort.set(true);

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -18,7 +18,7 @@ use rustc_type_ir::Upcast as _;
 use tracing::{debug, instrument};
 
 use super::nice_region_error::find_anon_type;
-use super::ObligationCauseAsDiagArg;
+use super::{ObligationCauseAsDiagArg, TypeErrorRole};
 use crate::error_reporting::infer::ObligationCauseExt;
 use crate::error_reporting::TypeErrCtxt;
 use crate::errors::{
@@ -295,7 +295,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let mut err = match origin {
             infer::Subtype(box trace) => {
                 let terr = TypeError::RegionsDoesNotOutlive(sup, sub);
-                let mut err = self.report_and_explain_type_error(trace, terr);
+                let mut err =
+                    self.report_and_explain_type_error(trace, terr, TypeErrorRole::Elsewhere);
                 match (*sub, *sup) {
                     (ty::RePlaceholder(_), ty::RePlaceholder(_)) => {}
                     (ty::RePlaceholder(_), _) => {
@@ -638,7 +639,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
             infer::Subtype(box trace) => {
                 let terr = TypeError::RegionsPlaceholderMismatch;
-                return self.report_and_explain_type_error(trace, terr);
+                return self.report_and_explain_type_error(trace, terr, TypeErrorRole::Elsewhere);
             }
             _ => {
                 return self.report_concrete_failure(

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -35,7 +35,7 @@ use super::suggestions::get_explanation_based_on_obligation;
 use super::{
     ArgKind, CandidateSimilarity, GetSafeTransmuteErrorAndReason, ImplCandidate, UnsatisfiedConst,
 };
-use crate::error_reporting::infer::TyCategory;
+use crate::error_reporting::infer::{TyCategory, TypeErrorRole};
 use crate::error_reporting::traits::report_object_safety_error;
 use crate::error_reporting::TypeErrCtxt;
 use crate::errors::{
@@ -667,6 +667,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     TypeError::Sorts(ty::error::ExpectedFound::new(true, expected_ty, ct_ty)),
                     false,
                     false,
+                    TypeErrorRole::Elsewhere
                 );
                 diag
             }
@@ -1410,6 +1411,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 err,
                 true,
                 false,
+                TypeErrorRole::Elsewhere,
             );
             self.note_obligation_cause(&mut diag, obligation);
             diag.emit()
@@ -2556,6 +2558,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         self.report_and_explain_type_error(
             TypeTrace::trait_refs(&cause, true, expected_trait_ref, found_trait_ref),
             terr,
+            TypeErrorRole::Elsewhere,
         )
     }
 
@@ -2653,6 +2656,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         found_trait_ref,
                     ),
                     ty::error::TypeError::Mismatch,
+                    TypeErrorRole::Elsewhere,
                 )
             } else if found.len() == expected.len() {
                 self.report_closure_arg_mismatch(

--- a/tests/ui/self/arbitrary-self-from-method-substs.feature.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs.feature.stderr
@@ -3,6 +3,8 @@ error[E0308]: mismatched types
    |
 LL |     foo.get::<&Foo>();
    |     ^^^ expected `&Foo`, found `Foo`
+   |
+   = note: this error occurred while resolving the `self` type of this method call
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Add extra diagnostics for cases where self types don't match.

Most of this is new tests. These are slightly duplicative of the existing `arbitrary-self-from-method-substs.rs` test, but test more permutations so it seems worth adding to the coverage as we explore improving the diagnostics here.

Improved diagnostics were suggested in commit 05c5caa5002297d2e3ba31f2ead7556a732a2289

This is a part of the arbitrary self types v2 project, https://github.com/rust-lang/rfcs/pull/3519
and specifically the sub-issue exploring questions around generics,
https://github.com/rust-lang/rust/issues/129147

Tracking:

- https://github.com/rust-lang/rust/issues/44874