### PR TITLE
Special case error message for a `build-fail` test that failed check build

### DIFF
--- a/src/tools/compiletest/src/runtest/incremental.rs
+++ b/src/tools/compiletest/src/runtest/incremental.rs
@@ -1,4 +1,4 @@
-use super::{TestCx, WillExecute};
+use super::{FailMode, TestCx, WillExecute};
 use crate::errors;
 
 impl TestCx<'_> {
@@ -96,7 +96,7 @@ impl TestCx<'_> {
     fn run_cfail_test(&self) {
         let pm = self.pass_mode();
         let proc_res = self.compile_test(WillExecute::No, self.should_emit_metadata(pm));
-        self.check_if_test_should_compile(&proc_res, pm);
+        self.check_if_test_should_compile(Some(FailMode::Build), pm, &proc_res);
         self.check_no_compiler_crash(&proc_res, self.props.should_ice);
 
         let output_to_check = self.get_output(&proc_res);

--- a/src/tools/compiletest/src/runtest/ui.rs
+++ b/src/tools/compiletest/src/runtest/ui.rs
@@ -18,14 +18,14 @@ impl TestCx<'_> {
             let pm = Some(PassMode::Check);
             let proc_res =
                 self.compile_test_general(WillExecute::No, Emit::Metadata, pm, Vec::new());
-            self.check_if_test_should_compile(&proc_res, pm);
+            self.check_if_test_should_compile(self.props.fail_mode, pm, &proc_res);
         }
 
         let pm = self.pass_mode();
         let should_run = self.should_run(pm);
         let emit_metadata = self.should_emit_metadata(pm);
         let proc_res = self.compile_test(should_run, emit_metadata);
-        self.check_if_test_should_compile(&proc_res, pm);
+        self.check_if_test_should_compile(self.props.fail_mode, pm, &proc_res);
         if matches!(proc_res.truncated, Truncated::Yes)
             && !self.props.dont_check_compiler_stdout
             && !self.props.dont_check_compiler_stderr


### PR DESCRIPTION
A `build-fail` test requires that a check build (roughly `--emit=metadata`, no codegen) succeeds but fails later. Previously, if its check build failed, the user will see the error message

```
error: test compilation failed although it shouldn't!
```

which is confusing. Because the test is `build-fail`, we want the test compilation to fail! This error message doesn't account for the difference between a check build and a complete build, so let's special case the error message for a `build-fail` test whose check build failed to instead say

```
error: `build-fail` test is required to pass check build, but check build failed
```

Fixes #130894.