### PR TITLE
fix typo in 'lang item with track_caller' message

### DIFF
--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -391,7 +391,7 @@ passes_lang_item_fn_with_target_feature =
 
 passes_lang_item_fn_with_track_caller =
     {passes_lang_item_fn} is not allowed to have `#[track_caller]`
-    .label = {passes_lang_item_fn} is not allowed to have `#[target_feature]`
+    .label = {passes_lang_item_fn} is not allowed to have `#[track_caller]`
 
 passes_lang_item_on_incorrect_target =
     `{$name}` lang item must be applied to a {$expected_target}

--- a/tests/ui/panic-handler/panic-handler-with-track-caller.stderr
+++ b/tests/ui/panic-handler/panic-handler-with-track-caller.stderr
@@ -5,7 +5,7 @@ LL | #[track_caller]
    | ^^^^^^^^^^^^^^^
 LL |
 LL | fn panic(info: &PanicInfo) -> ! {
-   | ------------------------------- `#[panic_handler]` function is not allowed to have `#[target_feature]`
+   | ------------------------------- `#[panic_handler]` function is not allowed to have `#[track_caller]`
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Revival of https://github.com/rust-lang/rust/pull/124912