### PR TITLE
Update documentation for std::fs::read_to_string to reflect performan…

### DIFF
--- a/library/std/src/fs.rs
+++ b/library/std/src/fs.rs
@@ -271,7 +271,8 @@ pub fn read<P: AsRef<Path>>(path: P) -> io::Result<Vec<u8>> {
 /// Reads the entire contents of a file into a string.
 ///
 /// This is a convenience function for using [`File::open`] and [`read_to_string`]
-/// with fewer imports and without an intermediate variable.
+/// with fewer imports, without an intermediate variable, and with improved performance
+/// by referencing the file's metadata to preallocate buffer size.
 ///
 /// [`read_to_string`]: Read::read_to_string
 ///


### PR DESCRIPTION
…ce improvements on Windows

Closes #130600.

This pull request updates the documentation for `std::fs::read_to_string` to clarify its performance advantages on Windows compared to the combination of `std::fs::File::open` and `std::io::Read::read_to_string`.

In [PR #110655](https://github.com/rust-lang/rust/pull/110655), optimizations were introduced to improve the performance of `std::fs::read_to_string` on Windows. However, the current documentation does not reflect these improvements, potentially misleading users into thinking that using `File::open` and `Read::read_to_string` would have the same performance characteristics.

The updated documentation now explicitly mentions that `std::fs::read_to_string` offers better performance on Windows than manually opening the file and using `std::io::Read::read_to_string`.

r? workingjubilee
