### PR TITLE
error on alignments greater than `isize::MAX`

### DIFF
--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -622,6 +622,10 @@ passes_remove_fields =
 passes_repr_align_function =
     `repr(align)` attributes on functions are unstable
 
+passes_repr_align_greater_than_target_max =
+    alignment must not be greater than `isize::MAX` bytes
+    .note = `isize::MAX` is {$size} for the current target
+
 passes_repr_conflicting =
     conflicting representation hints
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -567,6 +567,15 @@ pub(crate) struct ReprConflicting {
     pub hint_spans: Vec<Span>,
 }
 
+#[derive(Diagnostic)]
+#[diag(passes_repr_align_greater_than_target_max, code = E0589)]
+#[note]
+pub(crate) struct InvalidReprAlignForTarget {
+    #[primary_span]
+    pub span: Span,
+    pub size: u64,
+}
+
 #[derive(LintDiagnostic)]
 #[diag(passes_repr_conflicting, code = E0566)]
 pub(crate) struct ReprConflictingLint;

--- a/tests/ui/repr/repr_align_greater_usize.msp430.stderr
+++ b/tests/ui/repr/repr_align_greater_usize.msp430.stderr
@@ -1,0 +1,19 @@
+error[E0589]: alignment must not be greater than `isize::MAX` bytes
+  --> $DIR/repr_align_greater_usize.rs:21:8
+   |
+LL | #[repr(align(32768))]
+   |        ^^^^^^^^^^^^
+   |
+   = note: `isize::MAX` is 32767 for the current target
+
+error[E0589]: alignment must not be greater than `isize::MAX` bytes
+  --> $DIR/repr_align_greater_usize.rs:24:8
+   |
+LL | #[repr(align(65536))]
+   |        ^^^^^^^^^^^^
+   |
+   = note: `isize::MAX` is 32767 for the current target
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0589`.

--- a/tests/ui/repr/repr_align_greater_usize.rs
+++ b/tests/ui/repr/repr_align_greater_usize.rs
@@ -1,0 +1,25 @@
+//@ revisions: msp430 aarch32
+//@[msp430] needs-llvm-components: msp430
+//@[msp430] compile-flags: --target=msp430-none-elf
+//@[aarch32] build-pass
+//@[aarch32] needs-llvm-components: arm
+//@[aarch32] compile-flags: --target=thumbv7m-none-eabi
+
+// We should fail to compute alignment for types aligned higher than usize::MAX.
+// We can't handle alignments that require all 32 bits, so this only affects 16-bit.
+
+#![feature(lang_items, no_core)]
+#![no_core]
+#![crate_type = "lib"]
+
+#[lang = "sized"]
+trait Sized {}
+
+#[repr(align(16384))]
+struct Kitten;
+
+#[repr(align(32768))] //[msp430]~ ERROR alignment must not be greater than `isize::MAX`
+struct Cat;
+
+#[repr(align(65536))] //[msp430]~ ERROR alignment must not be greater than `isize::MAX`
+struct BigCat;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Fixes #131122

On zulip someone had a concern that it was legal to create a type with alignment `isize::MAX + 1`, but I do not believe this should be allowed for `repr(align)`, as `repr(align)` also increases the *size* of the type, and that would be larger than the maximum allowed size of objects.

(cc @workingjubilee #131276)
