### PR TITLE
Handle `rustc_interface` cases of `rustc::potential_query_instability` lint

### DIFF
--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -470,7 +470,6 @@ fn write_out_deps(tcx: TyCtxt<'_>, outputs: &OutputFilenames, out_filenames: &[P
             })
         }
 
-        #[allow(rustc::potential_query_instability)]
         let extra_tracked_files = hash_iter_files(
             file_depinfo.iter().map(|path_sym| normalize_path(PathBuf::from(path_sym.as_str()))),
             checksum_hash_algo,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This PR removes `#![allow(rustc::potential_query_instability)]` occurrences from [`compiler/rustc_interface/`](https://github.com/rust-lang/rust/blob/master/compiler/rustc_interface/) <s>and converts `FxHash{Map,Set}` types into `FxIndex{Map,Set}` to suppress lint errors</s> (was not necessary for this PR).

A somewhat tracking issue: https://github.com/rust-lang/rust/issues/84447

r? @compiler-errors 