### PR TITLE
Reject leading unsafe in `cfg!(...)` and `--check-cfg`

### DIFF
--- a/compiler/rustc_builtin_macros/src/cfg.rs
+++ b/compiler/rustc_builtin_macros/src/cfg.rs
@@ -43,7 +43,7 @@ fn parse_cfg<'a>(cx: &ExtCtxt<'a>, span: Span, tts: TokenStream) -> PResult<'a, 
         return Err(cx.dcx().create_err(errors::RequiresCfgPattern { span }));
     }
 
-    let cfg = p.parse_meta_item(AllowLeadingUnsafe::Yes)?;
+    let cfg = p.parse_meta_item(AllowLeadingUnsafe::No)?;
 
     let _ = p.eat(&token::Comma);
 

--- a/compiler/rustc_interface/src/interface.rs
+++ b/compiler/rustc_interface/src/interface.rs
@@ -174,7 +174,7 @@ pub(crate) fn parse_check_cfg(dcx: DiagCtxtHandle<'_>, specs: Vec<String>) -> Ch
             }
         };
 
-        let meta_item = match parser.parse_meta_item(AllowLeadingUnsafe::Yes) {
+        let meta_item = match parser.parse_meta_item(AllowLeadingUnsafe::No) {
             Ok(meta_item) if parser.token == token::Eof => meta_item,
             Ok(..) => expected_error(),
             Err(err) => {

--- a/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.rs
+++ b/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.rs
@@ -27,4 +27,8 @@ mod inner {
 #[unsafe(used)] //~ ERROR: is not an unsafe attribute
 static FOO: usize = 0;
 
-fn main() {}
+fn main() {
+    let _a = cfg!(unsafe(foo));
+    //~^ ERROR: expected identifier, found keyword `unsafe`
+    //~^^ ERROR: invalid predicate `r#unsafe`
+}

--- a/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.stderr
+++ b/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.stderr
@@ -22,6 +22,23 @@ LL | #[unsafe(test)]
    |
    = note: extraneous unsafe is not allowed in attributes
 
+error: expected identifier, found keyword `unsafe`
+  --> $DIR/extraneous-unsafe-attributes.rs:31:19
+   |
+LL |     let _a = cfg!(unsafe(foo));
+   |                   ^^^^^^ expected identifier, found keyword
+   |
+help: escape `unsafe` to use it as an identifier
+   |
+LL |     let _a = cfg!(r#unsafe(foo));
+   |                   ++
+
+error[E0537]: invalid predicate `r#unsafe`
+  --> $DIR/extraneous-unsafe-attributes.rs:31:19
+   |
+LL |     let _a = cfg!(unsafe(foo));
+   |                   ^^^^^^^^^^^
+
 error: `ignore` is not an unsafe attribute
   --> $DIR/extraneous-unsafe-attributes.rs:13:3
    |
@@ -62,5 +79,6 @@ LL | #[unsafe(used)]
    |
    = note: extraneous unsafe is not allowed in attributes
 
-error: aborting due to 8 previous errors
+error: aborting due to 10 previous errors
 
+For more information about this error, try `rustc --explain E0537`.

--- a/tests/ui/check-cfg/invalid-arguments.rs
+++ b/tests/ui/check-cfg/invalid-arguments.rs
@@ -8,7 +8,7 @@
 //@ revisions: values_any_missing_values values_any_before_ident ident_in_values_1
 //@ revisions: ident_in_values_2 unknown_meta_item_1 unknown_meta_item_2 unknown_meta_item_3
 //@ revisions: mixed_values_any mixed_any any_values giberich unterminated
-//@ revisions: none_not_empty cfg_none
+//@ revisions: none_not_empty cfg_none unsafe_attr
 //
 //@ [anything_else]compile-flags: --check-cfg=anything_else(...)
 //@ [boolean]compile-flags: --check-cfg=cfg(true)
@@ -33,5 +33,6 @@
 //@ [cfg_none]compile-flags: --check-cfg=cfg(none())
 //@ [giberich]compile-flags: --check-cfg=cfg(...)
 //@ [unterminated]compile-flags: --check-cfg=cfg(
+//@ [unsafe_attr]compile-flags: --check-cfg=unsafe(cfg(foo))
 
 fn main() {}

--- a/tests/ui/check-cfg/invalid-arguments.unsafe_attr.stderr
+++ b/tests/ui/check-cfg/invalid-arguments.unsafe_attr.stderr
@@ -1,0 +1,5 @@
+error: invalid `--check-cfg` argument: `unsafe(cfg(foo))`
+   |
+   = note: expected `cfg(name, values("value1", "value2", ... "valueN"))`
+   = note: visit <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more details
+


### PR DESCRIPTION
This PR reject leading unsafe in `cfg!(...)` and `--check-cfg`.

> `cfg!(unsafe(foo))` and `--check-cfg=unsafe(cfg(foo))` both are erroneously accepted on beta.

Fixes (after-backport) https://github.com/rust-lang/rust/issues/131055
r? @jieyouxu
