### PR TITLE
Add the Chinese translation entry to the RustByExample build process

### DIFF
--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -82,7 +82,7 @@ book!(
     EditionGuide, "src/doc/edition-guide", "edition-guide", &[], submodule;
     EmbeddedBook, "src/doc/embedded-book", "embedded-book", &[], submodule;
     Nomicon, "src/doc/nomicon", "nomicon", &[], submodule;
-    RustByExample, "src/doc/rust-by-example", "rust-by-example", &["ja"], submodule;
+    RustByExample, "src/doc/rust-by-example", "rust-by-example", &["ja", "zh"], submodule;
     RustdocBook, "src/doc/rustdoc", "rustdoc", &[];
     StyleGuide, "src/doc/style-guide", "style-guide", &[];
 );


### PR DESCRIPTION
Following the guidelines outlined at [https://github.com/rust-lang/rust-by-example/blob/master/TRANSLATING.md](https://github.com/rust-lang/rust-by-example/blob/master/TRANSLATING.md), I am adding a Chinese translation to Rust by Example. You can view the related pull request here: [https://github.com/rust-lang/rust-by-example/pull/1886#issue-2537891289](https://github.com/rust-lang/rust-by-example/pull/1886#issue-2537891289).

For similar issues and PRs, see [https://github.com/rust-lang/rust/issues/124641](https://github.com/rust-lang/rust/issues/124641) and [https://github.com/rust-lang/rust/pull/124731](https://github.com/rust-lang/rust/pull/124731).
