### PR TITLE
Add rustfmt 2024 reformatting to git blame ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -27,3 +27,5 @@ ec2cc761bc7067712ecc7734502f703fe3b024c8
 84ac80f1921afc243d71fd0caaa4f2838c294102
 # bless mir-opt tests to add `copy`
 99cb0c6bc399fb94a0ddde7e9b38e9c00d523bad
+# reformat with rustfmt edition 2024
+c682aa162b0d41e21cc6748f4fecfe01efb69d1f


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/130724 essentially reformatted the world, so we should add it to the git blame ignore list.

Tested with `git blame compiler/rustc_abi/src/lib.rs -L1137,1146`. I first thought that I have to ignore the merge commit, but it seems like the actual commit that did the reformatting should be ignored instead.

r? @compiler-errors