### PR TITLE
Fix doc of dest_prop

### DIFF
--- a/compiler/rustc_mir_transform/src/dest_prop.rs
+++ b/compiler/rustc_mir_transform/src/dest_prop.rs
@@ -22,7 +22,7 @@
 //!
 //! 1) Identify `dest = src;` statements with values for `dest` and `src` whose storage can soundly
 //!    be merged.
-//! 2) Replace all mentions of `src` with `dest` ("unifying" them and propagating the destination
+//! 2) Replace all mentions of `dest` with `src` ("unifying" them and propagating the destination
 //!    backwards).
 //! 3) Delete the `dest = src;` statement (by making it a `nop`).
 //!


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

In the doc of dest_prop, it should be "Replace all mentions of `dest` with `src`" instead of "Replace all mentions of `src` with `dest`" since `dest` is the one to be eliminated.