### PR TITLE
Don't call `fn_arg_names` query for non-`fn` foreign items in resolver

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -2068,33 +2068,34 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
             ) {
                 let res = binding.res();
                 if filter_fn(res) {
-                    let def_id = res.def_id();
-                    let has_self = match def_id.as_local() {
-                        Some(def_id) => {
-                            self.r.delegation_fn_sigs.get(&def_id).map_or(false, |sig| sig.has_self)
-                        }
-                        None => self
-                            .r
-                            .tcx
-                            .fn_arg_names(def_id)
-                            .first()
-                            .is_some_and(|ident| ident.name == kw::SelfLower),
-                    };
-                    if has_self {
-                        return Some(AssocSuggestion::MethodWithSelf { called });
-                    } else {
-                        match res {
-                            Res::Def(DefKind::AssocFn, _) => {
+                    match res {
+                        Res::Def(DefKind::Fn | DefKind::AssocFn, def_id) => {
+                            let has_self = match def_id.as_local() {
+                                Some(def_id) => self
+                                    .r
+                                    .delegation_fn_sigs
+                                    .get(&def_id)
+                                    .map_or(false, |sig| sig.has_self),
+                                None => self
+                                    .r
+                                    .tcx
+                                    .fn_arg_names(def_id)
+                                    .first()
+                                    .is_some_and(|ident| ident.name == kw::SelfLower),
+                            };
+                            if has_self {
+                                return Some(AssocSuggestion::MethodWithSelf { called });
+                            } else {
                                 return Some(AssocSuggestion::AssocFn { called });
                             }
-                            Res::Def(DefKind::AssocConst, _) => {
-                                return Some(AssocSuggestion::AssocConst);
-                            }
-                            Res::Def(DefKind::AssocTy, _) => {
-                                return Some(AssocSuggestion::AssocType);
-                            }
-                            _ => {}
                         }
+                        Res::Def(DefKind::AssocConst, _) => {
+                            return Some(AssocSuggestion::AssocConst);
+                        }
+                        Res::Def(DefKind::AssocTy, _) => {
+                            return Some(AssocSuggestion::AssocType);
+                        }
+                        _ => {}
                     }
                 }
             }

--- a/tests/ui/resolve/auxiliary/foreign-trait-with-assoc.rs
+++ b/tests/ui/resolve/auxiliary/foreign-trait-with-assoc.rs
@@ -1,0 +1,3 @@
+pub trait Foo {
+    type Bar;
+}

--- a/tests/ui/resolve/dont-compute-arg-names-for-non-fn.rs
+++ b/tests/ui/resolve/dont-compute-arg-names-for-non-fn.rs
@@ -1,0 +1,11 @@
+//@ aux-build:foreign-trait-with-assoc.rs
+
+extern crate foreign_trait_with_assoc;
+use foreign_trait_with_assoc::Foo;
+
+// Make sure we don't try to call `fn_arg_names` on a non-fn item.
+
+impl Foo for Bar {}
+//~^ ERROR cannot find type `Bar` in this scope
+
+fn main() {}

--- a/tests/ui/resolve/dont-compute-arg-names-for-non-fn.stderr
+++ b/tests/ui/resolve/dont-compute-arg-names-for-non-fn.stderr
@@ -1,0 +1,14 @@
+error[E0412]: cannot find type `Bar` in this scope
+  --> $DIR/dont-compute-arg-names-for-non-fn.rs:8:14
+   |
+LL | impl Foo for Bar {}
+   |              ^^^
+   |
+help: you might have meant to use the associated type
+   |
+LL | impl Foo for Self::Bar {}
+   |              ++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
Fixes #130015