### PR TITLE
Remove `CombineFields`

### DIFF
--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -184,30 +184,6 @@ impl<'a, 'tcx> At<'a, 'tcx> {
         Ok(InferOk { value: (), obligations: op.into_obligations() })
     }
 
-    /// Equates `expected` and `found` while structurally relating aliases.
-    /// This should only be used inside of the next generation trait solver
-    /// when relating rigid aliases.
-    pub fn eq_structurally_relating_aliases<T>(
-        self,
-        expected: T,
-        actual: T,
-    ) -> InferResult<'tcx, ()>
-    where
-        T: ToTrace<'tcx>,
-    {
-        assert!(self.infcx.next_trait_solver());
-        let mut op = TypeRelating::new(
-            self.infcx,
-            ToTrace::to_trace(self.cause, expected, actual),
-            self.param_env,
-            DefineOpaqueTypes::Yes,
-            StructurallyRelateAliases::Yes,
-            ty::Invariant,
-        );
-        op.relate(expected, actual)?;
-        Ok(InferOk { value: (), obligations: op.into_obligations() })
-    }
-
     pub fn relate<T>(
         self,
         define_opaque_types: DefineOpaqueTypes,
@@ -289,23 +265,6 @@ impl<'a, 'tcx> At<'a, 'tcx> {
             ToTrace::to_trace(self.cause, expected, actual),
             self.param_env,
             LatticeOpKind::Lub,
-        );
-        let value = op.relate(expected, actual)?;
-        Ok(InferOk { value, obligations: op.into_obligations() })
-    }
-
-    /// Computes the greatest-lower-bound, or mutual subtype, of two
-    /// values. As with `lub` order doesn't matter, except for error
-    /// cases.
-    pub fn glb<T>(self, expected: T, actual: T) -> InferResult<'tcx, T>
-    where
-        T: ToTrace<'tcx>,
-    {
-        let mut op = LatticeOp::new(
-            self.infcx,
-            ToTrace::to_trace(self.cause, expected, actual),
-            self.param_env,
-            LatticeOpKind::Glb,
         );
         let value = op.relate(expected, actual)?;
         Ok(InferOk { value, obligations: op.into_obligations() })

--- a/compiler/rustc_infer/src/infer/at.rs
+++ b/compiler/rustc_infer/src/infer/at.rs
@@ -280,12 +280,7 @@ impl<'a, 'tcx> At<'a, 'tcx> {
     /// this can result in an error (e.g., if asked to compute LUB of
     /// u32 and i32), it is meaningful to call one of them the
     /// "expected type".
-    pub fn lub<T>(
-        self,
-        define_opaque_types: DefineOpaqueTypes,
-        expected: T,
-        actual: T,
-    ) -> InferResult<'tcx, T>
+    pub fn lub<T>(self, expected: T, actual: T) -> InferResult<'tcx, T>
     where
         T: ToTrace<'tcx>,
     {
@@ -293,7 +288,6 @@ impl<'a, 'tcx> At<'a, 'tcx> {
             self.infcx,
             ToTrace::to_trace(self.cause, expected, actual),
             self.param_env,
-            define_opaque_types,
             LatticeOpKind::Lub,
         );
         let value = op.relate(expected, actual)?;
@@ -303,12 +297,7 @@ impl<'a, 'tcx> At<'a, 'tcx> {
     /// Computes the greatest-lower-bound, or mutual subtype, of two
     /// values. As with `lub` order doesn't matter, except for error
     /// cases.
-    pub fn glb<T>(
-        self,
-        define_opaque_types: DefineOpaqueTypes,
-        expected: T,
-        actual: T,
-    ) -> InferResult<'tcx, T>
+    pub fn glb<T>(self, expected: T, actual: T) -> InferResult<'tcx, T>
     where
         T: ToTrace<'tcx>,
     {
@@ -316,7 +305,6 @@ impl<'a, 'tcx> At<'a, 'tcx> {
             self.infcx,
             ToTrace::to_trace(self.cause, expected, actual),
             self.param_env,
-            define_opaque_types,
             LatticeOpKind::Glb,
         );
         let value = op.relate(expected, actual)?;

--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -14,7 +14,6 @@ use region_constraints::{
     GenericKind, RegionConstraintCollector, RegionConstraintStorage, VarInfos, VerifyBound,
 };
 pub use relate::StructurallyRelateAliases;
-use relate::combine::CombineFields;
 pub use relate::combine::PredicateEmittingRelation;
 use rustc_data_structures::captures::Captures;
 use rustc_data_structures::fx::{FxHashSet, FxIndexMap};

--- a/compiler/rustc_infer/src/infer/relate/lattice.rs
+++ b/compiler/rustc_infer/src/infer/relate/lattice.rs
@@ -24,8 +24,9 @@ use rustc_span::Span;
 use tracing::{debug, instrument};
 
 use super::StructurallyRelateAliases;
-use super::combine::{CombineFields, PredicateEmittingRelation};
-use crate::infer::{DefineOpaqueTypes, InferCtxt, SubregionOrigin};
+use super::combine::PredicateEmittingRelation;
+use crate::infer::{DefineOpaqueTypes, InferCtxt, SubregionOrigin, TypeTrace};
+use crate::traits::{Obligation, PredicateObligation};
 
 #[derive(Clone, Copy)]
 pub(crate) enum LatticeOpKind {
@@ -43,23 +44,36 @@ impl LatticeOpKind {
 }
 
 /// A greatest lower bound" (common subtype) or least upper bound (common supertype).
-pub(crate) struct LatticeOp<'combine, 'infcx, 'tcx> {
-    fields: &'combine mut CombineFields<'infcx, 'tcx>,
+pub(crate) struct LatticeOp<'infcx, 'tcx> {
+    infcx: &'infcx InferCtxt<'tcx>,
+    // Immutable fields
+    trace: TypeTrace<'tcx>,
+    param_env: ty::ParamEnv<'tcx>,
+    define_opaque_types: DefineOpaqueTypes,
+    // Mutable fields
     kind: LatticeOpKind,
+    obligations: Vec<PredicateObligation<'tcx>>,
 }
 
-impl<'combine, 'infcx, 'tcx> LatticeOp<'combine, 'infcx, 'tcx> {
+impl<'infcx, 'tcx> LatticeOp<'infcx, 'tcx> {
     pub(crate) fn new(
-        fields: &'combine mut CombineFields<'infcx, 'tcx>,
+        infcx: &'infcx InferCtxt<'tcx>,
+        trace: TypeTrace<'tcx>,
+        param_env: ty::ParamEnv<'tcx>,
+        define_opaque_types: DefineOpaqueTypes,
         kind: LatticeOpKind,
-    ) -> LatticeOp<'combine, 'infcx, 'tcx> {
-        LatticeOp { fields, kind }
+    ) -> LatticeOp<'infcx, 'tcx> {
+        LatticeOp { infcx, trace, param_env, define_opaque_types, kind, obligations: vec![] }
+    }
+
+    pub(crate) fn into_obligations(self) -> Vec<PredicateObligation<'tcx>> {
+        self.obligations
     }
 }
 
-impl<'tcx> TypeRelation<TyCtxt<'tcx>> for LatticeOp<'_, '_, 'tcx> {
+impl<'tcx> TypeRelation<TyCtxt<'tcx>> for LatticeOp<'_, 'tcx> {
     fn cx(&self) -> TyCtxt<'tcx> {
-        self.fields.tcx()
+        self.infcx.tcx
     }
 
     fn relate_with_variance<T: Relate<TyCtxt<'tcx>>>(
@@ -70,7 +84,15 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for LatticeOp<'_, '_, 'tcx> {
         b: T,
     ) -> RelateResult<'tcx, T> {
         match variance {
-            ty::Invariant => self.fields.equate(StructurallyRelateAliases::No).relate(a, b),
+            ty::Invariant => {
+                self.obligations.extend(
+                    self.infcx
+                        .at(&self.trace.cause, self.param_env)
+                        .eq_trace(self.define_opaque_types, self.trace.clone(), a, b)?
+                        .into_obligations(),
+                );
+                Ok(a)
+            }
             ty::Covariant => self.relate(a, b),
             // FIXME(#41044) -- not correct, need test
             ty::Bivariant => Ok(a),
@@ -90,7 +112,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for LatticeOp<'_, '_, 'tcx> {
             return Ok(a);
         }
 
-        let infcx = self.fields.infcx;
+        let infcx = self.infcx;
 
         let a = infcx.shallow_resolve(a);
         let b = infcx.shallow_resolve(b);
@@ -115,12 +137,12 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for LatticeOp<'_, '_, 'tcx> {
             // iterate on the subtype obligations that are returned, but I
             // think this suffices. -nmatsakis
             (&ty::Infer(TyVar(..)), _) => {
-                let v = infcx.next_ty_var(self.fields.trace.cause.span);
+                let v = infcx.next_ty_var(self.trace.cause.span);
                 self.relate_bound(v, b, a)?;
                 Ok(v)
             }
             (_, &ty::Infer(TyVar(..))) => {
-                let v = infcx.next_ty_var(self.fields.trace.cause.span);
+                let v = infcx.next_ty_var(self.trace.cause.span);
                 self.relate_bound(v, a, b)?;
                 Ok(v)
             }
@@ -132,7 +154,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for LatticeOp<'_, '_, 'tcx> {
 
             (&ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }), _)
             | (_, &ty::Alias(ty::Opaque, ty::AliasTy { def_id, .. }))
-                if self.fields.define_opaque_types == DefineOpaqueTypes::Yes
+                if self.define_opaque_types == DefineOpaqueTypes::Yes
                     && def_id.is_local()
                     && !infcx.next_trait_solver() =>
             {
@@ -155,8 +177,8 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for LatticeOp<'_, '_, 'tcx> {
         a: ty::Region<'tcx>,
         b: ty::Region<'tcx>,
     ) -> RelateResult<'tcx, ty::Region<'tcx>> {
-        let origin = SubregionOrigin::Subtype(Box::new(self.fields.trace.clone()));
-        let mut inner = self.fields.infcx.inner.borrow_mut();
+        let origin = SubregionOrigin::Subtype(Box::new(self.trace.clone()));
+        let mut inner = self.infcx.inner.borrow_mut();
         let mut constraints = inner.unwrap_region_constraints();
         Ok(match self.kind {
             // GLB(&'static u8, &'a u8) == &RegionLUB('static, 'a) u8 == &'static u8
@@ -173,7 +195,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for LatticeOp<'_, '_, 'tcx> {
         a: ty::Const<'tcx>,
         b: ty::Const<'tcx>,
     ) -> RelateResult<'tcx, ty::Const<'tcx>> {
-        self.fields.infcx.super_combine_consts(self, a, b)
+        self.infcx.super_combine_consts(self, a, b)
     }
 
     fn binders<T>(
@@ -202,7 +224,7 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for LatticeOp<'_, '_, 'tcx> {
     }
 }
 
-impl<'combine, 'infcx, 'tcx> LatticeOp<'combine, 'infcx, 'tcx> {
+impl<'infcx, 'tcx> LatticeOp<'infcx, 'tcx> {
     // Relates the type `v` to `a` and `b` such that `v` represents
     // the LUB/GLB of `a` and `b` as appropriate.
     //
@@ -210,24 +232,24 @@ impl<'combine, 'infcx, 'tcx> LatticeOp<'combine, 'infcx, 'tcx> {
     // relates `v` to `a` first, which may help us to avoid unnecessary
     // type variable obligations. See caller for details.
     fn relate_bound(&mut self, v: Ty<'tcx>, a: Ty<'tcx>, b: Ty<'tcx>) -> RelateResult<'tcx, ()> {
-        let mut sub = self.fields.sub();
+        let at = self.infcx.at(&self.trace.cause, self.param_env);
         match self.kind {
             LatticeOpKind::Glb => {
-                sub.relate(v, a)?;
-                sub.relate(v, b)?;
+                self.obligations.extend(at.sub(self.define_opaque_types, v, a)?.into_obligations());
+                self.obligations.extend(at.sub(self.define_opaque_types, v, b)?.into_obligations());
             }
             LatticeOpKind::Lub => {
-                sub.relate(a, v)?;
-                sub.relate(b, v)?;
+                self.obligations.extend(at.sub(self.define_opaque_types, a, v)?.into_obligations());
+                self.obligations.extend(at.sub(self.define_opaque_types, b, v)?.into_obligations());
             }
         }
         Ok(())
     }
 }
 
-impl<'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for LatticeOp<'_, '_, 'tcx> {
+impl<'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for LatticeOp<'_, 'tcx> {
     fn span(&self) -> Span {
-        self.fields.trace.span()
+        self.trace.span()
     }
 
     fn structurally_relate_aliases(&self) -> StructurallyRelateAliases {
@@ -235,21 +257,27 @@ impl<'tcx> PredicateEmittingRelation<InferCtxt<'tcx>> for LatticeOp<'_, '_, 'tcx
     }
 
     fn param_env(&self) -> ty::ParamEnv<'tcx> {
-        self.fields.param_env
+        self.param_env
     }
 
     fn register_predicates(
         &mut self,
-        obligations: impl IntoIterator<Item: ty::Upcast<TyCtxt<'tcx>, ty::Predicate<'tcx>>>,
+        preds: impl IntoIterator<Item: ty::Upcast<TyCtxt<'tcx>, ty::Predicate<'tcx>>>,
     ) {
-        self.fields.register_predicates(obligations);
+        self.obligations.extend(preds.into_iter().map(|pred| {
+            Obligation::new(self.infcx.tcx, self.trace.cause.clone(), self.param_env, pred)
+        }))
     }
 
-    fn register_goals(
-        &mut self,
-        obligations: impl IntoIterator<Item = Goal<'tcx, ty::Predicate<'tcx>>>,
-    ) {
-        self.fields.register_obligations(obligations);
+    fn register_goals(&mut self, goals: impl IntoIterator<Item = Goal<'tcx, ty::Predicate<'tcx>>>) {
+        self.obligations.extend(goals.into_iter().map(|goal| {
+            Obligation::new(
+                self.infcx.tcx,
+                self.trace.cause.clone(),
+                goal.param_env,
+                goal.predicate,
+            )
+        }))
     }
 
     fn register_alias_relate_predicate(&mut self, a: Ty<'tcx>, b: Ty<'tcx>) {

--- a/compiler/rustc_infer/src/infer/relate/mod.rs
+++ b/compiler/rustc_infer/src/infer/relate/mod.rs
@@ -11,5 +11,5 @@ pub use self::combine::PredicateEmittingRelation;
 pub(super) mod combine;
 mod generalize;
 mod higher_ranked;
-mod lattice;
-mod type_relating;
+pub(super) mod lattice;
+pub(super) mod type_relating;


### PR DESCRIPTION
This conflicts with #131263, but if this one lands first then perhaps #131263 could then go ahead and remove all the branching on solver in `TypeRelating`. We could perhaps then rename `TypeRelating` to `OldSolverRelating` or something, idk. 

r? lcnr