### PR TITLE
Compiler: Rename "object safe" to "dyn compatible"

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/call.rs
+++ b/compiler/rustc_const_eval/src/interpret/call.rs
@@ -598,7 +598,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             // codegen'd / interpreted as virtual calls through the vtable.
             ty::InstanceKind::Virtual(def_id, idx) => {
                 let mut args = args.to_vec();
-                // We have to implement all "object safe receivers". So we have to go search for a
+                // We have to implement all "dyn-compatible receivers". So we have to go search for a
                 // pointer or `dyn Trait` type, but it could be wrapped in newtypes. So recursively
                 // unwrap those newtypes until we are there.
                 // An `InPlace` does nothing here, we keep the original receiver intact. We can't

--- a/compiler/rustc_error_codes/src/error_codes/E0038.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0038.md
@@ -5,9 +5,9 @@ trait, written in type positions) but this was a bit too confusing, so we now
 write `dyn Trait`.
 
 Some traits are not allowed to be used as trait object types. The traits that
-are allowed to be used as trait object types are called "object-safe" traits.
-Attempting to use a trait object type for a trait that is not object-safe will
-trigger error E0038.
+are allowed to be used as trait object types are called "dyn-compatible"[^1]
+traits. Attempting to use a trait object type for a trait that is not
+dyn-compatible will trigger error E0038.
 
 Two general aspects of trait object types give rise to the restrictions:
 
@@ -25,13 +25,16 @@ Two general aspects of trait object types give rise to the restrictions:
      objects with the same trait object type may point to vtables from different
      implementations.
 
-The specific conditions that violate object-safety follow, most of which relate
-to missing size information and vtable polymorphism arising from these aspects.
+The specific conditions that violate dyn-compatibility follow, most of which
+relate to missing size information and vtable polymorphism arising from these
+aspects.
+
+[^1]: Formerly known as "object-safe".
 
 ### The trait requires `Self: Sized`
 
 Traits that are declared as `Trait: Sized` or which otherwise inherit a
-constraint of `Self:Sized` are not object-safe.
+constraint of `Self:Sized` are not dyn-compatible.
 
 The reasoning behind this is somewhat subtle. It derives from the fact that Rust
 requires (and defines) that every trait object type `dyn Trait` automatically
@@ -58,7 +61,7 @@ implement a sized trait like `Trait:Sized`. So, rather than allow an exception
 to the rule that `dyn Trait` always implements `Trait`, Rust chooses to prohibit
 such a `dyn Trait` from existing at all.
 
-Only unsized traits are considered object-safe.
+Only unsized traits are considered dyn-compatible.
 
 Generally, `Self: Sized` is used to indicate that the trait should not be used
 as a trait object. If the trait comes from your own crate, consider removing
@@ -103,8 +106,8 @@ fn call_foo(x: Box<dyn Trait>) {
 }
 ```
 
-If only some methods aren't object-safe, you can add a `where Self: Sized` bound
-on them to mark them as explicitly unavailable to trait objects. The
+If only some methods aren't dyn-compatible, you can add a `where Self: Sized`
+bound on them to mark them as explicitly unavailable to trait objects. The
 functionality will still be available to all other implementers, including
 `Box<dyn Trait>` which is itself sized (assuming you `impl Trait for Box<dyn
 Trait>`).
@@ -117,7 +120,7 @@ trait Trait {
 ```
 
 Now, `foo()` can no longer be called on a trait object, but you will now be
-allowed to make a trait object, and that will be able to call any object-safe
+allowed to make a trait object, and that will be able to call any dyn-compatible
 methods. With such a bound, one can still call `foo()` on types implementing
 that trait that aren't behind trait objects.
 
@@ -306,7 +309,7 @@ Here, the supertrait might have methods as follows:
 
 ```
 trait Super<A: ?Sized> {
-    fn get_a(&self) -> &A; // note that this is object safe!
+    fn get_a(&self) -> &A; // note that this is dyn-compatible!
 }
 ```
 
@@ -314,10 +317,10 @@ If the trait `Trait` was deriving from something like `Super<String>` or
 `Super<T>` (where `Foo` itself is `Foo<T>`), this is okay, because given a type
 `get_a()` will definitely return an object of that type.
 
-However, if it derives from `Super<Self>`, even though `Super` is object safe,
-the method `get_a()` would return an object of unknown type when called on the
-function. `Self` type parameters let us make object safe traits no longer safe,
-so they are forbidden when specifying supertraits.
+However, if it derives from `Super<Self>`, even though `Super` is
+dyn-compatible, the method `get_a()` would return an object of unknown type when
+called on the function. `Self` type parameters let us make dyn-compatible traits
+no longer compatible, so they are forbidden when specifying supertraits.
 
 There's no easy fix for this. Generally, code will need to be refactored so that
 you no longer need to derive from `Super<Self>`.

--- a/compiler/rustc_error_codes/src/lib.rs
+++ b/compiler/rustc_error_codes/src/lib.rs
@@ -623,7 +623,7 @@ E0800: 0800,
 //  E0314, // closure outlives stack frame
 //  E0315, // cannot invoke closure outside of its lifetime
 //  E0319, // trait impls for defaulted traits allowed just for structs/enums
-//  E0372, // coherence not object safe
+//  E0372, // coherence not dyn-compatible
 //  E0385, // {} in an aliasable location
 //  E0402, // cannot use an outer type parameter in this context
 //  E0406, // merged into 420

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -548,9 +548,12 @@ declare_features! (
     (unstable, non_exhaustive_omitted_patterns_lint, "1.57.0", Some(89554)),
     /// Allows `for<T>` binders in where-clauses
     (incomplete, non_lifetime_binders, "1.69.0", Some(108185)),
-    /// Allows making `dyn Trait` well-formed even if `Trait` is not object safe.
+    /// Allows making `dyn Trait` well-formed even if `Trait` is not dyn-compatible[^1].
     /// In that case, `dyn Trait: Trait` does not hold. Moreover, coercions and
     /// casts in safe Rust to `dyn Trait` for such a `Trait` is also forbidden.
+    ///
+    /// [^1]: Formerly known as "object safe".
+    // FIXME(dyn_compat_renaming): Rename feature.
     (unstable, object_safe_for_dispatch, "1.40.0", Some(43561)),
     /// Allows using enums in offset_of!
     (unstable, offset_of_enum, "1.75.0", Some(120141)),

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -558,7 +558,7 @@ hir_analysis_unrecognized_intrinsic_function =
     .help = if you're adding an intrinsic, be sure to update `check_intrinsic_type`
 
 hir_analysis_unused_associated_type_bounds =
-    unnecessary associated type bound for not object safe associated type
+    unnecessary associated type bound for dyn-incompatible associated type
     .note = this associated type has a `where Self: Sized` bound, and while the associated type can be specified, it cannot be used because trait objects are never `Sized`
     .suggestion = remove this bound
 

--- a/compiler/rustc_hir_analysis/src/coherence/mod.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/mod.rs
@@ -179,8 +179,8 @@ fn check_object_overlap<'tcx>(
 
     // check for overlap with the automatic `impl Trait for dyn Trait`
     if let ty::Dynamic(data, ..) = trait_ref.self_ty().kind() {
-        // This is something like impl Trait1 for Trait2. Illegal
-        // if Trait1 is a supertrait of Trait2 or Trait2 is not object safe.
+        // This is something like `impl Trait1 for Trait2`. Illegal if
+        // Trait1 is a supertrait of Trait2 or Trait2 is not dyn-compatible.
 
         let component_def_ids = data.iter().flat_map(|predicate| {
             match predicate.skip_binder() {
@@ -193,7 +193,8 @@ fn check_object_overlap<'tcx>(
         });
 
         for component_def_id in component_def_ids {
-            if !tcx.is_object_safe(component_def_id) {
+            if !tcx.is_dyn_compatible(component_def_id) {
+                // FIXME(dyn_compat_renaming): Rename test and update comment.
                 // Without the 'object_safe_for_dispatch' feature this is an error
                 // which will be reported by wfcheck. Ignore it here.
                 // This is tested by `coherence-impl-trait-for-trait-object-safe.rs`.

--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -109,16 +109,16 @@ pub(crate) fn orphan_check_impl(
         //
         //     auto trait AutoTrait {}
         //
-        //     trait ObjectSafeTrait {
+        //     trait DynCompatibleTrait {
         //         fn f(&self) where Self: AutoTrait;
         //     }
         //
-        // We can allow f to be called on `dyn ObjectSafeTrait + AutoTrait`.
+        // We can allow f to be called on `dyn DynCompatibleTrait + AutoTrait`.
         //
         // If we didn't deny `impl AutoTrait for dyn Trait`, it would be unsound
-        // for the ObjectSafeTrait shown above to be object safe because someone
-        // could take some type implementing ObjectSafeTrait but not AutoTrait,
-        // unsize it to `dyn ObjectSafeTrait`, and call .f() which has no
+        // for the `DynCompatibleTrait` shown above to be dyn-compatible because someone
+        // could take some type implementing `DynCompatibleTrait` but not `AutoTrait`,
+        // unsize it to `dyn DynCompatibleTrait`, and call `.f()` which has no
         // concrete implementation (issue #50781).
         enum LocalImpl {
             Allow,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -19,9 +19,9 @@ use rustc_session::parse::feature_err;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::symbol::{Ident, kw, sym};
 use rustc_span::{BytePos, DUMMY_SP, Span, Symbol};
-use rustc_trait_selection::error_reporting::traits::report_object_safety_error;
+use rustc_trait_selection::error_reporting::traits::report_dyn_incompatibility;
 use rustc_trait_selection::traits::{
-    FulfillmentError, TraitAliasExpansionInfo, object_safety_violations_for_assoc_item,
+    FulfillmentError, TraitAliasExpansionInfo, dyn_compatibility_violations_for_assoc_item,
 };
 
 use crate::errors::{
@@ -739,7 +739,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         // Account for things like `dyn Foo + 'a`, like in tests `issue-22434.rs` and
         // `issue-22560.rs`.
         let mut trait_bound_spans: Vec<Span> = vec![];
-        let mut object_safety_violations = false;
+        let mut dyn_compatibility_violations = false;
         for (span, items) in &associated_types {
             if !items.is_empty() {
                 trait_bound_spans.push(*span);
@@ -750,14 +750,14 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 names_len += 1;
 
                 let violations =
-                    object_safety_violations_for_assoc_item(tcx, trait_def_id, *assoc_item);
+                    dyn_compatibility_violations_for_assoc_item(tcx, trait_def_id, *assoc_item);
                 if !violations.is_empty() {
-                    report_object_safety_error(tcx, *span, None, trait_def_id, &violations).emit();
-                    object_safety_violations = true;
+                    report_dyn_incompatibility(tcx, *span, None, trait_def_id, &violations).emit();
+                    dyn_compatibility_violations = true;
                 }
             }
         }
-        if object_safety_violations {
+        if dyn_compatibility_violations {
             return;
         }
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/lint.rs
@@ -77,7 +77,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             if self_ty.span.can_be_used_for_suggestions()
                 && !self.maybe_suggest_impl_trait(self_ty, &mut diag)
             {
-                // FIXME: Only emit this suggestion if the trait is object safe.
+                // FIXME: Only emit this suggestion if the trait is dyn-compatible.
                 diag.multipart_suggestion_verbose(label, sugg, Applicability::MachineApplicable);
             }
             // Check if the impl trait that we are considering is an impl of a local trait.
@@ -89,7 +89,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 lint.primary_message("trait objects without an explicit `dyn` are deprecated");
                 if self_ty.span.can_be_used_for_suggestions() {
                     lint.multipart_suggestion_verbose(
-                        "if this is an object-safe trait, use `dyn`",
+                        "if this is a dyn-compatible trait, use `dyn`",
                         sugg,
                         Applicability::MachineApplicable,
                     );
@@ -196,7 +196,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         let mut is_downgradable = true;
 
         // Check if trait object is safe for suggesting dynamic dispatch.
-        let is_object_safe = match self_ty.kind {
+        let is_dyn_compatible = match self_ty.kind {
             hir::TyKind::TraitObject(objects, ..) => {
                 objects.iter().all(|(o, _)| match o.trait_ref.path.res {
                     Res::Def(DefKind::Trait, id) => {
@@ -204,7 +204,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                             // For recursive traits, don't downgrade the error. (#119652)
                             is_downgradable = false;
                         }
-                        tcx.is_object_safe(id)
+                        tcx.is_dyn_compatible(id)
                     }
                     _ => false,
                 })
@@ -221,8 +221,8 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         if let hir::FnRetTy::Return(ty) = sig.decl.output
             && ty.peel_refs().hir_id == self_ty.hir_id
         {
-            let pre = if !is_object_safe {
-                format!("`{trait_name}` is not object safe, ")
+            let pre = if !is_dyn_compatible {
+                format!("`{trait_name}` is dyn-incompatible, ")
             } else {
                 String::new()
             };
@@ -234,7 +234,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             diag.multipart_suggestion_verbose(msg, impl_sugg, Applicability::MachineApplicable);
 
             // Suggest `Box<dyn Trait>` for return type
-            if is_object_safe {
+            if is_dyn_compatible {
                 // If the return type is `&Trait`, we don't want
                 // the ampersand to be displayed in the `Box<dyn Trait>`
                 // suggestion.
@@ -253,7 +253,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     Applicability::MachineApplicable,
                 );
             } else if is_downgradable {
-                // We'll emit the object safety error already, with a structured suggestion.
+                // We'll emit the dyn-compatibility error already, with a structured suggestion.
                 diag.downgrade_to_delayed_bug();
             }
             return true;
@@ -276,10 +276,10 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 impl_sugg,
                 Applicability::MachineApplicable,
             );
-            if !is_object_safe {
-                diag.note(format!("`{trait_name}` it is not object safe, so it can't be `dyn`"));
+            if !is_dyn_compatible {
+                diag.note(format!("`{trait_name}` it is dyn-incompatible, so it can't be `dyn`"));
                 if is_downgradable {
-                    // We'll emit the object safety error already, with a structured suggestion.
+                    // We'll emit the dyn-compatibility error already, with a structured suggestion.
                     diag.downgrade_to_delayed_bug();
                 }
             } else {

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -15,10 +15,10 @@
 
 mod bounds;
 mod cmse;
+mod dyn_compatibility;
 pub mod errors;
 pub mod generics;
 mod lint;
-mod object_safety;
 
 use std::slice;
 

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -655,7 +655,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                     return Err(TypeError::Mismatch);
                 }
 
-                // Object safety violations or miscellaneous.
+                // Dyn-compatibility violations or miscellaneous.
                 Err(err) => {
                     self.err_ctxt().report_selection_error(obligation.clone(), &obligation, &err);
                     // Treat this like an obligation and follow through

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -757,7 +757,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // give us a `QPath::TypeRelative` with a trait object as
                 // `qself`. In that case, we want to avoid registering a WF obligation
                 // for `dyn MyTrait`, since we don't actually need the trait
-                // to be object-safe.
+                // to be dyn-compatible.
                 // We manually call `register_wf_obligation` in the success path
                 // below.
                 let ty = self.lowerer().lower_ty(qself);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/inspect_obligations.rs
@@ -50,7 +50,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             | ty::PredicateKind::Clause(ty::ClauseKind::RegionOutlives(..))
             | ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(..))
             | ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(..))
-            | ty::PredicateKind::ObjectSafe(..)
+            | ty::PredicateKind::DynCompatible(..)
             | ty::PredicateKind::NormalizesTo(..)
             | ty::PredicateKind::AliasRelate(..)
             | ty::PredicateKind::Clause(ty::ClauseKind::ConstEvaluatable(..))

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -292,7 +292,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                     // distinct types (e.g., if `Self` appeared as an
                     // argument type), but those cases have already
                     // been ruled out when we deemed the trait to be
-                    // "object safe".
+                    // "dyn-compatible".
                     let original_poly_trait_ref = principal.with_self_ty(this.tcx, object_ty);
                     let upcast_poly_trait_ref = this.upcast(original_poly_trait_ref, trait_def_id);
                     let upcast_trait_ref =

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -779,8 +779,8 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         });
 
         // It is illegal to invoke a method on a trait instance that refers to
-        // the `Self` type. An [`ObjectSafetyViolation::SupertraitSelf`] error
-        // will be reported by `object_safety.rs` if the method refers to the
+        // the `Self` type. An [`DynCompatibilityViolation::SupertraitSelf`] error
+        // will be reported by `dyn_compatibility.rs` if the method refers to the
         // `Self` type anywhere other than the receiver. Here, we use a
         // instantiation that replaces `Self` with the object type itself. Hence,
         // a `&self` method will wind up with an argument type like `&dyn Trait`.

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -912,7 +912,7 @@ fn analysis(tcx: TyCtxt<'_>, (): ()) -> Result<()> {
         let traits = tcx.traits(LOCAL_CRATE);
 
         for &tr in traits {
-            if !tcx.is_object_safe(tr) {
+            if !tcx.is_dyn_compatible(tr) {
                 continue;
             }
 

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -516,7 +516,7 @@ lint_mixed_script_confusables =
     .includes_note = the usage includes {$includes}
     .note = please recheck to make sure their usages are indeed what you want
 
-lint_multiple_supertrait_upcastable = `{$ident}` is object-safe and has multiple supertraits
+lint_multiple_supertrait_upcastable = `{$ident}` is dyn-compatible and has multiple supertraits
 
 lint_named_argument_used_positionally = named argument `{$named_arg_name}` is not used by name
     .label_named_arg = this named argument is referred to by position in formatting string

--- a/compiler/rustc_lint/src/multiple_supertrait_upcastable.rs
+++ b/compiler/rustc_lint/src/multiple_supertrait_upcastable.rs
@@ -4,7 +4,7 @@ use rustc_session::{declare_lint, declare_lint_pass};
 use crate::{LateContext, LateLintPass, LintContext};
 
 declare_lint! {
-    /// The `multiple_supertrait_upcastable` lint detects when an object-safe trait has multiple
+    /// The `multiple_supertrait_upcastable` lint detects when a dyn-compatible trait has multiple
     /// supertraits.
     ///
     /// ### Example
@@ -28,7 +28,7 @@ declare_lint! {
     /// additional overhead is justified.
     pub MULTIPLE_SUPERTRAIT_UPCASTABLE,
     Allow,
-    "detect when an object-safe trait has multiple supertraits",
+    "detect when a dyn-compatible trait has multiple supertraits",
     @feature_gate = multiple_supertrait_upcastable;
 }
 
@@ -37,10 +37,10 @@ declare_lint_pass!(MultipleSupertraitUpcastable => [MULTIPLE_SUPERTRAIT_UPCASTAB
 impl<'tcx> LateLintPass<'tcx> for MultipleSupertraitUpcastable {
     fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item<'tcx>) {
         let def_id = item.owner_id.to_def_id();
-        // NOTE(nbdd0121): use `object_safety_violations` instead of `is_object_safe` because
+        // NOTE(nbdd0121): use `object_safety_violations` instead of `is_dyn_compatible` because
         // the latter will report `where_clause_object_safety` lint.
         if let hir::ItemKind::Trait(_, _, _, _, _) = item.kind
-            && cx.tcx.is_object_safe(def_id)
+            && cx.tcx.is_dyn_compatible(def_id)
         {
             let direct_super_traits_iter = cx
                 .tcx

--- a/compiler/rustc_middle/src/arena.rs
+++ b/compiler/rustc_middle/src/arena.rs
@@ -83,7 +83,7 @@ macro_rules! arena_types {
                 >,
             [] effective_visibilities: rustc_middle::middle::privacy::EffectiveVisibilities,
             [] upvars_mentioned: rustc_data_structures::fx::FxIndexMap<rustc_hir::HirId, rustc_hir::Upvar>,
-            [] object_safety_violations: rustc_middle::traits::ObjectSafetyViolation,
+            [] dyn_compatibility_violations: rustc_middle::traits::DynCompatibilityViolation,
             [] codegen_unit: rustc_middle::mir::mono::CodegenUnit<'tcx>,
             [decode] attribute: rustc_ast::Attribute,
             [] name_set: rustc_data_structures::unord::UnordSet<rustc_span::symbol::Symbol>,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -70,8 +70,8 @@ use crate::traits::query::{
     MethodAutoderefStepsResult, NoSolution, NormalizationResult, OutlivesBound,
 };
 use crate::traits::{
-    CodegenObligationError, EvaluationResult, ImplSource, ObjectSafetyViolation, ObligationCause,
-    OverflowError, WellFormedLoc, specialization_graph,
+    CodegenObligationError, DynCompatibilityViolation, EvaluationResult, ImplSource,
+    ObligationCause, OverflowError, WellFormedLoc, specialization_graph,
 };
 use crate::ty::fast_reject::SimplifiedType;
 use crate::ty::layout::ValidityRequirement;
@@ -1338,11 +1338,11 @@ rustc_queries! {
         cache_on_disk_if { true }
         ensure_forwards_result_if_red
     }
-    query object_safety_violations(trait_id: DefId) -> &'tcx [ObjectSafetyViolation] {
-        desc { |tcx| "determining object safety of trait `{}`", tcx.def_path_str(trait_id) }
+    query dyn_compatibility_violations(trait_id: DefId) -> &'tcx [DynCompatibilityViolation] {
+        desc { |tcx| "determining dyn-compatibility of trait `{}`", tcx.def_path_str(trait_id) }
     }
-    query is_object_safe(trait_id: DefId) -> bool {
-        desc { |tcx| "checking if trait `{}` is object safe", tcx.def_path_str(trait_id) }
+    query is_dyn_compatible(trait_id: DefId) -> bool {
+        desc { |tcx| "checking if trait `{}` is dyn-compatible", tcx.def_path_str(trait_id) }
     }
 
     /// Gets the ParameterEnvironment for a given item; this environment

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -556,8 +556,8 @@ pub enum SelectionError<'tcx> {
     /// (which for closures includes the "input" type params) and they
     /// didn't resolve. See `confirm_poly_trait_refs` for more.
     SignatureMismatch(Box<SignatureMismatchData<'tcx>>),
-    /// The trait pointed by `DefId` is not object safe.
-    TraitNotObjectSafe(DefId),
+    /// The trait pointed by `DefId` is dyn-incompatible.
+    TraitDynIncompatible(DefId),
     /// A given constant couldn't be evaluated.
     NotConstEvaluatable(NotConstEvaluatable),
     /// Exceeded the recursion depth during type projection.
@@ -690,7 +690,7 @@ pub struct ImplSourceUserDefinedData<'tcx, N> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, PartialOrd, Ord)]
-pub enum ObjectSafetyViolation {
+pub enum DynCompatibilityViolation {
     /// `Self: Sized` declared on the trait.
     SizedSelf(SmallVec<[Span; 1]>),
 
@@ -711,11 +711,11 @@ pub enum ObjectSafetyViolation {
     GAT(Symbol, Span),
 }
 
-impl ObjectSafetyViolation {
+impl DynCompatibilityViolation {
     pub fn error_msg(&self) -> Cow<'static, str> {
         match self {
-            ObjectSafetyViolation::SizedSelf(_) => "it requires `Self: Sized`".into(),
-            ObjectSafetyViolation::SupertraitSelf(ref spans) => {
+            DynCompatibilityViolation::SizedSelf(_) => "it requires `Self: Sized`".into(),
+            DynCompatibilityViolation::SupertraitSelf(ref spans) => {
                 if spans.iter().any(|sp| *sp != DUMMY_SP) {
                     "it uses `Self` as a type parameter".into()
                 } else {
@@ -723,81 +723,87 @@ impl ObjectSafetyViolation {
                         .into()
                 }
             }
-            ObjectSafetyViolation::SupertraitNonLifetimeBinder(_) => {
+            DynCompatibilityViolation::SupertraitNonLifetimeBinder(_) => {
                 "where clause cannot reference non-lifetime `for<...>` variables".into()
             }
-            ObjectSafetyViolation::Method(name, MethodViolationCode::StaticMethod(_), _) => {
+            DynCompatibilityViolation::Method(name, MethodViolationCode::StaticMethod(_), _) => {
                 format!("associated function `{name}` has no `self` parameter").into()
             }
-            ObjectSafetyViolation::Method(
+            DynCompatibilityViolation::Method(
                 name,
                 MethodViolationCode::ReferencesSelfInput(_),
                 DUMMY_SP,
             ) => format!("method `{name}` references the `Self` type in its parameters").into(),
-            ObjectSafetyViolation::Method(name, MethodViolationCode::ReferencesSelfInput(_), _) => {
-                format!("method `{name}` references the `Self` type in this parameter").into()
-            }
-            ObjectSafetyViolation::Method(name, MethodViolationCode::ReferencesSelfOutput, _) => {
-                format!("method `{name}` references the `Self` type in its return type").into()
-            }
-            ObjectSafetyViolation::Method(
+            DynCompatibilityViolation::Method(
+                name,
+                MethodViolationCode::ReferencesSelfInput(_),
+                _,
+            ) => format!("method `{name}` references the `Self` type in this parameter").into(),
+            DynCompatibilityViolation::Method(
+                name,
+                MethodViolationCode::ReferencesSelfOutput,
+                _,
+            ) => format!("method `{name}` references the `Self` type in its return type").into(),
+            DynCompatibilityViolation::Method(
                 name,
                 MethodViolationCode::ReferencesImplTraitInTrait(_),
                 _,
             ) => {
                 format!("method `{name}` references an `impl Trait` type in its return type").into()
             }
-            ObjectSafetyViolation::Method(name, MethodViolationCode::AsyncFn, _) => {
+            DynCompatibilityViolation::Method(name, MethodViolationCode::AsyncFn, _) => {
                 format!("method `{name}` is `async`").into()
             }
-            ObjectSafetyViolation::Method(
+            DynCompatibilityViolation::Method(
                 name,
                 MethodViolationCode::WhereClauseReferencesSelf,
                 _,
             ) => format!("method `{name}` references the `Self` type in its `where` clause").into(),
-            ObjectSafetyViolation::Method(name, MethodViolationCode::Generic, _) => {
+            DynCompatibilityViolation::Method(name, MethodViolationCode::Generic, _) => {
                 format!("method `{name}` has generic type parameters").into()
             }
-            ObjectSafetyViolation::Method(
+            DynCompatibilityViolation::Method(
                 name,
                 MethodViolationCode::UndispatchableReceiver(_),
                 _,
             ) => format!("method `{name}`'s `self` parameter cannot be dispatched on").into(),
-            ObjectSafetyViolation::AssocConst(name, DUMMY_SP) => {
+            DynCompatibilityViolation::AssocConst(name, DUMMY_SP) => {
                 format!("it contains associated `const` `{name}`").into()
             }
-            ObjectSafetyViolation::AssocConst(..) => "it contains this associated `const`".into(),
-            ObjectSafetyViolation::GAT(name, _) => {
+            DynCompatibilityViolation::AssocConst(..) => {
+                "it contains this associated `const`".into()
+            }
+            DynCompatibilityViolation::GAT(name, _) => {
                 format!("it contains the generic associated type `{name}`").into()
             }
         }
     }
 
-    pub fn solution(&self) -> ObjectSafetyViolationSolution {
+    pub fn solution(&self) -> DynCompatibilityViolationSolution {
         match self {
-            ObjectSafetyViolation::SizedSelf(_)
-            | ObjectSafetyViolation::SupertraitSelf(_)
-            | ObjectSafetyViolation::SupertraitNonLifetimeBinder(..) => {
-                ObjectSafetyViolationSolution::None
+            DynCompatibilityViolation::SizedSelf(_)
+            | DynCompatibilityViolation::SupertraitSelf(_)
+            | DynCompatibilityViolation::SupertraitNonLifetimeBinder(..) => {
+                DynCompatibilityViolationSolution::None
             }
-            ObjectSafetyViolation::Method(
+            DynCompatibilityViolation::Method(
                 name,
                 MethodViolationCode::StaticMethod(Some((add_self_sugg, make_sized_sugg))),
                 _,
-            ) => ObjectSafetyViolationSolution::AddSelfOrMakeSized {
+            ) => DynCompatibilityViolationSolution::AddSelfOrMakeSized {
                 name: *name,
                 add_self_sugg: add_self_sugg.clone(),
                 make_sized_sugg: make_sized_sugg.clone(),
             },
-            ObjectSafetyViolation::Method(
+            DynCompatibilityViolation::Method(
                 name,
                 MethodViolationCode::UndispatchableReceiver(Some(span)),
                 _,
-            ) => ObjectSafetyViolationSolution::ChangeToRefSelf(*name, *span),
-            ObjectSafetyViolation::AssocConst(name, _)
-            | ObjectSafetyViolation::GAT(name, _)
-            | ObjectSafetyViolation::Method(name, ..) => {
-                ObjectSafetyViolationSolution::MoveToAnotherTrait(*name)
+            ) => DynCompatibilityViolationSolution::ChangeToRefSelf(*name, *span),
+            DynCompatibilityViolation::AssocConst(name, _)
+            | DynCompatibilityViolation::GAT(name, _)
+            | DynCompatibilityViolation::Method(name, ..) => {
+                DynCompatibilityViolationSolution::MoveToAnotherTrait(*name)
             }
         }
     }
@@ -806,12 +812,12 @@ impl ObjectSafetyViolation {
         // When `span` comes from a separate crate, it'll be `DUMMY_SP`. Treat it as `None` so
         // diagnostics use a `note` instead of a `span_label`.
         match self {
-            ObjectSafetyViolation::SupertraitSelf(spans)
-            | ObjectSafetyViolation::SizedSelf(spans)
-            | ObjectSafetyViolation::SupertraitNonLifetimeBinder(spans) => spans.clone(),
-            ObjectSafetyViolation::AssocConst(_, span)
-            | ObjectSafetyViolation::GAT(_, span)
-            | ObjectSafetyViolation::Method(_, _, span)
+            DynCompatibilityViolation::SupertraitSelf(spans)
+            | DynCompatibilityViolation::SizedSelf(spans)
+            | DynCompatibilityViolation::SupertraitNonLifetimeBinder(spans) => spans.clone(),
+            DynCompatibilityViolation::AssocConst(_, span)
+            | DynCompatibilityViolation::GAT(_, span)
+            | DynCompatibilityViolation::Method(_, _, span)
                 if *span != DUMMY_SP =>
             {
                 smallvec![*span]
@@ -822,7 +828,7 @@ impl ObjectSafetyViolation {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum ObjectSafetyViolationSolution {
+pub enum DynCompatibilityViolationSolution {
     None,
     AddSelfOrMakeSized {
         name: Symbol,
@@ -833,11 +839,11 @@ pub enum ObjectSafetyViolationSolution {
     MoveToAnotherTrait(Symbol),
 }
 
-impl ObjectSafetyViolationSolution {
+impl DynCompatibilityViolationSolution {
     pub fn add_to<G: EmissionGuarantee>(self, err: &mut Diag<'_, G>) {
         match self {
-            ObjectSafetyViolationSolution::None => {}
-            ObjectSafetyViolationSolution::AddSelfOrMakeSized {
+            DynCompatibilityViolationSolution::None => {}
+            DynCompatibilityViolationSolution::AddSelfOrMakeSized {
                 name,
                 add_self_sugg,
                 make_sized_sugg,
@@ -860,7 +866,7 @@ impl ObjectSafetyViolationSolution {
                     Applicability::MaybeIncorrect,
                 );
             }
-            ObjectSafetyViolationSolution::ChangeToRefSelf(name, span) => {
+            DynCompatibilityViolationSolution::ChangeToRefSelf(name, span) => {
                 err.span_suggestion(
                     span,
                     format!("consider changing method `{name}`'s `self` parameter to be `&self`"),
@@ -868,14 +874,14 @@ impl ObjectSafetyViolationSolution {
                     Applicability::MachineApplicable,
                 );
             }
-            ObjectSafetyViolationSolution::MoveToAnotherTrait(name) => {
+            DynCompatibilityViolationSolution::MoveToAnotherTrait(name) => {
                 err.help(format!("consider moving `{name}` to another trait"));
             }
         }
     }
 }
 
-/// Reasons a method might not be object-safe.
+/// Reasons a method might not be dyn-compatible.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, HashStable, PartialOrd, Ord)]
 pub enum MethodViolationCode {
     /// e.g., `fn foo()`

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -527,8 +527,8 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.trait_is_alias(trait_def_id)
     }
 
-    fn trait_is_object_safe(self, trait_def_id: DefId) -> bool {
-        self.is_object_safe(trait_def_id)
+    fn trait_is_dyn_compatible(self, trait_def_id: DefId) -> bool {
+        self.is_dyn_compatible(trait_def_id)
     }
 
     fn trait_is_fundamental(self, def_id: DefId) -> bool {

--- a/compiler/rustc_middle/src/ty/flags.rs
+++ b/compiler/rustc_middle/src/ty/flags.rs
@@ -301,7 +301,7 @@ impl FlagComputation {
             ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(arg)) => {
                 self.add_args(slice::from_ref(&arg));
             }
-            ty::PredicateKind::ObjectSafe(_def_id) => {}
+            ty::PredicateKind::DynCompatible(_def_id) => {}
             ty::PredicateKind::Clause(ty::ClauseKind::ConstEvaluatable(uv)) => {
                 self.add_const(uv);
             }

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -50,7 +50,7 @@ pub enum ReifyReason {
     /// * A vtable entry is directly converted to a function call (e.g. creating a fn ptr from a
     ///   method on a `dyn` object).
     /// * A function with `#[track_caller]` is converted to a function pointer
-    /// * If KCFI is enabled, creating a function pointer from a method on an object-safe trait.
+    /// * If KCFI is enabled, creating a function pointer from a method on a dyn-compatible trait.
     /// This includes the case of converting `::call`-like methods on closure-likes to function
     /// pointers.
     FnPtr,

--- a/compiler/rustc_middle/src/ty/predicate.rs
+++ b/compiler/rustc_middle/src/ty/predicate.rs
@@ -36,7 +36,7 @@ pub type PolyProjectionPredicate<'tcx> = ty::Binder<'tcx, ProjectionPredicate<'t
 
 /// A statement that can be proven by a trait solver. This includes things that may
 /// show up in where clauses, such as trait predicates and projection predicates,
-/// and also things that are emitted as part of type checking such as `ObjectSafe`
+/// and also things that are emitted as part of type checking such as `DynCompatible`
 /// predicate which is emitted when a type is coerced to a trait object.
 ///
 /// Use this rather than `PredicateKind`, whenever possible.
@@ -147,7 +147,7 @@ impl<'tcx> Predicate<'tcx> {
             | PredicateKind::Clause(ClauseKind::TypeOutlives(_))
             | PredicateKind::Clause(ClauseKind::Projection(_))
             | PredicateKind::Clause(ClauseKind::ConstArgHasType(..))
-            | PredicateKind::ObjectSafe(_)
+            | PredicateKind::DynCompatible(_)
             | PredicateKind::Subtype(_)
             | PredicateKind::Coerce(_)
             | PredicateKind::Clause(ClauseKind::ConstEvaluatable(_))
@@ -647,7 +647,7 @@ impl<'tcx> Predicate<'tcx> {
             | PredicateKind::Coerce(..)
             | PredicateKind::Clause(ClauseKind::RegionOutlives(..))
             | PredicateKind::Clause(ClauseKind::WellFormed(..))
-            | PredicateKind::ObjectSafe(..)
+            | PredicateKind::DynCompatible(..)
             | PredicateKind::Clause(ClauseKind::TypeOutlives(..))
             | PredicateKind::Clause(ClauseKind::ConstEvaluatable(..))
             | PredicateKind::ConstEquate(..)
@@ -667,7 +667,7 @@ impl<'tcx> Predicate<'tcx> {
             | PredicateKind::Coerce(..)
             | PredicateKind::Clause(ClauseKind::RegionOutlives(..))
             | PredicateKind::Clause(ClauseKind::WellFormed(..))
-            | PredicateKind::ObjectSafe(..)
+            | PredicateKind::DynCompatible(..)
             | PredicateKind::Clause(ClauseKind::TypeOutlives(..))
             | PredicateKind::Clause(ClauseKind::ConstEvaluatable(..))
             | PredicateKind::ConstEquate(..)

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -3088,8 +3088,8 @@ define_print! {
             }
             ty::PredicateKind::Subtype(predicate) => p!(print(predicate)),
             ty::PredicateKind::Coerce(predicate) => p!(print(predicate)),
-            ty::PredicateKind::ObjectSafe(trait_def_id) => {
-                p!("the trait `", print_def_path(trait_def_id, &[]), "` is object-safe")
+            ty::PredicateKind::DynCompatible(trait_def_id) => {
+                p!("the trait `", print_def_path(trait_def_id, &[]), "` is dyn-compatible")
             }
             ty::PredicateKind::ConstEquate(c1, c2) => {
                 p!("the constant `", print(c1), "` equals `", print(c2), "`")

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1602,7 +1602,7 @@ impl<'tcx> ExplicitSelf<'tcx> {
     /// `Other`.
     /// This is mainly used to require the arbitrary_self_types feature
     /// in the case of `Other`, to improve error messages in the common cases,
-    /// and to make `Other` non-object-safe.
+    /// and to make `Other` dyn-incompatible.
     ///
     /// Examples:
     ///

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -120,7 +120,7 @@
 //! #### Unsizing Casts
 //! A subtle way of introducing use edges is by casting to a trait object.
 //! Since the resulting fat-pointer contains a reference to a vtable, we need to
-//! instantiate all object-safe methods of the trait, as we need to store
+//! instantiate all dyn-compatible methods of the trait, as we need to store
 //! pointers to these functions even if they never get called anywhere. This can
 //! be seen as a special case of taking a function reference.
 //!

--- a/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/assembly/mod.rs
@@ -639,8 +639,8 @@ where
             ty::Dynamic(bounds, ..) => bounds,
         };
 
-        // Do not consider built-in object impls for non-object-safe types.
-        if bounds.principal_def_id().is_some_and(|def_id| !cx.trait_is_object_safe(def_id)) {
+        // Do not consider built-in object impls for dyn-incompatible types.
+        if bounds.principal_def_id().is_some_and(|def_id| !cx.trait_is_dyn_compatible(def_id)) {
             return;
         }
 

--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -423,8 +423,8 @@ where
                 ty::PredicateKind::Coerce(predicate) => {
                     self.compute_coerce_goal(Goal { param_env, predicate })
                 }
-                ty::PredicateKind::ObjectSafe(trait_def_id) => {
-                    self.compute_object_safe_goal(trait_def_id)
+                ty::PredicateKind::DynCompatible(trait_def_id) => {
+                    self.compute_dyn_compatible_goal(trait_def_id)
                 }
                 ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(arg)) => {
                     self.compute_well_formed_goal(Goal { param_env, predicate: arg })

--- a/compiler/rustc_next_trait_solver/src/solve/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/mod.rs
@@ -111,8 +111,8 @@ where
         }
     }
 
-    fn compute_object_safe_goal(&mut self, trait_def_id: I::DefId) -> QueryResult<I> {
-        if self.cx().trait_is_object_safe(trait_def_id) {
+    fn compute_dyn_compatible_goal(&mut self, trait_def_id: I::DefId) -> QueryResult<I> {
+        if self.cx().trait_is_dyn_compatible(trait_def_id) {
             self.evaluate_added_goals_and_make_canonical_response(Certainty::Yes)
         } else {
             Err(NoSolution)

--- a/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/trait_goals.rs
@@ -832,8 +832,8 @@ where
         let cx = self.cx();
         let Goal { predicate: (a_ty, _), .. } = goal;
 
-        // Can only unsize to an object-safe trait.
-        if b_data.principal_def_id().is_some_and(|def_id| !cx.trait_is_object_safe(def_id)) {
+        // Can only unsize to an dyn-compatible trait.
+        if b_data.principal_def_id().is_some_and(|def_id| !cx.trait_is_dyn_compatible(def_id)) {
             return Err(NoSolution);
         }
 

--- a/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
+++ b/compiler/rustc_sanitizers/src/cfi/typeid/itanium_cxx_abi/transform.rs
@@ -475,7 +475,7 @@ fn implemented_method<'tcx>(
     } else {
         return None;
     };
-    let vtable_possible =
-        traits::is_vtable_safe_method(tcx, trait_id, trait_method) && tcx.is_object_safe(trait_id);
+    let vtable_possible = traits::is_vtable_safe_method(tcx, trait_id, trait_method)
+        && tcx.is_dyn_compatible(trait_id);
     vtable_possible.then_some((trait_ref, method_id, ancestor))
 }

--- a/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
@@ -632,8 +632,8 @@ impl<'tcx> Stable<'tcx> for ty::PredicateKind<'tcx> {
             PredicateKind::Clause(clause_kind) => {
                 stable_mir::ty::PredicateKind::Clause(clause_kind.stable(tables))
             }
-            PredicateKind::ObjectSafe(did) => {
-                stable_mir::ty::PredicateKind::ObjectSafe(tables.trait_def(*did))
+            PredicateKind::DynCompatible(did) => {
+                stable_mir::ty::PredicateKind::DynCompatible(tables.trait_def(*did))
             }
             PredicateKind::Subtype(subtype_predicate) => {
                 stable_mir::ty::PredicateKind::SubType(subtype_predicate.stable(tables))

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -37,7 +37,7 @@ use super::{
 };
 use crate::error_reporting::TypeErrCtxt;
 use crate::error_reporting::infer::TyCategory;
-use crate::error_reporting::traits::report_object_safety_error;
+use crate::error_reporting::traits::report_dyn_incompatibility;
 use crate::errors::{
     AsyncClosureNotFn, ClosureFnMutLabel, ClosureFnOnceLabel, ClosureKindMismatch,
 };
@@ -46,7 +46,7 @@ use crate::traits::query::evaluate_obligation::InferCtxtExt as _;
 use crate::traits::{
     MismatchedProjectionTypes, NormalizeExt, Obligation, ObligationCause, ObligationCauseCode,
     ObligationCtxt, Overflow, PredicateObligation, SelectionError, SignatureMismatch,
-    TraitNotObjectSafe, elaborate,
+    TraitDynIncompatible, elaborate,
 };
 
 impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
@@ -547,9 +547,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         )
                     }
 
-                    ty::PredicateKind::ObjectSafe(trait_def_id) => {
-                        let violations = self.tcx.object_safety_violations(trait_def_id);
-                        report_object_safety_error(self.tcx, span, None, trait_def_id, violations)
+                    ty::PredicateKind::DynCompatible(trait_def_id) => {
+                        let violations = self.tcx.dyn_compatibility_violations(trait_def_id);
+                        report_dyn_incompatibility(self.tcx, span, None, trait_def_id, violations)
                     }
 
                     ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(ty)) => {
@@ -624,9 +624,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 def_id,
             ),
 
-            TraitNotObjectSafe(did) => {
-                let violations = self.tcx.object_safety_violations(did);
-                report_object_safety_error(self.tcx, span, None, did, violations)
+            TraitDynIncompatible(did) => {
+                let violations = self.tcx.dyn_compatibility_violations(did);
+                report_dyn_incompatibility(self.tcx, span, None, did, violations)
             }
 
             SelectionError::NotConstEvaluatable(NotConstEvaluatable::MentionsInfer) => {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -12,8 +12,8 @@ use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::intravisit::Visitor;
 use rustc_hir::{self as hir, LangItem};
 use rustc_infer::traits::{
-    ObjectSafetyViolation, Obligation, ObligationCause, ObligationCauseCode, PredicateObligation,
-    SelectionError,
+    DynCompatibilityViolation, Obligation, ObligationCause, ObligationCauseCode,
+    PredicateObligation, SelectionError,
 };
 use rustc_middle::ty::print::{PrintTraitRefExt as _, with_no_trimmed_paths};
 use rustc_middle::ty::{self, Ty, TyCtxt};
@@ -406,12 +406,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     }
 }
 
-pub fn report_object_safety_error<'tcx>(
+pub fn report_dyn_incompatibility<'tcx>(
     tcx: TyCtxt<'tcx>,
     span: Span,
     hir_id: Option<hir::HirId>,
     trait_def_id: DefId,
-    violations: &[ObjectSafetyViolation],
+    violations: &[DynCompatibilityViolation],
 ) -> Diag<'tcx> {
     let trait_str = tcx.def_path_str(trait_def_id);
     let trait_span = tcx.hir().get_if_local(trait_def_id).and_then(|node| match node {
@@ -449,12 +449,12 @@ pub fn report_object_safety_error<'tcx>(
     let mut multi_span = vec![];
     let mut messages = vec![];
     for violation in violations {
-        if let ObjectSafetyViolation::SizedSelf(sp) = &violation
+        if let DynCompatibilityViolation::SizedSelf(sp) = &violation
             && !sp.is_empty()
         {
             // Do not report `SizedSelf` without spans pointing at `SizedSelf` obligations
             // with a `Span`.
-            reported_violations.insert(ObjectSafetyViolation::SizedSelf(vec![].into()));
+            reported_violations.insert(DynCompatibilityViolation::SizedSelf(vec![].into()));
         }
         if reported_violations.insert(violation.clone()) {
             let spans = violation.spans();
@@ -481,9 +481,10 @@ pub fn report_object_safety_error<'tcx>(
     for (span, msg) in iter::zip(multi_span, messages) {
         note_span.push_span_label(span, msg);
     }
+    // FIXME(dyn_compat_renaming): Update the URL.
     err.span_note(
         note_span,
-        "for a trait to be \"object safe\" it needs to allow building a vtable to allow the call \
+        "for a trait to be \"dyn-compatible\" it needs to allow building a vtable to allow the call \
          to be resolvable dynamically; for more information visit \
          <https://doc.rust-lang.org/reference/items/traits.html#object-safety>",
     );

--- a/compiler/rustc_trait_selection/src/solve/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/solve/fulfill.rs
@@ -275,7 +275,7 @@ fn fulfillment_error_for_no_solution<'tcx>(
             FulfillmentErrorCode::Subtype(expected_found, TypeError::Sorts(expected_found))
         }
         ty::PredicateKind::Clause(_)
-        | ty::PredicateKind::ObjectSafe(_)
+        | ty::PredicateKind::DynCompatible(_)
         | ty::PredicateKind::Ambiguous => {
             FulfillmentErrorCode::Select(SelectionError::Unimplemented)
         }

--- a/compiler/rustc_trait_selection/src/traits/auto_trait.rs
+++ b/compiler/rustc_trait_selection/src/traits/auto_trait.rs
@@ -802,7 +802,7 @@ impl<'tcx> AutoTraitFinder<'tcx> {
                 | ty::PredicateKind::Clause(ty::ClauseKind::ConstArgHasType(..))
                 | ty::PredicateKind::NormalizesTo(..)
                 | ty::PredicateKind::AliasRelate(..)
-                | ty::PredicateKind::ObjectSafe(..)
+                | ty::PredicateKind::DynCompatible(..)
                 | ty::PredicateKind::Subtype(..)
                 // FIXME(generic_const_exprs): you can absolutely add this as a where clauses
                 | ty::PredicateKind::Clause(ty::ClauseKind::ConstEvaluatable(..))

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -363,7 +363,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                 | ty::PredicateKind::Clause(ty::ClauseKind::TypeOutlives(_))
                 | ty::PredicateKind::Clause(ty::ClauseKind::ConstArgHasType(..))
                 | ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(_))
-                | ty::PredicateKind::ObjectSafe(_)
+                | ty::PredicateKind::DynCompatible(_)
                 | ty::PredicateKind::Subtype(_)
                 | ty::PredicateKind::Coerce(_)
                 | ty::PredicateKind::Clause(ty::ClauseKind::ConstEvaluatable(..))
@@ -418,8 +418,8 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                     )
                 }
 
-                ty::PredicateKind::ObjectSafe(trait_def_id) => {
-                    if !self.selcx.tcx().is_object_safe(trait_def_id) {
+                ty::PredicateKind::DynCompatible(trait_def_id) => {
+                    if !self.selcx.tcx().is_dyn_compatible(trait_def_id) {
                         ProcessResult::Error(FulfillmentErrorCode::Select(Unimplemented))
                     } else {
                         ProcessResult::Changed(vec![])

--- a/compiler/rustc_trait_selection/src/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/mod.rs
@@ -5,11 +5,11 @@
 pub mod auto_trait;
 pub(crate) mod coherence;
 pub mod const_evaluatable;
+mod dyn_compatibility;
 mod engine;
 mod fulfill;
 pub mod misc;
 pub mod normalize;
-mod object_safety;
 pub mod outlives_bounds;
 pub mod project;
 pub mod query;
@@ -43,13 +43,13 @@ pub use self::coherence::{
     InCrate, IsFirstInputType, OrphanCheckErr, OrphanCheckMode, OverlapResult, UncoveredTyParams,
     add_placeholder_note, orphan_check_trait_ref, overlapping_impls,
 };
+pub use self::dyn_compatibility::{
+    DynCompatibilityViolation, dyn_compatibility_violations_for_assoc_item,
+    hir_ty_lowering_dyn_compatibility_violations, is_vtable_safe_method,
+};
 pub use self::engine::{ObligationCtxt, TraitEngineExt};
 pub use self::fulfill::{FulfillmentContext, OldSolverError, PendingPredicateObligation};
 pub use self::normalize::NormalizeExt;
-pub use self::object_safety::{
-    ObjectSafetyViolation, hir_ty_lowering_object_safety_violations, is_vtable_safe_method,
-    object_safety_violations_for_assoc_item,
-};
 pub use self::project::{normalize_inherent_projection, normalize_projection_ty};
 pub use self::select::{
     EvaluationCache, EvaluationResult, IntercrateAmbiguityCause, OverflowError, SelectionCache,
@@ -593,7 +593,7 @@ fn is_impossible_associated_item(
 }
 
 pub fn provide(providers: &mut Providers) {
-    object_safety::provide(providers);
+    dyn_compatibility::provide(providers);
     vtable::provide(providers);
     *providers = Providers {
         specialization_graph_of: specialize::specialization_graph_provider,

--- a/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/type_op/implied_outlives_bounds.rs
@@ -113,7 +113,7 @@ pub fn compute_implied_outlives_bounds_inner<'tcx>(
                 | ty::PredicateKind::Subtype(..)
                 | ty::PredicateKind::Coerce(..)
                 | ty::PredicateKind::Clause(ty::ClauseKind::Projection(..))
-                | ty::PredicateKind::ObjectSafe(..)
+                | ty::PredicateKind::DynCompatible(..)
                 | ty::PredicateKind::Clause(ty::ClauseKind::ConstEvaluatable(..))
                 | ty::PredicateKind::ConstEquate(..)
                 | ty::PredicateKind::Ambiguous
@@ -217,7 +217,7 @@ pub fn compute_implied_outlives_bounds_compat_inner<'tcx>(
                 | ty::PredicateKind::Subtype(..)
                 | ty::PredicateKind::Coerce(..)
                 | ty::PredicateKind::Clause(ty::ClauseKind::Projection(..))
-                | ty::PredicateKind::ObjectSafe(..)
+                | ty::PredicateKind::DynCompatible(..)
                 | ty::PredicateKind::Clause(ty::ClauseKind::ConstEvaluatable(..))
                 | ty::PredicateKind::ConstEquate(..)
                 | ty::PredicateKind::Ambiguous

--- a/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/candidate_assembly.rs
@@ -883,7 +883,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         if let Some(principal) = data.principal() {
                             if !self.infcx.tcx.features().object_safe_for_dispatch {
                                 principal.with_self_ty(self.tcx(), self_ty)
-                            } else if self.tcx().is_object_safe(principal.def_id()) {
+                            } else if self.tcx().is_dyn_compatible(principal.def_id()) {
                                 principal.with_self_ty(self.tcx(), self_ty)
                             } else {
                                 return;

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -772,8 +772,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                     Ok(EvaluatedToOkModuloRegions)
                 }
 
-                ty::PredicateKind::ObjectSafe(trait_def_id) => {
-                    if self.tcx().is_object_safe(trait_def_id) {
+                ty::PredicateKind::DynCompatible(trait_def_id) => {
+                    if self.tcx().is_dyn_compatible(trait_def_id) {
                         Ok(EvaluatedToOk)
                     } else {
                         Ok(EvaluatedToErr)

--- a/compiler/rustc_trait_selection/src/traits/wf.rs
+++ b/compiler/rustc_trait_selection/src/traits/wf.rs
@@ -838,7 +838,7 @@ impl<'a, 'tcx> TypeVisitor<TyCtxt<'tcx>> for WfPredicates<'a, 'tcx> {
                             self.cause(ObligationCauseCode::WellFormed(None)),
                             self.recursion_depth,
                             self.param_env,
-                            ty::Binder::dummy(ty::PredicateKind::ObjectSafe(principal)),
+                            ty::Binder::dummy(ty::PredicateKind::DynCompatible(principal)),
                         ));
                     }
                 }

--- a/compiler/rustc_traits/src/normalize_erasing_regions.rs
+++ b/compiler/rustc_traits/src/normalize_erasing_regions.rs
@@ -59,7 +59,7 @@ fn not_outlives_predicate(p: ty::Predicate<'_>) -> bool {
         | ty::PredicateKind::NormalizesTo(..)
         | ty::PredicateKind::AliasRelate(..)
         | ty::PredicateKind::Clause(ty::ClauseKind::WellFormed(..))
-        | ty::PredicateKind::ObjectSafe(..)
+        | ty::PredicateKind::DynCompatible(..)
         | ty::PredicateKind::Subtype(..)
         | ty::PredicateKind::Coerce(..)
         | ty::PredicateKind::Clause(ty::ClauseKind::ConstEvaluatable(..))

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -255,7 +255,7 @@ pub trait Interner:
 
     fn trait_is_alias(self, trait_def_id: Self::DefId) -> bool;
 
-    fn trait_is_object_safe(self, trait_def_id: Self::DefId) -> bool;
+    fn trait_is_dyn_compatible(self, trait_def_id: Self::DefId) -> bool;
 
     fn trait_is_fundamental(self, def_id: Self::DefId) -> bool;
 

--- a/compiler/rustc_type_ir/src/predicate_kind.rs
+++ b/compiler/rustc_type_ir/src/predicate_kind.rs
@@ -46,8 +46,8 @@ pub enum PredicateKind<I: Interner> {
     /// Prove a clause
     Clause(ClauseKind<I>),
 
-    /// Trait must be object-safe.
-    ObjectSafe(I::DefId),
+    /// Trait must be dyn-compatible.
+    DynCompatible(I::DefId),
 
     /// `T1 <: T2`
     ///
@@ -128,8 +128,8 @@ impl<I: Interner> fmt::Debug for PredicateKind<I> {
             PredicateKind::Clause(a) => a.fmt(f),
             PredicateKind::Subtype(pair) => pair.fmt(f),
             PredicateKind::Coerce(pair) => pair.fmt(f),
-            PredicateKind::ObjectSafe(trait_def_id) => {
-                write!(f, "ObjectSafe({trait_def_id:?})")
+            PredicateKind::DynCompatible(trait_def_id) => {
+                write!(f, "DynCompatible({trait_def_id:?})")
             }
             PredicateKind::ConstEquate(c1, c2) => write!(f, "ConstEquate({c1:?}, {c2:?})"),
             PredicateKind::Ambiguous => write!(f, "Ambiguous"),

--- a/compiler/stable_mir/src/ty.rs
+++ b/compiler/stable_mir/src/ty.rs
@@ -1420,7 +1420,7 @@ pub struct GenericPredicates {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum PredicateKind {
     Clause(ClauseKind),
-    ObjectSafe(TraitDef),
+    DynCompatible(TraitDef),
     SubType(SubtypePredicate),
     Coerce(CoercePredicate),
     ConstEquate(TyConst, TyConst),

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1444,7 +1444,7 @@ impl Trait {
         tcx.trait_def(self.def_id).safety
     }
     pub(crate) fn is_object_safe(&self, tcx: TyCtxt<'_>) -> bool {
-        tcx.is_object_safe(self.def_id)
+        tcx.is_dyn_compatible(self.def_id)
     }
 }
 

--- a/tests/rustdoc-ui/invalid_const_in_lifetime_position.stderr
+++ b/tests/rustdoc-ui/invalid_const_in_lifetime_position.stderr
@@ -98,7 +98,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL | fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
    |                    ^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/invalid_const_in_lifetime_position.rs:2:10
    |
 LL | trait X {

--- a/tests/rustdoc-ui/issues/issue-105742.stderr
+++ b/tests/rustdoc-ui/issues/issue-105742.stderr
@@ -300,7 +300,7 @@ error[E0038]: the trait `SVec` cannot be made into an object
 LL | pub fn next<'a, T>(s: &'a mut dyn SVec<Item = T, Output = T>) {
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SVec` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-105742.rs:14:17
    |
 LL |    pub trait SVec: Index<

--- a/tests/ui/associated-consts/associated-const-in-trait.stderr
+++ b/tests/ui/associated-consts/associated-const-in-trait.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | impl dyn Trait {
    |      ^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/associated-const-in-trait.rs:4:11
    |
 LL | trait Trait {
@@ -19,7 +19,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL |     const fn n() -> usize { Self::N }
    |                             ^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/associated-const-in-trait.rs:4:11
    |
 LL | trait Trait {

--- a/tests/ui/associated-item/issue-48027.stderr
+++ b/tests/ui/associated-item/issue-48027.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | impl dyn Bar {}
    |      ^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-48027.rs:2:11
    |
 LL | trait Bar {

--- a/tests/ui/associated-type-bounds/suggest-assoc-ty-bound-on-eq-bound.stderr
+++ b/tests/ui/associated-type-bounds/suggest-assoc-ty-bound-on-eq-bound.stderr
@@ -5,7 +5,7 @@ LL | fn f(_: impl Trait<T = Copy>) {}
    |                    ^^^^^^^^ `Copy` cannot be made into an object
    |
    = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
 error[E0225]: only auto traits can be used as additional traits in a trait object
   --> $DIR/suggest-assoc-ty-bound-on-eq-bound.rs:10:42
@@ -24,7 +24,7 @@ error[E0038]: the trait `Eq` cannot be made into an object
 LL | fn g(_: impl Trait<T = std::fmt::Debug + Eq>) {}
    |                        ^^^^^^^^^^^^^^^^^^^^ `Eq` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: the trait cannot be made into an object because it uses `Self` as a type parameter

--- a/tests/ui/async-await/async-fn/dyn-pos.stderr
+++ b/tests/ui/async-await/async-fn/dyn-pos.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `AsyncFnMut` cannot be made into an object
 LL | fn foo(x: &dyn async Fn()) {}
    |                ^^^^^^^^^^ `AsyncFnMut` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/ops/async_function.rs:LL:COL
    |
    = note: the trait cannot be made into an object because it contains the generic associated type `CallRefFuture`
@@ -19,7 +19,7 @@ error[E0038]: the trait `AsyncFnMut` cannot be made into an object
 LL | fn foo(x: &dyn async Fn()) {}
    |                ^^^^^^^^^^ `AsyncFnMut` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/ops/async_function.rs:LL:COL
    |
    = note: the trait cannot be made into an object because it contains the generic associated type `CallRefFuture`
@@ -35,7 +35,7 @@ error[E0038]: the trait `AsyncFnMut` cannot be made into an object
 LL | fn foo(x: &dyn async Fn()) {}
    |                ^^^^^^^^^^ `AsyncFnMut` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/ops/async_function.rs:LL:COL
    |
    = note: the trait cannot be made into an object because it contains the generic associated type `CallRefFuture`
@@ -51,7 +51,7 @@ error[E0038]: the trait `AsyncFn` cannot be made into an object
 LL | fn foo(x: &dyn async Fn()) {}
    |            ^^^^^^^^^^^^^^ `AsyncFn` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/ops/async_function.rs:LL:COL
    |
    = note: the trait cannot be made into an object because it contains the generic associated type `CallRefFuture`

--- a/tests/ui/async-await/in-trait/object-safety.stderr
+++ b/tests/ui/async-await/in-trait/object-safety.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let x: &dyn Foo = todo!();
    |            ^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety.rs:5:14
    |
 LL | trait Foo {

--- a/tests/ui/async-await/inference_var_self_argument.stderr
+++ b/tests/ui/async-await/inference_var_self_argument.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     async fn foo(self: &dyn Foo) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/inference_var_self_argument.rs:5:14
    |
 LL | trait Foo {

--- a/tests/ui/coherence/coherence-impl-trait-for-trait-object-safe.stderr
+++ b/tests/ui/coherence/coherence-impl-trait-for-trait-object-safe.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `NotObjectSafe` cannot be made into an object
 LL | impl NotObjectSafe for dyn NotObjectSafe { }
    |                        ^^^^^^^^^^^^^^^^^ `NotObjectSafe` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/coherence-impl-trait-for-trait-object-safe.rs:6:43
    |
 LL | trait NotObjectSafe { fn eq(&self, other: Self); }

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_object_safety.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_object_safety.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `ConstParamTy_` cannot be made into an object
 LL | fn foo(a: &dyn ConstParamTy_) {}
    |            ^^^^^^^^^^^^^^^^^ `ConstParamTy_` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: the trait cannot be made into an object because it uses `Self` as a type parameter
@@ -19,7 +19,7 @@ error[E0038]: the trait `UnsizedConstParamTy` cannot be made into an object
 LL | fn bar(a: &dyn UnsizedConstParamTy) {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^ `UnsizedConstParamTy` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: the trait cannot be made into an object because it uses `Self` as a type parameter

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
@@ -98,7 +98,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
    |                        ^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-102768.rs:5:10
    |
 LL | trait X {

--- a/tests/ui/const-generics/generic_const_exprs/object-safety-err-ret.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/object-safety-err-ret.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | fn use_dyn(v: &dyn Foo) {
    |                ^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-err-ret.rs:8:8
    |
 LL | trait Foo {
@@ -22,7 +22,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     v.test();
    |     ^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-err-ret.rs:8:8
    |
 LL | trait Foo {

--- a/tests/ui/const-generics/generic_const_exprs/object-safety-err-where-bounds.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/object-safety-err-where-bounds.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | fn use_dyn(v: &dyn Foo) {
    |                ^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-err-where-bounds.rs:8:8
    |
 LL | trait Foo {
@@ -20,7 +20,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     v.test();
    |     ^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-err-where-bounds.rs:8:8
    |
 LL | trait Foo {

--- a/tests/ui/const-generics/not_wf_param_in_rpitit.stderr
+++ b/tests/ui/const-generics/not_wf_param_in_rpitit.stderr
@@ -24,7 +24,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | trait Trait<const N: Trait = bar> {
    |                      ^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/not_wf_param_in_rpitit.rs:11:14
    |
 LL | trait Trait<const N: Trait = bar> {
@@ -47,7 +47,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | trait Trait<const N: Trait = bar> {
    |             ^^^^^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/not_wf_param_in_rpitit.rs:11:14
    |
 LL | trait Trait<const N: Trait = bar> {
@@ -78,7 +78,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | trait Trait<const N: Trait = bar> {
    |             ^^^^^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/not_wf_param_in_rpitit.rs:11:14
    |
 LL | trait Trait<const N: Trait = bar> {

--- a/tests/ui/consts/const_refs_to_static-ice-121413.rs
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.rs
@@ -12,7 +12,7 @@ const REF_INTERIOR_MUT: &usize = {
     //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
     //~| ERROR the size for values of type `(dyn Sync + 'static)` cannot be known at compilation time
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-    //~| HELP if this is an object-safe trait, use `dyn`
+    //~| HELP if this is a dyn-compatible trait, use `dyn`
     //~| HELP the trait `Sized` is not implemented for `(dyn Sync + 'static)`
     //~| HELP the trait `Sized` is not implemented for `(dyn Sync + 'static)`
     unsafe { &*(&FOO as *const _ as *const usize) }

--- a/tests/ui/consts/const_refs_to_static-ice-121413.stderr
+++ b/tests/ui/consts/const_refs_to_static-ice-121413.stderr
@@ -18,7 +18,7 @@ LL |     static FOO: Sync = AtomicUsize::new(0);
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     static FOO: dyn Sync = AtomicUsize::new(0);
    |                 +++

--- a/tests/ui/did_you_mean/bad-assoc-ty.stderr
+++ b/tests/ui/did_you_mean/bad-assoc-ty.stderr
@@ -182,7 +182,7 @@ LL | type H = Fn(u8) -> (u8)::Output;
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | type H = <dyn Fn(u8) -> (u8)>::Output;
    |          ++++               +

--- a/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
+++ b/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
@@ -27,7 +27,7 @@ LL |     let _: &Copy + 'static;
    |            ^^^^^ `Copy` cannot be made into an object
    |
    = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/dyn-keyword/dyn-2018-edition-lint.stderr
+++ b/tests/ui/dyn-keyword/dyn-2018-edition-lint.stderr
@@ -11,7 +11,7 @@ note: the lint level is defined here
    |
 LL | #[deny(bare_trait_objects)]
    |        ^^^^^^^^^^^^^^^^^^
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn function(x: &dyn SomeTrait, y: Box<SomeTrait>) {
    |                 +++
@@ -24,7 +24,7 @@ LL | fn function(x: &SomeTrait, y: Box<SomeTrait>) {
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn function(x: &SomeTrait, y: Box<dyn SomeTrait>) {
    |                                   +++
@@ -37,7 +37,7 @@ LL |     let _x: &SomeTrait = todo!();
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _x: &dyn SomeTrait = todo!();
    |              +++

--- a/tests/ui/dyn-keyword/dyn-angle-brackets.stderr
+++ b/tests/ui/dyn-keyword/dyn-angle-brackets.stderr
@@ -11,7 +11,7 @@ note: the lint level is defined here
    |
 LL | #![deny(bare_trait_objects)]
    |         ^^^^^^^^^^^^^^^^^^
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |         <dyn fmt::Debug>::fmt(self, f)
    |          +++

--- a/tests/ui/error-codes/E0038.stderr
+++ b/tests/ui/error-codes/E0038.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | fn call_foo(x: Box<dyn Trait>) {
    |                    ^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/E0038.rs:2:22
    |
 LL | trait Trait {
@@ -19,7 +19,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL |     let y = x.foo();
    |             ^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/E0038.rs:2:22
    |
 LL | trait Trait {

--- a/tests/ui/errors/dynless-turbofish-e0191-issue-91997.stderr
+++ b/tests/ui/errors/dynless-turbofish-e0191-issue-91997.stderr
@@ -7,7 +7,7 @@ LL |     let _ = MyIterator::next;
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _ = <dyn MyIterator>::next;
    |             ++++           +

--- a/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.stderr
+++ b/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.stderr
@@ -7,7 +7,7 @@ LL |     fn ptr(self: Ptr<Self>);
 LL |     Ptr(Box::new(4)) as Ptr<dyn Trait>;
    |                         ^^^^^^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:25:18
    |
 LL | trait Trait {
@@ -25,7 +25,7 @@ LL |     fn ptr(self: Ptr<Self>);
 LL |     Ptr(Box::new(4)) as Ptr<dyn Trait>;
    |     ^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:25:18
    |
 LL | trait Trait {

--- a/tests/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
+++ b/tests/ui/feature-gates/feature-gate-object_safe_for_dispatch.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `NonObjectSafe1` cannot be made into an object
 LL | fn takes_non_object_safe_ref<T>(obj: &dyn NonObjectSafe1) {
    |                                       ^^^^^^^^^^^^^^^^^^ `NonObjectSafe1` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:4:23
    |
 LL | trait NonObjectSafe1: Sized {}
@@ -18,7 +18,7 @@ error[E0038]: the trait `NonObjectSafe2` cannot be made into an object
 LL | fn return_non_object_safe_ref() -> &'static dyn NonObjectSafe2 {
    |                                             ^^^^^^^^^^^^^^^^^^ `NonObjectSafe2` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:7:8
    |
 LL | trait NonObjectSafe2 {
@@ -40,7 +40,7 @@ error[E0038]: the trait `NonObjectSafe3` cannot be made into an object
 LL | fn takes_non_object_safe_box(obj: Box<dyn NonObjectSafe3>) {
    |                                       ^^^^^^^^^^^^^^^^^^ `NonObjectSafe3` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:11:8
    |
 LL | trait NonObjectSafe3 {
@@ -55,7 +55,7 @@ error[E0038]: the trait `NonObjectSafe4` cannot be made into an object
 LL | fn return_non_object_safe_rc() -> std::rc::Rc<dyn NonObjectSafe4> {
    |                                               ^^^^^^^^^^^^^^^^^^ `NonObjectSafe4` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:15:22
    |
 LL | trait NonObjectSafe4 {
@@ -70,7 +70,7 @@ error[E0038]: the trait `NonObjectSafe1` cannot be made into an object
 LL | impl Trait for dyn NonObjectSafe1 {}
    |                ^^^^^^^^^^^^^^^^^^ `NonObjectSafe1` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-object_safe_for_dispatch.rs:4:23
    |
 LL | trait NonObjectSafe1: Sized {}

--- a/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.stderr
@@ -42,7 +42,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:2:8
    |
 LL | trait X {

--- a/tests/ui/generic-associated-types/gat-in-trait-path.base.stderr
+++ b/tests/ui/generic-associated-types/gat-in-trait-path.base.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | fn f(_arg : Box<dyn for<'a> Foo<A<'a> = &'a ()>>) {}
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-in-trait-path.rs:10:10
    |
 LL | trait Foo {
@@ -22,7 +22,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |   f(Box::new(foo));
    |     ^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-in-trait-path.rs:10:10
    |
 LL | trait Foo {
@@ -40,7 +40,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |   f(Box::new(foo));
    |     ^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-in-trait-path.rs:10:10
    |
 LL | trait Foo {

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
@@ -129,7 +129,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
    |                     ^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
    |
 LL | trait X {
@@ -194,7 +194,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
    |                     ^^^^^^^^^^^^^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
    |
 LL | trait X {

--- a/tests/ui/generic-associated-types/issue-67510-pass.base.stderr
+++ b/tests/ui/generic-associated-types/issue-67510-pass.base.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL | fn _func1<'a>(_x: Box<dyn X<Y<'a>=&'a ()>>) {}
    |                       ^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-67510-pass.rs:9:10
    |
 LL | trait X {

--- a/tests/ui/generic-associated-types/issue-67510.stderr
+++ b/tests/ui/generic-associated-types/issue-67510.stderr
@@ -35,7 +35,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL | fn f(x: Box<dyn X<Y<'a> = &'a ()>>) {}
    |             ^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-67510.rs:2:10
    |
 LL | trait X {

--- a/tests/ui/generic-associated-types/issue-71176.stderr
+++ b/tests/ui/generic-associated-types/issue-71176.stderr
@@ -54,7 +54,7 @@ error[E0038]: the trait `Provider` cannot be made into an object
 LL |   inner: Box<dyn Provider<A = B>>,
    |              ^^^^^^^^^^^^^^^^^^^ `Provider` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-71176.rs:2:10
    |
 LL | trait Provider {
@@ -70,7 +70,7 @@ error[E0038]: the trait `Provider` cannot be made into an object
 LL |         inner: Box::new(()),
    |                ^^^^^^^^^^^^ `Provider` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-71176.rs:2:10
    |
 LL | trait Provider {

--- a/tests/ui/generic-associated-types/issue-76535.base.stderr
+++ b/tests/ui/generic-associated-types/issue-76535.base.stderr
@@ -20,7 +20,7 @@ error[E0038]: the trait `SuperTrait` cannot be made into an object
 LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-76535.rs:9:10
    |
 LL | pub trait SuperTrait {
@@ -37,7 +37,7 @@ error[E0038]: the trait `SuperTrait` cannot be made into an object
 LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
    |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-76535.rs:9:10
    |
 LL | pub trait SuperTrait {

--- a/tests/ui/generic-associated-types/issue-78671.base.stderr
+++ b/tests/ui/generic-associated-types/issue-78671.base.stderr
@@ -20,7 +20,7 @@ error[E0038]: the trait `CollectionFamily` cannot be made into an object
 LL |     Box::new(Family) as &dyn CollectionFamily<Member=usize>
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CollectionFamily` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-78671.rs:7:10
    |
 LL | trait CollectionFamily {

--- a/tests/ui/generic-associated-types/issue-79422.base.stderr
+++ b/tests/ui/generic-associated-types/issue-79422.base.stderr
@@ -20,7 +20,7 @@ error[E0038]: the trait `MapLike` cannot be made into an object
 LL |         as Box<dyn MapLike<u8, u8, VRefCont = dyn RefCont<'_, u8>>>;
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-79422.rs:23:10
    |
 LL | trait MapLike<K, V> {
@@ -38,7 +38,7 @@ error[E0038]: the trait `MapLike` cannot be made into an object
 LL |     let m = Box::new(std::collections::BTreeMap::<u8, u8>::new())
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-79422.rs:23:10
    |
 LL | trait MapLike<K, V> {

--- a/tests/ui/generic-associated-types/missing_lifetime_args.stderr
+++ b/tests/ui/generic-associated-types/missing_lifetime_args.stderr
@@ -54,7 +54,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/missing_lifetime_args.rs:2:10
    |
 LL | trait X {

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
@@ -98,7 +98,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
    |                       ^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/trait-path-type-error-once-implemented.rs:2:10
    |
 LL | trait X {

--- a/tests/ui/generic-associated-types/trait-objects.base.stderr
+++ b/tests/ui/generic-associated-types/trait-objects.base.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `StreamingIterator` cannot be made into an object
 LL | fn min_size(x: &mut dyn for<'a> StreamingIterator<Item<'a> = &'a i32>) -> usize {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `StreamingIterator` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/trait-objects.rs:7:10
    |
 LL | trait StreamingIterator {
@@ -19,7 +19,7 @@ error[E0038]: the trait `StreamingIterator` cannot be made into an object
 LL |     x.size_hint().0
    |       ^^^^^^^^^ `StreamingIterator` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/trait-objects.rs:7:10
    |
 LL | trait StreamingIterator {
@@ -34,7 +34,7 @@ error[E0038]: the trait `StreamingIterator` cannot be made into an object
 LL |     x.size_hint().0
    |     ^^^^^^^^^^^^^ `StreamingIterator` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/trait-objects.rs:7:10
    |
 LL | trait StreamingIterator {

--- a/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let x: &dyn Foo = &();
    |                       ^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/span-bug-issue-121597.rs:4:12
    |
 LL | trait Foo: for<T> Bar<T> {}
@@ -19,7 +19,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let x: &dyn Foo = &();
    |            ^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/span-bug-issue-121597.rs:4:12
    |
 LL | trait Foo: for<T> Bar<T> {}

--- a/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
+++ b/tests/ui/impl-trait/fresh-lifetime-from-bare-trait-obj-114664.stderr
@@ -7,7 +7,7 @@ LL | fn ice() -> impl AsRef<Fn(&())> {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn ice() -> impl AsRef<dyn Fn(&())> {
    |                        +++
@@ -21,7 +21,7 @@ LL | fn ice() -> impl AsRef<Fn(&())> {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn ice() -> impl AsRef<dyn Fn(&())> {
    |                        +++

--- a/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-object-safety.stderr
+++ b/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-object-safety.stderr
@@ -14,7 +14,7 @@ error[E0038]: the trait `MyTrait` cannot be made into an object
 LL |         MyTrait::foo(&self)
    |         ^^^^^^^^^^^^ `MyTrait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/cycle-effective-visibilities-during-object-safety.rs:5:22
    |
 LL | trait MyTrait {
@@ -38,7 +38,7 @@ error[E0038]: the trait `MyTrait` cannot be made into an object
 LL | impl dyn MyTrait {
    |      ^^^^^^^^^^^ `MyTrait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/cycle-effective-visibilities-during-object-safety.rs:5:22
    |
 LL | trait MyTrait {
@@ -54,7 +54,7 @@ error[E0038]: the trait `MyTrait` cannot be made into an object
 LL |     fn other(&self) -> impl Marker {
    |               ^^^^ `MyTrait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/cycle-effective-visibilities-during-object-safety.rs:5:22
    |
 LL | trait MyTrait {

--- a/tests/ui/impl-trait/in-trait/foreign-dyn-error.stderr
+++ b/tests/ui/impl-trait/in-trait/foreign-dyn-error.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let _: &dyn rpitit::Foo = todo!();
    |            ^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/auxiliary/rpitit.rs:4:21
    |
 LL |     fn bar(self) -> impl Deref<Target = impl Sized>;

--- a/tests/ui/impl-trait/in-trait/object-safety.stderr
+++ b/tests/ui/impl-trait/in-trait/object-safety.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let i = Box::new(42_u32) as Box<dyn Foo>;
    |                                 ^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety.rs:4:22
    |
 LL | trait Foo {
@@ -20,7 +20,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let s = i.baz();
    |               ^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety.rs:4:22
    |
 LL | trait Foo {
@@ -36,7 +36,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let s = i.baz();
    |             ^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety.rs:4:22
    |
 LL | trait Foo {
@@ -52,7 +52,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let i = Box::new(42_u32) as Box<dyn Foo>;
    |             ^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety.rs:4:22
    |
 LL | trait Foo {

--- a/tests/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
+++ b/tests/ui/impl-trait/object-unsafe-trait-in-return-position-dyn-trait.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `NotObjectSafe` cannot be made into an object
 LL | fn car() -> dyn NotObjectSafe {
    |             ^^^^^^^^^^^^^^^^^ `NotObjectSafe` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:3:8
    |
 LL | trait NotObjectSafe {
@@ -29,7 +29,7 @@ error[E0038]: the trait `NotObjectSafe` cannot be made into an object
 LL | fn cat() -> Box<dyn NotObjectSafe> {
    |                 ^^^^^^^^^^^^^^^^^ `NotObjectSafe` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:3:8
    |
 LL | trait NotObjectSafe {
@@ -71,7 +71,7 @@ error[E0038]: the trait `NotObjectSafe` cannot be made into an object
 LL |         return Box::new(A);
    |                ^^^^^^^^^^^ `NotObjectSafe` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:3:8
    |
 LL | trait NotObjectSafe {
@@ -97,7 +97,7 @@ error[E0038]: the trait `NotObjectSafe` cannot be made into an object
 LL |     Box::new(B)
    |     ^^^^^^^^^^^ `NotObjectSafe` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-in-return-position-dyn-trait.rs:3:8
    |
 LL | trait NotObjectSafe {

--- a/tests/ui/issues/issue-18959.stderr
+++ b/tests/ui/issues/issue-18959.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | fn foo(b: &dyn Bar) {
    |            ^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-18959.rs:1:20
    |
 LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
@@ -19,7 +19,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     b.foo(&0)
    |     ^^^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-18959.rs:1:20
    |
 LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
@@ -34,7 +34,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     let test: &dyn Bar = &mut thing;
    |               ^^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-18959.rs:1:20
    |
 LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
@@ -49,7 +49,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     let test: &dyn Bar = &mut thing;
    |                          ^^^^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-18959.rs:1:20
    |
 LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
@@ -65,7 +65,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     foo(test);
    |         ^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-18959.rs:1:20
    |
 LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }

--- a/tests/ui/issues/issue-19380.stderr
+++ b/tests/ui/issues/issue-19380.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Qiz` cannot be made into an object
 LL |   foos: &'static [&'static (dyn Qiz + 'static)]
    |                             ^^^^^^^^^^^^^^^^^ `Qiz` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-19380.rs:2:6
    |
 LL | trait Qiz {
@@ -27,7 +27,7 @@ error[E0038]: the trait `Qiz` cannot be made into an object
 LL | const BAR : Bar = Bar { foos: &[&FOO]};
    |                                 ^^^^ `Qiz` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-19380.rs:2:6
    |
 LL | trait Qiz {
@@ -51,7 +51,7 @@ error[E0038]: the trait `Qiz` cannot be made into an object
 LL | const BAR : Bar = Bar { foos: &[&FOO]};
    |                               ^^^^^^^ `Qiz` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-19380.rs:2:6
    |
 LL | trait Qiz {

--- a/tests/ui/issues/issue-26056.stderr
+++ b/tests/ui/issues/issue-26056.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Map` cannot be made into an object
 LL |         as &dyn Map<Key=u32,MapValue=u32>;
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Map` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-26056.rs:9:12
    |
 LL | trait Map: MapLookup<<Self as Map>::Key> {

--- a/tests/ui/issues/issue-28344.stderr
+++ b/tests/ui/issues/issue-28344.stderr
@@ -7,7 +7,7 @@ LL |     let x: u8 = BitXor::bitor(0 as u8, 0 as u8);
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let x: u8 = <dyn BitXor>::bitor(0 as u8, 0 as u8);
    |                 ++++       +
@@ -35,7 +35,7 @@ LL |     let g = BitXor::bitor;
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let g = <dyn BitXor>::bitor;
    |             ++++       +

--- a/tests/ui/issues/issue-34373.stderr
+++ b/tests/ui/issues/issue-34373.stderr
@@ -23,7 +23,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | pub struct Foo<T = Box<Trait<DefaultFoo>>>;
    |                        ^^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-34373.rs:4:8
    |
 LL | trait Trait<T> {

--- a/tests/ui/issues/issue-50781.stderr
+++ b/tests/ui/issues/issue-50781.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL | impl Trait for dyn X {}
    |                ^^^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-50781.rs:4:8
    |
 LL | trait X {
@@ -20,7 +20,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL |     <dyn X as X>::foo(&());
    |                       ^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-50781.rs:4:8
    |
 LL | trait X {
@@ -37,7 +37,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL |     <dyn X as X>::foo(&());
    |      ^^^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-50781.rs:4:8
    |
 LL | trait X {

--- a/tests/ui/issues/issue-58734.stderr
+++ b/tests/ui/issues/issue-58734.stderr
@@ -7,7 +7,7 @@ LL |     Trait::nonexistent(());
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     <dyn Trait>::nonexistent(());
    |     ++++      +

--- a/tests/ui/issues/issue-86756.stderr
+++ b/tests/ui/issues/issue-86756.stderr
@@ -21,7 +21,7 @@ LL |     eq::<dyn, Foo>
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     eq::<dyn, dyn Foo>
    |               +++

--- a/tests/ui/kindck/kindck-inherited-copy-bound.curr.stderr
+++ b/tests/ui/kindck/kindck-inherited-copy-bound.curr.stderr
@@ -25,7 +25,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let z = &x as &dyn Foo;
    |                   ^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/kindck-inherited-copy-bound.rs:10:13
    |
 LL | trait Foo : Copy {
@@ -39,7 +39,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let z = &x as &dyn Foo;
    |             ^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/kindck-inherited-copy-bound.rs:10:13
    |
 LL | trait Foo : Copy {

--- a/tests/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
+++ b/tests/ui/kindck/kindck-inherited-copy-bound.object_safe_for_dispatch.stderr
@@ -25,7 +25,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let z = &x as &dyn Foo;
    |             ^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/kindck-inherited-copy-bound.rs:10:13
    |
 LL | trait Foo : Copy {

--- a/tests/ui/lint/bare-trait-objects-path.stderr
+++ b/tests/ui/lint/bare-trait-objects-path.stderr
@@ -7,7 +7,7 @@ LL |     let _: Dyn::Ty;
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _: <dyn Dyn>::Ty;
    |            ++++    +
@@ -26,7 +26,7 @@ LL |     Dyn::func();
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     <dyn Dyn>::func();
    |     ++++    +
@@ -39,7 +39,7 @@ LL |     ::Dyn::func();
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     <dyn (::Dyn)>::func();
    |     ++++++     ++
@@ -52,7 +52,7 @@ LL |     Dyn::CONST;
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     <dyn Dyn>::CONST;
    |     ++++    +

--- a/tests/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/allowed-group-warn-by-default-lint.stderr
@@ -7,7 +7,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: requested on the command line with `--force-warn bare-trait-objects`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
    |                         +++

--- a/tests/ui/lint/force-warn/cap-lints-allow.stderr
+++ b/tests/ui/lint/force-warn/cap-lints-allow.stderr
@@ -7,7 +7,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: requested on the command line with `--force-warn bare-trait-objects`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
    |                         +++

--- a/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-cli-warn-by-default-lint.stderr
@@ -7,7 +7,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
    |                         +++

--- a/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-lint-group.stderr
@@ -7,7 +7,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
    |                         +++

--- a/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
+++ b/tests/ui/lint/force-warn/lint-group-allowed-warn-by-default-lint.stderr
@@ -7,7 +7,7 @@ LL | pub fn function(_x: Box<SomeTrait>) {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `--force-warn bare-trait-objects` implied by `--force-warn rust-2018-idioms`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | pub fn function(_x: Box<dyn SomeTrait>) {}
    |                         +++

--- a/tests/ui/object-safety/almost-supertrait-associated-type.stderr
+++ b/tests/ui/object-safety/almost-supertrait-associated-type.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | impl<T, U> Dyn for dyn Foo<T, U> + '_ {
    |                    ^^^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/almost-supertrait-associated-type.rs:33:34
    |
 LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T>
@@ -21,7 +21,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     (&PhantomData::<T> as &dyn Foo<T, U>).transmute(t)
    |                           ^^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/almost-supertrait-associated-type.rs:33:34
    |
 LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T>
@@ -38,7 +38,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     (&PhantomData::<T> as &dyn Foo<T, U>).transmute(t)
    |      ^^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/almost-supertrait-associated-type.rs:33:34
    |
 LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T>

--- a/tests/ui/object-safety/assoc_type_bounds_sized_unnecessary.rs
+++ b/tests/ui/object-safety/assoc_type_bounds_sized_unnecessary.rs
@@ -7,7 +7,7 @@ trait Foo {
 }
 
 fn foo(_: &dyn Foo<Bar = ()>) {}
-//~^ WARN: unnecessary associated type bound for not object safe associated type
+//~^ WARN: unnecessary associated type bound for dyn-incompatible associated type
 
 #[allow(unused_associated_type_bounds)]
 fn bar(_: &dyn Foo<Bar = ()>) {}

--- a/tests/ui/object-safety/assoc_type_bounds_sized_unnecessary.stderr
+++ b/tests/ui/object-safety/assoc_type_bounds_sized_unnecessary.stderr
@@ -1,4 +1,4 @@
-warning: unnecessary associated type bound for not object safe associated type
+warning: unnecessary associated type bound for dyn-incompatible associated type
   --> $DIR/assoc_type_bounds_sized_unnecessary.rs:9:20
    |
 LL | fn foo(_: &dyn Foo<Bar = ()>) {}

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.new.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.new.stderr
@@ -5,7 +5,7 @@ LL | fn id<F>(f: Copy) -> usize {
    |             ^^^^ `Copy` cannot be made into an object
    |
    = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
 error[E0618]: expected function, found `(dyn Copy + 'static)`
   --> $DIR/avoid-ice-on-warning-2.rs:11:5

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.old.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.old.stderr
@@ -7,7 +7,7 @@ LL | fn id<F>(f: Copy) -> usize {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn id<F>(f: dyn Copy) -> usize {
    |             +++
@@ -21,7 +21,7 @@ LL | fn id<F>(f: Copy) -> usize {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn id<F>(f: dyn Copy) -> usize {
    |             +++
@@ -33,7 +33,7 @@ LL | fn id<F>(f: Copy) -> usize {
    |             ^^^^ `Copy` cannot be made into an object
    |
    = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
 error[E0618]: expected function, found `(dyn Copy + 'static)`
   --> $DIR/avoid-ice-on-warning-2.rs:11:5

--- a/tests/ui/object-safety/avoid-ice-on-warning-3.new.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-3.new.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `A` cannot be made into an object
 LL | trait B { fn f(a: A) -> A; }
    |                   ^ `A` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/avoid-ice-on-warning-3.rs:12:14
    |
 LL | trait A { fn g(b: B) -> B; }
@@ -26,7 +26,7 @@ error[E0038]: the trait `B` cannot be made into an object
 LL | trait A { fn g(b: B) -> B; }
    |                   ^ `B` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/avoid-ice-on-warning-3.rs:4:14
    |
 LL | trait B { fn f(a: A) -> A; }

--- a/tests/ui/object-safety/avoid-ice-on-warning-3.old.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-3.old.stderr
@@ -7,7 +7,7 @@ LL | trait B { fn f(a: A) -> A; }
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait B { fn f(a: dyn A) -> A; }
    |                   +++
@@ -20,7 +20,7 @@ LL | trait B { fn f(a: A) -> A; }
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait B { fn f(a: A) -> dyn A; }
    |                         +++
@@ -33,7 +33,7 @@ LL | trait A { fn g(b: B) -> B; }
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait A { fn g(b: dyn B) -> B; }
    |                   +++
@@ -46,7 +46,7 @@ LL | trait A { fn g(b: B) -> B; }
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait A { fn g(b: B) -> dyn B; }
    |                         +++
@@ -60,7 +60,7 @@ LL | trait B { fn f(a: A) -> A; }
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait B { fn f(a: dyn A) -> A; }
    |                   +++
@@ -71,7 +71,7 @@ error[E0038]: the trait `A` cannot be made into an object
 LL | trait B { fn f(a: A) -> A; }
    |                   ^ `A` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/avoid-ice-on-warning-3.rs:12:14
    |
 LL | trait A { fn g(b: B) -> B; }
@@ -96,7 +96,7 @@ LL | trait A { fn g(b: B) -> B; }
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait A { fn g(b: dyn B) -> B; }
    |                   +++
@@ -107,7 +107,7 @@ error[E0038]: the trait `B` cannot be made into an object
 LL | trait A { fn g(b: B) -> B; }
    |                   ^ `B` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/avoid-ice-on-warning-3.rs:4:14
    |
 LL | trait B { fn f(a: A) -> A; }

--- a/tests/ui/object-safety/avoid-ice-on-warning.old.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning.old.stderr
@@ -24,7 +24,7 @@ LL | fn call_this<F>(f: F) : Fn(&str) + call_that {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn call_this<F>(f: F) : dyn Fn(&str) + call_that {}
    |                         +++

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.new.stderr
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.new.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Ord` cannot be made into an object
 LL | fn ord_prefer_dot(s: String) -> Ord {
    |                                 ^^^ `Ord` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: the trait cannot be made into an object because it uses `Self` as a type parameter

--- a/tests/ui/object-safety/bare-trait-dont-suggest-dyn.old.stderr
+++ b/tests/ui/object-safety/bare-trait-dont-suggest-dyn.old.stderr
@@ -11,7 +11,7 @@ note: the lint level is defined here
    |
 LL | #![deny(bare_trait_objects)]
    |         ^^^^^^^^^^^^^^^^^^
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn ord_prefer_dot(s: String) -> dyn Ord {
    |                                 +++
@@ -22,7 +22,7 @@ error[E0038]: the trait `Ord` cannot be made into an object
 LL | fn ord_prefer_dot(s: String) -> Ord {
    |                                 ^^^ `Ord` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: the trait cannot be made into an object because it uses `Self` as a type parameter

--- a/tests/ui/object-safety/issue-102762.stderr
+++ b/tests/ui/object-safety/issue-102762.stderr
@@ -7,7 +7,7 @@ LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>>
 LL | fn fetcher() -> Box<dyn Fetcher> {
    |                     ^^^^^^^^^^^ `Fetcher` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-102762.rs:10:22
    |
 LL | pub trait Fetcher: Send + Sync {
@@ -24,7 +24,7 @@ LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>>
 LL |     let fetcher = fetcher();
    |                   ^^^^^^^^^ `Fetcher` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-102762.rs:10:22
    |
 LL | pub trait Fetcher: Send + Sync {
@@ -41,7 +41,7 @@ LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>>
 LL |     let _ = fetcher.get();
    |             ^^^^^^^^^^^^^ `Fetcher` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-102762.rs:10:22
    |
 LL | pub trait Fetcher: Send + Sync {

--- a/tests/ui/object-safety/issue-19538.stderr
+++ b/tests/ui/object-safety/issue-19538.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     let test: &mut dyn Bar = &mut thing;
    |               ^^^^^^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-19538.rs:2:8
    |
 LL |     fn foo<T>(&self, val: T);
@@ -21,7 +21,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     let test: &mut dyn Bar = &mut thing;
    |                              ^^^^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-19538.rs:2:8
    |
 LL |     fn foo<T>(&self, val: T);

--- a/tests/ui/object-safety/object-safety-associated-consts.curr.stderr
+++ b/tests/ui/object-safety/object-safety-associated-consts.curr.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                               ^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-associated-consts.rs:9:11
    |
 LL | trait Bar {
@@ -19,7 +19,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t
    |     ^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-associated-consts.rs:9:11
    |
 LL | trait Bar {

--- a/tests/ui/object-safety/object-safety-associated-consts.object_safe_for_dispatch.stderr
+++ b/tests/ui/object-safety/object-safety-associated-consts.object_safe_for_dispatch.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t
    |     ^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-associated-consts.rs:9:11
    |
 LL | trait Bar {

--- a/tests/ui/object-safety/object-safety-bounds.stderr
+++ b/tests/ui/object-safety/object-safety-bounds.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `X` cannot be made into an object
 LL | fn f() -> Box<dyn X<U = u32>> {
    |               ^^^^^^^^^^^^^^ `X` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-bounds.rs:4:13
    |
 LL | trait X {

--- a/tests/ui/object-safety/object-safety-generics.curr.stderr
+++ b/tests/ui/object-safety/object-safety-generics.curr.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                               ^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-generics.rs:10:8
    |
 LL | trait Bar {
@@ -19,7 +19,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | fn make_bar_explicit<T:Bar>(t: &T) -> &dyn Bar {
    |                                        ^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-generics.rs:10:8
    |
 LL | trait Bar {
@@ -34,7 +34,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t
    |     ^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-generics.rs:10:8
    |
 LL | trait Bar {
@@ -50,7 +50,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t as &dyn Bar
    |          ^^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-generics.rs:10:8
    |
 LL | trait Bar {
@@ -65,7 +65,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t as &dyn Bar
    |     ^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-generics.rs:10:8
    |
 LL | trait Bar {

--- a/tests/ui/object-safety/object-safety-generics.object_safe_for_dispatch.stderr
+++ b/tests/ui/object-safety/object-safety-generics.object_safe_for_dispatch.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t
    |     ^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-generics.rs:10:8
    |
 LL | trait Bar {
@@ -20,7 +20,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t as &dyn Bar
    |     ^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-generics.rs:10:8
    |
 LL | trait Bar {

--- a/tests/ui/object-safety/object-safety-issue-22040.stderr
+++ b/tests/ui/object-safety/object-safety-issue-22040.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Expr` cannot be made into an object
 LL |     elements: Vec<Box<dyn Expr + 'x>>,
    |                       ^^^^^^^^^^^^^ `Expr` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-issue-22040.rs:5:21
    |
 LL | trait Expr: Debug + PartialEq {
@@ -19,7 +19,7 @@ error[E0038]: the trait `Expr` cannot be made into an object
 LL |     let a: Box<dyn Expr> = Box::new(SExpr::new());
    |                ^^^^^^^^ `Expr` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-issue-22040.rs:5:21
    |
 LL | trait Expr: Debug + PartialEq {
@@ -34,7 +34,7 @@ error[E0038]: the trait `Expr` cannot be made into an object
 LL |     let b: Box<dyn Expr> = Box::new(SExpr::new());
    |                ^^^^^^^^ `Expr` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-issue-22040.rs:5:21
    |
 LL | trait Expr: Debug + PartialEq {

--- a/tests/ui/object-safety/object-safety-mentions-Self.curr.stderr
+++ b/tests/ui/object-safety/object-safety-mentions-Self.curr.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                               ^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-mentions-Self.rs:11:22
    |
 LL | trait Bar {
@@ -19,7 +19,7 @@ error[E0038]: the trait `Baz` cannot be made into an object
 LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
    |                               ^^^^^^^ `Baz` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-mentions-Self.rs:15:22
    |
 LL | trait Baz {
@@ -34,7 +34,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t
    |     ^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-mentions-Self.rs:11:22
    |
 LL | trait Bar {
@@ -50,7 +50,7 @@ error[E0038]: the trait `Baz` cannot be made into an object
 LL |     t
    |     ^ `Baz` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-mentions-Self.rs:15:22
    |
 LL | trait Baz {

--- a/tests/ui/object-safety/object-safety-mentions-Self.object_safe_for_dispatch.stderr
+++ b/tests/ui/object-safety/object-safety-mentions-Self.object_safe_for_dispatch.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t
    |     ^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-mentions-Self.rs:11:22
    |
 LL | trait Bar {
@@ -20,7 +20,7 @@ error[E0038]: the trait `Baz` cannot be made into an object
 LL |     t
    |     ^ `Baz` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-mentions-Self.rs:15:22
    |
 LL | trait Baz {

--- a/tests/ui/object-safety/object-safety-no-static.curr.stderr
+++ b/tests/ui/object-safety/object-safety-no-static.curr.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | fn diverges() -> Box<dyn Foo> {
    |                      ^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-no-static.rs:9:8
    |
 LL | trait Foo {
@@ -27,7 +27,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let b: Box<dyn Foo> = Box::new(Bar);
    |            ^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-no-static.rs:9:8
    |
 LL | trait Foo {
@@ -50,7 +50,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let b: Box<dyn Foo> = Box::new(Bar);
    |                           ^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-no-static.rs:9:8
    |
 LL | trait Foo {

--- a/tests/ui/object-safety/object-safety-no-static.object_safe_for_dispatch.stderr
+++ b/tests/ui/object-safety/object-safety-no-static.object_safe_for_dispatch.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let b: Box<dyn Foo> = Box::new(Bar);
    |                           ^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-no-static.rs:9:8
    |
 LL | trait Foo {

--- a/tests/ui/object-safety/object-safety-sized-2.curr.stderr
+++ b/tests/ui/object-safety/object-safety-sized-2.curr.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
    |                               ^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-sized-2.rs:9:18
    |
 LL | trait Bar
@@ -18,7 +18,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t
    |     ^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-sized-2.rs:9:18
    |
 LL | trait Bar

--- a/tests/ui/object-safety/object-safety-sized-2.object_safe_for_dispatch.stderr
+++ b/tests/ui/object-safety/object-safety-sized-2.object_safe_for_dispatch.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t
    |     ^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-sized-2.rs:9:18
    |
 LL | trait Bar

--- a/tests/ui/object-safety/object-safety-sized.curr.stderr
+++ b/tests/ui/object-safety/object-safety-sized.curr.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL | fn make_bar<T: Bar>(t: &T) -> &dyn Bar {
    |                                ^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-sized.rs:8:12
    |
 LL | trait Bar: Sized {
@@ -18,7 +18,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t
    |     ^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-sized.rs:8:12
    |
 LL | trait Bar: Sized {

--- a/tests/ui/object-safety/object-safety-sized.object_safe_for_dispatch.stderr
+++ b/tests/ui/object-safety/object-safety-sized.object_safe_for_dispatch.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     t
    |     ^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-sized.rs:8:12
    |
 LL | trait Bar: Sized {

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-GAT.stderr
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-GAT.stderr
@@ -26,7 +26,7 @@ error[E0038]: the trait `SuperTrait` cannot be made into an object
 LL |     fn c(&self) -> dyn SuperTrait<T>;
    |                    ^^^^^^^^^^^^^^^^^ `SuperTrait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-supertrait-mentions-GAT.rs:4:10
    |
 LL |     type Gat<'a>

--- a/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
+++ b/tests/ui/object-safety/object-safety-supertrait-mentions-Self.stderr
@@ -24,7 +24,7 @@ error[E0038]: the trait `Baz` cannot be made into an object
 LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
    |                               ^^^^^^^ `Baz` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-safety-supertrait-mentions-Self.rs:8:13
    |
 LL | trait Baz : Bar<Self> {

--- a/tests/ui/parser/trait-object-trait-parens.stderr
+++ b/tests/ui/parser/trait-object-trait-parens.stderr
@@ -34,7 +34,7 @@ LL |     let _: Box<(Obj) + (?Sized) + (for<'a> Trait<'a>)>;
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _: Box<dyn (Obj) + (?Sized) + (for<'a> Trait<'a>)>;
    |                +++
@@ -58,7 +58,7 @@ LL |     let _: Box<?Sized + (for<'a> Trait<'a>) + (Obj)>;
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _: Box<dyn ?Sized + (for<'a> Trait<'a>) + (Obj)>;
    |                +++
@@ -82,7 +82,7 @@ LL |     let _: Box<for<'a> Trait<'a> + (Obj) + (?Sized)>;
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let _: Box<dyn for<'a> Trait<'a> + (Obj) + (?Sized)>;
    |                +++

--- a/tests/ui/resolve/issue-3907-2.stderr
+++ b/tests/ui/resolve/issue-3907-2.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `issue_3907::Foo` cannot be made into an object
 LL | fn bar(_x: Foo) {}
    |            ^^^ `issue_3907::Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/auxiliary/issue-3907.rs:2:8
    |
 LL |     fn bar();

--- a/tests/ui/self/arbitrary-self-types-not-object-safe.curr.stderr
+++ b/tests/ui/self/arbitrary-self-types-not-object-safe.curr.stderr
@@ -7,7 +7,7 @@ LL |     fn foo(self: &Rc<Self>) -> usize;
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
    |                                ^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/arbitrary-self-types-not-object-safe.rs:8:18
    |
 LL | trait Foo {
@@ -25,7 +25,7 @@ LL |     fn foo(self: &Rc<Self>) -> usize;
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
    |             ^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/arbitrary-self-types-not-object-safe.rs:8:18
    |
 LL | trait Foo {

--- a/tests/ui/self/arbitrary-self-types-not-object-safe.object_safe_for_dispatch.stderr
+++ b/tests/ui/self/arbitrary-self-types-not-object-safe.object_safe_for_dispatch.stderr
@@ -7,7 +7,7 @@ LL |     fn foo(self: &Rc<Self>) -> usize;
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
    |             ^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/arbitrary-self-types-not-object-safe.rs:8:18
    |
 LL | trait Foo {

--- a/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
+++ b/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Qux` cannot be made into an object
 LL |     pub desc: &'static dyn Qux,
    |                        ^^^^^^^ `Qux` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/unsizing-wfcheck-issue-127299.rs:4:8
    |
 LL | trait Qux {
@@ -42,7 +42,7 @@ error[E0038]: the trait `Qux` cannot be made into an object
 LL | static FOO: &Lint = &Lint { desc: "desc" };
    |                                   ^^^^^^ `Qux` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/unsizing-wfcheck-issue-127299.rs:4:8
    |
 LL | trait Qux {
@@ -65,7 +65,7 @@ error[E0038]: the trait `Qux` cannot be made into an object
 LL | static FOO: &Lint = &Lint { desc: "desc" };
    |                                   ^^^^^^ `Qux` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/unsizing-wfcheck-issue-127299.rs:4:8
    |
 LL | trait Qux {

--- a/tests/ui/suggestions/issue-116434-2015.rs
+++ b/tests/ui/suggestions/issue-116434-2015.rs
@@ -3,10 +3,10 @@ trait Foo {
     fn foo() -> Clone;
     //~^ WARNING trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
     //~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-    //~| HELP if this is an object-safe trait, use `dyn`
+    //~| HELP if this is a dyn-compatible trait, use `dyn`
     //~| WARNING trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
     //~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-    //~| HELP if this is an object-safe trait, use `dyn`
+    //~| HELP if this is a dyn-compatible trait, use `dyn`
     //~| ERROR the trait `Clone` cannot be made into an object [E0038]
     //~| HELP there is an associated type with the same name
 }
@@ -18,10 +18,10 @@ trait DbInterface {
     fn handle() -> DbHandle;
     //~^ WARNING trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
     //~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-    //~| HELP if this is an object-safe trait, use `dyn`
+    //~| HELP if this is a dyn-compatible trait, use `dyn`
     //~| WARNING trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
     //~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-    //~| HELP if this is an object-safe trait, use `dyn`
+    //~| HELP if this is a dyn-compatible trait, use `dyn`
     //~| ERROR the trait `DbHandle` cannot be made into an object [E0038]
     //~| HELP there is an associated type with the same name
 }

--- a/tests/ui/suggestions/issue-116434-2015.stderr
+++ b/tests/ui/suggestions/issue-116434-2015.stderr
@@ -7,7 +7,7 @@ LL |     fn foo() -> Clone;
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     fn foo() -> dyn Clone;
    |                 +++
@@ -20,7 +20,7 @@ LL |     fn handle() -> DbHandle;
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     fn handle() -> dyn DbHandle;
    |                    +++
@@ -34,7 +34,7 @@ LL |     fn foo() -> Clone;
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     fn foo() -> dyn Clone;
    |                 +++
@@ -46,7 +46,7 @@ LL |     fn foo() -> Clone;
    |                 ^^^^^ `Clone` cannot be made into an object
    |
    = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 help: there is an associated type with the same name
    |
 LL |     fn foo() -> Self::Clone;
@@ -61,7 +61,7 @@ LL |     fn handle() -> DbHandle;
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     fn handle() -> dyn DbHandle;
    |                    +++
@@ -72,7 +72,7 @@ error[E0038]: the trait `DbHandle` cannot be made into an object
 LL |     fn handle() -> DbHandle;
    |                    ^^^^^^^^ `DbHandle` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-116434-2015.rs:14:17
    |
 LL | trait DbHandle: Sized {}

--- a/tests/ui/suggestions/issue-116434-2021.stderr
+++ b/tests/ui/suggestions/issue-116434-2021.stderr
@@ -5,7 +5,7 @@ LL |     fn foo() -> Clone;
    |                 ^^^^^ `Clone` cannot be made into an object
    |
    = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 help: there is an associated type with the same name
    |
 LL |     fn foo() -> Self::Clone;
@@ -17,7 +17,7 @@ error[E0038]: the trait `DbHandle` cannot be made into an object
 LL |     fn handle() -> DbHandle;
    |                    ^^^^^^^^ `DbHandle` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-116434-2021.rs:10:17
    |
 LL | trait DbHandle: Sized {}

--- a/tests/ui/suggestions/issue-61963.stderr
+++ b/tests/ui/suggestions/issue-61963.stderr
@@ -11,7 +11,7 @@ note: the lint level is defined here
    |
 LL | #![deny(bare_trait_objects)]
    |         ^^^^^^^^^^^^^^^^^^
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     bar: Box<dyn Bar>,
    |              +++
@@ -24,7 +24,7 @@ LL | pub struct Foo {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | dyn pub struct Foo {
    | +++

--- a/tests/ui/suggestions/issue-98500.stderr
+++ b/tests/ui/suggestions/issue-98500.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `B` cannot be made into an object
 LL | struct S(Box<dyn B>);
    |              ^^^^^ `B` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/auxiliary/not-object-safe.rs:4:8
    |
 LL |     fn f();

--- a/tests/ui/suggestions/object-unsafe-trait-references-self.stderr
+++ b/tests/ui/suggestions/object-unsafe-trait-references-self.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | fn bar(x: &dyn Trait) {}
    |            ^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-references-self.rs:2:22
    |
 LL | trait Trait {
@@ -23,7 +23,7 @@ error[E0038]: the trait `Other` cannot be made into an object
 LL | fn foo(x: &dyn Other) {}
    |            ^^^^^^^^^ `Other` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-references-self.rs:11:14
    |
 LL | trait Other: Sized {}

--- a/tests/ui/suggestions/object-unsafe-trait-should-use-self-2021-without-dyn.stderr
+++ b/tests/ui/suggestions/object-unsafe-trait-should-use-self-2021-without-dyn.stderr
@@ -17,7 +17,7 @@ error[E0038]: the trait `A` cannot be made into an object
 LL |     fn f(a: A) -> A;
    |             ^ `A` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:3:10
    |
 LL | trait A: Sized {
@@ -44,7 +44,7 @@ error[E0038]: the trait `B` cannot be made into an object
 LL |     fn f(b: B) -> B;
    |             ^ `B` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:11:8
    |
 LL | trait B {
@@ -81,7 +81,7 @@ LL |     fn f(&self, c: C) -> C;
    |          |
    |          help: consider changing method `f`'s `self` parameter to be `&self` (notice the capitalization): `&Self`
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-should-use-self-2021-without-dyn.rs:18:10
    |
 LL | trait C {
@@ -95,7 +95,7 @@ error[E0782]: trait objects must include the `dyn` keyword
 LL |     fn f(a: A) -> A;
    |             ^
    |
-   = note: `A` it is not object safe, so it can't be `dyn`
+   = note: `A` it is dyn-incompatible, so it can't be `dyn`
 help: use a new generic type parameter, constrained by `A`
    |
 LL |     fn f<T: A>(a: T) -> A;
@@ -111,7 +111,7 @@ error[E0782]: trait objects must include the `dyn` keyword
 LL |     fn f(a: A) -> A;
    |                   ^
    |
-help: `A` is not object safe, use `impl A` to return an opaque type, as long as you return a single underlying type
+help: `A` is dyn-incompatible, use `impl A` to return an opaque type, as long as you return a single underlying type
    |
 LL |     fn f(a: A) -> impl A;
    |                   ++++
@@ -122,7 +122,7 @@ error[E0782]: trait objects must include the `dyn` keyword
 LL |     fn f(b: B) -> B;
    |             ^
    |
-   = note: `B` it is not object safe, so it can't be `dyn`
+   = note: `B` it is dyn-incompatible, so it can't be `dyn`
 help: use a new generic type parameter, constrained by `B`
    |
 LL |     fn f<T: B>(b: T) -> B;
@@ -138,7 +138,7 @@ error[E0782]: trait objects must include the `dyn` keyword
 LL |     fn f(b: B) -> B;
    |                   ^
    |
-help: `B` is not object safe, use `impl B` to return an opaque type, as long as you return a single underlying type
+help: `B` is dyn-incompatible, use `impl B` to return an opaque type, as long as you return a single underlying type
    |
 LL |     fn f(b: B) -> impl B;
    |                   ++++
@@ -149,7 +149,7 @@ error[E0782]: trait objects must include the `dyn` keyword
 LL |     fn f(&self, c: C) -> C;
    |                    ^
    |
-   = note: `C` it is not object safe, so it can't be `dyn`
+   = note: `C` it is dyn-incompatible, so it can't be `dyn`
 help: use a new generic type parameter, constrained by `C`
    |
 LL |     fn f<T: C>(&self, c: T) -> C;
@@ -165,7 +165,7 @@ error[E0782]: trait objects must include the `dyn` keyword
 LL |     fn f(&self, c: C) -> C;
    |                          ^
    |
-help: `C` is not object safe, use `impl C` to return an opaque type, as long as you return a single underlying type
+help: `C` is dyn-incompatible, use `impl C` to return an opaque type, as long as you return a single underlying type
    |
 LL |     fn f(&self, c: C) -> impl C;
    |                          ++++

--- a/tests/ui/suggestions/object-unsafe-trait-should-use-self-2021.stderr
+++ b/tests/ui/suggestions/object-unsafe-trait-should-use-self-2021.stderr
@@ -17,7 +17,7 @@ error[E0038]: the trait `A` cannot be made into an object
 LL |     fn f(a: dyn A) -> dyn A;
    |             ^^^^^ `A` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-should-use-self-2021.rs:3:10
    |
 LL | trait A: Sized {
@@ -44,7 +44,7 @@ error[E0038]: the trait `B` cannot be made into an object
 LL |     fn f(a: dyn B) -> dyn B;
    |             ^^^^^ `B` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-should-use-self-2021.rs:9:8
    |
 LL | trait B {

--- a/tests/ui/suggestions/object-unsafe-trait-should-use-self.stderr
+++ b/tests/ui/suggestions/object-unsafe-trait-should-use-self.stderr
@@ -17,7 +17,7 @@ error[E0038]: the trait `A` cannot be made into an object
 LL |     fn f(a: A) -> A;
    |             ^ `A` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-should-use-self.rs:2:10
    |
 LL | trait A: Sized {
@@ -44,7 +44,7 @@ error[E0038]: the trait `B` cannot be made into an object
 LL |     fn f(a: B) -> B;
    |             ^ `B` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-should-use-self.rs:8:8
    |
 LL | trait B {

--- a/tests/ui/suggestions/object-unsafe-trait-should-use-where-sized.stderr
+++ b/tests/ui/suggestions/object-unsafe-trait-should-use-where-sized.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | fn bar(x: &dyn Trait) {}
    |            ^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-trait-should-use-where-sized.rs:5:8
    |
 LL | trait Trait {

--- a/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
+++ b/tests/ui/suggestions/suggest-swapping-self-ty-and-trait.stderr
@@ -67,7 +67,7 @@ LL | impl<'a, T> Struct<T> for Trait<'a, T> {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | impl<'a, T> Struct<T> for dyn Trait<'a, T> {}
    |                           +++
@@ -80,7 +80,7 @@ LL | impl<'a, T> Enum<T> for Trait<'a, T> {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | impl<'a, T> Enum<T> for dyn Trait<'a, T> {}
    |                         +++
@@ -93,7 +93,7 @@ LL | impl<'a, T> Union<T> for Trait<'a, T> {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | impl<'a, T> Union<T> for dyn Trait<'a, T> {}
    |                          +++

--- a/tests/ui/traits/alias/object-fail.stderr
+++ b/tests/ui/traits/alias/object-fail.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Eq` cannot be made into an object
 LL |     let _: &dyn EqAlias = &123;
    |             ^^^^^^^^^^^ `Eq` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: the trait cannot be made into an object because it uses `Self` as a type parameter

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -7,7 +7,7 @@ LL | fn foo(_x: Foo + Send) {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | fn foo(_x: dyn Foo + Send) {
    |            +++

--- a/tests/ui/traits/issue-20692.stderr
+++ b/tests/ui/traits/issue-20692.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Array` cannot be made into an object
 LL |     &dyn Array;
    |     ^^^^^^^^^^ `Array` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-20692.rs:1:14
    |
 LL | trait Array: Sized + Copy {}
@@ -19,7 +19,7 @@ error[E0038]: the trait `Array` cannot be made into an object
 LL |     let _ = x
    |             ^ `Array` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-20692.rs:1:14
    |
 LL | trait Array: Sized + Copy {}

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -25,7 +25,7 @@ LL | /            dyn Bar
 LL | |               <Assoc=()>
    | |________________________^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-28576.rs:5:16
    |
 LL | pub trait Bar: Foo<Assoc=()> {

--- a/tests/ui/traits/issue-38404.stderr
+++ b/tests/ui/traits/issue-38404.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `B` cannot be made into an object
 LL | trait C<T>: A<dyn B<T, Output = usize>> {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38404.rs:1:13
    |
 LL | trait A<T>: std::ops::Add<Self> + Sized {}
@@ -18,7 +18,7 @@ error[E0038]: the trait `B` cannot be made into an object
 LL | trait C<T>: A<dyn B<T, Output = usize>> {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38404.rs:1:13
    |
 LL | trait A<T>: std::ops::Add<Self> + Sized {}
@@ -33,7 +33,7 @@ error[E0038]: the trait `B` cannot be made into an object
 LL | trait C<T>: A<dyn B<T, Output = usize>> {}
    |               ^^^^^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38404.rs:1:13
    |
 LL | trait A<T>: std::ops::Add<Self> + Sized {}

--- a/tests/ui/traits/issue-38604.stderr
+++ b/tests/ui/traits/issue-38604.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let _f: Box<dyn Foo> =
    |             ^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38604.rs:2:22
    |
 LL | trait Foo where u32: Q<Self> {
@@ -19,7 +19,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |         Box::new(());
    |         ^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38604.rs:2:22
    |
 LL | trait Foo where u32: Q<Self> {

--- a/tests/ui/traits/issue-72410.stderr
+++ b/tests/ui/traits/issue-72410.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Bar` cannot be made into an object
 LL |     where for<'a> &'a mut [dyn Bar]: ;
    |                   ^^^^^^^^^^^^^^^^^ `Bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-72410.rs:13:8
    |
 LL | pub trait Bar {

--- a/tests/ui/traits/issue-78372.stderr
+++ b/tests/ui/traits/issue-78372.stderr
@@ -64,7 +64,7 @@ LL |     fn foo(self: Smaht<Self, T>);
 LL | impl Marker for dyn Foo {}
    |                 ^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-78372.rs:9:18
    |
 LL | trait Foo: X<u32> {}

--- a/tests/ui/traits/item-privacy.stderr
+++ b/tests/ui/traits/item-privacy.stderr
@@ -142,7 +142,7 @@ error[E0038]: the trait `assoc_const::C` cannot be made into an object
 LL |     <dyn C>::A;
    |      ^^^^^ `assoc_const::C` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/item-privacy.rs:25:15
    |
 LL |         const A: u8 = 0;

--- a/tests/ui/traits/non_lifetime_binders/supertrait-object-safety.stderr
+++ b/tests/ui/traits/non_lifetime_binders/supertrait-object-safety.stderr
@@ -13,7 +13,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let x: &dyn Foo = &();
    |                       ^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/supertrait-object-safety.rs:4:12
    |
 LL | trait Foo: for<T> Bar<T> {}
@@ -29,7 +29,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     let x: &dyn Foo = &();
    |            ^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/supertrait-object-safety.rs:4:12
    |
 LL | trait Foo: for<T> Bar<T> {}
@@ -44,7 +44,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL |     needs_bar(x);
    |     ^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/supertrait-object-safety.rs:4:12
    |
 LL | trait Foo: for<T> Bar<T> {}

--- a/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.stderr
+++ b/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.stderr
@@ -12,7 +12,7 @@ error[E0038]: the trait `FromResidual` cannot be made into an object
 LL |     let b: &dyn FromResidual = &();
    |            ^^^^^^^^^^^^^^^^^ `FromResidual` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/canonicalize-fresh-infer-vars-issue-103626.rs:2:8
    |
 LL | trait FromResidual<R = <Self as Try>::Residual> {

--- a/tests/ui/traits/object/macro-matcher.stderr
+++ b/tests/ui/traits/object/macro-matcher.stderr
@@ -11,7 +11,7 @@ LL |     m!(dyn Copy + Send + 'static);
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^ `Copy` cannot be made into an object
    |
    = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/object/object-unsafe-missing-assoc-type.stderr
+++ b/tests/ui/traits/object/object-unsafe-missing-assoc-type.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | fn bar(x: &dyn Foo) {}
    |                ^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
    |
 LL | trait Foo {
@@ -19,7 +19,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | fn bar(x: &dyn Foo) {}
    |                ^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
    |
 LL | trait Foo {
@@ -35,7 +35,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | fn bar(x: &dyn Foo) {}
    |                ^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
    |
 LL | trait Foo {
@@ -51,7 +51,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | fn bar(x: &dyn Foo) {}
    |            ^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/object-unsafe-missing-assoc-type.rs:2:10
    |
 LL | trait Foo {

--- a/tests/ui/traits/object/pretty.stderr
+++ b/tests/ui/traits/object/pretty.stderr
@@ -1,4 +1,4 @@
-warning: unnecessary associated type bound for not object safe associated type
+warning: unnecessary associated type bound for dyn-incompatible associated type
   --> $DIR/pretty.rs:41:35
    |
 LL | fn dyn_has_gat(x: &dyn HasGat<u8, Assoc<bool> = ()>) { x }

--- a/tests/ui/traits/object/safety.stderr
+++ b/tests/ui/traits/object/safety.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Tr` cannot be made into an object
 LL |     let _: &dyn Tr = &St;
    |                      ^^^ `Tr` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/safety.rs:4:8
    |
 LL | trait Tr {
@@ -28,7 +28,7 @@ error[E0038]: the trait `Tr` cannot be made into an object
 LL |     let _: &dyn Tr = &St;
    |            ^^^^^^^ `Tr` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/safety.rs:4:8
    |
 LL | trait Tr {

--- a/tests/ui/traits/test-2.stderr
+++ b/tests/ui/traits/test-2.stderr
@@ -32,7 +32,7 @@ error[E0038]: the trait `bar` cannot be made into an object
 LL |     (Box::new(10) as Box<dyn bar>).dup();
    |                      ^^^^^^^^^^^^ `bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/test-2.rs:4:30
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
@@ -52,7 +52,7 @@ error[E0038]: the trait `bar` cannot be made into an object
 LL |     (Box::new(10) as Box<dyn bar>).dup();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/test-2.rs:4:30
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
@@ -72,7 +72,7 @@ error[E0038]: the trait `bar` cannot be made into an object
 LL |     (Box::new(10) as Box<dyn bar>).dup();
    |      ^^^^^^^^^^^^ `bar` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/test-2.rs:4:30
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }

--- a/tests/ui/traits/trait-upcasting/multiple_supertrait_upcastable.rs
+++ b/tests/ui/traits/trait-upcasting/multiple_supertrait_upcastable.rs
@@ -5,6 +5,6 @@ trait A {}
 trait B {}
 
 trait C: A + B {}
-//~^ ERROR `C` is object-safe and has multiple supertraits
+//~^ ERROR `C` is dyn-compatible and has multiple supertraits
 
 fn main() {}

--- a/tests/ui/traits/trait-upcasting/multiple_supertrait_upcastable.stderr
+++ b/tests/ui/traits/trait-upcasting/multiple_supertrait_upcastable.stderr
@@ -1,4 +1,4 @@
-error: `C` is object-safe and has multiple supertraits
+error: `C` is dyn-compatible and has multiple supertraits
   --> $DIR/multiple_supertrait_upcastable.rs:7:1
    |
 LL | trait C: A + B {}

--- a/tests/ui/traits/unspecified-self-in-trait-ref.stderr
+++ b/tests/ui/traits/unspecified-self-in-trait-ref.stderr
@@ -7,7 +7,7 @@ LL |     let a = Foo::lol();
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let a = <dyn Foo>::lol();
    |             ++++    +
@@ -26,7 +26,7 @@ LL |     let b = Foo::<_>::lol();
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let b = <dyn Foo::<_>>::lol();
    |             ++++         +
@@ -45,7 +45,7 @@ LL |     let c = Bar::lol();
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let c = <dyn Bar>::lol();
    |             ++++    +
@@ -64,7 +64,7 @@ LL |     let d = Bar::<usize, _>::lol();
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let d = <dyn Bar::<usize, _>>::lol();
    |             ++++                +
@@ -83,7 +83,7 @@ LL |     let e = Bar::<usize>::lol();
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     let e = <dyn Bar::<usize>>::lol();
    |             ++++             +

--- a/tests/ui/type/type-parameter-defaults-referencing-Self-ppaux.stderr
+++ b/tests/ui/type/type-parameter-defaults-referencing-Self-ppaux.stderr
@@ -16,7 +16,7 @@ error[E0038]: the trait `MyAdd` cannot be made into an object
 LL |     let y = x as dyn MyAdd<i32>;
    |                  ^^^^^^^^^^^^^^ `MyAdd` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:6:55
    |
 LL | trait MyAdd<Rhs=Self> { fn add(&self, other: &Rhs) -> Self; }

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.stderr
@@ -34,7 +34,7 @@ LL | trait Trait<const N: Trait = bar> {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait Trait<const N: dyn Trait = bar> {
    |                      +++
@@ -67,7 +67,7 @@ LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     fn fnc<const N: dyn Trait = u32>(&self) -> Trait {
    |                     +++
@@ -80,7 +80,7 @@ LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     fn fnc<const N: Trait = u32>(&self) -> dyn Trait {
    |                                            +++
@@ -94,7 +94,7 @@ LL | trait Trait<const N: Trait = bar> {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait Trait<const N: dyn Trait = bar> {
    |                      +++
@@ -105,7 +105,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | trait Trait<const N: Trait = bar> {
    |                      ^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:8
    |
 LL | trait Trait<const N: Trait = bar> {
@@ -121,7 +121,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | trait Trait<const N: Trait = bar> {
    |             ^^^^^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:8
    |
 LL | trait Trait<const N: Trait = bar> {
@@ -162,7 +162,7 @@ LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL |     fn fnc<const N: dyn Trait = u32>(&self) -> Trait {
    |                     +++
@@ -173,7 +173,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
    |                     ^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:8
    |
 LL | trait Trait<const N: Trait = bar> {
@@ -189,7 +189,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL | trait Trait<const N: Trait = bar> {
    |             ^^^^^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:8
    |
 LL | trait Trait<const N: Trait = bar> {

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
@@ -7,7 +7,7 @@ LL | trait Foo<const N: Bar<2>> {
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
    = note: `#[warn(bare_trait_objects)]` on by default
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait Foo<const N: dyn Bar<2>> {
    |                    +++
@@ -20,7 +20,7 @@ LL | trait Bar<const M: Foo<2>> {}
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
-help: if this is an object-safe trait, use `dyn`
+help: if this is a dyn-compatible trait, use `dyn`
    |
 LL | trait Bar<const M: dyn Foo<2>> {}
    |                    +++
@@ -50,7 +50,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | trait Foo<const N: Bar<2>> {
    |                        ^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:8:8
    |
 LL | trait Foo<const N: Bar<2>> {
@@ -81,7 +81,7 @@ error[E0038]: the trait `Foo` cannot be made into an object
 LL | trait Bar<const M: Foo<2>> {}
    |           ^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:8:8
    |
 LL | trait Foo<const N: Bar<2>> {

--- a/tests/ui/wf/issue-87495.stderr
+++ b/tests/ui/wf/issue-87495.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `T` cannot be made into an object
 LL |     const CONST: (bool, dyn T);
    |                         ^^^^^ `T` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-87495.rs:4:11
    |
 LL | trait T {

--- a/tests/ui/wf/wf-convert-unsafe-trait-obj-box.stderr
+++ b/tests/ui/wf/wf-convert-unsafe-trait-obj-box.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL |     let t_box: Box<dyn Trait> = Box::new(S);
    |                                 ^^^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-convert-unsafe-trait-obj-box.rs:6:14
    |
 LL | trait Trait: Sized {}
@@ -20,7 +20,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL |     takes_box(Box::new(S));
    |               ^^^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-convert-unsafe-trait-obj-box.rs:6:14
    |
 LL | trait Trait: Sized {}
@@ -36,7 +36,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL |     Box::new(S) as Box<dyn Trait>;
    |     ^^^^^^^^^^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-convert-unsafe-trait-obj-box.rs:6:14
    |
 LL | trait Trait: Sized {}

--- a/tests/ui/wf/wf-convert-unsafe-trait-obj.stderr
+++ b/tests/ui/wf/wf-convert-unsafe-trait-obj.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL |     let t: &dyn Trait = &S;
    |                         ^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-convert-unsafe-trait-obj.rs:6:14
    |
 LL | trait Trait: Sized {}
@@ -20,7 +20,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL |     takes_trait(&S);
    |                 ^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-convert-unsafe-trait-obj.rs:6:14
    |
 LL | trait Trait: Sized {}
@@ -36,7 +36,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL |     &S as &dyn Trait;
    |     ^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-convert-unsafe-trait-obj.rs:6:14
    |
 LL | trait Trait: Sized {}

--- a/tests/ui/wf/wf-fn-where-clause.stderr
+++ b/tests/ui/wf/wf-fn-where-clause.stderr
@@ -21,7 +21,7 @@ LL | fn bar() where Vec<dyn Copy>:, {}
    |                ^^^^^^^^^^^^^ `Copy` cannot be made into an object
    |
    = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
 error[E0277]: the size for values of type `(dyn Copy + 'static)` cannot be known at compilation time
   --> $DIR/wf-fn-where-clause.rs:12:16

--- a/tests/ui/wf/wf-object-safe.stderr
+++ b/tests/ui/wf/wf-object-safe.stderr
@@ -4,7 +4,7 @@ error[E0038]: the trait `A` cannot be made into an object
 LL |     let _x: &dyn A;
    |             ^^^^^^ `A` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-object-safe.rs:5:23
    |
 LL | trait A {

--- a/tests/ui/wf/wf-unsafe-trait-obj-match.stderr
+++ b/tests/ui/wf/wf-unsafe-trait-obj-match.stderr
@@ -18,7 +18,7 @@ error[E0038]: the trait `Trait` cannot be made into an object
 LL |         Some(()) => &S,
    |                     ^^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-unsafe-trait-obj-match.rs:6:14
    |
 LL | trait Trait: Sized {}
@@ -40,7 +40,7 @@ LL | |         None => &R,
 LL | |     };
    | |_____^ `Trait` cannot be made into an object
    |
-note: for a trait to be "object safe" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-unsafe-trait-obj-match.rs:6:14
    |
 LL | trait Trait: Sized {}


### PR DESCRIPTION
Completed T-lang FCP: https://github.com/rust-lang/lang-team/issues/286#issuecomment-2338905118.
Tracking issue: https://github.com/rust-lang/rust/issues/130852

Excludes `compiler/rustc_codegen_cranelift` (to be filed separately).
Includes Stable MIR.

Regarding https://github.com/rust-lang/rust/labels/relnotes, I guess I will manually open a https://github.com/rust-lang/rust/labels/relnotes-tracking-issue since this change affects everything (compiler, library, tools, docs, books, everyday language).

r? ghost