### PR TITLE
core/ptr: Add simulate_realloc()

### DIFF
--- a/compiler/rustc_codegen_llvm/src/attributes.rs
+++ b/compiler/rustc_codegen_llvm/src/attributes.rs
@@ -482,6 +482,10 @@ pub(crate) fn llfn_attrs_from_instance<'ll, 'tcx>(
         let allocated_pointer = AttributeKind::AllocatedPointer.create_attr(cx.llcx);
         attributes::apply_to_llfn(llfn, AttributePlace::Argument(0), &[allocated_pointer]);
     }
+    if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::SIMULATE_ALLOCATOR) {
+        let no_alias = AttributeKind::NoAlias.create_attr(cx.llcx);
+        attributes::apply_to_llfn(llfn, AttributePlace::ReturnValue, &[no_alias]);
+    }
     if let Some(align) = codegen_fn_attrs.alignment {
         llvm::set_alignment(llfn, align);
     }

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -110,6 +110,9 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
             sym::rustc_nounwind => codegen_fn_attrs.flags |= CodegenFnAttrFlags::NEVER_UNWIND,
             sym::rustc_reallocator => codegen_fn_attrs.flags |= CodegenFnAttrFlags::REALLOCATOR,
             sym::rustc_deallocator => codegen_fn_attrs.flags |= CodegenFnAttrFlags::DEALLOCATOR,
+            sym::rustc_simulate_allocator => {
+                codegen_fn_attrs.flags |= CodegenFnAttrFlags::SIMULATE_ALLOCATOR
+            }
             sym::rustc_allocator_zeroed => {
                 codegen_fn_attrs.flags |= CodegenFnAttrFlags::ALLOCATOR_ZEROED
             }

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -691,6 +691,10 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         rustc_allocator_zeroed, Normal, template!(Word), WarnFollowing,
         EncodeCrossCrate::No, IMPL_DETAIL
     ),
+    rustc_attr!(
+        rustc_simulate_allocator, Normal, template!(Word), WarnFollowing,
+        EncodeCrossCrate::No, IMPL_DETAIL
+    ),
     gated!(
         default_lib_allocator, Normal, template!(Word), WarnFollowing,
         EncodeCrossCrate::No, allocator_internals, experimental!(default_lib_allocator),

--- a/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
+++ b/compiler/rustc_middle/src/middle/codegen_fn_attrs.rs
@@ -133,6 +133,8 @@ bitflags::bitflags! {
         const ALLOCATOR_ZEROED          = 1 << 18;
         /// `#[no_builtins]`: indicates that disable implicit builtin knowledge of functions for the function.
         const NO_BUILTINS               = 1 << 19;
+        /// `#[rustc_simulate_allocator]`: a hint to LLVM that the function simulates an allocation
+        const SIMULATE_ALLOCATOR        = 1 << 20;
     }
 }
 rustc_data_structures::external_bitflags_debug! { CodegenFnAttrFlags }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1735,6 +1735,7 @@ symbols! {
         rustc_runtime,
         rustc_safe_intrinsic,
         rustc_serialize,
+        rustc_simulate_allocator,
         rustc_skip_during_method_dispatch,
         rustc_specialization_trait,
         rustc_std_internal_symbol,


### PR DESCRIPTION
Add a `simulate_realloc()` helper function to core/ptr to simulate
reallocating memory from a pointer to some arbitrary address.
The function is intended to be used with architecture features such as
AArch64 Top-Byte Ignore where two different 64-bit addresses can point
to the same chunk of memory due to some bits being ignored.

To make the function accurately simulate an allocator, its return value
needs to be annotated with `noalias` in LLVM the same way as it is done
by actual allocator functions. To make that possible, add a new rustc
built-in attribute `rustc_simulate_allocator` that does the annotating.

Accompanying implementation for [RFC 3700](https://github.com/rust-lang/rfcs/pull/3700), currently posted on [Rust Internals](https://internals.rust-lang.org/t/pre-rfc-core-simulate-realloc/21745).

r? @RalfJung 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->