### PR TITLE
library: Compute `RUST_EXCEPTION_CLASS` from native-endian bytes

### DIFF
--- a/library/panic_unwind/src/gcc.rs
+++ b/library/panic_unwind/src/gcc.rs
@@ -107,4 +107,4 @@ pub unsafe fn cleanup(ptr: *mut u8) -> Box<dyn Any + Send> {
 
 // Rust's exception class identifier.  This is used by personality routines to
 // determine whether the exception was thrown by their own runtime.
-const RUST_EXCEPTION_CLASS: uw::_Unwind_Exception_Class = u64::from_be_bytes(*b"MOZ\0RUST");
+const RUST_EXCEPTION_CLASS: uw::_Unwind_Exception_Class = u64::from_ne_bytes(*b"MOZ\0RUST");


### PR DESCRIPTION
This makes it appear correctly in hexdumps on both LE and BE platforms.

<!-- homu-ignore:start -->
As discussed extensively in https://github.com/rust-lang/rust/pull/130381/files#r1760034980
<!-- homu-ignore:end -->
