### PR TITLE
interpret: remove outdated FIXME

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -221,7 +221,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         }
 
         // Fall back to exact equality.
-        // FIXME: We are missing the rules for "repr(C) wrapping compatible types".
         Ok(caller == callee)
     }
 


### PR DESCRIPTION
The rule about `repr(C)` types with compatible fields got removed from the ABI compat docs before they landed, so this FIXME here is no longer correct. (So this is basically a follow-up to https://github.com/rust-lang/rust/pull/130185, doing some more cleanup around deciding not to guarantee ABI compatibility for structurally compatible `repr(C)` types.)