### PR TITLE
Pin memchr to 2.5.0 in the library rather than rustc_ast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"

--- a/compiler/rustc_ast/Cargo.toml
+++ b/compiler/rustc_ast/Cargo.toml
@@ -4,10 +4,9 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-# FIXME: bumping memchr to 2.7.1 causes linker errors in MSVC thin-lto
 # tidy-alphabetical-start
 bitflags = "2.4.1"
-memchr = "=2.5.0"
+memchr = "2.7.4"
 rustc_ast_ir = { path = "../rustc_ast_ir" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_index = { path = "../rustc_index" }

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -326,6 +326,7 @@ dependencies = [
  "hashbrown",
  "hermit-abi",
  "libc",
+ "memchr",
  "miniz_oxide",
  "object",
  "panic_abort",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -23,6 +23,10 @@ unwind = { path = "../unwind" }
 hashbrown = { version = "0.14", default-features = false, features = [
     'rustc-dep-of-std',
 ] }
+# FIXME(#127890): `object` depends on `memchr`, but `memchr` > v2.5 causes
+# issues with LTO. This dependency is not used directly, but pin it here so
+# it resolves to 2.5. To be removed once rust-lang/rust#127890 is fixed.
+memchr = { version = "=2.5.0", default-features = false, features = ["rustc-dep-of-std"] }
 std_detect = { path = "../stdarch/crates/std_detect", default-features = false, features = [
     'rustc-dep-of-std',
 ] }


### PR DESCRIPTION
The latest versions of `memchr` experience LTO-related issues when compiling for windows-gnu [1], so needs to be pinned. The issue is present in the standard library.

`memchr` has been pinned in `rustc_ast`, but since the workspace was recently split, this pin no longer has any effect on library crates.

Resolve this by adding `memchr` as an _unused_ dependency in `std`, pinned to 2.5. Additionally, remove the pin in `rustc_ast` to allow non-library crates to upgrade to the latest version.

Link: https://github.com/rust-lang/rust/issues/127890 [1]

try-job: x86_64-mingw
try-job: x86_64-msvc

<!-- homu-ignore:start -->
This was split from https://github.com/rust-lang/rust/pull/129624 which has a very high failure rate. 

r? @Mark-Simulacrum
<!-- homu-ignore:end -->