### PR TITLE
Update llvm triple for OpenHarmony targets

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_linux_ohos.rs
@@ -5,8 +5,7 @@ pub(crate) fn target() -> Target {
     base.max_atomic_width = Some(128);
 
     Target {
-        // LLVM 15 doesn't support OpenHarmony yet, use a linux target instead.
-        llvm_target: "aarch64-unknown-linux-musl".into(),
+        llvm_target: "aarch64-unknown-linux-ohos".into(),
         metadata: crate::spec::TargetMetadata {
             description: Some("ARM64 OpenHarmony".into()),
             tier: Some(2),

--- a/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7_unknown_linux_ohos.rs
@@ -7,8 +7,7 @@ pub(crate) fn target() -> Target {
     // Most of these settings are copied from the armv7_unknown_linux_musleabi
     // target.
     Target {
-        // LLVM 15 doesn't support OpenHarmony yet, use a linux target instead.
-        llvm_target: "armv7-unknown-linux-gnueabi".into(),
+        llvm_target: "armv7-unknown-linux-ohos".into(),
         metadata: crate::spec::TargetMetadata {
             description: Some("Armv7-A OpenHarmony".into()),
             tier: Some(2),

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
@@ -2,8 +2,7 @@ use crate::spec::{Target, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
-        // LLVM 15 doesn't support OpenHarmony yet, use a linux target instead.
-        llvm_target: "loongarch64-unknown-linux-musl".into(),
+        llvm_target: "loongarch64-unknown-linux-ohos".into(),
         metadata: crate::spec::TargetMetadata {
             description: Some("LoongArch64 OpenHarmony".into()),
             tier: Some(3),

--- a/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_unknown_linux_ohos.rs
@@ -15,8 +15,7 @@ pub(crate) fn target() -> Target {
     base.supports_xray = true;
 
     Target {
-        // LLVM 15 doesn't support OpenHarmony yet, use a linux target instead.
-        llvm_target: "x86_64-unknown-linux-musl".into(),
+        llvm_target: "x86_64-unknown-linux-ohos".into(),
         metadata: crate::spec::TargetMetadata {
             description: Some("x86_64 OpenHarmony".into()),
             tier: Some(2),


### PR DESCRIPTION
The `ohos` triple has been supported since LLVM 17, so it's time to update them.
