### PR TITLE
make basic allocation functions track_caller in Miri for nicer backtraces

### DIFF
--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -89,6 +89,7 @@ pub use std::alloc::Global;
 #[stable(feature = "global_alloc", since = "1.28.0")]
 #[must_use = "losing the pointer will leak memory"]
 #[inline]
+#[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 pub unsafe fn alloc(layout: Layout) -> *mut u8 {
     unsafe {
         // Make sure we don't accidentally allow omitting the allocator shim in
@@ -113,6 +114,7 @@ pub unsafe fn alloc(layout: Layout) -> *mut u8 {
 /// See [`GlobalAlloc::dealloc`].
 #[stable(feature = "global_alloc", since = "1.28.0")]
 #[inline]
+#[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
 }
@@ -132,6 +134,7 @@ pub unsafe fn dealloc(ptr: *mut u8, layout: Layout) {
 #[stable(feature = "global_alloc", since = "1.28.0")]
 #[must_use = "losing the pointer will leak memory"]
 #[inline]
+#[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 pub unsafe fn realloc(ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
     unsafe { __rust_realloc(ptr, layout.size(), layout.align(), new_size) }
 }
@@ -166,6 +169,7 @@ pub unsafe fn realloc(ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 
 #[stable(feature = "global_alloc", since = "1.28.0")]
 #[must_use = "losing the pointer will leak memory"]
 #[inline]
+#[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
     unsafe { __rust_alloc_zeroed(layout.size(), layout.align()) }
 }
@@ -173,6 +177,7 @@ pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
 #[cfg(not(test))]
 impl Global {
     #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     fn alloc_impl(&self, layout: Layout, zeroed: bool) -> Result<NonNull<[u8]>, AllocError> {
         match layout.size() {
             0 => Ok(NonNull::slice_from_raw_parts(layout.dangling(), 0)),
@@ -187,6 +192,7 @@ impl Global {
 
     // SAFETY: Same as `Allocator::grow`
     #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     unsafe fn grow_impl(
         &self,
         ptr: NonNull<u8>,
@@ -237,16 +243,19 @@ impl Global {
 #[cfg(not(test))]
 unsafe impl Allocator for Global {
     #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         self.alloc_impl(layout, false)
     }
 
     #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         self.alloc_impl(layout, true)
     }
 
     #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         if layout.size() != 0 {
             // SAFETY: `layout` is non-zero in size,
@@ -256,6 +265,7 @@ unsafe impl Allocator for Global {
     }
 
     #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     unsafe fn grow(
         &self,
         ptr: NonNull<u8>,
@@ -267,6 +277,7 @@ unsafe impl Allocator for Global {
     }
 
     #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     unsafe fn grow_zeroed(
         &self,
         ptr: NonNull<u8>,
@@ -278,6 +289,7 @@ unsafe impl Allocator for Global {
     }
 
     #[inline]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     unsafe fn shrink(
         &self,
         ptr: NonNull<u8>,
@@ -325,6 +337,7 @@ unsafe impl Allocator for Global {
 #[cfg(all(not(no_global_oom_handling), not(test)))]
 #[lang = "exchange_malloc"]
 #[inline]
+#[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 unsafe fn exchange_malloc(size: usize, align: usize) -> *mut u8 {
     let layout = unsafe { Layout::from_size_align_unchecked(size, align) };
     match Global.allocate(layout) {

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -250,6 +250,7 @@ impl<T> Box<T> {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
     #[rustc_diagnostic_item = "box_new"]
+    #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
     pub fn new(x: T) -> Self {
         #[rustc_box]
         Box::new(x)

--- a/src/tools/miri/tests/fail/alloc/deallocate-bad-alignment.rs
+++ b/src/tools/miri/tests/fail/alloc/deallocate-bad-alignment.rs
@@ -1,10 +1,8 @@
 use std::alloc::{alloc, dealloc, Layout};
 
-//@error-in-other-file: has size 1 and alignment 1, but gave size 1 and alignment 2
-
 fn main() {
     unsafe {
         let x = alloc(Layout::from_size_align_unchecked(1, 1));
-        dealloc(x, Layout::from_size_align_unchecked(1, 2));
+        dealloc(x, Layout::from_size_align_unchecked(1, 2)); //~ERROR: has size 1 and alignment 1, but gave size 1 and alignment 2
     }
 }

--- a/src/tools/miri/tests/fail/alloc/deallocate-bad-alignment.stderr
+++ b/src/tools/miri/tests/fail/alloc/deallocate-bad-alignment.stderr
@@ -1,18 +1,13 @@
 error: Undefined Behavior: incorrect layout on deallocation: ALLOC has size 1 and alignment ALIGN, but gave size 1 and alignment ALIGN
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> $DIR/deallocate-bad-alignment.rs:LL:CC
    |
-LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect layout on deallocation: ALLOC has size 1 and alignment ALIGN, but gave size 1 and alignment ALIGN
+LL |         dealloc(x, Layout::from_size_align_unchecked(1, 2));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect layout on deallocation: ALLOC has size 1 and alignment ALIGN, but gave size 1 and alignment ALIGN
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
-   = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-note: inside `main`
-  --> $DIR/deallocate-bad-alignment.rs:LL:CC
-   |
-LL |         dealloc(x, Layout::from_size_align_unchecked(1, 2));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: inside `main` at $DIR/deallocate-bad-alignment.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/alloc/deallocate-bad-size.rs
+++ b/src/tools/miri/tests/fail/alloc/deallocate-bad-size.rs
@@ -1,10 +1,8 @@
 use std::alloc::{alloc, dealloc, Layout};
 
-//@error-in-other-file: has size 1 and alignment 1, but gave size 2 and alignment 1
-
 fn main() {
     unsafe {
         let x = alloc(Layout::from_size_align_unchecked(1, 1));
-        dealloc(x, Layout::from_size_align_unchecked(2, 1));
+        dealloc(x, Layout::from_size_align_unchecked(2, 1)); //~ERROR: has size 1 and alignment 1, but gave size 2 and alignment 1
     }
 }

--- a/src/tools/miri/tests/fail/alloc/deallocate-bad-size.stderr
+++ b/src/tools/miri/tests/fail/alloc/deallocate-bad-size.stderr
@@ -1,18 +1,13 @@
 error: Undefined Behavior: incorrect layout on deallocation: ALLOC has size 1 and alignment ALIGN, but gave size 2 and alignment ALIGN
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> $DIR/deallocate-bad-size.rs:LL:CC
    |
-LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect layout on deallocation: ALLOC has size 1 and alignment ALIGN, but gave size 2 and alignment ALIGN
+LL |         dealloc(x, Layout::from_size_align_unchecked(2, 1));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect layout on deallocation: ALLOC has size 1 and alignment ALIGN, but gave size 2 and alignment ALIGN
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
-   = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-note: inside `main`
-  --> $DIR/deallocate-bad-size.rs:LL:CC
-   |
-LL |         dealloc(x, Layout::from_size_align_unchecked(2, 1));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: inside `main` at $DIR/deallocate-bad-size.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/alloc/deallocate-twice.rs
+++ b/src/tools/miri/tests/fail/alloc/deallocate-twice.rs
@@ -1,11 +1,9 @@
 use std::alloc::{alloc, dealloc, Layout};
 
-//@error-in-other-file: has been freed
-
 fn main() {
     unsafe {
         let x = alloc(Layout::from_size_align_unchecked(1, 1));
         dealloc(x, Layout::from_size_align_unchecked(1, 1));
-        dealloc(x, Layout::from_size_align_unchecked(1, 1));
+        dealloc(x, Layout::from_size_align_unchecked(1, 1)); //~ERROR: has been freed
     }
 }

--- a/src/tools/miri/tests/fail/alloc/deallocate-twice.stderr
+++ b/src/tools/miri/tests/fail/alloc/deallocate-twice.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: memory access failed: ALLOC has been freed, so this pointer is dangling
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> $DIR/deallocate-twice.rs:LL:CC
    |
-LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: ALLOC has been freed, so this pointer is dangling
+LL |         dealloc(x, Layout::from_size_align_unchecked(1, 1));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: ALLOC has been freed, so this pointer is dangling
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
@@ -17,12 +17,7 @@ help: ALLOC was deallocated here:
 LL |         dealloc(x, Layout::from_size_align_unchecked(1, 1));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
-   = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-note: inside `main`
-  --> $DIR/deallocate-twice.rs:LL:CC
-   |
-LL |         dealloc(x, Layout::from_size_align_unchecked(1, 1));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: inside `main` at $DIR/deallocate-twice.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/alloc/reallocate-bad-size.rs
+++ b/src/tools/miri/tests/fail/alloc/reallocate-bad-size.rs
@@ -1,10 +1,8 @@
 use std::alloc::{alloc, realloc, Layout};
 
-//@error-in-other-file: has size 1 and alignment 1, but gave size 2 and alignment 1
-
 fn main() {
     unsafe {
         let x = alloc(Layout::from_size_align_unchecked(1, 1));
-        let _y = realloc(x, Layout::from_size_align_unchecked(2, 1), 1);
+        let _y = realloc(x, Layout::from_size_align_unchecked(2, 1), 1); //~ERROR: has size 1 and alignment 1, but gave size 2 and alignment 1
     }
 }

--- a/src/tools/miri/tests/fail/alloc/reallocate-bad-size.stderr
+++ b/src/tools/miri/tests/fail/alloc/reallocate-bad-size.stderr
@@ -1,18 +1,13 @@
 error: Undefined Behavior: incorrect layout on deallocation: ALLOC has size 1 and alignment ALIGN, but gave size 2 and alignment ALIGN
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> $DIR/reallocate-bad-size.rs:LL:CC
    |
-LL |     unsafe { __rust_realloc(ptr, layout.size(), layout.align(), new_size) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect layout on deallocation: ALLOC has size 1 and alignment ALIGN, but gave size 2 and alignment ALIGN
+LL |         let _y = realloc(x, Layout::from_size_align_unchecked(2, 1), 1);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect layout on deallocation: ALLOC has size 1 and alignment ALIGN, but gave size 2 and alignment ALIGN
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
-   = note: inside `std::alloc::realloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-note: inside `main`
-  --> $DIR/reallocate-bad-size.rs:LL:CC
-   |
-LL |         let _y = realloc(x, Layout::from_size_align_unchecked(2, 1), 1);
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: inside `main` at $DIR/reallocate-bad-size.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/alloc/reallocate-dangling.rs
+++ b/src/tools/miri/tests/fail/alloc/reallocate-dangling.rs
@@ -1,11 +1,9 @@
 use std::alloc::{alloc, dealloc, realloc, Layout};
 
-//@error-in-other-file: has been freed
-
 fn main() {
     unsafe {
         let x = alloc(Layout::from_size_align_unchecked(1, 1));
         dealloc(x, Layout::from_size_align_unchecked(1, 1));
-        let _z = realloc(x, Layout::from_size_align_unchecked(1, 1), 1);
+        let _z = realloc(x, Layout::from_size_align_unchecked(1, 1), 1); //~ERROR: has been freed
     }
 }

--- a/src/tools/miri/tests/fail/alloc/reallocate-dangling.stderr
+++ b/src/tools/miri/tests/fail/alloc/reallocate-dangling.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: memory access failed: ALLOC has been freed, so this pointer is dangling
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> $DIR/reallocate-dangling.rs:LL:CC
    |
-LL |     unsafe { __rust_realloc(ptr, layout.size(), layout.align(), new_size) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: ALLOC has been freed, so this pointer is dangling
+LL |         let _z = realloc(x, Layout::from_size_align_unchecked(1, 1), 1);
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ memory access failed: ALLOC has been freed, so this pointer is dangling
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
@@ -17,12 +17,7 @@ help: ALLOC was deallocated here:
 LL |         dealloc(x, Layout::from_size_align_unchecked(1, 1));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
-   = note: inside `std::alloc::realloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-note: inside `main`
-  --> $DIR/reallocate-dangling.rs:LL:CC
-   |
-LL |         let _z = realloc(x, Layout::from_size_align_unchecked(1, 1), 1);
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: inside `main` at $DIR/reallocate-dangling.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/alloc/stack_free.stderr
+++ b/src/tools/miri/tests/fail/alloc/stack_free.stderr
@@ -1,14 +1,12 @@
 error: Undefined Behavior: deallocating ALLOC, which is stack variable memory, using Rust heap deallocation operation
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating ALLOC, which is stack variable memory, using Rust heap deallocation operation
+LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating ALLOC, which is stack variable memory, using Rust heap deallocation operation
    |
    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
    = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
    = note: BACKTRACE:
-   = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `<std::alloc::Global as std::alloc::Allocator>::deallocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `<std::boxed::Box<i32> as std::ops::Drop>::drop` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::ptr::drop_in_place::<std::boxed::Box<i32>> - shim(Some(std::boxed::Box<i32>))` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
    = note: inside `std::mem::drop::<std::boxed::Box<i32>>` at RUSTLIB/core/src/mem/mod.rs:LL:CC

--- a/src/tools/miri/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/newtype_pair_retagging.tree.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocation through <TAG> at ALLOC[0x0] is forbidden
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> at ALLOC[0x0] is forbidden
+LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)
@@ -25,8 +25,6 @@ LL |             || drop(Box::from_raw(ptr)),
    |                     ^^^^^^^^^^^^^^^^^^
    = help: this transition corresponds to a temporary loss of write permissions until function exit
    = note: BACKTRACE (of the first span):
-   = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `<std::alloc::Global as std::alloc::Allocator>::deallocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `<std::boxed::Box<i32> as std::ops::Drop>::drop` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::ptr::drop_in_place::<std::boxed::Box<i32>> - shim(Some(std::boxed::Box<i32>))` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
    = note: inside `std::mem::drop::<std::boxed::Box<i32>>` at RUSTLIB/core/src/mem/mod.rs:LL:CC

--- a/src/tools/miri/tests/fail/both_borrows/newtype_retagging.tree.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/newtype_retagging.tree.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocation through <TAG> at ALLOC[0x0] is forbidden
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> at ALLOC[0x0] is forbidden
+LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the accessed tag <TAG> is foreign to the protected tag <TAG> (i.e., it is not a child)
@@ -25,8 +25,6 @@ LL |             || drop(Box::from_raw(ptr)),
    |                     ^^^^^^^^^^^^^^^^^^
    = help: this transition corresponds to a temporary loss of write permissions until function exit
    = note: BACKTRACE (of the first span):
-   = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `<std::alloc::Global as std::alloc::Allocator>::deallocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `<std::boxed::Box<i32> as std::ops::Drop>::drop` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::ptr::drop_in_place::<std::boxed::Box<i32>> - shim(Some(std::boxed::Box<i32>))` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
    = note: inside `std::mem::drop::<std::boxed::Box<i32>>` at RUSTLIB/core/src/mem/mod.rs:LL:CC

--- a/src/tools/miri/tests/fail/both_borrows/zero-sized-protected.rs
+++ b/src/tools/miri/tests/fail/both_borrows/zero-sized-protected.rs
@@ -1,13 +1,12 @@
 //@revisions: stack tree
 //@[tree]compile-flags: -Zmiri-tree-borrows
-//@[tree]error-in-other-file: /deallocation .* is forbidden/
 use std::alloc::{alloc, dealloc, Layout};
 
 // `x` is strongly protected but covers zero bytes.
 // Let's see if deallocating the allocation x points to is UB:
 // in TB, it is UB, but in SB it is not.
 fn test(_x: &mut (), ptr: *mut u8, l: Layout) {
-    unsafe { dealloc(ptr, l) };
+    unsafe { dealloc(ptr, l) }; //~[tree] ERROR: /deallocation .* is forbidden/
 }
 
 fn main() {

--- a/src/tools/miri/tests/fail/both_borrows/zero-sized-protected.tree.stderr
+++ b/src/tools/miri/tests/fail/both_borrows/zero-sized-protected.tree.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocation through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> $DIR/zero-sized-protected.rs:LL:CC
    |
-LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
+LL |     unsafe { dealloc(ptr, l) };
+   |              ^^^^^^^^^^^^^^^ deallocation through <TAG> (root of the allocation) at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the allocation of the accessed tag <TAG> (root of the allocation) also contains the strongly protected tag <TAG>
@@ -18,12 +18,7 @@ help: the strongly protected tag <TAG> was created here, in the initial state Re
 LL | fn test(_x: &mut (), ptr: *mut u8, l: Layout) {
    |         ^^
    = note: BACKTRACE (of the first span):
-   = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-note: inside `test`
-  --> $DIR/zero-sized-protected.rs:LL:CC
-   |
-LL |     unsafe { dealloc(ptr, l) };
-   |              ^^^^^^^^^^^^^^^
+   = note: inside `test` at $DIR/zero-sized-protected.rs:LL:CC
 note: inside `main`
   --> $DIR/zero-sized-protected.rs:LL:CC
    |

--- a/src/tools/miri/tests/fail/memleak.rs
+++ b/src/tools/miri/tests/fail/memleak.rs
@@ -1,6 +1,5 @@
-//@error-in-other-file: memory leaked
 //@normalize-stderr-test: ".*│.*" -> "$$stripped$$"
 
 fn main() {
-    std::mem::forget(Box::new(42));
+    std::mem::forget(Box::new(42)); //~ERROR: memory leaked
 }

--- a/src/tools/miri/tests/fail/memleak.stderr
+++ b/src/tools/miri/tests/fail/memleak.stderr
@@ -1,20 +1,11 @@
 error: memory leaked: ALLOC (Rust heap, size: 4, align: 4), allocated here:
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
-   |
-LL |         __rust_alloc(layout.size(), layout.align())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: BACKTRACE:
-   = note: inside `std::alloc::alloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `std::alloc::Global::alloc_impl` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `<std::alloc::Global as std::alloc::Allocator>::allocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `alloc::alloc::exchange_malloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `std::boxed::Box::<i32>::new` at RUSTLIB/alloc/src/boxed.rs:LL:CC
-note: inside `main`
   --> $DIR/memleak.rs:LL:CC
    |
 LL |     std::mem::forget(Box::new(42));
    |                      ^^^^^^^^^^^^
+   |
+   = note: BACKTRACE:
+   = note: inside `main` at $DIR/memleak.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/memleak_rc.stderr
+++ b/src/tools/miri/tests/fail/memleak_rc.stderr
@@ -1,15 +1,10 @@
 error: memory leaked: ALLOC (Rust heap, SIZE, ALIGN), allocated here:
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> RUSTLIB/alloc/src/rc.rs:LL:CC
    |
-LL |         __rust_alloc(layout.size(), layout.align())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |                 Box::leak(Box::new(RcBox { strong: Cell::new(1), weak: Cell::new(1), value }))
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: BACKTRACE:
-   = note: inside `std::alloc::alloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `std::alloc::Global::alloc_impl` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `<std::alloc::Global as std::alloc::Allocator>::allocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `alloc::alloc::exchange_malloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `std::boxed::Box::<std::rc::RcBox<std::cell::RefCell<std::option::Option<Dummy>>>>::new` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::rc::Rc::<std::cell::RefCell<std::option::Option<Dummy>>>::new` at RUSTLIB/alloc/src/rc.rs:LL:CC
 note: inside `main`
   --> $DIR/memleak_rc.rs:LL:CC

--- a/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/deallocate_against_protector1.stderr
@@ -1,14 +1,12 @@
 error: Undefined Behavior: deallocating while item [Unique for <TAG>] is strongly protected
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item [Unique for <TAG>] is strongly protected
+LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocating while item [Unique for <TAG>] is strongly protected
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
    = note: BACKTRACE:
-   = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `<std::alloc::Global as std::alloc::Allocator>::deallocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `<std::boxed::Box<i32> as std::ops::Drop>::drop` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::ptr::drop_in_place::<std::boxed::Box<i32>> - shim(Some(std::boxed::Box<i32>))` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
    = note: inside `std::mem::drop::<std::boxed::Box<i32>>` at RUSTLIB/core/src/mem/mod.rs:LL:CC

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_dealloc1.rs
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_dealloc1.rs
@@ -1,4 +1,3 @@
-//@error-in-other-file: /deallocation .* tag does not exist in the borrow stack/
 use std::alloc::{alloc, dealloc, Layout};
 
 fn main() {
@@ -10,5 +9,6 @@ fn main() {
         ptr1.write(0);
         // Deallocate through ptr2.
         dealloc(ptr2, Layout::from_size_align_unchecked(1, 1));
+        //~^ERROR: /deallocation .* tag does not exist in the borrow stack/
     }
 }

--- a/src/tools/miri/tests/fail/stacked_borrows/illegal_dealloc1.stderr
+++ b/src/tools/miri/tests/fail/stacked_borrows/illegal_dealloc1.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: attempting deallocation using <TAG> at ALLOC, but that tag does not exist in the borrow stack for this location
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> $DIR/illegal_deALLOC.rs:LL:CC
    |
-LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempting deallocation using <TAG> at ALLOC, but that tag does not exist in the borrow stack for this location
+LL |         dealloc(ptr2, Layout::from_size_align_unchecked(1, 1));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempting deallocation using <TAG> at ALLOC, but that tag does not exist in the borrow stack for this location
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
@@ -17,12 +17,7 @@ help: <TAG> was later invalidated at offsets [0x0..0x1] by a write access
 LL |         ptr1.write(0);
    |         ^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
-   = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-note: inside `main`
-  --> $DIR/illegal_deALLOC.rs:LL:CC
-   |
-LL |         dealloc(ptr2, Layout::from_size_align_unchecked(1, 1));
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: inside `main` at $DIR/illegal_deALLOC.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/tls_macro_leak.rs
+++ b/src/tools/miri/tests/fail/tls_macro_leak.rs
@@ -1,4 +1,3 @@
-//@error-in-other-file: memory leaked
 //@normalize-stderr-test: ".*│.*" -> "$$stripped$$"
 
 use std::cell::Cell;
@@ -10,7 +9,7 @@ pub fn main() {
 
     std::thread::spawn(|| {
         TLS.with(|cell| {
-            cell.set(Some(Box::leak(Box::new(123))));
+            cell.set(Some(Box::leak(Box::new(123)))); //~ERROR: memory leaked
         });
     })
     .join()

--- a/src/tools/miri/tests/fail/tls_macro_leak.stderr
+++ b/src/tools/miri/tests/fail/tls_macro_leak.stderr
@@ -1,20 +1,11 @@
 error: memory leaked: ALLOC (Rust heap, size: 4, align: 4), allocated here:
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
-   |
-LL |         __rust_alloc(layout.size(), layout.align())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: BACKTRACE:
-   = note: inside `std::alloc::alloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `std::alloc::Global::alloc_impl` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `<std::alloc::Global as std::alloc::Allocator>::allocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `alloc::alloc::exchange_malloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `std::boxed::Box::<i32>::new` at RUSTLIB/alloc/src/boxed.rs:LL:CC
-note: inside closure
   --> $DIR/tls_macro_leak.rs:LL:CC
    |
 LL |             cell.set(Some(Box::leak(Box::new(123))));
    |                                     ^^^^^^^^^^^^^
+   |
+   = note: BACKTRACE:
+   = note: inside closure at $DIR/tls_macro_leak.rs:LL:CC
    = note: inside `std::thread::LocalKey::<std::cell::Cell<std::option::Option<&i32>>>::try_with::<{closure@$DIR/tls_macro_leak.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/local.rs:LL:CC
    = note: inside `std::thread::LocalKey::<std::cell::Cell<std::option::Option<&i32>>>::with::<{closure@$DIR/tls_macro_leak.rs:LL:CC}, ()>` at RUSTLIB/std/src/thread/local.rs:LL:CC
 note: inside closure

--- a/src/tools/miri/tests/fail/tls_static_leak.rs
+++ b/src/tools/miri/tests/fail/tls_static_leak.rs
@@ -1,4 +1,3 @@
-//@error-in-other-file: memory leaked
 //@normalize-stderr-test: ".*│.*" -> "$$stripped$$"
 
 #![feature(thread_local)]
@@ -12,7 +11,7 @@ pub fn main() {
     static TLS: Cell<Option<&'static i32>> = Cell::new(None);
 
     std::thread::spawn(|| {
-        TLS.set(Some(Box::leak(Box::new(123))));
+        TLS.set(Some(Box::leak(Box::new(123)))); //~ERROR: memory leaked
     })
     .join()
     .unwrap();

--- a/src/tools/miri/tests/fail/tls_static_leak.stderr
+++ b/src/tools/miri/tests/fail/tls_static_leak.stderr
@@ -1,20 +1,11 @@
 error: memory leaked: ALLOC (Rust heap, size: 4, align: 4), allocated here:
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
-   |
-LL |         __rust_alloc(layout.size(), layout.align())
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: BACKTRACE:
-   = note: inside `std::alloc::alloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `std::alloc::Global::alloc_impl` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `<std::alloc::Global as std::alloc::Allocator>::allocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `alloc::alloc::exchange_malloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `std::boxed::Box::<i32>::new` at RUSTLIB/alloc/src/boxed.rs:LL:CC
-note: inside closure
   --> $DIR/tls_static_leak.rs:LL:CC
    |
 LL |         TLS.set(Some(Box::leak(Box::new(123))));
    |                                ^^^^^^^^^^^^^
+   |
+   = note: BACKTRACE:
+   = note: inside closure at $DIR/tls_static_leak.rs:LL:CC
 
 note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
 

--- a/src/tools/miri/tests/fail/tree_borrows/strongly-protected.stderr
+++ b/src/tools/miri/tests/fail/tree_borrows/strongly-protected.stderr
@@ -1,8 +1,8 @@
 error: Undefined Behavior: deallocation through <TAG> at ALLOC[0x0] is forbidden
-  --> RUSTLIB/alloc/src/alloc.rs:LL:CC
+  --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL |     unsafe { __rust_dealloc(ptr, layout.size(), layout.align()) }
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> at ALLOC[0x0] is forbidden
+LL |                 self.1.deallocate(From::from(ptr.cast()), layout);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ deallocation through <TAG> at ALLOC[0x0] is forbidden
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Tree Borrows rules it violated are still experimental
    = help: the allocation of the accessed tag <TAG> also contains the strongly protected tag <TAG>
@@ -18,8 +18,6 @@ help: the strongly protected tag <TAG> was created here, in the initial state Re
 LL | fn inner(x: &mut i32, f: fn(*mut i32)) {
    |          ^
    = note: BACKTRACE (of the first span):
-   = note: inside `std::alloc::dealloc` at RUSTLIB/alloc/src/alloc.rs:LL:CC
-   = note: inside `<std::alloc::Global as std::alloc::Allocator>::deallocate` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `<std::boxed::Box<i32> as std::ops::Drop>::drop` at RUSTLIB/alloc/src/boxed.rs:LL:CC
    = note: inside `std::ptr::drop_in_place::<std::boxed::Box<i32>> - shim(Some(std::boxed::Box<i32>))` at RUSTLIB/core/src/ptr/mod.rs:LL:CC
    = note: inside `std::mem::drop::<std::boxed::Box<i32>>` at RUSTLIB/core/src/mem/mod.rs:LL:CC


### PR DESCRIPTION
This matches what we did with basic pointer and atomic operations.