### PR TITLE
Flatten redundant test module `run_make_support::diff::tests::tests`

### DIFF
--- a/src/tools/run-make-support/src/diff/tests.rs
+++ b/src/tools/run-make-support/src/diff/tests.rs
@@ -1,28 +1,23 @@
-#[cfg(test)]
-mod tests {
-    use crate::*;
+use crate::*;
 
-    #[test]
-    fn test_diff() {
-        let expected = "foo\nbar\nbaz\n";
-        let actual = "foo\nbar\nbaz\n";
+#[test]
+fn test_diff() {
+    let expected = "foo\nbar\nbaz\n";
+    let actual = "foo\nbar\nbaz\n";
+    diff().expected_text("EXPECTED_TEXT", expected).actual_text("ACTUAL_TEXT", actual).run();
+}
+
+#[test]
+fn test_should_panic() {
+    let expected = "foo\nbar\nbaz\n";
+    let actual = "foo\nbaz\nbar\n";
+
+    let output = std::panic::catch_unwind(|| {
         diff().expected_text("EXPECTED_TEXT", expected).actual_text("ACTUAL_TEXT", actual).run();
-    }
+    })
+    .unwrap_err();
 
-    #[test]
-    fn test_should_panic() {
-        let expected = "foo\nbar\nbaz\n";
-        let actual = "foo\nbaz\nbar\n";
-
-        let output = std::panic::catch_unwind(|| {
-            diff()
-                .expected_text("EXPECTED_TEXT", expected)
-                .actual_text("ACTUAL_TEXT", actual)
-                .run();
-        })
-        .unwrap_err();
-
-        let expected_output = "\
+    let expected_output = "\
 test failed: `EXPECTED_TEXT` is different from `ACTUAL_TEXT`
 
 --- EXPECTED_TEXT
@@ -34,28 +29,27 @@ test failed: `EXPECTED_TEXT` is different from `ACTUAL_TEXT`
 -baz
 ";
 
-        assert_eq!(output.downcast_ref::<String>().unwrap(), expected_output);
-    }
+    assert_eq!(output.downcast_ref::<String>().unwrap(), expected_output);
+}
 
-    #[test]
-    fn test_normalize() {
-        let expected = "
+#[test]
+fn test_normalize() {
+    let expected = "
 running 2 tests
 ..
 
 test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 ";
-        let actual = "
+    let actual = "
 running 2 tests
 ..
 
 test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
 ";
 
-        diff()
-            .expected_text("EXPECTED_TEXT", expected)
-            .actual_text("ACTUAL_TEXT", actual)
-            .normalize(r#"finished in \d+\.\d+s"#, "finished in $$TIME")
-            .run();
-    }
+    diff()
+        .expected_text("EXPECTED_TEXT", expected)
+        .actual_text("ACTUAL_TEXT", actual)
+        .normalize(r#"finished in \d+\.\d+s"#, "finished in $$TIME")
+        .run();
 }

--- a/src/tools/run-make-support/src/diff/tests.rs
+++ b/src/tools/run-make-support/src/diff/tests.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use crate::diff;
 
 #[test]
 fn test_diff() {


### PR DESCRIPTION
This module is already named `tests`, and is already gated by `#[cfg(test)]`, so there's no need for it to also contain `mod tests`.

r? jieyouxu