### PR TITLE
rustdoc: add two regression tests

### DIFF
--- a/tests/rustdoc-ui/projection-as-union-type-error.rs
+++ b/tests/rustdoc-ui/projection-as-union-type-error.rs
@@ -1,0 +1,14 @@
+// Test to ensure that there is no ICE when normalizing a projection.
+// See also <https://github.com/rust-lang/rust/pull/106938>.
+// issue: rust-lang/rust#107872
+
+pub trait Identity {
+    type Identity;
+}
+
+pub type Foo = u8;
+
+pub union Bar {
+    a:  <Foo as Identity>::Identity, //~ ERROR the trait bound `u8: Identity` is not satisfied
+    b: u8,
+}

--- a/tests/rustdoc-ui/projection-as-union-type-error.stderr
+++ b/tests/rustdoc-ui/projection-as-union-type-error.stderr
@@ -1,0 +1,15 @@
+error[E0277]: the trait bound `u8: Identity` is not satisfied
+  --> $DIR/projection-as-union-type-error.rs:12:9
+   |
+LL |     a:  <Foo as Identity>::Identity,
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Identity` is not implemented for `u8`
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/projection-as-union-type-error.rs:5:1
+   |
+LL | pub trait Identity {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/rustdoc-ui/recursive-type-alias-impl-trait-declaration-too-subtle-2.rs
+++ b/tests/rustdoc-ui/recursive-type-alias-impl-trait-declaration-too-subtle-2.rs
@@ -1,0 +1,23 @@
+// issue: rust-lang/rust#98250
+//@ check-pass
+
+#![feature(type_alias_impl_trait)]
+
+mod foo {
+    pub type Foo = impl PartialEq<(Foo, i32)>;
+
+    fn foo() -> Foo {
+        super::Bar
+    }
+}
+use foo::Foo;
+
+struct Bar;
+
+impl PartialEq<(Foo, i32)> for Bar {
+    fn eq(&self, _other: &(Foo, i32)) -> bool {
+        true
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
They were basically copy/pasted from `tests/ui/` to `tests/rustdoc-ui/`.
Not sure if it's worth adding these, I can just close these issues as is if you want.

This brings the number of https://github.com/rust-lang/rust/labels/T-rustdoc + https://github.com/rust-lang/rust/labels/E-needs-test from 3 down to 1.
The remaining one – #103004 — is a nasty one to retroactively find a proper(!) test for.

Fixes #98250.
Fixes #107872.

r? rustdoc
