### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -614,34 +614,34 @@ pub macro declare_arena([$($a:tt $name:ident: $ty:ty,)*]) {
 
     pub trait ArenaAllocatable<'tcx, C = rustc_arena::IsNotCopy>: Sized {
         #[allow(clippy::mut_from_ref)]
-        fn allocate_on<'a>(self, arena: &'a Arena<'tcx>) -> &'a mut Self;
+        fn allocate_on(self, arena: &'tcx Arena<'tcx>) -> &'tcx mut Self;
         #[allow(clippy::mut_from_ref)]
-        fn allocate_from_iter<'a>(
-            arena: &'a Arena<'tcx>,
+        fn allocate_from_iter(
+            arena: &'tcx Arena<'tcx>,
             iter: impl ::std::iter::IntoIterator<Item = Self>,
-        ) -> &'a mut [Self];
+        ) -> &'tcx mut [Self];
     }
 
     // Any type that impls `Copy` can be arena-allocated in the `DroplessArena`.
     impl<'tcx, T: Copy> ArenaAllocatable<'tcx, rustc_arena::IsCopy> for T {
         #[inline]
         #[allow(clippy::mut_from_ref)]
-        fn allocate_on<'a>(self, arena: &'a Arena<'tcx>) -> &'a mut Self {
+        fn allocate_on(self, arena: &'tcx Arena<'tcx>) -> &'tcx mut Self {
             arena.dropless.alloc(self)
         }
         #[inline]
         #[allow(clippy::mut_from_ref)]
-        fn allocate_from_iter<'a>(
-            arena: &'a Arena<'tcx>,
+        fn allocate_from_iter(
+            arena: &'tcx Arena<'tcx>,
             iter: impl ::std::iter::IntoIterator<Item = Self>,
-        ) -> &'a mut [Self] {
+        ) -> &'tcx mut [Self] {
             arena.dropless.alloc_from_iter(iter)
         }
     }
     $(
         impl<'tcx> ArenaAllocatable<'tcx, rustc_arena::IsNotCopy> for $ty {
             #[inline]
-            fn allocate_on<'a>(self, arena: &'a Arena<'tcx>) -> &'a mut Self {
+            fn allocate_on(self, arena: &'tcx Arena<'tcx>) -> &'tcx mut Self {
                 if !::std::mem::needs_drop::<Self>() {
                     arena.dropless.alloc(self)
                 } else {
@@ -651,10 +651,10 @@ pub macro declare_arena([$($a:tt $name:ident: $ty:ty,)*]) {
 
             #[inline]
             #[allow(clippy::mut_from_ref)]
-            fn allocate_from_iter<'a>(
-                arena: &'a Arena<'tcx>,
+            fn allocate_from_iter(
+                arena: &'tcx Arena<'tcx>,
                 iter: impl ::std::iter::IntoIterator<Item = Self>,
-            ) -> &'a mut [Self] {
+            ) -> &'tcx mut [Self] {
                 if !::std::mem::needs_drop::<Self>() {
                     arena.dropless.alloc_from_iter(iter)
                 } else {
@@ -667,7 +667,7 @@ pub macro declare_arena([$($a:tt $name:ident: $ty:ty,)*]) {
     impl<'tcx> Arena<'tcx> {
         #[inline]
         #[allow(clippy::mut_from_ref)]
-        pub fn alloc<T: ArenaAllocatable<'tcx, C>, C>(&self, value: T) -> &mut T {
+        pub fn alloc<T: ArenaAllocatable<'tcx, C>, C>(&'tcx self, value: T) -> &mut T {
             value.allocate_on(self)
         }
 
@@ -691,7 +691,7 @@ pub macro declare_arena([$($a:tt $name:ident: $ty:ty,)*]) {
 
         #[allow(clippy::mut_from_ref)]
         pub fn alloc_from_iter<T: ArenaAllocatable<'tcx, C>, C>(
-            &self,
+            &'tcx self,
             iter: impl ::std::iter::IntoIterator<Item = T>,
         ) -> &mut [T] {
             T::allocate_from_iter(self, iter)

--- a/compiler/rustc_borrowck/src/dataflow.rs
+++ b/compiler/rustc_borrowck/src/dataflow.rs
@@ -113,16 +113,16 @@ pub struct Borrows<'a, 'tcx> {
     borrows_out_of_scope_at_location: FxIndexMap<Location, Vec<BorrowIndex>>,
 }
 
-struct OutOfScopePrecomputer<'mir, 'tcx> {
+struct OutOfScopePrecomputer<'a, 'tcx> {
     visited: BitSet<mir::BasicBlock>,
     visit_stack: Vec<mir::BasicBlock>,
-    body: &'mir Body<'tcx>,
-    regioncx: &'mir RegionInferenceContext<'tcx>,
+    body: &'a Body<'tcx>,
+    regioncx: &'a RegionInferenceContext<'tcx>,
     borrows_out_of_scope_at_location: FxIndexMap<Location, Vec<BorrowIndex>>,
 }
 
-impl<'mir, 'tcx> OutOfScopePrecomputer<'mir, 'tcx> {
-    fn new(body: &'mir Body<'tcx>, regioncx: &'mir RegionInferenceContext<'tcx>) -> Self {
+impl<'a, 'tcx> OutOfScopePrecomputer<'a, 'tcx> {
+    fn new(body: &'a Body<'tcx>, regioncx: &'a RegionInferenceContext<'tcx>) -> Self {
         OutOfScopePrecomputer {
             visited: BitSet::new_empty(body.basic_blocks.len()),
             visit_stack: vec![],
@@ -225,17 +225,17 @@ pub fn calculate_borrows_out_of_scope_at_location<'tcx>(
     prec.borrows_out_of_scope_at_location
 }
 
-struct PoloniusOutOfScopePrecomputer<'mir, 'tcx> {
+struct PoloniusOutOfScopePrecomputer<'a, 'tcx> {
     visited: BitSet<mir::BasicBlock>,
     visit_stack: Vec<mir::BasicBlock>,
-    body: &'mir Body<'tcx>,
-    regioncx: &'mir RegionInferenceContext<'tcx>,
+    body: &'a Body<'tcx>,
+    regioncx: &'a RegionInferenceContext<'tcx>,
 
     loans_out_of_scope_at_location: FxIndexMap<Location, Vec<BorrowIndex>>,
 }
 
-impl<'mir, 'tcx> PoloniusOutOfScopePrecomputer<'mir, 'tcx> {
-    fn new(body: &'mir Body<'tcx>, regioncx: &'mir RegionInferenceContext<'tcx>) -> Self {
+impl<'a, 'tcx> PoloniusOutOfScopePrecomputer<'a, 'tcx> {
+    fn new(body: &'a Body<'tcx>, regioncx: &'a RegionInferenceContext<'tcx>) -> Self {
         Self {
             visited: BitSet::new_empty(body.basic_blocks.len()),
             visit_stack: vec![],

--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -3540,7 +3540,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         location: Location,
         mpi: MovePathIndex,
     ) -> (Vec<MoveSite>, Vec<Location>) {
-        fn predecessor_locations<'tcx, 'a>(
+        fn predecessor_locations<'a, 'tcx>(
             body: &'a mir::Body<'tcx>,
             location: Location,
         ) -> impl Iterator<Item = Location> + Captures<'tcx> + 'a {

--- a/compiler/rustc_borrowck/src/diagnostics/find_use.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/find_use.rs
@@ -21,15 +21,15 @@ pub(crate) fn find<'tcx>(
     uf.find()
 }
 
-struct UseFinder<'cx, 'tcx> {
-    body: &'cx Body<'tcx>,
-    regioncx: &'cx Rc<RegionInferenceContext<'tcx>>,
+struct UseFinder<'a, 'tcx> {
+    body: &'a Body<'tcx>,
+    regioncx: &'a Rc<RegionInferenceContext<'tcx>>,
     tcx: TyCtxt<'tcx>,
     region_vid: RegionVid,
     start_point: Location,
 }
 
-impl<'cx, 'tcx> UseFinder<'cx, 'tcx> {
+impl<'a, 'tcx> UseFinder<'a, 'tcx> {
     fn find(&mut self) -> Option<Cause> {
         let mut queue = VecDeque::new();
         let mut visited = FxIndexSet::default();
@@ -93,8 +93,8 @@ impl<'cx, 'tcx> UseFinder<'cx, 'tcx> {
     }
 }
 
-struct DefUseVisitor<'cx, 'tcx> {
-    body: &'cx Body<'tcx>,
+struct DefUseVisitor<'a, 'tcx> {
+    body: &'a Body<'tcx>,
     tcx: TyCtxt<'tcx>,
     region_vid: RegionVid,
     def_use_result: Option<DefUseResult>,
@@ -106,7 +106,7 @@ enum DefUseResult {
     UseDrop { local: Local },
 }
 
-impl<'cx, 'tcx> Visitor<'tcx> for DefUseVisitor<'cx, 'tcx> {
+impl<'a, 'tcx> Visitor<'tcx> for DefUseVisitor<'a, 'tcx> {
     fn visit_local(&mut self, local: Local, context: PlaceContext, _: Location) {
         let local_ty = self.body.local_decls[local].ty;
 

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -558,7 +558,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 ty: Ty<'tcx>,
                 suggested: bool,
             }
-            impl<'a, 'cx, 'tcx> Visitor<'tcx> for SuggestIndexOperatorAlternativeVisitor<'a, 'cx, 'tcx> {
+            impl<'a, 'infcx, 'tcx> Visitor<'tcx> for SuggestIndexOperatorAlternativeVisitor<'a, 'infcx, 'tcx> {
                 fn visit_stmt(&mut self, stmt: &'tcx hir::Stmt<'tcx>) {
                     hir::intravisit::walk_stmt(self, stmt);
                     let expr = match stmt.kind {

--- a/compiler/rustc_borrowck/src/polonius/loan_invalidations.rs
+++ b/compiler/rustc_borrowck/src/polonius/loan_invalidations.rs
@@ -32,18 +32,18 @@ pub(super) fn emit_loan_invalidations<'tcx>(
     visitor.visit_body(body);
 }
 
-struct LoanInvalidationsGenerator<'cx, 'tcx> {
+struct LoanInvalidationsGenerator<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
-    all_facts: &'cx mut AllFacts,
-    location_table: &'cx LocationTable,
-    body: &'cx Body<'tcx>,
-    dominators: &'cx Dominators<BasicBlock>,
-    borrow_set: &'cx BorrowSet<'tcx>,
+    all_facts: &'a mut AllFacts,
+    location_table: &'a LocationTable,
+    body: &'a Body<'tcx>,
+    dominators: &'a Dominators<BasicBlock>,
+    borrow_set: &'a BorrowSet<'tcx>,
 }
 
 /// Visits the whole MIR and generates `invalidates()` facts.
 /// Most of the code implementing this was stolen from `borrow_check/mod.rs`.
-impl<'cx, 'tcx> Visitor<'tcx> for LoanInvalidationsGenerator<'cx, 'tcx> {
+impl<'a, 'tcx> Visitor<'tcx> for LoanInvalidationsGenerator<'a, 'tcx> {
     fn visit_statement(&mut self, statement: &Statement<'tcx>, location: Location) {
         self.check_activations(location);
 
@@ -212,7 +212,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for LoanInvalidationsGenerator<'cx, 'tcx> {
     }
 }
 
-impl<'cx, 'tcx> LoanInvalidationsGenerator<'cx, 'tcx> {
+impl<'a, 'tcx> LoanInvalidationsGenerator<'a, 'tcx> {
     /// Simulates mutation of a place.
     fn mutate_place(&mut self, location: Location, place: Place<'tcx>, kind: AccessDepth) {
         self.access_place(

--- a/compiler/rustc_borrowck/src/polonius/loan_kills.rs
+++ b/compiler/rustc_borrowck/src/polonius/loan_kills.rs
@@ -25,15 +25,15 @@ pub(super) fn emit_loan_kills<'tcx>(
     }
 }
 
-struct LoanKillsGenerator<'cx, 'tcx> {
+struct LoanKillsGenerator<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
-    all_facts: &'cx mut AllFacts,
-    location_table: &'cx LocationTable,
-    borrow_set: &'cx BorrowSet<'tcx>,
-    body: &'cx Body<'tcx>,
+    all_facts: &'a mut AllFacts,
+    location_table: &'a LocationTable,
+    borrow_set: &'a BorrowSet<'tcx>,
+    body: &'a Body<'tcx>,
 }
 
-impl<'cx, 'tcx> Visitor<'tcx> for LoanKillsGenerator<'cx, 'tcx> {
+impl<'a, 'tcx> Visitor<'tcx> for LoanKillsGenerator<'a, 'tcx> {
     fn visit_statement(&mut self, statement: &Statement<'tcx>, location: Location) {
         // Also record CFG facts here.
         self.all_facts.cfg_edge.push((

--- a/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
+++ b/compiler/rustc_borrowck/src/type_check/free_region_relations.rs
@@ -181,12 +181,12 @@ impl UniversalRegionRelations<'_> {
     }
 }
 
-struct UniversalRegionRelationsBuilder<'this, 'tcx> {
-    infcx: &'this InferCtxt<'tcx>,
+struct UniversalRegionRelationsBuilder<'a, 'tcx> {
+    infcx: &'a InferCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     universal_regions: Rc<UniversalRegions<'tcx>>,
     implicit_region_bound: ty::Region<'tcx>,
-    constraints: &'this mut MirTypeckRegionConstraints<'tcx>,
+    constraints: &'a mut MirTypeckRegionConstraints<'tcx>,
 
     // outputs:
     outlives: TransitiveRelationBuilder<RegionVid>,

--- a/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/mod.rs
@@ -148,12 +148,12 @@ fn record_regular_live_regions<'tcx>(
 }
 
 /// Visitor looking for regions that should be live within rvalues or calls.
-struct LiveVariablesVisitor<'cx, 'tcx> {
+struct LiveVariablesVisitor<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
-    liveness_constraints: &'cx mut LivenessValues,
+    liveness_constraints: &'a mut LivenessValues,
 }
 
-impl<'cx, 'tcx> Visitor<'tcx> for LiveVariablesVisitor<'cx, 'tcx> {
+impl<'a, 'tcx> Visitor<'tcx> for LiveVariablesVisitor<'a, 'tcx> {
     /// We sometimes have `args` within an rvalue, or within a
     /// call. Make them live at the location where they appear.
     fn visit_args(&mut self, args: &GenericArgsRef<'tcx>, location: Location) {
@@ -188,7 +188,7 @@ impl<'cx, 'tcx> Visitor<'tcx> for LiveVariablesVisitor<'cx, 'tcx> {
     }
 }
 
-impl<'cx, 'tcx> LiveVariablesVisitor<'cx, 'tcx> {
+impl<'a, 'tcx> LiveVariablesVisitor<'a, 'tcx> {
     /// Some variable is "regular live" at `location` -- i.e., it may be used later. This means that
     /// all regions appearing in the type of `value` must be live at `location`.
     fn record_regions_live_at<T>(&mut self, value: T, location: Location)

--- a/compiler/rustc_borrowck/src/type_check/liveness/polonius.rs
+++ b/compiler/rustc_borrowck/src/type_check/liveness/polonius.rs
@@ -11,13 +11,13 @@ use crate::location::{LocationIndex, LocationTable};
 type VarPointRelation = Vec<(Local, LocationIndex)>;
 type PathPointRelation = Vec<(MovePathIndex, LocationIndex)>;
 
-struct UseFactsExtractor<'me, 'tcx> {
-    var_defined_at: &'me mut VarPointRelation,
-    var_used_at: &'me mut VarPointRelation,
-    location_table: &'me LocationTable,
-    var_dropped_at: &'me mut VarPointRelation,
-    move_data: &'me MoveData<'tcx>,
-    path_accessed_at_base: &'me mut PathPointRelation,
+struct UseFactsExtractor<'a, 'tcx> {
+    var_defined_at: &'a mut VarPointRelation,
+    var_used_at: &'a mut VarPointRelation,
+    location_table: &'a LocationTable,
+    var_dropped_at: &'a mut VarPointRelation,
+    move_data: &'a MoveData<'tcx>,
+    path_accessed_at_base: &'a mut PathPointRelation,
 }
 
 // A Visitor to walk through the MIR and extract point-wise facts

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -58,8 +58,8 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
     }
 }
 
-struct NllTypeRelating<'me, 'bccx, 'tcx> {
-    type_checker: &'me mut TypeChecker<'bccx, 'tcx>,
+struct NllTypeRelating<'a, 'b, 'tcx> {
+    type_checker: &'a mut TypeChecker<'b, 'tcx>,
 
     /// Where (and why) is this relation taking place?
     locations: Locations,
@@ -82,9 +82,9 @@ struct NllTypeRelating<'me, 'bccx, 'tcx> {
     ambient_variance_info: ty::VarianceDiagInfo<TyCtxt<'tcx>>,
 }
 
-impl<'me, 'bccx, 'tcx> NllTypeRelating<'me, 'bccx, 'tcx> {
+impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
     fn new(
-        type_checker: &'me mut TypeChecker<'bccx, 'tcx>,
+        type_checker: &'a mut TypeChecker<'b, 'tcx>,
         locations: Locations,
         category: ConstraintCategory<'tcx>,
         universe_info: UniverseInfo<'tcx>,
@@ -309,7 +309,7 @@ impl<'me, 'bccx, 'tcx> NllTypeRelating<'me, 'bccx, 'tcx> {
     }
 }
 
-impl<'bccx, 'tcx> TypeRelation<TyCtxt<'tcx>> for NllTypeRelating<'_, 'bccx, 'tcx> {
+impl<'b, 'tcx> TypeRelation<TyCtxt<'tcx>> for NllTypeRelating<'_, 'b, 'tcx> {
     fn cx(&self) -> TyCtxt<'tcx> {
         self.type_checker.infcx.tcx
     }
@@ -520,7 +520,7 @@ impl<'bccx, 'tcx> TypeRelation<TyCtxt<'tcx>> for NllTypeRelating<'_, 'bccx, 'tcx
     }
 }
 
-impl<'bccx, 'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for NllTypeRelating<'_, 'bccx, 'tcx> {
+impl<'b, 'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for NllTypeRelating<'_, 'b, 'tcx> {
     fn span(&self) -> Span {
         self.locations.span(self.type_checker.body)
     }

--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -65,7 +65,7 @@ struct AllocFnFactory<'a, 'b> {
     span: Span,
     ty_span: Span,
     global: Ident,
-    cx: &'b ExtCtxt<'a>,
+    cx: &'a ExtCtxt<'b>,
 }
 
 impl AllocFnFactory<'_, '_> {

--- a/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/simd.rs
@@ -180,34 +180,20 @@ pub(super) fn codegen_simd_intrinsic_call<'tcx>(
                 return;
             }
 
-            // Make sure this is actually an array, since typeck only checks the length-suffixed
-            // version of this intrinsic.
+            // Make sure this is actually a SIMD vector.
             let idx_ty = fx.monomorphize(idx.node.ty(fx.mir, fx.tcx));
-            let n: u16 = match idx_ty.kind() {
-                ty::Array(ty, len) if matches!(ty.kind(), ty::Uint(ty::UintTy::U32)) => len
-                    .try_eval_target_usize(fx.tcx, ty::ParamEnv::reveal_all())
-                    .unwrap_or_else(|| {
-                        span_bug!(span, "could not evaluate shuffle index array length")
-                    })
-                    .try_into()
-                    .unwrap(),
-                _ if idx_ty.is_simd()
-                    && matches!(
-                        idx_ty.simd_size_and_type(fx.tcx).1.kind(),
-                        ty::Uint(ty::UintTy::U32)
-                    ) =>
-                {
-                    idx_ty.simd_size_and_type(fx.tcx).0.try_into().unwrap()
-                }
-                _ => {
-                    fx.tcx.dcx().span_err(
-                        span,
-                        format!("simd_shuffle index must be an array of `u32`, got `{}`", idx_ty),
-                    );
-                    // Prevent verifier error
-                    fx.bcx.ins().trap(TrapCode::UnreachableCodeReached);
-                    return;
-                }
+            let n: u16 = if idx_ty.is_simd()
+                && matches!(idx_ty.simd_size_and_type(fx.tcx).1.kind(), ty::Uint(ty::UintTy::U32))
+            {
+                idx_ty.simd_size_and_type(fx.tcx).0.try_into().unwrap()
+            } else {
+                fx.tcx.dcx().span_err(
+                    span,
+                    format!("simd_shuffle index must be a SIMD vector of `u32`, got `{}`", idx_ty),
+                );
+                // Prevent verifier error
+                fx.bcx.ins().trap(TrapCode::UnreachableCodeReached);
+                return;
             };
 
             assert_eq!(x.layout(), y.layout());

--- a/compiler/rustc_codegen_gcc/src/intrinsic/simd.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/simd.rs
@@ -14,7 +14,6 @@ use rustc_codegen_ssa::traits::{BaseTypeMethods, BuilderMethods};
 #[cfg(feature = "master")]
 use rustc_hir as hir;
 use rustc_middle::mir::BinOp;
-use rustc_middle::span_bug;
 use rustc_middle::ty::layout::HasTyCtxt;
 use rustc_middle::ty::{self, Ty};
 use rustc_span::{sym, Span, Symbol};
@@ -353,24 +352,14 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(
     }
 
     if name == sym::simd_shuffle {
-        // Make sure this is actually an array or SIMD vector, since typeck only checks the length-suffixed
-        // version of this intrinsic.
+        // Make sure this is actually a SIMD vector.
         let idx_ty = args[2].layout.ty;
-        let n: u64 = match idx_ty.kind() {
-            ty::Array(ty, len) if matches!(*ty.kind(), ty::Uint(ty::UintTy::U32)) => {
-                len.try_eval_target_usize(bx.cx.tcx, ty::ParamEnv::reveal_all()).unwrap_or_else(
-                    || span_bug!(span, "could not evaluate shuffle index array length"),
-                )
-            }
-            _ if idx_ty.is_simd()
-                && matches!(
-                    idx_ty.simd_size_and_type(bx.cx.tcx).1.kind(),
-                    ty::Uint(ty::UintTy::U32)
-                ) =>
-            {
-                idx_ty.simd_size_and_type(bx.cx.tcx).0
-            }
-            _ => return_error!(InvalidMonomorphization::SimdShuffle { span, name, ty: idx_ty }),
+        let n: u64 = if idx_ty.is_simd()
+            && matches!(idx_ty.simd_size_and_type(bx.cx.tcx).1.kind(), ty::Uint(ty::UintTy::U32))
+        {
+            idx_ty.simd_size_and_type(bx.cx.tcx).0
+        } else {
+            return_error!(InvalidMonomorphization::SimdShuffle { span, name, ty: idx_ty })
         };
         require_simd!(ret_ty, InvalidMonomorphization::SimdReturn { span, name, ty: ret_ty });
 

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -132,7 +132,7 @@ codegen_ssa_invalid_monomorphization_simd_return = invalid monomorphization of `
 
 codegen_ssa_invalid_monomorphization_simd_second = invalid monomorphization of `{$name}` intrinsic: expected SIMD second type, found non-SIMD `{$ty}`
 
-codegen_ssa_invalid_monomorphization_simd_shuffle = invalid monomorphization of `{$name}` intrinsic: simd_shuffle index must be an array of `u32`, got `{$ty}`
+codegen_ssa_invalid_monomorphization_simd_shuffle = invalid monomorphization of `{$name}` intrinsic: simd_shuffle index must be a SIMD vector of `u32`, got `{$ty}`
 
 codegen_ssa_invalid_monomorphization_simd_third = invalid monomorphization of `{$name}` intrinsic: expected SIMD third type, found non-SIMD `{$ty}`
 

--- a/compiler/rustc_codegen_ssa/src/mir/constant.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/constant.rs
@@ -1,6 +1,6 @@
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::ty::layout::HasTyCtxt;
-use rustc_middle::ty::{self, Ty, ValTree};
+use rustc_middle::ty::{self, Ty};
 use rustc_middle::{bug, mir, span_bug};
 use rustc_target::abi::Abi;
 
@@ -66,15 +66,8 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
         constant: &mir::ConstOperand<'tcx>,
     ) -> (Bx::Value, Ty<'tcx>) {
         let ty = self.monomorphize(constant.ty());
-        let ty_is_simd = ty.is_simd();
-        // FIXME: ideally we'd assert that this is a SIMD type, but simd_shuffle
-        // in its current form relies on a regular array being passed as an
-        // immediate argument. This hack can be removed once that is fixed.
-        let field_ty = if ty_is_simd {
-            ty.simd_size_and_type(bx.tcx()).1
-        } else {
-            ty.builtin_index().unwrap()
-        };
+        assert!(ty.is_simd());
+        let field_ty = ty.simd_size_and_type(bx.tcx()).1;
 
         let val = self
             .eval_unevaluated_mir_constant_to_valtree(constant)
@@ -82,19 +75,13 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
             .map(|x| x.ok())
             .flatten()
             .map(|val| {
-                // Depending on whether this is a SIMD type with an array field
-                // or a type with many fields (one for each elements), the valtree
-                // is either a single branch with N children, or a root node
-                // with exactly one child which then in turn has many children.
-                // So we look at the first child to determine whether it is a
-                // leaf or whether we have to go one more layer down.
-                let branch_or_leaf = val.unwrap_branch();
-                let first = branch_or_leaf.get(0).unwrap();
-                let field_iter = match first {
-                    ValTree::Branch(_) => first.unwrap_branch().iter(),
-                    ValTree::Leaf(_) => branch_or_leaf.iter(),
-                };
-                let values: Vec<_> = field_iter
+                // A SIMD type has a single field, which is an array.
+                let fields = val.unwrap_branch();
+                assert_eq!(fields.len(), 1);
+                let array = fields[0].unwrap_branch();
+                // Iterate over the array elements to obtain the values in the vector.
+                let values: Vec<_> = array
+                    .iter()
                     .map(|field| {
                         if let Some(prim) = field.try_to_scalar() {
                             let layout = bx.layout_of(field_ty);
@@ -107,7 +94,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         }
                     })
                     .collect();
-                if ty_is_simd { bx.const_vector(&values) } else { bx.const_struct(&values, false) }
+                bx.const_vector(&values)
             })
             .unwrap_or_else(|| {
                 bx.tcx().dcx().emit_err(errors::ShuffleIndicesEvaluation { span: constant.span });

--- a/compiler/rustc_const_eval/src/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/check_consts/check.rs
@@ -166,12 +166,12 @@ impl<'mir, 'tcx> Qualifs<'mir, 'tcx> {
     }
 }
 
-struct LocalReturnTyVisitor<'ck, 'mir, 'tcx> {
+struct LocalReturnTyVisitor<'a, 'mir, 'tcx> {
     kind: LocalKind,
-    checker: &'ck mut Checker<'mir, 'tcx>,
+    checker: &'a mut Checker<'mir, 'tcx>,
 }
 
-impl<'ck, 'mir, 'tcx> TypeVisitor<TyCtxt<'tcx>> for LocalReturnTyVisitor<'ck, 'mir, 'tcx> {
+impl<'a, 'mir, 'tcx> TypeVisitor<TyCtxt<'tcx>> for LocalReturnTyVisitor<'a, 'mir, 'tcx> {
     fn visit_ty(&mut self, t: Ty<'tcx>) {
         match t.kind() {
             ty::FnPtr(..) => {}

--- a/compiler/rustc_const_eval/src/interpret/memory.rs
+++ b/compiler/rustc_const_eval/src/interpret/memory.rs
@@ -1114,7 +1114,7 @@ impl<'a, 'tcx, M: Machine<'tcx>> std::fmt::Debug for DumpAllocs<'a, 'tcx, M> {
 }
 
 /// Reading and writing.
-impl<'tcx, 'a, Prov: Provenance, Extra, Bytes: AllocBytes>
+impl<'a, 'tcx, Prov: Provenance, Extra, Bytes: AllocBytes>
     AllocRefMut<'a, 'tcx, Prov, Extra, Bytes>
 {
     pub fn as_ref<'b>(&'b self) -> AllocRef<'b, 'tcx, Prov, Extra, Bytes> {
@@ -1162,7 +1162,7 @@ impl<'tcx, 'a, Prov: Provenance, Extra, Bytes: AllocBytes>
     }
 }
 
-impl<'tcx, 'a, Prov: Provenance, Extra, Bytes: AllocBytes> AllocRef<'a, 'tcx, Prov, Extra, Bytes> {
+impl<'a, 'tcx, Prov: Provenance, Extra, Bytes: AllocBytes> AllocRef<'a, 'tcx, Prov, Extra, Bytes> {
     /// `range` is relative to this allocation reference, not the base of the allocation.
     pub fn read_scalar(
         &self,

--- a/compiler/rustc_const_eval/src/interpret/projection.rs
+++ b/compiler/rustc_const_eval/src/interpret/projection.rs
@@ -101,7 +101,7 @@ pub trait Projectable<'tcx, Prov: Provenance>: Sized + std::fmt::Debug {
 }
 
 /// A type representing iteration over the elements of an array.
-pub struct ArrayIterator<'tcx, 'a, Prov: Provenance, P: Projectable<'tcx, Prov>> {
+pub struct ArrayIterator<'a, 'tcx, Prov: Provenance, P: Projectable<'tcx, Prov>> {
     base: &'a P,
     range: Range<u64>,
     stride: Size,
@@ -109,7 +109,7 @@ pub struct ArrayIterator<'tcx, 'a, Prov: Provenance, P: Projectable<'tcx, Prov>>
     _phantom: PhantomData<Prov>, // otherwise it says `Prov` is never used...
 }
 
-impl<'tcx, 'a, Prov: Provenance, P: Projectable<'tcx, Prov>> ArrayIterator<'tcx, 'a, Prov, P> {
+impl<'a, 'tcx, Prov: Provenance, P: Projectable<'tcx, Prov>> ArrayIterator<'a, 'tcx, Prov, P> {
     /// Should be the same `ecx` on each call, and match the one used to create the iterator.
     pub fn next<M: Machine<'tcx, Provenance = Prov>>(
         &mut self,
@@ -273,7 +273,7 @@ where
     pub fn project_array_fields<'a, P: Projectable<'tcx, M::Provenance>>(
         &self,
         base: &'a P,
-    ) -> InterpResult<'tcx, ArrayIterator<'tcx, 'a, M::Provenance, P>> {
+    ) -> InterpResult<'tcx, ArrayIterator<'a, 'tcx, M::Provenance, P>> {
         let abi::FieldsShape::Array { stride, .. } = base.layout().fields else {
             span_bug!(self.cur_span(), "project_array_fields: expected an array layout");
         };

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -207,17 +207,17 @@ pub fn diagnostics_registry() -> Registry {
 }
 
 /// This is the primary entry point for rustc.
-pub struct RunCompiler<'a, 'b> {
+pub struct RunCompiler<'a> {
     at_args: &'a [String],
-    callbacks: &'b mut (dyn Callbacks + Send),
+    callbacks: &'a mut (dyn Callbacks + Send),
     file_loader: Option<Box<dyn FileLoader + Send + Sync>>,
     make_codegen_backend:
         Option<Box<dyn FnOnce(&config::Options) -> Box<dyn CodegenBackend> + Send>>,
     using_internal_features: Arc<std::sync::atomic::AtomicBool>,
 }
 
-impl<'a, 'b> RunCompiler<'a, 'b> {
-    pub fn new(at_args: &'a [String], callbacks: &'b mut (dyn Callbacks + Send)) -> Self {
+impl<'a> RunCompiler<'a> {
+    pub fn new(at_args: &'a [String], callbacks: &'a mut (dyn Callbacks + Send)) -> Self {
         Self {
             at_args,
             callbacks,

--- a/compiler/rustc_expand/src/proc_macro.rs
+++ b/compiler/rustc_expand/src/proc_macro.rs
@@ -43,9 +43,9 @@ pub struct BangProcMacro {
 }
 
 impl base::BangProcMacro for BangProcMacro {
-    fn expand<'cx>(
+    fn expand(
         &self,
-        ecx: &'cx mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_>,
         span: Span,
         input: TokenStream,
     ) -> Result<TokenStream, ErrorGuaranteed> {
@@ -73,9 +73,9 @@ pub struct AttrProcMacro {
 }
 
 impl base::AttrProcMacro for AttrProcMacro {
-    fn expand<'cx>(
+    fn expand(
         &self,
-        ecx: &'cx mut ExtCtxt<'_>,
+        ecx: &mut ExtCtxt<'_>,
         span: Span,
         annotation: TokenStream,
         annotated: TokenStream,

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -711,7 +711,7 @@ pub(crate) struct CastThinPointerToFatPointer<'tcx> {
 
 #[derive(Diagnostic)]
 #[diag(hir_typeck_pass_to_variadic_function, code = E0617)]
-pub(crate) struct PassToVariadicFunction<'tcx, 'a> {
+pub(crate) struct PassToVariadicFunction<'a, 'tcx> {
     #[primary_span]
     pub span: Span,
     pub ty: Ty<'tcx>,

--- a/compiler/rustc_hir_typeck/src/fallback.rs
+++ b/compiler/rustc_hir_typeck/src/fallback.rs
@@ -603,12 +603,12 @@ fn compute_unsafe_infer_vars<'a, 'tcx>(
         root_ctxt.tcx.hir().maybe_body_owned_by(body_id).expect("body id must have an owner");
     let mut res = UnordMap::default();
 
-    struct UnsafeInferVarsVisitor<'a, 'tcx, 'r> {
+    struct UnsafeInferVarsVisitor<'a, 'tcx> {
         root_ctxt: &'a TypeckRootCtxt<'tcx>,
-        res: &'r mut UnordMap<ty::TyVid, (HirId, Span, UnsafeUseReason)>,
+        res: &'a mut UnordMap<ty::TyVid, (HirId, Span, UnsafeUseReason)>,
     }
 
-    impl Visitor<'_> for UnsafeInferVarsVisitor<'_, '_, '_> {
+    impl Visitor<'_> for UnsafeInferVarsVisitor<'_, '_> {
         fn visit_expr(&mut self, ex: &'_ hir::Expr<'_>) {
             let typeck_results = self.root_ctxt.typeck_results.borrow();
 

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1234,7 +1234,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             infer_args_for_err: &'a FxHashSet<usize>,
             segments: &'tcx [hir::PathSegment<'tcx>],
         }
-        impl<'tcx, 'a> GenericArgsLowerer<'a, 'tcx> for CtorGenericArgsCtxt<'a, 'tcx> {
+        impl<'a, 'tcx> GenericArgsLowerer<'a, 'tcx> for CtorGenericArgsCtxt<'a, 'tcx> {
             fn args_for_def_id(
                 &mut self,
                 def_id: DefId,

--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -83,7 +83,7 @@ struct TopInfo<'tcx> {
 }
 
 #[derive(Copy, Clone)]
-struct PatInfo<'tcx, 'a> {
+struct PatInfo<'a, 'tcx> {
     binding_mode: ByRef,
     max_ref_mutbl: MutblCap,
     top_info: &'a TopInfo<'tcx>,
@@ -222,7 +222,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     /// Outside of this module, `check_pat_top` should always be used.
     /// Conversely, inside this module, `check_pat_top` should never be used.
     #[instrument(level = "debug", skip(self, pat_info))]
-    fn check_pat(&self, pat: &'tcx Pat<'tcx>, expected: Ty<'tcx>, pat_info: PatInfo<'tcx, '_>) {
+    fn check_pat(&self, pat: &'tcx Pat<'tcx>, expected: Ty<'tcx>, pat_info: PatInfo<'_, 'tcx>) {
         let PatInfo { binding_mode, max_ref_mutbl, top_info: ti, current_depth, .. } = pat_info;
 
         let path_res = match &pat.kind {
@@ -668,7 +668,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         ident: Ident,
         sub: Option<&'tcx Pat<'tcx>>,
         expected: Ty<'tcx>,
-        pat_info: PatInfo<'tcx, '_>,
+        pat_info: PatInfo<'_, 'tcx>,
     ) -> Ty<'tcx> {
         let PatInfo { binding_mode: def_br, top_info: ti, .. } = pat_info;
 
@@ -981,7 +981,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         fields: &'tcx [hir::PatField<'tcx>],
         has_rest_pat: bool,
         expected: Ty<'tcx>,
-        pat_info: PatInfo<'tcx, '_>,
+        pat_info: PatInfo<'_, 'tcx>,
     ) -> Ty<'tcx> {
         // Resolve the path and check the definition for errors.
         let (variant, pat_ty) = match self.check_struct_path(qpath, pat.hir_id) {
@@ -1184,7 +1184,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         subpats: &'tcx [Pat<'tcx>],
         ddpos: hir::DotDotPos,
         expected: Ty<'tcx>,
-        pat_info: PatInfo<'tcx, '_>,
+        pat_info: PatInfo<'_, 'tcx>,
     ) -> Ty<'tcx> {
         let tcx = self.tcx;
         let on_error = |e| {
@@ -1441,7 +1441,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         elements: &'tcx [Pat<'tcx>],
         ddpos: hir::DotDotPos,
         expected: Ty<'tcx>,
-        pat_info: PatInfo<'tcx, '_>,
+        pat_info: PatInfo<'_, 'tcx>,
     ) -> Ty<'tcx> {
         let tcx = self.tcx;
         let mut expected_len = elements.len();
@@ -1479,7 +1479,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         variant: &'tcx ty::VariantDef,
         fields: &'tcx [hir::PatField<'tcx>],
         has_rest_pat: bool,
-        pat_info: PatInfo<'tcx, '_>,
+        pat_info: PatInfo<'_, 'tcx>,
     ) -> Result<(), ErrorGuaranteed> {
         let tcx = self.tcx;
 
@@ -2070,7 +2070,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span: Span,
         inner: &'tcx Pat<'tcx>,
         expected: Ty<'tcx>,
-        pat_info: PatInfo<'tcx, '_>,
+        pat_info: PatInfo<'_, 'tcx>,
     ) -> Ty<'tcx> {
         let tcx = self.tcx;
         let (box_ty, inner_ty) = self
@@ -2096,7 +2096,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span: Span,
         inner: &'tcx Pat<'tcx>,
         expected: Ty<'tcx>,
-        pat_info: PatInfo<'tcx, '_>,
+        pat_info: PatInfo<'_, 'tcx>,
     ) -> Ty<'tcx> {
         let tcx = self.tcx;
         // Register a `DerefPure` bound, which is required by all `deref!()` pats.
@@ -2137,7 +2137,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         inner: &'tcx Pat<'tcx>,
         pat_mutbl: Mutability,
         mut expected: Ty<'tcx>,
-        mut pat_info: PatInfo<'tcx, '_>,
+        mut pat_info: PatInfo<'_, 'tcx>,
     ) -> Ty<'tcx> {
         let tcx = self.tcx;
         let features = tcx.features();
@@ -2345,7 +2345,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         slice: Option<&'tcx Pat<'tcx>>,
         after: &'tcx [Pat<'tcx>],
         expected: Ty<'tcx>,
-        pat_info: PatInfo<'tcx, '_>,
+        pat_info: PatInfo<'_, 'tcx>,
     ) -> Ty<'tcx> {
         let expected = self.try_structurally_resolve_type(span, expected);
 
@@ -2517,7 +2517,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         &self,
         span: Span,
         expected_ty: Ty<'tcx>,
-        pat_info: PatInfo<'tcx, '_>,
+        pat_info: PatInfo<'_, 'tcx>,
     ) -> ErrorGuaranteed {
         let PatInfo { top_info: ti, current_depth, .. } = pat_info;
 

--- a/compiler/rustc_lint/src/async_closures.rs
+++ b/compiler/rustc_lint/src/async_closures.rs
@@ -12,6 +12,7 @@ declare_lint! {
     /// ### Example
     ///
     /// ```rust
+    /// #![feature(async_closure)]
     /// #![warn(closure_returning_async_block)]
     /// let c = |x: &str| async {};
     /// ```

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -267,16 +267,16 @@ pub(crate) struct MacroExprFragment2024 {
     pub suggestion: Span,
 }
 
-pub(crate) struct BuiltinTypeAliasBounds<'a, 'hir> {
+pub(crate) struct BuiltinTypeAliasBounds<'hir> {
     pub in_where_clause: bool,
     pub label: Span,
     pub enable_feat_help: bool,
     pub suggestions: Vec<(Span, String)>,
     pub preds: &'hir [hir::WherePredicate<'hir>],
-    pub ty: Option<&'a hir::Ty<'hir>>,
+    pub ty: Option<&'hir hir::Ty<'hir>>,
 }
 
-impl<'a> LintDiagnostic<'a, ()> for BuiltinTypeAliasBounds<'_, '_> {
+impl<'a> LintDiagnostic<'a, ()> for BuiltinTypeAliasBounds<'_> {
     fn decorate_lint<'b>(self, diag: &'b mut Diag<'a, ()>) {
         diag.primary_message(if self.in_where_clause {
             fluent::lint_builtin_type_alias_bounds_where_clause

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -1713,13 +1713,13 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
         hir_ty: &hir::Ty<'tcx>,
         ty: Ty<'tcx>,
     ) -> Vec<(Ty<'tcx>, Span)> {
-        struct FnPtrFinder<'parent, 'a, 'tcx> {
-            visitor: &'parent ImproperCTypesVisitor<'a, 'tcx>,
+        struct FnPtrFinder<'a, 'b, 'tcx> {
+            visitor: &'a ImproperCTypesVisitor<'b, 'tcx>,
             spans: Vec<Span>,
             tys: Vec<Ty<'tcx>>,
         }
 
-        impl<'parent, 'a, 'tcx> hir::intravisit::Visitor<'_> for FnPtrFinder<'parent, 'a, 'tcx> {
+        impl<'a, 'b, 'tcx> hir::intravisit::Visitor<'_> for FnPtrFinder<'a, 'b, 'tcx> {
             fn visit_ty(&mut self, ty: &'_ hir::Ty<'_>) {
                 debug!(?ty);
                 if let hir::TyKind::BareFn(hir::BareFnTy { abi, .. }) = ty.kind
@@ -1732,7 +1732,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             }
         }
 
-        impl<'vis, 'a, 'tcx> ty::visit::TypeVisitor<TyCtxt<'tcx>> for FnPtrFinder<'vis, 'a, 'tcx> {
+        impl<'a, 'b, 'tcx> ty::visit::TypeVisitor<TyCtxt<'tcx>> for FnPtrFinder<'a, 'b, 'tcx> {
             type Result = ControlFlow<Ty<'tcx>>;
 
             fn visit_ty(&mut self, ty: Ty<'tcx>) -> Self::Result {
@@ -1746,7 +1746,7 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
             }
         }
 
-        let mut visitor = FnPtrFinder { visitor: &*self, spans: Vec::new(), tys: Vec::new() };
+        let mut visitor = FnPtrFinder { visitor: self, spans: Vec::new(), tys: Vec::new() };
         ty.visit_with(&mut visitor);
         hir::intravisit::Visitor::visit_ty(&mut visitor, hir_ty);
 

--- a/compiler/rustc_mir_build/src/build/custom/mod.rs
+++ b/compiler/rustc_mir_build/src/build/custom/mod.rs
@@ -134,13 +134,12 @@ fn parse_attribute(attr: &Attribute) -> MirPhase {
     MirPhase::parse(dialect, phase)
 }
 
-struct ParseCtxt<'tcx, 'body> {
+struct ParseCtxt<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     param_env: ParamEnv<'tcx>,
-    thir: &'body Thir<'tcx>,
+    thir: &'a Thir<'tcx>,
     source_scope: SourceScope,
-
-    body: &'body mut Body<'tcx>,
+    body: &'a mut Body<'tcx>,
     local_map: FxHashMap<LocalVarId, Local>,
     block_map: FxHashMap<LocalVarId, BasicBlock>,
 }
@@ -151,7 +150,7 @@ struct ParseError {
     expected: String,
 }
 
-impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
+impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
     fn expr_error(&self, expr: ExprId, expected: &'static str) -> ParseError {
         let expr = &self.thir[expr];
         ParseError {

--- a/compiler/rustc_mir_build/src/build/custom/parse.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse.rs
@@ -68,7 +68,7 @@ macro_rules! parse_by_kind {
 }
 pub(crate) use parse_by_kind;
 
-impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
+impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
     /// Expressions should only ever be matched on after preparsing them. This removes extra scopes
     /// we don't care about.
     fn preparse(&self, expr_id: ExprId) -> ExprId {

--- a/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
+++ b/compiler/rustc_mir_build/src/build/custom/parse/instruction.rs
@@ -12,7 +12,7 @@ use super::{parse_by_kind, PResult, ParseCtxt};
 use crate::build::custom::ParseError;
 use crate::build::expr::as_constant::as_constant_inner;
 
-impl<'tcx, 'body> ParseCtxt<'tcx, 'body> {
+impl<'a, 'tcx> ParseCtxt<'a, 'tcx> {
     pub(crate) fn parse_statement(&self, expr_id: ExprId) -> PResult<StatementKind<'tcx>> {
         parse_by_kind!(self, expr_id, _, "statement",
             @call(mir_storage_live, args) => {

--- a/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
+++ b/compiler/rustc_mir_dataflow/src/elaborate_drops.rs
@@ -155,11 +155,11 @@ pub trait DropElaborator<'a, 'tcx>: fmt::Debug {
 }
 
 #[derive(Debug)]
-struct DropCtxt<'l, 'b, 'tcx, D>
+struct DropCtxt<'a, 'b, 'tcx, D>
 where
     D: DropElaborator<'b, 'tcx>,
 {
-    elaborator: &'l mut D,
+    elaborator: &'a mut D,
 
     source_info: SourceInfo,
 
@@ -192,7 +192,7 @@ pub fn elaborate_drop<'b, 'tcx, D>(
     DropCtxt { elaborator, source_info, place, path, succ, unwind }.elaborate_drop(bb)
 }
 
-impl<'l, 'b, 'tcx, D> DropCtxt<'l, 'b, 'tcx, D>
+impl<'a, 'b, 'tcx, D> DropCtxt<'a, 'b, 'tcx, D>
 where
     D: DropElaborator<'b, 'tcx>,
     'tcx: 'b,

--- a/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/storage_liveness.rs
@@ -18,7 +18,7 @@ impl<'a> MaybeStorageLive<'a> {
     }
 }
 
-impl<'tcx, 'a> crate::AnalysisDomain<'tcx> for MaybeStorageLive<'a> {
+impl<'a, 'tcx> crate::AnalysisDomain<'tcx> for MaybeStorageLive<'a> {
     type Domain = BitSet<Local>;
 
     const NAME: &'static str = "maybe_storage_live";
@@ -40,7 +40,7 @@ impl<'tcx, 'a> crate::AnalysisDomain<'tcx> for MaybeStorageLive<'a> {
     }
 }
 
-impl<'tcx, 'a> crate::GenKillAnalysis<'tcx> for MaybeStorageLive<'a> {
+impl<'a, 'tcx> crate::GenKillAnalysis<'tcx> for MaybeStorageLive<'a> {
     type Idx = Local;
 
     fn domain_size(&self, body: &Body<'tcx>) -> usize {
@@ -91,7 +91,7 @@ impl<'a> MaybeStorageDead<'a> {
     }
 }
 
-impl<'tcx, 'a> crate::AnalysisDomain<'tcx> for MaybeStorageDead<'a> {
+impl<'a, 'tcx> crate::AnalysisDomain<'tcx> for MaybeStorageDead<'a> {
     type Domain = BitSet<Local>;
 
     const NAME: &'static str = "maybe_storage_dead";
@@ -112,7 +112,7 @@ impl<'tcx, 'a> crate::AnalysisDomain<'tcx> for MaybeStorageDead<'a> {
     }
 }
 
-impl<'tcx, 'a> crate::GenKillAnalysis<'tcx> for MaybeStorageDead<'a> {
+impl<'a, 'tcx> crate::GenKillAnalysis<'tcx> for MaybeStorageDead<'a> {
     type Idx = Local;
 
     fn domain_size(&self, body: &Body<'tcx>) -> usize {

--- a/compiler/rustc_mir_transform/src/check_alignment.rs
+++ b/compiler/rustc_mir_transform/src/check_alignment.rs
@@ -62,14 +62,14 @@ impl<'tcx> crate::MirPass<'tcx> for CheckAlignment {
     }
 }
 
-struct PointerFinder<'tcx, 'a> {
+struct PointerFinder<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     local_decls: &'a mut LocalDecls<'tcx>,
     param_env: ParamEnv<'tcx>,
     pointers: Vec<(Place<'tcx>, Ty<'tcx>)>,
 }
 
-impl<'tcx, 'a> Visitor<'tcx> for PointerFinder<'tcx, 'a> {
+impl<'a, 'tcx> Visitor<'tcx> for PointerFinder<'a, 'tcx> {
     fn visit_place(&mut self, place: &Place<'tcx>, context: PlaceContext, location: Location) {
         // We want to only check reads and writes to Places, so we specifically exclude
         // Borrow and RawBorrow.

--- a/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
+++ b/compiler/rustc_mir_transform/src/dataflow_const_prop.rs
@@ -554,13 +554,13 @@ impl<'tcx> Patch<'tcx> {
     }
 }
 
-struct Collector<'tcx, 'locals> {
+struct Collector<'a, 'tcx> {
     patch: Patch<'tcx>,
-    local_decls: &'locals LocalDecls<'tcx>,
+    local_decls: &'a LocalDecls<'tcx>,
 }
 
-impl<'tcx, 'locals> Collector<'tcx, 'locals> {
-    pub(crate) fn new(tcx: TyCtxt<'tcx>, local_decls: &'locals LocalDecls<'tcx>) -> Self {
+impl<'a, 'tcx> Collector<'a, 'tcx> {
+    pub(crate) fn new(tcx: TyCtxt<'tcx>, local_decls: &'a LocalDecls<'tcx>) -> Self {
         Self { patch: Patch::new(tcx), local_decls }
     }
 
@@ -722,7 +722,7 @@ fn try_write_constant<'tcx>(
 
 impl<'mir, 'tcx>
     ResultsVisitor<'mir, 'tcx, Results<'tcx, ValueAnalysisWrapper<ConstAnalysis<'_, 'tcx>>>>
-    for Collector<'tcx, '_>
+    for Collector<'_, 'tcx>
 {
     type FlowState = State<FlatSet<Scalar>>;
 
@@ -839,9 +839,9 @@ impl<'tcx> MutVisitor<'tcx> for Patch<'tcx> {
     }
 }
 
-struct OperandCollector<'a, 'locals, 'tcx> {
+struct OperandCollector<'a, 'b, 'tcx> {
     state: &'a State<FlatSet<Scalar>>,
-    visitor: &'a mut Collector<'tcx, 'locals>,
+    visitor: &'a mut Collector<'b, 'tcx>,
     ecx: &'a mut InterpCx<'tcx, DummyMachine>,
     map: &'a Map<'tcx>,
 }

--- a/compiler/rustc_mir_transform/src/deduplicate_blocks.rs
+++ b/compiler/rustc_mir_transform/src/deduplicate_blocks.rs
@@ -98,7 +98,7 @@ fn find_duplicates(body: &Body<'_>) -> FxHashMap<BasicBlock, BasicBlock> {
     duplicates
 }
 
-struct BasicBlockHashable<'tcx, 'a> {
+struct BasicBlockHashable<'a, 'tcx> {
     basic_block_data: &'a BasicBlockData<'tcx>,
 }
 

--- a/compiler/rustc_mir_transform/src/elaborate_box_derefs.rs
+++ b/compiler/rustc_mir_transform/src/elaborate_box_derefs.rs
@@ -38,7 +38,7 @@ pub(super) fn build_projection<'tcx>(
     ]
 }
 
-struct ElaborateBoxDerefVisitor<'tcx, 'a> {
+struct ElaborateBoxDerefVisitor<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     unique_did: DefId,
     nonnull_did: DefId,
@@ -46,7 +46,7 @@ struct ElaborateBoxDerefVisitor<'tcx, 'a> {
     patch: MirPatch<'tcx>,
 }
 
-impl<'tcx, 'a> MutVisitor<'tcx> for ElaborateBoxDerefVisitor<'tcx, 'a> {
+impl<'a, 'tcx> MutVisitor<'tcx> for ElaborateBoxDerefVisitor<'a, 'tcx> {
     fn tcx(&self) -> TyCtxt<'tcx> {
         self.tcx
     }

--- a/compiler/rustc_mir_transform/src/errors.rs
+++ b/compiler/rustc_mir_transform/src/errors.rs
@@ -89,7 +89,7 @@ pub(crate) struct FnItemRef {
     pub ident: String,
 }
 
-pub(crate) struct MustNotSupend<'tcx, 'a> {
+pub(crate) struct MustNotSupend<'a, 'tcx> {
     pub tcx: TyCtxt<'tcx>,
     pub yield_sp: Span,
     pub reason: Option<MustNotSuspendReason>,

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -63,13 +63,13 @@ impl<'tcx> crate::MirPass<'tcx> for InstSimplify {
     }
 }
 
-struct InstSimplifyContext<'tcx, 'a> {
+struct InstSimplifyContext<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     local_decls: &'a LocalDecls<'tcx>,
     param_env: ParamEnv<'tcx>,
 }
 
-impl<'tcx> InstSimplifyContext<'tcx, '_> {
+impl<'tcx> InstSimplifyContext<'_, 'tcx> {
     fn should_simplify(&self, source_info: &SourceInfo, rvalue: &Rvalue<'tcx>) -> bool {
         self.should_simplify_custom(source_info, "Rvalue", rvalue)
     }

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -117,7 +117,7 @@ struct ThreadingOpportunity {
     target: BasicBlock,
 }
 
-struct TOFinder<'tcx, 'a> {
+struct TOFinder<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     ecx: InterpCx<'tcx, DummyMachine>,
@@ -183,7 +183,7 @@ impl<'a> ConditionSet<'a> {
     }
 }
 
-impl<'tcx, 'a> TOFinder<'tcx, 'a> {
+impl<'a, 'tcx> TOFinder<'a, 'tcx> {
     fn is_empty(&self, state: &State<ConditionSet<'a>>) -> bool {
         state.all_bottom()
     }

--- a/compiler/rustc_mir_transform/src/match_branches.rs
+++ b/compiler/rustc_mir_transform/src/match_branches.rs
@@ -295,7 +295,7 @@ struct SimplifyToExp {
 }
 
 #[derive(Clone, Copy)]
-enum ExpectedTransformKind<'tcx, 'a> {
+enum ExpectedTransformKind<'a, 'tcx> {
     /// Identical statements.
     Same(&'a StatementKind<'tcx>),
     /// Assignment statements have the same value.

--- a/compiler/rustc_mir_transform/src/ssa.rs
+++ b/compiler/rustc_mir_transform/src/ssa.rs
@@ -235,7 +235,7 @@ impl SsaLocals {
     }
 }
 
-struct SsaVisitor<'tcx, 'a> {
+struct SsaVisitor<'a, 'tcx> {
     body: &'a Body<'tcx>,
     dominators: &'a Dominators<BasicBlock>,
     assignments: IndexVec<Local, Set1<DefLocation>>,
@@ -261,7 +261,7 @@ impl SsaVisitor<'_, '_> {
     }
 }
 
-impl<'tcx> Visitor<'tcx> for SsaVisitor<'tcx, '_> {
+impl<'tcx> Visitor<'tcx> for SsaVisitor<'_, 'tcx> {
     fn visit_local(&mut self, local: Local, ctxt: PlaceContext, loc: Location) {
         match ctxt {
             PlaceContext::MutatingUse(MutatingUseContext::Projection)

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1098,7 +1098,7 @@ impl<'a> Parser<'a> {
                     let dot_span = span
                         .with_lo(span.lo + ident1_len)
                         .with_hi(span.lo + ident1_len + BytePos(1));
-                    let ident2_span = self.token.span.with_lo(span.lo + ident1_len + BytePos(1));
+                    let ident2_span = span.with_lo(span.lo + ident1_len + BytePos(1));
                     (ident1_span, dot_span, ident2_span)
                 } else {
                     (span, span, span)

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -1012,12 +1012,12 @@ pub(crate) struct FeatureStableTwice {
 
 #[derive(Diagnostic)]
 #[diag(passes_feature_previously_declared, code = E0711)]
-pub(crate) struct FeaturePreviouslyDeclared<'a, 'b> {
+pub(crate) struct FeaturePreviouslyDeclared<'a> {
     #[primary_span]
     pub span: Span,
     pub feature: Symbol,
     pub declared: &'a str,
-    pub prev_declared: &'b str,
+    pub prev_declared: &'a str,
 }
 
 pub(crate) struct BreakNonLoop<'a> {

--- a/compiler/rustc_passes/src/loops.rs
+++ b/compiler/rustc_passes/src/loops.rs
@@ -9,7 +9,6 @@ use rustc_middle::hir::nested_filter;
 use rustc_middle::query::Providers;
 use rustc_middle::span_bug;
 use rustc_middle::ty::TyCtxt;
-use rustc_session::Session;
 use rustc_span::hygiene::DesugaringKind;
 use rustc_span::{BytePos, Span};
 use Context::*;
@@ -65,7 +64,6 @@ impl fmt::Display for BreakContextKind {
 
 #[derive(Clone)]
 struct CheckLoopVisitor<'tcx> {
-    sess: &'tcx Session,
     tcx: TyCtxt<'tcx>,
     // Keep track of a stack of contexts, so that suggestions
     // are not made for contexts where it would be incorrect,
@@ -76,12 +74,8 @@ struct CheckLoopVisitor<'tcx> {
 }
 
 fn check_mod_loops(tcx: TyCtxt<'_>, module_def_id: LocalModDefId) {
-    let mut check = CheckLoopVisitor {
-        sess: tcx.sess,
-        tcx,
-        cx_stack: vec![Normal],
-        block_breaks: Default::default(),
-    };
+    let mut check =
+        CheckLoopVisitor { tcx, cx_stack: vec![Normal], block_breaks: Default::default() };
     tcx.hir().visit_item_likes_in_module(module_def_id, &mut check);
     check.report_outside_loop_error();
 }
@@ -213,7 +207,7 @@ impl<'hir> Visitor<'hir> for CheckLoopVisitor<'hir> {
                     Ok(loop_id) => Some(loop_id),
                     Err(hir::LoopIdError::OutsideLoopScope) => None,
                     Err(hir::LoopIdError::UnlabeledCfInWhileCondition) => {
-                        self.sess.dcx().emit_err(UnlabeledCfInWhileCondition {
+                        self.tcx.dcx().emit_err(UnlabeledCfInWhileCondition {
                             span: e.span,
                             cf_type: "break",
                         });
@@ -248,7 +242,7 @@ impl<'hir> Visitor<'hir> for CheckLoopVisitor<'hir> {
                                     .label
                                     .map_or_else(String::new, |l| format!(" {}", l.ident))
                             );
-                            self.sess.dcx().emit_err(BreakNonLoop {
+                            self.tcx.dcx().emit_err(BreakNonLoop {
                                 span: e.span,
                                 head,
                                 kind: kind.name(),
@@ -280,14 +274,14 @@ impl<'hir> Visitor<'hir> for CheckLoopVisitor<'hir> {
                 match destination.target_id {
                     Ok(loop_id) => {
                         if let Node::Block(block) = self.tcx.hir_node(loop_id) {
-                            self.sess.dcx().emit_err(ContinueLabeledBlock {
+                            self.tcx.dcx().emit_err(ContinueLabeledBlock {
                                 span: e.span,
                                 block_span: block.span,
                             });
                         }
                     }
                     Err(hir::LoopIdError::UnlabeledCfInWhileCondition) => {
-                        self.sess.dcx().emit_err(UnlabeledCfInWhileCondition {
+                        self.tcx.dcx().emit_err(UnlabeledCfInWhileCondition {
                             span: e.span,
                             cf_type: "continue",
                         });
@@ -326,7 +320,7 @@ impl<'hir> CheckLoopVisitor<'hir> {
         match self.cx_stack[cx_pos] {
             LabeledBlock | Loop(_) => {}
             Closure(closure_span) => {
-                self.sess.dcx().emit_err(BreakInsideClosure {
+                self.tcx.dcx().emit_err(BreakInsideClosure {
                     span,
                     closure_span,
                     name: &br_cx_kind.to_string(),
@@ -343,7 +337,7 @@ impl<'hir> CheckLoopVisitor<'hir> {
                     hir::CoroutineSource::Closure => "closure",
                     hir::CoroutineSource::Fn => "function",
                 };
-                self.sess.dcx().emit_err(BreakInsideCoroutine {
+                self.tcx.dcx().emit_err(BreakInsideCoroutine {
                     span,
                     coroutine_span,
                     name: &br_cx_kind.to_string(),
@@ -366,7 +360,7 @@ impl<'hir> CheckLoopVisitor<'hir> {
                 self.require_break_cx(br_cx_kind, span, break_span, cx_pos - 1);
             }
             Normal | AnonConst | Fn | UnlabeledBlock(_) | UnlabeledIfBlock(_) | ConstBlock => {
-                self.sess.dcx().emit_err(OutsideLoop {
+                self.tcx.dcx().emit_err(OutsideLoop {
                     spans: vec![span],
                     name: &br_cx_kind.to_string(),
                     is_break: br_cx_kind == BreakContextKind::Break,
@@ -386,7 +380,7 @@ impl<'hir> CheckLoopVisitor<'hir> {
             && self.cx_stack.last() == Some(&LabeledBlock)
             && label.label.is_none()
         {
-            self.sess.dcx().emit_err(UnlabeledInLabeledBlock { span, cf_type });
+            self.tcx.dcx().emit_err(UnlabeledInLabeledBlock { span, cf_type });
             return true;
         }
         false
@@ -394,7 +388,7 @@ impl<'hir> CheckLoopVisitor<'hir> {
 
     fn report_outside_loop_error(&self) {
         for (s, block) in &self.block_breaks {
-            self.sess.dcx().emit_err(OutsideLoop {
+            self.tcx.dcx().emit_err(OutsideLoop {
                 spans: block.spans.clone(),
                 name: &block.name,
                 is_break: true,

--- a/compiler/rustc_passes/src/loops.rs
+++ b/compiler/rustc_passes/src/loops.rs
@@ -64,8 +64,8 @@ impl fmt::Display for BreakContextKind {
 }
 
 #[derive(Clone)]
-struct CheckLoopVisitor<'a, 'tcx> {
-    sess: &'a Session,
+struct CheckLoopVisitor<'tcx> {
+    sess: &'tcx Session,
     tcx: TyCtxt<'tcx>,
     // Keep track of a stack of contexts, so that suggestions
     // are not made for contexts where it would be incorrect,
@@ -90,7 +90,7 @@ pub(crate) fn provide(providers: &mut Providers) {
     *providers = Providers { check_mod_loops, ..*providers };
 }
 
-impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
+impl<'hir> Visitor<'hir> for CheckLoopVisitor<'hir> {
     type NestedFilter = nested_filter::OnlyBodies;
 
     fn nested_visit_map(&mut self) -> Self::Map {
@@ -129,7 +129,7 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
             hir::ExprKind::If(cond, then, else_opt) => {
                 self.visit_expr(cond);
 
-                let get_block = |ck_loop: &CheckLoopVisitor<'a, 'hir>,
+                let get_block = |ck_loop: &CheckLoopVisitor<'hir>,
                                  expr: &hir::Expr<'hir>|
                  -> Option<&hir::Block<'hir>> {
                     if let hir::ExprKind::Block(b, None) = expr.kind
@@ -306,10 +306,10 @@ impl<'a, 'hir> Visitor<'hir> for CheckLoopVisitor<'a, 'hir> {
     }
 }
 
-impl<'a, 'hir> CheckLoopVisitor<'a, 'hir> {
+impl<'hir> CheckLoopVisitor<'hir> {
     fn with_context<F>(&mut self, cx: Context, f: F)
     where
-        F: FnOnce(&mut CheckLoopVisitor<'a, 'hir>),
+        F: FnOnce(&mut CheckLoopVisitor<'hir>),
     {
         self.cx_stack.push(cx);
         f(self);

--- a/compiler/rustc_privacy/src/lib.rs
+++ b/compiler/rustc_privacy/src/lib.rs
@@ -852,12 +852,12 @@ impl<'tcx> DefIdVisitor<'tcx> for ReachEverythingInTheInterfaceVisitor<'_, 'tcx>
 ////////////////////////////////////////////////////////////////////////////////
 /// Visitor, used for EffectiveVisibilities table checking
 ////////////////////////////////////////////////////////////////////////////////
-pub struct TestReachabilityVisitor<'tcx, 'a> {
+pub struct TestReachabilityVisitor<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     effective_visibilities: &'a EffectiveVisibilities,
 }
 
-impl<'tcx, 'a> TestReachabilityVisitor<'tcx, 'a> {
+impl<'a, 'tcx> TestReachabilityVisitor<'a, 'tcx> {
     fn effective_visibility_diagnostic(&mut self, def_id: LocalDefId) {
         if self.tcx.has_attr(def_id, sym::rustc_effective_visibility) {
             let mut error_msg = String::new();
@@ -878,7 +878,7 @@ impl<'tcx, 'a> TestReachabilityVisitor<'tcx, 'a> {
     }
 }
 
-impl<'tcx, 'a> Visitor<'tcx> for TestReachabilityVisitor<'tcx, 'a> {
+impl<'a, 'tcx> Visitor<'tcx> for TestReachabilityVisitor<'a, 'tcx> {
     fn visit_item(&mut self, item: &'tcx hir::Item<'tcx>) {
         self.effective_visibility_diagnostic(item.owner_id.def_id);
 
@@ -1425,12 +1425,12 @@ impl<'tcx> DefIdVisitor<'tcx> for SearchInterfaceForPrivateItemsVisitor<'tcx> {
     }
 }
 
-struct PrivateItemsInPublicInterfacesChecker<'tcx, 'a> {
+struct PrivateItemsInPublicInterfacesChecker<'a, 'tcx> {
     tcx: TyCtxt<'tcx>,
     effective_visibilities: &'a EffectiveVisibilities,
 }
 
-impl<'tcx> PrivateItemsInPublicInterfacesChecker<'tcx, '_> {
+impl<'tcx> PrivateItemsInPublicInterfacesChecker<'_, 'tcx> {
     fn check(
         &self,
         def_id: LocalDefId,

--- a/compiler/rustc_query_impl/src/profiling_support.rs
+++ b/compiler/rustc_query_impl/src/profiling_support.rs
@@ -19,18 +19,18 @@ impl QueryKeyStringCache {
     }
 }
 
-struct QueryKeyStringBuilder<'p, 'tcx> {
-    profiler: &'p SelfProfiler,
+struct QueryKeyStringBuilder<'a, 'tcx> {
+    profiler: &'a SelfProfiler,
     tcx: TyCtxt<'tcx>,
-    string_cache: &'p mut QueryKeyStringCache,
+    string_cache: &'a mut QueryKeyStringCache,
 }
 
-impl<'p, 'tcx> QueryKeyStringBuilder<'p, 'tcx> {
+impl<'a, 'tcx> QueryKeyStringBuilder<'a, 'tcx> {
     fn new(
-        profiler: &'p SelfProfiler,
+        profiler: &'a SelfProfiler,
         tcx: TyCtxt<'tcx>,
-        string_cache: &'p mut QueryKeyStringCache,
-    ) -> QueryKeyStringBuilder<'p, 'tcx> {
+        string_cache: &'a mut QueryKeyStringCache,
+    ) -> QueryKeyStringBuilder<'a, 'tcx> {
         QueryKeyStringBuilder { profiler, tcx, string_cache }
     }
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -842,14 +842,14 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         lifetime: Region<'tcx>,
         add_lt_suggs: &mut Vec<(Span, String)>,
     ) -> String {
-        struct LifetimeReplaceVisitor<'tcx, 'a> {
+        struct LifetimeReplaceVisitor<'a, 'tcx> {
             tcx: TyCtxt<'tcx>,
             needle: hir::LifetimeName,
             new_lt: &'a str,
             add_lt_suggs: &'a mut Vec<(Span, String)>,
         }
 
-        impl<'hir, 'tcx> hir::intravisit::Visitor<'hir> for LifetimeReplaceVisitor<'tcx, '_> {
+        impl<'hir, 'tcx> hir::intravisit::Visitor<'hir> for LifetimeReplaceVisitor<'_, 'tcx> {
             fn visit_lifetime(&mut self, lt: &'hir hir::Lifetime) {
                 if lt.res == self.needle {
                     self.add_lt_suggs.push(lt.suggestion(self.new_lt));

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -61,9 +61,9 @@ pub enum CoroutineInteriorOrUpvar {
 // This type provides a uniform interface to retrieve data on coroutines, whether it originated from
 // the local crate being compiled or from a foreign crate.
 #[derive(Debug)]
-struct CoroutineData<'tcx, 'a>(&'a TypeckResults<'tcx>);
+struct CoroutineData<'a, 'tcx>(&'a TypeckResults<'tcx>);
 
-impl<'tcx, 'a> CoroutineData<'tcx, 'a> {
+impl<'a, 'tcx> CoroutineData<'a, 'tcx> {
     /// Try to get information about variables captured by the coroutine that matches a type we are
     /// looking for with `ty_matches` function. We uses it to find upvar which causes a failure to
     /// meet an obligation

--- a/compiler/rustc_trait_selection/src/traits/query/normalize.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/normalize.rs
@@ -25,7 +25,7 @@ use crate::traits::{
 };
 
 #[extension(pub trait QueryNormalizeExt<'tcx>)]
-impl<'cx, 'tcx> At<'cx, 'tcx> {
+impl<'a, 'tcx> At<'a, 'tcx> {
     /// Normalize `value` in the context of the inference context,
     /// yielding a resulting type, or an error if `value` cannot be
     /// normalized. If you don't care about regions, you should prefer
@@ -160,9 +160,9 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for MaxEscapingBoundVarVisitor {
     }
 }
 
-struct QueryNormalizer<'cx, 'tcx> {
-    infcx: &'cx InferCtxt<'tcx>,
-    cause: &'cx ObligationCause<'tcx>,
+struct QueryNormalizer<'a, 'tcx> {
+    infcx: &'a InferCtxt<'tcx>,
+    cause: &'a ObligationCause<'tcx>,
     param_env: ty::ParamEnv<'tcx>,
     obligations: Vec<PredicateObligation<'tcx>>,
     cache: SsoHashMap<Ty<'tcx>, Ty<'tcx>>,
@@ -170,7 +170,7 @@ struct QueryNormalizer<'cx, 'tcx> {
     universes: Vec<Option<ty::UniverseIndex>>,
 }
 
-impl<'cx, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for QueryNormalizer<'cx, 'tcx> {
+impl<'a, 'tcx> FallibleTypeFolder<TyCtxt<'tcx>> for QueryNormalizer<'a, 'tcx> {
     type Error = NoSolution;
 
     fn cx(&self) -> TyCtxt<'tcx> {

--- a/compiler/rustc_trait_selection/src/traits/util.rs
+++ b/compiler/rustc_trait_selection/src/traits/util.rs
@@ -332,8 +332,8 @@ pub fn with_replaced_escaping_bound_vars<
     }
 }
 
-pub struct BoundVarReplacer<'me, 'tcx> {
-    infcx: &'me InferCtxt<'tcx>,
+pub struct BoundVarReplacer<'a, 'tcx> {
+    infcx: &'a InferCtxt<'tcx>,
     // These three maps track the bound variable that were replaced by placeholders. It might be
     // nice to remove these since we already have the `kind` in the placeholder; we really just need
     // the `var` (but we *could* bring that into scope if we were to track them as we pass them).
@@ -345,15 +345,15 @@ pub struct BoundVarReplacer<'me, 'tcx> {
     current_index: ty::DebruijnIndex,
     // The `UniverseIndex` of the binding levels above us. These are optional, since we are lazy:
     // we don't actually create a universe until we see a bound var we have to replace.
-    universe_indices: &'me mut Vec<Option<ty::UniverseIndex>>,
+    universe_indices: &'a mut Vec<Option<ty::UniverseIndex>>,
 }
 
-impl<'me, 'tcx> BoundVarReplacer<'me, 'tcx> {
+impl<'a, 'tcx> BoundVarReplacer<'a, 'tcx> {
     /// Returns `Some` if we *were* able to replace bound vars. If there are any bound vars that
     /// use a binding level above `universe_indices.len()`, we fail.
     pub fn replace_bound_vars<T: TypeFoldable<TyCtxt<'tcx>>>(
-        infcx: &'me InferCtxt<'tcx>,
-        universe_indices: &'me mut Vec<Option<ty::UniverseIndex>>,
+        infcx: &'a InferCtxt<'tcx>,
+        universe_indices: &'a mut Vec<Option<ty::UniverseIndex>>,
         value: T,
     ) -> (
         T,
@@ -479,22 +479,22 @@ impl<'tcx> TypeFolder<TyCtxt<'tcx>> for BoundVarReplacer<'_, 'tcx> {
 }
 
 /// The inverse of [`BoundVarReplacer`]: replaces placeholders with the bound vars from which they came.
-pub struct PlaceholderReplacer<'me, 'tcx> {
-    infcx: &'me InferCtxt<'tcx>,
+pub struct PlaceholderReplacer<'a, 'tcx> {
+    infcx: &'a InferCtxt<'tcx>,
     mapped_regions: FxIndexMap<ty::PlaceholderRegion, ty::BoundRegion>,
     mapped_types: FxIndexMap<ty::PlaceholderType, ty::BoundTy>,
     mapped_consts: BTreeMap<ty::PlaceholderConst, ty::BoundVar>,
-    universe_indices: &'me [Option<ty::UniverseIndex>],
+    universe_indices: &'a [Option<ty::UniverseIndex>],
     current_index: ty::DebruijnIndex,
 }
 
-impl<'me, 'tcx> PlaceholderReplacer<'me, 'tcx> {
+impl<'a, 'tcx> PlaceholderReplacer<'a, 'tcx> {
     pub fn replace_placeholders<T: TypeFoldable<TyCtxt<'tcx>>>(
-        infcx: &'me InferCtxt<'tcx>,
+        infcx: &'a InferCtxt<'tcx>,
         mapped_regions: FxIndexMap<ty::PlaceholderRegion, ty::BoundRegion>,
         mapped_types: FxIndexMap<ty::PlaceholderType, ty::BoundTy>,
         mapped_consts: BTreeMap<ty::PlaceholderConst, ty::BoundVar>,
-        universe_indices: &'me [Option<ty::UniverseIndex>],
+        universe_indices: &'a [Option<ty::UniverseIndex>],
         value: T,
     ) -> T {
         let mut replacer = PlaceholderReplacer {

--- a/compiler/rustc_ty_utils/src/layout_sanity_check.rs
+++ b/compiler/rustc_ty_utils/src/layout_sanity_check.rs
@@ -28,7 +28,7 @@ pub(super) fn sanity_check_layout<'tcx>(
     }
 
     /// Yields non-ZST fields of the type
-    fn non_zst_fields<'tcx, 'a>(
+    fn non_zst_fields<'a, 'tcx>(
         cx: &'a LayoutCx<'tcx, TyCtxt<'tcx>>,
         layout: &'a TyAndLayout<'tcx>,
     ) -> impl Iterator<Item = (Size, TyAndLayout<'tcx>)> + 'a {

--- a/library/core/src/intrinsics/simd.rs
+++ b/library/core/src/intrinsics/simd.rs
@@ -232,7 +232,7 @@ extern "rust-intrinsic" {
     ///
     /// `T` must be a vector.
     ///
-    /// `U` must be a **const** array or vector of `u32`s. This means it must either refer to a named
+    /// `U` must be a **const** vector of `u32`s. This means it must either refer to a named
     /// const or be given as an inline const expression (`const { ... }`).
     ///
     /// `V` must be a vector with the same element type as `T` and the same length as `U`.

--- a/library/portable-simd/crates/core_simd/src/swizzle.rs
+++ b/library/portable-simd/crates/core_simd/src/swizzle.rs
@@ -85,7 +85,7 @@ pub trait Swizzle<const N: usize> {
         LaneCount<N>: SupportedLaneCount,
         LaneCount<M>: SupportedLaneCount,
     {
-        // Safety: `vector` is a vector, and the index is a const array of u32.
+        // Safety: `vector` is a vector, and the index is a const vector of u32.
         unsafe {
             core::intrinsics::simd::simd_shuffle(
                 vector,
@@ -103,7 +103,11 @@ pub trait Swizzle<const N: usize> {
                         output[i] = index as u32;
                         i += 1;
                     }
-                    output
+
+                    // The index list needs to be returned as a vector.
+                    #[repr(simd)]
+                    struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
+                    SimdShuffleIdx(output)
                 },
             )
         }
@@ -121,7 +125,7 @@ pub trait Swizzle<const N: usize> {
         LaneCount<N>: SupportedLaneCount,
         LaneCount<M>: SupportedLaneCount,
     {
-        // Safety: `first` and `second` are vectors, and the index is a const array of u32.
+        // Safety: `first` and `second` are vectors, and the index is a const vector of u32.
         unsafe {
             core::intrinsics::simd::simd_shuffle(
                 first,
@@ -139,7 +143,11 @@ pub trait Swizzle<const N: usize> {
                         output[i] = index as u32;
                         i += 1;
                     }
-                    output
+
+                    // The index list needs to be returned as a vector.
+                    #[repr(simd)]
+                    struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
+                    SimdShuffleIdx(output)
                 },
             )
         }

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -2754,7 +2754,6 @@ impl<'a, K, V> Entry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(entry_insert)]
     /// use std::collections::HashMap;
     ///
     /// let mut map: HashMap<&str, String> = HashMap::new();
@@ -2763,7 +2762,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     /// assert_eq!(entry.key(), &"poneyland");
     /// ```
     #[inline]
-    #[unstable(feature = "entry_insert", issue = "65225")]
+    #[stable(feature = "entry_insert", since = "CURRENT_RUSTC_VERSION")]
     pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V> {
         match self {
             Occupied(mut entry) => {
@@ -3097,7 +3096,6 @@ impl<'a, K: 'a, V: 'a> VacantEntry<'a, K, V> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(entry_insert)]
     /// use std::collections::HashMap;
     /// use std::collections::hash_map::Entry;
     ///
@@ -3109,7 +3107,7 @@ impl<'a, K: 'a, V: 'a> VacantEntry<'a, K, V> {
     /// assert_eq!(map["poneyland"], 37);
     /// ```
     #[inline]
-    #[unstable(feature = "entry_insert", issue = "65225")]
+    #[stable(feature = "entry_insert", since = "CURRENT_RUSTC_VERSION")]
     pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V> {
         let base = self.base.insert_entry(value);
         OccupiedEntry { base }

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -847,7 +847,7 @@ enum SimplifiedParam {
 ///
 /// This function also works recursively.
 #[instrument(level = "trace", skip(tcx, res, rgen, cache))]
-fn simplify_fn_type<'tcx, 'a>(
+fn simplify_fn_type<'a, 'tcx>(
     self_: Option<&'a Type>,
     generics: &Generics,
     arg: &'a Type,
@@ -1192,7 +1192,7 @@ fn simplify_fn_type<'tcx, 'a>(
     }
 }
 
-fn simplify_fn_constraint<'tcx, 'a>(
+fn simplify_fn_constraint<'a, 'tcx>(
     self_: Option<&'a Type>,
     generics: &Generics,
     constraint: &'a clean::AssocItemConstraint,

--- a/src/tools/miri/src/intrinsics/simd.rs
+++ b/src/tools/miri/src/intrinsics/simd.rs
@@ -664,14 +664,8 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 let [left, right, index] = check_arg_count(args)?;
                 let (left, left_len) = this.project_to_simd(left)?;
                 let (right, right_len) = this.project_to_simd(right)?;
+                let (index, index_len) = this.project_to_simd(index)?;
                 let (dest, dest_len) = this.project_to_simd(dest)?;
-
-                // `index` is an array or a SIMD type
-                let (index, index_len) = match index.layout.ty.kind() {
-                    // FIXME: remove this once `index` must always be a SIMD vector.
-                    ty::Array(..) => (index.clone(), index.len(this)?),
-                    _ => this.project_to_simd(index)?,
-                };
 
                 assert_eq!(left_len, right_len);
                 assert_eq!(index_len, dest_len);

--- a/src/tools/miri/tests/pass/intrinsics/portable-simd.rs
+++ b/src/tools/miri/tests/pass/intrinsics/portable-simd.rs
@@ -619,17 +619,12 @@ fn simd_intrinsics() {
             i32x4::from_array([10, 2, 10, 10])
         );
         assert_eq!(simd_shuffle_generic::<_, i32x4, { &[3, 1, 0, 2] }>(a, b), a,);
-        assert_eq!(simd_shuffle::<_, _, i32x4>(a, b, const { [3u32, 1, 0, 2] }), a,);
         assert_eq!(
             simd_shuffle::<_, _, i32x4>(a, b, const { u32x4::from_array([3u32, 1, 0, 2]) }),
             a,
         );
         assert_eq!(
             simd_shuffle_generic::<_, i32x4, { &[7, 5, 4, 6] }>(a, b),
-            i32x4::from_array([4, 2, 1, 10]),
-        );
-        assert_eq!(
-            simd_shuffle::<_, _, i32x4>(a, b, const { [7u32, 5, 4, 6] }),
             i32x4::from_array([4, 2, 1, 10]),
         );
         assert_eq!(

--- a/tests/coverage/async.cov-map
+++ b/tests/coverage/async.cov-map
@@ -1,103 +1,103 @@
 Function name: async::c
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 09, 01, 00, 19]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 0c, 01, 00, 19]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 9, 1) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 12, 1) to (start + 0, 25)
 
 Function name: async::c::{closure#0}
-Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 09, 19, 01, 0e, 05, 02, 09, 00, 0a, 02, 02, 09, 00, 0a, 01, 02, 01, 00, 02]
+Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 0c, 19, 01, 0e, 05, 02, 09, 00, 0a, 02, 02, 09, 00, 0a, 01, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
 Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 9, 25) to (start + 1, 14)
+- Code(Counter(0)) at (prev + 12, 25) to (start + 1, 14)
 - Code(Counter(1)) at (prev + 2, 9) to (start + 0, 10)
 - Code(Expression(0, Sub)) at (prev + 2, 9) to (start + 0, 10)
     = (c0 - c1)
 - Code(Counter(0)) at (prev + 2, 1) to (start + 0, 2)
 
 Function name: async::d
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 11, 01, 00, 14]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 14, 01, 00, 14]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 17, 1) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 20, 1) to (start + 0, 20)
 
 Function name: async::d::{closure#0}
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 11, 14, 00, 19]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 14, 14, 00, 19]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 17, 20) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 20, 20) to (start + 0, 25)
 
 Function name: async::e (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 13, 01, 00, 14]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 16, 01, 00, 14]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 19, 1) to (start + 0, 20)
+- Code(Zero) at (prev + 22, 1) to (start + 0, 20)
 
 Function name: async::e::{closure#0} (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 13, 14, 00, 19]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 16, 14, 00, 19]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 19, 20) to (start + 0, 25)
+- Code(Zero) at (prev + 22, 20) to (start + 0, 25)
 
 Function name: async::f
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 15, 01, 00, 14]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 18, 01, 00, 14]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 21, 1) to (start + 0, 20)
+- Code(Counter(0)) at (prev + 24, 1) to (start + 0, 20)
 
 Function name: async::f::{closure#0}
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 15, 14, 00, 19]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 18, 14, 00, 19]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 21, 20) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 24, 20) to (start + 0, 25)
 
 Function name: async::foo (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 17, 01, 00, 1e]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 1a, 01, 00, 1e]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 23, 1) to (start + 0, 30)
+- Code(Zero) at (prev + 26, 1) to (start + 0, 30)
 
 Function name: async::foo::{closure#0} (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 17, 1e, 00, 2d]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 1a, 1e, 00, 2d]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 23, 30) to (start + 0, 45)
+- Code(Zero) at (prev + 26, 30) to (start + 0, 45)
 
 Function name: async::g
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 19, 01, 00, 17]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 1c, 01, 00, 17]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 25, 1) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 28, 1) to (start + 0, 23)
 
 Function name: async::g::{closure#0} (unused)
-Raw bytes (59): 0x[01, 01, 00, 0b, 00, 19, 17, 01, 0c, 00, 02, 09, 00, 0a, 00, 00, 0e, 00, 17, 00, 00, 1b, 00, 1c, 00, 00, 20, 00, 22, 00, 01, 09, 00, 0a, 00, 00, 0e, 00, 17, 00, 00, 1b, 00, 1c, 00, 00, 20, 00, 22, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
+Raw bytes (59): 0x[01, 01, 00, 0b, 00, 1c, 17, 01, 0c, 00, 02, 09, 00, 0a, 00, 00, 0e, 00, 17, 00, 00, 1b, 00, 1c, 00, 00, 20, 00, 22, 00, 01, 09, 00, 0a, 00, 00, 0e, 00, 17, 00, 00, 1b, 00, 1c, 00, 00, 20, 00, 22, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 11
-- Code(Zero) at (prev + 25, 23) to (start + 1, 12)
+- Code(Zero) at (prev + 28, 23) to (start + 1, 12)
 - Code(Zero) at (prev + 2, 9) to (start + 0, 10)
 - Code(Zero) at (prev + 0, 14) to (start + 0, 23)
 - Code(Zero) at (prev + 0, 27) to (start + 0, 28)
@@ -110,20 +110,20 @@ Number of file 0 mappings: 11
 - Code(Zero) at (prev + 2, 1) to (start + 0, 2)
 
 Function name: async::h
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 21, 01, 00, 16]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 24, 01, 00, 16]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 33, 1) to (start + 0, 22)
+- Code(Counter(0)) at (prev + 36, 1) to (start + 0, 22)
 
 Function name: async::h::{closure#0} (unused)
-Raw bytes (39): 0x[01, 01, 00, 07, 00, 21, 16, 03, 0c, 00, 04, 09, 00, 0a, 00, 00, 0e, 00, 19, 00, 00, 1a, 00, 1b, 00, 00, 20, 00, 22, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
+Raw bytes (39): 0x[01, 01, 00, 07, 00, 24, 16, 03, 0c, 00, 04, 09, 00, 0a, 00, 00, 0e, 00, 19, 00, 00, 1a, 00, 1b, 00, 00, 20, 00, 22, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 7
-- Code(Zero) at (prev + 33, 22) to (start + 3, 12)
+- Code(Zero) at (prev + 36, 22) to (start + 3, 12)
 - Code(Zero) at (prev + 4, 9) to (start + 0, 10)
 - Code(Zero) at (prev + 0, 14) to (start + 0, 25)
 - Code(Zero) at (prev + 0, 26) to (start + 0, 27)
@@ -132,22 +132,22 @@ Number of file 0 mappings: 7
 - Code(Zero) at (prev + 2, 1) to (start + 0, 2)
 
 Function name: async::i
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 2a, 01, 00, 13]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 2d, 01, 00, 13]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 42, 1) to (start + 0, 19)
+- Code(Counter(0)) at (prev + 45, 1) to (start + 0, 19)
 
 Function name: async::i::{closure#0}
-Raw bytes (63): 0x[01, 01, 02, 07, 19, 11, 15, 0b, 01, 2a, 13, 04, 0c, 09, 05, 09, 00, 0a, 01, 00, 0e, 00, 18, 05, 00, 1c, 00, 21, 09, 00, 27, 00, 30, 15, 01, 09, 00, 0a, 0d, 00, 0e, 00, 17, 1d, 00, 1b, 00, 20, 15, 00, 24, 00, 26, 19, 01, 0e, 00, 10, 03, 02, 01, 00, 02]
+Raw bytes (63): 0x[01, 01, 02, 07, 19, 11, 15, 0b, 01, 2d, 13, 04, 0c, 09, 05, 09, 00, 0a, 01, 00, 0e, 00, 18, 05, 00, 1c, 00, 21, 09, 00, 27, 00, 30, 15, 01, 09, 00, 0a, 0d, 00, 0e, 00, 17, 1d, 00, 1b, 00, 20, 15, 00, 24, 00, 26, 19, 01, 0e, 00, 10, 03, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 2
 - expression 0 operands: lhs = Expression(1, Add), rhs = Counter(6)
 - expression 1 operands: lhs = Counter(4), rhs = Counter(5)
 Number of file 0 mappings: 11
-- Code(Counter(0)) at (prev + 42, 19) to (start + 4, 12)
+- Code(Counter(0)) at (prev + 45, 19) to (start + 4, 12)
 - Code(Counter(2)) at (prev + 5, 9) to (start + 0, 10)
 - Code(Counter(0)) at (prev + 0, 14) to (start + 0, 24)
 - Code(Counter(1)) at (prev + 0, 28) to (start + 0, 33)
@@ -161,14 +161,14 @@ Number of file 0 mappings: 11
     = ((c4 + c5) + c6)
 
 Function name: async::j
-Raw bytes (58): 0x[01, 01, 02, 07, 0d, 05, 09, 0a, 01, 35, 01, 00, 0d, 01, 0b, 0b, 00, 0c, 05, 01, 09, 00, 0a, 01, 00, 0e, 00, 1b, 05, 00, 1f, 00, 27, 09, 01, 09, 00, 0a, 11, 00, 0e, 00, 1a, 09, 00, 1e, 00, 20, 0d, 01, 0e, 00, 10, 03, 02, 01, 00, 02]
+Raw bytes (58): 0x[01, 01, 02, 07, 0d, 05, 09, 0a, 01, 38, 01, 00, 0d, 01, 0b, 0b, 00, 0c, 05, 01, 09, 00, 0a, 01, 00, 0e, 00, 1b, 05, 00, 1f, 00, 27, 09, 01, 09, 00, 0a, 11, 00, 0e, 00, 1a, 09, 00, 1e, 00, 20, 0d, 01, 0e, 00, 10, 03, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 2
 - expression 0 operands: lhs = Expression(1, Add), rhs = Counter(3)
 - expression 1 operands: lhs = Counter(1), rhs = Counter(2)
 Number of file 0 mappings: 10
-- Code(Counter(0)) at (prev + 53, 1) to (start + 0, 13)
+- Code(Counter(0)) at (prev + 56, 1) to (start + 0, 13)
 - Code(Counter(0)) at (prev + 11, 11) to (start + 0, 12)
 - Code(Counter(1)) at (prev + 1, 9) to (start + 0, 10)
 - Code(Counter(0)) at (prev + 0, 14) to (start + 0, 27)
@@ -181,48 +181,48 @@ Number of file 0 mappings: 10
     = ((c1 + c2) + c3)
 
 Function name: async::j::c
-Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 37, 05, 01, 12, 05, 02, 0d, 00, 0e, 02, 02, 0d, 00, 0e, 01, 02, 05, 00, 06]
+Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 3a, 05, 01, 12, 05, 02, 0d, 00, 0e, 02, 02, 0d, 00, 0e, 01, 02, 05, 00, 06]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
 Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 55, 5) to (start + 1, 18)
+- Code(Counter(0)) at (prev + 58, 5) to (start + 1, 18)
 - Code(Counter(1)) at (prev + 2, 13) to (start + 0, 14)
 - Code(Expression(0, Sub)) at (prev + 2, 13) to (start + 0, 14)
     = (c0 - c1)
 - Code(Counter(0)) at (prev + 2, 5) to (start + 0, 6)
 
 Function name: async::j::d
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 3e, 05, 00, 17]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 41, 05, 00, 17]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 62, 5) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 65, 5) to (start + 0, 23)
 
 Function name: async::j::f
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 3f, 05, 00, 17]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 42, 05, 00, 17]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 63, 5) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 66, 5) to (start + 0, 23)
 
 Function name: async::k (unused)
-Raw bytes (29): 0x[01, 01, 00, 05, 00, 47, 01, 01, 0c, 00, 02, 0e, 00, 10, 00, 01, 0e, 00, 10, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
+Raw bytes (29): 0x[01, 01, 00, 05, 00, 4a, 01, 01, 0c, 00, 02, 0e, 00, 10, 00, 01, 0e, 00, 10, 00, 01, 0e, 00, 10, 00, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 5
-- Code(Zero) at (prev + 71, 1) to (start + 1, 12)
+- Code(Zero) at (prev + 74, 1) to (start + 1, 12)
 - Code(Zero) at (prev + 2, 14) to (start + 0, 16)
 - Code(Zero) at (prev + 1, 14) to (start + 0, 16)
 - Code(Zero) at (prev + 1, 14) to (start + 0, 16)
 - Code(Zero) at (prev + 2, 1) to (start + 0, 2)
 
 Function name: async::l
-Raw bytes (37): 0x[01, 01, 04, 01, 07, 05, 09, 0f, 02, 09, 05, 05, 01, 4f, 01, 01, 0c, 02, 02, 0e, 00, 10, 05, 01, 0e, 00, 10, 09, 01, 0e, 00, 10, 0b, 02, 01, 00, 02]
+Raw bytes (37): 0x[01, 01, 04, 01, 07, 05, 09, 0f, 02, 09, 05, 05, 01, 52, 01, 01, 0c, 02, 02, 0e, 00, 10, 05, 01, 0e, 00, 10, 09, 01, 0e, 00, 10, 0b, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 4
@@ -231,7 +231,7 @@ Number of expressions: 4
 - expression 2 operands: lhs = Expression(3, Add), rhs = Expression(0, Sub)
 - expression 3 operands: lhs = Counter(2), rhs = Counter(1)
 Number of file 0 mappings: 5
-- Code(Counter(0)) at (prev + 79, 1) to (start + 1, 12)
+- Code(Counter(0)) at (prev + 82, 1) to (start + 1, 12)
 - Code(Expression(0, Sub)) at (prev + 2, 14) to (start + 0, 16)
     = (c0 - (c1 + c2))
 - Code(Counter(1)) at (prev + 1, 14) to (start + 0, 16)
@@ -240,26 +240,26 @@ Number of file 0 mappings: 5
     = ((c2 + c1) + (c0 - (c1 + c2)))
 
 Function name: async::m
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 57, 01, 00, 19]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 5a, 01, 00, 19]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 87, 1) to (start + 0, 25)
+- Code(Counter(0)) at (prev + 90, 1) to (start + 0, 25)
 
 Function name: async::m::{closure#0} (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 57, 19, 00, 22]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 5a, 19, 00, 22]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 87, 25) to (start + 0, 34)
+- Code(Zero) at (prev + 90, 25) to (start + 0, 34)
 
 Function name: async::main
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 59, 01, 08, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 5c, 01, 08, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 89, 1) to (start + 8, 2)
+- Code(Counter(0)) at (prev + 92, 1) to (start + 8, 2)
 

--- a/tests/coverage/async.coverage
+++ b/tests/coverage/async.coverage
@@ -6,6 +6,9 @@
    LL|       |//@ edition: 2018
    LL|       |//@ compile-flags: -Copt-level=1
    LL|       |
+   LL|       |//@ aux-build: executor.rs
+   LL|       |extern crate executor;
+   LL|       |
    LL|      1|async fn c(x: u8) -> u8 {
    LL|      1|    if x == 8 {
    LL|      1|        1
@@ -100,22 +103,4 @@
    LL|      1|    let _ = m(5);
    LL|      1|    executor::block_on(future.as_mut());
    LL|      1|}
-   LL|       |
-   LL|       |mod executor {
-   LL|       |    use core::future::Future;
-   LL|       |    use core::pin::pin;
-   LL|       |    use core::task::{Context, Poll, Waker};
-   LL|       |
-   LL|       |    #[coverage(off)]
-   LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-   LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
-   LL|       |
-   LL|       |        loop {
-   LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-   LL|       |                break val;
-   LL|       |            }
-   LL|       |        }
-   LL|       |    }
-   LL|       |}
 

--- a/tests/coverage/async.rs
+++ b/tests/coverage/async.rs
@@ -6,6 +6,9 @@
 //@ edition: 2018
 //@ compile-flags: -Copt-level=1
 
+//@ aux-build: executor.rs
+extern crate executor;
+
 async fn c(x: u8) -> u8 {
     if x == 8 {
         1
@@ -94,22 +97,4 @@ fn main() {
     l(6);
     let _ = m(5);
     executor::block_on(future.as_mut());
-}
-
-mod executor {
-    use core::future::Future;
-    use core::pin::pin;
-    use core::task::{Context, Poll, Waker};
-
-    #[coverage(off)]
-    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-        let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
-
-        loop {
-            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-                break val;
-            }
-        }
-    }
 }

--- a/tests/coverage/async2.cov-map
+++ b/tests/coverage/async2.cov-map
@@ -1,53 +1,53 @@
 Function name: async2::async_func
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 0d, 01, 00, 17]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 10, 01, 00, 17]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 13, 1) to (start + 0, 23)
+- Code(Counter(0)) at (prev + 16, 1) to (start + 0, 23)
 
 Function name: async2::async_func::{closure#0}
-Raw bytes (24): 0x[01, 01, 00, 04, 01, 0d, 17, 03, 09, 05, 03, 0a, 02, 06, 00, 02, 06, 00, 07, 01, 01, 01, 00, 02]
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 10, 17, 03, 09, 05, 03, 0a, 02, 06, 00, 02, 06, 00, 07, 01, 01, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 13, 23) to (start + 3, 9)
+- Code(Counter(0)) at (prev + 16, 23) to (start + 3, 9)
 - Code(Counter(1)) at (prev + 3, 10) to (start + 2, 6)
 - Code(Zero) at (prev + 2, 6) to (start + 0, 7)
 - Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)
 
 Function name: async2::async_func_just_println
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 15, 01, 00, 24]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 18, 01, 00, 24]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 21, 1) to (start + 0, 36)
+- Code(Counter(0)) at (prev + 24, 1) to (start + 0, 36)
 
 Function name: async2::async_func_just_println::{closure#0}
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 15, 24, 02, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 18, 24, 02, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 21, 36) to (start + 2, 2)
+- Code(Counter(0)) at (prev + 24, 36) to (start + 2, 2)
 
 Function name: async2::main
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 19, 01, 07, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 1c, 01, 07, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 25, 1) to (start + 7, 2)
+- Code(Counter(0)) at (prev + 28, 1) to (start + 7, 2)
 
 Function name: async2::non_async_func
-Raw bytes (24): 0x[01, 01, 00, 04, 01, 05, 01, 03, 09, 05, 03, 0a, 02, 06, 00, 02, 06, 00, 07, 01, 01, 01, 00, 02]
+Raw bytes (24): 0x[01, 01, 00, 04, 01, 08, 01, 03, 09, 05, 03, 0a, 02, 06, 00, 02, 06, 00, 07, 01, 01, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 5, 1) to (start + 3, 9)
+- Code(Counter(0)) at (prev + 8, 1) to (start + 3, 9)
 - Code(Counter(1)) at (prev + 3, 10) to (start + 2, 6)
 - Code(Zero) at (prev + 2, 6) to (start + 0, 7)
 - Code(Counter(0)) at (prev + 1, 1) to (start + 0, 2)

--- a/tests/coverage/async2.coverage
+++ b/tests/coverage/async2.coverage
@@ -2,6 +2,9 @@
    LL|       |#![feature(noop_waker)]
    LL|       |//@ edition: 2018
    LL|       |
+   LL|       |//@ aux-build: executor.rs
+   LL|       |extern crate executor;
+   LL|       |
    LL|      1|fn non_async_func() {
    LL|      1|    println!("non_async_func was covered");
    LL|      1|    let b = true;
@@ -32,22 +35,4 @@
    LL|      1|    executor::block_on(async_func());
    LL|      1|    executor::block_on(async_func_just_println());
    LL|      1|}
-   LL|       |
-   LL|       |mod executor {
-   LL|       |    use core::future::Future;
-   LL|       |    use core::pin::pin;
-   LL|       |    use core::task::{Context, Poll, Waker};
-   LL|       |
-   LL|       |    #[coverage(off)]
-   LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-   LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
-   LL|       |
-   LL|       |        loop {
-   LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-   LL|       |                break val;
-   LL|       |            }
-   LL|       |        }
-   LL|       |    }
-   LL|       |}
 

--- a/tests/coverage/async2.rs
+++ b/tests/coverage/async2.rs
@@ -2,6 +2,9 @@
 #![feature(noop_waker)]
 //@ edition: 2018
 
+//@ aux-build: executor.rs
+extern crate executor;
+
 fn non_async_func() {
     println!("non_async_func was covered");
     let b = true;
@@ -29,22 +32,4 @@ fn main() {
 
     executor::block_on(async_func());
     executor::block_on(async_func_just_println());
-}
-
-mod executor {
-    use core::future::Future;
-    use core::pin::pin;
-    use core::task::{Context, Poll, Waker};
-
-    #[coverage(off)]
-    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-        let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
-
-        loop {
-            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-                break val;
-            }
-        }
-    }
 }

--- a/tests/coverage/async_block.cov-map
+++ b/tests/coverage/async_block.cov-map
@@ -1,11 +1,11 @@
 Function name: async_block::main
-Raw bytes (36): 0x[01, 01, 01, 01, 05, 06, 01, 05, 01, 00, 0b, 05, 01, 09, 00, 0a, 03, 00, 0e, 00, 13, 05, 00, 14, 01, 16, 05, 07, 0a, 02, 06, 01, 03, 01, 00, 02]
+Raw bytes (36): 0x[01, 01, 01, 01, 05, 06, 01, 08, 01, 00, 0b, 05, 01, 09, 00, 0a, 03, 00, 0e, 00, 13, 05, 00, 14, 01, 16, 05, 07, 0a, 02, 06, 01, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
 Number of file 0 mappings: 6
-- Code(Counter(0)) at (prev + 5, 1) to (start + 0, 11)
+- Code(Counter(0)) at (prev + 8, 1) to (start + 0, 11)
 - Code(Counter(1)) at (prev + 1, 9) to (start + 0, 10)
 - Code(Expression(0, Add)) at (prev + 0, 14) to (start + 0, 19)
     = (c0 + c1)
@@ -14,13 +14,13 @@ Number of file 0 mappings: 6
 - Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: async_block::main::{closure#0}
-Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 07, 1c, 01, 17, 05, 01, 18, 02, 0e, 02, 02, 14, 02, 0e, 01, 03, 09, 00, 0a]
+Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 0a, 1c, 01, 17, 05, 01, 18, 02, 0e, 02, 02, 14, 02, 0e, 01, 03, 09, 00, 0a]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
 Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 7, 28) to (start + 1, 23)
+- Code(Counter(0)) at (prev + 10, 28) to (start + 1, 23)
 - Code(Counter(1)) at (prev + 1, 24) to (start + 2, 14)
 - Code(Expression(0, Sub)) at (prev + 2, 20) to (start + 2, 14)
     = (c0 - c1)

--- a/tests/coverage/async_block.coverage
+++ b/tests/coverage/async_block.coverage
@@ -2,6 +2,9 @@
    LL|       |#![feature(noop_waker)]
    LL|       |//@ edition: 2021
    LL|       |
+   LL|       |//@ aux-build: executor.rs
+   LL|       |extern crate executor;
+   LL|       |
    LL|      1|fn main() {
    LL|     17|    for i in 0..16 {
                       ^16
@@ -15,22 +18,4 @@
    LL|     16|        executor::block_on(future);
    LL|     16|    }
    LL|      1|}
-   LL|       |
-   LL|       |mod executor {
-   LL|       |    use core::future::Future;
-   LL|       |    use core::pin::pin;
-   LL|       |    use core::task::{Context, Poll, Waker};
-   LL|       |
-   LL|       |    #[coverage(off)]
-   LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-   LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
-   LL|       |
-   LL|       |        loop {
-   LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-   LL|       |                break val;
-   LL|       |            }
-   LL|       |        }
-   LL|       |    }
-   LL|       |}
 

--- a/tests/coverage/async_block.rs
+++ b/tests/coverage/async_block.rs
@@ -2,6 +2,9 @@
 #![feature(noop_waker)]
 //@ edition: 2021
 
+//@ aux-build: executor.rs
+extern crate executor;
+
 fn main() {
     for i in 0..16 {
         let future = async {
@@ -12,23 +15,5 @@ fn main() {
             }
         };
         executor::block_on(future);
-    }
-}
-
-mod executor {
-    use core::future::Future;
-    use core::pin::pin;
-    use core::task::{Context, Poll, Waker};
-
-    #[coverage(off)]
-    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-        let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
-
-        loop {
-            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-                break val;
-            }
-        }
     }
 }

--- a/tests/coverage/auxiliary/executor.rs
+++ b/tests/coverage/auxiliary/executor.rs
@@ -1,0 +1,19 @@
+#![feature(coverage_attribute, noop_waker)]
+//@ edition: 2021
+
+use core::future::Future;
+use core::pin::pin;
+use core::task::{Context, Poll, Waker};
+
+/// Dummy "executor" that just repeatedly polls a future until it's ready.
+#[coverage(off)]
+pub fn block_on<F: Future>(mut future: F) -> F::Output {
+    let mut future = pin!(future);
+    let mut context = Context::from_waker(Waker::noop());
+
+    loop {
+        if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
+            break val;
+        }
+    }
+}

--- a/tests/coverage/await_ready.cov-map
+++ b/tests/coverage/await_ready.cov-map
@@ -1,25 +1,17 @@
 Function name: await_ready::await_ready
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 0a, 01, 00, 1e]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 0f, 01, 00, 1e]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 10, 1) to (start + 0, 30)
+- Code(Counter(0)) at (prev + 15, 1) to (start + 0, 30)
 
 Function name: await_ready::await_ready::{closure#0}
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 0a, 1e, 03, 0f, 05, 04, 01, 00, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 0f, 1e, 03, 0f, 05, 04, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 10, 30) to (start + 3, 15)
+- Code(Counter(0)) at (prev + 15, 30) to (start + 3, 15)
 - Code(Counter(1)) at (prev + 4, 1) to (start + 0, 2)
-
-Function name: await_ready::main
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 10, 01, 03, 02]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 16, 1) to (start + 3, 2)
 

--- a/tests/coverage/await_ready.coverage
+++ b/tests/coverage/await_ready.coverage
@@ -1,38 +1,25 @@
    LL|       |#![feature(coverage_attribute)]
-   LL|       |#![feature(custom_inner_attributes)] // for #![rustfmt::skip]
    LL|       |#![feature(noop_waker)]
-   LL|       |#![rustfmt::skip]
+   LL|       |#![coverage(off)]
    LL|       |//@ edition: 2021
    LL|       |
-   LL|       |#[coverage(off)]
-   LL|       |async fn ready() -> u8 { 1 }
+   LL|       |//@ aux-build: executor.rs
+   LL|       |extern crate executor;
    LL|       |
+   LL|       |async fn ready() -> u8 {
+   LL|       |    1
+   LL|       |}
+   LL|       |
+   LL|       |#[coverage(on)]
+   LL|       |#[rustfmt::skip]
    LL|      1|async fn await_ready() -> u8 {
    LL|      1|    // await should be covered even if the function never yields
    LL|      1|    ready()
    LL|      1|        .await
    LL|      1|}
    LL|       |
-   LL|      1|fn main() {
-   LL|      1|    let mut future = Box::pin(await_ready());
-   LL|      1|    executor::block_on(future.as_mut());
-   LL|      1|}
-   LL|       |
-   LL|       |mod executor {
-   LL|       |    use core::future::Future;
-   LL|       |    use core::pin::pin;
-   LL|       |    use core::task::{Context, Poll, Waker};
-   LL|       |
-   LL|       |    #[coverage(off)]
-   LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-   LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
-   LL|       |
-   LL|       |        loop {
-   LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-   LL|       |                break val;
-   LL|       |            }
-   LL|       |        }
-   LL|       |    }
+   LL|       |fn main() {
+   LL|       |    let mut future = Box::pin(await_ready());
+   LL|       |    executor::block_on(future.as_mut());
    LL|       |}
 

--- a/tests/coverage/await_ready.rs
+++ b/tests/coverage/await_ready.rs
@@ -1,12 +1,17 @@
 #![feature(coverage_attribute)]
-#![feature(custom_inner_attributes)] // for #![rustfmt::skip]
 #![feature(noop_waker)]
-#![rustfmt::skip]
+#![coverage(off)]
 //@ edition: 2021
 
-#[coverage(off)]
-async fn ready() -> u8 { 1 }
+//@ aux-build: executor.rs
+extern crate executor;
 
+async fn ready() -> u8 {
+    1
+}
+
+#[coverage(on)]
+#[rustfmt::skip]
 async fn await_ready() -> u8 {
     // await should be covered even if the function never yields
     ready()
@@ -16,22 +21,4 @@ async fn await_ready() -> u8 {
 fn main() {
     let mut future = Box::pin(await_ready());
     executor::block_on(future.as_mut());
-}
-
-mod executor {
-    use core::future::Future;
-    use core::pin::pin;
-    use core::task::{Context, Poll, Waker};
-
-    #[coverage(off)]
-    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-        let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
-
-        loop {
-            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-                break val;
-            }
-        }
-    }
 }

--- a/tests/coverage/closure_macro_async.cov-map
+++ b/tests/coverage/closure_macro_async.cov-map
@@ -1,27 +1,27 @@
 Function name: closure_macro_async::load_configuration_files
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 1f, 01, 02, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 22, 01, 02, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 31, 1) to (start + 2, 2)
+- Code(Counter(0)) at (prev + 34, 1) to (start + 2, 2)
 
 Function name: closure_macro_async::test
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 23, 01, 00, 2b]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 26, 01, 00, 2b]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 35, 1) to (start + 0, 43)
+- Code(Counter(0)) at (prev + 38, 1) to (start + 0, 43)
 
 Function name: closure_macro_async::test::{closure#0}
-Raw bytes (36): 0x[01, 01, 01, 01, 05, 06, 01, 23, 2b, 01, 21, 02, 02, 09, 00, 0f, 01, 00, 12, 00, 54, 05, 00, 54, 00, 55, 02, 02, 09, 02, 0b, 01, 03, 01, 00, 02]
+Raw bytes (36): 0x[01, 01, 01, 01, 05, 06, 01, 26, 2b, 01, 21, 02, 02, 09, 00, 0f, 01, 00, 12, 00, 54, 05, 00, 54, 00, 55, 02, 02, 09, 02, 0b, 01, 03, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
 Number of file 0 mappings: 6
-- Code(Counter(0)) at (prev + 35, 43) to (start + 1, 33)
+- Code(Counter(0)) at (prev + 38, 43) to (start + 1, 33)
 - Code(Expression(0, Sub)) at (prev + 2, 9) to (start + 0, 15)
     = (c0 - c1)
 - Code(Counter(0)) at (prev + 0, 18) to (start + 0, 84)
@@ -31,7 +31,7 @@ Number of file 0 mappings: 6
 - Code(Counter(0)) at (prev + 3, 1) to (start + 0, 2)
 
 Function name: closure_macro_async::test::{closure#0}::{closure#0}
-Raw bytes (35): 0x[01, 01, 03, 01, 05, 05, 0b, 09, 00, 05, 01, 12, 1c, 03, 21, 05, 04, 11, 01, 27, 02, 03, 11, 00, 16, 00, 00, 17, 00, 1e, 07, 02, 09, 00, 0a]
+Raw bytes (35): 0x[01, 01, 03, 01, 05, 05, 0b, 09, 00, 05, 01, 15, 1c, 03, 21, 05, 04, 11, 01, 27, 02, 03, 11, 00, 16, 00, 00, 17, 00, 1e, 07, 02, 09, 00, 0a]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 3
@@ -39,7 +39,7 @@ Number of expressions: 3
 - expression 1 operands: lhs = Counter(1), rhs = Expression(2, Add)
 - expression 2 operands: lhs = Counter(2), rhs = Zero
 Number of file 0 mappings: 5
-- Code(Counter(0)) at (prev + 18, 28) to (start + 3, 33)
+- Code(Counter(0)) at (prev + 21, 28) to (start + 3, 33)
 - Code(Counter(1)) at (prev + 4, 17) to (start + 1, 39)
 - Code(Expression(0, Sub)) at (prev + 3, 17) to (start + 0, 22)
     = (c0 - c1)

--- a/tests/coverage/closure_macro_async.coverage
+++ b/tests/coverage/closure_macro_async.coverage
@@ -2,6 +2,9 @@
    LL|       |#![feature(noop_waker)]
    LL|       |//@ edition: 2018
    LL|       |
+   LL|       |//@ aux-build: executor.rs
+   LL|       |extern crate executor;
+   LL|       |
    LL|       |macro_rules! bail {
    LL|       |    ($msg:literal $(,)?) => {
    LL|       |        if $msg.len() > 0 {
@@ -45,23 +48,5 @@
    LL|       |#[coverage(off)]
    LL|       |fn main() {
    LL|       |    executor::block_on(test()).unwrap();
-   LL|       |}
-   LL|       |
-   LL|       |mod executor {
-   LL|       |    use core::future::Future;
-   LL|       |    use core::pin::pin;
-   LL|       |    use core::task::{Context, Poll, Waker};
-   LL|       |
-   LL|       |    #[coverage(off)]
-   LL|       |    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-   LL|       |        let mut future = pin!(future);
-   LL|       |        let mut context = Context::from_waker(Waker::noop());
-   LL|       |
-   LL|       |        loop {
-   LL|       |            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-   LL|       |                break val;
-   LL|       |            }
-   LL|       |        }
-   LL|       |    }
    LL|       |}
 

--- a/tests/coverage/closure_macro_async.rs
+++ b/tests/coverage/closure_macro_async.rs
@@ -2,6 +2,9 @@
 #![feature(noop_waker)]
 //@ edition: 2018
 
+//@ aux-build: executor.rs
+extern crate executor;
+
 macro_rules! bail {
     ($msg:literal $(,)?) => {
         if $msg.len() > 0 {
@@ -44,22 +47,4 @@ pub async fn test() -> Result<(), String> {
 #[coverage(off)]
 fn main() {
     executor::block_on(test()).unwrap();
-}
-
-mod executor {
-    use core::future::Future;
-    use core::pin::pin;
-    use core::task::{Context, Poll, Waker};
-
-    #[coverage(off)]
-    pub fn block_on<F: Future>(mut future: F) -> F::Output {
-        let mut future = pin!(future);
-        let mut context = Context::from_waker(Waker::noop());
-
-        loop {
-            if let Poll::Ready(val) = future.as_mut().poll(&mut context) {
-                break val;
-            }
-        }
-    }
 }

--- a/tests/incremental/issue-61530.rs
+++ b/tests/incremental/issue-61530.rs
@@ -9,9 +9,12 @@ extern "rust-intrinsic" {
     fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 
+#[repr(simd)]
+struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
+
 fn main() {
     unsafe {
-        const IDX: [u32; 2] = [0, 0];
+        const IDX: SimdShuffleIdx<2> = SimdShuffleIdx([0, 0]);
         let _: I32x2 = simd_shuffle(I32x2([1, 2]), I32x2([3, 4]), IDX);
         let _: I32x2 = simd_shuffle(I32x2([1, 2]), I32x2([3, 4]), IDX);
     }

--- a/tests/ui/offset-of/offset-of-tuple.rs
+++ b/tests/ui/offset-of/offset-of-tuple.rs
@@ -28,6 +28,7 @@ type ComplexTup = (((u8, u8), u8), u8);
 
 fn nested() {
     offset_of!(((u8, u16), (u32, u16, u8)), 0.2); //~ ERROR no field `2`
+    offset_of!(((u8, u16), (u32, u16, u8)), 0.1e2); //~ ERROR no field `1e2`
     offset_of!(((u8, u16), (u32, u16, u8)), 1.2);
     offset_of!(((u8, u16), (u32, u16, u8)), 1.2.0); //~ ERROR no field `0`
 

--- a/tests/ui/offset-of/offset-of-tuple.stderr
+++ b/tests/ui/offset-of/offset-of-tuple.stderr
@@ -29,43 +29,43 @@ LL |     { builtin # offset_of((u8, u8), 1 .) };
    |                                        ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:46:45
+  --> $DIR/offset-of-tuple.rs:47:45
    |
 LL |     { builtin # offset_of(ComplexTup, 0.0.1.) };
    |                                             ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:47:46
+  --> $DIR/offset-of-tuple.rs:48:46
    |
 LL |     { builtin # offset_of(ComplexTup, 0 .0.1.) };
    |                                              ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:48:47
+  --> $DIR/offset-of-tuple.rs:49:47
    |
 LL |     { builtin # offset_of(ComplexTup, 0 . 0.1.) };
    |                                               ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:49:46
+  --> $DIR/offset-of-tuple.rs:50:46
    |
 LL |     { builtin # offset_of(ComplexTup, 0. 0.1.) };
    |                                              ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:50:46
+  --> $DIR/offset-of-tuple.rs:51:46
    |
 LL |     { builtin # offset_of(ComplexTup, 0.0 .1.) };
    |                                              ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:51:47
+  --> $DIR/offset-of-tuple.rs:52:47
    |
 LL |     { builtin # offset_of(ComplexTup, 0.0 . 1.) };
    |                                               ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:52:46
+  --> $DIR/offset-of-tuple.rs:53:46
    |
 LL |     { builtin # offset_of(ComplexTup, 0.0. 1.) };
    |                                              ^
@@ -104,43 +104,43 @@ LL |     offset_of!((u8, u8), 1 .);
    |                             ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:35:34
+  --> $DIR/offset-of-tuple.rs:36:34
    |
 LL |     offset_of!(ComplexTup, 0.0.1.);
    |                                  ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:36:35
+  --> $DIR/offset-of-tuple.rs:37:35
    |
 LL |     offset_of!(ComplexTup, 0 .0.1.);
    |                                   ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:37:36
+  --> $DIR/offset-of-tuple.rs:38:36
    |
 LL |     offset_of!(ComplexTup, 0 . 0.1.);
    |                                    ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:38:35
+  --> $DIR/offset-of-tuple.rs:39:35
    |
 LL |     offset_of!(ComplexTup, 0. 0.1.);
    |                                   ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:39:35
+  --> $DIR/offset-of-tuple.rs:40:35
    |
 LL |     offset_of!(ComplexTup, 0.0 .1.);
    |                                   ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:40:36
+  --> $DIR/offset-of-tuple.rs:41:36
    |
 LL |     offset_of!(ComplexTup, 0.0 . 1.);
    |                                    ^
 
 error: unexpected token: `)`
-  --> $DIR/offset-of-tuple.rs:41:35
+  --> $DIR/offset-of-tuple.rs:42:35
    |
 LL |     offset_of!(ComplexTup, 0.0. 1.);
    |                                   ^
@@ -196,22 +196,21 @@ LL |     builtin # offset_of((u8, u8), 1_u8);
 error[E0609]: no field `2` on type `(u8, u16)`
   --> $DIR/offset-of-tuple.rs:30:47
    |
-LL |       offset_of!(((u8, u16), (u32, u16, u8)), 0.2);
-   |  _____------------------------------------------^-
-   | |     |
-   | |     in this macro invocation
-LL | |     offset_of!(((u8, u16), (u32, u16, u8)), 1.2);
-LL | |     offset_of!(((u8, u16), (u32, u16, u8)), 1.2.0);
-...  |
+LL |     offset_of!(((u8, u16), (u32, u16, u8)), 0.2);
+   |                                               ^
+
+error[E0609]: no field `1e2` on type `(u8, u16)`
+  --> $DIR/offset-of-tuple.rs:31:47
    |
-   = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
+LL |     offset_of!(((u8, u16), (u32, u16, u8)), 0.1e2);
+   |                                               ^^^
 
 error[E0609]: no field `0` on type `u8`
-  --> $DIR/offset-of-tuple.rs:32:49
+  --> $DIR/offset-of-tuple.rs:33:49
    |
 LL |     offset_of!(((u8, u16), (u32, u16, u8)), 1.2.0);
    |                                                 ^
 
-error: aborting due to 33 previous errors
+error: aborting due to 34 previous errors
 
 For more information about this error, try `rustc --explain E0609`.

--- a/tests/ui/simd/intrinsic/generic-elements-pass.rs
+++ b/tests/ui/simd/intrinsic/generic-elements-pass.rs
@@ -23,6 +23,9 @@ extern "rust-intrinsic" {
     fn simd_shuffle<T, I, U>(x: T, y: T, idx: I) -> U;
 }
 
+#[repr(simd)]
+struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
+
 macro_rules! all_eq {
     ($a: expr, $b: expr) => {{
         let a = $a;
@@ -30,9 +33,8 @@ macro_rules! all_eq {
         // type inference works better with the concrete type on the
         // left, but humans work better with the expected on the
         // right.
-        assert!(b == a,
-                "{:?} != {:?}", a, b);
-    }}
+        assert!(b == a, "{:?} != {:?}", a, b);
+    }};
 }
 
 fn main() {
@@ -79,20 +81,34 @@ fn main() {
     let y4 = i32x4([140, 141, 142, 143]);
     let y8 = i32x8([180, 181, 182, 183, 184, 185, 186, 187]);
     unsafe {
-        all_eq!(simd_shuffle(x2, y2, const { [3u32, 0] }), i32x2([121, 20]));
-        all_eq!(simd_shuffle(x2, y2, const { [3u32, 0, 1, 2] }), i32x4([121, 20, 21, 120]));
-        all_eq!(simd_shuffle(x2, y2, const { [3u32, 0, 1, 2, 1, 2, 3, 0] }),
-                i32x8([121, 20, 21, 120, 21, 120, 121, 20]));
+        all_eq!(simd_shuffle(x2, y2, const { SimdShuffleIdx([3u32, 0]) }), i32x2([121, 20]));
+        all_eq!(
+            simd_shuffle(x2, y2, const { SimdShuffleIdx([3u32, 0, 1, 2]) }),
+            i32x4([121, 20, 21, 120])
+        );
+        all_eq!(
+            simd_shuffle(x2, y2, const { SimdShuffleIdx([3u32, 0, 1, 2, 1, 2, 3, 0]) }),
+            i32x8([121, 20, 21, 120, 21, 120, 121, 20])
+        );
 
-        all_eq!(simd_shuffle(x4, y4, const { [7u32, 2] }), i32x2([143, 42]));
-        all_eq!(simd_shuffle(x4, y4, const { [7u32, 2, 5, 0] }), i32x4([143, 42, 141, 40]));
-        all_eq!(simd_shuffle(x4, y4, const { [7u32, 2, 5, 0, 3, 6, 4, 1] }),
-                i32x8([143, 42, 141, 40, 43, 142, 140, 41]));
+        all_eq!(simd_shuffle(x4, y4, const { SimdShuffleIdx([7u32, 2]) }), i32x2([143, 42]));
+        all_eq!(
+            simd_shuffle(x4, y4, const { SimdShuffleIdx([7u32, 2, 5, 0]) }),
+            i32x4([143, 42, 141, 40])
+        );
+        all_eq!(
+            simd_shuffle(x4, y4, const { SimdShuffleIdx([7u32, 2, 5, 0, 3, 6, 4, 1]) }),
+            i32x8([143, 42, 141, 40, 43, 142, 140, 41])
+        );
 
-        all_eq!(simd_shuffle(x8, y8, const { [11u32, 5] }), i32x2([183, 85]));
-        all_eq!(simd_shuffle(x8, y8, const { [11u32, 5, 15, 0] }), i32x4([183, 85, 187, 80]));
-        all_eq!(simd_shuffle(x8, y8, const { [11u32, 5, 15, 0, 3, 8, 12, 1] }),
-                i32x8([183, 85, 187, 80, 83, 180, 184, 81]));
+        all_eq!(simd_shuffle(x8, y8, const { SimdShuffleIdx([11u32, 5]) }), i32x2([183, 85]));
+        all_eq!(
+            simd_shuffle(x8, y8, const { SimdShuffleIdx([11u32, 5, 15, 0]) }),
+            i32x4([183, 85, 187, 80])
+        );
+        all_eq!(
+            simd_shuffle(x8, y8, const { SimdShuffleIdx([11u32, 5, 15, 0, 3, 8, 12, 1]) }),
+            i32x8([183, 85, 187, 80, 83, 180, 184, 81])
+        );
     }
-
 }

--- a/tests/ui/simd/intrinsic/generic-elements.rs
+++ b/tests/ui/simd/intrinsic/generic-elements.rs
@@ -37,6 +37,9 @@ extern "rust-intrinsic" {
     fn simd_shuffle_generic<T, U, const IDX: &'static [u32]>(x: T, y: T) -> U;
 }
 
+#[repr(simd)]
+struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
+
 fn main() {
     let x = i32x4([0, 0, 0, 0]);
 
@@ -48,13 +51,13 @@ fn main() {
         simd_extract::<_, f32>(x, 0);
         //~^ ERROR expected return type `i32` (element of input `i32x4`), found `f32`
 
-        const IDX2: [u32; 2] = [0; 2];
+        const IDX2: SimdShuffleIdx<2> = SimdShuffleIdx([0; 2]);
         simd_shuffle::<i32, _, i32>(0, 0, IDX2);
         //~^ ERROR expected SIMD input type, found non-SIMD `i32`
-        const IDX4: [u32; 4] = [0; 4];
+        const IDX4: SimdShuffleIdx<4> = SimdShuffleIdx([0; 4]);
         simd_shuffle::<i32, _, i32>(0, 0, IDX4);
         //~^ ERROR expected SIMD input type, found non-SIMD `i32`
-        const IDX8: [u32; 8] = [0; 8];
+        const IDX8: SimdShuffleIdx<8> = SimdShuffleIdx([0; 8]);
         simd_shuffle::<i32, _, i32>(0, 0, IDX8);
         //~^ ERROR expected SIMD input type, found non-SIMD `i32`
 

--- a/tests/ui/simd/intrinsic/generic-elements.stderr
+++ b/tests/ui/simd/intrinsic/generic-elements.stderr
@@ -1,125 +1,125 @@
 error[E0511]: invalid monomorphization of `simd_insert` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:44:9
+  --> $DIR/generic-elements.rs:47:9
    |
 LL |         simd_insert(0, 0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_insert` intrinsic: expected inserted type `i32` (element of input `i32x4`), found `f64`
-  --> $DIR/generic-elements.rs:46:9
+  --> $DIR/generic-elements.rs:49:9
    |
 LL |         simd_insert(x, 0, 1.0);
    |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_extract` intrinsic: expected return type `i32` (element of input `i32x4`), found `f32`
-  --> $DIR/generic-elements.rs:48:9
+  --> $DIR/generic-elements.rs:51:9
    |
 LL |         simd_extract::<_, f32>(x, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:52:9
+  --> $DIR/generic-elements.rs:55:9
    |
 LL |         simd_shuffle::<i32, _, i32>(0, 0, IDX2);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:55:9
+  --> $DIR/generic-elements.rs:58:9
    |
 LL |         simd_shuffle::<i32, _, i32>(0, 0, IDX4);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:58:9
+  --> $DIR/generic-elements.rs:61:9
    |
 LL |         simd_shuffle::<i32, _, i32>(0, 0, IDX8);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x2` with element type `f32`
-  --> $DIR/generic-elements.rs:61:9
+  --> $DIR/generic-elements.rs:64:9
    |
 LL |         simd_shuffle::<_, _, f32x2>(x, x, IDX2);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x4` with element type `f32`
-  --> $DIR/generic-elements.rs:63:9
+  --> $DIR/generic-elements.rs:66:9
    |
 LL |         simd_shuffle::<_, _, f32x4>(x, x, IDX4);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x8` with element type `f32`
-  --> $DIR/generic-elements.rs:65:9
+  --> $DIR/generic-elements.rs:68:9
    |
 LL |         simd_shuffle::<_, _, f32x8>(x, x, IDX8);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 2, found `i32x8` with length 8
-  --> $DIR/generic-elements.rs:68:9
+  --> $DIR/generic-elements.rs:71:9
    |
 LL |         simd_shuffle::<_, _, i32x8>(x, x, IDX2);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 4, found `i32x8` with length 8
-  --> $DIR/generic-elements.rs:70:9
+  --> $DIR/generic-elements.rs:73:9
    |
 LL |         simd_shuffle::<_, _, i32x8>(x, x, IDX4);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 8, found `i32x2` with length 2
-  --> $DIR/generic-elements.rs:72:9
+  --> $DIR/generic-elements.rs:75:9
    |
 LL |         simd_shuffle::<_, _, i32x2>(x, x, IDX8);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_generic` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:76:9
+  --> $DIR/generic-elements.rs:79:9
    |
 LL |         simd_shuffle_generic::<i32, i32, I2>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_generic` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:79:9
+  --> $DIR/generic-elements.rs:82:9
    |
 LL |         simd_shuffle_generic::<i32, i32, I4>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_generic` intrinsic: expected SIMD input type, found non-SIMD `i32`
-  --> $DIR/generic-elements.rs:82:9
+  --> $DIR/generic-elements.rs:85:9
    |
 LL |         simd_shuffle_generic::<i32, i32, I8>(0, 0);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_generic` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x2` with element type `f32`
-  --> $DIR/generic-elements.rs:85:9
+  --> $DIR/generic-elements.rs:88:9
    |
 LL |         simd_shuffle_generic::<_, f32x2, I2>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_generic` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x4` with element type `f32`
-  --> $DIR/generic-elements.rs:87:9
+  --> $DIR/generic-elements.rs:90:9
    |
 LL |         simd_shuffle_generic::<_, f32x4, I4>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_generic` intrinsic: expected return element type `i32` (element of input `i32x4`), found `f32x8` with element type `f32`
-  --> $DIR/generic-elements.rs:89:9
+  --> $DIR/generic-elements.rs:92:9
    |
 LL |         simd_shuffle_generic::<_, f32x8, I8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_generic` intrinsic: expected return type of length 2, found `i32x8` with length 8
-  --> $DIR/generic-elements.rs:92:9
+  --> $DIR/generic-elements.rs:95:9
    |
 LL |         simd_shuffle_generic::<_, i32x8, I2>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_generic` intrinsic: expected return type of length 4, found `i32x8` with length 8
-  --> $DIR/generic-elements.rs:94:9
+  --> $DIR/generic-elements.rs:97:9
    |
 LL |         simd_shuffle_generic::<_, i32x8, I4>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle_generic` intrinsic: expected return type of length 8, found `i32x2` with length 2
-  --> $DIR/generic-elements.rs:96:9
+  --> $DIR/generic-elements.rs:99:9
    |
 LL |         simd_shuffle_generic::<_, i32x2, I8>(x, x);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/intrinsic/generic-shuffle.rs
+++ b/tests/ui/simd/intrinsic/generic-shuffle.rs
@@ -14,12 +14,15 @@ extern "rust-intrinsic" {
 }
 
 fn main() {
-    const I: [u32; 2] = [0; 2];
-    const I2: [f32; 2] = [0.; 2];
+    const I: Simd<u32, 2> = Simd([0; 2]);
+    const I2: Simd<f32, 2> = Simd([0.; 2]);
     let v = Simd::<u32, 4>([0; 4]);
 
     unsafe {
         let _: Simd<u32, 2> = simd_shuffle(v, v, I);
+
+        let _: Simd<u32, 2> = simd_shuffle(v, v, const { [0u32; 2] });
+        //~^ ERROR invalid monomorphization of `simd_shuffle` intrinsic
 
         let _: Simd<u32, 4> = simd_shuffle(v, v, I);
         //~^ ERROR invalid monomorphization of `simd_shuffle` intrinsic

--- a/tests/ui/simd/intrinsic/generic-shuffle.stderr
+++ b/tests/ui/simd/intrinsic/generic-shuffle.stderr
@@ -1,21 +1,27 @@
-error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 2, found `Simd<u32, 4>` with length 4
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: simd_shuffle index must be a SIMD vector of `u32`, got `[u32; 2]`
   --> $DIR/generic-shuffle.rs:24:31
+   |
+LL |         let _: Simd<u32, 2> = simd_shuffle(v, v, const { [0u32; 2] });
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return type of length 2, found `Simd<u32, 4>` with length 4
+  --> $DIR/generic-shuffle.rs:27:31
    |
 LL |         let _: Simd<u32, 4> = simd_shuffle(v, v, I);
    |                               ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: expected return element type `u32` (element of input `Simd<u32, 4>`), found `Simd<f32, 2>` with element type `f32`
-  --> $DIR/generic-shuffle.rs:27:31
+  --> $DIR/generic-shuffle.rs:30:31
    |
 LL |         let _: Simd<f32, 2> = simd_shuffle(v, v, I);
    |                               ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: simd_shuffle index must be an array of `u32`, got `[f32; 2]`
-  --> $DIR/generic-shuffle.rs:30:31
+error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: simd_shuffle index must be a SIMD vector of `u32`, got `Simd<f32, 2>`
+  --> $DIR/generic-shuffle.rs:33:31
    |
 LL |         let _: Simd<u32, 2> = simd_shuffle(v, v, I2);
    |                               ^^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0511`.

--- a/tests/ui/simd/intrinsic/inlining-issue67557-ice.rs
+++ b/tests/ui/simd/intrinsic/inlining-issue67557-ice.rs
@@ -13,6 +13,9 @@ extern "rust-intrinsic" {
 #[derive(Debug, PartialEq)]
 struct Simd2([u8; 2]);
 
+#[repr(simd)]
+struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
+
 fn main() {
     unsafe {
         let _: Simd2 = inline_me();
@@ -21,6 +24,6 @@ fn main() {
 
 #[inline(always)]
 unsafe fn inline_me() -> Simd2 {
-    const IDX: [u32; 2] = [0, 3];
+    const IDX: SimdShuffleIdx<2> = SimdShuffleIdx([0, 3]);
     simd_shuffle(Simd2([10, 11]), Simd2([12, 13]), IDX)
 }

--- a/tests/ui/simd/intrinsic/inlining-issue67557.rs
+++ b/tests/ui/simd/intrinsic/inlining-issue67557.rs
@@ -13,9 +13,12 @@ extern "rust-intrinsic" {
 #[derive(Debug, PartialEq)]
 struct Simd2([u8; 2]);
 
+#[repr(simd)]
+struct SimdShuffleIdx<const LEN: usize>([u32; LEN]);
+
 fn main() {
     unsafe {
-        const IDX: [u32; 2] = [0, 1];
+        const IDX: SimdShuffleIdx<2> = SimdShuffleIdx([0, 1]);
         let p_res: Simd2 = simd_shuffle(Simd2([10, 11]), Simd2([12, 13]), IDX);
         let a_res: Simd2 = inline_me();
 
@@ -37,6 +40,6 @@ fn assert_10_13(x: Simd2) {
 
 #[inline(always)]
 unsafe fn inline_me() -> Simd2 {
-    const IDX: [u32; 2] = [0, 3];
+    const IDX: SimdShuffleIdx<2> = SimdShuffleIdx([0, 3]);
     simd_shuffle(Simd2([10, 11]), Simd2([12, 13]), IDX)
 }

--- a/tests/ui/simd/monomorphize-shuffle-index.generic.stderr
+++ b/tests/ui/simd/monomorphize-shuffle-index.generic.stderr
@@ -1,8 +1,8 @@
 error: overly complex generic constant
   --> $DIR/monomorphize-shuffle-index.rs:29:45
    |
-LL |         return simd_shuffle_generic::<_, _, { &Self::I }>(a, b);
-   |                                             ^^--------^^
+LL |         return simd_shuffle_generic::<_, _, { &Self::I.0 }>(a, b);
+   |                                             ^^----------^^
    |                                               |
    |                                               pointer casts are not allowed in generic constants
    |

--- a/tests/ui/simd/monomorphize-shuffle-index.rs
+++ b/tests/ui/simd/monomorphize-shuffle-index.rs
@@ -16,8 +16,8 @@ extern "rust-intrinsic" {
 struct Simd<T, const N: usize>([T; N]);
 
 trait Shuffle<const N: usize> {
-    const I: [u32; N];
-    const J: &'static [u32] = &Self::I;
+    const I: Simd<u32, N>;
+    const J: &'static [u32] = &Self::I.0;
 
     unsafe fn shuffle<T, const M: usize>(&self, a: Simd<T, M>, b: Simd<T, M>) -> Simd<T, N>
     where
@@ -26,7 +26,7 @@ trait Shuffle<const N: usize> {
         #[cfg(old)]
         return simd_shuffle(a, b, Self::I);
         #[cfg(generic)]
-        return simd_shuffle_generic::<_, _, { &Self::I }>(a, b);
+        return simd_shuffle_generic::<_, _, { &Self::I.0 }>(a, b);
         //[generic]~^ overly complex generic constant
         #[cfg(generic_with_fn)]
         return simd_shuffle_generic::<_, _, { Self::J }>(a, b);
@@ -38,12 +38,12 @@ struct Thing<const X: &'static [u32]>;
 fn main() {
     struct I1;
     impl Shuffle<4> for I1 {
-        const I: [u32; 4] = [0, 2, 4, 6];
+        const I: Simd<u32, 4> = Simd([0, 2, 4, 6]);
     }
 
     struct I2;
     impl Shuffle<2> for I2 {
-        const I: [u32; 2] = [1, 5];
+        const I: Simd<u32, 2> = Simd([1, 5]);
     }
 
     let a = Simd::<u8, 4>([0, 1, 2, 3]);

--- a/tests/ui/simd/not-out-of-bounds.stderr
+++ b/tests/ui/simd/not-out-of-bounds.stderr
@@ -1,7 +1,7 @@
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 4)
-  --> $DIR/not-out-of-bounds.rs:49:21
+  --> $DIR/not-out-of-bounds.rs:52:21
    |
-LL |                     $y(vec1, vec2, ARR)
+LL |                     $y(vec1, vec2, IDX)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     test_shuffle_lanes!(2, u8x2, simd_shuffle);
@@ -10,9 +10,9 @@ LL |     test_shuffle_lanes!(2, u8x2, simd_shuffle);
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 8)
-  --> $DIR/not-out-of-bounds.rs:49:21
+  --> $DIR/not-out-of-bounds.rs:52:21
    |
-LL |                     $y(vec1, vec2, ARR)
+LL |                     $y(vec1, vec2, IDX)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     test_shuffle_lanes!(4, u8x4, simd_shuffle);
@@ -21,9 +21,9 @@ LL |     test_shuffle_lanes!(4, u8x4, simd_shuffle);
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 16)
-  --> $DIR/not-out-of-bounds.rs:49:21
+  --> $DIR/not-out-of-bounds.rs:52:21
    |
-LL |                     $y(vec1, vec2, ARR)
+LL |                     $y(vec1, vec2, IDX)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     test_shuffle_lanes!(8, u8x8, simd_shuffle);
@@ -32,9 +32,9 @@ LL |     test_shuffle_lanes!(8, u8x8, simd_shuffle);
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 32)
-  --> $DIR/not-out-of-bounds.rs:49:21
+  --> $DIR/not-out-of-bounds.rs:52:21
    |
-LL |                     $y(vec1, vec2, ARR)
+LL |                     $y(vec1, vec2, IDX)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     test_shuffle_lanes!(16, u8x16, simd_shuffle);
@@ -43,9 +43,9 @@ LL |     test_shuffle_lanes!(16, u8x16, simd_shuffle);
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 64)
-  --> $DIR/not-out-of-bounds.rs:49:21
+  --> $DIR/not-out-of-bounds.rs:52:21
    |
-LL |                     $y(vec1, vec2, ARR)
+LL |                     $y(vec1, vec2, IDX)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     test_shuffle_lanes!(32, u8x32, simd_shuffle);
@@ -54,9 +54,9 @@ LL |     test_shuffle_lanes!(32, u8x32, simd_shuffle);
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 128)
-  --> $DIR/not-out-of-bounds.rs:49:21
+  --> $DIR/not-out-of-bounds.rs:52:21
    |
-LL |                     $y(vec1, vec2, ARR)
+LL |                     $y(vec1, vec2, IDX)
    |                     ^^^^^^^^^^^^^^^^^^^
 ...
 LL |     test_shuffle_lanes!(64, u8x64, simd_shuffle);
@@ -65,19 +65,19 @@ LL |     test_shuffle_lanes!(64, u8x64, simd_shuffle);
    = note: this error originates in the macro `test_shuffle_lanes` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0511]: invalid monomorphization of `simd_shuffle` intrinsic: SIMD index #0 is out of bounds (limit 4)
-  --> $DIR/not-out-of-bounds.rs:74:23
+  --> $DIR/not-out-of-bounds.rs:77:23
    |
 LL |         let _: u8x2 = simd_shuffle(v, v, I);
    |                       ^^^^^^^^^^^^^^^^^^^^^
 
-error[E0511]: invalid monomorphization of `simd_insert` intrinsic: expected inserted type `u8` (element of input `u8x2`), found `i32`
-  --> $DIR/not-out-of-bounds.rs:80:9
+error[E0511]: invalid monomorphization of `simd_insert` intrinsic: SIMD index #1 is out of bounds (limit 2)
+  --> $DIR/not-out-of-bounds.rs:83:9
    |
-LL |         simd_insert(v, 2, 0);
-   |         ^^^^^^^^^^^^^^^^^^^^
+LL |         simd_insert(v, 2, 0u8);
+   |         ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0511]: invalid monomorphization of `simd_extract` intrinsic: SIMD index #1 is out of bounds (limit 2)
-  --> $DIR/not-out-of-bounds.rs:81:24
+  --> $DIR/not-out-of-bounds.rs:84:24
    |
 LL |         let _val: u8 = simd_extract(v, 2);
    |                        ^^^^^^^^^^^^^^^^^^

--- a/tests/ui/simd/shuffle.rs
+++ b/tests/ui/simd/shuffle.rs
@@ -16,16 +16,13 @@ extern "rust-intrinsic" {
 #[repr(simd)]
 struct Simd<T, const N: usize>([T; N]);
 
-unsafe fn __shuffle_vector16<const IDX: [u32; 16], T, U>(x: T, y: T) -> U {
-    simd_shuffle(x, y, IDX)
-}
-unsafe fn __shuffle_vector16_v2<const IDX: Simd<u32, 16>, T, U>(x: T, y: T) -> U {
+unsafe fn __shuffle_vector16<const IDX: Simd<u32, 16>, T, U>(x: T, y: T) -> U {
     simd_shuffle(x, y, IDX)
 }
 
 fn main() {
-    const I1: [u32; 4] = [0, 2, 4, 6];
-    const I2: [u32; 2] = [1, 5];
+    const I1: Simd<u32, 4> = Simd([0, 2, 4, 6]);
+    const I2: Simd<u32, 2> = Simd([1, 5]);
     let a = Simd::<u8, 4>([0, 1, 2, 3]);
     let b = Simd::<u8, 4>([4, 5, 6, 7]);
     unsafe {
@@ -33,16 +30,6 @@ fn main() {
         assert_eq!(x.0, [0, 2, 4, 6]);
 
         let y: Simd<u8, 2> = simd_shuffle(a, b, I2);
-        assert_eq!(y.0, [1, 5]);
-    }
-    // Test that we can also use a SIMD vector instead of a normal array for the shuffle.
-    const I1_SIMD: Simd<u32, 4> = Simd([0, 2, 4, 6]);
-    const I2_SIMD: Simd<u32, 2> = Simd([1, 5]);
-    unsafe {
-        let x: Simd<u8, 4> = simd_shuffle(a, b, I1_SIMD);
-        assert_eq!(x.0, [0, 2, 4, 6]);
-
-        let y: Simd<u8, 2> = simd_shuffle(a, b, I2_SIMD);
         assert_eq!(y.0, [1, 5]);
     }
 
@@ -53,13 +40,6 @@ fn main() {
     let b = Simd::<u8, 16>([16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
     unsafe {
         __shuffle_vector16::<
-            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] },
-            Simd<u8, 16>,
-            Simd<u8, 16>,
-        >(a, b);
-    }
-    unsafe {
-        __shuffle_vector16_v2::<
             { Simd([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]) },
             Simd<u8, 16>,
             Simd<u8, 16>,


### PR DESCRIPTION
Successful merges:

 - #130017 (coverage: Extract `executor::block_on` from several async coverage tests)
 - #130268 (simd_shuffle: require index argument to be a vector)
 - #130290 (Stabilize entry_insert)
 - #130294 (Lifetime cleanups)
 - #130343 (docs: Enable required feature for 'closure_returning_async_block' lint)
 - #130349 (Fix `Parser::break_up_float`'s right span)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=130017,130268,130290,130294,130343,130349)
<!-- homu-ignore:end -->