### PR TITLE
compiler: Accept "improper" ctypes in extern "rust-cold" fn

### DIFF
--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -1320,7 +1320,10 @@ impl<'a, 'tcx> ImproperCTypesVisitor<'a, 'tcx> {
     }
 
     fn is_internal_abi(&self, abi: SpecAbi) -> bool {
-        matches!(abi, SpecAbi::Rust | SpecAbi::RustCall | SpecAbi::RustIntrinsic)
+        matches!(
+            abi,
+            SpecAbi::Rust | SpecAbi::RustCall | SpecAbi::RustCold | SpecAbi::RustIntrinsic
+        )
     }
 
     /// Find any fn-ptr types with external ABIs in `ty`.

--- a/tests/ui/lint/rust-cold-fn-accept-improper-ctypes.rs
+++ b/tests/ui/lint/rust-cold-fn-accept-improper-ctypes.rs
@@ -1,0 +1,14 @@
+//@ check-pass
+#![feature(rust_cold_cc)]
+
+// extern "rust-cold" is a "Rust" ABI so we accept `repr(Rust)` types as arg/ret without warnings.
+
+pub extern "rust-cold" fn f(_: ()) -> Result<(), ()> {
+    Ok(())
+}
+
+extern "rust-cold" {
+    pub fn g(_: ()) -> Result<(), ()>;
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
Closes #125830
<!-- homu-ignore:end -->
