### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3416,6 +3416,7 @@ dependencies = [
  "measureme",
  "object 0.36.4",
  "rustc-demangle",
+ "rustc_abi",
  "rustc_ast",
  "rustc_attr",
  "rustc_codegen_ssa",
@@ -3456,6 +3457,7 @@ dependencies = [
  "object 0.36.4",
  "pathdiff",
  "regex",
+ "rustc_abi",
  "rustc_arena",
  "rustc_ast",
  "rustc_attr",
@@ -3493,6 +3495,7 @@ name = "rustc_const_eval"
 version = "0.0.0"
 dependencies = [
  "either",
+ "rustc_abi",
  "rustc_apfloat",
  "rustc_ast",
  "rustc_attr",
@@ -3772,6 +3775,7 @@ name = "rustc_hir_typeck"
 version = "0.0.0"
 dependencies = [
  "itertools",
+ "rustc_abi",
  "rustc_ast",
  "rustc_ast_ir",
  "rustc_attr",
@@ -4027,6 +4031,7 @@ dependencies = [
  "gsgdt",
  "polonius-engine",
  "rustc-rayon-core",
+ "rustc_abi",
  "rustc_apfloat",
  "rustc_arena",
  "rustc_ast",
@@ -4522,6 +4527,7 @@ name = "rustc_ty_utils"
 version = "0.0.0"
 dependencies = [
  "itertools",
+ "rustc_abi",
  "rustc_ast_ir",
  "rustc_data_structures",
  "rustc_errors",

--- a/compiler/rustc_codegen_cranelift/src/discriminant.rs
+++ b/compiler/rustc_codegen_cranelift/src/discriminant.rs
@@ -3,7 +3,8 @@
 //! Adapted from <https://github.com/rust-lang/rust/blob/31c0645b9d2539f47eecb096142474b29dc542f7/compiler/rustc_codegen_ssa/src/mir/place.rs>
 //! (<https://github.com/rust-lang/rust/pull/104535>)
 
-use rustc_target::abi::{Int, TagEncoding, Variants};
+use rustc_abi::Primitive::Int;
+use rustc_abi::{TagEncoding, Variants};
 
 use crate::prelude::*;
 

--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -15,6 +15,7 @@
 extern crate jobserver;
 #[macro_use]
 extern crate rustc_middle;
+extern crate rustc_abi;
 extern crate rustc_ast;
 extern crate rustc_codegen_ssa;
 extern crate rustc_data_structures;

--- a/compiler/rustc_codegen_gcc/src/builder.rs
+++ b/compiler/rustc_codegen_gcc/src/builder.rs
@@ -7,6 +7,8 @@ use gccjit::{
     BinaryOp, Block, ComparisonOp, Context, Function, LValue, Location, RValue, ToRValue, Type,
     UnaryOp,
 };
+use rustc_abi as abi;
+use rustc_abi::{Align, HasDataLayout, Size, TargetDataLayout, WrappingRange};
 use rustc_apfloat::{Float, Round, Status, ieee};
 use rustc_codegen_ssa::MemFlags;
 use rustc_codegen_ssa::common::{
@@ -28,7 +30,6 @@ use rustc_middle::ty::{Instance, ParamEnv, Ty, TyCtxt};
 use rustc_span::Span;
 use rustc_span::def_id::DefId;
 use rustc_target::abi::call::FnAbi;
-use rustc_target::abi::{self, Align, HasDataLayout, Size, TargetDataLayout, WrappingRange};
 use rustc_target::spec::{HasTargetSpec, HasWasmCAbiOpt, Target, WasmCAbi};
 
 use crate::common::{SignType, TypeReflection, type_is_pointer};
@@ -998,12 +999,12 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         ) {
             let vr = scalar.valid_range(bx);
             match scalar.primitive() {
-                abi::Int(..) => {
+                abi::Primitive::Int(..) => {
                     if !scalar.is_always_valid(bx) {
                         bx.range_metadata(load, vr);
                     }
                 }
-                abi::Pointer(_) if vr.start < vr.end && !vr.contains(0) => {
+                abi::Primitive::Pointer(_) if vr.start < vr.end && !vr.contains(0) => {
                     bx.nonnull_metadata(load);
                 }
                 _ => {}

--- a/compiler/rustc_codegen_gcc/src/common.rs
+++ b/compiler/rustc_codegen_gcc/src/common.rs
@@ -1,11 +1,13 @@
 use gccjit::{LValue, RValue, ToRValue, Type};
+use rustc_abi as abi;
+use rustc_abi::HasDataLayout;
+use rustc_abi::Primitive::Pointer;
 use rustc_codegen_ssa::traits::{
     BaseTypeCodegenMethods, ConstCodegenMethods, MiscCodegenMethods, StaticCodegenMethods,
 };
 use rustc_middle::mir::Mutability;
 use rustc_middle::mir::interpret::{ConstAllocation, GlobalAlloc, Scalar};
 use rustc_middle::ty::layout::LayoutOf;
-use rustc_target::abi::{self, HasDataLayout, Pointer};
 
 use crate::consts::const_alloc_to_gcc;
 use crate::context::CodegenCx;

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -32,6 +32,7 @@ extern crate tempfile;
 extern crate tracing;
 
 // The rustc crates we need
+extern crate rustc_abi;
 extern crate rustc_apfloat;
 extern crate rustc_ast;
 extern crate rustc_attr;

--- a/compiler/rustc_codegen_gcc/src/type_of.rs
+++ b/compiler/rustc_codegen_gcc/src/type_of.rs
@@ -1,6 +1,9 @@
 use std::fmt::Write;
 
 use gccjit::{Struct, Type};
+use rustc_abi as abi;
+use rustc_abi::Primitive::*;
+use rustc_abi::{Abi, FieldsShape, Integer, PointeeInfo, Size, Variants};
 use rustc_codegen_ssa::traits::{
     BaseTypeCodegenMethods, DerivedTypeCodegenMethods, LayoutTypeCodegenMethods,
 };
@@ -8,11 +11,8 @@ use rustc_middle::bug;
 use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::ty::print::with_no_trimmed_paths;
 use rustc_middle::ty::{self, CoroutineArgsExt, Ty, TypeVisitableExt};
+use rustc_target::abi::TyAbiInterface;
 use rustc_target::abi::call::{CastTarget, FnAbi, Reg};
-use rustc_target::abi::{
-    self, Abi, FieldsShape, Float, Int, Integer, PointeeInfo, Pointer, Size, TyAbiInterface,
-    Variants,
-};
 
 use crate::abi::{FnAbiGcc, FnAbiGccExt, GccType};
 use crate::context::CodegenCx;

--- a/compiler/rustc_codegen_llvm/Cargo.toml
+++ b/compiler/rustc_codegen_llvm/Cargo.toml
@@ -14,6 +14,7 @@ libc = "0.2"
 measureme = "11"
 object = { version = "0.36.3", default-features = false, features = ["std", "read"] }
 rustc-demangle = "0.1.21"
+rustc_abi = { path = "../rustc_abi" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_attr = { path = "../rustc_attr" }
 rustc_codegen_ssa = { path = "../rustc_codegen_ssa" }

--- a/compiler/rustc_codegen_llvm/src/abi.rs
+++ b/compiler/rustc_codegen_llvm/src/abi.rs
@@ -1,6 +1,9 @@
 use std::cmp;
 
 use libc::c_uint;
+use rustc_abi as abi;
+use rustc_abi::Primitive::Int;
+use rustc_abi::{HasDataLayout, Size};
 use rustc_codegen_ssa::MemFlags;
 use rustc_codegen_ssa::mir::operand::{OperandRef, OperandValue};
 use rustc_codegen_ssa::mir::place::{PlaceRef, PlaceValue};
@@ -11,7 +14,6 @@ pub(crate) use rustc_middle::ty::layout::{WIDE_PTR_ADDR, WIDE_PTR_EXTRA};
 use rustc_middle::{bug, ty};
 use rustc_session::config;
 pub(crate) use rustc_target::abi::call::*;
-use rustc_target::abi::{self, HasDataLayout, Int, Size};
 use rustc_target::spec::SanitizerSet;
 pub(crate) use rustc_target::spec::abi::Abi;
 use smallvec::SmallVec;

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -3,6 +3,8 @@ use std::ops::Deref;
 use std::{iter, ptr};
 
 use libc::{c_char, c_uint};
+use rustc_abi as abi;
+use rustc_abi::{Align, Size, WrappingRange};
 use rustc_codegen_ssa::MemFlags;
 use rustc_codegen_ssa::common::{IntPredicate, RealPredicate, SynchronizationScope, TypeKind};
 use rustc_codegen_ssa::mir::operand::{OperandRef, OperandValue};
@@ -20,7 +22,6 @@ use rustc_sanitizers::{cfi, kcfi};
 use rustc_session::config::OptLevel;
 use rustc_span::Span;
 use rustc_target::abi::call::FnAbi;
-use rustc_target::abi::{self, Align, Size, WrappingRange};
 use rustc_target::spec::{HasTargetSpec, SanitizerSet, Target};
 use smallvec::SmallVec;
 use tracing::{debug, instrument};
@@ -505,12 +506,12 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
             }
 
             match scalar.primitive() {
-                abi::Int(..) => {
+                abi::Primitive::Int(..) => {
                     if !scalar.is_always_valid(bx) {
                         bx.range_metadata(load, scalar.valid_range(bx));
                     }
                 }
-                abi::Pointer(_) => {
+                abi::Primitive::Pointer(_) => {
                     if !scalar.valid_range(bx).contains(0) {
                         bx.nonnull_metadata(load);
                     }
@@ -521,7 +522,7 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
                         }
                     }
                 }
-                abi::Float(_) => {}
+                abi::Primitive::Float(_) => {}
             }
         }
 

--- a/compiler/rustc_codegen_llvm/src/common.rs
+++ b/compiler/rustc_codegen_llvm/src/common.rs
@@ -1,6 +1,9 @@
 //! Code that is useful in various codegen modules.
 
 use libc::{c_char, c_uint};
+use rustc_abi as abi;
+use rustc_abi::Primitive::Pointer;
+use rustc_abi::{AddressSpace, HasDataLayout};
 use rustc_ast::Mutability;
 use rustc_codegen_ssa::traits::*;
 use rustc_data_structures::stable_hasher::{Hash128, HashStable, StableHasher};
@@ -9,7 +12,6 @@ use rustc_middle::bug;
 use rustc_middle::mir::interpret::{ConstAllocation, GlobalAlloc, Scalar};
 use rustc_middle::ty::TyCtxt;
 use rustc_session::cstore::DllImport;
-use rustc_target::abi::{self, AddressSpace, HasDataLayout, Pointer};
 use tracing::debug;
 
 use crate::consts::const_alloc_to_llvm;

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -1187,10 +1187,11 @@ impl<'tcx> FnAbiOfHelpers<'tcx> for CodegenCx<'_, 'tcx> {
         span: Span,
         fn_abi_request: FnAbiRequest<'tcx>,
     ) -> ! {
-        if let FnAbiError::Layout(LayoutError::SizeOverflow(_)) = err {
-            self.tcx.dcx().emit_fatal(Spanned { span, node: err })
-        } else {
-            match fn_abi_request {
+        match err {
+            FnAbiError::Layout(LayoutError::SizeOverflow(_) | LayoutError::Cycle(_)) => {
+                self.tcx.dcx().emit_fatal(Spanned { span, node: err });
+            }
+            _ => match fn_abi_request {
                 FnAbiRequest::OfFnPtr { sig, extra_args } => {
                     span_bug!(span, "`fn_abi_of_fn_ptr({sig}, {extra_args:?})` failed: {err:?}",);
                 }
@@ -1200,7 +1201,7 @@ impl<'tcx> FnAbiOfHelpers<'tcx> for CodegenCx<'_, 'tcx> {
                         "`fn_abi_of_instance({instance}, {extra_args:?})` failed: {err:?}",
                     );
                 }
-            }
+            },
         }
     }
 }

--- a/compiler/rustc_codegen_llvm/src/type_of.rs
+++ b/compiler/rustc_codegen_llvm/src/type_of.rs
@@ -1,11 +1,12 @@
 use std::fmt::Write;
 
+use rustc_abi::Primitive::{Float, Int, Pointer};
+use rustc_abi::{Abi, Align, FieldsShape, Scalar, Size, Variants};
 use rustc_codegen_ssa::traits::*;
 use rustc_middle::bug;
 use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
 use rustc_middle::ty::print::{with_no_trimmed_paths, with_no_visible_paths};
 use rustc_middle::ty::{self, CoroutineArgsExt, Ty, TypeVisitableExt};
-use rustc_target::abi::{Abi, Align, FieldsShape, Float, Int, Pointer, Scalar, Size, Variants};
 use tracing::debug;
 
 use crate::common::*;

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -14,6 +14,7 @@ itertools = "0.12"
 jobserver = "0.1.28"
 pathdiff = "0.2.0"
 regex = "1.4"
+rustc_abi = { path = "../rustc_abi" }
 rustc_arena = { path = "../rustc_arena" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_attr = { path = "../rustc_attr" }

--- a/compiler/rustc_codegen_ssa/src/mir/operand.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/operand.rs
@@ -3,12 +3,13 @@ use std::fmt;
 
 use arrayvec::ArrayVec;
 use either::Either;
+use rustc_abi as abi;
+use rustc_abi::{Abi, Align, Size};
 use rustc_middle::bug;
 use rustc_middle::mir::interpret::{Pointer, Scalar, alloc_range};
 use rustc_middle::mir::{self, ConstValue};
 use rustc_middle::ty::Ty;
 use rustc_middle::ty::layout::{LayoutOf, TyAndLayout};
-use rustc_target::abi::{self, Abi, Align, Size};
 use tracing::debug;
 
 use super::place::{PlaceRef, PlaceValue};
@@ -207,7 +208,7 @@ impl<'a, 'tcx, V: CodegenObject> OperandRef<'tcx, V> {
             match alloc.0.read_scalar(
                 bx,
                 alloc_range(start, size),
-                /*read_provenance*/ matches!(s.primitive(), abi::Pointer(_)),
+                /*read_provenance*/ matches!(s.primitive(), abi::Primitive::Pointer(_)),
             ) {
                 Ok(val) => bx.scalar_to_backend(val, s, ty),
                 Err(_) => bx.const_poison(ty),

--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -1,10 +1,10 @@
+use rustc_abi::Primitive::{Int, Pointer};
+use rustc_abi::{Align, FieldsShape, Size, TagEncoding, Variants};
 use rustc_middle::mir::tcx::PlaceTy;
 use rustc_middle::ty::layout::{HasTyCtxt, LayoutOf, TyAndLayout};
 use rustc_middle::ty::{self, Ty};
 use rustc_middle::{bug, mir};
-use rustc_target::abi::{
-    Align, FieldsShape, Int, Pointer, Size, TagEncoding, VariantIdx, Variants,
-};
+use rustc_target::abi::VariantIdx;
 use tracing::{debug, instrument};
 
 use super::operand::OperandValue;

--- a/compiler/rustc_const_eval/Cargo.toml
+++ b/compiler/rustc_const_eval/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 # tidy-alphabetical-start
 either = "1"
+rustc_abi = { path = "../rustc_abi" }
 rustc_apfloat = "0.2.0"
 rustc_ast = { path = "../rustc_ast" }
 rustc_attr = { path = "../rustc_attr" }

--- a/compiler/rustc_error_codes/src/error_codes/E0793.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0793.md
@@ -1,4 +1,4 @@
-An unaligned references to a field of a [packed] struct got created.
+An unaligned reference to a field of a [packed] struct got created.
 
 Erroneous code example:
 

--- a/compiler/rustc_hir_typeck/Cargo.toml
+++ b/compiler/rustc_hir_typeck/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 # tidy-alphabetical-start
 itertools = "0.12"
+rustc_abi = { path = "../rustc_abi" }
 rustc_ast = { path = "../rustc_ast" }
 rustc_ast_ir = { path = "../rustc_ast_ir" }
 rustc_attr = { path = "../rustc_attr" }

--- a/compiler/rustc_hir_typeck/src/intrinsicck.rs
+++ b/compiler/rustc_hir_typeck/src/intrinsicck.rs
@@ -1,4 +1,5 @@
 use hir::HirId;
+use rustc_abi::Primitive::Pointer;
 use rustc_errors::codes::*;
 use rustc_errors::struct_span_code_err;
 use rustc_hir as hir;
@@ -6,7 +7,7 @@ use rustc_index::Idx;
 use rustc_middle::bug;
 use rustc_middle::ty::layout::{LayoutError, SizeSkeleton};
 use rustc_middle::ty::{self, Ty, TyCtxt, TypeVisitableExt};
-use rustc_target::abi::{Pointer, VariantIdx};
+use rustc_target::abi::VariantIdx;
 use tracing::trace;
 
 use super::FnCtxt;

--- a/compiler/rustc_middle/Cargo.toml
+++ b/compiler/rustc_middle/Cargo.toml
@@ -12,6 +12,7 @@ field-offset = "0.3.5"
 gsgdt = "0.1.2"
 polonius-engine = "0.13.0"
 rustc-rayon-core = { version = "0.5.0", optional = true }
+rustc_abi = { path = "../rustc_abi" }
 rustc_apfloat = "0.2.0"
 rustc_arena = { path = "../rustc_arena" }
 rustc_ast = { path = "../rustc_ast" }

--- a/compiler/rustc_middle/src/ty/layout.rs
+++ b/compiler/rustc_middle/src/ty/layout.rs
@@ -2,11 +2,15 @@ use std::num::NonZero;
 use std::ops::Bound;
 use std::{cmp, fmt};
 
+use rustc_abi::Primitive::{self, Float, Int, Pointer};
+use rustc_abi::{
+    Abi, AddressSpace, Align, FieldsShape, HasDataLayout, Integer, LayoutCalculator, LayoutS,
+    PointeeInfo, PointerKind, ReprOptions, Scalar, Size, TagEncoding, TargetDataLayout, Variants,
+};
 use rustc_error_messages::DiagMessage;
 use rustc_errors::{
     Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, IntoDiagArg, Level,
 };
-use rustc_hir as hir;
 use rustc_hir::LangItem;
 use rustc_hir::def_id::DefId;
 use rustc_index::IndexVec;
@@ -15,10 +19,11 @@ use rustc_session::config::OptLevel;
 use rustc_span::symbol::{Symbol, sym};
 use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span};
 use rustc_target::abi::call::FnAbi;
-use rustc_target::abi::*;
+use rustc_target::abi::{FieldIdx, TyAbiInterface, VariantIdx, call};
 use rustc_target::spec::abi::Abi as SpecAbi;
 use rustc_target::spec::{HasTargetSpec, HasWasmCAbiOpt, PanicStrategy, Target, WasmCAbi};
 use tracing::debug;
+use {rustc_abi as abi, rustc_hir as hir};
 
 use crate::error::UnsupportedFnAbi;
 use crate::middle::codegen_fn_attrs::CodegenFnAttrFlags;
@@ -27,9 +32,10 @@ use crate::ty::normalize_erasing_regions::NormalizationError;
 use crate::ty::{self, CoroutineArgsExt, Ty, TyCtxt, TypeVisitableExt};
 
 #[extension(pub trait IntegerExt)]
-impl Integer {
+impl abi::Integer {
     #[inline]
     fn to_ty<'tcx>(&self, tcx: TyCtxt<'tcx>, signed: bool) -> Ty<'tcx> {
+        use abi::Integer::{I8, I16, I32, I64, I128};
         match (*self, signed) {
             (I8, false) => tcx.types.u8,
             (I16, false) => tcx.types.u16,
@@ -44,7 +50,8 @@ impl Integer {
         }
     }
 
-    fn from_int_ty<C: HasDataLayout>(cx: &C, ity: ty::IntTy) -> Integer {
+    fn from_int_ty<C: HasDataLayout>(cx: &C, ity: ty::IntTy) -> abi::Integer {
+        use abi::Integer::{I8, I16, I32, I64, I128};
         match ity {
             ty::IntTy::I8 => I8,
             ty::IntTy::I16 => I16,
@@ -54,7 +61,8 @@ impl Integer {
             ty::IntTy::Isize => cx.data_layout().ptr_sized_integer(),
         }
     }
-    fn from_uint_ty<C: HasDataLayout>(cx: &C, ity: ty::UintTy) -> Integer {
+    fn from_uint_ty<C: HasDataLayout>(cx: &C, ity: ty::UintTy) -> abi::Integer {
+        use abi::Integer::{I8, I16, I32, I64, I128};
         match ity {
             ty::UintTy::U8 => I8,
             ty::UintTy::U16 => I16,
@@ -102,7 +110,7 @@ impl Integer {
             tcx.data_layout().c_enum_min_size
         } else {
             // repr(Rust) enums try to be as small as possible
-            I8
+            Integer::I8
         };
 
         // If there are no negative values, we can use the unsigned fit.
@@ -115,9 +123,10 @@ impl Integer {
 }
 
 #[extension(pub trait FloatExt)]
-impl Float {
+impl abi::Float {
     #[inline]
     fn to_ty<'tcx>(&self, tcx: TyCtxt<'tcx>) -> Ty<'tcx> {
+        use abi::Float::*;
         match *self {
             F16 => tcx.types.f16,
             F32 => tcx.types.f32,
@@ -127,6 +136,7 @@ impl Float {
     }
 
     fn from_float_ty(fty: ty::FloatTy) -> Self {
+        use abi::Float::*;
         match fty {
             ty::FloatTy::F16 => F16,
             ty::FloatTy::F32 => F32,

--- a/compiler/rustc_target/src/abi/mod.rs
+++ b/compiler/rustc_target/src/abi/mod.rs
@@ -1,9 +1,8 @@
 use std::fmt;
 use std::ops::Deref;
 
-pub use Float::*;
-pub use Integer::*;
-pub use Primitive::*;
+use Float::*;
+use Primitive::*;
 use rustc_data_structures::intern::Interned;
 use rustc_macros::HashStable_Generic;
 

--- a/compiler/rustc_ty_utils/Cargo.toml
+++ b/compiler/rustc_ty_utils/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 # tidy-alphabetical-start
 itertools = "0.12"
+rustc_abi = { path = "../rustc_abi" }
 rustc_ast_ir = { path = "../rustc_ast_ir" }
 rustc_data_structures = { path = "../rustc_data_structures" }
 rustc_errors = { path = "../rustc_errors" }

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -1,5 +1,8 @@
 use std::iter;
 
+use rustc_abi::Float::*;
+use rustc_abi::Primitive::{Float, Pointer};
+use rustc_abi::{Abi, AddressSpace, PointerKind, Scalar, Size};
 use rustc_hir as hir;
 use rustc_hir::lang_items::LangItem;
 use rustc_middle::bug;
@@ -14,7 +17,6 @@ use rustc_target::abi::call::{
     ArgAbi, ArgAttribute, ArgAttributes, ArgExtension, Conv, FnAbi, PassMode, Reg, RegKind,
     RiscvInterruptKind,
 };
-use rustc_target::abi::*;
 use rustc_target::spec::abi::Abi as SpecAbi;
 use tracing::debug;
 

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -55,7 +55,7 @@ fi
 # If runner uses an incompatible option and `FORCE_CI_RUSTC` is not defined,
 # switch to in-tree rustc.
 if [ "$FORCE_CI_RUSTC" == "" ]; then
-    echo "debug: `DISABLE_CI_RUSTC_IF_INCOMPATIBLE` configured."
+    echo 'debug: `DISABLE_CI_RUSTC_IF_INCOMPATIBLE` configured.'
     DISABLE_CI_RUSTC_IF_INCOMPATIBLE=1
 fi
 

--- a/src/tools/compiletest/src/command-list.rs
+++ b/src/tools/compiletest/src/command-list.rs
@@ -208,6 +208,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "pretty-compare-only",
     "pretty-expanded",
     "pretty-mode",
+    "reference",
     "regex-error-pattern",
     "remap-src-base",
     "revisions",

--- a/tests/crashes/130956.rs
+++ b/tests/crashes/130956.rs
@@ -1,0 +1,37 @@
+//@ known-bug: #130956
+
+mod impl_trait_mod {
+    use super::*;
+    pub type OpaqueBlock = impl Trait;
+    pub type OpaqueIf = impl Trait;
+
+    pub struct BlockWrapper(OpaqueBlock);
+    pub struct IfWrapper(pub OpaqueIf);
+
+    pub fn if_impl() -> Parser<OpaqueIf> {
+        bind(option(block()), |_| block())
+    }
+}
+use impl_trait_mod::*;
+
+pub trait Trait {
+    type Assoc;
+}
+pub struct Parser<P>(P);
+pub struct Bind<P, F>(P, F);
+impl<P, F> Trait for Bind<P, F> { type Assoc = (); }
+impl Trait for BlockWrapper { type Assoc = (); }
+impl Trait for IfWrapper { type Assoc = (); }
+
+pub fn block() -> Parser<BlockWrapper> {
+    loop {}
+}
+pub fn option<P: Trait>(arg: Parser<P>) -> Parser<impl Trait> {
+    bind(arg, |_| block())
+}
+fn bind<P: Trait, P2, F: Fn(P::Assoc) -> Parser<P2>>(_: Parser<P>, _: F) -> Parser<Bind<P, F>>
+    { loop {} }
+
+fn main() {
+    if_impl().0;
+}

--- a/tests/crashes/130967.rs
+++ b/tests/crashes/130967.rs
@@ -1,0 +1,13 @@
+//@ known-bug: #130967
+
+trait Producer {
+    type Produced;
+    fn make_one() -> Self::Produced;
+}
+
+impl<E: ?Sized> Producer for () {
+    type Produced = Option<E>;
+    fn make_one() -> Self::Produced {
+        loop {}
+    }
+}

--- a/tests/crashes/131046.rs
+++ b/tests/crashes/131046.rs
@@ -1,0 +1,15 @@
+//@ known-bug: #131046
+
+trait Owner {
+    const C<const N: u32>: u32;
+}
+
+impl Owner for () {
+    const C<const N: u32>: u32 = N;
+}
+
+fn take0<const N: u64>(_: impl Owner<C<N> = { N }>) {}
+
+fn main() {
+    take0::<128>(());
+}

--- a/tests/crashes/131048.rs
+++ b/tests/crashes/131048.rs
@@ -1,0 +1,7 @@
+//@ known-bug: #131048
+
+impl<A> std::ops::CoerceUnsized<A> for A {}
+
+fn main() {
+    format_args!("Hello, world!");
+}

--- a/tests/crashes/131050.rs
+++ b/tests/crashes/131050.rs
@@ -1,0 +1,27 @@
+//@ known-bug: #131050
+//@ compile-flags: --edition=2021
+
+fn query_as<D>() {}
+
+async fn create_user() {
+    query_as();
+}
+
+async fn post_user_filter() -> impl Filter {
+    AndThen(&(), || async { create_user().await })
+}
+
+async fn get_app() -> impl Send {
+    post_user_filter().await
+}
+
+trait Filter {}
+
+struct AndThen<T, F>(T, F);
+
+impl<T, F, R> Filter for AndThen<T, F>
+where
+    F: Fn() -> R,
+    R: Send,
+{
+}

--- a/tests/crashes/131052.rs
+++ b/tests/crashes/131052.rs
@@ -1,0 +1,8 @@
+//@ known-bug: #131052
+#![feature(adt_const_params)]
+
+struct ConstBytes<const T: &'static [*mut u8; 3]>;
+
+pub fn main() {
+    let _: ConstBytes<b"AAA"> = ConstBytes::<b"BBB">;
+}

--- a/tests/crashes/131101.rs
+++ b/tests/crashes/131101.rs
@@ -1,0 +1,12 @@
+//@ known-bug: #131101
+trait Foo<const N: u8> {
+    fn do_x(&self) -> [u8; N];
+}
+
+struct Bar;
+
+impl Foo<const 3> for Bar {
+    fn do_x(&self) -> [u8; 3] {
+        [0u8; 3]
+    }
+}

--- a/tests/crashes/131102.rs
+++ b/tests/crashes/131102.rs
@@ -1,0 +1,4 @@
+//@ known-bug: #131102
+pub struct Blorb<const N: u16>([String; N]);
+pub struct Wrap(Blorb<0>);
+pub const fn i(_: Wrap) {}

--- a/tests/crashes/131103.rs
+++ b/tests/crashes/131103.rs
@@ -1,0 +1,6 @@
+//@ known-bug: #131103
+struct Struct<const N: i128>(pub [u8; N]);
+
+pub fn function(value: Struct<3>) -> u8 {
+    value.0[0]
+}

--- a/tests/crashes/131190.rs
+++ b/tests/crashes/131190.rs
@@ -1,0 +1,19 @@
+//@ known-bug: #131190
+//@ compile-flags: -Cinstrument-coverage --edition=2018
+
+use std::future::Future;
+
+pub fn block_on<T>(fut: impl Future<Output = T>) -> T {}
+
+async fn call_once(f: impl async FnOnce(DropMe)) {
+    f(DropMe("world")).await;
+}
+
+struct DropMe(&'static str);
+
+pub fn main() {
+    block_on(async {
+        let async_closure = async move |a: DropMe| {};
+        call_once(async_closure).await;
+    });
+}

--- a/tests/crashes/131227.rs
+++ b/tests/crashes/131227.rs
@@ -1,0 +1,16 @@
+//@ known-bug: #131227
+//@ compile-flags: -Zmir-opt-level=3
+
+static mut G: () = ();
+
+fn myfunc() -> i32 {
+    let var = &raw mut G;
+    if var.is_null() {
+        return 0;
+    }
+    0
+}
+
+fn main() {
+    myfunc();
+}

--- a/tests/crashes/131292.rs
+++ b/tests/crashes/131292.rs
@@ -1,0 +1,7 @@
+//@ known-bug: #131292
+//@ only-x86_64
+use std::arch::asm;
+
+unsafe fn f6() {
+    asm!(concat!(r#"lJ𐏿Æ�.𐏿�"#, "{}/day{:02}.txt"));
+}

--- a/tests/crashes/131294-2.rs
+++ b/tests/crashes/131294-2.rs
@@ -1,0 +1,25 @@
+//@ known-bug: #131294
+//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir -Zcross-crate-inline-threshold=always
+
+// https://github.com/rust-lang/rust/issues/131294#issuecomment-2395088049 second comment
+struct Rows;
+
+impl Iterator for Rows {
+    type Item = String;
+
+    fn next() -> Option<String> {
+        let args = format_args!("Hello world");
+
+        {
+            match args.as_str() {
+                Some(t) => t.to_owned(),
+                None => String::new(),
+            }
+        }
+            .into()
+    }
+}
+
+fn main() {
+    Rows.next();
+}

--- a/tests/crashes/131294.rs
+++ b/tests/crashes/131294.rs
@@ -1,0 +1,16 @@
+//@ known-bug: #131294
+//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir -Zcross-crate-inline-threshold=always
+
+struct Rows;
+
+impl Iterator for Rows {
+    type Item = String;
+
+    fn next() -> Option<Self::Item> {
+        std::fmt::format(format_args!("Hello world")).into()
+    }
+}
+
+fn main() {
+    Rows.next();
+}

--- a/tests/crashes/131295.rs
+++ b/tests/crashes/131295.rs
@@ -1,0 +1,9 @@
+//@ known-bug: #131295
+
+#![feature(generic_const_exprs)]
+
+async fn foo<'a>() -> [(); {
+       let _y: &'a ();
+       4
+   }] {
+}

--- a/tests/crashes/131298.rs
+++ b/tests/crashes/131298.rs
@@ -1,0 +1,12 @@
+//@ known-bug: #131298
+
+fn dyn_hoops<T>() -> *const dyn Iterator<Item = impl Captures> {
+    loop {}
+}
+
+mod typeck {
+    type Opaque = impl Sized;
+    fn define() -> Opaque {
+        let _: Opaque = super::dyn_hoops::<u8>();
+    }
+}

--- a/tests/crashes/131342-2.rs
+++ b/tests/crashes/131342-2.rs
@@ -1,0 +1,40 @@
+//@ known-bug: #131342
+// see also: 131342.rs
+
+fn main() {
+    problem_thingy(Once);
+}
+
+struct Once;
+
+impl Iterator for Once {
+    type Item = ();
+}
+
+fn problem_thingy(items: impl Iterator) {
+    let peeker = items.peekable();
+    problem_thingy(&peeker);
+}
+
+trait Iterator {
+    type Item;
+
+    fn peekable(self) -> Peekable<Self>
+    where
+        Self: Sized,
+    {
+        loop {}
+    }
+}
+
+struct Peekable<I: Iterator> {
+    _peeked: I::Item,
+}
+
+impl<I: Iterator> Iterator for Peekable<I> {
+    type Item = I::Item;
+}
+
+impl<I: Iterator + ?Sized> Iterator for &I {
+    type Item = I::Item;
+}

--- a/tests/crashes/131342.rs
+++ b/tests/crashes/131342.rs
@@ -1,0 +1,16 @@
+//@ known-bug: #131342
+// see also: 131342-2.rs
+
+fn main() {
+  let mut items = vec![1, 2, 3, 4, 5].into_iter();
+  problem_thingy(&mut items);
+}
+
+fn problem_thingy(items: &mut impl Iterator<Item = u8>) {
+  let mut peeker = items.peekable();
+  match peeker.peek() {
+    Some(_) => (),
+    None => return (),
+  }
+  problem_thingy(&mut peeker);
+}

--- a/tests/crashes/131347.rs
+++ b/tests/crashes/131347.rs
@@ -1,0 +1,9 @@
+//@ known-bug: #131347
+//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir
+
+struct S;
+static STUFF: [i8] = [0; S::N];
+
+fn main() {
+    assert_eq!(STUFF, [0; 63]);
+}

--- a/tests/crashes/131373.rs
+++ b/tests/crashes/131373.rs
@@ -1,0 +1,33 @@
+//@ known-bug: #131373
+
+trait LockReference: 'static {
+    type Ref<'a>;
+}
+
+struct SliceRef<'a, T: ?Sized> {
+    _x: &'a T,
+}
+
+impl<'a, T: ?Sized, SR: LockReference> IntoIterator for SliceRef<'a, T>
+where
+    &'a T: IntoIterator<Item = &'a SR>,
+{
+    type Item = SR::Ref<'a>;
+    type IntoIter = std::iter::Map<<&'a T as IntoIterator>::IntoIter,
+        for<'c> fn(&'c SR) -> SR::Ref<'c>>;
+    fn into_iter(self) -> Self::IntoIter {
+        loop {}
+    }
+}
+
+impl LockReference for () {
+    type Ref<'a> = ();
+}
+
+fn locked() -> SliceRef<'static, [()]> {
+    loop {}
+}
+
+fn main() {
+    let _ = locked().into_iter();
+}

--- a/tests/crashes/131406.rs
+++ b/tests/crashes/131406.rs
@@ -1,0 +1,12 @@
+//@ known-bug: #131406
+
+trait Owner {
+    const C<const N: u32>: u32 = N;
+}
+
+impl Owner for () {}
+fn take0<const N: u64>(_: impl Owner<C<N> = { N }>) {}
+
+fn main() {
+    take0::<128>(());
+}

--- a/tests/run-make/broken-pipe-no-ice/rmake.rs
+++ b/tests/run-make/broken-pipe-no-ice/rmake.rs
@@ -5,6 +5,12 @@
 
 //@ ignore-cross-compile (needs to run test binary)
 
+//@ ignore-apple
+// FIXME(#131436): on macOS rustc is still reporting the std broken pipe io error panick but it
+// doesn't fail with 101 exit status (it terminates with a wait status of SIGPIPE). It doesn't say
+// Internal Compiler Error strangely, but it doesn't even go through normal diagnostic infra. Very
+// strange.
+
 #![feature(anonymous_pipe)]
 
 use std::io::Read;

--- a/tests/ui/layout/post-mono-layout-cycle-2.rs
+++ b/tests/ui/layout/post-mono-layout-cycle-2.rs
@@ -1,0 +1,59 @@
+//@ build-fail
+//@ edition: 2021
+
+#![feature(async_closure, noop_waker)]
+
+use std::future::Future;
+use std::pin::pin;
+use std::task::*;
+
+pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
+    let mut fut = pin!(fut);
+    // Poll loop, just to test the future...
+    let ctx = &mut Context::from_waker(Waker::noop());
+
+    loop {
+        match fut.as_mut().poll(ctx) {
+            Poll::Pending => {}
+            Poll::Ready(t) => break t,
+        }
+    }
+}
+
+trait Blah {
+    async fn iter<T>(&mut self, iterator: T)
+    where
+        T: IntoIterator<Item = ()>;
+}
+
+impl Blah for () {
+    async fn iter<T>(&mut self, iterator: T)
+    //~^ ERROR recursion in an async fn requires boxing
+    where
+        T: IntoIterator<Item = ()>,
+    {
+        Blah::iter(self, iterator).await
+    }
+}
+
+struct Wrap<T: Blah> {
+    t: T,
+}
+
+impl<T: Blah> Wrap<T>
+where
+    T: Blah,
+{
+    async fn ice(&mut self) {
+        //~^ ERROR a cycle occurred during layout computation
+        let arr: [(); 0] = [];
+        self.t.iter(arr.into_iter()).await;
+    }
+}
+
+fn main() {
+    block_on(async {
+        let mut t = Wrap { t: () };
+        t.ice();
+    })
+}

--- a/tests/ui/layout/post-mono-layout-cycle-2.stderr
+++ b/tests/ui/layout/post-mono-layout-cycle-2.stderr
@@ -1,0 +1,23 @@
+error[E0733]: recursion in an async fn requires boxing
+  --> $DIR/post-mono-layout-cycle-2.rs:30:5
+   |
+LL | /     async fn iter<T>(&mut self, iterator: T)
+LL | |
+LL | |     where
+LL | |         T: IntoIterator<Item = ()>,
+   | |___________________________________^
+LL |       {
+LL |           Blah::iter(self, iterator).await
+   |           -------------------------------- recursive call here
+   |
+   = note: a recursive `async fn` call must introduce indirection such as `Box::pin` to avoid an infinitely sized future
+
+error: a cycle occurred during layout computation
+  --> $DIR/post-mono-layout-cycle-2.rs:47:5
+   |
+LL |     async fn ice(&mut self) {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0733`.

--- a/tests/ui/layout/post-mono-layout-cycle.rs
+++ b/tests/ui/layout/post-mono-layout-cycle.rs
@@ -1,0 +1,25 @@
+//@ build-fail
+//~^ cycle detected when computing layout of `Wrapper<()>`
+
+trait Trait {
+    type Assoc;
+}
+
+impl Trait for () {
+    type Assoc = Wrapper<()>;
+}
+
+struct Wrapper<T: Trait> {
+    _x: <T as Trait>::Assoc,
+}
+
+fn abi<T: Trait>(_: Option<Wrapper<T>>) {}
+//~^ ERROR a cycle occurred during layout computation
+
+fn indirect<T: Trait>() {
+    abi::<T>(None);
+}
+
+fn main() {
+    indirect::<()>();
+}

--- a/tests/ui/layout/post-mono-layout-cycle.stderr
+++ b/tests/ui/layout/post-mono-layout-cycle.stderr
@@ -1,0 +1,16 @@
+error[E0391]: cycle detected when computing layout of `Wrapper<()>`
+   |
+   = note: ...which requires computing layout of `<() as Trait>::Assoc`...
+   = note: ...which again requires computing layout of `Wrapper<()>`, completing the cycle
+   = note: cycle used when computing layout of `core::option::Option<Wrapper<()>>`
+   = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
+
+error: a cycle occurred during layout computation
+  --> $DIR/post-mono-layout-cycle.rs:16:1
+   |
+LL | fn abi<T: Trait>(_: Option<Wrapper<T>>) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0391`.


### PR DESCRIPTION
Successful merges:

 - #131382 (Add "reference" as a known compiletest header)
 - #131420 (Dont ICE when encountering post-mono layout cycle error)
 - #131424 (compiler: Stop reexporting enum-globs from `rustc_target::abi`)
 - #131426 (Fix quotation marks around debug line in `src/ci/run.sh`)
 - #131435 (Ignore broken-pipe-no-ice on apple (specifically macOS) for now)
 - #131447 (add more crash tests)
 - #131456 (Fix typo in E0793)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131382,131420,131424,131426,131435,131447,131456)
<!-- homu-ignore:end -->