### PR TITLE
Fix needless_lifetimes in rustc_serialize

### DIFF
--- a/compiler/rustc_serialize/src/serialize.rs
+++ b/compiler/rustc_serialize/src/serialize.rs
@@ -325,7 +325,7 @@ impl<D: Decoder, const N: usize> Decodable<D> for [u8; N] {
     }
 }
 
-impl<'a, S: Encoder, T: Encodable<S>> Encodable<S> for Cow<'a, [T]>
+impl<S: Encoder, T: Encodable<S>> Encodable<S> for Cow<'_, [T]>
 where
     [T]: ToOwned<Owned = Vec<T>>,
 {
@@ -345,14 +345,14 @@ where
     }
 }
 
-impl<'a, S: Encoder> Encodable<S> for Cow<'a, str> {
+impl<S: Encoder> Encodable<S> for Cow<'_, str> {
     fn encode(&self, s: &mut S) {
         let val: &str = self;
         val.encode(s)
     }
 }
 
-impl<'a, D: Decoder> Decodable<D> for Cow<'a, str> {
+impl<D: Decoder> Decodable<D> for Cow<'_, str> {
     fn decode(d: &mut D) -> Cow<'static, str> {
         let v: String = Decodable::decode(d);
         Cow::Owned(v)


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Hi,

This PR fixes the following clipy warnings: 

```
warning: the following explicit lifetimes could be elided: 'a
   --> compiler/rustc_serialize/src/serialize.rs:328:6
    |
328 | impl<'a, S: Encoder, T: Encodable<S>> Encodable<S> for Cow<'a, [T]>
    |      ^^                                                    ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
    |
328 - impl<'a, S: Encoder, T: Encodable<S>> Encodable<S> for Cow<'a, [T]>
328 + impl<S: Encoder, T: Encodable<S>> Encodable<S> for Cow<'_, [T]>
    |

warning: the following explicit lifetimes could be elided: 'a
   --> compiler/rustc_serialize/src/serialize.rs:348:6
    |
348 | impl<'a, S: Encoder> Encodable<S> for Cow<'a, str> {
    |      ^^                                   ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
348 - impl<'a, S: Encoder> Encodable<S> for Cow<'a, str> {
348 + impl<S: Encoder> Encodable<S> for Cow<'_, str> {
    |

warning: the following explicit lifetimes could be elided: 'a
   --> compiler/rustc_serialize/src/serialize.rs:355:6
    |
355 | impl<'a, D: Decoder> Decodable<D> for Cow<'a, str> {
    |      ^^                                   ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
355 - impl<'a, D: Decoder> Decodable<D> for Cow<'a, str> {
355 + impl<D: Decoder> Decodable<D> for Cow<'_, str> {
```

Best regards,
Michal