### PR TITLE
move dummy commit logic into x86_64-gnu-llvm-18

### DIFF
--- a/src/ci/docker/host-x86_64/mingw-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check/Dockerfile
@@ -47,18 +47,6 @@ ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
 # We disable optimized compiler built-ins because that requires a C toolchain for the target.
 # We also skip the x86_64-unknown-linux-gnu target as it is well-tested by other jobs.
 ENV SCRIPT \
-           # `core::builder::tests::ci_rustc_if_unchanged_logic` bootstrap test covers the `rust.download-rustc=if-unchanged` logic.
-           # Here we are adding a dummy commit on compiler and running that test to ensure when there is a change on the compiler,
-           # we never download ci rustc with `rust.download-rustc=if-unchanged` option.
-           echo \"\" >> ../compiler/rustc/src/main.rs && \
-           git config --global user.email \"dummy@dummy.com\" && \
-           git config --global user.name \"dummy\" && \
-           git add ../compiler/rustc/src/main.rs && \
-           git commit -m \"test commit for rust.download-rustc=if-unchanged logic\" && \
-           DISABLE_CI_RUSTC_IF_INCOMPATIBLE=0 python3 ../x.py test bootstrap -- core::builder::tests::ci_rustc_if_unchanged_logic && \
-           # Revert the dummy commit
-           git reset --hard HEAD~1 && \
-
            python3 ../x.py check --stage 0 --set build.optimized-compiler-builtins=false core alloc std --target=aarch64-unknown-linux-gnu,i686-pc-windows-msvc,i686-unknown-linux-gnu,x86_64-apple-darwin,x86_64-pc-windows-gnu,x86_64-pc-windows-msvc && \
            /scripts/check-default-config-profiles.sh && \
            python3 ../x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu && \

--- a/src/ci/docker/scripts/x86_64-gnu-llvm.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-llvm.sh
@@ -2,6 +2,22 @@
 
 set -ex
 
+if [ "$READ_ONLY_SRC" = "0" ]; then
+    # `core::builder::tests::ci_rustc_if_unchanged_logic` bootstrap test ensures that
+    # "download-rustc=if-unchanged" logic don't use CI rustc while there are changes on
+    # compiler and/or library. Here we are adding a dummy commit on compiler and running
+    # that test to make sure we never download CI rustc with a change on the compiler tree.
+    echo "" >> ../compiler/rustc/src/main.rs
+    git config --global user.email "dummy@dummy.com"
+    git config --global user.name "dummy"
+    git add ../compiler/rustc/src/main.rs
+    git commit -m "test commit for rust.download-rustc=if-unchanged logic"
+    DISABLE_CI_RUSTC_IF_INCOMPATIBLE=0 ../x.py test bootstrap \
+        -- core::builder::tests::ci_rustc_if_unchanged_logic
+    # Revert the dummy commit
+    git reset --hard HEAD~1
+fi
+
 # Only run the stage 1 tests on merges, not on PR CI jobs.
 if [[ -z "${PR_CI_JOB}" ]]; then
     ../x.py --stage 1 test --skip src/tools/tidy

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -85,9 +85,6 @@ envs:
 # it in each job definition.
 pr:
   - image: mingw-check
-    env:
-      # We are adding (temporarily) a dummy commit on the compiler
-      READ_ONLY_SRC: "0"
     <<: *job-linux-4c
   - image: mingw-check-tidy
     continue_on_error: true
@@ -95,6 +92,8 @@ pr:
   - image: x86_64-gnu-llvm-18
     env:
       ENABLE_GCC_CODEGEN: "1"
+      # We are adding (temporarily) a dummy commit on the compiler
+      READ_ONLY_SRC: "0"
     <<: *job-linux-16c
   - image: x86_64-gnu-tools
     <<: *job-linux-16c
@@ -210,8 +209,6 @@ auto:
     <<: *job-linux-8c
 
   - image: mingw-check
-    env:
-      READ_ONLY_SRC: 0
     <<: *job-linux-4c
 
   - image: test-various
@@ -264,6 +261,7 @@ auto:
   - image: x86_64-gnu-llvm-18
     env:
       RUST_BACKTRACE: 1
+      READ_ONLY_SRC: "0"
     <<: *job-linux-8c
 
   - image: x86_64-gnu-nopt


### PR DESCRIPTION
Doing the dummy commit logic in a runner that uses CI-LLVM breaks in merge CI. This should be properly fixed by https://github.com/rust-lang/rust/pull/131358 (see the [actual problem](https://github.com/rust-lang/rust/pull/131448#issuecomment-2406516261)). Since we can also fix it by moving the dummy commit into the runner where we use in-tree LLVM, so why not do that as well?