### PR TITLE
remove 'const' from 'Option::iter'

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1338,9 +1338,8 @@ impl<T> Option<T> {
     /// assert_eq!(x.iter().next(), None);
     /// ```
     #[inline]
-    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub const fn iter(&self) -> Iter<'_, T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter { inner: Item { opt: self.as_ref() } }
     }
 


### PR DESCRIPTION
This is kind of pointless to be a `const fn` since you can't do anything with the iterator. It is also the only `const fn iter*` in the entire standard library. It probably got constified when `~const` traits got added everywhere, and then was forgotten to be de-constified when that was undone.

The rest of the const_option feature seems like it can reasonably be stabilized, but this one IMO should not be stabilized, and it's not worth creating a new tracking issue.

Cc https://github.com/rust-lang/rust/issues/67441