### PR TITLE
Pass correct HirId to late_bound_vars in diagnostic code

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -882,7 +882,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let ty = self.lowerer().lower_ty(hir_ty);
                     debug!(?ty, "return type (lowered)");
                     debug!(?expected, "expected type");
-                    let bound_vars = self.tcx.late_bound_vars(hir_ty.hir_id.owner.into());
+                    let bound_vars =
+                        self.tcx.late_bound_vars(self.tcx.local_def_id_to_hir_id(fn_id));
                     let ty = Binder::bind_with_vars(ty, bound_vars);
                     let ty = self.normalize(hir_ty.span, ty);
                     let ty = self.tcx.instantiate_bound_regions_with_erased(ty);

--- a/tests/crashes/125655.rs
+++ b/tests/crashes/125655.rs
@@ -1,8 +1,0 @@
-//@ known-bug: rust-lang/rust#125655
-
-fn main() {
-    static foo: dyn Fn() -> u32 = || -> u32 {
-        ...
-        0
-    };
-}

--- a/tests/ui/closures/binder/closure-return-type-mismatch.rs
+++ b/tests/ui/closures/binder/closure-return-type-mismatch.rs
@@ -1,0 +1,15 @@
+// We used to bind the closure return type `&'a ()` with the late-bound vars of
+// the owner (here `main` & `env` resp.) instead of the ones of the enclosing
+// function-like / closure inside diagnostic code which was incorrect.
+
+#![feature(closure_lifetime_binder)]
+
+// issue: rust-lang/rust#130391
+fn main() {
+    let _ = for<'a> |x: &'a u8| -> &'a () { x }; //~ ERROR mismatched types
+}
+
+// issue: rust-lang/rust#130663
+fn env<'r>() {
+    let _ = for<'a> |x: &'a u8| -> &'a () { x }; //~ ERROR mismatched types
+}

--- a/tests/ui/closures/binder/closure-return-type-mismatch.stderr
+++ b/tests/ui/closures/binder/closure-return-type-mismatch.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/closure-return-type-mismatch.rs:9:45
+   |
+LL |     let _ = for<'a> |x: &'a u8| -> &'a () { x };
+   |                                    ------   ^ expected `&()`, found `&u8`
+   |                                    |
+   |                                    expected `&'a ()` because of return type
+   |
+   = note: expected reference `&'a ()`
+              found reference `&'a u8`
+
+error[E0308]: mismatched types
+  --> $DIR/closure-return-type-mismatch.rs:14:45
+   |
+LL |     let _ = for<'a> |x: &'a u8| -> &'a () { x };
+   |                                    ------   ^ expected `&()`, found `&u8`
+   |                                    |
+   |                                    expected `&'a ()` because of return type
+   |
+   = note: expected reference `&'a ()`
+              found reference `&'a u8`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/closures/closure-return-type-mismatch.rs
+++ b/tests/ui/closures/closure-return-type-mismatch.rs
@@ -15,3 +15,7 @@ fn main() {
         b
     };
 }
+
+// issue: rust-lang/rust#130858 rust-lang/rust#125655
+static FOO: fn() -> bool = || -> bool { 1 };
+//~^ ERROR mismatched types

--- a/tests/ui/closures/closure-return-type-mismatch.stderr
+++ b/tests/ui/closures/closure-return-type-mismatch.stderr
@@ -1,4 +1,12 @@
 error[E0308]: mismatched types
+  --> $DIR/closure-return-type-mismatch.rs:20:41
+   |
+LL | static FOO: fn() -> bool = || -> bool { 1 };
+   |                                  ----   ^ expected `bool`, found integer
+   |                                  |
+   |                                  expected `bool` because of return type
+
+error[E0308]: mismatched types
   --> $DIR/closure-return-type-mismatch.rs:7:9
    |
 LL |         a
@@ -19,6 +27,6 @@ LL |         if false {
 LL |             return "hello"
    |                    ^^^^^^^ expected `bool`, found `&str`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
Fixes #130858.
Fixes #125655.
Fixes #130391.
Fixes #130663.

r? compiler-errors