### PR TITLE
Add tracking issue for io_error_inprogress

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -402,7 +402,7 @@ pub enum ErrorKind {
 
     /// The operation was partially successful and needs to be checked
     /// later on due to not blocking.
-    #[unstable(feature = "io_error_inprogress", issue = "none")]
+    #[unstable(feature = "io_error_inprogress", issue = "130840")]
     InProgress,
 
     // "Unusual" error kinds which do not correspond simply to (sets


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

I forgot to mention this in #130789 