### PR TITLE
Enable `--no-sandbox` option by default for rustdoc GUI tests

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -100,4 +100,4 @@ RUN /scripts/build-gccjit.sh /scripts
 # the local version of the package is different than the one used by the CI.
 ENV SCRIPT /tmp/checktools.sh ../x.py && \
   npm install browser-ui-test@$(head -n 1 /tmp/browser-ui-test.version) --unsafe-perm=true && \
-  python3 ../x.py test tests/rustdoc-gui --stage 2 --test-args "'--no-sandbox --jobs 1'"
+  python3 ../x.py test tests/rustdoc-gui --stage 2 --test-args "'--jobs 1'"

--- a/tests/rustdoc-gui/README.md
+++ b/tests/rustdoc-gui/README.md
@@ -23,12 +23,5 @@ $ ./x.py test tests/rustdoc-gui --stage 1 --test-args --no-headless
 
 To see the supported options, use `--help`.
 
-Important to be noted: if the chromium instance crashes when you run it, you might need to
-use `--no-sandbox` to make it work:
-
-```bash
-$ ./x.py test tests/rustdoc-gui --stage 1 --test-args --no-sandbox
-```
-
 [browser-ui-test]: https://github.com/GuillaumeGomez/browser-UI-test/
 [puppeteer]: https://pptr.dev/


### PR DESCRIPTION
It's apparently common enough for people to have issues with the `sandbox` mode in chromium, so better disable it by default.

r? @notriddle 