### PR TITLE
Fix most ui tests on emscripten target

### DIFF
--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -612,6 +612,9 @@ impl Target {
         if triple.contains("-none") || triple.contains("nvptx") || triple.contains("switch") {
             target.no_std = true;
         }
+        if triple.contains("emscripten") {
+            target.runner = Some("node".into());
+        }
         target
     }
 }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1643,7 +1643,9 @@ impl<'test> TestCx<'test> {
         // double the length.
         let mut f = self.output_base_dir().join("a");
         // FIXME: This is using the host architecture exe suffix, not target!
-        if self.config.target.starts_with("wasm") {
+        if self.config.target.contains("emscripten") {
+            f = f.with_extra_extension("js");
+        } else if self.config.target.starts_with("wasm") {
             f = f.with_extra_extension("wasm");
         } else if self.config.target.contains("spirv") {
             f = f.with_extra_extension("spv");

--- a/src/tools/tidy/src/issues.txt
+++ b/src/tools/tidy/src/issues.txt
@@ -1520,7 +1520,6 @@ ui/issues/issue-12567.rs
 ui/issues/issue-12612.rs
 ui/issues/issue-12660.rs
 ui/issues/issue-12677.rs
-ui/issues/issue-12699.rs
 ui/issues/issue-12729.rs
 ui/issues/issue-12744.rs
 ui/issues/issue-12860.rs

--- a/src/tools/tidy/src/ui_tests.rs
+++ b/src/tools/tidy/src/ui_tests.rs
@@ -17,7 +17,7 @@ use ignore::Walk;
 const ENTRY_LIMIT: u32 = 901;
 // FIXME: The following limits should be reduced eventually.
 
-const ISSUES_ENTRY_LIMIT: u32 = 1673;
+const ISSUES_ENTRY_LIMIT: u32 = 1672;
 
 const EXPECTED_TEST_FILE_EXTENSIONS: &[&str] = &[
     "rs",     // test source files

--- a/tests/ui/intrinsics/intrinsic-alignment.rs
+++ b/tests/ui/intrinsics/intrinsic-alignment.rs
@@ -13,7 +13,6 @@ mod rusti {
 #[cfg(any(
     target_os = "android",
     target_os = "dragonfly",
-    target_os = "emscripten",
     target_os = "freebsd",
     target_os = "fuchsia",
     target_os = "hurd",

--- a/tests/ui/process/process-sigpipe.rs
+++ b/tests/ui/process/process-sigpipe.rs
@@ -15,11 +15,12 @@
 
 //@ ignore-vxworks no 'sh'
 //@ ignore-fuchsia no 'sh'
+//@ ignore-emscripten No threads
+//@ only-unix SIGPIPE is a unix feature
 
 use std::process;
 use std::thread;
 
-#[cfg(unix)]
 fn main() {
     // Just in case `yes` doesn't check for EPIPE...
     thread::spawn(|| {
@@ -33,9 +34,4 @@ fn main() {
         .unwrap();
     assert!(output.status.success());
     assert!(output.stderr.len() == 0);
-}
-
-#[cfg(not(unix))]
-fn main() {
-    // Not worried about signal masks on other platforms
 }

--- a/tests/ui/std/thread-sleep-ms.rs
+++ b/tests/ui/std/thread-sleep-ms.rs
@@ -1,6 +1,9 @@
 //@ run-pass
 //@ ignore-sgx not supported
+//@ ignore-emscripten
+// FIXME: test hangs on emscripten
 #![allow(deprecated)]
+#![allow(unused_imports)]
 
 use std::thread;
 

--- a/tests/ui/structs-enums/rec-align-u64.rs
+++ b/tests/ui/structs-enums/rec-align-u64.rs
@@ -33,7 +33,6 @@ struct Outer {
 #[cfg(any(
     target_os = "android",
     target_os = "dragonfly",
-    target_os = "emscripten",
     target_os = "freebsd",
     target_os = "fuchsia",
     target_os = "hurd",


### PR DESCRIPTION
To fix the linker errors, we need to set the output extension to `.js` instead of `.wasm`. Setting the output to a `.wasm` file puts Emscripten into standalone mode which is effectively a distinct target. We need to set the runner to be `node` as well.

This fixes most of the ui tests. I fixed 4 additional tests with simple problems:

- `intrinsics/intrinsic-alignment.rs` -- Two `#[cfg]` macros match for Emscripten so we got duplicate definition
- `structs-enums/rec-align-u64.rs` -- same problem
- `issues/issue-12699.rs` -- hangs so I disabled it
- `process/process-sigpipe.rs` -- Not expected to work on Emscripten so I disabled it

Resolves #131666.

There are 7 more failing tests. I'll try to investigate more and see if I can fix them or at least understand why they happen.

- abi/numbers-arithmetic/return-float.rs (problem with [wasm treatment of noncanonical floats](https://webassembly.github.io/spec/core/exec/numerics.html#nan-propagation)?)
- async-await/issue-60709.rs -- linker error related to memcpy. Possible Emscripten bug?
- backtrace/dylib-dep.rs -- Says "Not supported"
- backtrace/line-tables-only.rs -- Says "Not supported"
- no_std/no-std-unwind-binary.rs -- compiler says `error: lang item required, but not found: eh_catch_typeinfo`
- structs-enums/enum-rec/issue-17431-6.rs -- One of the two compiler errors is missing
- test-attrs/test-passed.rs

    r?workingjubilee r?jieyouxu

