### PR TITLE
Update FIXME comment in s390x_unknown_linux_*.rs

### DIFF
--- a/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_gnu.rs
@@ -6,9 +6,8 @@ pub(crate) fn target() -> Target {
     base.endian = Endian::Big;
     // z10 is the oldest CPU supported by LLVM
     base.cpu = "z10".into();
-    // FIXME: The ABI implementation in cabi_s390x.rs is for now hard-coded to assume the no-vector
-    // ABI. Pass the -vector feature string to LLVM to respect this assumption. On LLVM < 16, we
-    // also strip v128 from the data_layout below to match the older LLVM's expectation.
+    // FIXME: The ABI implementation in abi/call/s390x.rs is for now hard-coded to assume the no-vector
+    // ABI. Pass the -vector feature string to LLVM to respect this assumption.
     base.features = "-vector".into();
     base.max_atomic_width = Some(128);
     base.min_global_align = Some(16);

--- a/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_musl.rs
@@ -6,9 +6,8 @@ pub(crate) fn target() -> Target {
     base.endian = Endian::Big;
     // z10 is the oldest CPU supported by LLVM
     base.cpu = "z10".into();
-    // FIXME: The ABI implementation in cabi_s390x.rs is for now hard-coded to assume the no-vector
-    // ABI. Pass the -vector feature string to LLVM to respect this assumption. On LLVM < 16, we
-    // also strip v128 from the data_layout below to match the older LLVM's expectation.
+    // FIXME: The ABI implementation in abi/call/s390x.rs is for now hard-coded to assume the no-vector
+    // ABI. Pass the -vector feature string to LLVM to respect this assumption.
     base.features = "-vector".into();
     base.max_atomic_width = Some(128);
     base.min_global_align = Some(16);


### PR DESCRIPTION
- Remove comment about "LLVM < 16" since the minimum external LLVM version is 16+ since https://github.com/rust-lang/rust/pull/117947
- Reflect rename of cabi_s390x.rs in https://github.com/rust-lang/rust/commit/030244cd4a76914af7dc2939ed1a16f394ceda48 (renamed to [abi/call/s390x.rs](https://github.com/rust-lang/rust/commit/030244cd4a76914af7dc2939ed1a16f394ceda48#diff-20136d4a18fa0ef9bd4fc2e6f92e88daad6be88bfb156e5702af39ee87ca4879), and it is currently [still in the same location](https://github.com/rust-lang/rust/blob/9e394f551c050ff03c6fc57f190e0761cf0be6e8/compiler/rustc_target/src/abi/call/s390x.rs)).

r? @cuviper

@rustbot label +O-SystemZ