### PR TITLE
Fix typo in E0793

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0793.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0793.md
@@ -1,4 +1,4 @@
-An unaligned references to a field of a [packed] struct got created.
+An unaligned reference to a field of a [packed] struct got created.
 
 Erroneous code example:
 


### PR DESCRIPTION
`s/references/reference/`