### PR TITLE
Fix needless_lifetimes in stable_mir

### DIFF
--- a/compiler/stable_mir/src/mir/visit.rs
+++ b/compiler/stable_mir/src/mir/visit.rs
@@ -487,7 +487,7 @@ pub struct PlaceRef<'a> {
     pub projection: &'a [ProjectionElem],
 }
 
-impl<'a> PlaceRef<'a> {
+impl PlaceRef<'_> {
     /// Get the type of this place.
     pub fn ty(&self, locals: &[LocalDecl]) -> Result<Ty, Error> {
         self.projection.iter().fold(Ok(locals[self.local].ty), |place_ty, elem| elem.ty(place_ty?))


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Hi,

This PR fixes the following clippy warning

```
warning: the following explicit lifetimes could be elided: 'a
   --> compiler/stable_mir/src/mir/visit.rs:490:6
    |
490 | impl<'a> PlaceRef<'a> {
    |      ^^           ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
    |
490 - impl<'a> PlaceRef<'a> {
490 + impl PlaceRef<'_> {
    |
```

Best regards,
Michal
