### PR TITLE
Rollup of 11 pull requests

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -882,7 +882,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     let ty = self.lowerer().lower_ty(hir_ty);
                     debug!(?ty, "return type (lowered)");
                     debug!(?expected, "expected type");
-                    let bound_vars = self.tcx.late_bound_vars(hir_ty.hir_id.owner.into());
+                    let bound_vars =
+                        self.tcx.late_bound_vars(self.tcx.local_def_id_to_hir_id(fn_id));
                     let ty = Binder::bind_with_vars(ty, bound_vars);
                     let ty = self.normalize(hir_ty.span, ty);
                     let ty = self.tcx.instantiate_bound_regions_with_erased(ty);

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -531,7 +531,7 @@ lint_non_binding_let_multi_suggestion =
     consider immediately dropping the value
 
 lint_non_binding_let_on_drop_type =
-    non-binding let on a type that implements `Drop`
+    non-binding let on a type that has a destructor
 
 lint_non_binding_let_on_sync_lock = non-binding let on a synchronization lock
     .label = this lock is not assigned to a binding and is immediately dropped

--- a/compiler/rustc_lint/src/let_underscore.rs
+++ b/compiler/rustc_lint/src/let_underscore.rs
@@ -51,7 +51,7 @@ declare_lint! {
     /// intent.
     pub LET_UNDERSCORE_DROP,
     Allow,
-    "non-binding let on a type that implements `Drop`"
+    "non-binding let on a type that has a destructor"
 }
 
 declare_lint! {

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -732,12 +732,7 @@ extern "C" LLVMRustResult LLVMRustOptimize(
   PTO.SLPVectorization = SLPVectorize;
   PTO.MergeFunctions = MergeFunctions;
 
-  // FIXME: We may want to expose this as an option.
-  bool DebugPassManager = false;
-
   PassInstrumentationCallbacks PIC;
-  StandardInstrumentations SI(TheModule->getContext(), DebugPassManager);
-  SI.registerCallbacks(PIC);
 
   if (LlvmSelfProfiler) {
     LLVMSelfProfileInitializeCallbacks(PIC, LlvmSelfProfiler,
@@ -783,6 +778,12 @@ extern "C" LLVMRustResult LLVMRustOptimize(
   FunctionAnalysisManager FAM;
   CGSCCAnalysisManager CGAM;
   ModuleAnalysisManager MAM;
+
+  // FIXME: We may want to expose this as an option.
+  bool DebugPassManager = false;
+
+  StandardInstrumentations SI(TheModule->getContext(), DebugPassManager);
+  SI.registerCallbacks(PIC, &MAM);
 
   if (LLVMPluginsLen) {
     auto PluginsStr = StringRef(LLVMPlugins, LLVMPluginsLen);

--- a/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_gnu.rs
@@ -6,9 +6,8 @@ pub(crate) fn target() -> Target {
     base.endian = Endian::Big;
     // z10 is the oldest CPU supported by LLVM
     base.cpu = "z10".into();
-    // FIXME: The ABI implementation in cabi_s390x.rs is for now hard-coded to assume the no-vector
-    // ABI. Pass the -vector feature string to LLVM to respect this assumption. On LLVM < 16, we
-    // also strip v128 from the data_layout below to match the older LLVM's expectation.
+    // FIXME: The ABI implementation in abi/call/s390x.rs is for now hard-coded to assume the no-vector
+    // ABI. Pass the -vector feature string to LLVM to respect this assumption.
     base.features = "-vector".into();
     base.max_atomic_width = Some(128);
     base.min_global_align = Some(16);

--- a/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/s390x_unknown_linux_musl.rs
@@ -6,9 +6,8 @@ pub(crate) fn target() -> Target {
     base.endian = Endian::Big;
     // z10 is the oldest CPU supported by LLVM
     base.cpu = "z10".into();
-    // FIXME: The ABI implementation in cabi_s390x.rs is for now hard-coded to assume the no-vector
-    // ABI. Pass the -vector feature string to LLVM to respect this assumption. On LLVM < 16, we
-    // also strip v128 from the data_layout below to match the older LLVM's expectation.
+    // FIXME: The ABI implementation in abi/call/s390x.rs is for now hard-coded to assume the no-vector
+    // ABI. Pass the -vector feature string to LLVM to respect this assumption.
     base.features = "-vector".into();
     base.max_atomic_width = Some(128);
     base.min_global_align = Some(16);

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2635,49 +2635,47 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         // This shouldn't be common unless manually implementing one of the
         // traits manually, but don't make it more confusing when it does
         // happen.
-        Ok(
-            if Some(expected_trait_ref.def_id) != self.tcx.lang_items().coroutine_trait()
-                && not_tupled
-            {
-                self.report_and_explain_type_error(
-                    TypeTrace::trait_refs(
-                        &obligation.cause,
-                        true,
-                        expected_trait_ref,
-                        found_trait_ref,
-                    ),
-                    ty::error::TypeError::Mismatch,
-                )
-            } else if found.len() == expected.len() {
-                self.report_closure_arg_mismatch(
-                    span,
-                    found_span,
-                    found_trait_ref,
-                    expected_trait_ref,
-                    obligation.cause.code(),
-                    found_node,
-                    obligation.param_env,
-                )
-            } else {
-                let (closure_span, closure_arg_span, found) = found_did
-                    .and_then(|did| {
-                        let node = self.tcx.hir().get_if_local(did)?;
-                        let (found_span, closure_arg_span, found) =
-                            self.get_fn_like_arguments(node)?;
-                        Some((Some(found_span), closure_arg_span, found))
-                    })
-                    .unwrap_or((found_span, None, found));
+        if Some(expected_trait_ref.def_id) != self.tcx.lang_items().coroutine_trait() && not_tupled
+        {
+            return Ok(self.report_and_explain_type_error(
+                TypeTrace::trait_refs(&obligation.cause, true, expected_trait_ref, found_trait_ref),
+                ty::error::TypeError::Mismatch,
+            ));
+        }
+        if found.len() != expected.len() {
+            let (closure_span, closure_arg_span, found) = found_did
+                .and_then(|did| {
+                    let node = self.tcx.hir().get_if_local(did)?;
+                    let (found_span, closure_arg_span, found) = self.get_fn_like_arguments(node)?;
+                    Some((Some(found_span), closure_arg_span, found))
+                })
+                .unwrap_or((found_span, None, found));
 
-                self.report_arg_count_mismatch(
+            // If the coroutine take a single () as its argument,
+            // the trait argument would found the coroutine take 0 arguments,
+            // but get_fn_like_arguments would give 1 argument.
+            // This would result in "Expected to take 1 argument, but it takes 1 argument".
+            // Check again to avoid this.
+            if found.len() != expected.len() {
+                return Ok(self.report_arg_count_mismatch(
                     span,
                     closure_span,
                     expected,
                     found,
                     found_trait_ty.is_closure(),
                     closure_arg_span,
-                )
-            },
-        )
+                ));
+            }
+        }
+        Ok(self.report_closure_arg_mismatch(
+            span,
+            found_span,
+            found_trait_ref,
+            expected_trait_ref,
+            obligation.cause.code(),
+            found_node,
+            obligation.param_env,
+        ))
     }
 
     /// Given some node representing a fn-like thing in the HIR map,

--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -63,22 +63,21 @@ use crate::ptr;
 /// # Safety hazards when storing `ManuallyDrop` in a struct or an enum.
 ///
 /// Special care is needed when all of the conditions below are met:
-/// * A field of a struct or enum is a `ManuallyDrop` or contains a
-///   `ManuallyDrop`, without the `ManuallyDrop` being inside a `union`.
+/// * A struct or enum contains a `ManuallyDrop`.
+/// * The `ManuallyDrop` is not inside a `union`.
 /// * The struct or enum is part of public API, or is stored in a struct or an
 ///   enum that is part of public API.
-/// * There is code outside of a `Drop` implementation that calls
-///   [`ManuallyDrop::drop`] or [`ManuallyDrop::take`] on the `ManuallyDrop`
-///   field.
+/// * There is code that drops the contents of the `ManuallyDrop` field, and
+///   this code is outside the struct or enum's `Drop` implementation.
 ///
-/// In particular, the following hazards can occur:
+/// In particular, the following hazards may occur:
 ///
 /// #### Storing generic types
 ///
 /// If the `ManuallyDrop` contains a client-supplied generic type, the client
-/// might provide a `Box`, causing undefined behavior when the struct / enum is
-/// later moved, as mentioned above. For example, the following code causes
-/// undefined behavior:
+/// might provide a `Box` as that type. This would cause undefined behavior when
+/// the struct or enum is later moved, as mentioned in the previous section. For
+/// example, the following code causes undefined behavior:
 ///
 /// ```no_run
 /// use std::mem::ManuallyDrop;
@@ -114,7 +113,7 @@ use crate::ptr;
 /// #### Deriving traits
 ///
 /// Deriving `Debug`, `Clone`, `PartialEq`, `PartialOrd`, `Ord`, or `Hash` on
-/// the struct / enum could be unsound, since the derived implementations of
+/// the struct or enum could be unsound, since the derived implementations of
 /// these traits would access the `ManuallyDrop` field. For example, the
 /// following code causes undefined behavior:
 ///

--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -41,8 +41,9 @@ use crate::ptr;
 ///
 /// # Interaction with `Box`
 ///
-/// Currently, once the `Box<T>` inside a `ManuallyDrop<Box<T>>` is dropped,
-/// moving the `ManuallyDrop<Box<T>>` is [considered to be undefined
+/// Currently, if you have a `ManuallyDrop<T>`, where the type `T` is a `Box` or
+/// contains a `Box` inside, then dropping the `T` followed by moving the
+/// `ManuallyDrop<T>` is [considered to be undefined
 /// behavior](https://github.com/rust-lang/unsafe-code-guidelines/issues/245).
 /// That is, the following code causes undefined behavior:
 ///

--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -15,7 +15,7 @@ use crate::ptr;
 /// that a `ManuallyDrop<T>` whose content has been dropped must not be exposed
 /// through a public safe API. Correspondingly, `ManuallyDrop::drop` is unsafe.
 ///
-/// # `ManuallyDrop` and drop order.
+/// # `ManuallyDrop` and drop order
 ///
 /// Rust has a well-defined [drop order] of values. To make sure that fields or
 /// locals are dropped in a specific order, reorder the declarations such that
@@ -39,7 +39,7 @@ use crate::ptr;
 /// }
 /// ```
 ///
-/// # Interaction with `Box`.
+/// # Interaction with `Box`
 ///
 /// Currently, once the `Box<T>` inside a `ManuallyDrop<Box<T>>` is dropped,
 /// moving the `ManuallyDrop<Box<T>>` is [considered to be undefined
@@ -56,16 +56,17 @@ use crate::ptr;
 /// let y = x; // Undefined behavior!
 /// ```
 ///
-/// This may change in the future. In the meantime, consider using
-/// [`MaybeUninit`] instead.
+/// This is [likely to change in the
+/// future](https://rust-lang.github.io/rfcs/3336-maybe-dangling.html). In the
+/// meantime, consider using [`MaybeUninit`] instead.
 ///
-/// # Safety hazards when storing `ManuallyDrop` in a struct / enum.
+/// # Safety hazards when storing `ManuallyDrop` in a struct or an enum.
 ///
 /// Special care is needed when all of the conditions below are met:
 /// * A field of a struct or enum is a `ManuallyDrop` or contains a
 ///   `ManuallyDrop`, without the `ManuallyDrop` being inside a `union`.
-/// * The struct or enum is part of public API, or is stored in a struct or enum
-///   that is part of public API.
+/// * The struct or enum is part of public API, or is stored in a struct or an
+///   enum that is part of public API.
 /// * There is code outside of a `Drop` implementation that calls
 ///   [`ManuallyDrop::drop`] or [`ManuallyDrop::take`] on the `ManuallyDrop`
 ///   field.
@@ -120,14 +121,15 @@ use crate::ptr;
 /// ```no_run
 /// use std::mem::ManuallyDrop;
 ///
-/// #[derive(Debug)] // This is unsound!
+/// // This derive is unsound in combination with the `ManuallyDrop::drop` call.
+/// #[derive(Debug)]
 /// pub struct Foo {
 ///     value: ManuallyDrop<String>,
 /// }
 /// impl Foo {
 ///     pub fn new() -> Self {
 ///         let mut temp = Self {
-///             value: ManuallyDrop::new(String::from("Unsafe rust is hard"))
+///             value: ManuallyDrop::new(String::from("Unsafe rust is hard."))
 ///         };
 ///         unsafe {
 ///             // SAFETY: `value` hasn't been dropped yet.

--- a/library/core/src/mem/manually_drop.rs
+++ b/library/core/src/mem/manually_drop.rs
@@ -1,20 +1,19 @@
 use crate::ops::{Deref, DerefMut, DerefPure};
 use crate::ptr;
 
-/// A wrapper to inhibit the compiler from automatically calling `T`’s destructor.
-/// This wrapper is 0-cost.
+/// A wrapper to inhibit the compiler from automatically calling `T`’s
+/// destructor. This wrapper is 0-cost.
 ///
 /// `ManuallyDrop<T>` is guaranteed to have the same layout and bit validity as
-/// `T`, and is subject to the same layout optimizations as `T`. As a consequence,
-/// it has *no effect* on the assumptions that the compiler makes about its
-/// contents. For example, initializing a `ManuallyDrop<&mut T>` with [`mem::zeroed`]
-/// is undefined behavior. If you need to handle uninitialized data, use
-/// [`MaybeUninit<T>`] instead.
+/// `T`, and is subject to the same layout optimizations as `T`. As a
+/// consequence, it has *no effect* on the assumptions that the compiler makes
+/// about its contents. For example, initializing a `ManuallyDrop<&mut T>` with
+/// [`mem::zeroed`] is undefined behavior. If you need to handle uninitialized
+/// data, use [`MaybeUninit<T>`] instead.
 ///
-/// Note that accessing the value inside a `ManuallyDrop<T>` is safe.
-/// This means that a `ManuallyDrop<T>` whose content has been dropped must not
-/// be exposed through a public safe API.
-/// Correspondingly, `ManuallyDrop::drop` is unsafe.
+/// Note that accessing the value inside a `ManuallyDrop<T>` is safe. This means
+/// that a `ManuallyDrop<T>` whose content has been dropped must not be exposed
+/// through a public safe API. Correspondingly, `ManuallyDrop::drop` is unsafe.
 ///
 /// # `ManuallyDrop` and drop order.
 ///
@@ -40,9 +39,114 @@ use crate::ptr;
 /// }
 /// ```
 ///
+/// # Interaction with `Box`.
+///
+/// Currently, once the `Box<T>` inside a `ManuallyDrop<Box<T>>` is dropped,
+/// moving the `ManuallyDrop<Box<T>>` is [considered to be undefined
+/// behavior](https://github.com/rust-lang/unsafe-code-guidelines/issues/245).
+/// That is, the following code causes undefined behavior:
+///
+/// ```no_run
+/// use std::mem::ManuallyDrop;
+///
+/// let mut x = ManuallyDrop::new(Box::new(42));
+/// unsafe {
+///     ManuallyDrop::drop(&mut x);
+/// }
+/// let y = x; // Undefined behavior!
+/// ```
+///
+/// This may change in the future. In the meantime, consider using
+/// [`MaybeUninit`] instead.
+///
+/// # Safety hazards when storing `ManuallyDrop` in a struct / enum.
+///
+/// Special care is needed when all of the conditions below are met:
+/// * A field of a struct or enum is a `ManuallyDrop` or contains a
+///   `ManuallyDrop`, without the `ManuallyDrop` being inside a `union`.
+/// * The struct or enum is part of public API, or is stored in a struct or enum
+///   that is part of public API.
+/// * There is code outside of a `Drop` implementation that calls
+///   [`ManuallyDrop::drop`] or [`ManuallyDrop::take`] on the `ManuallyDrop`
+///   field.
+///
+/// In particular, the following hazards can occur:
+///
+/// #### Storing generic types
+///
+/// If the `ManuallyDrop` contains a client-supplied generic type, the client
+/// might provide a `Box`, causing undefined behavior when the struct / enum is
+/// later moved, as mentioned above. For example, the following code causes
+/// undefined behavior:
+///
+/// ```no_run
+/// use std::mem::ManuallyDrop;
+///
+/// pub struct BadOption<T> {
+///     // Invariant: Has been dropped iff `is_some` is false.
+///     value: ManuallyDrop<T>,
+///     is_some: bool,
+/// }
+/// impl<T> BadOption<T> {
+///     pub fn new(value: T) -> Self {
+///         Self { value: ManuallyDrop::new(value), is_some: true }
+///     }
+///     pub fn change_to_none(&mut self) {
+///         if self.is_some {
+///             self.is_some = false;
+///             unsafe {
+///                 // SAFETY: `value` hasn't been dropped yet, as per the invariant
+///                 // (This is actually unsound!)
+///                 ManuallyDrop::drop(&mut self.value);
+///             }
+///         }
+///     }
+/// }
+///
+/// // In another crate:
+///
+/// let mut option = BadOption::new(Box::new(42));
+/// option.change_to_none();
+/// let option2 = option; // Undefined behavior!
+/// ```
+///
+/// #### Deriving traits
+///
+/// Deriving `Debug`, `Clone`, `PartialEq`, `PartialOrd`, `Ord`, or `Hash` on
+/// the struct / enum could be unsound, since the derived implementations of
+/// these traits would access the `ManuallyDrop` field. For example, the
+/// following code causes undefined behavior:
+///
+/// ```no_run
+/// use std::mem::ManuallyDrop;
+///
+/// #[derive(Debug)] // This is unsound!
+/// pub struct Foo {
+///     value: ManuallyDrop<String>,
+/// }
+/// impl Foo {
+///     pub fn new() -> Self {
+///         let mut temp = Self {
+///             value: ManuallyDrop::new(String::from("Unsafe rust is hard"))
+///         };
+///         unsafe {
+///             // SAFETY: `value` hasn't been dropped yet.
+///             ManuallyDrop::drop(&mut temp.value);
+///         }
+///         temp
+///     }
+/// }
+///
+/// // In another crate:
+///
+/// let foo = Foo::new();
+/// println!("{:?}", foo); // Undefined behavior!
+/// ```
+///
 /// [drop order]: https://doc.rust-lang.org/reference/destructors.html
 /// [`mem::zeroed`]: crate::mem::zeroed
 /// [`MaybeUninit<T>`]: crate::mem::MaybeUninit
+/// [`MaybeUninit`]: crate::mem::MaybeUninit
 #[stable(feature = "manually_drop", since = "1.20.0")]
 #[lang = "manually_drop"]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/library/core/src/ptr/alignment.rs
+++ b/library/core/src/ptr/alignment.rs
@@ -155,7 +155,7 @@ impl Alignment {
         !(unsafe { self.as_usize().unchecked_sub(1) })
     }
 
-    // Remove me once `Ord::max` is usable in const
+    // FIXME(const-hack) Remove me once `Ord::max` is usable in const
     pub(crate) const fn max(a: Self, b: Self) -> Self {
         if a.as_usize() > b.as_usize() { a } else { b }
     }

--- a/library/core/src/str/lossy.rs
+++ b/library/core/src/str/lossy.rs
@@ -8,6 +8,8 @@ impl [u8] {
     /// Creates an iterator over the contiguous valid UTF-8 ranges of this
     /// slice, and the non-UTF-8 fragments in between.
     ///
+    /// See the [`Utf8Chunk`] type for documenation of the items yielded by this iterator.
+    ///
     /// # Examples
     ///
     /// This function formats arbitrary but mostly-UTF-8 bytes into Rust source
@@ -147,6 +149,8 @@ impl fmt::Debug for Debug<'_> {
 ///
 /// If you want a simple conversion from UTF-8 byte slices to string slices,
 /// [`from_utf8`] is easier to use.
+///
+/// See the [`Utf8Chunk`] type for documenation of the items yielded by this iterator.
 ///
 /// [byteslice]: slice
 /// [`from_utf8`]: super::from_utf8

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -15,7 +15,9 @@ mod libc {
     pub type socklen_t = u32;
     pub struct sockaddr;
     #[derive(Clone)]
-    pub struct sockaddr_un;
+    pub struct sockaddr_un {
+        pub sun_path: [u8; 1],
+    }
 }
 
 const SUN_PATH_OFFSET: usize = mem::offset_of!(libc::sockaddr_un, sun_path);

--- a/library/std/src/os/unix/net/addr.rs
+++ b/library/std/src/os/unix/net/addr.rs
@@ -18,12 +18,7 @@ mod libc {
     pub struct sockaddr_un;
 }
 
-fn sun_path_offset(addr: &libc::sockaddr_un) -> usize {
-    // Work with an actual instance of the type since using a null pointer is UB
-    let base = (addr as *const libc::sockaddr_un).addr();
-    let path = core::ptr::addr_of!(addr.sun_path).addr();
-    path - base
-}
+const SUN_PATH_OFFSET: usize = mem::offset_of!(libc::sockaddr_un, sun_path);
 
 pub(super) fn sockaddr_un(path: &Path) -> io::Result<(libc::sockaddr_un, libc::socklen_t)> {
     // SAFETY: All zeros is a valid representation for `sockaddr_un`.
@@ -53,7 +48,7 @@ pub(super) fn sockaddr_un(path: &Path) -> io::Result<(libc::sockaddr_un, libc::s
         ptr::copy_nonoverlapping(bytes.as_ptr(), addr.sun_path.as_mut_ptr().cast(), bytes.len())
     };
 
-    let mut len = sun_path_offset(&addr) + bytes.len();
+    let mut len = SUN_PATH_OFFSET + bytes.len();
     match bytes.get(0) {
         Some(&0) | None => {}
         Some(_) => len += 1,
@@ -114,13 +109,13 @@ impl SocketAddr {
             let sun_path: &[u8] =
                 unsafe { mem::transmute::<&[libc::c_char], &[u8]>(&addr.sun_path) };
             len = core::slice::memchr::memchr(0, sun_path)
-                .map_or(len, |new_len| (new_len + sun_path_offset(&addr)) as libc::socklen_t);
+                .map_or(len, |new_len| (new_len + SUN_PATH_OFFSET) as libc::socklen_t);
         }
 
         if len == 0 {
             // When there is a datagram from unnamed unix socket
             // linux returns zero bytes of address
-            len = sun_path_offset(&addr) as libc::socklen_t; // i.e., zero-length address
+            len = SUN_PATH_OFFSET as libc::socklen_t; // i.e., zero-length address
         } else if addr.sun_family != libc::AF_UNIX as libc::sa_family_t {
             return Err(io::const_io_error!(
                 io::ErrorKind::InvalidInput,
@@ -238,7 +233,7 @@ impl SocketAddr {
     }
 
     fn address(&self) -> AddressKind<'_> {
-        let len = self.len as usize - sun_path_offset(&self.addr);
+        let len = self.len as usize - SUN_PATH_OFFSET;
         let path = unsafe { mem::transmute::<&[libc::c_char], &[u8]>(&self.addr.sun_path) };
 
         // macOS seems to return a len of 16 and a zeroed sun_path for unnamed addresses
@@ -287,7 +282,7 @@ impl linux_ext::addr::SocketAddrExt for SocketAddr {
                 addr.sun_path.as_mut_ptr().add(1) as *mut u8,
                 name.len(),
             );
-            let len = (sun_path_offset(&addr) + 1 + name.len()) as libc::socklen_t;
+            let len = (SUN_PATH_OFFSET + 1 + name.len()) as libc::socklen_t;
             SocketAddr::from_parts(addr, len)
         }
     }

--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -46,6 +46,7 @@ static SETTINGS_HASHES: &[&str] = &[
     "47d227f424bf889b0d899b9cc992d5695e1b78c406e183cd78eafefbe5488923",
     "b526bd58d0262dd4dda2bff5bc5515b705fb668a46235ace3e057f807963a11a",
     "828666b021d837a33e78d870b56d34c88a5e2c85de58b693607ec574f0c27000",
+    "811fb3b063c739d261fd8590dd30242e117908f5a095d594fa04585daa18ec4d",
 ];
 static RUST_ANALYZER_SETTINGS: &str = include_str!("../../../../etc/rust_analyzer_settings.json");
 

--- a/src/etc/rust_analyzer_settings.json
+++ b/src/etc/rust_analyzer_settings.json
@@ -10,6 +10,7 @@
     ],
     "rust-analyzer.linkedProjects": [
         "Cargo.toml",
+        "library/Cargo.toml",
         "src/tools/x/Cargo.toml",
         "src/bootstrap/Cargo.toml",
         "src/tools/rust-analyzer/Cargo.toml",

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1687,7 +1687,12 @@ instead, we check that it's not a "finger" cursor.
 	padding-right: 3px;
 	background-color: var(--target-background-color);
 	border-right: 3px solid var(--target-border-color);
-	animation: 0.65s cubic-bezier(0, 0, 0.1, 1.0) 0.1s targetfadein;
+}
+
+@media not (prefers-reduced-motion) {
+	:target {
+		animation: 0.65s cubic-bezier(0, 0, 0.1, 1.0) 0.1s targetfadein;
+	}
 }
 
 .code-header a.tooltip {
@@ -1712,12 +1717,14 @@ a.tooltip:hover::after {
 	content: "\00a0";
 }
 
-/* This animation is layered onto the mistake-proofing delay for dismissing
-	a hovered tooltip, to ensure it feels responsive even with the delay.
-	*/
-.fade-out {
-	opacity: 0;
-	transition: opacity 0.45s cubic-bezier(0, 0, 0.1, 1.0);
+@media not (prefers-reduced-motion) {
+	/* This animation is layered onto the mistake-proofing delay for dismissing
+		a hovered tooltip, to ensure it feels responsive even with the delay.
+		*/
+	.fade-out {
+		opacity: 0;
+		transition: opacity 0.45s cubic-bezier(0, 0, 0.1, 1.0);
+	}
 }
 
 .popover.tooltip .content {

--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -1689,12 +1689,6 @@ instead, we check that it's not a "finger" cursor.
 	border-right: 3px solid var(--target-border-color);
 }
 
-@media not (prefers-reduced-motion) {
-	:target {
-		animation: 0.65s cubic-bezier(0, 0, 0.1, 1.0) 0.1s targetfadein;
-	}
-}
-
 .code-header a.tooltip {
 	color: inherit;
 	margin-right: 15px;
@@ -1718,6 +1712,10 @@ a.tooltip:hover::after {
 }
 
 @media not (prefers-reduced-motion) {
+	:target {
+		animation: 0.65s cubic-bezier(0, 0, 0.1, 1.0) 0.1s targetfadein;
+	}
+
 	/* This animation is layered onto the mistake-proofing delay for dismissing
 		a hovered tooltip, to ensure it feels responsive even with the delay.
 		*/

--- a/tests/crashes/125655.rs
+++ b/tests/crashes/125655.rs
@@ -1,8 +1,0 @@
-//@ known-bug: rust-lang/rust#125655
-
-fn main() {
-    static foo: dyn Fn() -> u32 = || -> u32 {
-        ...
-        0
-    };
-}

--- a/tests/ui/closures/binder/closure-return-type-mismatch.rs
+++ b/tests/ui/closures/binder/closure-return-type-mismatch.rs
@@ -1,0 +1,15 @@
+// We used to bind the closure return type `&'a ()` with the late-bound vars of
+// the owner (here `main` & `env` resp.) instead of the ones of the enclosing
+// function-like / closure inside diagnostic code which was incorrect.
+
+#![feature(closure_lifetime_binder)]
+
+// issue: rust-lang/rust#130391
+fn main() {
+    let _ = for<'a> |x: &'a u8| -> &'a () { x }; //~ ERROR mismatched types
+}
+
+// issue: rust-lang/rust#130663
+fn env<'r>() {
+    let _ = for<'a> |x: &'a u8| -> &'a () { x }; //~ ERROR mismatched types
+}

--- a/tests/ui/closures/binder/closure-return-type-mismatch.stderr
+++ b/tests/ui/closures/binder/closure-return-type-mismatch.stderr
@@ -1,0 +1,25 @@
+error[E0308]: mismatched types
+  --> $DIR/closure-return-type-mismatch.rs:9:45
+   |
+LL |     let _ = for<'a> |x: &'a u8| -> &'a () { x };
+   |                                    ------   ^ expected `&()`, found `&u8`
+   |                                    |
+   |                                    expected `&'a ()` because of return type
+   |
+   = note: expected reference `&'a ()`
+              found reference `&'a u8`
+
+error[E0308]: mismatched types
+  --> $DIR/closure-return-type-mismatch.rs:14:45
+   |
+LL |     let _ = for<'a> |x: &'a u8| -> &'a () { x };
+   |                                    ------   ^ expected `&()`, found `&u8`
+   |                                    |
+   |                                    expected `&'a ()` because of return type
+   |
+   = note: expected reference `&'a ()`
+              found reference `&'a u8`
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/closures/closure-return-type-mismatch.rs
+++ b/tests/ui/closures/closure-return-type-mismatch.rs
@@ -15,3 +15,7 @@ fn main() {
         b
     };
 }
+
+// issue: rust-lang/rust#130858 rust-lang/rust#125655
+static FOO: fn() -> bool = || -> bool { 1 };
+//~^ ERROR mismatched types

--- a/tests/ui/closures/closure-return-type-mismatch.stderr
+++ b/tests/ui/closures/closure-return-type-mismatch.stderr
@@ -1,4 +1,12 @@
 error[E0308]: mismatched types
+  --> $DIR/closure-return-type-mismatch.rs:20:41
+   |
+LL | static FOO: fn() -> bool = || -> bool { 1 };
+   |                                  ----   ^ expected `bool`, found integer
+   |                                  |
+   |                                  expected `bool` because of return type
+
+error[E0308]: mismatched types
   --> $DIR/closure-return-type-mismatch.rs:7:9
    |
 LL |         a
@@ -19,6 +27,6 @@ LL |         if false {
 LL |             return "hello"
    |                    ^^^^^^^ expected `bool`, found `&str`
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/coroutine/arg-count-mismatch-on-unit-input.rs
+++ b/tests/ui/coroutine/arg-count-mismatch-on-unit-input.rs
@@ -1,0 +1,11 @@
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+
+use std::ops::Coroutine;
+
+fn foo() -> impl Coroutine<u8> {
+    //~^ ERROR type mismatch in coroutine arguments
+    #[coroutine]
+    |_: ()| {}
+}
+
+fn main() { }

--- a/tests/ui/coroutine/arg-count-mismatch-on-unit-input.stderr
+++ b/tests/ui/coroutine/arg-count-mismatch-on-unit-input.stderr
@@ -1,0 +1,15 @@
+error[E0631]: type mismatch in coroutine arguments
+  --> $DIR/arg-count-mismatch-on-unit-input.rs:5:13
+   |
+LL | fn foo() -> impl Coroutine<u8> {
+   |             ^^^^^^^^^^^^^^^^^^ expected due to this
+...
+LL |     |_: ()| {}
+   |     ------- found signature defined here
+   |
+   = note: expected coroutine signature `fn(u8) -> _`
+              found coroutine signature `fn(()) -> _`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0631`.

--- a/tests/ui/lint/let_underscore/issue-119696-err-on-fn.rs
+++ b/tests/ui/lint/let_underscore/issue-119696-err-on-fn.rs
@@ -2,7 +2,7 @@
 
 #![deny(let_underscore_drop)]
 fn main() {
-    let _ = foo(); //~ ERROR non-binding let on a type that implements `Drop`
+    let _ = foo(); //~ ERROR non-binding let on a type that has a destructor
 }
 
 async fn from_config(_: Config) {}

--- a/tests/ui/lint/let_underscore/issue-119696-err-on-fn.stderr
+++ b/tests/ui/lint/let_underscore/issue-119696-err-on-fn.stderr
@@ -1,4 +1,4 @@
-error: non-binding let on a type that implements `Drop`
+error: non-binding let on a type that has a destructor
   --> $DIR/issue-119696-err-on-fn.rs:5:5
    |
 LL |     let _ = foo();

--- a/tests/ui/lint/let_underscore/issue-119697-extra-let.rs
+++ b/tests/ui/lint/let_underscore/issue-119697-extra-let.rs
@@ -12,9 +12,9 @@ pub fn ice_cold(beverage: Tait) {
     // Must destructure at least one field of `Foo`
     let Foo { field } = beverage;
     // boom
-    _ = field; //~ ERROR non-binding let on a type that implements `Drop`
+    _ = field; //~ ERROR non-binding let on a type that has a destructor
 
-    let _ = field; //~ ERROR non-binding let on a type that implements `Drop`
+    let _ = field; //~ ERROR non-binding let on a type that has a destructor
 }
 
 

--- a/tests/ui/lint/let_underscore/issue-119697-extra-let.stderr
+++ b/tests/ui/lint/let_underscore/issue-119697-extra-let.stderr
@@ -1,4 +1,4 @@
-error: non-binding let on a type that implements `Drop`
+error: non-binding let on a type that has a destructor
   --> $DIR/issue-119697-extra-let.rs:15:5
    |
 LL |     _ = field;
@@ -18,7 +18,7 @@ help: consider immediately dropping the value
 LL |     drop(field);
    |     ~~~~~     +
 
-error: non-binding let on a type that implements `Drop`
+error: non-binding let on a type that has a destructor
   --> $DIR/issue-119697-extra-let.rs:17:5
    |
 LL |     let _ = field;

--- a/tests/ui/lint/let_underscore/let_underscore_drop.rs
+++ b/tests/ui/lint/let_underscore/let_underscore_drop.rs
@@ -10,7 +10,7 @@ impl Drop for NontrivialDrop {
 }
 
 fn main() {
-    let _ = NontrivialDrop; //~WARNING non-binding let on a type that implements `Drop`
+    let _ = NontrivialDrop; //~WARNING non-binding let on a type that has a destructor
 
     let (_, _) = (NontrivialDrop, NontrivialDrop); // This should be ignored.
 }

--- a/tests/ui/lint/let_underscore/let_underscore_drop.stderr
+++ b/tests/ui/lint/let_underscore/let_underscore_drop.stderr
@@ -1,4 +1,4 @@
-warning: non-binding let on a type that implements `Drop`
+warning: non-binding let on a type that has a destructor
   --> $DIR/let_underscore_drop.rs:13:5
    |
 LL |     let _ = NontrivialDrop;


### PR DESCRIPTION
Successful merges:

 - #130279 (Document subtleties of `ManuallyDrop`)
 - #130517 (Add the library workspace to the suggested rust-analyzer config)
 - #130820 (Fix diagnostics for coroutines with () as input.)
 - #130833 (Fix the misleading diagnostic for `let_underscore_drop` on type without `Drop` implementation)
 - #130845 (Utf8Chunks: add link to Utf8Chunk)
 - #130850 (Pass Module Analysis Manager to Standard Instrumentations)
 - #130861 (Use `mem::offset_of!` for `sockaddr_un.sun_path`)
 - #130862 (rustdoc: do not animate :target when user prefers reduced motion)
 - #130868 (Update FIXME comment in s390x_unknown_linux_*.rs)
 - #130879 (Pass correct HirId to late_bound_vars in diagnostic code)
 - #130880 (add missing FIXME(const-hack))

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=130279,130517,130820,130833,130845,130850,130861,130862,130868,130879,130880)
<!-- homu-ignore:end -->