### PR TITLE
Use `&raw` in the compiler

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/archive.rs
+++ b/compiler/rustc_codegen_llvm/src/back/archive.rs
@@ -123,7 +123,7 @@ fn get_llvm_object_symbols(
         llvm::LLVMRustGetSymbols(
             buf.as_ptr(),
             buf.len(),
-            std::ptr::addr_of_mut!(*state) as *mut c_void,
+            (&raw mut *state) as *mut c_void,
             callback,
             error_callback,
         )

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -167,7 +167,7 @@ impl WriteBackendMethods for LlvmCodegenBackend {
     fn print_pass_timings(&self) {
         unsafe {
             let mut size = 0;
-            let cstr = llvm::LLVMRustPrintPassTimings(std::ptr::addr_of_mut!(size));
+            let cstr = llvm::LLVMRustPrintPassTimings(&raw mut size);
             if cstr.is_null() {
                 println!("failed to get pass timings");
             } else {
@@ -180,7 +180,7 @@ impl WriteBackendMethods for LlvmCodegenBackend {
     fn print_statistics(&self) {
         unsafe {
             let mut size = 0;
-            let cstr = llvm::LLVMRustPrintStatistics(std::ptr::addr_of_mut!(size));
+            let cstr = llvm::LLVMRustPrintStatistics(&raw mut size);
             if cstr.is_null() {
                 println!("failed to get pass stats");
             } else {

--- a/compiler/rustc_codegen_llvm/src/llvm_util.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm_util.rs
@@ -478,7 +478,7 @@ pub(crate) fn print(req: &PrintRequest, mut out: &mut String, sess: &Session) {
                     &tm,
                     cpu_cstring.as_ptr(),
                     callback,
-                    std::ptr::addr_of_mut!(out) as *mut c_void,
+                    (&raw mut out) as *mut c_void,
                 );
             }
         }

--- a/compiler/rustc_data_structures/src/sync.rs
+++ b/compiler/rustc_data_structures/src/sync.rs
@@ -437,7 +437,7 @@ impl<T> RwLock<T> {
     #[inline(always)]
     pub fn leak(&self) -> &T {
         let guard = self.read();
-        let ret = unsafe { &*std::ptr::addr_of!(*guard) };
+        let ret = unsafe { &*(&raw const *guard) };
         std::mem::forget(guard);
         ret
     }

--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -233,7 +233,7 @@ impl<'sess> OnDiskCache<'sess> {
 
                 for (index, file) in files.iter().enumerate() {
                     let index = SourceFileIndex(index as u32);
-                    let file_ptr: *const SourceFile = std::ptr::addr_of!(**file);
+                    let file_ptr: *const SourceFile = &raw const **file;
                     file_to_file_index.insert(file_ptr, index);
                     let source_file_id = EncodedSourceFileId::new(tcx, file);
                     file_index_to_stable_id.insert(index, source_file_id);
@@ -827,7 +827,7 @@ pub struct CacheEncoder<'a, 'tcx> {
 impl<'a, 'tcx> CacheEncoder<'a, 'tcx> {
     #[inline]
     fn source_file_index(&mut self, source_file: Lrc<SourceFile>) -> SourceFileIndex {
-        self.file_to_file_index[&std::ptr::addr_of!(*source_file)]
+        self.file_to_file_index[&(&raw const *source_file)]
     }
 
     /// Encode something with additional information that allows to do some

--- a/compiler/stable_mir/src/compiler_interface.rs
+++ b/compiler/stable_mir/src/compiler_interface.rs
@@ -255,7 +255,7 @@ where
     if TLV.is_set() {
         Err(Error::from("StableMIR already running"))
     } else {
-        let ptr: *const () = std::ptr::addr_of!(context) as _;
+        let ptr: *const () = (&raw const context) as _;
         TLV.set(&Cell::new(ptr), || Ok(f()))
     }
 }


### PR DESCRIPTION
Like #130865 did for the standard library, we can use `&raw` in the
compiler now that stage0 supports it. Also like the other issue, I did
not make any doc or test changes at this time.
