### PR TITLE
interpret: always enable write_immediate sanity checks

### DIFF
--- a/compiler/rustc_const_eval/src/interpret/operand.rs
+++ b/compiler/rustc_const_eval/src/interpret/operand.rs
@@ -118,6 +118,7 @@ impl<Prov: Provenance> Immediate<Prov> {
             (Immediate::Scalar(scalar), Abi::Scalar(s)) => {
                 assert_eq!(scalar.size(), s.size(cx));
                 if !matches!(s.primitive(), abi::Pointer(..)) {
+                    // This is not a pointer, it should not carry provenance.
                     assert!(matches!(scalar, Scalar::Int(..)));
                 }
             }

--- a/compiler/rustc_const_eval/src/interpret/place.rs
+++ b/compiler/rustc_const_eval/src/interpret/place.rs
@@ -652,6 +652,8 @@ where
                     M::after_local_write(self, local, /*storage_live*/ false)?;
                 }
                 // Double-check that the value we are storing and the local fit to each other.
+                // Things can ge wrong in quite weird ways when this is violated.
+                // Unfortunately this is too expensive to do in release builds.
                 if cfg!(debug_assertions) {
                     src.assert_matches_abi(local_layout.abi, self);
                 }
@@ -672,9 +674,9 @@ where
         layout: TyAndLayout<'tcx>,
         dest: MemPlace<M::Provenance>,
     ) -> InterpResult<'tcx> {
-        if cfg!(debug_assertions) {
-            value.assert_matches_abi(layout.abi, self);
-        }
+        // We use the sizes from `value` below.
+        // Ensure that matches the type of the place it is written to.
+        value.assert_matches_abi(layout.abi, self);
         // Note that it is really important that the type here is the right one, and matches the
         // type things are read at. In case `value` is a `ScalarPair`, we don't do any magic here
         // to handle padding properly, which is only correct if we never look at this data with the


### PR DESCRIPTION
Writing a wrongly-sized scalar somewhere can have quite confusing effects. Let's see how expensive it is to catch this early.