### PR TITLE
coverage: Disable the zombie MC/DC tests until they support LLVM 19

### DIFF
--- a/tests/coverage/mcdc/condition-limit.rs
+++ b/tests/coverage/mcdc/condition-limit.rs
@@ -1,6 +1,6 @@
 #![feature(coverage_attribute)]
 //@ edition: 2021
-//@ ignore-llvm-version: 19 - 99
+//@ ignore-test (needs #126733 for LLVM 19 support)
 //@ compile-flags: -Zcoverage-options=mcdc
 //@ llvm-cov-flags: --show-branches=count --show-mcdc
 

--- a/tests/coverage/mcdc/if.rs
+++ b/tests/coverage/mcdc/if.rs
@@ -1,6 +1,6 @@
 #![feature(coverage_attribute)]
 //@ edition: 2021
-//@ ignore-llvm-version: 19 - 99
+//@ ignore-test (needs #126733 for LLVM 19 support)
 //@ compile-flags: -Zcoverage-options=mcdc
 //@ llvm-cov-flags: --show-branches=count --show-mcdc
 

--- a/tests/coverage/mcdc/inlined_expressions.rs
+++ b/tests/coverage/mcdc/inlined_expressions.rs
@@ -1,6 +1,6 @@
 #![feature(coverage_attribute)]
 //@ edition: 2021
-//@ ignore-llvm-version: 19 - 99
+//@ ignore-test (needs #126733 for LLVM 19 support)
 //@ compile-flags: -Zcoverage-options=mcdc -Copt-level=z -Cllvm-args=--inline-threshold=0
 //@ llvm-cov-flags: --show-branches=count --show-mcdc
 

--- a/tests/coverage/mcdc/nested_if.rs
+++ b/tests/coverage/mcdc/nested_if.rs
@@ -1,6 +1,6 @@
 #![feature(coverage_attribute)]
 //@ edition: 2021
-//@ ignore-llvm-version: 19 - 99
+//@ ignore-test (needs #126733 for LLVM 19 support)
 //@ compile-flags: -Zcoverage-options=mcdc
 //@ llvm-cov-flags: --show-branches=count --show-mcdc
 

--- a/tests/coverage/mcdc/non_control_flow.rs
+++ b/tests/coverage/mcdc/non_control_flow.rs
@@ -1,6 +1,6 @@
 #![feature(coverage_attribute)]
 //@ edition: 2021
-//@ ignore-llvm-version: 19 - 99
+//@ ignore-test (needs #126733 for LLVM 19 support)
 //@ compile-flags: -Zcoverage-options=mcdc
 //@ llvm-cov-flags: --show-branches=count --show-mcdc
 


### PR DESCRIPTION
Currently these tests only run against LLVM 18, but the default is now LLVM 19, which makes them very tricky to bless. Since #126733 is going to drop support for MC/DC in LLVM 18 anyway, it's easier to just completely disable the tests until that PR fixes them.

(For context, MC/DC is currently unstable anyway, and LLVM's MC/DC APIs have changes between 18 and 19, so supporting both would be an unnecessary headache.)

r? jieyouxu