### PR TITLE
rustdoc: Remove usage of `allow(unused)` attribute on `no_run` merged doctests

### DIFF
--- a/src/librustdoc/doctest/runner.rs
+++ b/src/librustdoc/doctest/runner.rs
@@ -208,10 +208,6 @@ fn generate_mergeable_doctest(
     } else {
         writeln!(output, "mod {test_id} {{\n{}{}", doctest.crates, doctest.maybe_crate_attrs)
             .unwrap();
-        if scraped_test.langstr.no_run {
-            // To prevent having warnings about unused items since they're not called.
-            writeln!(output, "#![allow(unused)]").unwrap();
-        }
         if doctest.has_main_fn {
             output.push_str(&doctest.everything_else);
         } else {

--- a/tests/rustdoc-ui/doctest/dead-code-2024.rs
+++ b/tests/rustdoc-ui/doctest/dead-code-2024.rs
@@ -1,0 +1,15 @@
+// This test ensures that the 2024 edition merged doctest will not use `#[allow(unused)]`.
+
+//@ compile-flags:--test -Zunstable-options --edition 2024
+//@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ failure-status: 101
+
+#![doc(test(attr(allow(unused_variables), deny(warnings))))]
+
+/// Example
+///
+/// ```rust,no_run
+/// trait T { fn f(); }
+/// ```
+pub fn f() {}

--- a/tests/rustdoc-ui/doctest/dead-code-2024.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-2024.stdout
@@ -1,0 +1,29 @@
+
+running 1 test
+test $DIR/dead-code-2024.rs - f (line 12) - compile ... FAILED
+
+failures:
+
+---- $DIR/dead-code-2024.rs - f (line 12) stdout ----
+error: trait `T` is never used
+  --> $DIR/dead-code-2024.rs:13:7
+   |
+LL | trait T { fn f(); }
+   |       ^
+   |
+note: the lint level is defined here
+  --> $DIR/dead-code-2024.rs:11:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(dead_code)]` implied by `#[deny(warnings)]`
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+
+failures:
+    $DIR/dead-code-2024.rs - f (line 12)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/doctest/dead-code.rs
+++ b/tests/rustdoc-ui/doctest/dead-code.rs
@@ -1,0 +1,15 @@
+// This test ensures that the doctest will not use `#[allow(unused)]`.
+
+//@ compile-flags:--test
+//@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
+//@ failure-status: 101
+
+#![doc(test(attr(allow(unused_variables), deny(warnings))))]
+
+/// Example
+///
+/// ```rust,no_run
+/// trait T { fn f(); }
+/// ```
+pub fn f() {}

--- a/tests/rustdoc-ui/doctest/dead-code.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code.stdout
@@ -1,0 +1,29 @@
+
+running 1 test
+test $DIR/dead-code.rs - f (line 12) - compile ... FAILED
+
+failures:
+
+---- $DIR/dead-code.rs - f (line 12) stdout ----
+error: trait `T` is never used
+  --> $DIR/dead-code.rs:13:7
+   |
+LL | trait T { fn f(); }
+   |       ^
+   |
+note: the lint level is defined here
+  --> $DIR/dead-code.rs:11:9
+   |
+LL | #![deny(warnings)]
+   |         ^^^^^^^^
+   = note: `#[deny(dead_code)]` implied by `#[deny(warnings)]`
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+
+failures:
+    $DIR/dead-code.rs - f (line 12)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
Fixes [#130681](https://github.com/rust-lang/rust/issues/130681).

It fixes the behaviour difference with the current doctests.

r? @notriddle 