### PR TITLE
Implement RFC 3678: Final trait methods

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -2648,8 +2648,16 @@ pub enum Const {
 /// For details see the [RFC #2532](https://github.com/rust-lang/rfcs/pull/2532).
 #[derive(Copy, Clone, PartialEq, Encodable, Decodable, Debug, HashStable_Generic)]
 pub enum Defaultness {
+    /// `default`
     Default(Span),
-    Final,
+    /// Item is unmarked. Implicitly determined based off of position.
+    /// For impls, this is `final`; for traits, this is `default`.
+    ///
+    /// If you're expanding an item in a built-in macro or parsing an item
+    /// by hand, you probably want to use this.
+    Implicit,
+    /// `final`; per RFC 3678, only trait items may be *explicitly* marked final.
+    Final(Span),
 }
 
 #[derive(Copy, Clone, PartialEq, Encodable, Decodable, HashStable_Generic)]
@@ -3440,7 +3448,7 @@ impl AssocItemKind {
             | Self::Fn(box Fn { defaultness, .. })
             | Self::Type(box TyAlias { defaultness, .. }) => defaultness,
             Self::MacCall(..) | Self::Delegation(..) | Self::DelegationMac(..) => {
-                Defaultness::Final
+                Defaultness::Implicit
             }
         }
     }

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -832,7 +832,8 @@ fn visit_nonterminal<T: MutVisitor>(vis: &mut T, nt: &mut token::Nonterminal) {
 fn visit_defaultness<T: MutVisitor>(vis: &mut T, defaultness: &mut Defaultness) {
     match defaultness {
         Defaultness::Default(span) => vis.visit_span(span),
-        Defaultness::Final => {}
+        Defaultness::Final(span) => vis.visit_span(span),
+        Defaultness::Implicit => {}
     }
 }
 

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1058,7 +1058,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 (hir::Defaultness::Default { has_value }, Some(self.lower_span(sp)))
             }
             Defaultness::Final(sp) => {
-                assert!(has_value);
                 (hir::Defaultness::Final, Some(sp))
             }
         }

--- a/compiler/rustc_ast_lowering/src/item.rs
+++ b/compiler/rustc_ast_lowering/src/item.rs
@@ -1057,9 +1057,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             Defaultness::Default(sp) => {
                 (hir::Defaultness::Default { has_value }, Some(self.lower_span(sp)))
             }
-            Defaultness::Final(sp) => {
-                (hir::Defaultness::Final, Some(sp))
-            }
+            Defaultness::Final(sp) => (hir::Defaultness::Final, Some(sp)),
         }
     }
 

--- a/compiler/rustc_ast_passes/messages.ftl
+++ b/compiler/rustc_ast_passes/messages.ftl
@@ -127,6 +127,14 @@ ast_passes_forbidden_default =
     `default` is only allowed on items in trait impls
     .label = `default` because of this
 
+ast_passes_forbidden_final =
+    `final` is only allowed on associated functions in traits
+    .label = `final` because of this
+
+ast_passes_forbidden_final_without_body =
+    `final` is only allowed on associated functions if they have a body
+    .label = `final` because of this
+
 ast_passes_forbidden_non_lifetime_param =
     only lifetime parameters can be used in this context
 

--- a/compiler/rustc_ast_passes/src/errors.rs
+++ b/compiler/rustc_ast_passes/src/errors.rs
@@ -125,6 +125,24 @@ pub(crate) struct ForbiddenDefault {
 }
 
 #[derive(Diagnostic)]
+#[diag(ast_passes_forbidden_final)]
+pub(crate) struct ForbiddenFinal {
+    #[primary_span]
+    pub span: Span,
+    #[label]
+    pub def_span: Span,
+}
+
+#[derive(Diagnostic)]
+#[diag(ast_passes_forbidden_final_without_body)]
+pub(crate) struct ForbiddenFinalWithoutBody {
+    #[primary_span]
+    pub span: Span,
+    #[label]
+    pub def_span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(ast_passes_assoc_const_without_body)]
 pub(crate) struct AssocConstWithoutBody {
     #[primary_span]

--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -545,6 +545,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     gate_all!(mut_ref, "mutable by-reference bindings are experimental");
     gate_all!(global_registration, "global registration is experimental");
     gate_all!(return_type_notation, "return type notation is experimental");
+    gate_all!(final_associated_functions, "`final` on trait functions is experimental");
 
     if !visitor.features.never_patterns {
         if let Some(spans) = spans.get(&sym::never_patterns) {

--- a/compiler/rustc_ast_pretty/src/pprust/state/item.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/item.rs
@@ -46,7 +46,7 @@ impl<'a> State<'a> {
                     ty,
                     expr.as_deref(),
                     vis,
-                    ast::Defaultness::Final,
+                    ast::Defaultness::Implicit,
                 )
             }
             ast::ForeignItemKind::TyAlias(box ast::TyAlias {
@@ -181,7 +181,7 @@ impl<'a> State<'a> {
                     ty,
                     body.as_deref(),
                     &item.vis,
-                    ast::Defaultness::Final,
+                    ast::Defaultness::Implicit,
                 );
             }
             ast::ItemKind::Const(box ast::ConstItem { defaultness, generics, ty, expr }) => {

--- a/compiler/rustc_builtin_macros/src/alloc_error_handler.rs
+++ b/compiler/rustc_builtin_macros/src/alloc_error_handler.rs
@@ -83,7 +83,7 @@ fn generate_handler(cx: &ExtCtxt<'_>, handler: Ident, span: Span, sig_span: Span
 
     let body = Some(cx.block_expr(call));
     let kind = ItemKind::Fn(Box::new(Fn {
-        defaultness: ast::Defaultness::Final,
+        defaultness: ast::Defaultness::Implicit,
         sig,
         generics: Generics::default(),
         body,

--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -608,7 +608,7 @@ impl<'a> TraitDef<'a> {
                 },
                 attrs: ast::AttrVec::new(),
                 kind: ast::AssocItemKind::Type(Box::new(ast::TyAlias {
-                    defaultness: ast::Defaultness::Final,
+                    defaultness: ast::Defaultness::Implicit,
                     generics: Generics::default(),
                     where_clauses: ast::TyAliasWhereClauses::default(),
                     bounds: Vec::new(),
@@ -799,7 +799,7 @@ impl<'a> TraitDef<'a> {
             ast::ItemKind::Impl(Box::new(ast::Impl {
                 safety: ast::Safety::Default,
                 polarity: ast::ImplPolarity::Positive,
-                defaultness: ast::Defaultness::Final,
+                defaultness: ast::Defaultness::Implicit,
                 constness: if self.is_const { ast::Const::Yes(DUMMY_SP) } else { ast::Const::No },
                 generics: trait_generics,
                 of_trait: opt_trait_ref,
@@ -1026,7 +1026,7 @@ impl<'a> MethodDef<'a> {
         let trait_lo_sp = span.shrink_to_lo();
 
         let sig = ast::FnSig { header: ast::FnHeader::default(), decl: fn_decl, span };
-        let defaultness = ast::Defaultness::Final;
+        let defaultness = ast::Defaultness::Implicit;
 
         // Create the method.
         P(ast::AssocItem {

--- a/compiler/rustc_builtin_macros/src/deriving/smart_ptr.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/smart_ptr.rs
@@ -144,7 +144,7 @@ pub(crate) fn expand_deriving_smart_ptr(
             ast::ItemKind::Impl(Box::new(ast::Impl {
                 safety: ast::Safety::Default,
                 polarity: ast::ImplPolarity::Positive,
-                defaultness: ast::Defaultness::Final,
+                defaultness: ast::Defaultness::Implicit,
                 constness: ast::Const::No,
                 generics,
                 of_trait: Some(trait_ref),

--- a/compiler/rustc_builtin_macros/src/global_allocator.rs
+++ b/compiler/rustc_builtin_macros/src/global_allocator.rs
@@ -79,7 +79,7 @@ impl AllocFnFactory<'_, '_> {
         let sig = FnSig { decl, header, span: self.span };
         let body = Some(self.cx.block_expr(result));
         let kind = ItemKind::Fn(Box::new(Fn {
-            defaultness: ast::Defaultness::Final,
+            defaultness: ast::Defaultness::Implicit,
             sig,
             generics: Generics::default(),
             body,

--- a/compiler/rustc_builtin_macros/src/test.rs
+++ b/compiler/rustc_builtin_macros/src/test.rs
@@ -260,7 +260,7 @@ pub(crate) fn expand_test_or_bench(
         // const $ident: test::TestDescAndFn =
         ast::ItemKind::Const(
             ast::ConstItem {
-                defaultness: ast::Defaultness::Final,
+                defaultness: ast::Defaultness::Implicit,
                 generics: ast::Generics::default(),
                 ty: cx.ty(sp, ast::TyKind::Path(None, test_path("TestDescAndFn"))),
                 // test::TestDescAndFn {

--- a/compiler/rustc_builtin_macros/src/test_harness.rs
+++ b/compiler/rustc_builtin_macros/src/test_harness.rs
@@ -341,7 +341,7 @@ fn mk_main(cx: &mut TestCtxt<'_>) -> P<ast::Item> {
 
     let decl = ecx.fn_decl(ThinVec::new(), ast::FnRetTy::Ty(main_ret_ty));
     let sig = ast::FnSig { decl, header: ast::FnHeader::default(), span: sp };
-    let defaultness = ast::Defaultness::Final;
+    let defaultness = ast::Defaultness::Implicit;
     let main = ast::ItemKind::Fn(Box::new(ast::Fn {
         defaultness,
         sig,

--- a/compiler/rustc_expand/src/build.rs
+++ b/compiler/rustc_expand/src/build.rs
@@ -642,7 +642,7 @@ impl<'a> ExtCtxt<'a> {
         ty: P<ast::Ty>,
         expr: P<ast::Expr>,
     ) -> P<ast::Item> {
-        let defaultness = ast::Defaultness::Final;
+        let defaultness = ast::Defaultness::Implicit;
         self.item(
             span,
             name,

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -467,6 +467,8 @@ declare_features! (
     (unstable, ffi_const, "1.45.0", Some(58328)),
     /// Allows the use of `#[ffi_pure]` on foreign functions.
     (unstable, ffi_pure, "1.45.0", Some(58329)),
+    /// Allows marking trait functions as `final` to prevent overriding impls
+    (unstable, final_associated_functions, "CURRENT_RUSTC_VERSION", Some(1)),
     /// Controlling the behavior of fmt::Debug
     (unstable, fmt_debug, "1.82.0", Some(129709)),
     /// Allows using `#[repr(align(...))]` on function items

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -374,6 +374,9 @@ hir_analysis_opaque_captures_higher_ranked_lifetime = `impl Trait` cannot captur
     .label = `impl Trait` implicitly captures all lifetimes in scope
     .note = lifetime declared here
 
+hir_analysis_overriding_final_trait_function = cannot override `{$name}` because it already has a `final` definition in the trait
+    .note = `{$name}` is marked final here
+
 hir_analysis_param_in_ty_of_assoc_const_binding =
     the type of the associated constant `{$assoc_const}` must not depend on {$param_category ->
         [self] `Self`

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -197,18 +197,6 @@ fn maybe_check_static_with_link_section(tcx: TyCtxt<'_>, id: LocalDefId) {
     }
 }
 
-fn report_forbidden_specialization(tcx: TyCtxt<'_>, impl_item: DefId, parent_impl: DefId) {
-    let span = tcx.def_span(impl_item);
-    let ident = tcx.item_name(impl_item);
-
-    let err = match tcx.span_of_impl(parent_impl) {
-        Ok(sp) => errors::ImplNotMarkedDefault::Ok { span, ident, ok_label: sp },
-        Err(cname) => errors::ImplNotMarkedDefault::Err { span, ident, cname },
-    };
-
-    tcx.dcx().emit_err(err);
-}
-
 fn missing_items_err(
     tcx: TyCtxt<'_>,
     impl_def_id: LocalDefId,

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -917,6 +917,16 @@ pub(crate) enum ImplNotMarkedDefault {
 }
 
 #[derive(Diagnostic)]
+#[diag(hir_analysis_overriding_final_trait_function)]
+pub(crate) struct OverridingFinalTraitFunction {
+    #[primary_span]
+    pub impl_span: Span,
+    #[note]
+    pub trait_span: Span,
+    pub name: Symbol,
+}
+
+#[derive(Diagnostic)]
 #[diag(hir_analysis_missing_trait_item, code = E0046)]
 pub(crate) struct MissingTraitItem {
     #[primary_span]

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -309,6 +309,10 @@ parse_inappropriate_default = {$article} {$descr} cannot be `default`
     .label = `default` because of this
     .note = only associated `fn`, `const`, and `type` items can be `default`
 
+parse_inappropriate_final = {$article} {$descr} cannot be `final`
+    .label = `final` because of this
+    .note = only associated functions in traits can be `final`
+
 parse_inclusive_range_extra_equals = unexpected `=` after inclusive range
     .suggestion_remove_eq = use `..=` instead
     .note = inclusive ranges end with a single equals sign (`..=`)

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2940,6 +2940,17 @@ pub(crate) struct InappropriateDefault {
 }
 
 #[derive(Diagnostic)]
+#[diag(parse_inappropriate_final)]
+#[note]
+pub(crate) struct InappropriateFinal {
+    #[primary_span]
+    #[label]
+    pub span: Span,
+    pub article: &'static str,
+    pub descr: &'static str,
+}
+
+#[derive(Diagnostic)]
 #[diag(parse_recover_import_as_use)]
 pub(crate) struct RecoverImportAsUse {
     #[primary_span]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -897,6 +897,7 @@ symbols! {
         field_init_shorthand,
         file,
         file_options,
+        final_associated_functions,
         float,
         float_to_int_unchecked,
         floorf128,

--- a/src/librustdoc/fold.rs
+++ b/src/librustdoc/fold.rs
@@ -80,7 +80,7 @@ pub(crate) trait DocFolder: Sized {
             | StaticItem(_)
             | ConstantItem(..)
             | TraitAliasItem(_)
-            | TyMethodItem(_)
+            | TyMethodItem(..)
             | MethodItem(_, _)
             | StructFieldItem(_)
             | ForeignFunctionItem(..)

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1782,10 +1782,6 @@ pub(crate) fn print_abi_with_space(abi: Abi) -> impl Display {
     })
 }
 
-pub(crate) fn print_default_space<'a>(v: bool) -> &'a str {
-    if v { "default " } else { "" }
-}
-
 impl clean::GenericArg {
     pub(crate) fn print<'a, 'tcx: 'a>(
         &'a self,

--- a/src/librustdoc/html/render/search_index.rs
+++ b/src/librustdoc/html/render/search_index.rs
@@ -759,7 +759,9 @@ pub(crate) fn get_function_type_for_search<'tcx>(
         }
     });
     let (mut inputs, mut output, where_clause) = match item.kind {
-        clean::FunctionItem(ref f) | clean::MethodItem(ref f, _) | clean::TyMethodItem(ref f) => {
+        clean::FunctionItem(ref f)
+        | clean::MethodItem(ref f, _)
+        | clean::TyMethodItem(ref f, _) => {
             get_fn_inputs_and_outputs(f, tcx, impl_or_trait_generics, cache)
         }
         _ => return None,

--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -327,7 +327,7 @@ fn from_clean_item(item: clean::Item, tcx: TyCtxt<'_>) -> ItemEnum {
         TraitItem(t) => ItemEnum::Trait((*t).into_tcx(tcx)),
         TraitAliasItem(t) => ItemEnum::TraitAlias(t.into_tcx(tcx)),
         MethodItem(m, _) => ItemEnum::Function(from_function(m, true, header.unwrap(), tcx)),
-        TyMethodItem(m) => ItemEnum::Function(from_function(m, false, header.unwrap(), tcx)),
+        TyMethodItem(m, _) => ItemEnum::Function(from_function(m, false, header.unwrap(), tcx)),
         ImplItem(i) => ItemEnum::Impl((*i).into_tcx(tcx)),
         StaticItem(s) => ItemEnum::Static(s.into_tcx(tcx)),
         ForeignStaticItem(s, _) => ItemEnum::Static(s.into_tcx(tcx)),

--- a/src/librustdoc/visit.rs
+++ b/src/librustdoc/visit.rs
@@ -29,7 +29,7 @@ pub(crate) trait DocVisitor: Sized {
             | StaticItem(_)
             | ConstantItem(..)
             | TraitAliasItem(_)
-            | TyMethodItem(_)
+            | TyMethodItem(..)
             | MethodItem(_, _)
             | StructFieldItem(_)
             | ForeignFunctionItem(..)

--- a/src/tools/clippy/clippy_utils/src/ast_utils.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils.rs
@@ -670,7 +670,9 @@ pub fn eq_use_tree_kind(l: &UseTreeKind, r: &UseTreeKind) -> bool {
 pub fn eq_defaultness(l: Defaultness, r: Defaultness) -> bool {
     matches!(
         (l, r),
-        (Defaultness::Final, Defaultness::Final) | (Defaultness::Default(_), Defaultness::Default(_))
+        (Defaultness::Final(_), Defaultness::Final(_))
+            | (Defaultness::Default(_), Defaultness::Default(_))
+            | (Defaultness::Implicit, Defaultness::Implicit)
     )
 }
 

--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -314,12 +314,13 @@ impl<'a> FnSig<'a> {
         method_sig: &'a ast::FnSig,
         generics: &'a ast::Generics,
         visibility: &'a ast::Visibility,
+        defaultness: ast::Defaultness,
     ) -> FnSig<'a> {
         FnSig {
             safety: method_sig.header.safety,
             coroutine_kind: Cow::Borrowed(&method_sig.header.coroutine_kind),
             constness: method_sig.header.constness,
-            defaultness: ast::Defaultness::Final,
+            defaultness,
             ext: method_sig.header.ext,
             decl: &*method_sig.decl,
             generics,
@@ -334,9 +335,7 @@ impl<'a> FnSig<'a> {
     ) -> FnSig<'a> {
         match *fn_kind {
             visit::FnKind::Fn(visit::FnCtxt::Assoc(..), _, fn_sig, vis, generics, _) => {
-                let mut fn_sig = FnSig::from_method_sig(fn_sig, generics, vis);
-                fn_sig.defaultness = defaultness;
-                fn_sig
+                FnSig::from_method_sig(fn_sig, generics, vis, defaultness)
             }
             visit::FnKind::Fn(_, _, fn_sig, vis, generics, _) => FnSig {
                 decl,
@@ -454,6 +453,7 @@ impl<'a> FmtVisitor<'a> {
         sig: &ast::FnSig,
         vis: &ast::Visibility,
         generics: &ast::Generics,
+        defaultness: ast::Defaultness,
         span: Span,
     ) -> RewriteResult {
         // Drop semicolon or it will be interpreted as comment.
@@ -464,7 +464,7 @@ impl<'a> FmtVisitor<'a> {
             &context,
             indent,
             ident,
-            &FnSig::from_method_sig(sig, generics, vis),
+            &FnSig::from_method_sig(sig, generics, vis, defaultness),
             span,
             FnBraceStyle::None,
         )?;
@@ -3460,7 +3460,7 @@ impl Rewrite for ast::ForeignItem {
                         context,
                         shape.indent,
                         self.ident,
-                        &FnSig::from_method_sig(sig, generics, &self.vis),
+                        &FnSig::from_method_sig(sig, generics, &self.vis, defaultness),
                         span,
                         FnBraceStyle::None,
                     )

--- a/src/tools/rustfmt/src/utils.rs
+++ b/src/tools/rustfmt/src/utils.rs
@@ -103,7 +103,8 @@ pub(crate) fn format_constness_right(constness: ast::Const) -> &'static str {
 pub(crate) fn format_defaultness(defaultness: ast::Defaultness) -> &'static str {
     match defaultness {
         ast::Defaultness::Default(..) => "default ",
-        ast::Defaultness::Final => "",
+        ast::Defaultness::Final(..) => "final ",
+        ast::Defaultness::Implicit => "",
     }
 }
 

--- a/src/tools/rustfmt/src/visitor.rs
+++ b/src/tools/rustfmt/src/visitor.rs
@@ -564,7 +564,13 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                         let indent = self.block_indent;
                         let rewrite = self
                             .rewrite_required_fn(
-                                indent, item.ident, sig, &item.vis, generics, item.span,
+                                indent,
+                                item.ident,
+                                sig,
+                                &item.vis,
+                                generics,
+                                defaultness,
+                                item.span,
                             )
                             .ok();
                         self.push_rewrite(item.span, rewrite);
@@ -661,7 +667,15 @@ impl<'b, 'a: 'b> FmtVisitor<'a> {
                 } else {
                     let indent = self.block_indent;
                     let rewrite = self
-                        .rewrite_required_fn(indent, ai.ident, sig, &ai.vis, generics, ai.span)
+                        .rewrite_required_fn(
+                            indent,
+                            ai.ident,
+                            sig,
+                            &ai.vis,
+                            generics,
+                            defaultness,
+                            ai.span,
+                        )
                         .ok();
                     self.push_rewrite(ai.span, rewrite);
                 }

--- a/src/tools/rustfmt/tests/target/final-kw.rs
+++ b/src/tools/rustfmt/tests/target/final-kw.rs
@@ -1,0 +1,5 @@
+trait Foo {
+    final fn final_() {}
+
+    fn not_final() {}
+}

--- a/tests/rustdoc/final-trait-method.rs
+++ b/tests/rustdoc/final-trait-method.rs
@@ -1,0 +1,22 @@
+#![feature(final_associated_functions)]
+
+//@ has final_trait_method/trait.Item.html
+pub trait Item {
+    //@ has - '//*[@id="method.foo"]' 'final fn foo()'
+    //@ !has - '//*[@id="method.foo"]' 'default fn foo()'
+    final fn foo() {}
+
+    //@ has - '//*[@id="method.bar"]' 'fn bar()'
+    //@ !has - '//*[@id="method.bar"]' 'default fn bar()'
+    //@ !has - '//*[@id="method.bar"]' 'final fn bar()'
+    fn bar() {}
+}
+
+//@ has final_trait_method/struct.Foo.html
+pub struct Foo;
+impl Item for Foo {
+    //@ has - '//*[@id="method.bar"]' 'fn bar()'
+    //@ !has - '//*[@id="method.bar"]' 'final fn bar()'
+    //@ !has - '//*[@id="method.bar"]' 'default fn bar()'
+    fn bar() {}
+}

--- a/tests/ui/coroutine/gen_fn.none.stderr
+++ b/tests/ui/coroutine/gen_fn.none.stderr
@@ -1,8 +1,8 @@
-error: expected one of `#`, `async`, `const`, `default`, `extern`, `fn`, `pub`, `safe`, `unsafe`, or `use`, found `gen`
+error: expected one of `#`, `async`, `const`, `default`, `extern`, `final`, `fn`, `pub`, `safe`, `unsafe`, or `use`, found `gen`
   --> $DIR/gen_fn.rs:4:1
    |
 LL | gen fn foo() {}
-   | ^^^ expected one of 10 possible tokens
+   | ^^^ expected one of 11 possible tokens
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/coroutine/gen_fn.rs
+++ b/tests/ui/coroutine/gen_fn.rs
@@ -2,7 +2,7 @@
 //@[e2024] compile-flags: --edition 2024 -Zunstable-options
 
 gen fn foo() {}
-//[none]~^ ERROR: expected one of `#`, `async`, `const`, `default`, `extern`, `fn`, `pub`, `safe`, `unsafe`, or `use`, found `gen`
+//[none]~^ ERROR: expected one of `#`, `async`, `const`, `default`, `extern`, `final`, `fn`, `pub`, `safe`, `unsafe`, or `use`, found `gen`
 //[e2024]~^^ ERROR: gen blocks are experimental
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-final-associated-functions.rs
+++ b/tests/ui/feature-gates/feature-gate-final-associated-functions.rs
@@ -1,0 +1,6 @@
+trait Foo {
+    final fn bar() {}
+    //~^ ERROR `final` on trait functions is experimental
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-final-associated-functions.stderr
+++ b/tests/ui/feature-gates/feature-gate-final-associated-functions.stderr
@@ -1,0 +1,13 @@
+error[E0658]: `final` on trait functions is experimental
+  --> $DIR/feature-gate-final-associated-functions.rs:2:5
+   |
+LL |     final fn bar() {}
+   |     ^^^^^
+   |
+   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = help: add `#![feature(final_associated_functions)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/parser/duplicate-visibility.rs
+++ b/tests/ui/parser/duplicate-visibility.rs
@@ -2,8 +2,8 @@ fn main() {}
 
 extern "C" { //~ NOTE while parsing this item list starting here
     pub pub fn foo();
-    //~^ ERROR expected one of `(`, `async`, `const`, `default`, `extern`, `fn`, `safe`, `unsafe`, or `use`, found keyword `pub`
-    //~| NOTE expected one of 9 possible tokens
+    //~^ ERROR expected one of `(`, `async`, `const`, `default`, `extern`, `final`, `fn`, `safe`, `unsafe`, or `use`, found keyword `pub`
+    //~| NOTE expected one of 10 possible tokens
     //~| HELP there is already a visibility modifier, remove one
     //~| NOTE explicit visibility first seen here
 } //~ NOTE the item list ends here

--- a/tests/ui/parser/duplicate-visibility.stderr
+++ b/tests/ui/parser/duplicate-visibility.stderr
@@ -1,4 +1,4 @@
-error: expected one of `(`, `async`, `const`, `default`, `extern`, `fn`, `safe`, `unsafe`, or `use`, found keyword `pub`
+error: expected one of `(`, `async`, `const`, `default`, `extern`, `final`, `fn`, `safe`, `unsafe`, or `use`, found keyword `pub`
   --> $DIR/duplicate-visibility.rs:4:9
    |
 LL | extern "C" {
@@ -6,7 +6,7 @@ LL | extern "C" {
 LL |     pub pub fn foo();
    |         ^^^
    |         |
-   |         expected one of 9 possible tokens
+   |         expected one of 10 possible tokens
    |         help: there is already a visibility modifier, remove one
 ...
 LL | }

--- a/tests/ui/parser/misspelled-keywords/pub-fn.stderr
+++ b/tests/ui/parser/misspelled-keywords/pub-fn.stderr
@@ -1,8 +1,8 @@
-error: expected one of `#`, `async`, `auto`, `const`, `default`, `enum`, `extern`, `fn`, `gen`, `impl`, `macro_rules`, `macro`, `mod`, `pub`, `safe`, `static`, `struct`, `trait`, `type`, `unsafe`, or `use`, found `puB`
+error: expected one of `#`, `async`, `auto`, `const`, `default`, `enum`, `extern`, `final`, `fn`, `gen`, `impl`, `macro_rules`, `macro`, `mod`, `pub`, `safe`, `static`, `struct`, `trait`, `type`, `unsafe`, or `use`, found `puB`
   --> $DIR/pub-fn.rs:1:1
    |
 LL | puB fn code() {}
-   | ^^^ expected one of 21 possible tokens
+   | ^^^ expected one of 22 possible tokens
    |
 help: write keyword `pub` in lowercase
    |

--- a/tests/ui/traits/final/final-kw.gated.stderr
+++ b/tests/ui/traits/final/final-kw.gated.stderr
@@ -1,0 +1,13 @@
+error[E0658]: `final` on trait functions is experimental
+  --> $DIR/final-kw.rs:5:5
+   |
+LL |     final fn foo() {}
+   |     ^^^^^
+   |
+   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = help: add `#![feature(final_associated_functions)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/traits/final/final-kw.rs
+++ b/tests/ui/traits/final/final-kw.rs
@@ -1,0 +1,9 @@
+//@ revisions: ungated gated
+
+#[cfg(ungated)]
+trait Trait {
+    final fn foo() {}
+    //~^ ERROR `final` on trait functions is experimental
+}
+
+fn main() {}

--- a/tests/ui/traits/final/final-kw.ungated.stderr
+++ b/tests/ui/traits/final/final-kw.ungated.stderr
@@ -1,0 +1,13 @@
+error[E0658]: `final` on trait functions is experimental
+  --> $DIR/final-kw.rs:5:5
+   |
+LL |     final fn foo() {}
+   |     ^^^^^
+   |
+   = note: see issue #1 <https://github.com/rust-lang/rust/issues/1> for more information
+   = help: add `#![feature(final_associated_functions)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/traits/final/final-must-have-body.rs
+++ b/tests/ui/traits/final/final-must-have-body.rs
@@ -1,0 +1,8 @@
+#![feature(final_associated_functions)]
+
+trait Foo {
+    final fn method();
+    //~^ ERROR `final` is only allowed on associated functions if they have a body
+}
+
+fn main() {}

--- a/tests/ui/traits/final/final-must-have-body.stderr
+++ b/tests/ui/traits/final/final-must-have-body.stderr
@@ -1,0 +1,10 @@
+error: `final` is only allowed on associated functions if they have a body
+  --> $DIR/final-must-have-body.rs:4:5
+   |
+LL |     final fn method();
+   |     -----^^^^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/traits/final/overriding.rs
+++ b/tests/ui/traits/final/overriding.rs
@@ -1,0 +1,12 @@
+#![feature(final_associated_functions)]
+
+trait Foo {
+    final fn method() {}
+}
+
+impl Foo for () {
+    fn method() {}
+    //~^ ERROR cannot override `method` because it already has a `final` definition in the trait
+}
+
+fn main() {}

--- a/tests/ui/traits/final/overriding.stderr
+++ b/tests/ui/traits/final/overriding.stderr
@@ -1,0 +1,14 @@
+error: cannot override `method` because it already has a `final` definition in the trait
+  --> $DIR/overriding.rs:8:5
+   |
+LL |     fn method() {}
+   |     ^^^^^^^^^^^
+   |
+note: `method` is marked final here
+  --> $DIR/overriding.rs:4:5
+   |
+LL |     final fn method() {}
+   |     ^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/traits/final/positions.rs
+++ b/tests/ui/traits/final/positions.rs
@@ -1,0 +1,69 @@
+#![feature(final_associated_functions)]
+
+// Just for exercising the syntax positions
+#![feature(associated_type_defaults, extern_types, inherent_associated_types)]
+#![allow(incomplete_features)]
+
+final struct Foo {}
+//~^ ERROR a struct cannot be `final`
+
+final trait Trait {
+//~^ ERROR a trait cannot be `final`
+
+    final fn method() {}
+    // OK!
+
+    final type Foo = ();
+    //~^ ERROR `final` is only allowed on associated functions in traits
+
+    final const FOO: usize = 1;
+    //~^ ERROR `final` is only allowed on associated functions in traits
+}
+
+final impl Foo {
+    final fn method() {}
+    //~^ ERROR `final` is only allowed on associated functions in traits
+
+    final type Foo = ();
+    //~^ ERROR `final` is only allowed on associated functions in traits
+
+    final const FOO: usize = 1;
+    //~^ ERROR `final` is only allowed on associated functions in traits
+}
+
+final impl Trait for Foo {
+    final fn method() {}
+    //~^ ERROR `final` is only allowed on associated functions in traits
+
+    final type Foo = ();
+    //~^ ERROR `final` is only allowed on associated functions in traits
+
+    final const FOO: usize = 1;
+    //~^ ERROR `final` is only allowed on associated functions in traits
+}
+
+
+final fn foo() {}
+//~^ ERROR `final` is only allowed on associated functions in traits
+
+final type FooTy = ();
+//~^ ERROR `final` is only allowed on associated functions in traits
+
+final const FOO: usize = 0;
+//~^ ERROR `final` is only allowed on associated functions in traits
+
+final unsafe extern "C" {
+//~^ ERROR an extern block cannot be `final`
+
+    final fn foo_extern();
+    //~^ ERROR `final` is only allowed on associated functions in traits
+
+    final type FooExtern;
+    //~^ ERROR `final` is only allowed on associated functions in traits
+
+    final static FOO_EXTERN: usize = 0;
+    //~^ ERROR a static item cannot be `final`
+    //~| ERROR incorrect `static` inside `extern` block
+}
+
+fn main() {}

--- a/tests/ui/traits/final/positions.rs
+++ b/tests/ui/traits/final/positions.rs
@@ -34,12 +34,15 @@ final impl Foo {
 final impl Trait for Foo {
     final fn method() {}
     //~^ ERROR `final` is only allowed on associated functions in traits
+    //~| ERROR cannot override `method` because it already has a `final` definition in the trait
 
     final type Foo = ();
     //~^ ERROR `final` is only allowed on associated functions in traits
+    //~| ERROR cannot override `Foo` because it already has a `final` definition in the trait
 
     final const FOO: usize = 1;
     //~^ ERROR `final` is only allowed on associated functions in traits
+    //~| ERROR cannot override `FOO` because it already has a `final` definition in the trait
 }
 
 

--- a/tests/ui/traits/final/positions.stderr
+++ b/tests/ui/traits/final/positions.stderr
@@ -1,0 +1,151 @@
+error: a struct cannot be `final`
+  --> $DIR/positions.rs:7:1
+   |
+LL | final struct Foo {}
+   | ^^^^^ `final` because of this
+   |
+   = note: only associated functions in traits can be `final`
+
+error: a trait cannot be `final`
+  --> $DIR/positions.rs:10:1
+   |
+LL | final trait Trait {
+   | ^^^^^ `final` because of this
+   |
+   = note: only associated functions in traits can be `final`
+
+error: a static item cannot be `final`
+  --> $DIR/positions.rs:64:5
+   |
+LL |     final static FOO_EXTERN: usize = 0;
+   |     ^^^^^ `final` because of this
+   |
+   = note: only associated functions in traits can be `final`
+
+error: an extern block cannot be `final`
+  --> $DIR/positions.rs:55:1
+   |
+LL | final unsafe extern "C" {
+   | ^^^^^ `final` because of this
+   |
+   = note: only associated functions in traits can be `final`
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:16:5
+   |
+LL |     final type Foo = ();
+   |     -----^^^^^^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:19:5
+   |
+LL |     final const FOO: usize = 1;
+   |     -----^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:24:5
+   |
+LL |     final fn method() {}
+   |     -----^^^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:27:5
+   |
+LL |     final type Foo = ();
+   |     -----^^^^^^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:30:5
+   |
+LL |     final const FOO: usize = 1;
+   |     -----^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:35:5
+   |
+LL |     final fn method() {}
+   |     -----^^^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:38:5
+   |
+LL |     final type Foo = ();
+   |     -----^^^^^^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:41:5
+   |
+LL |     final const FOO: usize = 1;
+   |     -----^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:46:1
+   |
+LL | final fn foo() {}
+   | -----^^^^^^^^^
+   | |
+   | `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:49:1
+   |
+LL | final type FooTy = ();
+   | -----^^^^^^^^^^^^^^^^^
+   | |
+   | `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:52:1
+   |
+LL | final const FOO: usize = 0;
+   | -----^^^^^^^^^^^^^^^^^^^^^^
+   | |
+   | `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:58:5
+   |
+LL |     final fn foo_extern();
+   |     -----^^^^^^^^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: `final` is only allowed on associated functions in traits
+  --> $DIR/positions.rs:61:5
+   |
+LL |     final type FooExtern;
+   |     -----^^^^^^^^^^^^^^^^
+   |     |
+   |     `final` because of this
+
+error: incorrect `static` inside `extern` block
+  --> $DIR/positions.rs:64:18
+   |
+LL | final unsafe extern "C" {
+   | ----------------------- `extern` blocks define existing foreign statics and statics inside of them cannot have a body
+...
+LL |     final static FOO_EXTERN: usize = 0;
+   |                  ^^^^^^^^^^          - the invalid body
+   |                  |
+   |                  cannot have a body
+   |
+   = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
+
+error: aborting due to 18 previous errors
+

--- a/tests/ui/traits/final/positions.stderr
+++ b/tests/ui/traits/final/positions.stderr
@@ -15,7 +15,7 @@ LL | final trait Trait {
    = note: only associated functions in traits can be `final`
 
 error: a static item cannot be `final`
-  --> $DIR/positions.rs:64:5
+  --> $DIR/positions.rs:67:5
    |
 LL |     final static FOO_EXTERN: usize = 0;
    |     ^^^^^ `final` because of this
@@ -23,7 +23,7 @@ LL |     final static FOO_EXTERN: usize = 0;
    = note: only associated functions in traits can be `final`
 
 error: an extern block cannot be `final`
-  --> $DIR/positions.rs:55:1
+  --> $DIR/positions.rs:58:1
    |
 LL | final unsafe extern "C" {
    | ^^^^^ `final` because of this
@@ -79,7 +79,7 @@ LL |     final fn method() {}
    |     `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:38:5
+  --> $DIR/positions.rs:39:5
    |
 LL |     final type Foo = ();
    |     -----^^^^^^^^^^^^^^^
@@ -87,7 +87,7 @@ LL |     final type Foo = ();
    |     `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:41:5
+  --> $DIR/positions.rs:43:5
    |
 LL |     final const FOO: usize = 1;
    |     -----^^^^^^^^^^^^^^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     final const FOO: usize = 1;
    |     `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:46:1
+  --> $DIR/positions.rs:49:1
    |
 LL | final fn foo() {}
    | -----^^^^^^^^^
@@ -103,7 +103,7 @@ LL | final fn foo() {}
    | `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:49:1
+  --> $DIR/positions.rs:52:1
    |
 LL | final type FooTy = ();
    | -----^^^^^^^^^^^^^^^^^
@@ -111,7 +111,7 @@ LL | final type FooTy = ();
    | `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:52:1
+  --> $DIR/positions.rs:55:1
    |
 LL | final const FOO: usize = 0;
    | -----^^^^^^^^^^^^^^^^^^^^^^
@@ -119,7 +119,7 @@ LL | final const FOO: usize = 0;
    | `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:58:5
+  --> $DIR/positions.rs:61:5
    |
 LL |     final fn foo_extern();
    |     -----^^^^^^^^^^^^^^^^^
@@ -127,7 +127,7 @@ LL |     final fn foo_extern();
    |     `final` because of this
 
 error: `final` is only allowed on associated functions in traits
-  --> $DIR/positions.rs:61:5
+  --> $DIR/positions.rs:64:5
    |
 LL |     final type FooExtern;
    |     -----^^^^^^^^^^^^^^^^
@@ -135,7 +135,7 @@ LL |     final type FooExtern;
    |     `final` because of this
 
 error: incorrect `static` inside `extern` block
-  --> $DIR/positions.rs:64:18
+  --> $DIR/positions.rs:67:18
    |
 LL | final unsafe extern "C" {
    | ----------------------- `extern` blocks define existing foreign statics and statics inside of them cannot have a body
@@ -147,5 +147,41 @@ LL |     final static FOO_EXTERN: usize = 0;
    |
    = note: for more information, visit https://doc.rust-lang.org/std/keyword.extern.html
 
-error: aborting due to 18 previous errors
+error: cannot override `method` because it already has a `final` definition in the trait
+  --> $DIR/positions.rs:35:5
+   |
+LL |     final fn method() {}
+   |     ^^^^^^^^^^^^^^^^^
+   |
+note: `method` is marked final here
+  --> $DIR/positions.rs:13:5
+   |
+LL |     final fn method() {}
+   |     ^^^^^^^^^^^^^^^^^
+
+error: cannot override `Foo` because it already has a `final` definition in the trait
+  --> $DIR/positions.rs:39:5
+   |
+LL |     final type Foo = ();
+   |     ^^^^^^^^^^^^^^
+   |
+note: `Foo` is marked final here
+  --> $DIR/positions.rs:16:5
+   |
+LL |     final type Foo = ();
+   |     ^^^^^^^^^^^^^^
+
+error: cannot override `FOO` because it already has a `final` definition in the trait
+  --> $DIR/positions.rs:43:5
+   |
+LL |     final const FOO: usize = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: `FOO` is marked final here
+  --> $DIR/positions.rs:19:5
+   |
+LL |     final const FOO: usize = 1;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 21 previous errors
 

--- a/tests/ui/traits/final/works.rs
+++ b/tests/ui/traits/final/works.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+
+#![feature(final_associated_functions)]
+
+trait Foo {
+    final fn bar(&self) {}
+}
+
+impl Foo for () {}
+
+fn main() {
+    ().bar();
+}


### PR DESCRIPTION
Implements the surface part of [RFC 3678](https://github.com/rust-lang/rfcs/pull/3678). Gonna keep this open as a draft until the RFC finishes FCP.

What it doesn't implement are any optimizations that can be done on final trait methods, such as excluding them from the vtable of a `dyn Trait`. This also doesn't implement `final` for *other* trait items.

I'm using the word "method" in the title, but in the diagnostics and the feature gate I used "associated function", since that's more accurate.

r? @ghost

Tracking:

- https://github.com/rust-lang/rust/issues/131179