### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -221,7 +221,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         }
 
         // Fall back to exact equality.
-        // FIXME: We are missing the rules for "repr(C) wrapping compatible types".
         Ok(caller == callee)
     }
 

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2733,7 +2733,7 @@ extern "rust-intrinsic" {
 
     /// Lexicographically compare `[left, left + bytes)` and `[right, right + bytes)`
     /// as unsigned bytes, returning negative if `left` is less, zero if all the
-    /// bytes match, or positive if `right` is greater.
+    /// bytes match, or positive if `left` is greater.
     ///
     /// This underlies things like `<[u8]>::cmp`, and will usually lower to `memcmp`.
     ///

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -2538,6 +2538,7 @@ impl<T> Option<Option<T>> {
     #[stable(feature = "option_flattening", since = "1.40.0")]
     #[rustc_const_unstable(feature = "const_option", issue = "67441")]
     pub const fn flatten(self) -> Option<T> {
+        // FIXME(const-hack): could be written with `and_then`
         match self {
             Some(inner) => inner,
             None => None,

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -1676,8 +1676,13 @@ impl<T, E> Result<Result<T, E>, E> {
     /// ```
     #[inline]
     #[unstable(feature = "result_flattening", issue = "70142")]
-    pub fn flatten(self) -> Result<T, E> {
-        self.and_then(convert::identity)
+    #[rustc_const_unstable(feature = "result_flattening", issue = "70142")]
+    pub const fn flatten(self) -> Result<T, E> {
+        // FIXME(const-hack): could be written with `and_then`
+        match self {
+            Ok(inner) => inner,
+            Err(e) => Err(e),
+        }
     }
 }
 

--- a/src/doc/unstable-book/src/compiler-flags/branch-protection.md
+++ b/src/doc/unstable-book/src/compiler-flags/branch-protection.md
@@ -1,5 +1,9 @@
 # `branch-protection`
 
+The tracking issue for this feature is: [#113369](https://github.com/rust-lang/rust/issues/113369).
+
+------------------------
+
 This option lets you enable branch authentication instructions on AArch64.
 This option is only accepted when targeting AArch64 architectures.
 It takes some combination of the following values, separated by a `,`.

--- a/src/doc/unstable-book/src/language-features/more-qualified-paths.md
+++ b/src/doc/unstable-book/src/language-features/more-qualified-paths.md
@@ -3,6 +3,10 @@
 The `more_qualified_paths` feature can be used in order to enable the
 use of qualified paths in patterns.
 
+The tracking issue for this feature is: [#86935](https://github.com/rust-lang/rust/issues/86935).
+
+------------------------
+
 ## Example
 
 ```rust

--- a/src/doc/unstable-book/src/language-features/postfix-match.md
+++ b/src/doc/unstable-book/src/language-features/postfix-match.md
@@ -3,6 +3,10 @@
 `postfix-match` adds the feature for matching upon values postfix
 the expressions that generate the values.
 
+The tracking issue for this feature is: [#121618](https://github.com/rust-lang/rust/issues/121618).
+
+------------------------
+
 ```rust,edition2021
 #![feature(postfix_match)]
 


### PR DESCRIPTION
Successful merges:

 - #130658 (Fix docs of compare_bytes)
 - #130670 (delay uncapping the max_read_size in File::read_to_end)
 - #130690 (interpret: remove outdated FIXME)
 - #130692 (make unstable Result::flatten a const fn)
 - #130702 (Add some missing unstable book tracking issue links)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=130658,130670,130690,130692,130702)
<!-- homu-ignore:end -->