### PR TITLE
force "HEAD" for non-CI and `git_upstream_merge_base` for CI environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,9 @@ jobs:
           # which then uses log commands to actually set them.
           EXTRA_VARIABLES: ${{ toJson(matrix.env) }}
 
+      - name: setup upstream remote
+        run: src/ci/scripts/setup-upstream-remote.sh
+
       - name: ensure the channel matches the target branch
         run: src/ci/scripts/verify-channel.sh
 

--- a/src/ci/scripts/setup-upstream-remote.sh
+++ b/src/ci/scripts/setup-upstream-remote.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# In CI environments, bootstrap is forced to use the remote upstream based
+# on "git_repository" and "nightly_branch" values from src/stage0 file.
+# This script configures the remote as it may not exist by default.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+ci_dir=$(cd $(dirname $0) && pwd)/..
+source "$ci_dir/shared.sh"
+
+git_repository=$(parse_stage0_file_by_key "git_repository")
+nightly_branch=$(parse_stage0_file_by_key "nightly_branch")
+
+# Configure "rust-lang/rust" upstream remote only when it's not origin.
+if [ -z "$(git config remote.origin.url | grep $git_repository)" ]; then
+    echo "Configuring https://github.com/$git_repository remote as upstream."
+    git remote add upstream "https://github.com/$git_repository"
+    REMOTE_NAME="upstream"
+else
+    REMOTE_NAME="origin"
+fi
+
+git fetch $REMOTE_NAME $nightly_branch

--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -136,3 +136,15 @@ function releaseChannel {
         echo $RUST_CI_OVERRIDE_RELEASE_CHANNEL
     fi
 }
+
+# Parse values from src/stage0 file by key
+function parse_stage0_file_by_key {
+    local key="$1"
+    local file="$ci_dir/../stage0"
+    local value=$(awk -F= '{a[$1]=$2} END {print(a["'$key'"])}' $file)
+    if [ -z "$value" ]; then
+        echo "ERROR: Key '$key' not found in '$file'."
+        exit 1
+    fi
+    echo "$value"
+}


### PR DESCRIPTION
When rust-lang/rust is configured as remote, some of the git logic (for tracking changed files) that uses get_closest_merge_commit starts to produce annoying results as the upstream branch becomes outdated quickly (since it isn't updated with git pull). We can rely on HEAD for non-CI environments as we specifically treat bors commits as merge commits, which also exist on upstream. As for CI environments, we should use `git_upstream_merge_base` to correctly track modified files as bors commits may be in `HEAD` but not yet on the upstream remote.

This is also an alternative fix for https://github.com/rust-lang/rust/issues/129528 since https://github.com/rust-lang/rust/pull/131331 reverts the previous fix attempts.