### PR TITLE
On function and method calls in patterns, link to the book

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -812,7 +812,8 @@ parse_unexpected_expr_in_pat =
        *[false] a pattern
     }, found an expression
 
-    .label = arbitrary expressions are not allowed in patterns
+    .label = not a pattern
+    .note = arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 parse_unexpected_expr_in_pat_const_sugg = consider extracting the expression into a `const`
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2608,6 +2608,7 @@ pub(crate) struct ExpectedCommaAfterPatternField {
 
 #[derive(Diagnostic)]
 #[diag(parse_unexpected_expr_in_pat)]
+#[note]
 pub(crate) struct UnexpectedExpressionInPattern {
     /// The unexpected expr's span.
     #[primary_span]

--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -443,6 +443,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
         self.suggest_bare_struct_literal(&mut err);
         self.suggest_changing_type_to_const_param(&mut err, res, source, span);
+        self.explain_functions_in_pattern(&mut err, res, source);
 
         if self.suggest_pattern_match_with_let(&mut err, source, span) {
             // Fallback label.
@@ -1164,6 +1165,18 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
                 Applicability::HasPlaceholders,
             );
         }
+    }
+
+    fn explain_functions_in_pattern(
+        &mut self,
+        err: &mut Diag<'_>,
+        res: Option<Res>,
+        source: PathSource<'_>,
+    ) {
+        let PathSource::TupleStruct(_, _) = source else { return };
+        let Some(Res::Def(DefKind::Fn, _)) = res else { return };
+        err.primary_message("expected a pattern, found a function call");
+        err.note("function calls are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>");
     }
 
     fn suggest_changing_type_to_const_param(

--- a/tests/ui/half-open-range-patterns/range_pat_interactions1.stderr
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions1.stderr
@@ -2,8 +2,9 @@ error: expected a pattern range bound, found an expression
   --> $DIR/range_pat_interactions1.rs:17:16
    |
 LL |             0..5+1 => errors_only.push(x),
-   |                ^^^ arbitrary expressions are not allowed in patterns
+   |                ^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +         const VAL: /* Type */ = 5+1;

--- a/tests/ui/half-open-range-patterns/range_pat_interactions2.stderr
+++ b/tests/ui/half-open-range-patterns/range_pat_interactions2.stderr
@@ -14,8 +14,9 @@ error: expected a pattern range bound, found an expression
   --> $DIR/range_pat_interactions2.rs:10:18
    |
 LL |             0..=(5+1) => errors_only.push(x),
-   |                  ^^^ arbitrary expressions are not allowed in patterns
+   |                  ^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +         const VAL: /* Type */ = 5+1;

--- a/tests/ui/parser/bad-name.stderr
+++ b/tests/ui/parser/bad-name.stderr
@@ -8,7 +8,9 @@ error: expected a pattern, found an expression
   --> $DIR/bad-name.rs:2:7
    |
 LL |   let x.y::<isize>.z foo;
-   |       ^^^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |       ^^^^^^^^^^^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error: expected one of `(`, `.`, `::`, `:`, `;`, `=`, `?`, `|`, or an operator, found `foo`
   --> $DIR/bad-name.rs:2:22

--- a/tests/ui/parser/issues/issue-24197.stderr
+++ b/tests/ui/parser/issues/issue-24197.stderr
@@ -2,7 +2,9 @@ error: expected a pattern, found an expression
   --> $DIR/issue-24197.rs:2:9
    |
 LL |     let buf[0] = 0;
-   |         ^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/parser/issues/issue-24375.stderr
+++ b/tests/ui/parser/issues/issue-24375.stderr
@@ -2,8 +2,9 @@ error: expected a pattern, found an expression
   --> $DIR/issue-24375.rs:6:9
    |
 LL |         tmp[0] => {}
-   |         ^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == tmp[0] => {}

--- a/tests/ui/parser/pat-lt-bracket-5.stderr
+++ b/tests/ui/parser/pat-lt-bracket-5.stderr
@@ -2,7 +2,9 @@ error: expected a pattern, found an expression
   --> $DIR/pat-lt-bracket-5.rs:2:9
    |
 LL |     let v[0] = v[1];
-   |         ^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error[E0425]: cannot find value `v` in this scope
   --> $DIR/pat-lt-bracket-5.rs:2:16

--- a/tests/ui/parser/pat-lt-bracket-6.stderr
+++ b/tests/ui/parser/pat-lt-bracket-6.stderr
@@ -2,7 +2,9 @@ error: expected a pattern, found an expression
   --> $DIR/pat-lt-bracket-6.rs:5:14
    |
 LL |     let Test(&desc[..]) = x;
-   |              ^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |              ^^^^^^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error[E0308]: mismatched types
   --> $DIR/pat-lt-bracket-6.rs:10:30

--- a/tests/ui/parser/pat-ranges-3.stderr
+++ b/tests/ui/parser/pat-ranges-3.stderr
@@ -2,13 +2,17 @@ error: expected a pattern range bound, found an expression
   --> $DIR/pat-ranges-3.rs:4:16
    |
 LL |     let 10 ..= 10 + 3 = 12;
-   |                ^^^^^^ arbitrary expressions are not allowed in patterns
+   |                ^^^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error: expected a pattern range bound, found an expression
   --> $DIR/pat-ranges-3.rs:7:9
    |
 LL |     let 10 - 3 ..= 10 = 8;
-   |         ^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/recover/recover-pat-exprs.stderr
+++ b/tests/ui/parser/recover/recover-pat-exprs.stderr
@@ -2,8 +2,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:5:9
    |
 LL |         x.y => (),
-   |         ^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x.y => (),
@@ -24,8 +25,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:6:9
    |
 LL |         x.0 => (),
-   |         ^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x.0 => (),
@@ -47,8 +49,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:7:9
    |
 LL |         x._0 => (),
-   |         ^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x._0 => (),
@@ -71,8 +74,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:8:9
    |
 LL |         x.0.1 => (),
-   |         ^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x.0.1 => (),
@@ -95,8 +99,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:9:9
    |
 LL |         x.4.y.17.__z => (),
-   |         ^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x.4.y.17.__z => (),
@@ -149,8 +154,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:23:9
    |
 LL |         x[0] => (),
-   |         ^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x[0] => (),
@@ -170,8 +176,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:24:9
    |
 LL |         x[..] => (),
-   |         ^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x[..] => (),
@@ -219,8 +226,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:37:9
    |
 LL |         x.f() => (),
-   |         ^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x.f() => (),
@@ -240,8 +248,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:38:9
    |
 LL |         x._f() => (),
-   |         ^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x._f() => (),
@@ -262,8 +271,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:39:9
    |
 LL |         x? => (),
-   |         ^^ arbitrary expressions are not allowed in patterns
+   |         ^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x? => (),
@@ -285,8 +295,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:40:9
    |
 LL |         ().f() => (),
-   |         ^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == ().f() => (),
@@ -309,8 +320,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:41:9
    |
 LL |         (0, x)?.f() => (),
-   |         ^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == (0, x)?.f() => (),
@@ -333,8 +345,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:42:9
    |
 LL |         x.f().g() => (),
-   |         ^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x.f().g() => (),
@@ -357,8 +370,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:43:9
    |
 LL |         0.f()?.g()?? => (),
-   |         ^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == 0.f()?.g()?? => (),
@@ -381,8 +395,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:50:9
    |
 LL |         x as usize => (),
-   |         ^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x as usize => (),
@@ -402,8 +417,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:51:9
    |
 LL |         0 as usize => (),
-   |         ^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == 0 as usize => (),
@@ -424,8 +440,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:52:9
    |
 LL |         x.f().0.4 as f32 => (),
-   |         ^^^^^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == x.f().0.4 as f32 => (),
@@ -447,8 +464,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:59:9
    |
 LL |         1 + 1 => (),
-   |         ^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == 1 + 1 => (),
@@ -468,8 +486,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:60:9
    |
 LL |         (1 + 2) * 3 => (),
-   |         ^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == (1 + 2) * 3 => (),
@@ -490,8 +509,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:63:9
    |
 LL |         x.0 > 2 => (),
-   |         ^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == (x.0 > 2) => (),
@@ -514,8 +534,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:64:9
    |
 LL |         x.0 == 2 => (),
-   |         ^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == (x.0 == 2) => (),
@@ -538,8 +559,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:69:13
    |
 LL |         (x, y.0 > 2) if x != 0 => (),
-   |             ^^^^^^^ arbitrary expressions are not allowed in patterns
+   |             ^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to the match arm guard
    |
 LL |         (x, val) if x != 0 && val == (y.0 > 2) => (),
@@ -559,8 +581,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:70:13
    |
 LL |         (x, y.0 > 2) if x != 0 || x != 1 => (),
-   |             ^^^^^^^ arbitrary expressions are not allowed in patterns
+   |             ^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to the match arm guard
    |
 LL |         (x, val) if (x != 0 || x != 1) && val == (y.0 > 2) => (),
@@ -598,8 +621,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:81:9
    |
 LL |         u8::MAX.abs() => (),
-   |         ^^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == u8::MAX.abs() => (),
@@ -619,8 +643,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:86:17
    |
 LL |         z @ w @ v.u() => (),
-   |                 ^^^^^ arbitrary expressions are not allowed in patterns
+   |                 ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         z @ w @ val if val == v.u() => (),
@@ -643,8 +668,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:88:9
    |
 LL |         y.ilog(3) => (),
-   |         ^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == y.ilog(3) => (),
@@ -667,8 +693,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:90:9
    |
 LL |         n + 1 => (),
-   |         ^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == n + 1 => (),
@@ -691,8 +718,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:92:10
    |
 LL |         ("".f() + 14 * 8) => (),
-   |          ^^^^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |          ^^^^^^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         (val) if val == "".f() + 14 * 8 => (),
@@ -715,8 +743,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:95:9
    |
 LL |         f?() => (),
-   |         ^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         val if val == f?() => (),
@@ -739,7 +768,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:101:9
    |
 LL |     let 1 + 1 = 2;
-   |         ^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error: expected one of `)`, `,`, `@`, or `|`, found `*`
   --> $DIR/recover-pat-exprs.rs:104:28
@@ -754,19 +785,25 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:60:10
    |
 LL |         (1 + 2) * 3 => (),
-   |          ^^^^^ arbitrary expressions are not allowed in patterns
+   |          ^^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:75:5
    |
 LL |     1 + 2 * PI.cos() => 2,
-   |     ^^^^^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |     ^^^^^^^^^^^^^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error: expected a pattern, found an expression
   --> $DIR/recover-pat-exprs.rs:83:9
    |
 LL |         x.sqrt() @ .. => (),
-   |         ^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error: aborting due to 45 previous errors
 

--- a/tests/ui/parser/recover/recover-pat-issues.stderr
+++ b/tests/ui/parser/recover/recover-pat-issues.stderr
@@ -2,8 +2,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-issues.rs:6:13
    |
 LL |         Foo("hi".to_owned()) => true,
-   |             ^^^^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |             ^^^^^^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         Foo(val) if val == "hi".to_owned() => true,
@@ -23,8 +24,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-issues.rs:14:20
    |
 LL |         Bar { baz: "hi".to_owned() } => true,
-   |                    ^^^^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |                    ^^^^^^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         Bar { baz } if baz == "hi".to_owned() => true,
@@ -44,8 +46,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-issues.rs:25:11
    |
 LL |         &["foo".to_string()] => {}
-   |           ^^^^^^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |           ^^^^^^^^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider moving the expression to a match arm guard
    |
 LL |         &[val] if val == "foo".to_string() => {}
@@ -65,8 +68,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-issues.rs:36:17
    |
 LL |     if let Some(MAGIC.0 as usize) = None::<usize> {}
-   |                 ^^^^^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |                 ^^^^^^^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = MAGIC.0 as usize;
@@ -81,8 +85,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-issues.rs:41:13
    |
 LL |     if let (-1.some(4)) = (0, Some(4)) {}
-   |             ^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |             ^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = -1.some(4);
@@ -97,8 +102,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-issues.rs:44:13
    |
 LL |     if let (-1.Some(4)) = (0, Some(4)) {}
-   |             ^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |             ^^^^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = -1.Some(4);

--- a/tests/ui/parser/recover/recover-pat-lets.stderr
+++ b/tests/ui/parser/recover/recover-pat-lets.stderr
@@ -2,26 +2,33 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-lets.rs:4:9
    |
 LL |     let x.expect("foo");
-   |         ^^^^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^^^^^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error: expected a pattern, found an expression
   --> $DIR/recover-pat-lets.rs:7:9
    |
 LL |     let x.unwrap(): u32;
-   |         ^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^^^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error: expected a pattern, found an expression
   --> $DIR/recover-pat-lets.rs:10:9
    |
 LL |     let x[0] = 1;
-   |         ^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error: expected a pattern, found an expression
   --> $DIR/recover-pat-lets.rs:13:14
    |
 LL |     let Some(1 + 1) = x else {
-   |              ^^^^^ arbitrary expressions are not allowed in patterns
+   |              ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 1 + 1;
@@ -36,8 +43,9 @@ error: expected a pattern, found an expression
   --> $DIR/recover-pat-lets.rs:17:17
    |
 LL |     if let Some(1 + 1) = x {
-   |                 ^^^^^ arbitrary expressions are not allowed in patterns
+   |                 ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 1 + 1;

--- a/tests/ui/parser/recover/recover-pat-ranges.stderr
+++ b/tests/ui/parser/recover/recover-pat-ranges.stderr
@@ -86,8 +86,9 @@ error: expected a pattern range bound, found an expression
   --> $DIR/recover-pat-ranges.rs:11:12
    |
 LL |         ..=1 + 2 => (),
-   |            ^^^^^ arbitrary expressions are not allowed in patterns
+   |            ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 1 + 2;
@@ -106,8 +107,9 @@ error: expected a pattern range bound, found an expression
   --> $DIR/recover-pat-ranges.rs:15:10
    |
 LL |         (-4 + 0).. => (),
-   |          ^^^^^^ arbitrary expressions are not allowed in patterns
+   |          ^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = -4 + 0;
@@ -126,8 +128,9 @@ error: expected a pattern range bound, found an expression
   --> $DIR/recover-pat-ranges.rs:18:10
    |
 LL |         (1 + 4)...1 * 2 => (),
-   |          ^^^^^ arbitrary expressions are not allowed in patterns
+   |          ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 1 + 4;
@@ -146,8 +149,9 @@ error: expected a pattern range bound, found an expression
   --> $DIR/recover-pat-ranges.rs:18:19
    |
 LL |         (1 + 4)...1 * 2 => (),
-   |                   ^^^^^ arbitrary expressions are not allowed in patterns
+   |                   ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 1 * 2;
@@ -166,8 +170,9 @@ error: expected a pattern range bound, found an expression
   --> $DIR/recover-pat-ranges.rs:24:9
    |
 LL |         0.x()..="y".z() => (),
-   |         ^^^^^ arbitrary expressions are not allowed in patterns
+   |         ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 0.x();
@@ -186,8 +191,9 @@ error: expected a pattern range bound, found an expression
   --> $DIR/recover-pat-ranges.rs:24:17
    |
 LL |         0.x()..="y".z() => (),
-   |                 ^^^^^^^ arbitrary expressions are not allowed in patterns
+   |                 ^^^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = "y".z();

--- a/tests/ui/parser/recover/recover-pat-wildcards.stderr
+++ b/tests/ui/parser/recover/recover-pat-wildcards.stderr
@@ -75,8 +75,9 @@ error: expected a pattern range bound, found an expression
   --> $DIR/recover-pat-wildcards.rs:55:14
    |
 LL |         4..=(2 + _) => ()
-   |              ^^^^^ arbitrary expressions are not allowed in patterns
+   |              ^^^^^ not a pattern
    |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 help: consider extracting the expression into a `const`
    |
 LL +     const VAL: /* Type */ = 2 + _;

--- a/tests/ui/resolve/issue-10200.rs
+++ b/tests/ui/resolve/issue-10200.rs
@@ -3,7 +3,7 @@ fn foo(_: usize) -> Foo { Foo(false) }
 
 fn main() {
     match Foo(true) {
-        foo(x) //~ ERROR expected tuple struct or tuple variant, found function `foo`
+        foo(x) //~ ERROR expected a pattern, found a function call
         => ()
     }
 }

--- a/tests/ui/resolve/issue-10200.stderr
+++ b/tests/ui/resolve/issue-10200.stderr
@@ -1,4 +1,4 @@
-error[E0532]: expected tuple struct or tuple variant, found function `foo`
+error[E0532]: expected a pattern, found a function call
   --> $DIR/issue-10200.rs:6:9
    |
 LL | struct Foo(bool);
@@ -6,6 +6,8 @@ LL | struct Foo(bool);
 ...
 LL |         foo(x)
    |         ^^^ help: a tuple struct with a similar name exists (notice the capitalization): `Foo`
+   |
+   = note: function calls are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/sized/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.stderr
+++ b/tests/ui/sized/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.stderr
@@ -2,7 +2,9 @@ error: expected a pattern, found an expression
   --> $DIR/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.rs:2:31
    |
 LL |     let str::<{fn str() { let str::T>>::as_bytes; }}, T>::as_bytes;
-   |                               ^^^^^^^^^^^^^^^^^^ arbitrary expressions are not allowed in patterns
+   |                               ^^^^^^^^^^^^^^^^^^ not a pattern
+   |
+   = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
 
 error[E0412]: cannot find type `T` in this scope
   --> $DIR/ensure-overriding-bindings-in-pattern-with-ty-err-doesnt-ice.rs:2:55


### PR DESCRIPTION
```
error: expected a pattern, found an expression
 --> f889.rs:3:13
  |
3 |     let (x, y.drop()) = (1, 2);
  |             ^^^^^^^^ not a pattern
  |
  = note: arbitrary expressions are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>

error[E0532]: expected a pattern, found a function call
 --> f889.rs:2:13
  |
2 |     let (x, drop(y)) = (1, 2);
  |             ^^^^ not a tuple struct or tuple variant
  |
  = note: function calls are not allowed in patterns: <https://doc.rust-lang.org/book/ch18-00-patterns.html>
```

Fix #97200.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
