### PR TITLE
Infer nounwind and use it in MIR opts

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -980,7 +980,7 @@ fn run_required_analyses(tcx: TyCtxt<'_>) {
     });
     sess.time("MIR_effect_checking", || {
         tcx.par_hir_body_owners(|def_id| {
-            tcx.ensure_ok().has_ffi_unwind_calls(def_id);
+            tcx.ensure_ok().mir_flags(def_id);
 
             // If we need to codegen, ensure that we emit all errors from
             // `mir_drops_elaborated_and_const_checked` now, to avoid discovering

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -341,6 +341,7 @@ provide! { tcx, def_id, other, cdata,
     is_mir_available => { cdata.is_item_mir_available(def_id.index) }
     is_ctfe_mir_available => { cdata.is_ctfe_mir_available(def_id.index) }
     cross_crate_inlinable => { table_direct }
+    mir_flags => { table_direct }
 
     dylib_dependency_formats => { cdata.get_dylib_dependency_formats(tcx) }
     is_private_dep => { cdata.private_dep }

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -26,6 +26,7 @@ use rustc_middle::middle::debugger_visualizer::DebuggerVisualizerFile;
 use rustc_middle::middle::exported_symbols::{ExportedSymbol, SymbolExportInfo};
 use rustc_middle::middle::lib_features::FeatureStability;
 use rustc_middle::middle::resolve_bound_vars::ObjectLifetimeDefault;
+use rustc_middle::mir::MirFlags;
 use rustc_middle::ty::fast_reject::SimplifiedType;
 use rustc_middle::ty::{
     self, DeducedParamAttrs, ParameterizedOverTcx, Ty, TyCtxt, UnusedGenericParams,
@@ -408,6 +409,7 @@ define_tables! {
     // individually instead of `DefId`s.
     module_children_reexports: Table<DefIndex, LazyArray<ModChild>>,
     cross_crate_inlinable: Table<DefIndex, bool>,
+    mir_flags: Table<DefIndex, MirFlags>,
 
 - optional:
     attributes: Table<DefIndex, LazyArray<hir::Attribute>>,

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -53,6 +53,12 @@ impl IsDefault for UnusedGenericParams {
     }
 }
 
+impl IsDefault for MirFlags {
+    fn is_default(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 /// Helper trait, for encoding to, and decoding from, a fixed number of bytes.
 /// Used mainly for Lazy positions and lengths.
 /// Unchecked invariant: `Self::default()` should encode as `[0; BYTE_LEN]`,
@@ -282,6 +288,21 @@ impl FixedSizeEncoding for AttrFlags {
     #[inline]
     fn from_bytes(b: &[u8; 1]) -> Self {
         AttrFlags::from_bits_truncate(b[0])
+    }
+
+    #[inline]
+    fn write_to_bytes(self, b: &mut [u8; 1]) {
+        debug_assert!(!self.is_default());
+        b[0] = self.bits();
+    }
+}
+
+impl FixedSizeEncoding for MirFlags {
+    type ByteArray = [u8; 1];
+
+    #[inline]
+    fn from_bytes(b: &[u8; 1]) -> Self {
+        MirFlags::from_bits_truncate(b[0])
     }
 
     #[inline]

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -1691,6 +1691,16 @@ pub fn find_self_call<'tcx>(
     None
 }
 
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, TyEncodable, TyDecodable, HashStable)]
+pub struct MirFlags(u8);
+
+bitflags::bitflags! {
+    impl MirFlags: u8 {
+        const IS_NOUNWIND = 1 << 0;
+        const HAS_FFI_UNWIND_CALLS = 1 << 1;
+    }
+}
+
 // Some nodes are used a lot. Make sure they don't unintentionally get bigger.
 #[cfg(target_pointer_width = "64")]
 mod size_asserts {

--- a/compiler/rustc_middle/src/query/erase.rs
+++ b/compiler/rustc_middle/src/query/erase.rs
@@ -296,6 +296,7 @@ trivial! {
     rustc_middle::middle::resolve_bound_vars::ResolvedArg,
     rustc_middle::middle::stability::DeprecationEntry,
     rustc_middle::mir::ConstQualifs,
+    rustc_middle::mir::MirFlags,
     rustc_middle::mir::interpret::AllocId,
     rustc_middle::mir::interpret::CtfeProvenance,
     rustc_middle::mir::interpret::ErrorHandled,

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -56,6 +56,7 @@ use crate::middle::lib_features::LibFeatures;
 use crate::middle::privacy::EffectiveVisibilities;
 use crate::middle::resolve_bound_vars::{ObjectLifetimeDefault, ResolveBoundVars, ResolvedArg};
 use crate::middle::stability::{self, DeprecationEntry};
+use crate::mir::MirFlags;
 use crate::mir::interpret::{
     EvalStaticInitializerRawResult, EvalToAllocationRawResult, EvalToConstValueResult,
     EvalToValTreeResult, GlobalId, LitToConstInput,
@@ -1741,9 +1742,10 @@ rustc_queries! {
         desc { "checking if a crate is `#![profiler_runtime]`" }
         separate_provide_extern
     }
-    query has_ffi_unwind_calls(key: LocalDefId) -> bool {
-        desc { |tcx| "checking if `{}` contains FFI-unwind calls", tcx.def_path_str(key) }
-        cache_on_disk_if { true }
+    query mir_flags(key: DefId) -> MirFlags {
+        desc { |tcx| "stashing some local properties of `{}` before the body is stolen", tcx.def_path_str(key) }
+        cache_on_disk_if { key.is_local() }
+        separate_provide_extern
     }
     query required_panic_strategy(_: CrateNum) -> Option<PanicStrategy> {
         fatal_cycle

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -67,7 +67,7 @@ use crate::metadata::ModChild;
 use crate::middle::codegen_fn_attrs::{CodegenFnAttrs, TargetFeature};
 use crate::middle::{resolve_bound_vars, stability};
 use crate::mir::interpret::{self, Allocation, ConstAllocation};
-use crate::mir::{Body, Local, Place, PlaceElem, ProjectionKind, Promoted};
+use crate::mir::{Body, Local, MirFlags, Place, PlaceElem, ProjectionKind, Promoted};
 use crate::query::plumbing::QuerySystem;
 use crate::query::{IntoQueryParam, LocalCrate, Providers, TyCtxtAt};
 use crate::thir::Thir;
@@ -3380,6 +3380,14 @@ impl<'tcx> TyCtxt<'tcx> {
         } else {
             false
         }
+    }
+
+    pub fn is_nounwind(self, def_id: DefId) -> bool {
+        self.mir_flags(def_id).contains(MirFlags::IS_NOUNWIND)
+    }
+
+    pub fn has_ffi_unwind_calls(self, def_id: DefId) -> bool {
+        self.mir_flags(def_id).contains(MirFlags::HAS_FFI_UNWIND_CALLS)
     }
 
     /// Whether this is a trait implementation that has `#[diagnostic::do_not_recommend]`

--- a/compiler/rustc_middle/src/ty/parameterized.rs
+++ b/compiler/rustc_middle/src/ty/parameterized.rs
@@ -102,6 +102,7 @@ trivially_parameterized_over_tcx! {
     rustc_hir::PreciseCapturingArgKind<Symbol, Symbol>,
     rustc_index::bit_set::DenseBitSet<u32>,
     rustc_index::bit_set::FiniteBitSet<u32>,
+    rustc_middle::mir::MirFlags,
     rustc_session::cstore::ForeignModule,
     rustc_session::cstore::LinkagePreference,
     rustc_session::cstore::NativeLib,

--- a/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
+++ b/compiler/rustc_mir_transform/src/ffi_unwind_calls.rs
@@ -1,5 +1,5 @@
 use rustc_abi::ExternAbi;
-use rustc_hir::def_id::{LOCAL_CRATE, LocalDefId};
+use rustc_hir::def_id::LOCAL_CRATE;
 use rustc_middle::mir::*;
 use rustc_middle::query::{LocalCrate, Providers};
 use rustc_middle::ty::{self, TyCtxt, layout};
@@ -11,17 +11,10 @@ use tracing::debug;
 use crate::errors;
 
 // Check if the body of this def_id can possibly leak a foreign unwind into Rust code.
-fn has_ffi_unwind_calls(tcx: TyCtxt<'_>, local_def_id: LocalDefId) -> bool {
-    debug!("has_ffi_unwind_calls({local_def_id:?})");
+pub(crate) fn has_ffi_unwind_calls<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>) -> bool {
+    let def_id = body.source.def_id();
 
-    // Only perform check on functions because constants cannot call FFI functions.
-    let def_id = local_def_id.to_def_id();
-    let kind = tcx.def_kind(def_id);
-    if !kind.is_fn_like() {
-        return false;
-    }
-
-    let body = &*tcx.mir_built(local_def_id).borrow();
+    debug!("has_ffi_unwind_calls({def_id:?})");
 
     let body_ty = tcx.type_of(def_id).skip_binder();
     let body_abi = match body_ty.kind() {
@@ -110,7 +103,7 @@ fn required_panic_strategy(tcx: TyCtxt<'_>, _: LocalCrate) -> Option<PanicStrate
     }
 
     for def_id in tcx.hir_body_owners() {
-        if tcx.has_ffi_unwind_calls(def_id) {
+        if tcx.has_ffi_unwind_calls(def_id.into()) {
             // Given that this crate is compiled in `-C panic=unwind`, the `AbortUnwindingCalls`
             // MIR pass will not be run on FFI-unwind call sites, therefore a foreign exception
             // can enter Rust through these sites.
@@ -141,5 +134,5 @@ fn required_panic_strategy(tcx: TyCtxt<'_>, _: LocalCrate) -> Option<PanicStrate
 }
 
 pub(crate) fn provide(providers: &mut Providers) {
-    *providers = Providers { has_ffi_unwind_calls, required_panic_strategy, ..*providers };
+    *providers = Providers { required_panic_strategy, ..*providers };
 }

--- a/compiler/rustc_mir_transform/src/instsimplify.rs
+++ b/compiler/rustc_mir_transform/src/instsimplify.rs
@@ -269,7 +269,9 @@ impl<'tcx> InstSimplifyContext<'_, 'tcx> {
             _ => bug!("unexpected body ty: {body_ty:?}"),
         };
 
-        if !layout::fn_can_unwind(self.tcx, Some(def_id), body_abi) {
+        if !layout::fn_can_unwind(self.tcx, Some(def_id), body_abi)
+            || (self.tcx.sess.opts.incremental.is_none() && self.tcx.is_nounwind(def_id))
+        {
             *unwind = UnwindAction::Unreachable;
         }
     }

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -27,8 +27,8 @@ use rustc_hir::def_id::LocalDefId;
 use rustc_index::IndexVec;
 use rustc_middle::mir::{
     AnalysisPhase, Body, CallSource, ClearCrossCrate, ConstOperand, ConstQualifs, LocalDecl,
-    MirPhase, Operand, Place, ProjectionElem, Promoted, RuntimePhase, Rvalue, START_BLOCK,
-    SourceInfo, Statement, StatementKind, TerminatorKind,
+    MirFlags, MirPhase, Operand, Place, ProjectionElem, Promoted, RuntimePhase, Rvalue,
+    START_BLOCK, SourceInfo, Statement, StatementKind, TerminatorKind,
 };
 use rustc_middle::ty::{self, TyCtxt, TypeVisitableExt};
 use rustc_middle::util::Providers;
@@ -226,6 +226,7 @@ pub fn provide(providers: &mut Providers) {
         promoted_mir,
         deduced_param_attrs: deduce_param_attrs::deduced_param_attrs,
         coroutine_by_move_body_def_id: coroutine::coroutine_by_move_body_def_id,
+        mir_flags,
         ..providers.queries
     };
 }
@@ -427,9 +428,6 @@ fn mir_promoted(
         _ => ConstQualifs::default(),
     };
 
-    // the `has_ffi_unwind_calls` query uses the raw mir, so make sure it is run.
-    tcx.ensure_done().has_ffi_unwind_calls(def);
-
     // the `by_move_body` query uses the raw mir, so make sure it is run.
     if tcx.needs_coroutine_by_move_body_def_id(def.to_def_id()) {
         tcx.ensure_done().coroutine_by_move_body_def_id(def);
@@ -458,6 +456,33 @@ fn mir_promoted(
 
     let promoted = promote_pass.promoted_fragments.into_inner();
     (tcx.alloc_steal_mir(body), tcx.alloc_steal_promoted(promoted))
+}
+
+fn mir_flags<'tcx>(tcx: TyCtxt<'tcx>, local_def_id: LocalDefId) -> MirFlags {
+    let mut flags = MirFlags::default();
+    // Only perform check on functions because constants cannot call FFI functions.
+    let kind = tcx.def_kind(local_def_id);
+    if !kind.is_fn_like() {
+        return flags;
+    }
+
+    if !tcx.mir_keys(()).contains(&local_def_id) {
+        return flags;
+    }
+
+    let body = &*tcx.mir_promoted(local_def_id).0.borrow();
+
+    if is_nounwind(body) {
+        flags.insert(MirFlags::IS_NOUNWIND);
+    }
+    if ffi_unwind_calls::has_ffi_unwind_calls(tcx, body) {
+        flags.insert(MirFlags::HAS_FFI_UNWIND_CALLS);
+    }
+    flags
+}
+
+fn is_nounwind<'tcx>(body: &Body<'tcx>) -> bool {
+    body.basic_blocks.iter().all(|block| block.terminator().unwind().is_none())
 }
 
 /// Compute the MIR that is used during CTFE (and thus has no optimizations run on it)
@@ -513,6 +538,7 @@ fn mir_drops_elaborated_and_const_checked(tcx: TyCtxt<'_>, def: LocalDefId) -> &
         {
             tcx.ensure_done().mir_inliner_callees(ty::InstanceKind::Item(def.to_def_id()));
         }
+        tcx.ensure_done().mir_flags(def);
     }
 
     let (body, _) = tcx.mir_promoted(def);

--- a/tests/codegen/drop.rs
+++ b/tests/codegen/drop.rs
@@ -23,7 +23,7 @@ pub fn droppy() {
     // FIXME(eddyb) the `void @` forces a match on the instruction, instead of the
     // comment, that's `; call core::ptr::drop_in_place::<drop::SomeUniqueName>`
     // for the `v0` mangling, should switch to matching on that once `legacy` is gone.
-    // CHECK-COUNT-6: {{(call|invoke) void @.*}}drop_in_place{{.*}}SomeUniqueName
+    // CHECK-COUNT-5: {{(call|invoke) void @.*}}drop_in_place{{.*}}SomeUniqueName
     // CHECK-NOT: {{(call|invoke) void @.*}}drop_in_place{{.*}}SomeUniqueName
     // The next line checks for the } that ends the function definition
     // CHECK-LABEL: {{^[}]}}

--- a/tests/codegen/personality_lifetimes.rs
+++ b/tests/codegen/personality_lifetimes.rs
@@ -13,7 +13,9 @@ impl Drop for S {
 }
 
 #[inline(never)]
-fn might_unwind() {}
+fn might_unwind() {
+    panic!()
+}
 
 // CHECK-LABEL: @test
 #[no_mangle]

--- a/tests/mir-opt/inline/caller_with_trivial_bound.foo.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/caller_with_trivial_bound.foo.Inline.panic-unwind.diff
@@ -10,7 +10,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = bar::<T>() -> [return: bb1, unwind continue];
+          _1 = bar::<T>() -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/forced.caller.ForceInline.panic-unwind.diff
+++ b/tests/mir-opt/inline/forced.caller.ForceInline.panic-unwind.diff
@@ -9,7 +9,7 @@
   
       bb0: {
           StorageLive(_1);
--         _1 = callee_forced() -> [return: bb1, unwind continue];
+-         _1 = callee_forced() -> [return: bb1, unwind unreachable];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/inline/forced_closure.caller-{closure#0}.ForceInline.panic-unwind.diff
+++ b/tests/mir-opt/inline/forced_closure.caller-{closure#0}.ForceInline.panic-unwind.diff
@@ -9,7 +9,7 @@
   
       bb0: {
           StorageLive(_2);
--         _2 = callee_forced() -> [return: bb1, unwind continue];
+-         _2 = callee_forced() -> [return: bb1, unwind unreachable];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/inline/forced_dead_code.caller.ForceInline.panic-unwind.diff
+++ b/tests/mir-opt/inline/forced_dead_code.caller.ForceInline.panic-unwind.diff
@@ -9,7 +9,7 @@
   
       bb0: {
           StorageLive(_1);
--         _1 = callee_forced() -> [return: bb1, unwind continue];
+-         _1 = callee_forced() -> [return: bb1, unwind unreachable];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/inline/inline_coroutine.main.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/inline_coroutine.main.Inline.panic-unwind.diff
@@ -30,7 +30,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
--         _4 = g() -> [return: bb1, unwind continue];
+-         _4 = g() -> [return: bb1, unwind unreachable];
 +         _4 = {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8 (#0)};
 +         _3 = &mut _4;
 +         _2 = Pin::<&mut {coroutine@$DIR/inline_coroutine.rs:20:5: 20:8}> { pointer: copy _3 };

--- a/tests/mir-opt/inline/inline_options.main.Inline.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/inline_options.main.Inline.after.panic-unwind.mir
@@ -21,7 +21,7 @@ fn main() -> () {
         StorageLive(_3);
         StorageLive(_4);
         StorageLive(_5);
-        _3 = g() -> [return: bb3, unwind continue];
+        _3 = g() -> [return: bb3, unwind unreachable];
     }
 
     bb2: {
@@ -34,10 +34,10 @@ fn main() -> () {
     }
 
     bb3: {
-        _4 = g() -> [return: bb4, unwind continue];
+        _4 = g() -> [return: bb4, unwind unreachable];
     }
 
     bb4: {
-        _5 = g() -> [return: bb2, unwind continue];
+        _5 = g() -> [return: bb2, unwind unreachable];
     }
 }

--- a/tests/mir-opt/inline/inline_trait_method.test.Inline.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/inline_trait_method.test.Inline.after.panic-unwind.mir
@@ -8,7 +8,7 @@ fn test(_1: &dyn X) -> u32 {
     bb0: {
         StorageLive(_2);
         _2 = copy _1;
-        _0 = <dyn X as X>::y(move _2) -> [return: bb1, unwind continue];
+        _0 = <dyn X as X>::y(move _2) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {

--- a/tests/mir-opt/inline/inline_trait_method_2.test2.Inline.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/inline_trait_method_2.test2.Inline.after.panic-unwind.mir
@@ -15,7 +15,7 @@ fn test2(_1: &dyn X) -> bool {
         _3 = copy _1;
         _2 = move _3;
         StorageDead(_3);
-        _0 = <dyn X as X>::y(move _2) -> [return: bb1, unwind continue];
+        _0 = <dyn X as X>::y(move _2) -> [return: bb1, unwind unreachable];
     }
 
     bb1: {

--- a/tests/mir-opt/inline/issue_78442.bar.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/issue_78442.bar.Inline.panic-unwind.diff
@@ -19,7 +19,7 @@
           StorageLive(_2);
           StorageLive(_3);
           StorageLive(_4);
--         _4 = hide_foo() -> [return: bb1, unwind: bb4];
+-         _4 = hide_foo() -> [return: bb1, unwind unreachable];
 -     }
 - 
 -     bb1: {

--- a/tests/mir-opt/inline/rustc_no_mir_inline.caller.Inline.panic-unwind.diff
+++ b/tests/mir-opt/inline/rustc_no_mir_inline.caller.Inline.panic-unwind.diff
@@ -7,7 +7,7 @@
   
       bb0: {
           StorageLive(_1);
-          _1 = callee() -> [return: bb1, unwind continue];
+          _1 = callee() -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/inline/rustc_no_mir_inline.caller.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/inline/rustc_no_mir_inline.caller.PreCodegen.after.panic-unwind.mir
@@ -5,7 +5,7 @@ fn caller() -> () {
     let _1: ();
 
     bb0: {
-        _1 = callee() -> [return: bb1, unwind continue];
+        _1 = callee() -> [return: bb1, unwind unreachable];
     }
 
     bb1: {

--- a/tests/mir-opt/inline/unsized_argument.caller.Inline.diff
+++ b/tests/mir-opt/inline/unsized_argument.caller.Inline.diff
@@ -13,7 +13,7 @@
           StorageLive(_3);
           _3 = move _1;
           _4 = copy ((_3.0: std::ptr::Unique<[i32]>).0: std::ptr::NonNull<[i32]>) as *const [i32] (Transmute);
-          _2 = callee(move (*_4)) -> [return: bb1, unwind: bb3];
+          _2 = callee(move (*_4)) -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/pre-codegen/deref_nested_borrows.src.GVN.panic-unwind.diff
+++ b/tests/mir-opt/pre-codegen/deref_nested_borrows.src.GVN.panic-unwind.diff
@@ -20,7 +20,7 @@
 +         nop;
 +         _6 = copy (*_1);
           _2 = copy (*_6);
-          _3 = unknown() -> [return: bb1, unwind continue];
+          _3 = unknown() -> [return: bb1, unwind unreachable];
       }
   
       bb1: {

--- a/tests/mir-opt/pre-codegen/deref_nested_borrows.src.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/deref_nested_borrows.src.PreCodegen.after.panic-unwind.mir
@@ -15,7 +15,7 @@ fn src(_1: &&u8) -> bool {
     bb0: {
         _2 = copy (*_1);
         _3 = copy (*_2);
-        _4 = unknown() -> [return: bb1, unwind continue];
+        _4 = unknown() -> [return: bb1, unwind unreachable];
     }
 
     bb1: {

--- a/tests/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.panic-unwind.diff
+++ b/tests/mir-opt/simplify_if.main.SimplifyConstCondition-after-const-prop.panic-unwind.diff
@@ -11,7 +11,7 @@
       }
   
       bb1: {
-          _1 = noop() -> [return: bb2, unwind continue];
+          _1 = noop() -> [return: bb2, unwind unreachable];
       }
   
       bb2: {

--- a/tests/mir-opt/simplify_match.main.GVN.panic-unwind.diff
+++ b/tests/mir-opt/simplify_match.main.GVN.panic-unwind.diff
@@ -23,7 +23,7 @@
       }
   
       bb1: {
-          _0 = noop() -> [return: bb2, unwind continue];
+          _0 = noop() -> [return: bb2, unwind unreachable];
       }
   
       bb2: {

--- a/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.current.stderr
+++ b/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.current.stderr
@@ -25,11 +25,6 @@ note: ...which requires promoting constants in MIR for `<impl at $DIR/method-com
    |
 LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires checking if `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` contains FFI-unwind calls...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires building MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
   --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
    |

--- a/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.next.stderr
+++ b/tests/ui/impl-trait/in-trait/method-compatability-via-leakage-cycle.next.stderr
@@ -29,11 +29,6 @@ note: ...which requires promoting constants in MIR for `<impl at $DIR/method-com
    |
 LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires checking if `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` contains FFI-unwind calls...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires building MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
   --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
    |
@@ -84,11 +79,6 @@ note: ...which requires borrow-checking `<impl at $DIR/method-compatability-via-
 LL |     fn foo(b: bool) -> impl Sized {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires promoting constants in MIR for `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo`...
-  --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
-   |
-LL |     fn foo(b: bool) -> impl Sized {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires checking if `<impl at $DIR/method-compatability-via-leakage-cycle.rs:17:1: 17:19>::foo` contains FFI-unwind calls...
   --> $DIR/method-compatability-via-leakage-cycle.rs:21:5
    |
 LL |     fn foo(b: bool) -> impl Sized {

--- a/tests/ui/impl-trait/transmute/in-defining-scope.stderr
+++ b/tests/ui/impl-trait/transmute/in-defining-scope.stderr
@@ -19,11 +19,6 @@ note: ...which requires promoting constants in MIR for `foo`...
    |
 LL | fn foo() -> impl Sized {
    | ^^^^^^^^^^^^^^^^^^^^^^
-note: ...which requires checking if `foo` contains FFI-unwind calls...
-  --> $DIR/in-defining-scope.rs:6:1
-   |
-LL | fn foo() -> impl Sized {
-   | ^^^^^^^^^^^^^^^^^^^^^^
 note: ...which requires building MIR for `foo`...
   --> $DIR/in-defining-scope.rs:6:1
    |

--- a/tests/ui/pattern/non-structural-match-types-cycle-err.stderr
+++ b/tests/ui/pattern/non-structural-match-types-cycle-err.stderr
@@ -36,11 +36,6 @@ note: ...which requires promoting constants in MIR for `defines`...
    |
 LL | fn defines() {
    | ^^^^^^^^^^^^
-note: ...which requires checking if `defines` contains FFI-unwind calls...
-  --> $DIR/non-structural-match-types-cycle-err.rs:17:1
-   |
-LL | fn defines() {
-   | ^^^^^^^^^^^^
 note: ...which requires building MIR for `defines`...
   --> $DIR/non-structural-match-types-cycle-err.rs:17:1
    |

--- a/tests/ui/type-alias-impl-trait/in-where-clause.stderr
+++ b/tests/ui/type-alias-impl-trait/in-where-clause.stderr
@@ -34,13 +34,6 @@ LL | / fn foo() -> Bar
 LL | | where
 LL | |     Bar: Send,
    | |______________^
-note: ...which requires checking if `foo` contains FFI-unwind calls...
-  --> $DIR/in-where-clause.rs:9:1
-   |
-LL | / fn foo() -> Bar
-LL | | where
-LL | |     Bar: Send,
-   | |______________^
 note: ...which requires building MIR for `foo`...
   --> $DIR/in-where-clause.rs:9:1
    |


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/130909)*
<!-- homu-ignore:end -->

r? @ghost

Sinking this into `layout::fn_can_unwind` yields bigger MIR diffs. That's something to try tweaking.

But also, this analysis reduces incrementality because call sites depend on callee bodies. So I've currently disabled it when incremental is enabled. That's another tweak I want to try.