### PR TITLE
Add getentropy for RTEMS

### DIFF
--- a/library/std/src/random.rs
+++ b/library/std/src/random.rs
@@ -40,6 +40,7 @@ use crate::sys::random as sys;
 /// Horizon                | `getrandom` shim
 /// Hurd, L4Re, QNX        | `/dev/urandom`
 /// Redox                  | `/scheme/rand`
+/// RTEMS                  | [`arc4random_buf`](https://docs.rtems.org/branches/master/bsp-howto/getentropy.html)
 /// SGX                    | [`rdrand`](https://en.wikipedia.org/wiki/RDRAND)
 /// SOLID                  | `SOLID_RNG_SampleRandomBytes`
 /// TEEOS                  | `TEE_GenerateRandom`

--- a/library/std/src/sys/random/arc4random.rs
+++ b/library/std/src/sys/random/arc4random.rs
@@ -12,6 +12,7 @@
 #[cfg(not(any(
     target_os = "haiku",
     target_os = "illumos",
+    target_os = "rtems",
     target_os = "solaris",
     target_os = "vita",
 )))]
@@ -21,6 +22,7 @@ use libc::arc4random_buf;
 #[cfg(any(
     target_os = "haiku", // See https://git.haiku-os.org/haiku/tree/headers/compatibility/bsd/stdlib.h
     target_os = "illumos", // See https://www.illumos.org/man/3C/arc4random
+    target_os = "rtems", // See https://docs.rtems.org/branches/master/bsp-howto/getentropy.html
     target_os = "solaris", // See https://docs.oracle.com/cd/E88353_01/html/E37843/arc4random-3c.html
     target_os = "vita", // See https://github.com/vitasdk/newlib/blob/b89e5bc183b516945f9ee07eef483ecb916e45ff/newlib/libc/include/stdlib.h#L74
 ))]

--- a/library/std/src/sys/random/mod.rs
+++ b/library/std/src/sys/random/mod.rs
@@ -17,6 +17,7 @@ cfg_if::cfg_if! {
         target_os = "illumos",
         target_os = "netbsd",
         target_os = "openbsd",
+        target_os = "rtems",
         target_os = "solaris",
         target_os = "vita",
     ))] {


### PR DESCRIPTION
RTEMS provides the `getentropy` function.
Use this for providing random data.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->


This PR enables the `getentropy` function for the RTEMS operating system to get random data.
It is exposed via libc  (see https://github.com/rust-lang/libc/pull/3975).

