### PR TITLE
remove const_cow_is_borrowed feature gate

### DIFF
--- a/library/alloc/src/borrow.rs
+++ b/library/alloc/src/borrow.rs
@@ -225,7 +225,6 @@ impl<B: ?Sized + ToOwned> Cow<'_, B> {
     /// assert!(!bull.is_borrowed());
     /// ```
     #[unstable(feature = "cow_is_borrowed", issue = "65143")]
-    #[rustc_const_unstable(feature = "const_cow_is_borrowed", issue = "65143")]
     pub const fn is_borrowed(&self) -> bool {
         match *self {
             Borrowed(_) => true,
@@ -248,7 +247,6 @@ impl<B: ?Sized + ToOwned> Cow<'_, B> {
     /// assert!(!bull.is_owned());
     /// ```
     #[unstable(feature = "cow_is_borrowed", issue = "65143")]
-    #[rustc_const_unstable(feature = "const_cow_is_borrowed", issue = "65143")]
     pub const fn is_owned(&self) -> bool {
         !self.is_borrowed()
     }

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -108,7 +108,6 @@
 #![feature(coerce_unsized)]
 #![feature(const_align_of_val)]
 #![feature(const_box)]
-#![feature(const_cow_is_borrowed)]
 #![feature(const_eval_select)]
 #![feature(const_heap)]
 #![feature(const_maybe_uninit_write)]

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -4,7 +4,6 @@
 #![feature(assert_matches)]
 #![feature(btree_extract_if)]
 #![feature(cow_is_borrowed)]
-#![feature(const_cow_is_borrowed)]
 #![feature(const_heap)]
 #![cfg_attr(bootstrap, feature(const_mut_refs))]
 #![feature(const_ptr_write)]


### PR DESCRIPTION
The two functions guarded by this are still unstable, and there's no reason to require a separate feature gate for their const-ness -- we can just have `cow_is_borrowed` cover both kinds of stability.

Cc #65143