### PR TITLE
Add zlib to musl dist image so rust-lld will support zlib compression for debug info there.

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   patch \
   libssl-dev \
   pkg-config \
+  zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build/


### PR DESCRIPTION
Fixes #130063.

r? @Kobzol 