### PR TITLE
rustdoc: lists items that contain multiple paragraphs are more clear

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -958,6 +958,13 @@ pre, .rustdoc.src .example-wrap, .example-wrap .src-line-numbers {
 	display: inline-block;
 }
 
+.docblock li {
+	margin-bottom: .8em;
+}
+.docblock li p {
+	margin-bottom: .1em;
+}
+
 /* "where ..." clauses with block display are also smaller */
 div.where {
 	white-space: pre-wrap;


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/130622

before: ![before](https://github.com/user-attachments/assets/fe54d8ee-8a1a-45fc-9434-2737c5c6f4d5)

after: 
![after](https://github.com/user-attachments/assets/095be365-1bfc-4001-8664-59bc4125bb05)


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
