### PR TITLE
rustdoc-json: change item ID's repr from a string to an int

### DIFF
--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 /// This integer is incremented with every breaking change to the API,
 /// and is returned along with the JSON blob as [`Crate::format_version`].
 /// Consuming code should assert that this value matches the format version(s) that it supports.
-pub const FORMAT_VERSION: u32 = 34;
+pub const FORMAT_VERSION: u32 = 35;
 
 /// The root of the emitted JSON blob.
 ///
@@ -296,9 +296,9 @@ pub enum AssocItemConstraintKind {
 /// Rustdoc makes no guarantees about the inner value of Id's. Applications
 /// should treat them as opaque keys to lookup items, and avoid attempting
 /// to parse them, or otherwise depend on any implementation details.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 // FIXME(aDotInTheVoid): Consider making this non-public in rustdoc-types.
-pub struct Id(pub String);
+pub struct Id(pub u32);
 
 /// The fundamental kind of an item. Unlike [`ItemEnum`], this does not carry any aditional info.
 ///

--- a/src/tools/jsondoclint/src/validator.rs
+++ b/src/tools/jsondoclint/src/validator.rs
@@ -418,7 +418,7 @@ impl<'a> Validator<'a> {
         } else if !self.missing_ids.contains(id) {
             self.missing_ids.insert(id);
 
-            let sels = json_find::find_selector(&self.krate_json, &Value::String(id.0.clone()));
+            let sels = json_find::find_selector(&self.krate_json, &Value::Number(id.0.into()));
             assert_ne!(sels.len(), 0);
 
             self.fail(id, ErrorKind::NotFound(sels))

--- a/src/tools/jsondoclint/src/validator/tests.rs
+++ b/src/tools/jsondoclint/src/validator/tests.rs
@@ -15,24 +15,20 @@ fn check(krate: &Crate, errs: &[Error]) {
     assert_eq!(errs, &validator.errs[..]);
 }
 
-fn id(s: &str) -> Id {
-    Id(s.to_owned())
-}
-
 #[test]
 fn errors_on_missing_links() {
     let k = Crate {
-        root: id("0"),
+        root: Id(0),
         crate_version: None,
         includes_private: false,
-        index: FxHashMap::from_iter([(id("0"), Item {
+        index: FxHashMap::from_iter([(Id(0), Item {
             name: Some("root".to_owned()),
-            id: id(""),
+            id: Id(0),
             crate_id: 0,
             span: None,
             visibility: Visibility::Public,
             docs: None,
-            links: FxHashMap::from_iter([("Not Found".to_owned(), id("1"))]),
+            links: FxHashMap::from_iter([("Not Found".to_owned(), Id(1))]),
             attrs: vec![],
             deprecation: None,
             inner: ItemEnum::Module(Module { is_crate: true, items: vec![], is_stripped: false }),
@@ -49,7 +45,7 @@ fn errors_on_missing_links() {
             SelectorPart::Field("links".to_owned()),
             SelectorPart::Field("Not Found".to_owned()),
         ]]),
-        id: id("1"),
+        id: Id(1),
     }]);
 }
 
@@ -58,28 +54,28 @@ fn errors_on_missing_links() {
 #[test]
 fn errors_on_local_in_paths_and_not_index() {
     let krate = Crate {
-        root: id("0:0:1572"),
+        root: Id(0),
         crate_version: None,
         includes_private: false,
         index: FxHashMap::from_iter([
-            (id("0:0:1572"), Item {
-                id: id("0:0:1572"),
+            (Id(0), Item {
+                id: Id(0),
                 crate_id: 0,
                 name: Some("microcore".to_owned()),
                 span: None,
                 visibility: Visibility::Public,
                 docs: None,
-                links: FxHashMap::from_iter([(("prim@i32".to_owned(), id("0:1:1571")))]),
+                links: FxHashMap::from_iter([(("prim@i32".to_owned(), Id(2)))]),
                 attrs: Vec::new(),
                 deprecation: None,
                 inner: ItemEnum::Module(Module {
                     is_crate: true,
-                    items: vec![id("0:1:717")],
+                    items: vec![Id(1)],
                     is_stripped: false,
                 }),
             }),
-            (id("0:1:717"), Item {
-                id: id("0:1:717"),
+            (Id(1), Item {
+                id: Id(1),
                 crate_id: 0,
                 name: Some("i32".to_owned()),
                 span: None,
@@ -91,7 +87,7 @@ fn errors_on_local_in_paths_and_not_index() {
                 inner: ItemEnum::Primitive(Primitive { name: "i32".to_owned(), impls: vec![] }),
             }),
         ]),
-        paths: FxHashMap::from_iter([(id("0:1:1571"), ItemSummary {
+        paths: FxHashMap::from_iter([(Id(2), ItemSummary {
             crate_id: 0,
             path: vec!["microcore".to_owned(), "i32".to_owned()],
             kind: ItemKind::Primitive,
@@ -101,7 +97,7 @@ fn errors_on_local_in_paths_and_not_index() {
     };
 
     check(&krate, &[Error {
-        id: id("0:1:1571"),
+        id: Id(2),
         kind: ErrorKind::Custom("Id for local item in `paths` but not in `index`".to_owned()),
     }]);
 }
@@ -110,11 +106,11 @@ fn errors_on_local_in_paths_and_not_index() {
 #[should_panic = "LOCAL_CRATE_ID is wrong"]
 fn checks_local_crate_id_is_correct() {
     let krate = Crate {
-        root: id("root"),
+        root: Id(0),
         crate_version: None,
         includes_private: false,
-        index: FxHashMap::from_iter([(id("root"), Item {
-            id: id("root"),
+        index: FxHashMap::from_iter([(Id(0), Item {
+            id: Id(0),
             crate_id: LOCAL_CRATE_ID.wrapping_add(1),
             name: Some("irrelavent".to_owned()),
             span: None,


### PR DESCRIPTION
Following [this discussion on Zulip](https://rust-lang.zulipchat.com/#narrow/stream/266220-t-rustdoc/topic/Optimizing.20the.20.60Id.60.20type.20in.20.60rustdoc-types.60), I've changed the repr of `rustdoc_json_types::Id` from a String to a u32, by adding a `clean::ItemId` interner to `JsonRenderer`

r? @aDotInTheVoid
