### PR TITLE
Make clashing_extern_declarations considering generic args for ADT field

### DIFF
--- a/compiler/rustc_lint/src/foreign_modules.rs
+++ b/compiler/rustc_lint/src/foreign_modules.rs
@@ -280,7 +280,7 @@ fn structurally_same_type_impl<'tcx>(
 
         ensure_sufficient_stack(|| {
             match (a.kind(), b.kind()) {
-                (&Adt(a_def, _), &Adt(b_def, _)) => {
+                (&Adt(a_def, a_gen_args), &Adt(b_def, b_gen_args)) => {
                     // Only `repr(C)` types can be compared structurally.
                     if !(a_def.repr().c() && b_def.repr().c()) {
                         return false;
@@ -304,8 +304,8 @@ fn structurally_same_type_impl<'tcx>(
                                 seen_types,
                                 tcx,
                                 param_env,
-                                tcx.type_of(a_did).instantiate_identity(),
-                                tcx.type_of(b_did).instantiate_identity(),
+                                tcx.type_of(a_did).instantiate(tcx, a_gen_args),
+                                tcx.type_of(b_did).instantiate(tcx, b_gen_args),
                                 ckind,
                             )
                         },

--- a/tests/ui/lint/clashing-extern-fn-issue-130851.rs
+++ b/tests/ui/lint/clashing-extern-fn-issue-130851.rs
@@ -1,0 +1,42 @@
+//@ build-pass
+#![warn(clashing_extern_declarations)]
+
+#[repr(C)]
+pub struct A {
+    a: [u16; 4],
+}
+#[repr(C)]
+pub struct B {
+    b: [u32; 4],
+}
+
+pub mod a {
+    extern "C" {
+        pub fn foo(_: super::A);
+    }
+}
+pub mod b {
+    extern "C" {
+        pub fn foo(_: super::B);
+        //~^ WARN `foo` redeclared with a different signature
+    }
+}
+
+#[repr(C)]
+pub struct G<T> {
+    g: [T; 4],
+}
+
+pub mod x {
+    extern "C" {
+        pub fn bar(_: super::G<u16>);
+    }
+}
+pub mod y {
+    extern "C" {
+        pub fn bar(_: super::G<u32>);
+        //~^ WARN `bar` redeclared with a different signature
+    }
+}
+
+fn main() {}

--- a/tests/ui/lint/clashing-extern-fn-issue-130851.stderr
+++ b/tests/ui/lint/clashing-extern-fn-issue-130851.stderr
@@ -1,0 +1,31 @@
+warning: `foo` redeclared with a different signature
+  --> $DIR/clashing-extern-fn-issue-130851.rs:20:9
+   |
+LL |         pub fn foo(_: super::A);
+   |         ------------------------ `foo` previously declared here
+...
+LL |         pub fn foo(_: super::B);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
+   |
+   = note: expected `unsafe extern "C" fn(A)`
+              found `unsafe extern "C" fn(B)`
+note: the lint level is defined here
+  --> $DIR/clashing-extern-fn-issue-130851.rs:2:9
+   |
+LL | #![warn(clashing_extern_declarations)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: `bar` redeclared with a different signature
+  --> $DIR/clashing-extern-fn-issue-130851.rs:37:9
+   |
+LL |         pub fn bar(_: super::G<u16>);
+   |         ----------------------------- `bar` previously declared here
+...
+LL |         pub fn bar(_: super::G<u32>);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this signature doesn't match the previous declaration
+   |
+   = note: expected `unsafe extern "C" fn(G<u16>)`
+              found `unsafe extern "C" fn(G<u32>)`
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
In following example, G<u16> should be recognized as different from G<u32> :

```rust
#[repr(C)] pub struct G<T> { g: [T; 4] }

pub mod x { extern "C" { pub fn g(_: super::G<u16>); } }
pub mod y { extern "C" { pub fn g(_: super::G<u32>); } }
```

fixes #130851

