### PR TITLE
Stabilize `std::io::ErrorKind::CrossesDevices`

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -353,7 +353,7 @@ pub enum ErrorKind {
     #[stable(feature = "io_error_a_bit_more", since = "CURRENT_RUSTC_VERSION")]
     Deadlock,
     /// Cross-device or cross-filesystem (hard) link or rename.
-    #[unstable(feature = "io_error_more", issue = "86442")]
+    #[stable(feature = "io_error_crosses_devices", since = "CURRENT_RUSTC_VERSION")]
     CrossesDevices,
     /// Too many (hard) links to the same filesystem object.
     ///


### PR DESCRIPTION
FCP in #130191

cc #86442

See #130191 for more info and a recap of what has happened up until now.

TLDR: This had been FCP'd in December 2022 with some other `ErrorKind`s, but the stabilization got postponed due to some concerns voiced about several of the variants. However, the only concern ever voiced for this variant in particular was a wish to rename this to `NotSameDevice` analogous to Windows's `ERROR_NOT_SAME_DEVICE` (as opposed to Unix's `EXDEV`). This suggestion did not receive any support. So let's try to FCP this as is.

r? libs-api