### PR TITLE
Improve naming for `rustc_insignficant_dtor` attribute

### DIFF
--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -1022,7 +1022,7 @@ pub const BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         WarnFollowing, EncodeCrossCrate::No
     ),
     rustc_attr!(
-        TEST, rustc_insignificant_dtor, Normal, template!(Word),
+        TEST, rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation, Normal, template!(Word),
         WarnFollowing, EncodeCrossCrate::Yes
     ),
     rustc_attr!(

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1419,7 +1419,7 @@ rustc_queries! {
     }
 
     /// A list of types where the ADT requires drop if and only if any of those types
-    /// has significant drop. A type marked with the attribute `rustc_insignificant_dtor`
+    /// has significant drop. A type marked with the attribute `rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation`
     /// is considered to not be significant. A drop is significant if it is implemented
     /// by the user or does anything that will have any observable behavior (other than
     /// freeing up memory). If the ADT is known to have a significant destructor then

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -1473,7 +1473,7 @@ impl<'tcx> Ty<'tcx> {
     ///
     /// Note that this method can return false even if `ty` has a destructor
     /// attached; even if that is the case then the adt has been marked with
-    /// the attribute `rustc_insignificant_dtor`.
+    /// the attribute `rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation`.
     ///
     /// Note that this method is used to check for change in drop order for
     /// 2229 drop reorder migration analysis.

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1682,7 +1682,7 @@ symbols! {
         rustc_hidden_type_of_opaques,
         rustc_if_this_changed,
         rustc_inherit_overflow_checks,
-        rustc_insignificant_dtor,
+        rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation,
         rustc_intrinsic,
         rustc_intrinsic_must_be_overridden,
         rustc_layout,

--- a/compiler/rustc_ty_utils/src/needs_drop.rs
+++ b/compiler/rustc_ty_utils/src/needs_drop.rs
@@ -344,19 +344,19 @@ fn adt_consider_insignificant_dtor<'tcx>(
     tcx: TyCtxt<'tcx>,
 ) -> impl Fn(ty::AdtDef<'tcx>) -> Option<DtorType> + 'tcx {
     move |adt_def: ty::AdtDef<'tcx>| {
-        let is_marked_insig = tcx.has_attr(adt_def.did(), sym::rustc_insignificant_dtor);
+        let is_marked_insig = tcx.has_attr(adt_def.did(), sym::rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation);
         if is_marked_insig {
             // In some cases like `std::collections::HashMap` where the struct is a wrapper around
             // a type that is a Drop type, and the wrapped type (eg: `hashbrown::HashMap`) lies
             // outside stdlib, we might choose to still annotate the wrapper (std HashMap) with
-            // `rustc_insignificant_dtor`, even if the type itself doesn't have a `Drop` impl.
+            // `rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation`, even if the type itself doesn't have a `Drop` impl.
             Some(DtorType::Insignificant)
         } else if adt_def.destructor(tcx).is_some() {
             // There is a Drop impl and the type isn't marked insignificant, therefore Drop must be
             // significant.
             Some(DtorType::Significant)
         } else {
-            // No destructor found nor the type is annotated with `rustc_insignificant_dtor`, we
+            // No destructor found nor the type is annotated with `rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation`, we
             // treat this as the simple case of Drop impl for type.
             None
         }

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -169,7 +169,7 @@ pub(super) const MIN_LEN: usize = node::MIN_LEN_AFTER_SPLIT;
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "BTreeMap")]
-#[rustc_insignificant_dtor]
+#[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 pub struct BTreeMap<
     K,
     V,
@@ -422,7 +422,7 @@ impl<'a, K: 'a, V: 'a> Default for IterMut<'a, K, V> {
 ///
 /// [`into_iter`]: IntoIterator::into_iter
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_insignificant_dtor]
+#[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 pub struct IntoIter<
     K,
     V,

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -46,7 +46,7 @@ mod tests;
 /// [`VecDeque`]: super::vec_deque::VecDeque
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "LinkedList")]
-#[rustc_insignificant_dtor]
+#[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 pub struct LinkedList<
     T,
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -86,7 +86,7 @@ mod tests;
 /// [`make_contiguous`]: VecDeque::make_contiguous
 #[cfg_attr(not(test), rustc_diagnostic_item = "VecDeque")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_insignificant_dtor]
+#[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 pub struct VecDeque<
     T,
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -309,7 +309,7 @@ fn rcbox_layout_for_value_layout(layout: Layout) -> Layout {
 /// [get_mut]: Rc::get_mut
 #[cfg_attr(not(test), rustc_diagnostic_item = "Rc")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_insignificant_dtor]
+#[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 pub struct Rc<
     T: ?Sized,
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -41,7 +41,7 @@ macro non_null {
 /// let iter: std::vec::IntoIter<_> = v.into_iter();
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_insignificant_dtor]
+#[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 pub struct IntoIter<
     T,
     #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global,

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -393,7 +393,7 @@ mod spec_extend;
 /// [owned slice]: Box
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "Vec")]
-#[rustc_insignificant_dtor]
+#[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 pub struct Vec<T, #[unstable(feature = "allocator_api", issue = "32838")] A: Allocator = Global> {
     buf: RawVec<T, A>,
     len: usize,

--- a/library/core/src/array/iter.rs
+++ b/library/core/src/array/iter.rs
@@ -9,7 +9,7 @@ use crate::{fmt, ptr};
 
 /// A by-value [array] iterator.
 #[stable(feature = "array_value_iter", since = "1.51.0")]
-#[rustc_insignificant_dtor]
+#[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 #[rustc_diagnostic_item = "ArrayIntoIter"]
 pub struct IntoIter<T, const N: usize> {
     /// This is the array we are iterating over.

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -207,7 +207,7 @@ use crate::ops::Index;
 
 #[cfg_attr(not(test), rustc_diagnostic_item = "HashMap")]
 #[stable(feature = "rust1", since = "1.0.0")]
-#[rustc_insignificant_dtor]
+#[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 pub struct HashMap<K, V, S = RandomState> {
     base: base::HashMap<K, V, S>,
 }

--- a/src/tools/tidy/src/style.rs
+++ b/src/tools/tidy/src/style.rs
@@ -206,6 +206,9 @@ fn should_ignore(line: &str) -> bool {
         || static_regex!(
             "\\s*//@ \\!?(count|files|has|has-dir|hasraw|matches|matchesraw|snapshot)\\s.*"
         ).is_match(line)
+
+        // This can't be split across lines.
+        || line.contains("rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation")
 }
 
 /// Returns `true` if `line` is allowed to be longer than the normal limit.

--- a/tests/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.fixed
+++ b/tests/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.fixed
@@ -7,7 +7,7 @@
 
 use std::sync::Mutex;
 
-    #[rustc_insignificant_dtor]
+    #[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 struct InsignificantDropPoint {
     x: i32,
     y: Mutex<i32>,
@@ -23,7 +23,7 @@ impl Drop for SigDrop {
     fn drop(&mut self) {}
 }
 
-#[rustc_insignificant_dtor]
+#[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 struct GenericStruct<T>(T, T);
 
 impl<T> Drop for GenericStruct<T> {

--- a/tests/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.rs
+++ b/tests/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_migrations.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Mutex;
 
-    #[rustc_insignificant_dtor]
+    #[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 struct InsignificantDropPoint {
     x: i32,
     y: Mutex<i32>,
@@ -23,7 +23,7 @@ impl Drop for SigDrop {
     fn drop(&mut self) {}
 }
 
-#[rustc_insignificant_dtor]
+#[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 struct GenericStruct<T>(T, T);
 
 impl<T> Drop for GenericStruct<T> {

--- a/tests/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_no_migrations.rs
+++ b/tests/ui/closures/2229_closure_analysis/migrations/insignificant_drop_attr_no_migrations.rs
@@ -3,7 +3,7 @@
 #![deny(rust_2021_incompatible_closure_captures)]
 #![feature(rustc_attrs)]
 #![allow(unused)]
-#[rustc_insignificant_dtor]
+#[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
 
 struct InsignificantDropPoint {
     x: i32,

--- a/tests/ui/coroutine/drop-tracking-parent-expression.rs
+++ b/tests/ui/coroutine/drop-tracking-parent-expression.rs
@@ -58,7 +58,7 @@ fn main() {
         // NOT OK (we need to agree with MIR borrowck)
         insignificant_dtor => {
             #[derive(Default)]
-            #[rustc_insignificant_dtor]
+            #[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
             pub struct Client;
             impl Drop for Client {
                 fn drop(&mut self) {}

--- a/tests/ui/coroutine/parent-expression.rs
+++ b/tests/ui/coroutine/parent-expression.rs
@@ -58,7 +58,7 @@ fn main() {
         // NOT OK (we need to agree with MIR borrowck)
         insignificant_dtor => {
             #[derive(Default)]
-            #[rustc_insignificant_dtor]
+            #[rustc_dtor_that_is_insignificant_for_the_purpose_of_warning_users_about_edition_specific_drop_rules_mostly_regarding_mutex_locking_and_certainly_not_just_allocation]
             pub struct Client;
             impl Drop for Client {
                 fn drop(&mut self) {}


### PR DESCRIPTION
Some people were a bit confused by what it means for a dtor to be "significant", so I've elaborated the name (as suggested by @compiler-errors).

r? @compiler-errors 