### PR TITLE
fix(rustdoc): add space between struct fields and their descriptions

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -230,6 +230,9 @@ h4.code-header {
 	padding: 0;
 	white-space: pre-wrap;
 }
+.structfield {
+	margin: 0.6em 0;
+}
 
 #crate-search,
 h1, h2, h3, h4, h5, h6,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Stolen from #128541.
Fixes #128260.

<table>
  <thead>
    <tr>
      <th scope="col">Before</th>
      <th scope="col">After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td scope="row">
        <img
          src="https://github.com/user-attachments/assets/b1d3cb47-77c9-4897-a5d2-2192b11cb8a3"
        />
      </td>
      <td>
        <img
          src="https://github.com/user-attachments/assets/0b104672-d2be-49f4-ac9b-3506526fe2f1"
        />
      </td>
    </tr>
  </tbody>
</table>

<table>
  <thead>
    <tr>
      <th scope="col">Before</th>
      <th scope="col">After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td scope="row">
        <img
          src="https://github.com/user-attachments/assets/650c3e74-a067-492a-9ba3-557f9214f875"
        />
      </td>
      <td>
        <img
          src="https://github.com/user-attachments/assets/413ef9b0-8fca-4e16-978a-7b88d05299dc"
        />
      </td>
    </tr>
  </tbody>
</table>

Unlike original PR, I didn't add space between field headers; I put it between headers and descriptions. So if there are only headers, the space is not changed. Otherwise, I put a space like the space between paragraphs (.75em) which makes sense for me but feel free to adjust it or ask me to do so.

r? @GuillaumeGomez 