### PR TITLE
Ignore lint-non-snake-case-crate#proc_macro_ on targets without unwind

### DIFF
--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.cdylib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.cdylib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:25:18
+  --> $DIR/lint-non-snake-case-crate.rs:29:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:27:9
+  --> $DIR/lint-non-snake-case-crate.rs:31:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.dylib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.dylib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:25:18
+  --> $DIR/lint-non-snake-case-crate.rs:29:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:27:9
+  --> $DIR/lint-non-snake-case-crate.rs:31:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.lib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.lib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:25:18
+  --> $DIR/lint-non-snake-case-crate.rs:29:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:27:9
+  --> $DIR/lint-non-snake-case-crate.rs:31:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.proc_macro_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.proc_macro_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:25:18
+  --> $DIR/lint-non-snake-case-crate.rs:29:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:27:9
+  --> $DIR/lint-non-snake-case-crate.rs:31:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.rlib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.rlib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:25:18
+  --> $DIR/lint-non-snake-case-crate.rs:29:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:27:9
+  --> $DIR/lint-non-snake-case-crate.rs:31:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.rs
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.rs
@@ -22,6 +22,10 @@
 //@[rlib_] compile-flags: --crate-type=rlib
 //@[staticlib_] compile-flags: --crate-type=staticlib
 
+// The compiler may emit a warning that causes stderr output
+// that contains a warning this test does not wish to check.
+//@[proc_macro_] needs-unwind
+
 #![crate_name = "NonSnakeCase"]
 //[cdylib_,dylib_,lib_,proc_macro_,rlib_,staticlib_]~^ ERROR crate `NonSnakeCase` should have a snake case name
 #![deny(non_snake_case)]

--- a/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.staticlib_.stderr
+++ b/tests/ui/lint/non-snake-case/lint-non-snake-case-crate.staticlib_.stderr
@@ -1,11 +1,11 @@
 error: crate `NonSnakeCase` should have a snake case name
-  --> $DIR/lint-non-snake-case-crate.rs:25:18
+  --> $DIR/lint-non-snake-case-crate.rs:29:18
    |
 LL | #![crate_name = "NonSnakeCase"]
    |                  ^^^^^^^^^^^^ help: convert the identifier to snake case: `non_snake_case`
    |
 note: the lint level is defined here
-  --> $DIR/lint-non-snake-case-crate.rs:27:9
+  --> $DIR/lint-non-snake-case-crate.rs:31:9
    |
 LL | #![deny(non_snake_case)]
    |         ^^^^^^^^^^^^^^


### PR DESCRIPTION
The lint-non-snake-case-crate test may emit a warning in stderr if the target does not support unwinding

```
warning: building proc macro crate with `panic=abort` may crash the compiler should the proc-macro panic
```

Consequently, the test will fail on targets that don't support unwinding as written.

This change modifies the expected stderr for lint-non-snake-case-crate in the proc_macro_ to ignore lines that indicate a warning was emitted.
