### PR TITLE
Fix: ices on virtual-function-elimination about principal trait

### DIFF
--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -37,6 +37,7 @@ use crate::back::write::{
     submit_post_lto_module_to_llvm, submit_pre_lto_module_to_llvm, ComputedLtoType, OngoingCodegen,
 };
 use crate::common::{self, IntPredicate, RealPredicate, TypeKind};
+use crate::meth::load_vtable;
 use crate::mir::operand::OperandValue;
 use crate::mir::place::PlaceRef;
 use crate::traits::*;
@@ -135,14 +136,8 @@ fn unsized_info<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 
             if let Some(entry_idx) = vptr_entry_idx {
                 let ptr_size = bx.data_layout().pointer_size;
-                let ptr_align = bx.data_layout().pointer_align.abi;
                 let vtable_byte_offset = u64::try_from(entry_idx).unwrap() * ptr_size.bytes();
-                let gep = bx.inbounds_ptradd(old_info, bx.const_usize(vtable_byte_offset));
-                let new_vptr = bx.load(bx.type_ptr(), gep, ptr_align);
-                bx.nonnull_metadata(new_vptr);
-                // VTable loads are invariant.
-                bx.set_invariant_load(new_vptr);
-                new_vptr
+                load_vtable(bx, old_info, bx.type_ptr(), vtable_byte_offset, source, true)
             } else {
                 old_info
             }

--- a/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/intrinsic.rs
@@ -126,7 +126,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                     sym::vtable_align => ty::COMMON_VTABLE_ENTRIES_ALIGN,
                     _ => bug!(),
                 };
-                let value = meth::VirtualIndex::from_index(idx).get_usize(bx, vtable);
+                let value = meth::VirtualIndex::from_index(idx).get_usize(bx, vtable, callee_ty);
                 match name {
                     // Size is always <= isize::MAX.
                     sym::vtable_size => {

--- a/compiler/rustc_codegen_ssa/src/size_of_val.rs
+++ b/compiler/rustc_codegen_ssa/src/size_of_val.rs
@@ -28,9 +28,9 @@ pub fn size_and_align_of_dst<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
             // Load size/align from vtable.
             let vtable = info.unwrap();
             let size = meth::VirtualIndex::from_index(ty::COMMON_VTABLE_ENTRIES_SIZE)
-                .get_usize(bx, vtable);
+                .get_usize(bx, vtable, t);
             let align = meth::VirtualIndex::from_index(ty::COMMON_VTABLE_ENTRIES_ALIGN)
-                .get_usize(bx, vtable);
+                .get_usize(bx, vtable, t);
 
             // Size is always <= isize::MAX.
             let size_bound = bx.data_layout().ptr_sized_integer().signed_max() as u128;

--- a/tests/crashes/123955.rs
+++ b/tests/crashes/123955.rs
@@ -1,6 +1,0 @@
-//@ known-bug: #123955
-//@ compile-flags: -Clto -Zvirtual-function-elimination
-//@ only-x86_64
-pub fn main() {
-    _ = Box::new(()) as Box<dyn Send>;
-}

--- a/tests/crashes/124092.rs
+++ b/tests/crashes/124092.rs
@@ -1,7 +1,0 @@
-//@ known-bug: #124092
-//@ compile-flags: -Zvirtual-function-elimination=true -Clto=true
-//@ only-x86_64
-const X: for<'b> fn(&'b ()) = |&()| ();
-fn main() {
-    let dyn_debug = Box::new(X) as Box<fn(&'static ())> as Box<dyn Send>;
-}

--- a/tests/ui/codegen/virtual-function-elimination.rs
+++ b/tests/ui/codegen/virtual-function-elimination.rs
@@ -1,0 +1,17 @@
+//@ build-pass
+//@ compile-flags: -Zvirtual-function-elimination=true -Clto=true
+//@ only-x86_64
+//@ no-prefer-dynamic
+
+// issue #123955
+pub fn test0() {
+    _ = Box::new(()) as Box<dyn Send>;
+}
+
+// issue #124092
+const X: for<'b> fn(&'b ()) = |&()| ();
+pub fn test1() {
+    let _dyn_debug = Box::new(X) as Box<fn(&'static ())> as Box<dyn Send>;
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
Extract `load_vtable` function to ensure the `virtual_function_elimination` option is always checked.
It's okay not to use `llvm.type.checked.load` to load the vtable if there is no principal trait.

Fixes #123955 
Fixes #124092 