### PR TITLE
Use jemalloc and lto on musl builds

### DIFF
--- a/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-x86_64-musl/Dockerfile
@@ -42,6 +42,9 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-profiler \
       --enable-lld \
       --set target.x86_64-unknown-linux-musl.crt-static=false \
+      --set rust.jemalloc \
+      --set rust.lto=thin \
+      --set rust.codegen-units=1 \
       --build $HOSTS
 
 # Newer binutils broke things on some vms/distros (i.e., linking against


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This is just a placeholder for now, sorry for the noise if a draft pull isn't okay for this.

[Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler/topic/Why.20is.20rustc.20on.20Alpine.20so.20much.20slower.20and.20can.20it.20be.20fixed.3F) for reference.

try-job: dist-x86_64-musl