### PR TITLE
(fix) conflicting negative impl marker

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -344,7 +344,8 @@ pub(crate) fn to_pretty_impl_header(tcx: TyCtxt<'_>, impl_def_id: DefId) -> Opti
 
     write!(
         w,
-        " {} for {}",
+        " {}{} for {}",
+        tcx.impl_polarity(impl_def_id).as_str(),
         trait_ref.print_only_trait_path(),
         tcx.type_of(impl_def_id).instantiate_identity()
     )

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -196,6 +196,17 @@ impl fmt::Display for ImplPolarity {
     }
 }
 
+impl ImplPolarity {
+    /// The polarity marker in front of the impl trait ref if applicable.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Positive => "",
+            Self::Negative => "!",
+            Self::Reservation => "",
+        }
+    }
+}
+
 /// Polarity for a trait predicate. May either be negative or positive.
 /// Distinguished from [`ImplPolarity`] since we never compute goals with
 /// "reservation" level.

--- a/tests/ui/coherence/coherence-conflicting-repeated-negative-trait-impl-70849.rs
+++ b/tests/ui/coherence/coherence-conflicting-repeated-negative-trait-impl-70849.rs
@@ -1,0 +1,10 @@
+#![feature(negative_impls)]
+//@ edition: 2021
+// Test to ensure we are printing the polarity of the impl trait ref
+// when printing out conflicting trait impls
+
+struct MyType;
+
+impl !Clone for &mut MyType {}
+//~^ ERROR conflicting implementations of trait `Clone` for type `&mut MyType`
+fn main() {}

--- a/tests/ui/coherence/coherence-conflicting-repeated-negative-trait-impl-70849.stderr
+++ b/tests/ui/coherence/coherence-conflicting-repeated-negative-trait-impl-70849.stderr
@@ -1,0 +1,13 @@
+error[E0119]: conflicting implementations of trait `Clone` for type `&mut MyType`
+  --> $DIR/coherence-conflicting-repeated-negative-trait-impl-70849.rs:8:1
+   |
+LL | impl !Clone for &mut MyType {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: conflicting implementation in crate `core`:
+           - impl<T> !Clone for &mut T
+             where T: ?Sized;
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0119`.


### PR DESCRIPTION
## Context

This MR fixes the error message for conflicting negative trait impls by adding the corresponding the polarity marker to the trait name. 

## Issues

- closes #70849


r​? @fmease 
