### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5798,16 +5798,16 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-component-ld"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde17bc96539700198e12516230c76095cc215c84ef39ad206e1af3f84243e0f"
+checksum = "4d4aa6bd7fbe7cffbed29fe3e236fda74419def1bdef6f80f989ec51137edf44"
 dependencies = [
  "anyhow",
  "clap",
  "lexopt",
  "tempfile",
  "wasi-preview1-component-adapter-provider",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.0",
  "wat",
  "wit-component",
  "wit-parser",
@@ -5831,19 +5831,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.218.0"
+version = "0.219.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b896fa8ceb71091ace9bcb81e853f54043183a1c9667cf93422c40252ffa0a"
+checksum = "e2b1b95711b3ad655656a341e301cc64e33cbee94de9a99a1c5a2ab88efab79d"
 dependencies = [
  "leb128",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.218.0"
+version = "0.219.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5eeb071abe8a2132fdd5565dabffee70775ee8c24fc7e300ac43f51f4a8a91"
+checksum = "96132fe00dd17d092d2be289eeed5a0a68ad3cf30b68e8875bc953b96f55f0be"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -5851,8 +5851,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.218.0",
- "wasmparser 0.218.0",
+ "wasm-encoder 0.219.0",
+ "wasmparser 0.219.0",
 ]
 
 [[package]]
@@ -5867,9 +5867,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.218.0"
+version = "0.219.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09e46c7fceceaa72b2dd1a8a137ea7fd8f93dfaa69806010a709918e496c5dc"
+checksum = "324b4e56d24439495b88cd81439dad5e97f3c7b1eedc3c7e10455ed1e045e9a2"
 dependencies = [
  "ahash",
  "bitflags 2.6.0",
@@ -5881,22 +5881,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "218.0.0"
+version = "219.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a53cd1f0fa505df97557e36a58bddb8296e2fcdcd089529545ebfdb18a1b9d7"
+checksum = "06880ecb25662bc21db6a83f4fcc27c41f71fbcba4f1980b650c88ada92728e1"
 dependencies = [
  "bumpalo",
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.218.0",
+ "wasm-encoder 0.219.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.218.0"
+version = "1.219.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f87f8e14e776762e07927c27c2054d2cf678aab9aae2d431a79b3e31e4dd391"
+checksum = "11e56dbf9fc89111b0d97c91e683d7895b1a6e5633a729f2ccad2303724005b6"
 dependencies = [
  "wast",
 ]
@@ -6173,9 +6173,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.218.0"
+version = "0.219.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa53aa7e6bf2b3e8ccaffbcc963fbdb672a603dc0af393a481b6cec24c266406"
+checksum = "99a76111c20444a814019de20499d30940ecd219b9512ee296f034a5edb18a2d"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -6184,17 +6184,17 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.218.0",
+ "wasm-encoder 0.219.0",
  "wasm-metadata",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.0",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.218.0"
+version = "0.219.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d1066ab761b115f97fef2b191090faabcb0f37b555b758d3caf42d4ed9e55"
+checksum = "23102e180c0c464f36e293d31a27b524e3ece930d7b5527d2f33f9d2c963de64"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -6205,7 +6205,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.218.0",
+ "wasmparser 0.219.0",
 ]
 
 [[package]]

--- a/library/core/src/alloc/layout.rs
+++ b/library/core/src/alloc/layout.rs
@@ -540,7 +540,8 @@ impl Layout {
 )]
 pub type LayoutErr = LayoutError;
 
-/// The parameters given to `Layout::from_size_align`
+/// The `LayoutError` is returned when the parameters given
+/// to `Layout::from_size_align`
 /// or some other `Layout` constructor
 /// do not satisfy its documented constraints.
 #[stable(feature = "alloc_layout_error", since = "1.50.0")]

--- a/src/ci/docker/host-x86_64/mingw-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check/Dockerfile
@@ -47,18 +47,6 @@ ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
 # We disable optimized compiler built-ins because that requires a C toolchain for the target.
 # We also skip the x86_64-unknown-linux-gnu target as it is well-tested by other jobs.
 ENV SCRIPT \
-           # `core::builder::tests::ci_rustc_if_unchanged_logic` bootstrap test covers the `rust.download-rustc=if-unchanged` logic.
-           # Here we are adding a dummy commit on compiler and running that test to ensure when there is a change on the compiler,
-           # we never download ci rustc with `rust.download-rustc=if-unchanged` option.
-           echo \"\" >> ../compiler/rustc/src/main.rs && \
-           git config --global user.email \"dummy@dummy.com\" && \
-           git config --global user.name \"dummy\" && \
-           git add ../compiler/rustc/src/main.rs && \
-           git commit -m \"test commit for rust.download-rustc=if-unchanged logic\" && \
-           DISABLE_CI_RUSTC_IF_INCOMPATIBLE=0 python3 ../x.py test bootstrap -- core::builder::tests::ci_rustc_if_unchanged_logic && \
-           # Revert the dummy commit
-           git reset --hard HEAD~1 && \
-
            python3 ../x.py check --stage 0 --set build.optimized-compiler-builtins=false core alloc std --target=aarch64-unknown-linux-gnu,i686-pc-windows-msvc,i686-unknown-linux-gnu,x86_64-apple-darwin,x86_64-pc-windows-gnu,x86_64-pc-windows-msvc && \
            /scripts/check-default-config-profiles.sh && \
            python3 ../x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu && \

--- a/src/ci/docker/scripts/x86_64-gnu-llvm.sh
+++ b/src/ci/docker/scripts/x86_64-gnu-llvm.sh
@@ -2,6 +2,20 @@
 
 set -ex
 
+# `core::builder::tests::ci_rustc_if_unchanged_logic` bootstrap test ensures that
+# "download-rustc=if-unchanged" logic don't use CI rustc while there are changes on
+# compiler and/or library. Here we are adding a dummy commit on compiler and running
+# that test to make sure we never download CI rustc with a change on the compiler tree.
+echo "" >> ../compiler/rustc/src/main.rs
+git config --global user.email "dummy@dummy.com"
+git config --global user.name "dummy"
+git add ../compiler/rustc/src/main.rs
+git commit -m "test commit for rust.download-rustc=if-unchanged logic"
+DISABLE_CI_RUSTC_IF_INCOMPATIBLE=0 ../x.py test bootstrap \
+    -- core::builder::tests::ci_rustc_if_unchanged_logic
+# Revert the dummy commit
+git reset --hard HEAD~1
+
 # Only run the stage 1 tests on merges, not on PR CI jobs.
 if [[ -z "${PR_CI_JOB}" ]]; then
     ../x.py --stage 1 test --skip src/tools/tidy

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -85,9 +85,6 @@ envs:
 # it in each job definition.
 pr:
   - image: mingw-check
-    env:
-      # We are adding (temporarily) a dummy commit on the compiler
-      READ_ONLY_SRC: "0"
     <<: *job-linux-4c
   - image: mingw-check-tidy
     continue_on_error: true
@@ -95,6 +92,8 @@ pr:
   - image: x86_64-gnu-llvm-18
     env:
       ENABLE_GCC_CODEGEN: "1"
+      # We are adding (temporarily) a dummy commit on the compiler
+      READ_ONLY_SRC: "0"
     <<: *job-linux-16c
   - image: x86_64-gnu-tools
     <<: *job-linux-16c
@@ -210,8 +209,6 @@ auto:
     <<: *job-linux-8c
 
   - image: mingw-check
-    env:
-      READ_ONLY_SRC: 0
     <<: *job-linux-4c
 
   - image: test-various
@@ -264,6 +261,7 @@ auto:
   - image: x86_64-gnu-llvm-18
     env:
       RUST_BACKTRACE: 1
+      READ_ONLY_SRC: "0"
     <<: *job-linux-8c
 
   - image: x86_64-gnu-nopt

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -677,7 +677,7 @@ pub struct FunctionHeader {
 /// on unwinding for more info.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Abi {
-    // We only have a concrete listing here for stable ABI's because their are so many
+    // We only have a concrete listing here for stable ABI's because there are so many
     // See rustc_ast_passes::feature_gate::PostExpansionVisitor::check_abi for the list
     /// The default ABI, but that can also be written explicitly with `extern "Rust"`.
     Rust,

--- a/src/tools/wasm-component-ld/Cargo.toml
+++ b/src/tools/wasm-component-ld/Cargo.toml
@@ -10,4 +10,4 @@ name = "wasm-component-ld"
 path = "src/main.rs"
 
 [dependencies]
-wasm-component-ld = "0.5.9"
+wasm-component-ld = "0.5.10"

--- a/tests/ui/lint/non-local-defs/consts.rs
+++ b/tests/ui/lint/non-local-defs/consts.rs
@@ -63,6 +63,13 @@ fn main() {
 
         1
     };
+
+    const _: () = {
+        const _: () = {
+            impl Test {}
+            //~^ WARN non-local `impl` definition
+        };
+    };
 }
 
 trait Uto9 {}

--- a/tests/ui/lint/non-local-defs/consts.stderr
+++ b/tests/ui/lint/non-local-defs/consts.stderr
@@ -95,7 +95,21 @@ LL |         impl Test {
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:72:9
+  --> $DIR/consts.rs:69:13
+   |
+LL |         const _: () = {
+   |         ----------- move the `impl` block outside of this constant `_` and up 3 bodies
+LL |             impl Test {}
+   |             ^^^^^----
+   |                  |
+   |                  `Test` is not local
+   |
+   = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
+   = note: items in an anonymous const item (`const _: () = { ... }`) are treated as in the same scope as the anonymous const's declaration for the purpose of this lint
+   = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
+
+warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
+  --> $DIR/consts.rs:79:9
    |
 LL |     let _a = || {
    |              -- move the `impl` block outside of this closure `<unnameable>` and up 2 bodies
@@ -109,7 +123,7 @@ LL |         impl Uto9 for Test {}
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
 warning: non-local `impl` definition, `impl` blocks should be written at the same level as their item
-  --> $DIR/consts.rs:79:9
+  --> $DIR/consts.rs:86:9
    |
 LL |       type A = [u32; {
    |  ____________________-
@@ -126,5 +140,5 @@ LL | |     }];
    = note: an `impl` is never scoped, even when it is nested inside an item, as it may impact type checking outside of that item, which can be the case if neither the trait or the self type are at the same nesting level as the `impl`
    = note: this lint may become deny-by-default in the edition 2024 and higher, see the tracking issue <https://github.com/rust-lang/rust/issues/120363>
 
-warning: 8 warnings emitted
+warning: 9 warnings emitted
 

--- a/tests/ui/lint/non-local-defs/convoluted-locals-131474-with-mods.rs
+++ b/tests/ui/lint/non-local-defs/convoluted-locals-131474-with-mods.rs
@@ -1,0 +1,34 @@
+// This test check that no matter the nesting of const-anons and modules
+// we consider them as transparent.
+//
+// Similar to https://github.com/rust-lang/rust/issues/131474
+
+//@ check-pass
+
+pub mod tmp {
+    pub mod tmp {
+        pub struct Test;
+    }
+}
+
+const _: () = {
+    const _: () = {
+        const _: () = {
+            const _: () = {
+                impl tmp::tmp::Test {}
+            };
+        };
+    };
+};
+
+const _: () = {
+    const _: () = {
+        mod tmp {
+            pub(super) struct InnerTest;
+        }
+
+        impl tmp::InnerTest {}
+    };
+};
+
+fn main() {}

--- a/tests/ui/lint/non-local-defs/convoluted-locals-131474.rs
+++ b/tests/ui/lint/non-local-defs/convoluted-locals-131474.rs
@@ -1,0 +1,24 @@
+// This test check that no matter the nesting of const-anons we consider
+// them as transparent.
+//
+// https://github.com/rust-lang/rust/issues/131474
+
+//@ check-pass
+
+pub struct Test;
+
+const _: () = {
+    const _: () = {
+        impl Test {}
+    };
+};
+
+const _: () = {
+    const _: () = {
+        struct InnerTest;
+
+        impl InnerTest {}
+    };
+};
+
+fn main() {}

--- a/tests/ui/lint/non-local-defs/local.rs
+++ b/tests/ui/lint/non-local-defs/local.rs
@@ -51,3 +51,10 @@ fn bitflags() {
         impl Flags {}
     };
 }
+
+fn bitflags_internal() {
+    const _: () = {
+        struct InternalFlags;
+        impl InternalFlags {}
+    };
+}


### PR DESCRIPTION
Successful merges:

 - #131464 (Update wasm-component-ld to 0.5.10)
 - #131498 (Consider outermost const-anon in `non_local_def` lint)
 - #131512 (Fixing rustDoc for LayoutError.)
 - #131529 (rustdoc-json-types: fix typo in comment)
 - #131531 (move dummy commit logic into x86_64-gnu-llvm-18)

Failed merges:

 - #131476 (coverage: Include the highest counter ID seen in `.cov-map` dumps)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131464,131498,131512,131529,131531)
<!-- homu-ignore:end -->