### PR TITLE
Remove intra doc link items if they are private/hidden and the matching option is not enabled

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1228,15 +1228,14 @@ impl Attributes {
         for attr in self.other_attrs.lists(sym::doc).filter(|a| a.has_name(sym::alias)) {
             if let Some(values) = attr.meta_item_list() {
                 for l in values {
-                    match l.lit().unwrap().kind {
-                        ast::LitKind::Str(s, _) => {
-                            aliases.insert(s);
-                        }
-                        _ => unreachable!(),
+                    if let Some(lit) = l.lit()
+                        && let ast::LitKind::Str(s, _) = lit.kind
+                    {
+                        aliases.insert(s);
                     }
                 }
-            } else {
-                aliases.insert(attr.value_str().unwrap());
+            } else if let Some(value) = attr.value_str() {
+                aliases.insert(value);
             }
         }
         aliases.into_iter().collect::<Vec<_>>().into()

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -1688,7 +1688,7 @@ pub(crate) struct MarkdownLink {
     pub range: MarkdownLinkRange,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum MarkdownLinkRange {
     /// Normally, markdown link warnings point only at the destination.
     Destination(Range<usize>),

--- a/src/librustdoc/passes/collect_intra_doc_links.rs
+++ b/src/librustdoc/passes/collect_intra_doc_links.rs
@@ -1146,6 +1146,7 @@ impl LinkCollector<'_, '_> {
             || !did.is_local()
     }
 
+    #[allow(rustc::potential_query_instability)]
     pub(crate) fn resolve_ambiguities(&mut self) {
         let mut ambiguous_links = mem::take(&mut self.ambiguous_links);
 

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -27,6 +27,7 @@ mod propagate_stability;
 pub(crate) use self::propagate_stability::PROPAGATE_STABILITY;
 
 pub(crate) mod collect_intra_doc_links;
+pub(crate) use self::collect_intra_doc_links::COLLECT_INTRA_DOC_LINKS;
 
 mod check_doc_test_visibility;
 pub(crate) use self::check_doc_test_visibility::CHECK_DOC_TEST_VISIBILITY;
@@ -78,6 +79,7 @@ pub(crate) const PASSES: &[Pass] = &[
     STRIP_PRIV_IMPORTS,
     PROPAGATE_DOC_CFG,
     PROPAGATE_STABILITY,
+    COLLECT_INTRA_DOC_LINKS,
     COLLECT_TRAIT_IMPLS,
     CALCULATE_DOC_COVERAGE,
     RUN_LINTS,
@@ -91,6 +93,7 @@ pub(crate) const DEFAULT_PASSES: &[ConditionalPass] = &[
     ConditionalPass::new(STRIP_HIDDEN, WhenNotDocumentHidden),
     ConditionalPass::new(STRIP_PRIVATE, WhenNotDocumentPrivate),
     ConditionalPass::new(STRIP_PRIV_IMPORTS, WhenDocumentPrivate),
+    ConditionalPass::always(COLLECT_INTRA_DOC_LINKS),
     ConditionalPass::always(PROPAGATE_DOC_CFG),
     ConditionalPass::always(PROPAGATE_STABILITY),
     ConditionalPass::always(RUN_LINTS),

--- a/src/librustdoc/passes/mod.rs
+++ b/src/librustdoc/passes/mod.rs
@@ -27,7 +27,6 @@ mod propagate_stability;
 pub(crate) use self::propagate_stability::PROPAGATE_STABILITY;
 
 pub(crate) mod collect_intra_doc_links;
-pub(crate) use self::collect_intra_doc_links::COLLECT_INTRA_DOC_LINKS;
 
 mod check_doc_test_visibility;
 pub(crate) use self::check_doc_test_visibility::CHECK_DOC_TEST_VISIBILITY;
@@ -79,7 +78,6 @@ pub(crate) const PASSES: &[Pass] = &[
     STRIP_PRIV_IMPORTS,
     PROPAGATE_DOC_CFG,
     PROPAGATE_STABILITY,
-    COLLECT_INTRA_DOC_LINKS,
     COLLECT_TRAIT_IMPLS,
     CALCULATE_DOC_COVERAGE,
     RUN_LINTS,
@@ -93,7 +91,6 @@ pub(crate) const DEFAULT_PASSES: &[ConditionalPass] = &[
     ConditionalPass::new(STRIP_HIDDEN, WhenNotDocumentHidden),
     ConditionalPass::new(STRIP_PRIVATE, WhenNotDocumentPrivate),
     ConditionalPass::new(STRIP_PRIV_IMPORTS, WhenDocumentPrivate),
-    ConditionalPass::always(COLLECT_INTRA_DOC_LINKS),
     ConditionalPass::always(PROPAGATE_DOC_CFG),
     ConditionalPass::always(PROPAGATE_STABILITY),
     ConditionalPass::always(RUN_LINTS),

--- a/tests/rustdoc-ui/intra-doc/ambiguity.stderr
+++ b/tests/rustdoc-ui/intra-doc/ambiguity.stderr
@@ -33,20 +33,20 @@ help: to link to the struct, prefix with `struct@`
 LL | /// [`struct@ambiguous`] is ambiguous.
    |       +++++++
 
-error: `ambiguous` is both a function and a struct
-  --> $DIR/ambiguity.rs:29:6
+error: `foo::bar` is both a function and an enum
+  --> $DIR/ambiguity.rs:35:43
    |
-LL | /// [ambiguous] is ambiguous.
-   |      ^^^^^^^^^ ambiguous link
+LL | /// Ambiguous non-implied shortcut link [`foo::bar`].
+   |                                           ^^^^^^^^ ambiguous link
    |
 help: to link to the function, add parentheses
    |
-LL | /// [ambiguous()] is ambiguous.
-   |               ++
-help: to link to the struct, prefix with `struct@`
+LL | /// Ambiguous non-implied shortcut link [`foo::bar()`].
+   |                                                   ++
+help: to link to the enum, prefix with `enum@`
    |
-LL | /// [struct@ambiguous] is ambiguous.
-   |      +++++++
+LL | /// Ambiguous non-implied shortcut link [`enum@foo::bar`].
+   |                                           +++++
 
 error: `multi_conflict` is a function, a struct, and a macro
   --> $DIR/ambiguity.rs:31:7
@@ -82,20 +82,5 @@ help: to link to the module, prefix with `mod@`
 LL | /// Ambiguous [mod@type_and_value].
    |                ++++
 
-error: `foo::bar` is both a function and an enum
-  --> $DIR/ambiguity.rs:35:43
-   |
-LL | /// Ambiguous non-implied shortcut link [`foo::bar`].
-   |                                           ^^^^^^^^ ambiguous link
-   |
-help: to link to the function, add parentheses
-   |
-LL | /// Ambiguous non-implied shortcut link [`foo::bar()`].
-   |                                                   ++
-help: to link to the enum, prefix with `enum@`
-   |
-LL | /// Ambiguous non-implied shortcut link [`enum@foo::bar`].
-   |                                           +++++
-
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 

--- a/tests/rustdoc-ui/intra-doc/filter-out-private-2.rs
+++ b/tests/rustdoc-ui/intra-doc/filter-out-private-2.rs
@@ -1,0 +1,15 @@
+// This test ensures that ambiguities (not) resolved at a later stage still emit an error.
+
+#![deny(rustdoc::broken_intra_doc_links)]
+#![crate_name = "foo"]
+
+#[doc(hidden)]
+pub struct Thing {}
+
+#[allow(non_snake_case)]
+#[doc(hidden)]
+pub fn Thing() {}
+
+/// Do stuff with [`Thing`].
+//~^ ERROR all items matching `Thing` are either private or doc(hidden)
+pub fn repro(_: Thing) {}

--- a/tests/rustdoc-ui/intra-doc/filter-out-private-2.stderr
+++ b/tests/rustdoc-ui/intra-doc/filter-out-private-2.stderr
@@ -1,0 +1,14 @@
+error: all items matching `Thing` are either private or doc(hidden)
+  --> $DIR/filter-out-private-2.rs:13:21
+   |
+LL | /// Do stuff with [`Thing`].
+   |                     ^^^^^ unresolved link
+   |
+note: the lint level is defined here
+  --> $DIR/filter-out-private-2.rs:3:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/rustdoc-ui/intra-doc/filter-out-private.rs
+++ b/tests/rustdoc-ui/intra-doc/filter-out-private.rs
@@ -1,0 +1,13 @@
+// This test ensures that ambiguities resolved at a later stage still emit an error.
+
+#![deny(rustdoc::broken_intra_doc_links)]
+#![crate_name = "foo"]
+
+pub struct Thing {}
+
+#[allow(non_snake_case)]
+pub fn Thing() {}
+
+/// Do stuff with [`Thing`].
+//~^ ERROR `Thing` is both a function and a struct
+pub fn repro(_: Thing) {}

--- a/tests/rustdoc-ui/intra-doc/filter-out-private.stderr
+++ b/tests/rustdoc-ui/intra-doc/filter-out-private.stderr
@@ -1,0 +1,22 @@
+error: `Thing` is both a function and a struct
+  --> $DIR/filter-out-private.rs:11:21
+   |
+LL | /// Do stuff with [`Thing`].
+   |                     ^^^^^ ambiguous link
+   |
+note: the lint level is defined here
+  --> $DIR/filter-out-private.rs:3:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: to link to the function, add parentheses
+   |
+LL | /// Do stuff with [`Thing()`].
+   |                          ++
+help: to link to the struct, prefix with `struct@`
+   |
+LL | /// Do stuff with [`struct@Thing`].
+   |                     +++++++
+
+error: aborting due to 1 previous error
+

--- a/tests/rustdoc-ui/intra-doc/html-as-generics-intra-doc.stderr
+++ b/tests/rustdoc-ui/intra-doc/html-as-generics-intra-doc.stderr
@@ -1,32 +1,3 @@
-error: unresolved link to `NonExistentStruct`
-  --> $DIR/html-as-generics-intra-doc.rs:13:17
-   |
-LL | /// This [test][NonExistentStruct<i32>] thing!
-   |                 ^^^^^^^^^^^^^^^^^^^^^^ no item named `NonExistentStruct` in scope
-   |
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-note: the lint level is defined here
-  --> $DIR/html-as-generics-intra-doc.rs:2:9
-   |
-LL | #![deny(rustdoc::broken_intra_doc_links)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: unresolved link to `NonExistentStruct2`
-  --> $DIR/html-as-generics-intra-doc.rs:17:11
-   |
-LL | /// This [NonExistentStruct2<i32>] thing!
-   |           ^^^^^^^^^^^^^^^^^^^^^^^ no item named `NonExistentStruct2` in scope
-   |
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-
-error: unresolved link to `NonExistentStruct3`
-  --> $DIR/html-as-generics-intra-doc.rs:22:11
-   |
-LL | /// This [NonExistentStruct3<i32>][] thing!
-   |           ^^^^^^^^^^^^^^^^^^^^^^^ no item named `NonExistentStruct3` in scope
-   |
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-
 error: unclosed HTML tag `i32`
   --> $DIR/html-as-generics-intra-doc.rs:9:25
    |
@@ -64,6 +35,35 @@ help: try marking as source code
    |
 LL | /// This [`NonExistentStruct3<i32>`][] thing!
    |           +                       +
+
+error: unresolved link to `NonExistentStruct`
+  --> $DIR/html-as-generics-intra-doc.rs:13:17
+   |
+LL | /// This [test][NonExistentStruct<i32>] thing!
+   |                 ^^^^^^^^^^^^^^^^^^^^^^ no item named `NonExistentStruct` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+note: the lint level is defined here
+  --> $DIR/html-as-generics-intra-doc.rs:2:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unresolved link to `NonExistentStruct2`
+  --> $DIR/html-as-generics-intra-doc.rs:17:11
+   |
+LL | /// This [NonExistentStruct2<i32>] thing!
+   |           ^^^^^^^^^^^^^^^^^^^^^^^ no item named `NonExistentStruct2` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+
+error: unresolved link to `NonExistentStruct3`
+  --> $DIR/html-as-generics-intra-doc.rs:22:11
+   |
+LL | /// This [NonExistentStruct3<i32>][] thing!
+   |           ^^^^^^^^^^^^^^^^^^^^^^^ no item named `NonExistentStruct3` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
 
 error: aborting due to 6 previous errors
 

--- a/tests/rustdoc-ui/intra-doc/issue-108653-associated-items-3.stderr
+++ b/tests/rustdoc-ui/intra-doc/issue-108653-associated-items-3.stderr
@@ -1,29 +1,14 @@
-error: `Trait` is both a constant and a trait
-  --> $DIR/issue-108653-associated-items-3.rs:12:7
-   |
-LL | /// [`Trait`]
-   |       ^^^^^ ambiguous link
-   |
-note: the lint level is defined here
-  --> $DIR/issue-108653-associated-items-3.rs:4:9
-   |
-LL | #![deny(rustdoc::broken_intra_doc_links)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: to link to the constant, prefix with `const@`
-   |
-LL | /// [`const@Trait`]
-   |       ++++++
-help: to link to the trait, prefix with `trait@`
-   |
-LL | /// [`trait@Trait`]
-   |       ++++++
-
 error: `Trait::Trait` is both an associated constant and an associated type
   --> $DIR/issue-108653-associated-items-3.rs:14:7
    |
 LL | /// [`Trait::Trait`]
    |       ^^^^^^^^^^^^ ambiguous link
    |
+note: the lint level is defined here
+  --> $DIR/issue-108653-associated-items-3.rs:4:9
+   |
+LL | #![deny(rustdoc::broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: to link to the associated constant, prefix with `const@`
    |
 LL | /// [`const@Trait::Trait`]
@@ -32,6 +17,21 @@ help: to link to the associated type, prefix with `type@`
    |
 LL | /// [`type@Trait::Trait`]
    |       +++++
+
+error: `Trait` is both a constant and a trait
+  --> $DIR/issue-108653-associated-items-3.rs:12:7
+   |
+LL | /// [`Trait`]
+   |       ^^^^^ ambiguous link
+   |
+help: to link to the constant, prefix with `const@`
+   |
+LL | /// [`const@Trait`]
+   |       ++++++
+help: to link to the trait, prefix with `trait@`
+   |
+LL | /// [`trait@Trait`]
+   |       ++++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/rustdoc-ui/intra-doc/issue-108653-associated-items.stderr
+++ b/tests/rustdoc-ui/intra-doc/issue-108653-associated-items.stderr
@@ -1,5 +1,5 @@
-error: `Self::IDENT` is both an associated function and an associated type
-  --> $DIR/issue-108653-associated-items.rs:9:7
+error: `Self::IDENT` is both an associated function and a variant
+  --> $DIR/issue-108653-associated-items.rs:16:7
    |
 LL | /// [`Self::IDENT`]
    |       ^^^^^^^^^^^ ambiguous link
@@ -13,10 +13,10 @@ help: to link to the associated function, add parentheses
    |
 LL | /// [`Self::IDENT()`]
    |                  ++
-help: to link to the associated type, prefix with `type@`
+help: to link to the variant, prefix with `variant@`
    |
-LL | /// [`type@Self::IDENT`]
-   |       +++++
+LL | /// [`variant@Self::IDENT`]
+   |       ++++++++
 
 error: `Self::IDENT2` is both an associated constant and an associated type
   --> $DIR/issue-108653-associated-items.rs:23:7
@@ -33,8 +33,8 @@ help: to link to the associated type, prefix with `type@`
 LL | /// [`type@Self::IDENT2`]
    |       +++++
 
-error: `Self::IDENT` is both an associated function and a variant
-  --> $DIR/issue-108653-associated-items.rs:16:7
+error: `Self::IDENT` is both an associated function and an associated type
+  --> $DIR/issue-108653-associated-items.rs:9:7
    |
 LL | /// [`Self::IDENT`]
    |       ^^^^^^^^^^^ ambiguous link
@@ -43,10 +43,10 @@ help: to link to the associated function, add parentheses
    |
 LL | /// [`Self::IDENT()`]
    |                  ++
-help: to link to the variant, prefix with `variant@`
+help: to link to the associated type, prefix with `type@`
    |
-LL | /// [`variant@Self::IDENT`]
-   |       ++++++++
+LL | /// [`type@Self::IDENT`]
+   |       +++++
 
 error: `Self::IDENT2` is both an associated constant and an associated type
   --> $DIR/issue-108653-associated-items.rs:30:7

--- a/tests/rustdoc-ui/intra-doc/malformed-generics.stderr
+++ b/tests/rustdoc-ui/intra-doc/malformed-generics.stderr
@@ -1,3 +1,59 @@
+warning: unclosed HTML tag `T`
+  --> $DIR/malformed-generics.rs:5:13
+   |
+LL | //! [Vec<Box<T>]
+   |             ^^^
+   |
+   = note: `#[warn(rustdoc::invalid_html_tags)]` on by default
+
+warning: unclosed HTML tag `T`
+  --> $DIR/malformed-generics.rs:7:13
+   |
+LL | //! [Vec<Box<T>>>]
+   |             ^^^
+
+warning: unclosed HTML tag `T`
+  --> $DIR/malformed-generics.rs:9:9
+   |
+LL | //! [Vec<T>>>]
+   |         ^^^
+
+warning: unclosed HTML tag `T`
+  --> $DIR/malformed-generics.rs:13:6
+   |
+LL | //! [<T>]
+   |      ^^^
+
+warning: unclosed HTML tag `invalid`
+  --> $DIR/malformed-generics.rs:15:6
+   |
+LL | //! [<invalid syntax>]
+   |      ^^^^^^^^
+
+warning: unclosed HTML tag `T`
+  --> $DIR/malformed-generics.rs:17:10
+   |
+LL | //! [Vec:<T>:new()]
+   |          ^^^
+
+warning: unclosed HTML tag `T`
+  --> $DIR/malformed-generics.rs:19:10
+   |
+LL | //! [Vec<<T>>]
+   |          ^^^
+
+warning: unclosed HTML tag `Vec`
+  --> $DIR/malformed-generics.rs:25:6
+   |
+LL | //! [<Vec as IntoIterator>::into_iter]
+   |      ^^^^
+
+warning: unclosed HTML tag `T`
+  --> $DIR/malformed-generics.rs:27:10
+   |
+LL | //! [<Vec<T> as IntoIterator>::iter]
+   |          ^^^
+
 error: unresolved link to `Vec<`
   --> $DIR/malformed-generics.rs:3:6
    |
@@ -97,62 +153,6 @@ LL | //! [<Vec<T> as IntoIterator>::iter]
    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ fully-qualified syntax is unsupported
    |
    = note: see https://github.com/rust-lang/rust/issues/74563 for more information
-
-warning: unclosed HTML tag `T`
-  --> $DIR/malformed-generics.rs:5:13
-   |
-LL | //! [Vec<Box<T>]
-   |             ^^^
-   |
-   = note: `#[warn(rustdoc::invalid_html_tags)]` on by default
-
-warning: unclosed HTML tag `T`
-  --> $DIR/malformed-generics.rs:7:13
-   |
-LL | //! [Vec<Box<T>>>]
-   |             ^^^
-
-warning: unclosed HTML tag `T`
-  --> $DIR/malformed-generics.rs:9:9
-   |
-LL | //! [Vec<T>>>]
-   |         ^^^
-
-warning: unclosed HTML tag `T`
-  --> $DIR/malformed-generics.rs:13:6
-   |
-LL | //! [<T>]
-   |      ^^^
-
-warning: unclosed HTML tag `invalid`
-  --> $DIR/malformed-generics.rs:15:6
-   |
-LL | //! [<invalid syntax>]
-   |      ^^^^^^^^
-
-warning: unclosed HTML tag `T`
-  --> $DIR/malformed-generics.rs:17:10
-   |
-LL | //! [Vec:<T>:new()]
-   |          ^^^
-
-warning: unclosed HTML tag `T`
-  --> $DIR/malformed-generics.rs:19:10
-   |
-LL | //! [Vec<<T>>]
-   |          ^^^
-
-warning: unclosed HTML tag `Vec`
-  --> $DIR/malformed-generics.rs:25:6
-   |
-LL | //! [<Vec as IntoIterator>::into_iter]
-   |      ^^^^
-
-warning: unclosed HTML tag `T`
-  --> $DIR/malformed-generics.rs:27:10
-   |
-LL | //! [<Vec<T> as IntoIterator>::iter]
-   |          ^^^
 
 error: aborting due to 15 previous errors; 9 warnings emitted
 

--- a/tests/rustdoc-ui/lints/lint-group.stderr
+++ b/tests/rustdoc-ui/lints/lint-group.stderr
@@ -33,6 +33,14 @@ error: missing code example in this documentation
 LL | /// <unknown>
    | ^^^^^^^^^^^^^
 
+error: unclosed HTML tag `unknown`
+  --> $DIR/lint-group.rs:29:5
+   |
+LL | /// <unknown>
+   |     ^^^^^^^^^
+   |
+   = note: `#[deny(rustdoc::invalid_html_tags)]` implied by `#[deny(rustdoc::all)]`
+
 error: unresolved link to `error`
   --> $DIR/lint-group.rs:12:29
    |
@@ -41,14 +49,6 @@ LL | /// what up, let's make an [error]
    |
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
    = note: `#[deny(rustdoc::broken_intra_doc_links)]` implied by `#[deny(rustdoc::all)]`
-
-error: unclosed HTML tag `unknown`
-  --> $DIR/lint-group.rs:29:5
-   |
-LL | /// <unknown>
-   |     ^^^^^^^^^
-   |
-   = note: `#[deny(rustdoc::invalid_html_tags)]` implied by `#[deny(rustdoc::all)]`
 
 error: aborting due to 5 previous errors
 

--- a/tests/rustdoc-ui/lints/renamed-lint-still-applies.stderr
+++ b/tests/rustdoc-ui/lints/renamed-lint-still-applies.stderr
@@ -12,19 +12,6 @@ warning: lint `rustdoc::non_autolinks` has been renamed to `rustdoc::bare_urls`
 LL | #![deny(rustdoc::non_autolinks)]
    |         ^^^^^^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::bare_urls`
 
-error: unresolved link to `x`
-  --> $DIR/renamed-lint-still-applies.rs:4:6
-   |
-LL | //! [x]
-   |      ^ no item named `x` in scope
-   |
-   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
-note: the lint level is defined here
-  --> $DIR/renamed-lint-still-applies.rs:2:9
-   |
-LL | #![deny(broken_intra_doc_links)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^
-
 error: this URL is not a hyperlink
   --> $DIR/renamed-lint-still-applies.rs:9:5
    |
@@ -41,6 +28,19 @@ help: use an automatic link instead
    |
 LL | //! <http://example.com>
    |     +                  +
+
+error: unresolved link to `x`
+  --> $DIR/renamed-lint-still-applies.rs:4:6
+   |
+LL | //! [x]
+   |      ^ no item named `x` in scope
+   |
+   = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
+note: the lint level is defined here
+  --> $DIR/renamed-lint-still-applies.rs:2:9
+   |
+LL | #![deny(broken_intra_doc_links)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors; 2 warnings emitted
 

--- a/tests/rustdoc/intra-doc/filter-out-private.rs
+++ b/tests/rustdoc/intra-doc/filter-out-private.rs
@@ -1,0 +1,26 @@
+// This test ensures that private/hidden items don't create ambiguity.
+// This is a regression test for <https://github.com/rust-lang/rust/issues/130233>.
+
+#![deny(rustdoc::broken_intra_doc_links)]
+#![crate_name = "foo"]
+
+pub struct Thing {}
+
+#[doc(hidden)]
+#[allow(non_snake_case)]
+pub fn Thing() {}
+
+pub struct Bar {}
+
+#[allow(non_snake_case)]
+fn Bar() {}
+
+//@ has 'foo/fn.repro.html'
+//@ has - '//*[@class="toggle top-doc"]/*[@class="docblock"]//a/@href' 'struct.Thing.html'
+/// Do stuff with [`Thing`].
+pub fn repro(_: Thing) {}
+
+//@ has 'foo/fn.repro2.html'
+//@ has - '//*[@class="toggle top-doc"]/*[@class="docblock"]//a/@href' 'struct.Bar.html'
+/// Do stuff with [`Bar`].
+pub fn repro2(_: Bar) {}


### PR DESCRIPTION
Fixes #130233.

Since such items cannot be linked to, there is no point in keeping them as candidates.

r? @notriddle 