### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_target/src/asm/mod.rs
+++ b/compiler/rustc_target/src/asm/mod.rs
@@ -893,6 +893,7 @@ pub enum InlineAsmClobberAbi {
     RiscV,
     LoongArch,
     S390x,
+    Msp430,
 }
 
 impl InlineAsmClobberAbi {
@@ -944,6 +945,10 @@ impl InlineAsmClobberAbi {
             },
             InlineAsmArch::S390x => match name {
                 "C" | "system" => Ok(InlineAsmClobberAbi::S390x),
+                _ => Err(&["C", "system"]),
+            },
+            InlineAsmArch::Msp430 => match name {
+                "C" | "system" => Ok(InlineAsmClobberAbi::Msp430),
                 _ => Err(&["C", "system"]),
             },
             _ => Err(&[]),
@@ -1123,6 +1128,11 @@ impl InlineAsmClobberAbi {
                     // a0-a1 are reserved, other access registers are volatile
                     a2, a3, a4, a5, a6, a7,
                     a8, a9, a10, a11, a12, a13, a14, a15,
+                }
+            },
+            InlineAsmClobberAbi::Msp430 => clobbered_regs! {
+                Msp430 Msp430InlineAsmReg {
+                    r11, r12, r13, r14, r15,
                 }
             },
         }

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -674,8 +674,9 @@ impl char {
     /// 'ß'.encode_utf8(&mut b);
     /// ```
     #[stable(feature = "unicode_encode_char", since = "1.15.0")]
-    #[rustc_const_unstable(feature = "const_char_encode_utf8", issue = "130512")]
+    #[rustc_const_stable(feature = "const_char_encode_utf8", since = "CURRENT_RUSTC_VERSION")]
     #[inline]
+    #[cfg_attr(bootstrap, rustc_allow_const_fn_unstable(const_mut_refs))]
     pub const fn encode_utf8(self, dst: &mut [u8]) -> &mut str {
         // SAFETY: `char` is not a surrogate, so this is valid UTF-8.
         unsafe { from_utf8_unchecked_mut(encode_utf8_raw(self as u32, dst)) }
@@ -1770,9 +1771,11 @@ const fn len_utf16(code: u32) -> usize {
 /// Panics if the buffer is not large enough.
 /// A buffer of length four is large enough to encode any `char`.
 #[unstable(feature = "char_internals", reason = "exposed only for libstd", issue = "none")]
-#[rustc_const_unstable(feature = "const_char_encode_utf8", issue = "130512")]
+#[rustc_const_stable(feature = "const_char_encode_utf8", since = "CURRENT_RUSTC_VERSION")]
 #[doc(hidden)]
 #[inline]
+#[rustc_allow_const_fn_unstable(const_eval_select)]
+#[cfg_attr(bootstrap, rustc_allow_const_fn_unstable(const_mut_refs))]
 pub const fn encode_utf8_raw(code: u32, dst: &mut [u8]) -> &mut [u8] {
     const fn panic_at_const(_code: u32, _len: usize, _dst_len: usize) {
         // Note that we cannot format in constant expressions.

--- a/library/core/src/fmt/builders.rs
+++ b/library/core/src/fmt/builders.rs
@@ -366,8 +366,6 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(debug_more_non_exhaustive)]
-    ///
     /// use std::fmt;
     ///
     /// struct Foo(i32, String);
@@ -385,7 +383,7 @@ impl<'a, 'b: 'a> DebugTuple<'a, 'b> {
     ///     "Foo(10, ..)",
     /// );
     /// ```
-    #[unstable(feature = "debug_more_non_exhaustive", issue = "127942")]
+    #[stable(feature = "debug_more_non_exhaustive", since = "CURRENT_RUSTC_VERSION")]
     pub fn finish_non_exhaustive(&mut self) -> fmt::Result {
         self.result = self.result.and_then(|_| {
             if self.fields > 0 {
@@ -606,8 +604,6 @@ impl<'a, 'b: 'a> DebugSet<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(debug_more_non_exhaustive)]
-    ///
     /// use std::fmt;
     ///
     /// struct Foo(Vec<i32>);
@@ -630,7 +626,7 @@ impl<'a, 'b: 'a> DebugSet<'a, 'b> {
     ///     "{1, 2, ..}",
     /// );
     /// ```
-    #[unstable(feature = "debug_more_non_exhaustive", issue = "127942")]
+    #[stable(feature = "debug_more_non_exhaustive", since = "CURRENT_RUSTC_VERSION")]
     pub fn finish_non_exhaustive(&mut self) -> fmt::Result {
         self.inner.result = self.inner.result.and_then(|_| {
             if self.inner.has_fields {
@@ -800,8 +796,6 @@ impl<'a, 'b: 'a> DebugList<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(debug_more_non_exhaustive)]
-    ///
     /// use std::fmt;
     ///
     /// struct Foo(Vec<i32>);
@@ -824,7 +818,7 @@ impl<'a, 'b: 'a> DebugList<'a, 'b> {
     ///     "[1, 2, ..]",
     /// );
     /// ```
-    #[unstable(feature = "debug_more_non_exhaustive", issue = "127942")]
+    #[stable(feature = "debug_more_non_exhaustive", since = "CURRENT_RUSTC_VERSION")]
     pub fn finish_non_exhaustive(&mut self) -> fmt::Result {
         self.inner.result.and_then(|_| {
             if self.inner.has_fields {
@@ -1126,8 +1120,6 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(debug_more_non_exhaustive)]
-    ///
     /// use std::fmt;
     ///
     /// struct Foo(Vec<(String, i32)>);
@@ -1154,7 +1146,7 @@ impl<'a, 'b: 'a> DebugMap<'a, 'b> {
     ///     r#"{"A": 10, "B": 11, ..}"#,
     /// );
     /// ```
-    #[unstable(feature = "debug_more_non_exhaustive", issue = "127942")]
+    #[stable(feature = "debug_more_non_exhaustive", since = "CURRENT_RUSTC_VERSION")]
     pub fn finish_non_exhaustive(&mut self) -> fmt::Result {
         self.result = self.result.and_then(|_| {
             assert!(!self.has_key, "attempted to finish a map with a partial entry");

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -119,7 +119,6 @@
 #![feature(const_bigint_helper_methods)]
 #![feature(const_black_box)]
 #![feature(const_char_encode_utf16)]
-#![feature(const_char_encode_utf8)]
 #![feature(const_eval_select)]
 #![feature(const_exact_div)]
 #![feature(const_float_classify)]

--- a/library/core/src/result.rs
+++ b/library/core/src/result.rs
@@ -734,7 +734,8 @@ impl<T, E> Result<T, E> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_result", issue = "82814")]
+    #[rustc_const_stable(feature = "const_result", since = "CURRENT_RUSTC_VERSION")]
+    #[cfg_attr(bootstrap, rustc_allow_const_fn_unstable(const_mut_refs))]
     pub const fn as_mut(&mut self) -> Result<&mut T, &mut E> {
         match *self {
             Ok(ref mut x) => Ok(x),
@@ -1536,7 +1537,8 @@ impl<T, E> Result<&T, E> {
     /// ```
     #[inline]
     #[stable(feature = "result_copied", since = "1.59.0")]
-    #[rustc_const_unstable(feature = "const_result", issue = "82814")]
+    #[rustc_const_stable(feature = "const_result", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
     pub const fn copied(self) -> Result<T, E>
     where
         T: Copy,
@@ -1586,7 +1588,9 @@ impl<T, E> Result<&mut T, E> {
     /// ```
     #[inline]
     #[stable(feature = "result_copied", since = "1.59.0")]
-    #[rustc_const_unstable(feature = "const_result", issue = "82814")]
+    #[rustc_const_stable(feature = "const_result", since = "CURRENT_RUSTC_VERSION")]
+    #[cfg_attr(bootstrap, rustc_allow_const_fn_unstable(const_mut_refs))]
+    #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
     pub const fn copied(self) -> Result<T, E>
     where
         T: Copy,
@@ -1639,7 +1643,8 @@ impl<T, E> Result<Option<T>, E> {
     /// ```
     #[inline]
     #[stable(feature = "transpose_result", since = "1.33.0")]
-    #[rustc_const_unstable(feature = "const_result", issue = "82814")]
+    #[rustc_const_stable(feature = "const_result", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
     pub const fn transpose(self) -> Option<Result<T, E>> {
         match self {
             Ok(Some(x)) => Some(Ok(x)),

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -39,7 +39,6 @@
 #![feature(core_io_borrowed_buf)]
 #![feature(core_private_bignum)]
 #![feature(core_private_diy_float)]
-#![feature(debug_more_non_exhaustive)]
 #![feature(dec2flt)]
 #![feature(duration_constants)]
 #![feature(duration_constructors)]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -29,7 +29,6 @@
 #![feature(const_pin)]
 #![feature(const_pointer_is_aligned)]
 #![feature(const_ptr_write)]
-#![feature(const_result)]
 #![feature(const_three_way_compare)]
 #![feature(const_trait_impl)]
 #![feature(core_intrinsics)]

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 /// This integer is incremented with every breaking change to the API,
 /// and is returned along with the JSON blob as [`Crate::format_version`].
 /// Consuming code should assert that this value matches the format version(s) that it supports.
-pub const FORMAT_VERSION: u32 = 34;
+pub const FORMAT_VERSION: u32 = 35;
 
 /// The root of the emitted JSON blob.
 ///
@@ -296,9 +296,9 @@ pub enum AssocItemConstraintKind {
 /// Rustdoc makes no guarantees about the inner value of Id's. Applications
 /// should treat them as opaque keys to lookup items, and avoid attempting
 /// to parse them, or otherwise depend on any implementation details.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 // FIXME(aDotInTheVoid): Consider making this non-public in rustdoc-types.
-pub struct Id(pub String);
+pub struct Id(pub u32);
 
 /// The fundamental kind of an item. Unlike [`ItemEnum`], this does not carry any aditional info.
 ///

--- a/src/tools/jsondoclint/src/validator.rs
+++ b/src/tools/jsondoclint/src/validator.rs
@@ -418,7 +418,7 @@ impl<'a> Validator<'a> {
         } else if !self.missing_ids.contains(id) {
             self.missing_ids.insert(id);
 
-            let sels = json_find::find_selector(&self.krate_json, &Value::String(id.0.clone()));
+            let sels = json_find::find_selector(&self.krate_json, &Value::Number(id.0.into()));
             assert_ne!(sels.len(), 0);
 
             self.fail(id, ErrorKind::NotFound(sels))

--- a/src/tools/jsondoclint/src/validator/tests.rs
+++ b/src/tools/jsondoclint/src/validator/tests.rs
@@ -15,24 +15,20 @@ fn check(krate: &Crate, errs: &[Error]) {
     assert_eq!(errs, &validator.errs[..]);
 }
 
-fn id(s: &str) -> Id {
-    Id(s.to_owned())
-}
-
 #[test]
 fn errors_on_missing_links() {
     let k = Crate {
-        root: id("0"),
+        root: Id(0),
         crate_version: None,
         includes_private: false,
-        index: FxHashMap::from_iter([(id("0"), Item {
+        index: FxHashMap::from_iter([(Id(0), Item {
             name: Some("root".to_owned()),
-            id: id(""),
+            id: Id(0),
             crate_id: 0,
             span: None,
             visibility: Visibility::Public,
             docs: None,
-            links: FxHashMap::from_iter([("Not Found".to_owned(), id("1"))]),
+            links: FxHashMap::from_iter([("Not Found".to_owned(), Id(1))]),
             attrs: vec![],
             deprecation: None,
             inner: ItemEnum::Module(Module { is_crate: true, items: vec![], is_stripped: false }),
@@ -49,7 +45,7 @@ fn errors_on_missing_links() {
             SelectorPart::Field("links".to_owned()),
             SelectorPart::Field("Not Found".to_owned()),
         ]]),
-        id: id("1"),
+        id: Id(1),
     }]);
 }
 
@@ -58,28 +54,28 @@ fn errors_on_missing_links() {
 #[test]
 fn errors_on_local_in_paths_and_not_index() {
     let krate = Crate {
-        root: id("0:0:1572"),
+        root: Id(0),
         crate_version: None,
         includes_private: false,
         index: FxHashMap::from_iter([
-            (id("0:0:1572"), Item {
-                id: id("0:0:1572"),
+            (Id(0), Item {
+                id: Id(0),
                 crate_id: 0,
                 name: Some("microcore".to_owned()),
                 span: None,
                 visibility: Visibility::Public,
                 docs: None,
-                links: FxHashMap::from_iter([(("prim@i32".to_owned(), id("0:1:1571")))]),
+                links: FxHashMap::from_iter([(("prim@i32".to_owned(), Id(2)))]),
                 attrs: Vec::new(),
                 deprecation: None,
                 inner: ItemEnum::Module(Module {
                     is_crate: true,
-                    items: vec![id("0:1:717")],
+                    items: vec![Id(1)],
                     is_stripped: false,
                 }),
             }),
-            (id("0:1:717"), Item {
-                id: id("0:1:717"),
+            (Id(1), Item {
+                id: Id(1),
                 crate_id: 0,
                 name: Some("i32".to_owned()),
                 span: None,
@@ -91,7 +87,7 @@ fn errors_on_local_in_paths_and_not_index() {
                 inner: ItemEnum::Primitive(Primitive { name: "i32".to_owned(), impls: vec![] }),
             }),
         ]),
-        paths: FxHashMap::from_iter([(id("0:1:1571"), ItemSummary {
+        paths: FxHashMap::from_iter([(Id(2), ItemSummary {
             crate_id: 0,
             path: vec!["microcore".to_owned(), "i32".to_owned()],
             kind: ItemKind::Primitive,
@@ -101,7 +97,7 @@ fn errors_on_local_in_paths_and_not_index() {
     };
 
     check(&krate, &[Error {
-        id: id("0:1:1571"),
+        id: Id(2),
         kind: ErrorKind::Custom("Id for local item in `paths` but not in `index`".to_owned()),
     }]);
 }
@@ -110,11 +106,11 @@ fn errors_on_local_in_paths_and_not_index() {
 #[should_panic = "LOCAL_CRATE_ID is wrong"]
 fn checks_local_crate_id_is_correct() {
     let krate = Crate {
-        root: id("root"),
+        root: Id(0),
         crate_version: None,
         includes_private: false,
-        index: FxHashMap::from_iter([(id("root"), Item {
-            id: id("root"),
+        index: FxHashMap::from_iter([(Id(0), Item {
+            id: Id(0),
             crate_id: LOCAL_CRATE_ID.wrapping_add(1),
             name: Some("irrelavent".to_owned()),
             span: None,

--- a/tests/codegen/asm-msp430-clobbers.rs
+++ b/tests/codegen/asm-msp430-clobbers.rs
@@ -1,0 +1,36 @@
+//@ assembly-output: emit-asm
+//@ compile-flags: --target msp430-none-elf
+//@ needs-llvm-components: msp430
+
+#![crate_type = "rlib"]
+#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+
+// CHECK-LABEL: @sr_clobber
+// CHECK: call void asm sideeffect "", "~{sr}"()
+#[no_mangle]
+pub unsafe fn sr_clobber() {
+    asm!("", options(nostack, nomem));
+}
+
+// CHECK-LABEL: @no_clobber
+// CHECK: call void asm sideeffect "", ""()
+#[no_mangle]
+pub unsafe fn no_clobber() {
+    asm!("", options(nostack, nomem, preserves_flags));
+}
+
+// CHECK-LABEL: @clobber_abi
+// CHECK: asm sideeffect "", "={r11},={r12},={r13},={r14},={r15}"()
+#[no_mangle]
+pub unsafe fn clobber_abi() {
+    asm!("", clobber_abi("C"), options(nostack, nomem, preserves_flags));
+}


### PR DESCRIPTION
Successful merges:

 - #130078 (rustdoc-json: change item ID's repr from a string to an int)
 - #131109 (Stabilize `debug_more_non_exhaustive`)
 - #131287 (stabilize const_result)
 - #131310 (Support clobber_abi in MSP430 inline assembly)
 - #131463 (Stabilise `const_char_encode_utf8`.)
 - #131464 (Update wasm-component-ld to 0.5.10)
 - #131476 (coverage: Include the highest counter ID seen in `.cov-map` dumps)
 - #131497 (Add myself to bootstrap review rotation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=130078,131109,131287,131310,131463,131464,131476,131497)
<!-- homu-ignore:end -->