### PR TITLE
bootstrap `naked_asm!` for `compiler-builtins`

### DIFF
--- a/compiler/rustc_builtin_macros/src/lib.rs
+++ b/compiler/rustc_builtin_macros/src/lib.rs
@@ -94,6 +94,7 @@ pub fn register_builtin_macros(resolver: &mut dyn ResolverExpand) {
         line: source_util::expand_line,
         log_syntax: log_syntax::expand_log_syntax,
         module_path: source_util::expand_mod,
+        naked_asm: asm::expand_naked_asm,
         option_env: env::expand_option_env,
         pattern_type: pattern_type::expand,
         std_panic: edition_panic::expand_panic,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1254,6 +1254,7 @@ symbols! {
         mut_preserve_binding_mode_2024,
         mut_ref,
         naked,
+        naked_asm,
         naked_functions,
         name,
         names,

--- a/library/core/src/arch.rs
+++ b/library/core/src/arch.rs
@@ -26,6 +26,20 @@ pub macro asm("assembly template", $(operands,)* $(options($(option),*))?) {
     /* compiler built-in */
 }
 
+/// Inline assembly used in combination with `#[naked]` functions.
+///
+/// Refer to [Rust By Example] for a usage guide and the [reference] for
+/// detailed information about the syntax and available options.
+///
+/// [Rust By Example]: https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html
+/// [reference]: https://doc.rust-lang.org/nightly/reference/inline-assembly.html
+#[unstable(feature = "naked_functions", issue = "90957")]
+#[rustc_builtin_macro]
+#[cfg(not(bootstrap))]
+pub macro naked_asm("assembly template", $(operands,)* $(options($(option),*))?) {
+    /* compiler built-in */
+}
+
 /// Module-level inline assembly.
 ///
 /// Refer to [Rust By Example] for a usage guide and the [reference] for

--- a/tests/ui/asm/naked-functions-inline.rs
+++ b/tests/ui/asm/naked-functions-inline.rs
@@ -2,37 +2,37 @@
 #![feature(naked_functions)]
 #![crate_type = "lib"]
 
-use std::arch::asm;
+use std::arch::naked_asm;
 
 #[naked]
 pub unsafe extern "C" fn inline_none() {
-    asm!("", options(noreturn));
+    naked_asm!("");
 }
 
 #[naked]
 #[inline]
 //~^ ERROR [E0736]
 pub unsafe extern "C" fn inline_hint() {
-    asm!("", options(noreturn));
+    naked_asm!("");
 }
 
 #[naked]
 #[inline(always)]
 //~^ ERROR [E0736]
 pub unsafe extern "C" fn inline_always() {
-    asm!("", options(noreturn));
+    naked_asm!("");
 }
 
 #[naked]
 #[inline(never)]
 //~^ ERROR [E0736]
 pub unsafe extern "C" fn inline_never() {
-    asm!("", options(noreturn));
+    naked_asm!("");
 }
 
 #[naked]
 #[cfg_attr(all(), inline(never))]
 //~^ ERROR [E0736]
 pub unsafe extern "C" fn conditional_inline_never() {
-    asm!("", options(noreturn));
+    naked_asm!("");
 }


### PR DESCRIPTION
tracking issue: https://github.com/rust-lang/rust/issues/90957
parent PR: https://github.com/rust-lang/rust/pull/128651

in this PR, `naked_asm!` is added as an alias for `asm!` with one difference: `options(noreturn)` is always enabled by `naked_asm!`. That makes it future-compatible for when `naked_asm!` starts disallowing `options(noreturn)` later.

The `naked_asm!` macro must be introduced first so that we can upgrade `compiler-builtins` to use it, and can then change the implementation of `naked_asm!` in https://github.com/rust-lang/rust/pull/128651

I've added some usages for `naked_asm!` in the tests, so we can be confident that it works, but I've left upgrading the whole test suite to the parent PR.

r? @Amanieu 
