### PR TITLE
Cleanup some known-bug issues

### DIFF
--- a/tests/ui/async-await/in-trait/async-generics-and-bounds.rs
+++ b/tests/ui/async-await/in-trait/async-generics-and-bounds.rs
@@ -1,5 +1,4 @@
-//@ check-fail
-//@ known-bug: #102682
+//@ known-bug: #130935
 //@ edition: 2021
 
 use std::fmt::Debug;

--- a/tests/ui/async-await/in-trait/async-generics-and-bounds.stderr
+++ b/tests/ui/async-await/in-trait/async-generics-and-bounds.stderr
@@ -1,5 +1,5 @@
 error[E0311]: the parameter type `T` may not live long enough
-  --> $DIR/async-generics-and-bounds.rs:9:5
+  --> $DIR/async-generics-and-bounds.rs:8:5
    |
 LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
    |     ^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where T: Debug + Sized, U: Has
    |                 ++++  ++           ++                                       +++++++
 
 error[E0311]: the parameter type `U` may not live long enough
-  --> $DIR/async-generics-and-bounds.rs:9:5
+  --> $DIR/async-generics-and-bounds.rs:8:5
    |
 LL |     async fn foo(&self) -> &(T, U) where T: Debug + Sized, U: Hash;
    |     ^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/async-await/in-trait/async-generics.rs
+++ b/tests/ui/async-await/in-trait/async-generics.rs
@@ -1,5 +1,4 @@
-//@ check-fail
-//@ known-bug: #102682
+//@ known-bug: #130935
 //@ edition: 2021
 
 trait MyTrait<T, U> {

--- a/tests/ui/async-await/in-trait/async-generics.stderr
+++ b/tests/ui/async-await/in-trait/async-generics.stderr
@@ -1,5 +1,5 @@
 error[E0311]: the parameter type `T` may not live long enough
-  --> $DIR/async-generics.rs:6:5
+  --> $DIR/async-generics.rs:5:5
    |
 LL |     async fn foo(&self) -> &(T, U);
    |     ^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL |     async fn foo<'a>(&'a self) -> &'a (T, U) where T: 'a;
    |                 ++++  ++           ++        +++++++++++
 
 error[E0311]: the parameter type `U` may not live long enough
-  --> $DIR/async-generics.rs:6:5
+  --> $DIR/async-generics.rs:5:5
    |
 LL |     async fn foo(&self) -> &(T, U);
    |     ^^^^^^^^^^^^^-^^^^^^^^^^^^^^^^^

--- a/tests/ui/coherence/auxiliary/parametrized-trait.rs
+++ b/tests/ui/coherence/auxiliary/parametrized-trait.rs
@@ -1,2 +1,5 @@
 pub trait Trait0<T, U, V> {}
 pub trait Trait1<T, U> {}
+pub trait Trait2<T, U> {
+    type Assoc;
+}

--- a/tests/ui/coherence/occurs-check/associated-type.rs
+++ b/tests/ui/coherence/occurs-check/associated-type.rs
@@ -1,7 +1,7 @@
 //@ revisions: old next
 //@[next] compile-flags: -Znext-solver
 
-// A regression test for #105787
+// A (partial) regression test for #105787
 
 // Using the higher ranked projection hack to prevent us from replacing the projection
 // with an inference variable.

--- a/tests/ui/coherence/orphan-check-alias.classic.stderr
+++ b/tests/ui/coherence/orphan-check-alias.classic.stderr
@@ -1,0 +1,15 @@
+warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`B`)
+  --> $DIR/orphan-check-alias.rs:21:6
+   |
+LL | impl<T> foreign::Trait2<B, T> for <T as Id>::Assoc {
+   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`B`)
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: `#[warn(uncovered_param_in_projection)]` on by default
+
+warning: 1 warning emitted
+
+For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/coherence/orphan-check-alias.next.stderr
+++ b/tests/ui/coherence/orphan-check-alias.next.stderr
@@ -1,0 +1,15 @@
+warning[E0210]: type parameter `T` must be covered by another type when it appears before the first local type (`B`)
+  --> $DIR/orphan-check-alias.rs:21:6
+   |
+LL | impl<T> foreign::Trait2<B, T> for <T as Id>::Assoc {
+   |      ^ type parameter `T` must be covered by another type when it appears before the first local type (`B`)
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #124559 <https://github.com/rust-lang/rust/issues/124559>
+   = note: implementing a foreign trait is only possible if at least one of the types for which it is implemented is local, and no uncovered type parameters appear before that first local type
+   = note: in this case, 'before' refers to the following order: `impl<..> ForeignTrait<T1, ..., Tn> for T0`, where `T0` is the first and `Tn` is the last
+   = note: `#[warn(uncovered_param_in_projection)]` on by default
+
+warning: 1 warning emitted
+
+For more information about this error, try `rustc --explain E0210`.

--- a/tests/ui/coherence/orphan-check-alias.rs
+++ b/tests/ui/coherence/orphan-check-alias.rs
@@ -1,0 +1,25 @@
+// Alias might not cover type parameters.
+
+//@ revisions: classic next
+//@[next] compile-flags: -Znext-solver
+
+//@ aux-crate:foreign=parametrized-trait.rs
+//@ edition:2021
+
+//@ known-bug: #99554
+//@ check-pass
+
+trait Id {
+    type Assoc;
+}
+
+impl<T> Id for T {
+    type Assoc = T;
+}
+
+pub struct B;
+impl<T> foreign::Trait2<B, T> for <T as Id>::Assoc {
+    type Assoc = usize;
+}
+
+fn main() {}

--- a/tests/ui/generic-associated-types/bugs/issue-100013.rs
+++ b/tests/ui/generic-associated-types/bugs/issue-100013.rs
@@ -1,5 +1,5 @@
 //@ check-fail
-//@ known-bug: unknown
+//@ known-bug: #100013
 //@ edition: 2021
 
 // We really should accept this, but we need implied bounds between the regions

--- a/tests/ui/generic-associated-types/bugs/issue-87735.rs
+++ b/tests/ui/generic-associated-types/bugs/issue-87735.rs
@@ -1,5 +1,5 @@
 //@ check-fail
-//@ known-bug: #87735, #88526
+//@ known-bug: unknown
 
 // This should pass, but we need an extension of implied bounds (probably).
 

--- a/tests/ui/generic-associated-types/bugs/issue-91762.rs
+++ b/tests/ui/generic-associated-types/bugs/issue-91762.rs
@@ -1,5 +1,5 @@
 //@ check-fail
-//@ known-bug: unknown
+//@ known-bug: #91762
 
 // We almost certainly want this to pass, but
 // it's particularly difficult currently, because we need a way of specifying

--- a/tests/ui/never_type/exhaustive_patterns.rs
+++ b/tests/ui/never_type/exhaustive_patterns.rs
@@ -1,5 +1,4 @@
 //@ check-fail
-//@ known-bug: #104034
 
 #![feature(exhaustive_patterns, never_type)]
 
@@ -17,5 +16,8 @@ fn foo() -> Either<(), !> {
 }
 
 fn main() {
+    // We can't treat this a irrefutable, because `Either::B` could become
+    // inhabited in the future because it's private.
     let Either::A(()) = foo();
+    //~^ error refutable pattern in local binding
 }

--- a/tests/ui/never_type/exhaustive_patterns.stderr
+++ b/tests/ui/never_type/exhaustive_patterns.stderr
@@ -1,5 +1,5 @@
 error[E0005]: refutable pattern in local binding
-  --> $DIR/exhaustive_patterns.rs:20:9
+  --> $DIR/exhaustive_patterns.rs:21:9
    |
 LL |     let Either::A(()) = foo();
    |         ^^^^^^^^^^^^^ pattern `Either::B(_)` not covered
@@ -7,7 +7,7 @@ LL |     let Either::A(()) = foo();
    = note: `let` bindings require an "irrefutable pattern", like a `struct` or an `enum` with only one variant
    = note: for more information, visit https://doc.rust-lang.org/book/ch18-02-refutability.html
 note: `Either<(), !>` defined here
-  --> $DIR/exhaustive_patterns.rs:10:6
+  --> $DIR/exhaustive_patterns.rs:9:6
    |
 LL | enum Either<A, B> {
    |      ^^^^^^

--- a/tests/ui/traits/next-solver/coherence/issue-102048.next.stderr
+++ b/tests/ui/traits/next-solver/coherence/issue-102048.next.stderr
@@ -1,5 +1,5 @@
 error[E0119]: conflicting implementations of trait `Trait<for<'a> fn(<_ as WithAssoc1<'a>>::Assoc, <_ as WithAssoc2<'a>>::Assoc)>` for type `(_, _)`
-  --> $DIR/issue-102048.rs:39:1
+  --> $DIR/issue-102048.rs:44:1
    |
 LL | / impl<T, U> Trait<for<'a> fn(<T as WithAssoc1<'a>>::Assoc, <U as WithAssoc2<'a>>::Assoc)> for (T, U)
 LL | | where

--- a/tests/ui/traits/next-solver/coherence/issue-102048.rs
+++ b/tests/ui/traits/next-solver/coherence/issue-102048.rs
@@ -17,7 +17,12 @@
 // that to `i32`. We then try to unify `i32` from `impl1` with `u32` from `impl2` which fails,
 // causing coherence to consider these two impls distinct.
 
-//@ compile-flags: -Znext-solver
+//@ revisions: classic next
+//@[next] compile-flags: -Znext-solver
+
+//@[classic] known-bug: #102048
+//@[classic] check-pass
+
 pub trait Trait<T> {}
 
 pub trait WithAssoc1<'a> {
@@ -37,7 +42,7 @@ where
 
 // impl 2
 impl<T, U> Trait<for<'a> fn(<U as WithAssoc1<'a>>::Assoc, u32)> for (T, U) where
-    U: for<'a> WithAssoc1<'a> //~^ ERROR conflicting implementations of trait
+    U: for<'a> WithAssoc1<'a> //[next]~^ ERROR conflicting implementations of trait
 {
 }
 

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check.error.stderr
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check.error.stderr
@@ -1,0 +1,12 @@
+error[E0119]: conflicting implementations of trait `Yay` for type `Alias`
+  --> $DIR/implied_lifetime_wf_check.rs:26:1
+   |
+LL | impl Yay for <() as HideIt>::Assoc {}
+   | ---------------------------------- first implementation here
+LL | #[cfg(error)]
+LL | impl Yay for i32 {}
+   | ^^^^^^^^^^^^^^^^ conflicting implementation for `Alias`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0119`.

--- a/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check.rs
+++ b/tests/ui/type-alias-impl-trait/implied_lifetime_wf_check.rs
@@ -1,8 +1,9 @@
 #![feature(type_alias_impl_trait)]
 
-//@ known-bug: #99840
-// this should not compile
-//@ check-pass
+//@ revisions: pass error
+
+//@[pass] check-pass
+//@[error] check-fail
 
 type Alias = impl Sized;
 
@@ -21,7 +22,8 @@ impl HideIt for () {
 pub trait Yay {}
 
 impl Yay for <() as HideIt>::Assoc {}
-// impl Yay for i32 {} // this already errors
-// impl Yay for u32 {} // this also already errors
+#[cfg(error)]
+impl Yay for i32 {}
+//[error]~^ error conflicting implementations
 
 fn main() {}


### PR DESCRIPTION
I went through most of the known-bug tests (except those under `tests/crashes`) and made sure the issue had the `S-bug-has-test` label and checked that the linked issue was open. This is a bunch of cleanups, mainly issues that have been closed and the tests should have been updated.

Importantly, there are many known-bug tests linking to #110395. This *probably* isn't right - that is a tracking issue. But I don't really know what the "right" thing to do here. Probably, most that are actually *supposed* to be tests for const trait need to be linked to *that* tracking issue. And any other tests that were mislabeled need to be handled accordingly e.g. #130482. cc @fee1-dead 