### PR TITLE
Fix used_underscore_binding in rustc_serialize

### DIFF
--- a/compiler/rustc_serialize/src/opaque.rs
+++ b/compiler/rustc_serialize/src/opaque.rs
@@ -437,10 +437,10 @@ impl IntEncodedWithFixedSize {
 impl Encodable<FileEncoder> for IntEncodedWithFixedSize {
     #[inline]
     fn encode(&self, e: &mut FileEncoder) {
-        let _start_pos = e.position();
+        let start_pos = e.position();
         e.write_array(self.0.to_le_bytes());
-        let _end_pos = e.position();
-        debug_assert_eq!((_end_pos - _start_pos), IntEncodedWithFixedSize::ENCODED_SIZE);
+        let end_pos = e.position();
+        debug_assert_eq!((end_pos - start_pos), IntEncodedWithFixedSize::ENCODED_SIZE);
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Hi,

This PR fixes the following clippy warnings in rustc_serialize

```
warning: used underscore-prefixed binding
   --> compiler/rustc_serialize/src/opaque.rs:443:27
    |
443 |         debug_assert_eq!((_end_pos - _start_pos), IntEncodedWithFixedSize::ENCODED_SIZE);
    |                           ^^^^^^^^
    |
note: binding is defined here
   --> compiler/rustc_serialize/src/opaque.rs:442:13
    |
442 |         let _end_pos = e.position();
    |             ^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#used_underscore_binding
    = note: requested on the command line with `-W clippy::used-underscore-binding`

warning: used underscore-prefixed binding
   --> compiler/rustc_serialize/src/opaque.rs:443:38
    |
443 |         debug_assert_eq!((_end_pos - _start_pos), IntEncodedWithFixedSize::ENCODED_SIZE);
    |                                      ^^^^^^^^^^
    |
note: binding is defined here
   --> compiler/rustc_serialize/src/opaque.rs:440:13
    |
440 |         let _start_pos = e.position();
    |             ^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#used_underscore_binding
```

Best regards,
Michal