### PR TITLE
Use the same span for attributes and Try expansion of ?

### DIFF
--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -1837,7 +1837,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             Safety::Default,
             sym::allow,
             sym::unreachable_code,
-            self.lower_span(span),
+            try_span,
         );
         let attrs: AttrVec = thin_vec![attr];
 


### PR DESCRIPTION
This is needed for Clippy to know that the `#[allow(unused)]` attributes added by the expansion of `?` are part of the desugaring, and that they do not come from the user code.

rust-lang/rust-clippy#13380 exhibits a manifestation of this problem and will be fixed by this change.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
