### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabi.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabi.rs
@@ -14,6 +14,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: "arm".into(),
         options: TargetOptions {
+            abi: "eabi".into(),
             linker: Some("arm-kmc-eabi-gcc".into()),
             features: "+v7,+soft-float,+thumb2,-neon".into(),
             relocation_model: RelocModel::Static,

--- a/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabihf.rs
+++ b/compiler/rustc_target/src/spec/targets/armv7a_kmc_solid_asp3_eabihf.rs
@@ -14,6 +14,7 @@ pub(crate) fn target() -> Target {
         data_layout: "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64".into(),
         arch: "arm".into(),
         options: TargetOptions {
+            abi: "eabihf".into(),
             linker: Some("arm-kmc-eabi-gcc".into()),
             features: "+v7,+vfp3,-d32,+thumb2,-neon".into(),
             relocation_model: RelocModel::Static,

--- a/library/std/src/io/stdio.rs
+++ b/library/std/src/io/stdio.rs
@@ -394,6 +394,7 @@ impl Stdin {
     ///   in which case it will wait for the Enter key to be pressed before
     ///   continuing
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_confusables("get_line")]
     pub fn read_line(&self, buf: &mut String) -> io::Result<usize> {
         self.lock().read_line(buf)
     }

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -186,7 +186,6 @@ pub(crate) fn run(
 
                 let mut collector = CreateRunnableDocTests::new(options, opts);
                 let hir_collector = HirCollector::new(
-                    tcx.hir(),
                     ErrorCodes::from(compiler.sess.opts.unstable_features.is_nightly_build()),
                     enable_per_target_ignores,
                     tcx,

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -186,7 +186,6 @@ pub(crate) fn run(
 
                 let mut collector = CreateRunnableDocTests::new(options, opts);
                 let hir_collector = HirCollector::new(
-                    &compiler.sess,
                     tcx.hir(),
                     ErrorCodes::from(compiler.sess.opts.unstable_features.is_nightly_build()),
                     enable_per_target_ignores,

--- a/src/librustdoc/doctest/rust.rs
+++ b/src/librustdoc/doctest/rust.rs
@@ -10,7 +10,6 @@ use rustc_middle::hir::map::Map;
 use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::TyCtxt;
 use rustc_resolve::rustdoc::span_of_fragments;
-use rustc_session::Session;
 use rustc_span::source_map::SourceMap;
 use rustc_span::{BytePos, DUMMY_SP, FileName, Pos, Span};
 
@@ -63,8 +62,7 @@ impl DocTestVisitor for RustCollector {
     fn visit_header(&mut self, _name: &str, _level: u32) {}
 }
 
-pub(super) struct HirCollector<'a, 'tcx> {
-    sess: &'a Session,
+pub(super) struct HirCollector<'tcx> {
     map: Map<'tcx>,
     codes: ErrorCodes,
     tcx: TyCtxt<'tcx>,
@@ -72,21 +70,20 @@ pub(super) struct HirCollector<'a, 'tcx> {
     collector: RustCollector,
 }
 
-impl<'a, 'tcx> HirCollector<'a, 'tcx> {
+impl<'tcx> HirCollector<'tcx> {
     pub fn new(
-        sess: &'a Session,
         map: Map<'tcx>,
         codes: ErrorCodes,
         enable_per_target_ignores: bool,
         tcx: TyCtxt<'tcx>,
     ) -> Self {
         let collector = RustCollector {
-            source_map: sess.psess.clone_source_map(),
+            source_map: tcx.sess.psess.clone_source_map(),
             cur_path: vec![],
             position: DUMMY_SP,
             tests: vec![],
         };
-        Self { sess, map, codes, enable_per_target_ignores, tcx, collector }
+        Self { map, codes, enable_per_target_ignores, tcx, collector }
     }
 
     pub fn collect_crate(mut self) -> Vec<ScrapedDocTest> {
@@ -98,7 +95,7 @@ impl<'a, 'tcx> HirCollector<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> HirCollector<'a, 'tcx> {
+impl<'tcx> HirCollector<'tcx> {
     fn visit_testable<F: FnOnce(&mut Self)>(
         &mut self,
         name: String,
@@ -108,7 +105,7 @@ impl<'a, 'tcx> HirCollector<'a, 'tcx> {
     ) {
         let ast_attrs = self.tcx.hir().attrs(self.tcx.local_def_id_to_hir_id(def_id));
         if let Some(ref cfg) = ast_attrs.cfg(self.tcx, &FxHashSet::default()) {
-            if !cfg.matches(&self.sess.psess, Some(self.tcx.features())) {
+            if !cfg.matches(&self.tcx.sess.psess, Some(self.tcx.features())) {
                 return;
             }
         }
@@ -141,7 +138,7 @@ impl<'a, 'tcx> HirCollector<'a, 'tcx> {
     }
 }
 
-impl<'a, 'tcx> intravisit::Visitor<'tcx> for HirCollector<'a, 'tcx> {
+impl<'tcx> intravisit::Visitor<'tcx> for HirCollector<'tcx> {
     type NestedFilter = nested_filter::All;
 
     fn nested_visit_map(&mut self) -> Self::Map {

--- a/tests/ui/attributes/rustc_confusables_std_cases.rs
+++ b/tests/ui/attributes/rustc_confusables_std_cases.rs
@@ -23,4 +23,8 @@ fn main() {
     //~^ HELP you might have meant to use `push_str`
     String::new().append(""); //~ ERROR E0599
     //~^ HELP you might have meant to use `push_str`
+    let mut buffer = String::new();
+    let stdin = std::io::stdin();
+    stdin.get_line(&mut buffer).unwrap(); //~ ERROR E0599
+    //~^ HELP you might have meant to use `read_line`
 }

--- a/tests/ui/attributes/rustc_confusables_std_cases.stderr
+++ b/tests/ui/attributes/rustc_confusables_std_cases.stderr
@@ -106,7 +106,18 @@ help: you might have meant to use `push_str`
 LL |     String::new().push_str("");
    |                   ~~~~~~~~
 
-error: aborting due to 8 previous errors
+error[E0599]: no method named `get_line` found for struct `Stdin` in the current scope
+  --> $DIR/rustc_confusables_std_cases.rs:28:11
+   |
+LL |     stdin.get_line(&mut buffer).unwrap();
+   |           ^^^^^^^^ method not found in `Stdin`
+   |
+help: you might have meant to use `read_line`
+   |
+LL |     stdin.read_line(&mut buffer).unwrap();
+   |           ~~~~~~~~~
+
+error: aborting due to 9 previous errors
 
 Some errors have detailed explanations: E0308, E0599.
 For more information about an error, try `rustc --explain E0308`.


### PR DESCRIPTION
Successful merges:

 - #130419 (Streamline `HirCollector`)
 - #131163 (Add `get_line` confusable to `Stdin::read_line()`)
 - #131173 (Fix `target_abi` in SOLID targets)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=130419,131163,131173)
<!-- homu-ignore:end -->