### PR TITLE
docs: Enable required feature for 'closure_returning_async_block' lint

### DIFF
--- a/compiler/rustc_lint/src/async_closures.rs
+++ b/compiler/rustc_lint/src/async_closures.rs
@@ -12,6 +12,7 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust
+    /// #![feature(async_closure)]
     /// #![warn(closure_returning_async_block)]
     /// let c = |x: &str| async {};
     /// ```


### PR DESCRIPTION
Failing to do this results in the lint example output complaining about the lint not existing instead of the thing the lint is supposed to be complaining about.

See <https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#closure-returning-async-block>:
![image](https://github.com/user-attachments/assets/78bae16f-3fb6-4d6d-b8aa-768b477cd187)
