### PR TITLE
Add inline(usually)

### DIFF
--- a/compiler/rustc_attr_data_structures/src/attributes.rs
+++ b/compiler/rustc_attr_data_structures/src/attributes.rs
@@ -12,6 +12,7 @@ use crate::{DefaultBodyStability, PartialConstStability, PrintAttribute, RustcVe
 pub enum InlineAttr {
     None,
     Hint,
+    Usually,
     Always,
     Never,
     /// `#[rustc_force_inline]` forces inlining to happen in the MIR inliner - it reports an error
@@ -27,7 +28,7 @@ impl InlineAttr {
     pub fn always(&self) -> bool {
         match self {
             InlineAttr::Always | InlineAttr::Force { .. } => true,
-            InlineAttr::None | InlineAttr::Hint | InlineAttr::Never => false,
+            InlineAttr::None | InlineAttr::Hint | InlineAttr::Usually | InlineAttr::Never => false,
         }
     }
 }

--- a/compiler/rustc_codegen_gcc/src/attributes.rs
+++ b/compiler/rustc_codegen_gcc/src/attributes.rs
@@ -19,7 +19,7 @@ fn inline_attr<'gcc, 'tcx>(
     inline: InlineAttr,
 ) -> Option<FnAttribute<'gcc>> {
     match inline {
-        InlineAttr::Hint => Some(FnAttribute::Inline),
+        InlineAttr::Hint | InlineAttr::Usually => Some(FnAttribute::Inline),
         InlineAttr::Always | InlineAttr::Force { .. } => Some(FnAttribute::AlwaysInline),
         InlineAttr::Never => {
             if cx.sess().target.arch != "amdgpu" {

--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -40,6 +40,9 @@ fn inline_attr<'ll>(cx: &CodegenCx<'ll, '_>, inline: InlineAttr) -> Option<&'ll 
         InlineAttr::Always | InlineAttr::Force { .. } => {
             Some(AttributeKind::AlwaysInline.create_attr(cx.llcx))
         }
+        InlineAttr::Usually => {
+            Some(llvm::CreateAttrStringValue(cx.llcx, "function-inline-cost", "0"))
+        }
         InlineAttr::Never => {
             if cx.sess().target.arch != "amdgpu" {
                 Some(AttributeKind::NoInline.create_attr(cx.llcx))

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -486,6 +486,8 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
             InlineAttr::Always
         } else if item.has_name(sym::never) {
             InlineAttr::Never
+        } else if item.has_name(sym::usually) {
+            InlineAttr::Usually
         } else {
             tcx.dcx().emit_err(errors::InvalidArgument { span: items[0].span() });
 

--- a/compiler/rustc_mir_transform/src/cross_crate_inline.rs
+++ b/compiler/rustc_mir_transform/src/cross_crate_inline.rs
@@ -46,7 +46,9 @@ fn cross_crate_inlinable(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     // #[inline(never)] to force code generation.
     match codegen_fn_attrs.inline {
         InlineAttr::Never => return false,
-        InlineAttr::Hint | InlineAttr::Always | InlineAttr::Force { .. } => return true,
+        InlineAttr::Hint | InlineAttr::Usually | InlineAttr::Always | InlineAttr::Force { .. } => {
+            return true;
+        }
         _ => {}
     }
 

--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -309,7 +309,10 @@ impl<'tcx> Inliner<'tcx> for NormalInliner<'tcx> {
             changed: false,
             caller_is_inline_forwarder: matches!(
                 codegen_fn_attrs.inline,
-                InlineAttr::Hint | InlineAttr::Always | InlineAttr::Force { .. }
+                InlineAttr::Hint
+                    | InlineAttr::Usually
+                    | InlineAttr::Always
+                    | InlineAttr::Force { .. }
             ) && body_is_forwarder(body),
         }
     }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -2244,6 +2244,7 @@ symbols! {
         usize_legacy_fn_max_value,
         usize_legacy_fn_min_value,
         usize_legacy_mod,
+        usually,
         v8plus,
         va_arg,
         va_copy,


### PR DESCRIPTION
I'm looking into what kind of things could recover the perf improvement detected in https://github.com/rust-lang/rust/pull/121417#issuecomment-1958542729. I think it's worth spending quite a bit of effort to figure out how to capture a 45% incr-patched improvement.

As far as I can tell, the root cause of the problem is that we have taken very deliberate steps in the compiler to ensure that `#[inline(always)]`  causes inlining where possible, even when all optimizations are disabled. Some of the reasons that was done are now outdated or were misguided. I think the only remaining use case is where the inlined body even without optimizations is cheaper to codegen or call, for example SIMD intrinsics may require a lot of code to put their arguments on the stack, which is slow to compile and run.

I'm quite sure that the majority of users applied this attribute believing it does not cause inlining in unoptimized builds, or didn't appreciate the build time regressions that implies and would prefer it didn't if they knew. (if that's you, put a heart on this or say something elsewhere, don't reply on this PR)

I am going to _try_ to use the existing benchmark suite to evaluate a number of different approaches and take notes here, and hopefully I can collect enough data to shape any conversation about what we can do to help users.

The core of this PR is `InlineAttr::Usually` (name doesn't matter) which ensures that when optimizations are enabled that the function is inlined (usual exceptions like recursion apply). I think most users believe this is what `#[inline(always)]` does.

https://github.com/rust-lang/rust/pull/130685#issuecomment-2365991728 Replaced `#[inline(always)]` with `#[inline(usually)]` in the standard library, and did not recover the same 45% incr-patched improvement in regex. It's a tidy net positive though, and I suspect that perf improvement would normally be big enough to motivate merging a change. I think that means the standard library's use of `#[inline(always)]` is imposing marginal compile time overhead on the ecosystem, but the bigger opportunities are probably in third-party crates.

https://github.com/rust-lang/rust/pull/130679#issuecomment-2366960915 Treats `#[inline(always)]` as `#[inline(usually)]` literally everywhere; this gets the desired incr-patched improvement but suffers quite a few check and doc regressions. I think that means that `alwaysinline` is more powerful than `function-inline-cost=0` in LLVM.

https://github.com/rust-lang/rust/pull/130679#issuecomment-2369988959 Treats `#[inline(always)]` as `#[inline(usually)]` when `-Copt-level=0`, which looks basically the same as https://github.com/rust-lang/rust/pull/121417#issuecomment-1958542729 (omit `alwaysinline` when doing `-Copt-level=0` codegen).

https://github.com/rust-lang/rust/pull/130679#issuecomment-2372757311 replaces `alwaysinline` with a very negative inline cost, and it still has check and doc regressions. More investigation required on what the different inlining decision is.

https://github.com/rust-lang/rust/pull/130679#issuecomment-2373336167 is a likely explanation of this, with some interesting implications; adding `inline(always)` to a function that was going to be inlined anyway can change change optimizations (usually it seems to improve things?).

https://github.com/rust-lang/rust/pull/130679#issuecomment-2378223032 makes `#[inline(usually)]` also defy instantiation mode selection and always be LocalCopy the way `#[inline(always)]` does, but still has regressions in stm32f4. I think that proves that `alwaysinline` can actually improve debug build times.

https://github.com/rust-lang/rust/pull/130679#issuecomment-2380381173 infers `alwaysinline` for extremely trivial functions, but still has regressions for stm32f4. But of course it does, I left `inline(always)` treated as `inline(usually)` which slows down the compiler :facepalm: inconclusive perf run.

https://github.com/rust-lang/rust/pull/130679#issuecomment-2381048224 doesn't have any stm32f4 regressions :partying_face: I think this means that there is some threshold where `alwaysinline` produces faster debug builds.

So still two questions:
1. Why does `alwaysinline` sometimes make debug builds faster?
2. Is there any obvious threshold at which adding `alwaysinline` causes more work for debug builds?