### PR TITLE
Use environment variables instead of command line arguments for merged doctests

### DIFF
--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -644,8 +644,7 @@ fn run_test(
     } else {
         cmd = Command::new(&output_file);
         if doctest.is_multiple_tests {
-            cmd.arg("*doctest-bin-path");
-            cmd.arg(&output_file);
+            cmd.env("RUSTDOC_DOCTEST_BIN_PATH", &output_file);
         }
     }
     if let Some(run_directory) = &rustdoc_options.test_run_directory {


### PR DESCRIPTION
Fixes [#130796](https://github.com/rust-lang/rust/issues/130796).

Before merging this one, let's first ensure it has a smaller impact compared to command line arguments (results can be seen [here](https://github.com/rust-lang/rust/pull/130285)). I'll start a crater run once CI passed.

cc @ehuss
r? @notriddle 