### PR TITLE
[WIP] compiler: dont try to compile impossible alignment on 16-bit

### DIFF
--- a/compiler/rustc_ty_utils/src/layout.rs
+++ b/compiler/rustc_ty_utils/src/layout.rs
@@ -6,6 +6,7 @@ use rustc_hir as hir;
 use rustc_index::bit_set::BitSet;
 use rustc_index::{IndexSlice, IndexVec};
 use rustc_middle::bug;
+use rustc_middle::mir::interpret::PointerArithmetic;
 use rustc_middle::mir::{CoroutineLayout, CoroutineSavedLocal};
 use rustc_middle::query::Providers;
 use rustc_middle::ty::layout::{
@@ -560,6 +561,13 @@ fn layout_of_uncached<'tcx>(
                         .layout_of_union(&def.repr(), &variants)
                         .map_err(|err| map_error(cx, ty, err))?,
                 ));
+            }
+
+            // we're on a 16-bit target and this alignment is too big
+            if let Some(align) = def.repr().align {
+                if align.bytes() > (cx.target_isize_max() as u64) {
+                    return Err(error(cx, LayoutError::SizeOverflow(ty)));
+                }
             }
 
             let get_discriminant_type =

--- a/tests/ui/repr/16-bit-align-too-big.msp430.stderr
+++ b/tests/ui/repr/16-bit-align-too-big.msp430.stderr
@@ -1,0 +1,4 @@
+error: values of the type `Hello16BitAlign` are too big for the target architecture
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/repr/16-bit-align-too-big.rs
+++ b/tests/ui/repr/16-bit-align-too-big.rs
@@ -1,0 +1,38 @@
+// We should fail to compute alignment for types aligned higher than usize::MAX.
+// We can't handle alignments that require all 32 bits, so this only affects 16-bit.
+
+//@ revisions: msp430 aarch32
+//@ [msp430] build-fail
+//@ [msp430] needs-llvm-components: msp430
+//@ [msp430] compile-flags: --target=msp430-none-elf
+//@ [msp430] error-pattern: values of the type `Hello16BitAlign` are too big for the target architecture
+
+//@ [aarch32] build-pass
+//@ [aarch32] needs-llvm-components: arm
+//@ [aarch32] compile-flags: --target=thumbv7m-none-eabi
+
+#![feature(no_core, lang_items, intrinsics, staged_api, rustc_attrs)]
+#![no_core]
+#![crate_type = "lib"]
+#![stable(feature = "intrinsics_for_test", since = "3.3.3")]
+#![allow(dead_code)]
+
+extern "rust-intrinsic" {
+    #[stable(feature = "intrinsics_for_test", since = "3.3.3")]
+    #[rustc_const_stable(feature = "intrinsics_for_test", since = "3.3.3")]
+    #[rustc_safe_intrinsic]
+    fn min_align_of<T>() -> usize;
+}
+
+#[lang="sized"]
+trait Sized {}
+#[lang="copy"]
+trait Copy {}
+
+#[repr(align(65536))]
+#[stable(feature = "intrinsics_for_test", since = "3.3.3")]
+pub struct Hello16BitAlign;
+
+
+#[stable(feature = "intrinsics_for_test", since = "3.3.3")]
+pub fn bar() -> usize { min_align_of::<Hello16BitAlign>() }


### PR DESCRIPTION
Was originally intended to solve https://github.com/rust-lang/rust/issues/131122 but I'm not very happy with the lack of a span. Forgot about it and then remembered it was sitting around. Mostly posting this so @asquared31415 can cannibalize it if desired in the process of coming up with a better solution maybe.

<!-- homu-ignore:start -->
r? @ghost
<!-- homu-ignore:end -->