### PR TITLE
Replace zero-width whitespace with a visible `\` in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,6 @@ tracking issue or there are none, feel free to ignore this.
 This PR will get automatically assigned to a reviewer. In case you would like
 a specific user to review your work, you can assign it to them by using
 
-    r​? <reviewer name>
+    r\? <reviewer name> (with the `\` removed)
 -->
 <!-- homu-ignore:end -->


### PR DESCRIPTION
People (incl. myself) tried to copy the `r?` which had an invisible zero-width whitespace (meaning it was actually more like `r⌴?`), causing rustbot to not recognize the instruction, and which makes it difficult to figure out why it didn't work.

This PR replaces the zero-width whitespace with a visible `\` alongside a comment to remove the `\`. It's a bit less "visual", but at least it's visible why the rustbot assignment doesn't work.