### PR TITLE
linkchecker: add a reminder on broken links to add new/renamed pages to `SUMMARY.md` for mdBooks

### DIFF
--- a/src/tools/linkchecker/main.rs
+++ b/src/tools/linkchecker/main.rs
@@ -100,6 +100,7 @@ fn main() {
         links_ignored_external: 0,
         links_ignored_exception: 0,
         intra_doc_exceptions: 0,
+        has_broken_urls: false,
     };
     checker.walk(&docs, &mut report);
     report.report();
@@ -116,6 +117,8 @@ struct Checker {
 
 struct Report {
     errors: u32,
+    // Used to provide help message to remind the user to register a page in `SUMMARY.md`.
+    has_broken_urls: bool,
     start: Instant,
     html_files: u32,
     html_redirects: u32,
@@ -274,6 +277,7 @@ impl Checker {
                     report.links_ignored_exception += 1;
                 } else {
                     report.errors += 1;
+                    report.has_broken_urls = true;
                     println!("{}:{}: broken link - `{}`", pretty_path, i, target_pretty_path);
                 }
                 return;
@@ -438,6 +442,13 @@ impl Report {
         println!("number of links ignored due to exceptions: {}", self.links_ignored_exception);
         println!("number of intra doc links ignored: {}", self.intra_doc_exceptions);
         println!("errors found: {}", self.errors);
+
+        if self.has_broken_urls {
+            eprintln!(
+                "NOTE: if you are adding or renaming a markdown file in a mdBook, don't forget to \
+                register the page in SUMMARY.md"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
I spent an embarrassingly long amount of time trying to figure out why CI was failing for a PR adding new platform support docs. In turns out it's because the PR author didn't register the new page in `SUMMARY.md`. I completely forgot about it too, and was reading linkchecker source because I thought it was a bug in linkchecker.

So this PR adds a note to modify `SUMMARY.md` when adding new pages in a mdBook.

E.g.

```
# Adding a new `meow` target but forgor to register the page in `SUMMARY.md`
rustc\platform-support.html:183: broken link - `rustc\platform-support\meow.html`
rustc\print.html:9730: broken link - `rustc\platform-support\meow.html`
checked links in: 19.1s
number of HTML files scanned: 43588
number of HTML redirects found: 13735
number of links checked: 3145951
number of links ignored due to external: 156244
number of links ignored due to exceptions: 9
number of intra doc links ignored: 8
errors found: 2
NOTE: if you are adding or renaming a markdown file in a mdBook, don't forget to register the page in SUMMARY.md
found some broken links
```