### PR TITLE
Adds priority-inheritance futexes

### DIFF
--- a/library/std/src/sys/pal/unix/mod.rs
+++ b/library/std/src/sys/pal/unix/mod.rs
@@ -23,6 +23,7 @@ pub mod net;
 #[cfg(target_os = "l4re")]
 pub use self::l4re::net;
 pub mod os;
+pub mod pi_futex;
 pub mod pipe;
 pub mod process;
 pub mod stack_overflow;

--- a/library/std/src/sys/pal/unix/pi_futex.rs
+++ b/library/std/src/sys/pal/unix/pi_futex.rs
@@ -1,52 +1,171 @@
-#![cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+mod linux {
+    use crate::ops::Deref;
+    use crate::sync::atomic::AtomicU32;
+    use crate::sys::cvt;
+    use crate::{io, ptr};
 
-use crate::sync::atomic::AtomicU32;
-use crate::sys::cvt;
-use crate::{io, ptr};
+    pub type State = u32;
 
-pub const fn unlocked() -> u32 {
-    0
-}
+    pub struct Futex(AtomicU32);
 
-pub fn locked() -> u32 {
-    (unsafe { libc::gettid() }) as _
-}
+    impl Futex {
+        pub const fn new() -> Futex {
+            Futex(AtomicU32::new(0))
+        }
+    }
 
-pub fn is_contended(futex_val: u32) -> bool {
-    (futex_val & libc::FUTEX_WAITERS) != 0
-}
+    impl Deref for Futex {
+        type Target = AtomicU32;
+        fn deref(&self) -> &AtomicU32 {
+            &self.0
+        }
+    }
 
-pub fn is_owned_died(futex_val: u32) -> bool {
-    (futex_val & libc::FUTEX_OWNER_DIED) != 0
-}
+    pub const fn unlocked() -> State {
+        0
+    }
 
-pub fn futex_lock(futex: &AtomicU32) -> io::Result<()> {
-    loop {
-        match cvt(unsafe {
+    pub fn locked() -> State {
+        (unsafe { libc::gettid() }) as _
+    }
+
+    pub fn is_contended(futex_val: State) -> bool {
+        (futex_val & libc::FUTEX_WAITERS) != 0
+    }
+
+    pub fn is_owned_died(futex_val: State) -> bool {
+        (futex_val & libc::FUTEX_OWNER_DIED) != 0
+    }
+
+    pub fn futex_lock(futex: &Futex) -> io::Result<()> {
+        loop {
+            match cvt(unsafe {
+                libc::syscall(
+                    libc::SYS_futex,
+                    ptr::from_ref(futex.deref()),
+                    libc::FUTEX_LOCK_PI | libc::FUTEX_PRIVATE_FLAG,
+                    0,
+                    ptr::null::<u32>(),
+                    // remaining args are unused
+                )
+            }) {
+                Ok(_) => return Ok(()),
+                Err(e) if e.raw_os_error() == Some(libc::EINTR) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    pub fn futex_unlock(futex: &Futex) -> io::Result<()> {
+        cvt(unsafe {
             libc::syscall(
                 libc::SYS_futex,
-                ptr::from_ref(futex),
-                libc::FUTEX_LOCK_PI | libc::FUTEX_PRIVATE_FLAG,
-                0,
-                ptr::null::<u32>(),
+                ptr::from_ref(futex.deref()),
+                libc::FUTEX_UNLOCK_PI | libc::FUTEX_PRIVATE_FLAG,
                 // remaining args are unused
             )
-        }) {
-            Ok(_) => return Ok(()),
-            Err(e) if e.raw_os_error() == Some(libc::EINTR) => continue,
-            Err(e) => return Err(e),
-        }
+        })
+        .map(|_| ())
     }
 }
 
-pub fn futex_unlock(futex: &AtomicU32) -> io::Result<()> {
-    cvt(unsafe {
-        libc::syscall(
-            libc::SYS_futex,
-            ptr::from_ref(futex),
-            libc::FUTEX_UNLOCK_PI | libc::FUTEX_PRIVATE_FLAG,
-            // remaining args are unused
-        )
-    })
-    .map(|_| ())
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub use linux::*;
+
+#[cfg(target_os = "freebsd")]
+mod freebsd {
+    use crate::mem::transmute;
+    use crate::ops::Deref;
+    use crate::sync::atomic::AtomicU32;
+    use crate::sys::cvt;
+    use crate::{io, ptr};
+
+    pub type State = u32;
+
+    #[repr(C)]
+    pub struct umutex {
+        m_owner: libc::lwpid_t,
+        m_flags: u32,
+        m_ceilings: [u32; 2],
+        m_rb_link: libc::uintptr_t,
+        #[cfg(target_pointer_width = "32")]
+        m_pad: u32,
+        m_spare: [u32; 2],
+    }
+
+    pub struct Futex(umutex);
+
+    impl Futex {
+        pub const fn new() -> Futex {
+            Futex(umutex {
+                m_owner: 0,
+                m_flags: UMUTEX_PRIO_INHERIT,
+                m_ceilings: [0, 0],
+                m_rb_link: 0,
+                #[cfg(target_pointer_width = "32")]
+                m_pad: 0,
+                m_spare: [0, 0],
+            })
+        }
+    }
+
+    impl Deref for Futex {
+        type Target = AtomicU32;
+        fn deref(&self) -> &AtomicU32 {
+            unsafe { transmute(&self.0.m_owner) }
+        }
+    }
+
+    const UMUTEX_PRIO_INHERIT: u32 = 0x0004;
+    const UMUTEX_CONTESTED: u32 = 0x80000000;
+
+    pub const fn unlocked() -> State {
+        0
+    }
+
+    pub fn locked() -> State {
+        let mut tid: libc::c_long = 0;
+        let _ = unsafe { libc::thr_self(ptr::from_mut(&mut tid)) };
+        tid as _
+    }
+
+    pub fn is_contended(futex_val: State) -> bool {
+        (futex_val & UMUTEX_CONTESTED) != 0
+    }
+
+    pub fn is_owned_died(futex_val: State) -> bool {
+        // never happens for non-robust mutex
+        let _ = futex_val;
+        false
+    }
+
+    pub fn futex_lock(futex: &Futex) -> io::Result<()> {
+        cvt(unsafe {
+            libc::_umtx_op(
+                ptr::from_ref(futex.deref()) as _,
+                libc::UMTX_OP_MUTEX_LOCK,
+                0,
+                ptr::null_mut::<libc::c_void>(),
+                ptr::null_mut::<libc::c_void>(),
+            )
+        })
+        .map(|_| ())
+    }
+
+    pub fn futex_unlock(futex: &Futex) -> io::Result<()> {
+        cvt(unsafe {
+            libc::_umtx_op(
+                ptr::from_ref(futex.deref()) as _,
+                libc::UMTX_OP_MUTEX_UNLOCK,
+                0,
+                ptr::null_mut::<libc::c_void>(),
+                ptr::null_mut::<libc::c_void>(),
+            )
+        })
+        .map(|_| ())
+    }
 }
+
+#[cfg(target_os = "freebsd")]
+pub use freebsd::*;

--- a/library/std/src/sys/pal/unix/pi_futex.rs
+++ b/library/std/src/sys/pal/unix/pi_futex.rs
@@ -1,0 +1,52 @@
+#![cfg(any(target_os = "linux", target_os = "android"))]
+
+use crate::sync::atomic::AtomicU32;
+use crate::sys::cvt;
+use crate::{io, ptr};
+
+pub const fn unlocked() -> u32 {
+    0
+}
+
+pub fn locked() -> u32 {
+    (unsafe { libc::gettid() }) as _
+}
+
+pub fn is_contended(futex_val: u32) -> bool {
+    (futex_val & libc::FUTEX_WAITERS) != 0
+}
+
+pub fn is_owned_died(futex_val: u32) -> bool {
+    (futex_val & libc::FUTEX_OWNER_DIED) != 0
+}
+
+pub fn futex_lock(futex: &AtomicU32) -> io::Result<()> {
+    loop {
+        match cvt(unsafe {
+            libc::syscall(
+                libc::SYS_futex,
+                ptr::from_ref(futex),
+                libc::FUTEX_LOCK_PI | libc::FUTEX_PRIVATE_FLAG,
+                0,
+                ptr::null::<u32>(),
+                // remaining args are unused
+            )
+        }) {
+            Ok(_) => return Ok(()),
+            Err(e) if e.raw_os_error() == Some(libc::EINTR) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+pub fn futex_unlock(futex: &AtomicU32) -> io::Result<()> {
+    cvt(unsafe {
+        libc::syscall(
+            libc::SYS_futex,
+            ptr::from_ref(futex),
+            libc::FUTEX_UNLOCK_PI | libc::FUTEX_PRIVATE_FLAG,
+            // remaining args are unused
+        )
+    })
+    .map(|_| ())
+}

--- a/library/std/src/sys/sync/mutex/mod.rs
+++ b/library/std/src/sys/sync/mutex/mod.rs
@@ -1,8 +1,12 @@
 cfg_if::cfg_if! {
     if #[cfg(any(
-        all(target_os = "windows", not(target_vendor = "win7")),
         target_os = "linux",
         target_os = "android",
+    ))] {
+        mod pi_futex;
+        pub use pi_futex::Mutex;
+    } else if #[cfg(any(
+        all(target_os = "windows", not(target_vendor = "win7")),
         target_os = "freebsd",
         target_os = "openbsd",
         target_os = "dragonfly",

--- a/library/std/src/sys/sync/mutex/mod.rs
+++ b/library/std/src/sys/sync/mutex/mod.rs
@@ -2,12 +2,12 @@ cfg_if::cfg_if! {
     if #[cfg(any(
         target_os = "linux",
         target_os = "android",
+        target_os = "freebsd",
     ))] {
         mod pi_futex;
         pub use pi_futex::Mutex;
     } else if #[cfg(any(
         all(target_os = "windows", not(target_vendor = "win7")),
-        target_os = "freebsd",
         target_os = "openbsd",
         target_os = "dragonfly",
         all(target_family = "wasm", target_feature = "atomics"),

--- a/library/std/src/sys/sync/mutex/pi_futex.rs
+++ b/library/std/src/sys/sync/mutex/pi_futex.rs
@@ -1,0 +1,83 @@
+use crate::sync::atomic::AtomicU32;
+use crate::sync::atomic::Ordering::{Acquire, Relaxed, Release};
+use crate::sys::pi_futex as pi;
+
+pub struct Mutex {
+    futex: AtomicU32,
+}
+
+impl Mutex {
+    #[inline]
+    pub const fn new() -> Self {
+        Self { futex: AtomicU32::new(pi::unlocked()) }
+    }
+
+    #[inline]
+    pub fn try_lock(&self) -> bool {
+        self.futex.compare_exchange(pi::unlocked(), pi::locked(), Acquire, Relaxed).is_ok()
+    }
+
+    #[inline]
+    pub fn lock(&self) {
+        if self.futex.compare_exchange(pi::unlocked(), pi::locked(), Acquire, Relaxed).is_err() {
+            self.lock_contended();
+        }
+    }
+
+    #[cold]
+    fn lock_contended(&self) {
+        // Spin first to speed things up if the lock is released quickly.
+        let state = self.spin();
+
+        // If it's unlocked now, attempt to take the lock.
+        if state == pi::unlocked() {
+            if self.try_lock() {
+                return;
+            }
+        };
+
+        pi::futex_lock(&self.futex).expect("failed to lock mutex");
+
+        let state = self.futex.load(Relaxed);
+        if pi::is_owned_died(state) {
+            panic!(
+                "failed to lock mutex because the thread owning it finished without unlocking it"
+            );
+        }
+    }
+
+    fn spin(&self) -> u32 {
+        let mut spin = 100;
+        loop {
+            // We only use `load` (and not `swap` or `compare_exchange`)
+            // while spinning, to be easier on the caches.
+            let state = self.futex.load(Relaxed);
+
+            // We stop spinning when the mutex is unlocked,
+            // but also when it's contended.
+            if state == pi::unlocked() || pi::is_contended(state) || spin == 0 {
+                return state;
+            }
+
+            crate::hint::spin_loop();
+            spin -= 1;
+        }
+    }
+
+    #[inline]
+    pub unsafe fn unlock(&self) {
+        if self.futex.compare_exchange(pi::locked(), pi::unlocked(), Release, Relaxed).is_err() {
+            // We only wake up one thread. When that thread locks the mutex,
+            // the kernel will mark the mutex as contended automatically
+            // (futex != pi::locked() in this case),
+            // which makes sure that any other waiting threads will also be
+            // woken up eventually.
+            self.wake();
+        }
+    }
+
+    #[cold]
+    fn wake(&self) {
+        pi::futex_unlock(&self.futex).unwrap();
+    }
+}

--- a/library/std/src/sys/sync/mutex/pi_futex.rs
+++ b/library/std/src/sys/sync/mutex/pi_futex.rs
@@ -1,15 +1,14 @@
-use crate::sync::atomic::AtomicU32;
 use crate::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 use crate::sys::pi_futex as pi;
 
 pub struct Mutex {
-    futex: AtomicU32,
+    futex: pi::Futex,
 }
 
 impl Mutex {
     #[inline]
     pub const fn new() -> Self {
-        Self { futex: AtomicU32::new(pi::unlocked()) }
+        Self { futex: pi::Futex::new() }
     }
 
     #[inline]
@@ -46,7 +45,7 @@ impl Mutex {
         }
     }
 
-    fn spin(&self) -> u32 {
+    fn spin(&self) -> pi::State {
         let mut spin = 100;
         loop {
             // We only use `load` (and not `swap` or `compare_exchange`)


### PR DESCRIPTION
Linked: #131514, #128231

This PR uses `FUTEX_LOCK_PI` and `FUTEX_UNLOCK_PI` on Linux for priority-inheritance futexes to implement `Mutex`.

Quoted from `man 2 futex`:

> Priority inversion is the problem that occurs when a high-priority task is blocked waiting to acquire a lock held by a low-priority task, while tasks at an intermediate priority continuously preempt the low-priority task from the CPU. Consequently, the low-priority task makes no progress toward releasing the lock, and the high-priority task remains blocked.

> Priority inheritance is a mechanism for dealing with the priority-inversion problem.  With this mechanism, when a high- priority task becomes blocked by a lock held by a low-priority task, the priority of the low-priority task is temporarily raised to that of the high-priority task, so that it is not preempted by any intermediate level tasks, and can thus make progress toward releasing the lock.  To be effective, priority inheritance must be transitive, meaning that if a high-priority task blocks on a lock held by a lower-priority task that is itself blocked by a lock held by another intermediate-priority task (and so on, for chains of arbitrary length), then both of those tasks (or more generally, all of the tasks in a lock chain) have their priorities raised to be the same as the high-priority task.

I'm still working on an implementation of PI-futex on FreeBSD.