### PR TITLE
compiletest: Extract auxiliary-crate properties to their own module/struct

### DIFF
--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -9,11 +9,13 @@ use std::process::Command;
 use tracing::*;
 
 use crate::common::{Config, Debugger, FailMode, Mode, PassMode};
+use crate::header::auxiliary::{AuxProps, parse_and_update_aux};
 use crate::header::cfg::{MatchOutcome, parse_cfg_name_directive};
 use crate::header::needs::CachedNeedsConditions;
 use crate::util::static_regex;
 use crate::{extract_cdb_version, extract_gdb_version};
 
+pub(crate) mod auxiliary;
 mod cfg;
 mod needs;
 #[cfg(test)]
@@ -98,18 +100,8 @@ pub struct TestProps {
     // If present, the name of a file that this test should match when
     // pretty-printed
     pub pp_exact: Option<PathBuf>,
-    // Other crates that should be compiled (typically from the same
-    // directory as the test, but for backwards compatibility reasons
-    // we also check the auxiliary directory)
-    pub aux_builds: Vec<String>,
-    // Auxiliary crates that should be compiled as `#![crate_type = "bin"]`.
-    pub aux_bins: Vec<String>,
-    // Similar to `aux_builds`, but a list of NAME=somelib.rs of dependencies
-    // to build and pass with the `--extern` flag.
-    pub aux_crates: Vec<(String, String)>,
-    /// Similar to `aux_builds`, but also passes the resulting dylib path to
-    /// `-Zcodegen-backend`.
-    pub aux_codegen_backend: Option<String>,
+    /// Auxiliary crates that should be built and made available to this test.
+    pub(crate) aux: AuxProps,
     // Environment settings to use for compiling
     pub rustc_env: Vec<(String, String)>,
     // Environment variables to unset prior to compiling.
@@ -276,10 +268,7 @@ impl TestProps {
             run_flags: vec![],
             doc_flags: vec![],
             pp_exact: None,
-            aux_builds: vec![],
-            aux_bins: vec![],
-            aux_crates: vec![],
-            aux_codegen_backend: None,
+            aux: Default::default(),
             revisions: vec![],
             rustc_env: vec![
                 ("RUSTC_ICE".to_string(), "0".to_string()),
@@ -454,21 +443,10 @@ impl TestProps {
                         PRETTY_COMPARE_ONLY,
                         &mut self.pretty_compare_only,
                     );
-                    config.push_name_value_directive(ln, AUX_BUILD, &mut self.aux_builds, |r| {
-                        r.trim().to_string()
-                    });
-                    config.push_name_value_directive(ln, AUX_BIN, &mut self.aux_bins, |r| {
-                        r.trim().to_string()
-                    });
-                    config.push_name_value_directive(
-                        ln,
-                        AUX_CRATE,
-                        &mut self.aux_crates,
-                        Config::parse_aux_crate,
-                    );
-                    if let Some(r) = config.parse_name_value_directive(ln, AUX_CODEGEN_BACKEND) {
-                        self.aux_codegen_backend = Some(r.trim().to_owned());
-                    }
+
+                    // Call a helper method to deal with aux-related directives.
+                    parse_and_update_aux(config, ln, &mut self.aux);
+
                     config.push_name_value_directive(
                         ln,
                         EXEC_ENV,

--- a/src/tools/compiletest/src/header/auxiliary.rs
+++ b/src/tools/compiletest/src/header/auxiliary.rs
@@ -1,0 +1,44 @@
+//! Code for dealing with test directives that request an "auxiliary" crate to
+//! be built and made available to the test in some way.
+
+use crate::common::Config;
+use crate::header::directives::{AUX_BIN, AUX_BUILD, AUX_CODEGEN_BACKEND, AUX_CRATE};
+
+/// Properties parsed from `aux-*` test directives.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct AuxProps {
+    /// Other crates that should be built and made available to this test.
+    /// These are filenames relative to `./auxiliary/` in the test's directory.
+    pub(crate) builds: Vec<String>,
+    /// Auxiliary crates that should be compiled as `#![crate_type = "bin"]`.
+    pub(crate) bins: Vec<String>,
+    /// Similar to `builds`, but a list of NAME=somelib.rs of dependencies
+    /// to build and pass with the `--extern` flag.
+    pub(crate) crates: Vec<(String, String)>,
+    /// Similar to `builds`, but also uses the resulting dylib as a
+    /// `-Zcodegen-backend` when compiling the test file.
+    pub(crate) codegen_backend: Option<String>,
+}
+
+/// If the given test directive line contains an `aux-*` directive, parse it
+/// and update [`AuxProps`] accordingly.
+pub(super) fn parse_and_update_aux(config: &Config, ln: &str, aux: &mut AuxProps) {
+    if !ln.starts_with("aux-") {
+        return;
+    }
+
+    config.push_name_value_directive(ln, AUX_BUILD, &mut aux.builds, |r| r.trim().to_string());
+    config.push_name_value_directive(ln, AUX_BIN, &mut aux.bins, |r| r.trim().to_string());
+    config.push_name_value_directive(ln, AUX_CRATE, &mut aux.crates, parse_aux_crate);
+    if let Some(r) = config.parse_name_value_directive(ln, AUX_CODEGEN_BACKEND) {
+        aux.codegen_backend = Some(r.trim().to_owned());
+    }
+}
+
+fn parse_aux_crate(r: String) -> (String, String) {
+    let mut parts = r.trim().splitn(2, '=');
+    (
+        parts.next().expect("missing aux-crate name (e.g. log=log.rs)").to_string(),
+        parts.next().expect("missing aux-crate value (e.g. log=log.rs)").to_string(),
+    )
+}

--- a/src/tools/compiletest/src/header/auxiliary.rs
+++ b/src/tools/compiletest/src/header/auxiliary.rs
@@ -1,6 +1,8 @@
 //! Code for dealing with test directives that request an "auxiliary" crate to
 //! be built and made available to the test in some way.
 
+use std::iter;
+
 use crate::common::Config;
 use crate::header::directives::{AUX_BIN, AUX_BUILD, AUX_CODEGEN_BACKEND, AUX_CRATE};
 
@@ -18,6 +20,20 @@ pub(crate) struct AuxProps {
     /// Similar to `builds`, but also uses the resulting dylib as a
     /// `-Zcodegen-backend` when compiling the test file.
     pub(crate) codegen_backend: Option<String>,
+}
+
+impl AuxProps {
+    /// Yields all of the paths (relative to `./auxiliary/`) that have been
+    /// specified in `aux-*` directives for this test.
+    pub(crate) fn all_aux_path_strings(&self) -> impl Iterator<Item = &str> {
+        let Self { builds, bins, crates, codegen_backend } = self;
+
+        iter::empty()
+            .chain(builds.iter().map(String::as_str))
+            .chain(bins.iter().map(String::as_str))
+            .chain(crates.iter().map(|(_, path)| path.as_str()))
+            .chain(codegen_backend.iter().map(String::as_str))
+    }
 }
 
 /// If the given test directive line contains an `aux-*` directive, parse it

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -242,7 +242,8 @@ fn aux_build() {
         //@ aux-build: b.rs
         "
         )
-        .aux,
+        .aux
+        .builds,
         vec!["a.rs", "b.rs"],
     );
 }

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -862,7 +862,7 @@ fn files_related_to_test(
         related.push(testpaths.file.clone());
     }
 
-    for aux in &props.aux.builds {
+    for aux in props.aux.all_aux_path_strings() {
         // FIXME(Zalathar): Perform all `auxiliary` path resolution in one place.
         let path = testpaths.file.parent().unwrap().join("auxiliary").join(aux);
         related.push(path);

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -862,7 +862,8 @@ fn files_related_to_test(
         related.push(testpaths.file.clone());
     }
 
-    for aux in &props.aux {
+    for aux in &props.aux.builds {
+        // FIXME(Zalathar): Perform all `auxiliary` path resolution in one place.
         let path = testpaths.file.parent().unwrap().join("auxiliary").join(aux);
         related.push(path);
     }


### PR DESCRIPTION
This moves the values of the 4 different `aux-*` directives into their own sub-struct. That struct, along with its directive-parsing code, can then be shared by both `TestProps` and `EarlyProps`.

The final patch also fixes an oversight in up-to-date checking, by including *all* auxiliary crates in the timestamp, not just ordinary `aux-build` ones.

