### PR TITLE
[rustdoc] Fix list margins

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -961,10 +961,13 @@ pre, .rustdoc.src .example-wrap, .example-wrap .src-line-numbers {
 }
 
 .docblock li {
-	margin-bottom: .8em;
+	margin-bottom: .4em;
 }
-.docblock li p {
-	margin-bottom: .1em;
+.docblock li p:not(:last-child) {
+	/* This margin is voluntarily smaller than `.docblock li` to keep the visual
+	   list element items separated while also having a visual separation (although
+	   smaller) for paragraphs. */
+	margin-bottom: .3em;
 }
 
 /* "where ..." clauses with block display are also smaller */

--- a/tests/rustdoc-gui/list-margins.goml
+++ b/tests/rustdoc-gui/list-margins.goml
@@ -1,0 +1,11 @@
+// This test ensures that the documentation list markers are correctly placed.
+// It also serves as a regression test for <https://github.com/rust-lang/rust/issues/130622>.
+
+go-to: "file://" + |DOC_PATH| + "/test_docs/long_list/index.html"
+show-text: true
+
+// 0.3em
+assert-css: (".docblock li p:not(last-child)", {"margin-bottom": "4.8px"})
+assert-css: (".docblock li p + p:last-child", {"margin-bottom": "0px"})
+// 0.4em
+assert-css: (".docblock li", {"margin-bottom": "6.4px"})

--- a/tests/rustdoc-gui/src/test_docs/lib.rs
+++ b/tests/rustdoc-gui/src/test_docs/lib.rs
@@ -628,3 +628,27 @@ pub mod short_docs {
     /// subt_vec_num(x: &[f64], y: f64)
     pub fn subt_vec_num() {}
 }
+
+pub mod long_list {
+    //! bla
+    //!
+    //! * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque et libero ut leo
+    //!   interdum laoreet vitae a mi. Aliquam erat volutpat. Suspendisse volutpat non quam non
+    //!   commodo.
+    //!
+    //!   Praesent enim neque, imperdiet sed nisl at, lobortis egestas augue. Sed vitae tristique
+    //!   augue. Phasellus vel pretium lectus.
+    //! * Praesent enim neque, imperdiet sed nisl at, lobortis egestas augue. Sed vitae tristique
+    //!   augue. Phasellus vel pretium lectus.
+    //! * Praesent enim neque, imperdiet sed nisl at, lobortis egestas augue. Sed vitae tristique
+    //!   augue. Phasellus vel pretium lectus.
+    //!
+    //! Another list:
+    //!
+    //! * [`TryFromBytes`](#a) indicates that a type may safely be converted from certain byte
+    //!   sequence (conditional on runtime checks)
+    //! * [`FromZeros`](#a) indicates that a sequence of zero bytes represents a valid instance of
+    //!   a type
+    //! * [`FromBytes`](#a) indicates that a type may safely be converted from an arbitrary byte
+    //!   sequence
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/131106.
Fixes #131223.

Follow-up of  #130933.

This PR changes the display as follow: the margin between list items is reduced by half to ensure that they visually still seem part of the same list, while also being bigger than previously which improves display for list items with more than one paragragh. Paragraphs also get they bottom margin reduced to a little bit less than the list items bottom margin for two reasons:
1. The list items keep having the biggest bottom margin which makes it better for coherency.
2. The paragraphs are still visually separated but they don't "overcome" the list.

| before | after |
|-|-|
| ![Screenshot from 2024-10-04 17-58-51](https://github.com/user-attachments/assets/3fdc1472-781e-435d-a0d7-012f43aa8fb8) | ![image](https://github.com/user-attachments/assets/0366313d-416f-4f04-b905-bb16c54f4528) |

Can be tested [here](https://rustdoc.crud.net/imperio/fix-list-margins/doc/test_docs/long_list/index.html).

r? @notriddle 