### PR TITLE
CI: rfl: move job forward to Linux v6.12-rc2

### DIFF
--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-LINUX_VERSION=4c7864e81d8bbd51036dacf92fb0a400e13aaeee
+LINUX_VERSION=v6.12-rc2
 
 # Build rustc, rustdoc, cargo, clippy-driver and rustfmt
 ../x.py build --stage 2 library rustdoc clippy rustfmt


### PR DESCRIPTION
r? @Kobzol

try-job: x86_64-rust-for-linux