### PR TITLE
 Revert "bypass linker configuration and cross target check for specific commands #128871"

### DIFF
--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -2463,15 +2463,7 @@ impl Cargo {
         cmd_kind: Kind,
     ) -> Cargo {
         let mut cargo = builder.cargo(compiler, mode, source_type, target, cmd_kind);
-
-        match cmd_kind {
-            // No need to configure the target linker for these command types.
-            Kind::Clean | Kind::Check | Kind::Suggest | Kind::Format | Kind::Setup => {}
-            _ => {
-                cargo.configure_linker(builder);
-            }
-        }
-
+        cargo.configure_linker(builder);
         cargo
     }
 

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -87,29 +87,15 @@ fn new_cc_build(build: &Build, target: TargetSelection) -> cc::Build {
 }
 
 pub fn find(build: &Build) {
-    let targets: HashSet<_> = match build.config.cmd {
-        // We don't need to check cross targets for these commands.
-        crate::Subcommand::Clean { .. }
-        | crate::Subcommand::Check { .. }
-        | crate::Subcommand::Suggest { .. }
-        | crate::Subcommand::Format { .. }
-        | crate::Subcommand::Setup { .. } => {
-            build.hosts.iter().cloned().chain(iter::once(build.build)).collect()
-        }
-
-        _ => {
-            // For all targets we're going to need a C compiler for building some shims
-            // and such as well as for being a linker for Rust code.
-            build
-                .targets
-                .iter()
-                .chain(&build.hosts)
-                .cloned()
-                .chain(iter::once(build.build))
-                .collect()
-        }
-    };
-
+    // For all targets we're going to need a C compiler for building some shims
+    // and such as well as for being a linker for Rust code.
+    let targets = build
+        .targets
+        .iter()
+        .chain(&build.hosts)
+        .cloned()
+        .chain(iter::once(build.build))
+        .collect::<HashSet<_>>();
     for target in targets.into_iter() {
         find_target(build, target);
     }


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/128871 caused issues with the cargo cache which leads unnecessary rebuilds as explained in https://github.com/rust-lang/rust/issues/130108. Reverting it now and we can reland this implementation again along with the caching problem fix.

Closes https://github.com/rust-lang/rust/issues/130108