### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -641,7 +641,14 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
                 // current number of evaluated terminators is a power of 2. The latter gives us a cheap
                 // way to implement exponential backoff.
                 let span = ecx.cur_span();
-                ecx.tcx.dcx().emit_warn(LongRunningWarn { span, item_span: ecx.tcx.span });
+                // We store a unique number in `force_duplicate` to evade `-Z deduplicate-diagnostics`.
+                // `new_steps` is guaranteed to be unique because `ecx.machine.num_evaluated_steps` is
+                // always increasing.
+                ecx.tcx.dcx().emit_warn(LongRunningWarn {
+                    span,
+                    item_span: ecx.tcx.span,
+                    force_duplicate: new_steps,
+                });
             }
         }
 

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -243,6 +243,8 @@ pub struct LongRunningWarn {
     pub span: Span,
     #[help]
     pub item_span: Span,
+    // Used for evading `-Z deduplicate-diagnostics`.
+    pub force_duplicate: usize,
 }
 
 #[derive(Subdiagnostic)]

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -503,7 +503,8 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
     assert(ArgsCstrBuff[ArgsCstrBuffLen - 1] == '\0');
     auto Arg0 = std::string(ArgsCstrBuff);
     buffer_offset = Arg0.size() + 1;
-    auto ArgsCppStr = std::string(ArgsCstrBuff + buffer_offset, ArgsCstrBuffLen - 1);
+    auto ArgsCppStr =
+        std::string(ArgsCstrBuff + buffer_offset, ArgsCstrBuffLen - 1);
     auto i = 0;
     while (i != std::string::npos) {
       i = ArgsCppStr.find('\0', i + 1);

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -498,6 +498,21 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
   Options.EmitStackSizeSection = EmitStackSizeSection;
 
   if (ArgsCstrBuff != nullptr) {
+#if LLVM_VERSION_GE(20, 0)
+    int buffer_offset = 0;
+    assert(ArgsCstrBuff[ArgsCstrBuffLen - 1] == '\0');
+    auto Arg0 = std::string(ArgsCstrBuff);
+    buffer_offset = Arg0.size() + 1;
+    auto ArgsCppStr = std::string(ArgsCstrBuff + buffer_offset, ArgsCstrBuffLen - 1);
+    auto i = 0;
+    while (i != std::string::npos) {
+      i = ArgsCppStr.find('\0', i + 1);
+      if (i != std::string::npos)
+        ArgsCppStr.replace(i, i + 1, " ");
+    }
+    Options.MCOptions.Argv0 = Arg0;
+    Options.MCOptions.CommandlineArgs = ArgsCppStr;
+#else
     int buffer_offset = 0;
     assert(ArgsCstrBuff[ArgsCstrBuffLen - 1] == '\0');
 
@@ -523,6 +538,7 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
     Options.MCOptions.Argv0 = arg0;
     Options.MCOptions.CommandLineArgs =
         llvm::ArrayRef<std::string>(cmd_arg_strings, num_cmd_arg_strings);
+#endif
   }
 
   TargetMachine *TM = TheTarget->createTargetMachine(
@@ -531,10 +547,11 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
 }
 
 extern "C" void LLVMRustDisposeTargetMachine(LLVMTargetMachineRef TM) {
-
+#if LLVM_VERSION_LT(20, 0)
   MCTargetOptions &MCOptions = unwrap(TM)->Options.MCOptions;
   delete[] MCOptions.Argv0;
   delete[] MCOptions.CommandLineArgs.data();
+#endif
 
   delete unwrap(TM);
 }

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1057,6 +1057,10 @@ pub fn rustc_cargo(
     // killed, rather than having an error bubble up and cause a panic.
     cargo.rustflag("-Zon-broken-pipe=kill");
 
+    if builder.config.llvm_enzyme {
+        cargo.rustflag("-l").rustflag("Enzyme-19");
+    }
+
     // We currently don't support cross-crate LTO in stage0. This also isn't hugely necessary
     // and may just be a time sink.
     if compiler.stage != 0 {

--- a/src/bootstrap/src/core/builder.rs
+++ b/src/bootstrap/src/core/builder.rs
@@ -1591,12 +1591,6 @@ impl<'a> Builder<'a> {
             rustflags.arg(sysroot_str);
         }
 
-        // https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/.E2.9C.94.20link.20new.20library.20into.20stage1.2Frustc
-        if self.config.llvm_enzyme {
-            rustflags.arg("-l");
-            rustflags.arg("Enzyme-19");
-        }
-
         let use_new_symbol_mangling = match self.config.rust_new_symbol_mangling {
             Some(setting) => {
                 // If an explicit setting is given, use that

--- a/src/librustdoc/html/markdown.rs
+++ b/src/librustdoc/html/markdown.rs
@@ -261,7 +261,9 @@ impl<'a, I: Iterator<Item = Event<'a>>> Iterator for CodeBlocks<'_, 'a, I> {
                                  </pre>\
                              </div>",
                                 added_classes = added_classes.join(" "),
-                                text = Escape(&original_text),
+                                text = Escape(
+                                    original_text.strip_suffix('\n').unwrap_or(&original_text)
+                                ),
                             )
                             .into(),
                         ));

--- a/src/librustdoc/html/markdown/tests.rs
+++ b/src/librustdoc/html/markdown/tests.rs
@@ -524,15 +524,13 @@ fn test_ascii_with_prepending_hashtag() {
 ####.###..#....#....#..#.
 #..#.#....#....#....#..#.
 #..#.#....#....#....#..#.
-#..#.####.####.####..##..
-</code></pre></div>",
+#..#.####.####.####..##..</code></pre></div>",
     );
     t(
         r#"```markdown
 # hello
 ```"#,
         "<div class=\"example-wrap\"><pre class=\"language-markdown\"><code>\
-# hello
-</code></pre></div>",
+# hello</code></pre></div>",
     );
 }

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -986,7 +986,13 @@ function preLoadCss(cssUrl) {
     }());
 
     window.rustdoc_add_line_numbers_to_examples = () => {
-        onEachLazy(document.getElementsByClassName("rust-example-rendered"), x => {
+        if (document.querySelector(".rustdoc.src")) {
+            // We are in the source code page, nothing to be done here!
+            return;
+        }
+        onEachLazy(document.querySelectorAll(
+            ":not(.scraped-example) > .example-wrap > pre:not(.example-line-numbers)",
+        ), x => {
             const parent = x.parentNode;
             const line_numbers = parent.querySelectorAll(".example-line-numbers");
             if (line_numbers.length > 0) {
@@ -1005,12 +1011,8 @@ function preLoadCss(cssUrl) {
     };
 
     window.rustdoc_remove_line_numbers_from_examples = () => {
-        onEachLazy(document.getElementsByClassName("rust-example-rendered"), x => {
-            const parent = x.parentNode;
-            const line_numbers = parent.querySelectorAll(".example-line-numbers");
-            for (const node of line_numbers) {
-                parent.removeChild(node);
-            }
+        onEachLazy(document.querySelectorAll(".example-wrap > .example-line-numbers"), x => {
+            x.parentNode.removeChild(x);
         });
     };
 

--- a/tests/rustdoc-gui/docblock-code-block-line-number.goml
+++ b/tests/rustdoc-gui/docblock-code-block-line-number.goml
@@ -87,7 +87,7 @@ assert-css: ("#settings", {"display": "block"})
 
 // Then, click the toggle button.
 click: "input#line-numbers"
-wait-for: 100 // wait-for-false does not exist
+wait-for: 100 // FIXME: `wait-for-false` does not exist
 assert-false: "pre.example-line-numbers"
 assert-local-storage: {"rustdoc-line-numbers": "false" }
 
@@ -107,6 +107,8 @@ assert-css: (
 click: "input#line-numbers"
 wait-for: "pre.example-line-numbers"
 assert-local-storage: {"rustdoc-line-numbers": "true" }
+wait-for: 100 // FIXME: `wait-for-false` does not exist
+assert: "pre.example-line-numbers"
 
 // Same check with scraped examples line numbers.
 go-to: "file://" + |DOC_PATH| + "/scrape_examples/fn.test_many.html"
@@ -145,9 +147,6 @@ assert-css: (
     ALL,
 )
 
-// Checking line numbers on scraped code examples.
-go-to: "file://" + |DOC_PATH| + "/scrape_examples/fn.test_many.html"
-
 define-function: (
     "check-padding",
     [path, padding_bottom],
@@ -157,19 +156,19 @@ define-function: (
             "padding-bottom": "0px",
             "padding-left": "0px",
             "padding-right": "0px",
-        })
+        }, ALL)
         assert-css: (|path| + " .src-line-numbers > pre", {
             "padding-top": "14px",
             "padding-bottom": |padding_bottom|,
             "padding-left": "0px",
             "padding-right": "0px",
-        })
+        }, ALL)
         assert-css: (|path| + " .src-line-numbers > pre > span", {
             "padding-top": "0px",
             "padding-bottom": "0px",
             "padding-left": "8px",
             "padding-right": "8px",
-        })
+        }, ALL)
     },
 )
 
@@ -188,6 +187,35 @@ call-function: ("check-padding", {
     "padding_bottom": "14px",
 })
 
+define-function: ("check-line-numbers-existence", [], block {
+    assert-local-storage: {"rustdoc-line-numbers": "true" }
+    assert-false: ".example-line-numbers"
+    click: "#settings-menu"
+    wait-for: "#settings"
+
+    // Then, click the toggle button.
+    click: "input#line-numbers"
+    wait-for: 100 // FIXME: `wait-for-false` does not exist
+    assert-local-storage-false: {"rustdoc-line-numbers": "true" }
+    assert-false: ".example-line-numbers"
+    // Line numbers should still be there.
+    assert: ".src-line-numbers"
+    // Now disabling the setting.
+    click: "input#line-numbers"
+    wait-for: 100 // FIXME: `wait-for-false` does not exist
+    assert-local-storage: {"rustdoc-line-numbers": "true" }
+    assert-false: ".example-line-numbers"
+    // Line numbers should still be there.
+    assert: ".src-line-numbers"
+    // Closing settings menu.
+    click: "#settings-menu"
+    wait-for-css: ("#settings", {"display": "none"})
+})
+
+// Checking that turning off the line numbers setting won't remove line numbers from scraped
+// examples.
+call-function: ("check-line-numbers-existence", {})
+
 // Now checking the line numbers in the source code page.
 click: ".src"
 assert-css: (".src-line-numbers", {
@@ -202,3 +230,28 @@ assert-css: (".src-line-numbers > a", {
     "padding-left": "8px",
     "padding-right": "8px",
 })
+// Checking that turning off the line numbers setting won't remove line numbers.
+call-function: ("check-line-numbers-existence", {})
+
+// Now checking that even non-rust code blocks have line numbers generated.
+go-to: "file://" + |DOC_PATH| + "/lib2/sub_mod/struct.Foo.html"
+assert-local-storage: {"rustdoc-line-numbers": "true" }
+assert: ".example-wrap > pre.language-txt"
+assert: ".example-wrap > pre.rust"
+assert-count: (".example-wrap", 2)
+assert-count: (".example-wrap > pre.example-line-numbers", 2)
+
+click: "#settings-menu"
+wait-for: "#settings"
+
+// Then, click the toggle button.
+click: "input#line-numbers"
+wait-for: 100 // FIXME: `wait-for-false` does not exist
+assert-local-storage-false: {"rustdoc-line-numbers": "true" }
+assert-count: (".example-wrap > pre.example-line-numbers", 0)
+
+// Now turning off the setting.
+click: "input#line-numbers"
+wait-for: 100 // FIXME: `wait-for-false` does not exist
+assert-local-storage: {"rustdoc-line-numbers": "true" }
+assert-count: (".example-wrap > pre.example-line-numbers", 2)

--- a/tests/ui/consts/const-eval/stable-metric/evade-deduplication-issue-118612.rs
+++ b/tests/ui/consts/const-eval/stable-metric/evade-deduplication-issue-118612.rs
@@ -1,0 +1,24 @@
+//@ check-pass
+
+#![allow(long_running_const_eval)]
+
+//@ compile-flags: -Z tiny-const-eval-limit -Z deduplicate-diagnostics=yes
+const FOO: () = {
+    let mut i = 0;
+    loop {
+        //~^ WARN is taking a long time
+        //~| WARN is taking a long time
+        //~| WARN is taking a long time
+        //~| WARN is taking a long time
+        //~| WARN is taking a long time
+        if i == 1000 {
+            break;
+        } else {
+            i += 1;
+        }
+    }
+};
+
+fn main() {
+    FOO
+}

--- a/tests/ui/consts/const-eval/stable-metric/evade-deduplication-issue-118612.stderr
+++ b/tests/ui/consts/const-eval/stable-metric/evade-deduplication-issue-118612.stderr
@@ -16,5 +16,77 @@ help: the constant being evaluated
 LL | const FOO: () = {
    | ^^^^^^^^^^^^^
 
-warning: 1 warning emitted
+warning: constant evaluation is taking a long time
+  --> $DIR/evade-deduplication-issue-118612.rs:8:5
+   |
+LL | /     loop {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |         }
+LL | |     }
+   | |_____^ the const evaluator is currently interpreting this expression
+   |
+help: the constant being evaluated
+  --> $DIR/evade-deduplication-issue-118612.rs:6:1
+   |
+LL | const FOO: () = {
+   | ^^^^^^^^^^^^^
+
+warning: constant evaluation is taking a long time
+  --> $DIR/evade-deduplication-issue-118612.rs:8:5
+   |
+LL | /     loop {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |         }
+LL | |     }
+   | |_____^ the const evaluator is currently interpreting this expression
+   |
+help: the constant being evaluated
+  --> $DIR/evade-deduplication-issue-118612.rs:6:1
+   |
+LL | const FOO: () = {
+   | ^^^^^^^^^^^^^
+
+warning: constant evaluation is taking a long time
+  --> $DIR/evade-deduplication-issue-118612.rs:8:5
+   |
+LL | /     loop {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |         }
+LL | |     }
+   | |_____^ the const evaluator is currently interpreting this expression
+   |
+help: the constant being evaluated
+  --> $DIR/evade-deduplication-issue-118612.rs:6:1
+   |
+LL | const FOO: () = {
+   | ^^^^^^^^^^^^^
+
+warning: constant evaluation is taking a long time
+  --> $DIR/evade-deduplication-issue-118612.rs:8:5
+   |
+LL | /     loop {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |         }
+LL | |     }
+   | |_____^ the const evaluator is currently interpreting this expression
+   |
+help: the constant being evaluated
+  --> $DIR/evade-deduplication-issue-118612.rs:6:1
+   |
+LL | const FOO: () = {
+   | ^^^^^^^^^^^^^
+
+warning: 5 warnings emitted
 

--- a/tests/ui/consts/const-eval/stable-metric/evade-deduplication-issue-118612.stderr
+++ b/tests/ui/consts/const-eval/stable-metric/evade-deduplication-issue-118612.stderr
@@ -1,0 +1,20 @@
+warning: constant evaluation is taking a long time
+  --> $DIR/evade-deduplication-issue-118612.rs:8:5
+   |
+LL | /     loop {
+LL | |
+LL | |
+LL | |
+...  |
+LL | |         }
+LL | |     }
+   | |_____^ the const evaluator is currently interpreting this expression
+   |
+help: the constant being evaluated
+  --> $DIR/evade-deduplication-issue-118612.rs:6:1
+   |
+LL | const FOO: () = {
+   | ^^^^^^^^^^^^^
+
+warning: 1 warning emitted
+

--- a/tests/ui/lint/extern-C-fnptr-lints-slices.rs
+++ b/tests/ui/lint/extern-C-fnptr-lints-slices.rs
@@ -1,0 +1,9 @@
+#[deny(improper_ctypes_definitions)]
+
+// It's an improper ctype (a slice) arg in an extern "C" fnptr.
+
+pub type F = extern "C" fn(&[u8]);
+//~^ ERROR: `extern` fn uses type `[u8]`, which is not FFI-safe
+
+
+fn main() {}

--- a/tests/ui/lint/extern-C-fnptr-lints-slices.stderr
+++ b/tests/ui/lint/extern-C-fnptr-lints-slices.stderr
@@ -1,0 +1,16 @@
+error: `extern` fn uses type `[u8]`, which is not FFI-safe
+  --> $DIR/extern-C-fnptr-lints-slices.rs:5:14
+   |
+LL | pub type F = extern "C" fn(&[u8]);
+   |              ^^^^^^^^^^^^^^^^^^^^ not FFI-safe
+   |
+   = help: consider using a raw pointer instead
+   = note: slices have no C equivalent
+note: the lint level is defined here
+  --> $DIR/extern-C-fnptr-lints-slices.rs:1:8
+   |
+LL | #[deny(improper_ctypes_definitions)]
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Successful merges:

 - #130446 (rustc_llvm: adapt to flattened CLI args in LLVM)
 - #130648 (move enzyme flags from general cargo to rustc-specific cargo)
 - #130664 (Generate line numbers for non-rust code examples as well)
 - #130665 (Prevent Deduplication of `LongRunningWarn`)
 - #130669 (tests: Test that `extern "C" fn` ptrs lint on slices)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=130446,130648,130664,130665,130669)
<!-- homu-ignore:end -->