### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,4 +90,9 @@ tests/rustdoc-gui/src/**.lock
 .envrc
 .direnv/
 
+## nix
+flake.nix
+flake.lock
+default.nix
+
 # Before adding new lines, see the comment at the top.

--- a/.gitignore
+++ b/.gitignore
@@ -86,4 +86,8 @@ package.json
 ## Rustdoc GUI tests
 tests/rustdoc-gui/src/**.lock
 
+## direnv
+.envrc
+.direnv/
+
 # Before adding new lines, see the comment at the top.

--- a/compiler/rustc_middle/src/ty/consts/int.rs
+++ b/compiler/rustc_middle/src/ty/consts/int.rs
@@ -398,6 +398,11 @@ impl ScalarInt {
     pub fn to_f128(self) -> Quad {
         self.to_float()
     }
+
+    #[inline]
+    pub fn bitwise_not(self) -> Self {
+        Self { data: self.size().truncate(!self.data), size: self.size }
+    }
 }
 
 macro_rules! from_x_for_scalar_int {

--- a/compiler/rustc_mir_transform/src/coverage/query.rs
+++ b/compiler/rustc_mir_transform/src/coverage/query.rs
@@ -63,7 +63,8 @@ fn coverage_attr_on(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
             Some([item]) if item.has_name(sym::on) => return true,
             Some(_) | None => {
                 // Other possibilities should have been rejected by `rustc_parse::validate_attr`.
-                tcx.dcx().span_bug(attr.span, "unexpected value of coverage attribute");
+                // Use `span_delayed_bug` to avoid an ICE in failing builds (#127880).
+                tcx.dcx().span_delayed_bug(attr.span, "unexpected value of coverage attribute");
             }
         }
     }

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -150,10 +150,8 @@ impl Condition {
     }
 
     fn inv(mut self) -> Self {
-        self.polarity = match self.polarity {
-            Polarity::Eq => Polarity::Ne,
-            Polarity::Ne => Polarity::Eq,
-        };
+        self.value = self.value.bitwise_not();
+
         self
     }
 }

--- a/compiler/rustc_query_impl/src/lib.rs
+++ b/compiler/rustc_query_impl/src/lib.rs
@@ -2,7 +2,7 @@
 
 // tidy-alphabetical-start
 #![allow(internal_features)]
-#![allow(rustc::potential_query_instability, unused_parens)]
+#![allow(unused_parens)]
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(min_specialization)]

--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -374,7 +374,10 @@ impl<'a, T: Ord, A: Allocator> PeekMut<'a, T, A> {
             // the caller could've mutated the element. It is removed from the
             // heap on the next line and pop() is not sensitive to its value.
         }
-        this.heap.pop().unwrap()
+
+        // SAFETY: Have a `PeekMut` element proves that the associated binary heap being non-empty,
+        // so the `pop` operation will not fail.
+        unsafe { this.heap.pop().unwrap_unchecked() }
     }
 }
 

--- a/tests/codegen/binary-heap-peek-mut-pop-no-panic.rs
+++ b/tests/codegen/binary-heap-peek-mut-pop-no-panic.rs
@@ -1,0 +1,13 @@
+//@ compile-flags: -O
+//@ ignore-debug
+#![crate_type = "lib"]
+
+use std::collections::binary_heap::PeekMut;
+
+// CHECK-LABEL: @peek_mut_pop
+#[no_mangle]
+pub fn peek_mut_pop(peek_mut: PeekMut<u32>) -> u32 {
+    // CHECK-NOT: panic
+    // CHECK-NOT: unwrap_failed
+    PeekMut::pop(peek_mut)
+}

--- a/tests/crashes/127880.rs
+++ b/tests/crashes/127880.rs
@@ -1,5 +1,0 @@
-//@ known-bug: #127880
-//@ compile-flags: -Cinstrument-coverage
-
-#[coverage]
-fn main() {}

--- a/tests/mir-opt/jump_threading.not_int.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.not_int.JumpThreading.panic-abort.diff
@@ -1,0 +1,46 @@
+- // MIR for `not_int` before JumpThreading
++ // MIR for `not_int` after JumpThreading
+  
+  fn not_int() -> i32 {
+      let mut _0: i32;
+      let _1: i32;
+      let mut _2: bool;
+      let mut _3: i32;
+      let mut _4: i32;
+      scope 1 {
+          debug a => _1;
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          _1 = const 1_i32;
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = copy _1;
+          _3 = Not(move _4);
+          StorageDead(_4);
+          _2 = Eq(move _3, const 0_i32);
+-         switchInt(move _2) -> [0: bb2, otherwise: bb1];
++         goto -> bb1;
+      }
+  
+      bb1: {
+          StorageDead(_3);
+          _0 = const 1_i32;
+          goto -> bb3;
+      }
+  
+      bb2: {
+          StorageDead(_3);
+          _0 = const 0_i32;
+          goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_2);
+          StorageDead(_1);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/jump_threading.not_int.JumpThreading.panic-abort.diff
+++ b/tests/mir-opt/jump_threading.not_int.JumpThreading.panic-abort.diff
@@ -22,7 +22,7 @@
           StorageDead(_4);
           _2 = Eq(move _3, const 0_i32);
 -         switchInt(move _2) -> [0: bb2, otherwise: bb1];
-+         goto -> bb1;
++         goto -> bb2;
       }
   
       bb1: {

--- a/tests/mir-opt/jump_threading.not_int.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.not_int.JumpThreading.panic-unwind.diff
@@ -1,0 +1,46 @@
+- // MIR for `not_int` before JumpThreading
++ // MIR for `not_int` after JumpThreading
+  
+  fn not_int() -> i32 {
+      let mut _0: i32;
+      let _1: i32;
+      let mut _2: bool;
+      let mut _3: i32;
+      let mut _4: i32;
+      scope 1 {
+          debug a => _1;
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          _1 = const 1_i32;
+          StorageLive(_2);
+          StorageLive(_3);
+          StorageLive(_4);
+          _4 = copy _1;
+          _3 = Not(move _4);
+          StorageDead(_4);
+          _2 = Eq(move _3, const 0_i32);
+-         switchInt(move _2) -> [0: bb2, otherwise: bb1];
++         goto -> bb1;
+      }
+  
+      bb1: {
+          StorageDead(_3);
+          _0 = const 1_i32;
+          goto -> bb3;
+      }
+  
+      bb2: {
+          StorageDead(_3);
+          _0 = const 0_i32;
+          goto -> bb3;
+      }
+  
+      bb3: {
+          StorageDead(_2);
+          StorageDead(_1);
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/jump_threading.not_int.JumpThreading.panic-unwind.diff
+++ b/tests/mir-opt/jump_threading.not_int.JumpThreading.panic-unwind.diff
@@ -22,7 +22,7 @@
           StorageDead(_4);
           _2 = Eq(move _3, const 0_i32);
 -         switchInt(move _2) -> [0: bb2, otherwise: bb1];
-+         goto -> bb1;
++         goto -> bb2;
       }
   
       bb1: {

--- a/tests/mir-opt/jump_threading.rs
+++ b/tests/mir-opt/jump_threading.rs
@@ -533,7 +533,13 @@ fn floats() -> u32 {
 
 fn not_int() -> i32 {
     // CHECK-LABEL: fn not_int(
+    // CHECK: goto -> bb2
 
+    // CHECK-LABEL: bb1: {
+    // _0 = const 1_i32;
+
+    // CHECK-LABEL: bb2: {
+    // _0 = const 0_i32;
     // Test for issue #131195, where !a == b is assumed to be equivalent to a != b
     // This is only the case for bools
     let a = 1;

--- a/tests/mir-opt/jump_threading.rs
+++ b/tests/mir-opt/jump_threading.rs
@@ -531,6 +531,15 @@ fn floats() -> u32 {
     if x == 0.0 { 0 } else { 1 }
 }
 
+fn not_int() -> i32 {
+    // CHECK-LABEL: fn not_int(
+
+    // Test for issue #131195, where !a == b is assumed to be equivalent to a != b
+    // This is only the case for bools
+    let a = 1;
+    if !a == 0 { 1 } else { 0 }
+}
+
 fn main() {
     // CHECK-LABEL: fn main(
     too_complex(Ok(0));
@@ -546,6 +555,7 @@ fn main() {
     aggregate(7);
     assume(7, false);
     floats();
+    not_int();
 }
 
 // EMIT_MIR jump_threading.too_complex.JumpThreading.diff
@@ -562,3 +572,4 @@ fn main() {
 // EMIT_MIR jump_threading.assume.JumpThreading.diff
 // EMIT_MIR jump_threading.aggregate_copy.JumpThreading.diff
 // EMIT_MIR jump_threading.floats.JumpThreading.diff
+// EMIT_MIR jump_threading.not_int.JumpThreading.diff

--- a/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-unwind.mir
+++ b/tests/mir-opt/pre-codegen/checked_ops.step_forward.PreCodegen.after.panic-unwind.mir
@@ -33,7 +33,7 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
         StorageLive(_4);
         StorageLive(_3);
         _3 = Gt(copy _2, const 65535_usize);
-        switchInt(move _3) -> [0: bb1, otherwise: bb5];
+        switchInt(move _3) -> [0: bb1, otherwise: bb6];
     }
 
     bb1: {
@@ -54,27 +54,30 @@ fn step_forward(_1: u16, _2: usize) -> u16 {
     bb3: {
         StorageDead(_5);
         StorageDead(_6);
-        StorageDead(_7);
-        goto -> bb7;
+        goto -> bb5;
     }
 
     bb4: {
         StorageDead(_5);
         StorageDead(_6);
-        StorageDead(_7);
-        goto -> bb6;
+        goto -> bb5;
     }
 
     bb5: {
-        StorageDead(_3);
-        goto -> bb6;
+        StorageDead(_7);
+        goto -> bb7;
     }
 
     bb6: {
-        assert(!const true, "attempt to compute `{} + {}`, which would overflow", const core::num::<impl u16>::MAX, const 1_u16) -> [success: bb7, unwind continue];
+        StorageDead(_3);
+        goto -> bb7;
     }
 
     bb7: {
+        assert(!const true, "attempt to compute `{} + {}`, which would overflow", const core::num::<impl u16>::MAX, const 1_u16) -> [success: bb8, unwind continue];
+    }
+
+    bb8: {
         StorageLive(_8);
         _8 = copy _2 as u16 (IntToInt);
         _0 = Add(copy _1, copy _8);

--- a/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.feat.stderr
@@ -1,0 +1,15 @@
+error: malformed `coverage` attribute input
+  --> $DIR/bad-attr-ice.rs:10:1
+   |
+LL | #[coverage]
+   | ^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL | #[coverage(off)]
+   |
+LL | #[coverage(on)]
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.nofeat.stderr
@@ -1,0 +1,26 @@
+error: malformed `coverage` attribute input
+  --> $DIR/bad-attr-ice.rs:10:1
+   |
+LL | #[coverage]
+   | ^^^^^^^^^^^
+   |
+help: the following are the possible correct uses
+   |
+LL | #[coverage(off)]
+   |
+LL | #[coverage(on)]
+   |
+
+error[E0658]: the `#[coverage]` attribute is an experimental feature
+  --> $DIR/bad-attr-ice.rs:10:1
+   |
+LL | #[coverage]
+   | ^^^^^^^^^^^
+   |
+   = note: see issue #84605 <https://github.com/rust-lang/rust/issues/84605> for more information
+   = help: add `#![feature(coverage_attribute)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/coverage-attr/bad-attr-ice.rs
+++ b/tests/ui/coverage-attr/bad-attr-ice.rs
@@ -1,0 +1,16 @@
+#![cfg_attr(feat, feature(coverage_attribute))]
+//@ revisions: feat nofeat
+//@ compile-flags: -Cinstrument-coverage
+//@ needs-profiler-support
+
+// Malformed `#[coverage(..)]` attributes should not cause an ICE when built
+// with `-Cinstrument-coverage`.
+// Regression test for <https://github.com/rust-lang/rust/issues/127880>.
+
+#[coverage]
+//~^ ERROR malformed `coverage` attribute input
+//[nofeat]~| the `#[coverage]` attribute is an experimental feature
+fn main() {}
+
+// FIXME(#130766): When the `#[coverage(..)]` attribute is stabilized,
+// get rid of the revisions and just make this a normal test.


### PR DESCRIPTION
Successful merges:

 - #131176 (.gitignore files for nix)
 - #131187 (Avoid ICE in coverage builds with bad `#[coverage(..)]` attributes)
 - #131192 (Handle `rustc_query_impl` cases of `rustc::potential_query_instability` lint)
 - #131197 (Avoid emptiness check in `PeekMut::pop`)
 - #131203 (JumpThreading: fix bitwise not on non-booleans)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131176,131187,131192,131197,131203)
<!-- homu-ignore:end -->