### PR TITLE
[Clippy] Remove final std paths for diagnostic item

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -309,6 +309,7 @@ symbols! {
         RwLockReadGuard,
         RwLockWriteGuard,
         Saturating,
+        SeekFrom,
         Send,
         SeqCst,
         Sized,

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -2058,6 +2058,7 @@ pub trait Seek {
 /// It is used by the [`Seek`] trait.
 #[derive(Copy, PartialEq, Eq, Clone, Debug)]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "SeekFrom")]
 pub enum SeekFrom {
     /// Sets the offset to the provided number of bytes.
     #[stable(feature = "rust1", since = "1.0.0")]

--- a/src/tools/clippy/clippy_lints/src/methods/seek_from_current.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/seek_from_current.rs
@@ -8,7 +8,7 @@ use rustc_span::sym;
 use clippy_utils::diagnostics::span_lint_and_sugg;
 use clippy_utils::source::snippet_with_applicability;
 use clippy_utils::ty::implements_trait;
-use clippy_utils::{match_def_path, paths};
+use clippy_utils::is_enum_variant_ctor;
 
 use super::SEEK_FROM_CURRENT;
 
@@ -36,8 +36,8 @@ pub(super) fn check<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>, recv: &'
 fn arg_is_seek_from_current<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'_>) -> bool {
     if let ExprKind::Call(f, args) = expr.kind
         && let ExprKind::Path(ref path) = f.kind
-        && let Some(def_id) = cx.qpath_res(path, f.hir_id).opt_def_id()
-        && match_def_path(cx, def_id, &paths::STD_IO_SEEK_FROM_CURRENT)
+        && let Some(ctor_call_id) = cx.qpath_res(path, f.hir_id).opt_def_id()
+        && is_enum_variant_ctor(cx, sym::SeekFrom, sym!(Current), ctor_call_id)
     {
         // check if argument of `SeekFrom::Current` is `0`
         if args.len() == 1

--- a/src/tools/clippy/clippy_lints/src/methods/seek_to_start_instead_of_rewind.rs
+++ b/src/tools/clippy/clippy_lints/src/methods/seek_to_start_instead_of_rewind.rs
@@ -1,6 +1,6 @@
 use clippy_utils::diagnostics::span_lint_and_then;
 use clippy_utils::ty::implements_trait;
-use clippy_utils::{is_expr_used_or_unified, match_def_path, paths};
+use clippy_utils::{is_expr_used_or_unified, is_enum_variant_ctor};
 use rustc_ast::ast::{LitIntType, LitKind};
 use rustc_data_structures::packed::Pu128;
 use rustc_errors::Applicability;
@@ -28,8 +28,8 @@ pub(super) fn check<'tcx>(
         && implements_trait(cx, ty, seek_trait_id, &[])
         && let ExprKind::Call(func, args1) = arg.kind
         && let ExprKind::Path(ref path) = func.kind
-        && let Some(def_id) = cx.qpath_res(path, func.hir_id).opt_def_id()
-        && match_def_path(cx, def_id, &paths::STD_IO_SEEKFROM_START)
+        && let Some(ctor_call_id) = cx.qpath_res(path, func.hir_id).opt_def_id()
+        && is_enum_variant_ctor(cx, sym::SeekFrom, sym!(Start), ctor_call_id)
         && args1.len() == 1
         && let ExprKind::Lit(lit) = args1[0].kind
         && let LitKind::Int(Pu128(0), LitIntType::Unsuffixed) = lit.node

--- a/src/tools/clippy/clippy_utils/src/paths.rs
+++ b/src/tools/clippy/clippy_utils/src/paths.rs
@@ -29,8 +29,7 @@ pub const SYM_MODULE: [&str; 3] = ["rustc_span", "symbol", "sym"];
 pub const SYNTAX_CONTEXT: [&str; 3] = ["rustc_span", "hygiene", "SyntaxContext"];
 
 // Paths in `core`/`alloc`/`std`. This should be avoided and cleaned up by adding diagnostic items.
-pub const STD_IO_SEEK_FROM_CURRENT: [&str; 4] = ["std", "io", "SeekFrom", "Current"];
-pub const STD_IO_SEEKFROM_START: [&str; 4] = ["std", "io", "SeekFrom", "Start"];
+// ... none currently!
 
 // Paths in clippy itself
 pub const MSRV: [&str; 3] = ["clippy_config", "msrvs", "Msrv"];


### PR DESCRIPTION
Removes the paths to SeekFrom::Start/Current that were left in #130553.

This was split off as it involves introducing a utility to check for enum ctors, as both:
- enum variants cannot be diagnostic items
- even if they could, that wouldn't help because we need to get the enum variant ctor

While adding the `is_enum_variant_ctor`, I removed both `is_diagnostic_ctor` and `is_res_diagnostic_ctor` as they are unused and never worked due to the above bullet points.