### PR TITLE
Fix match_same_arms in stable_mir

### DIFF
--- a/compiler/stable_mir/src/mir/visit.rs
+++ b/compiler/stable_mir/src/mir/visit.rs
@@ -194,26 +194,16 @@ pub trait MirVisitor {
                 self.visit_place(place, PlaceContext::MUTATING, location);
                 self.visit_rvalue(rvalue, location);
             }
-            StatementKind::FakeRead(_, place) => {
+            StatementKind::FakeRead(_, place) | StatementKind::PlaceMention(place) => {
                 self.visit_place(place, PlaceContext::NON_MUTATING, location);
             }
-            StatementKind::SetDiscriminant { place, .. } => {
+            StatementKind::SetDiscriminant { place, .. }
+            | StatementKind::Deinit(place)
+            | StatementKind::Retag(_, place) => {
                 self.visit_place(place, PlaceContext::MUTATING, location);
             }
-            StatementKind::Deinit(place) => {
-                self.visit_place(place, PlaceContext::MUTATING, location);
-            }
-            StatementKind::StorageLive(local) => {
+            StatementKind::StorageLive(local) | StatementKind::StorageDead(local) => {
                 self.visit_local(local, PlaceContext::NON_USE, location);
-            }
-            StatementKind::StorageDead(local) => {
-                self.visit_local(local, PlaceContext::NON_USE, location);
-            }
-            StatementKind::Retag(_, place) => {
-                self.visit_place(place, PlaceContext::MUTATING, location);
-            }
-            StatementKind::PlaceMention(place) => {
-                self.visit_place(place, PlaceContext::NON_MUTATING, location);
             }
             StatementKind::AscribeUserType { place, projections, variance: _ } => {
                 self.visit_place(place, PlaceContext::NON_USE, location);
@@ -234,8 +224,7 @@ pub trait MirVisitor {
                     self.visit_operand(count, location);
                 }
             },
-            StatementKind::ConstEvalCounter => {}
-            StatementKind::Nop => {}
+            StatementKind::ConstEvalCounter | StatementKind::Nop => {}
         }
     }
 
@@ -304,14 +293,15 @@ pub trait MirVisitor {
         location: Location,
     ) {
         match elem {
-            ProjectionElem::Deref => {}
+            ProjectionElem::Downcast(_idx) => {}
+            ProjectionElem::ConstantIndex { offset: _, min_length: _, from_end: _ }
+            | ProjectionElem::Deref
+            | ProjectionElem::Subslice { from: _, to: _, from_end: _ } => {}
             ProjectionElem::Field(_idx, ty) => self.visit_ty(ty, location),
             ProjectionElem::Index(local) => self.visit_local(local, ptx, location),
-            ProjectionElem::ConstantIndex { offset: _, min_length: _, from_end: _ } => {}
-            ProjectionElem::Subslice { from: _, to: _, from_end: _ } => {}
-            ProjectionElem::Downcast(_idx) => {}
-            ProjectionElem::OpaqueCast(ty) => self.visit_ty(ty, location),
-            ProjectionElem::Subtype(ty) => self.visit_ty(ty, location),
+            ProjectionElem::OpaqueCast(ty) | ProjectionElem::Subtype(ty) => {
+                self.visit_ty(ty, location)
+            }
         }
     }
 

--- a/compiler/stable_mir/src/visitor.rs
+++ b/compiler/stable_mir/src/visitor.rs
@@ -35,8 +35,7 @@ impl Visitable for Ty {
         match self.kind() {
             super::ty::TyKind::RigidTy(ty) => ty.visit(visitor)?,
             super::ty::TyKind::Alias(_, alias) => alias.args.visit(visitor)?,
-            super::ty::TyKind::Param(_) => {}
-            super::ty::TyKind::Bound(_, _) => {}
+            super::ty::TyKind::Param(_) | super::ty::TyKind::Bound(_, _) => {}
         }
         ControlFlow::Continue(())
     }
@@ -48,8 +47,7 @@ impl Visitable for TyConst {
     }
     fn super_visit<V: Visitor>(&self, visitor: &mut V) -> ControlFlow<V::Break> {
         match &self.kind {
-            crate::ty::TyConstKind::Param(_) => {}
-            crate::ty::TyConstKind::Bound(_, _) => {}
+            crate::ty::TyConstKind::Param(_) | crate::ty::TyConstKind::Bound(_, _) => {}
             crate::ty::TyConstKind::Unevaluated(_, args) => args.visit(visitor)?,
             crate::ty::TyConstKind::Value(ty, alloc) => {
                 alloc.visit(visitor)?;
@@ -166,17 +164,17 @@ impl Visitable for RigidTy {
                 reg.visit(visitor);
                 ty.visit(visitor)
             }
-            RigidTy::FnDef(_, args) => args.visit(visitor),
+            RigidTy::Adt(_, args)
+            | RigidTy::Closure(_, args)
+            | RigidTy::Coroutine(_, args, _)
+            | RigidTy::CoroutineWitness(_, args)
+            | RigidTy::FnDef(_, args) => args.visit(visitor),
             RigidTy::FnPtr(sig) => sig.visit(visitor),
-            RigidTy::Closure(_, args) => args.visit(visitor),
-            RigidTy::Coroutine(_, args, _) => args.visit(visitor),
-            RigidTy::CoroutineWitness(_, args) => args.visit(visitor),
             RigidTy::Dynamic(pred, r, _) => {
                 pred.visit(visitor)?;
                 r.visit(visitor)
             }
             RigidTy::Tuple(fields) => fields.visit(visitor),
-            RigidTy::Adt(_, args) => args.visit(visitor),
         }
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->


Hi,

This PR fixes some clippy warnings

(Reopened https://github.com/rust-lang/rust/pull/131688)

```
warning: this match arm has an identical body to another arm
   --> compiler/stable_mir/src/mir/visit.rs:197:13
    |
197 | /             StatementKind::FakeRead(_, place) => {
198 | |                 self.visit_place(place, PlaceContext::NON_MUTATING, location);
199 | |             }
    | |_____________^
    |
    = help: try changing either arm body
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms
help: or try merging the arm patterns
    |
197 |             StatementKind::FakeRead(_, place) | StatementKind::PlaceMention(place) => {
    |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
help: and remove this obsolete arm
    |
209 -             StatementKind::PlaceMention(place) => {
210 -                 self.visit_place(place, PlaceContext::NON_MUTATING, location);
211 -             }
    |

```

Best regards,
Michal
