### PR TITLE
Remove `'apostrophes'` from `rustc_parse_format`

### DIFF
--- a/compiler/rustc_index_macros/Cargo.toml
+++ b/compiler/rustc_index_macros/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.9", features = ["full"] }
+syn = { version = "2.0.9", features = ["full", "extra-traits"] }
 proc-macro2 = "1"
 quote = "1"
 

--- a/compiler/rustc_parse_format/src/lib.rs
+++ b/compiler/rustc_parse_format/src/lib.rs
@@ -473,19 +473,19 @@ impl<'a> Parser<'a> {
             }
 
             pos = peek_pos;
-            description = format!("expected `'}}'`, found `{maybe:?}`");
+            description = format!("expected `}}`, found `{}`", maybe.escape_debug());
         } else {
-            description = "expected `'}'` but string was terminated".to_owned();
+            description = "expected `}` but string was terminated".to_owned();
             // point at closing `"`
             pos = self.input.len() - if self.append_newline { 1 } else { 0 };
         }
 
         let pos = self.to_span_index(pos);
 
-        let label = "expected `'}'`".to_owned();
+        let label = "expected `}`".to_owned();
         let (note, secondary_label) = if arg.format.fill == Some('}') {
             (
-                Some("the character `'}'` is interpreted as a fill character because of the `:` that precedes it".to_owned()),
+                Some("the character `}` is interpreted as a fill character because of the `:` that precedes it".to_owned()),
                 arg.format.fill_span.map(|sp| ("this is not interpreted as a formatting closing brace".to_owned(), sp)),
             )
         } else {

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.rs
@@ -178,7 +178,7 @@ struct ErrorWithNonexistentField {
 }
 
 #[derive(Diagnostic)]
-//~^ ERROR invalid format string: expected `'}'`
+//~^ ERROR invalid format string: expected `}`
 #[diag(no_crate_example, code = E0123)]
 struct ErrorMissingClosingBrace {
     #[suggestion(no_crate_suggestion, code = "{name")]

--- a/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
+++ b/tests/ui-fulldeps/session-diagnostic/diagnostic-derive.stderr
@@ -184,11 +184,11 @@ error: `name` doesn't refer to a field on this type
 LL |     #[suggestion(no_crate_suggestion, code = "{name}")]
    |                                              ^^^^^^^^
 
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/diagnostic-derive.rs:180:10
    |
 LL | #[derive(Diagnostic)]
-   |          ^^^^^^^^^^ expected `'}'` in format string
+   |          ^^^^^^^^^^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
    = note: this error originates in the derive macro `Diagnostic` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/diagnostic_namespace/on_unimplemented/broken_format.rs
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/broken_format.rs
@@ -19,8 +19,8 @@ trait ImportantTrait3 {}
 trait ImportantTrait4 {}
 
 #[diagnostic::on_unimplemented(message = "Test {Self:!}")]
-//~^WARN expected `'}'`, found `'!'`
-//~|WARN expected `'}'`, found `'!'`
+//~^WARN expected `}`, found `!`
+//~|WARN expected `}`, found `!`
 //~|WARN unmatched `}` found
 //~|WARN unmatched `}` found
 trait ImportantTrait5 {}

--- a/tests/ui/diagnostic_namespace/on_unimplemented/broken_format.stderr
+++ b/tests/ui/diagnostic_namespace/on_unimplemented/broken_format.stderr
@@ -30,7 +30,7 @@ LL | #[diagnostic::on_unimplemented(message = "Test {Self:123}")]
    |
    = help: no format specifier are supported in this position
 
-warning: expected `'}'`, found `'!'`
+warning: expected `}`, found `!`
   --> $DIR/broken_format.rs:21:32
    |
 LL | #[diagnostic::on_unimplemented(message = "Test {Self:!}")]
@@ -153,7 +153,7 @@ note: required by a bound in `check_4`
 LL | fn check_4(_: impl ImportantTrait4) {}
    |                    ^^^^^^^^^^^^^^^ required by this bound in `check_4`
 
-warning: expected `'}'`, found `'!'`
+warning: expected `}`, found `!`
   --> $DIR/broken_format.rs:21:32
    |
 LL | #[diagnostic::on_unimplemented(message = "Test {Self:!}")]

--- a/tests/ui/fmt/closing-brace-as-fill.rs
+++ b/tests/ui/fmt/closing-brace-as-fill.rs
@@ -4,5 +4,5 @@
 
 fn main() {
     println!("Hello, world! {0:}<3", 2);
-    //~^ ERROR invalid format string: expected `'}'` but string was terminated
+    //~^ ERROR invalid format string: expected `}` but string was terminated
 }

--- a/tests/ui/fmt/closing-brace-as-fill.stderr
+++ b/tests/ui/fmt/closing-brace-as-fill.stderr
@@ -1,12 +1,12 @@
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/closing-brace-as-fill.rs:6:35
    |
 LL |     println!("Hello, world! {0:}<3", 2);
-   |                                -  ^ expected `'}'` in format string
+   |                                -  ^ expected `}` in format string
    |                                |
    |                                this is not interpreted as a formatting closing brace
    |
-   = note: the character `'}'` is interpreted as a fill character because of the `:` that precedes it
+   = note: the character `}` is interpreted as a fill character because of the `:` that precedes it
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/fmt/format-string-error-2.rs
+++ b/tests/ui/fmt/format-string-error-2.rs
@@ -72,7 +72,7 @@ raw  { \n
 
     // note: `\x7B` is `{`
     println!("\x7B}\u{8} {", 1);
-    //~^ ERROR invalid format string: expected `'}'` but string was terminated
+    //~^ ERROR invalid format string: expected `}` but string was terminated
 
     println!("\x7B}\u8 {", 1);
     //~^ ERROR incorrect unicode escape sequence

--- a/tests/ui/fmt/format-string-error-2.stderr
+++ b/tests/ui/fmt/format-string-error-2.stderr
@@ -9,138 +9,138 @@ help: format of unicode escape sequences uses braces
 LL |     println!("\x7B}\u{8} {", 1);
    |                    ~~~~~
 
-error: invalid format string: expected `'}'`, found `'a'`
+error: invalid format string: expected `}`, found `a`
   --> $DIR/format-string-error-2.rs:5:5
    |
 LL |     format!("{
    |              - because of this opening brace
 LL |     a");
-   |     ^ expected `'}'` in format string
+   |     ^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'b'`
+error: invalid format string: expected `}`, found `b`
   --> $DIR/format-string-error-2.rs:9:5
    |
 LL |     format!("{ \
    |              - because of this opening brace
 LL |                \
 LL |     b");
-   |     ^ expected `'}'` in format string
+   |     ^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'\'`
+error: invalid format string: expected `}`, found `\`
   --> $DIR/format-string-error-2.rs:11:18
    |
 LL |     format!(r#"{ \
-   |                - ^ expected `'}'` in format string
+   |                - ^ expected `}` in format string
    |                |
    |                because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'\'`
+error: invalid format string: expected `}`, found `\`
   --> $DIR/format-string-error-2.rs:15:18
    |
 LL |     format!(r#"{ \n
-   |                - ^ expected `'}'` in format string
+   |                - ^ expected `}` in format string
    |                |
    |                because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'e'`
+error: invalid format string: expected `}`, found `e`
   --> $DIR/format-string-error-2.rs:21:5
    |
 LL |     format!("{ \n
    |              - because of this opening brace
 LL | \n
 LL |     e");
-   |     ^ expected `'}'` in format string
+   |     ^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'a'`
+error: invalid format string: expected `}`, found `a`
   --> $DIR/format-string-error-2.rs:25:5
    |
 LL |     {
    |     - because of this opening brace
 LL |     a");
-   |     ^ expected `'}'` in format string
+   |     ^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'a'`
+error: invalid format string: expected `}`, found `a`
   --> $DIR/format-string-error-2.rs:29:5
    |
 LL |     {
    |     - because of this opening brace
 LL |     a
-   |     ^ expected `'}'` in format string
+   |     ^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'b'`
+error: invalid format string: expected `}`, found `b`
   --> $DIR/format-string-error-2.rs:35:5
    |
 LL |     { \
    |     - because of this opening brace
 LL |         \
 LL |     b");
-   |     ^ expected `'}'` in format string
+   |     ^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'b'`
+error: invalid format string: expected `}`, found `b`
   --> $DIR/format-string-error-2.rs:40:5
    |
 LL |     { \
    |     - because of this opening brace
 LL |         \
 LL |     b \
-   |     ^ expected `'}'` in format string
+   |     ^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'\'`
+error: invalid format string: expected `}`, found `\`
   --> $DIR/format-string-error-2.rs:45:8
    |
 LL | raw  { \
-   |      - ^ expected `'}'` in format string
+   |      - ^ expected `}` in format string
    |      |
    |      because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'\'`
+error: invalid format string: expected `}`, found `\`
   --> $DIR/format-string-error-2.rs:50:8
    |
 LL | raw  { \n
-   |      - ^ expected `'}'` in format string
+   |      - ^ expected `}` in format string
    |      |
    |      because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'e'`
+error: invalid format string: expected `}`, found `e`
   --> $DIR/format-string-error-2.rs:57:5
    |
 LL |   { \n
    |   - because of this opening brace
 LL | \n
 LL |     e");
-   |     ^ expected `'}'` in format string
+   |     ^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'a'`
+error: invalid format string: expected `}`, found `a`
   --> $DIR/format-string-error-2.rs:67:5
    |
 LL |     {
    |     - because of this opening brace
 LL |     asdf}
-   |     ^ expected `'}'` in format string
+   |     ^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
@@ -150,11 +150,11 @@ error: 1 positional argument in format string, but no arguments were given
 LL |     println!("\t{}");
    |                 ^^
 
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/format-string-error-2.rs:74:27
    |
 LL |     println!("\x7B}\u{8} {", 1);
-   |                          -^ expected `'}'` in format string
+   |                          -^ expected `}` in format string
    |                          |
    |                          because of this opening brace
    |

--- a/tests/ui/fmt/format-string-error.rs
+++ b/tests/ui/fmt/format-string-error.rs
@@ -2,7 +2,7 @@
 
 fn main() {
     println!("{");
-    //~^ ERROR invalid format string: expected `'}'` but string was terminated
+    //~^ ERROR invalid format string: expected `}` but string was terminated
     println!("{{}}");
     println!("}");
     //~^ ERROR invalid format string: unmatched `}` found
@@ -13,11 +13,11 @@ fn main() {
     let _ = format!("{a:._$}", a = "", _ = 0);
     //~^ ERROR invalid format string: invalid argument name `_`
     let _ = format!("{");
-    //~^ ERROR invalid format string: expected `'}'` but string was terminated
+    //~^ ERROR invalid format string: expected `}` but string was terminated
     let _ = format!("}");
     //~^ ERROR invalid format string: unmatched `}` found
     let _ = format!("{\\}");
-    //~^ ERROR invalid format string: expected `'}'`, found `'\'`
+    //~^ ERROR invalid format string: expected `}`, found `\`
     let _ = format!("\n\n\n{\n\n\n");
     //~^ ERROR invalid format string
     let _ = format!(r###"

--- a/tests/ui/fmt/format-string-error.stderr
+++ b/tests/ui/fmt/format-string-error.stderr
@@ -1,8 +1,8 @@
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/format-string-error.rs:4:16
    |
 LL |     println!("{");
-   |               -^ expected `'}'` in format string
+   |               -^ expected `}` in format string
    |               |
    |               because of this opening brace
    |
@@ -40,11 +40,11 @@ LL |     let _ = format!("{a:._$}", a = "", _ = 0);
    |
    = note: argument name cannot be a single underscore
 
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/format-string-error.rs:15:23
    |
 LL |     let _ = format!("{");
-   |                      -^ expected `'}'` in format string
+   |                      -^ expected `}` in format string
    |                      |
    |                      because of this opening brace
    |
@@ -58,44 +58,44 @@ LL |     let _ = format!("}");
    |
    = note: if you intended to print `}`, you can escape it using `}}`
 
-error: invalid format string: expected `'}'`, found `'\'`
+error: invalid format string: expected `}`, found `\`
   --> $DIR/format-string-error.rs:19:23
    |
 LL |     let _ = format!("{\}");
-   |                      -^ expected `'}'` in format string
+   |                      -^ expected `}` in format string
    |                      |
    |                      because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/format-string-error.rs:21:35
    |
 LL |     let _ = format!("\n\n\n{\n\n\n");
-   |                            -      ^ expected `'}'` in format string
+   |                            -      ^ expected `}` in format string
    |                            |
    |                            because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/format-string-error.rs:27:3
    |
 LL |     {"###);
-   |     -^ expected `'}'` in format string
+   |     -^ expected `}` in format string
    |     |
    |     because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/format-string-error.rs:35:1
    |
 LL |     {
    |     - because of this opening brace
 LL |
 LL | "###);
-   | ^ expected `'}'` in format string
+   | ^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 

--- a/tests/ui/fmt/format-string-wrong-order.rs
+++ b/tests/ui/fmt/format-string-wrong-order.rs
@@ -7,9 +7,9 @@ fn main() {
     format!("{?:?}", bar);
     //~^ ERROR invalid format string: expected format parameter to occur after `:`
     format!("{??}", bar);
-    //~^ ERROR invalid format string: expected `'}'`, found `'?'`
+    //~^ ERROR invalid format string: expected `}`, found `?`
     format!("{?;bar}");
-    //~^ ERROR invalid format string: expected `'}'`, found `'?'`
+    //~^ ERROR invalid format string: expected `}`, found `?`
     format!("{?:#?}", bar);
     //~^ ERROR invalid format string: expected format parameter to occur after `:`
     format!("Hello {<5:}!", "x");

--- a/tests/ui/fmt/format-string-wrong-order.stderr
+++ b/tests/ui/fmt/format-string-wrong-order.stderr
@@ -22,21 +22,21 @@ LL |     format!("{?:?}", bar);
    |
    = note: `?` comes after `:`, try `:?` instead
 
-error: invalid format string: expected `'}'`, found `'?'`
+error: invalid format string: expected `}`, found `?`
   --> $DIR/format-string-wrong-order.rs:9:15
    |
 LL |     format!("{??}", bar);
-   |              -^ expected `'}'` in format string
+   |              -^ expected `}` in format string
    |              |
    |              because of this opening brace
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'`, found `'?'`
+error: invalid format string: expected `}`, found `?`
   --> $DIR/format-string-wrong-order.rs:11:15
    |
 LL |     format!("{?;bar}");
-   |              -^ expected `'}'` in format string
+   |              -^ expected `}` in format string
    |              |
    |              because of this opening brace
    |

--- a/tests/ui/fmt/ifmt-bad-arg.rs
+++ b/tests/ui/fmt/ifmt-bad-arg.rs
@@ -48,7 +48,7 @@ fn main() {
 
     // bad syntax of the format string
 
-    format!("{"); //~ ERROR: expected `'}'` but string was terminated
+    format!("{"); //~ ERROR: expected `}` but string was terminated
 
     format!("foo } bar"); //~ ERROR: unmatched `}` found
     format!("foo }"); //~ ERROR: unmatched `}` found

--- a/tests/ui/fmt/ifmt-bad-arg.stderr
+++ b/tests/ui/fmt/ifmt-bad-arg.stderr
@@ -136,11 +136,11 @@ LL |     format!("{valuea} {valueb}", valuea=5, valuec=7);
    |             |
    |             formatting specifier missing
 
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/ifmt-bad-arg.rs:51:15
    |
 LL |     format!("{");
-   |              -^ expected `'}'` in format string
+   |              -^ expected `}` in format string
    |              |
    |              because of this opening brace
    |
@@ -172,13 +172,13 @@ LL |     format!("foo %s baz", "bar");
    |
    = note: printf formatting is not supported; see the documentation for `std::fmt`
 
-error: invalid format string: expected `'}'`, found `'t'`
+error: invalid format string: expected `}`, found `t`
   --> $DIR/ifmt-bad-arg.rs:75:1
    |
 LL | ninth number: {
    |               - because of this opening brace
 LL | tenth number: {}",
-   | ^ expected `'}'` in format string
+   | ^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 

--- a/tests/ui/fmt/issue-91556.rs
+++ b/tests/ui/fmt/issue-91556.rs
@@ -1,8 +1,8 @@
 fn main() {
   let _ = format!(concat!("{0}𝖳𝖾𝗌𝗍{"), i);
-  //~^ ERROR: invalid format string: expected `'}'` but string was terminated
+  //~^ ERROR: invalid format string: expected `}` but string was terminated
   //~| NOTE: if you intended to print `{`, you can escape it using `{{`
   //~| NOTE: in this expansion of concat!
   //~| NOTE: in this expansion of concat!
-  //~| NOTE: expected `'}'` in format string
+  //~| NOTE: expected `}` in format string
 }

--- a/tests/ui/fmt/issue-91556.stderr
+++ b/tests/ui/fmt/issue-91556.stderr
@@ -1,8 +1,8 @@
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/issue-91556.rs:2:19
    |
 LL |   let _ = format!(concat!("{0}𝖳𝖾𝗌𝗍{"), i);
-   |                   ^^^^^^^^^^^^^^^^^^^ expected `'}'` in format string
+   |                   ^^^^^^^^^^^^^^^^^^^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
    = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/fmt/respanned-literal-issue-106191.rs
+++ b/tests/ui/fmt/respanned-literal-issue-106191.rs
@@ -4,7 +4,7 @@ extern crate format_string_proc_macro;
 
 fn main() {
     format_string_proc_macro::respan_to_invalid_format_literal!("¡");
-    //~^ ERROR invalid format string: expected `'}'` but string was terminated
+    //~^ ERROR invalid format string: expected `}` but string was terminated
     format_args!(r#concat!("¡        {"));
-    //~^ ERROR invalid format string: expected `'}'` but string was terminated
+    //~^ ERROR invalid format string: expected `}` but string was terminated
 }

--- a/tests/ui/fmt/respanned-literal-issue-106191.stderr
+++ b/tests/ui/fmt/respanned-literal-issue-106191.stderr
@@ -1,16 +1,16 @@
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/respanned-literal-issue-106191.rs:6:65
    |
 LL |     format_string_proc_macro::respan_to_invalid_format_literal!("¡");
-   |                                                                 ^^^ expected `'}'` in format string
+   |                                                                 ^^^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
 
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/respanned-literal-issue-106191.rs:8:18
    |
 LL |     format_args!(r#concat!("¡        {"));
-   |                  ^^^^^^^^^^^^^^^^^^^^^^^ expected `'}'` in format string
+   |                  ^^^^^^^^^^^^^^^^^^^^^^^ expected `}` in format string
    |
    = note: if you intended to print `{`, you can escape it using `{{`
    = note: this error originates in the macro `concat` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/macros/issue-51848.stderr
+++ b/tests/ui/macros/issue-51848.stderr
@@ -1,8 +1,8 @@
-error: invalid format string: expected `'}'` but string was terminated
+error: invalid format string: expected `}` but string was terminated
   --> $DIR/issue-51848.rs:6:20
    |
 LL |         println!("{");
-   |                   -^ expected `'}'` in format string
+   |                   -^ expected `}` in format string
    |                   |
    |                   because of this opening brace
 ...


### PR DESCRIPTION
The rest of the compiler uses \`grave accents\`, while `rustc_parse_format` uses \`'apostrophes.'\`

Also makes the crate compile as a stand-alone:
```
~/rust/compiler/rustc_parse_format $ cargo check
   Compiling rustc_index_macros v0.0.0 (/home/lieselotte/rust/compiler/rustc_index_macros)
error[E0277]: `syn::Lit` doesn't implement `Debug`
  --> compiler/rustc_index_macros/src/newtype.rs:52:57
   |
52 |                         panic!("Specified multiple max: {old:?}");
   |                                                         ^^^^^^^ `syn::Lit` cannot be formatted using `{:?}` because it doesn't implement `Debug`
   |
   = help: the trait `Debug` is not implemented for `syn::Lit`
   = note: this error originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0277]: `syn::Lit` doesn't implement `Debug`
  --> compiler/rustc_index_macros/src/newtype.rs:64:74
   |
64 |                         panic!("Specified multiple debug format options: {old:?}");
   |                                                                          ^^^^^^^ `syn::Lit` cannot be formatted using `{:?}` because it doesn't implement `Debug`
   |
   = help: the trait `Debug` is not implemented for `syn::Lit`
   = note: this error originates in the macro `$crate::const_format_args` which comes from the expansion of the macro `panic` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0277`.
error: could not compile `rustc_index_macros` (lib) due to 2 previous errors
```
@rustbot label +A-diagnostics