### PR TITLE
Support symbolicating zstd-compressed ELF sections

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -313,6 +313,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c3938e133aac070997ddc684d4b393777d293ba170f2988c8fd5ea2ad4ce21"
+dependencies = [
+ "compiler_builtins",
+ "rustc-std-workspace-alloc",
+ "rustc-std-workspace-core",
+]
+
+[[package]]
 name = "std"
 version = "0.0.0"
 dependencies = [
@@ -336,6 +347,7 @@ dependencies = [
  "rand",
  "rand_xorshift",
  "rustc-demangle",
+ "ruzstd",
  "std_detect",
  "unwind",
  "wasi",

--- a/library/Cargo.toml
+++ b/library/Cargo.toml
@@ -38,6 +38,8 @@ gimli.opt-level = "s"
 miniz_oxide.debug = 0
 object.debug = 0
 rustc-demangle.debug = 0
+ruzstd.debug = 0
+ruzstd.opt-level = "s"
 
 [patch.crates-io]
 # See comments in `library/rustc-std-workspace-core/README.md` for what's going on

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -33,6 +33,7 @@ rustc-demangle = { version = "0.1.24", features = ['rustc-dep-of-std'] }
 [target.'cfg(not(all(windows, target_env = "msvc", not(target_vendor = "uwp"))))'.dependencies]
 miniz_oxide = { version = "0.7.0", optional = true, default-features = false }
 addr2line = { version = "0.22.0", optional = true, default-features = false }
+ruzstd = { version = "0.7.2", default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
 libc = { version = "0.2.156", default-features = false, features = [
@@ -48,6 +49,7 @@ object = { version = "0.36.0", default-features = false, optional = true, featur
     'unaligned',
     'archive',
 ] }
+ruzstd = { version = "0.7.2", default-features = false, optional = true, features = [ "rustc-dep-of-std"] }
 
 [target.'cfg(target_os = "aix")'.dependencies]
 object = { version = "0.36.0", default-features = false, optional = true, features = [
@@ -89,8 +91,9 @@ r-efi-alloc = { version = "1.0.0", features = ['rustc-dep-of-std'] }
 [features]
 backtrace = [
     'addr2line/rustc-dep-of-std',
-    'object/rustc-dep-of-std',
     'miniz_oxide/rustc-dep-of-std',
+    'object/rustc-dep-of-std',
+    'ruzstd/rustc-dep-of-std',
 ]
 
 panic-unwind = ["panic_unwind"]

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -481,6 +481,7 @@ const PERMITTED_STDLIB_DEPENDENCIES: &[&str] = &[
     "rand_core",
     "rand_xorshift",
     "rustc-demangle",
+    "ruzstd",
     "unicode-width",
     "unwinding",
     "wasi",


### PR DESCRIPTION
This requires bumping backtrace to rust-lang/backtrace-rs@4f3acf7 which includes support for symbolicating from newer Android APK formats, as well as for using zstd-compressed ELF sections for debuginfo.

It also requires compiling ruzstd, a zstd decompressor written in Rust.

This can combine with rust-lld's support for zstd-compressed debuginfo for overall smaller debuginfo sections.

<!-- homu-ignore:start -->
r? @ghost
<!-- homu-ignore:end -->
