### PR TITLE
On implicit `Sized` bound on fn argument, point at type instead of pattern

### DIFF
--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -99,7 +99,7 @@ pub(super) fn check_fn<'a, 'tcx>(
         if !params_can_be_unsized {
             fcx.require_type_is_sized(
                 param_ty,
-                param.pat.span,
+                param.ty_span,
                 // ty.span == binding_span iff this is a closure parameter with no type ascription,
                 // or if it's an implicit `self` parameter
                 ObligationCauseCode::SizedArgumentType(

--- a/compiler/rustc_hir_typeck/src/gather_locals.rs
+++ b/compiler/rustc_hir_typeck/src/gather_locals.rs
@@ -144,7 +144,7 @@ impl<'a, 'tcx> Visitor<'tcx> for GatherLocalsVisitor<'a, 'tcx> {
                 if !self.fcx.tcx.features().unsized_fn_params {
                     self.fcx.require_type_is_sized(
                         var_ty,
-                        p.span,
+                        ty_span,
                         // ty_span == ident.span iff this is a closure parameter with no type
                         // ascription, or if it's an implicit `self` parameter
                         ObligationCauseCode::SizedArgumentType(

--- a/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
+++ b/src/tools/clippy/tests/ui/crashes/ice-6251.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> tests/ui/crashes/ice-6251.rs:4:45
+  --> tests/ui/crashes/ice-6251.rs:4:48
    |
 LL | fn bug<T>() -> impl Iterator<Item = [(); { |x: [u8]| x }]> {
-   |                                             ^ doesn't have a size known at compile-time
+   |                                                ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `std::marker::Sized` is not implemented for `[u8]`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/associated-types/issue-59324.stderr
+++ b/tests/ui/associated-types/issue-59324.stderr
@@ -79,10 +79,10 @@ LL | pub trait Foo: NotFoo {
    | ^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the size for values of type `(dyn ThriftService<(), AssocType = _> + 'static)` cannot be known at compilation time
-  --> $DIR/issue-59324.rs:23:20
+  --> $DIR/issue-59324.rs:23:29
    |
 LL | fn with_factory<H>(factory: dyn ThriftService<()>) {}
-   |                    ^^^^^^^ doesn't have a size known at compile-time
+   |                             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn ThriftService<(), AssocType = _> + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/coherence/occurs-check/opaques.next.stderr
+++ b/tests/ui/coherence/occurs-check/opaques.next.stderr
@@ -8,10 +8,10 @@ LL | impl<T> Trait<T> for defining_scope::Alias<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation
 
 error[E0282]: type annotations needed
-  --> $DIR/opaques.rs:13:20
+  --> $DIR/opaques.rs:13:23
    |
 LL |     pub fn cast<T>(x: Container<Alias<T>, T>) -> Container<T, T> {
-   |                    ^ cannot infer type
+   |                       ^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.stderr
+++ b/tests/ui/did_you_mean/replace-impl-infer-ty-from-trait.stderr
@@ -14,10 +14,10 @@ LL |     fn bar(i: i32, t: usize, s: &()) -> (usize, i32) {
    |               ~~~     ~~~~~     ~~~     ~~~~~~~~~~~~
 
 error[E0282]: type annotations needed
-  --> $DIR/replace-impl-infer-ty-from-trait.rs:9:12
+  --> $DIR/replace-impl-infer-ty-from-trait.rs:9:15
    |
 LL |     fn bar(i: _, t: _, s: _) -> _ {
-   |            ^ cannot infer type
+   |               ^ cannot infer type
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0277.stderr
+++ b/tests/ui/error-codes/E0277.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/E0277.rs:11:6
+  --> $DIR/E0277.rs:11:9
    |
 LL | fn f(p: Path) { }
-   |      ^ doesn't have a size known at compile-time
+   |         ^^^^ doesn't have a size known at compile-time
    |
    = help: within `Path`, the trait `Sized` is not implemented for `[u8]`, which is required by `Path: Sized`
 note: required because it appears within the type `Path`

--- a/tests/ui/feature-gates/feature-gate-unsized_fn_params.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_fn_params.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_fn_params.rs:17:8
+  --> $DIR/feature-gate-unsized_fn_params.rs:17:11
    |
 LL | fn foo(x: dyn Foo) {
-   |        ^ doesn't have a size known at compile-time
+   |           ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
    = help: unsized fn params are gated as an unstable feature
@@ -16,10 +16,10 @@ LL | fn foo(x: &dyn Foo) {
    |           +
 
 error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_fn_params.rs:21:8
+  --> $DIR/feature-gate-unsized_fn_params.rs:21:11
    |
 LL | fn bar(x: Foo) {
-   |        ^ doesn't have a size known at compile-time
+   |           ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
    = help: unsized fn params are gated as an unstable feature
@@ -33,10 +33,10 @@ LL | fn bar(x: &dyn Foo) {
    |           ++++
 
 error[E0277]: the size for values of type `[()]` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_fn_params.rs:25:8
+  --> $DIR/feature-gate-unsized_fn_params.rs:25:11
    |
 LL | fn qux(_: [()]) {}
-   |        ^ doesn't have a size known at compile-time
+   |           ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `[()]`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/feature-gates/feature-gate-unsized_locals.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized_locals.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn FnOnce() + 'static)` cannot be known at compilation time
-  --> $DIR/feature-gate-unsized_locals.rs:1:6
+  --> $DIR/feature-gate-unsized_locals.rs:1:9
    |
 LL | fn f(f: dyn FnOnce()) {}
-   |      ^ doesn't have a size known at compile-time
+   |         ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn FnOnce() + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/inference/ice-ifer-var-leaked-out-of-rollback-122098.stderr
+++ b/tests/ui/inference/ice-ifer-var-leaked-out-of-rollback-122098.stderr
@@ -36,10 +36,10 @@ LL | struct Query<'q> {}
    = help: consider removing `'q`, referring to it in a field, or using a marker such as `PhantomData`
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/ice-ifer-var-leaked-out-of-rollback-122098.rs:7:17
+  --> $DIR/ice-ifer-var-leaked-out-of-rollback-122098.rs:7:21
    |
 LL |     fn for_each(mut self, mut f: Box<dyn FnMut(Self::Item<'_>) + 'static>) {}
-   |                 ^^^^^^^^ doesn't have a size known at compile-time
+   |                     ^^^^ doesn't have a size known at compile-time
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider further restricting `Self`

--- a/tests/ui/issues/issue-38954.stderr
+++ b/tests/ui/issues/issue-38954.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/issue-38954.rs:1:10
+  --> $DIR/issue-38954.rs:1:18
    |
 LL | fn _test(ref _p: str) {}
-   |          ^^^^^^ doesn't have a size known at compile-time
+   |                  ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/issues/issue-41229-ref-str.stderr
+++ b/tests/ui/issues/issue-41229-ref-str.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/issue-41229-ref-str.rs:1:16
+  --> $DIR/issue-41229-ref-str.rs:1:23
    |
 LL | pub fn example(ref s: str) {}
-   |                ^^^^^ doesn't have a size known at compile-time
+   |                       ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/issues/issue-42312.stderr
+++ b/tests/ui/issues/issue-42312.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `<Self as Deref>::Target` cannot be known at compilation time
-  --> $DIR/issue-42312.rs:4:12
+  --> $DIR/issue-42312.rs:4:15
    |
 LL |     fn baz(_: Self::Target) where Self: Deref {}
-   |            ^ doesn't have a size known at compile-time
+   |               ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `<Self as Deref>::Target`
    = help: unsized fn params are gated as an unstable feature
@@ -16,10 +16,10 @@ LL |     fn baz(_: &Self::Target) where Self: Deref {}
    |               +
 
 error[E0277]: the size for values of type `(dyn ToString + 'static)` cannot be known at compilation time
-  --> $DIR/issue-42312.rs:8:10
+  --> $DIR/issue-42312.rs:8:13
    |
 LL | pub fn f(_: dyn ToString) {}
-   |          ^ doesn't have a size known at compile-time
+   |             ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn ToString + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/issues/issue-5883.stderr
+++ b/tests/ui/issues/issue-5883.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn A + 'static)` cannot be known at compilation time
-  --> $DIR/issue-5883.rs:8:5
+  --> $DIR/issue-5883.rs:8:8
    |
 LL |     r: dyn A + 'static
-   |     ^ doesn't have a size known at compile-time
+   |        ^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn A + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/issues/issue-66706.stderr
+++ b/tests/ui/issues/issue-66706.stderr
@@ -29,10 +29,10 @@ LL |     [0; match [|f @ &ref _| () ] {} ]
    |         while parsing this `match` expression
 
 error[E0282]: type annotations needed
-  --> $DIR/issue-66706.rs:2:11
+  --> $DIR/issue-66706.rs:2:14
    |
 LL |     [0; [|_: _ &_| ()].len()]
-   |           ^ cannot infer type
+   |              ^ cannot infer type
 
 error[E0282]: type annotations needed
   --> $DIR/issue-66706.rs:13:11

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.new.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.new.stderr
@@ -19,10 +19,10 @@ LL |     f()
    |     call expression requires function
 
 error[E0277]: the size for values of type `(dyn Copy + 'static)` cannot be known at compilation time
-  --> $DIR/avoid-ice-on-warning-2.rs:4:10
+  --> $DIR/avoid-ice-on-warning-2.rs:4:13
    |
 LL | fn id<F>(f: Copy) -> usize {
-   |          ^ doesn't have a size known at compile-time
+   |             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/object-safety/avoid-ice-on-warning-2.old.stderr
+++ b/tests/ui/object-safety/avoid-ice-on-warning-2.old.stderr
@@ -47,10 +47,10 @@ LL |     f()
    |     call expression requires function
 
 error[E0277]: the size for values of type `(dyn Copy + 'static)` cannot be known at compilation time
-  --> $DIR/avoid-ice-on-warning-2.rs:4:10
+  --> $DIR/avoid-ice-on-warning-2.rs:4:13
    |
 LL | fn id<F>(f: Copy) -> usize {
-   |          ^ doesn't have a size known at compile-time
+   |             ^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Copy + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/resolve/issue-3907-2.stderr
+++ b/tests/ui/resolve/issue-3907-2.stderr
@@ -11,10 +11,10 @@ LL |     fn bar();
    |        ^^^ the trait cannot be made into an object because associated function `bar` has no `self` parameter
 
 error[E0277]: the size for values of type `(dyn issue_3907::Foo + 'static)` cannot be known at compilation time
-  --> $DIR/issue-3907-2.rs:11:8
+  --> $DIR/issue-3907-2.rs:11:12
    |
 LL | fn bar(_x: Foo) {}
-   |        ^^ doesn't have a size known at compile-time
+   |            ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn issue_3907::Foo + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/resolve/issue-5035-2.stderr
+++ b/tests/ui/resolve/issue-5035-2.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn I + 'static)` cannot be known at compilation time
-  --> $DIR/issue-5035-2.rs:4:8
+  --> $DIR/issue-5035-2.rs:4:12
    |
 LL | fn foo(_x: K) {}
-   |        ^^ doesn't have a size known at compile-time
+   |            ^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn I + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/suggestions/object-unsafe-trait-references-self.stderr
+++ b/tests/ui/suggestions/object-unsafe-trait-references-self.stderr
@@ -32,10 +32,10 @@ LL | trait Other: Sized {}
    |       this trait cannot be made into an object...
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
-  --> $DIR/object-unsafe-trait-references-self.rs:2:19
+  --> $DIR/object-unsafe-trait-references-self.rs:2:22
    |
 LL |     fn baz(&self, _: Self) {}
-   |                   ^ doesn't have a size known at compile-time
+   |                      ^^^^ doesn't have a size known at compile-time
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider further restricting `Self`

--- a/tests/ui/suggestions/path-by-value.stderr
+++ b/tests/ui/suggestions/path-by-value.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `[u8]` cannot be known at compilation time
-  --> $DIR/path-by-value.rs:3:6
+  --> $DIR/path-by-value.rs:3:9
    |
 LL | fn f(p: Path) { }
-   |      ^ doesn't have a size known at compile-time
+   |         ^^^^ doesn't have a size known at compile-time
    |
    = help: within `Path`, the trait `Sized` is not implemented for `[u8]`, which is required by `Path: Sized`
 note: required because it appears within the type `Path`

--- a/tests/ui/suggestions/unsized-function-parameter.stderr
+++ b/tests/ui/suggestions/unsized-function-parameter.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/unsized-function-parameter.rs:5:9
+  --> $DIR/unsized-function-parameter.rs:5:14
    |
 LL | fn foo1(bar: str) {}
-   |         ^^^ doesn't have a size known at compile-time
+   |              ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: unsized fn params are gated as an unstable feature
@@ -12,10 +12,10 @@ LL | fn foo1(bar: &str) {}
    |              +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/unsized-function-parameter.rs:11:9
+  --> $DIR/unsized-function-parameter.rs:11:15
    |
 LL | fn foo2(_bar: str) {}
-   |         ^^^^ doesn't have a size known at compile-time
+   |               ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: unsized fn params are gated as an unstable feature
@@ -25,10 +25,10 @@ LL | fn foo2(_bar: &str) {}
    |               +
 
 error[E0277]: the size for values of type `str` cannot be known at compilation time
-  --> $DIR/unsized-function-parameter.rs:17:9
+  --> $DIR/unsized-function-parameter.rs:17:12
    |
 LL | fn foo3(_: str) {}
-   |         ^ doesn't have a size known at compile-time
+   |            ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/trait-bounds/apit-unsized.stderr
+++ b/tests/ui/trait-bounds/apit-unsized.stderr
@@ -1,10 +1,11 @@
 error[E0277]: the size for values of type `impl Iterator<Item = i32> + ?Sized` cannot be known at compilation time
-  --> $DIR/apit-unsized.rs:1:8
+  --> $DIR/apit-unsized.rs:1:11
    |
 LL | fn foo(_: impl Iterator<Item = i32> + ?Sized) {}
-   |        ^  ---------------------------------- this type parameter needs to be `Sized`
-   |        |
-   |        doesn't have a size known at compile-time
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |           |
+   |           doesn't have a size known at compile-time
+   |           this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider removing the `?Sized` bound to make the type parameter `Sized`
@@ -18,12 +19,13 @@ LL | fn foo(_: &impl Iterator<Item = i32> + ?Sized) {}
    |           +
 
 error[E0277]: the size for values of type `impl ?Sized` cannot be known at compilation time
-  --> $DIR/apit-unsized.rs:2:8
+  --> $DIR/apit-unsized.rs:2:11
    |
 LL | fn bar(_: impl ?Sized) {}
-   |        ^  ----------- this type parameter needs to be `Sized`
-   |        |
-   |        doesn't have a size known at compile-time
+   |           ^^^^^^^^^^^
+   |           |
+   |           doesn't have a size known at compile-time
+   |           this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider replacing `?Sized` with `Sized`

--- a/tests/ui/trait-bounds/bad-suggestionf-for-repeated-unsized-bound-127441.stderr
+++ b/tests/ui/trait-bounds/bad-suggestionf-for-repeated-unsized-bound-127441.stderr
@@ -35,10 +35,10 @@ LL | fn foo8(_: impl ?Sized + Debug + ?Sized ) {}
    |                 ^^^^^^           ^^^^^^
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:9:20
+  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:9:23
    |
 LL | fn foo1<T: ?Sized>(a: T) {}
-   |         -          ^ doesn't have a size known at compile-time
+   |         -             ^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `Sized`
    |
@@ -54,10 +54,10 @@ LL | fn foo1<T: ?Sized>(a: &T) {}
    |                       +
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:12:29
+  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:12:32
    |
 LL | fn foo2<T: ?Sized + ?Sized>(a: T) {}
-   |         -                   ^ doesn't have a size known at compile-time
+   |         -                      ^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `Sized`
    |
@@ -73,10 +73,10 @@ LL | fn foo2<T: ?Sized + ?Sized>(a: &T) {}
    |                                +
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:16:37
+  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:16:40
    |
 LL | fn foo3<T: ?Sized + ?Sized + Debug>(a: T) {}
-   |         -                           ^ doesn't have a size known at compile-time
+   |         -                              ^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `Sized`
    |
@@ -92,10 +92,10 @@ LL | fn foo3<T: ?Sized + ?Sized + Debug>(a: &T) {}
    |                                        +
 
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:20:38
+  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:20:41
    |
 LL | fn foo4<T: ?Sized + Debug + ?Sized >(a: T) {}
-   |         -                            ^ doesn't have a size known at compile-time
+   |         -                               ^ doesn't have a size known at compile-time
    |         |
    |         this type parameter needs to be `Sized`
    |
@@ -111,12 +111,13 @@ LL | fn foo4<T: ?Sized + Debug + ?Sized >(a: &T) {}
    |                                         +
 
 error[E0277]: the size for values of type `impl ?Sized` cannot be known at compilation time
-  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:24:9
+  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:24:12
    |
 LL | fn foo5(_: impl ?Sized) {}
-   |         ^  ----------- this type parameter needs to be `Sized`
-   |         |
-   |         doesn't have a size known at compile-time
+   |            ^^^^^^^^^^^
+   |            |
+   |            doesn't have a size known at compile-time
+   |            this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider replacing `?Sized` with `Sized`
@@ -130,12 +131,13 @@ LL | fn foo5(_: &impl ?Sized) {}
    |            +
 
 error[E0277]: the size for values of type `impl ?Sized + ?Sized` cannot be known at compilation time
-  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:27:9
+  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:27:12
    |
 LL | fn foo6(_: impl ?Sized + ?Sized) {}
-   |         ^  -------------------- this type parameter needs to be `Sized`
-   |         |
-   |         doesn't have a size known at compile-time
+   |            ^^^^^^^^^^^^^^^^^^^^
+   |            |
+   |            doesn't have a size known at compile-time
+   |            this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider restricting type parameters
@@ -149,12 +151,13 @@ LL | fn foo6(_: &impl ?Sized + ?Sized) {}
    |            +
 
 error[E0277]: the size for values of type `impl ?Sized + ?Sized + Debug` cannot be known at compilation time
-  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:31:9
+  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:31:12
    |
 LL | fn foo7(_: impl ?Sized + ?Sized + Debug) {}
-   |         ^  ---------------------------- this type parameter needs to be `Sized`
-   |         |
-   |         doesn't have a size known at compile-time
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            |
+   |            doesn't have a size known at compile-time
+   |            this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider restricting type parameters
@@ -168,12 +171,13 @@ LL | fn foo7(_: &impl ?Sized + ?Sized + Debug) {}
    |            +
 
 error[E0277]: the size for values of type `impl ?Sized + Debug + ?Sized` cannot be known at compilation time
-  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:35:9
+  --> $DIR/bad-suggestionf-for-repeated-unsized-bound-127441.rs:35:12
    |
 LL | fn foo8(_: impl ?Sized + Debug + ?Sized ) {}
-   |         ^  ---------------------------- this type parameter needs to be `Sized`
-   |         |
-   |         doesn't have a size known at compile-time
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            |
+   |            doesn't have a size known at compile-time
+   |            this type parameter needs to be `Sized`
    |
    = help: unsized fn params are gated as an unstable feature
 help: consider restricting type parameters

--- a/tests/ui/traits/alias/dont-elaborate-non-self.stderr
+++ b/tests/ui/traits/alias/dont-elaborate-non-self.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn Fn() -> Fut + 'static)` cannot be known at compilation time
-  --> $DIR/dont-elaborate-non-self.rs:7:11
+  --> $DIR/dont-elaborate-non-self.rs:7:14
    |
 LL | fn f<Fut>(a: dyn F<Fut>) {}
-   |           ^ doesn't have a size known at compile-time
+   |              ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Fn() -> Fut + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait-2021.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
-  --> $DIR/not-on-bare-trait-2021.rs:8:8
+  --> $DIR/not-on-bare-trait-2021.rs:8:12
    |
 LL | fn foo(_x: Foo + Send) {
-   |        ^^ doesn't have a size known at compile-time
+   |            ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
    = help: unsized fn params are gated as an unstable feature
@@ -16,10 +16,10 @@ LL | fn foo(_x: &(dyn Foo + Send)) {
    |            +++++           +
 
 error[E0277]: the size for values of type `(dyn Foo + 'static)` cannot be known at compilation time
-  --> $DIR/not-on-bare-trait-2021.rs:12:8
+  --> $DIR/not-on-bare-trait-2021.rs:12:11
    |
 LL | fn bar(x: Foo) -> Foo {
-   |        ^ doesn't have a size known at compile-time
+   |           ^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/traits/bound/not-on-bare-trait.stderr
+++ b/tests/ui/traits/bound/not-on-bare-trait.stderr
@@ -13,10 +13,10 @@ LL | fn foo(_x: dyn Foo + Send) {
    |            +++
 
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
-  --> $DIR/not-on-bare-trait.rs:7:8
+  --> $DIR/not-on-bare-trait.rs:7:12
    |
 LL | fn foo(_x: Foo + Send) {
-   |        ^^ doesn't have a size known at compile-time
+   |            ^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
    = help: unsized fn params are gated as an unstable feature
@@ -30,10 +30,10 @@ LL | fn foo(_x: &(dyn Foo + Send)) {
    |            +++++           +
 
 error[E0277]: the size for values of type `(dyn Foo + Send + 'static)` cannot be known at compilation time
-  --> $DIR/not-on-bare-trait.rs:12:8
+  --> $DIR/not-on-bare-trait.rs:12:12
    |
 LL | fn bar(_x: (dyn Foo + Send)) {
-   |        ^^ doesn't have a size known at compile-time
+   |            ^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `(dyn Foo + Send + 'static)`
    = help: unsized fn params are gated as an unstable feature

--- a/tests/ui/type/type-check/unknown_type_for_closure.stderr
+++ b/tests/ui/type/type-check/unknown_type_for_closure.stderr
@@ -16,10 +16,10 @@ LL |     let x = |_: /* Type */| {};
    |               ++++++++++++
 
 error[E0282]: type annotations needed
-  --> $DIR/unknown_type_for_closure.rs:10:14
+  --> $DIR/unknown_type_for_closure.rs:10:17
    |
 LL |     let x = |k: _| {};
-   |              ^ cannot infer type
+   |                 ^ cannot infer type
 
 error[E0282]: type annotations needed
   --> $DIR/unknown_type_for_closure.rs:14:28

--- a/tests/ui/typeck/typeck_type_placeholder_item.stderr
+++ b/tests/ui/typeck/typeck_type_placeholder_item.stderr
@@ -358,10 +358,10 @@ LL ~         b: (T, T),
    |
 
 error[E0282]: type annotations needed
-  --> $DIR/typeck_type_placeholder_item.rs:128:18
+  --> $DIR/typeck_type_placeholder_item.rs:128:21
    |
 LL |     fn fn_test11(_: _) -> (_, _) { panic!() }
-   |                  ^ cannot infer type
+   |                     ^ cannot infer type
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
   --> $DIR/typeck_type_placeholder_item.rs:128:28

--- a/tests/ui/unsized/unsized-fn-arg.stderr
+++ b/tests/ui/unsized/unsized-fn-arg.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the size for values of type `T` cannot be known at compilation time
-  --> $DIR/unsized-fn-arg.rs:5:17
+  --> $DIR/unsized-fn-arg.rs:5:20
    |
 LL | fn f<T: ?Sized>(t: T) {}
-   |      -          ^ doesn't have a size known at compile-time
+   |      -             ^ doesn't have a size known at compile-time
    |      |
    |      this type parameter needs to be `Sized`
    |

--- a/tests/ui/unsized/unsized6.stderr
+++ b/tests/ui/unsized/unsized6.stderr
@@ -206,10 +206,10 @@ LL + fn f4<X: T>(x1: Box<X>, x2: Box<X>, x3: Box<X>) {
    |
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:38:18
+  --> $DIR/unsized6.rs:38:21
    |
 LL | fn g1<X: ?Sized>(x: X) {}
-   |       -          ^ doesn't have a size known at compile-time
+   |       -             ^ doesn't have a size known at compile-time
    |       |
    |       this type parameter needs to be `Sized`
    |
@@ -225,10 +225,10 @@ LL | fn g1<X: ?Sized>(x: &X) {}
    |                     +
 
 error[E0277]: the size for values of type `X` cannot be known at compilation time
-  --> $DIR/unsized6.rs:40:22
+  --> $DIR/unsized6.rs:40:25
    |
 LL | fn g2<X: ?Sized + T>(x: X) {}
-   |       -              ^ doesn't have a size known at compile-time
+   |       -                 ^ doesn't have a size known at compile-time
    |       |
    |       this type parameter needs to be `Sized`
    |


### PR DESCRIPTION
Instead of

```
error[E0277]: the size for values of type `(dyn ThriftService<(), AssocType = _> + 'static)` cannot be known at compilation time
  --> $DIR/issue-59324.rs:23:20
   |
LL | fn with_factory<H>(factory: dyn ThriftService<()>) {}
   |                    ^^^^^^^ doesn't have a size known at compile-time
```

output

```
error[E0277]: the size for values of type `(dyn ThriftService<(), AssocType = _> + 'static)` cannot be known at compilation time
  --> $DIR/issue-59324.rs:23:29
   |
LL | fn with_factory<H>(factory: dyn ThriftService<()>) {}
   |                             ^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
