### PR TITLE
Win: Add dbghelp to the list of import libraries

### DIFF
--- a/library/windows_targets/src/lib.rs
+++ b/library/windows_targets/src/lib.rs
@@ -38,4 +38,5 @@ pub macro link {
 #[link(name = "ntdll")]
 #[link(name = "userenv")]
 #[link(name = "ws2_32")]
+#[link(name = "dbghelp")] // required for backtrace-rs symbolization
 extern "C" {}


### PR DESCRIPTION
This is used by the backtrace crate. But we use a submodule to include backtrace in std (rather than being a real crate) so we need to add the dependency here.