### PR TITLE
Refactor some `core::fmt` macros

### DIFF
--- a/library/core/src/fmt/float.rs
+++ b/library/core/src/fmt/float.rs
@@ -196,39 +196,40 @@ where
 }
 
 macro_rules! floating {
-    ($ty:ident) => {
-        #[stable(feature = "rust1", since = "1.0.0")]
-        impl Debug for $ty {
-            fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
-                float_to_general_debug(fmt, self)
+    ($($ty:ident)*) => {
+        $(
+            #[stable(feature = "rust1", since = "1.0.0")]
+            impl Debug for $ty {
+                fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
+                    float_to_general_debug(fmt, self)
+                }
             }
-        }
 
-        #[stable(feature = "rust1", since = "1.0.0")]
-        impl Display for $ty {
-            fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
-                float_to_decimal_display(fmt, self)
+            #[stable(feature = "rust1", since = "1.0.0")]
+            impl Display for $ty {
+                fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
+                    float_to_decimal_display(fmt, self)
+                }
             }
-        }
 
-        #[stable(feature = "rust1", since = "1.0.0")]
-        impl LowerExp for $ty {
-            fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
-                float_to_exponential_common(fmt, self, false)
+            #[stable(feature = "rust1", since = "1.0.0")]
+            impl LowerExp for $ty {
+                fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
+                    float_to_exponential_common(fmt, self, false)
+                }
             }
-        }
 
-        #[stable(feature = "rust1", since = "1.0.0")]
-        impl UpperExp for $ty {
-            fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
-                float_to_exponential_common(fmt, self, true)
+            #[stable(feature = "rust1", since = "1.0.0")]
+            impl UpperExp for $ty {
+                fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
+                    float_to_exponential_common(fmt, self, true)
+                }
             }
-        }
+        )*
     };
 }
 
-floating! { f32 }
-floating! { f64 }
+floating! { f32 f64 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl Debug for f16 {

--- a/library/core/src/fmt/nofloat.rs
+++ b/library/core/src/fmt/nofloat.rs
@@ -1,18 +1,17 @@
 use crate::fmt::{Debug, Formatter, Result};
 
 macro_rules! floating {
-    ($ty:ident) => {
-        #[stable(feature = "rust1", since = "1.0.0")]
-        impl Debug for $ty {
-            #[inline]
-            fn fmt(&self, _fmt: &mut Formatter<'_>) -> Result {
-                panic!("floating point support is turned off");
+    ($($ty:ident)*) => {
+        $(
+            #[stable(feature = "rust1", since = "1.0.0")]
+            impl Debug for $ty {
+                #[inline]
+                fn fmt(&self, _fmt: &mut Formatter<'_>) -> Result {
+                    panic!("floating point fmt support is turned off");
+                }
             }
-        }
+        )*
     };
 }
 
-floating! { f16 }
-floating! { f32 }
-floating! { f64 }
-floating! { f128 }
+floating! { f16 f32 f64 f128 }

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -31,22 +31,11 @@ macro_rules! impl_int {
       })*
     )
 }
-macro_rules! impl_uint {
-    ($($t:ident)*) => (
-      $(impl DisplayInt for $t {
-          fn zero() -> Self { 0 }
-          fn from_u8(u: u8) -> Self { u as Self }
-          fn to_u8(&self) -> u8 { *self as u8 }
-          #[cfg(not(any(target_pointer_width = "64", target_arch = "wasm32")))]
-          fn to_u32(&self) -> u32 { *self as u32 }
-          fn to_u64(&self) -> u64 { *self as u64 }
-          fn to_u128(&self) -> u128 { *self as u128 }
-      })*
-    )
-}
 
-impl_int! { i8 i16 i32 i64 i128 isize }
-impl_uint! { u8 u16 u32 u64 u128 usize }
+impl_int! {
+    i8 i16 i32 i64 i128 isize
+    u8 u16 u32 u64 u128 usize
+}
 
 /// A type that represents a specific radix
 ///

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -20,15 +20,15 @@ trait DisplayInt:
 
 macro_rules! impl_int {
     ($($t:ident)*) => (
-      $(impl DisplayInt for $t {
-          fn zero() -> Self { 0 }
-          fn from_u8(u: u8) -> Self { u as Self }
-          fn to_u8(&self) -> u8 { *self as u8 }
-          #[cfg(not(any(target_pointer_width = "64", target_arch = "wasm32")))]
-          fn to_u32(&self) -> u32 { *self as u32 }
-          fn to_u64(&self) -> u64 { *self as u64 }
-          fn to_u128(&self) -> u128 { *self as u128 }
-      })*
+        $(impl DisplayInt for $t {
+            fn zero() -> Self { 0 }
+            fn from_u8(u: u8) -> Self { u as Self }
+            fn to_u8(&self) -> u8 { *self as u8 }
+            #[cfg(not(any(target_pointer_width = "64", target_arch = "wasm32")))]
+            fn to_u32(&self) -> u32 { *self as u32 }
+            fn to_u64(&self) -> u64 { *self as u64 }
+            fn to_u128(&self) -> u128 { *self as u128 }
+        })*
     )
 }
 
@@ -169,21 +169,23 @@ integer! { i64, u64 }
 integer! { i128, u128 }
 
 macro_rules! impl_Debug {
-    ($($T:ident)*) => {$(
-        #[stable(feature = "rust1", since = "1.0.0")]
-        impl fmt::Debug for $T {
-            #[inline]
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                if f.debug_lower_hex() {
-                    fmt::LowerHex::fmt(self, f)
-                } else if f.debug_upper_hex() {
-                    fmt::UpperHex::fmt(self, f)
-                } else {
-                    fmt::Display::fmt(self, f)
+    ($($T:ident)*) => {
+        $(
+            #[stable(feature = "rust1", since = "1.0.0")]
+            impl fmt::Debug for $T {
+                #[inline]
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    if f.debug_lower_hex() {
+                        fmt::LowerHex::fmt(self, f)
+                    } else if f.debug_upper_hex() {
+                        fmt::UpperHex::fmt(self, f)
+                    } else {
+                        fmt::Display::fmt(self, f)
+                    }
                 }
             }
-        }
-    )*};
+        )*
+    };
 }
 
 // 2 digit decimal look up table
@@ -508,8 +510,8 @@ macro_rules! impl_Exp {
 }
 
 impl_Debug! {
-  i8 i16 i32 i64 i128 isize
-  u8 u16 u32 u64 u128 usize
+    i8 i16 i32 i64 i128 isize
+    u8 u16 u32 u64 u128 usize
 }
 
 // Include wasm32 in here since it doesn't reflect the native pointer size, and

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -167,7 +167,8 @@ integer! { i16, u16 }
 integer! { i32, u32 }
 integer! { i64, u64 }
 integer! { i128, u128 }
-macro_rules! debug {
+
+macro_rules! impl_Debug {
     ($($T:ident)*) => {$(
         #[stable(feature = "rust1", since = "1.0.0")]
         impl fmt::Debug for $T {
@@ -183,10 +184,6 @@ macro_rules! debug {
             }
         }
     )*};
-}
-debug! {
-  i8 i16 i32 i64 i128 isize
-  u8 u16 u32 u64 u128 usize
 }
 
 // 2 digit decimal look up table
@@ -508,6 +505,11 @@ macro_rules! impl_Exp {
                 }
             })*
     };
+}
+
+impl_Debug! {
+  i8 i16 i32 i64 i128 isize
+  u8 u16 u32 u64 u128 usize
 }
 
 // Include wasm32 in here since it doesn't reflect the native pointer size, and


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

While looking at the macros in `core::fmt`, find that the macros are not well organized. So I created a patch to fix it.

[`core/src/fmt/num.rs`](https://github.com/rust-lang/rust/blob/master/library/core/src/fmt/num.rs)
*  `impl_int!` and `impl_uint!` macro are **completly** same. It would be better to combine for readability
* `impl_int!` has a problem that the indenting is not uniform. It has unified into 4 spaces
* `debug` macro in `num` renamed to `impl_Debug`, And it was moved to a position close to the `impl_Display`.

[`core/src/fmt/float.rs`](https://github.com/rust-lang/rust/blob/master/library/core/src/fmt/float.rs)
[`core/src/fmt/nofloat.rs`](https://github.com/rust-lang/rust/blob/master/library/core/src/fmt/nofloat.rs)
* `floating` macro now receive multiple idents at once. It makes the code cleaner.
* Modified the panic message more clearly in fallback function of `cfg(no_fp_fmt_parse)`

