### PR TITLE
Implement Try, Neg, and FromIterator<Ordering> for Ordering

### DIFF
--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -681,7 +681,7 @@ impl ops::FromResidual for Ordering {
     }
 }
 
-/// Implementation of `FromIterator` that returns the first unequal comparison, or [`Ordering::Equal`] if there are none.
+/// Implementation of `FromIterator` that returns on the first inequal comparison, or [`Ordering::Equal`] if there are none.
 ///
 /// # Example
 ///

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -655,7 +655,7 @@ impl Ordering {
 ///     }
 /// }
 /// ```
-#[stable(feature = "ordering_extra_impl", since = "1.85.0")]
+#[stable(feature = "ordering_extra_impl", since = "1.83.0")]
 impl ops::Try for Ordering {
     type Output = Self;
     type Residual = Self;
@@ -673,7 +673,7 @@ impl ops::Try for Ordering {
     }
 }
 
-#[stable(feature = "ordering_extra_impl", since = "1.85.0")]
+#[stable(feature = "ordering_extra_impl", since = "1.83.0")]
 impl ops::FromResidual for Ordering {
     #[inline]
     fn from_residual(residual: Self) -> Self {
@@ -719,7 +719,7 @@ impl ops::FromResidual for Ordering {
 /// #     assert!(a > b); assert!(c < b); assert!(b == b); assert!(c < d);
 /// # }
 /// ```
-#[stable(feature = "ordering_extra_impl", since = "1.85.0")]
+#[stable(feature = "ordering_extra_impl", since = "1.83.0")]
 impl FromIterator<Ordering> for Ordering {
     fn from_iter<I: IntoIterator<Item = Ordering>>(i: I) -> Ordering {
         for ord in i {
@@ -729,7 +729,7 @@ impl FromIterator<Ordering> for Ordering {
     }
 }
 
-#[stable(feature = "ordering_extra_impl", since = "1.85.0")]
+#[stable(feature = "ordering_extra_impl", since = "1.83.0")]
 /// Shorthand for [`Ordering::reverse`].
 impl ops::Neg for Ordering {
     type Output = Self;

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -25,8 +25,8 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-
-use crate::{iter::FromIterator, ops::{self, ControlFlow}};
+use crate::iter::FromIterator;
+use crate::ops::{self, ControlFlow};
 
 mod bytewise;
 pub(crate) use bytewise::BytewiseEq;
@@ -668,7 +668,7 @@ impl ops::Try for Ordering {
     fn branch(self) -> ControlFlow<Self, Self> {
         match self {
             Ordering::Equal => ControlFlow::Continue(self),
-            _ => ControlFlow::Break(self)
+            _ => ControlFlow::Break(self),
         }
     }
 }
@@ -703,7 +703,7 @@ impl ops::FromResidual for Ordering {
 ///             .zip(other.digits.iter().rev())
 ///             .map(|(left, right)| left.cmp(right))
 ///             .map(|mut ord| {
-///                  if self.is_negative { ord = ord.reverse(); } 
+///                  if self.is_negative { ord = ord.reverse() }
 ///                  ord
 ///             })
 ///             .collect()

--- a/library/core/tests/cmp.rs
+++ b/library/core/tests/cmp.rs
@@ -215,6 +215,28 @@ fn cmp_default() {
     assert_eq!(Fool(false), Fool(true));
 }
 
+#[test]
+fn ordering_try() {
+    fn gt() -> Ordering {
+        5.cmp(&3)?;
+        unreachable!()
+    }
+
+    fn lt() -> Ordering {
+        3.cmp(&5)?;
+        unreachable!()
+    }
+
+    fn eq() -> Ordering {
+        4.cmp(&4)?;
+        Ordering::Equal
+    }
+
+    assert_eq!(eq(), Ordering::Equal);
+    assert_eq!(lt(), Ordering::Less);
+    assert_eq!(gt(), Ordering::Greater);
+}
+
 /* FIXME(#110395)
 mod const_cmp {
     use super::*;


### PR DESCRIPTION
This adds implementations of `Try`, `Neg`, and `FromIterator<Ordering>` to `Ordering`.
Note that since trait implementations cannot be marked as unstable, upon merging, this would instantly be stabilized.