### PR TITLE
Fix lint levels not getting overridden by attrs on `Stmt` nodes

### DIFF
--- a/compiler/rustc_lint/src/levels.rs
+++ b/compiler/rustc_lint/src/levels.rs
@@ -255,11 +255,9 @@ impl<'tcx> Visitor<'tcx> for LintLevelsBuilder<'_, LintLevelQueryMap<'tcx>> {
         intravisit::walk_foreign_item(self, it);
     }
 
-    fn visit_stmt(&mut self, e: &'tcx hir::Stmt<'tcx>) {
-        // We will call `add_id` when we walk
-        // the `StmtKind`. The outer statement itself doesn't
-        // define the lint levels.
-        intravisit::walk_stmt(self, e);
+    fn visit_stmt(&mut self, s: &'tcx hir::Stmt<'tcx>) {
+        self.add_id(s.hir_id);
+        intravisit::walk_stmt(self, s);
     }
 
     fn visit_expr(&mut self, e: &'tcx hir::Expr<'tcx>) {

--- a/src/tools/clippy/tests/ui/expect_tool_lint_rfc_2383.stderr
+++ b/src/tools/clippy/tests/ui/expect_tool_lint_rfc_2383.stderr
@@ -14,6 +14,14 @@ LL |         #[expect(invalid_nan_comparisons)]
    |                  ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: this lint expectation is unfulfilled
+  --> tests/ui/expect_tool_lint_rfc_2383.rs:36:18
+   |
+LL |         #[expect(invalid_nan_comparisons)]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: this lint expectation is unfulfilled
   --> tests/ui/expect_tool_lint_rfc_2383.rs:107:14
    |
 LL |     #[expect(clippy::almost_swapped)]
@@ -37,5 +45,5 @@ error: this lint expectation is unfulfilled
 LL |     #[expect(clippy::overly_complex_bool_expr)]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 6 previous errors
+error: aborting due to 7 previous errors
 

--- a/tests/ui/lint/lints-on-stmt-not-overridden-130142.rs
+++ b/tests/ui/lint/lints-on-stmt-not-overridden-130142.rs
@@ -1,0 +1,19 @@
+// Regression test for issue #130142
+
+// Checks that we emit no warnings when a lint's level
+// is overridden by an expect or allow attr on a Stmt node
+
+//@ check-pass
+
+#[must_use]
+pub fn must_use_result() -> i32 {
+    42
+}
+
+fn main() {
+    #[expect(unused_must_use)]
+    must_use_result();
+
+    #[allow(unused_must_use)]
+    must_use_result();
+}

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_tool_lint_rfc_2383.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_tool_lint_rfc_2383.rs
@@ -37,6 +37,8 @@ mod rustc_warn {
 
         #[expect(invalid_nan_comparisons)]
         //~^ WARNING this lint expectation is unfulfilled [unfulfilled_lint_expectations]
+        //~| WARNING this lint expectation is unfulfilled [unfulfilled_lint_expectations]
+        //~| NOTE duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
         let _b = x == 5;
     }
 }

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_tool_lint_rfc_2383.stderr
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_tool_lint_rfc_2383.stderr
@@ -12,5 +12,13 @@ warning: this lint expectation is unfulfilled
 LL |         #[expect(invalid_nan_comparisons)]
    |                  ^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: 2 warnings emitted
+warning: this lint expectation is unfulfilled
+  --> $DIR/expect_tool_lint_rfc_2383.rs:38:18
+   |
+LL |         #[expect(invalid_nan_comparisons)]
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: 3 warnings emitted
 

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_unfulfilled_expectation.rs
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_unfulfilled_expectation.rs
@@ -16,15 +16,22 @@
 pub fn normal_test_fn() {
     #[expect(unused_mut, reason = "this expectation will create a diagnostic with the default lint level")]
     //~^ WARNING this lint expectation is unfulfilled
+    //~| WARNING this lint expectation is unfulfilled
     //~| NOTE this expectation will create a diagnostic with the default lint level
+    //~| NOTE this expectation will create a diagnostic with the default lint level
+    //~| NOTE duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
     let mut v = vec![1, 1, 2, 3, 5];
     v.sort();
 
     // Check that lint lists including `unfulfilled_lint_expectations` are also handled correctly
     #[expect(unused, unfulfilled_lint_expectations, reason = "the expectation for `unused` should be fulfilled")]
     //~^ WARNING this lint expectation is unfulfilled
+    //~| WARNING this lint expectation is unfulfilled
+    //~| NOTE the expectation for `unused` should be fulfilled
     //~| NOTE the expectation for `unused` should be fulfilled
     //~| NOTE the `unfulfilled_lint_expectations` lint can't be expected and will always produce this message
+    //~| NOTE the `unfulfilled_lint_expectations` lint can't be expected and will always produce this message
+    //~| NOTE duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
     let value = "I'm unused";
 }
 

--- a/tests/ui/lint/rfc-2383-lint-reason/expect_unfulfilled_expectation.stderr
+++ b/tests/ui/lint/rfc-2383-lint-reason/expect_unfulfilled_expectation.stderr
@@ -26,7 +26,16 @@ LL |     #[expect(unused_mut, reason = "this expectation will create a diagnosti
    = note: this expectation will create a diagnostic with the default lint level
 
 warning: this lint expectation is unfulfilled
-  --> $DIR/expect_unfulfilled_expectation.rs:24:22
+  --> $DIR/expect_unfulfilled_expectation.rs:17:14
+   |
+LL |     #[expect(unused_mut, reason = "this expectation will create a diagnostic with the default lint level")]
+   |              ^^^^^^^^^^
+   |
+   = note: this expectation will create a diagnostic with the default lint level
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: this lint expectation is unfulfilled
+  --> $DIR/expect_unfulfilled_expectation.rs:27:22
    |
 LL |     #[expect(unused, unfulfilled_lint_expectations, reason = "the expectation for `unused` should be fulfilled")]
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,5 +43,15 @@ LL |     #[expect(unused, unfulfilled_lint_expectations, reason = "the expectati
    = note: the expectation for `unused` should be fulfilled
    = note: the `unfulfilled_lint_expectations` lint can't be expected and will always produce this message
 
-warning: 4 warnings emitted
+warning: this lint expectation is unfulfilled
+  --> $DIR/expect_unfulfilled_expectation.rs:27:22
+   |
+LL |     #[expect(unused, unfulfilled_lint_expectations, reason = "the expectation for `unused` should be fulfilled")]
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the expectation for `unused` should be fulfilled
+   = note: the `unfulfilled_lint_expectations` lint can't be expected and will always produce this message
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+warning: 6 warnings emitted
 


### PR DESCRIPTION
Fixes #130142. See comments on the issue for context.

r? @cjgillot 
