### PR TITLE
Fix false positive with `missing_docs` and `#[test]`

### DIFF
--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -277,6 +277,8 @@ pub(crate) fn expand_test_or_bench(
                 cx.attr_nested_word(sym::cfg, sym::test, attr_sp),
                 // #[rustc_test_marker = "test_case_sort_key"]
                 cx.attr_name_value_str(sym::rustc_test_marker, test_path_symbol, attr_sp),
+                // #[allow(missing_docs)]
+                cx.attr_nested_word(sym::allow, sym::missing_docs, attr_sp),
             ],
             // const $ident: test::TestDescAndFn =
             ast::ItemKind::Const(

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -277,8 +277,8 @@ pub(crate) fn expand_test_or_bench(
                 cx.attr_nested_word(sym::cfg, sym::test, attr_sp),
                 // #[rustc_test_marker = "test_case_sort_key"]
                 cx.attr_name_value_str(sym::rustc_test_marker, test_path_symbol, attr_sp),
-                // #[allow(missing_docs)]
-                cx.attr_nested_word(sym::allow, sym::missing_docs, attr_sp),
+                // #[doc(hidden)]
+                cx.attr_nested_word(sym::doc, sym::hidden, attr_sp),
             ],
             // const $ident: test::TestDescAndFn =
             ast::ItemKind::Const(

--- a/compiler/rustc_builtin_macros/src/test_harness.rs
+++ b/compiler/rustc_builtin_macros/src/test_harness.rs
@@ -326,8 +326,8 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> P<ast::Item> {
     let main_attr = ecx.attr_word(sym::rustc_main, sp);
     // #[coverage(off)]
     let coverage_attr = ecx.attr_nested_word(sym::coverage, sym::off, sp);
-    // #[allow(missing_docs)]
-    let missing_docs_attr = ecx.attr_nested_word(sym::allow, sym::missing_docs, sp);
+    // #[doc(hidden)]
+    let doc_hidden_attr = ecx.attr_nested_word(sym::doc, sym::hidden, sp);
 
     // pub fn main() { ... }
     let main_ret_ty = ecx.ty(sp, ast::TyKind::Tup(ThinVec::new()));
@@ -357,7 +357,7 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> P<ast::Item> {
 
     let main = P(ast::Item {
         ident: main_id,
-        attrs: thin_vec![main_attr, coverage_attr, missing_docs_attr],
+        attrs: thin_vec![main_attr, coverage_attr, doc_hidden_attr],
         id: ast::DUMMY_NODE_ID,
         kind: main,
         vis: ast::Visibility { span: sp, kind: ast::VisibilityKind::Public, tokens: None },

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1236,7 +1236,6 @@ symbols! {
         mir_unwind_unreachable,
         mir_variant,
         miri,
-        missing_docs,
         mmx_reg,
         modifiers,
         module,

--- a/tests/pretty/tests-are-sorted.pp
+++ b/tests/pretty/tests-are-sorted.pp
@@ -12,6 +12,7 @@ extern crate std;
 extern crate test;
 #[cfg(test)]
 #[rustc_test_marker = "m_test"]
+#[allow(missing_docs)]
 pub const m_test: test::TestDescAndFn =
     test::TestDescAndFn {
         desc: test::TestDesc {
@@ -36,6 +37,7 @@ fn m_test() {}
 extern crate test;
 #[cfg(test)]
 #[rustc_test_marker = "z_test"]
+#[allow(missing_docs)]
 pub const z_test: test::TestDescAndFn =
     test::TestDescAndFn {
         desc: test::TestDesc {
@@ -61,6 +63,7 @@ fn z_test() {}
 extern crate test;
 #[cfg(test)]
 #[rustc_test_marker = "a_test"]
+#[allow(missing_docs)]
 pub const a_test: test::TestDescAndFn =
     test::TestDescAndFn {
         desc: test::TestDesc {

--- a/tests/pretty/tests-are-sorted.pp
+++ b/tests/pretty/tests-are-sorted.pp
@@ -12,7 +12,7 @@ extern crate std;
 extern crate test;
 #[cfg(test)]
 #[rustc_test_marker = "m_test"]
-#[allow(missing_docs)]
+#[doc(hidden)]
 pub const m_test: test::TestDescAndFn =
     test::TestDescAndFn {
         desc: test::TestDesc {
@@ -37,7 +37,7 @@ fn m_test() {}
 extern crate test;
 #[cfg(test)]
 #[rustc_test_marker = "z_test"]
-#[allow(missing_docs)]
+#[doc(hidden)]
 pub const z_test: test::TestDescAndFn =
     test::TestDescAndFn {
         desc: test::TestDesc {
@@ -63,7 +63,7 @@ fn z_test() {}
 extern crate test;
 #[cfg(test)]
 #[rustc_test_marker = "a_test"]
-#[allow(missing_docs)]
+#[doc(hidden)]
 pub const a_test: test::TestDescAndFn =
     test::TestDescAndFn {
         desc: test::TestDesc {

--- a/tests/pretty/tests-are-sorted.pp
+++ b/tests/pretty/tests-are-sorted.pp
@@ -86,7 +86,7 @@ pub const a_test: test::TestDescAndFn =
 fn a_test() {}
 #[rustc_main]
 #[coverage(off)]
-#[allow(missing_docs)]
+#[doc(hidden)]
 pub fn main() -> () {
     extern crate test;
     test::test_main_static(&[&a_test, &m_test, &z_test])

--- a/tests/ui/lint/lint-missing-doc-test.rs
+++ b/tests/ui/lint/lint-missing-doc-test.rs
@@ -2,7 +2,9 @@
 //! on the generated test harness.
 
 //@ check-pass
-//@ compile-flags: --test -Dmissing_docs
+//@ compile-flags: --test
+
+#![forbid(missing_docs)]
 
 #[test]
 fn test() {}

--- a/tests/ui/lint/lint-missing-doc-test.rs
+++ b/tests/ui/lint/lint-missing-doc-test.rs
@@ -3,3 +3,6 @@
 
 //@ check-pass
 //@ compile-flags: --test -Dmissing_docs
+
+#[test]
+fn test() {}


### PR DESCRIPTION
Since #130025, the compiler don't ignore missing_docs when compiling the tests. But there is now a false positive warning for every `#[test]`

For example, this code
```rust
//! Crate docs
#![warn(missing_docs)]
#[test]
fn just_a_test() {}
```

Would emit this warning when running `cargo test`

```
warning: missing documentation for a constant
 --> src/lib.rs:5:1
  |
4 | #[test]
  | ------- in this procedural macro expansion
5 | fn just_a_test() {}
  | ^^^^^^^^^^^^^^^^^^^
```

