### PR TITLE
Suppress import errors for traits that couldve applied for method lookup error

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/mod.rs
+++ b/compiler/rustc_hir_typeck/src/method/mod.rs
@@ -199,6 +199,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             self_ty, segment, span, call_expr, self_expr, &pick, args,
         );
 
+        // NOTE: on the failure path, we also record the possibly-used trait methods
+        // since an unused import warning is kinda distracting from the method error.
         for &import_id in &pick.import_ids {
             debug!("used_trait_import: {:?}", import_id);
             self.typeck_results.borrow_mut().used_trait_imports.insert(import_id);

--- a/tests/ui/use/unused-trait-with-method-err.rs
+++ b/tests/ui/use/unused-trait-with-method-err.rs
@@ -1,0 +1,17 @@
+// Test that we don't issue an unused import warning when there's
+// a method lookup error and that trait was possibly applicable.
+
+use foo::Bar;
+
+mod foo {
+    pub trait Bar {
+        fn uwu(&self) {}
+    }
+}
+
+struct Foo;
+
+fn main() {
+    Foo.uwu();
+    //~^ ERROR no method named `uwu` found for struct `Foo` in the current scope
+}

--- a/tests/ui/use/unused-trait-with-method-err.stderr
+++ b/tests/ui/use/unused-trait-with-method-err.stderr
@@ -1,0 +1,19 @@
+error[E0599]: no method named `uwu` found for struct `Foo` in the current scope
+  --> $DIR/unused-trait-with-method-err.rs:15:9
+   |
+LL | struct Foo;
+   | ---------- method `uwu` not found for this struct
+...
+LL |     Foo.uwu();
+   |         ^^^ method not found in `Foo`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `Bar` defines an item `uwu`, perhaps you need to implement it
+  --> $DIR/unused-trait-with-method-err.rs:7:5
+   |
+LL |     pub trait Bar {
+   |     ^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
Self-explanatory. I hit this quite often when refactoring in rustc, so even though this isn't really showing up as significant in the UI test suite, it probably will matter more for multi-module projects.