### PR TITLE
Move `elided_named_lifetimes` into a separate pass

### DIFF
--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -829,12 +829,7 @@ pub enum LifetimeRes {
     /// late resolution. Those lifetimes will be inferred by typechecking.
     Infer,
     /// `'static` lifetime.
-    Static {
-        /// We do not want to emit `elided_named_lifetimes`
-        /// when we are inside of a const item or a static,
-        /// because it would get too annoying.
-        suppress_elision_warning: bool,
-    },
+    Static,
     /// Resolution failure.
     Error,
     /// HACK: This is used to recover the NodeId of an elided lifetime.

--- a/compiler/rustc_lint/src/context/diagnostics.rs
+++ b/compiler/rustc_lint/src/context/diagnostics.rs
@@ -8,13 +8,12 @@ use rustc_errors::{
     elided_lifetime_in_path_suggestion, Applicability, Diag, DiagArgValue, LintDiagnostic,
 };
 use rustc_middle::middle::stability;
-use rustc_session::lint::{BuiltinLintDiag, ElidedLifetimeResolution};
+use rustc_session::lint::BuiltinLintDiag;
 use rustc_session::Session;
-use rustc_span::symbol::kw;
 use rustc_span::BytePos;
 use tracing::debug;
 
-use crate::lints::{self, ElidedNamedLifetime};
+use crate::lints::{self};
 
 mod check_cfg;
 
@@ -445,17 +444,6 @@ pub(super) fn decorate_lint(sess: &Session, diagnostic: BuiltinLintDiag, diag: &
         }
         BuiltinLintDiag::UnexpectedBuiltinCfg { cfg, cfg_name, controlled_by } => {
             lints::UnexpectedBuiltinCfg { cfg, cfg_name, controlled_by }.decorate_lint(diag)
-        }
-        BuiltinLintDiag::ElidedNamedLifetimes { elided: (span, kind), resolution } => {
-            match resolution {
-                ElidedLifetimeResolution::Static => {
-                    ElidedNamedLifetime { span, kind, name: kw::StaticLifetime, declaration: None }
-                }
-                ElidedLifetimeResolution::Param(name, declaration) => {
-                    ElidedNamedLifetime { span, kind, name, declaration: Some(declaration) }
-                }
-            }
-            .decorate_lint(diag)
         }
     }
 }

--- a/compiler/rustc_lint/src/elided.rs
+++ b/compiler/rustc_lint/src/elided.rs
@@ -1,0 +1,116 @@
+use rustc_hir::{
+    ImplItem, ImplItemKind, Item, ItemKind, Lifetime, LifetimeName, TraitItem, TraitItemKind,
+};
+use rustc_middle::ty::layout::HasTyCtxt;
+use rustc_session::{declare_lint, impl_lint_pass};
+use rustc_span::symbol::kw;
+
+use crate::lints::{ElidedNamedLifetime, ElidedNamedLifetimeSuggestion};
+use crate::{LateContext, LateLintPass, LintContext};
+
+declare_lint! {
+    /// The `elided_named_lifetimes` lint detects when an elided
+    /// lifetime ends up being a named lifetime, such as `'static`
+    /// or some lifetime parameter `'a`.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// #![deny(elided_named_lifetimes)]
+    /// struct Foo;
+    /// impl Foo {
+    ///     pub fn get_mut(&'static self, x: &mut u8) -> &mut u8 {
+    ///         unsafe { &mut *(x as *mut _) }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Lifetime elision is quite useful, because it frees you from having
+    /// to give each lifetime its own name, but sometimes it can produce
+    /// somewhat surprising resolutions. In safe code, it is mostly okay,
+    /// because the borrow checker prevents any unsoundness, so the worst
+    /// case scenario is you get a confusing error message in some other place.
+    /// But with `unsafe` code, such unexpected resolutions may lead to unsound code.
+    pub ELIDED_NAMED_LIFETIMES,
+    Warn,
+    "detects when an elided lifetime gets resolved to be `'static` or some named parameter"
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ElidedNamedLifetimes {
+    allow_static: bool,
+}
+
+impl_lint_pass!(ElidedNamedLifetimes => [ELIDED_NAMED_LIFETIMES]);
+
+impl<'tcx> LateLintPass<'tcx> for ElidedNamedLifetimes {
+    fn check_trait_item(&mut self, _: &LateContext<'tcx>, item: &'tcx TraitItem<'tcx>) {
+        if let TraitItemKind::Const(..) = item.kind {
+            self.allow_static = true;
+        }
+    }
+    fn check_trait_item_post(&mut self, _: &LateContext<'tcx>, _: &'tcx TraitItem<'tcx>) {
+        self.allow_static = false;
+    }
+
+    fn check_impl_item(&mut self, _: &LateContext<'tcx>, item: &'tcx ImplItem<'tcx>) {
+        if let ImplItemKind::Const(..) = item.kind {
+            self.allow_static = true;
+        }
+    }
+    fn check_impl_item_post(&mut self, _: &LateContext<'tcx>, _: &'tcx ImplItem<'tcx>) {
+        self.allow_static = false;
+    }
+
+    fn check_item(&mut self, _: &LateContext<'tcx>, item: &'tcx Item<'tcx>) {
+        if let ItemKind::Const(..) | ItemKind::Static(..) = item.kind {
+            self.allow_static = true;
+        }
+    }
+    fn check_item_post(&mut self, _: &LateContext<'tcx>, _: &'tcx Item<'tcx>) {
+        self.allow_static = false;
+    }
+
+    fn check_lifetime(&mut self, cx: &LateContext<'tcx>, lifetime: &'tcx Lifetime) {
+        // `.is_elided()` should probably be called `.resolves_to_elided()`,
+        // and `.is_anonymous()` is actually the thing that we need here.
+        if !lifetime.is_anonymous() {
+            return;
+        }
+        let (name, declaration) = match lifetime.res {
+            LifetimeName::Param(param) => {
+                let name = cx.tcx().item_name(param.into());
+                if name == kw::UnderscoreLifetime {
+                    return;
+                }
+                let span = cx.tcx().def_span(param);
+                (name, Some(span))
+            }
+            LifetimeName::Static => {
+                if self.allow_static {
+                    return;
+                }
+                (kw::StaticLifetime, None)
+            }
+            LifetimeName::ImplicitObjectLifetimeDefault
+            | LifetimeName::Error
+            | LifetimeName::Infer => return,
+        };
+        cx.emit_lint(
+            ELIDED_NAMED_LIFETIMES,
+            ElidedNamedLifetime {
+                span: lifetime.ident.span,
+                sugg: {
+                    let (span, code) = lifetime.suggestion(name.as_str());
+                    ElidedNamedLifetimeSuggestion { span, code }
+                },
+                name,
+                declaration,
+            },
+        )
+    }
+}

--- a/compiler/rustc_lint/src/late.rs
+++ b/compiler/rustc_lint/src/late.rs
@@ -286,6 +286,7 @@ impl<'tcx, T: LateLintPass<'tcx>> hir_visit::Visitor<'tcx> for LateContextAndPas
             cx.with_param_env(trait_item.owner_id, |cx| {
                 lint_callback!(cx, check_trait_item, trait_item);
                 hir_visit::walk_trait_item(cx, trait_item);
+                lint_callback!(cx, check_trait_item_post, trait_item);
             });
         });
         self.context.generics = generics;
@@ -305,6 +306,7 @@ impl<'tcx, T: LateLintPass<'tcx>> hir_visit::Visitor<'tcx> for LateContextAndPas
     }
 
     fn visit_lifetime(&mut self, lt: &'tcx hir::Lifetime) {
+        lint_callback!(self, check_lifetime, lt);
         hir_visit::walk_lifetime(self, lt);
     }
 

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -50,6 +50,7 @@ mod context;
 mod deref_into_dyn_supertrait;
 mod drop_forget_useless;
 mod early;
+mod elided;
 mod enum_intrinsics_non_enums;
 mod errors;
 mod expect;
@@ -91,6 +92,7 @@ use async_fn_in_trait::AsyncFnInTrait;
 use builtin::*;
 use deref_into_dyn_supertrait::*;
 use drop_forget_useless::*;
+use elided::ElidedNamedLifetimes;
 use enum_intrinsics_non_enums::EnumIntrinsicsNonEnums;
 use for_loops_over_fallibles::*;
 use hidden_unicode_codepoints::*;
@@ -243,6 +245,7 @@ late_lint_methods!(
             NonLocalDefinitions: NonLocalDefinitions::default(),
             ImplTraitOvercaptures: ImplTraitOvercaptures,
             TailExprDropOrder: TailExprDropOrder,
+            ElidedNamedLifetimes: ElidedNamedLifetimes::default(),
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -7,9 +7,9 @@ use rustc_errors::{
     Applicability, Diag, DiagArgValue, DiagMessage, DiagStyledString, ElidedLifetimeInPathSubdiag,
     EmissionGuarantee, LintDiagnostic, MultiSpan, SubdiagMessageOp, Subdiagnostic, SuggestionStyle,
 };
+use rustc_hir as hir;
 use rustc_hir::def::Namespace;
 use rustc_hir::def_id::DefId;
-use rustc_hir::{self as hir, MissingLifetimeKind};
 use rustc_macros::{LintDiagnostic, Subdiagnostic};
 use rustc_middle::ty::inhabitedness::InhabitedPredicate;
 use rustc_middle::ty::{Clause, PolyExistentialTraitRef, Ty, TyCtxt};
@@ -2624,16 +2624,23 @@ pub(crate) struct ElidedLifetimesInPaths {
     pub subdiag: ElidedLifetimeInPathSubdiag,
 }
 
+#[allow(unused)]
 pub(crate) struct ElidedNamedLifetime {
     pub span: Span,
-    pub kind: MissingLifetimeKind,
     pub name: Symbol,
     pub declaration: Option<Span>,
+    pub sugg: ElidedNamedLifetimeSuggestion,
+}
+
+pub(crate) struct ElidedNamedLifetimeSuggestion {
+    pub span: Span,
+    pub code: String,
 }
 
 impl<G: EmissionGuarantee> LintDiagnostic<'_, G> for ElidedNamedLifetime {
     fn decorate_lint(self, diag: &mut rustc_errors::Diag<'_, G>) {
-        let Self { span, kind, name, declaration } = self;
+        let Self { span, name, declaration, sugg } = self;
+        diag.span(span);
         diag.primary_message(fluent::lint_elided_named_lifetime);
         diag.arg("name", name);
         diag.span_label(span, fluent::lint_label_elided);
@@ -2647,32 +2654,12 @@ impl<G: EmissionGuarantee> LintDiagnostic<'_, G> for ElidedNamedLifetime {
         if name != rustc_span::symbol::kw::StaticLifetime {
             return;
         }
-        match kind {
-            MissingLifetimeKind::Underscore => diag.span_suggestion_verbose(
-                span,
-                fluent::lint_suggestion,
-                format!("{name}"),
-                Applicability::MachineApplicable,
-            ),
-            MissingLifetimeKind::Ampersand => diag.span_suggestion_verbose(
-                span.shrink_to_hi(),
-                fluent::lint_suggestion,
-                format!("{name} "),
-                Applicability::MachineApplicable,
-            ),
-            MissingLifetimeKind::Comma => diag.span_suggestion_verbose(
-                span.shrink_to_hi(),
-                fluent::lint_suggestion,
-                format!("{name}, "),
-                Applicability::MachineApplicable,
-            ),
-            MissingLifetimeKind::Brackets => diag.span_suggestion_verbose(
-                span.shrink_to_hi(),
-                fluent::lint_suggestion,
-                format!("<{name}>"),
-                Applicability::MachineApplicable,
-            ),
-        };
+        diag.span_suggestion_verbose(
+            sugg.span,
+            fluent::lint_suggestion,
+            sugg.code,
+            Applicability::MachineApplicable,
+        );
     }
 }
 

--- a/compiler/rustc_lint/src/passes.rs
+++ b/compiler/rustc_lint/src/passes.rs
@@ -34,6 +34,7 @@ macro_rules! late_lint_methods {
                 d: rustc_span::Span,
                 e: rustc_span::def_id::LocalDefId);
             fn check_trait_item(a: &'tcx rustc_hir::TraitItem<'tcx>);
+            fn check_trait_item_post(a: &'tcx rustc_hir::TraitItem<'tcx>);
             fn check_impl_item(a: &'tcx rustc_hir::ImplItem<'tcx>);
             fn check_impl_item_post(a: &'tcx rustc_hir::ImplItem<'tcx>);
             fn check_struct_def(a: &'tcx rustc_hir::VariantData<'tcx>);
@@ -43,6 +44,7 @@ macro_rules! late_lint_methods {
             fn check_attribute(a: &'tcx rustc_ast::Attribute);
             fn check_attributes(a: &'tcx [rustc_ast::Attribute]);
             fn check_attributes_post(a: &'tcx [rustc_ast::Attribute]);
+            fn check_lifetime(lt: &'tcx rustc_hir::Lifetime);
         ]);
     )
 }

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -42,7 +42,6 @@ declare_lint_pass! {
         DUPLICATE_MACRO_ATTRIBUTES,
         ELIDED_LIFETIMES_IN_ASSOCIATED_CONSTANT,
         ELIDED_LIFETIMES_IN_PATHS,
-        ELIDED_NAMED_LIFETIMES,
         EXPLICIT_BUILTIN_CFGS_IN_FLAGS,
         EXPORTED_PRIVATE_DEPENDENCIES,
         FFI_UNWIND_CALLS,
@@ -1861,38 +1860,6 @@ declare_lint! {
     pub ELIDED_LIFETIMES_IN_PATHS,
     Allow,
     "hidden lifetime parameters in types are deprecated"
-}
-
-declare_lint! {
-    /// The `elided_named_lifetimes` lint detects when an elided
-    /// lifetime ends up being a named lifetime, such as `'static`
-    /// or some lifetime parameter `'a`.
-    ///
-    /// ### Example
-    ///
-    /// ```rust,compile_fail
-    /// #![deny(elided_named_lifetimes)]
-    /// struct Foo;
-    /// impl Foo {
-    ///     pub fn get_mut(&'static self, x: &mut u8) -> &mut u8 {
-    ///         unsafe { &mut *(x as *mut _) }
-    ///     }
-    /// }
-    /// ```
-    ///
-    /// {{produces}}
-    ///
-    /// ### Explanation
-    ///
-    /// Lifetime elision is quite useful, because it frees you from having
-    /// to give each lifetime its own name, but sometimes it can produce
-    /// somewhat surprising resolutions. In safe code, it is mostly okay,
-    /// because the borrow checker prevents any unsoundness, so the worst
-    /// case scenario is you get a confusing error message in some other place.
-    /// But with `unsafe` code, such unexpected resolutions may lead to unsound code.
-    pub ELIDED_NAMED_LIFETIMES,
-    Warn,
-    "detects when an elided lifetime gets resolved to be `'static` or some named parameter"
 }
 
 declare_lint! {

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -10,7 +10,7 @@ use rustc_data_structures::stable_hasher::{
 };
 use rustc_error_messages::{DiagMessage, MultiSpan};
 use rustc_hir::def::Namespace;
-use rustc_hir::{HashStableContext, HirId, MissingLifetimeKind};
+use rustc_hir::{HashStableContext, HirId};
 use rustc_macros::{Decodable, Encodable, HashStable_Generic};
 use rustc_span::edition::Edition;
 use rustc_span::symbol::{Ident, MacroRulesNormalizedIdent};
@@ -556,12 +556,6 @@ pub enum DeprecatedSinceKind {
     InVersion(String),
 }
 
-#[derive(Debug)]
-pub enum ElidedLifetimeResolution {
-    Static,
-    Param(Symbol, Span),
-}
-
 // This could be a closure, but then implementing derive trait
 // becomes hacky (and it gets allocated).
 #[derive(Debug)]
@@ -574,10 +568,6 @@ pub enum BuiltinLintDiag {
     },
     MacroExpandedMacroExportsAccessedByAbsolutePaths(Span),
     ElidedLifetimesInPaths(usize, Span, bool, Span),
-    ElidedNamedLifetimes {
-        elided: (Span, MissingLifetimeKind),
-        resolution: ElidedLifetimeResolution,
-    },
     UnknownCrateTypes {
         span: Span,
         candidate: Option<Symbol>,

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -102,13 +102,6 @@ fn import_candidate_to_enum_paths(suggestion: &ImportSuggestion) -> (String, Str
 pub(super) struct MissingLifetime {
     /// Used to overwrite the resolution with the suggestion, to avoid cascading errors.
     pub id: NodeId,
-    /// As we cannot yet emit lints in this crate and have to buffer them instead,
-    /// we need to associate each lint with some `NodeId`,
-    /// however for some `MissingLifetime`s their `NodeId`s are "fake",
-    /// in a sense that they are temporary and not get preserved down the line,
-    /// which means that the lints for those nodes will not get emitted.
-    /// To combat this, we can try to use some other `NodeId`s as a fallback option.
-    pub id_for_lint: NodeId,
     /// Where to suggest adding the lifetime.
     pub span: Span,
     /// How the lifetime was introduced, to have the correct space and comma.
@@ -3035,7 +3028,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                     maybe_static = true;
                     in_scope_lifetimes = vec![(
                         Ident::with_dummy_span(kw::StaticLifetime),
-                        (DUMMY_NODE_ID, LifetimeRes::Static { suppress_elision_warning: false }),
+                        (DUMMY_NODE_ID, LifetimeRes::Static),
                     )];
                 }
             } else if elided_len == 0 {
@@ -3047,7 +3040,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
                     maybe_static = true;
                     in_scope_lifetimes = vec![(
                         Ident::with_dummy_span(kw::StaticLifetime),
-                        (DUMMY_NODE_ID, LifetimeRes::Static { suppress_elision_warning: false }),
+                        (DUMMY_NODE_ID, LifetimeRes::Static),
                     )];
                 }
             } else if num_params == 1 {

--- a/src/tools/clippy/tests/ui/needless_lifetimes.stderr
+++ b/src/tools/clippy/tests/ui/needless_lifetimes.stderr
@@ -1,14 +1,3 @@
-error: elided lifetime has a name
-  --> tests/ui/needless_lifetimes.rs:266:52
-   |
-LL | fn named_input_elided_output<'a>(_arg: &'a str) -> &str {
-   |                              --                    ^ this elided lifetime gets resolved as `'a`
-   |                              |
-   |                              lifetime `'a` declared here
-   |
-   = note: `-D elided-named-lifetimes` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(elided_named_lifetimes)]`
-
 error: the following explicit lifetimes could be elided: 'a, 'b
   --> tests/ui/needless_lifetimes.rs:17:23
    |
@@ -563,6 +552,17 @@ help: elide the lifetimes
 LL -         fn one_input<'a>(x: &'a u8) -> &'a u8 {
 LL +         fn one_input(x: &u8) -> &u8 {
    |
+
+error: elided lifetime has a name
+  --> tests/ui/needless_lifetimes.rs:266:53
+   |
+LL | fn named_input_elided_output<'a>(_arg: &'a str) -> &str {
+   |                              --                     ^ this elided lifetime gets resolved as `'a`
+   |                              |
+   |                              lifetime `'a` declared here
+   |
+   = note: `-D elided-named-lifetimes` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(elided_named_lifetimes)]`
 
 error: aborting due to 47 previous errors
 

--- a/src/tools/clippy/tests/ui/ptr_arg.stderr
+++ b/src/tools/clippy/tests/ui/ptr_arg.stderr
@@ -1,12 +1,3 @@
-error: elided lifetime has a name
-  --> tests/ui/ptr_arg.rs:295:56
-   |
-LL |     fn cow_good_ret_ty<'a>(input: &'a Cow<'a, str>) -> &str {
-   |                        -- lifetime `'a` declared here  ^ this elided lifetime gets resolved as `'a`
-   |
-   = note: `-D elided-named-lifetimes` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(elided_named_lifetimes)]`
-
 error: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
   --> tests/ui/ptr_arg.rs:13:14
    |
@@ -220,6 +211,15 @@ error: using a reference to `Cow` is not recommended
    |
 LL |     fn cow_bad_ret_ty_2<'a, 'b>(input: &'a Cow<'a, str>) -> &'b str {
    |                                        ^^^^^^^^^^^^^^^^ help: change this to: `&str`
+
+error: elided lifetime has a name
+  --> tests/ui/ptr_arg.rs:295:57
+   |
+LL |     fn cow_good_ret_ty<'a>(input: &'a Cow<'a, str>) -> &str {
+   |                        -- lifetime `'a` declared here   ^ this elided lifetime gets resolved as `'a`
+   |
+   = note: `-D elided-named-lifetimes` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(elided_named_lifetimes)]`
 
 error: aborting due to 25 previous errors
 

--- a/tests/ui/async-await/issues/issue-63388-1.stderr
+++ b/tests/ui/async-await/issues/issue-63388-1.stderr
@@ -1,14 +1,3 @@
-warning: elided lifetime has a name
-  --> $DIR/issue-63388-1.rs:12:10
-   |
-LL |     async fn do_sth<'a>(
-   |                     -- lifetime `'a` declared here
-LL |         &'a self, foo: &dyn Foo
-LL |     ) -> &dyn Foo
-   |          ^ this elided lifetime gets resolved as `'a`
-   |
-   = note: `#[warn(elided_named_lifetimes)]` on by default
-
 error[E0621]: explicit lifetime required in the type of `foo`
   --> $DIR/issue-63388-1.rs:13:5
    |
@@ -21,6 +10,6 @@ LL | |         foo
 LL | |     }
    | |_____^ lifetime `'a` required
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0621`.

--- a/tests/ui/const-generics/type-dependent/issue-71348.full.stderr
+++ b/tests/ui/const-generics/type-dependent/issue-71348.full.stderr
@@ -1,8 +1,8 @@
 warning: elided lifetime has a name
-  --> $DIR/issue-71348.rs:18:68
+  --> $DIR/issue-71348.rs:18:69
    |
 LL |     fn ask<'a, const N: &'static str>(&'a self) -> &'a <Self as Get<N>>::Target
-   |            -- lifetime `'a` declared here                          ^ this elided lifetime gets resolved as `'a`
+   |            -- lifetime `'a` declared here                           ^ this elided lifetime gets resolved as `'a`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default
 

--- a/tests/ui/const-generics/type-dependent/issue-71348.min.stderr
+++ b/tests/ui/const-generics/type-dependent/issue-71348.min.stderr
@@ -1,11 +1,3 @@
-warning: elided lifetime has a name
-  --> $DIR/issue-71348.rs:18:68
-   |
-LL |     fn ask<'a, const N: &'static str>(&'a self) -> &'a <Self as Get<N>>::Target
-   |            -- lifetime `'a` declared here                          ^ this elided lifetime gets resolved as `'a`
-   |
-   = note: `#[warn(elided_named_lifetimes)]` on by default
-
 error: `&'static str` is forbidden as the type of a const generic parameter
   --> $DIR/issue-71348.rs:10:24
    |
@@ -38,5 +30,5 @@ help: add `#![feature(unsized_const_params)]` to the crate attributes to enable 
 LL + #![feature(unsized_const_params)]
    |
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/min_const_fn/min_const_fn.stderr
+++ b/tests/ui/consts/min_const_fn/min_const_fn.stderr
@@ -1,23 +1,3 @@
-warning: elided lifetime has a name
-  --> $DIR/min_const_fn.rs:47:34
-   |
-LL | impl<'a, T> Foo<T> {
-   |      -- lifetime `'a` declared here
-...
-LL |     const fn get_lt(&'a self) -> &T { &self.0 }
-   |                                  ^ this elided lifetime gets resolved as `'a`
-   |
-   = note: `#[warn(elided_named_lifetimes)]` on by default
-
-warning: elided lifetime has a name
-  --> $DIR/min_const_fn.rs:48:42
-   |
-LL | impl<'a, T> Foo<T> {
-   |      -- lifetime `'a` declared here
-...
-LL |     const fn get_mut_lt(&'a mut self) -> &mut T { &mut self.0 }
-   |                                          ^ this elided lifetime gets resolved as `'a`
-
 error[E0493]: destructor of `Foo<T>` cannot be evaluated at compile-time
   --> $DIR/min_const_fn.rs:37:25
    |
@@ -248,7 +228,7 @@ LL | const fn no_apit(_x: impl std::fmt::Debug) {}
    |                  |
    |                  the destructor for this type cannot be evaluated in constant functions
 
-error: aborting due to 24 previous errors; 2 warnings emitted
+error: aborting due to 24 previous errors
 
 Some errors have detailed explanations: E0493, E0658.
 For more information about an error, try `rustc --explain E0493`.

--- a/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
+++ b/tests/ui/impl-trait/impl-fn-hrtb-bounds.stderr
@@ -10,14 +10,6 @@ help: consider using the `'static` lifetime, but this is uncommon unless you're 
 LL | fn d() -> impl Fn() -> (impl Debug + 'static) {
    |                                      ~~~~~~~
 
-warning: elided lifetime has a name
-  --> $DIR/impl-fn-hrtb-bounds.rs:14:52
-   |
-LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
-   |                    -- lifetime `'a` declared here  ^^ this elided lifetime gets resolved as `'a`
-   |
-   = note: `#[warn(elided_named_lifetimes)]` on by default
-
 error[E0657]: `impl Trait` cannot capture higher-ranked lifetime from outer `impl Trait`
   --> $DIR/impl-fn-hrtb-bounds.rs:4:41
    |
@@ -54,7 +46,7 @@ note: lifetime declared here
 LL | fn c() -> impl for<'a> Fn(&'a u8) -> (impl Debug + '_) {
    |                    ^^
 
-error: aborting due to 4 previous errors; 1 warning emitted
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0106, E0657.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/impl-trait/impl-fn-predefined-lifetimes.stderr
+++ b/tests/ui/impl-trait/impl-fn-predefined-lifetimes.stderr
@@ -1,11 +1,3 @@
-warning: elided lifetime has a name
-  --> $DIR/impl-fn-predefined-lifetimes.rs:4:48
-   |
-LL | fn a<'a>() -> impl Fn(&'a u8) -> (impl Debug + '_) {
-   |      -- lifetime `'a` declared here            ^^ this elided lifetime gets resolved as `'a`
-   |
-   = note: `#[warn(elided_named_lifetimes)]` on by default
-
 error[E0792]: expected generic lifetime parameter, found `'_`
   --> $DIR/impl-fn-predefined-lifetimes.rs:7:9
    |
@@ -21,7 +13,7 @@ error[E0720]: cannot resolve opaque type
 LL | fn a<'a>() -> impl Fn(&'a u8) -> (impl Debug + '_) {
    |                                   ^^^^^^^^^^^^^^^ cannot resolve opaque type
 
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0720, E0792.
 For more information about an error, try `rustc --explain E0720`.

--- a/tests/ui/impl-trait/rpit-assoc-pair-with-lifetime.stderr
+++ b/tests/ui/impl-trait/rpit-assoc-pair-with-lifetime.stderr
@@ -2,7 +2,7 @@ warning: elided lifetime has a name
   --> $DIR/rpit-assoc-pair-with-lifetime.rs:3:82
    |
 LL | pub fn iter<'a>(v: Vec<(u32, &'a u32)>) -> impl DoubleEndedIterator<Item = (u32, &u32)> {
-   |             -- lifetime `'a` declared here                                       ^ this elided lifetime gets resolved as `'a`
+   |             -- lifetime `'a` declared here                                       ^^^^ this elided lifetime gets resolved as `'a`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default
 

--- a/tests/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
+++ b/tests/ui/lifetimes/lifetime-elision-return-type-requires-explicit-lifetime.stderr
@@ -105,16 +105,6 @@ help: consider using the `'a` lifetime
 LL | fn l<'a>(_: &'a str, _: &'a str) -> &'a str { "" }
    |                                      ++
 
-warning: elided lifetime has a name
-  --> $DIR/lifetime-elision-return-type-requires-explicit-lifetime.rs:49:29
-   |
-LL | fn m<'a>(_: &'a Foo<'a>) -> &str { "" }
-   |      --                     ^ this elided lifetime gets resolved as `'a`
-   |      |
-   |      lifetime `'a` declared here
-   |
-   = note: `#[warn(elided_named_lifetimes)]` on by default
-
-error: aborting due to 7 previous errors; 1 warning emitted
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-3.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex1-return-one-existing-name-if-else-using-impl-3.stderr
@@ -1,13 +1,3 @@
-warning: elided lifetime has a name
-  --> $DIR/ex1-return-one-existing-name-if-else-using-impl-3.rs:6:36
-   |
-LL |   fn foo<'a>(&'a self, x: &i32) -> &i32 {
-   |          --                        ^ this elided lifetime gets resolved as `'a`
-   |          |
-   |          lifetime `'a` declared here
-   |
-   = note: `#[warn(elided_named_lifetimes)]` on by default
-
 error[E0621]: explicit lifetime required in the type of `x`
   --> $DIR/ex1-return-one-existing-name-if-else-using-impl-3.rs:9:36
    |
@@ -17,6 +7,6 @@ LL |   fn foo<'a>(&'a self, x: &i32) -> &i32 {
 LL |     if true { &self.field } else { x }
    |                                    ^ lifetime `'a` required
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0621`.

--- a/tests/ui/lint/elided-named-lifetimes/example-from-issue48686.stderr
+++ b/tests/ui/lint/elided-named-lifetimes/example-from-issue48686.stderr
@@ -1,8 +1,8 @@
 error: elided lifetime has a name
-  --> $DIR/example-from-issue48686.rs:6:50
+  --> $DIR/example-from-issue48686.rs:6:51
    |
 LL |     pub fn get_mut(&'static self, x: &mut u8) -> &mut u8 {
-   |                                                  ^ this elided lifetime gets resolved as `'static`
+   |                                                   ^ this elided lifetime gets resolved as `'static`
    |
 note: the lint level is defined here
   --> $DIR/example-from-issue48686.rs:1:9

--- a/tests/ui/lint/elided-named-lifetimes/missing-lifetime-kind.stderr
+++ b/tests/ui/lint/elided-named-lifetimes/missing-lifetime-kind.stderr
@@ -1,8 +1,8 @@
 error: elided lifetime has a name
-  --> $DIR/missing-lifetime-kind.rs:3:32
+  --> $DIR/missing-lifetime-kind.rs:3:33
    |
 LL | fn ampersand<'a>(x: &'a u8) -> &u8 {
-   |              --                ^ this elided lifetime gets resolved as `'a`
+   |              --                 ^ this elided lifetime gets resolved as `'a`
    |              |
    |              lifetime `'a` declared here
    |
@@ -21,10 +21,10 @@ LL | fn brackets<'a>(x: &'a u8) -> Brackets {
    |             lifetime `'a` declared here
 
 error: elided lifetime has a name
-  --> $DIR/missing-lifetime-kind.rs:17:33
+  --> $DIR/missing-lifetime-kind.rs:17:34
    |
 LL | fn comma<'a>(x: &'a u8) -> Comma<u8> {
-   |          --                     ^ this elided lifetime gets resolved as `'a`
+   |          --                      ^ this elided lifetime gets resolved as `'a`
    |          |
    |          lifetime `'a` declared here
 

--- a/tests/ui/lint/elided-named-lifetimes/not-tied-to-crate.stderr
+++ b/tests/ui/lint/elided-named-lifetimes/not-tied-to-crate.stderr
@@ -1,8 +1,8 @@
 warning: elided lifetime has a name
-  --> $DIR/not-tied-to-crate.rs:5:31
+  --> $DIR/not-tied-to-crate.rs:5:32
    |
 LL |     fn bar(x: &'static u8) -> &u8 {
-   |                               ^ this elided lifetime gets resolved as `'static`
+   |                                ^ this elided lifetime gets resolved as `'static`
    |
 note: the lint level is defined here
   --> $DIR/not-tied-to-crate.rs:3:8
@@ -15,10 +15,10 @@ LL |     fn bar(x: &'static u8) -> &'static u8 {
    |                                +++++++
 
 error: elided lifetime has a name
-  --> $DIR/not-tied-to-crate.rs:11:31
+  --> $DIR/not-tied-to-crate.rs:11:32
    |
 LL |     fn baz(x: &'static u8) -> &u8 {
-   |                               ^ this elided lifetime gets resolved as `'static`
+   |                                ^ this elided lifetime gets resolved as `'static`
    |
 note: the lint level is defined here
   --> $DIR/not-tied-to-crate.rs:10:12

--- a/tests/ui/lint/elided-named-lifetimes/static.stderr
+++ b/tests/ui/lint/elided-named-lifetimes/static.stderr
@@ -1,8 +1,8 @@
 error: elided lifetime has a name
-  --> $DIR/static.rs:16:33
+  --> $DIR/static.rs:16:34
    |
 LL | fn ampersand(x: &'static u8) -> &u8 {
-   |                                 ^ this elided lifetime gets resolved as `'static`
+   |                                  ^ this elided lifetime gets resolved as `'static`
    |
 note: the lint level is defined here
   --> $DIR/static.rs:1:9
@@ -26,10 +26,10 @@ LL | fn brackets(x: &'static u8) -> Brackets<'static> {
    |                                        +++++++++
 
 error: elided lifetime has a name
-  --> $DIR/static.rs:30:34
+  --> $DIR/static.rs:30:35
    |
 LL | fn comma(x: &'static u8) -> Comma<u8> {
-   |                                  ^ this elided lifetime gets resolved as `'static`
+   |                                   ^ this elided lifetime gets resolved as `'static`
    |
 help: consider specifying it explicitly
    |

--- a/tests/ui/object-lifetime/object-lifetime-default-elision.stderr
+++ b/tests/ui/object-lifetime/object-lifetime-default-elision.stderr
@@ -1,13 +1,3 @@
-warning: elided lifetime has a name
-  --> $DIR/object-lifetime-default-elision.rs:48:40
-   |
-LL | fn load2<'a>(ss: &'a dyn SomeTrait) -> &dyn SomeTrait {
-   |          --                            ^ this elided lifetime gets resolved as `'a`
-   |          |
-   |          lifetime `'a` declared here
-   |
-   = note: `#[warn(elided_named_lifetimes)]` on by default
-
 error: lifetime may not live long enough
   --> $DIR/object-lifetime-default-elision.rs:73:5
    |
@@ -21,5 +11,5 @@ LL |     ss
    |
    = help: consider adding the following bound: `'a: 'b`
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 1 previous error
 

--- a/tests/ui/self/elision/ignore-non-reference-lifetimes.stderr
+++ b/tests/ui/self/elision/ignore-non-reference-lifetimes.stderr
@@ -1,16 +1,16 @@
 warning: elided lifetime has a name
-  --> $DIR/ignore-non-reference-lifetimes.rs:6:41
+  --> $DIR/ignore-non-reference-lifetimes.rs:6:42
    |
 LL |     fn a<'a>(self: Self, a: &'a str) -> &str {
-   |          -- lifetime `'a` declared here ^ this elided lifetime gets resolved as `'a`
+   |          -- lifetime `'a` declared here  ^ this elided lifetime gets resolved as `'a`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default
 
 warning: elided lifetime has a name
-  --> $DIR/ignore-non-reference-lifetimes.rs:10:44
+  --> $DIR/ignore-non-reference-lifetimes.rs:10:45
    |
 LL |     fn b<'a>(self: Foo<'b>, a: &'a str) -> &str {
-   |          -- lifetime `'a` declared here    ^ this elided lifetime gets resolved as `'a`
+   |          -- lifetime `'a` declared here     ^ this elided lifetime gets resolved as `'a`
 
 warning: 2 warnings emitted
 

--- a/tests/ui/self/self_lifetime-async.stderr
+++ b/tests/ui/self/self_lifetime-async.stderr
@@ -1,18 +1,18 @@
 warning: elided lifetime has a name
-  --> $DIR/self_lifetime-async.rs:6:44
+  --> $DIR/self_lifetime-async.rs:6:45
    |
 LL |     async fn foo<'b>(self: &'b Foo<'a>) -> &() { self.0 }
-   |                  --                        ^ this elided lifetime gets resolved as `'b`
+   |                  --                         ^ this elided lifetime gets resolved as `'b`
    |                  |
    |                  lifetime `'b` declared here
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default
 
 warning: elided lifetime has a name
-  --> $DIR/self_lifetime-async.rs:12:52
+  --> $DIR/self_lifetime-async.rs:12:53
    |
 LL |     async fn bar<'a>(self: &Alias, arg: &'a ()) -> &() { arg }
-   |                  -- lifetime `'a` declared here    ^ this elided lifetime gets resolved as `'a`
+   |                  -- lifetime `'a` declared here     ^ this elided lifetime gets resolved as `'a`
 
 warning: 2 warnings emitted
 

--- a/tests/ui/self/self_lifetime.stderr
+++ b/tests/ui/self/self_lifetime.stderr
@@ -1,18 +1,18 @@
 warning: elided lifetime has a name
-  --> $DIR/self_lifetime.rs:7:38
+  --> $DIR/self_lifetime.rs:7:39
    |
 LL |     fn foo<'b>(self: &'b Foo<'a>) -> &() { self.0 }
-   |            --                        ^ this elided lifetime gets resolved as `'b`
+   |            --                         ^ this elided lifetime gets resolved as `'b`
    |            |
    |            lifetime `'b` declared here
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default
 
 warning: elided lifetime has a name
-  --> $DIR/self_lifetime.rs:13:46
+  --> $DIR/self_lifetime.rs:13:47
    |
 LL |     fn bar<'a>(self: &Alias, arg: &'a ()) -> &() { arg }
-   |            -- lifetime `'a` declared here    ^ this elided lifetime gets resolved as `'a`
+   |            -- lifetime `'a` declared here     ^ this elided lifetime gets resolved as `'a`
 
 warning: 2 warnings emitted
 

--- a/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
+++ b/tests/ui/suggestions/impl-trait-missing-lifetime-gated.stderr
@@ -124,14 +124,6 @@ LL -     fn g(mut x: impl Foo<()>) -> Option<&()> { x.next() }
 LL +     fn g(mut x: impl Foo<()>) -> Option<()> { x.next() }
    |
 
-warning: elided lifetime has a name
-  --> $DIR/impl-trait-missing-lifetime-gated.rs:66:57
-   |
-LL | fn resolved_anonymous<'a, T: 'a>(f: impl Fn(&'a str) -> &T) {
-   |                       -- lifetime `'a` declared here    ^ this elided lifetime gets resolved as `'a`
-   |
-   = note: `#[warn(elided_named_lifetimes)]` on by default
-
 error[E0658]: anonymous lifetimes in `impl Trait` are unstable
   --> $DIR/impl-trait-missing-lifetime-gated.rs:6:35
    |
@@ -252,7 +244,7 @@ help: consider introducing a named lifetime parameter
 LL |     fn g<'a>(mut x: impl Foo<'a, ()>) -> Option<&()> { x.next() }
    |         ++++                 +++
 
-error: aborting due to 16 previous errors; 1 warning emitted
+error: aborting due to 16 previous errors
 
 Some errors have detailed explanations: E0106, E0658.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
+++ b/tests/ui/suggestions/lifetimes/missing-lifetimes-in-signature.stderr
@@ -6,14 +6,6 @@ LL | fn baz<G: 'a, T>(g: G, dest: &mut T) -> impl FnOnce() + '_
    |        |
    |        help: consider introducing lifetime `'a` here: `'a,`
 
-warning: elided lifetime has a name
-  --> $DIR/missing-lifetimes-in-signature.rs:102:64
-   |
-LL | fn ok2<'a, G: 'a, T>(g: G, dest: &'a mut T) -> impl FnOnce() + '_ + 'a
-   |        -- lifetime `'a` declared here                          ^^ this elided lifetime gets resolved as `'a`
-   |
-   = note: `#[warn(elided_named_lifetimes)]` on by default
-
 error[E0700]: hidden type for `impl FnOnce()` captures lifetime that does not appear in bounds
   --> $DIR/missing-lifetimes-in-signature.rs:19:5
    |
@@ -133,7 +125,7 @@ help: consider adding an explicit lifetime bound
 LL |     G: Get<T> + 'a,
    |               ++++
 
-error: aborting due to 8 previous errors; 1 warning emitted
+error: aborting due to 8 previous errors
 
 Some errors have detailed explanations: E0261, E0309, E0311, E0621, E0700.
 For more information about an error, try `rustc --explain E0261`.

--- a/tests/ui/type-alias-impl-trait/missing_lifetime_bound.stderr
+++ b/tests/ui/type-alias-impl-trait/missing_lifetime_bound.stderr
@@ -1,13 +1,3 @@
-warning: elided lifetime has a name
-  --> $DIR/missing_lifetime_bound.rs:5:41
-   |
-LL | fn defining<'a, T>(x: &'a i32) -> Opaque<T> { x }
-   |             --                          ^ this elided lifetime gets resolved as `'a`
-   |             |
-   |             lifetime `'a` declared here
-   |
-   = note: `#[warn(elided_named_lifetimes)]` on by default
-
 error[E0700]: hidden type for `Opaque2<T>` captures lifetime that does not appear in bounds
   --> $DIR/missing_lifetime_bound.rs:5:47
    |
@@ -19,6 +9,6 @@ LL | fn defining<'a, T>(x: &'a i32) -> Opaque<T> { x }
    |             |
    |             hidden type `&'a i32` captures the lifetime `'a` as defined here
 
-error: aborting due to 1 previous error; 1 warning emitted
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0700`.


### PR DESCRIPTION
r? @cjgillot 

Trying to move forward with https://github.com/rust-lang/rust/pull/129840#issuecomment-2335130734

Current results, from sad to happy:

- Some new false negatives. I have a feeling those lifetimes just do not get preserved when lowering AST to HIR, so fundamentally unlintable with this approach.
- Most of lifetime spans changed slightly. Personally I find the previous position more visually appealing.
- `ElidedNamedLifetime` diagnostic decorator can almost be moved from a hand-rolled impl to a derived one. (Is that a good thing?) The only problem seems to be that you can't slap both `#[label]` & `#[primary_span]` on the same field.
- There is now a `ElidedNamedLifetimes` pass. Yay.
- `LateLintPass` now has `check_trait_item_post` & `check_lifetime`.
- The `MissingLifetime.id_for_lint` & the `LifetimeRes::Static.suppress_elision_warning` hacks got removed.