### PR TITLE
Suggest flipping reversed `?#`/`?x`/`?X` in format specifiers

### DIFF
--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -162,7 +162,11 @@ builtin_macros_format_redundant_args = redundant {$n ->
     }
     .suggestion = this can be removed
 
+builtin_macros_format_remove = consider removing the format specifier instead
+
 builtin_macros_format_remove_raw_ident = remove the `r#`
+
+builtin_macros_format_reorder = consider reordering the format specifier instead
 
 builtin_macros_format_requires_string = requires at least a format string argument
 

--- a/compiler/rustc_builtin_macros/src/errors.rs
+++ b/compiler/rustc_builtin_macros/src/errors.rs
@@ -551,6 +551,25 @@ pub(crate) enum InvalidFormatStringSuggestion {
         #[primary_span]
         span: Span,
     },
+    #[multipart_suggestion(
+        builtin_macros_format_reorder,
+        style = "tool-only",
+        applicability = "machine-applicable"
+    )]
+    ReorderFormat {
+        #[suggestion_part(code = "{string}")]
+        span: Span,
+        string: String,
+    },
+    #[multipart_suggestion(
+        builtin_macros_format_remove,
+        style = "tool-only",
+        applicability = "machine-applicable"
+    )]
+    RemoveCharacter {
+        #[suggestion_part(code = "")]
+        span: Span,
+    },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_builtin_macros/src/format.rs
+++ b/compiler/rustc_builtin_macros/src/format.rs
@@ -302,6 +302,20 @@ fn make_format_args(
                     e.sugg_ = Some(errors::InvalidFormatStringSuggestion::RemoveRawIdent { span })
                 }
             }
+            parse::Suggestion::ReorderFormat(span) => {
+                let span = fmt_span.from_inner(InnerSpan::new(span.start, span.end));
+                if let Ok(original_string) = ecx.source_map().span_to_snippet(span) {
+                    let reversed_string: String = original_string.chars().rev().collect();
+                    e.sugg_ = Some(errors::InvalidFormatStringSuggestion::ReorderFormat {
+                        span: span,
+                        string: reversed_string,
+                    });
+                }
+            }
+            parse::Suggestion::RemoveCharacter(span) => {
+                let span = fmt_span.from_inner(InnerSpan::new(span.start, span.end));
+                e.sugg_ = Some(errors::InvalidFormatStringSuggestion::RemoveCharacter { span })
+            }
         }
         let guar = ecx.dcx().emit_err(e);
         return ExpandResult::Ready(Err(guar));

--- a/tests/ui/fmt/help-message-issue-129966-reorder-remove-format-specifier.rs
+++ b/tests/ui/fmt/help-message-issue-129966-reorder-remove-format-specifier.rs
@@ -1,0 +1,14 @@
+// Test checks for the help messages in the error output/
+//@ check-run-results
+
+struct Foo(u8, u8);
+
+fn main() {
+    let f = Foo(1, 2);
+    format!("{f:?#}");
+//~^ ERROR invalid format string: unknown format identifier '?#'
+    format!("{f:?x}");
+//~^ ERROR invalid format string: unknown format identifier '?x'
+    format!("{f:?X}");
+//~^ ERROR invalid format string: unknown format identifier '?X'
+}

--- a/tests/ui/fmt/help-message-issue-129966-reorder-remove-format-specifier.stderr
+++ b/tests/ui/fmt/help-message-issue-129966-reorder-remove-format-specifier.stderr
@@ -1,0 +1,26 @@
+error: invalid format string: unknown format identifier '?#'
+  --> $DIR/help-message-issue-129966-reorder-remove-format-specifier.rs:8:17
+   |
+LL |     format!("{f:?#}");
+   |                 ^^ help: the format parameter should be written `#?` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: unknown format identifier '?x'
+  --> $DIR/help-message-issue-129966-reorder-remove-format-specifier.rs:10:18
+   |
+LL |     format!("{f:?x}");
+   |                  ^ help: consider removing `x` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: invalid format string: unknown format identifier '?X'
+  --> $DIR/help-message-issue-129966-reorder-remove-format-specifier.rs:12:18
+   |
+LL |     format!("{f:?X}");
+   |                  ^ help: consider removing `X` in format string
+   |
+   = note: if you intended to print `{`, you can escape it using `{{`
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Edits format parsing to accomodate for helpful messages in case '#?' is incorrectly ordered or '?x', '?X' is written.

Fixes #129966.
