### PR TITLE
Add a test to help track wasm features over time

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -427,6 +427,13 @@ const WASM_ALLOWED_FEATURES: &[(&str, Stability, ImpliedFeatures)] = &[
     ("sign-ext", Stable, &[]),
     ("simd128", Stable, &[]),
     // tidy-alphabetical-end
+    //
+    // Note that if a new feature is added above please add it to the test at
+    // tests/ui/wasm/default-enabled-features.rs to ensure that its
+    // on-by-default state is tracked over time. If you'd also be so kind as to
+    // update the reference, such as in
+    // https://github.com/rust-lang/reference/pull/1638, it would also be much
+    // appreciated.
 ];
 
 const BPF_ALLOWED_FEATURES: &[(&str, Stability, ImpliedFeatures)] =

--- a/tests/ui/wasm/default-enabled-features.rs
+++ b/tests/ui/wasm/default-enabled-features.rs
@@ -1,0 +1,41 @@
+//@ only-wasm32
+//@ build-pass
+
+#![feature(wasm_target_feature)]
+
+fn main() {
+    #[cfg(any(
+        // on-by-default features
+        not(target_feature = "multivalue"),
+        not(target_feature = "mutable-globals"),
+        not(target_feature = "reference-types"),
+        not(target_feature = "sign-ext"),
+
+        // off-by-default features
+        target_feature = "atomics",
+        target_feature = "bulk-memory",
+        target_feature = "exception-handling",
+        target_feature = "extended-const",
+        target_feature = "nontrapping-fptoint",
+        target_feature = "simd128",
+        target_feature = "relaxed-simd",
+    ))]
+    compile_error!(
+        "\
+If this test fails to compile then it means that the default set of features
+active on WebAssembly targets is no longer what it used to be. This is likely
+due to LLVM being updated and changing the definition of the `generic` CPU in
+wasm.
+
+If you'd be so obliged please update the feature listings above this error
+message. Additionally please update this file too:
+
+* src/doc/rustc/src/platform-support/wasm32-unknown-unknown.md
+
+Specifically the section about \"Enabled WebAssembly features\". If you'd also
+be so kind as to ping wasm maintainers and/or the release team in the PR that
+updates this test it would also be much appreciated to ensure that this change
+is communicated out to users.
+"
+    );
+}


### PR DESCRIPTION
This came up [on Zulip][zulip] where currently we have no notification channel when the `generic` CPU for WebAssembly changes in LLVM other than users hitting possible breakage. This is going to continue to evolve over time, so the purpose of this test is to provide a location to help indicate what to do when the `generic` CPU changes. The purpose of this test is to provide a nudge to notify various folks that something is changing and warrants release notes and such. Otherwise it's expected that the test should be pretty easy to update if it starts failing.

[zulip]: https://rust-lang.zulipchat.com/#narrow/stream/233931-t-compiler.2Fmajor-changes/topic/Wasm.20minimal.20features.20target.20compiler-team.23791/near/476150388


<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
