### PR TITLE
weekly update: add header to compiler deps update

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -61,9 +61,11 @@ jobs:
           rustup toolchain install --no-self-update --profile minimal $TOOLCHAIN
           rustup default $TOOLCHAIN
 
-      - name: cargo update
+      - name: cargo update compiler & tools
         # Remove first line that always just says "Updating crates.io index"
-        run: cargo update 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
+        run: |
+          echo -e "\ncompiler & tools dependencies:" >> cargo_update.log
+          cargo update 2>&1 | sed '/crates.io index/d' | tee -a cargo_update.log
       - name: cargo update library
         run: |
           echo -e "\nlibrary dependencies:" >> cargo_update.log


### PR DESCRIPTION
Look at #131000: library and rustbook have nice headers for deps updates (i.e. `library dependencies:`), but not compiler one. Fixes this.