### PR TITLE
unstable-book: `trait_upcasting` example should not have `#![allow(incomplete_features)]`

### DIFF
--- a/src/doc/unstable-book/src/language-features/trait-upcasting.md
+++ b/src/doc/unstable-book/src/language-features/trait-upcasting.md
@@ -12,7 +12,6 @@ so long as `Bar: Foo`.
 
 ```rust,edition2018
 #![feature(trait_upcasting)]
-#![allow(incomplete_features)]
 
 trait Foo {}
 


### PR DESCRIPTION
Tracking issue: #65991

`trait_upcasting` is not currently an incomplete feature; therefore examples of its use do not require `#![allow(incomplete_features)]`.
