### PR TITLE
Fix utf8-bom test

### DIFF
--- a/tests/ui/utf8-bom.rs
+++ b/tests/ui/utf8-bom.rs
@@ -1,6 +1,4 @@
+﻿// This file has utf-8 BOM, it should be compiled normally without error.
 //@ run-pass
-//
-
-// This file has utf-8 BOM, it should be compiled normally without error.
 
 pub fn main() {}


### PR DESCRIPTION
The BOM was accidentally removed in https://github.com/rust-lang/rust/pull/57108

I had to move the run-pass line down, because compiletest doesn't seem to know about BOMs, so it does not parse the header if it is the first line.
