### PR TITLE
Fix `x test compiler` unit tests under `rust.parallel-compiler = true`

### DIFF
--- a/compiler/rustc_lint/Cargo.toml
+++ b/compiler/rustc_lint/Cargo.toml
@@ -27,3 +27,12 @@ rustc_type_ir = { path = "../rustc_type_ir" }
 tracing = "0.1"
 unicode-security = "0.1.0"
 # tidy-alphabetical-end
+
+[features]
+# tidy-alphabetical-start
+rustc_use_parallel_compiler = [
+    'rustc_data_structures/rustc_use_parallel_compiler',
+    'rustc_errors/rustc_use_parallel_compiler',
+    'rustc_middle/rustc_use_parallel_compiler',
+]
+# tidy-alphabetical-end

--- a/compiler/rustc_lint/src/if_let_rescope.rs
+++ b/compiler/rustc_lint/src/if_let_rescope.rs
@@ -23,7 +23,9 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust,edition2021
+    #[cfg_attr(bootstrap, doc = "```ignore")]
+    #[cfg_attr(not(bootstrap), doc = "```rust,edition2021")]
+    // ``` // Trick tidy's backtick count. Remove on bootstrap bump. #[cfg(not(bootstrap))]
     /// #![feature(if_let_rescope)]
     /// #![warn(if_let_rescope)]
     /// #![allow(unused_variables)]

--- a/compiler/rustc_lint_defs/Cargo.toml
+++ b/compiler/rustc_lint_defs/Cargo.toml
@@ -15,3 +15,11 @@ rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
 serde = { version = "1.0.125", features = ["derive"] }
 # tidy-alphabetical-end
+
+[features]
+# tidy-alphabetical-start
+rustc_use_parallel_compiler = [
+    'rustc_data_structures/rustc_use_parallel_compiler',
+    'rustc_error_messages/rustc_use_parallel_compiler',
+]
+# tidy-alphabetical-end

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1870,7 +1870,9 @@ declare_lint! {
     ///
     /// ### Example
     ///
-    /// ```rust,compile_fail
+    #[cfg_attr(bootstrap, doc = "```ignore")]
+    #[cfg_attr(not(bootstrap), doc = "```rust,compile_fail")]
+    // ``` // Trick tidy's backtick count. Remove on bootstrap bump. #[cfg(not(bootstrap))]
     /// #![deny(elided_named_lifetimes)]
     /// struct Foo;
     /// impl Foo {

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -41,5 +41,11 @@ tracing = "0.1"
 [features]
 # tidy-alphabetical-start
 rustc_randomized_layouts = []
-rustc_use_parallel_compiler = ["dep:rustc-rayon-core"]
+rustc_use_parallel_compiler = [
+    "dep:rustc-rayon-core",
+    "rustc_data_structures/rustc_use_parallel_compiler",
+    "rustc_errors/rustc_use_parallel_compiler",
+    "rustc_error_messages/rustc_use_parallel_compiler",
+    "rustc_query_system/rustc_use_parallel_compiler",
+]
 # tidy-alphabetical-end

--- a/compiler/rustc_mir_transform/Cargo.toml
+++ b/compiler/rustc_mir_transform/Cargo.toml
@@ -29,3 +29,12 @@ rustc_type_ir = { path = "../rustc_type_ir" }
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }
 tracing = "0.1"
 # tidy-alphabetical-end
+
+[features]
+# tidy-alphabetical-start
+rustc_use_parallel_compiler = [
+    'rustc_data_structures/rustc_use_parallel_compiler',
+    'rustc_errors/rustc_use_parallel_compiler',
+    'rustc_middle/rustc_use_parallel_compiler',
+]
+# tidy-alphabetical-end


### PR DESCRIPTION
When running unit tests in `compiler`, bootstrap dutifully enables the `rustc_use_parallel_compiler` feature for the target crate, but that feature isn't automatically propagated to dependencies. That results in various bogus failures, such as crates depending on `rustc_data_structures` being unable to find rayon.

The fix is to add a `rustc_use_parallel_compiler` feature to more compiler crates, and forward it to the appropriate dependencies. We already have *some* of this, which is why the unit tests work in CI, but these changes restore the ability to unit-test individual compiler crates from the command line.

As a related bonus, this PR also conditionally ignores some doctests that are incompatible with the stage 0 compiler, because they rely on behaviour that hasn't made its way to beta yet.