### PR TITLE
bump download-ci-llvm-stamp

### DIFF
--- a/src/bootstrap/download-ci-llvm-stamp
+++ b/src/bootstrap/download-ci-llvm-stamp
@@ -1,4 +1,4 @@
 Change this file to make users of the `download-ci-llvm` configuration download
 a new version of LLVM from CI, even if the LLVM submodule hasn’t changed.
 
-Last change is for: https://github.com/rust-lang/rust/pull/129116
+Last change is for: https://github.com/rust-lang/rust/pull/129788


### PR DESCRIPTION
This should trigger the download and extraction of the ci-llvm tarball, which should resolve https://github.com/rust-lang/rust/issues/130144.