### PR TITLE
Inline smaller callees first

### DIFF
--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1807,6 +1807,9 @@ options! {
         (default: preserve for debuginfo != None, otherwise remove)"),
     inline_mir_threshold: Option<usize> = (None, parse_opt_number, [TRACKED],
         "a default MIR inlining threshold (default: 50)"),
+    inline_mir_total_threshold: Option<usize> = (None, parse_opt_number, [TRACKED],
+        "maximum total cost of functions inlined into one caller (default: 300), \
+        to limit eventual MIR size in functions which make many calls"),
     input_stats: bool = (false, parse_bool, [UNTRACKED],
         "gather statistics about the input (default: no)"),
     instrument_mcount: bool = (false, parse_bool, [TRACKED],

--- a/tests/mir-opt/dest-prop/union.main.DestinationPropagation.panic-abort.diff
+++ b/tests/mir-opt/dest-prop/union.main.DestinationPropagation.panic-abort.diff
@@ -8,11 +8,11 @@
       let mut _3: u32;
       scope 1 {
           debug un => _1;
-          scope 3 (inlined std::mem::drop::<u32>) {
+          scope 2 (inlined std::mem::drop::<u32>) {
               debug _x => _3;
           }
       }
-      scope 2 (inlined val) {
+      scope 3 (inlined val) {
       }
   
       bb0: {

--- a/tests/mir-opt/dest-prop/union.main.DestinationPropagation.panic-unwind.diff
+++ b/tests/mir-opt/dest-prop/union.main.DestinationPropagation.panic-unwind.diff
@@ -8,11 +8,11 @@
       let mut _3: u32;
       scope 1 {
           debug un => _1;
-          scope 3 (inlined std::mem::drop::<u32>) {
+          scope 2 (inlined std::mem::drop::<u32>) {
               debug _x => _3;
           }
       }
-      scope 2 (inlined val) {
+      scope 3 (inlined val) {
       }
   
       bb0: {

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.panic-abort.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.panic-abort.diff
@@ -28,12 +28,12 @@
               scope 3 {
                   debug precision => _8;
                   let _8: usize;
-                  scope 5 (inlined Formatter::<'_>::precision) {
+                  scope 4 (inlined Formatter::<'_>::precision) {
                   }
               }
           }
       }
-      scope 4 (inlined Formatter::<'_>::sign_plus) {
+      scope 5 (inlined Formatter::<'_>::sign_plus) {
           let mut _20: u32;
           let mut _21: u32;
       }

--- a/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.panic-unwind.diff
+++ b/tests/mir-opt/funky_arms.float_to_exponential_common.GVN.panic-unwind.diff
@@ -28,12 +28,12 @@
               scope 3 {
                   debug precision => _8;
                   let _8: usize;
-                  scope 5 (inlined Formatter::<'_>::precision) {
+                  scope 4 (inlined Formatter::<'_>::precision) {
                   }
               }
           }
       }
-      scope 4 (inlined Formatter::<'_>::sign_plus) {
+      scope 5 (inlined Formatter::<'_>::sign_plus) {
           let mut _20: u32;
           let mut _21: u32;
       }

--- a/tests/mir-opt/inline/exponential_runtime.main.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/exponential_runtime.main.Inline.panic-abort.diff
@@ -12,26 +12,16 @@
 +             let _5: ();
 +             let _6: ();
 +             let _7: ();
-+             scope 3 (inlined <() as E>::call) {
-+                 let _8: ();
-+                 let _9: ();
-+                 let _10: ();
-+                 scope 4 (inlined <() as D>::call) {
-+                     let _11: ();
-+                     let _12: ();
-+                     let _13: ();
-+                     scope 5 (inlined <() as C>::call) {
-+                         let _14: ();
-+                         let _15: ();
-+                         let _16: ();
-+                         scope 6 (inlined <() as B>::call) {
-+                             let _17: ();
-+                             let _18: ();
-+                             let _19: ();
-+                         }
-+                     }
-+                 }
-+             }
++         }
++         scope 3 (inlined <() as F>::call) {
++             let _8: ();
++             let _9: ();
++             let _10: ();
++         }
++         scope 4 (inlined <() as F>::call) {
++             let _11: ();
++             let _12: ();
++             let _13: ();
 +         }
 +     }
   
@@ -44,22 +34,49 @@
 +         StorageLive(_5);
 +         StorageLive(_6);
 +         StorageLive(_7);
-+         StorageLive(_8);
-+         StorageLive(_9);
-+         StorageLive(_10);
-+         StorageLive(_11);
-+         StorageLive(_12);
-+         StorageLive(_13);
-+         StorageLive(_14);
-+         StorageLive(_15);
-+         StorageLive(_16);
-+         StorageLive(_17);
-+         StorageLive(_18);
-+         StorageLive(_19);
-+         _17 = <() as A>::call() -> [return: bb12, unwind unreachable];
++         _5 = <() as E>::call() -> [return: bb2, unwind unreachable];
       }
   
       bb1: {
++         StorageDead(_7);
++         StorageDead(_6);
++         StorageDead(_5);
++         StorageLive(_8);
++         StorageLive(_9);
++         StorageLive(_10);
++         _8 = <() as E>::call() -> [return: bb5, unwind unreachable];
++     }
++ 
++     bb2: {
++         _6 = <() as E>::call() -> [return: bb3, unwind unreachable];
++     }
++ 
++     bb3: {
++         _7 = <() as E>::call() -> [return: bb1, unwind unreachable];
++     }
++ 
++     bb4: {
++         StorageDead(_10);
++         StorageDead(_9);
++         StorageDead(_8);
++         StorageLive(_11);
++         StorageLive(_12);
++         StorageLive(_13);
++         _11 = <() as E>::call() -> [return: bb8, unwind unreachable];
++     }
++ 
++     bb5: {
++         _9 = <() as E>::call() -> [return: bb6, unwind unreachable];
++     }
++ 
++     bb6: {
++         _10 = <() as E>::call() -> [return: bb4, unwind unreachable];
++     }
++ 
++     bb7: {
++         StorageDead(_13);
++         StorageDead(_12);
++         StorageDead(_11);
 +         StorageDead(_4);
 +         StorageDead(_3);
 +         StorageDead(_2);
@@ -68,67 +85,12 @@
           return;
 +     }
 + 
-+     bb2: {
-+         _4 = <() as F>::call() -> [return: bb1, unwind unreachable];
-+     }
-+ 
-+     bb3: {
-+         StorageDead(_7);
-+         StorageDead(_6);
-+         StorageDead(_5);
-+         _3 = <() as F>::call() -> [return: bb2, unwind unreachable];
-+     }
-+ 
-+     bb4: {
-+         _7 = <() as E>::call() -> [return: bb3, unwind unreachable];
-+     }
-+ 
-+     bb5: {
-+         StorageDead(_10);
-+         StorageDead(_9);
-+         StorageDead(_8);
-+         _6 = <() as E>::call() -> [return: bb4, unwind unreachable];
-+     }
-+ 
-+     bb6: {
-+         _10 = <() as D>::call() -> [return: bb5, unwind unreachable];
-+     }
-+ 
-+     bb7: {
-+         StorageDead(_13);
-+         StorageDead(_12);
-+         StorageDead(_11);
-+         _9 = <() as D>::call() -> [return: bb6, unwind unreachable];
-+     }
-+ 
 +     bb8: {
-+         _13 = <() as C>::call() -> [return: bb7, unwind unreachable];
++         _12 = <() as E>::call() -> [return: bb9, unwind unreachable];
 +     }
 + 
 +     bb9: {
-+         StorageDead(_16);
-+         StorageDead(_15);
-+         StorageDead(_14);
-+         _12 = <() as C>::call() -> [return: bb8, unwind unreachable];
-+     }
-+ 
-+     bb10: {
-+         _16 = <() as B>::call() -> [return: bb9, unwind unreachable];
-+     }
-+ 
-+     bb11: {
-+         StorageDead(_19);
-+         StorageDead(_18);
-+         StorageDead(_17);
-+         _15 = <() as B>::call() -> [return: bb10, unwind unreachable];
-+     }
-+ 
-+     bb12: {
-+         _18 = <() as A>::call() -> [return: bb13, unwind unreachable];
-+     }
-+ 
-+     bb13: {
-+         _19 = <() as A>::call() -> [return: bb11, unwind unreachable];
++         _13 = <() as E>::call() -> [return: bb7, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/inline/exponential_runtime.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/exponential_runtime.main.Inline.panic-unwind.diff
@@ -12,26 +12,16 @@
 +             let _5: ();
 +             let _6: ();
 +             let _7: ();
-+             scope 3 (inlined <() as E>::call) {
-+                 let _8: ();
-+                 let _9: ();
-+                 let _10: ();
-+                 scope 4 (inlined <() as D>::call) {
-+                     let _11: ();
-+                     let _12: ();
-+                     let _13: ();
-+                     scope 5 (inlined <() as C>::call) {
-+                         let _14: ();
-+                         let _15: ();
-+                         let _16: ();
-+                         scope 6 (inlined <() as B>::call) {
-+                             let _17: ();
-+                             let _18: ();
-+                             let _19: ();
-+                         }
-+                     }
-+                 }
-+             }
++         }
++         scope 3 (inlined <() as F>::call) {
++             let _8: ();
++             let _9: ();
++             let _10: ();
++         }
++         scope 4 (inlined <() as F>::call) {
++             let _11: ();
++             let _12: ();
++             let _13: ();
 +         }
 +     }
   
@@ -44,22 +34,49 @@
 +         StorageLive(_5);
 +         StorageLive(_6);
 +         StorageLive(_7);
-+         StorageLive(_8);
-+         StorageLive(_9);
-+         StorageLive(_10);
-+         StorageLive(_11);
-+         StorageLive(_12);
-+         StorageLive(_13);
-+         StorageLive(_14);
-+         StorageLive(_15);
-+         StorageLive(_16);
-+         StorageLive(_17);
-+         StorageLive(_18);
-+         StorageLive(_19);
-+         _17 = <() as A>::call() -> [return: bb12, unwind continue];
++         _5 = <() as E>::call() -> [return: bb2, unwind continue];
       }
   
       bb1: {
++         StorageDead(_7);
++         StorageDead(_6);
++         StorageDead(_5);
++         StorageLive(_8);
++         StorageLive(_9);
++         StorageLive(_10);
++         _8 = <() as E>::call() -> [return: bb5, unwind continue];
++     }
++ 
++     bb2: {
++         _6 = <() as E>::call() -> [return: bb3, unwind continue];
++     }
++ 
++     bb3: {
++         _7 = <() as E>::call() -> [return: bb1, unwind continue];
++     }
++ 
++     bb4: {
++         StorageDead(_10);
++         StorageDead(_9);
++         StorageDead(_8);
++         StorageLive(_11);
++         StorageLive(_12);
++         StorageLive(_13);
++         _11 = <() as E>::call() -> [return: bb8, unwind continue];
++     }
++ 
++     bb5: {
++         _9 = <() as E>::call() -> [return: bb6, unwind continue];
++     }
++ 
++     bb6: {
++         _10 = <() as E>::call() -> [return: bb4, unwind continue];
++     }
++ 
++     bb7: {
++         StorageDead(_13);
++         StorageDead(_12);
++         StorageDead(_11);
 +         StorageDead(_4);
 +         StorageDead(_3);
 +         StorageDead(_2);
@@ -68,67 +85,12 @@
           return;
 +     }
 + 
-+     bb2: {
-+         _4 = <() as F>::call() -> [return: bb1, unwind continue];
-+     }
-+ 
-+     bb3: {
-+         StorageDead(_7);
-+         StorageDead(_6);
-+         StorageDead(_5);
-+         _3 = <() as F>::call() -> [return: bb2, unwind continue];
-+     }
-+ 
-+     bb4: {
-+         _7 = <() as E>::call() -> [return: bb3, unwind continue];
-+     }
-+ 
-+     bb5: {
-+         StorageDead(_10);
-+         StorageDead(_9);
-+         StorageDead(_8);
-+         _6 = <() as E>::call() -> [return: bb4, unwind continue];
-+     }
-+ 
-+     bb6: {
-+         _10 = <() as D>::call() -> [return: bb5, unwind continue];
-+     }
-+ 
-+     bb7: {
-+         StorageDead(_13);
-+         StorageDead(_12);
-+         StorageDead(_11);
-+         _9 = <() as D>::call() -> [return: bb6, unwind continue];
-+     }
-+ 
 +     bb8: {
-+         _13 = <() as C>::call() -> [return: bb7, unwind continue];
++         _12 = <() as E>::call() -> [return: bb9, unwind continue];
 +     }
 + 
 +     bb9: {
-+         StorageDead(_16);
-+         StorageDead(_15);
-+         StorageDead(_14);
-+         _12 = <() as C>::call() -> [return: bb8, unwind continue];
-+     }
-+ 
-+     bb10: {
-+         _16 = <() as B>::call() -> [return: bb9, unwind continue];
-+     }
-+ 
-+     bb11: {
-+         StorageDead(_19);
-+         StorageDead(_18);
-+         StorageDead(_17);
-+         _15 = <() as B>::call() -> [return: bb10, unwind continue];
-+     }
-+ 
-+     bb12: {
-+         _18 = <() as A>::call() -> [return: bb13, unwind continue];
-+     }
-+ 
-+     bb13: {
-+         _19 = <() as A>::call() -> [return: bb11, unwind continue];
++         _13 = <() as E>::call() -> [return: bb7, unwind continue];
       }
   }
   

--- a/tests/mir-opt/inline/exponential_runtime.rs
+++ b/tests/mir-opt/inline/exponential_runtime.rs
@@ -87,11 +87,12 @@ fn main() {
     // CHECK-LABEL: fn main(
     // CHECK-NOT: inlined
     // CHECK: (inlined <() as G>::call)
+    // CHECK-NOT: inlined
     // CHECK: (inlined <() as F>::call)
-    // CHECK: (inlined <() as E>::call)
-    // CHECK: (inlined <() as D>::call)
-    // CHECK: (inlined <() as C>::call)
-    // CHECK: (inlined <() as B>::call)
+    // CHECK-NOT: inlined
+    // CHECK: (inlined <() as F>::call)
+    // CHECK-NOT: inlined
+    // CHECK: (inlined <() as F>::call)
     // CHECK-NOT: inlined
     <() as G>::call();
 }

--- a/tests/mir-opt/inline/inline_cycle.one.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_cycle.one.Inline.panic-abort.diff
@@ -7,13 +7,34 @@
 +     scope 1 (inlined <C as Call>::call) {
 +         scope 2 (inlined <A<C> as Call>::call) {
 +             scope 3 (inlined <B<C> as Call>::call) {
++                 scope 4 (inlined <C as Call>::call) {
++                     scope 5 (inlined <A<C> as Call>::call) {
++                         scope 6 (inlined <B<C> as Call>::call) {
++                             scope 7 (inlined <C as Call>::call) {
++                                 scope 8 (inlined <A<C> as Call>::call) {
++                                     scope 9 (inlined <B<C> as Call>::call) {
++                                         scope 10 (inlined <C as Call>::call) {
++                                             scope 11 (inlined <A<C> as Call>::call) {
++                                                 scope 12 (inlined <B<C> as Call>::call) {
++                                                     scope 13 (inlined <C as Call>::call) {
++                                                     }
++                                                 }
++                                             }
++                                         }
++                                     }
++                                 }
++                             }
++                         }
++                     }
++                 }
 +             }
 +         }
 +     }
   
       bb0: {
           StorageLive(_1);
-          _1 = <C as Call>::call() -> [return: bb1, unwind unreachable];
+-         _1 = <C as Call>::call() -> [return: bb1, unwind unreachable];
++         _1 = <A<C> as Call>::call() -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/inline_cycle.one.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_cycle.one.Inline.panic-unwind.diff
@@ -7,13 +7,34 @@
 +     scope 1 (inlined <C as Call>::call) {
 +         scope 2 (inlined <A<C> as Call>::call) {
 +             scope 3 (inlined <B<C> as Call>::call) {
++                 scope 4 (inlined <C as Call>::call) {
++                     scope 5 (inlined <A<C> as Call>::call) {
++                         scope 6 (inlined <B<C> as Call>::call) {
++                             scope 7 (inlined <C as Call>::call) {
++                                 scope 8 (inlined <A<C> as Call>::call) {
++                                     scope 9 (inlined <B<C> as Call>::call) {
++                                         scope 10 (inlined <C as Call>::call) {
++                                             scope 11 (inlined <A<C> as Call>::call) {
++                                                 scope 12 (inlined <B<C> as Call>::call) {
++                                                     scope 13 (inlined <C as Call>::call) {
++                                                     }
++                                                 }
++                                             }
++                                         }
++                                     }
++                                 }
++                             }
++                         }
++                     }
++                 }
 +             }
 +         }
 +     }
   
       bb0: {
           StorageLive(_1);
-          _1 = <C as Call>::call() -> [return: bb1, unwind continue];
+-         _1 = <C as Call>::call() -> [return: bb1, unwind continue];
++         _1 = <A<C> as Call>::call() -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/inline_cycle_generic.main.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_cycle_generic.main.Inline.panic-abort.diff
@@ -7,6 +7,18 @@
 +     scope 1 (inlined <C as Call>::call) {
 +         scope 2 (inlined <B<A> as Call>::call) {
 +             scope 3 (inlined <A as Call>::call) {
++                 scope 4 (inlined <B<C> as Call>::call) {
++                     scope 5 (inlined <C as Call>::call) {
++                         scope 6 (inlined <B<A> as Call>::call) {
++                             scope 7 (inlined <A as Call>::call) {
++                                 scope 8 (inlined <B<C> as Call>::call) {
++                                     scope 9 (inlined <C as Call>::call) {
++                                     }
++                                 }
++                             }
++                         }
++                     }
++                 }
 +             }
 +         }
 +     }
@@ -14,7 +26,7 @@
       bb0: {
           StorageLive(_1);
 -         _1 = <C as Call>::call() -> [return: bb1, unwind unreachable];
-+         _1 = <B<C> as Call>::call() -> [return: bb1, unwind unreachable];
++         _1 = <B<A> as Call>::call() -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/inline_cycle_generic.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_cycle_generic.main.Inline.panic-unwind.diff
@@ -7,6 +7,18 @@
 +     scope 1 (inlined <C as Call>::call) {
 +         scope 2 (inlined <B<A> as Call>::call) {
 +             scope 3 (inlined <A as Call>::call) {
++                 scope 4 (inlined <B<C> as Call>::call) {
++                     scope 5 (inlined <C as Call>::call) {
++                         scope 6 (inlined <B<A> as Call>::call) {
++                             scope 7 (inlined <A as Call>::call) {
++                                 scope 8 (inlined <B<C> as Call>::call) {
++                                     scope 9 (inlined <C as Call>::call) {
++                                     }
++                                 }
++                             }
++                         }
++                     }
++                 }
 +             }
 +         }
 +     }
@@ -14,7 +26,7 @@
       bb0: {
           StorageLive(_1);
 -         _1 = <C as Call>::call() -> [return: bb1, unwind continue];
-+         _1 = <B<C> as Call>::call() -> [return: bb1, unwind continue];
++         _1 = <B<A> as Call>::call() -> [return: bb1, unwind continue];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline/inline_shims.drop.Inline.panic-abort.diff
@@ -8,13 +8,13 @@
       let _3: ();
       let mut _4: *mut std::vec::Vec<A>;
       let mut _5: *mut std::option::Option<B>;
-+     scope 1 (inlined std::ptr::drop_in_place::<Vec<A>> - shim(Some(Vec<A>))) {
-+         let mut _6: &mut std::vec::Vec<A>;
-+         let mut _7: ();
++     scope 1 (inlined std::ptr::drop_in_place::<Option<B>> - shim(Some(Option<B>))) {
++         let mut _6: isize;
++         let mut _7: isize;
 +     }
-+     scope 2 (inlined std::ptr::drop_in_place::<Option<B>> - shim(Some(Option<B>))) {
-+         let mut _8: isize;
-+         let mut _9: isize;
++     scope 2 (inlined std::ptr::drop_in_place::<Vec<A>> - shim(Some(Vec<A>))) {
++         let mut _8: &mut std::vec::Vec<A>;
++         let mut _9: ();
 +     }
   
       bb0: {
@@ -22,39 +22,42 @@
           StorageLive(_4);
           _4 = copy _1;
 -         _3 = std::ptr::drop_in_place::<Vec<A>>(move _4) -> [return: bb1, unwind unreachable];
-+         StorageLive(_6);
-+         StorageLive(_7);
-+         _6 = &mut (*_4);
-+         _7 = <Vec<A> as Drop>::drop(move _6) -> [return: bb2, unwind unreachable];
++         StorageLive(_8);
++         StorageLive(_9);
++         _8 = &mut (*_4);
++         _9 = <Vec<A> as Drop>::drop(move _8) -> [return: bb4, unwind unreachable];
       }
   
       bb1: {
 +         StorageDead(_7);
 +         StorageDead(_6);
-          StorageDead(_4);
-          StorageDead(_3);
-          StorageLive(_5);
-          _5 = copy _2;
--         _0 = std::ptr::drop_in_place::<Option<B>>(move _5) -> [return: bb2, unwind unreachable];
-+         StorageLive(_8);
-+         StorageLive(_9);
-+         _8 = discriminant((*_5));
-+         switchInt(move _8) -> [0: bb3, otherwise: bb4];
-      }
-  
-      bb2: {
-+         drop(((*_4).0: alloc::raw_vec::RawVec<A>)) -> [return: bb1, unwind unreachable];
++         StorageDead(_5);
++         return;
++     }
++ 
++     bb2: {
++         drop((((*_5) as Some).0: B)) -> [return: bb1, unwind unreachable];
 +     }
 + 
 +     bb3: {
 +         StorageDead(_9);
 +         StorageDead(_8);
-          StorageDead(_5);
-          return;
-+     }
-+ 
+          StorageDead(_4);
+          StorageDead(_3);
+          StorageLive(_5);
+          _5 = copy _2;
+-         _0 = std::ptr::drop_in_place::<Option<B>>(move _5) -> [return: bb2, unwind unreachable];
++         StorageLive(_6);
++         StorageLive(_7);
++         _6 = discriminant((*_5));
++         switchInt(move _6) -> [0: bb1, otherwise: bb2];
+      }
+  
+-     bb2: {
+-         StorageDead(_5);
+-         return;
 +     bb4: {
-+         drop((((*_5) as Some).0: B)) -> [return: bb3, unwind unreachable];
++         drop(((*_4).0: alloc::raw_vec::RawVec<A>)) -> [return: bb3, unwind unreachable];
       }
   }
   

--- a/tests/mir-opt/inline_coroutine_body.rs
+++ b/tests/mir-opt/inline_coroutine_body.rs
@@ -2,7 +2,7 @@
 // skip-filecheck
 //@ test-mir-pass: Inline
 //@ edition: 2021
-//@ compile-flags: -Zinline-mir-hint-threshold=10000 -Zinline-mir-threshold=10000 --crate-type=lib
+//@ compile-flags: -Zinline-mir-hint-threshold=10000 -Zinline-mir-threshold=10000 -Zinline_mir_total_threshold=10000 --crate-type=lib
 
 pub async fn run(permit: ActionPermit<'_, ()>, ctx: &mut core::task::Context<'_>) {
     run2(permit, ctx);

--- a/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-abort.diff
+++ b/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-abort.diff
@@ -55,8 +55,48 @@
 +                         let _26: ();
 +                         scope 9 {
 +                         }
++                         scope 11 (inlined Pin::<&mut std::future::Ready<()>>::new_unchecked) {
++                         }
++                         scope 13 (inlined <std::future::Ready<()> as Future>::poll) {
++                             let mut _42: ();
++                             let mut _43: std::option::Option<()>;
++                             let mut _44: &mut std::option::Option<()>;
++                             let mut _45: &mut std::future::Ready<()>;
++                             let mut _46: &mut std::pin::Pin<&mut std::future::Ready<()>>;
++                             scope 14 (inlined <Pin<&mut std::future::Ready<()>> as DerefMut>::deref_mut) {
++                                 let mut _47: std::pin::Pin<&mut std::future::Ready<()>>;
++                                 scope 15 (inlined Pin::<&mut std::future::Ready<()>>::get_mut) {
++                                 }
++                                 scope 16 (inlined Pin::<&mut std::future::Ready<()>>::as_mut) {
++                                     let mut _48: &mut &mut std::future::Ready<()>;
++                                     scope 17 (inlined Pin::<&mut std::future::Ready<()>>::new_unchecked) {
++                                     }
++                                     scope 18 (inlined <&mut std::future::Ready<()> as DerefMut>::deref_mut) {
++                                     }
++                                 }
++                             }
++                             scope 19 (inlined #[track_caller] Option::<()>::expect) {
++                                 let mut _49: isize;
++                                 let mut _50: !;
++                                 scope 20 {
++                                 }
++                             }
++                             scope 21 (inlined Option::<()>::take) {
++                                 let mut _51: std::option::Option<()>;
++                                 scope 22 (inlined std::mem::replace::<Option<()>>) {
++                                     scope 23 {
++                                         scope 25 (inlined std::ptr::write::<Option<()>>) {
++                                         }
++                                     }
++                                     scope 24 (inlined std::ptr::read::<Option<()>>) {
++                                     }
++                                 }
++                             }
++                         }
 +                     }
-+                     scope 10 (inlined ready::<()>) {
++                     scope 10 (inlined <std::future::Ready<()> as IntoFuture>::into_future) {
++                     }
++                     scope 12 (inlined ready::<()>) {
 +                         let mut _41: std::option::Option<()>;
 +                     }
 +                 }
@@ -113,7 +153,7 @@
 +         StorageLive(_40);
 +         _33 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
 +         _32 = discriminant((*_33));
-+         switchInt(move _32) -> [0: bb3, 1: bb13, 3: bb12, otherwise: bb8];
++         switchInt(move _32) -> [0: bb3, 1: bb10, 3: bb9, otherwise: bb5];
       }
   
 -     bb3: {
@@ -164,19 +204,16 @@
 +         _13 = std::future::Ready::<()>(move _41);
 +         StorageDead(_41);
 +         StorageDead(_14);
-+         _12 = <std::future::Ready<()> as IntoFuture>::into_future(move _13) -> [return: bb4, unwind unreachable];
++         _12 = move _13;
++         StorageDead(_13);
++         _36 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
++         (((*_36) as variant#3).1: std::future::Ready<()>) = move _12;
++         goto -> bb4;
 +     }
 + 
       bb4: {
 -         StorageDead(_2);
 -         return;
-+         StorageDead(_13);
-+         _36 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
-+         (((*_36) as variant#3).1: std::future::Ready<()>) = move _12;
-+         goto -> bb5;
-+     }
-+ 
-+     bb5: {
 +         StorageLive(_17);
 +         StorageLive(_18);
 +         StorageLive(_19);
@@ -185,10 +222,7 @@
 +         _37 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
 +         _21 = &mut (((*_37) as variant#3).1: std::future::Ready<()>);
 +         _20 = &mut (*_21);
-+         _19 = Pin::<&mut std::future::Ready<()>>::new_unchecked(move _20) -> [return: bb6, unwind unreachable];
-+     }
-+ 
-+     bb6: {
++         _19 = Pin::<&mut std::future::Ready<()>> { __pointer: copy _20 };
 +         StorageDead(_20);
 +         StorageLive(_22);
 +         StorageLive(_23);
@@ -197,21 +231,36 @@
 +         _23 = move _24;
 +         _22 = &mut (*_23);
 +         StorageDead(_24);
-+         _18 = <std::future::Ready<()> as Future>::poll(move _19, move _22) -> [return: bb7, unwind unreachable];
++         StorageLive(_45);
++         StorageLive(_46);
++         StorageLive(_50);
++         StorageLive(_51);
++         StorageLive(_42);
++         StorageLive(_43);
++         StorageLive(_44);
++         _46 = &mut _19;
++         StorageLive(_47);
++         StorageLive(_48);
++         _48 = &mut (_19.0: &mut std::future::Ready<()>);
++         _45 = copy (_19.0: &mut std::future::Ready<()>);
++         StorageDead(_48);
++         _47 = Pin::<&mut std::future::Ready<()>> { __pointer: copy _45 };
++         StorageDead(_47);
++         _44 = &mut ((*_45).0: std::option::Option<()>);
++         _51 = Option::<()>::None;
++         _43 = copy ((*_45).0: std::option::Option<()>);
++         ((*_45).0: std::option::Option<()>) = copy _51;
++         StorageDead(_44);
++         StorageLive(_49);
++         _49 = discriminant(_43);
++         switchInt(move _49) -> [0: bb11, 1: bb12, otherwise: bb5];
 +     }
 + 
-+     bb7: {
-+         StorageDead(_22);
-+         StorageDead(_19);
-+         _25 = discriminant(_18);
-+         switchInt(move _25) -> [0: bb10, 1: bb9, otherwise: bb8];
-+     }
-+ 
-+     bb8: {
++     bb5: {
 +         unreachable;
 +     }
 + 
-+     bb9: {
++     bb6: {
 +         _17 = const ();
 +         StorageDead(_23);
 +         StorageDead(_21);
@@ -229,7 +278,7 @@
 +         goto -> bb2;
 +     }
 + 
-+     bb10: {
++     bb7: {
 +         StorageLive(_26);
 +         _26 = copy ((_18 as Ready).0: ());
 +         _30 = copy _26;
@@ -240,17 +289,17 @@
 +         StorageDead(_17);
 +         StorageDead(_12);
 +         _39 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
-+         drop((((*_39) as variant#3).0: ActionPermit<'_, T>)) -> [return: bb11, unwind unreachable];
++         drop((((*_39) as variant#3).0: ActionPermit<'_, T>)) -> [return: bb8, unwind unreachable];
 +     }
 + 
-+     bb11: {
++     bb8: {
 +         _7 = Poll::<()>::Ready(move _30);
 +         _40 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
 +         discriminant((*_40)) = 1;
 +         goto -> bb2;
 +     }
 + 
-+     bb12: {
++     bb9: {
 +         StorageLive(_12);
 +         StorageLive(_28);
 +         StorageLive(_29);
@@ -259,11 +308,31 @@
 +         _31 = move _28;
 +         StorageDead(_28);
 +         _16 = const ();
-+         goto -> bb5;
++         goto -> bb4;
 +     }
 + 
-+     bb13: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb13, unwind unreachable];
++     bb10: {
++         assert(const false, "`async fn` resumed after completion") -> [success: bb10, unwind unreachable];
++     }
++ 
++     bb11: {
++         _50 = option::expect_failed(const "`Ready` polled after completion") -> unwind unreachable;
++     }
++ 
++     bb12: {
++         _42 = move ((_43 as Some).0: ());
++         StorageDead(_49);
++         StorageDead(_43);
++         _18 = Poll::<()>::Ready(move _42);
++         StorageDead(_42);
++         StorageDead(_51);
++         StorageDead(_50);
++         StorageDead(_46);
++         StorageDead(_45);
++         StorageDead(_22);
++         StorageDead(_19);
++         _25 = discriminant(_18);
++         switchInt(move _25) -> [0: bb7, 1: bb6, otherwise: bb5];
       }
   }
   

--- a/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline_coroutine_body.run2-{closure#0}.Inline.panic-unwind.diff
@@ -57,8 +57,48 @@
 +                         let _26: ();
 +                         scope 9 {
 +                         }
++                         scope 11 (inlined Pin::<&mut std::future::Ready<()>>::new_unchecked) {
++                         }
++                         scope 13 (inlined <std::future::Ready<()> as Future>::poll) {
++                             let mut _44: ();
++                             let mut _45: std::option::Option<()>;
++                             let mut _46: &mut std::option::Option<()>;
++                             let mut _47: &mut std::future::Ready<()>;
++                             let mut _48: &mut std::pin::Pin<&mut std::future::Ready<()>>;
++                             scope 14 (inlined <Pin<&mut std::future::Ready<()>> as DerefMut>::deref_mut) {
++                                 let mut _49: std::pin::Pin<&mut std::future::Ready<()>>;
++                                 scope 15 (inlined Pin::<&mut std::future::Ready<()>>::get_mut) {
++                                 }
++                                 scope 16 (inlined Pin::<&mut std::future::Ready<()>>::as_mut) {
++                                     let mut _50: &mut &mut std::future::Ready<()>;
++                                     scope 17 (inlined Pin::<&mut std::future::Ready<()>>::new_unchecked) {
++                                     }
++                                     scope 18 (inlined <&mut std::future::Ready<()> as DerefMut>::deref_mut) {
++                                     }
++                                 }
++                             }
++                             scope 19 (inlined #[track_caller] Option::<()>::expect) {
++                                 let mut _51: isize;
++                                 let mut _52: !;
++                                 scope 20 {
++                                 }
++                             }
++                             scope 21 (inlined Option::<()>::take) {
++                                 let mut _53: std::option::Option<()>;
++                                 scope 22 (inlined std::mem::replace::<Option<()>>) {
++                                     scope 23 {
++                                         scope 25 (inlined std::ptr::write::<Option<()>>) {
++                                         }
++                                     }
++                                     scope 24 (inlined std::ptr::read::<Option<()>>) {
++                                     }
++                                 }
++                             }
++                         }
 +                     }
-+                     scope 10 (inlined ready::<()>) {
++                     scope 10 (inlined <std::future::Ready<()> as IntoFuture>::into_future) {
++                     }
++                     scope 12 (inlined ready::<()>) {
 +                         let mut _43: std::option::Option<()>;
 +                     }
 +                 }
@@ -117,7 +157,7 @@
 +         StorageLive(_42);
 +         _33 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
 +         _32 = discriminant((*_33));
-+         switchInt(move _32) -> [0: bb5, 1: bb22, 2: bb21, 3: bb20, otherwise: bb10];
++         switchInt(move _32) -> [0: bb5, 1: bb15, 2: bb14, 3: bb13, otherwise: bb7];
       }
   
 -     bb3: {
@@ -181,21 +221,16 @@
 +         _13 = std::future::Ready::<()>(move _43);
 +         StorageDead(_43);
 +         StorageDead(_14);
-+         _12 = <std::future::Ready<()> as IntoFuture>::into_future(move _13) -> [return: bb6, unwind: bb17];
++         _12 = move _13;
++         StorageDead(_13);
++         _36 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
++         (((*_36) as variant#3).1: std::future::Ready<()>) = move _12;
++         goto -> bb6;
       }
   
 -     bb5 (cleanup): {
 -         drop(_2) -> [return: bb6, unwind terminate(cleanup)];
 +     bb6: {
-+         StorageDead(_13);
-+         _36 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
-+         (((*_36) as variant#3).1: std::future::Ready<()>) = move _12;
-+         goto -> bb7;
-      }
-  
--     bb6 (cleanup): {
--         resume;
-+     bb7: {
 +         StorageLive(_17);
 +         StorageLive(_18);
 +         StorageLive(_19);
@@ -204,10 +239,7 @@
 +         _37 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
 +         _21 = &mut (((*_37) as variant#3).1: std::future::Ready<()>);
 +         _20 = &mut (*_21);
-+         _19 = Pin::<&mut std::future::Ready<()>>::new_unchecked(move _20) -> [return: bb8, unwind: bb15];
-+     }
-+ 
-+     bb8: {
++         _19 = Pin::<&mut std::future::Ready<()>> { __pointer: copy _20 };
 +         StorageDead(_20);
 +         StorageLive(_22);
 +         StorageLive(_23);
@@ -216,21 +248,38 @@
 +         _23 = move _24;
 +         _22 = &mut (*_23);
 +         StorageDead(_24);
-+         _18 = <std::future::Ready<()> as Future>::poll(move _19, move _22) -> [return: bb9, unwind: bb14];
-+     }
-+ 
-+     bb9: {
-+         StorageDead(_22);
-+         StorageDead(_19);
-+         _25 = discriminant(_18);
-+         switchInt(move _25) -> [0: bb12, 1: bb11, otherwise: bb10];
-+     }
-+ 
-+     bb10: {
++         StorageLive(_47);
++         StorageLive(_48);
++         StorageLive(_52);
++         StorageLive(_53);
++         StorageLive(_44);
++         StorageLive(_45);
++         StorageLive(_46);
++         _48 = &mut _19;
++         StorageLive(_49);
++         StorageLive(_50);
++         _50 = &mut (_19.0: &mut std::future::Ready<()>);
++         _47 = copy (_19.0: &mut std::future::Ready<()>);
++         StorageDead(_50);
++         _49 = Pin::<&mut std::future::Ready<()>> { __pointer: copy _47 };
++         StorageDead(_49);
++         _46 = &mut ((*_47).0: std::option::Option<()>);
++         _53 = Option::<()>::None;
++         _45 = copy ((*_47).0: std::option::Option<()>);
++         ((*_47).0: std::option::Option<()>) = copy _53;
++         StorageDead(_46);
++         StorageLive(_51);
++         _51 = discriminant(_45);
++         switchInt(move _51) -> [0: bb16, 1: bb17, otherwise: bb7];
+      }
+  
+-     bb6 (cleanup): {
+-         resume;
++     bb7: {
 +         unreachable;
 +     }
 + 
-+     bb11: {
++     bb8: {
 +         _17 = const ();
 +         StorageDead(_23);
 +         StorageDead(_21);
@@ -248,7 +297,7 @@
 +         goto -> bb4;
 +     }
 + 
-+     bb12: {
++     bb9: {
 +         StorageLive(_26);
 +         _26 = copy ((_18 as Ready).0: ());
 +         _30 = copy _26;
@@ -259,54 +308,35 @@
 +         StorageDead(_17);
 +         StorageDead(_12);
 +         _39 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
-+         drop((((*_39) as variant#3).0: ActionPermit<'_, T>)) -> [return: bb13, unwind: bb19];
++         drop((((*_39) as variant#3).0: ActionPermit<'_, T>)) -> [return: bb10, unwind: bb12];
 +     }
 + 
-+     bb13: {
++     bb10: {
 +         _7 = Poll::<()>::Ready(move _30);
 +         _40 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
 +         discriminant((*_40)) = 1;
 +         goto -> bb4;
 +     }
 + 
-+     bb14 (cleanup): {
++     bb11 (cleanup): {
 +         StorageDead(_22);
 +         StorageDead(_19);
 +         StorageDead(_23);
-+         goto -> bb16;
-+     }
-+ 
-+     bb15 (cleanup): {
-+         StorageDead(_20);
-+         StorageDead(_19);
-+         goto -> bb16;
-+     }
-+ 
-+     bb16 (cleanup): {
 +         StorageDead(_21);
 +         StorageDead(_18);
 +         StorageDead(_17);
-+         goto -> bb18;
-+     }
-+ 
-+     bb17 (cleanup): {
-+         StorageDead(_13);
-+         goto -> bb18;
-+     }
-+ 
-+     bb18 (cleanup): {
 +         StorageDead(_12);
 +         _41 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
-+         drop((((*_41) as variant#3).0: ActionPermit<'_, T>)) -> [return: bb19, unwind terminate(cleanup)];
++         drop((((*_41) as variant#3).0: ActionPermit<'_, T>)) -> [return: bb12, unwind terminate(cleanup)];
 +     }
 + 
-+     bb19 (cleanup): {
++     bb12 (cleanup): {
 +         _42 = deref_copy (_8.0: &mut {async fn body of ActionPermit<'_, T>::perform()});
 +         discriminant((*_42)) = 2;
 +         goto -> bb2;
 +     }
 + 
-+     bb20: {
++     bb13: {
 +         StorageLive(_12);
 +         StorageLive(_28);
 +         StorageLive(_29);
@@ -315,15 +345,35 @@
 +         _31 = move _28;
 +         StorageDead(_28);
 +         _16 = const ();
-+         goto -> bb7;
++         goto -> bb6;
 +     }
 + 
-+     bb21: {
-+         assert(const false, "`async fn` resumed after panicking") -> [success: bb21, unwind: bb2];
++     bb14: {
++         assert(const false, "`async fn` resumed after panicking") -> [success: bb14, unwind: bb2];
 +     }
 + 
-+     bb22: {
-+         assert(const false, "`async fn` resumed after completion") -> [success: bb22, unwind: bb2];
++     bb15: {
++         assert(const false, "`async fn` resumed after completion") -> [success: bb15, unwind: bb2];
++     }
++ 
++     bb16: {
++         _52 = option::expect_failed(const "`Ready` polled after completion") -> bb11;
++     }
++ 
++     bb17: {
++         _44 = move ((_45 as Some).0: ());
++         StorageDead(_51);
++         StorageDead(_45);
++         _18 = Poll::<()>::Ready(move _44);
++         StorageDead(_44);
++         StorageDead(_53);
++         StorageDead(_52);
++         StorageDead(_48);
++         StorageDead(_47);
++         StorageDead(_22);
++         StorageDead(_19);
++         _25 = discriminant(_18);
++         switchInt(move _25) -> [0: bb9, 1: bb8, otherwise: bb7];
       }
   }
   

--- a/tests/mir-opt/issue_101973.inner.GVN.panic-abort.diff
+++ b/tests/mir-opt/issue_101973.inner.GVN.panic-abort.diff
@@ -16,12 +16,12 @@
       let mut _11: bool;
       let mut _12: u32;
       let mut _13: bool;
-      scope 1 (inlined imm8) {
-          let mut _14: u32;
-          scope 2 {
-          }
+      scope 1 (inlined core::num::<impl u32>::rotate_right) {
       }
-      scope 3 (inlined core::num::<impl u32>::rotate_right) {
+      scope 2 (inlined imm8) {
+          let mut _14: u32;
+          scope 3 {
+          }
       }
   
       bb0: {

--- a/tests/mir-opt/issue_101973.inner.GVN.panic-unwind.diff
+++ b/tests/mir-opt/issue_101973.inner.GVN.panic-unwind.diff
@@ -16,12 +16,12 @@
       let mut _11: bool;
       let mut _12: u32;
       let mut _13: bool;
-      scope 1 (inlined imm8) {
-          let mut _14: u32;
-          scope 2 {
-          }
+      scope 1 (inlined core::num::<impl u32>::rotate_right) {
       }
-      scope 3 (inlined core::num::<impl u32>::rotate_right) {
+      scope 2 (inlined imm8) {
+          let mut _14: u32;
+          scope 3 {
+          }
       }
   
       bb0: {

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-abort.mir
@@ -4,16 +4,16 @@ fn num_to_digit(_1: char) -> u32 {
     debug num => _1;
     let mut _0: u32;
     let mut _4: std::option::Option<u32>;
-    scope 1 (inlined char::methods::<impl char>::is_digit) {
-        let _2: std::option::Option<u32>;
-        scope 2 (inlined Option::<u32>::is_some) {
-            let mut _3: isize;
-        }
-    }
-    scope 3 (inlined #[track_caller] Option::<u32>::unwrap) {
+    scope 1 (inlined #[track_caller] Option::<u32>::unwrap) {
         let mut _5: isize;
         let mut _6: !;
-        scope 4 {
+        scope 2 {
+        }
+    }
+    scope 3 (inlined char::methods::<impl char>::is_digit) {
+        let _2: std::option::Option<u32>;
+        scope 4 (inlined Option::<u32>::is_some) {
+            let mut _3: isize;
         }
     }
 

--- a/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/issues/issue_59352.num_to_digit.PreCodegen.after.panic-unwind.mir
@@ -4,16 +4,16 @@ fn num_to_digit(_1: char) -> u32 {
     debug num => _1;
     let mut _0: u32;
     let mut _4: std::option::Option<u32>;
-    scope 1 (inlined char::methods::<impl char>::is_digit) {
-        let _2: std::option::Option<u32>;
-        scope 2 (inlined Option::<u32>::is_some) {
-            let mut _3: isize;
-        }
-    }
-    scope 3 (inlined #[track_caller] Option::<u32>::unwrap) {
+    scope 1 (inlined #[track_caller] Option::<u32>::unwrap) {
         let mut _5: isize;
         let mut _6: !;
-        scope 4 {
+        scope 2 {
+        }
+    }
+    scope 3 (inlined char::methods::<impl char>::is_digit) {
+        let _2: std::option::Option<u32>;
+        scope 4 (inlined Option::<u32>::is_some) {
+            let mut _3: isize;
         }
     }
 

--- a/tests/mir-opt/jump_threading.identity.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.identity.JumpThreading.panic-abort.diff
@@ -15,11 +15,11 @@
       scope 1 {
           debug residual => _6;
           scope 2 {
-              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) {
-                  let _14: i32;
-                  let mut _15: i32;
-                  scope 9 {
-                      scope 10 (inlined <i32 as From<i32>>::from) {
+              scope 5 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) {
+                  let _10: i32;
+                  let mut _11: i32;
+                  scope 6 {
+                      scope 7 (inlined <i32 as From<i32>>::from) {
                       }
                   }
               }
@@ -30,14 +30,14 @@
           scope 4 {
           }
       }
-      scope 5 (inlined <Result<i32, i32> as Try>::branch) {
-          let mut _10: isize;
-          let _11: i32;
-          let _12: i32;
-          let mut _13: std::result::Result<std::convert::Infallible, i32>;
-          scope 6 {
+      scope 8 (inlined <Result<i32, i32> as Try>::branch) {
+          let mut _12: isize;
+          let _13: i32;
+          let _14: i32;
+          let mut _15: std::result::Result<std::convert::Infallible, i32>;
+          scope 9 {
           }
-          scope 7 {
+          scope 10 {
           }
       }
   
@@ -46,11 +46,11 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = copy _1;
-          StorageLive(_10);
-          StorageLive(_11);
           StorageLive(_12);
-          _10 = discriminant(_4);
-          switchInt(move _10) -> [0: bb7, 1: bb6, otherwise: bb1];
+          StorageLive(_13);
+          StorageLive(_14);
+          _12 = discriminant(_4);
+          switchInt(move _12) -> [0: bb7, 1: bb6, otherwise: bb1];
       }
   
       bb1: {
@@ -73,13 +73,13 @@
           _6 = copy ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>);
           StorageLive(_8);
           _8 = copy _6;
-          StorageLive(_14);
-          _14 = move ((_8 as Err).0: i32);
-          StorageLive(_15);
-          _15 = move _14;
-          _0 = Result::<i32, i32>::Err(move _15);
-          StorageDead(_15);
-          StorageDead(_14);
+          StorageLive(_10);
+          _10 = move ((_8 as Err).0: i32);
+          StorageLive(_11);
+          _11 = move _10;
+          _0 = Result::<i32, i32>::Err(move _11);
+          StorageDead(_11);
+          StorageDead(_10);
           StorageDead(_8);
           StorageDead(_6);
           StorageDead(_2);
@@ -92,9 +92,9 @@
       }
   
       bb5: {
+          StorageDead(_14);
+          StorageDead(_13);
           StorageDead(_12);
-          StorageDead(_11);
-          StorageDead(_10);
           StorageDead(_4);
           _5 = discriminant(_3);
 -         switchInt(move _5) -> [0: bb2, 1: bb3, otherwise: bb1];
@@ -102,25 +102,25 @@
       }
   
       bb6: {
-          _12 = move ((_4 as Err).0: i32);
-          StorageLive(_13);
-          _13 = Result::<Infallible, i32>::Err(copy _12);
-          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _13);
-          StorageDead(_13);
+          _14 = move ((_4 as Err).0: i32);
+          StorageLive(_15);
+          _15 = Result::<Infallible, i32>::Err(copy _14);
+          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _15);
+          StorageDead(_15);
 -         goto -> bb5;
 +         goto -> bb8;
       }
   
       bb7: {
-          _11 = move ((_4 as Ok).0: i32);
-          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _11);
+          _13 = move ((_4 as Ok).0: i32);
+          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _13);
           goto -> bb5;
 +     }
 + 
 +     bb8: {
++         StorageDead(_14);
++         StorageDead(_13);
 +         StorageDead(_12);
-+         StorageDead(_11);
-+         StorageDead(_10);
 +         StorageDead(_4);
 +         _5 = discriminant(_3);
 +         goto -> bb3;

--- a/tests/mir-opt/jump_threading.identity.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.identity.JumpThreading.panic-unwind.diff
@@ -15,11 +15,11 @@
       scope 1 {
           debug residual => _6;
           scope 2 {
-              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) {
-                  let _14: i32;
-                  let mut _15: i32;
-                  scope 9 {
-                      scope 10 (inlined <i32 as From<i32>>::from) {
+              scope 5 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) {
+                  let _10: i32;
+                  let mut _11: i32;
+                  scope 6 {
+                      scope 7 (inlined <i32 as From<i32>>::from) {
                       }
                   }
               }
@@ -30,14 +30,14 @@
           scope 4 {
           }
       }
-      scope 5 (inlined <Result<i32, i32> as Try>::branch) {
-          let mut _10: isize;
-          let _11: i32;
-          let _12: i32;
-          let mut _13: std::result::Result<std::convert::Infallible, i32>;
-          scope 6 {
+      scope 8 (inlined <Result<i32, i32> as Try>::branch) {
+          let mut _12: isize;
+          let _13: i32;
+          let _14: i32;
+          let mut _15: std::result::Result<std::convert::Infallible, i32>;
+          scope 9 {
           }
-          scope 7 {
+          scope 10 {
           }
       }
   
@@ -46,11 +46,11 @@
           StorageLive(_3);
           StorageLive(_4);
           _4 = copy _1;
-          StorageLive(_10);
-          StorageLive(_11);
           StorageLive(_12);
-          _10 = discriminant(_4);
-          switchInt(move _10) -> [0: bb7, 1: bb6, otherwise: bb1];
+          StorageLive(_13);
+          StorageLive(_14);
+          _12 = discriminant(_4);
+          switchInt(move _12) -> [0: bb7, 1: bb6, otherwise: bb1];
       }
   
       bb1: {
@@ -73,13 +73,13 @@
           _6 = copy ((_3 as Break).0: std::result::Result<std::convert::Infallible, i32>);
           StorageLive(_8);
           _8 = copy _6;
-          StorageLive(_14);
-          _14 = move ((_8 as Err).0: i32);
-          StorageLive(_15);
-          _15 = move _14;
-          _0 = Result::<i32, i32>::Err(move _15);
-          StorageDead(_15);
-          StorageDead(_14);
+          StorageLive(_10);
+          _10 = move ((_8 as Err).0: i32);
+          StorageLive(_11);
+          _11 = move _10;
+          _0 = Result::<i32, i32>::Err(move _11);
+          StorageDead(_11);
+          StorageDead(_10);
           StorageDead(_8);
           StorageDead(_6);
           StorageDead(_2);
@@ -92,9 +92,9 @@
       }
   
       bb5: {
+          StorageDead(_14);
+          StorageDead(_13);
           StorageDead(_12);
-          StorageDead(_11);
-          StorageDead(_10);
           StorageDead(_4);
           _5 = discriminant(_3);
 -         switchInt(move _5) -> [0: bb2, 1: bb3, otherwise: bb1];
@@ -102,25 +102,25 @@
       }
   
       bb6: {
-          _12 = move ((_4 as Err).0: i32);
-          StorageLive(_13);
-          _13 = Result::<Infallible, i32>::Err(copy _12);
-          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _13);
-          StorageDead(_13);
+          _14 = move ((_4 as Err).0: i32);
+          StorageLive(_15);
+          _15 = Result::<Infallible, i32>::Err(copy _14);
+          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _15);
+          StorageDead(_15);
 -         goto -> bb5;
 +         goto -> bb8;
       }
   
       bb7: {
-          _11 = move ((_4 as Ok).0: i32);
-          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _11);
+          _13 = move ((_4 as Ok).0: i32);
+          _3 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _13);
           goto -> bb5;
 +     }
 + 
 +     bb8: {
++         StorageDead(_14);
++         StorageDead(_13);
 +         StorageDead(_12);
-+         StorageDead(_11);
-+         StorageDead(_10);
 +         StorageDead(_4);
 +         _5 = discriminant(_3);
 +         goto -> bb3;

--- a/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-abort.mir
@@ -8,24 +8,24 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
         let mut _8: u16;
         scope 2 {
         }
-        scope 3 (inlined <u16 as Step>::forward_checked) {
-            scope 4 {
-                scope 6 (inlined core::num::<impl u16>::checked_add) {
+        scope 3 (inlined core::num::<impl u16>::wrapping_add) {
+        }
+        scope 4 (inlined Option::<u16>::is_none) {
+            scope 5 (inlined Option::<u16>::is_some) {
+            }
+        }
+        scope 6 (inlined <u16 as Step>::forward_checked) {
+            scope 7 {
+                scope 8 (inlined core::num::<impl u16>::checked_add) {
                     let mut _5: (u16, bool);
                     let mut _6: bool;
                     let mut _7: bool;
                 }
             }
-            scope 5 (inlined convert::num::ptr_try_from_impls::<impl TryFrom<usize> for u16>::try_from) {
+            scope 9 (inlined convert::num::ptr_try_from_impls::<impl TryFrom<usize> for u16>::try_from) {
                 let mut _3: bool;
                 let mut _4: u16;
             }
-        }
-        scope 7 (inlined Option::<u16>::is_none) {
-            scope 8 (inlined Option::<u16>::is_some) {
-            }
-        }
-        scope 9 (inlined core::num::<impl u16>::wrapping_add) {
         }
     }
 

--- a/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-unwind.mir
@@ -8,24 +8,24 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
         let mut _8: u16;
         scope 2 {
         }
-        scope 3 (inlined <u16 as Step>::forward_checked) {
-            scope 4 {
-                scope 6 (inlined core::num::<impl u16>::checked_add) {
+        scope 3 (inlined core::num::<impl u16>::wrapping_add) {
+        }
+        scope 4 (inlined Option::<u16>::is_none) {
+            scope 5 (inlined Option::<u16>::is_some) {
+            }
+        }
+        scope 6 (inlined <u16 as Step>::forward_checked) {
+            scope 7 {
+                scope 8 (inlined core::num::<impl u16>::checked_add) {
                     let mut _5: (u16, bool);
                     let mut _6: bool;
                     let mut _7: bool;
                 }
             }
-            scope 5 (inlined convert::num::ptr_try_from_impls::<impl TryFrom<usize> for u16>::try_from) {
+            scope 9 (inlined convert::num::ptr_try_from_impls::<impl TryFrom<usize> for u16>::try_from) {
                 let mut _3: bool;
                 let mut _4: u16;
             }
-        }
-        scope 7 (inlined Option::<u16>::is_none) {
-            scope 8 (inlined Option::<u16>::is_some) {
-            }
-        }
-        scope 9 (inlined core::num::<impl u16>::wrapping_add) {
         }
     }
 

--- a/tests/mir-opt/pre-codegen/clone_as_copy.enum_clone_as_copy.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/clone_as_copy.enum_clone_as_copy.PreCodegen.after.mir
@@ -10,16 +10,16 @@ fn enum_clone_as_copy(_1: &Enum1) -> Enum1 {
         let mut _4: &NestCopy;
         scope 2 {
             debug __self_0 => _3;
-            scope 6 (inlined <AllCopy as Clone>::clone) {
+            scope 4 (inlined <AllCopy as Clone>::clone) {
                 debug self => _3;
             }
         }
         scope 3 {
             debug __self_0 => _4;
-            scope 4 (inlined <NestCopy as Clone>::clone) {
+            scope 5 (inlined <NestCopy as Clone>::clone) {
                 debug self => _4;
                 let _5: &AllCopy;
-                scope 5 (inlined <AllCopy as Clone>::clone) {
+                scope 6 (inlined <AllCopy as Clone>::clone) {
                     debug self => _5;
                 }
             }

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-abort.diff
@@ -17,27 +17,27 @@
           scope 2 {
               debug ptr => _3;
           }
-          scope 5 (inlined <std::alloc::Global as Allocator>::allocate) {
+          scope 3 (inlined <std::alloc::Global as Allocator>::allocate) {
           }
-          scope 6 (inlined #[track_caller] Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap) {
-              let mut _12: isize;
-              let _13: std::alloc::AllocError;
-              let mut _14: !;
-              let mut _15: &dyn std::fmt::Debug;
-              let _16: &std::alloc::AllocError;
-              scope 7 {
-              }
+          scope 6 (inlined NonNull::<[u8]>::as_ptr) {
+              let mut _12: *const [u8];
+          }
+          scope 7 (inlined #[track_caller] Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap) {
+              let mut _13: isize;
+              let _14: std::alloc::AllocError;
+              let mut _15: !;
+              let mut _16: &dyn std::fmt::Debug;
+              let _17: &std::alloc::AllocError;
               scope 8 {
               }
-          }
-          scope 9 (inlined NonNull::<[u8]>::as_ptr) {
-              let mut _17: *const [u8];
+              scope 9 {
+              }
           }
       }
-      scope 3 (inlined #[track_caller] Option::<Layout>::unwrap) {
+      scope 4 (inlined #[track_caller] Option::<Layout>::unwrap) {
           let mut _10: isize;
           let mut _11: !;
-          scope 4 {
+          scope 5 {
           }
       }
   
@@ -49,20 +49,29 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb1];
+-         switchInt(move _10) -> [0: bb3, 1: bb4, otherwise: bb2];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb1];
++         switchInt(const 0_isize) -> [0: bb3, 1: bb4, otherwise: bb2];
       }
   
       bb1: {
-          unreachable;
+          StorageDead(_8);
+          StorageDead(_7);
+          StorageLive(_13);
+          StorageLive(_17);
+          _13 = discriminant(_6);
+          switchInt(move _13) -> [0: bb6, 1: bb5, otherwise: bb2];
       }
   
       bb2: {
-          _11 = option::unwrap_failed() -> unwind unreachable;
+          unreachable;
       }
   
       bb3: {
+          _11 = option::unwrap_failed() -> unwind unreachable;
+      }
+  
+      bb4: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }};
           StorageDead(_10);
@@ -76,42 +85,33 @@
           _7 = copy _9;
           StorageLive(_8);
 -         _8 = copy _1;
--         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb4, unwind unreachable];
+-         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb1, unwind unreachable];
 +         _8 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }};
-+         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb4, unwind unreachable];
-      }
-  
-      bb4: {
-          StorageDead(_8);
-          StorageDead(_7);
-          StorageLive(_12);
-          StorageLive(_16);
-          _12 = discriminant(_6);
-          switchInt(move _12) -> [0: bb6, 1: bb5, otherwise: bb1];
++         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb1, unwind unreachable];
       }
   
       bb5: {
-          StorageLive(_15);
-          _16 = &_13;
-          _15 = copy _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize));
-          _14 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _15) -> unwind unreachable;
+          StorageLive(_16);
+          _17 = &_14;
+          _16 = copy _17 as &dyn std::fmt::Debug (PointerCoercion(Unsize));
+          _15 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _16) -> unwind unreachable;
       }
   
       bb6: {
           _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
-          StorageDead(_16);
-          StorageDead(_12);
+          StorageDead(_17);
+          StorageDead(_13);
           StorageDead(_6);
--         StorageLive(_17);
+-         StorageLive(_12);
 +         nop;
-          _17 = copy (_5.0: *const [u8]);
--         _4 = move _17 as *mut [u8] (PtrToPtr);
--         StorageDead(_17);
-+         _4 = copy _17 as *mut [u8] (PtrToPtr);
+          _12 = copy (_5.0: *const [u8]);
+-         _4 = move _12 as *mut [u8] (PtrToPtr);
+-         StorageDead(_12);
++         _4 = copy _12 as *mut [u8] (PtrToPtr);
 +         nop;
           StorageDead(_5);
 -         _3 = move _4 as *mut u8 (PtrToPtr);
-+         _3 = copy _17 as *mut u8 (PtrToPtr);
++         _3 = copy _12 as *mut u8 (PtrToPtr);
           StorageDead(_4);
           StorageDead(_3);
 -         StorageDead(_1);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.32bit.panic-unwind.diff
@@ -17,16 +17,16 @@
           scope 2 {
               debug ptr => _3;
           }
-          scope 5 (inlined <std::alloc::Global as Allocator>::allocate) {
+          scope 3 (inlined <std::alloc::Global as Allocator>::allocate) {
           }
           scope 6 (inlined NonNull::<[u8]>::as_ptr) {
               let mut _12: *const [u8];
           }
       }
-      scope 3 (inlined #[track_caller] Option::<Layout>::unwrap) {
+      scope 4 (inlined #[track_caller] Option::<Layout>::unwrap) {
           let mut _10: isize;
           let mut _11: !;
-          scope 4 {
+          scope 5 {
           }
       }
   
@@ -38,9 +38,9 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb3, 1: bb4, otherwise: bb2];
+-         switchInt(move _10) -> [0: bb4, 1: bb5, otherwise: bb3];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb3, 1: bb4, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb4, 1: bb5, otherwise: bb3];
       }
   
       bb1: {
@@ -63,14 +63,20 @@
       }
   
       bb2: {
-          unreachable;
+          StorageDead(_8);
+          StorageDead(_7);
+          _5 = Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap(move _6) -> [return: bb1, unwind continue];
       }
   
       bb3: {
-          _11 = option::unwrap_failed() -> unwind continue;
+          unreachable;
       }
   
       bb4: {
+          _11 = option::unwrap_failed() -> unwind continue;
+      }
+  
+      bb5: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }};
           StorageDead(_10);
@@ -84,15 +90,9 @@
           _7 = copy _9;
           StorageLive(_8);
 -         _8 = copy _1;
--         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb5, unwind continue];
+-         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb2, unwind continue];
 +         _8 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }};
-+         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb5, unwind continue];
-      }
-  
-      bb5: {
-          StorageDead(_8);
-          StorageDead(_7);
-          _5 = Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap(move _6) -> [return: bb1, unwind continue];
++         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(4 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x00000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb2, unwind continue];
       }
 + }
 + 

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-abort.diff
@@ -17,27 +17,27 @@
           scope 2 {
               debug ptr => _3;
           }
-          scope 5 (inlined <std::alloc::Global as Allocator>::allocate) {
+          scope 3 (inlined <std::alloc::Global as Allocator>::allocate) {
           }
-          scope 6 (inlined #[track_caller] Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap) {
-              let mut _12: isize;
-              let _13: std::alloc::AllocError;
-              let mut _14: !;
-              let mut _15: &dyn std::fmt::Debug;
-              let _16: &std::alloc::AllocError;
-              scope 7 {
-              }
+          scope 6 (inlined NonNull::<[u8]>::as_ptr) {
+              let mut _12: *const [u8];
+          }
+          scope 7 (inlined #[track_caller] Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap) {
+              let mut _13: isize;
+              let _14: std::alloc::AllocError;
+              let mut _15: !;
+              let mut _16: &dyn std::fmt::Debug;
+              let _17: &std::alloc::AllocError;
               scope 8 {
               }
-          }
-          scope 9 (inlined NonNull::<[u8]>::as_ptr) {
-              let mut _17: *const [u8];
+              scope 9 {
+              }
           }
       }
-      scope 3 (inlined #[track_caller] Option::<Layout>::unwrap) {
+      scope 4 (inlined #[track_caller] Option::<Layout>::unwrap) {
           let mut _10: isize;
           let mut _11: !;
-          scope 4 {
+          scope 5 {
           }
       }
   
@@ -49,20 +49,29 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb2, 1: bb3, otherwise: bb1];
+-         switchInt(move _10) -> [0: bb3, 1: bb4, otherwise: bb2];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb2, 1: bb3, otherwise: bb1];
++         switchInt(const 0_isize) -> [0: bb3, 1: bb4, otherwise: bb2];
       }
   
       bb1: {
-          unreachable;
+          StorageDead(_8);
+          StorageDead(_7);
+          StorageLive(_13);
+          StorageLive(_17);
+          _13 = discriminant(_6);
+          switchInt(move _13) -> [0: bb6, 1: bb5, otherwise: bb2];
       }
   
       bb2: {
-          _11 = option::unwrap_failed() -> unwind unreachable;
+          unreachable;
       }
   
       bb3: {
+          _11 = option::unwrap_failed() -> unwind unreachable;
+      }
+  
+      bb4: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
           StorageDead(_10);
@@ -76,42 +85,33 @@
           _7 = copy _9;
           StorageLive(_8);
 -         _8 = copy _1;
--         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb4, unwind unreachable];
+-         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb1, unwind unreachable];
 +         _8 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
-+         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb4, unwind unreachable];
-      }
-  
-      bb4: {
-          StorageDead(_8);
-          StorageDead(_7);
-          StorageLive(_12);
-          StorageLive(_16);
-          _12 = discriminant(_6);
-          switchInt(move _12) -> [0: bb6, 1: bb5, otherwise: bb1];
++         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb1, unwind unreachable];
       }
   
       bb5: {
-          StorageLive(_15);
-          _16 = &_13;
-          _15 = copy _16 as &dyn std::fmt::Debug (PointerCoercion(Unsize));
-          _14 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _15) -> unwind unreachable;
+          StorageLive(_16);
+          _17 = &_14;
+          _16 = copy _17 as &dyn std::fmt::Debug (PointerCoercion(Unsize));
+          _15 = result::unwrap_failed(const "called `Result::unwrap()` on an `Err` value", move _16) -> unwind unreachable;
       }
   
       bb6: {
           _5 = move ((_6 as Ok).0: std::ptr::NonNull<[u8]>);
-          StorageDead(_16);
-          StorageDead(_12);
+          StorageDead(_17);
+          StorageDead(_13);
           StorageDead(_6);
--         StorageLive(_17);
+-         StorageLive(_12);
 +         nop;
-          _17 = copy (_5.0: *const [u8]);
--         _4 = move _17 as *mut [u8] (PtrToPtr);
--         StorageDead(_17);
-+         _4 = copy _17 as *mut [u8] (PtrToPtr);
+          _12 = copy (_5.0: *const [u8]);
+-         _4 = move _12 as *mut [u8] (PtrToPtr);
+-         StorageDead(_12);
++         _4 = copy _12 as *mut [u8] (PtrToPtr);
 +         nop;
           StorageDead(_5);
 -         _3 = move _4 as *mut u8 (PtrToPtr);
-+         _3 = copy _17 as *mut u8 (PtrToPtr);
++         _3 = copy _12 as *mut u8 (PtrToPtr);
           StorageDead(_4);
           StorageDead(_3);
 -         StorageDead(_1);

--- a/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/issue_117368_print_invalid_constant.main.GVN.64bit.panic-unwind.diff
@@ -17,16 +17,16 @@
           scope 2 {
               debug ptr => _3;
           }
-          scope 5 (inlined <std::alloc::Global as Allocator>::allocate) {
+          scope 3 (inlined <std::alloc::Global as Allocator>::allocate) {
           }
           scope 6 (inlined NonNull::<[u8]>::as_ptr) {
               let mut _12: *const [u8];
           }
       }
-      scope 3 (inlined #[track_caller] Option::<Layout>::unwrap) {
+      scope 4 (inlined #[track_caller] Option::<Layout>::unwrap) {
           let mut _10: isize;
           let mut _11: !;
-          scope 4 {
+          scope 5 {
           }
       }
   
@@ -38,9 +38,9 @@
 +         _2 = const Option::<Layout>::None;
           StorageLive(_10);
 -         _10 = discriminant(_2);
--         switchInt(move _10) -> [0: bb3, 1: bb4, otherwise: bb2];
+-         switchInt(move _10) -> [0: bb4, 1: bb5, otherwise: bb3];
 +         _10 = const 0_isize;
-+         switchInt(const 0_isize) -> [0: bb3, 1: bb4, otherwise: bb2];
++         switchInt(const 0_isize) -> [0: bb4, 1: bb5, otherwise: bb3];
       }
   
       bb1: {
@@ -63,14 +63,20 @@
       }
   
       bb2: {
-          unreachable;
+          StorageDead(_8);
+          StorageDead(_7);
+          _5 = Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap(move _6) -> [return: bb1, unwind continue];
       }
   
       bb3: {
-          _11 = option::unwrap_failed() -> unwind continue;
+          unreachable;
       }
   
       bb4: {
+          _11 = option::unwrap_failed() -> unwind continue;
+      }
+  
+      bb5: {
 -         _1 = move ((_2 as Some).0: std::alloc::Layout);
 +         _1 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
           StorageDead(_10);
@@ -84,15 +90,9 @@
           _7 = copy _9;
           StorageLive(_8);
 -         _8 = copy _1;
--         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb5, unwind continue];
+-         _6 = std::alloc::Global::alloc_impl(move _7, move _8, const false) -> [return: bb2, unwind continue];
 +         _8 = const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }};
-+         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb5, unwind continue];
-      }
-  
-      bb5: {
-          StorageDead(_8);
-          StorageDead(_7);
-          _5 = Result::<NonNull<[u8]>, std::alloc::AllocError>::unwrap(move _6) -> [return: bb1, unwind continue];
++         _6 = std::alloc::Global::alloc_impl(copy _9, const Layout {{ size: Indirect { alloc_id: ALLOC0, offset: Size(8 bytes) }: usize, align: std::ptr::Alignment(Scalar(0x0000000000000000): std::ptr::alignment::AlignmentEnum) }}, const false) -> [return: bb2, unwind continue];
       }
 + }
 + 

--- a/tests/mir-opt/pre-codegen/loops.int_range.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/loops.int_range.PreCodegen.after.mir
@@ -15,7 +15,7 @@ fn int_range(_1: usize, _2: usize) -> () {
         scope 2 {
             debug i => _14;
         }
-        scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
+        scope 3 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
             debug self => _5;
             scope 5 (inlined <std::ops::Range<usize> as iter::range::RangeIteratorImpl>::spec_next) {
                 debug self => _5;
@@ -26,8 +26,20 @@ fn int_range(_1: usize, _2: usize) -> () {
                 let mut _12: usize;
                 scope 6 {
                     debug old => _11;
+                    scope 7 (inlined <usize as Step>::forward_unchecked) {
+                        debug start => _11;
+                        debug n => const 1_usize;
+                        scope 8 (inlined core::num::<impl usize>::unchecked_add) {
+                            debug self => _11;
+                            debug rhs => const 1_usize;
+                            scope 9 (inlined core::ub_checks::check_language_ub) {
+                                scope 10 (inlined core::ub_checks::check_language_ub::runtime) {
+                                }
+                            }
+                        }
+                    }
                 }
-                scope 7 (inlined std::cmp::impls::<impl PartialOrd for usize>::lt) {
+                scope 11 (inlined std::cmp::impls::<impl PartialOrd for usize>::lt) {
                     debug self => _6;
                     debug other => _7;
                     let mut _8: usize;
@@ -36,7 +48,7 @@ fn int_range(_1: usize, _2: usize) -> () {
             }
         }
     }
-    scope 3 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) {
+    scope 4 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) {
         debug self => _3;
     }
 
@@ -50,7 +62,6 @@ fn int_range(_1: usize, _2: usize) -> () {
     bb1: {
         StorageLive(_13);
         _5 = &mut _4;
-        StorageLive(_11);
         StorageLive(_10);
         StorageLive(_6);
         _6 = &(_4.0: usize);
@@ -70,7 +81,6 @@ fn int_range(_1: usize, _2: usize) -> () {
         StorageDead(_7);
         StorageDead(_6);
         StorageDead(_10);
-        StorageDead(_11);
         StorageDead(_13);
         StorageDead(_4);
         return;
@@ -81,20 +91,16 @@ fn int_range(_1: usize, _2: usize) -> () {
         StorageDead(_6);
         _11 = copy (_4.0: usize);
         StorageLive(_12);
-        _12 = <usize as Step>::forward_unchecked(copy _11, const 1_usize) -> [return: bb4, unwind continue];
-    }
-
-    bb4: {
+        _12 = AddUnchecked(copy _11, const 1_usize);
         (_4.0: usize) = move _12;
         StorageDead(_12);
         _13 = Option::<usize>::Some(copy _11);
         StorageDead(_10);
-        StorageDead(_11);
         _14 = copy ((_13 as Some).0: usize);
-        _15 = opaque::<usize>(move _14) -> [return: bb5, unwind continue];
+        _15 = opaque::<usize>(move _14) -> [return: bb4, unwind continue];
     }
 
-    bb5: {
+    bb4: {
         StorageDead(_13);
         goto -> bb1;
     }

--- a/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-abort.mir
@@ -17,20 +17,28 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
         scope 2 {
             debug x => _10;
         }
-        scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<u32>>::next) {
+        scope 3 (inlined iter::range::<impl Iterator for std::ops::Range<u32>>::next) {
             scope 5 (inlined <std::ops::Range<u32> as iter::range::RangeIteratorImpl>::spec_next) {
                 let mut _6: bool;
                 let _7: u32;
                 let mut _8: u32;
                 scope 6 {
+                    scope 7 (inlined <u32 as Step>::forward_unchecked) {
+                        scope 8 (inlined core::num::<impl u32>::unchecked_add) {
+                            scope 9 (inlined core::ub_checks::check_language_ub) {
+                                scope 10 (inlined core::ub_checks::check_language_ub::runtime) {
+                                }
+                            }
+                        }
+                    }
                 }
-                scope 7 (inlined std::cmp::impls::<impl PartialOrd for u32>::lt) {
+                scope 11 (inlined std::cmp::impls::<impl PartialOrd for u32>::lt) {
                     let mut _5: u32;
                 }
             }
         }
     }
-    scope 3 (inlined <std::ops::Range<u32> as IntoIterator>::into_iter) {
+    scope 4 (inlined <std::ops::Range<u32> as IntoIterator>::into_iter) {
     }
 
     bb0: {
@@ -41,7 +49,6 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
 
     bb1: {
         StorageLive(_9);
-        StorageLive(_7);
         StorageLive(_6);
         StorageLive(_5);
         _5 = copy _4;
@@ -52,7 +59,6 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
 
     bb2: {
         StorageDead(_6);
-        StorageDead(_7);
         StorageDead(_9);
         StorageDead(_4);
         drop(_3) -> [return: bb3, unwind unreachable];
@@ -65,24 +71,20 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     bb4: {
         _7 = copy _4;
         StorageLive(_8);
-        _8 = <u32 as Step>::forward_unchecked(copy _7, const 1_usize) -> [return: bb5, unwind unreachable];
-    }
-
-    bb5: {
+        _8 = AddUnchecked(copy _7, const 1_u32);
         _4 = move _8;
         StorageDead(_8);
         _9 = Option::<u32>::Some(copy _7);
         StorageDead(_6);
-        StorageDead(_7);
         _10 = copy ((_9 as Some).0: u32);
         StorageLive(_11);
         _11 = &_3;
         StorageLive(_12);
         _12 = (copy _10,);
-        _13 = <impl Fn(u32) as Fn<(u32,)>>::call(move _11, move _12) -> [return: bb6, unwind unreachable];
+        _13 = <impl Fn(u32) as Fn<(u32,)>>::call(move _11, move _12) -> [return: bb5, unwind unreachable];
     }
 
-    bb6: {
+    bb5: {
         StorageDead(_12);
         StorageDead(_11);
         StorageDead(_9);

--- a/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -17,20 +17,28 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
         scope 2 {
             debug x => _10;
         }
-        scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<u32>>::next) {
+        scope 3 (inlined iter::range::<impl Iterator for std::ops::Range<u32>>::next) {
             scope 5 (inlined <std::ops::Range<u32> as iter::range::RangeIteratorImpl>::spec_next) {
                 let mut _6: bool;
                 let _7: u32;
                 let mut _8: u32;
                 scope 6 {
+                    scope 7 (inlined <u32 as Step>::forward_unchecked) {
+                        scope 8 (inlined core::num::<impl u32>::unchecked_add) {
+                            scope 9 (inlined core::ub_checks::check_language_ub) {
+                                scope 10 (inlined core::ub_checks::check_language_ub::runtime) {
+                                }
+                            }
+                        }
+                    }
                 }
-                scope 7 (inlined std::cmp::impls::<impl PartialOrd for u32>::lt) {
+                scope 11 (inlined std::cmp::impls::<impl PartialOrd for u32>::lt) {
                     let mut _5: u32;
                 }
             }
         }
     }
-    scope 3 (inlined <std::ops::Range<u32> as IntoIterator>::into_iter) {
+    scope 4 (inlined <std::ops::Range<u32> as IntoIterator>::into_iter) {
     }
 
     bb0: {
@@ -41,7 +49,6 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
 
     bb1: {
         StorageLive(_9);
-        StorageLive(_7);
         StorageLive(_6);
         StorageLive(_5);
         _5 = copy _4;
@@ -52,7 +59,6 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
 
     bb2: {
         StorageDead(_6);
-        StorageDead(_7);
         StorageDead(_9);
         StorageDead(_4);
         drop(_3) -> [return: bb3, unwind continue];
@@ -65,35 +71,31 @@ fn forward_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
     bb4: {
         _7 = copy _4;
         StorageLive(_8);
-        _8 = <u32 as Step>::forward_unchecked(copy _7, const 1_usize) -> [return: bb5, unwind: bb7];
-    }
-
-    bb5: {
+        _8 = AddUnchecked(copy _7, const 1_u32);
         _4 = move _8;
         StorageDead(_8);
         _9 = Option::<u32>::Some(copy _7);
         StorageDead(_6);
-        StorageDead(_7);
         _10 = copy ((_9 as Some).0: u32);
         StorageLive(_11);
         _11 = &_3;
         StorageLive(_12);
         _12 = (copy _10,);
-        _13 = <impl Fn(u32) as Fn<(u32,)>>::call(move _11, move _12) -> [return: bb6, unwind: bb7];
+        _13 = <impl Fn(u32) as Fn<(u32,)>>::call(move _11, move _12) -> [return: bb5, unwind: bb6];
     }
 
-    bb6: {
+    bb5: {
         StorageDead(_12);
         StorageDead(_11);
         StorageDead(_9);
         goto -> bb1;
     }
 
-    bb7 (cleanup): {
-        drop(_3) -> [return: bb8, unwind terminate(cleanup)];
+    bb6 (cleanup): {
+        drop(_3) -> [return: bb7, unwind terminate(cleanup)];
     }
 
-    bb8 (cleanup): {
+    bb7 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-abort.mir
@@ -19,12 +19,12 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
         scope 2 {
             debug x => _9;
         }
-        scope 5 (inlined iter::range::<impl Iterator for RangeInclusive<u32>>::next) {
+        scope 3 (inlined iter::range::<impl Iterator for RangeInclusive<u32>>::next) {
         }
     }
-    scope 3 (inlined RangeInclusive::<u32>::new) {
+    scope 4 (inlined RangeInclusive::<u32>::new) {
     }
-    scope 4 (inlined <RangeInclusive<u32> as IntoIterator>::into_iter) {
+    scope 5 (inlined <RangeInclusive<u32> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.inclusive_loop.PreCodegen.after.panic-unwind.mir
@@ -19,12 +19,12 @@ fn inclusive_loop(_1: u32, _2: u32, _3: impl Fn(u32)) -> () {
         scope 2 {
             debug x => _9;
         }
-        scope 5 (inlined iter::range::<impl Iterator for RangeInclusive<u32>>::next) {
+        scope 3 (inlined iter::range::<impl Iterator for RangeInclusive<u32>>::next) {
         }
     }
-    scope 3 (inlined RangeInclusive::<u32>::new) {
+    scope 4 (inlined RangeInclusive::<u32>::new) {
     }
-    scope 4 (inlined <RangeInclusive<u32> as IntoIterator>::into_iter) {
+    scope 5 (inlined <RangeInclusive<u32> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-abort.mir
@@ -9,8 +9,16 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
             let _5: u32;
             let mut _6: u32;
             scope 3 {
+                scope 4 (inlined <u32 as Step>::forward_unchecked) {
+                    scope 5 (inlined core::num::<impl u32>::unchecked_add) {
+                        scope 6 (inlined core::ub_checks::check_language_ub) {
+                            scope 7 (inlined core::ub_checks::check_language_ub::runtime) {
+                            }
+                        }
+                    }
+                }
             }
-            scope 4 (inlined std::cmp::impls::<impl PartialOrd for u32>::lt) {
+            scope 8 (inlined std::cmp::impls::<impl PartialOrd for u32>::lt) {
                 let mut _2: u32;
                 let mut _3: u32;
             }
@@ -18,7 +26,6 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
     }
 
     bb0: {
-        StorageLive(_5);
         StorageLive(_4);
         StorageLive(_2);
         _2 = copy ((*_1).0: u32);
@@ -32,25 +39,21 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
 
     bb1: {
         _0 = const Option::<u32>::None;
-        goto -> bb4;
+        goto -> bb3;
     }
 
     bb2: {
         _5 = copy ((*_1).0: u32);
         StorageLive(_6);
-        _6 = <u32 as Step>::forward_unchecked(copy _5, const 1_usize) -> [return: bb3, unwind unreachable];
-    }
-
-    bb3: {
+        _6 = AddUnchecked(copy _5, const 1_u32);
         ((*_1).0: u32) = move _6;
         StorageDead(_6);
         _0 = Option::<u32>::Some(copy _5);
-        goto -> bb4;
+        goto -> bb3;
     }
 
-    bb4: {
+    bb3: {
         StorageDead(_4);
-        StorageDead(_5);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/range_iter.range_iter_next.PreCodegen.after.panic-unwind.mir
@@ -9,8 +9,16 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
             let _5: u32;
             let mut _6: u32;
             scope 3 {
+                scope 4 (inlined <u32 as Step>::forward_unchecked) {
+                    scope 5 (inlined core::num::<impl u32>::unchecked_add) {
+                        scope 6 (inlined core::ub_checks::check_language_ub) {
+                            scope 7 (inlined core::ub_checks::check_language_ub::runtime) {
+                            }
+                        }
+                    }
+                }
             }
-            scope 4 (inlined std::cmp::impls::<impl PartialOrd for u32>::lt) {
+            scope 8 (inlined std::cmp::impls::<impl PartialOrd for u32>::lt) {
                 let mut _2: u32;
                 let mut _3: u32;
             }
@@ -18,7 +26,6 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
     }
 
     bb0: {
-        StorageLive(_5);
         StorageLive(_4);
         StorageLive(_2);
         _2 = copy ((*_1).0: u32);
@@ -32,25 +39,21 @@ fn range_iter_next(_1: &mut std::ops::Range<u32>) -> Option<u32> {
 
     bb1: {
         _0 = const Option::<u32>::None;
-        goto -> bb4;
+        goto -> bb3;
     }
 
     bb2: {
         _5 = copy ((*_1).0: u32);
         StorageLive(_6);
-        _6 = <u32 as Step>::forward_unchecked(copy _5, const 1_usize) -> [return: bb3, unwind continue];
-    }
-
-    bb3: {
+        _6 = AddUnchecked(copy _5, const 1_u32);
         ((*_1).0: u32) = move _6;
         StorageDead(_6);
         _0 = Option::<u32>::Some(copy _5);
-        goto -> bb4;
+        goto -> bb3;
     }
 
-    bb4: {
+    bb3: {
         StorageDead(_4);
-        StorageDead(_5);
         return;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_filter.variant_a-{closure#0}.PreCodegen.after.mir
+++ b/tests/mir-opt/pre-codegen/slice_filter.variant_a-{closure#0}.PreCodegen.after.mir
@@ -30,32 +30,32 @@ fn variant_a::{closure#0}(_1: &mut {closure@$DIR/slice_filter.rs:7:25: 7:39}, _2
         scope 2 (inlined std::cmp::impls::<impl PartialOrd for &usize>::le) {
             debug self => _8;
             debug other => _10;
-            scope 3 (inlined std::cmp::impls::<impl PartialOrd for usize>::le) {
+            scope 6 (inlined std::cmp::impls::<impl PartialOrd for usize>::le) {
                 debug self => _4;
                 debug other => _6;
                 let mut _11: usize;
                 let mut _12: usize;
             }
         }
-        scope 4 (inlined std::cmp::impls::<impl PartialOrd for &usize>::le) {
+        scope 3 (inlined std::cmp::impls::<impl PartialOrd for &usize>::le) {
             debug self => _14;
             debug other => _16;
-            scope 5 (inlined std::cmp::impls::<impl PartialOrd for usize>::le) {
+            scope 7 (inlined std::cmp::impls::<impl PartialOrd for usize>::le) {
                 debug self => _7;
                 debug other => _5;
                 let mut _17: usize;
                 let mut _18: usize;
             }
         }
-        scope 6 (inlined std::cmp::impls::<impl PartialOrd for &usize>::le) {
+        scope 4 (inlined std::cmp::impls::<impl PartialOrd for &usize>::le) {
             debug self => _20;
             debug other => _22;
-            scope 7 (inlined std::cmp::impls::<impl PartialOrd for usize>::le) {
+            scope 8 (inlined std::cmp::impls::<impl PartialOrd for usize>::le) {
                 debug self => _6;
                 debug other => _4;
             }
         }
-        scope 8 (inlined std::cmp::impls::<impl PartialOrd for &usize>::le) {
+        scope 5 (inlined std::cmp::impls::<impl PartialOrd for &usize>::le) {
             debug self => _24;
             debug other => _26;
             scope 9 (inlined std::cmp::impls::<impl PartialOrd for usize>::le) {

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-abort.mir
@@ -31,7 +31,7 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
             }
             scope 19 {
                 scope 20 {
-                    scope 26 (inlined <Option<(usize, &T)> as FromResidual<Option<Infallible>>>::from_residual) {
+                    scope 24 (inlined <Option<(usize, &T)> as FromResidual<Option<Infallible>>>::from_residual) {
                     }
                 }
             }
@@ -39,49 +39,49 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                 scope 22 {
                 }
             }
-            scope 24 (inlined <Option<&T> as Try>::branch) {
+            scope 25 (inlined <Option<&T> as Try>::branch) {
                 let mut _16: isize;
                 let _17: &T;
-                scope 25 {
+                scope 26 {
                 }
             }
         }
     }
     scope 3 (inlined core::slice::<impl [T]>::iter) {
-        scope 4 (inlined std::slice::Iter::<'_, T>::new) {
+        scope 7 (inlined std::slice::Iter::<'_, T>::new) {
             let _3: usize;
             let mut _7: *mut T;
             let mut _8: *mut T;
             let mut _10: *const T;
-            scope 5 {
+            scope 8 {
                 let _6: std::ptr::NonNull<T>;
-                scope 6 {
+                scope 9 {
                     let _9: *const T;
-                    scope 7 {
+                    scope 10 {
                     }
                     scope 11 (inlined without_provenance::<T>) {
                     }
-                    scope 12 (inlined NonNull::<T>::as_ptr) {
+                    scope 12 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
                     }
-                    scope 13 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
+                    scope 14 (inlined NonNull::<T>::as_ptr) {
                     }
                 }
-                scope 8 (inlined <NonNull<[T]> as From<&[T]>>::from) {
+                scope 13 (inlined <NonNull<[T]> as From<&[T]>>::from) {
                     let mut _4: *const [T];
                 }
-                scope 9 (inlined NonNull::<[T]>::cast::<T>) {
+                scope 15 (inlined NonNull::<[T]>::cast::<T>) {
                     let mut _5: *const T;
-                    scope 10 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 16 (inlined NonNull::<[T]>::as_ptr) {
                     }
                 }
             }
         }
     }
-    scope 14 (inlined <std::slice::Iter<'_, T> as Iterator>::enumerate) {
-        scope 15 (inlined Enumerate::<std::slice::Iter<'_, T>>::new) {
+    scope 4 (inlined <std::slice::Iter<'_, T> as Iterator>::enumerate) {
+        scope 5 (inlined Enumerate::<std::slice::Iter<'_, T>>::new) {
         }
     }
-    scope 16 (inlined <Enumerate<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
+    scope 6 (inlined <Enumerate<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.enumerated_loop.PreCodegen.after.panic-unwind.mir
@@ -23,40 +23,40 @@ fn enumerated_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
         }
     }
     scope 3 (inlined core::slice::<impl [T]>::iter) {
-        scope 4 (inlined std::slice::Iter::<'_, T>::new) {
+        scope 7 (inlined std::slice::Iter::<'_, T>::new) {
             let _3: usize;
             let mut _7: *mut T;
             let mut _8: *mut T;
             let mut _10: *const T;
-            scope 5 {
+            scope 8 {
                 let _6: std::ptr::NonNull<T>;
-                scope 6 {
+                scope 9 {
                     let _9: *const T;
-                    scope 7 {
+                    scope 10 {
                     }
                     scope 11 (inlined without_provenance::<T>) {
                     }
-                    scope 12 (inlined NonNull::<T>::as_ptr) {
+                    scope 12 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
                     }
-                    scope 13 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
+                    scope 14 (inlined NonNull::<T>::as_ptr) {
                     }
                 }
-                scope 8 (inlined <NonNull<[T]> as From<&[T]>>::from) {
+                scope 13 (inlined <NonNull<[T]> as From<&[T]>>::from) {
                     let mut _4: *const [T];
                 }
-                scope 9 (inlined NonNull::<[T]>::cast::<T>) {
+                scope 15 (inlined NonNull::<[T]>::cast::<T>) {
                     let mut _5: *const T;
-                    scope 10 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 16 (inlined NonNull::<[T]>::as_ptr) {
                     }
                 }
             }
         }
     }
-    scope 14 (inlined <std::slice::Iter<'_, T> as Iterator>::enumerate) {
-        scope 15 (inlined Enumerate::<std::slice::Iter<'_, T>>::new) {
+    scope 4 (inlined <std::slice::Iter<'_, T> as Iterator>::enumerate) {
+        scope 5 (inlined Enumerate::<std::slice::Iter<'_, T>>::new) {
         }
     }
-    scope 16 (inlined <Enumerate<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
+    scope 6 (inlined <Enumerate<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-abort.mir
@@ -20,36 +20,36 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         }
     }
     scope 3 (inlined core::slice::<impl [T]>::iter) {
-        scope 4 (inlined std::slice::Iter::<'_, T>::new) {
+        scope 5 (inlined std::slice::Iter::<'_, T>::new) {
             let _3: usize;
             let mut _7: *mut T;
             let mut _8: *mut T;
             let mut _10: *const T;
-            scope 5 {
+            scope 6 {
                 let _6: std::ptr::NonNull<T>;
-                scope 6 {
+                scope 7 {
                     let _9: *const T;
-                    scope 7 {
+                    scope 8 {
                     }
-                    scope 11 (inlined without_provenance::<T>) {
+                    scope 9 (inlined without_provenance::<T>) {
+                    }
+                    scope 10 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
                     }
                     scope 12 (inlined NonNull::<T>::as_ptr) {
                     }
-                    scope 13 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
-                    }
                 }
-                scope 8 (inlined <NonNull<[T]> as From<&[T]>>::from) {
+                scope 11 (inlined <NonNull<[T]> as From<&[T]>>::from) {
                     let mut _4: *const [T];
                 }
-                scope 9 (inlined NonNull::<[T]>::cast::<T>) {
+                scope 13 (inlined NonNull::<[T]>::cast::<T>) {
                     let mut _5: *const T;
-                    scope 10 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 14 (inlined NonNull::<[T]>::as_ptr) {
                     }
                 }
             }
         }
     }
-    scope 14 (inlined <std::slice::Iter<'_, T> as IntoIterator>::into_iter) {
+    scope 4 (inlined <std::slice::Iter<'_, T> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.forward_loop.PreCodegen.after.panic-unwind.mir
@@ -20,36 +20,36 @@ fn forward_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         }
     }
     scope 3 (inlined core::slice::<impl [T]>::iter) {
-        scope 4 (inlined std::slice::Iter::<'_, T>::new) {
+        scope 5 (inlined std::slice::Iter::<'_, T>::new) {
             let _3: usize;
             let mut _7: *mut T;
             let mut _8: *mut T;
             let mut _10: *const T;
-            scope 5 {
+            scope 6 {
                 let _6: std::ptr::NonNull<T>;
-                scope 6 {
+                scope 7 {
                     let _9: *const T;
-                    scope 7 {
+                    scope 8 {
                     }
-                    scope 11 (inlined without_provenance::<T>) {
+                    scope 9 (inlined without_provenance::<T>) {
+                    }
+                    scope 10 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
                     }
                     scope 12 (inlined NonNull::<T>::as_ptr) {
                     }
-                    scope 13 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
-                    }
                 }
-                scope 8 (inlined <NonNull<[T]> as From<&[T]>>::from) {
+                scope 11 (inlined <NonNull<[T]> as From<&[T]>>::from) {
                     let mut _4: *const [T];
                 }
-                scope 9 (inlined NonNull::<[T]>::cast::<T>) {
+                scope 13 (inlined NonNull::<[T]>::cast::<T>) {
                     let mut _5: *const T;
-                    scope 10 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 14 (inlined NonNull::<[T]>::as_ptr) {
                     }
                 }
             }
         }
     }
-    scope 14 (inlined <std::slice::Iter<'_, T> as IntoIterator>::into_iter) {
+    scope 4 (inlined <std::slice::Iter<'_, T> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-abort.mir
@@ -23,20 +23,28 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                 debug x => _13;
             }
         }
-        scope 5 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
+        scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
             scope 6 (inlined <std::ops::Range<usize> as iter::range::RangeIteratorImpl>::spec_next) {
                 let mut _6: bool;
                 let _7: usize;
                 let mut _8: usize;
                 scope 7 {
+                    scope 8 (inlined <usize as Step>::forward_unchecked) {
+                        scope 9 (inlined core::num::<impl usize>::unchecked_add) {
+                            scope 10 (inlined core::ub_checks::check_language_ub) {
+                                scope 11 (inlined core::ub_checks::check_language_ub::runtime) {
+                                }
+                            }
+                        }
+                    }
                 }
-                scope 8 (inlined std::cmp::impls::<impl PartialOrd for usize>::lt) {
+                scope 12 (inlined std::cmp::impls::<impl PartialOrd for usize>::lt) {
                     let mut _5: usize;
                 }
             }
         }
     }
-    scope 4 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) {
+    scope 5 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) {
     }
 
     bb0: {
@@ -48,7 +56,6 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
 
     bb1: {
         StorageLive(_9);
-        StorageLive(_7);
         StorageLive(_6);
         StorageLive(_5);
         _5 = copy _4;
@@ -59,7 +66,6 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
 
     bb2: {
         StorageDead(_6);
-        StorageDead(_7);
         StorageDead(_9);
         StorageDead(_4);
         drop(_2) -> [return: bb3, unwind unreachable];
@@ -72,31 +78,27 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     bb4: {
         _7 = copy _4;
         StorageLive(_8);
-        _8 = <usize as Step>::forward_unchecked(copy _7, const 1_usize) -> [return: bb5, unwind unreachable];
-    }
-
-    bb5: {
+        _8 = AddUnchecked(copy _7, const 1_usize);
         _4 = move _8;
         StorageDead(_8);
         _9 = Option::<usize>::Some(copy _7);
         StorageDead(_6);
-        StorageDead(_7);
         _10 = copy ((_9 as Some).0: usize);
         _11 = Len((*_1));
         _12 = Lt(copy _10, copy _11);
-        assert(move _12, "index out of bounds: the length is {} but the index is {}", move _11, copy _10) -> [success: bb6, unwind unreachable];
+        assert(move _12, "index out of bounds: the length is {} but the index is {}", move _11, copy _10) -> [success: bb5, unwind unreachable];
     }
 
-    bb6: {
+    bb5: {
         _13 = &(*_1)[_10];
         StorageLive(_14);
         _14 = &_2;
         StorageLive(_15);
         _15 = (copy _10, copy _13);
-        _16 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _14, move _15) -> [return: bb7, unwind unreachable];
+        _16 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _14, move _15) -> [return: bb6, unwind unreachable];
     }
 
-    bb7: {
+    bb6: {
         StorageDead(_15);
         StorageDead(_14);
         StorageDead(_9);

--- a/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.range_loop.PreCodegen.after.panic-unwind.mir
@@ -23,20 +23,28 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
                 debug x => _13;
             }
         }
-        scope 5 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
+        scope 4 (inlined iter::range::<impl Iterator for std::ops::Range<usize>>::next) {
             scope 6 (inlined <std::ops::Range<usize> as iter::range::RangeIteratorImpl>::spec_next) {
                 let mut _6: bool;
                 let _7: usize;
                 let mut _8: usize;
                 scope 7 {
+                    scope 8 (inlined <usize as Step>::forward_unchecked) {
+                        scope 9 (inlined core::num::<impl usize>::unchecked_add) {
+                            scope 10 (inlined core::ub_checks::check_language_ub) {
+                                scope 11 (inlined core::ub_checks::check_language_ub::runtime) {
+                                }
+                            }
+                        }
+                    }
                 }
-                scope 8 (inlined std::cmp::impls::<impl PartialOrd for usize>::lt) {
+                scope 12 (inlined std::cmp::impls::<impl PartialOrd for usize>::lt) {
                     let mut _5: usize;
                 }
             }
         }
     }
-    scope 4 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) {
+    scope 5 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) {
     }
 
     bb0: {
@@ -48,7 +56,6 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
 
     bb1: {
         StorageLive(_9);
-        StorageLive(_7);
         StorageLive(_6);
         StorageLive(_5);
         _5 = copy _4;
@@ -59,7 +66,6 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
 
     bb2: {
         StorageDead(_6);
-        StorageDead(_7);
         StorageDead(_9);
         StorageDead(_4);
         drop(_2) -> [return: bb3, unwind continue];
@@ -72,42 +78,38 @@ fn range_loop(_1: &[T], _2: impl Fn(usize, &T)) -> () {
     bb4: {
         _7 = copy _4;
         StorageLive(_8);
-        _8 = <usize as Step>::forward_unchecked(copy _7, const 1_usize) -> [return: bb5, unwind: bb8];
-    }
-
-    bb5: {
+        _8 = AddUnchecked(copy _7, const 1_usize);
         _4 = move _8;
         StorageDead(_8);
         _9 = Option::<usize>::Some(copy _7);
         StorageDead(_6);
-        StorageDead(_7);
         _10 = copy ((_9 as Some).0: usize);
         _11 = Len((*_1));
         _12 = Lt(copy _10, copy _11);
-        assert(move _12, "index out of bounds: the length is {} but the index is {}", move _11, copy _10) -> [success: bb6, unwind: bb8];
+        assert(move _12, "index out of bounds: the length is {} but the index is {}", move _11, copy _10) -> [success: bb5, unwind: bb7];
     }
 
-    bb6: {
+    bb5: {
         _13 = &(*_1)[_10];
         StorageLive(_14);
         _14 = &_2;
         StorageLive(_15);
         _15 = (copy _10, copy _13);
-        _16 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _14, move _15) -> [return: bb7, unwind: bb8];
+        _16 = <impl Fn(usize, &T) as Fn<(usize, &T)>>::call(move _14, move _15) -> [return: bb6, unwind: bb7];
     }
 
-    bb7: {
+    bb6: {
         StorageDead(_15);
         StorageDead(_14);
         StorageDead(_9);
         goto -> bb1;
     }
 
-    bb8 (cleanup): {
-        drop(_2) -> [return: bb9, unwind terminate(cleanup)];
+    bb7 (cleanup): {
+        drop(_2) -> [return: bb8, unwind terminate(cleanup)];
     }
 
-    bb9 (cleanup): {
+    bb8 (cleanup): {
         resume;
     }
 }

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-abort.mir
@@ -18,45 +18,45 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         scope 2 {
             debug x => _17;
         }
-        scope 17 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
+        scope 7 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
             let mut _14: &mut std::slice::Iter<'_, T>;
         }
     }
     scope 3 (inlined core::slice::<impl [T]>::iter) {
-        scope 4 (inlined std::slice::Iter::<'_, T>::new) {
+        scope 8 (inlined std::slice::Iter::<'_, T>::new) {
             let _3: usize;
             let mut _7: *mut T;
             let mut _8: *mut T;
             let mut _10: *const T;
-            scope 5 {
+            scope 9 {
                 let _6: std::ptr::NonNull<T>;
-                scope 6 {
+                scope 10 {
                     let _9: *const T;
-                    scope 7 {
+                    scope 11 {
                     }
-                    scope 11 (inlined without_provenance::<T>) {
-                    }
-                    scope 12 (inlined NonNull::<T>::as_ptr) {
+                    scope 12 (inlined without_provenance::<T>) {
                     }
                     scope 13 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
                     }
+                    scope 15 (inlined NonNull::<T>::as_ptr) {
+                    }
                 }
-                scope 8 (inlined <NonNull<[T]> as From<&[T]>>::from) {
+                scope 14 (inlined <NonNull<[T]> as From<&[T]>>::from) {
                     let mut _4: *const [T];
                 }
-                scope 9 (inlined NonNull::<[T]>::cast::<T>) {
+                scope 16 (inlined NonNull::<[T]>::cast::<T>) {
                     let mut _5: *const T;
-                    scope 10 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 17 (inlined NonNull::<[T]>::as_ptr) {
                     }
                 }
             }
         }
     }
-    scope 14 (inlined <std::slice::Iter<'_, T> as Iterator>::rev) {
-        scope 15 (inlined Rev::<std::slice::Iter<'_, T>>::new) {
+    scope 4 (inlined <std::slice::Iter<'_, T> as Iterator>::rev) {
+        scope 5 (inlined Rev::<std::slice::Iter<'_, T>>::new) {
         }
     }
-    scope 16 (inlined <Rev<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
+    scope 6 (inlined <Rev<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.reverse_loop.PreCodegen.after.panic-unwind.mir
@@ -18,45 +18,45 @@ fn reverse_loop(_1: &[T], _2: impl Fn(&T)) -> () {
         scope 2 {
             debug x => _17;
         }
-        scope 17 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
+        scope 7 (inlined <Rev<std::slice::Iter<'_, T>> as Iterator>::next) {
             let mut _14: &mut std::slice::Iter<'_, T>;
         }
     }
     scope 3 (inlined core::slice::<impl [T]>::iter) {
-        scope 4 (inlined std::slice::Iter::<'_, T>::new) {
+        scope 8 (inlined std::slice::Iter::<'_, T>::new) {
             let _3: usize;
             let mut _7: *mut T;
             let mut _8: *mut T;
             let mut _10: *const T;
-            scope 5 {
+            scope 9 {
                 let _6: std::ptr::NonNull<T>;
-                scope 6 {
+                scope 10 {
                     let _9: *const T;
-                    scope 7 {
+                    scope 11 {
                     }
-                    scope 11 (inlined without_provenance::<T>) {
-                    }
-                    scope 12 (inlined NonNull::<T>::as_ptr) {
+                    scope 12 (inlined without_provenance::<T>) {
                     }
                     scope 13 (inlined std::ptr::mut_ptr::<impl *mut T>::add) {
                     }
+                    scope 15 (inlined NonNull::<T>::as_ptr) {
+                    }
                 }
-                scope 8 (inlined <NonNull<[T]> as From<&[T]>>::from) {
+                scope 14 (inlined <NonNull<[T]> as From<&[T]>>::from) {
                     let mut _4: *const [T];
                 }
-                scope 9 (inlined NonNull::<[T]>::cast::<T>) {
+                scope 16 (inlined NonNull::<[T]>::cast::<T>) {
                     let mut _5: *const T;
-                    scope 10 (inlined NonNull::<[T]>::as_ptr) {
+                    scope 17 (inlined NonNull::<[T]>::as_ptr) {
                     }
                 }
             }
         }
     }
-    scope 14 (inlined <std::slice::Iter<'_, T> as Iterator>::rev) {
-        scope 15 (inlined Rev::<std::slice::Iter<'_, T>>::new) {
+    scope 4 (inlined <std::slice::Iter<'_, T> as Iterator>::rev) {
+        scope 5 (inlined Rev::<std::slice::Iter<'_, T>>::new) {
         }
     }
-    scope 16 (inlined <Rev<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
+    scope 6 (inlined <Rev<std::slice::Iter<'_, T>> as IntoIterator>::into_iter) {
     }
 
     bb0: {

--- a/tests/mir-opt/pre-codegen/slice_iter.slice_iter_generic_is_empty.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.slice_iter_generic_is_empty.PreCodegen.after.panic-abort.mir
@@ -23,11 +23,11 @@ fn slice_iter_generic_is_empty(_1: &std::slice::Iter<'_, T>) -> bool {
                     }
                 }
             }
-            scope 5 (inlined std::ptr::const_ptr::<impl *const T>::addr) {
-                scope 6 (inlined std::ptr::const_ptr::<impl *const T>::cast::<()>) {
-                }
+            scope 5 (inlined std::ptr::const_ptr::<impl *const *const T>::cast::<NonNull<T>>) {
             }
-            scope 7 (inlined std::ptr::const_ptr::<impl *const *const T>::cast::<NonNull<T>>) {
+            scope 6 (inlined std::ptr::const_ptr::<impl *const T>::addr) {
+                scope 7 (inlined std::ptr::const_ptr::<impl *const T>::cast::<()>) {
+                }
             }
         }
     }

--- a/tests/mir-opt/pre-codegen/slice_iter.slice_iter_generic_is_empty.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/slice_iter.slice_iter_generic_is_empty.PreCodegen.after.panic-unwind.mir
@@ -23,11 +23,11 @@ fn slice_iter_generic_is_empty(_1: &std::slice::Iter<'_, T>) -> bool {
                     }
                 }
             }
-            scope 5 (inlined std::ptr::const_ptr::<impl *const T>::addr) {
-                scope 6 (inlined std::ptr::const_ptr::<impl *const T>::cast::<()>) {
-                }
+            scope 5 (inlined std::ptr::const_ptr::<impl *const *const T>::cast::<NonNull<T>>) {
             }
-            scope 7 (inlined std::ptr::const_ptr::<impl *const *const T>::cast::<NonNull<T>>) {
+            scope 6 (inlined std::ptr::const_ptr::<impl *const T>::addr) {
+                scope 7 (inlined std::ptr::const_ptr::<impl *const T>::cast::<()>) {
+                }
             }
         }
     }

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-abort.mir
@@ -6,65 +6,65 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
     scope 1 (inlined <Vec<u8> as Deref>::deref) {
         debug self => _1;
         let mut _6: usize;
-        scope 2 (inlined Vec::<u8>::as_ptr) {
+        scope 2 (inlined std::slice::from_raw_parts::<'_, u8>) {
+            debug data => _5;
+            debug len => _6;
+            let _7: *const [u8];
+            scope 3 (inlined core::ub_checks::check_language_ub) {
+                scope 4 (inlined core::ub_checks::check_language_ub::runtime) {
+                }
+            }
+            scope 5 (inlined std::mem::size_of::<u8>) {
+            }
+            scope 6 (inlined align_of::<u8>) {
+            }
+            scope 7 (inlined slice_from_raw_parts::<u8>) {
+                debug data => _5;
+                debug len => _6;
+                scope 8 (inlined std::ptr::from_raw_parts::<[u8], u8>) {
+                    debug data_pointer => _5;
+                    debug metadata => _6;
+                }
+            }
+        }
+        scope 9 (inlined Vec::<u8>::as_ptr) {
             debug self => _1;
             let mut _2: &alloc::raw_vec::RawVec<u8>;
-            scope 3 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
+            scope 10 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
                 debug self => _2;
                 let mut _3: &alloc::raw_vec::RawVecInner;
-                scope 4 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
+                scope 11 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
                     debug self => _3;
-                    scope 5 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
+                    scope 12 (inlined NonNull::<u8>::as_ptr) {
+                        debug self => _4;
+                    }
+                    scope 13 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
                         debug self => _3;
                         let mut _4: std::ptr::NonNull<u8>;
-                        scope 6 (inlined Unique::<u8>::cast::<u8>) {
+                        scope 14 (inlined #[track_caller] <Unique<u8> as Into<NonNull<u8>>>::into) {
                             debug ((self: Unique<u8>).0: std::ptr::NonNull<u8>) => _4;
                             debug ((self: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
-                            scope 7 (inlined NonNull::<u8>::cast::<u8>) {
-                                debug self => _4;
-                                scope 8 (inlined NonNull::<u8>::as_ptr) {
-                                    debug self => _4;
-                                    let mut _5: *const u8;
-                                }
-                            }
-                        }
-                        scope 9 (inlined #[track_caller] <Unique<u8> as Into<NonNull<u8>>>::into) {
-                            debug ((self: Unique<u8>).0: std::ptr::NonNull<u8>) => _4;
-                            debug ((self: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
-                            scope 10 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
+                            scope 15 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
                                 debug ((unique: Unique<u8>).0: std::ptr::NonNull<u8>) => _4;
                                 debug ((unique: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
-                                scope 11 (inlined Unique::<u8>::as_non_null_ptr) {
+                                scope 16 (inlined Unique::<u8>::as_non_null_ptr) {
                                     debug ((self: Unique<u8>).0: std::ptr::NonNull<u8>) => _4;
                                     debug ((self: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
                                 }
                             }
                         }
+                        scope 17 (inlined Unique::<u8>::cast::<u8>) {
+                            debug ((self: Unique<u8>).0: std::ptr::NonNull<u8>) => _4;
+                            debug ((self: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
+                            scope 18 (inlined NonNull::<u8>::cast::<u8>) {
+                                debug self => _4;
+                                scope 19 (inlined NonNull::<u8>::as_ptr) {
+                                    debug self => _4;
+                                    let mut _5: *const u8;
+                                }
+                            }
+                        }
                     }
-                    scope 12 (inlined NonNull::<u8>::as_ptr) {
-                        debug self => _4;
-                    }
-                }
-            }
-        }
-        scope 13 (inlined std::slice::from_raw_parts::<'_, u8>) {
-            debug data => _5;
-            debug len => _6;
-            let _7: *const [u8];
-            scope 14 (inlined core::ub_checks::check_language_ub) {
-                scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
-                }
-            }
-            scope 16 (inlined std::mem::size_of::<u8>) {
-            }
-            scope 17 (inlined align_of::<u8>) {
-            }
-            scope 18 (inlined slice_from_raw_parts::<u8>) {
-                debug data => _5;
-                debug len => _6;
-                scope 19 (inlined std::ptr::from_raw_parts::<[u8], u8>) {
-                    debug data_pointer => _5;
-                    debug metadata => _6;
                 }
             }
         }

--- a/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/vec_deref.vec_deref_to_slice.PreCodegen.after.panic-unwind.mir
@@ -6,65 +6,65 @@ fn vec_deref_to_slice(_1: &Vec<u8>) -> &[u8] {
     scope 1 (inlined <Vec<u8> as Deref>::deref) {
         debug self => _1;
         let mut _6: usize;
-        scope 2 (inlined Vec::<u8>::as_ptr) {
+        scope 2 (inlined std::slice::from_raw_parts::<'_, u8>) {
+            debug data => _5;
+            debug len => _6;
+            let _7: *const [u8];
+            scope 3 (inlined core::ub_checks::check_language_ub) {
+                scope 4 (inlined core::ub_checks::check_language_ub::runtime) {
+                }
+            }
+            scope 5 (inlined std::mem::size_of::<u8>) {
+            }
+            scope 6 (inlined align_of::<u8>) {
+            }
+            scope 7 (inlined slice_from_raw_parts::<u8>) {
+                debug data => _5;
+                debug len => _6;
+                scope 8 (inlined std::ptr::from_raw_parts::<[u8], u8>) {
+                    debug data_pointer => _5;
+                    debug metadata => _6;
+                }
+            }
+        }
+        scope 9 (inlined Vec::<u8>::as_ptr) {
             debug self => _1;
             let mut _2: &alloc::raw_vec::RawVec<u8>;
-            scope 3 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
+            scope 10 (inlined alloc::raw_vec::RawVec::<u8>::ptr) {
                 debug self => _2;
                 let mut _3: &alloc::raw_vec::RawVecInner;
-                scope 4 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
+                scope 11 (inlined alloc::raw_vec::RawVecInner::ptr::<u8>) {
                     debug self => _3;
-                    scope 5 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
+                    scope 12 (inlined NonNull::<u8>::as_ptr) {
+                        debug self => _4;
+                    }
+                    scope 13 (inlined alloc::raw_vec::RawVecInner::non_null::<u8>) {
                         debug self => _3;
                         let mut _4: std::ptr::NonNull<u8>;
-                        scope 6 (inlined Unique::<u8>::cast::<u8>) {
+                        scope 14 (inlined #[track_caller] <Unique<u8> as Into<NonNull<u8>>>::into) {
                             debug ((self: Unique<u8>).0: std::ptr::NonNull<u8>) => _4;
                             debug ((self: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
-                            scope 7 (inlined NonNull::<u8>::cast::<u8>) {
-                                debug self => _4;
-                                scope 8 (inlined NonNull::<u8>::as_ptr) {
-                                    debug self => _4;
-                                    let mut _5: *const u8;
-                                }
-                            }
-                        }
-                        scope 9 (inlined #[track_caller] <Unique<u8> as Into<NonNull<u8>>>::into) {
-                            debug ((self: Unique<u8>).0: std::ptr::NonNull<u8>) => _4;
-                            debug ((self: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
-                            scope 10 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
+                            scope 15 (inlined <NonNull<u8> as From<Unique<u8>>>::from) {
                                 debug ((unique: Unique<u8>).0: std::ptr::NonNull<u8>) => _4;
                                 debug ((unique: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
-                                scope 11 (inlined Unique::<u8>::as_non_null_ptr) {
+                                scope 16 (inlined Unique::<u8>::as_non_null_ptr) {
                                     debug ((self: Unique<u8>).0: std::ptr::NonNull<u8>) => _4;
                                     debug ((self: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
                                 }
                             }
                         }
+                        scope 17 (inlined Unique::<u8>::cast::<u8>) {
+                            debug ((self: Unique<u8>).0: std::ptr::NonNull<u8>) => _4;
+                            debug ((self: Unique<u8>).1: std::marker::PhantomData<u8>) => const PhantomData::<u8>;
+                            scope 18 (inlined NonNull::<u8>::cast::<u8>) {
+                                debug self => _4;
+                                scope 19 (inlined NonNull::<u8>::as_ptr) {
+                                    debug self => _4;
+                                    let mut _5: *const u8;
+                                }
+                            }
+                        }
                     }
-                    scope 12 (inlined NonNull::<u8>::as_ptr) {
-                        debug self => _4;
-                    }
-                }
-            }
-        }
-        scope 13 (inlined std::slice::from_raw_parts::<'_, u8>) {
-            debug data => _5;
-            debug len => _6;
-            let _7: *const [u8];
-            scope 14 (inlined core::ub_checks::check_language_ub) {
-                scope 15 (inlined core::ub_checks::check_language_ub::runtime) {
-                }
-            }
-            scope 16 (inlined std::mem::size_of::<u8>) {
-            }
-            scope 17 (inlined align_of::<u8>) {
-            }
-            scope 18 (inlined slice_from_raw_parts::<u8>) {
-                debug data => _5;
-                debug len => _6;
-                scope 19 (inlined std::ptr::from_raw_parts::<[u8], u8>) {
-                    debug data_pointer => _5;
-                    debug metadata => _6;
                 }
             }
         }

--- a/tests/mir-opt/separate_const_switch.identity.JumpThreading.diff
+++ b/tests/mir-opt/separate_const_switch.identity.JumpThreading.diff
@@ -11,10 +11,10 @@
       scope 1 {
           debug residual => _4;
           scope 2 {
-              scope 8 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) {
-                  let _10: i32;
-                  scope 9 {
-                      scope 10 (inlined <i32 as From<i32>>::from) {
+              scope 5 (inlined #[track_caller] <Result<i32, i32> as FromResidual<Result<Infallible, i32>>>::from_residual) {
+                  let _6: i32;
+                  scope 6 {
+                      scope 7 (inlined <i32 as From<i32>>::from) {
                       }
                   }
               }
@@ -25,24 +25,24 @@
           scope 4 {
           }
       }
-      scope 5 (inlined <Result<i32, i32> as Try>::branch) {
-          let mut _6: isize;
-          let _7: i32;
+      scope 8 (inlined <Result<i32, i32> as Try>::branch) {
+          let mut _7: isize;
           let _8: i32;
-          let mut _9: std::result::Result<std::convert::Infallible, i32>;
-          scope 6 {
+          let _9: i32;
+          let mut _10: std::result::Result<std::convert::Infallible, i32>;
+          scope 9 {
           }
-          scope 7 {
+          scope 10 {
           }
       }
   
       bb0: {
           StorageLive(_2);
-          StorageLive(_6);
           StorageLive(_7);
           StorageLive(_8);
-          _6 = discriminant(_1);
-          switchInt(move _6) -> [0: bb6, 1: bb5, otherwise: bb1];
+          StorageLive(_9);
+          _7 = discriminant(_1);
+          switchInt(move _7) -> [0: bb6, 1: bb5, otherwise: bb1];
       }
   
       bb1: {
@@ -58,41 +58,41 @@
   
       bb3: {
           _4 = copy ((_2 as Break).0: std::result::Result<std::convert::Infallible, i32>);
-          _10 = copy ((_4 as Err).0: i32);
-          _0 = Result::<i32, i32>::Err(copy _10);
+          _6 = copy ((_4 as Err).0: i32);
+          _0 = Result::<i32, i32>::Err(copy _6);
           StorageDead(_2);
           return;
       }
   
       bb4: {
+          StorageDead(_9);
           StorageDead(_8);
           StorageDead(_7);
-          StorageDead(_6);
           _3 = discriminant(_2);
 -         switchInt(move _3) -> [0: bb2, 1: bb3, otherwise: bb1];
 +         goto -> bb2;
       }
   
       bb5: {
-          _8 = copy ((_1 as Err).0: i32);
-          StorageLive(_9);
-          _9 = Result::<Infallible, i32>::Err(copy _8);
-          _2 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _9);
-          StorageDead(_9);
+          _9 = copy ((_1 as Err).0: i32);
+          StorageLive(_10);
+          _10 = Result::<Infallible, i32>::Err(copy _9);
+          _2 = ControlFlow::<Result<Infallible, i32>, i32>::Break(move _10);
+          StorageDead(_10);
 -         goto -> bb4;
 +         goto -> bb7;
       }
   
       bb6: {
-          _7 = copy ((_1 as Ok).0: i32);
-          _2 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _7);
+          _8 = copy ((_1 as Ok).0: i32);
+          _2 = ControlFlow::<Result<Infallible, i32>, i32>::Continue(copy _8);
           goto -> bb4;
 +     }
 + 
 +     bb7: {
++         StorageDead(_9);
 +         StorageDead(_8);
 +         StorageDead(_7);
-+         StorageDead(_6);
 +         _3 = discriminant(_2);
 +         goto -> bb3;
       }


### PR DESCRIPTION
Then limit the total size and number of inlined things, to allow more top-down inlining (particularly important after calling something generic that couldn't inline internally) without getting exponential blowup.

Fixes #130590
r? saethlin 