### PR TITLE
only query `params_in_repr` if def kind is adt

### DIFF
--- a/compiler/rustc_middle/src/values.rs
+++ b/compiler/rustc_middle/src/values.rs
@@ -358,7 +358,7 @@ fn find_item_ty_spans(
     match ty.kind {
         hir::TyKind::Path(hir::QPath::Resolved(_, path)) => {
             if let Res::Def(kind, def_id) = path.res
-                && !matches!(kind, DefKind::TyAlias)
+                && matches!(kind, DefKind::Enum | DefKind::Struct | DefKind::Union)
             {
                 let check_params = def_id.as_local().map_or(true, |def_id| {
                     if def_id == needle {

--- a/tests/crashes/128327.rs
+++ b/tests/crashes/128327.rs
@@ -1,5 +1,0 @@
-//@ known-bug: rust-lang/rust#128327
-
-use std::ops::Deref;
-struct Apple((Apple, <&'static [f64] as Deref>::Target(Banana ? Citron)));
-fn main(){}

--- a/tests/ui/infinite/auxiliary/alias.rs
+++ b/tests/ui/infinite/auxiliary/alias.rs
@@ -1,2 +1,5 @@
 pub struct W<T>(T);
 pub type Wrapper<T> = W<T>;
+pub trait Trait {
+    type T;
+}

--- a/tests/ui/infinite/infinite-assoc.rs
+++ b/tests/ui/infinite/infinite-assoc.rs
@@ -1,0 +1,16 @@
+//@ aux-build: alias.rs
+
+// issue#128327
+
+extern crate alias;
+
+use alias::Trait;
+struct S;
+impl Trait for S {
+    type T = ();
+}
+struct A((A, <S as Trait>::T<NOT_EXIST?>));
+//~^ ERROR: invalid `?` in type
+//~| ERROR: recursive type `A` has infinite size
+
+fn main() {}

--- a/tests/ui/infinite/infinite-assoc.stderr
+++ b/tests/ui/infinite/infinite-assoc.stderr
@@ -1,0 +1,25 @@
+error: invalid `?` in type
+  --> $DIR/infinite-assoc.rs:12:39
+   |
+LL | struct A((A, <S as Trait>::T<NOT_EXIST?>));
+   |                                       ^ `?` is only allowed on expressions, not types
+   |
+help: if you meant to express that the type might not contain a value, use the `Option` wrapper type
+   |
+LL | struct A((A, <S as Trait>::T<Option<NOT_EXIST>>));
+   |                              +++++++         ~
+
+error[E0072]: recursive type `A` has infinite size
+  --> $DIR/infinite-assoc.rs:12:1
+   |
+LL | struct A((A, <S as Trait>::T<NOT_EXIST?>));
+   | ^^^^^^^^  - recursive without indirection
+   |
+help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
+   |
+LL | struct A((Box<A>, <S as Trait>::T<NOT_EXIST?>));
+   |           ++++ +
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0072`.


### PR DESCRIPTION
Fixes #128327 

`params_in_repr` was only stored in `encode_info_for_adt`, so we only query it when the def kind belongs to them.

https://github.com/rust-lang/rust/blob/9e3e5174462afaf6c3b9db9b35c6d1934521848a/compiler/rustc_metadata/src/rmeta/encoder.rs#L1566-L1567