### PR TITLE
Fix `target_vendor` in QNX Neutrino targets

### DIFF
--- a/compiler/rustc_target/src/spec/targets/i586_pc_nto_qnx700.rs
+++ b/compiler/rustc_target/src/spec/targets/i586_pc_nto_qnx700.rs
@@ -21,6 +21,7 @@ pub(crate) fn target() -> Target {
                 "-Vgcc_ntox86_cxx",
             ]),
             env: "nto70".into(),
+            vendor: "pc".into(),
             stack_probes: StackProbeType::Inline,
             ..base::nto_qnx::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx710.rs
+++ b/compiler/rustc_target/src/spec/targets/x86_64_pc_nto_qnx710.rs
@@ -21,6 +21,7 @@ pub(crate) fn target() -> Target {
                 "-Vgcc_ntox86_64_cxx",
             ]),
             env: "nto71".into(),
+            vendor: "pc".into(),
             ..base::nto_qnx::opts()
         },
     }


### PR DESCRIPTION
The `x86_64-pc-nto-qnx710` and `i586-pc-nto-qnx700` targets have `pc` in their target triple names, but the vendor was set to the default `"unknown"`.

CC target maintainers @flba-eb, @gh-tr, @jonathanpallant and @japaric
