### PR TITLE
Add copy button to crate version.

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -644,6 +644,29 @@ ul.block, .block li, .block ul {
 	padding-left: var(--sidebar-elems-left-padding);
 }
 
+#copy-cargo-snippet {
+	color: var(--main-color);
+	background: var(--sidebar-background-color);
+	margin-left: 10px;
+	padding: 0;
+	padding-left: 2px;
+	border: 0;
+	font-size: 0;
+
+    scale: 80%;
+    justify-content: center;
+}
+#copy-cargo-snippet::before {
+	filter: var(--copy-path-img-filter);
+	content: var(--clipboard-image);
+}
+#copy-cargo-snippet:hover::before {
+	filter: var(--copy-path-img-hover-filter);
+}
+#copy-cargo-snippet.clicked::before {
+	content: var(--checkmark-image);
+}
+
 .sidebar a {
 	color: var(--sidebar-link-color);
 }
@@ -766,6 +789,9 @@ ul.block, .block li, .block ul {
 	font-weight: normal;
 	font-size: 1rem;
 	overflow-wrap: break-word;
+
+    display: flex;
+    align-items: center;
 }
 
 .sidebar-crate + .version {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -653,8 +653,8 @@ ul.block, .block li, .block ul {
 	border: 0;
 	font-size: 0;
 
-    scale: 80%;
-    justify-content: center;
+	scale: 80%;
+	justify-content: center;
 }
 #copy-cargo-snippet::before {
 	filter: var(--copy-path-img-filter);
@@ -790,8 +790,8 @@ ul.block, .block li, .block ul {
 	font-size: 1rem;
 	overflow-wrap: break-word;
 
-    display: flex;
-    align-items: center;
+	display: flex;
+	align-items: center;
 }
 
 .sidebar-crate + .version {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1842,6 +1842,19 @@ href="https://doc.rust-lang.org/${channel}/rustdoc/read-documentation/search.htm
         copyButtonAnimation(but);
     };
 
+    // Copy button that appears next to the crate version.
+    const crate_version_copy_button = document.getElementById("copy-cargo-snippet");
+    if (!crate_version_copy_button) {
+        return;
+    }
+    crate_version_copy_button.onclick = () => {
+        let crate_version = crate_version_copy_button.parentElement.textContent;
+        let snippet = `${window.currentCrate} = "${crate_version}"`;
+
+        copyContentToClipboard(snippet);
+        copyButtonAnimation(crate_version_copy_button);
+    };
+
     // Copy buttons on code examples.
     function copyCode(codeElem) {
         if (!codeElem) {

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -1848,8 +1848,8 @@ href="https://doc.rust-lang.org/${channel}/rustdoc/read-documentation/search.htm
         return;
     }
     crate_version_copy_button.onclick = () => {
-        let crate_version = crate_version_copy_button.parentElement.textContent;
-        let snippet = `${window.currentCrate} = "${crate_version}"`;
+        const crate_version = crate_version_copy_button.parentElement.textContent;
+        const snippet = `${window.currentCrate} = "${crate_version}"`;
 
         copyContentToClipboard(snippet);
         copyButtonAnimation(crate_version_copy_button);

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -100,7 +100,7 @@
             <h2> {# #}
                 <a href="{{page.root_path|safe}}{{display_krate_with_trailing_slash|safe}}index.html">{{display_krate|wrapped|safe}}</a>
                 {% if !display_krate_version_number.is_empty() %}
-                    <span class="version">{{+ display_krate_version_number}}<button id="copy-cargo-snippet" title="Copy Cargo.toml snippet to clipboard">{# #}</button></span>
+                    <span class="version">{{+ display_krate_version_number}}<button id="copy-cargo-snippet" title="Copy Cargo.toml snippet to clipboard"></button></span>
                 {% endif %}
             </h2> {# #}
         </div>

--- a/src/librustdoc/html/templates/page.html
+++ b/src/librustdoc/html/templates/page.html
@@ -100,7 +100,7 @@
             <h2> {# #}
                 <a href="{{page.root_path|safe}}{{display_krate_with_trailing_slash|safe}}index.html">{{display_krate|wrapped|safe}}</a>
                 {% if !display_krate_version_number.is_empty() %}
-                    <span class="version">{{+ display_krate_version_number}}</span>
+                    <span class="version">{{+ display_krate_version_number}}<button id="copy-cargo-snippet" title="Copy Cargo.toml snippet to clipboard">{# #}</button></span>
                 {% endif %}
             </h2> {# #}
         </div>


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
This PR closes #111143.

Instead of copying strictly the crate version number, this implementation copies a Cargo.toml 'snippet' (the same behavior as the Crates.io copy button). i.e. For a crate called `very_useful_crate` on version `0.1.0`, the copied string would be: `very_useful_crate = "0.1.0"`.