### PR TITLE
Fix linking error when compiling for 32-bit watchOS

### DIFF
--- a/library/std/src/sys/personality/dwarf/eh.rs
+++ b/library/std/src/sys/personality/dwarf/eh.rs
@@ -54,10 +54,10 @@ pub enum EHAction {
     Terminate,
 }
 
-/// 32-bit Apple ARM uses SjLj exceptions, except for watchOS.
+/// 32-bit ARM Darwin platforms uses SjLj exceptions.
 ///
-/// I.e. iOS and tvOS, as those are the only Apple OSes that used 32-bit ARM
-/// devices.
+/// The exception is watchOS armv7k (specifically that subarchitecture), which
+/// instead uses DWARF Call Frame Information (CFI) unwinding.
 ///
 /// <https://github.com/llvm/llvm-project/blob/llvmorg-18.1.4/clang/lib/Driver/ToolChains/Darwin.cpp#L3107-L3119>
 pub const USING_SJLJ_EXCEPTIONS: bool =

--- a/library/std/src/sys/personality/gcc.rs
+++ b/library/std/src/sys/personality/gcc.rs
@@ -95,14 +95,15 @@ const UNWIND_DATA_REG: (i32, i32) = (4, 5); // a0, a1
 
 cfg_if::cfg_if! {
     if #[cfg(all(
-            target_arch = "arm",
-            not(all(target_vendor = "apple", not(target_os = "watchos"))),
-            not(target_os = "netbsd"),
-        ))] {
+        target_arch = "arm",
+        not(target_vendor = "apple"),
+        not(target_os = "netbsd"),
+    ))] {
         /// personality fn called by [ARM EHABI][armeabi-eh]
         ///
-        /// Apple 32-bit ARM (but not watchOS) uses the default routine instead
-        /// since it uses "setjmp-longjmp" unwinding.
+        /// 32-bit ARM on iOS/tvOS/watchOS does not use ARM EHABI, it uses
+        /// either "setjmp-longjmp" unwinding or DWARF CFI unwinding, which is
+        /// handled by the default routine.
         ///
         /// [armeabi-eh]: https://web.archive.org/web/20190728160938/https://infocenter.arm.com/help/topic/com.arm.doc.ihi0038b/IHI0038B_ehabi.pdf
         #[lang = "eh_personality"]


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/124494 (or https://github.com/rust-lang/rust/pull/124748), I mistakenly conflated "not SjLj" to mean "ARM EHABI", which isn't true, 32-bit watchOS uses a third unwinding method called "DWARF CFI".

So this PR is effectively a revert of https://github.com/rust-lang/rust/pull/124494, with a few more comments explaining what's going on.

Fixes https://github.com/rust-lang/rust/issues/130071.

r? Mark-Simulacrum (since you reviewed the original)