### PR TITLE
add Access Key Shortcuts to rustdoc

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -932,6 +932,11 @@ rustdoc-toolbar {
 	min-height: 60px;
 }
 
+rustdoc-toolbar u {
+	text-decoration-color: #ffffff80;
+	text-decoration-thickness: 1px;
+}
+
 .docblock code, .docblock-short code,
 pre, .rustdoc.src .example-wrap, .example-wrap .src-line-numbers {
 	background-color: var(--code-block-background-color);

--- a/src/librustdoc/html/static/js/main.js
+++ b/src/librustdoc/html/static/js/main.js
@@ -491,7 +491,11 @@ function preLoadCss(cssUrl) {
                 ev.preventDefault();
                 searchState.focus();
                 break;
-
+            case "a":
+            case "A":
+                ev.preventDefault();
+                toggleAllDocs();
+                break;
             case "+":
                 ev.preventDefault();
                 expandAllDocs();
@@ -502,7 +506,14 @@ function preLoadCss(cssUrl) {
                 break;
 
             case "?":
+            case "h":
+            case "H":
                 showHelp();
+                break;
+
+            case "e":
+            case "E":
+                getSettingsButton().click();
                 break;
 
             default:
@@ -938,7 +949,7 @@ function preLoadCss(cssUrl) {
                 e.open = true;
             }
         });
-        innerToggle.children[0].innerText = "Summary";
+        innerToggle.children[0].innerHTML = "Summ<u>a</u>ry";
     }
 
     function collapseAllDocs() {
@@ -952,7 +963,7 @@ function preLoadCss(cssUrl) {
                 e.open = false;
             }
         });
-        innerToggle.children[0].innerText = "Show all";
+        innerToggle.children[0].innerHTML = "Show <u>a</u>ll";
     }
 
     function toggleAllDocs() {

--- a/src/librustdoc/html/static/js/storage.js
+++ b/src/librustdoc/html/static/js/storage.js
@@ -291,12 +291,12 @@ class RustdocToolbarElement extends HTMLElement {
         const rootPath = getVar("root-path");
         this.innerHTML = `
         <div id="settings-menu" tabindex="-1">
-            <a href="${rootPath}settings.html"><span class="label">Settings</span></a>
+            <a href="${rootPath}settings.html"><span class="label">S<u>e</u>ttings</span></a>
         </div>
         <div id="help-button" tabindex="-1">
-            <a href="${rootPath}help.html"><span class="label">Help</span></a>
+            <a href="${rootPath}help.html"><span class="label"><u>H</u>elp</span></a>
         </div>
-        <button id="toggle-all-docs"><span class="label">Summary</span></button>`;
+        <button id="toggle-all-docs"><span class="label">Summ<u>a</u>ry</span></button>`;
     }
 }
 window.customElements.define("rustdoc-toolbar", RustdocToolbarElement);


### PR DESCRIPTION
since the latest redesign was focused on accessability through embracing classic design patterns, this seems pretty on theme.

these underline a character in Settings, Help, and Summary, and that key can be used to activate that button.

![image](https://github.com/user-attachments/assets/6ac77496-ccca-47c3-905a-c0ea97addf88)


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->
