### PR TITLE
lexer: Treat more floats with empty exponent as valid tokens

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -194,7 +194,7 @@ pub enum DocStyle {
 pub enum LiteralKind {
     /// `12_u8`, `0o100`, `0b120i99`, `1f32`.
     Int { base: Base, empty_int: bool },
-    /// `12.34f32`, `1e3`, but not `1f32`.
+    /// `12.34f32`, `1e3` and `1e+`, but not `1f32` or `1em`.
     Float { base: Base, empty_exponent: bool },
     /// `'a'`, `'\\'`, `'''`, `';`
     Char { terminated: bool },
@@ -409,8 +409,8 @@ impl Cursor<'_> {
 
             // Numeric literal.
             c @ '0'..='9' => {
-                let literal_kind = self.number(c);
-                let suffix_start = self.pos_within_token();
+                let (literal_kind, suffix_start) = self.number(c);
+                let suffix_start = suffix_start.unwrap_or(self.pos_within_token());
                 self.eat_literal_suffix();
                 TokenKind::Literal { kind: literal_kind, suffix_start }
             }
@@ -606,7 +606,9 @@ impl Cursor<'_> {
         }
     }
 
-    fn number(&mut self, first_digit: char) -> LiteralKind {
+    /// Parses a number and in `.1` returns the offset of the literal suffix if
+    /// different from the current position on return.
+    fn number(&mut self, first_digit: char) -> (LiteralKind, Option<u32>) {
         debug_assert!('0' <= self.prev() && self.prev() <= '9');
         let mut base = Base::Decimal;
         if first_digit == '0' {
@@ -616,21 +618,21 @@ impl Cursor<'_> {
                     base = Base::Binary;
                     self.bump();
                     if !self.eat_decimal_digits() {
-                        return Int { base, empty_int: true };
+                        return (Int { base, empty_int: true }, None);
                     }
                 }
                 'o' => {
                     base = Base::Octal;
                     self.bump();
                     if !self.eat_decimal_digits() {
-                        return Int { base, empty_int: true };
+                        return (Int { base, empty_int: true }, None);
                     }
                 }
                 'x' => {
                     base = Base::Hexadecimal;
                     self.bump();
                     if !self.eat_hexadecimal_digits() {
-                        return Int { base, empty_int: true };
+                        return (Int { base, empty_int: true }, None);
                     }
                 }
                 // Not a base prefix; consume additional digits.
@@ -642,40 +644,79 @@ impl Cursor<'_> {
                 '.' | 'e' | 'E' => {}
 
                 // Just a 0.
-                _ => return Int { base, empty_int: false },
+                _ => return (Int { base, empty_int: false }, None),
             }
         } else {
             // No base prefix, parse number in the usual way.
             self.eat_decimal_digits();
         };
 
-        match self.first() {
+        match (self.first(), self.second()) {
             // Don't be greedy if this is actually an
             // integer literal followed by field/method access or a range pattern
             // (`0..2` and `12.foo()`)
-            '.' if self.second() != '.' && !is_id_start(self.second()) => {
-                // might have stuff after the ., and if it does, it needs to start
-                // with a number
+            ('.', second) if second != '.' && !is_id_start(second) => {
                 self.bump();
+                self.eat_decimal_digits();
+
                 let mut empty_exponent = false;
-                if self.first().is_ascii_digit() {
-                    self.eat_decimal_digits();
-                    match self.first() {
-                        'e' | 'E' => {
-                            self.bump();
-                            empty_exponent = !self.eat_float_exponent();
-                        }
-                        _ => (),
+                let suffix_start = match (self.first(), self.second()) {
+                    ('e' | 'E', '_') => self.eat_underscore_exponent(),
+                    ('e' | 'E', '0'..='9' | '+' | '-') => {
+                        // Definitely an exponent (which still can be empty).
+                        self.bump();
+                        empty_exponent = !self.eat_float_exponent();
+                        None
                     }
-                }
-                Float { base, empty_exponent }
+                    _ => None,
+                };
+                (Float { base, empty_exponent }, suffix_start)
             }
-            'e' | 'E' => {
+            ('e' | 'E', '_') => {
+                match self.eat_underscore_exponent() {
+                    Some(suffix_start) => {
+                        // The suffix begins at `e`, meaning the number is an integer.
+                        (Int { base, empty_int: false }, Some(suffix_start))
+                    }
+                    None => (Float { base, empty_exponent: false }, None),
+                }
+            }
+            ('e' | 'E', '0'..='9' | '+' | '-') => {
+                // Definitely an exponent (which still can be empty).
                 self.bump();
                 let empty_exponent = !self.eat_float_exponent();
-                Float { base, empty_exponent }
+                (Float { base, empty_exponent }, None)
             }
-            _ => Int { base, empty_int: false },
+            _ => (Int { base, empty_int: false }, None),
+        }
+    }
+
+    /// Try to find and eat an exponent
+    ///
+    /// Assumes the first character is `e`/`E` and second is `_`, and consumes
+    /// `e`/`E` followed by all consecutive `_`s.
+    ///
+    /// Returns `Some` if no exponent was found. In this case, the suffix is partially
+    /// consumed, and began at the return value.
+    fn eat_underscore_exponent(&mut self) -> Option<u32> {
+        debug_assert!(matches!(self.first(), 'e' | 'E'));
+        debug_assert!(matches!(self.second(), '_'));
+        let suffix_start = self.pos_within_token();
+
+        // check if series of `_` is ended by a digit. If yes
+        // include it in the number as exponent. If no include
+        // it in suffix.
+        self.bump();
+        while matches!(self.first(), '_') {
+            self.bump();
+        }
+        // If we find a digit, then the exponential was valid
+        // so the suffix will start at the cursor as usual.
+        if self.first().is_ascii_digit() {
+            self.eat_decimal_digits();
+            None
+        } else {
+            Some(suffix_start)
         }
     }
 
@@ -924,6 +965,7 @@ impl Cursor<'_> {
         }
     }
 
+    /// Returns `true` if a digit was consumed (rather than just '_'s).
     fn eat_decimal_digits(&mut self) -> bool {
         let mut has_digits = false;
         loop {
@@ -961,20 +1003,20 @@ impl Cursor<'_> {
     /// Eats the float exponent. Returns true if at least one digit was met,
     /// and returns false otherwise.
     fn eat_float_exponent(&mut self) -> bool {
-        debug_assert!(self.prev() == 'e' || self.prev() == 'E');
+        debug_assert!(matches!(self.prev(), 'e' | 'E'));
         if self.first() == '-' || self.first() == '+' {
             self.bump();
         }
         self.eat_decimal_digits()
     }
 
-    // Eats the suffix of the literal, e.g. "u8".
+    /// Eats the suffix of the literal, e.g. "u8".
     fn eat_literal_suffix(&mut self) {
-        self.eat_identifier();
+        self.eat_identifier()
     }
 
-    // Eats the identifier. Note: succeeds on `_`, which isn't a valid
-    // identifier.
+    /// Eats the identifier. Note: succeeds on `_`, which isn't a valid
+    /// identifier.
     fn eat_identifier(&mut self) {
         if !is_id_start(self.first()) {
             return;

--- a/compiler/rustc_session/messages.ftl
+++ b/compiler/rustc_session/messages.ftl
@@ -14,6 +14,8 @@ session_embed_source_insufficient_dwarf_version = `-Zembed-source=y` requires at
 
 session_embed_source_requires_debug_info = `-Zembed-source=y` requires debug information to be enabled
 
+session_empty_float_exponent = expected at least one digit in exponent
+
 session_expr_parentheses_needed = parentheses are required to parse this as an expression
 
 session_failed_to_create_profiler = failed to create profiler: {$err}

--- a/compiler/rustc_session/src/errors.rs
+++ b/compiler/rustc_session/src/errors.rs
@@ -377,6 +377,10 @@ pub fn report_lit_error(
         s.len() > 1 && s.starts_with(first_chars) && s[1..].chars().all(|c| c.is_ascii_digit())
     }
 
+    fn looks_like_empty_exponent(s: &str) -> bool {
+        s.len() == 1 && matches!(s.chars().next(), Some('e' | 'E'))
+    }
+
     // Try to lowercase the prefix if the prefix and suffix are valid.
     fn fix_base_capitalisation(prefix: &str, suffix: &str) -> Option<String> {
         let mut chars = suffix.chars();
@@ -409,6 +413,8 @@ pub fn report_lit_error(
             if looks_like_width_suffix(&['i', 'u'], suf) {
                 // If it looks like a width, try to be helpful.
                 dcx.emit_err(InvalidIntLiteralWidth { span, width: suf[1..].into() })
+            } else if looks_like_empty_exponent(suf) {
+                dcx.emit_err(EmptyFloatExponent { span })
             } else if let Some(fixed) = fix_base_capitalisation(lit.symbol.as_str(), suf) {
                 dcx.emit_err(InvalidNumLiteralBasePrefix { span, fixed })
             } else {
@@ -420,6 +426,8 @@ pub fn report_lit_error(
             if looks_like_width_suffix(&['f'], suf) {
                 // If it looks like a width, try to be helpful.
                 dcx.emit_err(InvalidFloatLiteralWidth { span, width: suf[1..].to_string() })
+            } else if looks_like_empty_exponent(suf) {
+                dcx.emit_err(EmptyFloatExponent { span })
             } else {
                 dcx.emit_err(InvalidFloatLiteralSuffix { span, suffix: suf.to_string() })
             }
@@ -489,3 +497,10 @@ pub(crate) struct SoftFloatIgnored;
 #[note]
 #[note(session_soft_float_deprecated_issue)]
 pub(crate) struct SoftFloatDeprecated;
+
+#[derive(Diagnostic)]
+#[diag(session_empty_float_exponent)]
+pub(crate) struct EmptyFloatExponent {
+    #[primary_span]
+    pub span: Span,
+}

--- a/tests/ui/consts/const-eval/issue-104390.stderr
+++ b/tests/ui/consts/const-eval/issue-104390.stderr
@@ -1,39 +1,3 @@
-error: expected at least one digit in exponent
-  --> $DIR/issue-104390.rs:1:27
-   |
-LL | fn f1() -> impl Sized { & 2E }
-   |                           ^^
-
-error: expected at least one digit in exponent
-  --> $DIR/issue-104390.rs:2:28
-   |
-LL | fn f2() -> impl Sized { && 2E }
-   |                            ^^
-
-error: expected at least one digit in exponent
-  --> $DIR/issue-104390.rs:3:29
-   |
-LL | fn f3() -> impl Sized { &'a 2E }
-   |                             ^^
-
-error: expected at least one digit in exponent
-  --> $DIR/issue-104390.rs:5:34
-   |
-LL | fn f4() -> impl Sized { &'static 2E }
-   |                                  ^^
-
-error: expected at least one digit in exponent
-  --> $DIR/issue-104390.rs:7:28
-   |
-LL | fn f5() -> impl Sized { *& 2E }
-   |                            ^^
-
-error: expected at least one digit in exponent
-  --> $DIR/issue-104390.rs:8:29
-   |
-LL | fn f6() -> impl Sized { &'_ 2E }
-   |                             ^^
-
 error: borrow expressions cannot be annotated with lifetimes
   --> $DIR/issue-104390.rs:3:25
    |
@@ -75,6 +39,42 @@ help: remove the lifetime annotation
 LL - fn f6() -> impl Sized { &'_ 2E }
 LL + fn f6() -> impl Sized { &2E }
    |
+
+error: expected at least one digit in exponent
+  --> $DIR/issue-104390.rs:1:27
+   |
+LL | fn f1() -> impl Sized { & 2E }
+   |                           ^^
+
+error: expected at least one digit in exponent
+  --> $DIR/issue-104390.rs:2:28
+   |
+LL | fn f2() -> impl Sized { && 2E }
+   |                            ^^
+
+error: expected at least one digit in exponent
+  --> $DIR/issue-104390.rs:3:29
+   |
+LL | fn f3() -> impl Sized { &'a 2E }
+   |                             ^^
+
+error: expected at least one digit in exponent
+  --> $DIR/issue-104390.rs:5:34
+   |
+LL | fn f4() -> impl Sized { &'static 2E }
+   |                                  ^^
+
+error: expected at least one digit in exponent
+  --> $DIR/issue-104390.rs:7:28
+   |
+LL | fn f5() -> impl Sized { *& 2E }
+   |                            ^^
+
+error: expected at least one digit in exponent
+  --> $DIR/issue-104390.rs:8:29
+   |
+LL | fn f6() -> impl Sized { &'_ 2E }
+   |                             ^^
 
 error: aborting due to 9 previous errors
 

--- a/tests/ui/consts/issue-91434.stderr
+++ b/tests/ui/consts/issue-91434.stderr
@@ -1,14 +1,14 @@
-error: expected at least one digit in exponent
-  --> $DIR/issue-91434.rs:2:11
-   |
-LL |     [9; [[9E; h]]];
-   |           ^^
-
 error[E0425]: cannot find value `h` in this scope
   --> $DIR/issue-91434.rs:2:15
    |
 LL |     [9; [[9E; h]]];
    |               ^ not found in this scope
+
+error: expected at least one digit in exponent
+  --> $DIR/issue-91434.rs:2:11
+   |
+LL |     [9; [[9E; h]]];
+   |           ^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
+++ b/tests/ui/did_you_mean/issue-49746-unicode-confusable-in-float-literal-expt.stderr
@@ -1,9 +1,3 @@
-error: expected at least one digit in exponent
-  --> $DIR/issue-49746-unicode-confusable-in-float-literal-expt.rs:1:47
-   |
-LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e−11; // m³⋅kg⁻¹⋅s⁻²
-   |                                               ^^^^^^
-
 error: unknown start of token: \u{2212}
   --> $DIR/issue-49746-unicode-confusable-in-float-literal-expt.rs:1:53
    |
@@ -15,6 +9,12 @@ help: Unicode character '−' (Minus Sign) looks like '-' (Minus/Hyphen), but it
 LL - const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e−11; // m³⋅kg⁻¹⋅s⁻²
 LL + const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e-11; // m³⋅kg⁻¹⋅s⁻²
    |
+
+error: expected at least one digit in exponent
+  --> $DIR/issue-49746-unicode-confusable-in-float-literal-expt.rs:1:47
+   |
+LL | const UNIVERSAL_GRAVITATIONAL_CONSTANT: f64 = 6.674e−11; // m³⋅kg⁻¹⋅s⁻²
+   |                                               ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/lexer/custom-suffixes-exponent-like.rs
+++ b/tests/ui/lexer/custom-suffixes-exponent-like.rs
@@ -1,0 +1,16 @@
+const _A: f64 = 1em;
+    //~^ ERROR invalid suffix `em` for number literal
+const _B: f64 = 1e0m;
+    //~^ ERROR invalid suffix `m` for float literal
+const _C: f64 = 1e_______________0m;
+    //~^ ERROR invalid suffix `m` for float literal
+const _D: f64 = 1e_______________m;
+    //~^ ERROR invalid suffix `e_______________m` for number literal
+
+// All the above patterns should not generate an error when used in a macro
+macro_rules! do_nothing {
+    ($($toks:tt)*) => {};
+}
+do_nothing!(1em 1e0m 1e_______________0m 1e_______________m);
+
+fn main() {}

--- a/tests/ui/lexer/custom-suffixes-exponent-like.stderr
+++ b/tests/ui/lexer/custom-suffixes-exponent-like.stderr
@@ -1,0 +1,34 @@
+error: invalid suffix `em` for number literal
+  --> $DIR/custom-suffixes-exponent-like.rs:1:17
+   |
+LL | const _A: f64 = 1em;
+   |                 ^^^ invalid suffix `em`
+   |
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+
+error: invalid suffix `m` for float literal
+  --> $DIR/custom-suffixes-exponent-like.rs:3:17
+   |
+LL | const _B: f64 = 1e0m;
+   |                 ^^^^ invalid suffix `m`
+   |
+   = help: valid suffixes are `f32` and `f64`
+
+error: invalid suffix `m` for float literal
+  --> $DIR/custom-suffixes-exponent-like.rs:5:17
+   |
+LL | const _C: f64 = 1e_______________0m;
+   |                 ^^^^^^^^^^^^^^^^^^^ invalid suffix `m`
+   |
+   = help: valid suffixes are `f32` and `f64`
+
+error: invalid suffix `e_______________m` for number literal
+  --> $DIR/custom-suffixes-exponent-like.rs:7:17
+   |
+LL | const _D: f64 = 1e_______________m;
+   |                 ^^^^^^^^^^^^^^^^^^ invalid suffix `e_______________m`
+   |
+   = help: the suffix must be one of the numeric types (`u32`, `isize`, `f32`, etc.)
+
+error: aborting due to 4 previous errors
+

--- a/tests/ui/lexer/custom-suffixes.rs
+++ b/tests/ui/lexer/custom-suffixes.rs
@@ -1,0 +1,22 @@
+//@ check-pass
+
+// This tests different kinds of valid suffixes.
+
+fn main() {
+    const _A: f64 = 1.;
+    const _B: f64 = 1f64;
+    const _C: f64 = 1.0f64;
+    const _D: f64 = 1e6;
+    const _E: f64 = 1.0e9;
+    const _F: f64 = 1e-6;
+    const _G: f64 = 1.0e-6;
+    const _H: f64 = 1.0e06;
+    const _I: f64 = 1.0e+6;
+    // these ones are perhaps more suprising.
+    const _J: f64 = 1.0e0________________________6;
+    const _K: f64 = 1.0e________________________6;
+    const _L: f64 = 1.0e+________________________6;
+    const _M: f64 = 1.0e-________________________6;
+    const _N: f64 = 1.0e-________________________9;
+    const _O: f64 = 1e_______________0f64;
+}


### PR DESCRIPTION
# Summary
[summary]: #summary

This PR changes the lexer to allow more tokens containing a number followed by 'e' with no exponent value (see https://github.com/rust-lang/rust/pull/131656#issuecomment-2698831039). I'll use the RFC template but keep it short.

This PR is a continuation of https://github.com/rust-lang/rust/pull/79912. It is also solving exactly the same problem as [#111628](https://github.com/rust-lang/rust/pull/111628). Also adds tests for various edge cases and improves diagnostics marginally/subjectively.

# Motivation
[motivation]: #motivation

When Rust parses a number, it is allowed to have an arbitrary suffix. If this suffix is a number literal suffix (`u8`, `i16`, `f32` etc), the compiler will use the corresponding type when parsing the number. If the suffix is not a literal, then the compiler rejects the number. This rejection happens after any proc macros have been run on the source code, enabling proc macros to interpret number suffixes as they wish. This means, for example, it is possible to parse `1px` into some structure like `{ number: f64, unit: &str }`: `{ number: 1.0, unit: Pixels }`. However, this is not possible for prefixes that begin with `e` or `E`, because in this case the lexer attempts to parse an exponent before proc macros are run, meaning the code is rejected before the proc macro authors have chance to interpret it.

This PR removes the special case for `e`/`E`, so numeric suffixes like `em` can be used in proc macros. An application example (given in one of the above issues) is CSS colors. Simplifying somewhat, a color looks like `#xxxxxx` where `x` is a hexadecimal character `[0-9a-fA-F]`. All colors are valid Rust tokens, for example `#123abc` is interpreted as `#` followed by the number `123` with suffix `abc`, while `#abc123` is `#` followed by the string `"123abc"`. There is one exception to this: cases with 1 or more numbers followed by 'e'. With this PR, all colors are valid tokens, and so html colors can be parsed in proc macros without using strings or other syntatic clutter.

# Guide-level explanation
[guide-level-explanation]: #guide-level-explanation

Before this PR, it was not possible to have numbers with suffixes starting with the 'e'/'E' character. This is because when the 'e' character was seen, the lexer tries to parse an exponent, and in the case of e.g. "1em" fails, resulting in a compiler error before a proc macro receives the input tokens. After this PR, the same check is carried out, but after proc macros have been run on the input. 

# Reference-level explanation
[reference-level-explanation]: #reference-level-explanation

This PR ensures that invalid exponents are passed to the parser as suffixes for numbers rather than an error. The parser then checks the suffix to see if it is prefixed by a valid exponent, and in this case parses the float. Otherwise, if the suffix is invalid (not `u8`, `i16` etc.) the compiler will reject the number with an 'invalid suffix' error.

Exponents that contain arbitrarily long underscore suffixes are handled without read-ahead by tracking the exponent start in case of invalid exponent, so the suffix start is correct. This is very much an edge-case (the user would have to write something like `1e_______________23`) but nevertheless it is handled correctly.

# Drawbacks
[drawbacks]: #drawbacks

I don't think there are any obvious drawbacks to doing this. Existing diagnostics are maintained, or in one case subjectively slightly improved (`1em` would give "invalid suffix" rather than "empty exponent"). The lexer still has bounded read-ahead (the new patch requires 2 character lookahead). The new code is perhaps slightly more complex, but I have endeavoured to document it clearly. Perf testing showed no regression.

# Rationale and alternatives
[rationale-and-alternatives]: #rationale-and-alternatives

The alternatives are to do nothing or to implement https://github.com/rust-lang/rust/pull/111628#issuecomment-1567408398. Implementing this is a long term goal, but will take more work, and someone motivated to do that work. This PR fixes the specific issue with exponents without waiting for that work to be completed.

# Prior art
[prior-art]: #prior-art

There are a number of previous attempts to implement this functionality: https://github.com/rust-lang/rust/pull/111628, https://github.com/rust-lang/rust/pull/79912.

# Unresolved questions
[unresolved-questions]: #unresolved-questions

None

# Future possibilities
[future-possibilities]: #future-possibilities

A more wholesale refactor of the lexer is proposed here: https://github.com/rust-lang/rust/pull/111628#issuecomment-1567408398. This PR does not block any future work towards that goal.

r: @petrochenkov, since they reviewed https://github.com/rust-lang/rust/pull/79912.