### PR TITLE
etc: Add sample rust-analyzer configs for eglot & helix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Session.vim
 .favorites.json
 .settings/
 .vs/
+.dir-locals.el
 
 ## Tool
 .valgrindrc

--- a/src/etc/rust_analyzer_eglot.el
+++ b/src/etc/rust_analyzer_eglot.el
@@ -1,0 +1,29 @@
+((rustic-mode
+  .((eglot-workspace-configuration
+     . (:rust-analyzer
+        ( :check ( :invocationLocation "root"
+                   :invocationStrategy "once"
+                   :overrideCommand ["python3"
+                                     "x.py"
+                                     "check"
+                                     "--json-output"])
+          :linkedProjects ["Cargo.toml"
+                           "src/tools/x/Cargo.toml"
+                           "src/bootstrap/Cargo.toml"
+                           "src/tools/rust-analyzer/Cargo.toml"
+                           "compiler/rustc_codegen_cranelift/Cargo.toml"
+                           "compiler/rustc_codegen_gcc/Cargo.toml"]
+          :rustfmt ( :overrideCommand ["build/host/rustfmt/bin/rustfmt"
+                                       "--edition=2021"])
+          :procMacro ( :server "build/host/stage0/libexec/rust-analyzer-proc-macro-srv"
+                       :enable t)
+          :cargo ( :buildScripts ( :enable t
+                                   :invocationLocation "root"
+                                   :invocationStrategy "once"
+                                   :overrideCommand ["python3"
+                                                     "x.py"
+                                                     "check"
+                                                     "--json-output"])
+                   :sysrootSrc "./library"
+                   :extraEnv (:RUSTC_BOOTSTRAP "1"))
+          :rustc ( :source "./Cargo.toml" )))))))

--- a/src/etc/rust_analyzer_helix.toml
+++ b/src/etc/rust_analyzer_helix.toml
@@ -1,0 +1,49 @@
+[language-server.rust-analyzer.config]
+linkedProjects = [
+    "Cargo.toml",
+    "src/tools/x/Cargo.toml",
+    "src/bootstrap/Cargo.toml",
+    "src/tools/rust-analyzer/Cargo.toml",
+    "compiler/rustc_codegen_cranelift/Cargo.toml",
+    "compiler/rustc_codegen_gcc/Cargo.toml"
+]
+
+[language-server.rust-analyzer.config.check]
+invocationLocation = "root"
+invocationStrategy = "once"
+overrideCommand = [
+    "python3",
+    "x.py",
+    "check",
+    "--json-output",
+]
+
+[language-server.rust-analyzer.config.rustfmt]
+overrideCommand = [
+    "build-rust-analyzer/host/rustfmt/bin/rustfmt",
+    "--edition=2021"
+]
+
+[language-server.rust-analyzer.config.procMacro]
+server = "build-rust-analyzer/host/stage0/libexec/rust-analyzer-proc-macro-srv"
+enable = true
+
+[language-server.rust-analyzer.config.rustc]
+source = "./Cargo.toml"
+
+[language-server.rust-analyzer.config.cargo]
+sysrootSrc = "./library"
+
+[language-server.rust-analyzer.config.cargo.extraEnv]
+RUSTC_BOOTSTRAP = "1"
+
+[language-server.rust-analyzer.config.cargo.buildScripts]
+enable = true
+invocationLocation = "root"
+invocationStrategy = "once"
+overrideCommand = [
+    "python3",
+    "x.py",
+    "check",
+    "--json-output",
+]


### PR DESCRIPTION
LSP configuration in editors like Emacs (eglot) and helix does not
use the same JSON format as vscode and vim do. It is not obvious
how to set up LSP for rustc in those editors and the dev guide currently
does not cover them. Adding sample configuration files for those editors
alongside the currently existing JSON one would be helpful.

I figured having those included in the repo like the JSON one might save
someone some time and frustration otherwise spent on trying to get the
more niche editors' LSP to work properly. I'll add a section in the dev
guide too.