### PR TITLE
Add system libs for LLVM when cross compiling for Windows

### DIFF
--- a/compiler/rustc_llvm/build.rs
+++ b/compiler/rustc_llvm/build.rs
@@ -220,7 +220,10 @@ fn main() {
     let mut cmd = Command::new(&llvm_config);
     cmd.arg(llvm_link_arg).arg("--libs");
 
-    if !is_crossed {
+    // Don't link system libs if cross-compiling unless targetting Windows.
+    // On Windows system DLLs aren't linked directly, instead import libraries are used.
+    // These import libraries are independent of the host.
+    if !is_crossed || target.contains("windows") {
         cmd.arg("--system-libs");
     }
 


### PR DESCRIPTION
Windows uses "import libraries" to link to system libraries. These are a kind of static lib that are distributed with the Windows SDK and therefore they don't rely on the host. All that matters is you have the right SDK installed for the target.