### PR TITLE
Re-run coverage tests if `coverage-dump` was modified

### DIFF
--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -647,6 +647,12 @@ fn common_inputs_stamp(config: &Config) -> Stamp {
         stamp.add_path(&rust_src_dir.join("src/etc/htmldocck.py"));
     }
 
+    // Re-run coverage tests if the `coverage-dump` tool was modified,
+    // because its output format might have changed.
+    if let Some(coverage_dump_path) = &config.coverage_dump_path {
+        stamp.add_path(coverage_dump_path)
+    }
+
     stamp.add_dir(&rust_src_dir.join("src/tools/run-make-support"));
 
     // Compiletest itself.


### PR DESCRIPTION
If the `coverage-dump` tool was modified, coverage tests should not be treated as up-to-date, because the tool's output might have changed.

Bootstrap already handles rebuilding the tool itself if its sources were changed, so all compiletest needs to do here is include the binary in the list of files whose timestamps are checked.

This should have no effect on non-coverage tests, because bootstrap won't pass the `--coverage-dump-path` flag, so the path in compiletest's config will be None.