### PR TITLE
bootstrap: Print more debug info when `find_initial_libdir` fails

### DIFF
--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -347,10 +347,14 @@ impl Build {
         };
         let Some(initial_libdir) = find_initial_libdir() else {
             panic!(
-                "couldn't determine `initial_libdir` \
-                from target dir {initial_target_dir:?} \
-                and sysroot {initial_sysroot:?}"
-            )
+                "couldn't determine `initial_libdir`:
+- config.initial_rustc:      {rustc:?}
+- initial_target_libdir_str: {initial_target_libdir_str:?}
+- initial_target_dir:        {initial_target_dir:?}
+- initial_sysroot:           {initial_sysroot:?}
+",
+                rustc = config.initial_rustc,
+            );
         };
 
         let version = std::fs::read_to_string(src.join("src").join("version"))


### PR DESCRIPTION
From looking at the failure messages printed by #129775, my hypothesis is that `rustc --print=sysroot` sometimes prints the wrong path when the rustc executable is hardlinked in multiple places, at least on my macOS system.

However, currently I don't have any concrete evidence of this actually happening. This PR therefore expands on #129775 by printing even more information on failure (including the actual rustc path), in the hope that when the failure next occurs we can confirm or reject the hypothesis that `rustc --print=sysroot` is printing the wrong path.