### PR TITLE
Map `WSAEDQUOT` to `ErrorKind::FilesystemQuotaExceeded`

### DIFF
--- a/library/std/src/sys/pal/windows/mod.rs
+++ b/library/std/src/sys/pal/windows/mod.rs
@@ -139,6 +139,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         c::WSAEHOSTUNREACH => HostUnreachable,
         c::WSAENETDOWN => NetworkDown,
         c::WSAENETUNREACH => NetworkUnreachable,
+        c::WSAEDQUOT => FilesystemQuotaExceeded,
 
         _ => Uncategorized,
     }


### PR DESCRIPTION
cc #86442

As summarized in #130190, there seems to be a consensus that this should be done.
