### PR TITLE
Rustfmt `for<'a> async` correctly

### DIFF
--- a/src/tools/rustfmt/tests/target/asyncness.rs
+++ b/src/tools/rustfmt/tests/target/asyncness.rs
@@ -1,3 +1,5 @@
 // rustfmt-edition: 2018
 
 fn foo() -> impl async Fn() {}
+
+fn bar() -> impl for<'a> async Fn(&'a ()) {}


### PR DESCRIPTION
In #127054, we decided to move the trait bound modifier for `async for<'a> Fn()`  to `for<'a> async Fn()`. This wasn't adjusted in rustfmt, so this PR implements that. It also requires consolidating the bound formatting into the `Rewrite` impl for `PolyTraitRef`.

Fixes #131649