### PR TITLE
Fix feature name in test

### DIFF
--- a/tests/ui/cfg/cfg-false-feature.rs
+++ b/tests/ui/cfg/cfg-false-feature.rs
@@ -5,7 +5,7 @@
 
 #![feature(decl_macro)]
 #![cfg(FALSE)]
-#![feature(box_syntax)]
+#![feature(box_patterns)]
 
 macro mac() {} // OK
 


### PR DESCRIPTION
This is meant to test that the `box_patterns` feature isn't active due to the `cfg(FALSE)`, but uses the removed `box_syntax` feature. Fix this so it's testing what it should be.