### PR TITLE
[beta] backports

### DIFF
--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -1212,11 +1212,7 @@ struct LLVMRustThinLTOData {
   // Not 100% sure what these are, but they impact what's internalized and
   // what's inlined across modules, I believe.
 #if LLVM_VERSION_GE(18, 0)
-#if LLVM_VERSION_GE(20, 0)
-  FunctionImporter::ImportListsTy ImportLists;
-#else
   DenseMap<StringRef, FunctionImporter::ImportMapTy> ImportLists;
-#endif
   DenseMap<StringRef, FunctionImporter::ExportSetTy> ExportLists;
   DenseMap<StringRef, GVSummaryMapTy> ModuleToDefinedGVSummaries;
 #else
@@ -1425,13 +1421,13 @@ LLVMRustPrepareThinLTOInternalize(const LLVMRustThinLTOData *Data,
   return true;
 }
 
-extern "C" bool LLVMRustPrepareThinLTOImport(LLVMRustThinLTOData *Data,
+extern "C" bool LLVMRustPrepareThinLTOImport(const LLVMRustThinLTOData *Data,
                                              LLVMModuleRef M,
                                              LLVMTargetMachineRef TM) {
   Module &Mod = *unwrap(M);
   TargetMachine &Target = *unwrap(TM);
 
-  const auto &ImportList = Data->ImportLists[Mod.getModuleIdentifier()];
+  const auto &ImportList = Data->ImportLists.lookup(Mod.getModuleIdentifier());
   auto Loader = [&](StringRef Identifier) {
     const auto &Memory = Data->ModuleMap.lookup(Identifier);
     auto &Context = Mod.getContext();
@@ -1614,7 +1610,7 @@ extern "C" void LLVMRustComputeLTOCacheKey(RustStringRef KeyOut,
                                            LLVMRustThinLTOData *Data) {
   SmallString<40> Key;
   llvm::lto::Config conf;
-  const auto &ImportList = Data->ImportLists[ModId];
+  const auto &ImportList = Data->ImportLists.lookup(ModId);
   const auto &ExportList = Data->ExportLists.lookup(ModId);
   const auto &ResolvedODR = Data->ResolvedODR.lookup(ModId);
   const auto &DefinedGlobals = Data->ModuleToDefinedGVSummaries.lookup(ModId);

--- a/compiler/rustc_pattern_analysis/src/usefulness.rs
+++ b/compiler/rustc_pattern_analysis/src/usefulness.rs
@@ -951,7 +951,11 @@ impl<Cx: PatCx> PlaceInfo<Cx> {
             self.is_scrutinee && matches!(ctors_for_ty, ConstructorSet::NoConstructors);
         // Whether empty patterns are counted as useful or not. We only warn an empty arm unreachable if
         // it is guaranteed unreachable by the opsem (i.e. if the place is `known_valid`).
-        let empty_arms_are_unreachable = self.validity.is_known_valid();
+        // We don't want to warn empty patterns as unreachable by default just yet. We will in a
+        // later version of rust or under a different lint name, see
+        // https://github.com/rust-lang/rust/pull/129103.
+        let empty_arms_are_unreachable = self.validity.is_known_valid()
+            && (is_toplevel_exception || cx.is_exhaustive_patterns_feature_on());
         // Whether empty patterns can be omitted for exhaustiveness. We ignore place validity in the
         // toplevel exception and `exhaustive_patterns` cases for backwards compatibility.
         let can_omit_empty_arms = self.validity.is_known_valid()

--- a/library/core/src/iter/sources/repeat_n.rs
+++ b/library/core/src/iter/sources/repeat_n.rs
@@ -1,5 +1,6 @@
+use crate::fmt;
 use crate::iter::{FusedIterator, TrustedLen, UncheckedIterator};
-use crate::mem::ManuallyDrop;
+use crate::mem::{self, MaybeUninit};
 use crate::num::NonZero;
 
 /// Creates a new iterator that repeats a single element a given number of times.
@@ -58,14 +59,12 @@ use crate::num::NonZero;
 #[inline]
 #[stable(feature = "iter_repeat_n", since = "1.82.0")]
 pub fn repeat_n<T: Clone>(element: T, count: usize) -> RepeatN<T> {
-    let mut element = ManuallyDrop::new(element);
-
-    if count == 0 {
-        // SAFETY: we definitely haven't dropped it yet, since we only just got
-        // passed it in, and because the count is zero the instance we're about
-        // to create won't drop it, so to avoid leaking we need to now.
-        unsafe { ManuallyDrop::drop(&mut element) };
-    }
+    let element = if count == 0 {
+        // `element` gets dropped eagerly.
+        MaybeUninit::uninit()
+    } else {
+        MaybeUninit::new(element)
+    };
 
     RepeatN { element, count }
 }
@@ -74,15 +73,23 @@ pub fn repeat_n<T: Clone>(element: T, count: usize) -> RepeatN<T> {
 ///
 /// This `struct` is created by the [`repeat_n()`] function.
 /// See its documentation for more.
-#[derive(Clone, Debug)]
 #[stable(feature = "iter_repeat_n", since = "1.82.0")]
 pub struct RepeatN<A> {
     count: usize,
-    // Invariant: has been dropped iff count == 0.
-    element: ManuallyDrop<A>,
+    // Invariant: uninit iff count == 0.
+    element: MaybeUninit<A>,
 }
 
 impl<A> RepeatN<A> {
+    /// Returns the element if it hasn't been dropped already.
+    fn element_ref(&self) -> Option<&A> {
+        if self.count > 0 {
+            // SAFETY: The count is non-zero, so it must be initialized.
+            Some(unsafe { self.element.assume_init_ref() })
+        } else {
+            None
+        }
+    }
     /// If we haven't already dropped the element, return it in an option.
     ///
     /// Clears the count so it won't be dropped again later.
@@ -90,12 +97,33 @@ impl<A> RepeatN<A> {
     fn take_element(&mut self) -> Option<A> {
         if self.count > 0 {
             self.count = 0;
+            let element = mem::replace(&mut self.element, MaybeUninit::uninit());
             // SAFETY: We just set count to zero so it won't be dropped again,
             // and it used to be non-zero so it hasn't already been dropped.
-            unsafe { Some(ManuallyDrop::take(&mut self.element)) }
+            unsafe { Some(element.assume_init()) }
         } else {
             None
         }
+    }
+}
+
+#[stable(feature = "iter_repeat_n", since = "1.82.0")]
+impl<A: Clone> Clone for RepeatN<A> {
+    fn clone(&self) -> RepeatN<A> {
+        RepeatN {
+            count: self.count,
+            element: self.element_ref().cloned().map_or_else(MaybeUninit::uninit, MaybeUninit::new),
+        }
+    }
+}
+
+#[stable(feature = "iter_repeat_n", since = "1.82.0")]
+impl<A: fmt::Debug> fmt::Debug for RepeatN<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RepeatN")
+            .field("count", &self.count)
+            .field("element", &self.element_ref())
+            .finish()
     }
 }
 
@@ -194,9 +222,11 @@ impl<A: Clone> UncheckedIterator for RepeatN<A> {
             // SAFETY: the check above ensured that the count used to be non-zero,
             // so element hasn't been dropped yet, and we just lowered the count to
             // zero so it won't be dropped later, and thus it's okay to take it here.
-            unsafe { ManuallyDrop::take(&mut self.element) }
+            unsafe { mem::replace(&mut self.element, MaybeUninit::uninit()).assume_init() }
         } else {
-            A::clone(&self.element)
+            // SAFETY: the count is non-zero, so it must have not been dropped yet.
+            let element = unsafe { self.element.assume_init_ref() };
+            A::clone(element)
         }
     }
 }

--- a/library/windows_targets/src/lib.rs
+++ b/library/windows_targets/src/lib.rs
@@ -38,4 +38,5 @@ pub macro link {
 #[link(name = "ntdll")]
 #[link(name = "userenv")]
 #[link(name = "ws2_32")]
+#[link(name = "dbghelp")] // required for backtrace-rs symbolization
 extern "C" {}

--- a/tests/run-make/compiler-builtins/rmake.rs
+++ b/tests/run-make/compiler-builtins/rmake.rs
@@ -11,6 +11,7 @@
 // wasm and nvptx targets don't produce rlib files that object can parse.
 //@ ignore-wasm
 //@ ignore-nvptx64
+//@ only-nightly
 
 #![deny(warnings)]
 

--- a/tests/run-make/thumb-none-cortex-m/rmake.rs
+++ b/tests/run-make/thumb-none-cortex-m/rmake.rs
@@ -13,6 +13,7 @@
 //! - thumbv7m-none-eabi (Bare Cortex-M3)
 
 //@ only-thumb
+//@ only-nightly
 
 use std::path::PathBuf;
 

--- a/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.never_pats.stderr
@@ -44,30 +44,6 @@ LL +     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:70:9
-   |
-LL |         (_, _) => {}
-   |         ^^^^^^ matches no values because `(u32, !)` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:76:9
-   |
-LL |         _ => {}
-   |         ^ matches no values because `(!, !)` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:79:9
-   |
-LL |         (_, _) => {}
-   |         ^^^^^^ matches no values because `(!, !)` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
    |
 LL |         _ => {}
@@ -93,22 +69,6 @@ LL ~     match res_u32_never {
 LL +         Ok(_) => todo!(),
 LL +     }
    |
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:94:9
-   |
-LL |         Err(_) => {}
-   |         ^^^^^^ matches no values because `!` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:99:9
-   |
-LL |         Err(_) => {}
-   |         ^^^^^^ matches no values because `!` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
   --> $DIR/empty-types.rs:96:11
@@ -157,54 +117,6 @@ LL |     let Ok(_x) = &res_u32_never else { todo!() };
    |                                 ++++++++++++++++
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:112:9
-   |
-LL |         _ => {}
-   |         ^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:115:9
-   |
-LL |         Ok(_) => {}
-   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:118:9
-   |
-LL |         Ok(_) => {}
-   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:119:9
-   |
-LL |         _ => {}
-   |         ^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:122:9
-   |
-LL |         Ok(_) => {}
-   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:123:9
-   |
-LL |         Err(_) => {}
-   |         ^^^^^^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
   --> $DIR/empty-types.rs:132:13
    |
 LL |             _ => {}
@@ -219,22 +131,6 @@ LL |             _ if false => {}
    |             ^ matches no values because `Void` is uninhabited
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:143:13
-   |
-LL |             Some(_) => {}
-   |             ^^^^^^^ matches no values because `Void` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:147:13
-   |
-LL |             None => {}
-   |             ---- matches all the relevant values
-LL |             _ => {}
-   |             ^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `Some(!)` not covered
   --> $DIR/empty-types.rs:156:15
@@ -300,30 +196,6 @@ error: unreachable pattern
    |
 LL |         _ => {}
    |         ^ matches no values because `!` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:284:9
-   |
-LL |         (_, _) => {}
-   |         ^^^^^^ matches no values because `(!, !)` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:287:9
-   |
-LL |         Ok(_) => {}
-   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:288:9
-   |
-LL |         Err(_) => {}
-   |         ^^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
@@ -474,30 +346,6 @@ LL +         _ => todo!(),
 LL +     }
    |
 
-error: unreachable pattern
-  --> $DIR/empty-types.rs:368:9
-   |
-LL |         _ => {}
-   |         ^ matches no values because `[!; 3]` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:371:9
-   |
-LL |         [_, _, _] => {}
-   |         ^^^^^^^^^ matches no values because `[!; 3]` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:374:9
-   |
-LL |         [_, ..] => {}
-   |         ^^^^^^^ matches no values because `[!; 3]` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
   --> $DIR/empty-types.rs:388:11
    |
@@ -533,40 +381,6 @@ help: ensure that all possible cases are being handled by adding a match arm wit
 LL ~         [..] if false => {},
 LL +         [] => todo!()
    |
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:416:9
-   |
-LL |         Some(_) => {}
-   |         ^^^^^^^ matches no values because `!` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:421:9
-   |
-LL |         Some(_a) => {}
-   |         ^^^^^^^^ matches no values because `!` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:426:9
-   |
-LL |         None => {}
-   |         ---- matches all the relevant values
-LL |         // !useful, !reachable
-LL |         _ => {}
-   |         ^ no value can reach this
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:431:9
-   |
-LL |         None => {}
-   |         ---- matches all the relevant values
-LL |         // !useful, !reachable
-LL |         _a => {}
-   |         ^^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `&Some(!)` not covered
   --> $DIR/empty-types.rs:451:11
@@ -744,7 +558,7 @@ LL ~         None => {},
 LL +         Some(!)
    |
 
-error: aborting due to 65 previous errors; 1 warning emitted
+error: aborting due to 42 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0004, E0005.
 For more information about an error, try `rustc --explain E0004`.

--- a/tests/ui/pattern/usefulness/empty-types.normal.stderr
+++ b/tests/ui/pattern/usefulness/empty-types.normal.stderr
@@ -35,30 +35,6 @@ LL +     }
    |
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:70:9
-   |
-LL |         (_, _) => {}
-   |         ^^^^^^ matches no values because `(u32, !)` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:76:9
-   |
-LL |         _ => {}
-   |         ^ matches no values because `(!, !)` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:79:9
-   |
-LL |         (_, _) => {}
-   |         ^^^^^^ matches no values because `(!, !)` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
   --> $DIR/empty-types.rs:83:9
    |
 LL |         _ => {}
@@ -84,22 +60,6 @@ LL ~     match res_u32_never {
 LL +         Ok(_) => todo!(),
 LL +     }
    |
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:94:9
-   |
-LL |         Err(_) => {}
-   |         ^^^^^^ matches no values because `!` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:99:9
-   |
-LL |         Err(_) => {}
-   |         ^^^^^^ matches no values because `!` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: `Ok(1_u32..=u32::MAX)` not covered
   --> $DIR/empty-types.rs:96:11
@@ -148,54 +108,6 @@ LL |     let Ok(_x) = &res_u32_never else { todo!() };
    |                                 ++++++++++++++++
 
 error: unreachable pattern
-  --> $DIR/empty-types.rs:112:9
-   |
-LL |         _ => {}
-   |         ^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:115:9
-   |
-LL |         Ok(_) => {}
-   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:118:9
-   |
-LL |         Ok(_) => {}
-   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:119:9
-   |
-LL |         _ => {}
-   |         ^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:122:9
-   |
-LL |         Ok(_) => {}
-   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:123:9
-   |
-LL |         Err(_) => {}
-   |         ^^^^^^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
   --> $DIR/empty-types.rs:132:13
    |
 LL |             _ => {}
@@ -210,22 +122,6 @@ LL |             _ if false => {}
    |             ^ matches no values because `Void` is uninhabited
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:143:13
-   |
-LL |             Some(_) => {}
-   |             ^^^^^^^ matches no values because `Void` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:147:13
-   |
-LL |             None => {}
-   |             ---- matches all the relevant values
-LL |             _ => {}
-   |             ^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `Some(_)` not covered
   --> $DIR/empty-types.rs:156:15
@@ -291,30 +187,6 @@ error: unreachable pattern
    |
 LL |         _ => {}
    |         ^ matches no values because `!` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:284:9
-   |
-LL |         (_, _) => {}
-   |         ^^^^^^ matches no values because `(!, !)` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:287:9
-   |
-LL |         Ok(_) => {}
-   |         ^^^^^ matches no values because `Result<!, !>` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:288:9
-   |
-LL |         Err(_) => {}
-   |         ^^^^^^ matches no values because `Result<!, !>` is uninhabited
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
@@ -465,30 +337,6 @@ LL +         _ => todo!(),
 LL +     }
    |
 
-error: unreachable pattern
-  --> $DIR/empty-types.rs:368:9
-   |
-LL |         _ => {}
-   |         ^ matches no values because `[!; 3]` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:371:9
-   |
-LL |         [_, _, _] => {}
-   |         ^^^^^^^^^ matches no values because `[!; 3]` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:374:9
-   |
-LL |         [_, ..] => {}
-   |         ^^^^^^^ matches no values because `[!; 3]` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
 error[E0004]: non-exhaustive patterns: type `[!; 0]` is non-empty
   --> $DIR/empty-types.rs:388:11
    |
@@ -524,40 +372,6 @@ help: ensure that all possible cases are being handled by adding a match arm wit
 LL ~         [..] if false => {},
 LL +         [] => todo!()
    |
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:416:9
-   |
-LL |         Some(_) => {}
-   |         ^^^^^^^ matches no values because `!` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:421:9
-   |
-LL |         Some(_a) => {}
-   |         ^^^^^^^^ matches no values because `!` is uninhabited
-   |
-   = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:426:9
-   |
-LL |         None => {}
-   |         ---- matches all the relevant values
-LL |         // !useful, !reachable
-LL |         _ => {}
-   |         ^ no value can reach this
-
-error: unreachable pattern
-  --> $DIR/empty-types.rs:431:9
-   |
-LL |         None => {}
-   |         ---- matches all the relevant values
-LL |         // !useful, !reachable
-LL |         _a => {}
-   |         ^^ no value can reach this
 
 error[E0004]: non-exhaustive patterns: `&Some(_)` not covered
   --> $DIR/empty-types.rs:451:11
@@ -735,7 +549,7 @@ LL ~         None => {},
 LL +         Some(_) => todo!()
    |
 
-error: aborting due to 65 previous errors
+error: aborting due to 42 previous errors
 
 Some errors have detailed explanations: E0004, E0005.
 For more information about an error, try `rustc --explain E0004`.

--- a/tests/ui/pattern/usefulness/empty-types.rs
+++ b/tests/ui/pattern/usefulness/empty-types.rs
@@ -67,16 +67,16 @@ fn basic(x: NeverBundle) {
     let tuple_half_never: (u32, !) = x.tuple_half_never;
     match tuple_half_never {}
     match tuple_half_never {
-        (_, _) => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        (_, _) => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
 
     let tuple_never: (!, !) = x.tuple_never;
     match tuple_never {}
     match tuple_never {
-        _ => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        _ => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     match tuple_never {
-        (_, _) => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        (_, _) => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     match tuple_never.0 {}
     match tuple_never.0 {
@@ -91,12 +91,12 @@ fn basic(x: NeverBundle) {
     }
     match res_u32_never {
         Ok(_) => {}
-        Err(_) => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        Err(_) => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     match res_u32_never {
         //~^ ERROR non-exhaustive
         Ok(0) => {}
-        Err(_) => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        Err(_) => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     let Ok(_x) = res_u32_never;
     let Ok(_x) = res_u32_never.as_ref();
@@ -109,18 +109,18 @@ fn basic(x: NeverBundle) {
     let result_never: Result<!, !> = x.result_never;
     match result_never {}
     match result_never {
-        _ => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        _ => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     match result_never {
-        Ok(_) => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        Ok(_) => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     match result_never {
-        Ok(_) => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
-        _ => {}     //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        Ok(_) => {} //[exhaustive_patterns]~ ERROR unreachable pattern
+        _ => {}     //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     match result_never {
-        Ok(_) => {}  //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
-        Err(_) => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        Ok(_) => {}  //[exhaustive_patterns]~ ERROR unreachable pattern
+        Err(_) => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
 }
 
@@ -140,11 +140,11 @@ fn void_same_as_never(x: NeverBundle) {
         }
         match opt_void {
             None => {}
-            Some(_) => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+            Some(_) => {} //[exhaustive_patterns]~ ERROR unreachable pattern
         }
         match opt_void {
             None => {}
-            _ => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+            _ => {} //[exhaustive_patterns]~ ERROR unreachable pattern
         }
 
         let ref_void: &Void = &x.void;
@@ -281,11 +281,11 @@ fn nested_validity_tracking(bundle: NeverBundle) {
         _ => {} //~ ERROR unreachable pattern
     }
     match tuple_never {
-        (_, _) => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        (_, _) => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     match result_never {
-        Ok(_) => {}  //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
-        Err(_) => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        Ok(_) => {}  //[exhaustive_patterns]~ ERROR unreachable pattern
+        Err(_) => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
 
     // These should be considered !known_valid and not warn unreachable.
@@ -365,13 +365,13 @@ fn arrays_and_slices(x: NeverBundle) {
     let array_3_never: [!; 3] = x.array_3_never;
     match array_3_never {}
     match array_3_never {
-        _ => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        _ => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     match array_3_never {
-        [_, _, _] => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        [_, _, _] => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     match array_3_never {
-        [_, ..] => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        [_, ..] => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
 
     let ref_array_3_never: &[!; 3] = &array_3_never;
@@ -413,22 +413,22 @@ fn bindings(x: NeverBundle) {
     match opt_never {
         None => {}
         // !useful, !reachable
-        Some(_) => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        Some(_) => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     match opt_never {
         None => {}
         // !useful, !reachable
-        Some(_a) => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        Some(_a) => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     match opt_never {
         None => {}
         // !useful, !reachable
-        _ => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        _ => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
     match opt_never {
         None => {}
         // !useful, !reachable
-        _a => {} //[exhaustive_patterns,normal,never_pats]~ ERROR unreachable pattern
+        _a => {} //[exhaustive_patterns]~ ERROR unreachable pattern
     }
 
     // The scrutinee is known_valid, but under the `&` isn't anymore.

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.rs
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.rs
@@ -1,4 +1,5 @@
 #![feature(never_type)]
+#![feature(exhaustive_patterns)]
 #![deny(unreachable_patterns)]
 //~^ NOTE lint level is defined here
 

--- a/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
+++ b/tests/ui/pattern/usefulness/explain-unreachable-pats.stderr
@@ -1,5 +1,5 @@
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:10:9
+  --> $DIR/explain-unreachable-pats.rs:11:9
    |
 LL |         (1 | 2,) => {}
    |         -------- matches all the relevant values
@@ -8,19 +8,19 @@ LL |         (2,) => {}
    |         ^^^^ no value can reach this
    |
 note: the lint level is defined here
-  --> $DIR/explain-unreachable-pats.rs:2:9
+  --> $DIR/explain-unreachable-pats.rs:3:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:21:9
+  --> $DIR/explain-unreachable-pats.rs:22:9
    |
 LL |         (1 | 2,) => {}
    |         ^^^^^^^^ no value can reach this
    |
 note: multiple earlier patterns match some of the same values
-  --> $DIR/explain-unreachable-pats.rs:21:9
+  --> $DIR/explain-unreachable-pats.rs:22:9
    |
 LL |         (1,) => {}
    |         ---- matches some of the same values
@@ -32,13 +32,13 @@ LL |         (1 | 2,) => {}
    |         ^^^^^^^^ collectively making this unreachable
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:40:9
+  --> $DIR/explain-unreachable-pats.rs:41:9
    |
 LL |         1 ..= 6 => {}
    |         ^^^^^^^ no value can reach this
    |
 note: multiple earlier patterns match some of the same values
-  --> $DIR/explain-unreachable-pats.rs:40:9
+  --> $DIR/explain-unreachable-pats.rs:41:9
    |
 LL |         1 => {}
    |         - matches some of the same values
@@ -56,7 +56,7 @@ LL |         1 ..= 6 => {}
    |         ^^^^^^^ ...and 2 other patterns collectively make this unreachable
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:51:9
+  --> $DIR/explain-unreachable-pats.rs:52:9
    |
 LL |         Err(_) => {}
    |         ^^^^^^ matches no values because `!` is uninhabited
@@ -64,7 +64,7 @@ LL |         Err(_) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:65:9
+  --> $DIR/explain-unreachable-pats.rs:66:9
    |
 LL |         (Err(_), Err(_)) => {}
    |         ^^^^^^^^^^^^^^^^ matches no values because `Void2` is uninhabited
@@ -72,7 +72,7 @@ LL |         (Err(_), Err(_)) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:72:9
+  --> $DIR/explain-unreachable-pats.rs:73:9
    |
 LL |         (Err(_), Err(_)) => {}
    |         ^^^^^^^^^^^^^^^^ matches no values because `Void1` is uninhabited
@@ -80,7 +80,7 @@ LL |         (Err(_), Err(_)) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:82:11
+  --> $DIR/explain-unreachable-pats.rs:83:11
    |
 LL |     if let (0
    |             - matches all the relevant values
@@ -89,13 +89,13 @@ LL |         | 0, _) = (0, 0) {}
    |           ^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:92:9
+  --> $DIR/explain-unreachable-pats.rs:93:9
    |
 LL |         (_, true) => {}
    |         ^^^^^^^^^ no value can reach this
    |
 note: multiple earlier patterns match some of the same values
-  --> $DIR/explain-unreachable-pats.rs:92:9
+  --> $DIR/explain-unreachable-pats.rs:93:9
    |
 LL |         (true, _) => {}
    |         --------- matches some of the same values
@@ -107,7 +107,7 @@ LL |         (_, true) => {}
    |         ^^^^^^^^^ collectively making this unreachable
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:105:9
+  --> $DIR/explain-unreachable-pats.rs:106:9
    |
 LL |         (true, _) => {}
    |         --------- matches all the relevant values
@@ -116,7 +116,7 @@ LL |         (true, true) => {}
    |         ^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/explain-unreachable-pats.rs:117:9
+  --> $DIR/explain-unreachable-pats.rs:118:9
    |
 LL |         (_, true, 0..10) => {}
    |         ---------------- matches all the relevant values

--- a/tests/ui/pattern/usefulness/impl-trait.rs
+++ b/tests/ui/pattern/usefulness/impl-trait.rs
@@ -1,6 +1,7 @@
 #![feature(never_type)]
 #![feature(type_alias_impl_trait)]
 #![feature(non_exhaustive_omitted_patterns_lint)]
+#![feature(exhaustive_patterns)]
 #![deny(unreachable_patterns)]
 // Test that the lint traversal handles opaques correctly
 #![deny(non_exhaustive_omitted_patterns)]

--- a/tests/ui/pattern/usefulness/impl-trait.stderr
+++ b/tests/ui/pattern/usefulness/impl-trait.stderr
@@ -1,18 +1,18 @@
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:16:13
+  --> $DIR/impl-trait.rs:17:13
    |
 LL |             _ => {}
    |             ^ matches no values because `Void` is uninhabited
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/impl-trait.rs:4:9
+  --> $DIR/impl-trait.rs:5:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:30:13
+  --> $DIR/impl-trait.rs:31:13
    |
 LL |             _ => {}
    |             ^ matches no values because `Void` is uninhabited
@@ -20,7 +20,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:44:13
+  --> $DIR/impl-trait.rs:45:13
    |
 LL |             Some(_) => {}
    |             ^^^^^^^ matches no values because `Void` is uninhabited
@@ -28,7 +28,7 @@ LL |             Some(_) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:48:13
+  --> $DIR/impl-trait.rs:49:13
    |
 LL |             None => {}
    |             ---- matches all the relevant values
@@ -36,7 +36,7 @@ LL |             _ => {}
    |             ^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:58:13
+  --> $DIR/impl-trait.rs:59:13
    |
 LL |             Some(_) => {}
    |             ^^^^^^^ matches no values because `Void` is uninhabited
@@ -44,7 +44,7 @@ LL |             Some(_) => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:62:13
+  --> $DIR/impl-trait.rs:63:13
    |
 LL |             None => {}
    |             ---- matches all the relevant values
@@ -52,7 +52,7 @@ LL |             _ => {}
    |             ^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:75:9
+  --> $DIR/impl-trait.rs:76:9
    |
 LL |         _ => {}
    |         ^ matches no values because `Void` is uninhabited
@@ -60,7 +60,7 @@ LL |         _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:85:9
+  --> $DIR/impl-trait.rs:86:9
    |
 LL |         _ => {}
    |         - matches any value
@@ -68,7 +68,7 @@ LL |         Some((a, b)) => {}
    |         ^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:93:13
+  --> $DIR/impl-trait.rs:94:13
    |
 LL |             _ => {}
    |             ^ matches no values because `Void` is uninhabited
@@ -76,7 +76,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:104:9
+  --> $DIR/impl-trait.rs:105:9
    |
 LL |         Some((a, b)) => {}
    |         ------------ matches all the relevant values
@@ -84,7 +84,7 @@ LL |         Some((mut x, mut y)) => {
    |         ^^^^^^^^^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:123:13
+  --> $DIR/impl-trait.rs:124:13
    |
 LL |             _ => {}
    |             - matches any value
@@ -92,7 +92,7 @@ LL |             Rec { n: 0, w: Some(Rec { n: 0, w: _ }) } => {}
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no value can reach this
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:137:13
+  --> $DIR/impl-trait.rs:138:13
    |
 LL |             _ => {}
    |             ^ matches no values because `SecretelyVoid` is uninhabited
@@ -100,7 +100,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/impl-trait.rs:150:13
+  --> $DIR/impl-trait.rs:151:13
    |
 LL |             _ => {}
    |             ^ matches no values because `SecretelyDoubleVoid` is uninhabited
@@ -108,7 +108,7 @@ LL |             _ => {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error[E0004]: non-exhaustive patterns: type `impl Copy` is non-empty
-  --> $DIR/impl-trait.rs:22:11
+  --> $DIR/impl-trait.rs:23:11
    |
 LL |     match return_never_rpit(x) {}
    |           ^^^^^^^^^^^^^^^^^^^^
@@ -122,7 +122,7 @@ LL +     }
    |
 
 error[E0004]: non-exhaustive patterns: type `T` is non-empty
-  --> $DIR/impl-trait.rs:36:11
+  --> $DIR/impl-trait.rs:37:11
    |
 LL |     match return_never_tait(x) {}
    |           ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/reachable/unreachable-loop-patterns.rs
+++ b/tests/ui/reachable/unreachable-loop-patterns.rs
@@ -1,3 +1,4 @@
+#![feature(exhaustive_patterns)]
 #![feature(never_type, never_type_fallback)]
 #![allow(unreachable_code)]
 #![deny(unreachable_patterns)]

--- a/tests/ui/reachable/unreachable-loop-patterns.stderr
+++ b/tests/ui/reachable/unreachable-loop-patterns.stderr
@@ -1,12 +1,12 @@
 error: unreachable pattern
-  --> $DIR/unreachable-loop-patterns.rs:16:9
+  --> $DIR/unreachable-loop-patterns.rs:17:9
    |
 LL |     for _ in unimplemented!() as Void {}
    |         ^ matches no values because `Void` is uninhabited
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/unreachable-loop-patterns.rs:3:9
+  --> $DIR/unreachable-loop-patterns.rs:4:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.rs
@@ -1,3 +1,4 @@
+#![feature(exhaustive_patterns)]
 #![feature(never_patterns)]
 #![allow(incomplete_features)]
 #![allow(dead_code, unreachable_code)]

--- a/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.stderr
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/unreachable.stderr
@@ -1,18 +1,18 @@
 error: unreachable pattern
-  --> $DIR/unreachable.rs:14:9
+  --> $DIR/unreachable.rs:15:9
    |
 LL |         Err(!),
    |         ^^^^^^ matches no values because `Void` is uninhabited
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/unreachable.rs:4:9
+  --> $DIR/unreachable.rs:5:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/unreachable.rs:17:19
+  --> $DIR/unreachable.rs:18:19
    |
 LL |     let (Ok(_x) | Err(!)) = res_void;
    |                   ^^^^^^ matches no values because `Void` is uninhabited
@@ -20,7 +20,7 @@ LL |     let (Ok(_x) | Err(!)) = res_void;
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/unreachable.rs:19:12
+  --> $DIR/unreachable.rs:20:12
    |
 LL |     if let Err(!) = res_void {}
    |            ^^^^^^ matches no values because `Void` is uninhabited
@@ -28,7 +28,7 @@ LL |     if let Err(!) = res_void {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/unreachable.rs:21:24
+  --> $DIR/unreachable.rs:22:24
    |
 LL |     if let (Ok(true) | Err(!)) = res_void {}
    |                        ^^^^^^ matches no values because `Void` is uninhabited
@@ -36,7 +36,7 @@ LL |     if let (Ok(true) | Err(!)) = res_void {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/unreachable.rs:23:23
+  --> $DIR/unreachable.rs:24:23
    |
 LL |     for (Ok(mut _x) | Err(!)) in [res_void] {}
    |                       ^^^^^^ matches no values because `Void` is uninhabited
@@ -44,7 +44,7 @@ LL |     for (Ok(mut _x) | Err(!)) in [res_void] {}
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/unreachable.rs:27:18
+  --> $DIR/unreachable.rs:28:18
    |
 LL | fn foo((Ok(_x) | Err(!)): Result<bool, Void>) {}
    |                  ^^^^^^ matches no values because `Void` is uninhabited

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns.rs
@@ -1,5 +1,6 @@
 //@ aux-build:uninhabited.rs
 //@ build-pass (FIXME(62277): could be check-pass?)
+#![feature(exhaustive_patterns)]
 #![deny(unreachable_patterns)]
 
 extern crate uninhabited;

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.rs
@@ -1,3 +1,4 @@
+#![feature(exhaustive_patterns)]
 #![deny(unreachable_patterns)]
 #![feature(never_type)]
 

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/uninhabited/patterns_same_crate.stderr
@@ -1,18 +1,18 @@
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:51:9
+  --> $DIR/patterns_same_crate.rs:52:9
    |
 LL |         Some(_x) => (),
    |         ^^^^^^^^ matches no values because `UninhabitedEnum` is uninhabited
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/patterns_same_crate.rs:1:9
+  --> $DIR/patterns_same_crate.rs:2:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:56:9
+  --> $DIR/patterns_same_crate.rs:57:9
    |
 LL |         Some(_x) => (),
    |         ^^^^^^^^ matches no values because `UninhabitedVariants` is uninhabited
@@ -20,7 +20,7 @@ LL |         Some(_x) => (),
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:60:15
+  --> $DIR/patterns_same_crate.rs:61:15
    |
 LL |     while let PartiallyInhabitedVariants::Struct { x } = partially_inhabited_variant() {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ matches no values because `!` is uninhabited
@@ -28,7 +28,7 @@ LL |     while let PartiallyInhabitedVariants::Struct { x } = partially_inhabite
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:64:15
+  --> $DIR/patterns_same_crate.rs:65:15
    |
 LL |     while let Some(_x) = uninhabited_struct() {
    |               ^^^^^^^^ matches no values because `UninhabitedStruct` is uninhabited
@@ -36,7 +36,7 @@ LL |     while let Some(_x) = uninhabited_struct() {
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/patterns_same_crate.rs:67:15
+  --> $DIR/patterns_same_crate.rs:68:15
    |
 LL |     while let Some(_x) = uninhabited_tuple_struct() {
    |               ^^^^^^^^ matches no values because `UninhabitedTupleStruct` is uninhabited

--- a/tests/ui/uninhabited/uninhabited-patterns.rs
+++ b/tests/ui/uninhabited/uninhabited-patterns.rs
@@ -1,3 +1,4 @@
+#![feature(exhaustive_patterns)]
 #![feature(box_patterns)]
 #![feature(never_type)]
 #![deny(unreachable_patterns)]

--- a/tests/ui/uninhabited/uninhabited-patterns.stderr
+++ b/tests/ui/uninhabited/uninhabited-patterns.stderr
@@ -1,18 +1,18 @@
 error: unreachable pattern
-  --> $DIR/uninhabited-patterns.rs:29:9
+  --> $DIR/uninhabited-patterns.rs:30:9
    |
 LL |         Ok(box _) => (),
    |         ^^^^^^^^^ matches no values because `NotSoSecretlyEmpty` is uninhabited
    |
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 note: the lint level is defined here
-  --> $DIR/uninhabited-patterns.rs:3:9
+  --> $DIR/uninhabited-patterns.rs:4:9
    |
 LL | #![deny(unreachable_patterns)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: unreachable pattern
-  --> $DIR/uninhabited-patterns.rs:38:9
+  --> $DIR/uninhabited-patterns.rs:39:9
    |
 LL |         Err(Ok(_y)) => (),
    |         ^^^^^^^^^^^ matches no values because `NotSoSecretlyEmpty` is uninhabited
@@ -20,7 +20,7 @@ LL |         Err(Ok(_y)) => (),
    = note: to learn more about uninhabited types, see https://doc.rust-lang.org/nomicon/exotic-sizes.html#empty-types
 
 error: unreachable pattern
-  --> $DIR/uninhabited-patterns.rs:41:15
+  --> $DIR/uninhabited-patterns.rs:42:15
    |
 LL |     while let Some(_y) = foo() {
    |               ^^^^^^^^ matches no values because `NotSoSecretlyEmpty` is uninhabited

--- a/tests/ui/unsafe/union-pat-in-param.rs
+++ b/tests/ui/unsafe/union-pat-in-param.rs
@@ -1,0 +1,19 @@
+union U {
+    a: &'static i32,
+    b: usize,
+}
+
+fn fun(U { a }: U) {
+    //~^ ERROR access to union field is unsafe
+    dbg!(*a);
+}
+
+fn main() {
+    fun(U { b: 0 });
+
+    let closure = |U { a }| {
+        //~^ ERROR access to union field is unsafe
+        dbg!(*a);
+    };
+    closure(U { b: 0 });
+}

--- a/tests/ui/unsafe/union-pat-in-param.stderr
+++ b/tests/ui/unsafe/union-pat-in-param.stderr
@@ -1,0 +1,19 @@
+error[E0133]: access to union field is unsafe and requires unsafe function or block
+  --> $DIR/union-pat-in-param.rs:6:12
+   |
+LL | fn fun(U { a }: U) {
+   |            ^ access to union field
+   |
+   = note: the field may not be properly initialized: using uninitialized data will cause undefined behavior
+
+error[E0133]: access to union field is unsafe and requires unsafe function or block
+  --> $DIR/union-pat-in-param.rs:14:24
+   |
+LL |     let closure = |U { a }| {
+   |                        ^ access to union field
+   |
+   = note: the field may not be properly initialized: using uninitialized data will cause undefined behavior
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0133`.


### PR DESCRIPTION
- Don't warn empty branches unreachable for now #129103
- Win: Add dbghelp to the list of import libraries #130047
- `RepeatN`: use MaybeUninit #130145
- Update LLVM to 19 327ca6c #130212
- Revert #129749 to fix segfault in LLVM #130477
- Check params for unsafety in THIR #130531

r? cuviper
try-job: dist-various-1