### PR TITLE
Make SearchPath::new public

### DIFF
--- a/compiler/rustc_session/src/search_paths.rs
+++ b/compiler/rustc_session/src/search_paths.rs
@@ -96,7 +96,7 @@ impl SearchPath {
         Self::new(PathKind::All, make_target_lib_path(sysroot, triple))
     }
 
-    fn new(kind: PathKind, dir: PathBuf) -> Self {
+    pub fn new(kind: PathKind, dir: PathBuf) -> Self {
         // Get the files within the directory.
         let files = match std::fs::read_dir(&dir) {
             Ok(files) => files


### PR DESCRIPTION
I'm writing a tool that uses `rustc_interface`, and would like to construct `SearchPath` with its `new` method.

As all three fields in `SearchPath` are public anyway, the proposed change should not change the privacy or encapsulation of the struct.