### PR TITLE
Remap path prefix in the panic message of `tests/ui/meta/revision-bad.rs`

### DIFF
--- a/tests/ui/meta/revision-bad.rs
+++ b/tests/ui/meta/revision-bad.rs
@@ -5,6 +5,7 @@
 //@ revisions: foo bar
 //@ should-fail
 //@ needs-run-enabled
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
 //@[foo] error-pattern:bar
 //@[bar] error-pattern:foo
 


### PR DESCRIPTION
Otherwise `error-pattern` on the test run stderr can incorrectly match if the paths in panic backtrace has a matching substring (like if we look for `bar` in the error pattern, but the username is `baron`).

Tested locally by checking run output `./x test .\tests\ui\meta\revision-bad.rs -- -- --nocapture`:

```
--- stderr -------------------------------
thread 'main' panicked at remapped\meta\revision-bad.rs:14:5:
foo
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
------------------------------------------
```

Fixes #130996.