### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -447,7 +447,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // this time with enough precision to check that the value
                 // whose address was taken can actually be made to live as long
                 // as it needs to live.
-                let region = self.next_region_var(infer::AddrOfRegion(expr.span));
+                let region = self.next_region_var(infer::BorrowRegion(expr.span));
                 Ty::new_ref(self.tcx, region, ty, mutbl)
             }
         }

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -458,8 +458,8 @@ pub enum RegionVariableOrigin {
     PatternRegion(Span),
 
     /// Regions created by `&` operator.
-    ///
-    AddrOfRegion(Span),
+    BorrowRegion(Span),
+
     /// Regions created as part of an autoref of a method receiver.
     Autoref(Span),
 
@@ -1741,7 +1741,7 @@ impl RegionVariableOrigin {
         match *self {
             MiscVariable(a)
             | PatternRegion(a)
-            | AddrOfRegion(a)
+            | BorrowRegion(a)
             | Autoref(a)
             | Coercion(a)
             | RegionParameterDefinition(a, ..)

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -426,12 +426,6 @@ impl MissingDoc {
         article: &'static str,
         desc: &'static str,
     ) {
-        // If we're building a test harness, then warning about
-        // documentation is probably not really relevant right now.
-        if cx.sess().opts.test {
-            return;
-        }
-
         // Only check publicly-visible items, using the result from the privacy pass.
         // It's an option so the crate root can also use this function (it doesn't
         // have a `NodeId`).

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -438,11 +438,10 @@ impl MissingDoc {
         let attrs = cx.tcx.hir().attrs(cx.tcx.local_def_id_to_hir_id(def_id));
         let has_doc = attrs.iter().any(has_doc);
         if !has_doc {
-            cx.emit_span_lint(
-                MISSING_DOCS,
-                cx.tcx.def_span(def_id),
-                BuiltinMissingDoc { article, desc },
-            );
+            let sp = cx.tcx.def_span(def_id);
+            if !sp.is_dummy() {
+                cx.emit_span_lint(MISSING_DOCS, sp, BuiltinMissingDoc { article, desc });
+            }
         }
     }
 }

--- a/compiler/rustc_target/src/spec/targets/wasm32_wasip2.rs
+++ b/compiler/rustc_target/src/spec/targets/wasm32_wasip2.rs
@@ -1,6 +1,6 @@
 //! The `wasm32-wasip2` target is the next evolution of the
 //! wasm32-wasi target. While the wasi specification is still under
-//! active development, the {review 2 iteration is considered an "island
+//! active development, the preview 2 iteration is considered an "island
 //! of stability" that should allow users to rely on it indefinitely.
 //!
 //! The `wasi` target is a proposal to define a standardized set of WebAssembly

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -1018,7 +1018,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let var_description = match var_origin {
             infer::MiscVariable(_) => String::new(),
             infer::PatternRegion(_) => " for pattern".to_string(),
-            infer::AddrOfRegion(_) => " for borrow expression".to_string(),
+            infer::BorrowRegion(_) => " for borrow expression".to_string(),
             infer::Autoref(_) => " for autoref".to_string(),
             infer::Coercion(_) => " for automatic coercion".to_string(),
             infer::BoundRegion(_, br, infer::FnCall) => {

--- a/compiler/rustc_type_ir/src/elaborate.rs
+++ b/compiler/rustc_type_ir/src/elaborate.rs
@@ -237,7 +237,7 @@ pub fn supertrait_def_ids<I: Interner>(
     cx: I,
     trait_def_id: I::DefId,
 ) -> impl Iterator<Item = I::DefId> {
-    let mut set: HashSet<I::DefId> = HashSet::default();
+    let mut set = HashSet::default();
     let mut stack = vec![trait_def_id];
 
     set.insert(trait_def_id);

--- a/config.example.toml
+++ b/config.example.toml
@@ -42,6 +42,9 @@
 # Unless you're developing for a target where Rust CI doesn't build a compiler
 # toolchain or changing LLVM locally, you probably want to leave this enabled.
 #
+# Set this to `true` to download if CI llvm available otherwise it builds
+# from `src/llvm-project`.
+#
 # Set this to `"if-unchanged"` to download only if the llvm-project has not
 # been modified. You can also use this if you are unsure whether you're on a
 # tier 1 target. All tier 1 targets are currently supported.
@@ -236,7 +239,7 @@
 # Instead of downloading the src/stage0 version of cargo-clippy specified,
 # use this cargo-clippy binary instead as the stage0 snapshot cargo-clippy.
 #
-# Note that this option should be used with the same toolchain as the `rustc` option above. 
+# Note that this option should be used with the same toolchain as the `rustc` option above.
 # Otherwise, clippy is likely to fail due to a toolchain conflict.
 #cargo-clippy = "/path/to/cargo-clippy"
 

--- a/library/alloc/src/slice.rs
+++ b/library/alloc/src/slice.rs
@@ -96,6 +96,7 @@ pub(crate) mod hack {
     // We shouldn't add inline attribute to this since this is used in
     // `vec!` macro mostly and causes perf regression. See #71204 for
     // discussion and perf results.
+    #[allow(missing_docs)]
     pub fn into_vec<T, A: Allocator>(b: Box<[T], A>) -> Vec<T, A> {
         unsafe {
             let len = b.len();
@@ -105,6 +106,7 @@ pub(crate) mod hack {
     }
 
     #[cfg(not(no_global_oom_handling))]
+    #[allow(missing_docs)]
     #[inline]
     pub fn to_vec<T: ConvertVec, A: Allocator>(s: &[T], alloc: A) -> Vec<T, A> {
         T::to_vec(s, alloc)

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -508,6 +508,7 @@ impl String {
     // NB see the slice::hack module in slice.rs for more information
     #[inline]
     #[cfg(test)]
+    #[allow(missing_docs)]
     pub fn from_str(_: &str) -> String {
         panic!("not available with cfg(test)");
     }

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1338,9 +1338,8 @@ impl<T> Option<T> {
     /// assert_eq!(x.iter().next(), None);
     /// ```
     #[inline]
-    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
     #[stable(feature = "rust1", since = "1.0.0")]
-    pub const fn iter(&self) -> Iter<'_, T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter { inner: Item { opt: self.as_ref() } }
     }
 

--- a/library/std/src/io/buffered/bufreader.rs
+++ b/library/std/src/io/buffered/bufreader.rs
@@ -267,6 +267,7 @@ impl<R: ?Sized> BufReader<R> {
 // This is only used by a test which asserts that the initialization-tracking is correct.
 #[cfg(test)]
 impl<R: ?Sized> BufReader<R> {
+    #[allow(missing_docs)]
     pub fn initialized(&self) -> usize {
         self.buf.initialized()
     }

--- a/src/bootstrap/defaults/config.compiler.toml
+++ b/src/bootstrap/defaults/config.compiler.toml
@@ -27,4 +27,5 @@ assertions = false
 # Enable warnings during the LLVM compilation (when LLVM is changed, causing a compilation)
 enable-warnings = true
 # Will download LLVM from CI if available on your platform.
-download-ci-llvm = "if-unchanged"
+# If you intend to modify `src/llvm-project`, use `"if-unchanged"` or `false` instead.
+download-ci-llvm = true

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2781,7 +2781,8 @@ impl Config {
                     );
                 }
 
-                b
+                // If download-ci-llvm=true we also want to check that CI llvm is available
+                b && llvm::is_ci_llvm_available(self, asserts)
             }
             Some(StringOrBool::String(s)) if s == "if-unchanged" => if_unchanged(),
             Some(StringOrBool::String(other)) => {

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -250,4 +250,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "New option `llvm.enzyme` to control whether the llvm based autodiff tool (Enzyme) is built.",
     },
+    ChangeInfo {
+        change_id: 129473,
+        severity: ChangeSeverity::Warning,
+        summary: "`download-ci-llvm = true` now checks if CI llvm is available and has become the default for the compiler profile",
+    },
 ];

--- a/src/tools/run-make-support/src/external_deps/cargo.rs
+++ b/src/tools/run-make-support/src/external_deps/cargo.rs
@@ -1,0 +1,7 @@
+use crate::command::Command;
+use crate::env_var;
+
+/// Returns a command that can be used to invoke Cargo.
+pub fn cargo() -> Command {
+    Command::new(env_var("BOOTSTRAP_CARGO"))
+}

--- a/src/tools/run-make-support/src/external_deps/llvm.rs
+++ b/src/tools/run-make-support/src/external_deps/llvm.rs
@@ -110,6 +110,13 @@ pub struct LlvmDwarfdump {
     cmd: Command,
 }
 
+/// A `llvm-pdbutil` invocation builder.
+#[derive(Debug)]
+#[must_use]
+pub struct LlvmPdbutil {
+    cmd: Command,
+}
+
 crate::macros::impl_common_helpers!(LlvmReadobj);
 crate::macros::impl_common_helpers!(LlvmProfdata);
 crate::macros::impl_common_helpers!(LlvmFilecheck);
@@ -118,6 +125,7 @@ crate::macros::impl_common_helpers!(LlvmAr);
 crate::macros::impl_common_helpers!(LlvmNm);
 crate::macros::impl_common_helpers!(LlvmBcanalyzer);
 crate::macros::impl_common_helpers!(LlvmDwarfdump);
+crate::macros::impl_common_helpers!(LlvmPdbutil);
 
 /// Generate the path to the bin directory of LLVM.
 #[must_use]
@@ -351,6 +359,22 @@ impl LlvmDwarfdump {
     pub fn new() -> Self {
         let llvm_dwarfdump = llvm_bin_dir().join("llvm-dwarfdump");
         let cmd = Command::new(llvm_dwarfdump);
+        Self { cmd }
+    }
+
+    /// Provide an input file.
+    pub fn input<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+        self.cmd.arg(path.as_ref());
+        self
+    }
+}
+
+impl LlvmPdbutil {
+    /// Construct a new `llvm-pdbutil` invocation. This assumes that `llvm-pdbutil` is available
+    /// at `$LLVM_BIN_DIR/llvm-pdbutil`.
+    pub fn new() -> Self {
+        let llvm_pdbutil = llvm_bin_dir().join("llvm-pdbutil");
+        let cmd = Command::new(llvm_pdbutil);
         Self { cmd }
     }
 

--- a/src/tools/run-make-support/src/external_deps/mod.rs
+++ b/src/tools/run-make-support/src/external_deps/mod.rs
@@ -2,6 +2,7 @@
 //! such as `cc` or `python`.
 
 pub mod c_build;
+pub mod cargo;
 pub mod cc;
 pub mod clang;
 pub mod htmldocck;

--- a/src/tools/run-make-support/src/external_deps/rustc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustc.rs
@@ -36,10 +36,13 @@ pub struct Rustc {
 
 crate::macros::impl_common_helpers!(Rustc);
 
+pub fn rustc_path() -> String {
+    env_var("RUSTC")
+}
+
 #[track_caller]
 fn setup_common() -> Command {
-    let rustc = env_var("RUSTC");
-    let mut cmd = Command::new(rustc);
+    let mut cmd = Command::new(rustc_path());
     set_host_rpath(&mut cmd);
     cmd
 }

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -48,6 +48,7 @@ pub use external_deps::{c_build, cc, clang, htmldocck, llvm, python, rustc, rust
 // These rely on external dependencies.
 pub use cc::{cc, cxx, extra_c_flags, extra_cxx_flags, Cc};
 pub use c_build::{build_native_dynamic_lib, build_native_static_lib, build_native_static_lib_optimized, build_native_static_lib_cxx};
+pub use cargo::cargo;
 pub use clang::{clang, Clang};
 pub use htmldocck::htmldocck;
 pub use llvm::{
@@ -56,7 +57,7 @@ pub use llvm::{
     LlvmProfdata, LlvmReadobj,
 };
 pub use python::python_command;
-pub use rustc::{aux_build, bare_rustc, rustc, Rustc};
+pub use rustc::{aux_build, bare_rustc, rustc, rustc_path, Rustc};
 pub use rustdoc::{bare_rustdoc, rustdoc, Rustdoc};
 
 /// [`diff`][mod@diff] is implemented in terms of the [similar] library.
@@ -96,3 +97,4 @@ pub use assertion_helpers::{
 pub use string::{
     count_regex_matches_in_files_with_extension, invalid_utf8_contains, invalid_utf8_not_contains,
 };
+use crate::external_deps::cargo;

--- a/tests/run-make/rustc-crates-on-stable/rmake.rs
+++ b/tests/run-make/rustc-crates-on-stable/rmake.rs
@@ -8,20 +8,17 @@ fn main() {
         // Use the stage0 beta cargo for the compilation (it shouldn't really matter which cargo we
         // use)
         let cargo = cargo()
-            // This is required to allow using nightly cargo features (public-dependency) with beta
-            // cargo
-            .env("RUSTC_BOOTSTRAP", "1")
-            .env("RUSTC_STAGE", "0") // Ensure `proc-macro2`'s nightly detection is disabled
+            // Ensure `proc-macro2`'s nightly detection is disabled
+            .env("RUSTC_STAGE", "0")
             .env("RUSTC", rustc_path())
+            // We want to disallow all nightly features to simulate a stable build
+            .env("RUSTFLAGS", "-Zallow-features=")
             .arg("build")
             .arg("--manifest-path")
             .arg(source_root().join("Cargo.toml"))
             .args(&[
                 "--config",
                 r#"workspace.exclude=["library/core"]"#,
-                // We want to disallow all nightly features, to simulate a stable build
-                // public-dependency needs to be enabled for cargo to work
-                "-Zallow-features=public-dependency",
                 // Avoid depending on transitive rustc crates
                 "--no-default-features",
                 // Emit artifacts in this temporary directory, not in the source_root's `target`

--- a/tests/run-make/rustc-crates-on-stable/rmake.rs
+++ b/tests/run-make/rustc-crates-on-stable/rmake.rs
@@ -1,36 +1,43 @@
 //! Checks if selected rustc crates can be compiled on the stable channel (or a "simulation" of it).
 //! These crates are designed to be used by downstream users.
 
-use run_make_support::{cargo, rustc_path, source_root};
+use run_make_support::{cargo, run_in_tmpdir, rustc_path, source_root};
 
 fn main() {
-    // Use the stage0 beta cargo for the compilation (it shouldn't really matter which cargo we use)
-    let cargo = cargo()
-        // This is required to allow using nightly cargo features (public-dependency) with beta
-        // cargo
-        .env("RUSTC_BOOTSTRAP", "1")
-        .env("RUSTC_STAGE", "0") // Ensure `proc-macro2`'s nightly detection is disabled
-        .env("RUSTC", rustc_path())
-        .arg("build")
-        .arg("--manifest-path")
-        .arg(source_root().join("Cargo.toml"))
-        .args(&[
-            "--config",
-            r#"workspace.exclude=["library/core"]"#,
-            // We want to disallow all nightly features, to simulate a stable build
-            // public-dependency needs to be enabled for cargo to work
-            "-Zallow-features=public-dependency",
-            // Avoid depending on transitive rustc crates
-            "--no-default-features",
-            // Check that these crates can be compiled on "stable"
-            "-p",
-            "rustc_type_ir",
-            "-p",
-            "rustc_next_trait_solver",
-            "-p",
-            "rustc_pattern_analysis",
-            "-p",
-            "rustc_lexer",
-        ])
-        .run();
+    run_in_tmpdir(|| {
+        // Use the stage0 beta cargo for the compilation (it shouldn't really matter which cargo we
+        // use)
+        let cargo = cargo()
+            // This is required to allow using nightly cargo features (public-dependency) with beta
+            // cargo
+            .env("RUSTC_BOOTSTRAP", "1")
+            .env("RUSTC_STAGE", "0") // Ensure `proc-macro2`'s nightly detection is disabled
+            .env("RUSTC", rustc_path())
+            .arg("build")
+            .arg("--manifest-path")
+            .arg(source_root().join("Cargo.toml"))
+            .args(&[
+                "--config",
+                r#"workspace.exclude=["library/core"]"#,
+                // We want to disallow all nightly features, to simulate a stable build
+                // public-dependency needs to be enabled for cargo to work
+                "-Zallow-features=public-dependency",
+                // Avoid depending on transitive rustc crates
+                "--no-default-features",
+                // Emit artifacts in this temporary directory, not in the source_root's `target`
+                // folder
+                "--target-dir",
+                ".",
+                // Check that these crates can be compiled on "stable"
+                "-p",
+                "rustc_type_ir",
+                "-p",
+                "rustc_next_trait_solver",
+                "-p",
+                "rustc_pattern_analysis",
+                "-p",
+                "rustc_lexer",
+            ])
+            .run();
+    });
 }

--- a/tests/run-make/rustc-crates-on-stable/rmake.rs
+++ b/tests/run-make/rustc-crates-on-stable/rmake.rs
@@ -1,0 +1,35 @@
+//! Checks if selected rustc crates can be compiled on the stable channel (or a "simulation" of it).
+//! These crates are designed to be used by downstream users.
+
+use run_make_support::{cargo, rustc_path, source_root};
+
+fn main() {
+    // Use the stage0 beta cargo for the compilation (it shouldn't really matter which cargo we use)
+    let cargo = cargo()
+        // This is required to allow using nightly cargo features (public-dependency) with beta
+        // cargo
+        .env("RUSTC_BOOTSTRAP", "1")
+        .env("RUSTC", rustc_path())
+        .arg("build")
+        .arg("--manifest-path")
+        .arg(source_root().join("Cargo.toml"))
+        .args(&[
+            "--config",
+            r#"workspace.exclude=["library/core"]"#,
+            // We want to disallow all nightly features, to simulate a stable build
+            // public-dependency needs to be enabled for cargo to work
+            "-Zallow-features=public-dependency",
+            // Avoid depending on transitive rustc crates
+            "--no-default-features",
+            // Check that these crates can be compiled on "stable"
+            "-p",
+            "rustc_type_ir",
+            "-p",
+            "rustc_next_trait_solver",
+            "-p",
+            "rustc_pattern_analysis",
+            "-p",
+            "rustc_lexer",
+        ])
+        .run();
+}

--- a/tests/run-make/rustc-crates-on-stable/rmake.rs
+++ b/tests/run-make/rustc-crates-on-stable/rmake.rs
@@ -1,42 +1,36 @@
 //! Checks if selected rustc crates can be compiled on the stable channel (or a "simulation" of it).
 //! These crates are designed to be used by downstream users.
 
-use run_make_support::{cargo, run_in_tmpdir, rustc_path, source_root};
+use run_make_support::{cargo, rustc_path, source_root};
 
 fn main() {
-    run_in_tmpdir(|| {
-        // Use the stage0 beta cargo for the compilation (it shouldn't really matter which cargo we
-        // use)
-        let cargo = cargo()
-            // Ensure `proc-macro2`'s nightly detection is disabled
-            .env("RUSTC_STAGE", "0")
-            .env("RUSTC", rustc_path())
-            // We want to disallow all nightly features to simulate a stable build
-            .env("RUSTFLAGS", "-Zallow-features=")
-            .arg("build")
-            .arg("--manifest-path")
-            .arg(source_root().join("Cargo.toml"))
-            .args(&[
-                "--config",
-                r#"workspace.exclude=["library/core"]"#,
-                // Avoid depending on transitive rustc crates
-                "--no-default-features",
-                // Emit artifacts in this temporary directory, not in the source_root's `target`
-                // folder
-                "--target-dir",
-                ".",
-            ])
-            // Check that these crates can be compiled on "stable"
-            .args(&[
-                "-p",
-                "rustc_type_ir",
-                "-p",
-                "rustc_next_trait_solver",
-                "-p",
-                "rustc_pattern_analysis",
-                "-p",
-                "rustc_lexer",
-            ])
-            .run();
-    });
+    // Use the stage0 beta cargo for the compilation (it shouldn't really matter which cargo we use)
+    cargo()
+        // Ensure `proc-macro2`'s nightly detection is disabled
+        .env("RUSTC_STAGE", "0")
+        .env("RUSTC", rustc_path())
+        // We want to disallow all nightly features to simulate a stable build
+        .env("RUSTFLAGS", "-Zallow-features=")
+        .arg("build")
+        .arg("--manifest-path")
+        .arg(source_root().join("Cargo.toml"))
+        .args(&[
+            // Avoid depending on transitive rustc crates
+            "--no-default-features",
+            // Emit artifacts in this temporary directory, not in the source_root's `target` folder
+            "--target-dir",
+            "target",
+        ])
+        // Check that these crates can be compiled on "stable"
+        .args(&[
+            "-p",
+            "rustc_type_ir",
+            "-p",
+            "rustc_next_trait_solver",
+            "-p",
+            "rustc_pattern_analysis",
+            "-p",
+            "rustc_lexer",
+        ])
+        .run();
 }

--- a/tests/run-make/rustc-crates-on-stable/rmake.rs
+++ b/tests/run-make/rustc-crates-on-stable/rmake.rs
@@ -9,6 +9,7 @@ fn main() {
         // This is required to allow using nightly cargo features (public-dependency) with beta
         // cargo
         .env("RUSTC_BOOTSTRAP", "1")
+        .env("RUSTC_STAGE", "0") // Ensure `proc-macro2`'s nightly detection is disabled
         .env("RUSTC", rustc_path())
         .arg("build")
         .arg("--manifest-path")

--- a/tests/run-make/rustc-crates-on-stable/rmake.rs
+++ b/tests/run-make/rustc-crates-on-stable/rmake.rs
@@ -25,7 +25,9 @@ fn main() {
                 // folder
                 "--target-dir",
                 ".",
-                // Check that these crates can be compiled on "stable"
+            ])
+            // Check that these crates can be compiled on "stable"
+            .args(&[
                 "-p",
                 "rustc_type_ir",
                 "-p",

--- a/tests/ui/lint/lint-missing-doc-expect.rs
+++ b/tests/ui/lint/lint-missing-doc-expect.rs
@@ -1,0 +1,13 @@
+// Make sure that `#[expect(missing_docs)]` is always correctly fulfilled.
+
+//@ check-pass
+//@ revisions: lib bin test
+//@ [lib]compile-flags: --crate-type lib
+//@ [bin]compile-flags: --crate-type bin
+//@ [test]compile-flags: --test
+
+#[expect(missing_docs)]
+pub fn foo() {}
+
+#[cfg(bin)]
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #129473 (use  `download-ci-llvm=true` in the default compiler config)
 - #129529 (Add test to build crates used by r-a on stable)
 - #130025 (Also emit `missing_docs` lint with `--test` to fulfil expectations)
 - #130048 (run-make-support: Add llvm-pdbutil)
 - #130070 (Rename variant `AddrOfRegion` of `RegionVariableOrigin` to `BorrowRegion`)
 - #130087 (remove 'const' from 'Option::iter')
 - #130092 (Fixes typo in wasm32-wasip2 doc comment)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=129473,129529,130025,130048,130070,130087,130092)
<!-- homu-ignore:end -->