### PR TITLE
Regression test for AVR `rjmp` offset

### DIFF
--- a/tests/assembly/avr-rjmp-offsets.rs
+++ b/tests/assembly/avr-rjmp-offsets.rs
@@ -21,6 +21,12 @@ macro_rules! asm {
 use minicore::ptr;
 
 // CHECK-LABEL: pin_toggling
+// CHECK: .LBB0_1:
+// CHECK-NEXT: out 5, r17
+// CHECK-NEXT: call delay
+// CHECK-NEXT: out 5, r16
+// CHECK-NEXT: call delay
+// CHECK-NEXT: rjmp .LBB0_1
 #[no_mangle]
 pub fn pin_toggling() {
     let port_b = 0x25 as *mut u8; // the I/O-address of PORTB
@@ -33,6 +39,7 @@ pub fn pin_toggling() {
 }
 
 #[inline(never)]
+#[no_mangle]
 fn delay(_: u32) {
     unsafe { asm!("nop") };
 }

--- a/tests/assembly/avr-rjmp-offsets.rs
+++ b/tests/assembly/avr-rjmp-offsets.rs
@@ -1,0 +1,62 @@
+//@ compile-flags: -Copt-level=s --target=avr-unknown-gnu-atmega328 -C panic=abort
+//@ needs-llvm-components: avr
+//@ assembly-output: emit-asm
+
+#![feature(
+    no_core,
+    lang_items,
+    intrinsics,
+    rustc_attrs,
+    arbitrary_self_types,
+    asm_experimental_arch
+)]
+#![crate_type = "rlib"]
+#![no_core]
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+
+use minicore::ptr;
+
+// CHECK-LABEL: pin_toggling
+#[no_mangle]
+pub fn pin_toggling() {
+    let port_b = 0x25 as *mut u8; // the I/O-address of PORTB
+    loop {
+        unsafe { ptr::write_volatile(port_b, 1) };
+        delay(500_0000);
+        unsafe { ptr::write_volatile(port_b, 2) };
+        delay(500_0000);
+    }
+}
+
+#[inline(never)]
+fn delay(_: u32) {
+    unsafe { asm!("nop") };
+}
+
+// FIXME: replace with proper minicore once available (#130693)
+mod minicore {
+    #[lang = "sized"]
+    pub trait Sized {}
+
+    #[lang = "copy"]
+    pub trait Copy {}
+    impl Copy for u32 {}
+    impl Copy for &u32 {}
+    impl<T: ?Sized> Copy for *mut T {}
+
+    pub mod ptr {
+        #[inline]
+        #[rustc_diagnostic_item = "ptr_write_volatile"]
+        pub unsafe fn write_volatile<T>(dst: *mut T, src: T) {
+            extern "rust-intrinsic" {
+                #[rustc_nounwind]
+                pub fn volatile_store<T>(dst: *mut T, val: T);
+            }
+            unsafe { volatile_store(dst, src) };
+        }
+    }
+}

--- a/tests/assembly/avr-rjmp-offsets.rs
+++ b/tests/assembly/avr-rjmp-offsets.rs
@@ -21,10 +21,12 @@ macro_rules! asm {
 use minicore::ptr;
 
 // CHECK-LABEL: pin_toggling
+// CHECK: ldi [[REG_1:r[0-9]+]], 1
+// CHECK: ldi [[REG_2:r[0-9]+]], 2
 // CHECK: .LBB0_1:
-// CHECK-NEXT: out 5, r17
+// CHECK-NEXT: out 5, [[REG_1]]
 // CHECK-NEXT: call delay
-// CHECK-NEXT: out 5, r16
+// CHECK-NEXT: out 5, [[REG_2]]
 // CHECK-NEXT: call delay
 // CHECK-NEXT: rjmp .LBB0_1
 #[no_mangle]

--- a/tests/run-make/avr-rjmp-offset/avr-rjmp-offsets.rs
+++ b/tests/run-make/avr-rjmp-offset/avr-rjmp-offsets.rs
@@ -1,16 +1,11 @@
 //! This test case is a `#![no_core]`-version of the MVCE presented in #129301.
 //!
-//! The function [`delay()`] is minimized and does not actually contain a loop
-//! in order to remove the need for additional lang items.
-#![feature(no_core, lang_items, intrinsics, rustc_attrs, asm_experimental_arch)]
+//! The function [`delay()`] is removed, as it is not necessary to trigger the
+//! wrong behavior and would require some additional lang items.
+#![feature(no_core, lang_items, intrinsics, rustc_attrs)]
 #![no_core]
 #![no_main]
 #![allow(internal_features)]
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
 
 use minicore::ptr;
 
@@ -23,16 +18,8 @@ pub fn main() -> ! {
     // sions did place it after the first loop instruction, causing unsoundness)
     loop {
         unsafe { ptr::write_volatile(port_b, 1) };
-        delay(500_0000);
         unsafe { ptr::write_volatile(port_b, 2) };
-        delay(500_0000);
     }
-}
-
-#[inline(never)]
-#[no_mangle]
-fn delay(_: u32) {
-    unsafe { asm!("nop") };
 }
 
 // FIXME: replace with proper minicore once available (#130693)

--- a/tests/run-make/avr-rjmp-offset/rmake.rs
+++ b/tests/run-make/avr-rjmp-offset/rmake.rs
@@ -1,0 +1,28 @@
+//@ needs-llvm-components: avr
+//! Regression test for #129301/llvm-project#106722 within `rustc`.
+//!
+//! Some LLVM-versions had wrong offsets in the local labels, causing the first
+//! loop instruction to be missed. This test therefore contains a simple loop
+//! with trivial instructions in it, to see, where the label is placed.
+//!
+//! This must be a `rmake`-test and cannot be a `tests/assembly`-test, since the
+//! wrong output is only produced with direct assembly generation, but not when
+//! "emit-asm" is used, as described in the issue description of #129301:
+//! https://github.com/rust-lang/rust/issues/129301#issue-2475070770
+use run_make_support::{llvm_objdump, rustc};
+
+fn main() {
+    rustc()
+        .input("avr-rjmp-offsets.rs")
+        .opt_level("s")
+        .panic("abort")
+        .target("avr-unknown-gnu-atmega328")
+        .output("compiled")
+        .run();
+
+    llvm_objdump()
+        .disassemble()
+        .input("compiled")
+        .run()
+        .assert_stdout_contains_regex(r"rjmp.*\.-14");
+}

--- a/tests/run-make/avr-rjmp-offset/rmake.rs
+++ b/tests/run-make/avr-rjmp-offset/rmake.rs
@@ -1,4 +1,5 @@
 //@ needs-llvm-components: avr
+//@ needs-rust-lld
 //! Regression test for #129301/llvm-project#106722 within `rustc`.
 //!
 //! Some LLVM-versions had wrong offsets in the local labels, causing the first
@@ -17,6 +18,13 @@ fn main() {
         .opt_level("s")
         .panic("abort")
         .target("avr-unknown-gnu-atmega328")
+        // normally one links with `avr-gcc`, but this is not available in CI,
+        // hence this test diverges from the default behavior to enable linking
+        // at all, which is necessary for the test (to resolve the labels). To
+        // not depend on a special linker script, the main-function is marked as
+        // the entry function, causing the linker to not remove it.
+        .linker("rust-lld")
+        .link_arg("--entry=main")
         .output("compiled")
         .run();
 
@@ -35,6 +43,7 @@ fn main() {
     // fore the relative jump has an impact on the label offset. Old versions
     // of the Rust compiler did produce a label `rjmp .-4` (misses the first
     // instruction in the loop).
+    assert!(disassembly.contains("<main>"), "no main function in output");
     disassembly
         .trim()
         .lines()


### PR DESCRIPTION
This adds a regression test for #129301 by minimizing the code in the linked issue and putting it into a `#![no_core]`-compatible format, so that it can easily be used within an `rmake`-test. This needs to be a `rmake` test (opposed to a `tests/assembly` one), since the linked issue describes, that the problem only occurs if the code is directly compiled. Note, that `lld` is used instead of `avr-gcc`; see the [comments](https://github.com/rust-lang/rust/pull/131755#issuecomment-2416469675) [below](https://github.com/rust-lang/rust/pull/131755#issuecomment-2417160045).
Closes #129301.

To show, that the test actually catches the wrong behavior, this can be tested with a faulty rustc:
```bash
$ rustup install nightly-2024-08-19
$ rustc +nightly-2024-08-19 -C opt-level=s -C panic=abort --target avr-unknown-gnu-atmega328 -Clinker=build/x86_64-unknown-linux-gnu/ci-llvm/bin/lld -Clink-arg='--entry=main' -o compiled tests/run-make/avr-rjmp-offset/avr-rjmp-offsets.rs
$ llvm-objdump -d compiled | grep '<main>' -A 6
000110b4 <main>:
   110b4: 81 e0         ldi     r24, 0x1
   110b6: 92 e0         ldi     r25, 0x2
   110b8: 85 b9         out     0x5, r24
   110ba: 95 b9         out     0x5, r25
   110bc: fe cf         rjmp    .-4
```
One can see, that the wrong label offset (`4` instead of `6`) is produced, which would trigger an assertion in the test case.

This would be a good candidate for using the `minicore` proposed in #130693. Since this is not yet merged, there is a FIXME.

r? Patryk27
I think, you are the yet-to-be official target maintainer, hence I'll assign to you.

@rustbot label +O-AVR