### PR TITLE
Create a generic AVR target: avr-none

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1990,6 +1990,7 @@ fn add_pre_link_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavor)
     if let Some(args) = sess.target.pre_link_args.get(&flavor) {
         cmd.verbatim_args(args.iter().map(Deref::deref));
     }
+
     cmd.verbatim_args(&sess.opts.unstable_opts.pre_link_args);
 }
 

--- a/compiler/rustc_target/src/spec/base/avr.rs
+++ b/compiler/rustc_target/src/spec/base/avr.rs
@@ -1,45 +1,5 @@
 use object::elf;
 
-use crate::spec::{Cc, LinkerFlavor, Lld, RelocModel, Target, TargetOptions};
-
-/// A base target for AVR devices using the GNU toolchain.
-///
-/// Requires GNU avr-gcc and avr-binutils on the host system.
-/// FIXME: Remove the second parameter when const string concatenation is possible.
-pub(crate) fn target(target_cpu: &'static str, mmcu: &'static str) -> Target {
-    Target {
-        arch: "avr".into(),
-        metadata: crate::spec::TargetMetadata {
-            description: None,
-            tier: None,
-            host_tools: None,
-            std: None,
-        },
-        data_layout: "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8".into(),
-        llvm_target: "avr-unknown-unknown".into(),
-        pointer_width: 16,
-        options: TargetOptions {
-            env: "gnu".into(),
-
-            c_int_width: "16".into(),
-            cpu: target_cpu.into(),
-            exe_suffix: ".elf".into(),
-
-            linker: Some("avr-gcc".into()),
-            eh_frame_header: false,
-            pre_link_args: TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[mmcu]),
-            late_link_args: TargetOptions::link_args(
-                LinkerFlavor::Gnu(Cc::Yes, Lld::No),
-                &["-lgcc"],
-            ),
-            max_atomic_width: Some(16),
-            atomic_cas: false,
-            relocation_model: RelocModel::Static,
-            ..TargetOptions::default()
-        },
-    }
-}
-
 /// Resolve the value of the EF_AVR_ARCH field for AVR ELF files, given the
 /// name of the target CPU / MCU.
 ///

--- a/compiler/rustc_target/src/spec/base/mod.rs
+++ b/compiler/rustc_target/src/spec/base/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod aix;
 pub(crate) mod android;
 pub(crate) mod apple;
-pub(crate) mod avr_gnu;
+pub(crate) mod avr;
 pub(crate) mod bpf;
 pub(crate) mod cygwin;
 pub(crate) mod dragonfly;

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -60,7 +60,7 @@ pub mod crt_objects;
 mod base;
 mod json;
 
-pub use base::avr_gnu::ef_avr_arch;
+pub use base::avr::ef_avr_arch;
 
 /// Linker is called through a C/C++ compiler.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -1797,7 +1797,7 @@ supported_targets! {
     ("riscv64gc-unknown-fuchsia", riscv64gc_unknown_fuchsia),
     ("x86_64-unknown-fuchsia", x86_64_unknown_fuchsia),
 
-    ("avr-unknown-gnu-atmega328", avr_unknown_gnu_atmega328),
+    ("avr-none", avr_none),
 
     ("x86_64-unknown-l4re-uclibc", x86_64_unknown_l4re_uclibc),
 
@@ -3062,7 +3062,10 @@ impl Target {
             &self.post_link_args,
         ] {
             for (&flavor, flavor_args) in args {
-                check!(!flavor_args.is_empty(), "linker flavor args must not be empty");
+                check!(
+                    !flavor_args.is_empty() || self.arch == "avr",
+                    "linker flavor args must not be empty"
+                );
                 // Check that flavors mentioned in link args are compatible with the default flavor.
                 match self.linker_flavor {
                     LinkerFlavor::Gnu(..) => {

--- a/compiler/rustc_target/src/spec/targets/avr_none.rs
+++ b/compiler/rustc_target/src/spec/targets/avr_none.rs
@@ -1,0 +1,32 @@
+use crate::spec::{Cc, LinkerFlavor, Lld, RelocModel, Target, TargetOptions};
+
+pub(crate) fn target() -> Target {
+    Target {
+        arch: "avr".into(),
+        metadata: crate::spec::TargetMetadata {
+            description: None,
+            tier: None,
+            host_tools: None,
+            std: None,
+        },
+        data_layout: "e-P1-p:16:8-i8:8-i16:8-i32:8-i64:8-f32:8-f64:8-n8-a:8".into(),
+        llvm_target: "avr-unknown-unknown".into(),
+        pointer_width: 16,
+        options: TargetOptions {
+            c_int_width: "16".into(),
+            exe_suffix: ".elf".into(),
+            linker: Some("avr-gcc".into()),
+            eh_frame_header: false,
+            pre_link_args: TargetOptions::link_args(LinkerFlavor::Gnu(Cc::Yes, Lld::No), &[]),
+            late_link_args: TargetOptions::link_args(
+                LinkerFlavor::Gnu(Cc::Yes, Lld::No),
+                &["-lgcc"],
+            ),
+            max_atomic_width: Some(16),
+            atomic_cas: false,
+            relocation_model: RelocModel::Static,
+            need_explicit_cpu: true,
+            ..TargetOptions::default()
+        },
+    }
+}

--- a/compiler/rustc_target/src/spec/targets/avr_unknown_gnu_atmega328.rs
+++ b/compiler/rustc_target/src/spec/targets/avr_unknown_gnu_atmega328.rs
@@ -1,5 +1,0 @@
-use crate::spec::{Target, base};
-
-pub(crate) fn target() -> Target {
-    base::avr_gnu::target("atmega328", "-mmcu=atmega328")
-}

--- a/src/doc/rustc/src/platform-support.md
+++ b/src/doc/rustc/src/platform-support.md
@@ -301,7 +301,7 @@ target | std | host | notes
 [`armv8r-none-eabihf`](platform-support/armv8r-none-eabihf.md) | * |  | Bare Armv8-R, hardfloat
 [`armv7a-nuttx-eabi`](platform-support/nuttx.md) | ✓ |  | ARMv7-A with NuttX
 [`armv7a-nuttx-eabihf`](platform-support/nuttx.md) | ✓ |  | ARMv7-A with NuttX, hardfloat
-`avr-unknown-gnu-atmega328` | * |  | AVR. Requires `-Z build-std=core`
+`avr-none` | * |  | AVR; requires `-Zbuild-std=core` and `-Ctarget-cpu=...`
 `bpfeb-unknown-none` | * |  | BPF (big endian)
 `bpfel-unknown-none` | * |  | BPF (little endian)
 `csky-unknown-linux-gnuabiv2` | ✓ |  | C-SKY abiv2 Linux (little endian)

--- a/src/doc/rustc/src/platform-support/avr-none.md
+++ b/src/doc/rustc/src/platform-support/avr-none.md
@@ -1,0 +1,81 @@
+# `avr-none`
+
+Series of microcontrollers from Atmel: ATmega8, ATmega328p etc.
+
+**Tier: 3**
+
+## Target maintainers
+
+- [Patryk Wychowaniec](https://github.com/Patryk27) <pwychowaniec@pm.me>
+
+## Requirements
+
+This target is only cross-compiled; x86-64 Linux, x86-64 macOS and aarch64 macOS
+hosts are confirmed to work, but in principle any machine able to run rustc and
+avr-gcc should be good.
+
+Compiling for this target requires `avr-gcc` installed, because a couple of
+intrinsics (like 32-bit multiplication) rely on [`libgcc`](https://github.com/gcc-mirror/gcc/blob/3269a722b7a03613e9c4e2862bc5088c4a17cc11/libgcc/config/avr/lib1funcs.S)
+and can't be provided through `compiler-builtins` yet. This is a limitation that
+[we hope to lift in the future](https://github.com/rust-lang/compiler-builtins/issues/711).
+
+You'll also need to setup the `.cargo/config` file - see below for details.
+
+## Building the target
+
+Rust comes with AVR support enabled, you don't have to rebuild the compiler.
+
+## Building Rust programs
+
+Install `avr-gcc`:
+
+```console
+# Ubuntu:
+$ sudo apt-get install gcc-avr
+
+# Mac:
+$ brew tap osx-cross/avr && brew install avr-gcc
+
+# NixOS (takes a couple of minutes, since it's not provided through Hydra):
+$ nix shell nixpkgs#pkgsCross.avr.buildPackages.gcc11
+```
+
+... setup `.cargo/config` for your project:
+
+```toml
+[build]
+target = "avr-none"
+rustflags = ["-C", "target-cpu=atmega328p"]
+
+[unstable]
+build-std = ["core"]
+```
+
+... and then simply run:
+
+```console
+$ cargo build --release
+```
+
+The final binary will be placed into
+`./target/avr-none/release/your-project.elf`.
+
+Note that since AVRs have rather small amounts of registers, ROM and RAM, it's
+recommended to always use `--release` to avoid running out of space.
+
+Also, please note that specifying `-C target-cpu` is required - here's a list of
+the possible variants:
+
+https://github.com/llvm/llvm-project/blob/093d4db2f3c874d4683fb01194b00dbb20e5c713/clang/lib/Basic/Targets/AVR.cpp#L32
+
+## Testing
+
+You can use [`simavr`](https://github.com/buserror/simavr) to emulate the
+resulting firmware on your machine:
+
+```console
+$ simavr -m atmega328p ./target/avr-none/release/your-project.elf
+```
+
+Alternatively, if you want to write a couple of actual `#[test]`s, you can use
+[`avr-tester`](https://github.com/Patryk27/avr-tester).

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -465,7 +465,10 @@ fn profiler_runtime() {
 #[test]
 fn asm_support() {
     let asms = [
+        #[cfg(bootstrap)]
         ("avr-unknown-gnu-atmega328", false),
+        #[cfg(not(bootstrap))]
+        ("avr-none", false),
         ("i686-unknown-netbsd", true),
         ("riscv32gc-unknown-linux-gnu", true),
         ("riscv64imac-unknown-none-elf", true),

--- a/src/tools/run-make-support/src/external_deps/rustc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustc.rs
@@ -253,6 +253,13 @@ impl Rustc {
         self
     }
 
+    /// Specify the target CPU.
+    pub fn target_cpu<S: AsRef<str>>(&mut self, target_cpu: S) -> &mut Self {
+        let target_cpu = target_cpu.as_ref();
+        self.cmd.arg(format!("-Ctarget-cpu={target_cpu}"));
+        self
+    }
+
     /// Specify the crate type.
     pub fn crate_type(&mut self, crate_type: &str) -> &mut Self {
         self.cmd.arg("--crate-type");

--- a/tests/assembly/asm/avr-modifiers.rs
+++ b/tests/assembly/asm/avr-modifiers.rs
@@ -1,6 +1,6 @@
 //@ add-core-stubs
 //@ assembly-output: emit-asm
-//@ compile-flags: --target avr-unknown-gnu-atmega328
+//@ compile-flags: --target avr-none -C target-cpu=atmega328p
 //@ needs-llvm-components: avr
 
 #![feature(no_core, asm_experimental_arch)]

--- a/tests/assembly/asm/avr-types.rs
+++ b/tests/assembly/asm/avr-types.rs
@@ -1,6 +1,6 @@
 //@ add-core-stubs
 //@ assembly-output: emit-asm
-//@ compile-flags: --target avr-unknown-gnu-atmega328
+//@ compile-flags: --target avr-none -C target-cpu=atmega328p
 //@ needs-llvm-components: avr
 
 #![feature(no_core, asm_experimental_arch)]

--- a/tests/assembly/targets/targets-pe.rs
+++ b/tests/assembly/targets/targets-pe.rs
@@ -15,9 +15,9 @@
 //@ revisions: arm64ec_pc_windows_msvc
 //@ [arm64ec_pc_windows_msvc] compile-flags: --target arm64ec-pc-windows-msvc
 //@ [arm64ec_pc_windows_msvc] needs-llvm-components: aarch64
-//@ revisions: avr_unknown_gnu_atmega328
-//@ [avr_unknown_gnu_atmega328] compile-flags: --target avr-unknown-gnu-atmega328
-//@ [avr_unknown_gnu_atmega328] needs-llvm-components: avr
+//@ revisions: avr_none
+//@ [avr_none] compile-flags: --target avr-none -C target-cpu=atmega328p
+//@ [avr_none] needs-llvm-components: avr
 //@ revisions: bpfeb_unknown_none
 //@ [bpfeb_unknown_none] compile-flags: --target bpfeb-unknown-none
 //@ [bpfeb_unknown_none] needs-llvm-components: bpf

--- a/tests/codegen/asm/avr-clobbers.rs
+++ b/tests/codegen/asm/avr-clobbers.rs
@@ -1,6 +1,6 @@
 //@ add-core-stubs
 //@ assembly-output: emit-asm
-//@ compile-flags: --target avr-unknown-gnu-atmega328
+//@ compile-flags: --target avr-none -C target-cpu=atmega328p
 //@ needs-llvm-components: avr
 
 #![crate_type = "rlib"]

--- a/tests/codegen/avr/avr-func-addrspace.rs
+++ b/tests/codegen/avr/avr-func-addrspace.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Copt-level=3 --target=avr-unknown-gnu-atmega328 --crate-type=rlib -C panic=abort
+//@ compile-flags: -Copt-level=3 --target=avr-none -C target-cpu=atmega328p --crate-type=rlib -C panic=abort
 //@ needs-llvm-components: avr
 
 // This test validates that function pointers can be stored in global variables

--- a/tests/run-make/avr-rjmp-offset/rmake.rs
+++ b/tests/run-make/avr-rjmp-offset/rmake.rs
@@ -22,7 +22,8 @@ fn main() {
         .input("avr-rjmp-offsets.rs")
         .opt_level("s")
         .panic("abort")
-        .target("avr-unknown-gnu-atmega328")
+        .target("avr-none")
+        .target_cpu("avr")
         // normally one links with `avr-gcc`, but this is not available in CI,
         // hence this test diverges from the default behavior to enable linking
         // at all, which is necessary for the test (to resolve the labels). To
@@ -49,6 +50,7 @@ fn main() {
     // of the Rust compiler did produce a label `rjmp .-4` (misses the first
     // instruction in the loop).
     assert!(disassembly.contains("<main>"), "no main function in output");
+
     disassembly
         .trim()
         .lines()

--- a/tests/run-make/avr-rjmp-offset/rmake.rs
+++ b/tests/run-make/avr-rjmp-offset/rmake.rs
@@ -23,6 +23,10 @@ fn main() {
         .opt_level("s")
         .panic("abort")
         .target("avr-none")
+        // rust-lld has some troubles understanding the -mmcu flag, so for the
+        // time being let's tell rustc to emit binary that's compatible with the
+        // target CPU that lld defaults to, i.e. just `avr` (that's simply the
+        // minimal common instruction set across all AVRs)
         .target_cpu("avr")
         // normally one links with `avr-gcc`, but this is not available in CI,
         // hence this test diverges from the default behavior to enable linking

--- a/tests/ui/feature-gates/feature-gate-abi-avr-interrupt.rs
+++ b/tests/ui/feature-gates/feature-gate-abi-avr-interrupt.rs
@@ -1,5 +1,5 @@
 //@ needs-llvm-components: avr
-//@ compile-flags: --target=avr-unknown-gnu-atmega328 --crate-type=rlib
+//@ compile-flags: --target=avr-none -C target-cpu=atmega328p --crate-type=rlib
 #![no_core]
 #![feature(no_core, lang_items)]
 #[lang="sized"]

--- a/tests/ui/repr/16-bit-repr-c-enum.rs
+++ b/tests/ui/repr/16-bit-repr-c-enum.rs
@@ -2,7 +2,7 @@
 //@ revisions: avr msp430
 //
 //@ [avr] needs-llvm-components: avr
-//@ [avr] compile-flags: --target=avr-unknown-gnu-atmega328 --crate-type=rlib
+//@ [avr] compile-flags: --target=avr-none -C target-cpu=atmega328p --crate-type=rlib
 //@ [msp430] needs-llvm-components: msp430
 //@ [msp430] compile-flags: --target=msp430-none-elf --crate-type=rlib
 #![feature(no_core, lang_items, intrinsics, staged_api, rustc_attrs)]


### PR DESCRIPTION
This commit removes the `avr-unknown-gnu-atmega328` target and replaces it with a more generic `avr-none` variant that must be specialized using `-C target-cpu` (e.g. `-C target-cpu=atmega328p`).

Seizing the day, I'm adding myself as the maintainer of this target - I've been already fixing the bugs anyway, might as well make it official 🙂 

Related discussions:
- https://github.com/rust-lang/rust/pull/131171
- https://github.com/rust-lang/compiler-team/issues/800

try-job: x86_64-gnu-debug