### PR TITLE
fix: Remove duplicate `LazyLock` example.

### DIFF
--- a/library/std/src/sync/lazy_lock.rs
+++ b/library/std/src/sync/lazy_lock.rs
@@ -44,8 +44,6 @@ union Data<T, F> {
 ///
 /// // The `String` is built, stored in the `LazyLock`, and returned as `&String`.
 /// let _ = &*DEEP_THOUGHT;
-/// // The `String` is retrieved from the `LazyLock` and returned as `&String`.
-/// let _ = &*DEEP_THOUGHT;
 /// ```
 ///
 /// Initialize fields with `LazyLock`.


### PR DESCRIPTION
The top-level docs for `LazyLock` included two lines of code, each with an accompanying comment, that were identical and with nearly- identical comments. This looks like an oversight from a past edit which was perhaps trying to rewrite an existing example but ended up duplicating rather than replacing, though I haven't gone back through the Git history to check.

This commit removes what I personally think is the less-clear of the two examples.