### PR TITLE
Fix error span if arg to `asm!()` is a macro call

### DIFF
--- a/tests/crashes/129503.rs
+++ b/tests/crashes/129503.rs
@@ -1,7 +1,0 @@
-//@ known-bug: rust-lang/rust#129503
-
-use std::arch::asm;
-
-unsafe fn f6() {
-    asm!(concat!(r#"lJ𐏿Æ�.𐏿�"#, "r} {}"));
-}

--- a/tests/ui/asm/ice-bad-err-span-in-template-129503.rs
+++ b/tests/ui/asm/ice-bad-err-span-in-template-129503.rs
@@ -1,0 +1,26 @@
+// Regression test for ICE #129503
+
+
+// Tests that we come up with decent error spans
+// when the template fed to `asm!()` is itself a
+// macro call like `concat!()` and should not ICE
+
+use std::arch::asm;
+
+fn main() {
+    // Should not ICE
+    asm!(concat!(r#"lJ𐏿Æ�.𐏿�"#, "r} {}"));
+    //~^ ERROR invalid asm template string: unmatched `}` found
+
+
+    // Macro call template: should point to
+    // everything within `asm!()` as error span
+    asm!(concat!("abc", "r} {}"));
+    //~^ ERROR invalid asm template string: unmatched `}` found
+
+
+    // Literal template: should point precisely to
+    // just the `}` as error span
+    asm!("abc", "r} {}");
+    //~^ ERROR invalid asm template string: unmatched `}` found
+}

--- a/tests/ui/asm/ice-bad-err-span-in-template-129503.stderr
+++ b/tests/ui/asm/ice-bad-err-span-in-template-129503.stderr
@@ -1,0 +1,28 @@
+error: invalid asm template string: unmatched `}` found
+  --> $DIR/ice-bad-err-span-in-template-129503.rs:12:10
+   |
+LL |     asm!(concat!(r#"lJ𐏿Æ�.𐏿�"#, "r} {}"));
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unmatched `}` in asm template string
+   |
+   = note: if you intended to print `}`, you can escape it using `}}`
+   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: invalid asm template string: unmatched `}` found
+  --> $DIR/ice-bad-err-span-in-template-129503.rs:18:10
+   |
+LL |     asm!(concat!("abc", "r} {}"));
+   |          ^^^^^^^^^^^^^^^^^^^^^^^ unmatched `}` in asm template string
+   |
+   = note: if you intended to print `}`, you can escape it using `}}`
+   = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: invalid asm template string: unmatched `}` found
+  --> $DIR/ice-bad-err-span-in-template-129503.rs:24:19
+   |
+LL |     asm!("abc", "r} {}");
+   |                   ^ unmatched `}` in asm template string
+   |
+   = note: if you intended to print `}`, you can escape it using `}}`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Fixes #129503 

When the argument to `asm!()` is a macro call, e.g. `asm!(concat!("abc", "{} pqr"))`, and there's an error in the resulting template string, we do not take into account the presence of this macro call while computing the error span. This PR fixes that. Now we will use the entire thing between the parenthesis of `asm!()` as the error span in this situation e.g. for `asm!(concat!("abc", "{} pqr"))` the error span will be `concat!("abc", "{} pqr")`. 