### PR TITLE
Make unused_parens's suggestion considering expr's attributes.

### DIFF
--- a/tests/ui/lint/unused/unused-parens-for-stmt-expr-attributes-issue-129833.fixed
+++ b/tests/ui/lint/unused/unused-parens-for-stmt-expr-attributes-issue-129833.fixed
@@ -1,0 +1,15 @@
+//@ run-rustfix
+// Check the `unused_parens` suggestion for paren_expr with attributes.
+// The suggestion should retain attributes in the front.
+
+#![feature(stmt_expr_attributes)]
+#![deny(unused_parens)]
+
+pub fn foo() -> impl Fn() {
+    let _ = #[inline] #[allow(dead_code)] || println!("Hello!"); //~ERROR unnecessary parentheses
+    #[inline] #[allow(dead_code)] || println!("Hello!") //~ERROR unnecessary parentheses
+}
+
+fn main() {
+    let _ = foo();
+}

--- a/tests/ui/lint/unused/unused-parens-for-stmt-expr-attributes-issue-129833.rs
+++ b/tests/ui/lint/unused/unused-parens-for-stmt-expr-attributes-issue-129833.rs
@@ -1,0 +1,15 @@
+//@ run-rustfix
+// Check the `unused_parens` suggestion for paren_expr with attributes.
+// The suggestion should retain attributes in the front.
+
+#![feature(stmt_expr_attributes)]
+#![deny(unused_parens)]
+
+pub fn foo() -> impl Fn() {
+    let _ = (#[inline] #[allow(dead_code)] || println!("Hello!")); //~ERROR unnecessary parentheses
+    (#[inline] #[allow(dead_code)] || println!("Hello!")) //~ERROR unnecessary parentheses
+}
+
+fn main() {
+    let _ = foo();
+}

--- a/tests/ui/lint/unused/unused-parens-for-stmt-expr-attributes-issue-129833.stderr
+++ b/tests/ui/lint/unused/unused-parens-for-stmt-expr-attributes-issue-129833.stderr
@@ -1,0 +1,31 @@
+error: unnecessary parentheses around assigned value
+  --> $DIR/unused-parens-for-stmt-expr-attributes-issue-129833.rs:9:13
+   |
+LL |     let _ = (#[inline] #[allow(dead_code)] || println!("Hello!"));
+   |             ^                                                   ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-parens-for-stmt-expr-attributes-issue-129833.rs:6:9
+   |
+LL | #![deny(unused_parens)]
+   |         ^^^^^^^^^^^^^
+help: remove these parentheses
+   |
+LL -     let _ = (#[inline] #[allow(dead_code)] || println!("Hello!"));
+LL +     let _ = #[inline] #[allow(dead_code)] || println!("Hello!");
+   |
+
+error: unnecessary parentheses around block return value
+  --> $DIR/unused-parens-for-stmt-expr-attributes-issue-129833.rs:10:5
+   |
+LL |     (#[inline] #[allow(dead_code)] || println!("Hello!"))
+   |     ^                                                   ^
+   |
+help: remove these parentheses
+   |
+LL -     (#[inline] #[allow(dead_code)] || println!("Hello!"))
+LL +     #[inline] #[allow(dead_code)] || println!("Hello!")
+   |
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
For the expr with attributes, 
like `let _ = (#[inline] || println!("Hello!"));`, 
the suggestion's span should contains the attributes, or the suggestion will remove them.

fixes #129833

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
