### PR TITLE
Improve `--print=check-cfg` documentation

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/print-check-cfg.md
+++ b/src/doc/unstable-book/src/compiler-flags/print-check-cfg.md
@@ -4,23 +4,28 @@ The tracking issue for this feature is: [#125704](https://github.com/rust-lang/r
 
 ------------------------
 
-This option of the `--print` flag print the list of expected cfgs.
+This option of the `--print` flag print the list of all the expected cfgs.
 
-This is related to the `--check-cfg` flag which allows specifying arbitrary expected
+This is related to the [`--check-cfg` flag][check-cfg] which allows specifying arbitrary expected
 names and values.
 
-This print option works similarly to `--print=cfg` (modulo check-cfg specifics):
- - *check_cfg syntax*: *output of --print=check-cfg*
- - `cfg(windows)`: `windows`
- - `cfg(feature, values("foo", "bar"))`: `feature="foo"` and `feature="bar"`
- - `cfg(feature, values(none(), ""))`: `feature` and `feature=""`
- - `cfg(feature, values(any()))`: `feature=any()`
- - `cfg(feature, values())`: `feature=`
- - `cfg(any())`: `any()`
- - *nothing*: `any()=any()`
+This print option works similarly to `--print=cfg` (modulo check-cfg specifics).
+
+| `--check-cfg`                     | `--print=check-cfg`         |
+|-----------------------------------|-----------------------------|
+| `cfg(foo)`                        | `foo`                       |
+| `cfg(foo, values("bar"))`         | `foo="bar"`                 |
+| `cfg(foo, values(none(), "bar"))` | `foo` & `foo="bar"`         |
+|                                   | *check-cfg specific syntax* |
+| `cfg(foo, values(any())`          | `foo=any()`                 |
+| `cfg(foo, values())`              | `foo=`                      |
+| `cfg(any())`                      | `any()`                     |
+| *none*                            | `any()=any()`               |
 
 To be used like this:
 
 ```bash
 rustc --print=check-cfg -Zunstable-options lib.rs
 ```
+
+[check-cfg]: https://doc.rust-lang.org/nightly/rustc/check-cfg.html


### PR DESCRIPTION
This PR improves the `--print=check-cfg` documentation by:
 1. switching to a table for better readability
 2. adding a clear indication where the specific check-cfg syntax starts
 3. adding a link to the main `--check-cfg` documentation

@rustbot label +F-check-cfg
