### PR TITLE
Fix circular fn_sig queries to correct number of args for methods

### DIFF
--- a/compiler/rustc_middle/src/values.rs
+++ b/compiler/rustc_middle/src/values.rs
@@ -56,7 +56,7 @@ impl<'tcx> Value<TyCtxt<'tcx>> for ty::Binder<'_, ty::FnSig<'_>> {
             && let Some(node) = tcx.hir().get_if_local(def_id)
             && let Some(sig) = node.fn_sig()
         {
-            sig.decl.inputs.len() + sig.decl.implicit_self.has_implicit_self() as usize
+            sig.decl.inputs.len()
         } else {
             tcx.dcx().abort_if_errors();
             unreachable!()

--- a/tests/ui/mismatched_types/mismatch-args-crash-issue-130400.rs
+++ b/tests/ui/mismatched_types/mismatch-args-crash-issue-130400.rs
@@ -1,0 +1,8 @@
+trait Bar {
+    fn foo(&mut self) -> _ {
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+        Self::foo() //~ ERROR  this function takes 1 argument but 0 arguments were supplied
+    }
+}
+
+fn main() {}

--- a/tests/ui/mismatched_types/mismatch-args-crash-issue-130400.stderr
+++ b/tests/ui/mismatched_types/mismatch-args-crash-issue-130400.stderr
@@ -1,0 +1,26 @@
+error[E0061]: this function takes 1 argument but 0 arguments were supplied
+  --> $DIR/mismatch-args-crash-issue-130400.rs:4:9
+   |
+LL |         Self::foo()
+   |         ^^^^^^^^^-- argument #1 is missing
+   |
+note: method defined here
+  --> $DIR/mismatch-args-crash-issue-130400.rs:2:8
+   |
+LL |     fn foo(&mut self) -> _ {
+   |        ^^^ ---------
+help: provide the argument
+   |
+LL |         Self::foo(/* value */)
+   |                  ~~~~~~~~~~~~~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/mismatch-args-crash-issue-130400.rs:2:26
+   |
+LL |     fn foo(&mut self) -> _ {
+   |                          ^ not allowed in type signatures
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0061, E0121.
+For more information about an error, try `rustc --explain E0061`.


### PR DESCRIPTION
Fixes #130400. This was a [debug assert](https://github.com/rust-lang/rust/blob/28e8f01c2a2f33fb4214925a704e3223b372cad5/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs#L2557) added to some argument error reporting code in #129320 which verified that the number of params (from the HIR) matched the `matched_inputs` which ultimately come from ty::FnSig. In the reduced test case:

```
fn foo(&mut self) -> _ {
    foo()
}
```

There is a circular dependency computing the ty::FnSig -- when trying to compute it, we try to figure out the return value, which again depends on this ty::FnSig. In #105162, this was supported by short-circuiting the cycle by synthesizing a FnSig with error types for parameters. The [code in question](https://github.com/rust-lang/rust/pull/105162/files#diff-a65feec6bfffb19fbdc60a80becd1030c82a56c16b177182cd277478fdb04592R44) computes the number of parameters by taking the number of parameters from the hir::FnDecl and adding 1 if there is an implicit self parameter. 

I might be missing a subtlety here, but AFAICT the adjustment for implicit self args is unnecessary and results in one too many args. For example, for this non-errorful code:

```
trait Foo { 
    fn bar(&self) {}
}
```

The resulting hir::FnDecl and ty::FnSig both have the same number of inputs -- 1. So, this PR removes that adjustment and adds a test for the debug ICE.

r? @compiler-errors 