### PR TITLE
Fix quotation marks around debug line in `src/ci/run.sh`

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -55,7 +55,7 @@ fi
 # If runner uses an incompatible option and `FORCE_CI_RUSTC` is not defined,
 # switch to in-tree rustc.
 if [ "$FORCE_CI_RUSTC" == "" ]; then
-    echo "debug: `DISABLE_CI_RUSTC_IF_INCOMPATIBLE` configured."
+    echo 'debug: `DISABLE_CI_RUSTC_IF_INCOMPATIBLE` configured.'
     DISABLE_CI_RUSTC_IF_INCOMPATIBLE=1
 fi
 


### PR DESCRIPTION
Without this change, the markdown-style backticks are treated as a shell
command substitution, which fails like so:

    /checkout/src/ci/run.sh: line 58: DISABLE_CI_RUSTC_IF_INCOMPATIBLE: command not found
    debug:  configured.

r? onur-ozkan