### PR TITLE
Fix a few relative paths in rustc doc

### DIFF
--- a/compiler/rustc_hir/src/lib.rs
+++ b/compiler/rustc_hir/src/lib.rs
@@ -33,6 +33,7 @@ pub mod weak_lang_items;
 #[cfg(test)]
 mod tests;
 
+#[doc(no_inline)]
 pub use hir::*;
 pub use hir_id::*;
 pub use lang_items::{LangItem, LanguageItems};

--- a/compiler/rustc_index/src/lib.rs
+++ b/compiler/rustc_index/src/lib.rs
@@ -17,6 +17,7 @@ mod vec;
 pub use idx::Idx;
 pub use rustc_index_macros::newtype_index;
 pub use slice::IndexSlice;
+#[doc(no_inline)]
 pub use vec::IndexVec;
 
 /// Type size assertion. The first argument is a type and the second argument is its expected size.


### PR DESCRIPTION
## Changes

- Don't inline the doc for re-exporting some structs that have relative paths in doc.

## Context

See #124028.

- Most of the relative links in rustdoc are there because of circular import (so syntax like `[MyType]: rustc_foo::bar` is difficult to achieve when we cannot import `rustc_xxx` due to circular import)
- Here, I disable new links for re-exports. I think it's fine for re-exported items in `hir::*`. 
- There is a few more relative links in other `rustc` crates, however they are not addressed in this PR, as they are not re-exported and/so the relative paths are working.

Closes #124028.

r​? @fmease 

Let me know if I miss anything or there's any other way to address this issue.
