### PR TITLE
Remove redundant check in `symlink_hard_link` test

### DIFF
--- a/library/std/src/fs/tests.rs
+++ b/library/std/src/fs/tests.rs
@@ -1,7 +1,5 @@
 use rand::RngCore;
 
-#[cfg(target_os = "macos")]
-use crate::ffi::{c_char, c_int};
 use crate::fs::{self, File, FileTimes, OpenOptions};
 use crate::io::prelude::*;
 use crate::io::{BorrowedBuf, ErrorKind, SeekFrom};
@@ -16,8 +14,6 @@ use crate::os::unix::fs::symlink as junction_point;
 use crate::os::windows::fs::{junction_point, symlink_dir, symlink_file, OpenOptionsExt};
 use crate::path::Path;
 use crate::sync::Arc;
-#[cfg(target_os = "macos")]
-use crate::sys::weak::weak;
 use crate::sys_common::io::test::{tmpdir, TempDir};
 use crate::time::{Duration, Instant, SystemTime};
 use crate::{env, str, thread};
@@ -78,17 +74,6 @@ pub fn got_symlink_permission(tmpdir: &TempDir) -> bool {
         Err(ref err) if err.raw_os_error() == Some(1314) => false,
         Ok(_) | Err(_) => true,
     }
-}
-
-#[cfg(target_os = "macos")]
-fn able_to_not_follow_symlinks_while_hard_linking() -> bool {
-    weak!(fn linkat(c_int, *const c_char, c_int, *const c_char, c_int) -> c_int);
-    linkat.get().is_some()
-}
-
-#[cfg(not(target_os = "macos"))]
-fn able_to_not_follow_symlinks_while_hard_linking() -> bool {
-    return true;
 }
 
 #[test]
@@ -1456,9 +1441,6 @@ fn symlink_hard_link() {
     if !got_symlink_permission(&tmpdir) {
         return;
     };
-    if !able_to_not_follow_symlinks_while_hard_linking() {
-        return;
-    }
 
     // Create "file", a file.
     check!(fs::File::create(tmpdir.join("file")));


### PR DESCRIPTION
We support macOS 10.12 and above, so it now always uses `linkat`, and so the check is redundant.

This was missed in #126351.

@rustbot label O-macos
