### PR TITLE
Remove `LLVMMD{String,Node}InContext`

### DIFF
--- a/compiler/rustc_codegen_llvm/src/asm.rs
+++ b/compiler/rustc_codegen_llvm/src/asm.rs
@@ -504,11 +504,21 @@ pub(crate) fn inline_asm_call<'ll>(
                 // due to the asm template string coming from a macro. LLVM will
                 // default to the first srcloc for lines that don't have an
                 // associated srcloc.
-                srcloc.push(bx.const_i32(0));
+                srcloc.push(llvm::LLVMValueAsMetadata(bx.const_i32(0)));
             }
-            srcloc.extend(line_spans.iter().map(|span| bx.const_i32(span.lo().to_u32() as i32)));
-            let md = llvm::LLVMMDNodeInContext(bx.llcx, srcloc.as_ptr(), srcloc.len() as u32);
-            llvm::LLVMSetMetadata(call, kind, md);
+            srcloc.extend(
+                line_spans
+                    .iter()
+                    .map(|span| llvm::LLVMValueAsMetadata(bx.const_i32(span.lo().to_u32() as i32))),
+            );
+            llvm::LLVMSetMetadata(
+                call,
+                kind,
+                llvm::LLVMMetadataAsValue(
+                    bx.llcx,
+                    llvm::LLVMMDNodeInContext2(bx.llcx, srcloc.as_ptr(), srcloc.len()),
+                ),
+            );
 
             Some(call)
         } else {

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -683,15 +683,18 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
 
         unsafe {
             let llty = self.cx.val_ty(load);
-            let v = [
-                self.cx.const_uint_big(llty, range.start),
-                self.cx.const_uint_big(llty, range.end.wrapping_add(1)),
+            let md = [
+                llvm::LLVMValueAsMetadata(self.cx.const_uint_big(llty, range.start)),
+                llvm::LLVMValueAsMetadata(self.cx.const_uint_big(llty, range.end.wrapping_add(1))),
             ];
 
             llvm::LLVMSetMetadata(
                 load,
                 llvm::MD_range as c_uint,
-                llvm::LLVMMDNodeInContext(self.cx.llcx, v.as_ptr(), v.len() as c_uint),
+                llvm::LLVMMetadataAsValue(
+                    self.cx.llcx,
+                    llvm::LLVMMDNodeInContext2(self.cx.llcx, md.as_ptr(), md.len()),
+                ),
             );
         }
     }
@@ -701,7 +704,10 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
             llvm::LLVMSetMetadata(
                 load,
                 llvm::MD_nonnull as c_uint,
-                llvm::LLVMMDNodeInContext(self.cx.llcx, ptr::null(), 0),
+                llvm::LLVMMetadataAsValue(
+                    self.cx.llcx,
+                    llvm::LLVMMDNodeInContext2(self.cx.llcx, ptr::null(), 0),
+                ),
             );
         }
     }
@@ -750,9 +756,18 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
                     // *always* point to a metadata value of the integer 1.
                     //
                     // [1]: https://llvm.org/docs/LangRef.html#store-instruction
-                    let one = self.cx.const_i32(1);
-                    let node = llvm::LLVMMDNodeInContext(self.cx.llcx, &one, 1);
-                    llvm::LLVMSetMetadata(store, llvm::MD_nontemporal as c_uint, node);
+                    llvm::LLVMSetMetadata(
+                        store,
+                        llvm::MD_nontemporal as c_uint,
+                        llvm::LLVMMetadataAsValue(
+                            self.cx.llcx,
+                            llvm::LLVMMDNodeInContext2(
+                                self.cx.llcx,
+                                &llvm::LLVMValueAsMetadata(self.cx.const_i32(1)),
+                                1,
+                            ),
+                        ),
+                    );
                 }
             }
             store
@@ -1219,7 +1234,10 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
             llvm::LLVMSetMetadata(
                 load,
                 llvm::MD_invariant_load as c_uint,
-                llvm::LLVMMDNodeInContext(self.cx.llcx, ptr::null(), 0),
+                llvm::LLVMMetadataAsValue(
+                    self.cx.llcx,
+                    llvm::LLVMMDNodeInContext2(self.cx.llcx, ptr::null(), 0),
+                ),
             );
         }
     }
@@ -1355,12 +1373,15 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
 
     fn align_metadata(&mut self, load: &'ll Value, align: Align) {
         unsafe {
-            let v = [self.cx.const_u64(align.bytes())];
+            let md = [llvm::LLVMValueAsMetadata(self.cx.const_u64(align.bytes()))];
 
             llvm::LLVMSetMetadata(
                 load,
                 llvm::MD_align as c_uint,
-                llvm::LLVMMDNodeInContext(self.cx.llcx, v.as_ptr(), v.len() as c_uint),
+                llvm::LLVMMetadataAsValue(
+                    self.cx.llcx,
+                    llvm::LLVMMDNodeInContext2(self.cx.llcx, md.as_ptr(), md.len()),
+                ),
             );
         }
     }
@@ -1370,7 +1391,10 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
             llvm::LLVMSetMetadata(
                 load,
                 llvm::MD_noundef as c_uint,
-                llvm::LLVMMDNodeInContext(self.cx.llcx, ptr::null(), 0),
+                llvm::LLVMMetadataAsValue(
+                    self.cx.llcx,
+                    llvm::LLVMMDNodeInContext2(self.cx.llcx, ptr::null(), 0),
+                ),
             );
         }
     }
@@ -1380,7 +1404,10 @@ impl<'a, 'll, 'tcx> Builder<'a, 'll, 'tcx> {
             llvm::LLVMSetMetadata(
                 inst,
                 llvm::MD_unpredictable as c_uint,
-                llvm::LLVMMDNodeInContext(self.cx.llcx, ptr::null(), 0),
+                llvm::LLVMMetadataAsValue(
+                    self.cx.llcx,
+                    llvm::LLVMMDNodeInContext2(self.cx.llcx, ptr::null(), 0),
+                ),
             );
         }
     }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -3,7 +3,6 @@ use std::cell::{Cell, RefCell};
 use std::ffi::CStr;
 use std::str;
 
-use libc::c_uint;
 use rustc_codegen_ssa::base::{wants_msvc_seh, wants_wasm_eh};
 use rustc_codegen_ssa::errors as ssa_errors;
 use rustc_codegen_ssa::traits::*;
@@ -413,18 +412,16 @@ pub(crate) unsafe fn create_module<'ll>(
     let rustc_producer =
         format!("rustc version {}", option_env!("CFG_VERSION").expect("CFG_VERSION"));
     let name_metadata = unsafe {
-        llvm::LLVMMDStringInContext(
+        llvm::LLVMMDStringInContext2(
             llcx,
             rustc_producer.as_ptr().cast(),
-            rustc_producer.as_bytes().len() as c_uint,
+            rustc_producer.as_bytes().len(),
         )
     };
     unsafe {
-        llvm::LLVMAddNamedMetadataOperand(
-            llmod,
-            c"llvm.ident".as_ptr(),
-            llvm::LLVMMDNodeInContext(llcx, &name_metadata, 1),
-        );
+        let meta = llvm::LLVMMDNodeInContext2(llcx, &name_metadata, 1);
+        let val = llvm::LLVMMetadataAsValue(llcx, meta);
+        llvm::LLVMAddNamedMetadataOperand(llmod, c"llvm.ident".as_ptr(), val);
     }
 
     // Emit RISC-V specific target-abi metadata

--- a/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
+++ b/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs
@@ -1545,20 +1545,16 @@ pub(crate) fn apply_vcall_visibility_metadata<'ll, 'tcx>(
     let trait_ref_typeid = typeid_for_trait_ref(cx.tcx, trait_ref);
 
     unsafe {
-        let typeid = llvm::LLVMMDStringInContext(
+        let typeid = llvm::LLVMMDStringInContext2(
             cx.llcx,
             trait_ref_typeid.as_ptr() as *const c_char,
-            trait_ref_typeid.as_bytes().len() as c_uint,
+            trait_ref_typeid.as_bytes().len(),
         );
-        let v = [cx.const_usize(0), typeid];
+        let meta = [llvm::LLVMValueAsMetadata(cx.const_usize(0)), typeid];
         llvm::LLVMRustGlobalAddMetadata(
             vtable,
             llvm::MD_type as c_uint,
-            llvm::LLVMValueAsMetadata(llvm::LLVMMDNodeInContext(
-                cx.llcx,
-                v.as_ptr(),
-                v.len() as c_uint,
-            )),
+            llvm::LLVMMDNodeInContext2(cx.llcx, meta.as_ptr(), meta.len()),
         );
         let vcall_visibility = llvm::LLVMValueAsMetadata(cx.const_u64(vcall_visibility as u64));
         let vcall_visibility_metadata = llvm::LLVMMDNodeInContext2(cx.llcx, &vcall_visibility, 1);

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -913,13 +913,6 @@ unsafe extern "C" {
 
     // Operations on metadata
     pub fn LLVMMDStringInContext2(C: &Context, Str: *const c_char, SLen: size_t) -> &Metadata;
-
-    // FIXME: deprecated, replace with LLVMMDNodeInContext2
-    pub fn LLVMMDNodeInContext<'a>(
-        C: &'a Context,
-        Vals: *const &'a Value,
-        Count: c_uint,
-    ) -> &'a Value;
     pub fn LLVMMDNodeInContext2<'a>(
         C: &'a Context,
         Vals: *const &'a Metadata,

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -912,9 +912,6 @@ unsafe extern "C" {
     pub fn LLVMGetPoison(Ty: &Type) -> &Value;
 
     // Operations on metadata
-    // FIXME: deprecated, replace with LLVMMDStringInContext2
-    pub fn LLVMMDStringInContext(C: &Context, Str: *const c_char, SLen: c_uint) -> &Value;
-
     pub fn LLVMMDStringInContext2(C: &Context, Str: *const c_char, SLen: size_t) -> &Metadata;
 
     // FIXME: deprecated, replace with LLVMMDNodeInContext2

--- a/compiler/rustc_codegen_llvm/src/type_.rs
+++ b/compiler/rustc_codegen_llvm/src/type_.rs
@@ -283,32 +283,30 @@ impl<'ll, 'tcx> LayoutTypeMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 impl<'ll, 'tcx> TypeMembershipMethods<'tcx> for CodegenCx<'ll, 'tcx> {
     fn add_type_metadata(&self, function: &'ll Value, typeid: String) {
         let typeid_metadata = self.typeid_metadata(typeid).unwrap();
-        let v = [self.const_usize(0), typeid_metadata];
         unsafe {
+            let meta = [
+                llvm::LLVMValueAsMetadata(self.const_usize(0)),
+                llvm::LLVMValueAsMetadata(typeid_metadata),
+            ];
             llvm::LLVMRustGlobalAddMetadata(
                 function,
                 llvm::MD_type as c_uint,
-                llvm::LLVMValueAsMetadata(llvm::LLVMMDNodeInContext(
-                    self.llcx,
-                    v.as_ptr(),
-                    v.len() as c_uint,
-                )),
+                llvm::LLVMMDNodeInContext2(self.llcx, meta.as_ptr(), meta.len()),
             )
         }
     }
 
     fn set_type_metadata(&self, function: &'ll Value, typeid: String) {
         let typeid_metadata = self.typeid_metadata(typeid).unwrap();
-        let v = [self.const_usize(0), typeid_metadata];
         unsafe {
+            let meta = [
+                llvm::LLVMValueAsMetadata(self.const_usize(0)),
+                llvm::LLVMValueAsMetadata(typeid_metadata),
+            ];
             llvm::LLVMGlobalSetMetadata(
                 function,
                 llvm::MD_type as c_uint,
-                llvm::LLVMValueAsMetadata(llvm::LLVMMDNodeInContext(
-                    self.llcx,
-                    v.as_ptr(),
-                    v.len() as c_uint,
-                )),
+                llvm::LLVMMDNodeInContext2(self.llcx, meta.as_ptr(), meta.len()),
             )
         }
     }

--- a/compiler/rustc_codegen_llvm/src/type_.rs
+++ b/compiler/rustc_codegen_llvm/src/type_.rs
@@ -315,11 +315,12 @@ impl<'ll, 'tcx> TypeMembershipMethods<'tcx> for CodegenCx<'ll, 'tcx> {
 
     fn typeid_metadata(&self, typeid: String) -> Option<&'ll Value> {
         Some(unsafe {
-            llvm::LLVMMDStringInContext(
+            let meta = llvm::LLVMMDStringInContext2(
                 self.llcx,
                 typeid.as_ptr() as *const c_char,
-                typeid.len() as c_uint,
-            )
+                typeid.len(),
+            );
+            llvm::LLVMMetadataAsValue(self.llcx, meta)
         })
     }
 


### PR DESCRIPTION
They are both marked with `FIXME` comments saying they should be removed, because the corresponding LLVM functions are deprecated.

r? @nikic
cc @klensy 