### PR TITLE
Avoid superfluous UB checks in `IndexRange`

### DIFF
--- a/tests/codegen/issues/issue-101082.rs
+++ b/tests/codegen/issues/issue-101082.rs
@@ -1,4 +1,9 @@
 //@ compile-flags: -O
+//@ revisions: host x86-64-v3
+
+// This particular CPU regressed in #131563
+//@[x86-64-v3] only-x86_64
+//@[x86-64-v3] compile-flags: -Ctarget-cpu=x86-64-v3
 
 #![crate_type = "lib"]
 


### PR DESCRIPTION
`IndexRange::len` is justified as an overall invariant, and
`take_prefix` and `take_suffix` are justified by local branch
conditions. A few more UB-checked calls remain in cases that are only
supported locally by `debug_assert!`, which won't do anything in
distributed builds, so those UB checks may still be useful.

We generally expect core's `#![rustc_preserve_ub_checks]` to optimize
away in user's release builds, but the mere presence of that extra code
can sometimes inhibit optimization, as seen in #131563.
