### PR TITLE
Resolved python deprecation warning in publish_toolstate.py

### DIFF
--- a/src/tools/publish_toolstate.py
+++ b/src/tools/publish_toolstate.py
@@ -235,7 +235,9 @@ try:
         exit(0)
 
     cur_commit = sys.argv[1]
-    cur_datetime = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+    cur_datetime = datetime.datetime.now(datetime.timezone.utc).strftime(
+        '%Y-%m-%dT%H:%M:%SZ'
+    )
     cur_commit_msg = sys.argv[2]
     save_message_to_path = sys.argv[3]
     github_token = sys.argv[4]


### PR DESCRIPTION
`utcnow()` is deprecated in favor of passing a timezone to `now()`. `utcnow()` would return a tz-naive datetime, while this returns a tz-aware datetime. For the purposes of the formatting we do, these are the same.

