### PR TITLE
Stabilize Option::get_or_insert_default

### DIFF
--- a/compiler/rustc_session/src/lib.rs
+++ b/compiler/rustc_session/src/lib.rs
@@ -1,9 +1,9 @@
 // tidy-alphabetical-start
 #![allow(internal_features)]
+#![cfg_attr(bootstrap, feature(option_get_or_insert_default))]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]
 #![feature(map_many_mut)]
-#![feature(option_get_or_insert_default)]
 #![feature(rustc_attrs)]
 #![warn(unreachable_pub)]
 // tidy-alphabetical-end

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1639,8 +1639,6 @@ impl<T> Option<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(option_get_or_insert_default)]
-    ///
     /// let mut x = None;
     ///
     /// {
@@ -1653,7 +1651,7 @@ impl<T> Option<T> {
     /// assert_eq!(x, Some(7));
     /// ```
     #[inline]
-    #[unstable(feature = "option_get_or_insert_default", issue = "82901")]
+    #[stable(feature = "option_get_or_insert_default", since = "CURRENT_RUSTC_VERSION")]
     pub fn get_or_insert_default(&mut self) -> &mut T
     where
         T: Default,


### PR DESCRIPTION
FCP completed in #82901.

Stabilized API:

```rust
impl<T> Option<T> {
    pub fn get_or_insert_default(&mut self) -> &mut T where T: Default;
}
```