### PR TITLE
avoid updating LLVM submodule during bootstrap unit tests

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2739,6 +2739,8 @@ impl Config {
                 return false;
             }
 
+            // Fetching the LLVM submodule is unnecessary for self-tests.
+            #[cfg(not(feature = "bootstrap-self-test"))]
             self.update_submodule("src/llvm-project");
 
             // Check for untracked changes in `src/llvm-project`.


### PR DESCRIPTION
To test this, make sure you don't have `src/llvm-project` fetched and then set `llvm.download-ci-llvm=true` and run `x test bootstrap`.