### PR TITLE
[stable] Clippy: Move `too_long_first_doc_paragraph` to `nursery`

### DIFF
--- a/src/tools/clippy/clippy_lints/src/doc/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/doc/mod.rs
@@ -451,7 +451,7 @@ declare_clippy_lint! {
     /// ```
     #[clippy::version = "1.81.0"]
     pub TOO_LONG_FIRST_DOC_PARAGRAPH,
-    style,
+    nursery,
     "ensure that the first line of a documentation paragraph isn't too long"
 }
 


### PR DESCRIPTION
r? @cuviper 

See: https://rust-lang.zulipchat.com/#narrow/stream/257328-clippy/topic/too_long_first_doc_paragraph.20to.20nursery.3F/near/476448239
