### PR TITLE
tests: Test that `extern "C" fn` ptrs lint on slices

### DIFF
--- a/tests/ui/lint/extern-C-fnptr-lints-slices.rs
+++ b/tests/ui/lint/extern-C-fnptr-lints-slices.rs
@@ -1,0 +1,9 @@
+#[deny(improper_ctypes_definitions)]
+
+// It's an improper ctype (a slice) arg in an extern "C" fnptr.
+
+pub type F = extern "C" fn(&[u8]);
+//~^ ERROR: `extern` fn uses type `[u8]`, which is not FFI-safe
+
+
+fn main() {}

--- a/tests/ui/lint/extern-C-fnptr-lints-slices.stderr
+++ b/tests/ui/lint/extern-C-fnptr-lints-slices.stderr
@@ -1,0 +1,16 @@
+error: `extern` fn uses type `[u8]`, which is not FFI-safe
+  --> $DIR/extern-C-fnptr-lints-slices.rs:5:14
+   |
+LL | pub type F = extern "C" fn(&[u8]);
+   |              ^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider using a raw pointer instead
+   = note: slices have no C equivalent
+note: the lint level is defined here
+  --> $DIR/extern-C-fnptr-lints-slices.rs:1:8
+   |
+LL | #[deny(improper_ctypes_definitions)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
This seems to have slipped past the `improper_ctypes_definitions` lint at some point. I found similar tests but not one with this exact combination, so test the semi-unique combination.

<!-- homu-ignore:start -->
Closes #95683
<!-- homu-ignore:end -->
