### PR TITLE
Update hashbrown to 0.15 and adjust some methods

### DIFF
--- a/compiler/rustc_session/src/config/cfg.rs
+++ b/compiler/rustc_session/src/config/cfg.rs
@@ -402,18 +402,18 @@ impl CheckCfg {
                 // Get all values map at once otherwise it would be costly.
                 // (8 values * 220 targets ~= 1760 times, at the time of writing this comment).
                 let [
-                    values_target_abi,
-                    values_target_arch,
-                    values_target_endian,
-                    values_target_env,
-                    values_target_family,
-                    values_target_os,
-                    values_target_pointer_width,
-                    values_target_vendor,
-                ] = self
-                    .expecteds
-                    .get_many_mut(VALUES)
-                    .expect("unable to get all the check-cfg values buckets");
+                    Some(values_target_abi),
+                    Some(values_target_arch),
+                    Some(values_target_endian),
+                    Some(values_target_env),
+                    Some(values_target_family),
+                    Some(values_target_os),
+                    Some(values_target_pointer_width),
+                    Some(values_target_vendor),
+                ] = self.expecteds.get_many_mut(VALUES)
+                else {
+                    panic!("unable to get all the check-cfg values buckets");
+                };
 
                 for target in TARGETS
                     .iter()

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 dependencies = [
  "allocator-api2",
  "compiler_builtins",

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -20,7 +20,7 @@ core = { path = "../core", public = true }
 compiler_builtins = { version = "0.1.130" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
-hashbrown = { version = "0.14", default-features = false, features = [
+hashbrown = { version = "0.15", default-features = false, features = [
     'rustc-dep-of-std',
 ] }
 # FIXME(#127890): `object` depends on `memchr`, but `memchr` > v2.5 causes

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -724,38 +724,6 @@ where
         self.base.get_or_insert(value)
     }
 
-    /// Inserts an owned copy of the given `value` into the set if it is not
-    /// present, then returns a reference to the value in the set.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// #![feature(hash_set_entry)]
-    ///
-    /// use std::collections::HashSet;
-    ///
-    /// let mut set: HashSet<String> = ["cat", "dog", "horse"]
-    ///     .iter().map(|&pet| pet.to_owned()).collect();
-    ///
-    /// assert_eq!(set.len(), 3);
-    /// for &pet in &["cat", "dog", "fish"] {
-    ///     let value = set.get_or_insert_owned(pet);
-    ///     assert_eq!(value, pet);
-    /// }
-    /// assert_eq!(set.len(), 4); // a new "fish" was inserted
-    /// ```
-    #[inline]
-    #[unstable(feature = "hash_set_entry", issue = "60896")]
-    pub fn get_or_insert_owned<Q: ?Sized>(&mut self, value: &Q) -> &T
-    where
-        T: Borrow<Q>,
-        Q: Hash + Eq + ToOwned<Owned = T>,
-    {
-        // Although the raw entry gives us `&mut T`, we only return `&T` to be consistent with
-        // `get`. Key mutation is "raw" because you're not supposed to affect `Eq` or `Hash`.
-        self.base.get_or_insert_owned(value)
-    }
-
     /// Inserts a value computed from `f` into the set if the given `value` is
     /// not present, then returns a reference to the value in the set.
     ///

--- a/tests/rustdoc-js-std/path-ordering.js
+++ b/tests/rustdoc-js-std/path-ordering.js
@@ -6,7 +6,6 @@ const EXPECTED = [
             { 'path': 'std::collections::hash_set::HashSet', 'name': 'insert' },
             { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert' },
             { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert_with' },
-            { 'path': 'std::collections::hash_set::HashSet', 'name': 'get_or_insert_owned' },
         ],
     },
     {


### PR DESCRIPTION
This PR updates `hashbrown` to 0.15 in the standard library and adjust some methods as well as removing some as they no longer exists in Hashbrown it-self.

 - `HashMap::get_many_mut` change API to return array-of-Option
 - `HashMap::{replace_entry, replace_key}` are removed, FCP close [already finished](https://github.com/rust-lang/rust/issues/44286#issuecomment-2293825619)
 - `HashSet::get_or_insert_owned` is removed as it no longer exists in hashbrown

Closes https://github.com/rust-lang/rust/issues/44286
r? @Amanieu
