### PR TITLE
Improve handling of raw-idents in check-cfg

### DIFF
--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -2180,6 +2180,7 @@ pub(crate) struct UnexpectedCfgName {
 pub(crate) mod unexpected_cfg_name {
     use rustc_errors::DiagSymbolList;
     use rustc_macros::Subdiagnostic;
+    use rustc_span::symbol::Ident;
     use rustc_span::{Span, Symbol};
 
     #[derive(Subdiagnostic)]
@@ -2260,7 +2261,7 @@ pub(crate) mod unexpected_cfg_name {
     #[derive(Subdiagnostic)]
     #[help_once(lint_unexpected_cfg_name_expected_names)]
     pub(crate) struct ExpectedNames {
-        pub possibilities: DiagSymbolList,
+        pub possibilities: DiagSymbolList<Ident>,
         pub and_more: usize,
     }
 

--- a/tests/ui/check-cfg/raw-keywords.edition2015.stderr
+++ b/tests/ui/check-cfg/raw-keywords.edition2015.stderr
@@ -1,0 +1,40 @@
+warning: unexpected `cfg` condition name: `tru`
+  --> $DIR/raw-keywords.rs:14:7
+   |
+LL | #[cfg(tru)]
+   |       ^^^ help: there is a config with a similar name: `r#true`
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(tru)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: unexpected `cfg` condition name: `r#false`
+  --> $DIR/raw-keywords.rs:19:7
+   |
+LL | #[cfg(r#false)]
+   |       ^^^^^^^
+   |
+   = help: expected names are: `async`, `clippy`, `debug_assertions`, `doc`, `doctest`, `edition2015`, `edition2021`, `fmt_debug`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `r#true`, `ub_checks`, `unix`, and `windows`
+   = help: to expect this configuration use `--check-cfg=cfg(r#false)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+
+warning: unexpected `cfg` condition name: `await`
+  --> $DIR/raw-keywords.rs:27:29
+   |
+LL | #[cfg_attr(edition2015, cfg(await))]
+   |                             ^^^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(await)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+
+warning: unexpected `cfg` condition name: `raw`
+  --> $DIR/raw-keywords.rs:33:7
+   |
+LL | #[cfg(r#raw)]
+   |       ^^^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(raw)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+
+warning: 4 warnings emitted
+

--- a/tests/ui/check-cfg/raw-keywords.edition2021.stderr
+++ b/tests/ui/check-cfg/raw-keywords.edition2021.stderr
@@ -1,0 +1,40 @@
+warning: unexpected `cfg` condition name: `tru`
+  --> $DIR/raw-keywords.rs:14:7
+   |
+LL | #[cfg(tru)]
+   |       ^^^ help: there is a config with a similar name: `r#true`
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(tru)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+   = note: `#[warn(unexpected_cfgs)]` on by default
+
+warning: unexpected `cfg` condition name: `r#false`
+  --> $DIR/raw-keywords.rs:19:7
+   |
+LL | #[cfg(r#false)]
+   |       ^^^^^^^
+   |
+   = help: expected names are: `r#async`, `clippy`, `debug_assertions`, `doc`, `doctest`, `edition2015`, `edition2021`, `fmt_debug`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `r#true`, `ub_checks`, `unix`, and `windows`
+   = help: to expect this configuration use `--check-cfg=cfg(r#false)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+
+warning: unexpected `cfg` condition name: `r#await`
+  --> $DIR/raw-keywords.rs:28:29
+   |
+LL | #[cfg_attr(edition2021, cfg(r#await))]
+   |                             ^^^^^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(r#await)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+
+warning: unexpected `cfg` condition name: `raw`
+  --> $DIR/raw-keywords.rs:33:7
+   |
+LL | #[cfg(r#raw)]
+   |       ^^^^^
+   |
+   = help: to expect this configuration use `--check-cfg=cfg(raw)`
+   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
+
+warning: 4 warnings emitted
+

--- a/tests/ui/check-cfg/raw-keywords.rs
+++ b/tests/ui/check-cfg/raw-keywords.rs
@@ -1,0 +1,40 @@
+// This test check that using raw keywords works with --cfg and --check-cfg
+// and that the diagnostics suggestions are coherent
+//
+//@ check-pass
+//@ no-auto-check-cfg
+//@ compile-flags: --cfg=true --cfg=async --check-cfg=cfg(r#true,r#async,edition2015,edition2021)
+//
+//@ revisions: edition2015 edition2021
+//@ [edition2021] compile-flags: --edition 2021
+
+#[cfg(r#true)]
+fn foo() {}
+
+#[cfg(tru)]
+//~^ WARNING unexpected `cfg` condition name: `tru`
+//~^^ SUGGESTION r#true
+fn foo() {}
+
+#[cfg(r#false)]
+//~^ WARNING unexpected `cfg` condition name: `r#false`
+fn foo() {}
+
+#[cfg_attr(edition2015, cfg(async))]
+#[cfg_attr(edition2021, cfg(r#async))]
+fn bar() {}
+
+#[cfg_attr(edition2015, cfg(await))]
+#[cfg_attr(edition2021, cfg(r#await))]
+//[edition2015]~^^ WARNING unexpected `cfg` condition name: `await`
+//[edition2021]~^^ WARNING unexpected `cfg` condition name: `r#await`
+fn zoo() {}
+
+#[cfg(r#raw)]
+//~^ WARNING unexpected `cfg` condition name: `raw`
+fn foo() {}
+
+fn main() {
+    foo();
+    bar();
+}


### PR DESCRIPTION
This PR improves the handling of raw-idents in the check-cfg diagnostics.

In particular the list of expected names and the suggestion now correctly take into account the "keyword-ness" of the ident, and correctly prefix the ident with `r#` when necessary. 

@rustbot labels +F-check-cfg
