### PR TITLE
Fix methods alignment on mobile

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -2435,7 +2435,7 @@ in src-script.js and main.js
 	}
 
 	/* Position of the "[-]" element. */
-	details.toggle:not(.top-doc) > summary {
+	details.toggle:not(.top-doc) > summary, .impl-items > section  {
 		margin-left: 10px;
 	}
 	.impl-items > details.toggle > summary:not(.hideme)::before,

--- a/tests/rustdoc-gui/methods-left-margin.goml
+++ b/tests/rustdoc-gui/methods-left-margin.goml
@@ -1,0 +1,17 @@
+// This test is to ensure that methods are correctly aligned on the left side.
+
+go-to: "file://" + |DOC_PATH| + "/test_docs/struct.Foo.html"
+
+// First we ensure that we have methods with and without documentation.
+assert: ".impl-items > details.method-toggle > summary > section.method"
+assert: ".impl-items > section.method"
+
+// Checking on desktop.
+set-window-size: (900, 600)
+store-position: (".impl-items section.method", {"x": x})
+assert-position: (".impl-items section.method", {"x": |x|}, ALL)
+
+// Checking on mobile.
+set-window-size: (600, 600)
+store-position: (".impl-items section.method", {"x": x})
+assert-position: (".impl-items section.method", {"x": |x|}, ALL)

--- a/tests/rustdoc-gui/methods-left-margin.goml
+++ b/tests/rustdoc-gui/methods-left-margin.goml
@@ -8,10 +8,12 @@ assert: ".impl-items > section.method"
 
 // Checking on desktop.
 set-window-size: (900, 600)
+wait-for-size: ("body", {"width": 900})
 store-position: (".impl-items section.method", {"x": x})
 assert-position: (".impl-items section.method", {"x": |x|}, ALL)
 
 // Checking on mobile.
 set-window-size: (600, 600)
+wait-for-size: ("body", {"width": 600})
 store-position: (".impl-items section.method", {"x": x})
 assert-position: (".impl-items section.method", {"x": |x|}, ALL)

--- a/tests/rustdoc-gui/notable-trait.goml
+++ b/tests/rustdoc-gui/notable-trait.goml
@@ -85,8 +85,8 @@ call-function: ("check-notable-tooltip-position", {
 // Checking on mobile now.
 set-window-size: (650, 600)
 call-function: ("check-notable-tooltip-position-complete", {
-    "x": 15,
-    "i_x": 293,
+    "x": 25,
+    "i_x": 303,
     "popover_x": 0,
 })
 

--- a/tests/rustdoc-gui/notable-trait.goml
+++ b/tests/rustdoc-gui/notable-trait.goml
@@ -84,6 +84,7 @@ call-function: ("check-notable-tooltip-position", {
 
 // Checking on mobile now.
 set-window-size: (650, 600)
+wait-for-size: ("body", {"width": 650})
 call-function: ("check-notable-tooltip-position-complete", {
     "x": 25,
     "i_x": 303,


### PR DESCRIPTION
I realized that on mobile, the methods are not aligned the same depending if they have documentation or not:

| before | after |
|-|-|
| ![Screenshot from 2024-10-08 20-40-22](https://github.com/user-attachments/assets/d31ba5e1-cf84-431f-9b2b-9962bc5a0365) | ![image](https://github.com/user-attachments/assets/ffde2161-bfcb-4462-8c5b-88538e61b366) |

r? @notriddle 

