### PR TITLE
Stabilize `const_maybe_uninit_write`

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -485,9 +485,9 @@ impl<T> MaybeUninit<T> {
     ///     }
     /// }
     /// ```
-    #[stable(feature = "maybe_uninit_write", since = "1.55.0")]
-    #[rustc_const_unstable(feature = "const_maybe_uninit_write", issue = "63567")]
     #[inline(always)]
+    #[stable(feature = "maybe_uninit_write", since = "1.55.0")]
+    #[rustc_const_stable(feature = "const_maybe_uninit_write", since = "CURRENT_RUSTC_VERSION")]
     pub const fn write(&mut self, val: T) -> &mut T {
         *self = MaybeUninit::new(val);
         // SAFETY: We just initialized this value.


### PR DESCRIPTION
Mark the following API const stable:

```rust
impl<T> MaybeUninit<T> {
    pub const fn write(&mut self, val: T) -> &mut T;
}
```

This depends on `const_mut_refs` and [`const_maybe_uninit_assume_init`](https://github.com/rust-lang/rust/issues/86722), both of which have recently been stabilized.

Closes: <https://github.com/rust-lang/rust/issues/63567>

<!-- homu-ignore:start -->
r? libs-api
<!-- homu-ignore:end -->
