### PR TITLE
less noisy change-tracker

### DIFF
--- a/compiler/rustc_codegen_cranelift/scripts/setup_rust_fork.sh
+++ b/compiler/rustc_codegen_cranelift/scripts/setup_rust_fork.sh
@@ -23,8 +23,6 @@ git -c user.name=Dummy -c user.email=dummy@example.com -c commit.gpgSign=false \
     am ../patches/*-stdlib-*.patch
 
 cat > config.toml <<EOF
-change-id = 999999
-
 [llvm]
 download-ci-llvm = true
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -30,7 +30,7 @@
 #
 # If `change-id` does not match the version that is currently running,
 # `x.py` will inform you about the changes made on bootstrap.
-#change-id = <latest change id in src/bootstrap/src/utils/change_tracker.rs>
+#change-id = <none>
 
 # =============================================================================
 # Tweaking how LLVM is compiled

--- a/src/bootstrap/src/bin/main.rs
+++ b/src/bootstrap/src/bin/main.rs
@@ -171,11 +171,14 @@ fn check_version(config: &Config) -> Option<String> {
         if io::stdout().is_terminal() && !config.dry_run() {
             t!(fs::write(warned_id_path, latest_change_id.to_string()));
         }
-    } else {
+
+        Some(msg)
+    } else if config.is_verbose() {
         msg.push_str("WARNING: The `change-id` is missing in the `config.toml`. This means that you will not be able to track the major changes made to the bootstrap configurations.\n");
         msg.push_str("NOTE: to silence this warning, ");
         msg.push_str(&format!("add `change-id = {latest_change_id}` at the top of `config.toml`"));
-    };
-
-    Some(msg)
+        Some(msg)
+    } else {
+        None
+    }
 }

--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -16,7 +16,6 @@ use std::{fmt, fs, io};
 use sha2::Digest;
 
 use crate::core::builder::{Builder, RunConfig, ShouldRun, Step};
-use crate::utils::change_tracker::CONFIG_CHANGE_HISTORY;
 use crate::utils::exec::command;
 use crate::utils::helpers::{self, hex_encode};
 use crate::{Config, t};
@@ -228,11 +227,9 @@ fn setup_config_toml(path: &PathBuf, profile: Profile, config: &Config) {
         return;
     }
 
-    let latest_change_id = CONFIG_CHANGE_HISTORY.last().unwrap().change_id;
     let settings = format!(
         "# Includes one of the default files in {PROFILE_DIR}\n\
-    profile = \"{profile}\"\n\
-    change-id = {latest_change_id}\n"
+    profile = \"{profile}\"\n"
     );
 
     t!(fs::write(path, settings));

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -47,11 +47,6 @@ source "$ci_dir/shared.sh"
 
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
-# suppress change-tracker warnings on CI
-if [ "$CI" != "" ]; then
-    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set change-id=99999999"
-fi
-
 if ! isCI || isCiBranch auto || isCiBranch beta || isCiBranch try || isCiBranch try-perf || \
   isCiBranch automation/bors/try; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set build.print-step-timings --enable-verbose-tests"


### PR DESCRIPTION
Reduces noise from `change-tracker` by disabling `change-tracker` by default and displaying its help messages only in verbose mode. This means users won't see any change-tracker helper or change messages unless it is explicitly enabled in `config.toml` or the verbose flag is passed.

Alternative to #130356.