### PR TITLE
update `compiler-builtins` to 0.1.126

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.125"
+version = "0.1.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd02a01d7bc069bed818e956600fe437ee222dd1d6ad92bfb9db87b43b71fd87"
+checksum = "758019257ad46e191b587d8f711022a6ac1d1fb6745d75e1d76c587fdcbca770"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { version = "0.1.125", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "0.1.126", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }

--- a/library/core/src/arch.rs
+++ b/library/core/src/arch.rs
@@ -3,6 +3,9 @@
 #[allow(unused_imports)]
 #[stable(feature = "simd_arch", since = "1.27.0")]
 pub use crate::core_arch::arch::*;
+#[unstable(feature = "naked_functions", issue = "90957")]
+#[cfg(bootstrap)]
+pub use crate::naked_asm;
 
 /// Inline assembly.
 ///
@@ -15,6 +18,37 @@ pub use crate::core_arch::arch::*;
 #[rustc_builtin_macro]
 pub macro asm("assembly template", $(operands,)* $(options($(option),*))?) {
     /* compiler built-in */
+}
+
+/// Inline assembly used in combination with `#[naked]` functions.
+///
+/// Refer to [Rust By Example] for a usage guide and the [reference] for
+/// detailed information about the syntax and available options.
+///
+/// [Rust By Example]: https://doc.rust-lang.org/nightly/rust-by-example/unsafe/asm.html
+/// [reference]: https://doc.rust-lang.org/nightly/reference/inline-assembly.html
+#[unstable(feature = "naked_functions", issue = "90957")]
+#[macro_export]
+#[cfg(bootstrap)]
+macro_rules! naked_asm {
+    ([$last:expr], [$($pushed:expr),*]) => {
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        {
+            core::arch::asm!($($pushed),*, options(att_syntax, noreturn))
+        }
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+        {
+            core::arch::asm!($($pushed),* , $last, options(noreturn))
+        }
+    };
+
+    ([$first:expr $(, $rest:expr)*], [$($pushed:expr),*]) => {
+        naked_asm!([$($rest),*], [$($pushed,)* $first]);
+    };
+
+    ($($expr:expr),* $(,)?) => {
+        naked_asm!([$($expr),*], []);
+    };
 }
 
 /// Inline assembly used in combination with `#[naked]` functions.

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "0.1.125" }
+compiler_builtins = { version = "0.1.126" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.14", default-features = false, features = [


### PR DESCRIPTION
this requires the addition of a bootstrap variant of the new `naked_asm!` macro

r? @tgross35 

extracted from https://github.com/rust-lang/rust/pull/128651