### PR TITLE
Fix unnecessary nesting in run-make test output directories

### DIFF
--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -22,6 +22,10 @@ impl TestCx<'_> {
         let src_root = self.config.src_base.parent().unwrap().parent().unwrap();
         let src_root = cwd.join(&src_root);
 
+        // FIXME(Zalathar): This should probably be `output_base_dir` to avoid
+        // an unnecessary extra subdirectory, but since legacy Makefile tests
+        // are hopefully going away, it seems safer to leave this perilous code
+        // as-is until it can all be deleted.
         let tmpdir = cwd.join(self.output_base_name());
         if tmpdir.exists() {
             self.aggressive_rm_rf(&tmpdir).unwrap();
@@ -213,7 +217,7 @@ impl TestCx<'_> {
         // `rmake_out/` directory.
         //
         // This setup intentionally diverges from legacy Makefile run-make tests.
-        let base_dir = self.output_base_name();
+        let base_dir = self.output_base_dir();
         if base_dir.exists() {
             self.aggressive_rm_rf(&base_dir).unwrap();
         }

--- a/tests/run-make/README.md
+++ b/tests/run-make/README.md
@@ -29,7 +29,7 @@ The setup for the `rmake.rs` version is a 3-stage process:
    structure within `build/<target>/test/run-make/`
 
    ```
-   <test-name>/<test-name>/
+   <test-name>/
        rmake.exe              # recipe binary
        rmake_out/             # sources from test sources copied over
    ```


### PR DESCRIPTION
Run-make tests were using `output_base_name` to determine their output directory, which results in a redundant subdirectory (e.g. `$build/test/run-make/<foo>/<foo>/`) because that method is intended to produce the name of an individual file.

The previous attempt to fix this double-nesting tried adding a special case in `output_base_dir`, which had the side-effect of breaking up-to-date checking for run-make tests, and had to be reverted in #131681.

The fix is simply to call `output_base_dir` directory, which gives the desired directory without any redundant part.

r? jieyouxu