### PR TITLE
Increase Stack Size for AIX

### DIFF
--- a/compiler/rustc_data_structures/src/stack.rs
+++ b/compiler/rustc_data_structures/src/stack.rs
@@ -5,7 +5,11 @@ const RED_ZONE: usize = 100 * 1024; // 100k
 
 // Only the first stack that is pushed, grows exponentially (2^n * STACK_PER_RECURSION) from then
 // on. This flag has performance relevant characteristics. Don't set it too high.
+#[cfg(not(target_os="aix"))]
 const STACK_PER_RECURSION: usize = 1024 * 1024; // 1MB
+// LLVM for AIX doesn't feature TCO, increase recursion size for workaround.
+#[cfg(target_os="aix")]
+const STACK_PER_RECURSION: usize = 16 * 1024 * 1024; // 16MB
 
 /// Grows the stack on demand to prevent stack overflow. Call this in strategic locations
 /// to "break up" recursive calls. E.g. almost any call to `visit_expr` or equivalent can benefit

--- a/compiler/rustc_data_structures/src/stack.rs
+++ b/compiler/rustc_data_structures/src/stack.rs
@@ -5,10 +5,10 @@ const RED_ZONE: usize = 100 * 1024; // 100k
 
 // Only the first stack that is pushed, grows exponentially (2^n * STACK_PER_RECURSION) from then
 // on. This flag has performance relevant characteristics. Don't set it too high.
-#[cfg(not(target_os="aix"))]
+#[cfg(not(target_os = "aix"))]
 const STACK_PER_RECURSION: usize = 1024 * 1024; // 1MB
 // LLVM for AIX doesn't feature TCO, increase recursion size for workaround.
-#[cfg(target_os="aix")]
+#[cfg(target_os = "aix")]
 const STACK_PER_RECURSION: usize = 16 * 1024 * 1024; // 16MB
 
 /// Grows the stack on demand to prevent stack overflow. Call this in strategic locations


### PR DESCRIPTION
On AIX, there are limited support for tail call optimizations, so we need to set a larger stack size value.

Fixes the following tests on AIX:
```
[ui] tests/ui/associated-consts/issue-93775.rs
[ui] tests/ui/closures/deeply-nested_closures.rs
[ui] tests/ui/issues/issue-74564-if-expr-stack-overflow.rs
[ui] tests/ui/parser/survive-peano-lesson-queue.rs
```