### PR TITLE
make unstable Result::flatten a const fn

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2538,6 +2538,7 @@ impl<T> Option<Option<T>> {
     #[stable(feature = "option_flattening", since = "1.40.0")]
     #[rustc_const_unstable(feature = "const_option", issue = "67441")]
     pub const fn flatten(self) -> Option<T> {
+        // FIXME(const-hack): could be written with `and_then`
         match self {
             Some(inner) => inner,
             None => None,

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1676,8 +1676,13 @@ impl<T, E> Result<Result<T, E>, E> {
     /// ```
     #[inline]
     #[unstable(feature = "result_flattening", issue = "70142")]
-    pub fn flatten(self) -> Result<T, E> {
-        self.and_then(convert::identity)
+    #[rustc_const_unstable(feature = "result_flattening", issue = "70142")]
+    pub const fn flatten(self) -> Result<T, E> {
+        // FIXME(const-hack): could be written with `and_then`
+        match self {
+            Ok(inner) => inner,
+            Err(e) => Err(e),
+        }
     }
 }
 


### PR DESCRIPTION
This method is still unstable (tracked at https://github.com/rust-lang/rust/issues/70142), but there's no reason I can see for it not to be const -- after all, `Option::flatten` is const. So let's make the `Result` one `const` as well, under the same feature gate.

Cc https://github.com/rust-lang/rust/issues/70142