### PR TITLE
Fix directives for lint-non-snake-case-crate

### DIFF
--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.cdylib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.cdylib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:29:18
+  --> $DIR/lint-non-snake-case-crate.rs:36:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:31:9
+  --> $DIR/lint-non-snake-case-crate.rs:38:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.dylib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.dylib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:29:18
+  --> $DIR/lint-non-snake-case-crate.rs:36:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:31:9
+  --> $DIR/lint-non-snake-case-crate.rs:38:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.lib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.lib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:29:18
+  --> $DIR/lint-non-snake-case-crate.rs:36:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:31:9
+  --> $DIR/lint-non-snake-case-crate.rs:38:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.proc_macro_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.proc_macro_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:29:18
+  --> $DIR/lint-non-snake-case-crate.rs:36:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:31:9
+  --> $DIR/lint-non-snake-case-crate.rs:38:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.rlib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.rlib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:29:18
+  --> $DIR/lint-non-snake-case-crate.rs:36:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:31:9
+  --> $DIR/lint-non-snake-case-crate.rs:38:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.rs
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.rs
@@ -10,10 +10,17 @@
 
 // But should fire on non-binary crates.
 
-//@[cdylib_] ignore-musl (dylibs are not supported)
-//@[dylib_] ignore-musl (dylibs are not supported)
-//@[dylib_] ignore-wasm (dylib is not supported)
-//@[proc_macro_] ignore-wasm (dylib is not supported)
+// FIXME(#132309): dylib crate type is not supported on wasm; we need a proper
+// supports-crate-type directive. Also, needs-dynamic-linking should rule out
+// musl since it supports neither dylibs nor cdylibs.
+//@[dylib_] ignore-wasm
+//@[dylib_] ignore-musl
+//@[cdylib_] ignore-musl
+
+//@[dylib_] needs-dynamic-linking
+//@[cdylib_] needs-dynamic-linking
+//@[proc_macro_] force-host
+//@[proc_macro_] no-prefer-dynamic
 
 //@[cdylib_] compile-flags: --crate-type=cdylib
 //@[dylib_] compile-flags: --crate-type=dylib

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.staticlib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.staticlib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:29:18
+  --> $DIR/lint-non-snake-case-crate.rs:36:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:31:9
+  --> $DIR/lint-non-snake-case-crate.rs:38:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^


### PR DESCRIPTION
This test fails on targets without unwinding or with `--target-rustcflags=-Cpanic=abort` because the proc macro was compiled as the target, not the host. Some targets were explicitly disabled to pass CI, but these directives are more general.

* `needs-dynamic-linking` is self explanatory
* `force-host` for proc macros
* `no-prefer-dynamic` is apparently also used for proc macros

Note that `needs-unwind` can also be useful for situations other than proc macros where unwinding is necessary.

r? @jieyouxu

try-job: test-various