### PR TITLE
Bump cc dependency

### DIFF
--- a/library/profiler_builtins/Cargo.toml
+++ b/library/profiler_builtins/Cargo.toml
@@ -13,4 +13,6 @@ core = { path = "../core" }
 compiler_builtins = { version = "0.1.0", features = ['rustc-dep-of-std'] }
 
 [build-dependencies]
-cc = "1.0.97"
+# FIXME: updates past a certain point haven't been able to merge successfully.
+# See rust-lang/rust#130720.
+cc = "=1.0.99"


### PR DESCRIPTION
We cannot merge the [PR](https://github.com/rust-lang/rust/pull/130720)
Let's try merging an older version for a change. 

https://github.com/rust-lang/rust/pull/130720#issuecomment-2377500262
https://github.com/rust-lang/rust/pull/130908#issuecomment-2378342343
https://github.com/rust-lang/rust/pull/130908

try-job: x86_64-msvc