### PR TITLE
properly handle EOF in BufReader::peek

### DIFF
--- a/library/std/src/io/buffered/bufreader/buffer.rs
+++ b/library/std/src/io/buffered/bufreader/buffer.rs
@@ -98,7 +98,7 @@ impl Buffer {
     }
 
     /// Read more bytes into the buffer without discarding any of its contents
-    pub fn read_more(&mut self, mut reader: impl Read) -> io::Result<()> {
+    pub fn read_more(&mut self, mut reader: impl Read) -> io::Result<usize> {
         let mut buf = BorrowedBuf::from(&mut self.buf[self.pos..]);
         let old_init = self.initialized - self.pos;
         unsafe {
@@ -107,7 +107,7 @@ impl Buffer {
         reader.read_buf(buf.unfilled())?;
         self.filled += buf.len();
         self.initialized += buf.init_len() - old_init;
-        Ok(())
+        Ok(buf.len())
     }
 
     /// Remove bytes that have already been read from the buffer.


### PR DESCRIPTION
previously this would cause an infinite loop due to it being unable to read `n` bytes.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
