### PR TITLE
run_make_support: rectify symlink handling

### DIFF
--- a/tests/run-make/invalid-symlink-search-path/rmake.rs
+++ b/tests/run-make/invalid-symlink-search-path/rmake.rs
@@ -1,13 +1,14 @@
-// In this test, the symlink created is invalid (valid relative to the root, but not
-// relatively to where it is located), and used to cause an internal
-// compiler error (ICE) when passed as a library search path. This was fixed in #26044,
-// and this test checks that the invalid symlink is instead simply ignored.
+// In this test, the symlink created is invalid (valid relative to the root, but not relatively to
+// where it is located), and used to cause an internal compiler error (ICE) when passed as a library
+// search path. This was fixed in #26044, and this test checks that the invalid symlink is instead
+// simply ignored.
+//
 // See https://github.com/rust-lang/rust/issues/26006
 
 //@ needs-symlink
 //Reason: symlink requires elevated permission in Windows
 
-use run_make_support::{rfs, rustc};
+use run_make_support::{path, rfs, rustc};
 
 fn main() {
     // We create two libs: `bar` which depends on `foo`. We need to compile `foo` first.
@@ -20,9 +21,9 @@ fn main() {
         .metadata("foo")
         .output("out/foo/libfoo.rlib")
         .run();
-    rfs::create_dir("out/bar");
-    rfs::create_dir("out/bar/deps");
-    rfs::create_symlink("out/foo/libfoo.rlib", "out/bar/deps/libfoo.rlib");
+    rfs::create_dir_all("out/bar/deps");
+    rfs::symlink_file(path("out/foo/libfoo.rlib"), path("out/bar/deps/libfoo.rlib"));
+
     // Check that the invalid symlink does not cause an ICE
     rustc()
         .input("in/bar/lib.rs")

--- a/tests/run-make/symlinked-extern/rmake.rs
+++ b/tests/run-make/symlinked-extern/rmake.rs
@@ -1,22 +1,22 @@
-// Crates that are resolved normally have their path canonicalized and all
-// symlinks resolved. This did not happen for paths specified
-// using the --extern option to rustc, which could lead to rustc thinking
-// that it encountered two different versions of a crate, when it's
-// actually the same version found through different paths.
-// See https://github.com/rust-lang/rust/pull/16505
-
-// This test checks that --extern and symlinks together
-// can result in successful compilation.
+// Crates that are resolved normally have their path canonicalized and all symlinks resolved. This
+// did not happen for paths specified using the `--extern` option to rustc, which could lead to
+// rustc thinking that it encountered two different versions of a crate, when it's actually the same
+// version found through different paths.
+//
+// This test checks that `--extern` and symlinks together can result in successful compilation.
+//
+// See <https://github.com/rust-lang/rust/pull/16505>.
 
 //@ ignore-cross-compile
 //@ needs-symlink
 
-use run_make_support::{cwd, rfs, rustc};
+use run_make_support::{cwd, path, rfs, rustc};
 
 fn main() {
     rustc().input("foo.rs").run();
     rfs::create_dir_all("other");
-    rfs::create_symlink("libfoo.rlib", "other");
+    rfs::symlink_file(path("libfoo.rlib"), path("other").join("libfoo.rlib"));
+
     rustc().input("bar.rs").library_search_path(cwd()).run();
-    rustc().input("baz.rs").extern_("foo", "other").library_search_path(cwd()).run();
+    rustc().input("baz.rs").extern_("foo", "other/libfoo.rlib").library_search_path(cwd()).run();
 }

--- a/tests/run-make/symlinked-rlib/rmake.rs
+++ b/tests/run-make/symlinked-rlib/rmake.rs
@@ -12,6 +12,6 @@ use run_make_support::{cwd, rfs, rustc};
 
 fn main() {
     rustc().input("foo.rs").crate_type("rlib").output("foo.xxx").run();
-    rfs::create_symlink("foo.xxx", "libfoo.rlib");
+    rfs::symlink_file("foo.xxx", "libfoo.rlib");
     rustc().input("bar.rs").library_search_path(cwd()).run();
 }


### PR DESCRIPTION
Avoid confusing Unix symlinks and Windows symlinks. Since their
semantics are quite different, we should avoid trying to make it
automagic in how symlinks are created and deleted. Notably, the tests
should reflect what type of symlinks are to be created to match what std
does to make it less surprising for test readers.