### PR TITLE
Relax a debug assertion for dyn principal *equality* in codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3448,6 +3448,7 @@ dependencies = [
  "rustc_span",
  "rustc_symbol_mangling",
  "rustc_target",
+ "rustc_trait_selection",
  "rustc_type_ir",
  "serde_json",
  "smallvec",

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -34,6 +34,7 @@ rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_symbol_mangling = { path = "../rustc_symbol_mangling" }
 rustc_target = { path = "../rustc_target" }
+rustc_trait_selection = { path = "../rustc_trait_selection" }
 rustc_type_ir = { path = "../rustc_type_ir" }
 serde_json = "1.0.59"
 smallvec = { version = "1.8.1", features = ["union", "may_dangle"] }

--- a/tests/ui/codegen/sub-principals-in-codegen.rs
+++ b/tests/ui/codegen/sub-principals-in-codegen.rs
@@ -1,0 +1,8 @@
+//@ build-pass
+
+// Regression test for an overly aggressive assertion in #130855.
+
+fn main() {
+    let subtype: &(dyn for<'a> Fn(&'a i32) -> &'a i32) = &|x| x;
+    let supertype: &(dyn Fn(&'static i32) -> &'static i32) = subtype;
+}


### PR DESCRIPTION
Maybe this sucks and I should just bite the bullet and use `infcx.sub` here. Thoughts?

r? lcnr

Fixes #130855