### PR TITLE
Unpin `cc` and upgrade to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,9 +393,12 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.0.105"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5208975e568d83b6b05cc0a063c8e7e9acc2b43bee6da15616a5b73e109d7437"
+checksum = "3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 ar_archive_writer = "0.4.2"
 arrayvec = { version = "0.7", default-features = false }
 bitflags = "2.4.1"
-cc = "=1.0.105" # FIXME(cc): pinned to keep support for VS2013
+cc = "1.1.23"
 either = "1.5.0"
 itertools = "0.12"
 jobserver = "0.1.28"

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -10,5 +10,5 @@ libc = "0.2.73"
 
 [build-dependencies]
 # tidy-alphabetical-start
-cc = "=1.0.105" # FIXME(cc): pinned to keep support for VS2013
+cc = "1.1.23"
 # tidy-alphabetical-end


### PR DESCRIPTION
`cc` was previously pinned because 1.1.106 dropped support for Visual Studio 12 (2013), and we wanted to decouple that from the rest of the automated updates. As noted in [2], there is no longer anything indicating we support VS2013, so it should be okay to unpin it.

`cc` 1.1.22 contains a fix that may help improve the high MSVC CI failure rate [3], so we also have motivation to update to that point.

[1]: https://github.com/rust-lang/rust/issues/129307
[2]: https://github.com/rust-lang/rust/issues/129307#issuecomment-2383749868
[3]: https://github.com/rust-lang/rust/issues/127883

try-job: x86_64-msvc-ext

<!-- homu-ignore:start -->
r? @ChrisDenton
cc @dpaoliello
cc @Mark-Simulacrum (from https://github.com/rust-lang/rust/pull/128722#issuecomment-2297672294)
<!-- homu-ignore:end -->