### PR TITLE
interpreter typed copy validation: statically disable padding/provenance in CTFE machine

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/machine.rs
+++ b/compiler/rustc_const_eval/src/interpret/machine.rs
@@ -148,6 +148,10 @@ pub trait Machine<'tcx>: Sized {
     /// already been checked before.
     const ALL_CONSTS_ARE_PRECHECKED: bool = true;
 
+    /// Whether *validated* typed copies should reset padding and provenance.
+    /// Has no effect when `enforce_validity` returns `false`!
+    const RESET_PROVENANCE_AND_PADDING: bool = false;
+
     /// Whether memory accesses should be alignment-checked.
     fn enforce_alignment(ecx: &InterpCx<'tcx, Self>) -> bool;
 

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -608,7 +608,6 @@ where
             self.validate_operand(
                 &dest.to_place(),
                 M::enforce_validity_recursively(self, dest.layout()),
-                /*reset_provenance_and_padding*/ true,
             )?;
         }
 
@@ -821,14 +820,9 @@ where
                 self.validate_operand(
                     &dest.transmute(src.layout(), self)?,
                     M::enforce_validity_recursively(self, src.layout()),
-                    /*reset_provenance_and_padding*/ true,
                 )?;
             }
-            self.validate_operand(
-                &dest,
-                M::enforce_validity_recursively(self, dest.layout()),
-                /*reset_provenance_and_padding*/ true,
-            )?;
+            self.validate_operand(&dest, M::enforce_validity_recursively(self, dest.layout()))?;
         }
 
         Ok(())

--- a/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
+++ b/compiler/rustc_const_eval/src/util/check_validity_requirement.rs
@@ -67,13 +67,7 @@ fn check_validity_requirement_strict<'tcx>(
     // due to this.
     // The value we are validating is temporary and discarded at the end of this function, so
     // there is no point in reseting provenance and padding.
-    Ok(cx
-        .validate_operand(
-            &allocated.into(),
-            /*recursive*/ false,
-            /*reset_provenance_and_padding*/ false,
-        )
-        .is_ok())
+    Ok(cx.validate_operand(&allocated.into(), /*recursive*/ false).is_ok())
 }
 
 /// Implements the 'lax' (default) version of the [`check_validity_requirement`] checks; see that

--- a/src/tools/miri/src/machine.rs
+++ b/src/tools/miri/src/machine.rs
@@ -889,6 +889,8 @@ impl<'tcx> Machine<'tcx> for MiriMachine<'tcx> {
 
     const PANIC_ON_ALLOC_FAIL: bool = false;
 
+    const RESET_PROVENANCE_AND_PADDING: bool = true;
+
     #[inline(always)]
     fn enforce_alignment(ecx: &MiriInterpCx<'tcx>) -> bool {
         ecx.machine.check_alignment != AlignmentCheck::None


### PR DESCRIPTION
Let's see if this fixes the perf impact in https://github.com/rust-lang/rust/pull/129778.

r? @saethlin 