### PR TITLE
library: Const-stabilize `MaybeUninit::assume_init_mut`

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -131,7 +131,6 @@
 #![feature(const_ipv6)]
 #![feature(const_likely)]
 #![feature(const_make_ascii)]
-#![feature(const_maybe_uninit_assume_init)]
 #![feature(const_nonnull_new)]
 #![feature(const_num_midpoint)]
 #![feature(const_option)]

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -913,7 +913,11 @@ impl<T> MaybeUninit<T> {
     /// };
     /// ```
     #[stable(feature = "maybe_uninit_ref", since = "1.55.0")]
-    #[rustc_const_unstable(feature = "const_maybe_uninit_assume_init", issue = "none")]
+    #[cfg_attr(bootstrap, rustc_allow_const_fn_unstable(const_mut_refs))]
+    #[rustc_const_stable(
+        feature = "const_maybe_uninit_assume_init",
+        since = "CURRENT_RUSTC_VERSION"
+    )]
     #[inline(always)]
     pub const unsafe fn assume_init_mut(&mut self) -> &mut T {
         // SAFETY: the caller must guarantee that `self` is initialized.
@@ -999,7 +1003,8 @@ impl<T> MaybeUninit<T> {
     ///
     /// [`assume_init_mut`]: MaybeUninit::assume_init_mut
     #[unstable(feature = "maybe_uninit_slice", issue = "63569")]
-    #[rustc_const_unstable(feature = "const_maybe_uninit_assume_init", issue = "none")]
+    #[cfg_attr(bootstrap, rustc_allow_const_fn_unstable(const_mut_refs))]
+    #[rustc_const_unstable(feature = "maybe_uninit_slice", issue = "63569")]
     #[inline(always)]
     pub const unsafe fn slice_assume_init_mut(slice: &mut [Self]) -> &mut [T] {
         // SAFETY: similar to safety notes for `slice_get_ref`, but we have a


### PR DESCRIPTION
FCP completed in https://github.com/rust-lang/rust/issues/86722#issuecomment-2393954459

<!-- homu-ignore:start -->
- Closes https://github.com/rust-lang/rust/issues/86722
- Relnotes in https://github.com/rust-lang/rust/issues/131252
<!-- homu-ignore:end -->

Also moves const-ness of an unstable fn under the `maybe_uninit_slice` gate, Cc https://github.com/rust-lang/rust/issues/63569