### PR TITLE
Always structurally resolve coercion target

### DIFF
--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -1860,8 +1860,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         base_expr: &'tcx Option<&'tcx hir::Expr<'tcx>>,
     ) {
         let tcx = self.tcx;
+        self.select_obligations_where_possible(|_| {});
 
-        let adt_ty = self.try_structurally_resolve_type(span, adt_ty);
         let adt_ty_hint = expected.only_has_type(self).and_then(|expected| {
             self.fudge_inference_if_ok(|| {
                 let ocx = ObligationCtxt::new(self);

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/checks.rs
@@ -208,11 +208,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             );
         }
 
+        // Guide inference on the formal output ty if necessary.
+        self.select_obligations_where_possible(|_| {});
+
         // First, let's unify the formal method signature with the expectation eagerly.
         // We use this to guide coercion inference; it's output is "fudged" which means
         // any remaining type variables are assigned to new, unrelated variables. This
         // is because the inference guidance here is only speculative.
-        let formal_output = self.resolve_vars_with_obligations(formal_output);
         let expected_input_tys: Option<Vec<_>> = expectation
             .only_has_type(self)
             .and_then(|expected_output| {

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -231,7 +231,10 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 self.check_expr(lhs_expr)
             }
         };
-        let lhs_ty = self.resolve_vars_with_obligations(lhs_ty);
+
+        // Guide inference on the lhs ty if necessary.
+        self.select_obligations_where_possible(|_| {});
+        let lhs_ty = self.resolve_vars_if_possible(lhs_ty);
 
         // N.B., as we have not yet type-checked the RHS, we don't have the
         // type at hand. Make a variable to represent it. The whole reason

--- a/compiler/rustc_hir_typeck/src/op.rs
+++ b/compiler/rustc_hir_typeck/src/op.rs
@@ -36,6 +36,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
     ) -> Ty<'tcx> {
         let (lhs_ty, rhs_ty, return_ty) =
             self.check_overloaded_binop(expr, lhs, rhs, op, IsAssign::Yes, expected);
+        let lhs_ty = self.try_structurally_resolve_type(lhs.span, lhs_ty);
+        let rhs_ty = self.try_structurally_resolve_type(rhs.span, rhs_ty);
 
         let ty =
             if !lhs_ty.is_ty_var() && !rhs_ty.is_ty_var() && is_builtin_binop(lhs_ty, rhs_ty, op) {
@@ -232,10 +234,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
         };
 
-        // Guide inference on the lhs ty if necessary.
-        self.select_obligations_where_possible(|_| {});
-        let lhs_ty = self.resolve_vars_if_possible(lhs_ty);
-
         // N.B., as we have not yet type-checked the RHS, we don't have the
         // type at hand. Make a variable to represent it. The whole reason
         // for this indirection is so that, below, we can check the expr
@@ -253,7 +251,6 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
 
         // see `NB` above
         let rhs_ty = self.check_expr_coercible_to_type(rhs_expr, rhs_ty_var, Some(lhs_expr));
-        let rhs_ty = self.resolve_vars_with_obligations(rhs_ty);
 
         let return_ty = match result {
             Ok(method) => {
@@ -299,6 +296,9 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 Ty::new_misc_error(self.tcx)
             }
             Err(errors) => {
+                let lhs_ty = self.try_structurally_resolve_type(lhs_expr.span, lhs_ty);
+                let rhs_ty = self.try_structurally_resolve_type(rhs_expr.span, rhs_ty);
+
                 let (_, trait_def_id) =
                     lang_item_for_op(self.tcx, Op::Binary(op, is_assign), op.span);
                 let missing_trait = trait_def_id

--- a/tests/ui/delegation/correct_body_owner_parent_found_in_diagnostics.stderr
+++ b/tests/ui/delegation/correct_body_owner_parent_found_in_diagnostics.stderr
@@ -52,15 +52,6 @@ LL | pub struct InvariantRef<'a, T: ?Sized>(&'a T, PhantomData<&'a mut &'a T>);
 LL |     pub const NEW: Self = InvariantRef::new(&());
    |                                         ^^^ function or associated item not found in `InvariantRef<'_, _>`
 
-error[E0308]: mismatched types
-  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:53
-   |
-LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
-   |                                                     ^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `InvariantRef<'_, ()>`
-   |
-   = note: expected type `u8`
-            found struct `InvariantRef<'_, ()>`
-
 error[E0277]: the trait bound `u8: Trait` is not satisfied
   --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:12
    |
@@ -77,7 +68,6 @@ LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW
    |
    = note: expected type `u8`
             found struct `InvariantRef<'_, ()>`
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `u8: Trait` is not satisfied
   --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:12
@@ -105,6 +95,16 @@ LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW
    |            ^^ the trait `Trait` is not implemented for `u8`
    |
    = help: the trait `Trait` is implemented for `Z`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0308]: mismatched types
+  --> $DIR/correct_body_owner_parent_found_in_diagnostics.rs:22:53
+   |
+LL |     reuse <u8 as Trait>::{foo, bar, meh} { &const { InvariantRef::<'a>::NEW } }
+   |                                                     ^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `InvariantRef<'_, ()>`
+   |
+   = note: expected type `u8`
+            found struct `InvariantRef<'_, ()>`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 10 previous errors

--- a/tests/ui/issues/issue-50781.stderr
+++ b/tests/ui/issues/issue-50781.stderr
@@ -15,6 +15,22 @@ LL |     fn foo(&self) where Self: Trait;
    = help: only type `()` implements the trait, consider using it directly instead
 
 error[E0038]: the trait `X` cannot be made into an object
+  --> $DIR/issue-50781.rs:16:6
+   |
+LL |     <dyn X as X>::foo(&());
+   |      ^^^^^ `X` cannot be made into an object
+   |
+note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/issue-50781.rs:4:8
+   |
+LL | trait X {
+   |       - this trait cannot be made into an object...
+LL |     fn foo(&self) where Self: Trait;
+   |        ^^^ ...because method `foo` references the `Self` type in its `where` clause
+   = help: consider moving `foo` to another trait
+   = help: only type `()` implements the trait, consider using it directly instead
+
+error[E0038]: the trait `X` cannot be made into an object
   --> $DIR/issue-50781.rs:16:23
    |
 LL |     <dyn X as X>::foo(&());
@@ -30,22 +46,6 @@ LL |     fn foo(&self) where Self: Trait;
    = help: consider moving `foo` to another trait
    = help: only type `()` implements the trait, consider using it directly instead
    = note: required for the cast from `&()` to `&dyn X`
-
-error[E0038]: the trait `X` cannot be made into an object
-  --> $DIR/issue-50781.rs:16:6
-   |
-LL |     <dyn X as X>::foo(&());
-   |      ^^^^^ `X` cannot be made into an object
-   |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
-  --> $DIR/issue-50781.rs:4:8
-   |
-LL | trait X {
-   |       - this trait cannot be made into an object...
-LL |     fn foo(&self) where Self: Trait;
-   |        ^^^ ...because method `foo` references the `Self` type in its `where` clause
-   = help: consider moving `foo` to another trait
-   = help: only type `()` implements the trait, consider using it directly instead
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/overloaded/overloaded-calls-nontuple.stderr
+++ b/tests/ui/overloaded/overloaded-calls-nontuple.stderr
@@ -39,17 +39,17 @@ LL |         self.call_mut(z)
 note: required by a bound in `call_mut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-error[E0059]: cannot use call notation; the first type parameter for the function trait is neither a tuple nor unit
-  --> $DIR/overloaded-calls-nontuple.rs:29:10
-   |
-LL |     drop(s(3))
-   |          ^^^^
-
 error[E0277]: `isize` is not a tuple
   --> $DIR/overloaded-calls-nontuple.rs:29:10
    |
 LL |     drop(s(3))
    |          ^^^^ the trait `Tuple` is not implemented for `isize`
+
+error[E0059]: cannot use call notation; the first type parameter for the function trait is neither a tuple nor unit
+  --> $DIR/overloaded-calls-nontuple.rs:29:10
+   |
+LL |     drop(s(3))
+   |          ^^^^
 
 error: aborting due to 7 previous errors
 

--- a/tests/ui/suggestions/fn-trait-notation.stderr
+++ b/tests/ui/suggestions/fn-trait-notation.stderr
@@ -37,17 +37,17 @@ LL |     F: Fn<i32, Output = i32>,
 note: required by a bound in `Fn`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
 
-error[E0059]: cannot use call notation; the first type parameter for the function trait is neither a tuple nor unit
-  --> $DIR/fn-trait-notation.rs:9:5
-   |
-LL |     f(3);
-   |     ^^^^
-
 error[E0277]: `i32` is not a tuple
   --> $DIR/fn-trait-notation.rs:9:5
    |
 LL |     f(3);
    |     ^^^^ the trait `Tuple` is not implemented for `i32`
+
+error[E0059]: cannot use call notation; the first type parameter for the function trait is neither a tuple nor unit
+  --> $DIR/fn-trait-notation.rs:9:5
+   |
+LL |     f(3);
+   |     ^^^^
 
 error[E0308]: mismatched types
   --> $DIR/fn-trait-notation.rs:17:5

--- a/tests/ui/traits/next-solver/more-object-bound.stderr
+++ b/tests/ui/traits/next-solver/more-object-bound.stderr
@@ -1,5 +1,5 @@
 error[E0271]: type mismatch resolving `<dyn Trait<A = A, B = B> as SuperTrait>::A == B`
-  --> $DIR/more-object-bound.rs:12:5
+  --> $DIR/more-object-bound.rs:12:17
    |
 LL | fn transmute<A, B>(x: A) -> B {
    |              -  -
@@ -9,7 +9,7 @@ LL | fn transmute<A, B>(x: A) -> B {
    |              found type parameter
    |              expected type parameter
 LL |     foo::<A, B, dyn Trait<A = A, B = B>>(x)
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `A`, found type parameter `B`
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter `A`, found type parameter `B`
    |
    = note: expected type parameter `A`
               found type parameter `B`


### PR DESCRIPTION
This is morally a no-op. We have a few callsites that manually call `resolve_vars_with_obligations` before coercion, so let's not do that and just always structurally resolve in the coerce function itself.

r? lcnr