### PR TITLE
skip in-tree compiler build for llvm-bitcode-linker if ci-rustc is on

### DIFF
--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -872,8 +872,11 @@ impl Step for LlvmBitcodeLinker {
     fn run(self, builder: &Builder<'_>) -> PathBuf {
         let bin_name = "llvm-bitcode-linker";
 
-        builder.ensure(compile::Std::new(self.compiler, self.compiler.host));
-        builder.ensure(compile::Rustc::new(self.compiler, self.target));
+        // If enabled, use ci-rustc and skip building the in-tree compiler.
+        if !builder.download_rustc() {
+            builder.ensure(compile::Std::new(self.compiler, self.compiler.host));
+            builder.ensure(compile::Rustc::new(self.compiler, self.target));
+        }
 
         let cargo = prepare_tool_cargo(
             builder,


### PR DESCRIPTION
Similar to https://github.com/rust-lang/rust/issues/108767, resolves the `multiple candidates` problem for ci-rustc.

See https://github.com/rust-lang/rust/pull/122709#issuecomment-2355436227 for more context.

Blocker for #122709.