### PR TITLE
Handle `rustc_query_impl` cases of `rustc::potential_query_instability` lint

### DIFF
--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -2,7 +2,7 @@
 
 // tidy-alphabetical-start
 #![allow(internal_features)]
-#![allow(rustc::potential_query_instability, unused_parens)]
+#![allow(unused_parens)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(min_specialization)]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This PR removes `#![allow(rustc::potential_query_instability)]` line from [`compiler/rustc_query_impl/src/lib.rs`](https://github.com/rust-lang/rust/blob/master/compiler/rustc_query_impl/src/lib.rs#L5) <s>and converts `FxHash{Map,Set}` types into `FxIndex{Map,Set}` to suppress lint errors</s> (was not necessary for this PR).

A somewhat tracking issue: https://github.com/rust-lang/rust/issues/84447

r? @compiler-errors 