### PR TITLE
Map `ERROR_CANT_RESOLVE_FILENAME` to `ErrorKind::FilesystemLoop`

### DIFF
--- a/library/std/src/sys/pal/windows/mod.rs
+++ b/library/std/src/sys/pal/windows/mod.rs
@@ -122,6 +122,7 @@ pub fn decode_error_kind(errno: i32) -> ErrorKind {
         c::ERROR_NOT_SAME_DEVICE => return CrossesDevices,
         c::ERROR_TOO_MANY_LINKS => return TooManyLinks,
         c::ERROR_FILENAME_EXCED_RANGE => return InvalidFilename,
+        c::ERROR_CANT_RESOLVE_FILENAME => return FilesystemLoop,
         _ => {}
     }
 


### PR DESCRIPTION
cc #86442

As summarized in #130188, there seems to be a consensus that this should be done.