### PR TITLE
small_data_threshold.rs: Adapt to LLVM head changes

### DIFF
--- a/tests/assembly/small_data_threshold.rs
+++ b/tests/assembly/small_data_threshold.rs
@@ -58,7 +58,7 @@ static mut Z: u64 = 0;
 // Currently, only MIPS and RISCV successfully put any objects in the small data
 // sections so the U/V/W/X tests are skipped on Hexagon and M68K
 
-//@ RISCV: .section .sdata,
+//@ RISCV: .section .sdata
 //@ RISCV-NOT: .section
 //@ RISCV: U:
 //@ RISCV: .section .sbss
@@ -71,7 +71,7 @@ static mut Z: u64 = 0;
 //@ RISCV-NOT: .section
 //@ RISCV: X:
 
-//@ MIPS: .section .sdata,
+//@ MIPS: .section .sdata
 //@ MIPS-NOT: .section
 //@ MIPS: U:
 //@ MIPS: .section .sbss


### PR DESCRIPTION
When compiled against LLVM head, `small_data_threshold.rs` [fails with](https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/31051#0191e508-f11d-437b-a4a0-5e18247debc9):

```
/.../small_data_threshold.rs:61:12: error: RISCV: expected string not found in input
--
  | //@ RISCV: .section .sdata,
  | ^
  | /.../small_data_threshold.s:1:1: note: scanning from here
  | .text
  | ^
  | /.../small_data_threshold.s:6:2: note: possible intended match here
  | .section .sdata.U,"aw",@progbits
  | ^
```

I don't know how exactly the current output looks like, or if there was a specific reason for including the trailing comma on the first line.

I only saw a failure for RISCV, but it seemed sensible to adjust MIPS as well.

CI passes with this patch applied: https://buildkite.com/llvm-project/rust-llvm-integrate-prototype/builds/31053

@rustbot label: +llvm-main

cc @paulmenage

