### PR TITLE
Special treatment empty tuple when suggest adding a string literal in format macro.

### DIFF
--- a/tests/ui/macros/format-empty-block-unit-tuple-suggestion-130170.fixed
+++ b/tests/ui/macros/format-empty-block-unit-tuple-suggestion-130170.fixed
@@ -1,0 +1,13 @@
+//@ run-rustfix
+
+fn main() {
+    let s = "123";
+    println!("{:?} {} {}", {}, "sss", s);
+    //~^ ERROR format argument must be a string literal
+    println!("{:?}", {});
+    //~^ ERROR format argument must be a string literal
+    println!("{} {} {} {:?}", s, "sss", s, {});
+    //~^ ERROR format argument must be a string literal
+    println!("{:?} {} {:?}", (), s, {});
+    //~^ ERROR format argument must be a string literal
+}

--- a/tests/ui/macros/format-empty-block-unit-tuple-suggestion-130170.rs
+++ b/tests/ui/macros/format-empty-block-unit-tuple-suggestion-130170.rs
@@ -1,0 +1,13 @@
+//@ run-rustfix
+
+fn main() {
+    let s = "123";
+    println!({}, "sss", s);
+    //~^ ERROR format argument must be a string literal
+    println!({});
+    //~^ ERROR format argument must be a string literal
+    println!(s, "sss", s, {});
+    //~^ ERROR format argument must be a string literal
+    println!((), s, {});
+    //~^ ERROR format argument must be a string literal
+}

--- a/tests/ui/macros/format-empty-block-unit-tuple-suggestion-130170.stderr
+++ b/tests/ui/macros/format-empty-block-unit-tuple-suggestion-130170.stderr
@@ -1,0 +1,46 @@
+error: format argument must be a string literal
+  --> $DIR/format-empty-block-unit-tuple-suggestion-130170.rs:5:14
+   |
+LL |     println!({}, "sss", s);
+   |              ^^
+   |
+help: you might be missing a string literal to format with
+   |
+LL |     println!("{:?} {} {}", {}, "sss", s);
+   |              +++++++++++++
+
+error: format argument must be a string literal
+  --> $DIR/format-empty-block-unit-tuple-suggestion-130170.rs:7:14
+   |
+LL |     println!({});
+   |              ^^
+   |
+help: you might be missing a string literal to format with
+   |
+LL |     println!("{:?}", {});
+   |              +++++++
+
+error: format argument must be a string literal
+  --> $DIR/format-empty-block-unit-tuple-suggestion-130170.rs:9:14
+   |
+LL |     println!(s, "sss", s, {});
+   |              ^
+   |
+help: you might be missing a string literal to format with
+   |
+LL |     println!("{} {} {} {:?}", s, "sss", s, {});
+   |              ++++++++++++++++
+
+error: format argument must be a string literal
+  --> $DIR/format-empty-block-unit-tuple-suggestion-130170.rs:11:14
+   |
+LL |     println!((), s, {});
+   |              ^^
+   |
+help: you might be missing a string literal to format with
+   |
+LL |     println!("{:?} {} {:?}", (), s, {});
+   |              +++++++++++++++
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
For example:
```rust
let s = "123";
println!({}, "sss", s);
```
Suggest:
`println!("{:?} {} {}", {}, "sss", s);`

fixes #130170

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
