### PR TITLE
Add "reference" as a known compiletest header

### DIFF
--- a/src/tools/compiletest/src/command-list.rs
+++ b/src/tools/compiletest/src/command-list.rs
@@ -208,6 +208,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "pretty-compare-only",
     "pretty-expanded",
     "pretty-mode",
+    "reference",
     "regex-error-pattern",
     "remap-src-base",
     "revisions",


### PR DESCRIPTION
This adds the "reference" compiletest header so that the Rust reference can add annotations to the test suite in order to link tests to individual rules in the reference.

Tooling in the reference repo will be responsible for collecting these annotations and linking to the tests.

More details are in MCP 783: https://github.com/rust-lang/compiler-team/issues/783

There is a change from the MCP in that I am not adding the JSON collection to compiletest (at least, not yet). In looking at this more closely, that actually makes things more difficult for our tooling, so I'm leaving it out for now. If in the future it looks like something we want, then I think we can add it later.

There are a few tests here which need adjusting due to the legacy header check. @jieyouxu indicated on Zulip that we could potentially remove the legacy header check, in which case those changes can be dropped from this PR.

r? @jieyouxu 
