### PR TITLE
Don't report `on_unimplemented` message for negative traits

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/suggest.rs
+++ b/compiler/rustc_hir_typeck/src/method/suggest.rs
@@ -952,7 +952,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         continue;
                     }
                     unimplemented_traits.entry(p.trait_ref.def_id).or_insert((
-                        predicate.kind().rebind(p.trait_ref),
+                        predicate.kind().rebind(p),
                         Obligation {
                             cause: cause.clone(),
                             param_env: self.param_env,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -202,7 +202,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             notes,
                             parent_label,
                             append_const_msg,
-                        } = self.on_unimplemented_note(main_trait_ref, o, &mut long_ty_file);
+                        } = self.on_unimplemented_note(main_trait_predicate, o, &mut long_ty_file);
 
                         let have_alt_message = message.is_some() || label.is_some();
                         let is_try_conversion = self.is_try_conversion(span, main_trait_ref.def_id());

--- a/tests/ui/traits/negative-bounds/on-unimplemented.rs
+++ b/tests/ui/traits/negative-bounds/on-unimplemented.rs
@@ -1,0 +1,12 @@
+#![feature(negative_bounds)]
+
+#[diagnostic::on_unimplemented(message = "this ain't fooing")]
+trait Foo {}
+struct NotFoo;
+
+fn hello() -> impl !Foo {
+    //~^ ERROR the trait bound `NotFoo: !Foo` is not satisfied
+    NotFoo
+}
+
+fn main() {}

--- a/tests/ui/traits/negative-bounds/on-unimplemented.stderr
+++ b/tests/ui/traits/negative-bounds/on-unimplemented.stderr
@@ -1,0 +1,18 @@
+error[E0277]: the trait bound `NotFoo: !Foo` is not satisfied
+  --> $DIR/on-unimplemented.rs:7:15
+   |
+LL | fn hello() -> impl !Foo {
+   |               ^^^^^^^^^ the trait bound `NotFoo: !Foo` is not satisfied
+LL |
+LL |     NotFoo
+   |     ------ return type was inferred to be `NotFoo` here
+   |
+help: this trait has no implementations, consider adding one
+  --> $DIR/on-unimplemented.rs:4:1
+   |
+LL | trait Foo {}
+   | ^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Kinda useless change but it was affecting my ability to read error messages when experimenting with negative bounds.