### PR TITLE
Fix hardcoded strip path when cross-compiling from Linux to Darwin

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1087,7 +1087,9 @@ fn link_natively(
     let strip = sess.opts.cg.strip;
 
     if sess.target.is_like_osx {
-        let stripcmd = "/usr/bin/strip";
+        // Use system `strip` when running on host macOS.
+        // <https://github.com/rust-lang/rust/pull/130781>
+        let stripcmd = if cfg!(target_os = "macos") { "/usr/bin/strip" } else { "strip" };
         match (strip, crate_type) {
             (Strip::Debuginfo, _) => {
                 strip_symbols_with_external_utility(sess, stripcmd, out_filename, Some("-S"))


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/131206.

I fear that https://github.com/rust-lang/rust/pull/131405 might end up taking some time, so opening this PR to resolve the regression.

@rustbot label O-apple