### PR TITLE
compiletest: Remove the magic hacks for finding output with `lto=thin`

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1780,58 +1780,14 @@ impl<'test> TestCx<'test> {
         proc_res.fatal(None, || on_failure(*self));
     }
 
-    fn get_output_file(&self, extension: &str) -> TargetLocation {
-        let thin_lto = self.props.compile_flags.iter().any(|s| s.ends_with("lto=thin"));
-        if thin_lto {
-            TargetLocation::ThisDirectory(self.output_base_dir())
-        } else {
-            // This works with both `--emit asm` (as default output name for the assembly)
-            // and `ptx-linker` because the latter can write output at requested location.
-            let output_path = self.output_base_name().with_extension(extension);
-
-            TargetLocation::ThisFile(output_path.clone())
-        }
-    }
-
-    fn get_filecheck_file(&self, extension: &str) -> PathBuf {
-        let thin_lto = self.props.compile_flags.iter().any(|s| s.ends_with("lto=thin"));
-        if thin_lto {
-            let name = self.testpaths.file.file_stem().unwrap().to_str().unwrap();
-            let canonical_name = name.replace('-', "_");
-            let mut output_file = None;
-            for entry in self.output_base_dir().read_dir().unwrap() {
-                if let Ok(entry) = entry {
-                    let entry_path = entry.path();
-                    let entry_file = entry_path.file_name().unwrap().to_str().unwrap();
-                    if entry_file.starts_with(&format!("{}.{}", name, canonical_name))
-                        && entry_file.ends_with(extension)
-                    {
-                        assert!(
-                            output_file.is_none(),
-                            "thinlto doesn't support multiple cgu tests"
-                        );
-                        output_file = Some(entry_file.to_string());
-                    }
-                }
-            }
-            if let Some(output_file) = output_file {
-                self.output_base_dir().join(output_file)
-            } else {
-                self.output_base_name().with_extension(extension)
-            }
-        } else {
-            self.output_base_name().with_extension(extension)
-        }
-    }
-
     // codegen tests (using FileCheck)
 
     fn compile_test_and_save_ir(&self) -> (ProcRes, PathBuf) {
-        let output_file = self.get_output_file("ll");
+        let output_path = self.output_base_name().with_extension("ll");
         let input_file = &self.testpaths.file;
         let rustc = self.make_compile_args(
             input_file,
-            output_file,
+            TargetLocation::ThisFile(output_path.clone()),
             Emit::LlvmIr,
             AllowUnused::No,
             LinkToAux::Yes,
@@ -1839,12 +1795,13 @@ impl<'test> TestCx<'test> {
         );
 
         let proc_res = self.compose_and_run_compiler(rustc, None, self.testpaths);
-        let output_path = self.get_filecheck_file("ll");
         (proc_res, output_path)
     }
 
     fn compile_test_and_save_assembly(&self) -> (ProcRes, PathBuf) {
-        let output_file = self.get_output_file("s");
+        // This works with both `--emit asm` (as default output name for the assembly)
+        // and `ptx-linker` because the latter can write output at requested location.
+        let output_path = self.output_base_name().with_extension("s");
         let input_file = &self.testpaths.file;
 
         let mut emit = Emit::None;
@@ -1867,7 +1824,7 @@ impl<'test> TestCx<'test> {
 
         let rustc = self.make_compile_args(
             input_file,
-            output_file,
+            TargetLocation::ThisFile(output_path.clone()),
             emit,
             AllowUnused::No,
             LinkToAux::Yes,
@@ -1875,7 +1832,6 @@ impl<'test> TestCx<'test> {
         );
 
         let proc_res = self.compose_and_run_compiler(rustc, None, self.testpaths);
-        let output_path = self.get_filecheck_file("s");
         (proc_res, output_path)
     }
 

--- a/tests/assembly/thin-lto.rs
+++ b/tests/assembly/thin-lto.rs
@@ -1,7 +1,0 @@
-//@ compile-flags: -O -C lto=thin -C prefer-dynamic=no
-//@ only-x86_64-unknown-linux-gnu
-//@ assembly-output: emit-asm
-
-// CHECK: main
-
-pub fn main() {}

--- a/tests/codegen/thin-lto.rs
+++ b/tests/codegen/thin-lto.rs
@@ -1,6 +1,0 @@
-//@ compile-flags: -O -C lto=thin -C prefer-dynamic=no
-//@ only-x86_64-unknown-linux-gnu
-
-// CHECK: main
-
-pub fn main() {}

--- a/tests/coverage/thin-lto.cov-map
+++ b/tests/coverage/thin-lto.cov-map
@@ -1,8 +1,0 @@
-Function name: thin_lto::main
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 03, 01, 00, 11]
-Number of files: 1
-- file 0 => global file 1
-Number of expressions: 0
-Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 3, 1) to (start + 0, 17)
-

--- a/tests/coverage/thin-lto.coverage
+++ b/tests/coverage/thin-lto.coverage
@@ -1,4 +1,0 @@
-   LL|       |//@ compile-flags: -O -C lto=thin -C prefer-dynamic=no
-   LL|       |
-   LL|      1|pub fn main() {}
-

--- a/tests/coverage/thin-lto.rs
+++ b/tests/coverage/thin-lto.rs
@@ -1,3 +1,0 @@
-//@ compile-flags: -O -C lto=thin -C prefer-dynamic=no
-
-pub fn main() {}


### PR DESCRIPTION
This hack was intended to handle the case where `-Clto=thin` causes the compiler to emit multiple output files (when producing LLVM-IR or assembly).

The hack only affects 4 tests, of which 3 are just meta-tests for the hack itself. The one remaining test that motivated the hack currently doesn't even need it!

(`tests/codegen/issues/issue-81408-dllimport-thinlto-windows.rs`)
