### PR TITLE
ABI compatibility: mention Result guarantee

### DIFF
--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -1761,6 +1761,8 @@ mod prim_ref {}
 /// - `i32` is ABI-compatible with `NonZero<i32>`, and similar for all other integer types.
 /// - If `T` is guaranteed to be subject to the [null pointer
 ///   optimization](option/index.html#representation), then `T` and `Option<T>` are ABI-compatible.
+///   Furthermore, if `U` satisfies the requirements [outlined here](result/index.html#representation),
+///   then `T` and `Result<T, U>` and `Result<U, T>` are all ABI-compatible.
 ///
 /// Furthermore, ABI compatibility satisfies the following general properties:
 ///


### PR DESCRIPTION
This has been already documented in https://doc.rust-lang.org/std/result/index.html#representation, but for `Option` we mirrored those docs in the "ABI compatibility" section, so let's do the same here.

Cc @workingjubilee @rust-lang/lang 