### PR TITLE
Add `get_line` confusable to `Stdin::read_line()`

### DIFF
--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -394,6 +394,7 @@ impl Stdin {
     ///   in which case it will wait for the Enter key to be pressed before
     ///   continuing
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_confusables("get_line")]
     pub fn read_line(&self, buf: &mut String) -> io::Result<usize> {
         self.lock().read_line(buf)
     }

--- a/tests/ui/attributes/rustc_confusables_std_cases.rs
+++ b/tests/ui/attributes/rustc_confusables_std_cases.rs
@@ -23,4 +23,8 @@ fn main() {
     //~^ HELP you might have meant to use `push_str`
     String::new().append(""); //~ ERROR E0599
     //~^ HELP you might have meant to use `push_str`
+    let mut buffer = String::new();
+    let stdin = std::io::stdin();
+    stdin.get_line(&mut buffer).unwrap(); //~ ERROR E0599
+    //~^ HELP you might have meant to use `read_line`
 }

--- a/tests/ui/attributes/rustc_confusables_std_cases.stderr
+++ b/tests/ui/attributes/rustc_confusables_std_cases.stderr
@@ -106,7 +106,18 @@ help: you might have meant to use `push_str`
 LL |     String::new().push_str("");
    |                   ~~~~~~~~
 
-error: aborting due to 8 previous errors
+error[E0599]: no method named `get_line` found for struct `Stdin` in the current scope
+  --> $DIR/rustc_confusables_std_cases.rs:28:11
+   |
+LL |     stdin.get_line(&mut buffer).unwrap();
+   |           ^^^^^^^^ method not found in `Stdin`
+   |
+help: you might have meant to use `read_line`
+   |
+LL |     stdin.read_line(&mut buffer).unwrap();
+   |           ~~~~~~~~~
+
+error: aborting due to 9 previous errors
 
 Some errors have detailed explanations: E0308, E0599.
 For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r​? <reviewer name>
-->
<!-- homu-ignore:end -->

This pull request resolves https://github.com/rust-lang/rust/issues/131091

---

I've updated tests for `tests/ui/attributes/rustc_confusables_std_cases` in order to verify this change is working as intended.

Before I submitted this pull request, I had a pull request to my local fork. If you're interested in seeing the conversation on that PR, go to https://github.com/JakenHerman/rust/pull/1.

---

**Testing**:
Run `./x.py test tests/ui/attributes/rustc_confusables_std_cases.rs`