### PR TITLE
Setting up indirect access to external data for loongarch64-linux-{musl,ohos}

### DIFF
--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_musl.rs
@@ -24,6 +24,7 @@ pub(crate) fn target() -> Target {
                 | SanitizerSet::LEAK
                 | SanitizerSet::MEMORY
                 | SanitizerSet::THREAD,
+            direct_access_external_data: Some(false),
             ..base::linux_musl::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
@@ -22,6 +22,7 @@ pub(crate) fn target() -> Target {
                 | SanitizerSet::LEAK
                 | SanitizerSet::MEMORY
                 | SanitizerSet::THREAD,
+            direct_access_external_data: Some(false),
             ..base::linux_ohos::opts()
         },
     }


### PR DESCRIPTION
In issue #118053, the `loongarch64-unknown-linux-gnu` target needs indirection to access external data, and so do the `loongarch64-unknown-linux-musl` and `loongarch64-unknown-linux-ohos` targets.