### PR TITLE
coverage: Extract `executor::block_on` from several async coverage tests

### DIFF
--- a/tests/coverage/async.cov-map
+++ b/tests/coverage/async.cov-map
@@ -1,103 +1,103 @@
 Function name: async::c
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 09, 01, 00, 19]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 0c, 01, 00, 19]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 9, 1) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 12, 1) to (start + 0, 25)
 
 Function name: async::c::{closure#0}
-Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 09, 19, 01, 0e, 05, 02, 09, 00, 0a, 02, 02, 09, 00, 0a, 01, 02, 01, 00, 02]
+Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 0c, 19, 01, 0e, 05, 02, 09, 00, 0a, 02, 02, 09, 00, 0a, 01, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
 Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 9, 25) to (start + 1, 14)
+- Code(Counter(0)) at (prev + 12, 25) to (start + 1, 14)
 - Code(Counter(1)) at (prev + 2, 9) to (start + 0, 10)
 - Code(Expression(0, Sub)) at (prev + 2, 9) to (start + 0, 10)
     = (c0 - c1)
 - Code(Counter(0)) at (prev + 2, 1) to (start + 0, 2)
 
 Function name: async::d
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 11, 01, 00, 14]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 14, 01, 00, 14]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 17, 1) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 20, 1) to (start + 0, 20)
 
 Function name: async::d::{closure#0}
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 11, 14, 00, 19]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 14, 14, 00, 19]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 17, 20) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 20, 20) to (start + 0, 25)
 
 Function name: async::e (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 13, 01, 00, 14]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 16, 01, 00, 14]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 19, 1) to (start + 0, 20)
+- Code(Zero) at (prev + 22, 1) to (start + 0, 20)
 
 Function name: async::e::{closure#0} (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 13, 14, 00, 19]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 16, 14, 00, 19]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 19, 20) to (start + 0, 25)
+- Code(Zero) at (prev + 22, 20) to (start + 0, 25)
 
 Function name: async::f
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 15, 01, 00, 14]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 18, 01, 00, 14]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 21, 1) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 24, 1) to (start + 0, 20)
 
 Function name: async::f::{closure#0}
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 15, 14, 00, 19]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 18, 14, 00, 19]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 21, 20) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 24, 20) to (start + 0, 25)
 
 Function name: async::foo (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 17, 01, 00, 1e]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 1a, 01, 00, 1e]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 23, 1) to (start + 0, 30)
+- Code(Zero) at (prev + 26, 1) to (start + 0, 30)
 
 Function name: async::foo::{closure#0} (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 17, 1e, 00, 2d]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 1a, 1e, 00, 2d]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 23, 30) to (start + 0, 45)
+- Code(Zero) at (prev + 26, 30) to (start + 0, 45)
 
 Function name: async::g
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 19, 01, 00, 17]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 1c, 01, 00, 17]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 25, 1) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 28, 1) to (start + 0, 23)
 
 Function name: async::g::{closure#0} (unused)
-Raw bytes (59): 0x[01, 01, 00, 0b, 00, 19, 17, 01, 0c, 00, 02, 09, 00, 0a, 00, 00, 0e, 00, 17, 00, 00, 1b, 00, 1c, 00, 00, 20, 00, 22, 00, 01, 09, 00, 0a, 00, 00, 0e, 00, 17, 00, 00, 1b, 00, 1c, 00, 00, 20, 00, 22, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
+Raw bytes (59): 0x[01, 01, 00, 0b, 00, 1c, 17, 01, 0c, 00, 02, 09, 00, 0a, 00, 00, 0e, 00, 17, 00, 00, 1b, 00, 1c, 00, 00, 20, 00, 22, 00, 01, 09, 00, 0a, 00, 00, 0e, 00, 17, 00, 00, 1b, 00, 1c, 00, 00, 20, 00, 22, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 11
-- Code(Zero) at (prev + 25, 23) to (start + 1, 12)
+- Code(Zero) at (prev + 28, 23) to (start + 1, 12)
 - Code(Zero) at (prev + 2, 9) to (start + 0, 10)
 - Code(Zero) at (prev + 0, 14) to (start + 0, 23)
 - Code(Zero) at (prev + 0, 27) to (start + 0, 28)
@@ -110,20 +110,20 @@ Number of file 0 mappings: 11
 - Code(Zero) at (prev + 2, 1) to (start + 0, 2)
 
 Function name: async::h
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 21, 01, 00, 16]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 24, 01, 00, 16]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 33, 1) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 36, 1) to (start + 0, 22)
 
 Function name: async::h::{closure#0} (unused)
-Raw bytes (39): 0x[01, 01, 00, 07, 00, 21, 16, 03, 0c, 00, 04, 09, 00, 0a, 00, 00, 0e, 00, 19, 00, 00, 1a, 00, 1b, 00, 00, 20, 00, 22, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
+Raw bytes (39): 0x[01, 01, 00, 07, 00, 24, 16, 03, 0c, 00, 04, 09, 00, 0a, 00, 00, 0e, 00, 19, 00, 00, 1a, 00, 1b, 00, 00, 20, 00, 22, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 7
-- Code(Zero) at (prev + 33, 22) to (start + 3, 12)
+- Code(Zero) at (prev + 36, 22) to (start + 3, 12)
 - Code(Zero) at (prev + 4, 9) to (start + 0, 10)
 - Code(Zero) at (prev + 0, 14) to (start + 0, 25)
 - Code(Zero) at (prev + 0, 26) to (start + 0, 27)
@@ -132,22 +132,22 @@ Number of file 0 mappings: 7
 - Code(Zero) at (prev + 2, 1) to (start + 0, 2)
 
 Function name: async::i
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 2a, 01, 00, 13]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 2d, 01, 00, 13]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 42, 1) to (start + 0, 19)
+- Code(Counter(0)) at (prev + 45, 1) to (start + 0, 19)
 
 Function name: async::i::{closure#0}
-Raw bytes (63): 0x[01, 01, 02, 07, 19, 11, 15, 0b, 01, 2a, 13, 04, 0c, 09, 05, 09, 00, 0a, 01, 00, 0e, 00, 18, 05, 00, 1c, 00, 21, 09, 00, 27, 00, 30, 15, 01, 09, 00, 0a, 0d, 00, 0e, 00, 17, 1d, 00, 1b, 00, 20, 15, 00, 24, 00, 26, 19, 01, 0e, 00, 10, 03, 02, 01, 00, 02]
+Raw bytes (63): 0x[01, 01, 02, 07, 19, 11, 15, 0b, 01, 2d, 13, 04, 0c, 09, 05, 09, 00, 0a, 01, 00, 0e, 00, 18, 05, 00, 1c, 00, 21, 09, 00, 27, 00, 30, 15, 01, 09, 00, 0a, 0d, 00, 0e, 00, 17, 1d, 00, 1b, 00, 20, 15, 00, 24, 00, 26, 19, 01, 0e, 00, 10, 03, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 2
 - expression 0 operands: lhs = Expression(1, Add), rhs = Counter(6)
 - expression 1 operands: lhs = Counter(4), rhs = Counter(5)
 Number of file 0 mappings: 11
-- Code(Counter(0)) at (prev + 42, 19) to (start + 4, 12)
+- Code(Counter(0)) at (prev + 45, 19) to (start + 4, 12)
 - Code(Counter(2)) at (prev + 5, 9) to (start + 0, 10)
 - Code(Counter(0)) at (prev + 0, 14) to (start + 0, 24)
 - Code(Counter(1)) at (prev + 0, 28) to (start + 0, 33)
@@ -161,14 +161,14 @@ Number of file 0 mappings: 11
     = ((c4 + c5) + c6)
 
 Function name: async::j
-Raw bytes (58): 0x[01, 01, 02, 07, 0d, 05, 09, 0a, 01, 35, 01, 00, 0d, 01, 0b, 0b, 00, 0c, 05, 01, 09, 00, 0a, 01, 00, 0e, 00, 1b, 05, 00, 1f, 00, 27, 09, 01, 09, 00, 0a, 11, 00, 0e, 00, 1a, 09, 00, 1e, 00, 20, 0d, 01, 0e, 00, 10, 03, 02, 01, 00, 02]
+Raw bytes (58): 0x[01, 01, 02, 07, 0d, 05, 09, 0a, 01, 38, 01, 00, 0d, 01, 0b, 0b, 00, 0c, 05, 01, 09, 00, 0a, 01, 00, 0e, 00, 1b, 05, 00, 1f, 00, 27, 09, 01, 09, 00, 0a, 11, 00, 0e, 00, 1a, 09, 00, 1e, 00, 20, 0d, 01, 0e, 00, 10, 03, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 2
 - expression 0 operands: lhs = Expression(1, Add), rhs = Counter(3)
 - expression 1 operands: lhs = Counter(1), rhs = Counter(2)
 Number of file 0 mappings: 10
-- Code(Counter(0)) at (prev + 53, 1) to (start + 0, 13)
+- Code(Counter(0)) at (prev + 56, 1) to (start + 0, 13)
 - Code(Counter(0)) at (prev + 11, 11) to (start + 0, 12)
 - Code(Counter(1)) at (prev + 1, 9) to (start + 0, 10)
 - Code(Counter(0)) at (prev + 0, 14) to (start + 0, 27)
@@ -181,48 +181,48 @@ Number of file 0 mappings: 10
     = ((c1 + c2) + c3)
 
 Function name: async::j::c
-Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 37, 05, 01, 12, 05, 02, 0d, 00, 0e, 02, 02, 0d, 00, 0e, 01, 02, 05, 00, 06]
+Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 3a, 05, 01, 12, 05, 02, 0d, 00, 0e, 02, 02, 0d, 00, 0e, 01, 02, 05, 00, 06]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
 Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 55, 5) to (start + 1, 18)
+- Code(Counter(0)) at (prev + 58, 5) to (start + 1, 18)
 - Code(Counter(1)) at (prev + 2, 13) to (start + 0, 14)
 - Code(Expression(0, Sub)) at (prev + 2, 13) to (start + 0, 14)
     = (c0 - c1)
 - Code(Counter(0)) at (prev + 2, 5) to (start + 0, 6)
 
 Function name: async::j::d
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 3e, 05, 00, 17]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 41, 05, 00, 17]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 62, 5) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 65, 5) to (start + 0, 23)
 
 Function name: async::j::f
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 3f, 05, 00, 17]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 42, 05, 00, 17]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 63, 5) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 66, 5) to (start + 0, 23)
 
 Function name: async::k (unused)
-Raw bytes (29): 0x[01, 01, 00, 05, 00, 47, 01, 01, 0c, 00, 02, 0e, 00, 10, 00, 01, 0e, 00, 10, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
+Raw bytes (29): 0x[01, 01, 00, 05, 00, 4a, 01, 01, 0c, 00, 02, 0e, 00, 10, 00, 01, 0e, 00, 10, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 5
-- Code(Zero) at (prev + 71, 1) to (start + 1, 12)
+- Code(Zero) at (prev + 74, 1) to (start + 1, 12)
 - Code(Zero) at (prev + 2, 14) to (start + 0, 16)
 - Code(Zero) at (prev + 1, 14) to (start + 0, 16)
 - Code(Zero) at (prev + 1, 14) to (start + 0, 16)
 - Code(Zero) at (prev + 2, 1) to (start + 0, 2)
 
 Function name: async::l
-Raw bytes (37): 0x[01, 01, 04, 01, 07, 05, 09, 0f, 02, 09, 05, 05, 01, 4f, 01, 01, 0c, 02, 02, 0e, 00, 10, 05, 01, 0e, 00, 10, 09, 01, 0e, 00, 10, 0b, 02, 01, 00, 02]
+Raw bytes (37): 0x[01, 01, 04, 01, 07, 05, 09, 0f, 02, 09, 05, 05, 01, 52, 01, 01, 0c, 02, 02, 0e, 00, 10, 05, 01, 0e, 00, 10, 09, 01, 0e, 00, 10, 0b, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 4
@@ -231,7 +231,7 @@ Number of expressions: 4
 - expression 2 operands: lhs = Expression(3, Add), rhs = Expression(0, Sub)
 - expression 3 operands: lhs = Counter(2), rhs = Counter(1)
 Number of file 0 mappings: 5
-- Code(Counter(0)) at (prev + 79, 1) to (start + 1, 12)
+- Code(Counter(0)) at (prev + 82, 1) to (start + 1, 12)
 - Code(Expression(0, Sub)) at (prev + 2, 14) to (start + 0, 16)
     = (c0 - (c1 + c2))
 - Code(Counter(1)) at (prev + 1, 14) to (start + 0, 16)
@@ -240,26 +240,26 @@ Number of file 0 mappings: 5
     = ((c2 + c1) + (c0 - (c1 + c2)))
 
 Function name: async::m
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 57, 01, 00, 19]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 5a, 01, 00, 19]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 87, 1) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 90, 1) to (start + 0, 25)
 
 Function name: async::m::{closure#0} (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 57, 19, 00, 22]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 5a, 19, 00, 22]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 87, 25) to (start + 0, 34)
+- Code(Zero) at (prev + 90, 25) to (start + 0, 34)
 
 Function name: async::main
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 59, 01, 08, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 5c, 01, 08, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 89, 1) to (start + 8, 2)
+- Code(Counter(0)) at (prev + 92, 1) to (start + 8, 2)
 

--- a/tests/coverage/async.coverage
+++ b/tests/coverage/async.coverage
@@ -6,6 +6,9 @@
    LL|       |//@ edition: 2018
    LL|       |//@ compile-flags: -Copt-level=1
    LL|       |
+   LL|       |//@ aux-build: executor.rs
+   LL|       |extern crate executor;
+   LL|       |
    LL|      1|async fn c(x: u8) -> u8 {
    LL|      1|    if x == 8 {
    LL|      1|        1
@@ -100,22 +103,4 @@
    LL|      1|    let _ = m(5);
    LL|      1|    executor::block_on(future.as_mut());
    LL|      1|}
-   LL|       |
-   LL|       |mod executor {
-   LL|       |    use core::future::Future;
-   LL|       |    use core::pin::pin;
-   LL|       |    use core::task::{Context, Poll, Waker};
-   LL|       |
-   LL|       |    #[coverage(off)]
-   LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-   LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
-   LL|       |
-   LL|       |        loop {
-   LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-   LL|       |                break val;
-   LL|       |            }
-   LL|       |        }
-   LL|       |    }
-   LL|       |}
 

--- a/tests/coverage/async.rs
+++ b/tests/coverage/async.rs
@@ -6,6 +6,9 @@
 //@ edition: 2018
 //@ compile-flags: -Copt-level=1
 
+//@ aux-build: executor.rs
+extern crate executor;
+
 async fn c(x: u8) -> u8 {
     if x == 8 {
         1
@@ -94,22 +97,4 @@ fn main() {
     l(6);
     let _ = m(5);
     executor::block_on(future.as_mut());
-}
-
-mod executor {
-    use core::future::Future;
-    use core::pin::pin;
-    use core::task::{Context, Poll, Waker};
-
-    #[coverage(off)]
-    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-        let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
-
-        loop {
-            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-                break val;
-            }
-        }
-    }
 }

--- a/tests/coverage/async2.cov-map
+++ b/tests/coverage/async2.cov-map
@@ -1,53 +1,53 @@
 Function name: async2::async_func
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 0d, 01, 00, 17]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 10, 01, 00, 17]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 13, 1) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 16, 1) to (start + 0, 23)
 
 Function name: async2::async_func::{closure#0}
-Raw bytes (24): 0x[01, 01, 00, 04, 01, 0d, 17, 03, 09, 05, 03, 0a, 02, 06, 00, 02, 06, 00, 07, 01, 01, 01, 00, 02]
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 10, 17, 03, 09, 05, 03, 0a, 02, 06, 00, 02, 06, 00, 07, 01, 01, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 13, 23) to (start + 3, 9)
+- Code(Counter(0)) at (prev + 16, 23) to (start + 3, 9)
 - Code(Counter(1)) at (prev + 3, 10) to (start + 2, 6)
 - Code(Zero) at (prev + 2, 6) to (start + 0, 7)
 - Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
 
 Function name: async2::async_func_just_println
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 15, 01, 00, 24]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 18, 01, 00, 24]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 21, 1) to (start + 0, 36)
+- Code(Counter(0)) at (prev + 24, 1) to (start + 0, 36)
 
 Function name: async2::async_func_just_println::{closure#0}
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 15, 24, 02, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 18, 24, 02, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 21, 36) to (start + 2, 2)
+- Code(Counter(0)) at (prev + 24, 36) to (start + 2, 2)
 
 Function name: async2::main
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 19, 01, 07, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 1c, 01, 07, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 25, 1) to (start + 7, 2)
+- Code(Counter(0)) at (prev + 28, 1) to (start + 7, 2)
 
 Function name: async2::non_async_func
-Raw bytes (24): 0x[01, 01, 00, 04, 01, 05, 01, 03, 09, 05, 03, 0a, 02, 06, 00, 02, 06, 00, 07, 01, 01, 01, 00, 02]
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 08, 01, 03, 09, 05, 03, 0a, 02, 06, 00, 02, 06, 00, 07, 01, 01, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 5, 1) to (start + 3, 9)
+- Code(Counter(0)) at (prev + 8, 1) to (start + 3, 9)
 - Code(Counter(1)) at (prev + 3, 10) to (start + 2, 6)
 - Code(Zero) at (prev + 2, 6) to (start + 0, 7)
 - Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)

--- a/tests/coverage/async2.coverage
+++ b/tests/coverage/async2.coverage
@@ -2,6 +2,9 @@
    LL|       |#![feature(noop_waker)]
    LL|       |//@ edition: 2018
    LL|       |
+   LL|       |//@ aux-build: executor.rs
+   LL|       |extern crate executor;
+   LL|       |
    LL|      1|fn non_async_func() {
    LL|      1|    println!("non_async_func was covered");
    LL|      1|    let b = true;
@@ -32,22 +35,4 @@
    LL|      1|    executor::block_on(async_func());
    LL|      1|    executor::block_on(async_func_just_println());
    LL|      1|}
-   LL|       |
-   LL|       |mod executor {
-   LL|       |    use core::future::Future;
-   LL|       |    use core::pin::pin;
-   LL|       |    use core::task::{Context, Poll, Waker};
-   LL|       |
-   LL|       |    #[coverage(off)]
-   LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-   LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
-   LL|       |
-   LL|       |        loop {
-   LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-   LL|       |                break val;
-   LL|       |            }
-   LL|       |        }
-   LL|       |    }
-   LL|       |}
 

--- a/tests/coverage/async2.rs
+++ b/tests/coverage/async2.rs
@@ -2,6 +2,9 @@
 #![feature(noop_waker)]
 //@ edition: 2018
 
+//@ aux-build: executor.rs
+extern crate executor;
+
 fn non_async_func() {
     println!("non_async_func was covered");
     let b = true;
@@ -29,22 +32,4 @@ fn main() {
 
     executor::block_on(async_func());
     executor::block_on(async_func_just_println());
-}
-
-mod executor {
-    use core::future::Future;
-    use core::pin::pin;
-    use core::task::{Context, Poll, Waker};
-
-    #[coverage(off)]
-    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-        let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
-
-        loop {
-            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-                break val;
-            }
-        }
-    }
 }

--- a/tests/coverage/async_block.cov-map
+++ b/tests/coverage/async_block.cov-map
@@ -1,11 +1,11 @@
 Function name: async_block::main
-Raw bytes (36): 0x[01, 01, 01, 01, 05, 06, 01, 05, 01, 00, 0b, 05, 01, 09, 00, 0a, 03, 00, 0e, 00, 13, 05, 00, 14, 01, 16, 05, 07, 0a, 02, 06, 01, 03, 01, 00, 02]
+Raw bytes (36): 0x[01, 01, 01, 01, 05, 06, 01, 08, 01, 00, 0b, 05, 01, 09, 00, 0a, 03, 00, 0e, 00, 13, 05, 00, 14, 01, 16, 05, 07, 0a, 02, 06, 01, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
 Number of file 0 mappings: 6
-- Code(Counter(0)) at (prev + 5, 1) to (start + 0, 11)
+- Code(Counter(0)) at (prev + 8, 1) to (start + 0, 11)
 - Code(Counter(1)) at (prev + 1, 9) to (start + 0, 10)
 - Code(Expression(0, Add)) at (prev + 0, 14) to (start + 0, 19)
     = (c0 + c1)
@@ -14,13 +14,13 @@ Number of file 0 mappings: 6
 - Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: async_block::main::{closure#0}
-Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 07, 1c, 01, 17, 05, 01, 18, 02, 0e, 02, 02, 14, 02, 0e, 01, 03, 09, 00, 0a]
+Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 0a, 1c, 01, 17, 05, 01, 18, 02, 0e, 02, 02, 14, 02, 0e, 01, 03, 09, 00, 0a]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
 Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 7, 28) to (start + 1, 23)
+- Code(Counter(0)) at (prev + 10, 28) to (start + 1, 23)
 - Code(Counter(1)) at (prev + 1, 24) to (start + 2, 14)
 - Code(Expression(0, Sub)) at (prev + 2, 20) to (start + 2, 14)
     = (c0 - c1)

--- a/tests/coverage/async_block.coverage
+++ b/tests/coverage/async_block.coverage
@@ -2,6 +2,9 @@
    LL|       |#![feature(noop_waker)]
    LL|       |//@ edition: 2021
    LL|       |
+   LL|       |//@ aux-build: executor.rs
+   LL|       |extern crate executor;
+   LL|       |
    LL|      1|fn main() {
    LL|     17|    for i in 0..16 {
                       ^16
@@ -15,22 +18,4 @@
    LL|     16|        executor::block_on(future);
    LL|     16|    }
    LL|      1|}
-   LL|       |
-   LL|       |mod executor {
-   LL|       |    use core::future::Future;
-   LL|       |    use core::pin::pin;
-   LL|       |    use core::task::{Context, Poll, Waker};
-   LL|       |
-   LL|       |    #[coverage(off)]
-   LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-   LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
-   LL|       |
-   LL|       |        loop {
-   LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-   LL|       |                break val;
-   LL|       |            }
-   LL|       |        }
-   LL|       |    }
-   LL|       |}
 

--- a/tests/coverage/async_block.rs
+++ b/tests/coverage/async_block.rs
@@ -2,6 +2,9 @@
 #![feature(noop_waker)]
 //@ edition: 2021
 
+//@ aux-build: executor.rs
+extern crate executor;
+
 fn main() {
     for i in 0..16 {
         let future = async {
@@ -12,23 +15,5 @@ fn main() {
             }
         };
         executor::block_on(future);
-    }
-}
-
-mod executor {
-    use core::future::Future;
-    use core::pin::pin;
-    use core::task::{Context, Poll, Waker};
-
-    #[coverage(off)]
-    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-        let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
-
-        loop {
-            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-                break val;
-            }
-        }
     }
 }

--- a/tests/coverage/auxiliary/executor.rs
+++ b/tests/coverage/auxiliary/executor.rs
@@ -1,0 +1,19 @@
+#![feature(coverage_attribute, noop_waker)]
+//@ edition: 2021
+
+use core::future::Future;
+use core::pin::pin;
+use core::task::{Context, Poll, Waker};
+
+/// Dummy "executor" that just repeatedly polls a future until it's ready.
+#[coverage(off)]
+pub fn block_on<F: Future>(mut future: F) -> F::Output {
+    let mut future = pin!(future);
+    let mut context = Context::from_waker(Waker::noop());
+
+    loop {
+        if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
+            break val;
+        }
+    }
+}

--- a/tests/coverage/await_ready.cov-map
+++ b/tests/coverage/await_ready.cov-map
@@ -1,25 +1,17 @@
 Function name: await_ready::await_ready
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 0a, 01, 00, 1e]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 0f, 01, 00, 1e]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 10, 1) to (start + 0, 30)
+- Code(Counter(0)) at (prev + 15, 1) to (start + 0, 30)
 
 Function name: await_ready::await_ready::{closure#0}
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 0a, 1e, 03, 0f, 05, 04, 01, 00, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 0f, 1e, 03, 0f, 05, 04, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 10, 30) to (start + 3, 15)
+- Code(Counter(0)) at (prev + 15, 30) to (start + 3, 15)
 - Code(Counter(1)) at (prev + 4, 1) to (start + 0, 2)
-
-Function name: await_ready::main
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 10, 01, 03, 02]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 16, 1) to (start + 3, 2)
 

--- a/tests/coverage/await_ready.coverage
+++ b/tests/coverage/await_ready.coverage
@@ -1,38 +1,25 @@
    LL|       |#![feature(coverage_attribute)]
-   LL|       |#![feature(custom_inner_attributes)] // for #![rustfmt::skip]
    LL|       |#![feature(noop_waker)]
-   LL|       |#![rustfmt::skip]
+   LL|       |#![coverage(off)]
    LL|       |//@ edition: 2021
    LL|       |
-   LL|       |#[coverage(off)]
-   LL|       |async fn ready() -> u8 { 1 }
+   LL|       |//@ aux-build: executor.rs
+   LL|       |extern crate executor;
    LL|       |
+   LL|       |async fn ready() -> u8 {
+   LL|       |    1
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(on)]
+   LL|       |#[rustfmt::skip]
    LL|      1|async fn await_ready() -> u8 {
    LL|      1|    // await should be covered even if the function never yields
    LL|      1|    ready()
    LL|      1|        .await
    LL|      1|}
    LL|       |
-   LL|      1|fn main() {
-   LL|      1|    let mut future = Box::pin(await_ready());
-   LL|      1|    executor::block_on(future.as_mut());
-   LL|      1|}
-   LL|       |
-   LL|       |mod executor {
-   LL|       |    use core::future::Future;
-   LL|       |    use core::pin::pin;
-   LL|       |    use core::task::{Context, Poll, Waker};
-   LL|       |
-   LL|       |    #[coverage(off)]
-   LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-   LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
-   LL|       |
-   LL|       |        loop {
-   LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-   LL|       |                break val;
-   LL|       |            }
-   LL|       |        }
-   LL|       |    }
+   LL|       |fn main() {
+   LL|       |    let mut future = Box::pin(await_ready());
+   LL|       |    executor::block_on(future.as_mut());
    LL|       |}
 

--- a/tests/coverage/await_ready.rs
+++ b/tests/coverage/await_ready.rs
@@ -1,12 +1,17 @@
 #![feature(coverage_attribute)]
-#![feature(custom_inner_attributes)] // for #![rustfmt::skip]
 #![feature(noop_waker)]
-#![rustfmt::skip]
+#![coverage(off)]
 //@ edition: 2021
 
-#[coverage(off)]
-async fn ready() -> u8 { 1 }
+//@ aux-build: executor.rs
+extern crate executor;
 
+async fn ready() -> u8 {
+    1
+}
+
+#[coverage(on)]
+#[rustfmt::skip]
 async fn await_ready() -> u8 {
     // await should be covered even if the function never yields
     ready()
@@ -16,22 +21,4 @@ async fn await_ready() -> u8 {
 fn main() {
     let mut future = Box::pin(await_ready());
     executor::block_on(future.as_mut());
-}
-
-mod executor {
-    use core::future::Future;
-    use core::pin::pin;
-    use core::task::{Context, Poll, Waker};
-
-    #[coverage(off)]
-    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-        let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
-
-        loop {
-            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-                break val;
-            }
-        }
-    }
 }

--- a/tests/coverage/closure_macro_async.cov-map
+++ b/tests/coverage/closure_macro_async.cov-map
@@ -1,27 +1,27 @@
 Function name: closure_macro_async::load_configuration_files
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 1f, 01, 02, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 22, 01, 02, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 31, 1) to (start + 2, 2)
+- Code(Counter(0)) at (prev + 34, 1) to (start + 2, 2)
 
 Function name: closure_macro_async::test
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 23, 01, 00, 2b]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 26, 01, 00, 2b]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 35, 1) to (start + 0, 43)
+- Code(Counter(0)) at (prev + 38, 1) to (start + 0, 43)
 
 Function name: closure_macro_async::test::{closure#0}
-Raw bytes (36): 0x[01, 01, 01, 01, 05, 06, 01, 23, 2b, 01, 21, 02, 02, 09, 00, 0f, 01, 00, 12, 00, 54, 05, 00, 54, 00, 55, 02, 02, 09, 02, 0b, 01, 03, 01, 00, 02]
+Raw bytes (36): 0x[01, 01, 01, 01, 05, 06, 01, 26, 2b, 01, 21, 02, 02, 09, 00, 0f, 01, 00, 12, 00, 54, 05, 00, 54, 00, 55, 02, 02, 09, 02, 0b, 01, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
 Number of file 0 mappings: 6
-- Code(Counter(0)) at (prev + 35, 43) to (start + 1, 33)
+- Code(Counter(0)) at (prev + 38, 43) to (start + 1, 33)
 - Code(Expression(0, Sub)) at (prev + 2, 9) to (start + 0, 15)
     = (c0 - c1)
 - Code(Counter(0)) at (prev + 0, 18) to (start + 0, 84)
@@ -31,7 +31,7 @@ Number of file 0 mappings: 6
 - Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: closure_macro_async::test::{closure#0}::{closure#0}
-Raw bytes (35): 0x[01, 01, 03, 01, 05, 05, 0b, 09, 00, 05, 01, 12, 1c, 03, 21, 05, 04, 11, 01, 27, 02, 03, 11, 00, 16, 00, 00, 17, 00, 1e, 07, 02, 09, 00, 0a]
+Raw bytes (35): 0x[01, 01, 03, 01, 05, 05, 0b, 09, 00, 05, 01, 15, 1c, 03, 21, 05, 04, 11, 01, 27, 02, 03, 11, 00, 16, 00, 00, 17, 00, 1e, 07, 02, 09, 00, 0a]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 3
@@ -39,7 +39,7 @@ Number of expressions: 3
 - expression 1 operands: lhs = Counter(1), rhs = Expression(2, Add)
 - expression 2 operands: lhs = Counter(2), rhs = Zero
 Number of file 0 mappings: 5
-- Code(Counter(0)) at (prev + 18, 28) to (start + 3, 33)
+- Code(Counter(0)) at (prev + 21, 28) to (start + 3, 33)
 - Code(Counter(1)) at (prev + 4, 17) to (start + 1, 39)
 - Code(Expression(0, Sub)) at (prev + 3, 17) to (start + 0, 22)
     = (c0 - c1)

--- a/tests/coverage/closure_macro_async.coverage
+++ b/tests/coverage/closure_macro_async.coverage
@@ -2,6 +2,9 @@
    LL|       |#![feature(noop_waker)]
    LL|       |//@ edition: 2018
    LL|       |
+   LL|       |//@ aux-build: executor.rs
+   LL|       |extern crate executor;
+   LL|       |
    LL|       |macro_rules! bail {
    LL|       |    ($msg:literal $(,)?) => {
    LL|       |        if $msg.len() > 0 {
@@ -45,23 +48,5 @@
    LL|       |#[coverage(off)]
    LL|       |fn main() {
    LL|       |    executor::block_on(test()).unwrap();
-   LL|       |}
-   LL|       |
-   LL|       |mod executor {
-   LL|       |    use core::future::Future;
-   LL|       |    use core::pin::pin;
-   LL|       |    use core::task::{Context, Poll, Waker};
-   LL|       |
-   LL|       |    #[coverage(off)]
-   LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-   LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
-   LL|       |
-   LL|       |        loop {
-   LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-   LL|       |                break val;
-   LL|       |            }
-   LL|       |        }
-   LL|       |    }
    LL|       |}
 

--- a/tests/coverage/closure_macro_async.rs
+++ b/tests/coverage/closure_macro_async.rs
@@ -2,6 +2,9 @@
 #![feature(noop_waker)]
 //@ edition: 2018
 
+//@ aux-build: executor.rs
+extern crate executor;
+
 macro_rules! bail {
     ($msg:literal $(,)?) => {
         if $msg.len() > 0 {
@@ -44,22 +47,4 @@ pub async fn test() -> Result<(), String> {
 #[coverage(off)]
 fn main() {
     executor::block_on(test()).unwrap();
-}
-
-mod executor {
-    use core::future::Future;
-    use core::pin::pin;
-    use core::task::{Context, Poll, Waker};
-
-    #[coverage(off)]
-    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-        let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
-
-        loop {
-            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-                break val;
-            }
-        }
-    }
 }


### PR DESCRIPTION
By moving `block_on` to an auxiliary crate, we avoid having to keep a separate copy of it in every async test.

