### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_abi/src/lib.rs
+++ b/compiler/rustc_abi/src/lib.rs
@@ -781,6 +781,14 @@ impl Align {
 }
 
 /// A pair of alignments, ABI-mandated and preferred.
+///
+/// The "preferred" alignment is an LLVM concept that is virtually meaningless to Rust code:
+/// it is not exposed semantically to programmers nor can they meaningfully affect it.
+/// The only concern for us is that preferred alignment must not be less than the mandated alignment
+/// and thus in practice the two values are almost always identical.
+///
+/// An example of a rare thing actually affected by preferred alignment is aligning of statics.
+/// It is of effectively no consequence for layout in structs and on the stack.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 #[cfg_attr(feature = "nightly", derive(HashStable_Generic))]
 pub struct AbiAndPrefAlign {

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -185,7 +185,13 @@ pub(crate) fn target_machine_factory(
     let reloc_model = to_llvm_relocation_model(sess.relocation_model());
 
     let (opt_level, _) = to_llvm_opt_settings(optlvl);
-    let use_softfp = sess.opts.cg.soft_float;
+    let use_softfp = if sess.target.arch == "arm" && sess.target.abi == "eabihf" {
+        sess.opts.cg.soft_float
+    } else {
+        // `validate_commandline_args_with_session_available` has already warned about this being ignored.
+        // Let's make sure LLVM doesn't suddenly start using this flag on more targets.
+        false
+    };
 
     let ffunction_sections =
         sess.opts.unstable_opts.function_sections.unwrap_or(sess.target.function_sections);

--- a/compiler/rustc_session/messages.ftl
+++ b/compiler/rustc_session/messages.ftl
@@ -107,6 +107,16 @@ session_sanitizer_not_supported = {$us} sanitizer is not supported for this targ
 session_sanitizers_not_supported = {$us} sanitizers are not supported for this target
 
 session_skipping_const_checks = skipping const checks
+
+session_soft_float_deprecated =
+    `-Csoft-float` is unsound and deprecated; use a corresponding *eabi target instead
+    .note = it will be removed or ignored in a future version of Rust
+session_soft_float_deprecated_issue = see issue #129893 <https://github.com/rust-lang/rust/issues/129893> for more information
+
+session_soft_float_ignored =
+    `-Csoft-float` is ignored on this target; it only has an effect on *eabihf targets
+    .note = this may become a hard error in a future version of Rust
+
 session_split_debuginfo_unstable_platform = `-Csplit-debuginfo={$debuginfo}` is unstable on this platform
 
 session_split_lto_unit_requires_lto = `-Zsplit-lto-unit` requires `-Clto`, `-Clto=thin`, or `-Clinker-plugin-lto`

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -484,3 +484,14 @@ pub(crate) struct FunctionReturnThunkExternRequiresNonLargeCodeModel;
 pub(crate) struct FailedToCreateProfiler {
     pub(crate) err: String,
 }
+
+#[derive(Diagnostic)]
+#[diag(session_soft_float_ignored)]
+#[note]
+pub(crate) struct SoftFloatIgnored;
+
+#[derive(Diagnostic)]
+#[diag(session_soft_float_deprecated)]
+#[note]
+#[note(session_soft_float_deprecated_issue)]
+pub(crate) struct SoftFloatDeprecated;

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1511,6 +1511,7 @@ options! {
     // - src/doc/rustc/src/codegen-options/index.md
 
     // tidy-alphabetical-start
+    #[rustc_lint_opt_deny_field_access("documented to do nothing")]
     ar: String = (String::new(), parse_string, [UNTRACKED],
         "this option is deprecated and does nothing"),
     #[rustc_lint_opt_deny_field_access("use `Session::code_model` instead of this field")]
@@ -1543,6 +1544,7 @@ options! {
         "force use of unwind tables"),
     incremental: Option<String> = (None, parse_opt_string, [UNTRACKED],
         "enable incremental compilation"),
+    #[rustc_lint_opt_deny_field_access("documented to do nothing")]
     inline_threshold: Option<u32> = (None, parse_opt_number, [TRACKED],
         "this option is deprecated and does nothing \
         (consider using `-Cllvm-args=--inline-threshold=...`)"),
@@ -1579,6 +1581,7 @@ options! {
         "give an empty list of passes to the pass manager"),
     no_redzone: Option<bool> = (None, parse_opt_bool, [TRACKED],
         "disable the use of the redzone"),
+    #[rustc_lint_opt_deny_field_access("documented to do nothing")]
     no_stack_check: bool = (false, parse_no_flag, [UNTRACKED],
         "this option is deprecated and does nothing"),
     no_vectorize_loops: bool = (false, parse_no_flag, [TRACKED],

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1615,7 +1615,7 @@ options! {
     save_temps: bool = (false, parse_bool, [UNTRACKED],
         "save all temporary output files during compilation (default: no)"),
     soft_float: bool = (false, parse_bool, [TRACKED],
-        "use soft float ABI (*eabihf targets only) (default: no)"),
+        "deprecated option: use soft float ABI (*eabihf targets only) (default: no)"),
     #[rustc_lint_opt_deny_field_access("use `Session::split_debuginfo` instead of this field")]
     split_debuginfo: Option<SplitDebuginfo> = (None, parse_split_debuginfo, [TRACKED],
         "how to handle split-debuginfo, a platform-specific option"),

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1340,6 +1340,16 @@ fn validate_commandline_args_with_session_available(sess: &Session) {
             }
         }
     }
+
+    if sess.opts.cg.soft_float {
+        if sess.target.arch == "arm" && sess.target.abi == "eabihf" {
+            sess.dcx().emit_warn(errors::SoftFloatDeprecated);
+        } else {
+            // All `use_softfp` does is the equivalent of `-mfloat-abi` in GCC/clang, which only exists on ARM targets.
+            // We document this flag to only affect `*eabihf` targets, so let's show a warning for all other targets.
+            sess.dcx().emit_warn(errors::SoftFloatIgnored);
+        }
+    }
 }
 
 /// Holds data on the current incremental compilation session, if there is one.

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -160,14 +160,9 @@ pub macro unreachable_2021 {
 /// to prevent unwinds. However, note that `extern "C" fn` will automatically
 /// convert unwinds to aborts, so using this function isn't necessary for FFI.
 #[unstable(feature = "abort_unwind", issue = "130338")]
+#[rustc_nounwind]
 pub fn abort_unwind<F: FnOnce() -> R, R>(f: F) -> R {
-    // This attribute adds the "unwinding out of nounwind function" guard.
-    #[rustc_nounwind]
-    fn abort_unwind_inner<F: FnOnce() -> R, R>(f: F) -> R {
-        f()
-    }
-
-    abort_unwind_inner(f)
+    f()
 }
 
 /// An internal trait used by std to pass data from std to `panic_unwind` and

--- a/library/std/src/panic.rs
+++ b/library/std/src/panic.rs
@@ -283,6 +283,9 @@ where
 {
 }
 
+#[unstable(feature = "abort_unwind", issue = "130338")]
+pub use core::panic::abort_unwind;
+
 /// Invokes a closure, capturing the cause of an unwinding panic if one occurs.
 ///
 /// This function will return `Ok` with the closure's result if the closure


### PR DESCRIPTION
Successful merges:

 - #129897 (deprecate -Csoft-float because it is unsound (and not fixable))
 - #130339 (Add `core::panic::abort_unwind`)
 - #130384 (compiler: Document AbiAndPrefAlign)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=129897,130339,130384)
<!-- homu-ignore:end -->