### PR TITLE
Compiletest: Custom differ

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -420,7 +420,7 @@
 #jobs = 0
 
 # What custom diff tool to use for displaying compiletest tests.
-#compiletest-diff-tool = "difft --color=always --background=light --display=side-by-side"
+#compiletest-diff-tool = <none>
 
 # =============================================================================
 # General install configuration options

--- a/config.example.toml
+++ b/config.example.toml
@@ -420,7 +420,7 @@
 #jobs = 0
 
 # What custom diff tool to use for displaying compiletest tests.
-#display-diff-tool = "difft --color=always --background=light --display=side-by-side"
+#compiletest-diff-tool = "difft --color=always --background=light --display=side-by-side"
 
 # =============================================================================
 # General install configuration options

--- a/config.example.toml
+++ b/config.example.toml
@@ -419,6 +419,9 @@
 # passed to cargo invocations.
 #jobs = 0
 
+# What custom diff tool to use for displaying compiletest tests.
+#display-diff-tool = "difft --color=always --background=light --display=side-by-side"
+
 # =============================================================================
 # General install configuration options
 # =============================================================================

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1834,8 +1834,8 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         if builder.config.cmd.only_modified() {
             cmd.arg("--only-modified");
         }
-        if let Some(display_diff_tool) = &builder.config.display_diff_tool {
-            cmd.arg("--display-diff-tool").arg(display_diff_tool);
+        if let Some(compiletest_diff_tool) = &builder.config.compiletest_diff_tool {
+            cmd.arg("--compiletest-diff-tool").arg(compiletest_diff_tool);
         }
 
         let mut flags = if is_rustdoc { Vec::new() } else { vec!["-Crpath".to_string()] };

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1834,6 +1834,9 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
         if builder.config.cmd.only_modified() {
             cmd.arg("--only-modified");
         }
+        if let Some(display_diff_tool) = &builder.config.display_diff_tool {
+            cmd.arg("--display-diff-tool").arg(display_diff_tool);
+        }
 
         let mut flags = if is_rustdoc { Vec::new() } else { vec!["-Crpath".to_string()] };
         flags.push(format!("-Cdebuginfo={}", builder.config.rust_debuginfo_level_tests));

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -369,8 +369,8 @@ pub struct Config {
     /// `paths=["foo", "bar"]`.
     pub paths: Vec<PathBuf>,
 
-    /// What custom diff tool to use for displaying compiletest tests.
-    pub display_diff_tool: Option<String>,
+    /// Command for visual diff display, e.g. `diff-tool --color=always`.
+    pub compiletest_diff_tool: Option<String>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -895,7 +895,7 @@ define_config! {
         android_ndk: Option<PathBuf> = "android-ndk",
         optimized_compiler_builtins: Option<bool> = "optimized-compiler-builtins",
         jobs: Option<u32> = "jobs",
-        display_diff_tool: Option<String> = "display-diff-tool",
+        compiletest_diff_tool: Option<String> = "compiletest-diff-tool",
     }
 }
 
@@ -1516,7 +1516,7 @@ impl Config {
             android_ndk,
             optimized_compiler_builtins,
             jobs,
-            display_diff_tool,
+            compiletest_diff_tool,
         } = toml.build.unwrap_or_default();
 
         config.jobs = Some(threads_from_config(flags.jobs.unwrap_or(jobs.unwrap_or(0))));
@@ -2163,7 +2163,7 @@ impl Config {
         config.rust_debuginfo_level_tests = debuginfo_level_tests.unwrap_or(DebuginfoLevel::None);
         config.optimized_compiler_builtins =
             optimized_compiler_builtins.unwrap_or(config.channel != "dev");
-        config.display_diff_tool = display_diff_tool;
+        config.compiletest_diff_tool = compiletest_diff_tool;
 
         let download_rustc = config.download_rustc_commit.is_some();
         // See https://github.com/rust-lang/compiler-team/issues/326

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -368,6 +368,9 @@ pub struct Config {
     /// The paths to work with. For example: with `./x check foo bar` we get
     /// `paths=["foo", "bar"]`.
     pub paths: Vec<PathBuf>,
+
+    /// What custom diff tool to use for displaying compiletest tests.
+    pub display_diff_tool: Option<String>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -892,6 +895,7 @@ define_config! {
         android_ndk: Option<PathBuf> = "android-ndk",
         optimized_compiler_builtins: Option<bool> = "optimized-compiler-builtins",
         jobs: Option<u32> = "jobs",
+        display_diff_tool: Option<String> = "display-diff-tool",
     }
 }
 
@@ -1512,6 +1516,7 @@ impl Config {
             android_ndk,
             optimized_compiler_builtins,
             jobs,
+            display_diff_tool,
         } = toml.build.unwrap_or_default();
 
         config.jobs = Some(threads_from_config(flags.jobs.unwrap_or(jobs.unwrap_or(0))));
@@ -2158,6 +2163,7 @@ impl Config {
         config.rust_debuginfo_level_tests = debuginfo_level_tests.unwrap_or(DebuginfoLevel::None);
         config.optimized_compiler_builtins =
             optimized_compiler_builtins.unwrap_or(config.channel != "dev");
+        config.display_diff_tool = display_diff_tool;
 
         let download_rustc = config.download_rustc_commit.is_some();
         // See https://github.com/rust-lang/compiler-team/issues/326

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -280,4 +280,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "Allow setting `--jobs` in config.toml with `build.jobs`.",
     },
+    ChangeInfo {
+        change_id: 131181,
+        severity: ChangeSeverity::Info,
+        summary: "New option `build.compiletest-diff-tool` that adds support for a custom differ for compiletest",
+    },
 ];

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -388,6 +388,7 @@ pub struct Config {
     /// Used by the "needs-profiler-runtime" directive in test files.
     pub profiler_runtime: bool,
 
+    /// Command for visual diff display, e.g. `diff-tool --color=always`.
     pub diff_command: Option<String>,
 }
 

--- a/src/tools/compiletest/src/common.rs
+++ b/src/tools/compiletest/src/common.rs
@@ -387,6 +387,8 @@ pub struct Config {
     /// True if the profiler runtime is enabled for this target.
     /// Used by the "needs-profiler-runtime" directive in test files.
     pub profiler_runtime: bool,
+
+    pub diff_command: Option<String>,
 }
 
 impl Config {

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -176,8 +176,12 @@ pub fn parse_config(args: Vec<String>) -> Config {
             "email address used for finding merge commits",
             "EMAIL",
         )
-        .optopt("", "display-diff-tool", "What custom diff tool to use for displaying compiletest tests.", "COMMAND")
-    ;
+        .optopt(
+            "",
+            "display-diff-tool",
+            "What custom diff tool to use for displaying compiletest tests.",
+            "COMMAND",
+        );
 
     let (argv0, args_) = args.split_first().unwrap();
     if args.len() == 1 || args[1] == "-h" || args[1] == "--help" {

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -364,6 +364,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         git_merge_commit_email: matches.opt_str("git-merge-commit-email").unwrap(),
 
         profiler_runtime: matches.opt_present("profiler-runtime"),
+        diff_command: env::var("COMPILETEST_DIFF_TOOL").ok(),
     }
 }
 

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -175,7 +175,9 @@ pub fn parse_config(args: Vec<String>) -> Config {
             "git-merge-commit-email",
             "email address used for finding merge commits",
             "EMAIL",
-        );
+        )
+        .optopt("", "display-diff-tool", "What custom diff tool to use for displaying compiletest tests.", "COMMAND")
+    ;
 
     let (argv0, args_) = args.split_first().unwrap();
     if args.len() == 1 || args[1] == "-h" || args[1] == "--help" {
@@ -364,7 +366,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         git_merge_commit_email: matches.opt_str("git-merge-commit-email").unwrap(),
 
         profiler_runtime: matches.opt_present("profiler-runtime"),
-        diff_command: env::var("COMPILETEST_DIFF_TOOL").ok(),
+        diff_command: matches.opt_str("display-diff-tool"),
     }
 }
 

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -178,7 +178,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         )
         .optopt(
             "",
-            "display-diff-tool",
+            "compiletest-diff-tool",
             "What custom diff tool to use for displaying compiletest tests.",
             "COMMAND",
         );
@@ -370,7 +370,7 @@ pub fn parse_config(args: Vec<String>) -> Config {
         git_merge_commit_email: matches.opt_str("git-merge-commit-email").unwrap(),
 
         profiler_runtime: matches.opt_present("profiler-runtime"),
-        diff_command: matches.opt_str("display-diff-tool"),
+        diff_command: matches.opt_str("compiletest-diff-tool"),
     }
 }
 

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -2534,7 +2534,7 @@ impl<'test> TestCx<'test> {
                             ));
                         }
                         Ok(output) => {
-                            let output = String::from_utf8_lossy_owned(output.stdout).unwrap();
+                            let output = String::from_utf8_lossy(&output.stdout);
                             print!("{output}");
                         }
                     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This adds support for a custom differ for compiletests. It’s purely visual and helps produce cleaner output when UI tests fail.

I’m using an environment variable for now since it’s experimental and I don’t want to drill the cli arguments all the way down. Also did a bit of general cleanup while I was at it.

This is how it looks [with debug info silenced](https://github.com/rust-lang/rust/pull/131182) (#131182)
`COMPILETEST_DIFF_TOOL="/usr/bin/env difft --color always --background light --display side-by-side" ./x test tests/ui/parser`
![image](https://github.com/user-attachments/assets/f740ce50-7564-4469-be0a-86e24bc50eb8)




