### PR TITLE
Report the `note` when specified in `diagnostic::on_unimplemented`

### DIFF
--- a/tests/ui/methods/suggest-convert-ptr-to-ref.stderr
+++ b/tests/ui/methods/suggest-convert-ptr-to-ref.stderr
@@ -11,6 +11,7 @@ note: the method `to_string` exists on the type `&u8`
    = note: the following trait bounds were not satisfied:
            `*const u8: std::fmt::Display`
            which is required by `*const u8: ToString`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 
 error[E0599]: `*mut u8` doesn't implement `std::fmt::Display`
   --> $DIR/suggest-convert-ptr-to-ref.rs:8:22
@@ -25,6 +26,7 @@ note: the method `to_string` exists on the type `&&mut u8`
    = note: the following trait bounds were not satisfied:
            `*mut u8: std::fmt::Display`
            which is required by `*mut u8: ToString`
+   = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
 
 error[E0599]: no method named `make_ascii_lowercase` found for raw pointer `*mut u8` in the current scope
   --> $DIR/suggest-convert-ptr-to-ref.rs:9:7

--- a/tests/ui/traits/custom-on-unimplemented-diagnostic.rs
+++ b/tests/ui/traits/custom-on-unimplemented-diagnostic.rs
@@ -1,0 +1,19 @@
+#[diagnostic::on_unimplemented(message = "my message", label = "my label", note = "my note")]
+pub trait ProviderLt {}
+
+pub trait ProviderExt {
+    fn request<R>(&self) {
+        todo!()
+    }
+}
+
+impl<T: ?Sized + ProviderLt> ProviderExt for T {}
+
+struct B;
+
+fn main() {
+    B.request();
+    //~^ my message [E0599]
+    //~| my label
+    //~| my note
+}

--- a/tests/ui/traits/custom-on-unimplemented-diagnostic.stderr
+++ b/tests/ui/traits/custom-on-unimplemented-diagnostic.stderr
@@ -1,0 +1,32 @@
+error[E0599]: my message
+  --> $DIR/custom-on-unimplemented-diagnostic.rs:15:7
+   |
+LL | struct B;
+   | -------- method `request` not found for this struct because it doesn't satisfy `B: ProviderExt` or `B: ProviderLt`
+...
+LL |     B.request();
+   |       ^^^^^^^ my label
+   |
+note: trait bound `B: ProviderLt` was not satisfied
+  --> $DIR/custom-on-unimplemented-diagnostic.rs:10:18
+   |
+LL | impl<T: ?Sized + ProviderLt> ProviderExt for T {}
+   |                  ^^^^^^^^^^  -----------     -
+   |                  |
+   |                  unsatisfied trait bound introduced here
+   = note: my note
+note: the trait `ProviderLt` must be implemented
+  --> $DIR/custom-on-unimplemented-diagnostic.rs:2:1
+   |
+LL | pub trait ProviderLt {}
+   | ^^^^^^^^^^^^^^^^^^^^
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `ProviderExt` defines an item `request`, perhaps you need to implement it
+  --> $DIR/custom-on-unimplemented-diagnostic.rs:4:1
+   |
+LL | pub trait ProviderExt {
+   | ^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Before this PR the `note` field was completely ignored for some reason, now it is shown (I think) correctly during the hir typechecking phase.

1. Report the `note` when specified in `diagnostic::on_unimplemented`
2. Added a test for unimplemented trait diagnostic
3. Added a test for custom unimplemented trait diagnostic

Close #130084

P.S. This is my first PR to rustc.