### PR TITLE
Don't suggest adding `as_deref` to the scrutinee when `T` is reference or an arm is `Err`

### DIFF
--- a/compiler/rustc_hir_typeck/src/pat.rs
+++ b/compiler/rustc_hir_typeck/src/pat.rs
@@ -9,9 +9,7 @@ use rustc_errors::{
 };
 use rustc_hir::def::{CtorKind, DefKind, Res};
 use rustc_hir::pat_util::EnumerateAndAdjustIterator;
-use rustc_hir::{
-    self as hir, BindingMode, ByRef, HirId, LangItem, Mutability, Node, Pat, PatKind, QPath,
-};
+use rustc_hir::{self as hir, BindingMode, ByRef, HirId, LangItem, Mutability, Pat, PatKind};
 use rustc_infer::infer;
 use rustc_middle::mir::interpret::ErrorHandled;
 use rustc_middle::ty::{self, Ty, TypeVisitableExt};
@@ -2544,19 +2542,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.is_slice_or_array_or_vector(resolved_ty);
             match resolved_ty.kind() {
                 ty::Adt(adt_def, _)
-                    if (self.tcx.is_diagnostic_item(sym::Option, adt_def.did())
-                        || self.tcx.is_diagnostic_item(sym::Result, adt_def.did())) =>
+                    if self.tcx.is_diagnostic_item(sym::Option, adt_def.did())
+                        || self.tcx.is_diagnostic_item(sym::Result, adt_def.did()) =>
                 'sugg_as_deref: {
-                    // `as_deref` doesn't make sense for `Result::Err`.
-                    if let Node::Pat(top_pat) = self.tcx.hir_node(ti.hir_id)
-                        && let PatKind::TupleStruct(QPath::Resolved(_, path), ..) = top_pat.kind
-                        && let Some(def_id) = path.res.opt_def_id()
-                        && let Some(def_id) = self.tcx.opt_parent(def_id)
-                        && self.tcx.is_lang_item(def_id, LangItem::ResultErr)
-                    {
-                        break 'sugg_as_deref;
-                    }
-
                     // `&T` in `Option<&T>` or `Result<&T, E>` can't be
                     // dereferenced to array or slice by `as_deref`,
                     // e.g. `Result<&Vec<T>, E>` would be `Result<&Vec<T>, &E>`.

--- a/tests/ui/typeck/suggest-adding-as-deref-to-scrutinee.rs
+++ b/tests/ui/typeck/suggest-adding-as-deref-to-scrutinee.rs
@@ -1,0 +1,81 @@
+use std::io::ErrorKind;
+
+type E = Vec<ErrorKind>;
+
+fn res(res: Result<Vec<i32>, E>) {
+    match res {
+        //~^ HELP: consider using `as_deref` here
+        Ok([1]) => true,
+        //~^ ERROR: expected an array or slice
+        Err(_) => false,
+    };
+
+    match res {
+        //~^ HELP: consider using `as_deref` here
+        Ok([1]) => true,
+        //~^ ERROR: expected an array or slice
+        Err([ErrorKind::NotFound]) => false,
+        //~^ ERROR: expected an array or slice
+    };
+}
+
+fn opt(opt: Option<Vec<i32>>) {
+    match opt {
+        //~^ HELP: consider using `as_deref` here
+        Some([1]) => true,
+        //~^ ERROR: expected an array or slice
+        None => false,
+    };
+}
+
+fn err_arm_only(res: Result<Vec<i32>, E>) {
+    // doesn't suggest `as_deref` since the arm is `Err`,
+    // which `as_deref` doesn't make sense
+    match res {
+        Err([ErrorKind::NotFound]) => true,
+        //~^ ERROR: expected an array or slice
+        _ => false,
+    };
+}
+
+fn res_cannot_be_array_or_slice(res: Result<i32, E>) {
+    // doesn't suggest `as_deref` since `T` in `Ok(T)` can't be dereferenced
+    // to an array or slice
+    match res {
+        Ok([1]) => true,
+        //~^ ERROR: expected an array or slice
+        _ => false,
+    };
+}
+
+fn opt_cannot_be_array_or_slice(opt: Option<i32>) {
+    // doesn't suggest `as_deref` since `T` in `Some(T)` can't be dereferenced
+    // to an array or slice
+    match opt {
+        Some([1]) => true,
+        //~^ ERROR: expected an array or slice
+        None => false,
+    };
+}
+
+fn res_has_ref(res: Result<&Vec<i32>, E>) {
+    // `T` in `Ok(T)` can't be dereferenced to an array or slice
+    // because `res.as_deref()` would return `Result<&Vec<i32>, &E>`
+    match res {
+        Ok([1]) => true,
+        //~^ ERROR: expected an array or slice
+        Err(_) => false,
+    };
+}
+
+fn opt_has_ref(opt: Option<&Vec<i32>>) {
+    // `T` in `Some(T)` can't be dereferenced to an array or slice
+    // because `opt.as_deref()` would return `Option<&Vec<i32>>`
+    match opt {
+        Some([1]) => true,
+        //~^ ERROR: expected an array or slice
+        None => false,
+    };
+}
+
+fn main() {}

--- a/tests/ui/typeck/suggest-adding-as-deref-to-scrutinee.stderr
+++ b/tests/ui/typeck/suggest-adding-as-deref-to-scrutinee.stderr
@@ -1,0 +1,72 @@
+error[E0529]: expected an array or slice, found `Vec<i32>`
+  --> $DIR/suggest-adding-as-deref-to-scrutinee.rs:8:12
+   |
+LL |         Ok([1]) => true,
+   |            ^^^ pattern cannot match with input type `Vec<i32>`
+   |
+help: consider using `as_deref` here
+   |
+LL |     match res.as_deref() {
+   |              +++++++++++
+
+error[E0529]: expected an array or slice, found `Vec<i32>`
+  --> $DIR/suggest-adding-as-deref-to-scrutinee.rs:15:12
+   |
+LL |         Ok([1]) => true,
+   |            ^^^ pattern cannot match with input type `Vec<i32>`
+   |
+help: consider using `as_deref` here
+   |
+LL |     match res.as_deref() {
+   |              +++++++++++
+
+error[E0529]: expected an array or slice, found `Vec<ErrorKind>`
+  --> $DIR/suggest-adding-as-deref-to-scrutinee.rs:17:13
+   |
+LL |         Err([ErrorKind::NotFound]) => false,
+   |             ^^^^^^^^^^^^^^^^^^^^^ pattern cannot match with input type `Vec<ErrorKind>`
+
+error[E0529]: expected an array or slice, found `Vec<i32>`
+  --> $DIR/suggest-adding-as-deref-to-scrutinee.rs:25:14
+   |
+LL |         Some([1]) => true,
+   |              ^^^ pattern cannot match with input type `Vec<i32>`
+   |
+help: consider using `as_deref` here
+   |
+LL |     match opt.as_deref() {
+   |              +++++++++++
+
+error[E0529]: expected an array or slice, found `Vec<ErrorKind>`
+  --> $DIR/suggest-adding-as-deref-to-scrutinee.rs:35:13
+   |
+LL |         Err([ErrorKind::NotFound]) => true,
+   |             ^^^^^^^^^^^^^^^^^^^^^ pattern cannot match with input type `Vec<ErrorKind>`
+
+error[E0529]: expected an array or slice, found `i32`
+  --> $DIR/suggest-adding-as-deref-to-scrutinee.rs:45:12
+   |
+LL |         Ok([1]) => true,
+   |            ^^^ pattern cannot match with input type `i32`
+
+error[E0529]: expected an array or slice, found `i32`
+  --> $DIR/suggest-adding-as-deref-to-scrutinee.rs:55:14
+   |
+LL |         Some([1]) => true,
+   |              ^^^ pattern cannot match with input type `i32`
+
+error[E0529]: expected an array or slice, found `Vec<i32>`
+  --> $DIR/suggest-adding-as-deref-to-scrutinee.rs:65:12
+   |
+LL |         Ok([1]) => true,
+   |            ^^^ pattern cannot match with input type `Vec<i32>`
+
+error[E0529]: expected an array or slice, found `Vec<i32>`
+  --> $DIR/suggest-adding-as-deref-to-scrutinee.rs:75:14
+   |
+LL |         Some([1]) => true,
+   |              ^^^ pattern cannot match with input type `Vec<i32>`
+
+error: aborting due to 9 previous errors
+
+For more information about this error, try `rustc --explain E0529`.

--- a/tests/ui/typeck/suggest-adding-as-deref-to-scrutinee.stderr
+++ b/tests/ui/typeck/suggest-adding-as-deref-to-scrutinee.stderr
@@ -25,6 +25,11 @@ error[E0529]: expected an array or slice, found `Vec<ErrorKind>`
    |
 LL |         Err([ErrorKind::NotFound]) => false,
    |             ^^^^^^^^^^^^^^^^^^^^^ pattern cannot match with input type `Vec<ErrorKind>`
+   |
+help: consider using `as_deref` here
+   |
+LL |     match res.as_deref() {
+   |              +++++++++++
 
 error[E0529]: expected an array or slice, found `Vec<i32>`
   --> $DIR/suggest-adding-as-deref-to-scrutinee.rs:25:14
@@ -42,6 +47,11 @@ error[E0529]: expected an array or slice, found `Vec<ErrorKind>`
    |
 LL |         Err([ErrorKind::NotFound]) => true,
    |             ^^^^^^^^^^^^^^^^^^^^^ pattern cannot match with input type `Vec<ErrorKind>`
+   |
+help: consider using `as_deref` here
+   |
+LL |     match res.as_deref() {
+   |              +++++++++++
 
 error[E0529]: expected an array or slice, found `i32`
   --> $DIR/suggest-adding-as-deref-to-scrutinee.rs:45:12


### PR DESCRIPTION
Closes #130243

Currently, the following code:

```rust
use std::io::ErrorKind;

fn f1(x: Result<i32, Vec<ErrorKind>>) -> bool {
    matches!(x, Err([ErrorKind::NotFound]))
}

fn f2(x: Result<&Vec<i32>, Vec<ErrorKind>>) -> bool {
    matches!(x, Ok([1]))
}
```

emits:

```rust
 --> src/main.rs:4:21
  |
4 |     matches!(x, Err([ErrorKind::NotFound]))
  |              -      ^^^^^^^^^^^^^^^^^^^^^ pattern cannot match with input type `Vec<ErrorKind>`
  |              |
  |              help: consider using `as_deref` here: `x.as_deref()`

error[E0529]: expected an array or slice, found `Vec<i32>`
 --> src/main.rs:8:20
  |
8 |     matches!(x, Ok([1]))
  |              -     ^^^ pattern cannot match with input type `Vec<i32>`
  |              |
  |              help: consider using `as_deref` here: `x.as_deref()`
```

- In `f1`,  `as_deref` doesn't dereference `E`, so the suggestion can't be applied.
- In `f2`, `as_deref` would return `Result<&Vec<i32>,  &Vec<ErrorKind>>`, which `T` can't be array or slice.

In this PR, suppress the suggestion when 
- a match arm is `Err`
- `T` in `Result<T, E>` or `Option<T>` is reference

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
