### PR TITLE
Call module_name_to_str instead of just unwrapping

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/lto.rs
+++ b/compiler/rustc_codegen_llvm/src/back/lto.rs
@@ -844,7 +844,7 @@ impl ThinLTOKeysMap {
                     llvm::LLVMRustComputeLTOCacheKey(rust_str, module.identifier, data.0);
                 })
                 .expect("Invalid ThinLTO module key");
-                (name.clone().into_string().unwrap(), key)
+                (module_name_to_str(name).to_string(), key)
             })
             .collect();
         Self { keys }


### PR DESCRIPTION
This makes the ICE message in https://github.com/rust-lang/rust/issues/130678 more clear. It looks like not calling this function was just an oversight in https://github.com/rust-lang/rust/pull/76859, but clearly not a major one because it's taken us 4 years to notice.

try-job: i686-msvc