### PR TITLE
[RFC] Convert to_string to to_owned in rustc_ast

### DIFF
--- a/compiler/rustc_ast/src/util/literal.rs
+++ b/compiler/rustc_ast/src/util/literal.rs
@@ -259,7 +259,7 @@ fn strip_underscores(symbol: Symbol) -> Symbol {
     // Do not allocate a new string unless necessary.
     let s = symbol.as_str();
     if s.contains('_') {
-        let mut s = s.to_string();
+        let mut s = s.to_owned();
         s.retain(|c| c != '_');
         return Symbol::intern(&s);
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Hi,

I would like to propose conversion from to_string to to_owned across Rust compiler code wherever it is possible for performance reasons.

What do you think about such micro-optimization?

Best regards,
Michal
