### PR TITLE
Eliminate needless returns

### DIFF
--- a/compiler/rustc_ast/src/ast_traits.rs
+++ b/compiler/rustc_ast/src/ast_traits.rs
@@ -153,7 +153,7 @@ impl HasTokens for StmtKind {
             StmtKind::Let(local) => local.tokens.as_ref(),
             StmtKind::Item(item) => item.tokens(),
             StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr.tokens(),
-            StmtKind::Empty => return None,
+            StmtKind::Empty => None,
             StmtKind::MacCall(mac) => mac.tokens.as_ref(),
         }
     }
@@ -162,7 +162,7 @@ impl HasTokens for StmtKind {
             StmtKind::Let(local) => Some(&mut local.tokens),
             StmtKind::Item(item) => item.tokens_mut(),
             StmtKind::Expr(expr) | StmtKind::Semi(expr) => expr.tokens_mut(),
-            StmtKind::Empty => return None,
+            StmtKind::Empty => None,
             StmtKind::MacCall(mac) => Some(&mut mac.tokens),
         }
     }

--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -1240,5 +1240,5 @@ pub fn parse_confusables(attr: &Attribute) -> Option<Vec<Symbol>> {
         candidates.push(meta_lit.symbol);
     }
 
-    return Some(candidates);
+    Some(candidates)
 }

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -3665,11 +3665,13 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     }
                 }
             }
+
             if any_match {
                 reinits.push(location);
-                return true;
+                true
+            } else {
+                false
             }
-            return false;
         };
 
         while let Some(location) = stack.pop() {

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -1904,7 +1904,6 @@ impl<'a, 'tcx> MirBorrowckCtxt<'a, '_, 'tcx> {
                     (place_span.0, place_span.0, place_span.1),
                     uninit_mpi,
                 );
-                return; // don't bother finding other problems.
             }
         }
     }

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -214,7 +214,7 @@ impl<'me, 'bccx, 'tcx> NllTypeRelating<'me, 'bccx, 'tcx> {
         let delegate = FnMutDelegate {
             regions: &mut |br: ty::BoundRegion| {
                 if let Some(ex_reg_var) = reg_map.get(&br) {
-                    return *ex_reg_var;
+                    *ex_reg_var
                 } else {
                     let ex_reg_var = self.next_existential_region_var(true, br.kind.get_name());
                     debug!(?ex_reg_var);

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -290,7 +290,7 @@ pub(crate) fn check_tied_features(
             }
         }
     }
-    return None;
+    None
 }
 
 /// Used to generate cfg variables and apply features

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -438,7 +438,7 @@ fn link_rlib<'a>(
         ab.add_file(&lib)
     }
 
-    return Ok(ab);
+    Ok(ab)
 }
 
 /// Extract all symbols defined in raw-dylib libraries, collated by library name.
@@ -1319,7 +1319,7 @@ fn link_sanitizer_runtime(
     fn find_sanitizer_runtime(sess: &Session, filename: &str) -> PathBuf {
         let path = sess.target_tlib_path.dir.join(filename);
         if path.exists() {
-            return sess.target_tlib_path.dir.clone();
+            sess.target_tlib_path.dir.clone()
         } else {
             let default_sysroot =
                 filesearch::get_or_default_sysroot().expect("Failed finding sysroot");
@@ -1327,7 +1327,7 @@ fn link_sanitizer_runtime(
                 &default_sysroot,
                 sess.opts.target_triple.triple(),
             );
-            return default_tlib;
+            default_tlib
         }
     }
 

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1484,7 +1484,6 @@ impl<'a> Linker for L4Bender<'a> {
     fn export_symbols(&mut self, _: &Path, _: CrateType, _: &[String]) {
         // ToDo, not implemented, copy from GCC
         self.sess.dcx().emit_warn(errors::L4BenderExportingSymbolsUnimplemented);
-        return;
     }
 
     fn subsystem(&mut self, subsystem: &str) {

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -171,10 +171,10 @@ pub(super) fn get_metadata_xcoff<'a>(path: &Path, data: &'a [u8]) -> Result<&'a 
                 "Metadata at offset {offset} with size {len} is beyond .info section"
             ));
         }
-        return Ok(&info_data[offset..(offset + len)]);
+        Ok(&info_data[offset..(offset + len)])
     } else {
-        return Err(format!("Unable to find symbol {AIX_METADATA_SYMBOL_NAME}"));
-    };
+        Err(format!("Unable to find symbol {AIX_METADATA_SYMBOL_NAME}"))
+    }
 }
 
 pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static>> {
@@ -413,7 +413,7 @@ fn macho_object_build_version_for_target(target: &Target) -> object::write::Mach
 
 /// Is Apple's CPU subtype `arm64e`s
 fn macho_is_arm64e(target: &Target) -> bool {
-    return target.llvm_target.starts_with("arm64e");
+    target.llvm_target.starts_with("arm64e")
 }
 
 pub enum MetadataPosition {

--- a/compiler/rustc_const_eval/src/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/check_consts/check.rs
@@ -1006,11 +1006,7 @@ fn place_as_reborrow<'tcx>(
                 // reborrow, even if the check above were to disappear.
                 let inner_ty = place_base.ty(body, tcx).ty;
 
-                if let ty::Ref(..) = inner_ty.kind() {
-                    return Some(place_base);
-                } else {
-                    return None;
-                }
+                if let ty::Ref(..) = inner_ty.kind() { Some(place_base) } else { None }
             }
         }
         _ => None,

--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -235,13 +235,13 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         if self.layout_compat(caller_abi.layout, callee_abi.layout)? {
             // Ensure that our checks imply actual ABI compatibility for this concrete call.
             assert!(caller_abi.eq_abi(callee_abi));
-            return Ok(true);
+            Ok(true)
         } else {
             trace!(
                 "check_argument_compat: incompatible ABIs:\ncaller: {:?}\ncallee: {:?}",
                 caller_abi, callee_abi
             );
-            return Ok(false);
+            Ok(false)
         }
     }
 

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -861,7 +861,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             }
             Some(GlobalAlloc::VTable(..)) => {
                 // No data to be accessed here. But vtables are pointer-aligned.
-                return (Size::ZERO, self.tcx.data_layout.pointer_align.abi, AllocKind::VTable);
+                (Size::ZERO, self.tcx.data_layout.pointer_align.abi, AllocKind::VTable)
             }
             // The rest must be dead.
             None => {

--- a/compiler/rustc_expand/src/mbe/transcribe.rs
+++ b/compiler/rustc_expand/src/mbe/transcribe.rs
@@ -775,7 +775,7 @@ fn extract_symbol_from_pnr<'a>(
             if let IdentIsRaw::Yes = is_raw {
                 return Err(dcx.struct_span_err(span_err, RAW_IDENT_ERR));
             }
-            return Ok(nt_ident.name);
+            Ok(nt_ident.name)
         }
         ParseNtResult::Tt(TokenTree::Token(
             Token { kind: TokenKind::Ident(symbol, is_raw), .. },
@@ -784,7 +784,7 @@ fn extract_symbol_from_pnr<'a>(
             if let IdentIsRaw::Yes = is_raw {
                 return Err(dcx.struct_span_err(span_err, RAW_IDENT_ERR));
             }
-            return Ok(*symbol);
+            Ok(*symbol)
         }
         ParseNtResult::Tt(TokenTree::Token(
             Token {
@@ -792,15 +792,13 @@ fn extract_symbol_from_pnr<'a>(
                 ..
             },
             _,
-        )) => {
-            return Ok(*symbol);
-        }
+        )) => Ok(*symbol),
         ParseNtResult::Nt(nt)
             if let Nonterminal::NtLiteral(expr) = &**nt
                 && let ExprKind::Lit(Lit { kind: LitKind::Str, symbol, suffix: None }) =
                     &expr.kind =>
         {
-            return Ok(*symbol);
+            Ok(*symbol)
         }
         _ => Err(dcx
             .struct_err(

--- a/compiler/rustc_hir_analysis/src/check/check.rs
+++ b/compiler/rustc_hir_analysis/src/check/check.rs
@@ -1118,7 +1118,6 @@ fn check_simd(tcx: TyCtxt<'_>, sp: Span, def_id: LocalDefId) {
                         primitive scalar (integer/float/pointer) type"
                 )
                 .emit();
-                return;
             }
         }
     }

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1038,7 +1038,7 @@ fn report_trait_method_mismatch<'tcx>(
         false,
     );
 
-    return diag.emit();
+    diag.emit()
 }
 
 fn check_region_bounds_on_impl_item<'tcx>(

--- a/compiler/rustc_hir_analysis/src/coherence/builtin.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/builtin.rs
@@ -271,10 +271,10 @@ fn visit_implementation_of_dispatch_from_dyn(checker: &Checker<'_>) -> Result<()
                             ty: ty_a,
                         }));
 
-                        return false;
+                        false
+                    } else {
+                        true
                     }
-
-                    return true;
                 })
                 .collect::<Vec<_>>();
 

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -122,7 +122,7 @@ fn anon_const_type_of<'tcx>(tcx: TyCtxt<'tcx>, def_id: LocalDefId) -> Ty<'tcx> {
                 (ty, None)
             };
             tcx.dcx().emit_err(TypeofReservedKeywordUsed { span, ty, opt_sugg });
-            return ty;
+            ty
         }
 
         _ => Ty::new_error_with_message(

--- a/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
+++ b/compiler/rustc_hir_analysis/src/errors/wrong_number_of_generic_args.rs
@@ -807,7 +807,7 @@ impl<'a, 'tcx> WrongNumberOfGenericArgs<'a, 'tcx> {
                         num_assoc_fn_excess_args,
                         num_trait_generics_except_self,
                     ),
-                _ => return,
+                _ => {}
             }
         }
     }

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -605,7 +605,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             Abi::Rust,
         ));
 
-        return Some(ExpectedSig { cause_span, sig });
+        Some(ExpectedSig { cause_span, sig })
     }
 
     fn sig_of_closure(

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -1042,7 +1042,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     fn explain_self_literal(
@@ -1182,7 +1182,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 };
                 maybe_emit_help(def_id, method.ident, args, CallableKind::Method)
             }
-            _ => return,
+            _ => {}
         }
     }
 }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -899,7 +899,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     match kind {
                         hir::ClosureKind::CoroutineClosure(_) => {
                             // FIXME(async_closures): Implement this.
-                            return None;
+                            None
                         }
                         hir::ClosureKind::Closure => Some((def_id, fn_decl, true)),
                         hir::ClosureKind::Coroutine(hir::CoroutineKind::Desugared(

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/arg_matrix.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/arg_matrix.rs
@@ -305,9 +305,10 @@ impl<'tcx> ArgMatrix<'tcx> {
             // Map unwrap to remove the first layer of Some
             let final_permutation: Vec<Option<usize>> =
                 permutation.into_iter().map(|x| x.unwrap()).collect();
-            return Some(Issue::Permutation(final_permutation));
+            Some(Issue::Permutation(final_permutation))
+        } else {
+            None
         }
-        return None;
     }
 
     // Obviously, detecting exact user intention is impossible, so the goal here is to
@@ -410,6 +411,6 @@ impl<'tcx> ArgMatrix<'tcx> {
         // sort errors with same type by the order they appear in the source
         // so that suggestion will be handled properly, see #112507
         errors.sort();
-        return (errors, matched_inputs);
+        (errors, matched_inputs)
     }
 }

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -697,7 +697,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         assoc.name,
                     ),
                 );
-                return;
             }
         };
         // A "softer" version of the `demand_compatible`, which checks types without persisting them,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -2028,7 +2028,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         let span = expr.span.find_oldest_ancestor_in_same_ctxt();
         err.span_suggestion_verbose(span.shrink_to_hi(), msg, sugg, Applicability::HasPlaceholders);
-        return true;
+        true
     }
 
     pub(crate) fn suggest_coercing_result_via_try_operator(

--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -511,9 +511,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         .is_ok()
                 {
                     self.sugg_let = Some(binding);
-                    return true;
+                    true
+                } else {
+                    false
                 }
-                return false;
             }
         }
 

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -380,7 +380,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'cx, 'tcx> {
             ty::Infer(ty::IntVar(vid)) => {
                 let nt = self.infcx.unwrap().opportunistic_resolve_int_var(vid);
                 if nt != t {
-                    return self.fold_ty(nt);
+                    self.fold_ty(nt)
                 } else {
                     self.canonicalize_ty_var(
                         CanonicalVarInfo { kind: CanonicalVarKind::Ty(CanonicalTyVarKind::Int) },
@@ -391,7 +391,7 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for Canonicalizer<'cx, 'tcx> {
             ty::Infer(ty::FloatVar(vid)) => {
                 let nt = self.infcx.unwrap().opportunistic_resolve_float_var(vid);
                 if nt != t {
-                    return self.fold_ty(nt);
+                    self.fold_ty(nt)
                 } else {
                     self.canonicalize_ty_var(
                         CanonicalVarInfo { kind: CanonicalVarKind::Ty(CanonicalTyVarKind::Float) },

--- a/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
+++ b/compiler/rustc_infer/src/infer/lexical_region_resolve/mod.rs
@@ -371,7 +371,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
     fn sub_region_values(&self, a: VarValue<'tcx>, b: VarValue<'tcx>) -> bool {
         match (a, b) {
             // Error region is `'static`
-            (VarValue::ErrorValue, _) | (_, VarValue::ErrorValue) => return true,
+            (VarValue::ErrorValue, _) | (_, VarValue::ErrorValue) => true,
             (VarValue::Empty(a_ui), VarValue::Empty(b_ui)) => {
                 // Empty regions are ordered according to the universe
                 // they are associated with.
@@ -439,7 +439,7 @@ impl<'cx, 'tcx> LexicalResolver<'cx, 'tcx> {
                         // If this empty region is from a universe that can
                         // name the placeholder, then the placeholder is
                         // larger; otherwise, the only ancestor is `'static`.
-                        return a_ui.can_name(placeholder.universe);
+                        a_ui.can_name(placeholder.universe)
                     }
                 }
             }

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -1481,7 +1481,7 @@ impl<'tcx> InferCtxt<'tcx> {
         // This hoists the borrow/release out of the loop body.
         let inner = self.inner.try_borrow();
 
-        return move |infer_var: TyOrConstInferVar| match (infer_var, &inner) {
+        move |infer_var: TyOrConstInferVar| match (infer_var, &inner) {
             (TyOrConstInferVar::Ty(ty_var), Ok(inner)) => {
                 use self::type_variable::TypeVariableValue;
 
@@ -1491,7 +1491,7 @@ impl<'tcx> InferCtxt<'tcx> {
                 )
             }
             _ => false,
-        };
+        }
     }
 
     /// `ty_or_const_infer_var_changed` is equivalent to one of these two:

--- a/compiler/rustc_lint/src/drop_forget_useless.rs
+++ b/compiler/rustc_lint/src/drop_forget_useless.rs
@@ -219,7 +219,7 @@ impl<'tcx> LateLintPass<'tcx> for DropForgetUseless {
                         },
                     );
                 }
-                _ => return,
+                _ => {}
             };
         }
     }

--- a/compiler/rustc_lint/src/for_loops_over_fallibles.rs
+++ b/compiler/rustc_lint/src/for_loops_over_fallibles.rs
@@ -133,7 +133,7 @@ fn extract_iterator_next_call<'tcx>(
     {
         Some(recv)
     } else {
-        return None;
+        None
     }
 }
 

--- a/compiler/rustc_lint/src/noop_method_call.rs
+++ b/compiler/rustc_lint/src/noop_method_call.rs
@@ -143,7 +143,7 @@ impl<'tcx> LateLintPass<'tcx> for NoopMethodCall {
             match name {
                 // If `type_of(x) == T` and `x.borrow()` is used to get `&T`,
                 // then that should be allowed
-                sym::noop_method_borrow => return,
+                sym::noop_method_borrow => {}
                 sym::noop_method_clone => cx.emit_span_lint(
                     SUSPICIOUS_DOUBLE_REF_OP,
                     span,
@@ -154,7 +154,7 @@ impl<'tcx> LateLintPass<'tcx> for NoopMethodCall {
                     span,
                     SuspiciousDoubleRefDerefDiag { ty: expr_ty },
                 ),
-                _ => return,
+                _ => {}
             }
         }
     }

--- a/compiler/rustc_metadata/src/locator.rs
+++ b/compiler/rustc_metadata/src/locator.rs
@@ -862,12 +862,10 @@ fn get_metadata_section<'p>(
             "invalid metadata version found: {}",
             filename.display()
         ))),
-        Err(Some(found_version)) => {
-            return Err(MetadataError::VersionMismatch {
-                expected_version: rustc_version(cfg_version),
-                found_version,
-            });
-        }
+        Err(Some(found_version)) => Err(MetadataError::VersionMismatch {
+            expected_version: rustc_version(cfg_version),
+            found_version,
+        }),
     }
 }
 

--- a/compiler/rustc_middle/src/hir/map/mod.rs
+++ b/compiler/rustc_middle/src/hir/map/mod.rs
@@ -71,7 +71,7 @@ impl<'hir> Iterator for ParentHirIterator<'hir> {
         debug_assert_ne!(parent_id, self.current_id);
 
         self.current_id = parent_id;
-        return Some(parent_id);
+        Some(parent_id)
     }
 }
 
@@ -103,7 +103,7 @@ impl<'hir> Iterator for ParentOwnerIterator<'hir> {
         self.current_id = HirId::make_owner(parent_id.def_id);
 
         let node = self.map.tcx.hir_owner_node(self.current_id.owner);
-        return Some((self.current_id.owner, node));
+        Some((self.current_id.owner, node))
     }
 }
 
@@ -1233,14 +1233,14 @@ pub(super) fn hir_module_items(tcx: TyCtxt<'_>, module_id: LocalModDefId) -> Mod
         body_owners,
         ..
     } = collector;
-    return ModuleItems {
+    ModuleItems {
         submodules: submodules.into_boxed_slice(),
         free_items: items.into_boxed_slice(),
         trait_items: trait_items.into_boxed_slice(),
         impl_items: impl_items.into_boxed_slice(),
         foreign_items: foreign_items.into_boxed_slice(),
         body_owners: body_owners.into_boxed_slice(),
-    };
+    }
 }
 
 pub(crate) fn hir_crate_items(tcx: TyCtxt<'_>, _: ()) -> ModuleItems {
@@ -1262,14 +1262,14 @@ pub(crate) fn hir_crate_items(tcx: TyCtxt<'_>, _: ()) -> ModuleItems {
         ..
     } = collector;
 
-    return ModuleItems {
+    ModuleItems {
         submodules: submodules.into_boxed_slice(),
         free_items: items.into_boxed_slice(),
         trait_items: trait_items.into_boxed_slice(),
         impl_items: impl_items.into_boxed_slice(),
         foreign_items: foreign_items.into_boxed_slice(),
         body_owners: body_owners.into_boxed_slice(),
-    };
+    }
 }
 
 struct ItemCollector<'tcx> {

--- a/compiler/rustc_middle/src/mir/consts.rs
+++ b/compiler/rustc_middle/src/mir/consts.rs
@@ -177,8 +177,8 @@ impl<'tcx> ConstValue<'tcx> {
     /// Can return `true` even if there is no provenance.
     pub fn may_have_provenance(&self, tcx: TyCtxt<'tcx>, size: Size) -> bool {
         match *self {
-            ConstValue::ZeroSized | ConstValue::Scalar(Scalar::Int(_)) => return false,
-            ConstValue::Scalar(Scalar::Ptr(..)) => return true,
+            ConstValue::ZeroSized | ConstValue::Scalar(Scalar::Int(_)) => false,
+            ConstValue::Scalar(Scalar::Ptr(..)) => true,
             // It's hard to find out the part of the allocation we point to;
             // just conservatively check everything.
             ConstValue::Slice { data, meta: _ } => !data.inner().provenance().ptrs().is_empty(),

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1169,7 +1169,7 @@ impl<'tcx> LocalDecl<'tcx> {
             LocalInfo::DerefTemp => return true,
             _ => (),
         }
-        return false;
+        false
     }
 
     /// Returns `true` is the local is from a compiler desugaring, e.g.,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2007,7 +2007,7 @@ impl<'tcx> TyCtxt<'tcx> {
                 ));
             }
         }
-        return None;
+        None
     }
 
     /// Checks if the bound region is in Impl Item.

--- a/compiler/rustc_middle/src/ty/print/mod.rs
+++ b/compiler/rustc_middle/src/ty/print/mod.rs
@@ -275,7 +275,7 @@ fn characteristic_def_id_of_type_cached<'a>(
             if visited.insert(ty) {
                 return characteristic_def_id_of_type_cached(ty, visited);
             }
-            return None;
+            None
         }),
 
         ty::FnDef(def_id, _)

--- a/compiler/rustc_middle/src/ty/region.rs
+++ b/compiler/rustc_middle/src/ty/region.rs
@@ -431,7 +431,7 @@ impl BoundRegionKind {
 
     pub fn get_id(&self) -> Option<DefId> {
         match *self {
-            BoundRegionKind::BrNamed(id, _) => return Some(id),
+            BoundRegionKind::BrNamed(id, _) => Some(id),
             _ => None,
         }
     }

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1790,9 +1790,7 @@ where
             }
             Ok(intern(folder.cx(), &new_list))
         }
-        Some((_, Err(err))) => {
-            return Err(err);
-        }
+        Some((_, Err(err))) => Err(err),
         None => Ok(list),
     }
 }

--- a/compiler/rustc_mir_build/src/build/custom/parse.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse.rs
@@ -82,13 +82,11 @@ impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
     fn statement_as_expr(&self, stmt_id: StmtId) -> PResult<ExprId> {
         match &self.thir[stmt_id].kind {
             StmtKind::Expr { expr, .. } => Ok(*expr),
-            kind @ StmtKind::Let { pattern, .. } => {
-                return Err(ParseError {
-                    span: pattern.span,
-                    item_description: format!("{kind:?}"),
-                    expected: "expression".to_string(),
-                });
-            }
+            kind @ StmtKind::Let { pattern, .. } => Err(ParseError {
+                span: pattern.span,
+                item_description: format!("{kind:?}"),
+                expected: "expression".to_string(),
+            }),
         }
     }
 

--- a/compiler/rustc_mir_transform/src/sroa.rs
+++ b/compiler/rustc_mir_transform/src/sroa.rs
@@ -149,7 +149,7 @@ fn escaping_locals<'tcx>(
                 // Storage statements are expanded in run_pass.
                 StatementKind::StorageLive(..)
                 | StatementKind::StorageDead(..)
-                | StatementKind::Deinit(..) => return,
+                | StatementKind::Deinit(..) => {}
                 _ => self.super_statement(statement, location),
             }
         }

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -648,7 +648,7 @@ impl<'a, 'tcx> MirUsedCollector<'a, 'tcx> {
             ),
             Err(err @ ErrorHandled::Reported(..)) => {
                 err.emit_note(self.tcx);
-                return None;
+                None
             }
         }
     }
@@ -1193,7 +1193,7 @@ fn assoc_fn_of_type<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, fn_ident: Ident) -> 
             return Some(new.def_id);
         }
     }
-    return None;
+    None
 }
 
 /// Scans the MIR in order to find function calls, closures, and drop-glue.

--- a/compiler/rustc_monomorphize/src/polymorphize.rs
+++ b/compiler/rustc_monomorphize/src/polymorphize.rs
@@ -106,11 +106,11 @@ fn should_polymorphize<'tcx>(
     match tcx.hir().body_const_context(def_id.expect_local()) {
         Some(ConstContext::ConstFn) | None if !tcx.is_mir_available(def_id) => {
             debug!("no mir available");
-            return false;
+            false
         }
         Some(_) if !tcx.is_ctfe_mir_available(def_id) => {
             debug!("no ctfe mir available");
-            return false;
+            false
         }
         _ => true,
     }

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -1172,7 +1172,7 @@ where
                     trace!(?def_id, ?goal, "disqualified auto-trait implementation");
                     // No need to actually consider the candidate here,
                     // since we do that in `consider_impl_candidate`.
-                    return Some(Err(NoSolution));
+                    Some(Err(NoSolution))
                 } else {
                     None
                 }

--- a/compiler/rustc_parse/src/lexer/tokentrees.rs
+++ b/compiler/rustc_parse/src/lexer/tokentrees.rs
@@ -299,7 +299,7 @@ impl<'psess, 'src> TokenTreesReader<'psess, 'src> {
             }
             return diff_errs;
         }
-        return errs;
+        errs
     }
 
     fn close_delim_err(&mut self, delim: Delimiter) -> PErr<'psess> {

--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -2553,7 +2553,9 @@ impl<'a> Parser<'a> {
                 err.delay_as_bug();
             }
         }
-        return Ok(false); // Don't continue.
+
+        // Don't continue.
+        Ok(false)
     }
 
     /// Attempt to parse a generic const argument that has not been enclosed in braces.

--- a/compiler/rustc_parse/src/parser/item.rs
+++ b/compiler/rustc_parse/src/parser/item.rs
@@ -457,7 +457,7 @@ impl<'a> Parser<'a> {
 
     fn parse_item_builtin(&mut self) -> PResult<'a, Option<ItemInfo>> {
         // To be expanded
-        return Ok(None);
+        Ok(None)
     }
 
     /// Parses an item macro, e.g., `item!();`.

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -1905,10 +1905,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
             || (int_reprs == 1
                 && is_c
                 && item.is_some_and(|item| {
-                    if let ItemLike::Item(item) = item {
-                        return is_c_like_enum(item);
-                    }
-                    return false;
+                    if let ItemLike::Item(item) = item { is_c_like_enum(item) } else { false }
                 }))
         {
             self.tcx.emit_node_span_lint(
@@ -2350,7 +2347,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
 
     fn check_coroutine(&self, attr: &Attribute, target: Target) {
         match target {
-            Target::Closure => return,
+            Target::Closure => {}
             _ => {
                 self.dcx().emit_err(errors::CoroutineOnNonClosure { span: attr.span });
             }

--- a/compiler/rustc_passes/src/dead.rs
+++ b/compiler/rustc_passes/src/dead.rs
@@ -193,17 +193,16 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
                             return true;
                         }
                     }
-                    return false;
+                    false
                 }
                 (hir::ExprKind::Field(lhs_l, ident_l), hir::ExprKind::Field(lhs_r, ident_r)) => {
                     if ident_l == ident_r {
-                        return check_for_self_assign_helper(typeck_results, lhs_l, lhs_r);
+                        check_for_self_assign_helper(typeck_results, lhs_l, lhs_r)
+                    } else {
+                        false
                     }
-                    return false;
                 }
-                _ => {
-                    return false;
-                }
+                _ => false,
             }
         }
 
@@ -394,7 +393,7 @@ impl<'tcx> MarkSymbolVisitor<'tcx> {
             }
         }
 
-        return false;
+        false
     }
 
     fn visit_node(&mut self, node: Node<'tcx>) {

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -3040,7 +3040,6 @@ impl<'tcx> visit::Visitor<'tcx> for UsePlacementFinder {
                 self.first_legal_span = Some(inject);
             }
             self.first_use_span = search_for_any_use_in_items(&c.items);
-            return;
         } else {
             visit::walk_crate(self, c);
         }
@@ -3054,7 +3053,6 @@ impl<'tcx> visit::Visitor<'tcx> for UsePlacementFinder {
                     self.first_legal_span = Some(inject);
                 }
                 self.first_use_span = search_for_any_use_in_items(items);
-                return;
             }
         } else {
             visit::walk_item(self, item);
@@ -3076,7 +3074,7 @@ fn search_for_any_use_in_items(items: &[P<ast::Item>]) -> Option<Span> {
             }
         }
     }
-    return None;
+    None
 }
 
 fn is_span_suitable_for_use_injection(s: Span) -> bool {

--- a/compiler/rustc_resolve/src/effective_visibilities.rs
+++ b/compiler/rustc_resolve/src/effective_visibilities.rs
@@ -231,7 +231,7 @@ impl<'r, 'ast, 'tcx> Visitor<'ast> for EffectiveVisibilitiesVisitor<'ast, 'r, 't
         // If it's a mod, also make the visitor walk all of its items
         match item.kind {
             // Resolved in rustc_privacy when types are available
-            ast::ItemKind::Impl(..) => return,
+            ast::ItemKind::Impl(..) => {}
 
             // Should be unreachable at this stage
             ast::ItemKind::MacCall(..) | ast::ItemKind::DelegationMac(..) => panic!(
@@ -276,7 +276,7 @@ impl<'r, 'ast, 'tcx> Visitor<'ast> for EffectiveVisibilitiesVisitor<'ast, 'r, 't
             | ast::ItemKind::MacroDef(..)
             | ast::ItemKind::ForeignMod(..)
             | ast::ItemKind::Fn(..)
-            | ast::ItemKind::Delegation(..) => return,
+            | ast::ItemKind::Delegation(..) => {}
         }
     }
 }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -5016,5 +5016,5 @@ fn def_id_matches_path(tcx: TyCtxt<'_>, mut def_id: DefId, expected_path: &[&str
         }
         def_id = parent;
     }
-    return true;
+    true
 }

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -779,7 +779,7 @@ impl<'a: 'ast, 'ast, 'tcx> LateResolutionVisitor<'a, '_, 'ast, 'tcx> {
             candidates = self.smart_resolve_partial_mod_path_errors(path, following_seg);
         }
 
-        return (false, candidates);
+        (false, candidates)
     }
 
     fn suggest_trait_and_bounds(

--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -182,7 +182,7 @@ pub fn sysroot_candidates() -> SmallVec<[PathBuf; 2]> {
         }
     }
 
-    return sysroot_candidates;
+    sysroot_candidates
 }
 
 /// Returns the provided sysroot or calls [`get_or_default_sysroot`] if it's none.

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -353,7 +353,7 @@ fn build_options<O: Default>(
             None => early_dcx.early_fatal(format!("unknown {outputname} option: `{key}`")),
         }
     }
-    return op;
+    op
 }
 
 #[allow(non_upper_case_globals)]

--- a/compiler/rustc_span/src/source_map.rs
+++ b/compiler/rustc_span/src/source_map.rs
@@ -779,7 +779,7 @@ impl SourceMap {
                     return Ok(false);
                 }
             }
-            return Ok(true);
+            Ok(true)
         })
         .is_ok_and(|is_accessible| is_accessible)
     }

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -188,7 +188,7 @@ impl ArgAttributes {
         if self.arg_ext != other.arg_ext {
             return false;
         }
-        return true;
+        true
     }
 }
 
@@ -632,7 +632,7 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
             PassMode::Indirect { .. } => {
                 self.mode = PassMode::Direct(ArgAttributes::new());
             }
-            PassMode::Ignore | PassMode::Direct(_) | PassMode::Pair(_, _) => return, // already direct
+            PassMode::Ignore | PassMode::Direct(_) | PassMode::Pair(_, _) => {}
             _ => panic!("Tried to make {:?} direct", self.mode),
         }
     }
@@ -644,10 +644,7 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
             PassMode::Direct(_) | PassMode::Pair(_, _) => {
                 self.mode = Self::indirect_pass_mode(&self.layout);
             }
-            PassMode::Indirect { attrs: _, meta_attrs: _, on_stack: false } => {
-                // already indirect
-                return;
-            }
+            PassMode::Indirect { attrs: _, meta_attrs: _, on_stack: false } => {}
             _ => panic!("Tried to make {:?} indirect", self.mode),
         }
     }
@@ -659,10 +656,7 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
             PassMode::Ignore => {
                 self.mode = Self::indirect_pass_mode(&self.layout);
             }
-            PassMode::Indirect { attrs: _, meta_attrs: _, on_stack: false } => {
-                // already indirect
-                return;
-            }
+            PassMode::Indirect { attrs: _, meta_attrs: _, on_stack: false } => {}
             _ => panic!("Tried to make {:?} indirect (expected `PassMode::Ignore`)", self.mode),
         }
     }

--- a/compiler/rustc_target/src/abi/call/sparc64.rs
+++ b/compiler/rustc_target/src/abi/call/sparc64.rs
@@ -66,7 +66,7 @@ where
         data.last_offset = offset + Reg::f64().size;
     }
     data.prefix_index += 1;
-    return data;
+    data
 }
 
 fn arg_scalar_pair<C>(
@@ -92,7 +92,7 @@ where
         offset += Size::from_bytes(4 - (offset.bytes() % 4));
     }
     data = arg_scalar(cx, scalar2, offset, data);
-    return data;
+    data
 }
 
 fn parse_structure<'a, Ty, C>(
@@ -128,7 +128,7 @@ where
         }
     }
 
-    return data;
+    data
 }
 
 fn classify_arg<'a, Ty, C>(cx: &C, arg: &mut ArgAbi<'a, Ty>, in_registers_max: Size)

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/suggest.rs
@@ -470,9 +470,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
 
                 diag.subdiagnostic(FnConsiderCasting { casting });
             }
-            _ => {
-                return;
-            }
+            _ => {}
         };
     }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
@@ -530,7 +530,7 @@ impl<'tcx> OnUnimplementedDirective {
 
     pub fn of_item(tcx: TyCtxt<'tcx>, item_def_id: DefId) -> Result<Option<Self>, ErrorGuaranteed> {
         if let Some(attr) = tcx.get_attr(item_def_id, sym::rustc_on_unimplemented) {
-            return Self::parse_attribute(attr, false, tcx, item_def_id);
+            Self::parse_attribute(attr, false, tcx, item_def_id)
         } else {
             tcx.get_attrs_by_path(item_def_id, &[sym::diagnostic, sym::on_unimplemented])
                 .filter_map(|attr| Self::parse_attribute(attr, true, tcx, item_def_id).transpose())

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -1401,7 +1401,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     return true;
                 }
             }
-            return false;
+            false
         };
 
         if let ObligationCauseCode::ImplDerived(cause) = &*code {

--- a/compiler/rustc_ty_utils/src/layout_sanity_check.rs
+++ b/compiler/rustc_ty_utils/src/layout_sanity_check.rs
@@ -109,7 +109,6 @@ pub(super) fn sanity_check_layout<'tcx>(
                     }
                     FieldsShape::Union(..) => {
                         // FIXME: I guess we could also check something here? Like, look at all fields?
-                        return;
                     }
                     FieldsShape::Arbitrary { .. } => {
                         // Should be an enum, the only field is the discriminant.


### PR DESCRIPTION
This is Rust, not Java! Returns are not necessary unless they interrupt control flow!

Fixes instances of `clippy::needless_return`. This is especially jarring when it's paired with match branches that do *not* return, like:

```
if whatever {
    return Some(x);
} else {
    None
}
```

or

```
match whatever {
    Variant => true,
    OtherVariant => return false,
}
```

... since it suggests that some exceptional control flow is happening even though it isn't.

I also tried to turn some:

```
if whatever {
    side_effect();
    return true;
}
return false;
```

into:

```
if whatever {
    side_effect();
    true
} else {
    false
}
```

Though I only did it when I noticed it.