### PR TITLE
rustdoc-json: Add tests for unsafe/safe extern blocks (RFC 3484)

### DIFF
--- a/tests/rustdoc-json/fns/extern_safe.rs
+++ b/tests/rustdoc-json/fns/extern_safe.rs
@@ -1,0 +1,17 @@
+extern "C" {
+    //@ is "$.index[*][?(@.name=='f1')].inner.function.header.is_unsafe" true
+    pub fn f1();
+
+    // items in unadorned `extern` blocks cannot have safety qualifiers
+}
+
+unsafe extern "C" {
+    //@ is "$.index[*][?(@.name=='f4')].inner.function.header.is_unsafe" true
+    pub fn f4();
+
+    //@ is "$.index[*][?(@.name=='f5')].inner.function.header.is_unsafe" true
+    pub unsafe fn f5();
+
+    //@ is "$.index[*][?(@.name=='f6')].inner.function.header.is_unsafe" false
+    pub safe fn f6();
+}


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust/issues/126786, turns out this all Just Works (TM)

Tracking issue: #123743

r? @GuillaumeGomez 