### PR TITLE
Update compiler-builtins to 0.1.132

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.130"
+version = "0.1.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64c30475571756801eff60a811520c3d18e0ceb9c56c97bad2047ae601f6709"
+checksum = "88f58330b127df19326d19e9debbb722578589cb1b9c061b5cdc4036d038b54b"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { version = "0.1.130", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "0.1.132", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "0.1.130" }
+compiler_builtins = { version = "0.1.132" }
 profiler_builtins = { path = "../profiler_builtins", optional = true }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.15", default-features = false, features = [


### PR DESCRIPTION
This commit updates compiler-builtins from 0.1.130 to 0.1.132.

PRs in the delta:
 - rust-lang/compiler-builtins#698
 - rust-lang/compiler-builtins#699
 - rust-lang/compiler-builtins#701
 - rust-lang/compiler-builtins#704
 - rust-lang/compiler-builtins#627
 - rust-lang/compiler-builtins#706