### PR TITLE
rustc_expand: remember module `#[path]`s during expansion

### DIFF
--- a/compiler/rustc_expand/src/module.rs
+++ b/compiler/rustc_expand/src/module.rs
@@ -171,7 +171,7 @@ fn mod_file_path<'a>(
 
 /// Derive a submodule path from the first found `#[path = "path_string"]`.
 /// The provided `dir_path` is joined with the `path_string`.
-fn mod_file_path_from_attr(
+pub(crate) fn mod_file_path_from_attr(
     sess: &Session,
     attrs: &[Attribute],
     dir_path: &Path,

--- a/tests/ui/parser/issues/circular-module-with-doc-comment-issue-97589/circular-module-with-doc-comment-issue-97589.rs
+++ b/tests/ui/parser/issues/circular-module-with-doc-comment-issue-97589/circular-module-with-doc-comment-issue-97589.rs
@@ -1,0 +1,6 @@
+//@ error-pattern: circular modules
+// Regression test for #97589: a doc-comment on a circular module bypassed cycle detection
+
+#![crate_type = "lib"]
+
+pub mod recursive;

--- a/tests/ui/parser/issues/circular-module-with-doc-comment-issue-97589/circular-module-with-doc-comment-issue-97589.stderr
+++ b/tests/ui/parser/issues/circular-module-with-doc-comment-issue-97589/circular-module-with-doc-comment-issue-97589.stderr
@@ -1,0 +1,8 @@
+error: circular modules: $DIR/recursive.rs -> $DIR/recursive.rs
+  --> $DIR/recursive.rs:6:1
+   |
+LL | mod recursive;
+   | ^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/issues/circular-module-with-doc-comment-issue-97589/recursive.rs
+++ b/tests/ui/parser/issues/circular-module-with-doc-comment-issue-97589/recursive.rs
@@ -1,0 +1,6 @@
+//@ ignore-test: this is an auxiliary file for circular-module-with-doc-comment-issue-97589.rs
+
+//! this comment caused the circular dependency checker to break
+
+#[path = "recursive.rs"]
+mod recursive;


### PR DESCRIPTION
During invocation collection, if a module item parsed from a `#[path]` attribute needed a second pass after parsing, its path wouldn't get added to the file path stack, so cycle detection broke. This checks the `#[path]` in such cases, so that it gets added appropriately. I think it should work identically to the case for external modules that don't need a second pass, but I'm not 100% sure.

Fixes #97589 