### PR TITLE
Don't call `extern_crate` when local crate name is the same as a dependency and we have a trait error

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1669,6 +1669,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             let name = self.tcx.crate_name(trait_def_id.krate);
             let spans: Vec<_> = [trait_def_id, found_type]
                 .into_iter()
+                .filter(|def_id| def_id.krate != LOCAL_CRATE)
                 .filter_map(|def_id| self.tcx.extern_crate(def_id.krate))
                 .map(|data| {
                     let dependency = if data.dependency_of == LOCAL_CRATE {

--- a/tests/ui/typeck/auxiliary/foreign_struct_trait_unimplemented.rs
+++ b/tests/ui/typeck/auxiliary/foreign_struct_trait_unimplemented.rs
@@ -1,0 +1,1 @@
+pub struct B;

--- a/tests/ui/typeck/foreign_struct_trait_unimplemented.rs
+++ b/tests/ui/typeck/foreign_struct_trait_unimplemented.rs
@@ -1,0 +1,15 @@
+//@ aux-build:foreign_struct_trait_unimplemented.rs
+
+extern crate foreign_struct_trait_unimplemented;
+
+pub trait Test {}
+
+struct A;
+impl Test for A {}
+
+fn needs_test(_: impl Test) {}
+
+fn main() {
+    needs_test(foreign_struct_trait_unimplemented::B);
+    //~^ ERROR the trait bound `B: Test` is not satisfied
+}

--- a/tests/ui/typeck/foreign_struct_trait_unimplemented.stderr
+++ b/tests/ui/typeck/foreign_struct_trait_unimplemented.stderr
@@ -1,0 +1,23 @@
+error[E0277]: the trait bound `B: Test` is not satisfied
+  --> $DIR/foreign_struct_trait_unimplemented.rs:13:16
+   |
+LL |     needs_test(foreign_struct_trait_unimplemented::B);
+   |     ---------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Test` is not implemented for `B`
+   |     |
+   |     required by a bound introduced by this call
+   |
+help: there are multiple different versions of crate `foreign_struct_trait_unimplemented` in the dependency graph
+  --> $DIR/foreign_struct_trait_unimplemented.rs:3:1
+   |
+LL | extern crate foreign_struct_trait_unimplemented;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one version of crate `foreign_struct_trait_unimplemented` is used here, as a direct dependency of the current crate
+   = help: you can use `cargo tree` to explore your dependency tree
+note: required by a bound in `needs_test`
+  --> $DIR/foreign_struct_trait_unimplemented.rs:10:23
+   |
+LL | fn needs_test(_: impl Test) {}
+   |                       ^^^^ required by this bound in `needs_test`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
#124944 implemented logic to point out when a trait bound failure involves a *trait* and *type* who come from identically named but different crates. This logic calls the `extern_crate` query which is not valid on `LOCAL_CRATE` cnum, so let's filter that out eagerly.

Fixes #130272
Fixes #129184