### PR TITLE
Fix needless_lifetimes in stable_mir

### DIFF
--- a/compiler/stable_mir/src/mir/visit.rs
+++ b/compiler/stable_mir/src/mir/visit.rs
@@ -76,9 +76,9 @@ pub trait MirVisitor {
         self.super_place(place, ptx, location)
     }
 
-    fn visit_projection_elem<'a>(
+    fn visit_projection_elem(
         &mut self,
-        place_ref: PlaceRef<'a>,
+        place_ref: PlaceRef<'_>,
         elem: &ProjectionElem,
         ptx: PlaceContext,
         location: Location,


### PR DESCRIPTION
Hi,

This PR fixes the following clippy warning in stable_mir

```
warning: the following explicit lifetimes could be elided: 'a
  --> compiler/stable_mir/src/mir/visit.rs:79:30
   |
79 |     fn visit_projection_elem<'a>(
   |                              ^^
80 |         &mut self,
81 |         place_ref: PlaceRef<'a>,
   |                             ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
   |
79 ~     fn visit_projection_elem(
80 |         &mut self,
81 ~         place_ref: PlaceRef<'_>,
   |
```

Best regards,
Michal

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
