### PR TITLE
Update compiler-builtins to 0.1.130

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.126"
+version = "0.1.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758019257ad46e191b587d8f711022a6ac1d1fb6745d75e1d76c587fdcbca770"
+checksum = "e64c30475571756801eff60a811520c3d18e0ceb9c56c97bad2047ae601f6709"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { version = "0.1.126", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "0.1.130", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "0.1.126" }
+compiler_builtins = { version = "0.1.130" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.14", default-features = false, features = [


### PR DESCRIPTION
This includes the following which add `__divtf3` and `__powtf2`, and do some feature cleanup:

- https://github.com/rust-lang/compiler-builtins/pull/622
- https://github.com/rust-lang/compiler-builtins/pull/692
- https://github.com/rust-lang/compiler-builtins/pull/614
- https://github.com/rust-lang/compiler-builtins/pull/694

The `cc` bump [1] was previously included but was reverted due to problems updating.

[1]: https://github.com/rust-lang/compiler-builtins/pull/690

<!-- homu-ignore:start -->
r? @Amanieu
<!-- homu-ignore:end -->
