### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,9 @@ jobs:
           # which then uses log commands to actually set them.
           EXTRA_VARIABLES: ${{ toJson(matrix.env) }}
 
+      - name: setup upstream remote
+        run: src/ci/scripts/setup-upstream-remote.sh
+
       - name: ensure the channel matches the target branch
         run: src/ci/scripts/verify-channel.sh
 

--- a/compiler/rustc_middle/src/lib.rs
+++ b/compiler/rustc_middle/src/lib.rs
@@ -37,7 +37,6 @@
 #![feature(box_as_ptr)]
 #![feature(box_patterns)]
 #![feature(closure_track_caller)]
-#![feature(const_option)]
 #![feature(const_type_name)]
 #![feature(core_intrinsics)]
 #![feature(coroutines)]

--- a/compiler/rustc_serialize/src/lib.rs
+++ b/compiler/rustc_serialize/src/lib.rs
@@ -10,7 +10,6 @@
     test(attr(allow(unused_variables), deny(warnings)))
 )]
 #![doc(rust_logo)]
-#![feature(const_option)]
 #![feature(core_intrinsics)]
 #![feature(min_specialization)]
 #![feature(never_type)]

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
@@ -1,4 +1,4 @@
-use crate::spec::{CodeModel, Target, TargetOptions, base};
+use crate::spec::{CodeModel, SanitizerSet, Target, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -18,6 +18,11 @@ pub(crate) fn target() -> Target {
             features: "+f,+d".into(),
             llvm_abiname: "lp64d".into(),
             max_atomic_width: Some(64),
+            supported_sanitizers: SanitizerSet::ADDRESS
+                | SanitizerSet::CFI
+                | SanitizerSet::LEAK
+                | SanitizerSet::MEMORY
+                | SanitizerSet::THREAD,
             direct_access_external_data: Some(false),
             ..base::linux_gnu::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_musl.rs
@@ -1,4 +1,4 @@
-use crate::spec::{CodeModel, Target, TargetOptions, base};
+use crate::spec::{CodeModel, SanitizerSet, Target, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -19,6 +19,11 @@ pub(crate) fn target() -> Target {
             llvm_abiname: "lp64d".into(),
             max_atomic_width: Some(64),
             crt_static_default: false,
+            supported_sanitizers: SanitizerSet::ADDRESS
+                | SanitizerSet::CFI
+                | SanitizerSet::LEAK
+                | SanitizerSet::MEMORY
+                | SanitizerSet::THREAD,
             ..base::linux_musl::opts()
         },
     }

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
@@ -1,4 +1,4 @@
-use crate::spec::{Target, TargetOptions, base};
+use crate::spec::{SanitizerSet, Target, TargetOptions, base};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -17,6 +17,11 @@ pub(crate) fn target() -> Target {
             features: "+f,+d".into(),
             llvm_abiname: "lp64d".into(),
             max_atomic_width: Some(64),
+            supported_sanitizers: SanitizerSet::ADDRESS
+                | SanitizerSet::CFI
+                | SanitizerSet::LEAK
+                | SanitizerSet::MEMORY
+                | SanitizerSet::THREAD,
             ..base::linux_ohos::opts()
         },
     }

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -112,7 +112,6 @@
 #![feature(const_eval_select)]
 #![feature(const_heap)]
 #![feature(const_maybe_uninit_write)]
-#![feature(const_option)]
 #![feature(const_pin)]
 #![feature(const_size_of_val)]
 #![feature(const_vec_string_slice)]

--- a/library/core/src/array/ascii.rs
+++ b/library/core/src/array/ascii.rs
@@ -9,7 +9,6 @@ impl<const N: usize> [u8; N] {
     ///
     /// ```
     /// #![feature(ascii_char)]
-    /// #![feature(const_option)]
     ///
     /// const HEX_DIGITS: [std::ascii::Char; 16] =
     ///     *b"0123456789abcdef".as_ascii().unwrap();

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -131,7 +131,6 @@
 #![feature(const_maybe_uninit_assume_init)]
 #![feature(const_nonnull_new)]
 #![feature(const_num_midpoint)]
-#![feature(const_option)]
 #![feature(const_option_ext)]
 #![feature(const_pin)]
 #![feature(const_pointer_is_aligned)]

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -723,7 +723,8 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
+    #[cfg_attr(bootstrap, rustc_allow_const_fn_unstable(const_mut_refs))]
+    #[rustc_const_stable(feature = "const_option", since = "CURRENT_RUSTC_VERSION")]
     pub const fn as_mut(&mut self) -> Option<&mut T> {
         match *self {
             Some(ref mut x) => Some(x),
@@ -924,7 +925,8 @@ impl<T> Option<T> {
     #[track_caller]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg_attr(not(test), rustc_diagnostic_item = "option_expect")]
-    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
+    #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
+    #[rustc_const_stable(feature = "const_option", since = "CURRENT_RUSTC_VERSION")]
     pub const fn expect(self, msg: &str) -> T {
         match self {
             Some(val) => val,
@@ -962,7 +964,8 @@ impl<T> Option<T> {
     #[track_caller]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[cfg_attr(not(test), rustc_diagnostic_item = "option_unwrap")]
-    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
+    #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
+    #[rustc_const_stable(feature = "const_option", since = "CURRENT_RUSTC_VERSION")]
     pub const fn unwrap(self) -> T {
         match self {
             Some(val) => val,
@@ -1069,7 +1072,8 @@ impl<T> Option<T> {
     #[inline]
     #[track_caller]
     #[stable(feature = "option_result_unwrap_unchecked", since = "1.58.0")]
-    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
+    #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
+    #[rustc_const_stable(feature = "const_option", since = "CURRENT_RUSTC_VERSION")]
     pub const unsafe fn unwrap_unchecked(self) -> T {
         match self {
             Some(val) => val,
@@ -1712,7 +1716,8 @@ impl<T> Option<T> {
     /// ```
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
+    #[cfg_attr(bootstrap, rustc_allow_const_fn_unstable(const_mut_refs))]
+    #[rustc_const_stable(feature = "const_option", since = "CURRENT_RUSTC_VERSION")]
     pub const fn take(&mut self) -> Option<T> {
         // FIXME(const-hack) replace `mem::replace` by `mem::take` when the latter is const ready
         mem::replace(self, None)
@@ -1769,8 +1774,9 @@ impl<T> Option<T> {
     /// assert_eq!(old, None);
     /// ```
     #[inline]
-    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
     #[stable(feature = "option_replace", since = "1.31.0")]
+    #[cfg_attr(bootstrap, rustc_allow_const_fn_unstable(const_mut_refs))]
+    #[rustc_const_stable(feature = "const_option", since = "CURRENT_RUSTC_VERSION")]
     pub const fn replace(&mut self, value: T) -> Option<T> {
         mem::replace(self, Some(value))
     }
@@ -1878,7 +1884,7 @@ impl<T> Option<&T> {
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "copied", since = "1.35.0")]
-    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
+    #[rustc_const_stable(feature = "const_option", since = "CURRENT_RUSTC_VERSION")]
     pub const fn copied(self) -> Option<T>
     where
         T: Copy,
@@ -1931,7 +1937,8 @@ impl<T> Option<&mut T> {
     /// ```
     #[must_use = "`self` will be dropped if the result is not used"]
     #[stable(feature = "copied", since = "1.35.0")]
-    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
+    #[cfg_attr(bootstrap, rustc_allow_const_fn_unstable(const_mut_refs))]
+    #[rustc_const_stable(feature = "const_option", since = "CURRENT_RUSTC_VERSION")]
     pub const fn copied(self) -> Option<T>
     where
         T: Copy,
@@ -1986,7 +1993,8 @@ impl<T, E> Option<Result<T, E>> {
     /// ```
     #[inline]
     #[stable(feature = "transpose_result", since = "1.33.0")]
-    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
+    #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
+    #[rustc_const_stable(feature = "const_option", since = "CURRENT_RUSTC_VERSION")]
     pub const fn transpose(self) -> Result<Option<T>, E> {
         match self {
             Some(Ok(x)) => Ok(Some(x)),
@@ -2009,7 +2017,6 @@ const fn unwrap_failed() -> ! {
 #[cfg_attr(feature = "panic_immediate_abort", inline)]
 #[cold]
 #[track_caller]
-#[rustc_const_unstable(feature = "const_option", issue = "67441")]
 const fn expect_failed(msg: &str) -> ! {
     panic_display(&msg)
 }
@@ -2534,7 +2541,8 @@ impl<T> Option<Option<T>> {
     /// ```
     #[inline]
     #[stable(feature = "option_flattening", since = "1.40.0")]
-    #[rustc_const_unstable(feature = "const_option", issue = "67441")]
+    #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
+    #[rustc_const_stable(feature = "const_option", since = "CURRENT_RUSTC_VERSION")]
     pub const fn flatten(self) -> Option<T> {
         // FIXME(const-hack): could be written with `and_then`
         match self {

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1211,7 +1211,6 @@ impl<T: ?Sized> NonNull<T> {
     ///
     /// ```
     /// #![feature(const_nonnull_new)]
-    /// #![feature(const_option)]
     /// #![feature(const_pointer_is_aligned)]
     /// use std::ptr::NonNull;
     ///
@@ -1264,7 +1263,6 @@ impl<T: ?Sized> NonNull<T> {
     ///
     /// ```
     /// #![feature(const_pointer_is_aligned)]
-    /// #![feature(const_option)]
     /// #![feature(const_nonnull_new)]
     /// use std::ptr::NonNull;
     ///

--- a/library/core/src/time.rs
+++ b/library/core/src/time.rs
@@ -626,7 +626,6 @@ impl Duration {
     /// ```
     #[stable(feature = "duration_abs_diff", since = "1.81.0")]
     #[rustc_const_stable(feature = "duration_abs_diff", since = "1.81.0")]
-    #[rustc_allow_const_fn_unstable(const_option)]
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[inline]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -24,7 +24,6 @@
 #![feature(const_ipv6)]
 #![feature(const_likely)]
 #![feature(const_nonnull_new)]
-#![feature(const_option)]
 #![feature(const_option_ext)]
 #![feature(const_pin)]
 #![feature(const_pointer_is_aligned)]

--- a/library/unwind/src/lib.rs
+++ b/library/unwind/src/lib.rs
@@ -3,11 +3,10 @@
 #![feature(link_cfg)]
 #![feature(staged_api)]
 #![feature(strict_provenance)]
-#![cfg_attr(target_arch = "wasm64", feature(simd_wasm64))]
 #![cfg_attr(not(target_env = "msvc"), feature(libc))]
 #![cfg_attr(
     all(target_family = "wasm", not(target_os = "emscripten")),
-    feature(link_llvm_intrinsics)
+    feature(simd_wasm64, wasm_exception_handling_intrinsics)
 )]
 #![allow(internal_features)]
 

--- a/library/unwind/src/wasm.rs
+++ b/library/unwind/src/wasm.rs
@@ -40,29 +40,25 @@ pub unsafe fn _Unwind_DeleteException(exception: *mut _Unwind_Exception) {
 }
 
 pub unsafe fn _Unwind_RaiseException(exception: *mut _Unwind_Exception) -> _Unwind_Reason_Code {
-    #[cfg(panic = "unwind")]
-    extern "C" {
-        /// LLVM lowers this intrinsic to the `throw` instruction.
-        // FIXME(coolreader18): move to stdarch
-        #[link_name = "llvm.wasm.throw"]
-        fn wasm_throw(tag: i32, ptr: *mut u8) -> !;
-    }
-
     // The wasm `throw` instruction takes a "tag", which differentiates certain
     // types of exceptions from others. LLVM currently just identifies these
     // via integers, with 0 corresponding to C++ exceptions and 1 to C setjmp()/longjmp().
     // Ideally, we'd be able to choose something unique for Rust, but for now,
     // we pretend to be C++ and implement the Itanium exception-handling ABI.
     cfg_if::cfg_if! {
-        // for now, unless we're -Zbuild-std with panic=unwind, never codegen a throw.
+        // panic=abort is default for wasm targets. Because an unknown instruction is a load-time
+        // error on wasm, instead of a runtime error like on traditional architectures, we never
+        // want to codegen a `throw` instruction, as that would break users using runtimes that
+        // don't yet support exceptions. The only time this first branch would be selected is if
+        // the user explicitly opts in to wasm exceptions, via -Zbuild-std with -Cpanic=unwind.
         if #[cfg(panic = "unwind")] {
-            wasm_throw(0, exception.cast())
+            // corresponds with llvm::WebAssembly::Tag::CPP_EXCEPTION
+            //     in llvm-project/llvm/include/llvm/CodeGen/WasmEHFuncInfo.h
+            const CPP_EXCEPTION_TAG: i32 = 0;
+            core::arch::wasm::throw::<CPP_EXCEPTION_TAG>(exception.cast())
         } else {
             let _ = exception;
-            #[cfg(target_arch = "wasm32")]
-            core::arch::wasm32::unreachable();
-            #[cfg(target_arch = "wasm64")]
-            core::arch::wasm64::unreachable();
+            core::arch::wasm::unreachable()
         }
     }
 }

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -1215,6 +1215,9 @@ fn supported_sanitizers(
         "aarch64-unknown-linux-ohos" => {
             common_libs("linux", "aarch64", &["asan", "lsan", "msan", "tsan", "hwasan"])
         }
+        "loongarch64-unknown-linux-gnu" | "loongarch64-unknown-linux-musl" => {
+            common_libs("linux", "loongarch64", &["asan", "lsan", "msan", "tsan"])
+        }
         "x86_64-apple-darwin" => darwin_libs("osx", &["asan", "lsan", "tsan"]),
         "x86_64-unknown-fuchsia" => common_libs("fuchsia", "x86_64", &["asan"]),
         "x86_64-apple-ios" => darwin_libs("iossim", &["asan", "tsan"]),

--- a/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
@@ -1,0 +1,57 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  g++ \
+  make \
+  ninja-build \
+  file \
+  curl \
+  ca-certificates \
+  python3 \
+  python3-dev \
+  libxml2-dev \
+  libncurses-dev \
+  libedit-dev \
+  swig \
+  doxygen \
+  git \
+  cmake \
+  sudo \
+  gdb \
+  libssl-dev \
+  pkg-config \
+  xz-utils \
+  lld \
+  clang \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY scripts/sccache.sh /scripts/
+RUN sh /scripts/sccache.sh
+
+ENV RUSTBUILD_FORCE_CLANG_BASED_TESTS 1
+ENV RUN_CHECK_WITH_PARALLEL_QUERIES 1
+
+# llvm.use-linker conflicts with downloading CI LLVM
+ENV NO_DOWNLOAD_CI_LLVM 1
+
+ENV RUST_CONFIGURE_ARGS \
+      --build=aarch64-unknown-linux-gnu \
+      --enable-debug \
+      --enable-lld \
+      --set llvm.use-linker=lld \
+      --set target.aarch64-unknown-linux-gnu.linker=clang \
+      --set target.aarch64-unknown-linux-gnu.cc=clang \
+      --set target.aarch64-unknown-linux-gnu.cxx=clang++
+
+# This job appears to be checking two separate things:
+# - That we can build the compiler with `--enable-debug`
+#   (without necessarily testing the result).
+# - That the tests with `//@ needs-force-clang-based-tests` pass, since they
+#   don't run by default unless RUSTBUILD_FORCE_CLANG_BASED_TESTS is set.
+#   - FIXME(https://github.com/rust-lang/rust/pull/126155#issuecomment-2156314273):
+#     Currently we only run the subset of tests with "clang" in their name.
+
+ENV SCRIPT \
+  python3 ../x.py --stage 2 build && \
+  python3 ../x.py --stage 2 test tests/run-make --test-args clang

--- a/src/ci/docker/host-x86_64/dist-loongarch64-linux/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-loongarch64-linux/Dockerfile
@@ -47,6 +47,7 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
       --enable-full-tools \
       --enable-profiler \
+      --enable-sanitizers \
       --disable-docs
 
 ENV SCRIPT python3 ../x.py dist --host $HOSTS --target $TARGETS

--- a/src/ci/docker/host-x86_64/dist-loongarch64-musl/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-loongarch64-musl/Dockerfile
@@ -29,6 +29,7 @@ ENV RUST_CONFIGURE_ARGS \
       --enable-extended \
       --enable-full-tools \
       --enable-profiler \
+      --enable-sanitizers \
       --disable-docs \
       --set target.loongarch64-unknown-linux-musl.crt-static=false \
       --musl-root-loongarch64=/x-tools/loongarch64-unknown-linux-musl/loongarch64-unknown-linux-musl/sysroot/usr

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -116,6 +116,9 @@ auto:
   - image: aarch64-gnu
     <<: *job-aarch64-linux
 
+  - image: aarch64-gnu-debug
+    <<: *job-aarch64-linux
+
   - image: arm-android
     <<: *job-linux-4c
 

--- a/src/ci/scripts/setup-upstream-remote.sh
+++ b/src/ci/scripts/setup-upstream-remote.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# In CI environments, bootstrap is forced to use the remote upstream based
+# on "git_repository" and "nightly_branch" values from src/stage0 file.
+# This script configures the remote as it may not exist by default.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+ci_dir=$(cd $(dirname $0) && pwd)/..
+source "$ci_dir/shared.sh"
+
+git_repository=$(parse_stage0_file_by_key "git_repository")
+nightly_branch=$(parse_stage0_file_by_key "nightly_branch")
+
+# Configure "rust-lang/rust" upstream remote only when it's not origin.
+if [ -z "$(git config remote.origin.url | grep $git_repository)" ]; then
+    echo "Configuring https://github.com/$git_repository remote as upstream."
+    git remote add upstream "https://github.com/$git_repository"
+    REMOTE_NAME="upstream"
+else
+    REMOTE_NAME="origin"
+fi
+
+git fetch $REMOTE_NAME $nightly_branch

--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -136,3 +136,15 @@ function releaseChannel {
         echo $RUST_CI_OVERRIDE_RELEASE_CHANNEL
     fi
 }
+
+# Parse values from src/stage0 file by key
+function parse_stage0_file_by_key {
+    local key="$1"
+    local file="$ci_dir/../stage0"
+    local value=$(awk -F= '{a[$1]=$2} END {print(a["'$key'"])}' $file)
+    if [ -z "$value" ]; then
+        echo "ERROR: Key '$key' not found in '$file'."
+        exit 1
+    fi
+    echo "$value"
+}

--- a/src/tools/clippy/tests/ui/doc/doc-fixable.fixed
+++ b/src/tools/clippy/tests/ui/doc/doc-fixable.fixed
@@ -3,7 +3,7 @@
 
 #![allow(dead_code, incomplete_features)]
 #![warn(clippy::doc_markdown)]
-#![feature(custom_inner_attributes, generic_const_exprs, const_option)]
+#![feature(custom_inner_attributes, generic_const_exprs)]
 #![rustfmt::skip]
 
 /// The `foo_bar` function does _nothing_. See also `foo::bar`. (note the dot there)

--- a/src/tools/clippy/tests/ui/doc/doc-fixable.rs
+++ b/src/tools/clippy/tests/ui/doc/doc-fixable.rs
@@ -3,7 +3,7 @@
 
 #![allow(dead_code, incomplete_features)]
 #![warn(clippy::doc_markdown)]
-#![feature(custom_inner_attributes, generic_const_exprs, const_option)]
+#![feature(custom_inner_attributes, generic_const_exprs)]
 #![rustfmt::skip]
 
 /// The foo_bar function does _nothing_. See also foo::bar. (note the dot there)

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(rustc_private)]
 #![feature(cell_update)]
-#![feature(const_option)]
 #![feature(float_gamma)]
 #![feature(map_try_insert)]
 #![feature(never_type)]

--- a/tests/crashes/131507.rs
+++ b/tests/crashes/131507.rs
@@ -1,0 +1,10 @@
+//@ known-bug: #131507
+//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir
+#![feature(non_lifetime_binders)]
+
+fn brick()
+where
+    for<T> T: Copy,
+{
+    || format_args!("");
+}

--- a/tests/crashes/131534.rs
+++ b/tests/crashes/131534.rs
@@ -1,0 +1,5 @@
+//@ known-bug: #131534
+#![feature(generic_const_exprs)]
+type Value<'v> = &[[u8; SIZE]];
+
+trait Trait: Fn(Value) -> Value {}

--- a/tests/crashes/131535.rs
+++ b/tests/crashes/131535.rs
@@ -1,0 +1,4 @@
+//@ known-bug: #131535
+#![feature(non_lifetime_binders)]
+trait v0<> {}
+fn kind  :(v0<'_, > impl for<v4> v0<'_, v2 = impl v0<v4> + '_>) {}

--- a/tests/crashes/131538.rs
+++ b/tests/crashes/131538.rs
@@ -1,0 +1,13 @@
+//@ known-bug: #131538
+#![feature(generic_associated_types_extended)]
+#![feature(trivial_bounds)]
+
+trait HealthCheck {
+    async fn check<const N: usize>();
+}
+
+fn do_health_check_par()
+where
+    HealthCheck: HealthCheck,
+{
+}

--- a/tests/run-make/pointer-auth-link-with-c-lto-clang/rmake.rs
+++ b/tests/run-make/pointer-auth-link-with-c-lto-clang/rmake.rs
@@ -1,0 +1,36 @@
+// `-Z branch protection` is an unstable compiler feature which adds pointer-authentication
+// code (PAC), a useful hashing measure for verifying that pointers have not been modified.
+// This test checks that compilation and execution is successful when this feature is activated,
+// with some of its possible extra arguments (bti, pac-ret, leaf) when doing LTO.
+// See https://github.com/rust-lang/rust/pull/88354
+
+//@ needs-force-clang-based-tests
+//@ only-aarch64
+// Reason: branch protection is not supported on other architectures
+//@ ignore-cross-compile
+// Reason: the compiled binary is executed
+
+use run_make_support::{clang, env_var, llvm_ar, run, rustc, static_lib_name};
+
+fn main() {
+    clang()
+        .arg("-v")
+        .lto("thin")
+        .arg("-mbranch-protection=bti+pac-ret+leaf")
+        .arg("-O2")
+        .arg("-c")
+        .out_exe("test.o")
+        .input("test.c")
+        .run();
+    llvm_ar().obj_to_ar().output_input(static_lib_name("test"), "test.o").run();
+    rustc()
+        .linker_plugin_lto("on")
+        .opt_level("2")
+        .linker(&env_var("CLANG"))
+        .link_arg("-fuse-ld=lld")
+        .arg("-Zbranch-protection=bti,pac-ret,leaf")
+        .input("test.rs")
+        .output("test.bin")
+        .run();
+    run("test.bin");
+}

--- a/tests/run-make/pointer-auth-link-with-c-lto-clang/test.c
+++ b/tests/run-make/pointer-auth-link-with-c-lto-clang/test.c
@@ -1,0 +1,1 @@
+int foo() { return 0; }

--- a/tests/run-make/pointer-auth-link-with-c-lto-clang/test.rs
+++ b/tests/run-make/pointer-auth-link-with-c-lto-clang/test.rs
@@ -1,0 +1,10 @@
+#[link(name = "test")]
+extern "C" {
+    fn foo() -> i32;
+}
+
+fn main() {
+    unsafe {
+        foo();
+    }
+}

--- a/tests/ui/consts/const-unwrap.rs
+++ b/tests/ui/consts/const-unwrap.rs
@@ -1,11 +1,15 @@
 //@ check-fail
-
-#![feature(const_option)]
+// Verify that panicking `const_option` methods do the correct thing
 
 const FOO: i32 = Some(42i32).unwrap();
 
 const BAR: i32 = Option::<i32>::None.unwrap();
-//~^ERROR: evaluation of constant value failed
+//~^ ERROR: evaluation of constant value failed
+//~| NOTE: the evaluated program panicked
+
+const BAZ: i32 = Option::<i32>::None.expect("absolutely not!");
+//~^ ERROR: evaluation of constant value failed
+//~| NOTE: absolutely not!
 
 fn main() {
     println!("{}", FOO);

--- a/tests/ui/consts/const-unwrap.stderr
+++ b/tests/ui/consts/const-unwrap.stderr
@@ -1,9 +1,15 @@
 error[E0080]: evaluation of constant value failed
-  --> $DIR/const-unwrap.rs:7:18
+  --> $DIR/const-unwrap.rs:6:18
    |
 LL | const BAR: i32 = Option::<i32>::None.unwrap();
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'called `Option::unwrap()` on a `None` value', $DIR/const-unwrap.rs:7:38
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'called `Option::unwrap()` on a `None` value', $DIR/const-unwrap.rs:6:38
 
-error: aborting due to 1 previous error
+error[E0080]: evaluation of constant value failed
+  --> $DIR/const-unwrap.rs:10:18
+   |
+LL | const BAZ: i32 = Option::<i32>::None.expect("absolutely not!");
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the evaluated program panicked at 'absolutely not!', $DIR/const-unwrap.rs:10:38
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/meta/revision-bad.rs
+++ b/tests/ui/meta/revision-bad.rs
@@ -5,6 +5,7 @@
 //@ revisions: foo bar
 //@ should-fail
 //@ needs-run-enabled
+//@ compile-flags: --remap-path-prefix={{src-base}}=remapped
 //@[foo] error-pattern:bar
 //@[bar] error-pattern:foo
 


### PR DESCRIPTION
Successful merges:

 - #131120 (Stabilize `const_option`)
 - #131207 (ci: aarch64-gnu-debug job)
 - #131334 (Enable sanitizers for loongarch64-unknown-*)
 - #131358 (force "HEAD" for non-CI and `git_upstream_merge_base` for CI environment)
 - #131418 (Use throw intrinsic from stdarch in wasm libunwind)
 - #131579 (Remap path prefix in the panic message of `tests/ui/meta/revision-bad.rs`)
 - #131591 (add latest crash tests)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131120,131207,131334,131358,131418,131579,131591)
<!-- homu-ignore:end -->