### PR TITLE
Don't call `ty::Const::normalize` in error reporting

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -17,7 +17,7 @@ use rustc_middle::traits::select::OverflowError;
 use rustc_middle::traits::SignatureMismatchData;
 use rustc_middle::ty::abstract_const::NotConstEvaluatable;
 use rustc_middle::ty::error::{ExpectedFound, TypeError};
-use rustc_middle::ty::fold::{BottomUpFolder, TypeFolder, TypeSuperFoldable};
+use rustc_middle::ty::fold::{TypeFolder, TypeSuperFoldable};
 use rustc_middle::ty::print::{
     with_forced_trimmed_paths, FmtPrinter, Print, PrintTraitPredicateExt as _,
     PrintTraitRefExt as _,
@@ -1794,22 +1794,18 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         return false;
                     }
 
-                    let cand = self.resolve_vars_if_possible(impl_trait_ref).fold_with(
-                        &mut BottomUpFolder {
-                            tcx: self.tcx,
-                            ty_op: |ty| ty,
-                            lt_op: |lt| lt,
-                            ct_op: |ct| ct.normalize(self.tcx, ty::ParamEnv::empty()),
-                        },
-                    );
-                    if cand.references_error() {
+                    let impl_trait_ref = self.resolve_vars_if_possible(impl_trait_ref);
+                    if impl_trait_ref.references_error() {
                         return false;
                     }
                     err.highlighted_help(vec![
-                        StringPart::normal(format!("the trait `{}` ", cand.print_trait_sugared())),
+                        StringPart::normal(format!(
+                            "the trait `{}` ",
+                            impl_trait_ref.print_trait_sugared()
+                        )),
                         StringPart::highlighted("is"),
                         StringPart::normal(" implemented for `"),
-                        StringPart::highlighted(cand.self_ty().to_string()),
+                        StringPart::highlighted(impl_trait_ref.self_ty().to_string()),
                         StringPart::normal("`"),
                     ]);
 
@@ -1921,15 +1917,18 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         let mut impl_candidates: Vec<_> = impl_candidates
             .iter()
             .cloned()
+            .filter(|cand| !cand.trait_ref.references_error())
             .map(|mut cand| {
-                // Fold the consts so that they shows up as, e.g., `10`
-                // instead of `core::::array::{impl#30}::{constant#0}`.
-                cand.trait_ref = cand.trait_ref.fold_with(&mut BottomUpFolder {
-                    tcx: self.tcx,
-                    ty_op: |ty| ty,
-                    lt_op: |lt| lt,
-                    ct_op: |ct| ct.normalize(self.tcx, ty::ParamEnv::empty()),
-                });
+                // Normalize the trait ref in its *own* param-env so
+                // that consts are folded and any trivial projections
+                // are normalized.
+                cand.trait_ref = self
+                    .tcx
+                    .try_normalize_erasing_regions(
+                        self.tcx.param_env(cand.impl_def_id),
+                        cand.trait_ref,
+                    )
+                    .unwrap_or(cand.trait_ref);
                 cand
             })
             .collect();

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -4621,7 +4621,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     format!("&{}{ty}", mutability.prefix_str())
                 }
             }
-            ty::Array(ty, len) if let Some(len) = len.try_eval_target_usize(tcx, param_env) => {
+            ty::Array(ty, len) if let Some(len) = len.try_to_target_usize(tcx) => {
                 if len == 0 {
                     "[]".to_string()
                 } else if self.type_is_copy_modulo_regions(param_env, ty) || len == 1 {

--- a/tests/ui/binop/binary-op-suggest-deref.stderr
+++ b/tests/ui/binop/binary-op-suggest-deref.stderr
@@ -303,8 +303,8 @@ LL |     let _ = FOO & (*"Sized".to_string().into_boxed_str());
    |
    = help: the trait `BitAnd<str>` is not implemented for `i32`
    = help: the following other types implement trait `BitAnd<Rhs>`:
-             `&'a i32` implements `BitAnd<i32>`
-             `&i32` implements `BitAnd<&i32>`
+             `&i32` implements `BitAnd<i32>`
+             `&i32` implements `BitAnd`
              `i32` implements `BitAnd<&i32>`
              `i32` implements `BitAnd`
 

--- a/tests/ui/binop/binop-mul-i32-f32.stderr
+++ b/tests/ui/binop/binop-mul-i32-f32.stderr
@@ -6,8 +6,8 @@ LL |     x * y
    |
    = help: the trait `Mul<f32>` is not implemented for `i32`
    = help: the following other types implement trait `Mul<Rhs>`:
-             `&'a i32` implements `Mul<i32>`
-             `&i32` implements `Mul<&i32>`
+             `&i32` implements `Mul<i32>`
+             `&i32` implements `Mul`
              `i32` implements `Mul<&i32>`
              `i32` implements `Mul`
 

--- a/tests/ui/binop/shift-various-bad-types.stderr
+++ b/tests/ui/binop/shift-various-bad-types.stderr
@@ -6,14 +6,14 @@ LL |     22 >> p.char;
    |
    = help: the trait `Shr<char>` is not implemented for `{integer}`
    = help: the following other types implement trait `Shr<Rhs>`:
-             `&'a i128` implements `Shr<i128>`
-             `&'a i128` implements `Shr<i16>`
-             `&'a i128` implements `Shr<i32>`
-             `&'a i128` implements `Shr<i64>`
-             `&'a i128` implements `Shr<i8>`
-             `&'a i128` implements `Shr<isize>`
-             `&'a i128` implements `Shr<u128>`
-             `&'a i128` implements `Shr<u16>`
+             `&i128` implements `Shr<&i16>`
+             `&i128` implements `Shr<&i32>`
+             `&i128` implements `Shr<&i64>`
+             `&i128` implements `Shr<&i8>`
+             `&i128` implements `Shr<&isize>`
+             `&i128` implements `Shr<&u128>`
+             `&i128` implements `Shr<&u16>`
+             `&i128` implements `Shr<&u32>`
            and 568 others
 
 error[E0277]: no implementation for `{integer} >> &str`
@@ -24,14 +24,14 @@ LL |     22 >> p.str;
    |
    = help: the trait `Shr<&str>` is not implemented for `{integer}`
    = help: the following other types implement trait `Shr<Rhs>`:
-             `&'a i128` implements `Shr<i128>`
-             `&'a i128` implements `Shr<i16>`
-             `&'a i128` implements `Shr<i32>`
-             `&'a i128` implements `Shr<i64>`
-             `&'a i128` implements `Shr<i8>`
-             `&'a i128` implements `Shr<isize>`
-             `&'a i128` implements `Shr<u128>`
-             `&'a i128` implements `Shr<u16>`
+             `&i128` implements `Shr<&i16>`
+             `&i128` implements `Shr<&i32>`
+             `&i128` implements `Shr<&i64>`
+             `&i128` implements `Shr<&i8>`
+             `&i128` implements `Shr<&isize>`
+             `&i128` implements `Shr<&u128>`
+             `&i128` implements `Shr<&u16>`
+             `&i128` implements `Shr<&u32>`
            and 568 others
 
 error[E0277]: no implementation for `{integer} >> &Panolpy`
@@ -42,14 +42,14 @@ LL |     22 >> p;
    |
    = help: the trait `Shr<&Panolpy>` is not implemented for `{integer}`
    = help: the following other types implement trait `Shr<Rhs>`:
-             `&'a i128` implements `Shr<i128>`
-             `&'a i128` implements `Shr<i16>`
-             `&'a i128` implements `Shr<i32>`
-             `&'a i128` implements `Shr<i64>`
-             `&'a i128` implements `Shr<i8>`
-             `&'a i128` implements `Shr<isize>`
-             `&'a i128` implements `Shr<u128>`
-             `&'a i128` implements `Shr<u16>`
+             `&i128` implements `Shr<&i16>`
+             `&i128` implements `Shr<&i32>`
+             `&i128` implements `Shr<&i64>`
+             `&i128` implements `Shr<&i8>`
+             `&i128` implements `Shr<&isize>`
+             `&i128` implements `Shr<&u128>`
+             `&i128` implements `Shr<&u16>`
+             `&i128` implements `Shr<&u32>`
            and 568 others
 
 error[E0308]: mismatched types

--- a/tests/ui/const-generics/occurs-check/unused-substs-1.stderr
+++ b/tests/ui/const-generics/occurs-check/unused-substs-1.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `A<_>: Bar<_>` is not satisfied
 LL |     let _ = A;
    |             ^ the trait `Bar<_>` is not implemented for `A<_>`
    |
-   = help: the trait `Bar<_>` is implemented for `A<7>`
+   = help: the trait `Bar<_>` is implemented for `A<{ 6 + 1 }>`
 note: required by a bound in `A`
   --> $DIR/unused-substs-1.rs:9:11
    |

--- a/tests/ui/consts/const-eval/const-eval-overflow-3b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-3b.stderr
@@ -12,8 +12,8 @@ LL |     = [0; (i8::MAX + 1u8) as usize];
    |
    = help: the trait `Add<u8>` is not implemented for `i8`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a i8` implements `Add<i8>`
-             `&i8` implements `Add<&i8>`
+             `&i8` implements `Add<i8>`
+             `&i8` implements `Add`
              `i8` implements `Add<&i8>`
              `i8` implements `Add`
 

--- a/tests/ui/consts/const-eval/const-eval-overflow-4b.stderr
+++ b/tests/ui/consts/const-eval/const-eval-overflow-4b.stderr
@@ -12,8 +12,8 @@ LL |     : [u32; (i8::MAX as i8 + 1u8) as usize]
    |
    = help: the trait `Add<u8>` is not implemented for `i8`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a i8` implements `Add<i8>`
-             `&i8` implements `Add<&i8>`
+             `&i8` implements `Add<i8>`
+             `&i8` implements `Add`
              `i8` implements `Add<&i8>`
              `i8` implements `Add`
 

--- a/tests/ui/impl-trait/equality.stderr
+++ b/tests/ui/impl-trait/equality.stderr
@@ -30,8 +30,8 @@ LL |         n + sum_to(n - 1)
    |
    = help: the trait `Add<impl Foo>` is not implemented for `u32`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a u32` implements `Add<u32>`
-             `&u32` implements `Add<&u32>`
+             `&u32` implements `Add<u32>`
+             `&u32` implements `Add`
              `u32` implements `Add<&u32>`
              `u32` implements `Add`
 

--- a/tests/ui/issues/issue-11771.stderr
+++ b/tests/ui/issues/issue-11771.stderr
@@ -6,14 +6,14 @@ LL |     1 +
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a f128` implements `Add<f128>`
-             `&'a f16` implements `Add<f16>`
-             `&'a f32` implements `Add<f32>`
-             `&'a f64` implements `Add<f64>`
-             `&'a i128` implements `Add<i128>`
-             `&'a i16` implements `Add<i16>`
-             `&'a i32` implements `Add<i32>`
-             `&'a i64` implements `Add<i64>`
+             `&f128` implements `Add<f128>`
+             `&f128` implements `Add`
+             `&f16` implements `Add<f16>`
+             `&f16` implements `Add`
+             `&f32` implements `Add<f32>`
+             `&f32` implements `Add`
+             `&f64` implements `Add<f64>`
+             `&f64` implements `Add`
            and 56 others
 
 error[E0277]: cannot add `()` to `{integer}`
@@ -24,14 +24,14 @@ LL |     1 +
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a f128` implements `Add<f128>`
-             `&'a f16` implements `Add<f16>`
-             `&'a f32` implements `Add<f32>`
-             `&'a f64` implements `Add<f64>`
-             `&'a i128` implements `Add<i128>`
-             `&'a i16` implements `Add<i16>`
-             `&'a i32` implements `Add<i32>`
-             `&'a i64` implements `Add<i64>`
+             `&f128` implements `Add<f128>`
+             `&f128` implements `Add`
+             `&f16` implements `Add<f16>`
+             `&f16` implements `Add`
+             `&f32` implements `Add<f32>`
+             `&f32` implements `Add`
+             `&f64` implements `Add<f64>`
+             `&f64` implements `Add`
            and 56 others
 
 error: aborting due to 2 previous errors

--- a/tests/ui/issues/issue-24352.stderr
+++ b/tests/ui/issues/issue-24352.stderr
@@ -6,8 +6,8 @@ LL |     1.0f64 - 1
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Sub<Rhs>`:
-             `&'a f64` implements `Sub<f64>`
-             `&f64` implements `Sub<&f64>`
+             `&f64` implements `Sub<f64>`
+             `&f64` implements `Sub`
              `f64` implements `Sub<&f64>`
              `f64` implements `Sub`
 help: consider using a floating-point literal by writing it with `.0`

--- a/tests/ui/issues/issue-50582.stderr
+++ b/tests/ui/issues/issue-50582.stderr
@@ -16,14 +16,14 @@ LL |     Vec::<[(); 1 + for x in 0..1 {}]>::new();
    |
    = help: the trait `Add<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a f128` implements `Add<f128>`
-             `&'a f16` implements `Add<f16>`
-             `&'a f32` implements `Add<f32>`
-             `&'a f64` implements `Add<f64>`
-             `&'a i128` implements `Add<i128>`
-             `&'a i16` implements `Add<i16>`
-             `&'a i32` implements `Add<i32>`
-             `&'a i64` implements `Add<i64>`
+             `&f128` implements `Add<f128>`
+             `&f128` implements `Add`
+             `&f16` implements `Add<f16>`
+             `&f16` implements `Add`
+             `&f32` implements `Add<f32>`
+             `&f32` implements `Add`
+             `&f64` implements `Add<f64>`
+             `&f64` implements `Add`
            and 56 others
 
 error: aborting due to 2 previous errors

--- a/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
@@ -33,7 +33,7 @@ LL |     println!("{}", scores.sum::<i32>());
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum<&i32>`
              `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:14:10
@@ -66,7 +66,7 @@ LL |             .sum::<i32>(),
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum<&i32>`
              `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:23:14
@@ -99,7 +99,7 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum<&i32>`
              `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:27:38

--- a/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-with-int-infer.stderr
@@ -8,7 +8,7 @@ LL |     let x = Some(()).iter().map(|()| 1).sum::<f32>();
    |
    = help: the trait `Sum<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Sum<A>`:
-             `f32` implements `Sum<&'a f32>`
+             `f32` implements `Sum<&f32>`
              `f32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-with-int-infer.rs:2:29

--- a/tests/ui/iterators/invalid-iterator-chain.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain.stderr
@@ -33,7 +33,7 @@ LL |     println!("{}", scores.sum::<i32>());
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum<&i32>`
              `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:12:10
@@ -65,7 +65,7 @@ LL |             .sum::<i32>(),
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum<&i32>`
              `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:25:14
@@ -104,7 +104,7 @@ LL |             .sum::<i32>(),
    |
    = help: the trait `Sum<f64>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum<&i32>`
              `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:33:14
@@ -134,7 +134,7 @@ LL |     println!("{}", vec![0, 1].iter().map(|x| { x; }).sum::<i32>());
    |
    = help: the trait `Sum<()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum<&i32>`
              `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:38:38
@@ -162,7 +162,7 @@ LL |     println!("{}", vec![(), ()].iter().sum::<i32>());
    |
    = help: the trait `Sum<&()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum<&i32>`
              `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:39:33

--- a/tests/ui/lazy-type-alias/trailing-where-clause.stderr
+++ b/tests/ui/lazy-type-alias/trailing-where-clause.stderr
@@ -9,7 +9,7 @@ LL |     let _: Alias<()>;
              `String` implements `From<&mut str>`
              `String` implements `From<&str>`
              `String` implements `From<Box<str>>`
-             `String` implements `From<Cow<'a, str>>`
+             `String` implements `From<Cow<'_, str>>`
              `String` implements `From<char>`
 note: required by a bound in `Alias`
   --> $DIR/trailing-where-clause.rs:8:13

--- a/tests/ui/mismatched_types/binops.stderr
+++ b/tests/ui/mismatched_types/binops.stderr
@@ -6,14 +6,14 @@ LL |     1 + Some(1);
    |
    = help: the trait `Add<Option<{integer}>>` is not implemented for `{integer}`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a f128` implements `Add<f128>`
-             `&'a f16` implements `Add<f16>`
-             `&'a f32` implements `Add<f32>`
-             `&'a f64` implements `Add<f64>`
-             `&'a i128` implements `Add<i128>`
-             `&'a i16` implements `Add<i16>`
-             `&'a i32` implements `Add<i32>`
-             `&'a i64` implements `Add<i64>`
+             `&f128` implements `Add<f128>`
+             `&f128` implements `Add`
+             `&f16` implements `Add<f16>`
+             `&f16` implements `Add`
+             `&f32` implements `Add<f32>`
+             `&f32` implements `Add`
+             `&f64` implements `Add<f64>`
+             `&f64` implements `Add`
            and 56 others
 
 error[E0277]: cannot subtract `Option<{integer}>` from `usize`
@@ -24,8 +24,8 @@ LL |     2 as usize - Some(1);
    |
    = help: the trait `Sub<Option<{integer}>>` is not implemented for `usize`
    = help: the following other types implement trait `Sub<Rhs>`:
-             `&'a usize` implements `Sub<usize>`
-             `&usize` implements `Sub<&usize>`
+             `&usize` implements `Sub<usize>`
+             `&usize` implements `Sub`
              `usize` implements `Sub<&usize>`
              `usize` implements `Sub`
 
@@ -37,14 +37,14 @@ LL |     3 * ();
    |
    = help: the trait `Mul<()>` is not implemented for `{integer}`
    = help: the following other types implement trait `Mul<Rhs>`:
-             `&'a f128` implements `Mul<f128>`
-             `&'a f16` implements `Mul<f16>`
-             `&'a f32` implements `Mul<f32>`
-             `&'a f64` implements `Mul<f64>`
-             `&'a i128` implements `Mul<i128>`
-             `&'a i16` implements `Mul<i16>`
-             `&'a i32` implements `Mul<i32>`
-             `&'a i64` implements `Mul<i64>`
+             `&f128` implements `Mul<f128>`
+             `&f128` implements `Mul`
+             `&f16` implements `Mul<f16>`
+             `&f16` implements `Mul`
+             `&f32` implements `Mul<f32>`
+             `&f32` implements `Mul`
+             `&f64` implements `Mul<f64>`
+             `&f64` implements `Mul`
            and 57 others
 
 error[E0277]: cannot divide `{integer}` by `&str`
@@ -55,14 +55,14 @@ LL |     4 / "";
    |
    = help: the trait `Div<&str>` is not implemented for `{integer}`
    = help: the following other types implement trait `Div<Rhs>`:
-             `&'a f128` implements `Div<f128>`
-             `&'a f16` implements `Div<f16>`
-             `&'a f32` implements `Div<f32>`
-             `&'a f64` implements `Div<f64>`
-             `&'a i128` implements `Div<i128>`
-             `&'a i16` implements `Div<i16>`
-             `&'a i32` implements `Div<i32>`
-             `&'a i64` implements `Div<i64>`
+             `&f128` implements `Div<f128>`
+             `&f128` implements `Div`
+             `&f16` implements `Div<f16>`
+             `&f16` implements `Div`
+             `&f32` implements `Div<f32>`
+             `&f32` implements `Div`
+             `&f64` implements `Div<f64>`
+             `&f64` implements `Div`
            and 62 others
 
 error[E0277]: can't compare `{integer}` with `String`

--- a/tests/ui/never_type/issue-13352.stderr
+++ b/tests/ui/never_type/issue-13352.stderr
@@ -6,8 +6,8 @@ LL |     2_usize + (loop {});
    |
    = help: the trait `Add<()>` is not implemented for `usize`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a usize` implements `Add<usize>`
-             `&usize` implements `Add<&usize>`
+             `&usize` implements `Add<usize>`
+             `&usize` implements `Add`
              `usize` implements `Add<&usize>`
              `usize` implements `Add`
 

--- a/tests/ui/numbers-arithmetic/not-suggest-float-literal.stderr
+++ b/tests/ui/numbers-arithmetic/not-suggest-float-literal.stderr
@@ -6,8 +6,8 @@ LL |     x + 100.0
    |
    = help: the trait `Add<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a u8` implements `Add<u8>`
-             `&u8` implements `Add<&u8>`
+             `&u8` implements `Add<u8>`
+             `&u8` implements `Add`
              `u8` implements `Add<&u8>`
              `u8` implements `Add`
 
@@ -19,8 +19,8 @@ LL |     x + "foo"
    |
    = help: the trait `Add<&str>` is not implemented for `f64`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a f64` implements `Add<f64>`
-             `&f64` implements `Add<&f64>`
+             `&f64` implements `Add<f64>`
+             `&f64` implements `Add`
              `f64` implements `Add<&f64>`
              `f64` implements `Add`
 
@@ -32,8 +32,8 @@ LL |     x + y
    |
    = help: the trait `Add<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a f64` implements `Add<f64>`
-             `&f64` implements `Add<&f64>`
+             `&f64` implements `Add<f64>`
+             `&f64` implements `Add`
              `f64` implements `Add<&f64>`
              `f64` implements `Add`
 
@@ -45,8 +45,8 @@ LL |     x - 100.0
    |
    = help: the trait `Sub<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Sub<Rhs>`:
-             `&'a u8` implements `Sub<u8>`
-             `&u8` implements `Sub<&u8>`
+             `&u8` implements `Sub<u8>`
+             `&u8` implements `Sub`
              `u8` implements `Sub<&u8>`
              `u8` implements `Sub`
 
@@ -58,8 +58,8 @@ LL |     x - "foo"
    |
    = help: the trait `Sub<&str>` is not implemented for `f64`
    = help: the following other types implement trait `Sub<Rhs>`:
-             `&'a f64` implements `Sub<f64>`
-             `&f64` implements `Sub<&f64>`
+             `&f64` implements `Sub<f64>`
+             `&f64` implements `Sub`
              `f64` implements `Sub<&f64>`
              `f64` implements `Sub`
 
@@ -71,8 +71,8 @@ LL |     x - y
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Sub<Rhs>`:
-             `&'a f64` implements `Sub<f64>`
-             `&f64` implements `Sub<&f64>`
+             `&f64` implements `Sub<f64>`
+             `&f64` implements `Sub`
              `f64` implements `Sub<&f64>`
              `f64` implements `Sub`
 
@@ -84,8 +84,8 @@ LL |     x * 100.0
    |
    = help: the trait `Mul<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Mul<Rhs>`:
-             `&'a u8` implements `Mul<u8>`
-             `&u8` implements `Mul<&u8>`
+             `&u8` implements `Mul<u8>`
+             `&u8` implements `Mul`
              `u8` implements `Mul<&u8>`
              `u8` implements `Mul`
 
@@ -97,8 +97,8 @@ LL |     x * "foo"
    |
    = help: the trait `Mul<&str>` is not implemented for `f64`
    = help: the following other types implement trait `Mul<Rhs>`:
-             `&'a f64` implements `Mul<f64>`
-             `&f64` implements `Mul<&f64>`
+             `&f64` implements `Mul<f64>`
+             `&f64` implements `Mul`
              `f64` implements `Mul<&f64>`
              `f64` implements `Mul`
 
@@ -110,8 +110,8 @@ LL |     x * y
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Mul<Rhs>`:
-             `&'a f64` implements `Mul<f64>`
-             `&f64` implements `Mul<&f64>`
+             `&f64` implements `Mul<f64>`
+             `&f64` implements `Mul`
              `f64` implements `Mul<&f64>`
              `f64` implements `Mul`
 
@@ -123,8 +123,8 @@ LL |     x / 100.0
    |
    = help: the trait `Div<{float}>` is not implemented for `u8`
    = help: the following other types implement trait `Div<Rhs>`:
-             `&'a u8` implements `Div<u8>`
-             `&u8` implements `Div<&u8>`
+             `&u8` implements `Div<u8>`
+             `&u8` implements `Div`
              `u8` implements `Div<&u8>`
              `u8` implements `Div<NonZero<u8>>`
              `u8` implements `Div`
@@ -137,8 +137,8 @@ LL |     x / "foo"
    |
    = help: the trait `Div<&str>` is not implemented for `f64`
    = help: the following other types implement trait `Div<Rhs>`:
-             `&'a f64` implements `Div<f64>`
-             `&f64` implements `Div<&f64>`
+             `&f64` implements `Div<f64>`
+             `&f64` implements `Div`
              `f64` implements `Div<&f64>`
              `f64` implements `Div`
 
@@ -150,8 +150,8 @@ LL |     x / y
    |
    = help: the trait `Div<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Div<Rhs>`:
-             `&'a f64` implements `Div<f64>`
-             `&f64` implements `Div<&f64>`
+             `&f64` implements `Div<f64>`
+             `&f64` implements `Div`
              `f64` implements `Div<&f64>`
              `f64` implements `Div`
 

--- a/tests/ui/numbers-arithmetic/suggest-float-literal.stderr
+++ b/tests/ui/numbers-arithmetic/suggest-float-literal.stderr
@@ -6,8 +6,8 @@ LL |     x + 100
    |
    = help: the trait `Add<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a f32` implements `Add<f32>`
-             `&f32` implements `Add<&f32>`
+             `&f32` implements `Add<f32>`
+             `&f32` implements `Add`
              `f32` implements `Add<&f32>`
              `f32` implements `Add`
 help: consider using a floating-point literal by writing it with `.0`
@@ -23,8 +23,8 @@ LL |     x + 100
    |
    = help: the trait `Add<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a f64` implements `Add<f64>`
-             `&f64` implements `Add<&f64>`
+             `&f64` implements `Add<f64>`
+             `&f64` implements `Add`
              `f64` implements `Add<&f64>`
              `f64` implements `Add`
 help: consider using a floating-point literal by writing it with `.0`
@@ -40,8 +40,8 @@ LL |     x - 100
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Sub<Rhs>`:
-             `&'a f32` implements `Sub<f32>`
-             `&f32` implements `Sub<&f32>`
+             `&f32` implements `Sub<f32>`
+             `&f32` implements `Sub`
              `f32` implements `Sub<&f32>`
              `f32` implements `Sub`
 help: consider using a floating-point literal by writing it with `.0`
@@ -57,8 +57,8 @@ LL |     x - 100
    |
    = help: the trait `Sub<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Sub<Rhs>`:
-             `&'a f64` implements `Sub<f64>`
-             `&f64` implements `Sub<&f64>`
+             `&f64` implements `Sub<f64>`
+             `&f64` implements `Sub`
              `f64` implements `Sub<&f64>`
              `f64` implements `Sub`
 help: consider using a floating-point literal by writing it with `.0`
@@ -74,8 +74,8 @@ LL |     x * 100
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Mul<Rhs>`:
-             `&'a f32` implements `Mul<f32>`
-             `&f32` implements `Mul<&f32>`
+             `&f32` implements `Mul<f32>`
+             `&f32` implements `Mul`
              `f32` implements `Mul<&f32>`
              `f32` implements `Mul`
 help: consider using a floating-point literal by writing it with `.0`
@@ -91,8 +91,8 @@ LL |     x * 100
    |
    = help: the trait `Mul<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Mul<Rhs>`:
-             `&'a f64` implements `Mul<f64>`
-             `&f64` implements `Mul<&f64>`
+             `&f64` implements `Mul<f64>`
+             `&f64` implements `Mul`
              `f64` implements `Mul<&f64>`
              `f64` implements `Mul`
 help: consider using a floating-point literal by writing it with `.0`
@@ -108,8 +108,8 @@ LL |     x / 100
    |
    = help: the trait `Div<{integer}>` is not implemented for `f32`
    = help: the following other types implement trait `Div<Rhs>`:
-             `&'a f32` implements `Div<f32>`
-             `&f32` implements `Div<&f32>`
+             `&f32` implements `Div<f32>`
+             `&f32` implements `Div`
              `f32` implements `Div<&f32>`
              `f32` implements `Div`
 help: consider using a floating-point literal by writing it with `.0`
@@ -125,8 +125,8 @@ LL |     x / 100
    |
    = help: the trait `Div<{integer}>` is not implemented for `f64`
    = help: the following other types implement trait `Div<Rhs>`:
-             `&'a f64` implements `Div<f64>`
-             `&f64` implements `Div<&f64>`
+             `&f64` implements `Div<f64>`
+             `&f64` implements `Div`
              `f64` implements `Div<&f64>`
              `f64` implements `Div`
 help: consider using a floating-point literal by writing it with `.0`

--- a/tests/ui/on-unimplemented/sum.stderr
+++ b/tests/ui/on-unimplemented/sum.stderr
@@ -8,7 +8,7 @@ LL |     vec![(), ()].iter().sum::<i32>();
    |
    = help: the trait `Sum<&()>` is not implemented for `i32`
    = help: the following other types implement trait `Sum<A>`:
-             `i32` implements `Sum<&'a i32>`
+             `i32` implements `Sum<&i32>`
              `i32` implements `Sum`
 note: the method call chain might not have had the expected associated types
   --> $DIR/sum.rs:4:18
@@ -30,7 +30,7 @@ LL |     vec![(), ()].iter().product::<i32>();
    |
    = help: the trait `Product<&()>` is not implemented for `i32`
    = help: the following other types implement trait `Product<A>`:
-             `i32` implements `Product<&'a i32>`
+             `i32` implements `Product<&i32>`
              `i32` implements `Product`
 note: the method call chain might not have had the expected associated types
   --> $DIR/sum.rs:7:18

--- a/tests/ui/span/multiline-span-simple.stderr
+++ b/tests/ui/span/multiline-span-simple.stderr
@@ -6,8 +6,8 @@ LL |     foo(1 as u32 +
    |
    = help: the trait `Add<()>` is not implemented for `u32`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a u32` implements `Add<u32>`
-             `&u32` implements `Add<&u32>`
+             `&u32` implements `Add<u32>`
+             `&u32` implements `Add`
              `u32` implements `Add<&u32>`
              `u32` implements `Add`
 

--- a/tests/ui/suggestions/imm-ref-trait-object-literal-bound-regions.stderr
+++ b/tests/ui/suggestions/imm-ref-trait-object-literal-bound-regions.stderr
@@ -6,7 +6,7 @@ LL |     foo::<S>(s);
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Trait` is implemented for `&'a mut S`
+   = help: the trait `Trait` is implemented for `&mut S`
    = note: `for<'b> Trait` is implemented for `&'b mut S`, but not for `&'b S`
 note: required by a bound in `foo`
   --> $DIR/imm-ref-trait-object-literal-bound-regions.rs:11:20

--- a/tests/ui/suggestions/imm-ref-trait-object-literal.stderr
+++ b/tests/ui/suggestions/imm-ref-trait-object-literal.stderr
@@ -6,7 +6,7 @@ LL |   foo(&s);
    |   |
    |   required by a bound introduced by this call
    |
-   = help: the trait `Trait` is implemented for `&'a mut S`
+   = help: the trait `Trait` is implemented for `&mut S`
 note: required by a bound in `foo`
   --> $DIR/imm-ref-trait-object-literal.rs:7:11
    |

--- a/tests/ui/suggestions/into-str.stderr
+++ b/tests/ui/suggestions/into-str.stderr
@@ -12,7 +12,7 @@ LL |     foo(String::new());
              `String` implements `From<&mut str>`
              `String` implements `From<&str>`
              `String` implements `From<Box<str>>`
-             `String` implements `From<Cow<'a, str>>`
+             `String` implements `From<Cow<'_, str>>`
              `String` implements `From<char>`
    = note: required for `String` to implement `Into<&str>`
 note: required by a bound in `foo`

--- a/tests/ui/traits/question-mark-result-err-mismatch.stderr
+++ b/tests/ui/traits/question-mark-result-err-mismatch.stderr
@@ -35,7 +35,7 @@ LL |         .map_err(|_| ())?;
              `String` implements `From<&mut str>`
              `String` implements `From<&str>`
              `String` implements `From<Box<str>>`
-             `String` implements `From<Cow<'a, str>>`
+             `String` implements `From<Cow<'_, str>>`
              `String` implements `From<char>`
    = note: required for `Result<(), String>` to implement `FromResidual<Result<Infallible, ()>>`
 

--- a/tests/ui/traits/suggest-dereferences/invalid-suggest-deref-issue-127590.stderr
+++ b/tests/ui/traits/suggest-dereferences/invalid-suggest-deref-issue-127590.stderr
@@ -23,7 +23,7 @@ LL |     for (src, dest) in std::iter::zip(fields.iter(), &variant.iter()) {
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&std::slice::Iter<'_, {integer}>` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&std::slice::Iter<'_, {integer}>`, which is required by `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>: IntoIterator`
-   = help: the trait `Iterator` is implemented for `std::slice::Iter<'a, T>`
+   = help: the trait `Iterator` is implemented for `std::slice::Iter<'_, T>`
    = note: required for `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>` to implement `Iterator`
    = note: required for `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>` to implement `IntoIterator`
 
@@ -52,7 +52,7 @@ LL |     for (src, dest) in std::iter::zip(fields.iter(), &variant.iter().clone(
    |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&std::slice::Iter<'_, {integer}>` is not an iterator
    |
    = help: the trait `Iterator` is not implemented for `&std::slice::Iter<'_, {integer}>`, which is required by `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>: IntoIterator`
-   = help: the trait `Iterator` is implemented for `std::slice::Iter<'a, T>`
+   = help: the trait `Iterator` is implemented for `std::slice::Iter<'_, T>`
    = note: required for `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>` to implement `Iterator`
    = note: required for `Zip<std::slice::Iter<'_, {integer}>, &std::slice::Iter<'_, {integer}>>` to implement `IntoIterator`
 

--- a/tests/ui/type/type-check-defaults.stderr
+++ b/tests/ui/type/type-check-defaults.stderr
@@ -66,8 +66,8 @@ LL | trait ProjectionPred<T:Iterator = IntoIter<i32>> where T::Item : Add<u8> {}
    |
    = help: the trait `Add<u8>` is not implemented for `i32`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a i32` implements `Add<i32>`
-             `&i32` implements `Add<&i32>`
+             `&i32` implements `Add<i32>`
+             `&i32` implements `Add`
              `i32` implements `Add<&i32>`
              `i32` implements `Add`
 

--- a/tests/ui/typeck/issue-81293.stderr
+++ b/tests/ui/typeck/issue-81293.stderr
@@ -21,8 +21,8 @@ LL |     a = c + b * 5;
    |
    = help: the trait `Add<u16>` is not implemented for `usize`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a usize` implements `Add<usize>`
-             `&usize` implements `Add<&usize>`
+             `&usize` implements `Add<usize>`
+             `&usize` implements `Add`
              `usize` implements `Add<&usize>`
              `usize` implements `Add`
 

--- a/tests/ui/typeck/issue-90101.stderr
+++ b/tests/ui/typeck/issue-90101.stderr
@@ -9,7 +9,7 @@ LL |     func(Path::new("hello").to_path_buf().to_string_lossy(), "world")
    = help: the following other types implement trait `From<T>`:
              `PathBuf` implements `From<&T>`
              `PathBuf` implements `From<Box<Path>>`
-             `PathBuf` implements `From<Cow<'a, Path>>`
+             `PathBuf` implements `From<Cow<'_, Path>>`
              `PathBuf` implements `From<OsString>`
              `PathBuf` implements `From<String>`
    = note: required for `Cow<'_, str>` to implement `Into<PathBuf>`

--- a/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
+++ b/tests/ui/ufcs/ufcs-qpath-self-mismatch.stderr
@@ -6,8 +6,8 @@ LL |     <i32 as Add<u32>>::add(1, 2);
    |
    = help: the trait `Add<u32>` is not implemented for `i32`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a i32` implements `Add<i32>`
-             `&i32` implements `Add<&i32>`
+             `&i32` implements `Add<i32>`
+             `&i32` implements `Add`
              `i32` implements `Add<&i32>`
              `i32` implements `Add`
 
@@ -63,8 +63,8 @@ LL |     <i32 as Add<u32>>::add(1, 2);
    |
    = help: the trait `Add<u32>` is not implemented for `i32`
    = help: the following other types implement trait `Add<Rhs>`:
-             `&'a i32` implements `Add<i32>`
-             `&i32` implements `Add<&i32>`
+             `&i32` implements `Add<i32>`
+             `&i32` implements `Add`
              `i32` implements `Add<&i32>`
              `i32` implements `Add`
 


### PR DESCRIPTION
We do this to ensure that trait refs with unevaluated consts have those consts simplified to their evaluated forms. Instead, use `try_normalize_erasing_regions`.

**NOTE:** This has the side-effect of erasing regions from all of our trait refs. If this is too much to review or you think it's too opinionated of a diagnostics change, then I could split out the effective change (i.e. erasing regions from this impl suggestion) into another PR and have someone else review it. 

<!-- homu-ignore:start -->
r? @BoxyUwU 
<!-- homu-ignore:end -->