### PR TITLE
A couple of fixes for dataflow graphviz dumps

### DIFF
--- a/compiler/rustc_borrowck/src/dataflow.rs
+++ b/compiler/rustc_borrowck/src/dataflow.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::graph;
 use rustc_index::bit_set::BitSet;
@@ -425,10 +423,6 @@ impl<'a, 'tcx> Borrows<'a, 'tcx> {
         Borrows { tcx, body, borrow_set, borrows_out_of_scope_at_location }
     }
 
-    pub fn location(&self, idx: BorrowIndex) -> &Location {
-        &self.borrow_set[idx].reserve_location
-    }
-
     /// Add all borrows to the kill set, if those borrows are out of scope at `location`.
     /// That means they went out of a nonlexical scope
     fn kill_loans_out_of_scope_at_location(
@@ -615,8 +609,4 @@ impl<'tcx> rustc_mir_dataflow::GenKillAnalysis<'tcx> for Borrows<'_, 'tcx> {
     }
 }
 
-impl DebugWithContext<Borrows<'_, '_>> for BorrowIndex {
-    fn fmt_with(&self, ctxt: &Borrows<'_, '_>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", ctxt.location(*self))
-    }
-}
+impl<C> DebugWithContext<C> for BorrowIndex {}

--- a/compiler/rustc_mir_dataflow/src/framework/engine.rs
+++ b/compiler/rustc_mir_dataflow/src/framework/engine.rs
@@ -285,7 +285,7 @@ where
             }
 
             None if dump_enabled(tcx, A::NAME, def_id) => {
-                create_dump_file(tcx, ".dot", false, A::NAME, &pass_name.unwrap_or("-----"), body)?
+                create_dump_file(tcx, "dot", false, A::NAME, &pass_name.unwrap_or("-----"), body)?
             }
 
             _ => return (Ok(()), results),


### PR DESCRIPTION
A couple of trivial drive-by fixes to issues I noticed while debugging my buggy borrowck code:

One is a fix of the `-Zdump-mir-dataflow` file extensions, the dataflow graphviz files are currently dumped  as `..dot`.

<details>

```console
-rw-rw-r-- 1 lqd lqd 13051 Oct  1 23:21 mir_dump/issue_47680.main.-------.borrows.borrowck..dot
-rw-rw-r-- 1 lqd lqd 13383 Oct  1 23:21 mir_dump/issue_47680.main.-------.ever_init.borrowck..dot
-rw-rw-r-- 1 lqd lqd 13591 Oct  1 23:21 mir_dump/issue_47680.main.-------.maybe_init.borrowck..dot
-rw-rw-r-- 1 lqd lqd  9257 Oct  1 23:21 mir_dump/issue_47680.main.-------.maybe_init.elaborate_drops..dot
-rw-rw-r-- 1 lqd lqd 14086 Oct  1 23:21 mir_dump/issue_47680.main.-------.maybe_uninit.borrowck..dot
-rw-rw-r-- 1 lqd lqd  9257 Oct  1 23:21 mir_dump/issue_47680.main.-------.maybe_uninit.elaborate_drops..dot
```

<summary>Some examples on nightly</summary>

</details>

And the other is for the specific `Borrows` dataflow analysis, whose domain is loans but shows locations when dumped (the location where the loan is introduced). It's not a huge deal but we didn't even print these locations in MIR dumps, and in general cross-referencing loan data (like loan liveness) is more annoying without this change.

<details>

![Untitled](https://github.com/user-attachments/assets/b325a6e9-1aee-4655-8441-d3b1b55ded3c)


<summary>Here's how it'll look in case inquisitive minds want to know</summary>

</details>

The visualization state diff display is still suboptimal in loops for some of the effects escaping a block, e.g. a gen that's not dominated/postdominated by a kill will not show up in statement diffs. (This happens in the previous screenshot, there's no `+bw1` anywhere). We can fix that in the future.