### PR TITLE
Mention `COMPILETEST_VERBOSE_CRASHES` on crash test failure

### DIFF
--- a/src/tools/compiletest/src/runtest/crash.rs
+++ b/src/tools/compiletest/src/runtest/crash.rs
@@ -15,10 +15,11 @@ impl TestCx<'_> {
         // if a test does not crash, consider it an error
         if proc_res.status.success() || matches!(proc_res.status.code(), Some(1 | 0)) {
             self.fatal(&format!(
-                "crashtest no longer crashes/triggers ICE, horray! Please give it a meaningful name, \
-            add a doc-comment to the start of the test explaining why it exists and \
-            move it to tests/ui or wherever you see fit. Adding 'Fixes #<issueNr>' to your PR description \
-            ensures that the corresponding ticket is auto-closed upon merge."
+                "crashtest no longer crashes/triggers ICE, horray! Please give it a meaningful \
+                name, add a doc-comment to the start of the test explaining why it exists and \
+                move it to tests/ui or wherever you see fit. Adding 'Fixes #<issueNr>' to your PR \
+                description ensures that the corresponding ticket is auto-closed upon merge. \
+                If you want to see verbose output, set `COMPILETEST_VERBOSE_CRASHES=1`."
             ));
         }
     }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/130776.

r? @matthiaskrgr (or compiler/bootstrap)
