### PR TITLE
add fixme to remove LLVM_ENABLE_TERMINFO when minimal llvm version is 19

### DIFF
--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -344,6 +344,7 @@ impl Step for Llvm {
             .define("LLVM_INCLUDE_DOCS", "OFF")
             .define("LLVM_INCLUDE_BENCHMARKS", "OFF")
             .define("LLVM_INCLUDE_TESTS", enable_tests)
+            // FIXME: remove this when minimal llvm is 19
             .define("LLVM_ENABLE_TERMINFO", "OFF")
             .define("LLVM_ENABLE_LIBEDIT", "OFF")
             .define("LLVM_ENABLE_BINDINGS", "OFF")


### PR DESCRIPTION
`LLVM_ENABLE_TERMINFO` was removed in llvm 19: https://github.com/llvm/llvm-project/blob/release/19.x/llvm/docs/ReleaseNotes.rst#changes-to-building-llvm; current minimal llvm is 18, so left fixme here.