### PR TITLE
Ensure that `keyword_ident` lint doesn't trigger on `'r#kw` lifetime

### DIFF
--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -299,6 +299,9 @@ impl<'psess, 'src> StringReader<'psess, 'src> {
                         lifetime_name += lifetime_name_without_tick;
                         let sym = Symbol::intern(&lifetime_name);
 
+                        // Make sure we mark this as a raw identifier.
+                        self.psess.raw_identifier_spans.push(self.mk_sp(start, self.pos));
+
                         token::Lifetime(sym, IdentIsRaw::Yes)
                     } else {
                         // Otherwise, this should be parsed like `'r`. Warn about it though.

--- a/tests/ui/rust-2024/raw-gen-lt.rs
+++ b/tests/ui/rust-2024/raw-gen-lt.rs
@@ -1,0 +1,8 @@
+//@ edition: 2021
+//@ check-pass
+
+#![deny(keyword_idents_2024)]
+
+fn foo<'r#gen>() {}
+
+fn main() {}


### PR DESCRIPTION
Fixes #130486