### PR TITLE
Convert all Makefile tests to rmake tests with `legacy-makefile-test`

### DIFF
--- a/src/tools/compiletest/src/command-list.rs
+++ b/src/tools/compiletest/src/command-list.rs
@@ -115,6 +115,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "ignore-x86_64-unknown-linux-gnu",
     "incremental",
     "known-bug",
+    "legacy-makefile-test",
     "llvm-cov-flags",
     "min-cdb-version",
     "min-gdb-version",

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -197,6 +197,9 @@ pub struct TestProps {
     pub no_auto_check_cfg: bool,
     /// Run tests which require enzyme being build
     pub has_enzyme: bool,
+    /// This `run-make` test should run a legacy Makefile, instead of building
+    /// and running `rmake.rs`.
+    pub legacy_makefile_test: bool,
 }
 
 mod directives {
@@ -242,6 +245,7 @@ mod directives {
     pub const LLVM_COV_FLAGS: &'static str = "llvm-cov-flags";
     pub const FILECHECK_FLAGS: &'static str = "filecheck-flags";
     pub const NO_AUTO_CHECK_CFG: &'static str = "no-auto-check-cfg";
+    pub const LEGACY_MAKEFILE_TEST: &'static str = "legacy-makefile-test";
     // This isn't a real directive, just one that is probably mistyped often
     pub const INCORRECT_COMPILER_FLAGS: &'static str = "compiler-flags";
 }
@@ -299,6 +303,7 @@ impl TestProps {
             filecheck_flags: vec![],
             no_auto_check_cfg: false,
             has_enzyme: false,
+            legacy_makefile_test: false,
         }
     }
 
@@ -563,6 +568,12 @@ impl TestProps {
                     }
 
                     config.set_name_directive(ln, NO_AUTO_CHECK_CFG, &mut self.no_auto_check_cfg);
+
+                    config.set_name_directive(
+                        ln,
+                        LEGACY_MAKEFILE_TEST,
+                        &mut self.legacy_makefile_test,
+                    );
                 },
             );
 
@@ -828,9 +839,6 @@ fn iter_header(
         }
     }
 
-    // NOTE(jieyouxu): once we get rid of `Makefile`s we can unconditionally check for `//@`.
-    let comment = if testfile.extension().is_some_and(|e| e == "rs") { "//@" } else { "#" };
-
     let mut rdr = BufReader::with_capacity(1024, rdr);
     let mut ln = String::new();
     let mut line_number = 0;
@@ -856,7 +864,7 @@ fn iter_header(
             return;
         }
 
-        let Some((header_revision, non_revisioned_directive_line)) = line_directive(comment, ln)
+        let Some((header_revision, non_revisioned_directive_line)) = line_directive("//@", ln)
         else {
             continue;
         };

--- a/src/tools/compiletest/src/lib.rs
+++ b/src/tools/compiletest/src/lib.rs
@@ -704,13 +704,7 @@ fn collect_tests_from_dir(
     }
 
     if config.mode == Mode::RunMake {
-        if dir.join("Makefile").exists() && dir.join("rmake.rs").exists() {
-            return Err(io::Error::other(
-                "run-make tests cannot have both `Makefile` and `rmake.rs`",
-            ));
-        }
-
-        if dir.join("Makefile").exists() || dir.join("rmake.rs").exists() {
+        if dir.join("rmake.rs").exists() {
             let paths = TestPaths {
                 file: dir.to_path_buf(),
                 relative_dir: relative_dir_path.parent().unwrap().to_path_buf(),
@@ -789,17 +783,7 @@ fn make_test(
     poisoned: &mut bool,
 ) -> Vec<test::TestDescAndFn> {
     let test_path = if config.mode == Mode::RunMake {
-        if testpaths.file.join("rmake.rs").exists() && testpaths.file.join("Makefile").exists() {
-            panic!("run-make tests cannot have both `rmake.rs` and `Makefile`");
-        }
-
-        if testpaths.file.join("rmake.rs").exists() {
-            // Parse directives in rmake.rs.
-            testpaths.file.join("rmake.rs")
-        } else {
-            // Parse directives in the Makefile.
-            testpaths.file.join("Makefile")
-        }
+        testpaths.file.join("rmake.rs")
     } else {
         PathBuf::from(&testpaths.file)
     };

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -19,7 +19,7 @@ use tracing::*;
 
 use crate::common::{
     Assembly, Codegen, CodegenUnits, CompareMode, Config, CoverageMap, CoverageRun, Crashes,
-    DebugInfo, Debugger, FailMode, Incremental, JsDocTest, MirOpt, PassMode, Pretty, RunMake,
+    DebugInfo, Debugger, FailMode, Incremental, JsDocTest, MirOpt, Mode, PassMode, Pretty, RunMake,
     Rustdoc, RustdocJson, TestPaths, UI_EXTENSIONS, UI_FIXED, UI_RUN_STDERR, UI_RUN_STDOUT,
     UI_STDERR, UI_STDOUT, UI_SVG, UI_WINDOWS_SVG, Ui, expected_output_path, incremental_dir,
     output_base_dir, output_base_name, output_testname_unique,
@@ -128,7 +128,13 @@ pub fn run(config: Arc<Config>, testpaths: &TestPaths, revision: Option<&str>) {
         print!("\n\n");
     }
     debug!("running {:?}", testpaths.file.display());
-    let mut props = TestProps::from_file(&testpaths.file, revision, &config);
+    let mut props = {
+        let file = match config.mode {
+            Mode::RunMake => &testpaths.file.join("rmake.rs"),
+            _ => &testpaths.file,
+        };
+        TestProps::from_file(file, revision, &config)
+    };
 
     // For non-incremental (i.e. regular UI) tests, the incremental directory
     // takes into account the revision name, since the revisions are independent

--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -7,17 +7,18 @@ use crate::util::{copy_dir_all, dylib_env_var};
 
 impl TestCx<'_> {
     pub(super) fn run_rmake_test(&self) {
-        let test_dir = &self.testpaths.file;
-        if test_dir.join("rmake.rs").exists() {
-            self.run_rmake_v2_test();
-        } else if test_dir.join("Makefile").exists() {
+        if self.props.legacy_makefile_test {
             self.run_rmake_legacy_test();
         } else {
-            self.fatal("failed to find either `rmake.rs` or `Makefile`")
+            self.run_rmake_v2_test();
         }
     }
 
     fn run_rmake_legacy_test(&self) {
+        if !self.testpaths.file.join("Makefile").exists() {
+            self.fatal("failed to find `Makefile` for legacy makefile test");
+        }
+
         let cwd = env::current_dir().unwrap();
         let src_root = self.config.src_base.parent().unwrap().parent().unwrap();
         let src_root = cwd.join(&src_root);

--- a/tests/run-make/branch-protection-check-IBT/rmake.rs
+++ b/tests/run-make/branch-protection-check-IBT/rmake.rs
@@ -1,0 +1,9 @@
+//@ legacy-makefile-test
+
+//@ only-x86_64
+
+//@ ignore-test
+// FIXME(jieyouxu): This test never runs because the `ifeq` check in the Makefile
+// compares `x86` to `x86_64`, which always evaluates to false.
+// When the test does run, the compilation does not include `.note.gnu.property`.
+// See https://github.com/rust-lang/rust/pull/126720 for more information.

--- a/tests/run-make/cat-and-grep-sanity-check/rmake.rs
+++ b/tests/run-make/cat-and-grep-sanity-check/rmake.rs
@@ -1,0 +1,1 @@
+//@ legacy-makefile-test

--- a/tests/run-make/extern-fn-reachable/rmake.rs
+++ b/tests/run-make/extern-fn-reachable/rmake.rs
@@ -1,0 +1,4 @@
+//@ legacy-makefile-test
+
+//@ ignore-cross-compile
+//@ ignore-windows-msvc

--- a/tests/run-make/incr-add-rust-src-component/rmake.rs
+++ b/tests/run-make/incr-add-rust-src-component/rmake.rs
@@ -1,0 +1,7 @@
+//@ legacy-makefile-test
+
+//@ ignore-cross-compile
+
+// This test uses `ln -s` rather than copying to save testing time, but its
+// usage doesn't work on windows. So ignore windows.
+//@ ignore-windows

--- a/tests/run-make/issue-84395-lto-embed-bitcode/rmake.rs
+++ b/tests/run-make/issue-84395-lto-embed-bitcode/rmake.rs
@@ -1,0 +1,3 @@
+//@ legacy-makefile-test
+
+//@ needs-force-clang-based-tests

--- a/tests/run-make/jobserver-error/rmake.rs
+++ b/tests/run-make/jobserver-error/rmake.rs
@@ -1,0 +1,4 @@
+//@ legacy-makefile-test
+
+//@ only-linux
+//@ ignore-cross-compile

--- a/tests/run-make/libs-through-symlinks/rmake.rs
+++ b/tests/run-make/libs-through-symlinks/rmake.rs
@@ -1,0 +1,4 @@
+//@ legacy-makefile-test
+
+//@ ignore-cross-compile
+//@ ignore-windows

--- a/tests/run-make/split-debuginfo/rmake.rs
+++ b/tests/run-make/split-debuginfo/rmake.rs
@@ -1,0 +1,4 @@
+//@ legacy-makefile-test
+
+//@ ignore-cross-compile
+//@ ignore-riscv64 On this platform only `-Csplit-debuginfo=off` is supported, see #120518

--- a/tests/run-make/symbol-mangling-hashed/rmake.rs
+++ b/tests/run-make/symbol-mangling-hashed/rmake.rs
@@ -1,0 +1,5 @@
+//@ legacy-makefile-test
+
+//@ ignore-cross-compile
+//@ only-linux
+//@ only-x86_64

--- a/tests/run-make/translation/rmake.rs
+++ b/tests/run-make/translation/rmake.rs
@@ -1,0 +1,5 @@
+//@ legacy-makefile-test
+
+// This test uses `ln -s` rather than copying to save testing time, but its
+// usage doesn't work on Windows.
+//@ ignore-windows


### PR DESCRIPTION
We can't remove Makefile support from compiletest yet, because #121876 isn't quite complete.

But it occurred to me that we can remove *some* of the Makefile support with a neat little trick: give every legacy Makefile test a dummy `rmake.rs` file containing a special directive that tells compiletest to run the Makefile, instead of building and running the rmake recipe.

Thus, while we still can't remove `run_rmake_legacy_test`, we can at least start removing Makefile support from the “frontend” parts like test discovery and directive parsing.

---

Marking as draft for now because I want to let the idea bake a little more. But so far it does seem like a useful step towards being able to clean up various parts of the compiletest frontend.

r? ghost