### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
+++ b/compiler/rustc_llvm/llvm-wrapper/LLVMWrapper.h
@@ -25,7 +25,6 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/Transforms/IPO.h"
-#include "llvm/Transforms/Instrumentation.h"
 #include "llvm/Transforms/Scalar.h"
 
 #define LLVM_VERSION_GE(major, minor)                                          \
@@ -33,6 +32,12 @@
    LLVM_VERSION_MAJOR == (major) && LLVM_VERSION_MINOR >= (minor))
 
 #define LLVM_VERSION_LT(major, minor) (!LLVM_VERSION_GE((major), (minor)))
+
+#if LLVM_VERSION_GE(20, 0)
+#include "llvm/Transforms/Utils/Instrumentation.h"
+#else
+#include "llvm/Transforms/Instrumentation.h"
+#endif
 
 #include "llvm/IR/LegacyPassManager.h"
 

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -39,7 +39,6 @@
 #include "llvm/TargetParser/Host.h"
 #endif
 #include "llvm/Support/TimeProfiler.h"
-#include "llvm/Transforms/Instrumentation.h"
 #include "llvm/Transforms/Instrumentation/AddressSanitizer.h"
 #include "llvm/Transforms/Instrumentation/DataFlowSanitizer.h"
 #if LLVM_VERSION_GE(19, 0)

--- a/compiler/rustc_mir_transform/src/coverage/counters.rs
+++ b/compiler/rustc_mir_transform/src/coverage/counters.rs
@@ -323,8 +323,7 @@ impl<'a> MakeBcbCounters<'a> {
         }
 
         // Determine the set of out-edges that don't yet have edge counters.
-        let candidate_successors = self
-            .bcb_successors(from_bcb)
+        let candidate_successors = self.basic_coverage_blocks.successors[from_bcb]
             .iter()
             .copied()
             .filter(|&to_bcb| self.edge_has_no_counter(from_bcb, to_bcb))
@@ -500,11 +499,6 @@ impl<'a> MakeBcbCounters<'a> {
         }
 
         None
-    }
-
-    #[inline]
-    fn bcb_successors(&self, bcb: BasicCoverageBlock) -> &[BasicCoverageBlock] {
-        &self.basic_coverage_blocks.successors[bcb]
     }
 
     #[inline]

--- a/compiler/rustc_mir_transform/src/coverage/graph.rs
+++ b/compiler/rustc_mir_transform/src/coverage/graph.rs
@@ -341,15 +341,15 @@ fn bcb_filtered_successors<'a, 'tcx>(terminator: &'a Terminator<'tcx>) -> Covera
         | FalseUnwind { real_target: target, .. }
         | Goto { target } => CoverageSuccessors::Chainable(target),
 
-        // A call terminator can normally be chained, except when they have no
-        // successor because they are known to diverge.
+        // A call terminator can normally be chained, except when it has no
+        // successor because it is known to diverge.
         Call { target: maybe_target, .. } => match maybe_target {
             Some(target) => CoverageSuccessors::Chainable(target),
             None => CoverageSuccessors::NotChainable(&[]),
         },
 
-        // An inline asm terminator can normally be chained, except when it diverges or uses asm
-        // goto.
+        // An inline asm terminator can normally be chained, except when it
+        // diverges or uses asm goto.
         InlineAsm { ref targets, .. } => {
             if let [target] = targets[..] {
                 CoverageSuccessors::Chainable(target)

--- a/compiler/rustc_mir_transform/src/coverage/graph.rs
+++ b/compiler/rustc_mir_transform/src/coverage/graph.rs
@@ -165,21 +165,15 @@ impl CoverageGraph {
         self.dominators.as_ref().unwrap().cmp_in_dominator_order(a, b)
     }
 
-    /// Returns true if the given node has 2 or more in-edges, i.e. 2 or more
-    /// predecessors.
-    ///
-    /// This property is interesting to code that assigns counters to nodes and
-    /// edges, because if a node _doesn't_ have multiple in-edges, then there's
-    /// no benefit in having a separate counter for its in-edge, because it
-    /// would have the same value as the node's own counter.
-    #[inline(always)]
-    pub(crate) fn bcb_has_multiple_in_edges(&self, bcb: BasicCoverageBlock) -> bool {
-        // Even though bcb0 conceptually has an extra virtual in-edge due to
-        // being the entry point, we've already asserted that it has no _other_
-        // in-edges, so there's no possibility of it having _multiple_ in-edges.
-        // (And since its virtual in-edge doesn't exist in the graph, that edge
-        // can't have a separate counter anyway.)
-        self.predecessors[bcb].len() > 1
+    /// Returns the source of this node's sole in-edge, if it has exactly one.
+    /// That edge can be assumed to have the same execution count as the node
+    /// itself (in the absence of panics).
+    pub(crate) fn sole_predecessor(
+        &self,
+        to_bcb: BasicCoverageBlock,
+    ) -> Option<BasicCoverageBlock> {
+        // Unlike `simple_successor`, there is no need for extra checks here.
+        if let &[from_bcb] = self.predecessors[to_bcb].as_slice() { Some(from_bcb) } else { None }
     }
 
     /// Returns the target of this node's sole out-edge, if it has exactly

--- a/library/std/src/sync/lazy_lock.rs
+++ b/library/std/src/sync/lazy_lock.rs
@@ -44,8 +44,6 @@ union Data<T, F> {
 ///
 /// // The `String` is built, stored in the `LazyLock`, and returned as `&String`.
 /// let _ = &*DEEP_THOUGHT;
-/// // The `String` is retrieved from the `LazyLock` and returned as `&String`.
-/// let _ = &*DEEP_THOUGHT;
 /// ```
 ///
 /// Initialize fields with `LazyLock`.

--- a/tests/run-make/invalid-symlink-search-path/rmake.rs
+++ b/tests/run-make/invalid-symlink-search-path/rmake.rs
@@ -1,13 +1,14 @@
-// In this test, the symlink created is invalid (valid relative to the root, but not
-// relatively to where it is located), and used to cause an internal
-// compiler error (ICE) when passed as a library search path. This was fixed in #26044,
-// and this test checks that the invalid symlink is instead simply ignored.
+// In this test, the symlink created is invalid (valid relative to the root, but not relatively to
+// where it is located), and used to cause an internal compiler error (ICE) when passed as a library
+// search path. This was fixed in #26044, and this test checks that the invalid symlink is instead
+// simply ignored.
+//
 // See https://github.com/rust-lang/rust/issues/26006
 
 //@ needs-symlink
 //Reason: symlink requires elevated permission in Windows
 
-use run_make_support::{rfs, rustc};
+use run_make_support::{path, rfs, rustc};
 
 fn main() {
     // We create two libs: `bar` which depends on `foo`. We need to compile `foo` first.
@@ -20,9 +21,9 @@ fn main() {
         .metadata("foo")
         .output("out/foo/libfoo.rlib")
         .run();
-    rfs::create_dir("out/bar");
-    rfs::create_dir("out/bar/deps");
-    rfs::create_symlink("out/foo/libfoo.rlib", "out/bar/deps/libfoo.rlib");
+    rfs::create_dir_all("out/bar/deps");
+    rfs::symlink_file(path("out/foo/libfoo.rlib"), path("out/bar/deps/libfoo.rlib"));
+
     // Check that the invalid symlink does not cause an ICE
     rustc()
         .input("in/bar/lib.rs")

--- a/tests/run-make/symlinked-extern/rmake.rs
+++ b/tests/run-make/symlinked-extern/rmake.rs
@@ -1,22 +1,22 @@
-// Crates that are resolved normally have their path canonicalized and all
-// symlinks resolved. This did not happen for paths specified
-// using the --extern option to rustc, which could lead to rustc thinking
-// that it encountered two different versions of a crate, when it's
-// actually the same version found through different paths.
-// See https://github.com/rust-lang/rust/pull/16505
-
-// This test checks that --extern and symlinks together
-// can result in successful compilation.
+// Crates that are resolved normally have their path canonicalized and all symlinks resolved. This
+// did not happen for paths specified using the `--extern` option to rustc, which could lead to
+// rustc thinking that it encountered two different versions of a crate, when it's actually the same
+// version found through different paths.
+//
+// This test checks that `--extern` and symlinks together can result in successful compilation.
+//
+// See <https://github.com/rust-lang/rust/pull/16505>.
 
 //@ ignore-cross-compile
 //@ needs-symlink
 
-use run_make_support::{cwd, rfs, rustc};
+use run_make_support::{cwd, path, rfs, rustc};
 
 fn main() {
     rustc().input("foo.rs").run();
     rfs::create_dir_all("other");
-    rfs::create_symlink("libfoo.rlib", "other");
+    rfs::symlink_file(path("libfoo.rlib"), path("other").join("libfoo.rlib"));
+
     rustc().input("bar.rs").library_search_path(cwd()).run();
-    rustc().input("baz.rs").extern_("foo", "other").library_search_path(cwd()).run();
+    rustc().input("baz.rs").extern_("foo", "other/libfoo.rlib").library_search_path(cwd()).run();
 }

--- a/tests/run-make/symlinked-rlib/rmake.rs
+++ b/tests/run-make/symlinked-rlib/rmake.rs
@@ -12,6 +12,6 @@ use run_make_support::{cwd, rfs, rustc};
 
 fn main() {
     rustc().input("foo.rs").crate_type("rlib").output("foo.xxx").run();
-    rfs::create_symlink("foo.xxx", "libfoo.rlib");
+    rfs::symlink_file("foo.xxx", "libfoo.rlib");
     rustc().input("bar.rs").library_search_path(cwd()).run();
 }


### PR DESCRIPTION
Successful merges:

 - #130380 (coverage: Clarify some parts of coverage counter creation)
 - #130427 (run_make_support: rectify symlink handling)
 - #130447 (rustc_llvm: update for llvm/llvm-project@2ae968a0d9fb61606b020e898d88…)
 - #130448 (fix: Remove duplicate `LazyLock` example.)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=130380,130427,130447,130448)
<!-- homu-ignore:end -->