### PR TITLE
add `Vec::set_len_zero` as a safe helper (internal)

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1489,6 +1489,47 @@ impl<T, A: Allocator> Vec<T, A> {
         self.len = new_len;
     }
 
+    /// Forces the length of the vector to `0usize`.
+    ///
+    /// This is a low-level operation that maintains some of the normal
+    /// invariants of the type. Normally changing the length of a vector
+    /// is done using one of the safe operations instead, such as
+    /// [`truncate`], [`resize`], [`extend`], or [`clear`].
+    ///
+    /// [`truncate`]: Vec::truncate
+    /// [`resize`]: Vec::resize
+    /// [`extend`]: Extend::extend
+    /// [`clear`]: Vec::clear
+    ///
+    /// # Examples
+    ///
+    /// While the following example is sound, there is a memory leak since
+    /// the inner vectors were not freed prior to the [`set_len`] call:
+    ///
+    /// [`set_len`]: Vec::set_len
+    ///
+    /// ```
+    /// let mut vec = vec![vec![1, 0, 0],
+    ///                    vec![0, 1, 0],
+    ///                    vec![0, 0, 1]];
+    /// // SAFETY:
+    /// // 1. `old_len..0` is empty so no elements need to be initialized.
+    /// // 2. `0 <= capacity` always holds whatever `capacity` is.
+    /// unsafe {
+    ///     vec.set_len_zero();
+    /// #   // FIXME(https://github.com/rust-lang/miri/issues/3670):
+    /// #   // use -Zmiri-disable-leak-check instead of unleaking in tests meant to leak.
+    /// #   vec.set_len(3);
+    /// }
+    /// ```
+    ///
+    /// Normally, here, one would use [`clear`] instead to correctly drop
+    /// the contents and thus not leak memory.
+    #[inline]
+    fn set_len_zero(&mut self) {
+        self.len = 0;
+    }
+
     /// Removes an element from the vector and returns it.
     ///
     /// The removed element is replaced by the last element of the vector.

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1508,7 +1508,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// [`set_len`]: Vec::set_len
     ///
-    /// ```
+    /// ```no_run
     /// let mut vec = vec![vec![1, 0, 0],
     ///                    vec![0, 1, 0],
     ///                    vec![0, 0, 1]];

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -1763,7 +1763,7 @@ impl<T, A: Allocator> Vec<T, A> {
 
         // Avoid double drop if the drop guard is not executed,
         // since we may make some holes during the process.
-        unsafe { self.set_len(0) };
+        self.set_len_zero();
 
         // Vec: [Kept, Kept, Hole, Hole, Hole, Hole, Unchecked, Unchecked]
         //      |<-              processed len   ->| ^- next to check
@@ -2185,10 +2185,8 @@ impl<T, A: Allocator> Vec<T, A> {
     #[inline]
     #[stable(feature = "append", since = "1.4.0")]
     pub fn append(&mut self, other: &mut Self) {
-        unsafe {
-            self.append_elements(other.as_slice() as _);
-            other.set_len(0);
-        }
+        unsafe { self.append_elements(other.as_slice() as _); }
+        other.set_len_zero();
     }
 
     /// Appends elements to `self` from other buffer.
@@ -3283,9 +3281,7 @@ impl<T, A: Allocator> Vec<T, A> {
         let old_len = self.len();
 
         // Guard against us getting leaked (leak amplification)
-        unsafe {
-            self.set_len(0);
-        }
+        self.set_len_zero();
 
         ExtractIf { vec: self, idx: 0, del: 0, old_len, pred: filter }
     }
@@ -3622,8 +3618,7 @@ impl<T, A: Allocator, const N: usize> TryFrom<Vec<T, A>> for [T; N] {
             return Err(vec);
         }
 
-        // SAFETY: `.set_len(0)` is always sound.
-        unsafe { vec.set_len(0) };
+        vec.set_len_zero();
 
         // SAFETY: A `Vec`'s pointer is always aligned properly, and
         // the alignment the array needs is the same as the items.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

`set_len_zero` is just a utility/helper private method that can be used as an alternative to `set_len(0)`. I expect this to be convenient, because it's not `unsafe` and always sound.

Maybe, in the future, it could be stabilized as `pub`!

I want to clarify that this PR is just a refactor. It's not meant to change the lib API, unless someone opens an RFC for it