### PR TITLE
Expand `ptr::fn_addr_eq()` documentation.

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -2180,7 +2180,7 @@ pub fn addr_eq<T: ?Sized, U: ?Sized>(p: *const T, q: *const U) -> bool {
 ///   let f: fn(i32) -> i32 = |x| x;
 ///   let g: fn(i32) -> i32 = |x| x + 0;  // different closure, different body
 ///   let h: fn(u32) -> u32 = |x| x + 0;  // different signature too
-///   dbg!(std::ptr::fn_addr_eq(f, g), std::ptr::fn_addr_eq(f, h));
+///   dbg!(std::ptr::fn_addr_eq(f, g), std::ptr::fn_addr_eq(f, h)); // not guaranteed to be equal
 ///   ```
 ///
 /// * May return `false` in any case.

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -2166,10 +2166,12 @@ pub fn addr_eq<T: ?Sized, U: ?Sized>(p: *const T, q: *const U) -> bool {
 ///
 /// This is the same as `f == g`, but using this function makes clear that the potentially
 /// surprising semantics of function pointer comparison are involved.
-/// There are very few guarantees about how functions are compiled and they have no intrinsic
+///
+/// There are **very few guarantees** about how functions are compiled and they have no intrinsic
 /// “identity”; in particular, this comparison:
 ///
 /// * May return `true` unexpectedly, in cases where functions are equivalent.
+///
 ///   For example, the following program is likely (but not guaranteed) to print `(true, true)`
 ///   when compiled with optimization:
 ///
@@ -2182,6 +2184,7 @@ pub fn addr_eq<T: ?Sized, U: ?Sized>(p: *const T, q: *const U) -> bool {
 ///   ```
 ///
 /// * May return `false` in any case.
+///
 ///   This is particularly likely with generic functions but may happen with any function.
 ///   (From an implementation perspective, this is possible because functions may sometimes be
 ///   processed more than once by the compiler, resulting in duplicate machine code.)
@@ -2207,7 +2210,6 @@ pub fn addr_eq<T: ?Sized, U: ?Sized>(p: *const T, q: *const U) -> bool {
 /// ```
 ///
 /// [subtype]: https://doc.rust-lang.org/reference/subtyping.html
-
 #[unstable(feature = "ptr_fn_addr_eq", issue = "129322")]
 #[inline(always)]
 #[must_use = "function pointer comparison produces a value"]


### PR DESCRIPTION
* Describe more clearly what is (not) guaranteed, and de-emphasize the description of rustc implementation details.
* Explain what you *can* reliably use it for.

Tracking issue for `ptr_fn_addr_eq`: #129322

The motivation for this PR is that I just learned that `ptr::fn_addr_eq()` exists, read the documentation, and thought: “*I* know what this means, but someone not already familiar with how `rustc` works could be left wondering whether this is even good for anything.” Fixing that seems especially important if we’re going to recommend people use it instead of `==` (as per #118833).