### PR TITLE
Update Trusty target maintainers

### DIFF
--- a/src/doc/rustc/src/platform-support/trusty.md
+++ b/src/doc/rustc/src/platform-support/trusty.md
@@ -8,7 +8,8 @@ Environment (TEE) for Android.
 ## Target maintainers
 
 - Nicole LeGare (@randomPoison)
-- Stephen Crane (@rinon)
+- Andrei Homescu (@ahomescu)
+- Chris Wailes (chriswailes@google.com)
 - As a fallback trusty-dev-team@google.com can be contacted
 
 ## Requirements


### PR DESCRIPTION
Remove Stephen Crane from the list of Trusty target maintainers and add Andrei Homescu (@ahomescu) and Chris Wailes.
