### PR TITLE
Fix the misleading diagnostic for `let_underscore_drop` on type without `Drop` implementation

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -531,7 +531,7 @@ lint_non_binding_let_multi_suggestion =
     consider immediately dropping the value
 
 lint_non_binding_let_on_drop_type =
-    non-binding let on a type that implements `Drop`
+    non-binding let on a type that has a destructor
 
 lint_non_binding_let_on_sync_lock = non-binding let on a synchronization lock
     .label = this lock is not assigned to a binding and is immediately dropped

--- a/compiler/rustc_lint/src/let_underscore.rs
+++ b/compiler/rustc_lint/src/let_underscore.rs
@@ -51,7 +51,7 @@ declare_lint! {
     /// intent.
     pub LET_UNDERSCORE_DROP,
     Allow,
-    "non-binding let on a type that implements `Drop`"
+    "non-binding let on a type that has a destructor"
 }
 
 declare_lint! {

--- a/tests/ui/lint/let_underscore/issue-119696-err-on-fn.rs
+++ b/tests/ui/lint/let_underscore/issue-119696-err-on-fn.rs
@@ -2,7 +2,7 @@
 
 #![deny(let_underscore_drop)]
 fn main() {
-    let _ = foo(); //~ ERROR non-binding let on a type that implements `Drop`
+    let _ = foo(); //~ ERROR non-binding let on a type that has a destructor
 }
 
 async fn from_config(_: Config) {}

--- a/tests/ui/lint/let_underscore/issue-119696-err-on-fn.stderr
+++ b/tests/ui/lint/let_underscore/issue-119696-err-on-fn.stderr
@@ -1,4 +1,4 @@
-error: non-binding let on a type that implements `Drop`
+error: non-binding let on a type that has a destructor
   --> $DIR/issue-119696-err-on-fn.rs:5:5
    |
 LL |     let _ = foo();

--- a/tests/ui/lint/let_underscore/issue-119697-extra-let.rs
+++ b/tests/ui/lint/let_underscore/issue-119697-extra-let.rs
@@ -12,9 +12,9 @@ pub fn ice_cold(beverage: Tait) {
     // Must destructure at least one field of `Foo`
     let Foo { field } = beverage;
     // boom
-    _ = field; //~ ERROR non-binding let on a type that implements `Drop`
+    _ = field; //~ ERROR non-binding let on a type that has a destructor
 
-    let _ = field; //~ ERROR non-binding let on a type that implements `Drop`
+    let _ = field; //~ ERROR non-binding let on a type that has a destructor
 }
 
 

--- a/tests/ui/lint/let_underscore/issue-119697-extra-let.stderr
+++ b/tests/ui/lint/let_underscore/issue-119697-extra-let.stderr
@@ -1,4 +1,4 @@
-error: non-binding let on a type that implements `Drop`
+error: non-binding let on a type that has a destructor
   --> $DIR/issue-119697-extra-let.rs:15:5
    |
 LL |     _ = field;
@@ -18,7 +18,7 @@ help: consider immediately dropping the value
 LL |     drop(field);
    |     ~~~~~     +
 
-error: non-binding let on a type that implements `Drop`
+error: non-binding let on a type that has a destructor
   --> $DIR/issue-119697-extra-let.rs:17:5
    |
 LL |     let _ = field;

--- a/tests/ui/lint/let_underscore/let_underscore_drop.rs
+++ b/tests/ui/lint/let_underscore/let_underscore_drop.rs
@@ -10,7 +10,7 @@ impl Drop for NontrivialDrop {
 }
 
 fn main() {
-    let _ = NontrivialDrop; //~WARNING non-binding let on a type that implements `Drop`
+    let _ = NontrivialDrop; //~WARNING non-binding let on a type that has a destructor
 
     let (_, _) = (NontrivialDrop, NontrivialDrop); // This should be ignored.
 }

--- a/tests/ui/lint/let_underscore/let_underscore_drop.stderr
+++ b/tests/ui/lint/let_underscore/let_underscore_drop.stderr
@@ -1,4 +1,4 @@
-warning: non-binding let on a type that implements `Drop`
+warning: non-binding let on a type that has a destructor
   --> $DIR/let_underscore_drop.rs:13:5
    |
 LL |     let _ = NontrivialDrop;


### PR DESCRIPTION
Closes: #130430 
r? rust-lang/diagnostics