### PR TITLE
Add an unstable `const_sockaddr_setters` feature

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -136,6 +136,7 @@
 #![feature(const_raw_ptr_comparison)]
 #![feature(const_size_of_val)]
 #![feature(const_size_of_val_raw)]
+#![feature(const_sockaddr_setters)]
 #![feature(const_strict_overflow_ops)]
 #![feature(const_swap)]
 #![feature(const_try)]

--- a/library/core/src/net/socket_addr.rs
+++ b/library/core/src/net/socket_addr.rs
@@ -159,9 +159,10 @@ impl SocketAddr {
     /// socket.set_ip(IpAddr::V4(Ipv4Addr::new(10, 10, 0, 1)));
     /// assert_eq!(socket.ip(), IpAddr::V4(Ipv4Addr::new(10, 10, 0, 1)));
     /// ```
-    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
     #[inline]
-    pub fn set_ip(&mut self, new_ip: IpAddr) {
+    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
+    #[rustc_const_unstable(feature = "const_sockaddr_setters", issue = "131714")]
+    pub const fn set_ip(&mut self, new_ip: IpAddr) {
         // `match (*self, new_ip)` would have us mutate a copy of self only to throw it away.
         match (self, new_ip) {
             (&mut SocketAddr::V4(ref mut a), IpAddr::V4(new_ip)) => a.set_ip(new_ip),
@@ -202,9 +203,10 @@ impl SocketAddr {
     /// socket.set_port(1025);
     /// assert_eq!(socket.port(), 1025);
     /// ```
-    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
     #[inline]
-    pub fn set_port(&mut self, new_port: u16) {
+    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
+    #[rustc_const_unstable(feature = "const_sockaddr_setters", issue = "131714")]
+    pub const fn set_port(&mut self, new_port: u16) {
         match *self {
             SocketAddr::V4(ref mut a) => a.set_port(new_port),
             SocketAddr::V6(ref mut a) => a.set_port(new_port),
@@ -307,9 +309,10 @@ impl SocketAddrV4 {
     /// socket.set_ip(Ipv4Addr::new(192, 168, 0, 1));
     /// assert_eq!(socket.ip(), &Ipv4Addr::new(192, 168, 0, 1));
     /// ```
-    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
     #[inline]
-    pub fn set_ip(&mut self, new_ip: Ipv4Addr) {
+    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
+    #[rustc_const_unstable(feature = "const_sockaddr_setters", issue = "131714")]
+    pub const fn set_ip(&mut self, new_ip: Ipv4Addr) {
         self.ip = new_ip;
     }
 
@@ -342,9 +345,10 @@ impl SocketAddrV4 {
     /// socket.set_port(4242);
     /// assert_eq!(socket.port(), 4242);
     /// ```
-    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
     #[inline]
-    pub fn set_port(&mut self, new_port: u16) {
+    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
+    #[rustc_const_unstable(feature = "const_sockaddr_setters", issue = "131714")]
+    pub const fn set_port(&mut self, new_port: u16) {
         self.port = new_port;
     }
 }
@@ -403,9 +407,10 @@ impl SocketAddrV6 {
     /// socket.set_ip(Ipv6Addr::new(76, 45, 0, 0, 0, 0, 0, 0));
     /// assert_eq!(socket.ip(), &Ipv6Addr::new(76, 45, 0, 0, 0, 0, 0, 0));
     /// ```
-    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
     #[inline]
-    pub fn set_ip(&mut self, new_ip: Ipv6Addr) {
+    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
+    #[rustc_const_unstable(feature = "const_sockaddr_setters", issue = "131714")]
+    pub const fn set_ip(&mut self, new_ip: Ipv6Addr) {
         self.ip = new_ip;
     }
 
@@ -438,9 +443,10 @@ impl SocketAddrV6 {
     /// socket.set_port(4242);
     /// assert_eq!(socket.port(), 4242);
     /// ```
-    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
     #[inline]
-    pub fn set_port(&mut self, new_port: u16) {
+    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
+    #[rustc_const_unstable(feature = "const_sockaddr_setters", issue = "131714")]
+    pub const fn set_port(&mut self, new_port: u16) {
         self.port = new_port;
     }
 
@@ -485,9 +491,10 @@ impl SocketAddrV6 {
     /// socket.set_flowinfo(56);
     /// assert_eq!(socket.flowinfo(), 56);
     /// ```
-    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
     #[inline]
-    pub fn set_flowinfo(&mut self, new_flowinfo: u32) {
+    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
+    #[rustc_const_unstable(feature = "const_sockaddr_setters", issue = "131714")]
+    pub const fn set_flowinfo(&mut self, new_flowinfo: u32) {
         self.flowinfo = new_flowinfo;
     }
 
@@ -527,9 +534,10 @@ impl SocketAddrV6 {
     /// socket.set_scope_id(42);
     /// assert_eq!(socket.scope_id(), 42);
     /// ```
-    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
     #[inline]
-    pub fn set_scope_id(&mut self, new_scope_id: u32) {
+    #[stable(feature = "sockaddr_setters", since = "1.9.0")]
+    #[rustc_const_unstable(feature = "const_sockaddr_setters", issue = "131714")]
+    pub const fn set_scope_id(&mut self, new_scope_id: u32) {
         self.scope_id = new_scope_id;
     }
 }


### PR DESCRIPTION
Unstably add `const` to the `sockaddr_setters` methods. Included API:

```rust
// core::net

impl SocketAddr {
    pub const fn set_ip(&mut self, new_ip: IpAddr);
    pub const fn set_port(&mut self, new_port: u16);
}

impl SocketAddrV4 {
    pub const fn set_ip(&mut self, new_ip: Ipv4Addr);
    pub const fn set_port(&mut self, new_port: u16);
}

impl SocketAddrV6 {
    pub const fn set_ip(&mut self, new_ip: Ipv6Addr);
    pub const fn set_port(&mut self, new_port: u16);
}
```

Tracking issue: <https://github.com/rust-lang/rust/issues/131714>

<!-- homu-ignore:start -->
r? libs-api
<!-- homu-ignore:end -->
