### PR TITLE
rustdoc-json-types: update `ProcMacro` docs section on helper attributes

### DIFF
--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -1168,7 +1168,7 @@ pub struct ProcMacro {
     pub kind: MacroKind,
     /// Helper attributes defined by a macro to be used inside it.
     ///
-    /// Defined only for attribute & derive macros.
+    /// Defined only for derive macros.
     ///
     /// E.g. the [`Default`] derive macro defines a `#[default]` helper attribute so that one can
     /// do:


### PR DESCRIPTION
I believe the mention of attribute macros in the section on proc macro helper attributes is erroneous. As far as I can tell, attribute macros cannot define helper attributes.

The following attribute macro is not valid (fails to build), no matter how I try to define (or skip defining) the helpers:
```rust
#[proc_macro_attribute(attributes(helper))]
pub fn attribute_helpers(_attr: TokenStream, item: TokenStream) -> TokenStream {
    item
}
```

The [language reference](https://doc.rust-lang.org/reference/procedural-macros.html#attribute-macros) also doesn't seem to mention attribute macro helpers. The helpers subsection is inside the section on derive macros.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
