### PR TITLE
ci: aarch64-gnu-debug job

### DIFF
--- a/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
@@ -1,0 +1,58 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  ninja-build \
+  file \
+  curl \
+  ca-certificates \
+  python3 \
+  python3-dev \
+  libxml2-dev \
+  libncurses-dev \
+  libedit-dev \
+  swig \
+  doxygen \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  libssl-dev \
+  pkg-config \
+  xz-utils \
+  lld \
+  clang \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS 1
+ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
+
+# llvm.use-linker conflicts with downloading CI LLVM
+ENV NO_DOWNLOAD_CI_LLVM 1
+
+ENV RUST_CONFIGURE_ARGS \
+      --build=aarch64-unknown-linux-gnu \
+      --enable-debug \
+      --enable-lld \
+      --set llvm.use-linker=lld \
+      --set target.aarch64-unknown-linux-gnu.linker=clang \
+      --set target.aarch64-unknown-linux-gnu.cc=clang \
+      --set target.aarch64-unknown-linux-gnu.cxx=clang++
+
+# This job appears to be checking two separate things:
+# - That we can build the compiler with `--enable-debug`
+#   (without necessarily testing the result).
+# - That the tests with `//@ needs-force-clang-based-tests` pass, since they
+#   don't run by default unless RUSTBUILD_FORCE_CLANG_BASED_TESTS is set.
+#   - FIXME(https://github.com/rust-lang/rust/pull/126155#issuecomment-2156314273):
+#     Currently we only run the subset of tests with "clang" in their name.
+#   - See also FIXME(#132034)
+
+ENV SCRIPT \
+  python3 ../x.py --stage 2 build && \
+  python3 ../x.py --stage 2 test tests/run-make --test-args clang

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -123,6 +123,9 @@ auto:
   - image: aarch64-gnu
     <<: *job-aarch64-linux
 
+  - image: aarch64-gnu-debug
+    <<: *job-aarch64-linux
+
   - image: arm-android
     <<: *job-linux-4c
 

--- a/tests/run-make/cross-lang-lto-clang/rmake.rs
+++ b/tests/run-make/cross-lang-lto-clang/rmake.rs
@@ -9,6 +9,24 @@
 
 use run_make_support::{clang, env_var, llvm_ar, llvm_objdump, rustc, static_lib_name};
 
+#[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+static RUST_ALWAYS_INLINED_PATTERN: &'static str = "bl.*<rust_always_inlined>";
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+static RUST_ALWAYS_INLINED_PATTERN: &'static str = "call.*rust_always_inlined";
+#[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+static C_ALWAYS_INLINED_PATTERN: &'static str = "bl.*<c_always_inlined>";
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+static C_ALWAYS_INLINED_PATTERN: &'static str = "call.*c_always_inlined";
+
+#[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+static RUST_NEVER_INLINED_PATTERN: &'static str = "bl.*<rust_never_inlined>";
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+static RUST_NEVER_INLINED_PATTERN: &'static str = "call.*rust_never_inlined";
+#[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+static C_NEVER_INLINED_PATTERN: &'static str = "bl.*<c_never_inlined>";
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+static C_NEVER_INLINED_PATTERN: &'static str = "call.*c_never_inlined";
+
 fn main() {
     rustc()
         .linker_plugin_lto("on")
@@ -31,14 +49,14 @@ fn main() {
         .disassemble()
         .input("cmain")
         .run()
-        .assert_stdout_not_contains_regex("call.*rust_always_inlined");
+        .assert_stdout_not_contains_regex(RUST_ALWAYS_INLINED_PATTERN);
     // As a sanity check, make sure we do find a call instruction to a
     // non-inlined function
     llvm_objdump()
         .disassemble()
         .input("cmain")
         .run()
-        .assert_stdout_contains_regex("call.*rust_never_inlined");
+        .assert_stdout_contains_regex(RUST_NEVER_INLINED_PATTERN);
     clang().input("clib.c").lto("thin").arg("-c").out_exe("clib.o").arg("-O2").run();
     llvm_ar().obj_to_ar().output_input(static_lib_name("xyz"), "clib.o").run();
     rustc()
@@ -53,10 +71,10 @@ fn main() {
         .disassemble()
         .input("rsmain")
         .run()
-        .assert_stdout_not_contains_regex("call.*c_always_inlined");
+        .assert_stdout_not_contains_regex(C_ALWAYS_INLINED_PATTERN);
     llvm_objdump()
         .disassemble()
         .input("rsmain")
         .run()
-        .assert_stdout_contains_regex("call.*c_never_inlined");
+        .assert_stdout_contains_regex(C_NEVER_INLINED_PATTERN);
 }

--- a/tests/run-make/pointer-auth-link-with-c-lto-clang/rmake.rs
+++ b/tests/run-make/pointer-auth-link-with-c-lto-clang/rmake.rs
@@ -1,0 +1,36 @@
+// `-Z branch protection` is an unstable compiler feature which adds pointer-authentication
+// code (PAC), a useful hashing measure for verifying that pointers have not been modified.
+// This test checks that compilation and execution is successful when this feature is activated,
+// with some of its possible extra arguments (bti, pac-ret, leaf) when doing LTO.
+// See https://github.com/rust-lang/rust/pull/88354
+
+//@ needs-force-clang-based-tests
+//@ only-aarch64
+// Reason: branch protection is not supported on other architectures
+//@ ignore-cross-compile
+// Reason: the compiled binary is executed
+
+use run_make_support::{clang, env_var, llvm_ar, run, rustc, static_lib_name};
+
+fn main() {
+    clang()
+        .arg("-v")
+        .lto("thin")
+        .arg("-mbranch-protection=bti+pac-ret+leaf")
+        .arg("-O2")
+        .arg("-c")
+        .out_exe("test.o")
+        .input("test.c")
+        .run();
+    llvm_ar().obj_to_ar().output_input(static_lib_name("test"), "test.o").run();
+    rustc()
+        .linker_plugin_lto("on")
+        .opt_level("2")
+        .linker(&env_var("CLANG"))
+        .link_arg("-fuse-ld=lld")
+        .arg("-Zbranch-protection=bti,pac-ret,leaf")
+        .input("test.rs")
+        .output("test.bin")
+        .run();
+    run("test.bin");
+}

--- a/tests/run-make/pointer-auth-link-with-c-lto-clang/test.c
+++ b/tests/run-make/pointer-auth-link-with-c-lto-clang/test.c
@@ -1,0 +1,1 @@
+int foo() { return 0; }

--- a/tests/run-make/pointer-auth-link-with-c-lto-clang/test.rs
+++ b/tests/run-make/pointer-auth-link-with-c-lto-clang/test.rs
@@ -1,0 +1,10 @@
+#[link(name = "test")]
+extern "C" {
+    fn foo() -> i32;
+}
+
+fn main() {
+    unsafe {
+        foo();
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

- Adds a new CI job which checks that the compiler builds with `--enable-debug` and tests that `needs-force-clang-based-tests` pass (where cross-language LTO is tested).
- Add a test confirming that `-Zbranch-protection=pac-ret` and cross-language LTO work together.

r? @Mark-Simulacrum 

try-job: aarch64-gnu-debug