### PR TITLE
Add support for reborrowing pinned method receivers

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -235,6 +235,15 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                     target,
                 });
             }
+
+            Some(probe::AutorefOrPtrAdjustment::ReborrowPin(mutbl)) => {
+                let region = self.next_region_var(infer::Autoref(self.span));
+
+                adjustments.push(Adjustment {
+                    kind: Adjust::ReborrowPin(region, mutbl),
+                    target,
+                });
+            }
             None => {}
         }
 

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -239,10 +239,18 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             Some(probe::AutorefOrPtrAdjustment::ReborrowPin(mutbl)) => {
                 let region = self.next_region_var(infer::Autoref(self.span));
 
-                adjustments.push(Adjustment {
-                    kind: Adjust::ReborrowPin(region, mutbl),
-                    target,
-                });
+                target = match target.kind() {
+                    ty::Adt(pin, args) if self.tcx.is_lang_item(pin.did(), hir::LangItem::Pin) => {
+                        let inner_ty = match args[0].expect_ty().kind() {
+                            ty::Ref(_, ty, _) => *ty,
+                            _ => bug!("Expected a reference type for argument to Pin"),
+                        };
+                        Ty::new_pinned_ref(self.tcx, region, inner_ty, mutbl)
+                    }
+                    _ => bug!("Cannot adjust receiver type for reborrowing pin of {target:?}"),
+                };
+
+                adjustments.push(Adjustment { kind: Adjust::ReborrowPin(region, mutbl), target });
             }
             None => {}
         }

--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -584,6 +584,16 @@ impl<'tcx> Ty<'tcx> {
         Ty::new_ref(tcx, r, ty, hir::Mutability::Not)
     }
 
+    pub fn new_pinned_ref(
+        tcx: TyCtxt<'tcx>,
+        r: Region<'tcx>,
+        ty: Ty<'tcx>,
+        mutbl: ty::Mutability,
+    ) -> Ty<'tcx> {
+        let pin = tcx.adt_def(tcx.require_lang_item(LangItem::Pin, None));
+        Ty::new_adt(tcx, pin, tcx.mk_args(&[Ty::new_ref(tcx, r, ty, mutbl).into()]))
+    }
+
     #[inline]
     pub fn new_ptr(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>, mutbl: ty::Mutability) -> Ty<'tcx> {
         Ty::new(tcx, ty::RawPtr(ty, mutbl))

--- a/tests/ui/async-await/pin-reborrow-self.rs
+++ b/tests/ui/async-await/pin-reborrow-self.rs
@@ -1,24 +1,34 @@
 //@ check-pass
-//@ignore-test
-
-// Currently ignored due to self reborrowing not being implemented for Pin
 
 #![feature(pin_ergonomics)]
 #![allow(incomplete_features)]
 
 use std::pin::Pin;
 
-struct Foo;
+pub struct Foo;
 
 impl Foo {
     fn foo(self: Pin<&mut Self>) {
     }
+
+    fn baz(self: Pin<&Self>) {
+    }
 }
 
-fn bar(x: Pin<&mut Foo>) {
+pub fn bar(x: Pin<&mut Foo>) {
     x.foo();
     x.foo(); // for this to work we need to automatically reborrow,
              // as if the user had written `x.as_mut().foo()`.
+
+    Foo::baz(x);
+
+    // FIXME: We should allow downgrading a Pin<&mut T> to Pin<&T>
+    // x.baz();
+}
+
+pub fn baaz(x: Pin<&Foo>) {
+    x.baz();
+    x.baz();
 }
 
 fn main() {}

--- a/tests/ui/async-await/pin-reborrow-self.rs
+++ b/tests/ui/async-await/pin-reborrow-self.rs
@@ -22,8 +22,7 @@ pub fn bar(x: Pin<&mut Foo>) {
 
     Foo::baz(x);
 
-    // FIXME: We should allow downgrading a Pin<&mut T> to Pin<&T>
-    // x.baz();
+    x.baz();
 }
 
 pub fn baaz(x: Pin<&Foo>) {

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
@@ -15,8 +15,10 @@ fn foo(_: Pin<&mut Foo>) {
 fn bar(mut x: Pin<&mut Foo>) {
     foo(x);
     foo(x); //~ ERROR use of moved value: `x`
+}
 
-    x.foo(); //~ ERROR use of moved value: `x`
+fn baz(mut x: Pin<&mut Foo>) {
+    x.foo();
     x.foo(); //~ ERROR use of moved value: `x`
 }
 

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.rs
@@ -4,12 +4,20 @@ use std::pin::Pin;
 
 struct Foo;
 
+impl Foo {
+    fn foo(self: Pin<&mut Self>) {
+    }
+}
+
 fn foo(_: Pin<&mut Foo>) {
 }
 
 fn bar(mut x: Pin<&mut Foo>) {
     foo(x);
     foo(x); //~ ERROR use of moved value: `x`
+
+    x.foo(); //~ ERROR use of moved value: `x`
+    x.foo(); //~ ERROR use of moved value: `x`
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
@@ -1,5 +1,5 @@
 error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:12:9
+  --> $DIR/feature-gate-pin_ergonomics.rs:17:9
    |
 LL | fn bar(mut x: Pin<&mut Foo>) {
    |        ----- move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
@@ -9,13 +9,54 @@ LL |     foo(x);
    |         ^ value used here after move
    |
 note: consider changing this parameter type in function `foo` to borrow instead if owning the value isn't necessary
-  --> $DIR/feature-gate-pin_ergonomics.rs:7:11
+  --> $DIR/feature-gate-pin_ergonomics.rs:12:11
    |
 LL | fn foo(_: Pin<&mut Foo>) {
    |    ---    ^^^^^^^^^^^^^ this parameter takes ownership of the value
    |    |
    |    in this function
 
-error: aborting due to 1 previous error
+error[E0382]: use of moved value: `x`
+  --> $DIR/feature-gate-pin_ergonomics.rs:19:5
+   |
+LL | fn bar(mut x: Pin<&mut Foo>) {
+   |        ----- move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
+LL |     foo(x);
+LL |     foo(x);
+   |         - value moved here
+LL |
+LL |     x.foo();
+   |     ^ value used here after move
+   |
+note: consider changing this parameter type in function `foo` to borrow instead if owning the value isn't necessary
+  --> $DIR/feature-gate-pin_ergonomics.rs:12:11
+   |
+LL | fn foo(_: Pin<&mut Foo>) {
+   |    ---    ^^^^^^^^^^^^^ this parameter takes ownership of the value
+   |    |
+   |    in this function
+
+error[E0382]: use of moved value: `x`
+  --> $DIR/feature-gate-pin_ergonomics.rs:20:5
+   |
+LL | fn bar(mut x: Pin<&mut Foo>) {
+   |        ----- move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
+...
+LL |     x.foo();
+   |       ----- `x` moved due to this method call
+LL |     x.foo();
+   |     ^ value used here after move
+   |
+note: `Foo::foo` takes ownership of the receiver `self`, which moves `x`
+  --> $DIR/feature-gate-pin_ergonomics.rs:8:12
+   |
+LL |     fn foo(self: Pin<&mut Self>) {
+   |            ^^^^
+help: consider reborrowing the `Pin` instead of moving it
+   |
+LL |     x.as_mut().foo();
+   |      +++++++++
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
+++ b/tests/ui/feature-gates/feature-gate-pin_ergonomics.stderr
@@ -17,31 +17,10 @@ LL | fn foo(_: Pin<&mut Foo>) {
    |    in this function
 
 error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:19:5
+  --> $DIR/feature-gate-pin_ergonomics.rs:22:5
    |
-LL | fn bar(mut x: Pin<&mut Foo>) {
+LL | fn baz(mut x: Pin<&mut Foo>) {
    |        ----- move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
-LL |     foo(x);
-LL |     foo(x);
-   |         - value moved here
-LL |
-LL |     x.foo();
-   |     ^ value used here after move
-   |
-note: consider changing this parameter type in function `foo` to borrow instead if owning the value isn't necessary
-  --> $DIR/feature-gate-pin_ergonomics.rs:12:11
-   |
-LL | fn foo(_: Pin<&mut Foo>) {
-   |    ---    ^^^^^^^^^^^^^ this parameter takes ownership of the value
-   |    |
-   |    in this function
-
-error[E0382]: use of moved value: `x`
-  --> $DIR/feature-gate-pin_ergonomics.rs:20:5
-   |
-LL | fn bar(mut x: Pin<&mut Foo>) {
-   |        ----- move occurs because `x` has type `Pin<&mut Foo>`, which does not implement the `Copy` trait
-...
 LL |     x.foo();
    |       ----- `x` moved due to this method call
 LL |     x.foo();
@@ -57,6 +36,6 @@ help: consider reborrowing the `Pin` instead of moving it
 LL |     x.as_mut().foo();
    |      +++++++++
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0382`.


### PR DESCRIPTION
This builds on #130526 to add pinned reborrowing for method receivers. This enables the folllowing examples to work:

```rust 
#![feature(pin_ergonomics)]
#![allow(incomplete_features)]

use std::pin::Pin;

pub struct Foo;

impl Foo {
    fn foo(self: Pin<&mut Self>) {
    }

    fn baz(self: Pin<&Self>) {
    }
}

pub fn bar(x: Pin<&mut Foo>) {
    x.foo();
    x.foo();

    x.baz(); // Pin<&mut Foo> is downgraded to Pin<&Foo>
}

pub fn baaz(x: Pin<&Foo>) {
    x.baz();
    x.baz();
}
```

This PR includes the original one, which is currently in the commit queue, but the only code changes are in the latest commit (d3c53aaa5c6fcb1018c58d229bc5d92202fa6880).

#130494 

r? @compiler-errors 