### PR TITLE
Enable debug assertions on alt builds

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -134,6 +134,11 @@ if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
 
   CODEGEN_BACKENDS="${CODEGEN_BACKENDS:-llvm}"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.codegen-backends=$CODEGEN_BACKENDS"
+
+  # Unless explicitly disabled, we want rustc debug assertions on the -alt builds
+  if [ "$DEPLOY_ALT" != "" ] && [ "$NO_DEBUG_ASSERTIONS" = "" ]; then
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-debug-assertions"
+  fi
 else
   # We almost always want debug assertions enabled, but sometimes this takes too
   # long for too little benefit, so we just turn them off.

--- a/src/tools/opt-dist/src/environment.rs
+++ b/src/tools/opt-dist/src/environment.rs
@@ -45,7 +45,7 @@ pub struct TestConfig {
     /// Whether the build under test is explicitly using `--enable-debug-assertions`.
     /// Note that this flag can be implied from others, like `rust.debug`, and we do not handle any
     /// of these subtleties and defaults here, as per the FIXME above.
-    pub enable_debug_assertions: bool,
+    pub rust_debug_assertions: bool,
 }
 
 impl Environment {
@@ -135,7 +135,7 @@ impl TestConfig {
     pub fn from_configure_args(configure_args: &str) -> TestConfig {
         let enable_debug_assertions =
             configure_args.split(" ").find(|part| *part == "--enable-debug-assertions").is_some();
-        TestConfig { enable_debug_assertions }
+        TestConfig { rust_debug_assertions: enable_debug_assertions }
     }
 }
 

--- a/src/tools/opt-dist/src/tests.rs
+++ b/src/tools/opt-dist/src/tests.rs
@@ -85,7 +85,7 @@ llvm-config = "{llvm_config}"
         rustc = rustc_path.to_string().replace('\\', "/"),
         cargo = cargo_path.to_string().replace('\\', "/"),
         llvm_config = llvm_config.to_string().replace('\\', "/"),
-        debug_assertions = env.test_config().enable_debug_assertions,
+        debug_assertions = env.test_config().rust_debug_assertions,
     );
     log::info!("Using following `bootstrap.toml` for running tests:\n{config_content}");
 

--- a/src/tools/opt-dist/src/tests.rs
+++ b/src/tools/opt-dist/src/tests.rs
@@ -72,6 +72,7 @@ change-id = 115898
 [rust]
 channel = "{channel}"
 verbose-tests = true
+debug-assertions = {debug_assertions}
 
 [build]
 rustc = "{rustc}"
@@ -83,7 +84,8 @@ llvm-config = "{llvm_config}"
 "#,
         rustc = rustc_path.to_string().replace('\\', "/"),
         cargo = cargo_path.to_string().replace('\\', "/"),
-        llvm_config = llvm_config.to_string().replace('\\', "/")
+        llvm_config = llvm_config.to_string().replace('\\', "/"),
+        debug_assertions = env.test_config().enable_debug_assertions,
     );
     log::info!("Using following `bootstrap.toml` for running tests:\n{config_content}");
 


### PR DESCRIPTION
Alt builds already have llvm assertions enabled, and this PR adds rustc's debug assertions.

We've discussed that this would be useful a few times in the past, most recently in [this zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/182449-t-compiler.2Fhelp/topic/cargo.20bisect-rustc'ing.20a.20debug.20assertions-only.20ICE), for example to bisect the source PR of an unexpected tripped debug assert, which is not that rare of an occurrence.

[In another thread](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Alt.20builds.20with.20debug.20assertions) we discussed how it would help with Matthias' fuzzing workflow, and some of Ben's work.

I don't _believe_ this needs an MCP, but am not sure.

To my knowledge there are 2 alt builds (x64 linux, x64 msvc) and this enables it for both, though we could limit to x64 linux if we wanted to.

try-job: dist-x86_64-msvc-alt
try-job: dist-x86_64-linux-alt