### PR TITLE
mark InterpResult as must_use

### DIFF
--- a/compiler/rustc_middle/src/mir/interpret/error.rs
+++ b/compiler/rustc_middle/src/mir/interpret/error.rs
@@ -754,6 +754,7 @@ impl Drop for Guard {
 ///
 /// We also make things panic if this type is ever implicitly dropped.
 #[derive(Debug)]
+#[must_use]
 pub struct InterpResult_<'tcx, T> {
     res: Result<T, InterpErrorInfo<'tcx>>,
     guard: Guard,


### PR DESCRIPTION
This was forgotten in https://github.com/rust-lang/rust/pull/130885