### PR TITLE
Make fuchsia-test-runner.py compatible with new JSON output from llvm-readelf

### DIFF
--- a/src/ci/docker/scripts/fuchsia-test-runner.py
+++ b/src/ci/docker/scripts/fuchsia-test-runner.py
@@ -193,18 +193,38 @@ class TestEnvironment:
             stderr=subprocess.STDOUT,
         )
         if process.returncode:
-            self.env_logger.error(
-                f"llvm-readelf failed for binary {binary} with output {process.stdout}"
+            e = f"llvm-readelf failed for binary {binary} with output {process.stdout}"
+            self.env_logger.error(e)
+            raise Exception(e)
+
+        try:
+            elf_output = json.loads(process.stdout)
+        except Exception as e:
+            e.add_note(f"Failed to read JSON from llvm-readelf for binary {binary}")
+            e.add_note(f"stdout: {process.stdout}")
+            raise
+
+        try:
+            note_sections = elf_output[0]["NoteSections"]
+        except Exception as e:
+            e.add_note(
+                f'Failed to read "NoteSections" from llvm-readelf for binary {binary}'
             )
-            raise Exception(f"Unreadable build-id for binary {binary}")
-        data = json.loads(process.stdout)
-        if len(data) != 1:
-            raise Exception(f"Unreadable output from llvm-readelf for binary {binary}")
-        notes = data[0]["Notes"]
-        for note in notes:
-            note_section = note["NoteSection"]
-            if note_section["Name"] == ".note.gnu.build-id":
-                return note_section["Note"]["Build ID"]
+            e.add_note(f"elf_output: {elf_output}")
+            raise
+
+        for entry in note_sections:
+            try:
+                note_section = entry["NoteSection"]
+                if note_section["Name"] == ".note.gnu.build-id":
+                    return note_section["Notes"][0]["Build ID"]
+            except Exception as e:
+                e.add_note(
+                    f'Failed to read ".note.gnu.build-id" from NoteSections \
+                        entry in llvm-readelf for binary {binary}'
+                )
+                e.add_note(f"NoteSections: {note_sections}")
+                raise
         raise Exception(f"Build ID not found for binary {binary}")
 
     def generate_buildid_dir(


### PR DESCRIPTION
[A recent commit in LLVM](https://github.com/llvm/llvm-project/commit/ab930ee7cad8b8bf7968bb8d0c0d72524e2313c4) modified the JSON output of LLVM. The LLVM change renamed "Notes" to "NoteSections" and inserted a new "Notes" key nested under each "NoteSection".

This change shores up exceptions around reading the JSON output of llvm-readelf and reads from "NoteSections" instead of the non-existent "Notes".

r? @erickt 