### PR TITLE
Support `char::encode_utf8` in const scenarios.

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -119,6 +119,7 @@
 #![feature(const_bigint_helper_methods)]
 #![feature(const_black_box)]
 #![feature(const_cell_into_inner)]
+#![feature(const_char_encode_utf8)]
 #![feature(const_eval_select)]
 #![feature(const_exact_div)]
 #![feature(const_float_classify)]


### PR DESCRIPTION
This PR implements [`rust-lang/rfcs#3696`](https://github.com/rust-lang/rfcs/pull/3696/).

This assumes [`const_slice_from_raw_parts_mut`](https://github.com/rust-lang/rust/issues/67456/).