### PR TITLE
Update compiler-builtins to 0.1.125

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.123"
+version = "0.1.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47fcbecb558bdad78c7d3a998523c60a50dd6cd046d5fe74163e309e878fff7"
+checksum = "bd02a01d7bc069bed818e956600fe437ee222dd1d6ad92bfb9db87b43b71fd87"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { version = "0.1.123", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "0.1.125", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "0.1.123" }
+compiler_builtins = { version = "0.1.125" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.14", default-features = false, features = [


### PR DESCRIPTION
This commit updates the compiler-builtins crate from 0.1.123 to 0.1.125. The changes in this update are:

* https://github.com/rust-lang/compiler-builtins/pull/682
* https://github.com/rust-lang/compiler-builtins/pull/678
* https://github.com/rust-lang/compiler-builtins/pull/685

<!-- homu-ignore:start -->
Fixes: https://github.com/rust-lang/rust/issues/129823
<!-- homu-ignore:end -->