### PR TITLE
Avoid emptiness check in `PeekMut::pop`

### DIFF
--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -374,7 +374,10 @@ impl<'a, T: Ord, A: Allocator> PeekMut<'a, T, A> {
             // the caller could've mutated the element. It is removed from the
             // heap on the next line and pop() is not sensitive to its value.
         }
-        this.heap.pop().unwrap()
+
+        // SAFETY: Have a `PeekMut` element proves that the associated binary heap being non-empty,
+        // so the `pop` operation will not fail.
+        unsafe { this.heap.pop().unwrap_unchecked() }
     }
 }
 

--- a/tests/codegen/binary-heap-peek-mut-pop-no-panic.rs
+++ b/tests/codegen/binary-heap-peek-mut-pop-no-panic.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -O
+//@ ignore-debug
+#![crate_type = "lib"]
+
+use std::collections::binary_heap::PeekMut;
+
+// CHECK-LABEL: @peek_mut_pop
+#[no_mangle]
+pub fn peek_mut_pop(peek_mut: PeekMut<u32>) -> u32 {
+    // CHECK-NOT: panic
+    // CHECK-NOT: unwrap_failed
+    PeekMut::pop(peek_mut)
+}


### PR DESCRIPTION
This PR avoids an unnecessary emptiness check in `PeekMut::pop` by replacing `Option::unwrap` with `Option::unwrap_unchecked`.