### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -45,7 +45,16 @@ impl LanguageItems {
 
     pub fn set(&mut self, item: LangItem, def_id: DefId) {
         self.items[item as usize] = Some(def_id);
-        self.reverse_items.insert(def_id, item);
+        let preexisting = self.reverse_items.insert(def_id, item);
+
+        // This needs to be a bijection.
+        if let Some(preexisting) = preexisting {
+            panic!(
+                "For the bijection of LangItem <=> DefId to work,\
+                one item DefId may only be assigned one LangItem. \
+                Separate the LangItem definitions for {item:?} and {preexisting:?}."
+            );
+        }
     }
 
     pub fn from_def_id(&self, def_id: DefId) -> Option<LangItem> {

--- a/tests/codegen/repr/transparent-byval-struct-ptr.rs
+++ b/tests/codegen/repr/transparent-byval-struct-ptr.rs
@@ -14,8 +14,9 @@
 
 // See ./transparent.rs
 // Some platforms pass large aggregates using immediate arrays in LLVMIR
-// Other platforms pass large aggregates using struct pointer in LLVMIR
-// This covers the "struct pointer" case.
+// Other platforms pass large aggregates using by-value struct pointer in LLVMIR
+// Yet more platforms pass large aggregates using opaque pointer in LLVMIR
+// This covers the "by-value struct pointer" case.
 
 #![feature(no_core, lang_items, transparent_unions)]
 #![crate_type = "lib"]

--- a/tests/codegen/repr/transparent-imm-array.rs
+++ b/tests/codegen/repr/transparent-imm-array.rs
@@ -18,7 +18,8 @@
 
 // See ./transparent.rs
 // Some platforms pass large aggregates using immediate arrays in LLVMIR
-// Other platforms pass large aggregates using struct pointer in LLVMIR
+// Other platforms pass large aggregates using by-value struct pointer in LLVMIR
+// Yet more platforms pass large aggregates using opaque pointer in LLVMIR
 // This covers the "immediate array" case.
 
 #![feature(no_core, lang_items, transparent_unions)]

--- a/tests/codegen/repr/transparent-opaque-ptr.rs
+++ b/tests/codegen/repr/transparent-opaque-ptr.rs
@@ -1,0 +1,111 @@
+//@ revisions: aarch64-linux aarch64-darwin
+//@ compile-flags: -O -C no-prepopulate-passes
+
+//@[aarch64-linux] compile-flags: --target aarch64-unknown-linux-gnu
+//@[aarch64-linux] needs-llvm-components: aarch64
+//@[aarch64-darwin] compile-flags: --target aarch64-apple-darwin
+//@[aarch64-darwin] needs-llvm-components: aarch64
+
+// See ./transparent.rs
+// Some platforms pass large aggregates using immediate arrays in LLVMIR
+// Other platforms pass large aggregates using by-value struct pointer in LLVMIR
+// Yet more platforms pass large aggregates using opaque pointer in LLVMIR
+// This covers the "opaque pointer" case.
+
+#![feature(no_core, lang_items, transparent_unions)]
+#![crate_type = "lib"]
+#![no_std]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "freeze"]
+trait Freeze {}
+#[lang = "copy"]
+trait Copy {}
+
+impl Copy for [u32; 16] {}
+impl Copy for BigS {}
+impl Copy for BigU {}
+
+#[repr(C)]
+pub struct BigS([u32; 16]);
+
+#[repr(transparent)]
+pub struct TsBigS(BigS);
+
+#[repr(transparent)]
+pub union TuBigS {
+    field: BigS,
+}
+
+#[repr(transparent)]
+pub enum TeBigS {
+    Variant(BigS),
+}
+
+// CHECK: define{{.*}}void @test_BigS(ptr [[BIGS_RET_ATTRS1:.*]] sret([64 x i8]) [[BIGS_RET_ATTRS2:.*]], ptr [[BIGS_ARG_ATTRS1:.*]])
+#[no_mangle]
+pub extern "C" fn test_BigS(_: BigS) -> BigS {
+    loop {}
+}
+
+// CHECK: define{{.*}}void @test_TsBigS(ptr [[BIGS_RET_ATTRS1]] sret([64 x i8]) [[BIGS_RET_ATTRS2]], ptr [[BIGS_ARG_ATTRS1]])
+#[no_mangle]
+pub extern "C" fn test_TsBigS(_: TsBigS) -> TsBigS {
+    loop {}
+}
+
+// CHECK: define{{.*}}void @test_TuBigS(ptr [[BIGS_RET_ATTRS1]] sret([64 x i8]) [[BIGS_RET_ATTRS2]], ptr [[BIGS_ARG_ATTRS1]])
+#[no_mangle]
+pub extern "C" fn test_TuBigS(_: TuBigS) -> TuBigS {
+    loop {}
+}
+
+// CHECK: define{{.*}}void @test_TeBigS(ptr [[BIGS_RET_ATTRS1]] sret([64 x i8]) [[BIGS_RET_ATTRS2]], ptr [[BIGS_ARG_ATTRS1]])
+#[no_mangle]
+pub extern "C" fn test_TeBigS(_: TeBigS) -> TeBigS {
+    loop {}
+}
+
+#[repr(C)]
+pub union BigU {
+    foo: [u32; 16],
+}
+
+#[repr(transparent)]
+pub struct TsBigU(BigU);
+
+#[repr(transparent)]
+pub union TuBigU {
+    field: BigU,
+}
+
+#[repr(transparent)]
+pub enum TeBigU {
+    Variant(BigU),
+}
+
+// CHECK: define{{.*}}void @test_BigU(ptr [[BIGU_RET_ATTRS1:.*]] sret([64 x i8]) [[BIGU_RET_ATTRS2:.*]], ptr [[BIGU_ARG_ATTRS1:.*]])
+#[no_mangle]
+pub extern "C" fn test_BigU(_: BigU) -> BigU {
+    loop {}
+}
+
+// CHECK: define{{.*}}void @test_TsBigU(ptr [[BIGU_RET_ATTRS1:.*]] sret([64 x i8]) [[BIGU_RET_ATTRS2:.*]], ptr [[BIGU_ARG_ATTRS1]])
+#[no_mangle]
+pub extern "C" fn test_TsBigU(_: TsBigU) -> TsBigU {
+    loop {}
+}
+
+// CHECK: define{{.*}}void @test_TuBigU(ptr [[BIGU_RET_ATTRS1]] sret([64 x i8]) [[BIGU_RET_ATTRS2:.*]], ptr [[BIGU_ARG_ATTRS1]])
+#[no_mangle]
+pub extern "C" fn test_TuBigU(_: TuBigU) -> TuBigU {
+    loop {}
+}
+
+// CHECK: define{{.*}}void @test_TeBigU(ptr [[BIGU_RET_ATTRS1]] sret([64 x i8]) [[BIGU_RET_ATTRS2:.*]], ptr [[BIGU_ARG_ATTRS1]])
+#[no_mangle]
+pub extern "C" fn test_TeBigU(_: TeBigU) -> TeBigU {
+    loop {}
+}

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -966,7 +966,7 @@ libs = [
     "@jhpratt",
     "@tgross35",
     "@thomcc",
-    "@ibraheemdev"
+    "@ibraheemdev",
 ]
 bootstrap = [
     "@Mark-Simulacrum",

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -966,6 +966,7 @@ libs = [
     "@jhpratt",
     "@tgross35",
     "@thomcc",
+    "@ibraheemdev"
 ]
 bootstrap = [
     "@Mark-Simulacrum",


### PR DESCRIPTION
Successful merges:

 - #130466 (tests: add repr/transparent test for aarch64)
 - #130468 (Make sure that def id <=> lang item map is bidirectional)
 - #130499 (Add myself to the libs review rotation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=130466,130468,130499)
<!-- homu-ignore:end -->