### PR TITLE
compiletest failing tests aren't that noisy by default

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -733,7 +733,9 @@ impl<'test> TestCx<'test> {
                 unexpected.len(),
                 not_found.len()
             ));
-            println!("status: {}\ncommand: {}\n", proc_res.status, proc_res.cmdline);
+            if env::var("COMPILETEST_DEBUG_INFO").is_ok() {
+                println!("status: {}\ncommand: {}\n", proc_res.status, proc_res.cmdline);
+            }
             if !unexpected.is_empty() {
                 println!("{}", "--- unexpected errors (from JSON output) ---".green());
                 for error in &unexpected {
@@ -2730,6 +2732,9 @@ impl ProcRes {
                      ------------------------------------------",
                 )
             }
+        }
+        if env::var("COMPILETEST_DEBUG_INFO").is_err() {
+            return;
         }
 
         println!(


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This suppresses the whole block if the env var is not set.

I don't think that it's very useful to have that information, especially when it's in the middle of other important information.

I'd even suggest pushing all of the duplicate information up or down in order to condense the diffs as much as possible.

![image](https://github.com/user-attachments/assets/c3116110-52da-41cf-ac11-e44b70888c1e)
