### PR TITLE
Handle gracefully true/false in `cfg(target(..))` compact

### DIFF
--- a/compiler/rustc_attr/src/builtin.rs
+++ b/compiler/rustc_attr/src/builtin.rs
@@ -723,7 +723,13 @@ pub fn eval_condition(
                     }
 
                     mis.iter().fold(true, |res, mi| {
-                        let mut mi = mi.meta_item().unwrap().clone();
+                        let Some(mut mi) = mi.meta_item().cloned() else {
+                            dcx.emit_err(session_diagnostics::CfgPredicateIdentifier {
+                                span: mi.span(),
+                            });
+                            return false;
+                        };
+
                         if let [seg, ..] = &mut mi.path.segments[..] {
                             seg.ident.name = Symbol::intern(&format!("target_{}", seg.ident.name));
                         }

--- a/tests/ui/cfg/cfg-target-compact-errors.rs
+++ b/tests/ui/cfg/cfg-target-compact-errors.rs
@@ -14,4 +14,8 @@ fn two() {}
 //~^ ERROR invalid predicate `target_pointer`
 fn three() {}
 
+#[cfg(target(true))]
+//~^ ERROR `cfg` predicate key must be an identifier
+fn four() {}
+
 fn main() {}

--- a/tests/ui/cfg/cfg-target-compact-errors.stderr
+++ b/tests/ui/cfg/cfg-target-compact-errors.stderr
@@ -16,7 +16,13 @@ error[E0537]: invalid predicate `target_pointer`
 LL | #[cfg(target(os = "linux", pointer(width = "64")))]
    |                            ^^^^^^^^^^^^^^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: `cfg` predicate key must be an identifier
+  --> $DIR/cfg-target-compact-errors.rs:17:14
+   |
+LL | #[cfg(target(true))]
+   |              ^^^^
+
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0537, E0565.
 For more information about an error, try `rustc --explain E0537`.


### PR DESCRIPTION
This PR handles gracefully `true`/`false` in `cfg(target(..))` compact instead of ICE.

r? @nnethercote
Fixes #131759