### PR TITLE
remove blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,4 +1,0 @@
----
-name: Blank Issue
-about: Create a blank issue.
----


### PR DESCRIPTION
r? @Noratrieb 

So there are currently two blank issue templates. One called "Blank Issue" and one called "Blank issue". Wildly different, of course. It seems that one is auto generated by GitHub, while the other one has an explicit template for it. This removes the explicit one so there's only one "Blank [iI]ssue" in the list. Unfortunately, the only way to test if it works is merging this and finding out, but it seems obvious that it would work.

![image](https://github.com/user-attachments/assets/f802ca88-a80f-48e8-9aff-4008ec030dfa)
