### PR TITLE
Avoid ICE in coverage builds with bad `#[coverage(..)]` attributes

### DIFF
--- a/compiler/rustc_mir_transform/src/coverage/query.rs
+++ b/compiler/rustc_mir_transform/src/coverage/query.rs
@@ -63,7 +63,8 @@ fn coverage_attr_on(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
             Some([item]) if item.has_name(sym::on) => return true,
             Some(_) | None => {
                 // Other possibilities should have been rejected by `rustc_parse::validate_attr`.
-                tcx.dcx().span_bug(attr.span, "unexpected value of coverage attribute");
+                // Use `span_delayed_bug` to avoid an ICE in failing builds (#127880).
+                tcx.dcx().span_delayed_bug(attr.span, "unexpected value of coverage attribute");
             }
         }
     }

--- a/tests/crashes/127880.rs
+++ b/tests/crashes/127880.rs
@@ -1,5 +1,0 @@
-//@ known-bug: #127880
-//@ compile-flags: -Cinstrument-coverage
-
-#[coverage]
-fn main() {}

--- a/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
@@ -1,0 +1,15 @@
+error: malformed `coverage` attribute input
+  --> $DIR/bad-attr-ice.rs:10:1
+   |
+LL | #[coverage]
+   | ^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL | #[coverage(off)]
+   |
+LL | #[coverage(on)]
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
@@ -1,0 +1,26 @@
+error: malformed `coverage` attribute input
+  --> $DIR/bad-attr-ice.rs:10:1
+   |
+LL | #[coverage]
+   | ^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL | #[coverage(off)]
+   |
+LL | #[coverage(on)]
+   |
+
+error[E0658]: the `#[coverage]` attribute is an experimental feature
+  --> $DIR/bad-attr-ice.rs:10:1
+   |
+LL | #[coverage]
+   | ^^^^^^^^^^^
+   |
+   = note: see issue #84605 <https://github.com/rust-lang/rust/issues/84605> for more information
+   = help: add `#![feature(coverage_attribute)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/coverage-attr/bad-attr-ice.rs
+++ b/tests/ui/coverage-attr/bad-attr-ice.rs
@@ -1,0 +1,16 @@
+#![cfg_attr(feat, feature(coverage_attribute))]
+//@ revisions: feat nofeat
+//@ compile-flags: -Cinstrument-coverage
+//@ needs-profiler-support
+
+// Malformed `#[coverage(..)]` attributes should not cause an ICE when built
+// with `-Cinstrument-coverage`.
+// Regression test for <https://github.com/rust-lang/rust/issues/127880>.
+
+#[coverage]
+//~^ ERROR malformed `coverage` attribute input
+//[nofeat]~| the `#[coverage]` attribute is an experimental feature
+fn main() {}
+
+// FIXME(#130766): When the `#[coverage(..)]` attribute is stabilized,
+// get rid of the revisions and just make this a normal test.


### PR DESCRIPTION
This code can sometimes witness malformed coverage attributes in builds that are going to fail, so use `span_delayed_bug` to avoid an inappropriate ICE in that case.

Fixes #127880.