### PR TITLE
Split x86_64-msvc-ext into two jobs

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
@@ -71,7 +71,7 @@ esac
 # but it ensures that the crates build properly when tested with Miri.
 
 #FIXME: Re-enable this for msvc once CI issues are fixed
-if [ "$HOST_TARGET" != "x86_64-pc-windows-msvc" ]
+if [ "$HOST_TARGET" != "x86_64-pc-windows-msvc" ]; then
   python3 "$X_PY" miri --stage 2 library/core --test-args notest
   python3 "$X_PY" miri --stage 2 library/alloc --test-args notest
   python3 "$X_PY" miri --stage 2 library/std --test-args notest

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
@@ -69,7 +69,10 @@ case $HOST_TARGET in
 esac
 # Also smoke-test `x.py miri`. This doesn't run any actual tests (that would take too long),
 # but it ensures that the crates build properly when tested with Miri.
-#FIXME: Re-enable this once CI issues are fixed
-#python3 "$X_PY" miri --stage 2 library/core --test-args notest
-#python3 "$X_PY" miri --stage 2 library/alloc --test-args notest
-#python3 "$X_PY" miri --stage 2 library/std --test-args notest
+
+#FIXME: Re-enable this for msvc once CI issues are fixed
+if [ "$HOST_TARGET" != "x86_64-pc-windows-msvc" ]
+  python3 "$X_PY" miri --stage 2 library/core --test-args notest
+  python3 "$X_PY" miri --stage 2 library/alloc --test-args notest
+  python3 "$X_PY" miri --stage 2 library/std --test-args notest
+fi

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
@@ -58,8 +58,9 @@ case $HOST_TARGET in
     # Strangely, Linux targets do not work here. cargo always says
     # "error: cannot produce cdylib for ... as the target ... does not support these crate types".
     # Only run "pass" tests, which is quite a bit faster.
-    python3 "$X_PY" test --stage 2 src/tools/miri --target aarch64-apple-darwin --test-args pass
-    python3 "$X_PY" test --stage 2 src/tools/miri --target i686-pc-windows-gnu --test-args pass
+    #FIXME: Re-enable this once CI issues are fixed
+    #python3 "$X_PY" test --stage 2 src/tools/miri --target aarch64-apple-darwin --test-args pass
+    #python3 "$X_PY" test --stage 2 src/tools/miri --target i686-pc-windows-gnu --test-args pass
     ;;
   *)
     echo "FATAL: unexpected host $HOST_TARGET"
@@ -68,6 +69,7 @@ case $HOST_TARGET in
 esac
 # Also smoke-test `x.py miri`. This doesn't run any actual tests (that would take too long),
 # but it ensures that the crates build properly when tested with Miri.
-python3 "$X_PY" miri --stage 2 library/core --test-args notest
-python3 "$X_PY" miri --stage 2 library/alloc --test-args notest
-python3 "$X_PY" miri --stage 2 library/std --test-args notest
+#FIXME: Re-enable this once CI issues are fixed
+#python3 "$X_PY" miri --stage 2 library/core --test-args notest
+#python3 "$X_PY" miri --stage 2 library/alloc --test-args notest
+#python3 "$X_PY" miri --stage 2 library/std --test-args notest

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -382,8 +382,6 @@ auto:
         python x.py miri --stage 2 library/core --test-args notest &&
         python x.py miri --stage 2 library/alloc --test-args notest &&
         python x.py miri --stage 2 library/std --test-args notest
-
-      HOST_TARGET: x86_64-pc-windows-msvc
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld
     <<: *job-windows-8c
 

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -373,6 +373,20 @@ auto:
       DEPLOY_TOOLSTATES_JSON: toolstates-windows.json
     <<: *job-windows-8c
 
+  # Temporary builder to workaround CI issues
+  - image: x86_64-msvc-ext2
+    env:
+      SCRIPT: >
+        python x.py test --stage 2 src/tools/miri --target aarch64-apple-darwin --test-args pass &&
+        python x.py test --stage 2 src/tools/miri --target i686-pc-windows-gnu --test-args pass &&
+        python x.py miri --stage 2 library/core --test-args notest &&
+        python x.py miri --stage 2 library/alloc --test-args notest &&
+        python x.py miri --stage 2 library/std --test-args notest
+
+      HOST_TARGET: x86_64-pc-windows-msvc
+      RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld
+    <<: *job-windows-8c
+
   # 32/64-bit MinGW builds.
   #
   # We are using MinGW with POSIX threads since LLVM requires


### PR DESCRIPTION
This is an attempt to mitigate (but not resolve) the high failure rate of the x86_64-msvc-ext builder. The theory being that doing less makes it less likely to fail. But this may not work as having an extra job that may fail might be worse.

Related to https://github.com/rust-lang/rust/issues/127883

try-job: x86_64-msvc-ext
try-job: x86_64-msvc-ext2