### PR TITLE
Fix ICE caused by missing span in a region error

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -625,11 +625,19 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 if let ObligationCauseCode::WhereClause(_, span)
                 | ObligationCauseCode::WhereClauseInExpr(_, span, ..) =
                     &trace.cause.code().peel_derives()
-                    && !span.is_dummy()
                 {
                     let span = *span;
-                    self.report_concrete_failure(generic_param_scope, placeholder_origin, sub, sup)
-                        .with_span_note(span, "the lifetime requirement is introduced here")
+                    let mut err = self.report_concrete_failure(
+                        generic_param_scope,
+                        placeholder_origin,
+                        sub,
+                        sup,
+                    );
+                    if !span.is_dummy() {
+                        err =
+                            err.with_span_note(span, "the lifetime requirement is introduced here");
+                    }
+                    err
                 } else {
                     unreachable!(
                         "control flow ensures we have a `BindingObligation` or `WhereClauseInExpr` here..."

--- a/tests/ui/wf/ice-wf-missing-span-in-error-130012.rs
+++ b/tests/ui/wf/ice-wf-missing-span-in-error-130012.rs
@@ -1,0 +1,18 @@
+// Regression test for ICE #130012
+// Checks that we do not ICE while reporting
+// lifetime mistmatch error
+
+trait Fun {
+    type Assoc;
+}
+
+trait MyTrait: for<'a> Fun<Assoc = &'a ()> {}
+//~^ ERROR binding for associated type `Assoc` references lifetime `'a`, which does not appear in the trait input types
+//~| ERROR binding for associated type `Assoc` references lifetime `'a`, which does not appear in the trait input types
+//~| ERROR binding for associated type `Assoc` references lifetime `'a`, which does not appear in the trait input types
+
+impl<F: for<'b> Fun<Assoc = &'b ()>> MyTrait for F {}
+//~^ ERROR binding for associated type `Assoc` references lifetime `'b`, which does not appear in the trait input types
+//~| ERROR mismatched types
+
+fn main() {}

--- a/tests/ui/wf/ice-wf-missing-span-in-error-130012.stderr
+++ b/tests/ui/wf/ice-wf-missing-span-in-error-130012.stderr
@@ -1,0 +1,41 @@
+error[E0582]: binding for associated type `Assoc` references lifetime `'a`, which does not appear in the trait input types
+  --> $DIR/ice-wf-missing-span-in-error-130012.rs:9:28
+   |
+LL | trait MyTrait: for<'a> Fun<Assoc = &'a ()> {}
+   |                            ^^^^^^^^^^^^^^
+
+error[E0582]: binding for associated type `Assoc` references lifetime `'a`, which does not appear in the trait input types
+  --> $DIR/ice-wf-missing-span-in-error-130012.rs:9:28
+   |
+LL | trait MyTrait: for<'a> Fun<Assoc = &'a ()> {}
+   |                            ^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0582]: binding for associated type `Assoc` references lifetime `'a`, which does not appear in the trait input types
+  --> $DIR/ice-wf-missing-span-in-error-130012.rs:9:28
+   |
+LL | trait MyTrait: for<'a> Fun<Assoc = &'a ()> {}
+   |                            ^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0582]: binding for associated type `Assoc` references lifetime `'b`, which does not appear in the trait input types
+  --> $DIR/ice-wf-missing-span-in-error-130012.rs:14:21
+   |
+LL | impl<F: for<'b> Fun<Assoc = &'b ()>> MyTrait for F {}
+   |                     ^^^^^^^^^^^^^^
+
+error[E0308]: mismatched types
+  --> $DIR/ice-wf-missing-span-in-error-130012.rs:14:50
+   |
+LL | impl<F: for<'b> Fun<Assoc = &'b ()>> MyTrait for F {}
+   |                                                  ^ lifetime mismatch
+   |
+   = note: expected reference `&()`
+              found reference `&'b ()`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0308, E0582.
+For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #130012

The ICE occurs on line 634 in this error handling code: https://github.com/rust-lang/rust/blob/085744b7ad8b227239bcee0a44cd78dcd0310ab9/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs#L617-L637 It is caused by the span being a dummy span and `!span.is_dummy()` on line 628 evaluating to `false`. 

A dummy span, however, is expected here thanks to the `Self: Trait` predicate from `predicates_of` (see line 61): https://github.com/rust-lang/rust/blob/085744b7ad8b227239bcee0a44cd78dcd0310ab9/compiler/rustc_hir_analysis/src/collect/predicates_of.rs#L61-L69 

This PR changes the error handling code to omit the note which needed the span instead of ICE'ing in the presence of a dummy span.