### PR TITLE
std: fix stdout-before-main

### DIFF
--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -102,9 +102,24 @@ unsafe fn init(argc: isize, argv: *const *const u8, sigpipe: u8) {
         sys::init(argc, argv, sigpipe)
     };
 
-    // Set up the current thread to give it the right name.
-    let thread = Thread::new_main();
-    thread::set_current(thread);
+    // Set up the current thread handle to give it the right name.
+    //
+    // When code running before main uses `ReentrantLock` (for example by
+    // using `println!`), the thread ID can become initialized before we
+    // create this handle. Since `set_current` fails when the ID of the
+    // handle does not match the current ID, we should attempt to use the
+    // current thread ID here instead of unconditionally creating a new
+    // one. Also see #130210.
+    let thread = Thread::new_main(thread::current_id());
+    if let Err(_thread) = thread::set_current(thread) {
+        // `thread::current` will create a new handle if none has been set yet.
+        // Thus, if someone uses it before main, this call will fail. That's a
+        // bad idea though, as we then cannot set the main thread name here.
+        //
+        // FIXME: detect the main thread in `thread::current` and use the
+        //        correct name there.
+        rtabort!("code running before main must not use thread::current");
+    }
 }
 
 /// Clean up the thread-local runtime state. This *should* be run after all other

--- a/tests/ui/runtime/stdout-before-main.rs
+++ b/tests/ui/runtime/stdout-before-main.rs
@@ -1,0 +1,24 @@
+//@ run-pass
+//@ check-run-results
+//@ only-gnu
+//@ only-linux
+//
+// Regression test for #130210.
+// .init_array doesn't work everywhere, so we limit the test to just GNU/Linux.
+
+use std::ffi::c_int;
+use std::thread;
+
+#[used]
+#[link_section = ".init_array"]
+static INIT: extern "C" fn(c_int, *const *const u8, *const *const u8) = {
+    extern "C" fn init(_argc: c_int, _argv: *const *const u8, _envp: *const *const u8) {
+        print!("Hello from before ");
+    }
+
+    init
+};
+
+fn main() {
+    println!("{}!", thread::current().name().unwrap());
+}

--- a/tests/ui/runtime/stdout-before-main.run.stdout
+++ b/tests/ui/runtime/stdout-before-main.run.stdout
@@ -1,0 +1,1 @@
+Hello from before main!


### PR DESCRIPTION
Fixes #130210.

Since #124881, `ReentrantLock` uses `ThreadId` to identify threads. This has the unfortunate consequence of breaking uses of `Stdout` before main: Locking the `ReentrantLock` that synchronizes the output will initialize the thread ID before the handle for the main thread is set in `rt::init`. But since that would overwrite the current thread ID, `thread::set_current` triggers an abort.

This PR fixes the problem by using the already initialized thread ID for constructing the main thread handle and allowing `set_current` calls that do not change the thread's ID.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
