### PR TITLE
Add `core::panic::abort_unwind`

### DIFF
--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -160,14 +160,9 @@ pub macro unreachable_2021 {
 /// to prevent unwinds. However, note that `extern "C" fn` will automatically
 /// convert unwinds to aborts, so using this function isn't necessary for FFI.
 #[unstable(feature = "abort_unwind", issue = "130338")]
+#[rustc_nounwind]
 pub fn abort_unwind<F: FnOnce() -> R, R>(f: F) -> R {
-    // This attribute adds the "unwinding out of nounwind function" guard.
-    #[rustc_nounwind]
-    fn abort_unwind_inner<F: FnOnce() -> R, R>(f: F) -> R {
-        f()
-    }
-
-    abort_unwind_inner(f)
+    f()
 }
 
 /// An internal trait used by std to pass data from std to `panic_unwind` and

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -283,6 +283,9 @@ where
 {
 }
 
+#[unstable(feature = "abort_unwind", issue = "130338")]
+pub use core::panic::abort_unwind;
+
 /// Invokes a closure, capturing the cause of an unwinding panic if one occurs.
 ///
 /// This function will return `Ok` with the closure's result if the closure


### PR DESCRIPTION
`abort_unwind` is like `catch_unwind` except that it aborts the process if it unwinds, using the `#[rustc_nounwind]` mechanism also used by `extern "C" fn` to abort unwinding. The docs attempt to make it clear when to (rarely) and when not to (usually) use the function.

Although usage of the function is discouraged, having it available will help to normalize the experience when abort_unwind shims are hit, as opposed to the current ecosystem where there exist multiple common patterns for converting unwinding into a process abort.

For further information and justification, see the linked ACP.

- Tracking issue: https://github.com/rust-lang/rust/issues/130338
- ACP: https://github.com/rust-lang/libs-team/issues/441