### PR TITLE
Fix uninlined_format_args in stable_mir

### DIFF
--- a/compiler/stable_mir/src/mir/pretty.rs
+++ b/compiler/stable_mir/src/mir/pretty.rs
@@ -22,7 +22,7 @@ impl Debug for Place {
 }
 
 pub(crate) fn function_body<W: Write>(writer: &mut W, body: &Body, name: &str) -> io::Result<()> {
-    write!(writer, "fn {}(", name)?;
+    write!(writer, "fn {name}(")?;
     body.arg_locals()
         .iter()
         .enumerate()
@@ -54,7 +54,7 @@ pub(crate) fn function_body<W: Write>(writer: &mut W, body: &Body, name: &str) -
         .iter()
         .enumerate()
         .map(|(index, block)| -> io::Result<()> {
-            writeln!(writer, "    bb{}: {{", index)?;
+            writeln!(writer, "    bb{index}: {{")?;
             let _ = block
                 .statements
                 .iter()
@@ -75,7 +75,7 @@ pub(crate) fn function_body<W: Write>(writer: &mut W, body: &Body, name: &str) -
 fn pretty_statement<W: Write>(writer: &mut W, statement: &StatementKind) -> io::Result<()> {
     match statement {
         StatementKind::Assign(place, rval) => {
-            write!(writer, "        {:?} = ", place)?;
+            write!(writer, "        {place:?} = ")?;
             pretty_rvalue(writer, rval)?;
             writeln!(writer, ";")
         }
@@ -165,7 +165,7 @@ fn pretty_terminator_head<W: Write>(writer: &mut W, terminator: &TerminatorKind)
         Abort => write!(writer, "{INDENT}abort"),
         Return => write!(writer, "{INDENT}return"),
         Unreachable => write!(writer, "{INDENT}unreachable"),
-        Drop { place, .. } => write!(writer, "{INDENT}drop({:?})", place),
+        Drop { place, .. } => write!(writer, "{INDENT}drop({place:?})"),
         Call { func, args, destination, .. } => {
             write!(writer, "{INDENT}{:?} = {}(", destination, pretty_operand(func))?;
             let mut args_iter = args.iter();
@@ -304,10 +304,10 @@ fn pretty_assert_message<W: Write>(writer: &mut W, msg: &AssertMessage) -> io::R
 fn pretty_operand(operand: &Operand) -> String {
     match operand {
         Operand::Copy(copy) => {
-            format!("{:?}", copy)
+            format!("{copy:?}")
         }
         Operand::Move(mv) => {
-            format!("move {:?}", mv)
+            format!("move {mv:?}")
         }
         Operand::Constant(cnst) => pretty_mir_const(&cnst.const_),
     }
@@ -344,13 +344,13 @@ fn pretty_rvalue<W: Write>(writer: &mut W, rval: &Rvalue) -> io::Result<()> {
             write!(writer, "Checked{:?}({}, {})", bin, pretty_operand(op1), pretty_operand(op2))
         }
         Rvalue::CopyForDeref(deref) => {
-            write!(writer, "CopyForDeref({:?})", deref)
+            write!(writer, "CopyForDeref({deref:?})")
         }
         Rvalue::Discriminant(place) => {
-            write!(writer, "discriminant({:?})", place)
+            write!(writer, "discriminant({place:?})")
         }
         Rvalue::Len(len) => {
-            write!(writer, "len({:?})", len)
+            write!(writer, "len({len:?})")
         }
         Rvalue::Ref(_, borrowkind, place) => {
             let kind = match borrowkind {
@@ -359,17 +359,17 @@ fn pretty_rvalue<W: Write>(writer: &mut W, rval: &Rvalue) -> io::Result<()> {
                 BorrowKind::Fake(FakeBorrowKind::Shallow) => "&fake shallow ",
                 BorrowKind::Mut { .. } => "&mut ",
             };
-            write!(writer, "{kind}{:?}", place)
+            write!(writer, "{kind}{place:?}")
         }
         Rvalue::Repeat(op, cnst) => {
             write!(writer, "{} \" \" {}", pretty_operand(op), pretty_ty_const(cnst))
         }
         Rvalue::ShallowInitBox(_, _) => Ok(()),
         Rvalue::ThreadLocalRef(item) => {
-            write!(writer, "thread_local_ref{:?}", item)
+            write!(writer, "thread_local_ref{item:?}")
         }
         Rvalue::NullaryOp(nul, ty) => {
-            write!(writer, "{:?} {} \" \"", nul, ty)
+            write!(writer, "{nul:?} {ty} \" \"")
         }
         Rvalue::UnaryOp(un, op) => {
             write!(writer, "{} \" \" {:?}", pretty_operand(op), un)


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Hi,

This PR fixes some clippy warnings

```
warning: variables can be used directly in the `format!` string
   --> compiler/stable_mir/src/mir/pretty.rs:362:13
    |
362 |             write!(writer, "{kind}{:?}", place)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: requested on the command line with `-W clippy::uninlined-format-args`
help: change this to
    |
362 -             write!(writer, "{kind}{:?}", place)
362 +             write!(writer, "{kind}{place:?}")
    |
```

Best regards,
Michal
