### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -16,7 +16,7 @@ use rustc_errors::emitter::Emitter;
 use rustc_errors::translation::Translate;
 use rustc_errors::{
     Diag, DiagArgMap, DiagCtxt, DiagMessage, ErrCode, FatalError, FluentBundle, Level, MultiSpan,
-    Style,
+    Style, Suggestions,
 };
 use rustc_fs_util::link_or_copy;
 use rustc_hir::def_id::{CrateNum, LOCAL_CRATE};
@@ -1903,7 +1903,7 @@ impl Emitter for SharedEmitter {
         // Check that we aren't missing anything interesting when converting to
         // the cut-down local `DiagInner`.
         assert_eq!(diag.span, MultiSpan::new());
-        assert_eq!(diag.suggestions, Ok(vec![]));
+        assert_eq!(diag.suggestions, Suggestions::Enabled(vec![]));
         assert_eq!(diag.sort_span, rustc_span::DUMMY_SP);
         assert_eq!(diag.is_lint, None);
         // No sensible check for `diag.emitted_at`.

--- a/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
+++ b/compiler/rustc_errors/src/annotate_snippet_emitter_writer.rs
@@ -48,7 +48,7 @@ impl Emitter for AnnotateSnippetEmitter {
     fn emit_diagnostic(&mut self, mut diag: DiagInner) {
         let fluent_args = to_fluent_args(diag.args.iter());
 
-        let mut suggestions = diag.suggestions.unwrap_or(vec![]);
+        let mut suggestions = diag.suggestions.unwrap_tag();
         self.primary_span_formatted(&mut diag.span, &mut suggestions, &fluent_args);
 
         self.fix_multispans_in_extern_macros_and_render_macro_backtrace(

--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -498,7 +498,7 @@ impl Emitter for HumanEmitter {
     fn emit_diagnostic(&mut self, mut diag: DiagInner) {
         let fluent_args = to_fluent_args(diag.args.iter());
 
-        let mut suggestions = diag.suggestions.unwrap_or(vec![]);
+        let mut suggestions = diag.suggestions.unwrap_tag();
         self.primary_span_formatted(&mut diag.span, &mut suggestions, &fluent_args);
 
         self.fix_multispans_in_extern_macros_and_render_macro_backtrace(

--- a/compiler/rustc_errors/src/lib.rs
+++ b/compiler/rustc_errors/src/lib.rs
@@ -126,6 +126,41 @@ impl SuggestionStyle {
     }
 }
 
+/// Represents the help messages seen on a diagnostic.
+#[derive(Clone, Debug, PartialEq, Hash, Encodable, Decodable)]
+pub enum Suggestions {
+    /// Indicates that new suggestions can be added or removed from this diagnostic.
+    ///
+    /// `DiagInner`'s new_* methods initialize the `suggestions` field with
+    /// this variant. Also, this is the default variant for `Suggestions`.
+    Enabled(Vec<CodeSuggestion>),
+    /// Indicates that suggestions cannot be added or removed from this diagnostic.
+    ///
+    /// Gets toggled when `.seal_suggestions()` is called on the `DiagInner`.
+    Sealed(Box<[CodeSuggestion]>),
+    /// Indicates that no suggestion is available for this diagnostic.
+    ///
+    /// Gets toggled when `.disable_suggestions()` is called on the `DiagInner`.
+    Disabled,
+}
+
+impl Suggestions {
+    /// Returns the underlying list of suggestions.
+    pub fn unwrap_tag(self) -> Vec<CodeSuggestion> {
+        match self {
+            Suggestions::Enabled(suggestions) => suggestions,
+            Suggestions::Sealed(suggestions) => suggestions.into_vec(),
+            Suggestions::Disabled => Vec::new(),
+        }
+    }
+}
+
+impl Default for Suggestions {
+    fn default() -> Self {
+        Self::Enabled(vec![])
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Hash, Encodable, Decodable)]
 pub struct CodeSuggestion {
     /// Each substitute can have multiple variants due to multiple

--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -1,6 +1,6 @@
 use core::ops::ControlFlow;
 
-use rustc_errors::{Applicability, StashKey};
+use rustc_errors::{Applicability, StashKey, Suggestions};
 use rustc_hir as hir;
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::HirId;
@@ -670,7 +670,7 @@ fn infer_placeholder_type<'tcx>(
 
                 // The parser provided a sub-optimal `HasPlaceholders` suggestion for the type.
                 // We are typeck and have the real type, so remove that and suggest the actual type.
-                if let Ok(suggestions) = &mut err.suggestions {
+                if let Suggestions::Enabled(suggestions) = &mut err.suggestions {
                     suggestions.clear();
                 }
 

--- a/compiler/rustc_middle/src/values.rs
+++ b/compiler/rustc_middle/src/values.rs
@@ -56,7 +56,7 @@ impl<'tcx> Value<TyCtxt<'tcx>> for ty::Binder<'_, ty::FnSig<'_>> {
             && let Some(node) = tcx.hir().get_if_local(def_id)
             && let Some(sig) = node.fn_sig()
         {
-            sig.decl.inputs.len() + sig.decl.implicit_self.has_implicit_self() as usize
+            sig.decl.inputs.len()
         } else {
             tcx.dcx().abort_if_errors();
             unreachable!()

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -299,6 +299,9 @@ impl<'psess, 'src> StringReader<'psess, 'src> {
                         lifetime_name += lifetime_name_without_tick;
                         let sym = Symbol::intern(&lifetime_name);
 
+                        // Make sure we mark this as a raw identifier.
+                        self.psess.raw_identifier_spans.push(self.mk_sp(start, self.pos));
+
                         token::Lifetime(sym, IdentIsRaw::Yes)
                     } else {
                         // Otherwise, this should be parsed like `'r`. Warn about it though.

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -17,7 +17,7 @@ use rustc_ast::visit::{visit_opt, walk_list, AssocCtxt, BoundKind, FnCtxt, FnKin
 use rustc_ast::*;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet, FxIndexMap};
 use rustc_errors::codes::*;
-use rustc_errors::{Applicability, DiagArgValue, IntoDiagArg, StashKey};
+use rustc_errors::{Applicability, DiagArgValue, IntoDiagArg, StashKey, Suggestions};
 use rustc_hir::def::Namespace::{self, *};
 use rustc_hir::def::{self, CtorKind, DefKind, LifetimeRes, NonMacroAttrKind, PartialRes, PerNS};
 use rustc_hir::def_id::{DefId, LocalDefId, CRATE_DEF_ID, LOCAL_CRATE};
@@ -4052,17 +4052,23 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                 err.sort_span = parent_err.sort_span;
                 err.is_lint = parent_err.is_lint.clone();
 
-                // merge the parent's suggestions with the typo suggestions
-                fn append_result<T, E>(res1: &mut Result<Vec<T>, E>, res2: Result<Vec<T>, E>) {
-                    match res1 {
-                        Ok(vec1) => match res2 {
-                            Ok(mut vec2) => vec1.append(&mut vec2),
-                            Err(e) => *res1 = Err(e),
-                        },
-                        Err(_) => (),
-                    };
+                // merge the parent_err's suggestions with the typo (err's) suggestions
+                match &mut err.suggestions {
+                    Suggestions::Enabled(typo_suggestions) => match &mut parent_err.suggestions {
+                        Suggestions::Enabled(parent_suggestions) => {
+                            // If both suggestions are enabled, append parent_err's suggestions to err's suggestions.
+                            typo_suggestions.append(parent_suggestions)
+                        }
+                        Suggestions::Sealed(_) | Suggestions::Disabled => {
+                            // If the parent's suggestions are either sealed or disabled, it signifies that
+                            // new suggestions cannot be added or removed from the diagnostic. Therefore,
+                            // we assign both types of suggestions to err's suggestions and discard the
+                            // existing suggestions in err.
+                            err.suggestions = std::mem::take(&mut parent_err.suggestions);
+                        }
+                    },
+                    Suggestions::Sealed(_) | Suggestions::Disabled => (),
                 }
-                append_result(&mut err.suggestions, parent_err.suggestions.clone());
 
                 parent_err.cancel();
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -6,7 +6,7 @@ use rustc_data_structures::unord::UnordSet;
 use rustc_errors::codes::*;
 use rustc_errors::{
     pluralize, struct_span_code_err, Applicability, Diag, ErrorGuaranteed, MultiSpan, StashKey,
-    StringPart,
+    StringPart, Suggestions,
 };
 use rustc_hir::def::Namespace;
 use rustc_hir::def_id::{DefId, LocalDefId, LOCAL_CRATE};
@@ -2136,8 +2136,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             if let Some(span) = err.span.primary_span()
                 && let Some(mut diag) =
                     self.dcx().steal_non_err(span, StashKey::AssociatedTypeSuggestion)
-                && let Ok(ref mut s1) = err.suggestions
-                && let Ok(ref mut s2) = diag.suggestions
+                && let Suggestions::Enabled(ref mut s1) = err.suggestions
+                && let Suggestions::Enabled(ref mut s2) = diag.suggestions
             {
                 s1.append(s2);
                 diag.cancel()

--- a/tests/crashes/120016.rs
+++ b/tests/crashes/120016.rs
@@ -1,0 +1,19 @@
+//@ known-bug: #120016
+//@ compile-flags: -Zcrate-attr=feature(const_async_blocks) --edition=2021
+
+#![feature(type_alias_impl_trait, const_async_blocks)]
+
+struct Bug {
+    V1: [(); {
+        type F = impl std::future::Future<Output = impl Sized>;
+        fn concrete_use() -> F {
+            //~^ ERROR to be a future that resolves to `u8`, but it resolves to `()`
+            async {}
+        }
+        let f: F = async { 1 };
+        //~^ ERROR `async` blocks are not allowed in constants
+        1
+    }],
+}
+
+fn main() {}

--- a/tests/crashes/127804.rs
+++ b/tests/crashes/127804.rs
@@ -1,0 +1,12 @@
+//@ known-bug: #127804
+
+struct Thing;
+
+pub trait Every {
+    type Assoc;
+}
+impl<T: ?Sized> Every for Thing {
+    type Assoc = T;
+}
+
+fn foo(_: <Thing as Every>::Assoc) {}

--- a/tests/crashes/128119.rs
+++ b/tests/crashes/128119.rs
@@ -1,0 +1,15 @@
+//@ known-bug: #128119
+
+trait Trait {
+    reuse to_reuse::foo { self }
+}
+
+struct S;
+
+mod to_reuse {
+    pub fn foo(&self) -> u32 {}
+}
+
+impl Trait  S {
+    reuse to_reuse::foo { self }
+}

--- a/tests/crashes/128232.rs
+++ b/tests/crashes/128232.rs
@@ -1,0 +1,15 @@
+//@ known-bug: #128232
+
+#![feature(generic_const_exprs, unsized_const_params)]
+
+fn function() {}
+
+struct Wrapper<const F: fn()>;
+
+impl Wrapper<{ bar() }> {
+    fn call() {}
+}
+
+fn main() {
+    Wrapper::<function>::call;
+}

--- a/tests/crashes/130411.rs
+++ b/tests/crashes/130411.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #130411
+trait Project {
+    const SELF: Self;
+}
+
+fn take1(_: Project<SELF = {}>) {}

--- a/tests/crashes/130413.rs
+++ b/tests/crashes/130413.rs
@@ -1,0 +1,17 @@
+//@ known-bug: #130413
+
+#![feature(transmutability)]
+trait Aaa {
+    type Y;
+}
+
+trait Bbb {
+    type B: std::mem::TransmuteFrom<()>;
+}
+
+impl<T> Bbb for T
+where
+    T: Aaa,
+{
+    type B = T::Y;
+}

--- a/tests/crashes/130425.rs
+++ b/tests/crashes/130425.rs
@@ -1,0 +1,13 @@
+//@ known-bug: #130425
+//@ compile-flags: -Zmir-opt-level=5 -Zpolymorphize=on
+
+struct S<T>(T)
+where
+    [T; (
+        |_: u8| {
+            static FOO: Sync = AtomicUsize::new(0);
+            unsafe { &*(&FOO as *const _ as *const usize) }
+        },
+        1,
+    )
+        .1]: Copy;

--- a/tests/ui/mismatched_types/mismatch-args-crash-issue-130400.rs
+++ b/tests/ui/mismatched_types/mismatch-args-crash-issue-130400.rs
@@ -1,0 +1,8 @@
+trait Bar {
+    fn foo(&mut self) -> _ {
+        //~^ ERROR the placeholder `_` is not allowed within types on item signatures for return types
+        Self::foo() //~ ERROR  this function takes 1 argument but 0 arguments were supplied
+    }
+}
+
+fn main() {}

--- a/tests/ui/mismatched_types/mismatch-args-crash-issue-130400.stderr
+++ b/tests/ui/mismatched_types/mismatch-args-crash-issue-130400.stderr
@@ -1,0 +1,26 @@
+error[E0061]: this function takes 1 argument but 0 arguments were supplied
+  --> $DIR/mismatch-args-crash-issue-130400.rs:4:9
+   |
+LL |         Self::foo()
+   |         ^^^^^^^^^-- argument #1 is missing
+   |
+note: method defined here
+  --> $DIR/mismatch-args-crash-issue-130400.rs:2:8
+   |
+LL |     fn foo(&mut self) -> _ {
+   |        ^^^ ---------
+help: provide the argument
+   |
+LL |         Self::foo(/* value */)
+   |                  ~~~~~~~~~~~~~
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
+  --> $DIR/mismatch-args-crash-issue-130400.rs:2:26
+   |
+LL |     fn foo(&mut self) -> _ {
+   |                          ^ not allowed in type signatures
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0061, E0121.
+For more information about an error, try `rustc --explain E0061`.

--- a/tests/ui/parser/issues/issue-70549-resolve-after-recovered-self-ctor.stderr
+++ b/tests/ui/parser/issues/issue-70549-resolve-after-recovered-self-ctor.stderr
@@ -14,10 +14,6 @@ help: there is a keyword `mut` with a similar name
    |
 LL |     fn foo(&mut Self) {}
    |             ~~~
-help: declare the type after the parameter binding
-   |
-LL |     fn foo(<identifier>: <type>) {}
-   |            ~~~~~~~~~~~~~~~~~~~~
 
 error: unexpected lifetime `'static` in pattern
   --> $DIR/issue-70549-resolve-after-recovered-self-ctor.rs:8:13
@@ -47,10 +43,6 @@ help: there is a keyword `mut` with a similar name
    |
 LL |     fn bar(&'static mut Self) {}
    |                     ~~~
-help: declare the type after the parameter binding
-   |
-LL |     fn bar(<identifier>: <type>) {}
-   |            ~~~~~~~~~~~~~~~~~~~~
 
 error: expected one of `:`, `@`, or `|`, found keyword `Self`
   --> $DIR/issue-70549-resolve-after-recovered-self-ctor.rs:14:17

--- a/tests/ui/parser/misspelled-keywords/impl-trait.stderr
+++ b/tests/ui/parser/misspelled-keywords/impl-trait.stderr
@@ -8,10 +8,6 @@ help: there is a keyword `impl` with a similar name
    |
 LL | fn code<T: impl Debug>() -> u8 {}
    |            ~~~~
-help: you might have meant to end the type parameters here
-   |
-LL | fn code<T: impll> Debug>() -> u8 {}
-   |                 +
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/misspelled-keywords/ref.stderr
+++ b/tests/ui/parser/misspelled-keywords/ref.stderr
@@ -8,10 +8,6 @@ help: there is a keyword `ref` with a similar name
    |
 LL |         Some(ref list) => println!("{list:?}"),
    |              ~~~
-help: missing `,`
-   |
-LL |         Some(refe, list) => println!("{list:?}"),
-   |                  +
 
 error[E0023]: this pattern has 2 fields, but the corresponding tuple variant has 1 field
   --> $DIR/ref.rs:4:14

--- a/tests/ui/rust-2024/raw-gen-lt.rs
+++ b/tests/ui/rust-2024/raw-gen-lt.rs
@@ -1,0 +1,8 @@
+//@ edition: 2021
+//@ check-pass
+
+#![deny(keyword_idents_2024)]
+
+fn foo<'r#gen>() {}
+
+fn main() {}


### PR DESCRIPTION
Successful merges:

 - #130116 (Implement a Method to Seal `DiagInner`'s Suggestions)
 - #130489 (Ensure that `keyword_ident` lint doesn't trigger on `'r#kw` lifetime)
 - #130491 (more crash tests)
 - #130496 (Fix circular fn_sig queries to correct number of args for methods)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=130116,130489,130491,130496)
<!-- homu-ignore:end -->