### PR TITLE
skip target sanity check when it's a `local-rebuild`

### DIFF
--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -233,7 +233,8 @@ than building it.
         }
 
         // Ignore fake targets that are only used for unit tests in bootstrap.
-        if cfg!(not(feature = "bootstrap-self-test")) && !skip_target_sanity {
+        if cfg!(not(feature = "bootstrap-self-test")) && !skip_target_sanity && !build.local_rebuild
+        {
             let mut has_target = false;
             let target_str = target.to_string();
 

--- a/src/tools/opt-dist/src/tests.rs
+++ b/src/tools/opt-dist/src/tests.rs
@@ -67,6 +67,7 @@ change-id = 115898
 [build]
 rustc = "{rustc}"
 cargo = "{cargo}"
+local-rebuild = true
 
 [target.{host_triple}]
 llvm-config = "{llvm_config}"
@@ -102,13 +103,7 @@ llvm-config = "{llvm_config}"
     for test_path in env.skipped_tests() {
         args.extend(["--skip", test_path]);
     }
-    cmd(&args)
-        .env("COMPILETEST_FORCE_STAGE0", "1")
-        // Above we override the stage 0 compiler with previously compiled compiler,
-        // which can cause confusion in bootstrap's target sanity checks.
-        .env("BOOTSTRAP_SKIP_TARGET_SANITY", "1")
-        .run()
-        .context("Cannot execute tests")
+    cmd(&args).env("COMPILETEST_FORCE_STAGE0", "1").run().context("Cannot execute tests")
 }
 
 /// Tries to find the version of the dist artifacts (either nightly, beta, or 1.XY.Z).


### PR DESCRIPTION
Running the stage0 target sanity check on the newly built compiler can result in errors and incorrect assumptions.

Resolves #130242