### PR TITLE
Consider outermost const-anon in `non_local_def` lint

### DIFF
--- a/tests/ui/lint/non-local-defs/consts.rs
+++ b/tests/ui/lint/non-local-defs/consts.rs
@@ -63,6 +63,13 @@ fn main() {
 
         1
     };
+
+    const _: () = {
+        const _: () = {
+            impl Test {}
+            //~^ WARN non-local `impl` definition
+        };
+    };
 }
 
 trait Uto9 {}

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -95,7 +95,21 @@ LL |         impl Test {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:72:9
+  --> $DIR/consts.rs:69:13
+   |
+LL |         const _: () = {
+   |         ----------- move the `impl` block outside of this constant `_` and up 3 bodies
+LL |             impl Test {}
+   |             ^^^^^----
+   |                  |
+   |                  `Test` is not local
+   |
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
+   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
+
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
+  --> $DIR/consts.rs:79:9
    |
 LL |     let _a = || {
    |              -- move the `impl` block outside of this closure `<unnameable>` and up 2 bodies
@@ -109,7 +123,7 @@ LL |         impl Uto9 for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:79:9
+  --> $DIR/consts.rs:86:9
    |
 LL |       type A = [u32; {
    |  ____________________-
@@ -126,5 +140,5 @@ LL | |     }];
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: 8 warnings emitted
+warning: 9 warnings emitted
 

--- a/tests/ui/lint/non-local-defs/convoluted-locals-131474-with-mods.rs
+++ b/tests/ui/lint/non-local-defs/convoluted-locals-131474-with-mods.rs
@@ -1,0 +1,34 @@
+// This test check that no matter the nesting of const-anons and modules
+// we consider them as transparent.
+//
+// Similar to https://github.com/rust-lang/rust/issues/131474
+
+//@ check-pass
+
+pub mod tmp {
+    pub mod tmp {
+        pub struct Test;
+    }
+}
+
+const _: () = {
+    const _: () = {
+        const _: () = {
+            const _: () = {
+                impl tmp::tmp::Test {}
+            };
+        };
+    };
+};
+
+const _: () = {
+    const _: () = {
+        mod tmp {
+            pub(super) struct InnerTest;
+        }
+
+        impl tmp::InnerTest {}
+    };
+};
+
+fn main() {}

--- a/tests/ui/lint/non-local-defs/convoluted-locals-131474.rs
+++ b/tests/ui/lint/non-local-defs/convoluted-locals-131474.rs
@@ -1,0 +1,24 @@
+// This test check that no matter the nesting of const-anons we consider
+// them as transparent.
+//
+// https://github.com/rust-lang/rust/issues/131474
+
+//@ check-pass
+
+pub struct Test;
+
+const _: () = {
+    const _: () = {
+        impl Test {}
+    };
+};
+
+const _: () = {
+    const _: () = {
+        struct InnerTest;
+
+        impl InnerTest {}
+    };
+};
+
+fn main() {}

--- a/tests/ui/lint/non-local-defs/local.rs
+++ b/tests/ui/lint/non-local-defs/local.rs
@@ -51,3 +51,10 @@ fn bitflags() {
         impl Flags {}
     };
 }
+
+fn bitflags_internal() {
+    const _: () = {
+        struct InternalFlags;
+        impl InternalFlags {}
+    };
+}


### PR DESCRIPTION
This PR change the logic for finding the parent of the `impl` definition in the `non_local_definitions` lint to consider multiple level of const-anon items, instead of only one currently.

I also took the opportunity to cleanup the related code.

cc @traviscross
Fixes https://github.com/rust-lang/rust/issues/131474
