### PR TITLE
read_volatile __rust_no_alloc_shim_is_unstable in alloc_zeroed

### DIFF
--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -171,7 +171,13 @@ pub unsafe fn realloc(ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 
 #[inline]
 #[cfg_attr(miri, track_caller)] // even without panics, this helps for Miri backtraces
 pub unsafe fn alloc_zeroed(layout: Layout) -> *mut u8 {
-    unsafe { __rust_alloc_zeroed(layout.size(), layout.align()) }
+    unsafe {
+        // Make sure we don't accidentally allow omitting the allocator shim in
+        // stable code until it is actually stabilized.
+        core::ptr::read_volatile(&__rust_no_alloc_shim_is_unstable);
+
+        __rust_alloc_zeroed(layout.size(), layout.align())
+    }
 }
 
 #[cfg(not(test))]


### PR DESCRIPTION
It was pointed out in https://github.com/rust-lang/rust/issues/128854#issuecomment-2278919897 that the magic volatile read was probably missing from `alloc_zeroed`. I can't find any mention of `alloc_zeroed` on https://github.com/rust-lang/rust/pull/86844, so it looks like this was just missed initially.