### PR TITLE
Drop conditionally applied cargo `-Zon-broken-pipe=kill` flags to fix stage 1 cargo rebuilds

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -1053,10 +1053,6 @@ pub fn rustc_cargo(
 
     cargo.rustdocflag("-Zcrate-attr=warn(rust_2018_idioms)");
 
-    // If the rustc output is piped to e.g. `head -n1` we want the process to be
-    // killed, rather than having an error bubble up and cause a panic.
-    cargo.rustflag("-Zon-broken-pipe=kill");
-
     if builder.config.llvm_enzyme {
         cargo.rustflag("-l").rustflag("Enzyme-19");
     }

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -200,6 +200,10 @@ pub fn prepare_tool_cargo(
         cargo.arg("--features").arg(features.join(", "));
     }
 
+    // Warning: be very careful with RUSTFLAGS or command-line options, as conditionally applied
+    // RUSTFLAGS or cli flags can lead to hard-to-diagnose rebuilds due to flag differences, causing
+    // previous tool build artifacts to get invalidated.
+
     // Enable internal lints for clippy and rustdoc
     // NOTE: this doesn't enable lints for any other tools unless they explicitly add `#![warn(rustc::internal)]`
     // See https://github.com/rust-lang/rust/pull/80573#issuecomment-754010776
@@ -208,13 +212,6 @@ pub fn prepare_tool_cargo(
     // and `x test $tool` executions.
     // See https://github.com/rust-lang/rust/issues/116538
     cargo.rustflag("-Zunstable-options");
-
-    // `-Zon-broken-pipe=kill` breaks cargo tests
-    if !path.ends_with("cargo") {
-        // If the output is piped to e.g. `head -n1` we want the process to be killed,
-        // rather than having an error bubble up and cause a panic.
-        cargo.rustflag("-Zon-broken-pipe=kill");
-    }
 
     cargo
 }


### PR DESCRIPTION
The conditionally applied `-Zon-broken-pipe=kill` flag trigger rebuilds because they can invalidate previous tool build cache due to differing flags. This PR removes those flags to stop tool build cache invalidation.

> The build cache for clippy will be broken because bootstrap sets `-Zon-broken-pipe=kill` for every invocation except for cargo. Which means building cargo will invalidate any tool build cache which was built previously.
>
> *From <https://rust-lang.zulipchat.com/#narrow/stream/326414-t-infra.2Fbootstrap/topic/Modifying.20run-make.20tests.20unnecessarily.20rebuild.20stage.201.20cargo/near/473486972>*

Fixes #130980.
But introduces #131059 (breaks 2 cargo tests in case of `RUSTFLAGS=-Zon-broken-pipe=kill ./x test src/tools/cargo`).

r? @onur-ozkan (or bootstrap)
