### PR TITLE
fix `ci_rustc_if_unchanged_logic` test

### DIFF
--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -239,7 +239,7 @@ fn ci_rustc_if_unchanged_logic() {
     builder.run_step_descriptions(&Builder::get_step_descriptions(config.cmd.kind()), &[]);
 
     let compiler_path = build.src.join("compiler");
-    let library_path = build.src.join("compiler");
+    let library_path = build.src.join("library");
 
     let commit =
         get_closest_merge_commit(Some(&builder.config.src), &builder.config.git_config(), &[


### PR DESCRIPTION
Kind a typo from https://github.com/rust-lang/rust/pull/122709, which makes `ci_rustc_if_unchanged_logic` test to fail in any PR that has a change in "library" tree (e.g., https://github.com/rust-lang/rust/pull/131418#issuecomment-2400878904). This fixes that.

r? ghost