### PR TITLE
E0793: Clarify that it applies to unions as well

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0793.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0793.md
@@ -1,4 +1,4 @@
-An unaligned references to a field of a [packed] struct got created.
+An unaligned reference to a field of a [packed] `struct` or `union` was created.
 
 Erroneous code example:
 
@@ -45,9 +45,36 @@ unsafe {
     // For formatting, we can create a copy to avoid the direct reference.
     let copy = foo.field1;
     println!("{}", copy);
+
     // Creating a copy can be written in a single line with curly braces.
     // (This is equivalent to the two lines above.)
     println!("{}", { foo.field1 });
+
+    // A reference to a field that will always be sufficiently aligned is safe:
+    println!("{}", foo.field2);
+}
+```
+
+### Unions
+
+Even though creating a reference to a `union` field is `unsafe`, this error
+will still be triggered when referencing a field that is not sufficiently
+aligned. `addr_of!` and raw pointers should be used the same way as is done
+for `struct` fields.
+
+```compile_fail,E0793
+#[repr(packed)]
+pub union Foo {
+    field1: u64,
+    field2: u8,
+}
+
+unsafe {
+    let foo = Foo { field1: 0 };
+    // Accessing the field directly is fine.
+    let val = foo.field1;
+    // A reference to a packed union field causes a error.
+    let val = &foo.field1; // ERROR
 }
 ```
 


### PR DESCRIPTION
Also:

- Adjust the language slightly to be more consistent with other similar messages (`was created` instead of `got created`).
- Add a short section on `union`.
- Add an example line showing referencing a field in a packed struct is safe if the field's type isn't more strictly aligned than the pack.

This might need to wait for #131456 to merge first? Not sure.

r? compiler-errors