### PR TITLE
Avoid `InferOk<'tcx, ()>`

### DIFF
--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -890,7 +890,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let cause = self.misc(span);
         // We know the type of `effect` to be `bool`, there will be no opaque type inference.
         match self.at(&cause, self.param_env).eq(infer::DefineOpaqueTypes::Yes, effect, param) {
-            Ok(infer::InferOk { obligations, value: () }) => {
+            Ok(obligations) => {
                 self.register_predicates(obligations);
             }
             Err(e) => {

--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -918,7 +918,7 @@ impl<'a, 'tcx> CastCheck<'tcx> {
                         if fcx
                             .at(&cause, fcx.param_env)
                             .eq(DefineOpaqueTypes::Yes, src_obj, dst_obj)
-                            .map(|infer_ok| fcx.register_infer_ok_obligations(infer_ok))
+                            .map(|obligations| fcx.register_predicates(obligations))
                             .is_err()
                         {
                             return Err(CastError::DifferingKinds { src_kind, dst_kind });

--- a/compiler/rustc_hir_typeck/src/closure.rs
+++ b/compiler/rustc_hir_typeck/src/closure.rs
@@ -820,7 +820,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             ) {
                 // Check that E' = S'.
                 let cause = self.misc(hir_ty.span);
-                let InferOk { value: (), obligations } = self.at(&cause, self.param_env).eq(
+                let obligations = self.at(&cause, self.param_env).eq(
                     DefineOpaqueTypes::Yes,
                     *expected_ty,
                     supplied_ty,
@@ -830,7 +830,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             let supplied_output_ty = supplied_sig.output();
             let cause = &self.misc(decl.output.span());
-            let InferOk { value: (), obligations } = self.at(cause, self.param_env).eq(
+            let obligations = self.at(cause, self.param_env).eq(
                 DefineOpaqueTypes::Yes,
                 expected_sigs.liberated_sig.output(),
                 supplied_output_ty,

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -138,7 +138,7 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
                 at.lub(DefineOpaqueTypes::Yes, b, a)
             } else {
                 at.sup(DefineOpaqueTypes::Yes, b, a)
-                    .map(|InferOk { value: (), obligations }| InferOk { value: b, obligations })
+                    .map(|obligations| InferOk { value: b, obligations })
             };
 
             // In the new solver, lazy norm may allow us to shallowly equate
@@ -1599,8 +1599,8 @@ impl<'tcx, 'exprs, E: AsCoercionSite> CoerceMany<'tcx, 'exprs, E> {
                     expected,
                     found,
                 )
-                .map(|infer_ok| {
-                    fcx.register_infer_ok_obligations(infer_ok);
+                .map(|obligations| {
+                    fcx.register_predicates(obligations);
                     expression_ty
                 })
         };

--- a/compiler/rustc_hir_typeck/src/demand.rs
+++ b/compiler/rustc_hir_typeck/src/demand.rs
@@ -190,7 +190,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Result<(), Diag<'a>> {
         self.at(cause, self.param_env)
             .sup(DefineOpaqueTypes::Yes, expected, actual)
-            .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
+            .map(|obligations| self.register_predicates(obligations))
             .map_err(|e| self.err_ctxt().report_mismatched_types(cause, expected, actual, e))
     }
 
@@ -217,7 +217,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Result<(), Diag<'a>> {
         self.at(cause, self.param_env)
             .eq(DefineOpaqueTypes::Yes, expected, actual)
-            .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
+            .map(|obligations| self.register_predicates(obligations))
             .map_err(|e| self.err_ctxt().report_mismatched_types(cause, expected, actual, e))
     }
 

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -16,7 +16,7 @@ use rustc_hir::lang_items::LangItem;
 use rustc_hir::{ExprKind, HirId, QPath};
 use rustc_hir_analysis::hir_ty_lowering::HirTyLowerer as _;
 use rustc_infer::infer;
-use rustc_infer::infer::{DefineOpaqueTypes, InferOk};
+use rustc_infer::infer::DefineOpaqueTypes;
 use rustc_infer::traits::ObligationCause;
 use rustc_infer::traits::query::NoSolution;
 use rustc_middle::ty::adjustment::{Adjust, Adjustment, AllowTwoPhase};
@@ -1832,7 +1832,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     target_ty,
                                     fru_ty,
                                 ) {
-                                    Ok(InferOk { obligations, value: () }) => {
+                                    Ok(obligations) => {
                                         self.register_predicates(obligations)
                                     }
                                     Err(_) => {

--- a/compiler/rustc_hir_typeck/src/fallback.rs
+++ b/compiler/rustc_hir_typeck/src/fallback.rs
@@ -7,7 +7,7 @@ use rustc_data_structures::unord::{UnordBag, UnordMap, UnordSet};
 use rustc_hir as hir;
 use rustc_hir::HirId;
 use rustc_hir::intravisit::Visitor;
-use rustc_infer::infer::{DefineOpaqueTypes, InferOk};
+use rustc_infer::infer::DefineOpaqueTypes;
 use rustc_middle::bug;
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeSuperVisitable, TypeVisitable};
 use rustc_session::lint;
@@ -116,7 +116,7 @@ impl<'tcx> FnCtxt<'_, 'tcx> {
             let expected = self.tcx.consts.true_;
             let cause = self.misc(DUMMY_SP);
             match self.at(&cause, self.param_env).eq(DefineOpaqueTypes::Yes, expected, effect) {
-                Ok(InferOk { obligations, value: () }) => {
+                Ok(obligations) => {
                     self.register_predicates(obligations);
                 }
                 Err(e) => {

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -613,12 +613,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let ty::Infer(ty::InferTy::TyVar(_)) = interior.kind() else {
                 span_bug!(span, "coroutine interior witness not infer: {:?}", interior.kind())
             };
-            let ok = self
+            let mut obligations = self
                 .at(&self.misc(span), self.param_env)
                 // Will never define opaque types, as all we do is instantiate a type variable.
                 .eq(DefineOpaqueTypes::Yes, interior, witness)
                 .expect("Failed to unify coroutine interior type");
-            let mut obligations = ok.obligations;
 
             // Also collect the obligations that were unstalled by this unification.
             obligations
@@ -1386,7 +1385,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 impl_ty,
                 self_ty,
             ) {
-                Ok(ok) => self.register_infer_ok_obligations(ok),
+                Ok(obligations) => self.register_predicates(obligations),
                 Err(_) => {
                     self.dcx().span_bug(
                         span,

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -15,7 +15,7 @@ use rustc_hir_analysis::check::intrinsicck::InlineAsmCtxt;
 use rustc_hir_analysis::check::potentially_plural_count;
 use rustc_hir_analysis::hir_ty_lowering::HirTyLowerer;
 use rustc_index::IndexVec;
-use rustc_infer::infer::{DefineOpaqueTypes, InferOk, TypeTrace};
+use rustc_infer::infer::{DefineOpaqueTypes, TypeTrace};
 use rustc_middle::ty::adjustment::AllowTwoPhase;
 use rustc_middle::ty::error::TypeError;
 use rustc_middle::ty::visit::TypeVisitableExt;
@@ -338,7 +338,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
             // If neither check failed, the types are compatible
             match formal_ty_error {
-                Ok(InferOk { obligations, value: () }) => {
+                Ok(obligations) => {
                     self.register_predicates(obligations);
                     Compatibility::Compatible
                 }

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -9,7 +9,7 @@ use rustc_hir_analysis::hir_ty_lowering::generics::{
 use rustc_hir_analysis::hir_ty_lowering::{
     GenericArgsLowerer, HirTyLowerer, IsMethodCall, RegionInferReason,
 };
-use rustc_infer::infer::{self, DefineOpaqueTypes, InferOk};
+use rustc_infer::infer::{self, DefineOpaqueTypes};
 use rustc_middle::traits::{ObligationCauseCode, UnifyReceiverContext};
 use rustc_middle::ty::adjustment::{
     Adjust, Adjustment, AllowTwoPhase, AutoBorrow, AutoBorrowMutability, PointerCoercion,
@@ -512,7 +512,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             })),
         );
         match self.at(&cause, self.param_env).sup(DefineOpaqueTypes::Yes, method_self_ty, self_ty) {
-            Ok(InferOk { obligations, value: () }) => {
+            Ok(obligations) => {
                 self.register_predicates(obligations);
             }
             Err(terr) => {

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -187,28 +187,6 @@ impl<'a, 'tcx> At<'a, 'tcx> {
         })
     }
 
-    /// Equates `expected` and `found` while structurally relating aliases.
-    /// This should only be used inside of the next generation trait solver
-    /// when relating rigid aliases.
-    pub fn eq_structurally_relating_aliases<T>(
-        self,
-        expected: T,
-        actual: T,
-    ) -> InferResult<'tcx, ()>
-    where
-        T: ToTrace<'tcx>,
-    {
-        assert!(self.infcx.next_trait_solver());
-        let mut fields = CombineFields::new(
-            self.infcx,
-            ToTrace::to_trace(self.cause, expected, actual),
-            self.param_env,
-            DefineOpaqueTypes::Yes,
-        );
-        fields.equate(StructurallyRelateAliases::Yes).relate(expected, actual)?;
-        Ok(InferOk { value: (), obligations: fields.into_obligations() })
-    }
-
     pub fn relate<T>(
         self,
         define_opaque_types: DefineOpaqueTypes,

--- a/compiler/rustc_infer/src/infer/opaque_types/mod.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/mod.rs
@@ -541,7 +541,6 @@ impl<'tcx> InferCtxt<'tcx> {
                 goals.extend(
                     self.at(&ObligationCause::dummy_with_span(span), param_env)
                         .eq(DefineOpaqueTypes::Yes, prev, hidden_ty)?
-                        .obligations
                         .into_iter()
                         // FIXME: Shuttling between obligations and goals is awkward.
                         .map(Goal::from),

--- a/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
+++ b/compiler/rustc_trait_selection/src/solve/inspect/analyse.rs
@@ -13,7 +13,7 @@ use std::assert_matches::assert_matches;
 
 use rustc_ast_ir::try_visit;
 use rustc_ast_ir::visit::VisitorResult;
-use rustc_infer::infer::{DefineOpaqueTypes, InferCtxt, InferOk};
+use rustc_infer::infer::{DefineOpaqueTypes, InferCtxt};
 use rustc_macros::extension;
 use rustc_middle::traits::ObligationCause;
 use rustc_middle::traits::solve::{Certainty, Goal, GoalSource, NoSolution, QueryResult};
@@ -72,7 +72,7 @@ impl<'tcx> NormalizesToTermHack<'tcx> {
             .at(&ObligationCause::dummy_with_span(span), param_env)
             .eq(DefineOpaqueTypes::Yes, self.term, self.unconstrained_term)
             .map_err(|_| NoSolution)
-            .and_then(|InferOk { value: (), obligations }| {
+            .and_then(|obligations| {
                 let ocx = ObligationCtxt::new(infcx);
                 ocx.register_obligations(obligations);
                 let errors = ocx.select_all_or_error();

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -292,7 +292,7 @@ fn equate_impl_headers<'tcx>(
             _ => bug!("equate_impl_headers given mismatched impl kinds"),
         };
 
-    result.map(|infer_ok| infer_ok.obligations).ok()
+    result.map(|obligations| obligations).ok()
 }
 
 /// The result of [fn impl_intersection_has_impossible_obligation].
@@ -464,7 +464,7 @@ fn plug_infer_with_placeholders<'tcx>(
         fn visit_ty(&mut self, ty: Ty<'tcx>) {
             let ty = self.infcx.shallow_resolve(ty);
             if ty.is_ty_var() {
-                let Ok(InferOk { value: (), obligations }) =
+                let Ok(obligations) =
                     self.infcx.at(&ObligationCause::dummy(), ty::ParamEnv::empty()).eq(
                         // Comparing against a type variable never registers hidden types anyway
                         DefineOpaqueTypes::Yes,
@@ -489,7 +489,7 @@ fn plug_infer_with_placeholders<'tcx>(
         fn visit_const(&mut self, ct: ty::Const<'tcx>) {
             let ct = self.infcx.shallow_resolve_const(ct);
             if ct.is_ct_infer() {
-                let Ok(InferOk { value: (), obligations }) =
+                let Ok(obligations) =
                     self.infcx.at(&ObligationCause::dummy(), ty::ParamEnv::empty()).eq(
                         // The types of the constants are the same, so there is no hidden type
                         // registration happening anyway.
@@ -518,7 +518,7 @@ fn plug_infer_with_placeholders<'tcx>(
                     .unwrap_region_constraints()
                     .opportunistic_resolve_var(self.infcx.tcx, vid);
                 if r.is_var() {
-                    let Ok(InferOk { value: (), obligations }) =
+                    let Ok(obligations) =
                         self.infcx.at(&ObligationCause::dummy(), ty::ParamEnv::empty()).eq(
                             // Lifetimes don't contain opaque types (or any types for that matter).
                             DefineOpaqueTypes::Yes,

--- a/compiler/rustc_trait_selection/src/traits/engine.rs
+++ b/compiler/rustc_trait_selection/src/traits/engine.rs
@@ -131,7 +131,7 @@ where
         self.infcx
             .at(cause, param_env)
             .eq(DefineOpaqueTypes::Yes, expected, actual)
-            .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
+            .map(|obligations| self.register_obligations(obligations))
     }
 
     pub fn eq_trace<T: Relate<TyCtxt<'tcx>>>(
@@ -145,7 +145,7 @@ where
         self.infcx
             .at(cause, param_env)
             .eq_trace(DefineOpaqueTypes::Yes, trace, expected, actual)
-            .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
+            .map(|obligations| self.register_obligations(obligations))
     }
 
     /// Checks whether `expected` is a subtype of `actual`: `expected <: actual`.
@@ -159,7 +159,7 @@ where
         self.infcx
             .at(cause, param_env)
             .sub(DefineOpaqueTypes::Yes, expected, actual)
-            .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
+            .map(|obligations| self.register_obligations(obligations))
     }
 
     pub fn relate<T: ToTrace<'tcx>>(
@@ -173,7 +173,7 @@ where
         self.infcx
             .at(cause, param_env)
             .relate(DefineOpaqueTypes::Yes, expected, variance, actual)
-            .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
+            .map(|obligations| self.register_obligations(obligations))
     }
 
     /// Checks whether `expected` is a supertype of `actual`: `expected :> actual`.
@@ -187,7 +187,7 @@ where
         self.infcx
             .at(cause, param_env)
             .sup(DefineOpaqueTypes::Yes, expected, actual)
-            .map(|infer_ok| self.register_infer_ok_obligations(infer_ok))
+            .map(|infer_ok| self.register_obligations(infer_ok))
     }
 
     #[must_use]

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -477,7 +477,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                         ct_ty,
                         ty,
                     ) {
-                        Ok(inf_ok) => ProcessResult::Changed(mk_pending(inf_ok.into_obligations())),
+                        Ok(obligations) => ProcessResult::Changed(mk_pending(obligations)),
                         Err(_) => ProcessResult::Error(FulfillmentErrorCode::Select(
                             SelectionError::ConstArgHasWrongType { ct, ct_ty, expected_ty: ty },
                         )),
@@ -527,11 +527,11 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                                 vec![TyOrConstInferVar::Ty(a), TyOrConstInferVar::Ty(b)];
                             ProcessResult::Unchanged
                         }
-                        Ok(Ok(mut ok)) => {
-                            for subobligation in &mut ok.obligations {
+                        Ok(Ok(mut obligations)) => {
+                            for subobligation in &mut obligations {
                                 subobligation.set_depth_from_parent(obligation.recursion_depth);
                             }
-                            ProcessResult::Changed(mk_pending(ok.obligations))
+                            ProcessResult::Changed(mk_pending(obligations))
                         }
                         Ok(Err(err)) => {
                             let expected_found =
@@ -553,7 +553,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                                 vec![TyOrConstInferVar::Ty(a), TyOrConstInferVar::Ty(b)];
                             ProcessResult::Unchanged
                         }
-                        Ok(Ok(ok)) => ProcessResult::Changed(mk_pending(ok.obligations)),
+                        Ok(Ok(obligations)) => ProcessResult::Changed(mk_pending(obligations)),
                         Ok(Err(err)) => {
                             let expected_found = ExpectedFound::new(false, coerce.a, coerce.b);
                             ProcessResult::Error(FulfillmentErrorCode::Subtype(expected_found, err))
@@ -616,9 +616,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                                         ty::AliasTerm::from(b),
                                     )
                                 {
-                                    return ProcessResult::Changed(mk_pending(
-                                        new_obligations.into_obligations(),
-                                    ));
+                                    return ProcessResult::Changed(mk_pending(new_obligations));
                                 }
                             }
                             (_, Unevaluated(_)) | (Unevaluated(_), _) => (),
@@ -629,9 +627,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                                     // `generic_const_exprs`
                                     .eq(DefineOpaqueTypes::Yes, c1, c2)
                                 {
-                                    return ProcessResult::Changed(mk_pending(
-                                        new_obligations.into_obligations(),
-                                    ));
+                                    return ProcessResult::Changed(mk_pending(new_obligations));
                                 }
                             }
                         }
@@ -673,9 +669,7 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                                 c1,
                                 c2,
                             ) {
-                                Ok(inf_ok) => {
-                                    ProcessResult::Changed(mk_pending(inf_ok.into_obligations()))
-                                }
+                                Ok(obligations) => ProcessResult::Changed(mk_pending(obligations)),
                                 Err(err) => {
                                     ProcessResult::Error(FulfillmentErrorCode::ConstEquate(
                                         ExpectedFound::new(true, c1, c2),

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -266,7 +266,7 @@ fn project_and_unify_term<'cx, 'tcx>(
         normalized,
         actual,
     ) {
-        Ok(InferOk { obligations: inferred_obligations, value: () }) => {
+        Ok(inferred_obligations) => {
             obligations.extend(inferred_obligations);
             ProjectAndUnifyResult::Holds(obligations)
         }
@@ -638,7 +638,7 @@ pub fn compute_inherent_assoc_ty_args<'a, 'b, 'tcx>(
     }
 
     match selcx.infcx.at(&cause, param_env).eq(DefineOpaqueTypes::Yes, impl_ty, self_ty) {
-        Ok(mut ok) => obligations.append(&mut ok.obligations),
+        Ok(mut more_obligations) => obligations.append(&mut more_obligations),
         Err(_) => {
             tcx.dcx().span_bug(
                 cause.span,
@@ -2021,7 +2021,7 @@ fn confirm_param_env_candidate<'cx, 'tcx>(
         cache_projection,
         obligation_projection,
     ) {
-        Ok(InferOk { value: _, obligations }) => {
+        Ok(obligations) => {
             nested_obligations.extend(obligations);
             assoc_ty_own_obligations(selcx, obligation, &mut nested_obligations);
             // FIXME(associated_const_equality): Handle consts here as well? Maybe this progress type should just take

--- a/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/specialize/mod.rs
@@ -28,7 +28,7 @@ use tracing::{debug, instrument};
 use super::{SelectionContext, util};
 use crate::error_reporting::traits::to_pretty_impl_header;
 use crate::errors::NegativePositiveConflict;
-use crate::infer::{InferCtxt, InferOk, TyCtxtInferExt};
+use crate::infer::{InferCtxt, TyCtxtInferExt};
 use crate::traits::select::IntercrateAmbiguityCause;
 use crate::traits::{FutureCompatOverlapErrorKind, ObligationCause, ObligationCtxt, coherence};
 
@@ -235,7 +235,7 @@ fn fulfill_implication<'tcx>(
         util::impl_subject_and_oblig(&selcx, param_env, target_impl, target_args, error_cause);
 
     // do the impls unify? If not, no specialization.
-    let Ok(InferOk { obligations: more_obligations, .. }) = infcx
+    let Ok(more_obligations) = infcx
         .at(&ObligationCause::dummy(), param_env)
         // Ok to use `Yes`, as all the generic params are already replaced by inference variables,
         // which will match the opaque type no matter if it is defining or not.

--- a/src/librustdoc/clean/blanket_impl.rs
+++ b/src/librustdoc/clean/blanket_impl.rs
@@ -1,5 +1,5 @@
 use rustc_hir as hir;
-use rustc_infer::infer::{DefineOpaqueTypes, InferOk, TyCtxtInferExt};
+use rustc_infer::infer::{DefineOpaqueTypes, TyCtxtInferExt};
 use rustc_infer::traits;
 use rustc_middle::ty::{self, Upcast};
 use rustc_span::DUMMY_SP;
@@ -48,14 +48,13 @@ pub(crate) fn synthesize_blanket_impls(
 
             // Require the type the impl is implemented on to match
             // our type, and ignore the impl if there was a mismatch.
-            let Ok(eq_result) = infcx.at(&traits::ObligationCause::dummy(), param_env).eq(
+            let Ok(obligations) = infcx.at(&traits::ObligationCause::dummy(), param_env).eq(
                 DefineOpaqueTypes::Yes,
                 impl_trait_ref.self_ty(),
                 impl_ty,
             ) else {
                 continue;
             };
-            let InferOk { value: (), obligations } = eq_result;
             // FIXME(eddyb) ignoring `obligations` might cause false positives.
             drop(obligations);
 


### PR DESCRIPTION
`InferOk<'tcx, ()>` is a silly type. This PR converts uses of it to something simpler.

r? @lcnr