### PR TITLE
make Result::copied unstably const

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1894,7 +1894,7 @@ impl<T> Option<&T> {
     where
         T: Copy,
     {
-        // FIXME: this implementation, which sidesteps using `Option::map` since it's not const
+        // FIXME(const-hack): this implementation, which sidesteps using `Option::map` since it's not const
         // ready yet, should be reverted when possible to avoid code repetition
         match self {
             Some(&v) => Some(v),

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1942,7 +1942,7 @@ impl<T> Option<&mut T> {
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "copied", since = "1.35.0")]
-    #[rustc_const_unstable(feature = "const_option_ext", issue = "91930")]
+    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
     pub const fn copied(self) -> Option<T>
     where
         T: Copy,

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1535,11 +1535,17 @@ impl<T, E> Result<&T, E> {
     /// ```
     #[inline]
     #[stable(feature = "result_copied", since = "1.59.0")]
-    pub fn copied(self) -> Result<T, E>
+    #[rustc_const_unstable(feature = "const_result", issue = "82814")]
+    pub const fn copied(self) -> Result<T, E>
     where
         T: Copy,
     {
-        self.map(|&t| t)
+        // FIXME: this implementation, which sidesteps using `Result::map` since it's not const
+        // ready yet, should be reverted when possible to avoid code repetition
+        match self {
+            Ok(&v) => Ok(v),
+            Err(e) => Err(e),
+        }
     }
 
     /// Maps a `Result<&T, E>` to a `Result<T, E>` by cloning the contents of the

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1585,11 +1585,17 @@ impl<T, E> Result<&mut T, E> {
     /// ```
     #[inline]
     #[stable(feature = "result_copied", since = "1.59.0")]
-    pub fn copied(self) -> Result<T, E>
+    #[rustc_const_unstable(feature = "const_result", issue = "82814")]
+    pub const fn copied(self) -> Result<T, E>
     where
         T: Copy,
     {
-        self.map(|&mut t| t)
+        // FIXME(const-hack): this implementation, which sidesteps using `Result::map` since it's not const
+        // ready yet, should be reverted when possible to avoid code repetition
+        match self {
+            Ok(&mut v) => Ok(v),
+            Err(e) => Err(e),
+        }
     }
 
     /// Maps a `Result<&mut T, E>` to a `Result<T, E>` by cloning the contents of the

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1540,7 +1540,7 @@ impl<T, E> Result<&T, E> {
     where
         T: Copy,
     {
-        // FIXME: this implementation, which sidesteps using `Result::map` since it's not const
+        // FIXME(const-hack): this implementation, which sidesteps using `Result::map` since it's not const
         // ready yet, should be reverted when possible to avoid code repetition
         match self {
             Ok(&v) => Ok(v),


### PR DESCRIPTION
The corresponding `Option::copied` is unstably const, so seems reasonable to do the same here.