### PR TITLE
Handle `rustc_middle` cases of `rustc::potential_query_instability` lint

### DIFF
--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -27,7 +27,6 @@
 // tidy-alphabetical-start
 #![allow(internal_features)]
 #![allow(rustc::diagnostic_outside_of_impl)]
-#![allow(rustc::potential_query_instability)]
 #![allow(rustc::untranslatable_diagnostic)]
 #![cfg_attr(doc, recursion_limit = "256")] // FIXME(nnethercote): will be removed by #124141
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -2169,7 +2169,7 @@ rustc_queries! {
     query maybe_unused_trait_imports(_: ()) -> &'tcx FxIndexSet<LocalDefId> {
         desc { "fetching potentially unused trait imports" }
     }
-    query names_imported_by_glob_use(def_id: LocalDefId) -> &'tcx UnordSet<Symbol> {
+    query names_imported_by_glob_use(def_id: LocalDefId) -> &'tcx FxIndexSet<Symbol> {
         desc { |tcx| "finding names imported by glob use for `{}`", tcx.def_path_str(def_id) }
     }
 

--- a/compiler/rustc_middle/src/query/on_disk_cache.rs
+++ b/compiler/rustc_middle/src/query/on_disk_cache.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::Entry;
 use std::mem;
 use std::sync::Arc;
 
-use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
+use rustc_data_structures::fx::{FxHashMap, FxIndexMap, FxIndexSet};
 use rustc_data_structures::memmap::Mmap;
 use rustc_data_structures::sync::{HashMapExt, Lock, RwLock};
 use rustc_data_structures::unhash::UnhashMap;
@@ -57,7 +57,7 @@ pub struct OnDiskCache {
 
     // Collects all `QuerySideEffect` created during the current compilation
     // session.
-    current_side_effects: Lock<FxHashMap<DepNodeIndex, QuerySideEffect>>,
+    current_side_effects: Lock<FxIndexMap<DepNodeIndex, QuerySideEffect>>,
 
     file_index_to_stable_id: FxHashMap<SourceFileIndex, EncodedSourceFileId>,
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -28,7 +28,6 @@ use rustc_data_structures::steal::Steal;
 use rustc_data_structures::sync::{
     self, DynSend, DynSync, FreezeReadGuard, Lock, RwLock, WorkerLocal,
 };
-use rustc_data_structures::unord::UnordSet;
 use rustc_errors::{
     Applicability, Diag, DiagCtxtHandle, ErrorGuaranteed, LintDiagnostic, MultiSpan,
 };
@@ -2378,6 +2377,8 @@ macro_rules! sty_debug_print {
                 $(let mut $variant = total;)*
 
                 for shard in tcx.interners.type_.lock_shards() {
+                    // It seems that ordering doesn't affect anything here.
+                    #[allow(rustc::potential_query_instability)]
                     let types = shard.iter();
                     for &(InternedInSet(t), ()) in types {
                         let variant = match t.internee {
@@ -3355,9 +3356,7 @@ pub fn provide(providers: &mut Providers) {
     providers.maybe_unused_trait_imports =
         |tcx, ()| &tcx.resolutions(()).maybe_unused_trait_imports;
     providers.names_imported_by_glob_use = |tcx, id| {
-        tcx.arena.alloc(UnordSet::from(
-            tcx.resolutions(()).glob_map.get(&id).cloned().unwrap_or_default(),
-        ))
+        tcx.arena.alloc(tcx.resolutions(()).glob_map.get(&id).cloned().unwrap_or_default())
     };
 
     providers.extern_mod_stmt_cnum =

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -3,7 +3,7 @@
 use std::fmt::Write;
 use std::ops::ControlFlow;
 
-use rustc_data_structures::fx::FxHashMap;
+use rustc_data_structures::fx::FxIndexMap;
 use rustc_errors::{
     Applicability, Diag, DiagArgValue, IntoDiagArg, into_diag_arg_using_display, listify, pluralize,
 };
@@ -287,7 +287,7 @@ pub fn suggest_constraining_type_params<'a>(
     param_names_and_constraints: impl Iterator<Item = (&'a str, &'a str, Option<DefId>)>,
     span_to_replace: Option<Span>,
 ) -> bool {
-    let mut grouped = FxHashMap::default();
+    let mut grouped = FxIndexMap::default();
     let mut unstable_suggestion = false;
     param_names_and_constraints.for_each(|(param_name, constraint, def_id)| {
         let stable = match def_id {

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -172,7 +172,7 @@ pub struct ResolverGlobalCtxt {
     pub extern_crate_map: UnordMap<LocalDefId, CrateNum>,
     pub maybe_unused_trait_imports: FxIndexSet<LocalDefId>,
     pub module_children: LocalDefIdMap<Vec<ModChild>>,
-    pub glob_map: FxHashMap<LocalDefId, FxHashSet<Symbol>>,
+    pub glob_map: FxIndexMap<LocalDefId, FxIndexSet<Symbol>>,
     pub main_def: Option<MainDefinition>,
     pub trait_impls: FxIndexMap<DefId, Vec<LocalDefId>>,
     /// A list of proc macro LocalDefIds, written out in the order in which

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -6,7 +6,7 @@ use std::ops::{Deref, DerefMut};
 use rustc_abi::{ExternAbi, Size};
 use rustc_apfloat::Float;
 use rustc_apfloat::ieee::{Double, Half, Quad, Single};
-use rustc_data_structures::fx::{FxHashMap, FxIndexMap};
+use rustc_data_structures::fx::{FxIndexMap, IndexEntry};
 use rustc_data_structures::unord::UnordMap;
 use rustc_hir as hir;
 use rustc_hir::LangItem;
@@ -3489,8 +3489,8 @@ pub fn trimmed_def_paths(tcx: TyCtxt<'_>, (): ()) -> DefIdMap<Symbol> {
 
     // Once constructed, unique namespace+symbol pairs will have a `Some(_)` entry, while
     // non-unique pairs will have a `None` entry.
-    let unique_symbols_rev: &mut FxHashMap<(Namespace, Symbol), Option<DefId>> =
-        &mut FxHashMap::default();
+    let unique_symbols_rev: &mut FxIndexMap<(Namespace, Symbol), Option<DefId>> =
+        &mut FxIndexMap::default();
 
     for symbol_set in tcx.resolutions(()).glob_map.values() {
         for symbol in symbol_set {
@@ -3500,27 +3500,23 @@ pub fn trimmed_def_paths(tcx: TyCtxt<'_>, (): ()) -> DefIdMap<Symbol> {
         }
     }
 
-    for_each_def(tcx, |ident, ns, def_id| {
-        use std::collections::hash_map::Entry::{Occupied, Vacant};
-
-        match unique_symbols_rev.entry((ns, ident.name)) {
-            Occupied(mut v) => match v.get() {
-                None => {}
-                Some(existing) => {
-                    if *existing != def_id {
-                        v.insert(None);
-                    }
+    for_each_def(tcx, |ident, ns, def_id| match unique_symbols_rev.entry((ns, ident.name)) {
+        IndexEntry::Occupied(mut v) => match v.get() {
+            None => {}
+            Some(existing) => {
+                if *existing != def_id {
+                    v.insert(None);
                 }
-            },
-            Vacant(v) => {
-                v.insert(Some(def_id));
             }
+        },
+        IndexEntry::Vacant(v) => {
+            v.insert(Some(def_id));
         }
     });
 
     // Put the symbol from all the unique namespace+symbol pairs into `map`.
     let mut map: DefIdMap<Symbol> = Default::default();
-    for ((_, symbol), opt_def_id) in unique_symbols_rev.drain() {
+    for ((_, symbol), opt_def_id) in unique_symbols_rev.drain(..) {
         use std::collections::hash_map::Entry::{Occupied, Vacant};
 
         if let Some(def_id) = opt_def_id {

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -1104,7 +1104,7 @@ pub struct Resolver<'ra, 'tcx> {
     underscore_disambiguator: u32,
 
     /// Maps glob imports to the names of items actually imported.
-    glob_map: FxHashMap<LocalDefId, FxHashSet<Symbol>>,
+    glob_map: FxIndexMap<LocalDefId, FxIndexSet<Symbol>>,
     glob_error: Option<ErrorGuaranteed>,
     visibilities_for_hashing: Vec<(LocalDefId, ty::Visibility)>,
     used_imports: FxHashSet<NodeId>,

--- a/src/tools/clippy/clippy_lints/src/wildcard_imports.rs
+++ b/src/tools/clippy/clippy_lints/src/wildcard_imports.rs
@@ -150,7 +150,7 @@ impl LateLintPass<'_> for WildcardImports {
                 (span, false)
             };
 
-            let mut imports = used_imports.items().map(ToString::to_string).into_sorted_stable_ord();
+            let mut imports: Vec<_> = used_imports.iter().map(ToString::to_string).collect();
             let imports_string = if imports.len() == 1 {
                 imports.pop().unwrap()
             } else if braced_glob {

--- a/src/tools/clippy/tests/ui/wildcard_imports.fixed
+++ b/src/tools/clippy/tests/ui/wildcard_imports.fixed
@@ -16,7 +16,7 @@ use crate::fn_mod::foo;
 //~^ wildcard_imports
 use crate::mod_mod::inner_mod;
 //~^ wildcard_imports
-use crate::multi_fn_mod::{multi_bar, multi_foo, multi_inner_mod};
+use crate::multi_fn_mod::{multi_foo, multi_bar, multi_inner_mod};
 //~^ wildcard_imports
 #[macro_use]
 use crate::struct_mod::{A, inner_struct_mod};
@@ -26,7 +26,7 @@ use crate::struct_mod::{A, inner_struct_mod};
 use wildcard_imports_helper::inner::inner_for_self_import;
 use wildcard_imports_helper::inner::inner_for_self_import::inner_extern_bar;
 //~^ wildcard_imports
-use wildcard_imports_helper::{ExternA, extern_foo};
+use wildcard_imports_helper::{extern_foo, ExternA};
 //~^ wildcard_imports
 
 use std::io::prelude::*;
@@ -138,7 +138,7 @@ mod in_fn_test {
     fn test_extern() {
         use wildcard_imports_helper::inner::inner_for_self_import::{self, inner_extern_foo};
         //~^ wildcard_imports
-        use wildcard_imports_helper::{ExternA, extern_foo};
+        use wildcard_imports_helper::{extern_foo, ExternA};
         //~^ wildcard_imports
 
         inner_for_self_import::inner_extern_foo();
@@ -160,7 +160,7 @@ mod in_fn_test {
     }
 
     fn test_extern_reexported() {
-        use wildcard_imports_helper::{ExternExportedEnum, ExternExportedStruct, extern_exported};
+        use wildcard_imports_helper::{extern_exported, ExternExportedStruct, ExternExportedEnum};
         //~^ wildcard_imports
 
         extern_exported();
@@ -190,7 +190,7 @@ mod in_fn_test {
 }
 
 fn test_reexported() {
-    use crate::in_fn_test::{ExportedEnum, ExportedStruct, exported};
+    use crate::in_fn_test::{exported, ExportedStruct, ExportedEnum};
     //~^ wildcard_imports
 
     exported();

--- a/src/tools/clippy/tests/ui/wildcard_imports.stderr
+++ b/src/tools/clippy/tests/ui/wildcard_imports.stderr
@@ -17,7 +17,7 @@ error: usage of wildcard import
   --> tests/ui/wildcard_imports.rs:19:5
    |
 LL | use crate::multi_fn_mod::*;
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `crate::multi_fn_mod::{multi_bar, multi_foo, multi_inner_mod}`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `crate::multi_fn_mod::{multi_foo, multi_bar, multi_inner_mod}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports.rs:22:5
@@ -35,7 +35,7 @@ error: usage of wildcard import
   --> tests/ui/wildcard_imports.rs:29:5
    |
 LL | use wildcard_imports_helper::*;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{ExternA, extern_foo}`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{extern_foo, ExternA}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports.rs:100:13
@@ -59,7 +59,7 @@ error: usage of wildcard import
   --> tests/ui/wildcard_imports.rs:141:13
    |
 LL |         use wildcard_imports_helper::*;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{ExternA, extern_foo}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{extern_foo, ExternA}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports.rs:154:20
@@ -77,13 +77,13 @@ error: usage of wildcard import
   --> tests/ui/wildcard_imports.rs:163:13
    |
 LL |         use wildcard_imports_helper::*;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{ExternExportedEnum, ExternExportedStruct, extern_exported}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{extern_exported, ExternExportedStruct, ExternExportedEnum}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports.rs:193:9
    |
 LL |     use crate::in_fn_test::*;
-   |         ^^^^^^^^^^^^^^^^^^^^ help: try: `crate::in_fn_test::{ExportedEnum, ExportedStruct, exported}`
+   |         ^^^^^^^^^^^^^^^^^^^^ help: try: `crate::in_fn_test::{exported, ExportedStruct, ExportedEnum}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports.rs:203:9

--- a/src/tools/clippy/tests/ui/wildcard_imports_2021.edition2018.fixed
+++ b/src/tools/clippy/tests/ui/wildcard_imports_2021.edition2018.fixed
@@ -14,7 +14,7 @@ use crate::fn_mod::foo;
 //~^ wildcard_imports
 use crate::mod_mod::inner_mod;
 //~^ wildcard_imports
-use crate::multi_fn_mod::{multi_bar, multi_foo, multi_inner_mod};
+use crate::multi_fn_mod::{multi_foo, multi_bar, multi_inner_mod};
 //~^ wildcard_imports
 use crate::struct_mod::{A, inner_struct_mod};
 //~^ wildcard_imports
@@ -23,7 +23,7 @@ use crate::struct_mod::{A, inner_struct_mod};
 use wildcard_imports_helper::inner::inner_for_self_import::inner_extern_bar;
 //~^ wildcard_imports
 use wildcard_imports_helper::prelude::v1::*;
-use wildcard_imports_helper::{ExternA, extern_foo};
+use wildcard_imports_helper::{extern_foo, ExternA};
 //~^ wildcard_imports
 
 use std::io::prelude::*;
@@ -132,7 +132,7 @@ mod in_fn_test {
     fn test_extern() {
         use wildcard_imports_helper::inner::inner_for_self_import::{self, inner_extern_foo};
         //~^ wildcard_imports
-        use wildcard_imports_helper::{ExternA, extern_foo};
+        use wildcard_imports_helper::{extern_foo, ExternA};
         //~^ wildcard_imports
 
         inner_for_self_import::inner_extern_foo();
@@ -154,7 +154,7 @@ mod in_fn_test {
     }
 
     fn test_extern_reexported() {
-        use wildcard_imports_helper::{ExternExportedEnum, ExternExportedStruct, extern_exported};
+        use wildcard_imports_helper::{extern_exported, ExternExportedStruct, ExternExportedEnum};
         //~^ wildcard_imports
 
         extern_exported();
@@ -184,7 +184,7 @@ mod in_fn_test {
 }
 
 fn test_reexported() {
-    use crate::in_fn_test::{ExportedEnum, ExportedStruct, exported};
+    use crate::in_fn_test::{exported, ExportedStruct, ExportedEnum};
     //~^ wildcard_imports
 
     exported();

--- a/src/tools/clippy/tests/ui/wildcard_imports_2021.edition2018.stderr
+++ b/src/tools/clippy/tests/ui/wildcard_imports_2021.edition2018.stderr
@@ -17,7 +17,7 @@ error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:17:5
    |
 LL | use crate::multi_fn_mod::*;
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `crate::multi_fn_mod::{multi_bar, multi_foo, multi_inner_mod}`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `crate::multi_fn_mod::{multi_foo, multi_bar, multi_inner_mod}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:19:5
@@ -35,7 +35,7 @@ error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:26:5
    |
 LL | use wildcard_imports_helper::*;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{ExternA, extern_foo}`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{extern_foo, ExternA}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:95:13
@@ -59,7 +59,7 @@ error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:135:13
    |
 LL |         use wildcard_imports_helper::*;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{ExternA, extern_foo}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{extern_foo, ExternA}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:148:20
@@ -77,13 +77,13 @@ error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:157:13
    |
 LL |         use wildcard_imports_helper::*;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{ExternExportedEnum, ExternExportedStruct, extern_exported}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{extern_exported, ExternExportedStruct, ExternExportedEnum}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:187:9
    |
 LL |     use crate::in_fn_test::*;
-   |         ^^^^^^^^^^^^^^^^^^^^ help: try: `crate::in_fn_test::{ExportedEnum, ExportedStruct, exported}`
+   |         ^^^^^^^^^^^^^^^^^^^^ help: try: `crate::in_fn_test::{exported, ExportedStruct, ExportedEnum}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:197:9

--- a/src/tools/clippy/tests/ui/wildcard_imports_2021.edition2021.fixed
+++ b/src/tools/clippy/tests/ui/wildcard_imports_2021.edition2021.fixed
@@ -14,7 +14,7 @@ use crate::fn_mod::foo;
 //~^ wildcard_imports
 use crate::mod_mod::inner_mod;
 //~^ wildcard_imports
-use crate::multi_fn_mod::{multi_bar, multi_foo, multi_inner_mod};
+use crate::multi_fn_mod::{multi_foo, multi_bar, multi_inner_mod};
 //~^ wildcard_imports
 use crate::struct_mod::{A, inner_struct_mod};
 //~^ wildcard_imports
@@ -23,7 +23,7 @@ use crate::struct_mod::{A, inner_struct_mod};
 use wildcard_imports_helper::inner::inner_for_self_import::inner_extern_bar;
 //~^ wildcard_imports
 use wildcard_imports_helper::prelude::v1::*;
-use wildcard_imports_helper::{ExternA, extern_foo};
+use wildcard_imports_helper::{extern_foo, ExternA};
 //~^ wildcard_imports
 
 use std::io::prelude::*;
@@ -132,7 +132,7 @@ mod in_fn_test {
     fn test_extern() {
         use wildcard_imports_helper::inner::inner_for_self_import::{self, inner_extern_foo};
         //~^ wildcard_imports
-        use wildcard_imports_helper::{ExternA, extern_foo};
+        use wildcard_imports_helper::{extern_foo, ExternA};
         //~^ wildcard_imports
 
         inner_for_self_import::inner_extern_foo();
@@ -154,7 +154,7 @@ mod in_fn_test {
     }
 
     fn test_extern_reexported() {
-        use wildcard_imports_helper::{ExternExportedEnum, ExternExportedStruct, extern_exported};
+        use wildcard_imports_helper::{extern_exported, ExternExportedStruct, ExternExportedEnum};
         //~^ wildcard_imports
 
         extern_exported();
@@ -184,7 +184,7 @@ mod in_fn_test {
 }
 
 fn test_reexported() {
-    use crate::in_fn_test::{ExportedEnum, ExportedStruct, exported};
+    use crate::in_fn_test::{exported, ExportedStruct, ExportedEnum};
     //~^ wildcard_imports
 
     exported();

--- a/src/tools/clippy/tests/ui/wildcard_imports_2021.edition2021.stderr
+++ b/src/tools/clippy/tests/ui/wildcard_imports_2021.edition2021.stderr
@@ -17,7 +17,7 @@ error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:17:5
    |
 LL | use crate::multi_fn_mod::*;
-   |     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `crate::multi_fn_mod::{multi_bar, multi_foo, multi_inner_mod}`
+   |     ^^^^^^^^^^^^^^^^^^^^^^ help: try: `crate::multi_fn_mod::{multi_foo, multi_bar, multi_inner_mod}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:19:5
@@ -35,7 +35,7 @@ error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:26:5
    |
 LL | use wildcard_imports_helper::*;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{ExternA, extern_foo}`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{extern_foo, ExternA}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:95:13
@@ -59,7 +59,7 @@ error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:135:13
    |
 LL |         use wildcard_imports_helper::*;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{ExternA, extern_foo}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{extern_foo, ExternA}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:148:20
@@ -77,13 +77,13 @@ error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:157:13
    |
 LL |         use wildcard_imports_helper::*;
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{ExternExportedEnum, ExternExportedStruct, extern_exported}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `wildcard_imports_helper::{extern_exported, ExternExportedStruct, ExternExportedEnum}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:187:9
    |
 LL |     use crate::in_fn_test::*;
-   |         ^^^^^^^^^^^^^^^^^^^^ help: try: `crate::in_fn_test::{ExportedEnum, ExportedStruct, exported}`
+   |         ^^^^^^^^^^^^^^^^^^^^ help: try: `crate::in_fn_test::{exported, ExportedStruct, ExportedEnum}`
 
 error: usage of wildcard import
   --> tests/ui/wildcard_imports_2021.rs:197:9


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

This PR removes `#![allow(rustc::potential_query_instability)]` line from [`compiler/rustc_middle/src/lib.rs`](https://github.com/rust-lang/rust/blob/master/compiler/rustc_middle/src/lib.rs#L29) and converts `FxHash{Map,Set}` types into `FxIndex{Map,Set}` to suppress lint errors.

A somewhat tracking issue: https://github.com/rust-lang/rust/issues/84447

r? @compiler-errors 