### PR TITLE
Update Vec<T> documentation: Fix layout diagram 

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -311,15 +311,15 @@ mod spec_extend;
 /// The bottom part is the allocation on the heap, a contiguous memory block.
 ///
 /// ```text
-///             ptr      len  capacity
+///         capacity   ptr       len
 ///        +--------+--------+--------+
-///        | 0x0123 |      2 |      4 |
+///        |    4   | 0x0123 |    2   |
 ///        +--------+--------+--------+
-///             |
-///             v
-/// Heap   +--------+--------+--------+--------+
-///        |    'a' |    'b' | uninit | uninit |
-///        +--------+--------+--------+--------+
+///                      |
+///                      v
+/// Heap             +--------+--------+--------+--------+
+///                  |    'a' |    'b' | uninit | uninit |
+///                  +--------+--------+--------+--------+
 /// ```
 ///
 /// - **uninit** represents memory that is not initialized, see [`MaybeUninit`].


### PR DESCRIPTION
The documentation previously mentioned the vector layout as being ptr, length, and capacity. However, testing (as demonstrated by the code below written by @cdstanford) reveals that the actual structure of the vector is capacity, ptr, and length. This has also been confirmed by code [here](https://github.com/DavisPL/rust-counterexamples/blob/main/src/bin/proc_self_mem_2.rs)

```
Rust
use std::vec::Vec;
fn main() {
    let mut v = Vec::with_capacity(100);
    v.push(123);
    v.push(456);

    let v_ptr: *const usize = &v as *const Vec<i32> as *const usize;
    let len = v.len();
    let cap = v.capacity();

    println!("v: {:?}, len: {}, cap: {}", v, len, cap);
    println!("vector ptr: {}", v_ptr as usize);
    println!("buffer ptr: {}", v.as_mut_ptr() as usize);

    unsafe {
        let p0 = v_ptr;
        let p1 = v_ptr.wrapping_offset(1);
        let p2 = v_ptr.wrapping_offset(2);

        println!("v raw memory: {}, {}, {}", *p0, *p1, *p2)
    }
}
```

This produces the following output : 

```
v: [123, 456], len: 2, cap: 100
vector ptr: 6125413944
buffer ptr: 5416968256
v raw memory: 100, 5416968256, 2
```
