### PR TITLE
Ignore broken-pipe-no-ice on apple (specifically macOS) for now

### DIFF
--- a/tests/run-make/broken-pipe-no-ice/rmake.rs
+++ b/tests/run-make/broken-pipe-no-ice/rmake.rs
@@ -5,6 +5,12 @@
 
 //@ ignore-cross-compile (needs to run test binary)
 
+//@ ignore-apple
+// FIXME(#131436): on macOS rustc is still reporting the std broken pipe io error panick but it
+// doesn't fail with 101 exit status (it terminates with a wait status of SIGPIPE). It doesn't say
+// Internal Compiler Error strangely, but it doesn't even go through normal diagnostic infra. Very
+// strange.
+
 #![feature(anonymous_pipe)]
 
 use std::io::Read;


### PR DESCRIPTION
This test fails for me locally (initially reported by Zalathar) because apparently on macOS it doesn't say "internal compiler error" but it does report the std I/O panic, and it doesn't exit with a code of 101 but instead terminates with a wait signal of SIGPIPE.

Ignore this test on apple for now, until we try to actually address the underlying issue.

See https://github.com/rust-lang/rust/pull/131155 and https://github.com/rust-lang/rust/issues/131436 for more context.