### PR TITLE
generalize: track relevant info in cache key

### DIFF
--- a/tests/ui/const-generics/occurs-check/unused-substs-3.rs
+++ b/tests/ui/const-generics/occurs-check/unused-substs-3.rs
@@ -11,9 +11,11 @@ fn bind<T>() -> (T, [u8; 6 + 1]) {
 
 fn main() {
     let (mut t, foo) = bind();
+    //~^ ERROR mismatched types
+    //~| NOTE cyclic type
+
     // `t` is `ty::Infer(TyVar(?1t))`
     // `foo` contains `ty::Infer(TyVar(?1t))` in its substs
     t = foo;
-    //~^ ERROR mismatched types
-    //~| NOTE cyclic type
+
 }

--- a/tests/ui/const-generics/occurs-check/unused-substs-3.stderr
+++ b/tests/ui/const-generics/occurs-check/unused-substs-3.stderr
@@ -1,10 +1,8 @@
 error[E0308]: mismatched types
-  --> $DIR/unused-substs-3.rs:16:9
+  --> $DIR/unused-substs-3.rs:13:24
    |
-LL |     t = foo;
-   |         ^^^- help: try using a conversion method: `.to_vec()`
-   |         |
-   |         cyclic type of infinite size
+LL |     let (mut t, foo) = bind();
+   |                        ^^^^^^ cyclic type of infinite size
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
This was previously theoretically incomplete as we could incorrectly generalize as if the type was in an invariant context even though we're in a covariant one. Similar with the `in_alias` flag.

r? @compiler-errors 