### PR TITLE
Fixing rustDoc for LayoutError.

### DIFF
--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -540,7 +540,8 @@ impl Layout {
 )]
 pub type LayoutErr = LayoutError;
 
-/// The parameters given to `Layout::from_size_align`
+/// The `LayoutError` is returned when the parameters given
+/// to `Layout::from_size_align`
 /// or some other `Layout` constructor
 /// do not satisfy its documented constraints.
 #[stable(feature = "alloc_layout_error", since = "1.50.0")]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

I started reading the the std lib from start to finish and noticed that this rustdoc comment wasn't correct.