### PR TITLE
Emscripten: Xfail backtrace ui tests

### DIFF
--- a/tests/ui/backtrace/dylib-dep.rs
+++ b/tests/ui/backtrace/dylib-dep.rs
@@ -9,6 +9,7 @@
 //@ ignore-musl musl doesn't support dynamic libraries (at least when the original test was written).
 //@ needs-unwind
 //@ compile-flags: -g -Copt-level=0 -Cstrip=none -Cforce-frame-pointers=yes
+//@ ignore-emscripten Requires custom symbolization code
 //@ aux-crate: dylib_dep_helper=dylib-dep-helper.rs
 //@ aux-crate: auxiliary=dylib-dep-helper-aux.rs
 //@ run-pass

--- a/tests/ui/backtrace/line-tables-only.rs
+++ b/tests/ui/backtrace/line-tables-only.rs
@@ -10,6 +10,7 @@
 //@ compile-flags: -Cstrip=none -Cdebuginfo=line-tables-only
 //@ ignore-android FIXME #17520
 //@ ignore-fuchsia Backtraces not symbolized
+//@ ignore-emscripten Requires custom symbolization code
 //@ needs-unwind
 //@ aux-build: line-tables-only-helper.rs
 


### PR DESCRIPTION
It is possible to link libunwind and use the normal backtrace code, but it fails to symbolize stack traces. I investigated and could get the list of instruction pointers and symbol names, but I'm not sure how to use the dwarf info to map from instruction pointer to source location. In any case, fixing this is not a high priority.

See https://github.com/rust-lang/rust/issues/131738

r?jieyouxu
