### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -3044,7 +3044,7 @@ fn get_apple_sdk_root(sdk_name: &str) -> Result<String, errors::AppleSdkRootErro
             "iphonesimulator"
                 if sdkroot.contains("iPhoneOS.platform") || sdkroot.contains("MacOSX.platform") => {
             }
-            "macosx10.15"
+            "macosx"
                 if sdkroot.contains("iPhoneOS.platform")
                     || sdkroot.contains("iPhoneSimulator.platform") => {}
             "watchos"

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -344,7 +344,8 @@ pub(crate) fn to_pretty_impl_header(tcx: TyCtxt<'_>, impl_def_id: DefId) -> Opti
 
     write!(
         w,
-        " {} for {}",
+        " {}{} for {}",
+        tcx.impl_polarity(impl_def_id).as_str(),
         trait_ref.print_only_trait_path(),
         tcx.type_of(impl_def_id).instantiate_identity()
     )

--- a/compiler/rustc_type_ir/src/predicate.rs
+++ b/compiler/rustc_type_ir/src/predicate.rs
@@ -196,6 +196,17 @@ impl fmt::Display for ImplPolarity {
     }
 }
 
+impl ImplPolarity {
+    /// The polarity marker in front of the impl trait ref if applicable.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Positive => "",
+            Self::Negative => "!",
+            Self::Reservation => "",
+        }
+    }
+}
+
 /// Polarity for a trait predicate. May either be negative or positive.
 /// Distinguished from [`ImplPolarity`] since we never compute goals with
 /// "reservation" level.

--- a/library/core/src/iter/adapters/peekable.rs
+++ b/library/core/src/iter/adapters/peekable.rs
@@ -269,7 +269,7 @@ impl<I: Iterator> Peekable<I> {
     /// let mut iter = (0..5).peekable();
     /// // The first item of the iterator is 0; consume it.
     /// assert_eq!(iter.next_if(|&x| x == 0), Some(0));
-    /// // The next item returned is now 1, so `consume` will return `false`.
+    /// // The next item returned is now 1, so `next_if` will return `None`.
     /// assert_eq!(iter.next_if(|&x| x == 0), None);
     /// // `next_if` saves the value of the next item if it was not equal to `expected`.
     /// assert_eq!(iter.next(), Some(1));
@@ -304,7 +304,7 @@ impl<I: Iterator> Peekable<I> {
     /// let mut iter = (0..5).peekable();
     /// // The first item of the iterator is 0; consume it.
     /// assert_eq!(iter.next_if_eq(&0), Some(0));
-    /// // The next item returned is now 1, so `consume` will return `false`.
+    /// // The next item returned is now 1, so `next_if` will return `None`.
     /// assert_eq!(iter.next_if_eq(&0), None);
     /// // `next_if_eq` saves the value of the next item if it was not equal to `expected`.
     /// assert_eq!(iter.next(), Some(1));

--- a/tests/assembly/small_data_threshold.rs
+++ b/tests/assembly/small_data_threshold.rs
@@ -58,7 +58,7 @@ static mut Z: u64 = 0;
 // Currently, only MIPS and RISCV successfully put any objects in the small data
 // sections so the U/V/W/X tests are skipped on Hexagon and M68K
 
-//@ RISCV: .section .sdata,
+//@ RISCV: .section .sdata
 //@ RISCV-NOT: .section
 //@ RISCV: U:
 //@ RISCV: .section .sbss
@@ -71,7 +71,7 @@ static mut Z: u64 = 0;
 //@ RISCV-NOT: .section
 //@ RISCV: X:
 
-//@ MIPS: .section .sdata,
+//@ MIPS: .section .sdata
 //@ MIPS-NOT: .section
 //@ MIPS: U:
 //@ MIPS: .section .sbss

--- a/tests/ui/coherence/coherence-conflicting-repeated-negative-trait-impl-70849.rs
+++ b/tests/ui/coherence/coherence-conflicting-repeated-negative-trait-impl-70849.rs
@@ -1,0 +1,10 @@
+#![feature(negative_impls)]
+//@ edition: 2021
+// Test to ensure we are printing the polarity of the impl trait ref
+// when printing out conflicting trait impls
+
+struct MyType;
+
+impl !Clone for &mut MyType {}
+//~^ ERROR conflicting implementations of trait `Clone` for type `&mut MyType`
+fn main() {}

--- a/tests/ui/coherence/coherence-conflicting-repeated-negative-trait-impl-70849.stderr
+++ b/tests/ui/coherence/coherence-conflicting-repeated-negative-trait-impl-70849.stderr
@@ -1,0 +1,13 @@
+error[E0119]: conflicting implementations of trait `Clone` for type `&mut MyType`
+  --> $DIR/coherence-conflicting-repeated-negative-trait-impl-70849.rs:8:1
+   |
+LL | impl !Clone for &mut MyType {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: conflicting implementation in crate `core`:
+           - impl<T> !Clone for &mut T
+             where T: ?Sized;
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0119`.


### PR DESCRIPTION
Successful merges:

 - #130053 (fix doc comments for Peekable::next_if(_eq))
 - #130267 (small_data_threshold.rs: Adapt to LLVM head changes)
 - #130311 ((fix) conflicting negative impl marker)
 - #130334 (Fix `SDKROOT` ignore on macOS)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=130053,130267,130311,130334)
<!-- homu-ignore:end -->