### PR TITLE
Also use outermost const-anon for impl items in `non_local_defs` lint

### DIFF
--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -301,9 +301,13 @@ fn did_has_local_parent(
         return false;
     };
 
-    peel_parent_while(tcx, parent_did, |tcx, did| tcx.def_kind(did) == DefKind::Mod)
-        .map(|parent_did| parent_did == impl_parent || Some(parent_did) == outermost_impl_parent)
-        .unwrap_or(false)
+    peel_parent_while(tcx, parent_did, |tcx, did| {
+        tcx.def_kind(did) == DefKind::Mod
+            || (tcx.def_kind(did) == DefKind::Const
+                && tcx.opt_item_name(did) == Some(kw::Underscore))
+    })
+    .map(|parent_did| parent_did == impl_parent || Some(parent_did) == outermost_impl_parent)
+    .unwrap_or(false)
 }
 
 /// Given a `DefId` checks if it satisfies `f` if it does check with it's parent and continue

--- a/tests/ui/lint/non-local-defs/convoluted-locals-131474-with-mods.rs
+++ b/tests/ui/lint/non-local-defs/convoluted-locals-131474-with-mods.rs
@@ -31,4 +31,15 @@ const _: () = {
     };
 };
 
+// https://github.com/rust-lang/rust/issues/131643
+const _: () = {
+    const _: () = {
+        impl tmp::InnerTest {}
+    };
+
+    mod tmp {
+        pub(super) struct InnerTest;
+    }
+};
+
 fn main() {}

--- a/tests/ui/lint/non-local-defs/convoluted-locals-131474.rs
+++ b/tests/ui/lint/non-local-defs/convoluted-locals-131474.rs
@@ -21,4 +21,13 @@ const _: () = {
     };
 };
 
+// https://github.com/rust-lang/rust/issues/131643
+const _: () = {
+    const _: () = {
+        impl InnerTest {}
+    };
+
+    struct InnerTest;
+};
+
 fn main() {}


### PR DESCRIPTION
This PR update the logic for the impl paths (items) in the `non_local_definitions` lint to also consider const-anon in case the impl definition is wrapped inside const-anon it-self wrapped into a const-anon where the items are.

r? @jieyouxu *(since you interacted on the issue)*
Fixes *(after beta-backport)* #131643