### PR TITLE
Support clobber_abi in MSP430 inline assembly

### DIFF
--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -893,6 +893,7 @@ pub enum InlineAsmClobberAbi {
     RiscV,
     LoongArch,
     S390x,
+    Msp430,
 }
 
 impl InlineAsmClobberAbi {
@@ -944,6 +945,10 @@ impl InlineAsmClobberAbi {
             },
             InlineAsmArch::S390x => match name {
                 "C" | "system" => Ok(InlineAsmClobberAbi::S390x),
+                _ => Err(&["C", "system"]),
+            },
+            InlineAsmArch::Msp430 => match name {
+                "C" | "system" => Ok(InlineAsmClobberAbi::Msp430),
                 _ => Err(&["C", "system"]),
             },
             _ => Err(&[]),
@@ -1123,6 +1128,11 @@ impl InlineAsmClobberAbi {
                     // a0-a1 are reserved, other access registers are volatile
                     a2, a3, a4, a5, a6, a7,
                     a8, a9, a10, a11, a12, a13, a14, a15,
+                }
+            },
+            InlineAsmClobberAbi::Msp430 => clobbered_regs! {
+                Msp430 Msp430InlineAsmReg {
+                    r11, r12, r13, r14, r15,
                 }
             },
         }

--- a/tests/codegen/asm-msp430-clobbers.rs
+++ b/tests/codegen/asm-msp430-clobbers.rs
@@ -1,0 +1,36 @@
+//@ assembly-output: emit-asm
+//@ compile-flags: --target msp430-none-elf
+//@ needs-llvm-components: msp430
+
+#![crate_type = "rlib"]
+#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+
+// CHECK-LABEL: @sr_clobber
+// CHECK: call void asm sideeffect "", "~{sr}"()
+#[no_mangle]
+pub unsafe fn sr_clobber() {
+    asm!("", options(nostack, nomem));
+}
+
+// CHECK-LABEL: @no_clobber
+// CHECK: call void asm sideeffect "", ""()
+#[no_mangle]
+pub unsafe fn no_clobber() {
+    asm!("", options(nostack, nomem, preserves_flags));
+}
+
+// CHECK-LABEL: @clobber_abi
+// CHECK: asm sideeffect "", "={r11},={r12},={r13},={r14},={r15}"()
+#[no_mangle]
+pub unsafe fn clobber_abi() {
+    asm!("", clobber_abi("C"), options(nostack, nomem, preserves_flags));
+}


### PR DESCRIPTION
This supports `clobber_abi` which is one of the requirements of stabilization mentioned in #93335.

Refs: Section 3.2 "Register Conventions" in [MSP430 Embedded Application Binary Interface](https://www.ti.com/lit/an/slaa534a/slaa534a.pdf)

cc @cr1901

r? @Amanieu

@rustbot label +O-msp430 +A-inline-assembly