### PR TITLE
CI: use free runners for 4-core Linux jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,18 @@ jobs:
         with:
           fetch-depth: 2
 
+      # Free up disk space on Linux by removing preinstalled components that
+      # we do not need. We do this to enable some of the less resource
+      # intensive jobs to run on free runners, which however also have
+      # less disk space.
+      - name: free up disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        if: contains(matrix.os, 'ubuntu')
+        with:
+          # Removing packages with APT saves ~5 GiB, but takes several
+          # minutes (and potentially removes important packages).
+          large-packages: false
+
       # Rust Log Analyzer can't currently detect the PR number of a GitHub
       # Actions build on its own, so a hint in the log message is needed to
       # point it in the right direction.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,11 @@ jobs:
       - name: create github artifacts
         run: src/ci/scripts/create-doc-artifacts.sh
 
+      - name: print disk usage
+        run: |
+          echo "disk usage:"
+          df -h
+
       - name: upload artifacts to github
         uses: actions/upload-artifact@v4
         with:

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -5,6 +5,11 @@ runners:
     env: { }
 
   - &job-linux-4c
+    os: ubuntu-20.04
+    <<: *base-job
+
+  # Large runner used mainly for its bigger disk capacity
+  - &job-linux-4c-largedisk
     os: ubuntu-20.04-4core-16gb
     <<: *base-job
 
@@ -127,7 +132,7 @@ auto:
   - image: dist-aarch64-linux
     env:
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-linux-4c
+    <<: *job-linux-4c-largedisk
 
   - image: dist-android
     <<: *job-linux-4c
@@ -148,28 +153,28 @@ auto:
     <<: *job-linux-4c
 
   - image: dist-loongarch64-linux
-    <<: *job-linux-4c
+    <<: *job-linux-4c-largedisk
 
   - image: dist-loongarch64-musl
-    <<: *job-linux-4c
+    <<: *job-linux-4c-largedisk
 
   - image: dist-ohos
     <<: *job-linux-4c
 
   - image: dist-powerpc-linux
-    <<: *job-linux-4c
+    <<: *job-linux-4c-largedisk
 
   - image: dist-powerpc64-linux
-    <<: *job-linux-4c
+    <<: *job-linux-4c-largedisk
 
   - image: dist-powerpc64le-linux
-    <<: *job-linux-4c
+    <<: *job-linux-4c-largedisk
 
   - image: dist-riscv64-linux
     <<: *job-linux-4c
 
   - image: dist-s390x-linux
-    <<: *job-linux-4c
+    <<: *job-linux-4c-largedisk
 
   - image: dist-various-1
     <<: *job-linux-4c


### PR DESCRIPTION
It looks like the [free runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) already have the same spec as the `4c` custom "large" runner (4 cores, 16 GiB of memory, Ubuntu 20.04).

try-job: arm-android
try-job: armhf-gnu
try-job: dist-aarch64-linux
try-job: dist-android
try-job: dist-arm-linux
try-job: dist-armhf-linux
try-job: dist-armv7-linux
try-job: dist-i586-gnu-i586-i686-musl
try-job: dist-i686-linux
try-job: dist-loongarch64-linux
try-job: dist-loongarch64-musl
try-job: dist-ohos
try-job: dist-powerpc-linux
try-job: dist-powerpc64-linux
try-job: dist-powerpc64le-linux
try-job: dist-riscv64-linux
try-job: dist-s390x-linux
try-job: dist-various-1
try-job: dist-various-2
try-job: dist-x86_64-freebsd
try-job: dist-x86_64-illumos
try-job: dist-x86_64-netbsd
try-job: mingw-check
try-job: test-various
try-job: x86_64-gnu
try-job: x86_64-gnu-stable
try-job: x86_64-gnu-aux
try-job: x86_64-gnu-debug
try-job: x86_64-gnu-nopt