### PR TITLE
Run most `core::num` tests in const context too

### DIFF
--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -16,11 +16,14 @@
 #![feature(clone_to_uninit)]
 #![feature(const_align_of_val_raw)]
 #![feature(const_align_offset)]
+#![feature(const_bigint_helper_methods)]
 #![feature(const_black_box)]
+#![feature(const_eval_select)]
 #![feature(const_hash)]
 #![feature(const_heap)]
 #![feature(const_likely)]
 #![feature(const_nonnull_new)]
+#![feature(const_num_midpoint)]
 #![feature(const_option_ext)]
 #![feature(const_pin)]
 #![feature(const_pointer_is_aligned)]
@@ -45,6 +48,7 @@
 #![feature(get_many_mut)]
 #![feature(hasher_prefixfree_extras)]
 #![feature(hashmap_internals)]
+#![feature(inline_const_pat)]
 #![feature(int_roundings)]
 #![feature(ip)]
 #![feature(ip_from)]
@@ -103,6 +107,37 @@
 #![allow(internal_features)]
 #![deny(fuzzy_provenance_casts)]
 #![deny(unsafe_op_in_unsafe_fn)]
+
+/// Version of `assert_matches` that ignores fancy runtime printing in const context and uses structural equality.
+macro_rules! assert_eq_const_safe {
+    ($left:expr, $right:expr$(, $($arg:tt)+)?) => {
+        {
+            fn runtime() {
+                assert_eq!($left, $right, $($arg)*);
+            }
+            const fn compiletime() {
+                assert!(matches!($left, const { $right }));
+            }
+            core::intrinsics::const_eval_select((), compiletime, runtime)
+        }
+    };
+}
+
+/// Creates a test for runtime and a test for constant-time.
+macro_rules! test_runtime_and_compiletime {
+    ($(
+        $(#[$attr:meta])*
+        fn $test:ident() $block:block
+    )*) => {
+        $(
+            $(#[$attr])*
+            #[test]
+            fn $test() $block
+            $(#[$attr])*
+            const _: () = $block;
+        )*
+    }
+}
 
 mod alloc;
 mod any;

--- a/library/core/tests/num/int_macros.rs
+++ b/library/core/tests/num/int_macros.rs
@@ -18,42 +18,6 @@ macro_rules! int_module {
         }
 
         #[test]
-        fn test_rem_euclid() {
-            assert_eq!((-1 as $T).rem_euclid(MIN), MAX);
-        }
-
-        #[test]
-        pub fn test_abs() {
-            assert_eq!((1 as $T).abs(), 1 as $T);
-            assert_eq!((0 as $T).abs(), 0 as $T);
-            assert_eq!((-1 as $T).abs(), 1 as $T);
-        }
-
-        #[test]
-        fn test_signum() {
-            assert_eq!((1 as $T).signum(), 1 as $T);
-            assert_eq!((0 as $T).signum(), 0 as $T);
-            assert_eq!((-0 as $T).signum(), 0 as $T);
-            assert_eq!((-1 as $T).signum(), -1 as $T);
-        }
-
-        #[test]
-        fn test_is_positive() {
-            assert!((1 as $T).is_positive());
-            assert!(!(0 as $T).is_positive());
-            assert!(!(-0 as $T).is_positive());
-            assert!(!(-1 as $T).is_positive());
-        }
-
-        #[test]
-        fn test_is_negative() {
-            assert!(!(1 as $T).is_negative());
-            assert!(!(0 as $T).is_negative());
-            assert!(!(-0 as $T).is_negative());
-            assert!((-1 as $T).is_negative());
-        }
-
-        #[test]
         fn test_bitwise_operators() {
             assert_eq!(0b1110 as $T, (0b1100 as $T).bitor(0b1010 as $T));
             assert_eq!(0b1000 as $T, (0b1100 as $T).bitand(0b1010 as $T));
@@ -63,6 +27,40 @@ macro_rules! int_module {
             assert_eq!(-(0b11 as $T) - (1 as $T), (0b11 as $T).not());
         }
 
+        test_runtime_and_compiletime! {
+
+            fn test_rem_euclid() {
+                assert_eq_const_safe!((-1 as $T).rem_euclid(MIN), MAX);
+            }
+
+            fn test_abs() {
+                assert_eq_const_safe!((1 as $T).abs(), 1 as $T);
+                assert_eq_const_safe!((0 as $T).abs(), 0 as $T);
+                assert_eq_const_safe!((-1 as $T).abs(), 1 as $T);
+            }
+
+            fn test_signum() {
+                assert_eq_const_safe!((1 as $T).signum(), 1 as $T);
+                assert_eq_const_safe!((0 as $T).signum(), 0 as $T);
+                assert_eq_const_safe!((-0 as $T).signum(), 0 as $T);
+                assert_eq_const_safe!((-1 as $T).signum(), -1 as $T);
+            }
+
+            fn test_is_positive() {
+                assert!((1 as $T).is_positive());
+                assert!(!(0 as $T).is_positive());
+                assert!(!(-0 as $T).is_positive());
+                assert!(!(-1 as $T).is_positive());
+            }
+
+            fn test_is_negative() {
+                assert!(!(1 as $T).is_negative());
+                assert!(!(0 as $T).is_negative());
+                assert!(!(-0 as $T).is_negative());
+                assert!((-1 as $T).is_negative());
+            }
+        }
+
         const A: $T = 0b0101100;
         const B: $T = 0b0100001;
         const C: $T = 0b1111001;
@@ -70,134 +68,126 @@ macro_rules! int_module {
         const _0: $T = 0;
         const _1: $T = !0;
 
-        #[test]
-        fn test_count_ones() {
-            assert_eq!(A.count_ones(), 3);
-            assert_eq!(B.count_ones(), 2);
-            assert_eq!(C.count_ones(), 5);
-        }
+        test_runtime_and_compiletime! {
+            fn test_count_ones() {
+                assert_eq_const_safe!(A.count_ones(), 3);
+                assert_eq_const_safe!(B.count_ones(), 2);
+                assert_eq_const_safe!(C.count_ones(), 5);
+            }
 
-        #[test]
-        fn test_count_zeros() {
-            assert_eq!(A.count_zeros(), $T::BITS - 3);
-            assert_eq!(B.count_zeros(), $T::BITS - 2);
-            assert_eq!(C.count_zeros(), $T::BITS - 5);
-        }
+            fn test_count_zeros() {
+                assert_eq_const_safe!(A.count_zeros(), $T::BITS - 3);
+                assert_eq_const_safe!(B.count_zeros(), $T::BITS - 2);
+                assert_eq_const_safe!(C.count_zeros(), $T::BITS - 5);
+            }
 
-        #[test]
-        fn test_leading_trailing_ones() {
-            let a: $T = 0b0101_1111;
-            assert_eq!(a.trailing_ones(), 5);
-            assert_eq!((!a).leading_ones(), $T::BITS - 7);
+            fn test_leading_trailing_ones() {
+                const A: $T = 0b0101_1111;
+                assert_eq_const_safe!(A.trailing_ones(), 5);
+                assert_eq_const_safe!((!A).leading_ones(), $T::BITS - 7);
 
-            assert_eq!(a.reverse_bits().leading_ones(), 5);
+                assert_eq_const_safe!(A.reverse_bits().leading_ones(), 5);
 
-            assert_eq!(_1.leading_ones(), $T::BITS);
-            assert_eq!(_1.trailing_ones(), $T::BITS);
+                assert_eq_const_safe!(_1.leading_ones(), $T::BITS);
+                assert_eq_const_safe!(_1.trailing_ones(), $T::BITS);
 
-            assert_eq!((_1 << 1).trailing_ones(), 0);
-            assert_eq!(MAX.leading_ones(), 0);
+                assert_eq_const_safe!((_1 << 1).trailing_ones(), 0);
+                assert_eq_const_safe!(MAX.leading_ones(), 0);
 
-            assert_eq!((_1 << 1).leading_ones(), $T::BITS - 1);
-            assert_eq!(MAX.trailing_ones(), $T::BITS - 1);
+                assert_eq_const_safe!((_1 << 1).leading_ones(), $T::BITS - 1);
+                assert_eq_const_safe!(MAX.trailing_ones(), $T::BITS - 1);
 
-            assert_eq!(_0.leading_ones(), 0);
-            assert_eq!(_0.trailing_ones(), 0);
+                assert_eq_const_safe!(_0.leading_ones(), 0);
+                assert_eq_const_safe!(_0.trailing_ones(), 0);
 
-            let x: $T = 0b0010_1100;
-            assert_eq!(x.leading_ones(), 0);
-            assert_eq!(x.trailing_ones(), 0);
-        }
+                const X: $T = 0b0010_1100;
+                assert_eq_const_safe!(X.leading_ones(), 0);
+                assert_eq_const_safe!(X.trailing_ones(), 0);
+            }
 
-        #[test]
-        fn test_rotate() {
-            assert_eq!(A.rotate_left(6).rotate_right(2).rotate_right(4), A);
-            assert_eq!(B.rotate_left(3).rotate_left(2).rotate_right(5), B);
-            assert_eq!(C.rotate_left(6).rotate_right(2).rotate_right(4), C);
+            fn test_rotate() {
+                assert_eq_const_safe!(A.rotate_left(6).rotate_right(2).rotate_right(4), A);
+                assert_eq_const_safe!(B.rotate_left(3).rotate_left(2).rotate_right(5), B);
+                assert_eq_const_safe!(C.rotate_left(6).rotate_right(2).rotate_right(4), C);
 
-            // Rotating these should make no difference
-            //
-            // We test using 124 bits because to ensure that overlong bit shifts do
-            // not cause undefined behaviour. See #10183.
-            assert_eq!(_0.rotate_left(124), _0);
-            assert_eq!(_1.rotate_left(124), _1);
-            assert_eq!(_0.rotate_right(124), _0);
-            assert_eq!(_1.rotate_right(124), _1);
+                // Rotating these should make no difference
+                //
+                // We test using 124 bits because to ensure that overlong bit shifts do
+                // not cause undefined behaviour. See #10183.
+                assert_eq_const_safe!(_0.rotate_left(124), _0);
+                assert_eq_const_safe!(_1.rotate_left(124), _1);
+                assert_eq_const_safe!(_0.rotate_right(124), _0);
+                assert_eq_const_safe!(_1.rotate_right(124), _1);
 
-            // Rotating by 0 should have no effect
-            assert_eq!(A.rotate_left(0), A);
-            assert_eq!(B.rotate_left(0), B);
-            assert_eq!(C.rotate_left(0), C);
-            // Rotating by a multiple of word size should also have no effect
-            assert_eq!(A.rotate_left(128), A);
-            assert_eq!(B.rotate_left(128), B);
-            assert_eq!(C.rotate_left(128), C);
-        }
+                // Rotating by 0 should have no effect
+                assert_eq_const_safe!(A.rotate_left(0), A);
+                assert_eq_const_safe!(B.rotate_left(0), B);
+                assert_eq_const_safe!(C.rotate_left(0), C);
+                // Rotating by a multiple of word size should also have no effect
+                assert_eq_const_safe!(A.rotate_left(128), A);
+                assert_eq_const_safe!(B.rotate_left(128), B);
+                assert_eq_const_safe!(C.rotate_left(128), C);
+            }
 
-        #[test]
-        fn test_swap_bytes() {
-            assert_eq!(A.swap_bytes().swap_bytes(), A);
-            assert_eq!(B.swap_bytes().swap_bytes(), B);
-            assert_eq!(C.swap_bytes().swap_bytes(), C);
+            fn test_swap_bytes() {
+                assert_eq_const_safe!(A.swap_bytes().swap_bytes(), A);
+                assert_eq_const_safe!(B.swap_bytes().swap_bytes(), B);
+                assert_eq_const_safe!(C.swap_bytes().swap_bytes(), C);
 
-            // Swapping these should make no difference
-            assert_eq!(_0.swap_bytes(), _0);
-            assert_eq!(_1.swap_bytes(), _1);
-        }
+                // Swapping these should make no difference
+                assert_eq_const_safe!(_0.swap_bytes(), _0);
+                assert_eq_const_safe!(_1.swap_bytes(), _1);
+            }
 
-        #[test]
-        fn test_le() {
-            assert_eq!($T::from_le(A.to_le()), A);
-            assert_eq!($T::from_le(B.to_le()), B);
-            assert_eq!($T::from_le(C.to_le()), C);
-            assert_eq!($T::from_le(_0), _0);
-            assert_eq!($T::from_le(_1), _1);
-            assert_eq!(_0.to_le(), _0);
-            assert_eq!(_1.to_le(), _1);
-        }
+            fn test_le() {
+                assert_eq_const_safe!($T::from_le(A.to_le()), A);
+                assert_eq_const_safe!($T::from_le(B.to_le()), B);
+                assert_eq_const_safe!($T::from_le(C.to_le()), C);
+                assert_eq_const_safe!($T::from_le(_0), _0);
+                assert_eq_const_safe!($T::from_le(_1), _1);
+                assert_eq_const_safe!(_0.to_le(), _0);
+                assert_eq_const_safe!(_1.to_le(), _1);
+            }
 
-        #[test]
-        fn test_be() {
-            assert_eq!($T::from_be(A.to_be()), A);
-            assert_eq!($T::from_be(B.to_be()), B);
-            assert_eq!($T::from_be(C.to_be()), C);
-            assert_eq!($T::from_be(_0), _0);
-            assert_eq!($T::from_be(_1), _1);
-            assert_eq!(_0.to_be(), _0);
-            assert_eq!(_1.to_be(), _1);
-        }
+            fn test_be() {
+                assert_eq_const_safe!($T::from_be(A.to_be()), A);
+                assert_eq_const_safe!($T::from_be(B.to_be()), B);
+                assert_eq_const_safe!($T::from_be(C.to_be()), C);
+                assert_eq_const_safe!($T::from_be(_0), _0);
+                assert_eq_const_safe!($T::from_be(_1), _1);
+                assert_eq_const_safe!(_0.to_be(), _0);
+                assert_eq_const_safe!(_1.to_be(), _1);
+            }
 
-        #[test]
-        fn test_signed_checked_div() {
-            assert_eq!((10 as $T).checked_div(2), Some(5));
-            assert_eq!((5 as $T).checked_div(0), None);
-            assert_eq!(isize::MIN.checked_div(-1), None);
-        }
+            fn test_signed_checked_div() {
+                assert_eq_const_safe!((10 as $T).checked_div(2), Some(5));
+                assert_eq_const_safe!((5 as $T).checked_div(0), None);
+                assert_eq_const_safe!(isize::MIN.checked_div(-1), None);
+            }
 
-        #[test]
-        fn test_saturating_abs() {
-            assert_eq!((0 as $T).saturating_abs(), 0);
-            assert_eq!((123 as $T).saturating_abs(), 123);
-            assert_eq!((-123 as $T).saturating_abs(), 123);
-            assert_eq!((MAX - 2).saturating_abs(), MAX - 2);
-            assert_eq!((MAX - 1).saturating_abs(), MAX - 1);
-            assert_eq!(MAX.saturating_abs(), MAX);
-            assert_eq!((MIN + 2).saturating_abs(), MAX - 1);
-            assert_eq!((MIN + 1).saturating_abs(), MAX);
-            assert_eq!(MIN.saturating_abs(), MAX);
-        }
+            fn test_saturating_abs() {
+                assert_eq_const_safe!((0 as $T).saturating_abs(), 0);
+                assert_eq_const_safe!((123 as $T).saturating_abs(), 123);
+                assert_eq_const_safe!((-123 as $T).saturating_abs(), 123);
+                assert_eq_const_safe!((MAX - 2).saturating_abs(), MAX - 2);
+                assert_eq_const_safe!((MAX - 1).saturating_abs(), MAX - 1);
+                assert_eq_const_safe!(MAX.saturating_abs(), MAX);
+                assert_eq_const_safe!((MIN + 2).saturating_abs(), MAX - 1);
+                assert_eq_const_safe!((MIN + 1).saturating_abs(), MAX);
+                assert_eq_const_safe!(MIN.saturating_abs(), MAX);
+            }
 
-        #[test]
-        fn test_saturating_neg() {
-            assert_eq!((0 as $T).saturating_neg(), 0);
-            assert_eq!((123 as $T).saturating_neg(), -123);
-            assert_eq!((-123 as $T).saturating_neg(), 123);
-            assert_eq!((MAX - 2).saturating_neg(), MIN + 3);
-            assert_eq!((MAX - 1).saturating_neg(), MIN + 2);
-            assert_eq!(MAX.saturating_neg(), MIN + 1);
-            assert_eq!((MIN + 2).saturating_neg(), MAX - 1);
-            assert_eq!((MIN + 1).saturating_neg(), MAX);
-            assert_eq!(MIN.saturating_neg(), MAX);
+            fn test_saturating_neg() {
+                assert_eq_const_safe!((0 as $T).saturating_neg(), 0);
+                assert_eq_const_safe!((123 as $T).saturating_neg(), -123);
+                assert_eq_const_safe!((-123 as $T).saturating_neg(), 123);
+                assert_eq_const_safe!((MAX - 2).saturating_neg(), MIN + 3);
+                assert_eq_const_safe!((MAX - 1).saturating_neg(), MIN + 2);
+                assert_eq_const_safe!(MAX.saturating_neg(), MIN + 1);
+                assert_eq_const_safe!((MIN + 2).saturating_neg(), MAX - 1);
+                assert_eq_const_safe!((MIN + 1).saturating_neg(), MAX);
+                assert_eq_const_safe!(MIN.saturating_neg(), MAX);
+            }
         }
 
         #[test]
@@ -222,173 +212,173 @@ macro_rules! int_module {
             assert_eq!(from_str::<$T>("x"), None);
         }
 
-        #[test]
-        fn test_from_str_radix() {
-            assert_eq!($T::from_str_radix("123", 10), Ok(123 as $T));
-            assert_eq!($T::from_str_radix("1001", 2), Ok(9 as $T));
-            assert_eq!($T::from_str_radix("123", 8), Ok(83 as $T));
-            assert_eq!(i32::from_str_radix("123", 16), Ok(291 as i32));
-            assert_eq!(i32::from_str_radix("ffff", 16), Ok(65535 as i32));
-            assert_eq!(i32::from_str_radix("FFFF", 16), Ok(65535 as i32));
-            assert_eq!($T::from_str_radix("z", 36), Ok(35 as $T));
-            assert_eq!($T::from_str_radix("Z", 36), Ok(35 as $T));
+        test_runtime_and_compiletime! {
+            fn test_from_str_radix() {
+                assert_eq_const_safe!($T::from_str_radix("123", 10), Ok(123 as $T));
+                assert_eq_const_safe!($T::from_str_radix("1001", 2), Ok(9 as $T));
+                assert_eq_const_safe!($T::from_str_radix("123", 8), Ok(83 as $T));
+                assert_eq_const_safe!(i32::from_str_radix("123", 16), Ok(291 as i32));
+                assert_eq_const_safe!(i32::from_str_radix("ffff", 16), Ok(65535 as i32));
+                assert_eq_const_safe!(i32::from_str_radix("FFFF", 16), Ok(65535 as i32));
+                assert_eq_const_safe!($T::from_str_radix("z", 36), Ok(35 as $T));
+                assert_eq_const_safe!($T::from_str_radix("Z", 36), Ok(35 as $T));
 
-            assert_eq!($T::from_str_radix("-123", 10), Ok(-123 as $T));
-            assert_eq!($T::from_str_radix("-1001", 2), Ok(-9 as $T));
-            assert_eq!($T::from_str_radix("-123", 8), Ok(-83 as $T));
-            assert_eq!(i32::from_str_radix("-123", 16), Ok(-291 as i32));
-            assert_eq!(i32::from_str_radix("-ffff", 16), Ok(-65535 as i32));
-            assert_eq!(i32::from_str_radix("-FFFF", 16), Ok(-65535 as i32));
-            assert_eq!($T::from_str_radix("-z", 36), Ok(-35 as $T));
-            assert_eq!($T::from_str_radix("-Z", 36), Ok(-35 as $T));
+                assert_eq_const_safe!($T::from_str_radix("-123", 10), Ok(-123 as $T));
+                assert_eq_const_safe!($T::from_str_radix("-1001", 2), Ok(-9 as $T));
+                assert_eq_const_safe!($T::from_str_radix("-123", 8), Ok(-83 as $T));
+                assert_eq_const_safe!(i32::from_str_radix("-123", 16), Ok(-291 as i32));
+                assert_eq_const_safe!(i32::from_str_radix("-ffff", 16), Ok(-65535 as i32));
+                assert_eq_const_safe!(i32::from_str_radix("-FFFF", 16), Ok(-65535 as i32));
+                assert_eq_const_safe!($T::from_str_radix("-z", 36), Ok(-35 as $T));
+                assert_eq_const_safe!($T::from_str_radix("-Z", 36), Ok(-35 as $T));
 
-            assert_eq!($T::from_str_radix("Z", 35).ok(), None::<$T>);
-            assert_eq!($T::from_str_radix("-9", 2).ok(), None::<$T>);
-            assert_eq!($T::from_str_radix("10_0", 10).ok(), None::<$T>);
-            assert_eq!(u32::from_str_radix("-9", 10).ok(), None::<u32>);
-        }
+                assert!($T::from_str_radix("Z", 35).is_err());
+                assert!($T::from_str_radix("-9", 2).is_err());
+                assert!($T::from_str_radix("10_0", 10).is_err());
+                assert!(u32::from_str_radix("-9", 10).is_err());
+            }
 
-        #[test]
-        fn test_pow() {
-            let mut r = 2 as $T;
-            assert_eq!(r.pow(2), 4 as $T);
-            assert_eq!(r.pow(0), 1 as $T);
-            assert_eq!(r.wrapping_pow(2), 4 as $T);
-            assert_eq!(r.wrapping_pow(0), 1 as $T);
-            assert_eq!(r.checked_pow(2), Some(4 as $T));
-            assert_eq!(r.checked_pow(0), Some(1 as $T));
-            assert_eq!(r.overflowing_pow(2), (4 as $T, false));
-            assert_eq!(r.overflowing_pow(0), (1 as $T, false));
-            assert_eq!(r.saturating_pow(2), 4 as $T);
-            assert_eq!(r.saturating_pow(0), 1 as $T);
+            fn test_pow() {
+                {
+                    const R: $T = 2;
+                    assert_eq_const_safe!(R.pow(2), 4 as $T);
+                    assert_eq_const_safe!(R.pow(0), 1 as $T);
+                    assert_eq_const_safe!(R.wrapping_pow(2), 4 as $T);
+                    assert_eq_const_safe!(R.wrapping_pow(0), 1 as $T);
+                    assert_eq_const_safe!(R.checked_pow(2), Some(4 as $T));
+                    assert_eq_const_safe!(R.checked_pow(0), Some(1 as $T));
+                    assert_eq_const_safe!(R.overflowing_pow(2), (4 as $T, false));
+                    assert_eq_const_safe!(R.overflowing_pow(0), (1 as $T, false));
+                    assert_eq_const_safe!(R.saturating_pow(2), 4 as $T);
+                    assert_eq_const_safe!(R.saturating_pow(0), 1 as $T);
+                }
 
-            r = MAX;
-            // use `^` to represent .pow() with no overflow.
-            // if itest::MAX == 2^j-1, then itest is a `j` bit int,
-            // so that `itest::MAX*itest::MAX == 2^(2*j)-2^(j+1)+1`,
-            // thussaturating_pow the overflowing result is exactly 1.
-            assert_eq!(r.wrapping_pow(2), 1 as $T);
-            assert_eq!(r.checked_pow(2), None);
-            assert_eq!(r.overflowing_pow(2), (1 as $T, true));
-            assert_eq!(r.saturating_pow(2), MAX);
-            //test for negative exponent.
-            r = -2 as $T;
-            assert_eq!(r.pow(2), 4 as $T);
-            assert_eq!(r.pow(3), -8 as $T);
-            assert_eq!(r.pow(0), 1 as $T);
-            assert_eq!(r.wrapping_pow(2), 4 as $T);
-            assert_eq!(r.wrapping_pow(3), -8 as $T);
-            assert_eq!(r.wrapping_pow(0), 1 as $T);
-            assert_eq!(r.checked_pow(2), Some(4 as $T));
-            assert_eq!(r.checked_pow(3), Some(-8 as $T));
-            assert_eq!(r.checked_pow(0), Some(1 as $T));
-            assert_eq!(r.overflowing_pow(2), (4 as $T, false));
-            assert_eq!(r.overflowing_pow(3), (-8 as $T, false));
-            assert_eq!(r.overflowing_pow(0), (1 as $T, false));
-            assert_eq!(r.saturating_pow(2), 4 as $T);
-            assert_eq!(r.saturating_pow(3), -8 as $T);
-            assert_eq!(r.saturating_pow(0), 1 as $T);
-        }
+                {
+                    const R: $T = MAX;
+                    // use `^` to represent .pow() with no overflow.
+                    // if itest::MAX == 2^j-1, then itest is a `j` bit int,
+                    // so that `itest::MAX*itest::MAX == 2^(2*j)-2^(j+1)+1`,
+                    // thussaturating_pow the overflowing result is exactly 1.
+                    assert_eq_const_safe!(R.wrapping_pow(2), 1 as $T);
+                    assert_eq_const_safe!(R.checked_pow(2), None);
+                    assert_eq_const_safe!(R.overflowing_pow(2), (1 as $T, true));
+                    assert_eq_const_safe!(R.saturating_pow(2), MAX);
+                }
 
-        #[test]
-        fn test_div_floor() {
-            let a: $T = 8;
-            let b = 3;
-            assert_eq!(a.div_floor(b), 2);
-            assert_eq!(a.div_floor(-b), -3);
-            assert_eq!((-a).div_floor(b), -3);
-            assert_eq!((-a).div_floor(-b), 2);
-        }
+                {
+                    // test for negative exponent.
+                    const R: $T = -2;
+                    assert_eq_const_safe!(R.pow(2), 4 as $T);
+                    assert_eq_const_safe!(R.pow(3), -8 as $T);
+                    assert_eq_const_safe!(R.pow(0), 1 as $T);
+                    assert_eq_const_safe!(R.wrapping_pow(2), 4 as $T);
+                    assert_eq_const_safe!(R.wrapping_pow(3), -8 as $T);
+                    assert_eq_const_safe!(R.wrapping_pow(0), 1 as $T);
+                    assert_eq_const_safe!(R.checked_pow(2), Some(4 as $T));
+                    assert_eq_const_safe!(R.checked_pow(3), Some(-8 as $T));
+                    assert_eq_const_safe!(R.checked_pow(0), Some(1 as $T));
+                    assert_eq_const_safe!(R.overflowing_pow(2), (4 as $T, false));
+                    assert_eq_const_safe!(R.overflowing_pow(3), (-8 as $T, false));
+                    assert_eq_const_safe!(R.overflowing_pow(0), (1 as $T, false));
+                    assert_eq_const_safe!(R.saturating_pow(2), 4 as $T);
+                    assert_eq_const_safe!(R.saturating_pow(3), -8 as $T);
+                    assert_eq_const_safe!(R.saturating_pow(0), 1 as $T);
+                }
+            }
 
-        #[test]
-        fn test_div_ceil() {
-            let a: $T = 8;
-            let b = 3;
-            assert_eq!(a.div_ceil(b), 3);
-            assert_eq!(a.div_ceil(-b), -2);
-            assert_eq!((-a).div_ceil(b), -2);
-            assert_eq!((-a).div_ceil(-b), 3);
-        }
+            fn test_div_floor() {
+                const A: $T = 8;
+                const B: $T = 3;
+                assert_eq_const_safe!(A.div_floor(B), 2);
+                assert_eq_const_safe!(A.div_floor(-B), -3);
+                assert_eq_const_safe!((-A).div_floor(B), -3);
+                assert_eq_const_safe!((-A).div_floor(-B), 2);
+            }
 
-        #[test]
-        fn test_next_multiple_of() {
-            assert_eq!((16 as $T).next_multiple_of(8), 16);
-            assert_eq!((23 as $T).next_multiple_of(8), 24);
-            assert_eq!((16 as $T).next_multiple_of(-8), 16);
-            assert_eq!((23 as $T).next_multiple_of(-8), 16);
-            assert_eq!((-16 as $T).next_multiple_of(8), -16);
-            assert_eq!((-23 as $T).next_multiple_of(8), -16);
-            assert_eq!((-16 as $T).next_multiple_of(-8), -16);
-            assert_eq!((-23 as $T).next_multiple_of(-8), -24);
-            assert_eq!(MIN.next_multiple_of(-1), MIN);
-        }
+            fn test_div_ceil() {
+                const A: $T = 8;
+                const B: $T = 3;
+                assert_eq_const_safe!(A.div_ceil(B), 3);
+                assert_eq_const_safe!(A.div_ceil(-B), -2);
+                assert_eq_const_safe!((-A).div_ceil(B), -2);
+                assert_eq_const_safe!((-A).div_ceil(-B), 3);
+            }
 
-        #[test]
-        fn test_checked_next_multiple_of() {
-            assert_eq!((16 as $T).checked_next_multiple_of(8), Some(16));
-            assert_eq!((23 as $T).checked_next_multiple_of(8), Some(24));
-            assert_eq!((16 as $T).checked_next_multiple_of(-8), Some(16));
-            assert_eq!((23 as $T).checked_next_multiple_of(-8), Some(16));
-            assert_eq!((-16 as $T).checked_next_multiple_of(8), Some(-16));
-            assert_eq!((-23 as $T).checked_next_multiple_of(8), Some(-16));
-            assert_eq!((-16 as $T).checked_next_multiple_of(-8), Some(-16));
-            assert_eq!((-23 as $T).checked_next_multiple_of(-8), Some(-24));
-            assert_eq!((1 as $T).checked_next_multiple_of(0), None);
-            assert_eq!(MAX.checked_next_multiple_of(2), None);
-            assert_eq!(MIN.checked_next_multiple_of(-3), None);
-            assert_eq!(MIN.checked_next_multiple_of(-1), Some(MIN));
-        }
+            fn test_next_multiple_of() {
+                assert_eq_const_safe!((16 as $T).next_multiple_of(8), 16);
+                assert_eq_const_safe!((23 as $T).next_multiple_of(8), 24);
+                assert_eq_const_safe!((16 as $T).next_multiple_of(-8), 16);
+                assert_eq_const_safe!((23 as $T).next_multiple_of(-8), 16);
+                assert_eq_const_safe!((-16 as $T).next_multiple_of(8), -16);
+                assert_eq_const_safe!((-23 as $T).next_multiple_of(8), -16);
+                assert_eq_const_safe!((-16 as $T).next_multiple_of(-8), -16);
+                assert_eq_const_safe!((-23 as $T).next_multiple_of(-8), -24);
+                assert_eq_const_safe!(MIN.next_multiple_of(-1), MIN);
+            }
 
-        #[test]
-        fn test_carrying_add() {
-            assert_eq!($T::MAX.carrying_add(1, false), ($T::MIN, true));
-            assert_eq!($T::MAX.carrying_add(0, true), ($T::MIN, true));
-            assert_eq!($T::MAX.carrying_add(1, true), ($T::MIN + 1, true));
-            assert_eq!($T::MAX.carrying_add(-1, false), ($T::MAX - 1, false));
-            assert_eq!($T::MAX.carrying_add(-1, true), ($T::MAX, false)); // no intermediate overflow
-            assert_eq!($T::MIN.carrying_add(-1, false), ($T::MAX, true));
-            assert_eq!($T::MIN.carrying_add(-1, true), ($T::MIN, false)); // no intermediate overflow
-            assert_eq!((0 as $T).carrying_add($T::MAX, true), ($T::MIN, true));
-            assert_eq!((0 as $T).carrying_add($T::MIN, true), ($T::MIN + 1, false));
-        }
+            fn test_checked_next_multiple_of() {
+                assert_eq_const_safe!((16 as $T).checked_next_multiple_of(8), Some(16));
+                assert_eq_const_safe!((23 as $T).checked_next_multiple_of(8), Some(24));
+                assert_eq_const_safe!((16 as $T).checked_next_multiple_of(-8), Some(16));
+                assert_eq_const_safe!((23 as $T).checked_next_multiple_of(-8), Some(16));
+                assert_eq_const_safe!((-16 as $T).checked_next_multiple_of(8), Some(-16));
+                assert_eq_const_safe!((-23 as $T).checked_next_multiple_of(8), Some(-16));
+                assert_eq_const_safe!((-16 as $T).checked_next_multiple_of(-8), Some(-16));
+                assert_eq_const_safe!((-23 as $T).checked_next_multiple_of(-8), Some(-24));
+                assert_eq_const_safe!((1 as $T).checked_next_multiple_of(0), None);
+                assert_eq_const_safe!(MAX.checked_next_multiple_of(2), None);
+                assert_eq_const_safe!(MIN.checked_next_multiple_of(-3), None);
+                assert_eq_const_safe!(MIN.checked_next_multiple_of(-1), Some(MIN));
+            }
 
-        #[test]
-        fn test_borrowing_sub() {
-            assert_eq!($T::MIN.borrowing_sub(1, false), ($T::MAX, true));
-            assert_eq!($T::MIN.borrowing_sub(0, true), ($T::MAX, true));
-            assert_eq!($T::MIN.borrowing_sub(1, true), ($T::MAX - 1, true));
-            assert_eq!($T::MIN.borrowing_sub(-1, false), ($T::MIN + 1, false));
-            assert_eq!($T::MIN.borrowing_sub(-1, true), ($T::MIN, false)); // no intermediate overflow
-            assert_eq!($T::MAX.borrowing_sub(-1, false), ($T::MIN, true));
-            assert_eq!($T::MAX.borrowing_sub(-1, true), ($T::MAX, false)); // no intermediate overflow
-            assert_eq!((0 as $T).borrowing_sub($T::MIN, false), ($T::MIN, true));
-            assert_eq!((0 as $T).borrowing_sub($T::MIN, true), ($T::MAX, false));
-        }
+            fn test_carrying_add() {
+                assert_eq_const_safe!(MAX.carrying_add(1, false), (MIN, true));
+                assert_eq_const_safe!(MAX.carrying_add(0, true), (MIN, true));
+                assert_eq_const_safe!(MAX.carrying_add(1, true), (MIN + 1, true));
+                assert_eq_const_safe!(MAX.carrying_add(-1, false), (MAX - 1, false));
+                assert_eq_const_safe!(MAX.carrying_add(-1, true), (MAX, false)); // no intermediate overflow
+                assert_eq_const_safe!(MIN.carrying_add(-1, false), (MAX, true));
+                assert_eq_const_safe!(MIN.carrying_add(-1, true), (MIN, false)); // no intermediate overflow
+                assert_eq_const_safe!((0 as $T).carrying_add(MAX, true), (MIN, true));
+                assert_eq_const_safe!((0 as $T).carrying_add(MIN, true), (MIN + 1, false));
+            }
 
-        #[test]
-        fn test_midpoint() {
-            assert_eq!(<$T>::midpoint(1, 3), 2);
-            assert_eq!(<$T>::midpoint(3, 1), 2);
+            fn test_borrowing_sub() {
+                assert_eq_const_safe!(MIN.borrowing_sub(1, false), (MAX, true));
+                assert_eq_const_safe!(MIN.borrowing_sub(0, true), (MAX, true));
+                assert_eq_const_safe!(MIN.borrowing_sub(1, true), (MAX - 1, true));
+                assert_eq_const_safe!(MIN.borrowing_sub(-1, false), (MIN + 1, false));
+                assert_eq_const_safe!(MIN.borrowing_sub(-1, true), (MIN, false)); // no intermediate overflow
+                assert_eq_const_safe!(MAX.borrowing_sub(-1, false), (MIN, true));
+                assert_eq_const_safe!(MAX.borrowing_sub(-1, true), (MAX, false)); // no intermediate overflow
+                assert_eq_const_safe!((0 as $T).borrowing_sub(MIN, false), (MIN, true));
+                assert_eq_const_safe!((0 as $T).borrowing_sub(MIN, true), (MAX, false));
+            }
 
-            assert_eq!(<$T>::midpoint(0, 0), 0);
-            assert_eq!(<$T>::midpoint(0, 2), 1);
-            assert_eq!(<$T>::midpoint(2, 0), 1);
-            assert_eq!(<$T>::midpoint(2, 2), 2);
+            fn test_midpoint() {
+                assert_eq_const_safe!(<$T>::midpoint(1, 3), 2);
+                assert_eq_const_safe!(<$T>::midpoint(3, 1), 2);
 
-            assert_eq!(<$T>::midpoint(1, 4), 2);
-            assert_eq!(<$T>::midpoint(4, 1), 2);
-            assert_eq!(<$T>::midpoint(3, 4), 3);
-            assert_eq!(<$T>::midpoint(4, 3), 3);
+                assert_eq_const_safe!(<$T>::midpoint(0, 0), 0);
+                assert_eq_const_safe!(<$T>::midpoint(0, 2), 1);
+                assert_eq_const_safe!(<$T>::midpoint(2, 0), 1);
+                assert_eq_const_safe!(<$T>::midpoint(2, 2), 2);
 
-            assert_eq!(<$T>::midpoint(<$T>::MIN, <$T>::MAX), -1);
-            assert_eq!(<$T>::midpoint(<$T>::MAX, <$T>::MIN), -1);
-            assert_eq!(<$T>::midpoint(<$T>::MIN, <$T>::MIN), <$T>::MIN);
-            assert_eq!(<$T>::midpoint(<$T>::MAX, <$T>::MAX), <$T>::MAX);
+                assert_eq_const_safe!(<$T>::midpoint(1, 4), 2);
+                assert_eq_const_safe!(<$T>::midpoint(4, 1), 2);
+                assert_eq_const_safe!(<$T>::midpoint(3, 4), 3);
+                assert_eq_const_safe!(<$T>::midpoint(4, 3), 3);
 
-            assert_eq!(<$T>::midpoint(<$T>::MIN, 6), <$T>::MIN / 2 + 3);
-            assert_eq!(<$T>::midpoint(6, <$T>::MIN), <$T>::MIN / 2 + 3);
-            assert_eq!(<$T>::midpoint(<$T>::MAX, 6), <$T>::MAX / 2 + 3);
-            assert_eq!(<$T>::midpoint(6, <$T>::MAX), <$T>::MAX / 2 + 3);
+                assert_eq_const_safe!(<$T>::midpoint(<$T>::MIN, <$T>::MAX), -1);
+                assert_eq_const_safe!(<$T>::midpoint(<$T>::MAX, <$T>::MIN), -1);
+                assert_eq_const_safe!(<$T>::midpoint(<$T>::MIN, <$T>::MIN), <$T>::MIN);
+                assert_eq_const_safe!(<$T>::midpoint(<$T>::MAX, <$T>::MAX), <$T>::MAX);
+
+                assert_eq_const_safe!(<$T>::midpoint(<$T>::MIN, 6), <$T>::MIN / 2 + 3);
+                assert_eq_const_safe!(<$T>::midpoint(6, <$T>::MIN), <$T>::MIN / 2 + 3);
+                assert_eq_const_safe!(<$T>::midpoint(<$T>::MAX, 6), <$T>::MAX / 2 + 3);
+                assert_eq_const_safe!(<$T>::midpoint(6, <$T>::MAX), <$T>::MAX / 2 + 3);
+            }
         }
     };
 }

--- a/library/core/tests/num/uint_macros.rs
+++ b/library/core/tests/num/uint_macros.rs
@@ -2,7 +2,6 @@ macro_rules! uint_module {
     ($T:ident) => {
         use core::ops::{BitAnd, BitOr, BitXor, Not, Shl, Shr};
         use core::$T::*;
-        use std::str::FromStr;
 
         use crate::num;
 
@@ -35,122 +34,115 @@ macro_rules! uint_module {
         const _0: $T = 0;
         const _1: $T = !0;
 
-        #[test]
-        fn test_count_ones() {
-            assert!(A.count_ones() == 3);
-            assert!(B.count_ones() == 2);
-            assert!(C.count_ones() == 5);
+        test_runtime_and_compiletime! {
+            fn test_count_ones() {
+                assert!(A.count_ones() == 3);
+                assert!(B.count_ones() == 2);
+                assert!(C.count_ones() == 5);
+            }
+
+            fn test_count_zeros() {
+                assert!(A.count_zeros() == $T::BITS - 3);
+                assert!(B.count_zeros() == $T::BITS - 2);
+                assert!(C.count_zeros() == $T::BITS - 5);
+            }
+
+            fn test_leading_trailing_ones() {
+                const A: $T = 0b0101_1111;
+                assert_eq_const_safe!(A.trailing_ones(), 5);
+                assert_eq_const_safe!((!A).leading_ones(), $T::BITS - 7);
+
+                assert_eq_const_safe!(A.reverse_bits().leading_ones(), 5);
+
+                assert_eq_const_safe!(_1.leading_ones(), $T::BITS);
+                assert_eq_const_safe!(_1.trailing_ones(), $T::BITS);
+
+                assert_eq_const_safe!((_1 << 1).trailing_ones(), 0);
+                assert_eq_const_safe!((_1 >> 1).leading_ones(), 0);
+
+                assert_eq_const_safe!((_1 << 1).leading_ones(), $T::BITS - 1);
+                assert_eq_const_safe!((_1 >> 1).trailing_ones(), $T::BITS - 1);
+
+                assert_eq_const_safe!(_0.leading_ones(), 0);
+                assert_eq_const_safe!(_0.trailing_ones(), 0);
+
+                const X: $T = 0b0010_1100;
+                assert_eq_const_safe!(X.leading_ones(), 0);
+                assert_eq_const_safe!(X.trailing_ones(), 0);
+            }
+
+            fn test_rotate() {
+                assert_eq_const_safe!(A.rotate_left(6).rotate_right(2).rotate_right(4), A);
+                assert_eq_const_safe!(B.rotate_left(3).rotate_left(2).rotate_right(5), B);
+                assert_eq_const_safe!(C.rotate_left(6).rotate_right(2).rotate_right(4), C);
+
+                // Rotating these should make no difference
+                //
+                // We test using 124 bits because to ensure that overlong bit shifts do
+                // not cause undefined behaviour. See #10183.
+                assert_eq_const_safe!(_0.rotate_left(124), _0);
+                assert_eq_const_safe!(_1.rotate_left(124), _1);
+                assert_eq_const_safe!(_0.rotate_right(124), _0);
+                assert_eq_const_safe!(_1.rotate_right(124), _1);
+
+                // Rotating by 0 should have no effect
+                assert_eq_const_safe!(A.rotate_left(0), A);
+                assert_eq_const_safe!(B.rotate_left(0), B);
+                assert_eq_const_safe!(C.rotate_left(0), C);
+                // Rotating by a multiple of word size should also have no effect
+                assert_eq_const_safe!(A.rotate_left(128), A);
+                assert_eq_const_safe!(B.rotate_left(128), B);
+                assert_eq_const_safe!(C.rotate_left(128), C);
+            }
+
+            fn test_swap_bytes() {
+                assert_eq_const_safe!(A.swap_bytes().swap_bytes(), A);
+                assert_eq_const_safe!(B.swap_bytes().swap_bytes(), B);
+                assert_eq_const_safe!(C.swap_bytes().swap_bytes(), C);
+
+                // Swapping these should make no difference
+                assert_eq_const_safe!(_0.swap_bytes(), _0);
+                assert_eq_const_safe!(_1.swap_bytes(), _1);
+            }
+
+            fn test_reverse_bits() {
+                assert_eq_const_safe!(A.reverse_bits().reverse_bits(), A);
+                assert_eq_const_safe!(B.reverse_bits().reverse_bits(), B);
+                assert_eq_const_safe!(C.reverse_bits().reverse_bits(), C);
+
+                // Swapping these should make no difference
+                assert_eq_const_safe!(_0.reverse_bits(), _0);
+                assert_eq_const_safe!(_1.reverse_bits(), _1);
+            }
+
+            fn test_le() {
+                assert_eq_const_safe!($T::from_le(A.to_le()), A);
+                assert_eq_const_safe!($T::from_le(B.to_le()), B);
+                assert_eq_const_safe!($T::from_le(C.to_le()), C);
+                assert_eq_const_safe!($T::from_le(_0), _0);
+                assert_eq_const_safe!($T::from_le(_1), _1);
+                assert_eq_const_safe!(_0.to_le(), _0);
+                assert_eq_const_safe!(_1.to_le(), _1);
+            }
+
+            fn test_be() {
+                assert_eq_const_safe!($T::from_be(A.to_be()), A);
+                assert_eq_const_safe!($T::from_be(B.to_be()), B);
+                assert_eq_const_safe!($T::from_be(C.to_be()), C);
+                assert_eq_const_safe!($T::from_be(_0), _0);
+                assert_eq_const_safe!($T::from_be(_1), _1);
+                assert_eq_const_safe!(_0.to_be(), _0);
+                assert_eq_const_safe!(_1.to_be(), _1);
+            }
+
+            fn test_unsigned_checked_div() {
+                assert_eq_const_safe!((10 as $T).checked_div(2), Some(5));
+                assert_eq_const_safe!((5 as $T).checked_div(0), None);
+            }
         }
 
-        #[test]
-        fn test_count_zeros() {
-            assert!(A.count_zeros() == $T::BITS - 3);
-            assert!(B.count_zeros() == $T::BITS - 2);
-            assert!(C.count_zeros() == $T::BITS - 5);
-        }
-
-        #[test]
-        fn test_leading_trailing_ones() {
-            let a: $T = 0b0101_1111;
-            assert_eq!(a.trailing_ones(), 5);
-            assert_eq!((!a).leading_ones(), $T::BITS - 7);
-
-            assert_eq!(a.reverse_bits().leading_ones(), 5);
-
-            assert_eq!(_1.leading_ones(), $T::BITS);
-            assert_eq!(_1.trailing_ones(), $T::BITS);
-
-            assert_eq!((_1 << 1).trailing_ones(), 0);
-            assert_eq!((_1 >> 1).leading_ones(), 0);
-
-            assert_eq!((_1 << 1).leading_ones(), $T::BITS - 1);
-            assert_eq!((_1 >> 1).trailing_ones(), $T::BITS - 1);
-
-            assert_eq!(_0.leading_ones(), 0);
-            assert_eq!(_0.trailing_ones(), 0);
-
-            let x: $T = 0b0010_1100;
-            assert_eq!(x.leading_ones(), 0);
-            assert_eq!(x.trailing_ones(), 0);
-        }
-
-        #[test]
-        fn test_rotate() {
-            assert_eq!(A.rotate_left(6).rotate_right(2).rotate_right(4), A);
-            assert_eq!(B.rotate_left(3).rotate_left(2).rotate_right(5), B);
-            assert_eq!(C.rotate_left(6).rotate_right(2).rotate_right(4), C);
-
-            // Rotating these should make no difference
-            //
-            // We test using 124 bits because to ensure that overlong bit shifts do
-            // not cause undefined behaviour. See #10183.
-            assert_eq!(_0.rotate_left(124), _0);
-            assert_eq!(_1.rotate_left(124), _1);
-            assert_eq!(_0.rotate_right(124), _0);
-            assert_eq!(_1.rotate_right(124), _1);
-
-            // Rotating by 0 should have no effect
-            assert_eq!(A.rotate_left(0), A);
-            assert_eq!(B.rotate_left(0), B);
-            assert_eq!(C.rotate_left(0), C);
-            // Rotating by a multiple of word size should also have no effect
-            assert_eq!(A.rotate_left(128), A);
-            assert_eq!(B.rotate_left(128), B);
-            assert_eq!(C.rotate_left(128), C);
-        }
-
-        #[test]
-        fn test_swap_bytes() {
-            assert_eq!(A.swap_bytes().swap_bytes(), A);
-            assert_eq!(B.swap_bytes().swap_bytes(), B);
-            assert_eq!(C.swap_bytes().swap_bytes(), C);
-
-            // Swapping these should make no difference
-            assert_eq!(_0.swap_bytes(), _0);
-            assert_eq!(_1.swap_bytes(), _1);
-        }
-
-        #[test]
-        fn test_reverse_bits() {
-            assert_eq!(A.reverse_bits().reverse_bits(), A);
-            assert_eq!(B.reverse_bits().reverse_bits(), B);
-            assert_eq!(C.reverse_bits().reverse_bits(), C);
-
-            // Swapping these should make no difference
-            assert_eq!(_0.reverse_bits(), _0);
-            assert_eq!(_1.reverse_bits(), _1);
-        }
-
-        #[test]
-        fn test_le() {
-            assert_eq!($T::from_le(A.to_le()), A);
-            assert_eq!($T::from_le(B.to_le()), B);
-            assert_eq!($T::from_le(C.to_le()), C);
-            assert_eq!($T::from_le(_0), _0);
-            assert_eq!($T::from_le(_1), _1);
-            assert_eq!(_0.to_le(), _0);
-            assert_eq!(_1.to_le(), _1);
-        }
-
-        #[test]
-        fn test_be() {
-            assert_eq!($T::from_be(A.to_be()), A);
-            assert_eq!($T::from_be(B.to_be()), B);
-            assert_eq!($T::from_be(C.to_be()), C);
-            assert_eq!($T::from_be(_0), _0);
-            assert_eq!($T::from_be(_1), _1);
-            assert_eq!(_0.to_be(), _0);
-            assert_eq!(_1.to_be(), _1);
-        }
-
-        #[test]
-        fn test_unsigned_checked_div() {
-            assert!((10 as $T).checked_div(2) == Some(5));
-            assert!((5 as $T).checked_div(0) == None);
-        }
-
-        fn from_str<T: FromStr>(t: &str) -> Option<T> {
-            FromStr::from_str(t).ok()
+        fn from_str<T: core::str::FromStr>(t: &str) -> Option<T> {
+            core::str::FromStr::from_str(t).ok()
         }
 
         #[test]
@@ -166,52 +158,55 @@ macro_rules! uint_module {
             assert_eq!(from_str::<$T>("x"), None);
         }
 
-        #[test]
-        pub fn test_parse_bytes() {
-            assert_eq!($T::from_str_radix("123", 10), Ok(123 as $T));
-            assert_eq!($T::from_str_radix("1001", 2), Ok(9 as $T));
-            assert_eq!($T::from_str_radix("123", 8), Ok(83 as $T));
-            assert_eq!(u16::from_str_radix("123", 16), Ok(291 as u16));
-            assert_eq!(u16::from_str_radix("ffff", 16), Ok(65535 as u16));
-            assert_eq!($T::from_str_radix("z", 36), Ok(35 as $T));
+        test_runtime_and_compiletime! {
+            fn test_parse_bytes() {
+                assert_eq_const_safe!($T::from_str_radix("123", 10), Ok(123 as $T));
+                assert_eq_const_safe!($T::from_str_radix("1001", 2), Ok(9 as $T));
+                assert_eq_const_safe!($T::from_str_radix("123", 8), Ok(83 as $T));
+                assert_eq_const_safe!(u16::from_str_radix("123", 16), Ok(291 as u16));
+                assert_eq_const_safe!(u16::from_str_radix("ffff", 16), Ok(65535 as u16));
+                assert_eq_const_safe!($T::from_str_radix("z", 36), Ok(35 as $T));
 
-            assert_eq!($T::from_str_radix("Z", 10).ok(), None::<$T>);
-            assert_eq!($T::from_str_radix("_", 2).ok(), None::<$T>);
-        }
+                assert!($T::from_str_radix("Z", 10).is_err());
+                assert!($T::from_str_radix("_", 2).is_err());
+            }
 
-        #[test]
-        fn test_pow() {
-            let mut r = 2 as $T;
-            assert_eq!(r.pow(2), 4 as $T);
-            assert_eq!(r.pow(0), 1 as $T);
-            assert_eq!(r.wrapping_pow(2), 4 as $T);
-            assert_eq!(r.wrapping_pow(0), 1 as $T);
-            assert_eq!(r.checked_pow(2), Some(4 as $T));
-            assert_eq!(r.checked_pow(0), Some(1 as $T));
-            assert_eq!(r.overflowing_pow(2), (4 as $T, false));
-            assert_eq!(r.overflowing_pow(0), (1 as $T, false));
-            assert_eq!(r.saturating_pow(2), 4 as $T);
-            assert_eq!(r.saturating_pow(0), 1 as $T);
+            fn test_pow() {
+                {
+                    const R: $T = 2;
+                    assert_eq_const_safe!(R.pow(2), 4 as $T);
+                    assert_eq_const_safe!(R.pow(0), 1 as $T);
+                    assert_eq_const_safe!(R.wrapping_pow(2), 4 as $T);
+                    assert_eq_const_safe!(R.wrapping_pow(0), 1 as $T);
+                    assert_eq_const_safe!(R.checked_pow(2), Some(4 as $T));
+                    assert_eq_const_safe!(R.checked_pow(0), Some(1 as $T));
+                    assert_eq_const_safe!(R.overflowing_pow(2), (4 as $T, false));
+                    assert_eq_const_safe!(R.overflowing_pow(0), (1 as $T, false));
+                    assert_eq_const_safe!(R.saturating_pow(2), 4 as $T);
+                    assert_eq_const_safe!(R.saturating_pow(0), 1 as $T);
+                }
 
-            r = MAX;
-            // use `^` to represent .pow() with no overflow.
-            // if itest::MAX == 2^j-1, then itest is a `j` bit int,
-            // so that `itest::MAX*itest::MAX == 2^(2*j)-2^(j+1)+1`,
-            // thussaturating_pow the overflowing result is exactly 1.
-            assert_eq!(r.wrapping_pow(2), 1 as $T);
-            assert_eq!(r.checked_pow(2), None);
-            assert_eq!(r.overflowing_pow(2), (1 as $T, true));
-            assert_eq!(r.saturating_pow(2), MAX);
-        }
+                {
+                    const R: $T = $T::MAX;
+                    // use `^` to represent .pow() with no overflow.
+                    // if itest::MAX == 2^j-1, then itest is a `j` bit int,
+                    // so that `itest::MAX*itest::MAX == 2^(2*j)-2^(j+1)+1`,
+                    // thussaturating_pow the overflowing result is exactly 1.
+                    assert_eq_const_safe!(R.wrapping_pow(2), 1 as $T);
+                    assert_eq_const_safe!(R.checked_pow(2), None);
+                    assert_eq_const_safe!(R.overflowing_pow(2), (1 as $T, true));
+                    assert_eq_const_safe!(R.saturating_pow(2), MAX);
+                }
+            }
 
-        #[test]
-        fn test_isqrt() {
-            assert_eq!((0 as $T).isqrt(), 0 as $T);
-            assert_eq!((1 as $T).isqrt(), 1 as $T);
-            assert_eq!((2 as $T).isqrt(), 1 as $T);
-            assert_eq!((99 as $T).isqrt(), 9 as $T);
-            assert_eq!((100 as $T).isqrt(), 10 as $T);
-            assert_eq!($T::MAX.isqrt(), (1 << ($T::BITS / 2)) - 1);
+            fn test_isqrt() {
+                assert_eq_const_safe!((0 as $T).isqrt(), 0 as $T);
+                assert_eq_const_safe!((1 as $T).isqrt(), 1 as $T);
+                assert_eq_const_safe!((2 as $T).isqrt(), 1 as $T);
+                assert_eq_const_safe!((99 as $T).isqrt(), 9 as $T);
+                assert_eq_const_safe!((100 as $T).isqrt(), 10 as $T);
+                assert_eq_const_safe!($T::MAX.isqrt(), (1 << ($T::BITS / 2)) - 1);
+            }
         }
 
         #[cfg(not(miri))] // Miri is too slow
@@ -233,85 +228,79 @@ macro_rules! uint_module {
             }
         }
 
-        #[test]
-        fn test_div_floor() {
-            assert_eq!((8 as $T).div_floor(3), 2);
-        }
+        test_runtime_and_compiletime! {
+            fn test_div_floor() {
+                assert_eq_const_safe!((8 as $T).div_floor(3), 2);
+            }
 
-        #[test]
-        fn test_div_ceil() {
-            assert_eq!((8 as $T).div_ceil(3), 3);
-        }
+            fn test_div_ceil() {
+                assert_eq_const_safe!((8 as $T).div_ceil(3), 3);
+            }
 
-        #[test]
-        fn test_next_multiple_of() {
-            assert_eq!((16 as $T).next_multiple_of(8), 16);
-            assert_eq!((23 as $T).next_multiple_of(8), 24);
-            assert_eq!(MAX.next_multiple_of(1), MAX);
-        }
+            fn test_next_multiple_of() {
+                assert_eq_const_safe!((16 as $T).next_multiple_of(8), 16);
+                assert_eq_const_safe!((23 as $T).next_multiple_of(8), 24);
+                assert_eq_const_safe!(MAX.next_multiple_of(1), MAX);
+            }
 
-        #[test]
-        fn test_checked_next_multiple_of() {
-            assert_eq!((16 as $T).checked_next_multiple_of(8), Some(16));
-            assert_eq!((23 as $T).checked_next_multiple_of(8), Some(24));
-            assert_eq!((1 as $T).checked_next_multiple_of(0), None);
-            assert_eq!(MAX.checked_next_multiple_of(2), None);
-        }
+            fn test_checked_next_multiple_of() {
+                assert_eq_const_safe!((16 as $T).checked_next_multiple_of(8), Some(16));
+                assert_eq_const_safe!((23 as $T).checked_next_multiple_of(8), Some(24));
+                assert_eq_const_safe!((1 as $T).checked_next_multiple_of(0), None);
+                assert_eq_const_safe!(MAX.checked_next_multiple_of(2), None);
+            }
 
-        #[test]
-        fn test_is_next_multiple_of() {
-            assert!((12 as $T).is_multiple_of(4));
-            assert!(!(12 as $T).is_multiple_of(5));
-            assert!((0 as $T).is_multiple_of(0));
-            assert!(!(12 as $T).is_multiple_of(0));
-        }
+            fn test_is_next_multiple_of() {
+                assert!((12 as $T).is_multiple_of(4));
+                assert!(!(12 as $T).is_multiple_of(5));
+                assert!((0 as $T).is_multiple_of(0));
+                assert!(!(12 as $T).is_multiple_of(0));
+            }
 
-        #[test]
-        fn test_carrying_add() {
-            assert_eq!($T::MAX.carrying_add(1, false), (0, true));
-            assert_eq!($T::MAX.carrying_add(0, true), (0, true));
-            assert_eq!($T::MAX.carrying_add(1, true), (1, true));
+            fn test_carrying_add() {
+                assert_eq_const_safe!($T::MAX.carrying_add(1, false), (0, true));
+                assert_eq_const_safe!($T::MAX.carrying_add(0, true), (0, true));
+                assert_eq_const_safe!($T::MAX.carrying_add(1, true), (1, true));
 
-            assert_eq!($T::MIN.carrying_add($T::MAX, false), ($T::MAX, false));
-            assert_eq!($T::MIN.carrying_add(0, true), (1, false));
-            assert_eq!($T::MIN.carrying_add($T::MAX, true), (0, true));
-        }
+                assert_eq_const_safe!($T::MIN.carrying_add($T::MAX, false), ($T::MAX, false));
+                assert_eq_const_safe!($T::MIN.carrying_add(0, true), (1, false));
+                assert_eq_const_safe!($T::MIN.carrying_add($T::MAX, true), (0, true));
+            }
 
-        #[test]
-        fn test_borrowing_sub() {
-            assert_eq!($T::MIN.borrowing_sub(1, false), ($T::MAX, true));
-            assert_eq!($T::MIN.borrowing_sub(0, true), ($T::MAX, true));
-            assert_eq!($T::MIN.borrowing_sub(1, true), ($T::MAX - 1, true));
+            fn test_borrowing_sub() {
+                assert_eq_const_safe!($T::MIN.borrowing_sub(1, false), ($T::MAX, true));
+                assert_eq_const_safe!($T::MIN.borrowing_sub(0, true), ($T::MAX, true));
+                assert_eq_const_safe!($T::MIN.borrowing_sub(1, true), ($T::MAX - 1, true));
 
-            assert_eq!($T::MAX.borrowing_sub($T::MAX, false), (0, false));
-            assert_eq!($T::MAX.borrowing_sub(0, true), ($T::MAX - 1, false));
-            assert_eq!($T::MAX.borrowing_sub($T::MAX, true), ($T::MAX, true));
-        }
+                assert_eq_const_safe!($T::MAX.borrowing_sub($T::MAX, false), (0, false));
+                assert_eq_const_safe!($T::MAX.borrowing_sub(0, true), ($T::MAX - 1, false));
+                assert_eq_const_safe!($T::MAX.borrowing_sub($T::MAX, true), ($T::MAX, true));
+            }
 
-        #[test]
-        fn test_midpoint() {
-            assert_eq!(<$T>::midpoint(1, 3), 2);
-            assert_eq!(<$T>::midpoint(3, 1), 2);
+            fn test_midpoint() {
+                assert_eq_const_safe!(<$T>::midpoint(1, 3), 2);
+                assert_eq_const_safe!(<$T>::midpoint(3, 1), 2);
 
-            assert_eq!(<$T>::midpoint(0, 0), 0);
-            assert_eq!(<$T>::midpoint(0, 2), 1);
-            assert_eq!(<$T>::midpoint(2, 0), 1);
-            assert_eq!(<$T>::midpoint(2, 2), 2);
+                assert_eq_const_safe!(<$T>::midpoint(0, 0), 0);
+                assert_eq_const_safe!(<$T>::midpoint(0, 2), 1);
+                assert_eq_const_safe!(<$T>::midpoint(2, 0), 1);
+                assert_eq_const_safe!(<$T>::midpoint(2, 2), 2);
 
-            assert_eq!(<$T>::midpoint(1, 4), 2);
-            assert_eq!(<$T>::midpoint(4, 1), 2);
-            assert_eq!(<$T>::midpoint(3, 4), 3);
-            assert_eq!(<$T>::midpoint(4, 3), 3);
+                assert_eq_const_safe!(<$T>::midpoint(1, 4), 2);
+                assert_eq_const_safe!(<$T>::midpoint(4, 1), 2);
+                assert_eq_const_safe!(<$T>::midpoint(3, 4), 3);
+                assert_eq_const_safe!(<$T>::midpoint(4, 3), 3);
 
-            assert_eq!(<$T>::midpoint(<$T>::MIN, <$T>::MAX), (<$T>::MAX - <$T>::MIN) / 2);
-            assert_eq!(<$T>::midpoint(<$T>::MAX, <$T>::MIN), (<$T>::MAX - <$T>::MIN) / 2);
-            assert_eq!(<$T>::midpoint(<$T>::MIN, <$T>::MIN), <$T>::MIN);
-            assert_eq!(<$T>::midpoint(<$T>::MAX, <$T>::MAX), <$T>::MAX);
+                assert_eq_const_safe!(<$T>::midpoint(<$T>::MIN, <$T>::MAX), (<$T>::MAX - <$T>::MIN) / 2);
+                assert_eq_const_safe!(<$T>::midpoint(<$T>::MAX, <$T>::MIN), (<$T>::MAX - <$T>::MIN) / 2);
+                assert_eq_const_safe!(<$T>::midpoint(<$T>::MIN, <$T>::MIN), <$T>::MIN);
+                assert_eq_const_safe!(<$T>::midpoint(<$T>::MAX, <$T>::MAX), <$T>::MAX);
 
-            assert_eq!(<$T>::midpoint(<$T>::MIN, 6), <$T>::MIN / 2 + 3);
-            assert_eq!(<$T>::midpoint(6, <$T>::MIN), <$T>::MIN / 2 + 3);
-            assert_eq!(<$T>::midpoint(<$T>::MAX, 6), (<$T>::MAX - <$T>::MIN) / 2 + 3);
-            assert_eq!(<$T>::midpoint(6, <$T>::MAX), (<$T>::MAX - <$T>::MIN) / 2 + 3);
+                assert_eq_const_safe!(<$T>::midpoint(<$T>::MIN, 6), <$T>::MIN / 2 + 3);
+                assert_eq_const_safe!(<$T>::midpoint(6, <$T>::MIN), <$T>::MIN / 2 + 3);
+                assert_eq_const_safe!(<$T>::midpoint(<$T>::MAX, 6), (<$T>::MAX - <$T>::MIN) / 2 + 3);
+                assert_eq_const_safe!(<$T>::midpoint(6, <$T>::MAX), (<$T>::MAX - <$T>::MIN) / 2 + 3);
+            }
         }
     };
 }


### PR DESCRIPTION
This adds some infrastructure for something I was going to use in #131566, but it felt worthwhile enough on its own to merge/discuss separately.

Essentially, right now we tend to rely on UI tests to ensure that things work in const context, rather than just using library tests. This uses a few simple macro tricks to make it *relatively* painless to execute tests in both runtime and compile-time context. And this only applies to the numeric tests, and not anything else.

Recommended to review without whitespace in the diff.

cc @RalfJung