### PR TITLE
miri: fix overflow detection for unsigned pointer offset

### DIFF
--- a/src/tools/miri/tests/fail/intrinsics/ptr_offset_unsigned_overflow.rs
+++ b/src/tools/miri/tests/fail/intrinsics/ptr_offset_unsigned_overflow.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let x = &[0i32; 2];
+    let x = x.as_ptr().wrapping_add(1);
+    // If the `!0` is interpreted as `isize`, it is just `-1` and hence harmless.
+    // However, this is unsigned arithmetic, so really this is `usize::MAX` and hence UB.
+    unsafe { x.byte_add(!0).read() }; //~ERROR: does not fit in an `isize`
+}

--- a/src/tools/miri/tests/fail/intrinsics/ptr_offset_unsigned_overflow.stderr
+++ b/src/tools/miri/tests/fail/intrinsics/ptr_offset_unsigned_overflow.stderr
@@ -1,0 +1,15 @@
+error: Undefined Behavior: overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
+  --> $DIR/ptr_offset_unsigned_overflow.rs:LL:CC
+   |
+LL |     unsafe { x.byte_add(!0).read() };
+   |              ^^^^^^^^^^^^^^ overflowing pointer arithmetic: the total offset in bytes does not fit in an `isize`
+   |
+   = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+   = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/ptr_offset_unsigned_overflow.rs:LL:CC
+
+note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This is the Miri part of https://github.com/rust-lang/rust/pull/130229. This ~~is already UB~~ is planned to become UB in codegen so we better make Miri detect it; updating the docs may take time if we have to follow some approval process, but let's make Miri match reality ASAP.

r? @scottmcm 