### PR TITLE
use verbose flag as a default value for `rust.verbose-tests`

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -641,7 +641,7 @@
 #stack-protector = "none"
 
 # Prints each test name as it is executed, to help debug issues in the test harness itself.
-#verbose-tests = false
+#verbose-tests = if is_verbose { true } else { false }
 
 # Flag indicating whether tests are compiled with optimizations (the -O flag).
 #optimize-tests = true

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1600,6 +1600,9 @@ impl Config {
 
         config.verbose = cmp::max(config.verbose, flags.verbose as usize);
 
+        // Verbose flag is a good default for `rust.verbose-tests`.
+        config.verbose_tests = config.is_verbose();
+
         if let Some(install) = toml.install {
             let Install { prefix, sysconfdir, docdir, bindir, libdir, mandir, datadir } = install;
             config.prefix = prefix.map(PathBuf::from);

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -317,3 +317,12 @@ fn order_of_clippy_rules() {
 
     assert_eq!(expected, actual);
 }
+
+#[test]
+fn verbose_tests_default_value() {
+    let config = Config::parse(Flags::parse(&["build".into(), "compiler".into()]));
+    assert_eq!(config.verbose_tests, false);
+
+    let config = Config::parse(Flags::parse(&["build".into(), "compiler".into(), "-v".into()]));
+    assert_eq!(config.verbose_tests, true);
+}


### PR DESCRIPTION
See the [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/326414-t-infra.2Fbootstrap/topic/Run.20tests.20in.20x.2Epy.20with.20.22pretty.22.20test.20rendering.3F) for more context.