### PR TITLE
Reduce confusion about `make_indirect_byval` by renaming it

### DIFF
--- a/compiler/rustc_target/src/abi/call/m68k.rs
+++ b/compiler/rustc_target/src/abi/call/m68k.rs
@@ -14,7 +14,7 @@ fn classify_arg<Ty>(arg: &mut ArgAbi<'_, Ty>) {
         return;
     }
     if arg.layout.is_aggregate() {
-        arg.make_indirect_byval(None);
+        arg.pass_by_stack_offset(None);
     } else {
         arg.extend_integer_width_to(32);
     }

--- a/compiler/rustc_target/src/abi/call/mod.rs
+++ b/compiler/rustc_target/src/abi/call/mod.rs
@@ -64,7 +64,7 @@ pub enum PassMode {
     /// (which ensures that padding is preserved and that we do not rely on LLVM's struct layout),
     /// and will use the alignment specified in `attrs.pointee_align` (if `Some`) or the type's
     /// alignment (if `None`). This means that the alignment will not always
-    /// match the Rust type's alignment; see documentation of `make_indirect_byval` for more info.
+    /// match the Rust type's alignment; see documentation of `pass_by_stack_offset` for more info.
     ///
     /// `on_stack` cannot be true for unsized arguments, i.e., when `meta_attrs` is `Some`.
     Indirect { attrs: ArgAttributes, meta_attrs: Option<ArgAttributes>, on_stack: bool },
@@ -681,7 +681,7 @@ impl<'a, Ty> ArgAbi<'a, Ty> {
     /// either in the caller (if the type's alignment is lower than the byval alignment)
     /// or in the callee (if the type's alignment is higher than the byval alignment),
     /// to ensure that Rust code never sees an underaligned pointer.
-    pub fn make_indirect_byval(&mut self, byval_align: Option<Align>) {
+    pub fn pass_by_stack_offset(&mut self, byval_align: Option<Align>) {
         assert!(!self.layout.is_unsized(), "used byval ABI for unsized layout");
         self.make_indirect();
         match self.mode {
@@ -879,8 +879,7 @@ impl<'a, Ty> FnAbi<'a, Ty> {
     {
         if abi == spec::abi::Abi::X86Interrupt {
             if let Some(arg) = self.args.first_mut() {
-                // FIXME(pcwalton): This probably should use the x86 `byval` ABI...
-                arg.make_indirect_byval(None);
+                arg.pass_by_stack_offset(None);
             }
             return Ok(());
         }

--- a/compiler/rustc_target/src/abi/call/wasm.rs
+++ b/compiler/rustc_target/src/abi/call/wasm.rs
@@ -40,7 +40,7 @@ where
     }
     arg.extend_integer_width_to(32);
     if arg.layout.is_aggregate() && !unwrap_trivial_aggregate(cx, arg) {
-        arg.make_indirect_byval(None);
+        arg.make_indirect();
     }
 }
 

--- a/compiler/rustc_target/src/abi/call/x86.rs
+++ b/compiler/rustc_target/src/abi/call/x86.rs
@@ -122,7 +122,7 @@ where
                 align_4
             };
 
-            arg.make_indirect_byval(Some(byval_align));
+            arg.pass_by_stack_offset(Some(byval_align));
         } else {
             arg.extend_integer_width_to(32);
         }

--- a/compiler/rustc_target/src/abi/call/x86_64.rs
+++ b/compiler/rustc_target/src/abi/call/x86_64.rs
@@ -219,7 +219,7 @@ where
                 if is_arg {
                     // The x86_64 ABI doesn't have any special requirements for `byval` alignment,
                     // the type's alignment is always used.
-                    arg.make_indirect_byval(None);
+                    arg.pass_by_stack_offset(None);
                 } else {
                     // `sret` parameter thus one less integer register available
                     arg.make_indirect();

--- a/compiler/rustc_target/src/abi/call/xtensa.rs
+++ b/compiler/rustc_target/src/abi/call/xtensa.rs
@@ -68,7 +68,7 @@ where
     *arg_gprs_left -= needed_arg_gprs;
 
     if must_use_stack {
-        arg.make_indirect_byval(None);
+        arg.pass_by_stack_offset(None);
     } else if is_xtensa_aggregate(arg) {
         // Aggregates which are <= max_size will be passed in
         // registers if possible, so coerce to integers.

--- a/tests/codegen/align-byval.rs
+++ b/tests/codegen/align-byval.rs
@@ -1,10 +1,8 @@
 // ignore-tidy-linelength
-//@ revisions:m68k wasm x86_64-linux x86_64-windows i686-linux i686-windows
+//@ revisions:m68k x86_64-linux x86_64-windows i686-linux i686-windows
 
 //@[m68k] compile-flags: --target m68k-unknown-linux-gnu
 //@[m68k] needs-llvm-components: m68k
-//@[wasm] compile-flags: --target wasm32-unknown-emscripten
-//@[wasm] needs-llvm-components: webassembly
 //@[x86_64-linux] compile-flags: --target x86_64-unknown-linux-gnu
 //@[x86_64-linux] needs-llvm-components: x86
 //@[x86_64-windows] compile-flags: --target x86_64-pc-windows-msvc
@@ -15,7 +13,7 @@
 //@[i686-windows] needs-llvm-components: x86
 
 // Tests that `byval` alignment is properly specified (#80127).
-// The only targets that use `byval` are m68k, wasm, x86-64, and x86.
+// The only targets that use `byval` are m68k, x86-64, and x86.
 // Note also that Windows mandates a by-ref ABI here, so it does not use byval.
 
 #![feature(no_core, lang_items)]
@@ -112,9 +110,6 @@ pub unsafe fn call_na1(x: NaturalAlign1) {
     // m68k: [[ALLOCA:%[a-z0-9+]]] = alloca [2 x i8], align 1
     // m68k: call void @natural_align_1({{.*}}byval([2 x i8]) align 1{{.*}} [[ALLOCA]])
 
-    // wasm: [[ALLOCA:%[a-z0-9+]]] = alloca [2 x i8], align 1
-    // wasm: call void @natural_align_1({{.*}}byval([2 x i8]) align 1{{.*}} [[ALLOCA]])
-
     // x86_64-linux: call void @natural_align_1(i16
 
     // x86_64-windows: call void @natural_align_1(i16
@@ -133,7 +128,6 @@ pub unsafe fn call_na2(x: NaturalAlign2) {
     // CHECK: start:
 
     // m68k-NEXT: call void @natural_align_2
-    // wasm-NEXT: call void @natural_align_2
     // x86_64-linux-NEXT: call void @natural_align_2
     // x86_64-windows-NEXT: call void @natural_align_2
 
@@ -204,8 +198,6 @@ pub unsafe fn call_fa16(x: ForceAlign16) {
 extern "C" {
     // m68k: declare void @natural_align_1({{.*}}byval([2 x i8]) align 1{{.*}})
 
-    // wasm: declare void @natural_align_1({{.*}}byval([2 x i8]) align 1{{.*}})
-
     // x86_64-linux: declare void @natural_align_1(i16)
 
     // x86_64-windows: declare void @natural_align_1(i16)
@@ -216,8 +208,6 @@ extern "C" {
     fn natural_align_1(x: NaturalAlign1);
 
     // m68k: declare void @natural_align_2({{.*}}byval([34 x i8]) align 2{{.*}})
-
-    // wasm: declare void @natural_align_2({{.*}}byval([34 x i8]) align 2{{.*}})
 
     // x86_64-linux: declare void @natural_align_2({{.*}}byval([34 x i8]) align 2{{.*}})
 
@@ -232,8 +222,6 @@ extern "C" {
 
     // m68k: declare void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
 
-    // wasm: declare void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
-
     // x86_64-linux: declare void @force_align_4({{.*}}byval([20 x i8]) align 4{{.*}})
 
     // x86_64-windows: declare void @force_align_4(
@@ -247,8 +235,6 @@ extern "C" {
 
     // m68k: declare void @natural_align_8({{.*}}byval([24 x i8]) align 4{{.*}})
 
-    // wasm: declare void @natural_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
-
     // x86_64-linux: declare void @natural_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
 
     // x86_64-windows: declare void @natural_align_8(
@@ -261,8 +247,6 @@ extern "C" {
     fn natural_align_8(x: NaturalAlign8);
 
     // m68k: declare void @force_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // wasm: declare void @force_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
 
     // x86_64-linux: declare void @force_align_8({{.*}}byval([24 x i8]) align 8{{.*}})
 
@@ -279,8 +263,6 @@ extern "C" {
 
     // m68k: declare void @lower_fa8({{.*}}byval([24 x i8]) align 4{{.*}})
 
-    // wasm: declare void @lower_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
-
     // x86_64-linux: declare void @lower_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
 
     // x86_64-windows: declare void @lower_fa8(
@@ -293,8 +275,6 @@ extern "C" {
     fn lower_fa8(x: LowerFA8);
 
     // m68k: declare void @wrapped_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
-
-    // wasm: declare void @wrapped_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
 
     // x86_64-linux: declare void @wrapped_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
 
@@ -311,8 +291,6 @@ extern "C" {
 
     // m68k: declare void @transparent_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
 
-    // wasm: declare void @transparent_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
-
     // x86_64-linux: declare void @transparent_fa8({{.*}}byval([24 x i8]) align 8{{.*}})
 
     // x86_64-windows: declare void @transparent_fa8(
@@ -327,8 +305,6 @@ extern "C" {
     fn transparent_fa8(x: TransparentFA8);
 
     // m68k: declare void @force_align_16({{.*}}byval([80 x i8]) align 16{{.*}})
-
-    // wasm: declare void @force_align_16({{.*}}byval([80 x i8]) align 16{{.*}})
 
     // x86_64-linux: declare void @force_align_16({{.*}}byval([80 x i8]) align 16{{.*}})
 

--- a/tests/codegen/repr/transparent-byval-struct-ptr.rs
+++ b/tests/codegen/repr/transparent-byval-struct-ptr.rs
@@ -1,4 +1,4 @@
-//@ revisions: i686-linux i686-freebsd x64-linux x64-apple wasm32
+//@ revisions: i686-linux i686-freebsd x64-linux x64-apple
 //@ compile-flags: -O -C no-prepopulate-passes
 
 //@[i686-linux] compile-flags: --target i686-unknown-linux-gnu
@@ -9,8 +9,6 @@
 //@[x64-linux] needs-llvm-components: x86
 //@[x64-apple] compile-flags: --target x86_64-apple-darwin
 //@[x64-apple] needs-llvm-components: x86
-//@[wasm32] compile-flags: --target wasm32-wasi
-//@[wasm32] needs-llvm-components: webassembly
 
 // See ./transparent.rs
 // Some platforms pass large aggregates using immediate arrays in LLVMIR

--- a/tests/codegen/repr/transparent-opaque-ptr.rs
+++ b/tests/codegen/repr/transparent-opaque-ptr.rs
@@ -1,10 +1,12 @@
-//@ revisions: aarch64-linux aarch64-darwin
+//@ revisions: aarch64-linux aarch64-darwin wasm32-wasi
 //@ compile-flags: -O -C no-prepopulate-passes
 
 //@[aarch64-linux] compile-flags: --target aarch64-unknown-linux-gnu
 //@[aarch64-linux] needs-llvm-components: aarch64
 //@[aarch64-darwin] compile-flags: --target aarch64-apple-darwin
 //@[aarch64-darwin] needs-llvm-components: aarch64
+//@[wasm32-wasi] compile-flags: --target wasm32-wasi
+//@[wasm32-wasi] needs-llvm-components: webassembly
 
 // See ./transparent.rs
 // Some platforms pass large aggregates using immediate arrays in LLVMIR


### PR DESCRIPTION
As part of doing so, remove the incorrect handling of the wasm target's `make_indirect_byval` (i.e. using it at all).

<!-- homu-ignore:start -->
Fixes https://github.com/rust-lang/rust/issues/130442

r? @bjorn3

Advice requested: what to do about `tests/codegen/repr/transparent-struct-ptr.rs`? It seems incorrect to simply remove wasm from that one... does another test cover the relevant handling?
<!-- homu-ignore:end -->