### PR TITLE
Ignore reduce-fadd-unordered on SGX platform

### DIFF
--- a/tests/assembly/simd/reduce-fadd-unordered.rs
+++ b/tests/assembly/simd/reduce-fadd-unordered.rs
@@ -4,6 +4,7 @@
 //@[aarch64] only-aarch64
 //@[x86_64] only-x86_64
 //@[x86_64] compile-flags: -Ctarget-feature=+sse3
+//@ ignore-sgx Test incompatible with LVI mitigations
 #![feature(portable_simd)]
 #![feature(core_intrinsics)]
 use std::intrinsics::simd as intrinsics;


### PR DESCRIPTION
#130325 added the `tests/assembly/simd/reduce-fadd-unordered.rs` test. Unfortunately, the use of `CHECK: ret` makes that this test is not compatible with LVI mitigations applied for the SGX target. This PR makes sure this test is ignored for the SGX target, until a nicer solution is available.