### PR TITLE
Generate line numbers for non-rust code examples as well

### DIFF
--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -261,7 +261,9 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
                                  </pre>\
                              </div>",
                                 added_classes = added_classes.join(" "),
-                                text = Escape(&original_text),
+                                text = Escape(
+                                    original_text.strip_suffix('\n').unwrap_or(&original_text)
+                                ),
                             )
                             .into(),
                         ));

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -524,15 +524,13 @@ fn test_ascii_with_prepending_hashtag() {
 ####.###..#....#....#..#.
 #..#.#....#....#....#..#.
 #..#.#....#....#....#..#.
-#..#.####.####.####..##..
-</code></pre></div>",
+#..#.####.####.####..##..</code></pre></div>",
     );
     t(
         r#"```markdown
 # hello
 ```"#,
         "<div class=\"example-wrap\"><pre class=\"language-markdown\"><code>\
-# hello
-</code></pre></div>",
+# hello</code></pre></div>",
     );
 }

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -986,7 +986,13 @@ function preLoadCss(cssUrl) {
     }());
 
     window.rustdoc_add_line_numbers_to_examples = () => {
-        onEachLazy(document.getElementsByClassName("rust-example-rendered"), x => {
+        if (document.querySelector(".rustdoc.src")) {
+            // We are in the source code page, nothing to be done here!
+            return;
+        }
+        onEachLazy(document.querySelectorAll(
+            ":not(.scraped-example) > .example-wrap > pre:not(.example-line-numbers)",
+        ), x => {
             const parent = x.parentNode;
             const line_numbers = parent.querySelectorAll(".example-line-numbers");
             if (line_numbers.length > 0) {
@@ -1005,12 +1011,8 @@ function preLoadCss(cssUrl) {
     };
 
     window.rustdoc_remove_line_numbers_from_examples = () => {
-        onEachLazy(document.getElementsByClassName("rust-example-rendered"), x => {
-            const parent = x.parentNode;
-            const line_numbers = parent.querySelectorAll(".example-line-numbers");
-            for (const node of line_numbers) {
-                parent.removeChild(node);
-            }
+        onEachLazy(document.querySelectorAll(".example-wrap > .example-line-numbers"), x => {
+            x.parentNode.removeChild(x);
         });
     };
 

--- a/tests/rustdoc-gui/docblock-code-block-line-number.goml
+++ b/tests/rustdoc-gui/docblock-code-block-line-number.goml
@@ -87,7 +87,7 @@ assert-css: ("#settings", {"display": "block"})
 
 // Then, click the toggle button.
 click: "input#line-numbers"
-wait-for: 100 // wait-for-false does not exist
+wait-for: 100 // FIXME: `wait-for-false` does not exist
 assert-false: "pre.example-line-numbers"
 assert-local-storage: {"rustdoc-line-numbers": "false" }
 
@@ -107,6 +107,8 @@ assert-css: (
 click: "input#line-numbers"
 wait-for: "pre.example-line-numbers"
 assert-local-storage: {"rustdoc-line-numbers": "true" }
+wait-for: 100 // FIXME: `wait-for-false` does not exist
+assert: "pre.example-line-numbers"
 
 // Same check with scraped examples line numbers.
 go-to: "file://" + |DOC_PATH| + "/scrape_examples/fn.test_many.html"
@@ -145,9 +147,6 @@ assert-css: (
     ALL,
 )
 
-// Checking line numbers on scraped code examples.
-go-to: "file://" + |DOC_PATH| + "/scrape_examples/fn.test_many.html"
-
 define-function: (
     "check-padding",
     [path, padding_bottom],
@@ -157,19 +156,19 @@ define-function: (
             "padding-bottom": "0px",
             "padding-left": "0px",
             "padding-right": "0px",
-        })
+        }, ALL)
         assert-css: (|path| + " .src-line-numbers > pre", {
             "padding-top": "14px",
             "padding-bottom": |padding_bottom|,
             "padding-left": "0px",
             "padding-right": "0px",
-        })
+        }, ALL)
         assert-css: (|path| + " .src-line-numbers > pre > span", {
             "padding-top": "0px",
             "padding-bottom": "0px",
             "padding-left": "8px",
             "padding-right": "8px",
-        })
+        }, ALL)
     },
 )
 
@@ -188,6 +187,35 @@ call-function: ("check-padding", {
     "padding_bottom": "14px",
 })
 
+define-function: ("check-line-numbers-existence", [], block {
+    assert-local-storage: {"rustdoc-line-numbers": "true" }
+    assert-false: ".example-line-numbers"
+    click: "#settings-menu"
+    wait-for: "#settings"
+
+    // Then, click the toggle button.
+    click: "input#line-numbers"
+    wait-for: 100 // FIXME: `wait-for-false` does not exist
+    assert-local-storage-false: {"rustdoc-line-numbers": "true" }
+    assert-false: ".example-line-numbers"
+    // Line numbers should still be there.
+    assert: ".src-line-numbers"
+    // Now disabling the setting.
+    click: "input#line-numbers"
+    wait-for: 100 // FIXME: `wait-for-false` does not exist
+    assert-local-storage: {"rustdoc-line-numbers": "true" }
+    assert-false: ".example-line-numbers"
+    // Line numbers should still be there.
+    assert: ".src-line-numbers"
+    // Closing settings menu.
+    click: "#settings-menu"
+    wait-for-css: ("#settings", {"display": "none"})
+})
+
+// Checking that turning off the line numbers setting won't remove line numbers from scraped
+// examples.
+call-function: ("check-line-numbers-existence", {})
+
 // Now checking the line numbers in the source code page.
 click: ".src"
 assert-css: (".src-line-numbers", {
@@ -202,3 +230,28 @@ assert-css: (".src-line-numbers > a", {
     "padding-left": "8px",
     "padding-right": "8px",
 })
+// Checking that turning off the line numbers setting won't remove line numbers.
+call-function: ("check-line-numbers-existence", {})
+
+// Now checking that even non-rust code blocks have line numbers generated.
+go-to: "file://" + |DOC_PATH| + "/lib2/sub_mod/struct.Foo.html"
+assert-local-storage: {"rustdoc-line-numbers": "true" }
+assert: ".example-wrap > pre.language-txt"
+assert: ".example-wrap > pre.rust"
+assert-count: (".example-wrap", 2)
+assert-count: (".example-wrap > pre.example-line-numbers", 2)
+
+click: "#settings-menu"
+wait-for: "#settings"
+
+// Then, click the toggle button.
+click: "input#line-numbers"
+wait-for: 100 // FIXME: `wait-for-false` does not exist
+assert-local-storage-false: {"rustdoc-line-numbers": "true" }
+assert-count: (".example-wrap > pre.example-line-numbers", 0)
+
+// Now turning off the setting.
+click: "input#line-numbers"
+wait-for: 100 // FIXME: `wait-for-false` does not exist
+assert-local-storage: {"rustdoc-line-numbers": "true" }
+assert-count: (".example-wrap > pre.example-line-numbers", 2)


### PR DESCRIPTION
Currently, the "enable line numbers" setting only generated it for rust code examples. Found this limitation a bit strange so I decided to remove it.

You can test it [here](https://rustdoc.crud.net/imperio/generate-line-number-non-rust/doc/lib2/sub_mod/struct.Foo.html).

r? @notriddle