### PR TITLE
Revert "warn_old_master_branch" check

### DIFF
--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -93,6 +93,7 @@ fn get_modified_rs_files(build: &Builder<'_>) -> Result<Option<Vec<String>>, Str
     if !verify_rustfmt_version(build) {
         return Ok(None);
     }
+
     get_git_modified_files(&build.config.git_config(), Some(&build.config.src), &["rs"])
 }
 

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -383,5 +383,13 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
         cmd_finder.must_have(s);
     }
 
-    warn_old_master_branch(&build.config.git_config(), &build.config.src);
+    // this warning is useless in CI,
+    // and CI probably won't have the right branches anyway.
+    if !build_helper::ci::CiEnv::is_ci() {
+        if let Err(e) = warn_old_master_branch(&build.config.git_config(), &build.config.src)
+            .map_err(|e| e.to_string())
+        {
+            eprintln!("unable to check if upstream branch is old: {e}");
+        }
+    }
 }

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -13,8 +13,6 @@ use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 use std::{env, fs};
 
-use build_helper::git::warn_old_master_branch;
-
 use crate::Build;
 #[cfg(not(feature = "bootstrap-self-test"))]
 use crate::builder::Builder;
@@ -381,15 +379,5 @@ $ pacman -R cmake && pacman -S mingw-w64-x86_64-cmake
 
     if let Some(ref s) = build.config.ccache {
         cmd_finder.must_have(s);
-    }
-
-    // this warning is useless in CI,
-    // and CI probably won't have the right branches anyway.
-    if !build_helper::ci::CiEnv::is_ci() {
-        if let Err(e) = warn_old_master_branch(&build.config.git_config(), &build.config.src)
-            .map_err(|e| e.to_string())
-        {
-            eprintln!("unable to check if upstream branch is old: {e}");
-        }
     }
 }

--- a/src/tools/build_helper/src/git.rs
+++ b/src/tools/build_helper/src/git.rs
@@ -204,20 +204,21 @@ pub fn get_git_untracked_files(
 ///
 /// This can result in formatting thousands of files instead of a dozen,
 /// so we should warn the user something is wrong.
-pub fn warn_old_master_branch(config: &GitConfig<'_>, git_dir: &Path) {
-    if crate::ci::CiEnv::is_ci() {
-        // this warning is useless in CI,
-        // and CI probably won't have the right branches anyway.
-        return;
-    }
-    // this will be overwritten by the actual name, if possible
-    let mut updated_master = "the upstream master branch".to_string();
-    match warn_old_master_branch_(config, git_dir, &mut updated_master) {
-        Ok(branch_is_old) => {
-            if !branch_is_old {
-                return;
+pub fn warn_old_master_branch(
+    config: &GitConfig<'_>,
+    git_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::time::Duration;
+    const WARN_AFTER: Duration = Duration::from_secs(60 * 60 * 24 * 10);
+    let updated_master = updated_master_branch(config, Some(git_dir))?;
+    let branch_path = git_dir.join(".git/refs/remotes").join(&updated_master);
+    match std::fs::metadata(branch_path) {
+        Ok(meta) => {
+            if meta.modified()?.elapsed()? > WARN_AFTER {
+                eprintln!("warning: {updated_master} has not been updated in 10 days");
+            } else {
+                return Ok(());
             }
-            // otherwise fall through and print the rest of the warning
         }
         Err(err) => {
             eprintln!("warning: unable to check if {updated_master} is old due to error: {err}")
@@ -225,38 +226,7 @@ pub fn warn_old_master_branch(config: &GitConfig<'_>, git_dir: &Path) {
     }
     eprintln!(
         "warning: {updated_master} is used to determine if files have been modified\n\
-         warning: if it is not updated, this may cause files to be needlessly reformatted"
+               warning: if it is not updated, this may cause files to be needlessly reformatted"
     );
-}
-
-pub fn warn_old_master_branch_(
-    config: &GitConfig<'_>,
-    git_dir: &Path,
-    updated_master: &mut String,
-) -> Result<bool, Box<dyn std::error::Error>> {
-    use std::time::Duration;
-    *updated_master = updated_master_branch(config, Some(git_dir))?;
-    let branch_path = git_dir.join(".git/refs/remotes").join(&updated_master);
-    const WARN_AFTER: Duration = Duration::from_secs(60 * 60 * 24 * 10);
-    let meta = match std::fs::metadata(&branch_path) {
-        Ok(meta) => meta,
-        Err(err) => {
-            let gcd = git_common_dir(&git_dir)?;
-            if branch_path.starts_with(&gcd) {
-                return Err(Box::new(err));
-            }
-            std::fs::metadata(Path::new(&gcd).join("refs/remotes").join(&updated_master))?
-        }
-    };
-    if meta.modified()?.elapsed()? > WARN_AFTER {
-        eprintln!("warning: {updated_master} has not been updated in 10 days");
-        Ok(true)
-    } else {
-        Ok(false)
-    }
-}
-
-fn git_common_dir(dir: &Path) -> Result<String, String> {
-    output_result(Command::new("git").arg("-C").arg(dir).arg("rev-parse").arg("--git-common-dir"))
-        .map(|x| x.trim().to_string())
+    Ok(())
 }

--- a/src/tools/build_helper/src/git.rs
+++ b/src/tools/build_helper/src/git.rs
@@ -196,37 +196,3 @@ pub fn get_git_untracked_files(
         .collect();
     Ok(Some(files))
 }
-
-/// Print a warning if the branch returned from `updated_master_branch` is old
-///
-/// For certain configurations of git repository, this remote will not be
-/// updated when running `git pull`.
-///
-/// This can result in formatting thousands of files instead of a dozen,
-/// so we should warn the user something is wrong.
-pub fn warn_old_master_branch(
-    config: &GitConfig<'_>,
-    git_dir: &Path,
-) -> Result<(), Box<dyn std::error::Error>> {
-    use std::time::Duration;
-    const WARN_AFTER: Duration = Duration::from_secs(60 * 60 * 24 * 10);
-    let updated_master = updated_master_branch(config, Some(git_dir))?;
-    let branch_path = git_dir.join(".git/refs/remotes").join(&updated_master);
-    match std::fs::metadata(branch_path) {
-        Ok(meta) => {
-            if meta.modified()?.elapsed()? > WARN_AFTER {
-                eprintln!("warning: {updated_master} has not been updated in 10 days");
-            } else {
-                return Ok(());
-            }
-        }
-        Err(err) => {
-            eprintln!("warning: unable to check if {updated_master} is old due to error: {err}")
-        }
-    }
-    eprintln!(
-        "warning: {updated_master} is used to determine if files have been modified\n\
-               warning: if it is not updated, this may cause files to be needlessly reformatted"
-    );
-    Ok(())
-}


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/131296#issuecomment-2395486918.

Reverts https://github.com/rust-lang/rust/pull/130121 and https://github.com/rust-lang/rust/pull/129584.

Fixes https://github.com/rust-lang/rust/issues/131296 and https://github.com/rust-lang/rust/issues/131324.