### PR TITLE
[perf] skip normalizing param env if it is already normalized

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -409,6 +409,9 @@ pub fn normalize_param_env_or_error<'tcx>(
     debug!("normalize_param_env_or_error: elaborated-predicates={:?}", predicates);
 
     let elaborated_env = ty::ParamEnv::new(tcx.mk_clauses(&predicates), unnormalized_env.reveal());
+    if !normalize::needs_normalization(&elaborated_env, unnormalized_env.reveal()) {
+        return elaborated_env;
+    }
 
     // HACK: we are trying to normalize the param-env inside *itself*. The problem is that
     // normalization expects its param-env to be already normalized, which means we have


### PR DESCRIPTION
If the param env is already normalized after elaboration, then we can skip a bunch of expensive operations.

> [!note]
> This makes it so that outlives predicates are no longer sorted after non-outlives predicates. Surely this won't make a semantic difference.

r? ghost