### PR TITLE
Reorganize Test Headers

### DIFF
--- a/tests/ui/consts/const-eval/stable-metric/ctfe-simple-loop.allow.stderr
+++ b/tests/ui/consts/const-eval/stable-metric/ctfe-simple-loop.allow.stderr
@@ -1,5 +1,5 @@
 warning: constant evaluation is taking a long time
-  --> $DIR/ctfe-simple-loop.rs:9:5
+  --> $DIR/ctfe-simple-loop.rs:10:5
    |
 LL | /     while index < n {
 LL | |
@@ -10,7 +10,7 @@ LL | |     }
    | |_____^ the const evaluator is currently interpreting this expression
    |
 help: the constant being evaluated
-  --> $DIR/ctfe-simple-loop.rs:19:1
+  --> $DIR/ctfe-simple-loop.rs:20:1
    |
 LL | const Y: u32 = simple_loop(35);
    | ^^^^^^^^^^^^

--- a/tests/ui/consts/const-eval/stable-metric/ctfe-simple-loop.rs
+++ b/tests/ui/consts/const-eval/stable-metric/ctfe-simple-loop.rs
@@ -1,9 +1,10 @@
 //@ check-pass
 //@ revisions: warn allow
+//@ compile-flags: -Z tiny-const-eval-limit
+
 #![cfg_attr(warn, warn(long_running_const_eval))]
 #![cfg_attr(allow, allow(long_running_const_eval))]
 
-//@ compile-flags: -Z tiny-const-eval-limit
 const fn simple_loop(n: u32) -> u32 {
     let mut index = 0;
     while index < n {

--- a/tests/ui/consts/const-eval/stable-metric/ctfe-simple-loop.warn.stderr
+++ b/tests/ui/consts/const-eval/stable-metric/ctfe-simple-loop.warn.stderr
@@ -1,29 +1,5 @@
 warning: constant evaluation is taking a long time
-  --> $DIR/ctfe-simple-loop.rs:9:5
-   |
-LL | /     while index < n {
-LL | |
-LL | |
-LL | |
-LL | |         index = index + 1;
-LL | |     }
-   | |_____^
-   |
-   = note: this lint makes sure the compiler doesn't get stuck due to infinite loops in const eval.
-           If your compilation actually takes a long time, you can safely allow the lint.
-help: the constant being evaluated
-  --> $DIR/ctfe-simple-loop.rs:18:1
-   |
-LL | const X: u32 = simple_loop(19);
-   | ^^^^^^^^^^^^
-note: the lint level is defined here
-  --> $DIR/ctfe-simple-loop.rs:3:24
-   |
-LL | #![cfg_attr(warn, warn(long_running_const_eval))]
-   |                        ^^^^^^^^^^^^^^^^^^^^^^^
-
-warning: constant evaluation is taking a long time
-  --> $DIR/ctfe-simple-loop.rs:9:5
+  --> $DIR/ctfe-simple-loop.rs:10:5
    |
 LL | /     while index < n {
 LL | |
@@ -38,11 +14,35 @@ LL | |     }
 help: the constant being evaluated
   --> $DIR/ctfe-simple-loop.rs:19:1
    |
+LL | const X: u32 = simple_loop(19);
+   | ^^^^^^^^^^^^
+note: the lint level is defined here
+  --> $DIR/ctfe-simple-loop.rs:5:24
+   |
+LL | #![cfg_attr(warn, warn(long_running_const_eval))]
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: constant evaluation is taking a long time
+  --> $DIR/ctfe-simple-loop.rs:10:5
+   |
+LL | /     while index < n {
+LL | |
+LL | |
+LL | |
+LL | |         index = index + 1;
+LL | |     }
+   | |_____^
+   |
+   = note: this lint makes sure the compiler doesn't get stuck due to infinite loops in const eval.
+           If your compilation actually takes a long time, you can safely allow the lint.
+help: the constant being evaluated
+  --> $DIR/ctfe-simple-loop.rs:20:1
+   |
 LL | const Y: u32 = simple_loop(35);
    | ^^^^^^^^^^^^
 
 warning: constant evaluation is taking a long time
-  --> $DIR/ctfe-simple-loop.rs:9:5
+  --> $DIR/ctfe-simple-loop.rs:10:5
    |
 LL | /     while index < n {
 LL | |
@@ -53,7 +53,7 @@ LL | |     }
    | |_____^ the const evaluator is currently interpreting this expression
    |
 help: the constant being evaluated
-  --> $DIR/ctfe-simple-loop.rs:19:1
+  --> $DIR/ctfe-simple-loop.rs:20:1
    |
 LL | const Y: u32 = simple_loop(35);
    | ^^^^^^^^^^^^

--- a/tests/ui/consts/const-eval/stable-metric/evade-deduplication-issue-118612.rs
+++ b/tests/ui/consts/const-eval/stable-metric/evade-deduplication-issue-118612.rs
@@ -1,8 +1,8 @@
 //@ check-pass
+//@ compile-flags: -Z tiny-const-eval-limit -Z deduplicate-diagnostics=yes
 
 #![allow(long_running_const_eval)]
 
-//@ compile-flags: -Z tiny-const-eval-limit -Z deduplicate-diagnostics=yes
 const FOO: () = {
     let mut i = 0;
     loop {


### PR DESCRIPTION
This PR moves the test headers to the top in a couple of test files to maintain consistent style.

Based on this comment: https://github.com/rust-lang/rust/pull/130665#discussion_r1770506261