### PR TITLE
Instantiate binders in `supertrait_vtable_slot`

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/vtable.rs
+++ b/compiler/rustc_trait_selection/src/traits/vtable.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::ops::ControlFlow;
 
 use rustc_hir::def_id::DefId;
+use rustc_infer::infer::at::ToTrace;
 use rustc_infer::infer::{BoundRegionConversionTime, TyCtxtInferExt};
 use rustc_infer::traits::ObligationCause;
 use rustc_infer::traits::util::PredicateSet;
@@ -24,6 +25,8 @@ pub enum VtblSegment<'tcx> {
 }
 
 /// Prepare the segments for a vtable
+// FIXME: This should take a `PolyExistentialTraitRef`, since we don't care
+// about our `Self` type here.
 pub fn prepare_vtable_segments<'tcx, T>(
     tcx: TyCtxt<'tcx>,
     trait_ref: ty::PolyTraitRef<'tcx>,
@@ -385,7 +388,7 @@ pub(crate) fn supertrait_vtable_slot<'tcx>(
     let ty::Dynamic(target, _, _) = *target.kind() else {
         bug!();
     };
-    let target_principal = target.principal()?.with_self_ty(tcx, tcx.types.trait_object_dummy_self);
+    let target_principal = target.principal()?;
 
     // Given that we have a target principal, it is a bug for there not to be a source principal.
     let ty::Dynamic(source, _, _) = *source.kind() else {
@@ -394,29 +397,6 @@ pub(crate) fn supertrait_vtable_slot<'tcx>(
     let source_principal =
         source.principal().unwrap().with_self_ty(tcx, tcx.types.trait_object_dummy_self);
 
-    let infcx = tcx.infer_ctxt().build();
-    let param_env = ty::ParamEnv::reveal_all();
-    let trait_refs_are_compatible =
-        |source: ty::PolyTraitRef<'tcx>, target: ty::PolyTraitRef<'tcx>| {
-            infcx.probe(|_| {
-                let ocx = ObligationCtxt::new(&infcx);
-                let source = ocx.normalize(&ObligationCause::dummy(), param_env, source);
-                let target = ocx.normalize(&ObligationCause::dummy(), param_env, target);
-                infcx.enter_forall(target, |target| {
-                    let source = infcx.instantiate_binder_with_fresh_vars(
-                        DUMMY_SP,
-                        BoundRegionConversionTime::HigherRankedType,
-                        source,
-                    );
-                    let Ok(()) = ocx.eq(&ObligationCause::dummy(), param_env, target, source)
-                    else {
-                        return false;
-                    };
-                    ocx.select_all_or_error().is_empty()
-                })
-            })
-        };
-
     let vtable_segment_callback = {
         let mut vptr_offset = 0;
         move |segment| {
@@ -424,9 +404,15 @@ pub(crate) fn supertrait_vtable_slot<'tcx>(
                 VtblSegment::MetadataDSA => {
                     vptr_offset += TyCtxt::COMMON_VTABLE_ENTRIES.len();
                 }
-                VtblSegment::TraitOwnEntries { trait_ref, emit_vptr } => {
-                    vptr_offset += tcx.own_existential_vtable_entries(trait_ref.def_id()).len();
-                    if trait_refs_are_compatible(trait_ref, target_principal) {
+                VtblSegment::TraitOwnEntries { trait_ref: vtable_principal, emit_vptr } => {
+                    vptr_offset +=
+                        tcx.own_existential_vtable_entries(vtable_principal.def_id()).len();
+                    if trait_refs_are_compatible(
+                        tcx,
+                        vtable_principal
+                            .map_bound(|t| ty::ExistentialTraitRef::erase_self_ty(tcx, t)),
+                        target_principal,
+                    ) {
                         if emit_vptr {
                             return ControlFlow::Break(Some(vptr_offset));
                         } else {
@@ -444,6 +430,41 @@ pub(crate) fn supertrait_vtable_slot<'tcx>(
     };
 
     prepare_vtable_segments(tcx, source_principal, vtable_segment_callback).unwrap()
+}
+
+fn trait_refs_are_compatible<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    hr_vtable_principal: ty::PolyExistentialTraitRef<'tcx>,
+    hr_target_principal: ty::PolyExistentialTraitRef<'tcx>,
+) -> bool {
+    if hr_vtable_principal.def_id() != hr_target_principal.def_id() {
+        return false;
+    }
+
+    let infcx = tcx.infer_ctxt().build();
+    let param_env = ty::ParamEnv::reveal_all();
+    let ocx = ObligationCtxt::new(&infcx);
+    let hr_source_principal =
+        ocx.normalize(&ObligationCause::dummy(), param_env, hr_vtable_principal);
+    let hr_target_principal =
+        ocx.normalize(&ObligationCause::dummy(), param_env, hr_target_principal);
+    infcx.enter_forall(hr_target_principal, |target_principal| {
+        let source_principal = infcx.instantiate_binder_with_fresh_vars(
+            DUMMY_SP,
+            BoundRegionConversionTime::HigherRankedType,
+            hr_source_principal,
+        );
+        let Ok(()) = ocx.eq_trace(
+            &ObligationCause::dummy(),
+            param_env,
+            ToTrace::to_trace(&ObligationCause::dummy(), hr_target_principal, hr_source_principal),
+            target_principal,
+            source_principal,
+        ) else {
+            return false;
+        };
+        ocx.select_all_or_error().is_empty()
+    })
 }
 
 pub(super) fn provide(providers: &mut Providers) {

--- a/tests/ui/traits/trait-upcasting/higher-ranked-upcasting-ok.rs
+++ b/tests/ui/traits/trait-upcasting/higher-ranked-upcasting-ok.rs
@@ -1,21 +1,22 @@
 //@ revisions: current next
 //@ ignore-compare-mode-next-solver (explicit revisions)
 //@[next] compile-flags: -Znext-solver
-//@ check-pass
+//@ build-pass
 
-// We should be able to instantiate a binder during trait upcasting.
-// This test could be `check-pass`, but we should make sure that we
-// do so in both trait solvers.
+// Check that we are able to instantiate a binder during trait upcasting,
+// and that it doesn't cause any issues with codegen either.
 
 #![feature(trait_upcasting)]
 
 trait Supertrait<'a, 'b> {}
 trait Subtrait<'a, 'b>: Supertrait<'a, 'b> {}
 
-impl<'a> Supertrait<'a, 'a> for () {}
-impl<'a> Subtrait<'a, 'a> for () {}
+impl Supertrait<'_, '_> for () {}
+impl Subtrait<'_, '_> for () {}
 fn ok(x: &dyn for<'a, 'b> Subtrait<'a, 'b>) -> &dyn for<'a> Supertrait<'a, 'a> {
     x
 }
 
-fn main() {}
+fn main() {
+    ok(&());
+}


### PR DESCRIPTION
`supertrait_vtable_slot` was previously using structural equality when probing for the vtable slot, which led to an ICE since we need a *subtype* match, not an exact match.

Fixes #131027

r? lcnr