### PR TITLE
fix some cfg logic around optimize_for_size and 16-bit targets

### DIFF
--- a/library/core/src/slice/sort/shared/mod.rs
+++ b/library/core/src/slice/sort/shared/mod.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "optimize_for_size", allow(dead_code))]
+#![cfg_attr(any(feature = "optimize_for_size", target_pointer_width = "16"), allow(dead_code))]
 
 use crate::marker::Freeze;
 

--- a/library/core/src/slice/sort/unstable/mod.rs
+++ b/library/core/src/slice/sort/unstable/mod.rs
@@ -2,9 +2,9 @@
 
 use crate::intrinsics;
 use crate::mem::SizedTypeProperties;
-#[cfg(not(feature = "optimize_for_size"))]
+#[cfg(not(any(feature = "optimize_for_size", target_pointer_width = "16")))]
 use crate::slice::sort::shared::find_existing_run;
-#[cfg(not(feature = "optimize_for_size"))]
+#[cfg(not(any(feature = "optimize_for_size", target_pointer_width = "16")))]
 use crate::slice::sort::shared::smallsort::insertion_sort_shift_left;
 
 pub(crate) mod heapsort;
@@ -55,7 +55,7 @@ pub fn sort<T, F: FnMut(&T, &T) -> bool>(v: &mut [T], is_less: &mut F) {
 ///
 /// Deliberately don't inline the main sorting routine entrypoint to ensure the
 /// inlined insertion sort i-cache footprint remains minimal.
-#[cfg(not(feature = "optimize_for_size"))]
+#[cfg(not(any(feature = "optimize_for_size", target_pointer_width = "16")))]
 #[inline(never)]
 fn ipnsort<T, F>(v: &mut [T], is_less: &mut F)
 where


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/130818.
Fixes https://github.com/rust-lang/rust/issues/129910.

There are still some warnings when building on a 16bit target:
```
warning: struct `AlignedStorage` is never constructed
   --> /home/r/src/rust/rustc.2/library/core/src/slice/sort/stable/mod.rs:135:8
    |
135 | struct AlignedStorage<T, const N: usize> {
    |        ^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: associated items `new` and `as_uninit_slice_mut` are never used
   --> /home/r/src/rust/rustc.2/library/core/src/slice/sort/stable/mod.rs:141:8
    |
140 | impl<T, const N: usize> AlignedStorage<T, N> {
    | -------------------------------------------- associated items in this implementation
141 |     fn new() -> Self {
    |        ^^^
...
145 |     fn as_uninit_slice_mut(&mut self) -> &mut [MaybeUninit<T>] {
    |        ^^^^^^^^^^^^^^^^^^^

warning: function `quicksort` is never used
  --> /home/r/src/rust/rustc.2/library/core/src/slice/sort/unstable/quicksort.rs:19:15
   |
19 | pub(crate) fn quicksort<'a, T, F>(
   |               ^^^^^^^^^

warning: `core` (lib) generated 3 warnings
```

However, the cfg stuff here is sufficiently messy that I didn't want to touch more of it. I think all `feature = "optimize_for_size"` should become `any(feature = "optimize_for_size", target_pointer_width = "16")` but I am not entirely certain. Warnings are fine, Miri will just ignore them.

Cc @Voultapher 