### PR TITLE
Don't ICE when generating `Fn` shim for async closure with borrowck error

### DIFF
--- a/tests/ui/async-await/async-closures/closure-shim-borrowck-error.rs
+++ b/tests/ui/async-await/async-closures/closure-shim-borrowck-error.rs
@@ -1,4 +1,3 @@
-//@ known-bug: rust-lang/rust#129262
 //@ compile-flags: -Zvalidate-mir --edition=2018 --crate-type=lib -Copt-level=3
 
 #![feature(async_closure)]
@@ -11,6 +10,7 @@ fn needs_fn_mut<T>(mut x: impl FnMut() -> T) {
 
 fn hello(x: Ty) {
     needs_fn_mut(async || {
+        //~^ ERROR cannot move out of `x`
         x.hello();
     });
 }

--- a/tests/ui/async-await/async-closures/closure-shim-borrowck-error.stderr
+++ b/tests/ui/async-await/async-closures/closure-shim-borrowck-error.stderr
@@ -1,0 +1,24 @@
+error[E0507]: cannot move out of `x` which is behind a mutable reference
+  --> $DIR/closure-shim-borrowck-error.rs:12:18
+   |
+LL |     needs_fn_mut(async || {
+   |                  ^^^^^^^^ `x` is moved here
+LL |
+LL |         x.hello();
+   |         -
+   |         |
+   |         variable moved due to use in coroutine
+   |         move occurs because `x` has type `Ty`, which does not implement the `Copy` trait
+   |
+note: if `Ty` implemented `Clone`, you could clone the value
+  --> $DIR/closure-shim-borrowck-error.rs:18:1
+   |
+LL |         x.hello();
+   |         - you could clone this value
+...
+LL | struct Ty;
+   | ^^^^^^^^^ consider implementing `Clone` for this type
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0507`.


### PR DESCRIPTION
Turn an assumption that I had originally written as an assert into a delayed bug, because this shim code is reachable even if we have borrowck errors via the MIR inliner.

Fixes #129262.