### PR TITLE
Fix `adt_const_params` leaking `{type error}` in error msg

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -961,13 +961,20 @@ fn check_param_wf(tcx: TyCtxt<'_>, param: &hir::GenericParam<'_>) -> Result<(), 
                         hir_ty.span,
                         "using raw pointers as const generic parameters is forbidden",
                     ),
-                    _ => tcx.dcx().struct_span_err(
-                        hir_ty.span,
-                        format!("`{}` is forbidden as the type of a const generic parameter", ty),
-                    ),
+                    _ => {
+                        // Avoid showing "{type error}" to users. See #118179.
+                        ty.error_reported()?;
+
+                        tcx.dcx().struct_span_err(
+                            hir_ty.span,
+                            format!(
+                                "`{ty}` is forbidden as the type of a const generic parameter",
+                            ),
+                        )
+                    }
                 };
 
-                diag.note("the only supported types are integers, `bool` and `char`");
+                diag.note("the only supported types are integers, `bool`, and `char`");
 
                 let cause = ObligationCause::misc(hir_ty.span, param.def_id);
                 let adt_const_params_feature_string =

--- a/tests/ui/const-generics/adt_const_params/suggest_feature_only_when_possible.stderr
+++ b/tests/ui/const-generics/adt_const_params/suggest_feature_only_when_possible.stderr
@@ -4,7 +4,7 @@ error: `&'static mut ()` is forbidden as the type of a const generic parameter
 LL | fn uwu_0<const N: &'static mut ()>() {}
    |                   ^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: `&'static u32` is forbidden as the type of a const generic parameter
   --> $DIR/suggest_feature_only_when_possible.rs:15:19
@@ -12,7 +12,7 @@ error: `&'static u32` is forbidden as the type of a const generic parameter
 LL | fn owo_0<const N: &'static u32>() {}
    |                   ^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -28,7 +28,7 @@ error: `Meow` is forbidden as the type of a const generic parameter
 LL | fn meow_0<const N: Meow>() {}
    |                    ^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -40,7 +40,7 @@ error: `&'static Meow` is forbidden as the type of a const generic parameter
 LL | fn meow_1<const N: &'static Meow>() {}
    |                    ^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -56,7 +56,7 @@ error: `[Meow; 100]` is forbidden as the type of a const generic parameter
 LL | fn meow_2<const N: [Meow; 100]>() {}
    |                    ^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: `(Meow, u8)` is forbidden as the type of a const generic parameter
   --> $DIR/suggest_feature_only_when_possible.rs:29:20
@@ -64,7 +64,7 @@ error: `(Meow, u8)` is forbidden as the type of a const generic parameter
 LL | fn meow_3<const N: (Meow, u8)>() {}
    |                    ^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: `(Meow, String)` is forbidden as the type of a const generic parameter
   --> $DIR/suggest_feature_only_when_possible.rs:34:20
@@ -72,7 +72,7 @@ error: `(Meow, String)` is forbidden as the type of a const generic parameter
 LL | fn meow_4<const N: (Meow, String)>() {}
    |                    ^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: `String` is forbidden as the type of a const generic parameter
   --> $DIR/suggest_feature_only_when_possible.rs:38:19
@@ -80,7 +80,7 @@ error: `String` is forbidden as the type of a const generic parameter
 LL | fn nya_0<const N: String>() {}
    |                   ^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: `Vec<u32>` is forbidden as the type of a const generic parameter
   --> $DIR/suggest_feature_only_when_possible.rs:40:19
@@ -88,7 +88,7 @@ error: `Vec<u32>` is forbidden as the type of a const generic parameter
 LL | fn nya_1<const N: Vec<u32>>() {}
    |                   ^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/const-generics/const-param-elided-lifetime.full.stderr
+++ b/tests/ui/const-generics/const-param-elided-lifetime.full.stderr
@@ -5,25 +5,25 @@ LL | struct A<const N: &u8>;
    |                   ^ explicit lifetime name needed here
 
 error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/const-param-elided-lifetime.rs:14:15
+  --> $DIR/const-param-elided-lifetime.rs:13:15
    |
 LL | impl<const N: &u8> A<N> {
    |               ^ explicit lifetime name needed here
 
 error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/const-param-elided-lifetime.rs:17:21
+  --> $DIR/const-param-elided-lifetime.rs:15:21
    |
 LL |     fn foo<const M: &u8>(&self) {}
    |                     ^ explicit lifetime name needed here
 
 error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/const-param-elided-lifetime.rs:22:15
+  --> $DIR/const-param-elided-lifetime.rs:19:15
    |
 LL | impl<const N: &u8> B for A<N> {}
    |               ^ explicit lifetime name needed here
 
 error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/const-param-elided-lifetime.rs:26:17
+  --> $DIR/const-param-elided-lifetime.rs:22:17
    |
 LL | fn bar<const N: &u8>() {}
    |                 ^ explicit lifetime name needed here

--- a/tests/ui/const-generics/const-param-elided-lifetime.min.stderr
+++ b/tests/ui/const-generics/const-param-elided-lifetime.min.stderr
@@ -5,109 +5,29 @@ LL | struct A<const N: &u8>;
    |                   ^ explicit lifetime name needed here
 
 error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/const-param-elided-lifetime.rs:14:15
+  --> $DIR/const-param-elided-lifetime.rs:13:15
    |
 LL | impl<const N: &u8> A<N> {
    |               ^ explicit lifetime name needed here
 
 error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/const-param-elided-lifetime.rs:17:21
+  --> $DIR/const-param-elided-lifetime.rs:15:21
    |
 LL |     fn foo<const M: &u8>(&self) {}
    |                     ^ explicit lifetime name needed here
 
 error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/const-param-elided-lifetime.rs:22:15
+  --> $DIR/const-param-elided-lifetime.rs:19:15
    |
 LL | impl<const N: &u8> B for A<N> {}
    |               ^ explicit lifetime name needed here
 
 error[E0637]: `&` without an explicit lifetime name cannot be used here
-  --> $DIR/const-param-elided-lifetime.rs:26:17
+  --> $DIR/const-param-elided-lifetime.rs:22:17
    |
 LL | fn bar<const N: &u8>() {}
    |                 ^ explicit lifetime name needed here
 
-error: `&u8` is forbidden as the type of a const generic parameter
-  --> $DIR/const-param-elided-lifetime.rs:9:19
-   |
-LL | struct A<const N: &u8>;
-   |                   ^^^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
-   |
-LL + #![feature(adt_const_params)]
-   |
-help: add `#![feature(unsized_const_params)]` to the crate attributes to enable references to implement the `ConstParamTy` trait
-   |
-LL + #![feature(unsized_const_params)]
-   |
-
-error: `&u8` is forbidden as the type of a const generic parameter
-  --> $DIR/const-param-elided-lifetime.rs:14:15
-   |
-LL | impl<const N: &u8> A<N> {
-   |               ^^^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
-   |
-LL + #![feature(adt_const_params)]
-   |
-help: add `#![feature(unsized_const_params)]` to the crate attributes to enable references to implement the `ConstParamTy` trait
-   |
-LL + #![feature(unsized_const_params)]
-   |
-
-error: `&u8` is forbidden as the type of a const generic parameter
-  --> $DIR/const-param-elided-lifetime.rs:22:15
-   |
-LL | impl<const N: &u8> B for A<N> {}
-   |               ^^^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
-   |
-LL + #![feature(adt_const_params)]
-   |
-help: add `#![feature(unsized_const_params)]` to the crate attributes to enable references to implement the `ConstParamTy` trait
-   |
-LL + #![feature(unsized_const_params)]
-   |
-
-error: `&u8` is forbidden as the type of a const generic parameter
-  --> $DIR/const-param-elided-lifetime.rs:26:17
-   |
-LL | fn bar<const N: &u8>() {}
-   |                 ^^^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
-   |
-LL + #![feature(adt_const_params)]
-   |
-help: add `#![feature(unsized_const_params)]` to the crate attributes to enable references to implement the `ConstParamTy` trait
-   |
-LL + #![feature(unsized_const_params)]
-   |
-
-error: `&u8` is forbidden as the type of a const generic parameter
-  --> $DIR/const-param-elided-lifetime.rs:17:21
-   |
-LL |     fn foo<const M: &u8>(&self) {}
-   |                     ^^^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
-   |
-LL + #![feature(adt_const_params)]
-   |
-help: add `#![feature(unsized_const_params)]` to the crate attributes to enable references to implement the `ConstParamTy` trait
-   |
-LL + #![feature(unsized_const_params)]
-   |
-
-error: aborting due to 10 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0637`.

--- a/tests/ui/const-generics/const-param-elided-lifetime.rs
+++ b/tests/ui/const-generics/const-param-elided-lifetime.rs
@@ -8,23 +8,18 @@
 
 struct A<const N: &u8>;
 //~^ ERROR `&` without an explicit lifetime name cannot be used here
-//[min]~^^ ERROR `&u8` is forbidden
 trait B {}
 
 impl<const N: &u8> A<N> {
     //~^ ERROR `&` without an explicit lifetime name cannot be used here
-    //[min]~^^ ERROR `&u8` is forbidden
     fn foo<const M: &u8>(&self) {}
     //~^ ERROR `&` without an explicit lifetime name cannot be used here
-    //[min]~^^ ERROR `&u8` is forbidden
 }
 
 impl<const N: &u8> B for A<N> {}
 //~^ ERROR `&` without an explicit lifetime name cannot be used here
-//[min]~^^ ERROR `&u8` is forbidden
 
 fn bar<const N: &u8>() {}
 //~^ ERROR `&` without an explicit lifetime name cannot be used here
-//[min]~^^ ERROR `&u8` is forbidden
 
 fn main() {}

--- a/tests/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
+++ b/tests/ui/const-generics/const-param-type-depends-on-const-param.min.stderr
@@ -20,7 +20,7 @@ error: `[u8; N]` is forbidden as the type of a const generic parameter
 LL | pub struct Dependent<const N: usize, const X: [u8; N]>([(); N]);
    |                                               ^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -32,7 +32,7 @@ error: `[u8; N]` is forbidden as the type of a const generic parameter
 LL | pub struct SelfDependent<const N: [u8; N]>;
    |                                   ^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/default-ty-closure.stderr
+++ b/tests/ui/const-generics/default-ty-closure.stderr
@@ -4,7 +4,7 @@ error: using function pointers as const generic parameters is forbidden
 LL | struct X<const FN: fn() = { || {} }>;
    |                    ^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/float-generic.simple.stderr
+++ b/tests/ui/const-generics/float-generic.simple.stderr
@@ -4,7 +4,7 @@ error: `f32` is forbidden as the type of a const generic parameter
 LL | fn foo<const F: f32>() {}
    |                 ^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/fn-const-param-call.min.stderr
+++ b/tests/ui/const-generics/fn-const-param-call.min.stderr
@@ -4,7 +4,7 @@ error: using function pointers as const generic parameters is forbidden
 LL | struct Wrapper<const F: fn() -> u32>;
    |                         ^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/fn-const-param-call.rs:15:15
@@ -12,7 +12,7 @@ error: using function pointers as const generic parameters is forbidden
 LL | impl<const F: fn() -> u32> Wrapper<F> {
    |               ^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/fn-const-param-infer.min.stderr
+++ b/tests/ui/const-generics/fn-const-param-infer.min.stderr
@@ -4,7 +4,7 @@ error: using function pointers as const generic parameters is forbidden
 LL | struct Checked<const F: fn(usize) -> bool>;
    |                         ^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error[E0308]: mismatched types
   --> $DIR/fn-const-param-infer.rs:33:25

--- a/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.min.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/array-size-in-generic-struct-param.min.stderr
@@ -22,7 +22,7 @@ error: `Config` is forbidden as the type of a const generic parameter
 LL | struct B<const CFG: Config> {
    |                     ^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/generic_const_exprs/error_in_ty.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/error_in_ty.stderr
@@ -12,7 +12,7 @@ error: `[usize; x]` is forbidden as the type of a const generic parameter
 LL | pub struct A<const z: [usize; x]> {}
    |                       ^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
@@ -66,7 +66,7 @@ error: `[[usize; v4]; v4]` is forbidden as the type of a const generic parameter
 LL |     pub struct v17<const v10: usize, const v7: v11> {
    |                                                ^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/ice-118285-fn-ptr-value.stderr
+++ b/tests/ui/const-generics/ice-118285-fn-ptr-value.stderr
@@ -4,7 +4,7 @@ error: using function pointers as const generic parameters is forbidden
 LL | struct Checked<const F: fn(usize) -> bool>;
    |                         ^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/intrinsics-type_name-as-const-argument.min.stderr
+++ b/tests/ui/const-generics/intrinsics-type_name-as-const-argument.min.stderr
@@ -13,7 +13,7 @@ error: `&'static str` is forbidden as the type of a const generic parameter
 LL | trait Trait<const S: &'static str> {}
    |                      ^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/issues/issue-56445-1.min.stderr
+++ b/tests/ui/const-generics/issues/issue-56445-1.min.stderr
@@ -6,22 +6,6 @@ LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
    |
    = note: lifetime parameters may not be used in the type of const parameters
 
-error: `&str` is forbidden as the type of a const generic parameter
-  --> $DIR/issue-56445-1.rs:9:25
-   |
-LL | struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
-   |                         ^^^^^^^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
-   |
-LL + #![feature(adt_const_params)]
-   |
-help: add `#![feature(unsized_const_params)]` to the crate attributes to enable references to implement the `ConstParamTy` trait
-   |
-LL + #![feature(unsized_const_params)]
-   |
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0770`.

--- a/tests/ui/const-generics/issues/issue-56445-1.rs
+++ b/tests/ui/const-generics/issues/issue-56445-1.rs
@@ -8,6 +8,5 @@ use std::marker::PhantomData;
 
 struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
 //~^ ERROR: the type of const parameters must not depend on other generic parameters
-//[min]~| ERROR: `&str` is forbidden as the type of a const generic parameter
 
 impl Bug<'_, ""> {}

--- a/tests/ui/const-generics/issues/issue-62878.min.stderr
+++ b/tests/ui/const-generics/issues/issue-62878.min.stderr
@@ -12,7 +12,7 @@ error: `[u8; N]` is forbidden as the type of a const generic parameter
 LL | fn foo<const N: usize, const A: [u8; N]>() {}
    |                                 ^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/issues/issue-63322-forbid-dyn.min.stderr
+++ b/tests/ui/const-generics/issues/issue-63322-forbid-dyn.min.stderr
@@ -4,7 +4,7 @@ error: `&'static (dyn A + 'static)` is forbidden as the type of a const generic 
 LL | fn test<const T: &'static dyn A>() {
    |                  ^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/issues/issue-68366.full.stderr
+++ b/tests/ui/const-generics/issues/issue-68366.full.stderr
@@ -4,7 +4,7 @@ error: `Option<usize>` is forbidden as the type of a const generic parameter
 LL | struct Collatz<const N: Option<usize>>;
    |                         ^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/issues/issue-68366.min.stderr
+++ b/tests/ui/const-generics/issues/issue-68366.min.stderr
@@ -13,7 +13,7 @@ error: `Option<usize>` is forbidden as the type of a const generic parameter
 LL | struct Collatz<const N: Option<usize>>;
    |                         ^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/issues/issue-68615-adt.min.stderr
+++ b/tests/ui/const-generics/issues/issue-68615-adt.min.stderr
@@ -4,7 +4,7 @@ error: `[usize; 0]` is forbidden as the type of a const generic parameter
 LL | struct Const<const V: [usize; 0]> {}
    |                       ^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/issues/issue-68615-array.min.stderr
+++ b/tests/ui/const-generics/issues/issue-68615-array.min.stderr
@@ -4,7 +4,7 @@ error: `[usize; 0]` is forbidden as the type of a const generic parameter
 LL | struct Foo<const V: [usize; 0] > {}
    |                     ^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/issues/issue-71169.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71169.min.stderr
@@ -12,7 +12,7 @@ error: `[u8; LEN]` is forbidden as the type of a const generic parameter
 LL | fn foo<const LEN: usize, const DATA: [u8; LEN]>() {}
    |                                      ^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/issues/issue-71381.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71381.min.stderr
@@ -20,7 +20,7 @@ error: using function pointers as const generic parameters is forbidden
 LL |     pub fn call_me<Args: Sized, const IDX: usize, const FN: unsafe extern "C" fn(Args)>(&self) {
    |                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/issue-71381.rs:23:19
@@ -28,7 +28,7 @@ error: using function pointers as const generic parameters is forbidden
 LL |         const FN: unsafe extern "C" fn(Args),
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/issues/issue-71382.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71382.min.stderr
@@ -4,7 +4,7 @@ error: using function pointers as const generic parameters is forbidden
 LL |     fn test<const FN: fn()>(&self) {
    |                       ^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-71611.min.stderr
+++ b/tests/ui/const-generics/issues/issue-71611.min.stderr
@@ -12,7 +12,7 @@ error: using function pointers as const generic parameters is forbidden
 LL | fn func<A, const F: fn(inner: A)>(outer: A) {
    |                     ^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/issues/issue-72352.min.stderr
+++ b/tests/ui/const-generics/issues/issue-72352.min.stderr
@@ -4,7 +4,7 @@ error: using function pointers as const generic parameters is forbidden
 LL | unsafe fn unsafely_do_the_thing<const F: fn(&CStr) -> usize>(ptr: *const c_char) -> usize {
    |                                          ^^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/issues/issue-73491.min.stderr
+++ b/tests/ui/const-generics/issues/issue-73491.min.stderr
@@ -4,7 +4,7 @@ error: `[u32; LEN]` is forbidden as the type of a const generic parameter
 LL | fn hoge<const IN: [u32; LEN]>() {}
    |                   ^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/issues/issue-73727-static-reference-array-const-param.min.stderr
+++ b/tests/ui/const-generics/issues/issue-73727-static-reference-array-const-param.min.stderr
@@ -4,7 +4,7 @@ error: `&'static [u32]` is forbidden as the type of a const generic parameter
 LL | fn a<const X: &'static [u32]>() {}
    |               ^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/issues/issue-74101.min.stderr
+++ b/tests/ui/const-generics/issues/issue-74101.min.stderr
@@ -4,7 +4,7 @@ error: `[u8; 1 + 2]` is forbidden as the type of a const generic parameter
 LL | fn test<const N: [u8; 1 + 2]>() {}
    |                  ^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -16,7 +16,7 @@ error: `[u8; 1 + 2]` is forbidden as the type of a const generic parameter
 LL | struct Foo<const N: [u8; 1 + 2]>;
    |                     ^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/issues/issue-74255.min.stderr
+++ b/tests/ui/const-generics/issues/issue-74255.min.stderr
@@ -4,7 +4,7 @@ error: `IceEnum` is forbidden as the type of a const generic parameter
 LL |     fn ice_struct_fn<const I: IceEnum>() {}
    |                               ^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/issues/issue-74950.min.stderr
+++ b/tests/ui/const-generics/issues/issue-74950.min.stderr
@@ -4,7 +4,7 @@ error: `Inner` is forbidden as the type of a const generic parameter
 LL | struct Outer<const I: Inner>;
    |                       ^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -16,7 +16,7 @@ error: `Inner` is forbidden as the type of a const generic parameter
 LL | struct Outer<const I: Inner>;
    |                       ^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
@@ -29,7 +29,7 @@ error: `Inner` is forbidden as the type of a const generic parameter
 LL | struct Outer<const I: Inner>;
    |                       ^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
@@ -42,7 +42,7 @@ error: `Inner` is forbidden as the type of a const generic parameter
 LL | struct Outer<const I: Inner>;
    |                       ^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |

--- a/tests/ui/const-generics/issues/issue-75047.min.stderr
+++ b/tests/ui/const-generics/issues/issue-75047.min.stderr
@@ -4,7 +4,7 @@ error: `[u8; Bar::<u32>::value()]` is forbidden as the type of a const generic p
 LL | struct Foo<const N: [u8; Bar::<u32>::value()]>;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/lifetime-in-const-param.rs
+++ b/tests/ui/const-generics/lifetime-in-const-param.rs
@@ -4,6 +4,5 @@ struct S2<'b>(&'b ());
 
 struct S<'a, const N: S2>(&'a ());
 //~^ ERROR missing lifetime specifier [E0106]
-//~| ERROR `S2<'_>` is forbidden as the type of a const generic parameter
 
 fn main() {}

--- a/tests/ui/const-generics/lifetime-in-const-param.stderr
+++ b/tests/ui/const-generics/lifetime-in-const-param.stderr
@@ -4,18 +4,6 @@ error[E0106]: missing lifetime specifier
 LL | struct S<'a, const N: S2>(&'a ());
    |                       ^^ expected named lifetime parameter
 
-error: `S2<'_>` is forbidden as the type of a const generic parameter
-  --> $DIR/lifetime-in-const-param.rs:5:23
-   |
-LL | struct S<'a, const N: S2>(&'a ());
-   |                       ^^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
-   |
-LL + #![feature(adt_const_params)]
-   |
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0106`.

--- a/tests/ui/const-generics/min_const_generics/complex-types.stderr
+++ b/tests/ui/const-generics/min_const_generics/complex-types.stderr
@@ -4,7 +4,7 @@ error: `[u8; 0]` is forbidden as the type of a const generic parameter
 LL | struct Foo<const N: [u8; 0]>;
    |                     ^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -16,7 +16,7 @@ error: `()` is forbidden as the type of a const generic parameter
 LL | struct Bar<const N: ()>;
    |                     ^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -28,7 +28,7 @@ error: `No` is forbidden as the type of a const generic parameter
 LL | struct Fez<const N: No>;
    |                     ^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -40,7 +40,7 @@ error: `&'static u8` is forbidden as the type of a const generic parameter
 LL | struct Faz<const N: &'static u8>;
    |                     ^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -56,7 +56,7 @@ error: `!` is forbidden as the type of a const generic parameter
 LL | struct Fiz<const N: !>;
    |                     ^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: `()` is forbidden as the type of a const generic parameter
   --> $DIR/complex-types.rs:20:19
@@ -64,7 +64,7 @@ error: `()` is forbidden as the type of a const generic parameter
 LL | enum Goo<const N: ()> { A, B }
    |                   ^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -76,7 +76,7 @@ error: `()` is forbidden as the type of a const generic parameter
 LL | union Boo<const N: ()> { a: () }
    |                    ^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/nested-type.min.stderr
+++ b/tests/ui/const-generics/nested-type.min.stderr
@@ -29,7 +29,7 @@ LL | |
 LL | | }]>;
    | |__^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/not_wf_param_in_rpitit.rs
+++ b/tests/ui/const-generics/not_wf_param_in_rpitit.rs
@@ -6,7 +6,6 @@ trait Trait<const N: Trait = bar> {
     //~| ERROR: the trait `Trait` cannot be made into an object
     //~| ERROR: the trait `Trait` cannot be made into an object
     //~| ERROR: the trait `Trait` cannot be made into an object
-    //~| ERROR: `(dyn Trait<{const error}> + 'static)` is forbidden as the type of a const generic parameter
     //~| ERROR: trait objects must include the `dyn` keyword
     async fn a() {}
 }

--- a/tests/ui/const-generics/not_wf_param_in_rpitit.stderr
+++ b/tests/ui/const-generics/not_wf_param_in_rpitit.stderr
@@ -25,7 +25,7 @@ LL | trait Trait<const N: Trait = bar> {
    |                      ^^^^^ `Trait` cannot be made into an object
    |
 note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/not_wf_param_in_rpitit.rs:11:14
+  --> $DIR/not_wf_param_in_rpitit.rs:10:14
    |
 LL | trait Trait<const N: Trait = bar> {
    |       ----- this trait cannot be made into an object...
@@ -48,7 +48,7 @@ LL | trait Trait<const N: Trait = bar> {
    |             ^^^^^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
    |
 note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/not_wf_param_in_rpitit.rs:11:14
+  --> $DIR/not_wf_param_in_rpitit.rs:10:14
    |
 LL | trait Trait<const N: Trait = bar> {
    |       ----- this trait cannot be made into an object...
@@ -64,14 +64,6 @@ help: alternatively, consider constraining `a` so it does not apply to trait obj
 LL |     async fn a() where Self: Sized {}
    |                  +++++++++++++++++
 
-error: `(dyn Trait<{const error}> + 'static)` is forbidden as the type of a const generic parameter
-  --> $DIR/not_wf_param_in_rpitit.rs:3:22
-   |
-LL | trait Trait<const N: Trait = bar> {
-   |                      ^^^^^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-
 error[E0038]: the trait `Trait` cannot be made into an object
   --> $DIR/not_wf_param_in_rpitit.rs:3:13
    |
@@ -79,7 +71,7 @@ LL | trait Trait<const N: Trait = bar> {
    |             ^^^^^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
    |
 note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/not_wf_param_in_rpitit.rs:11:14
+  --> $DIR/not_wf_param_in_rpitit.rs:10:14
    |
 LL | trait Trait<const N: Trait = bar> {
    |       ----- this trait cannot be made into an object...
@@ -107,7 +99,7 @@ help: add `dyn` keyword before this trait
 LL | trait Trait<const N: dyn Trait = bar> {
    |                      +++
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0038, E0391, E0425, E0782.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/const-generics/opaque_types.stderr
+++ b/tests/ui/const-generics/opaque_types.stderr
@@ -74,7 +74,7 @@ error: `Foo` is forbidden as the type of a const generic parameter
 LL | fn foo<const C: Foo>() {}
    |                 ^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error[E0391]: cycle detected when computing type of opaque `Foo::{opaque#0}`
   --> $DIR/opaque_types.rs:3:12

--- a/tests/ui/const-generics/projection-as-arg-const.stderr
+++ b/tests/ui/const-generics/projection-as-arg-const.stderr
@@ -4,7 +4,7 @@ error: `<i32 as Identity>::Identity` is forbidden as the type of a const generic
 LL | pub fn foo<const X: <i32 as Identity>::Identity>() {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/const-generics/raw-ptr-const-param-deref.min.stderr
+++ b/tests/ui/const-generics/raw-ptr-const-param-deref.min.stderr
@@ -4,7 +4,7 @@ error: using raw pointers as const generic parameters is forbidden
 LL | struct Const<const P: *const u32>;
    |                       ^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: using raw pointers as const generic parameters is forbidden
   --> $DIR/raw-ptr-const-param-deref.rs:13:15
@@ -12,7 +12,7 @@ error: using raw pointers as const generic parameters is forbidden
 LL | impl<const P: *const u32> Const<P> {
    |               ^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/raw-ptr-const-param.min.stderr
+++ b/tests/ui/const-generics/raw-ptr-const-param.min.stderr
@@ -4,7 +4,7 @@ error: using raw pointers as const generic parameters is forbidden
 LL | struct Const<const P: *const u32>;
    |                       ^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error[E0308]: mismatched types
   --> $DIR/raw-ptr-const-param.rs:11:40

--- a/tests/ui/const-generics/slice-const-param-mismatch.min.stderr
+++ b/tests/ui/const-generics/slice-const-param-mismatch.min.stderr
@@ -4,7 +4,7 @@ error: `&'static str` is forbidden as the type of a const generic parameter
 LL | struct ConstString<const T: &'static str>;
    |                             ^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -20,7 +20,7 @@ error: `&'static [u8]` is forbidden as the type of a const generic parameter
 LL | struct ConstBytes<const T: &'static [u8]>;
    |                            ^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/std/const-generics-range.min.stderr
+++ b/tests/ui/const-generics/std/const-generics-range.min.stderr
@@ -4,7 +4,7 @@ error: `std::ops::Range<usize>` is forbidden as the type of a const generic para
 LL | struct _Range<const R: std::ops::Range<usize>>;
    |                        ^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -16,7 +16,7 @@ error: `RangeFrom<usize>` is forbidden as the type of a const generic parameter
 LL | struct _RangeFrom<const R: std::ops::RangeFrom<usize>>;
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -28,7 +28,7 @@ error: `RangeFull` is forbidden as the type of a const generic parameter
 LL | struct _RangeFull<const R: std::ops::RangeFull>;
    |                            ^^^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -40,7 +40,7 @@ error: `RangeInclusive<usize>` is forbidden as the type of a const generic param
 LL | struct _RangeInclusive<const R: std::ops::RangeInclusive<usize>>;
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -52,7 +52,7 @@ error: `RangeTo<usize>` is forbidden as the type of a const generic parameter
 LL | struct _RangeTo<const R: std::ops::RangeTo<usize>>;
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -64,7 +64,7 @@ error: `RangeToInclusive<usize>` is forbidden as the type of a const generic par
 LL | struct _RangeToInclusive<const R: std::ops::RangeToInclusive<usize>>;
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/transmute-const-param-static-reference.min.stderr
+++ b/tests/ui/const-generics/transmute-const-param-static-reference.min.stderr
@@ -4,7 +4,7 @@ error: `&'static ()` is forbidden as the type of a const generic parameter
 LL | struct Const<const P: &'static ()>;
    |                       ^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/type-dependent/issue-71348.min.stderr
+++ b/tests/ui/const-generics/type-dependent/issue-71348.min.stderr
@@ -12,7 +12,7 @@ error: `&'static str` is forbidden as the type of a const generic parameter
 LL | trait Get<'a, const N: &'static str> {
    |                        ^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -28,7 +28,7 @@ error: `&'static str` is forbidden as the type of a const generic parameter
 LL |     fn ask<'a, const N: &'static str>(&'a self) -> &'a <Self as Get<N>>::Target
    |                         ^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/const-generics/type-dependent/issue-71382.stderr
+++ b/tests/ui/const-generics/type-dependent/issue-71382.stderr
@@ -4,7 +4,7 @@ error: using function pointers as const generic parameters is forbidden
 LL |     fn test<const FN: fn() -> u8>(&self) -> u8 {
    |                       ^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/issue-103790.rs
+++ b/tests/ui/consts/issue-103790.rs
@@ -6,6 +6,5 @@ struct S<const S: (), const S: S = { S }>;
 //~| ERROR missing generics for struct `S`
 //~| ERROR cycle detected when computing type of `S::S`
 //~| ERROR `()` is forbidden as the type of a const generic parameter
-//~| ERROR `S<{const error}, {const error}>` is forbidden as the type of a const generic parameter
 
 fn main() {}

--- a/tests/ui/consts/issue-103790.stderr
+++ b/tests/ui/consts/issue-103790.stderr
@@ -42,25 +42,13 @@ error: `()` is forbidden as the type of a const generic parameter
 LL | struct S<const S: (), const S: S = { S }>;
    |                   ^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
    |
 
-error: `S<{const error}, {const error}>` is forbidden as the type of a const generic parameter
-  --> $DIR/issue-103790.rs:4:32
-   |
-LL | struct S<const S: (), const S: S = { S }>;
-   |                                ^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
-   |
-LL + #![feature(adt_const_params)]
-   |
-
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0107, E0391, E0403.
 For more information about an error, try `rustc --explain E0107`.

--- a/tests/ui/feature-gates/feature-gate-adt_const_params.stderr
+++ b/tests/ui/feature-gates/feature-gate-adt_const_params.stderr
@@ -4,7 +4,7 @@ error: `&'static str` is forbidden as the type of a const generic parameter
 LL | struct Foo<const NAME: &'static str>;
    |                        ^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/feature-gates/feature-gate-unsized-const-params.stderr
+++ b/tests/ui/feature-gates/feature-gate-unsized-const-params.stderr
@@ -4,7 +4,7 @@ error: `[u8]` is forbidden as the type of a const generic parameter
 LL | struct Foo<const N: [u8]>;
    |                     ^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/generic-const-items/elided-lifetimes.rs
+++ b/tests/ui/generic-const-items/elided-lifetimes.rs
@@ -9,7 +9,6 @@ where
 
 const I<const S: &str>: &str = "";
 //~^ ERROR `&` without an explicit lifetime name cannot be used here
-//~| ERROR `&str` is forbidden as the type of a const generic parameter
 
 const B<T: Trait<'_>>: () = (); //~ ERROR `'_` cannot be used here
 

--- a/tests/ui/generic-const-items/elided-lifetimes.stderr
+++ b/tests/ui/generic-const-items/elided-lifetimes.stderr
@@ -16,27 +16,11 @@ LL | const I<const S: &str>: &str = "";
    |                  ^ explicit lifetime name needed here
 
 error[E0637]: `'_` cannot be used here
-  --> $DIR/elided-lifetimes.rs:14:18
+  --> $DIR/elided-lifetimes.rs:13:18
    |
 LL | const B<T: Trait<'_>>: () = ();
    |                  ^^ `'_` is a reserved lifetime name
 
-error: `&str` is forbidden as the type of a const generic parameter
-  --> $DIR/elided-lifetimes.rs:10:18
-   |
-LL | const I<const S: &str>: &str = "";
-   |                  ^^^^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
-   |
-LL + #![feature(adt_const_params)]
-   |
-help: add `#![feature(unsized_const_params)]` to the crate attributes to enable references to implement the `ConstParamTy` trait
-   |
-LL + #![feature(unsized_const_params)]
-   |
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0637`.

--- a/tests/ui/generic-const-items/wfcheck_err_leak_issue_118179.rs
+++ b/tests/ui/generic-const-items/wfcheck_err_leak_issue_118179.rs
@@ -1,0 +1,7 @@
+//! Regression test for #118179: `adt_const_params` feature shouldn't leak
+//! `{type error}` in error messages.
+
+struct G<T, const N: Vec<T>>(T);
+//~^ ERROR the type of const parameters must not depend on other generic parameters
+
+fn main() {}

--- a/tests/ui/generic-const-items/wfcheck_err_leak_issue_118179.stderr
+++ b/tests/ui/generic-const-items/wfcheck_err_leak_issue_118179.stderr
@@ -1,0 +1,11 @@
+error[E0770]: the type of const parameters must not depend on other generic parameters
+  --> $DIR/wfcheck_err_leak_issue_118179.rs:4:26
+   |
+LL | struct G<T, const N: Vec<T>>(T);
+   |                          ^ the type must not depend on the parameter `T`
+   |
+   = note: type parameters may not be used in the type of const parameters
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0770`.

--- a/tests/ui/lifetimes/unusual-rib-combinations.rs
+++ b/tests/ui/lifetimes/unusual-rib-combinations.rs
@@ -20,11 +20,9 @@ fn c<T = u8()>() {}
 // Elided lifetime in path in ConstGeneric
 fn d<const C: S>() {}
 //~^ ERROR missing lifetime specifier
-//~| ERROR `S<'_>` is forbidden as the type of a const generic parameter
 
 trait Foo<'a> {}
 struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
 //~^ ERROR the type of const parameters must not depend on other generic parameters
-//~| ERROR `&dyn for<'a> Foo<'a>` is forbidden as the type of a const generic parameter
 
 fn main() {}

--- a/tests/ui/lifetimes/unusual-rib-combinations.stderr
+++ b/tests/ui/lifetimes/unusual-rib-combinations.stderr
@@ -5,7 +5,7 @@ LL | fn d<const C: S>() {}
    |               ^ expected named lifetime parameter
 
 error[E0770]: the type of const parameters must not depend on other generic parameters
-  --> $DIR/unusual-rib-combinations.rs:26:22
+  --> $DIR/unusual-rib-combinations.rs:25:22
    |
 LL | struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
    |                      ^^ the type must not depend on the parameter `'a`
@@ -40,35 +40,7 @@ error[E0308]: mismatched types
 LL | fn a() -> [u8; foo()] {
    |                ^^^^^ expected `usize`, found `()`
 
-error: `S<'_>` is forbidden as the type of a const generic parameter
-  --> $DIR/unusual-rib-combinations.rs:21:15
-   |
-LL | fn d<const C: S>() {}
-   |               ^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
-   |
-LL + #![feature(adt_const_params)]
-   |
-
-error: `&dyn for<'a> Foo<'a>` is forbidden as the type of a const generic parameter
-  --> $DIR/unusual-rib-combinations.rs:26:21
-   |
-LL | struct Bar<const N: &'a (dyn for<'a> Foo<'a>)>;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
-   |
-LL + #![feature(adt_const_params)]
-   |
-help: add `#![feature(unsized_const_params)]` to the crate attributes to enable references to implement the `ConstParamTy` trait
-   |
-LL + #![feature(unsized_const_params)]
-   |
-
-error: aborting due to 8 previous errors
+error: aborting due to 6 previous errors
 
 Some errors have detailed explanations: E0106, E0214, E0308, E0770.
 For more information about an error, try `rustc --explain E0106`.

--- a/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/mismatched_generic_args.stderr
+++ b/tests/ui/rfcs/rfc-2632-const-trait-impl/effects/mismatched_generic_args.stderr
@@ -22,7 +22,7 @@ error: `Dimension` is forbidden as the type of a const generic parameter
 LL | pub struct Quantity<S, const D: Dimension>(S);
    |                                 ^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -40,7 +40,7 @@ error: `Dimension` is forbidden as the type of a const generic parameter
 LL | impl<const D: Dimension, LHS, RHS> Add<LHS, D> for Quantity<LHS, { Dimension }> {}
    |               ^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -52,7 +52,7 @@ error: `Dimension` is forbidden as the type of a const generic parameter
 LL | pub fn add<const U: Dimension>(x: Quantity<f32, U>) -> Quantity<f32, U> {
    |                     ^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/specialization/default-proj-ty-as-type-of-const-issue-125757.stderr
+++ b/tests/ui/specialization/default-proj-ty-as-type-of-const-issue-125757.stderr
@@ -4,7 +4,7 @@ error: `<i32 as Trait>::Type` is forbidden as the type of a const generic parame
 LL | struct Wrapper<const C: <i32 as Trait>::Type> {}
    |                         ^^^^^^^^^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: the constant `C` is not of type `<i32 as Trait>::Type`
   --> $DIR/default-proj-ty-as-type-of-const-issue-125757.rs:15:22

--- a/tests/ui/traits/next-solver/canonical/const-region-infer-to-static-in-binder.stderr
+++ b/tests/ui/traits/next-solver/canonical/const-region-infer-to-static-in-binder.stderr
@@ -10,7 +10,7 @@ error: using function pointers as const generic parameters is forbidden
 LL | struct X<const FN: fn() = { || {} }>;
    |                    ^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: using function pointers as const generic parameters is forbidden
   --> $DIR/const-region-infer-to-static-in-binder.rs:4:20
@@ -18,7 +18,7 @@ error: using function pointers as const generic parameters is forbidden
 LL | struct X<const FN: fn() = { || {} }>;
    |                    ^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/type-alias-impl-trait/const_generic_type.infer.stderr
+++ b/tests/ui/type-alias-impl-trait/const_generic_type.infer.stderr
@@ -4,7 +4,7 @@ error: `Bar` is forbidden as the type of a const generic parameter
 LL | async fn test<const N: crate::Bar>() {
    |                        ^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/const_generic_type.no_infer.stderr
+++ b/tests/ui/type-alias-impl-trait/const_generic_type.no_infer.stderr
@@ -45,7 +45,7 @@ error: `Bar` is forbidden as the type of a const generic parameter
 LL | async fn test<const N: crate::Bar>() {
    |                        ^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/typeck/ice-unexpected-region-123863.stderr
+++ b/tests/ui/typeck/ice-unexpected-region-123863.stderr
@@ -4,7 +4,7 @@ error: `&'static str` is forbidden as the type of a const generic parameter
 LL | const fn concat_strs<const A: &'static str>() -> &'static str {
    |                               ^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]
@@ -20,7 +20,7 @@ error: `&'static str` is forbidden as the type of a const generic parameter
 LL |     struct Inner<const A: &'static str>;
    |                           ^^^^^^^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 help: add `#![feature(adt_const_params)]` to the crate attributes to enable more complex and user defined types
    |
 LL + #![feature(adt_const_params)]

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.rs
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.rs
@@ -4,7 +4,6 @@ trait Trait<const N: Trait = bar> {
     //~| ERROR the trait `Trait` cannot be made into an object
     //~| ERROR the trait `Trait` cannot be made into an object
     //~| ERROR the trait `Trait` cannot be made into an object
-    //~| ERROR `(dyn Trait<{const error}> + 'static)` is forbidden as the type of a const generic parameter
     //~| WARN trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
     //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     //~| WARN trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
@@ -15,7 +14,6 @@ trait Trait<const N: Trait = bar> {
         //~| ERROR defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
         //~| ERROR associated item referring to unboxed trait object for its own trait
         //~| ERROR the trait `Trait` cannot be made into an object
-        //~| ERROR `(dyn Trait<{const error}> + 'static)` is forbidden as the type of a const generic parameter
         //~| WARN trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
         //~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
         //~| WARN trait objects without an explicit `dyn` are deprecated [bare_trait_objects]

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122199.stderr
@@ -1,5 +1,5 @@
 error[E0403]: the name `N` is already used for a generic parameter in this item's generic parameters
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:18
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:11:18
    |
 LL | trait Trait<const N: Trait = bar> {
    |                   - first use of `N`
@@ -14,13 +14,13 @@ LL | trait Trait<const N: Trait = bar> {
    |                              ^^^ not found in this scope
 
 error[E0423]: expected value, found builtin type `u32`
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:29
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:11:29
    |
 LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
    |                             ^^^ not a value
 
 error[E0425]: cannot find value `bar` in this scope
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:25:9
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:23:9
    |
 LL |         bar
    |         ^^^ not found in this scope
@@ -54,13 +54,13 @@ LL | trait Trait<const N: Trait = bar> {
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: defaults for const parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:12
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:11:12
    |
 LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
    |            ^^^^^^^^^^^^^^^^^^^^
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:21
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:11:21
    |
 LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
    |                     ^^^^^
@@ -73,7 +73,7 @@ LL |     fn fnc<const N: dyn Trait = u32>(&self) -> Trait {
    |                     +++
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:44
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:11:44
    |
 LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
    |                                            ^^^^^
@@ -106,7 +106,7 @@ LL | trait Trait<const N: Trait = bar> {
    |                      ^^^^^ `Trait` cannot be made into an object
    |
 note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:8
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:11:8
    |
 LL | trait Trait<const N: Trait = bar> {
    |       ----- this trait cannot be made into an object...
@@ -122,7 +122,7 @@ LL | trait Trait<const N: Trait = bar> {
    |             ^^^^^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
    |
 note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:8
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:11:8
    |
 LL | trait Trait<const N: Trait = bar> {
    |       ----- this trait cannot be made into an object...
@@ -131,16 +131,8 @@ LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
    |        ^^^ ...because method `fnc` has generic type parameters
    = help: consider moving `fnc` to another trait
 
-error: `(dyn Trait<{const error}> + 'static)` is forbidden as the type of a const generic parameter
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:1:22
-   |
-LL | trait Trait<const N: Trait = bar> {
-   |                      ^^^^^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-
 error: associated item referring to unboxed trait object for its own trait
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:44
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:11:44
    |
 LL | trait Trait<const N: Trait = bar> {
    |       ----- in this trait
@@ -154,7 +146,7 @@ LL |     fn fnc<const N: Trait = u32>(&self) -> Self {
    |                                            ~~~~
 
 warning: trait objects without an explicit `dyn` are deprecated
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:21
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:11:21
    |
 LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
    |                     ^^^^^
@@ -168,13 +160,13 @@ LL |     fn fnc<const N: dyn Trait = u32>(&self) -> Trait {
    |                     +++
 
 error[E0038]: the trait `Trait` cannot be made into an object
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:21
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:11:21
    |
 LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
    |                     ^^^^^ `Trait` cannot be made into an object
    |
 note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:8
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:11:8
    |
 LL | trait Trait<const N: Trait = bar> {
    |       ----- this trait cannot be made into an object...
@@ -190,7 +182,7 @@ LL | trait Trait<const N: Trait = bar> {
    |             ^^^^^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
    |
 note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:8
+  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:11:8
    |
 LL | trait Trait<const N: Trait = bar> {
    |       ----- this trait cannot be made into an object...
@@ -200,15 +192,7 @@ LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
    = help: consider moving `fnc` to another trait
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: `(dyn Trait<{const error}> + 'static)` is forbidden as the type of a const generic parameter
-  --> $DIR/ice-hir-wf-check-anon-const-issue-122199.rs:12:21
-   |
-LL |     fn fnc<const N: Trait = u32>(&self) -> Trait {
-   |                     ^^^^^
-   |
-   = note: the only supported types are integers, `bool` and `char`
-
-error: aborting due to 13 previous errors; 5 warnings emitted
+error: aborting due to 11 previous errors; 5 warnings emitted
 
 Some errors have detailed explanations: E0038, E0391, E0403, E0423, E0425.
 For more information about an error, try `rustc --explain E0038`.

--- a/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
+++ b/tests/ui/wf/ice-hir-wf-check-anon-const-issue-122989.stderr
@@ -73,7 +73,7 @@ error: `(dyn Bar<2> + 'static)` is forbidden as the type of a const generic para
 LL | trait Foo<const N: Bar<2>> {
    |                    ^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error[E0038]: the trait `Foo` cannot be made into an object
   --> $DIR/ice-hir-wf-check-anon-const-issue-122989.rs:11:11
@@ -104,7 +104,7 @@ error: `(dyn Foo<2> + 'static)` is forbidden as the type of a const generic para
 LL | trait Bar<const M: Foo<2>> {}
    |                    ^^^^^^
    |
-   = note: the only supported types are integers, `bool` and `char`
+   = note: the only supported types are integers, `bool`, and `char`
 
 error: aborting due to 5 previous errors; 2 warnings emitted
 


### PR DESCRIPTION
Fixes the confusing diagnostic described in #118179. (users would see `{type error}` in some situations, which is pretty weird)

Fixes #118179.

`adt_const_params` tracking issue: #95174

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
