### PR TITLE
stabilize `ci_rustc_if_unchanged_logic` test

### DIFF
--- a/compiler/rustc_borrowck/src/places_conflict.rs
+++ b/compiler/rustc_borrowck/src/places_conflict.rs
@@ -3,7 +3,7 @@
 //! we can prove overlap one way or another. Essentially, we treat `Overlap` as
 //! a monoid and report a conflict if the product ends up not being `Disjoint`.
 //!
-//! At each step, if we didn't run out of borrow or place, we know that our elements
+//! On each step, if we didn't run out of borrow or place, we know that our elements
 //! have the same type, and that they only overlap if they are the identical.
 //!
 //! For example, if we are comparing these:


### PR DESCRIPTION
Makes `ci_rustc_if_unchanged_logic` test more stable and re-enables it. Previously, it was expecting CI-rustc to be used all the time when there were no changes, which wasn’t always the case. Purpose of this test is making sure we don't use CI-rustc while there are changes in compiler and/or library, but we don't really need to cover cases where CI-rustc is not enabled.

Second commit was pushed for making a change in the compiler tree, so `ci_rustc_if_unchanged_logic` can be tested properly in merge CI.