### PR TITLE
Utf8Chunks: add link to Utf8Chunk

### DIFF
--- a/library/core/src/str/lossy.rs
+++ b/library/core/src/str/lossy.rs
@@ -8,6 +8,8 @@ impl [u8] {
     /// Creates an iterator over the contiguous valid UTF-8 ranges of this
     /// slice, and the non-UTF-8 fragments in between.
     ///
+    /// See the [`Utf8Chunk`] type for documenation of the items yielded by this iterator.
+    ///
     /// # Examples
     ///
     /// This function formats arbitrary but mostly-UTF-8 bytes into Rust source
@@ -147,6 +149,8 @@ impl fmt::Debug for Debug<'_> {
 ///
 /// If you want a simple conversion from UTF-8 byte slices to string slices,
 /// [`from_utf8`] is easier to use.
+///
+/// See the [`Utf8Chunk`] type for documenation of the items yielded by this iterator.
 ///
 /// [byteslice]: slice
 /// [`from_utf8`]: super::from_utf8


### PR DESCRIPTION
It is currently surprisingly non-trivial to go from the `utf8_chunks` method to the docs of the `valid`/`invalid` methods used in the example. This should help.