### PR TITLE
Remove uneeded PartialOrd bound in cmp::Ord::clamp

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -901,7 +901,6 @@ pub trait Ord: Eq + PartialOrd<Self> {
     fn clamp(self, min: Self, max: Self) -> Self
     where
         Self: Sized,
-        Self: PartialOrd,
     {
         assert!(min <= max);
         if self < min {


### PR DESCRIPTION
There is a `Self: PartialOrd` bound in `Ord::clamp`, but it is already required by the trait itself. Likely a left-over from the const trait deletion in 76dbe2910465072f85e74d6f7115ec9e6803e8bf.

Reported-by: @noeensarguet

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
