### PR TITLE
Add suggestion for removing invalid path sep `::` in fn def

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -415,6 +415,9 @@ parse_invalid_meta_item = expected unsuffixed literal, found `{$token}`
 
 parse_invalid_offset_of = offset_of expects dot-separated field and variant names
 
+parse_invalid_path_sep_in_fn_definition = invalid path separator in function definition
+    .suggestion = remove invalid path separator
+
 parse_invalid_unicode_escape = invalid unicode character escape
     .label = invalid escape
     .help = unicode escape must {$surrogate ->

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -1756,6 +1756,14 @@ pub(crate) struct MissingFnParams {
 }
 
 #[derive(Diagnostic)]
+#[diag(parse_invalid_path_sep_in_fn_definition)]
+pub(crate) struct InvalidPathSepInFnDefinition {
+    #[primary_span]
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(parse_missing_trait_in_trait_impl)]
 pub(crate) struct MissingTraitInTraitImpl {
     #[primary_span]

--- a/compiler/rustc_parse/src/parser/generics.rs
+++ b/compiler/rustc_parse/src/parser/generics.rs
@@ -269,6 +269,13 @@ impl<'a> Parser<'a> {
     ///                  | ( < lifetimes , typaramseq ( , )? > )
     /// where   typaramseq = ( typaram ) | ( typaram , typaramseq )
     pub(super) fn parse_generics(&mut self) -> PResult<'a, ast::Generics> {
+        // invalid path separator `::` in function definition
+        // for example `fn invalid_path_separator::<T>() {}`
+        if self.eat_noexpect(&token::PathSep) {
+            self.dcx()
+                .emit_err(errors::InvalidPathSepInFnDefinition { span: self.prev_token.span });
+        }
+
         let span_lo = self.token.span;
         let (params, span) = if self.eat_lt() {
             let params = self.parse_generic_params()?;

--- a/tests/ui/parser/issues/invalid-path-sep-in-fn-definition-issue-130791.fixed
+++ b/tests/ui/parser/issues/invalid-path-sep-in-fn-definition-issue-130791.fixed
@@ -1,0 +1,7 @@
+//@ run-rustfix
+
+#[allow(dead_code)]
+fn invalid_path_separator<T>() {}
+//~^ ERROR invalid path separator in function definition
+
+fn main() {}

--- a/tests/ui/parser/issues/invalid-path-sep-in-fn-definition-issue-130791.rs
+++ b/tests/ui/parser/issues/invalid-path-sep-in-fn-definition-issue-130791.rs
@@ -1,0 +1,7 @@
+//@ run-rustfix
+
+#[allow(dead_code)]
+fn invalid_path_separator::<T>() {}
+//~^ ERROR invalid path separator in function definition
+
+fn main() {}

--- a/tests/ui/parser/issues/invalid-path-sep-in-fn-definition-issue-130791.stderr
+++ b/tests/ui/parser/issues/invalid-path-sep-in-fn-definition-issue-130791.stderr
@@ -1,0 +1,14 @@
+error: invalid path separator in function definition
+  --> $DIR/invalid-path-sep-in-fn-definition-issue-130791.rs:4:26
+   |
+LL | fn invalid_path_separator::<T>() {}
+   |                          ^^
+   |
+help: remove invalid path separator
+   |
+LL - fn invalid_path_separator::<T>() {}
+LL + fn invalid_path_separator<T>() {}
+   |
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Add suggestion for removing invalid path separator `::` in function definition.

for example: `fn invalid_path_separator::<T>() {}`

fixes #130791

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
