### PR TITLE
Stabilize Arm64EC inline assembly

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -45,6 +45,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     | asm::InlineAsmArch::X86_64
                     | asm::InlineAsmArch::Arm
                     | asm::InlineAsmArch::AArch64
+                    | asm::InlineAsmArch::Arm64EC
                     | asm::InlineAsmArch::RiscV32
                     | asm::InlineAsmArch::RiscV64
                     | asm::InlineAsmArch::LoongArch64

--- a/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
@@ -18,7 +18,6 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 - MSP430
 - M68k
 - CSKY
-- Arm64EC
 - SPARC
 
 ## Register classes
@@ -53,9 +52,6 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | CSKY         | `freg`         | `f[0-31]`                          | `f`                  |
 | SPARC        | `reg`          | `r[2-29]`                          | `r`                  |
 | SPARC        | `yreg`         | `y`                                | Only clobbers        |
-| Arm64EC      | `reg`          | `x[0-12]`, `x[15-22]`, `x[25-27]`, `x30` | `r`            |
-| Arm64EC      | `vreg`         | `v[0-15]`                          | `w`                  |
-| Arm64EC      | `vreg_low16`   | `v[0-15]`                          | `x`                  |
 
 > **Notes**:
 > - NVPTX doesn't have a fixed register set, so named registers are not supported.
@@ -92,8 +88,6 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | CSKY         | `freg`                          | None           | `f32`,                                  |
 | SPARC        | `reg`                           | None           | `i8`, `i16`, `i32`, `i64` (SPARC64 only) |
 | SPARC        | `yreg`                          | N/A            | Only clobbers                           |
-| Arm64EC      | `reg`                           | None           | `i8`, `i16`, `i32`, `f32`, `i64`, `f64` |
-| Arm64EC      | `vreg`                          | None           | `i8`, `i16`, `i32`, `f32`, `i64`, `f64`, <br> `i8x8`, `i16x4`, `i32x2`, `i64x1`, `f32x2`, `f64x1`, <br> `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2` |
 
 ## Register aliases
 
@@ -134,12 +128,6 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | SPARC        | `r[8-15]`     | `o[0-7]`  |
 | SPARC        | `r[16-23]`    | `l[0-7]`  |
 | SPARC        | `r[24-31]`    | `i[0-7]`  |
-| Arm64EC      | `x[0-30]`     | `w[0-30]` |
-| Arm64EC      | `x29`         | `fp`      |
-| Arm64EC      | `x30`         | `lr`      |
-| Arm64EC      | `sp`          | `wsp`     |
-| Arm64EC      | `xzr`         | `wzr`     |
-| Arm64EC      | `v[0-15]`     | `b[0-15]`, `h[0-15]`, `s[0-15]`, `d[0-15]`, `q[0-15]` |
 
 > **Notes**:
 > - TI does not mandate a frame pointer for MSP430, but toolchains are allowed
@@ -150,8 +138,8 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | Architecture | Unsupported register                    | Reason                                                                                                                                                                              |
 | ------------ | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | All          | `sp`, `r14`/`o6` (SPARC)                | The stack pointer must be restored to its original value at the end of an asm code block.                                                                                           |
-| All          | `fr` (Hexagon), `fp` (PowerPC), `$fp` (MIPS), `Y` (AVR), `r4` (MSP430), `a6` (M68k), `r30`/`i6` (SPARC), `x29` (Arm64EC) | The frame pointer cannot be used as an input or output.                                            |
-| All          | `r19` (Hexagon), `r29` (PowerPC), `r30` (PowerPC), `x19` (Arm64EC) | These are used internally by LLVM as "base pointer" for functions with complex stack frames.                                                             |
+| All          | `fr` (Hexagon), `fp` (PowerPC), `$fp` (MIPS), `Y` (AVR), `r4` (MSP430), `a6` (M68k), `r30`/`i6` (SPARC) | The frame pointer cannot be used as an input or output.                                                             |
+| All          | `r19` (Hexagon), `r29` (PowerPC), `r30` (PowerPC) | These are used internally by LLVM as "base pointer" for functions with complex stack frames.                                                                              |
 | MIPS         | `$0` or `$zero`                         | This is a constant zero register which can't be modified.                                                                                                                           |
 | MIPS         | `$1` or `$at`                           | Reserved for assembler.                                                                                                                                                             |
 | MIPS         | `$26`/`$k0`, `$27`/`$k1`                | OS-reserved registers.                                                                                                                                                              |
@@ -176,9 +164,6 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | SPARC        | `r5`/`g5`                               | Reserved for system. (SPARC32 only) |
 | SPARC        | `r6`/`g6`, `r7`/`g7`                    | Reserved for system. |
 | SPARC        | `r31`/`i7`                              | Return address cannot be used as inputs or outputs. |
-| Arm64EC      | `xzr`                                   | This is a constant zero register which can't be modified. |
-| Arm64EC      | `x18`                                   | This is an OS-reserved register. |
-| Arm64EC      | `x13`, `x14`, `x23`, `x24`, `x28`, `v[16-31]` | These are AArch64 registers that are not supported for Arm64EC. |
 
 
 ## Template modifiers
@@ -197,16 +182,6 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | SPARC        | `reg`          | None     | `%o0`          | None          |
 | CSKY         | `reg`          | None     | `r0`           | None          |
 | CSKY         | `freg`         | None     | `f0`           | None          |
-| Arm64EC      | `reg`          | None     | `x0`           | `x`           |
-| Arm64EC      | `reg`          | `w`      | `w0`           | `w`           |
-| Arm64EC      | `reg`          | `x`      | `x0`           | `x`           |
-| Arm64EC      | `vreg`         | None     | `v0`           | None          |
-| Arm64EC      | `vreg`         | `v`      | `v0`           | None          |
-| Arm64EC      | `vreg`         | `b`      | `b0`           | `b`           |
-| Arm64EC      | `vreg`         | `h`      | `h0`           | `h`           |
-| Arm64EC      | `vreg`         | `s`      | `s0`           | `s`           |
-| Arm64EC      | `vreg`         | `d`      | `d0`           | `d`           |
-| Arm64EC      | `vreg`         | `q`      | `q0`           | `q`           |
 
 # Flags covered by `preserves_flags`
 
@@ -220,6 +195,3 @@ These flags registers must be restored upon exiting the asm block if the `preser
 - SPARC
   - Integer condition codes (`icc` and `xcc`)
   - Floating-point condition codes (`fcc[0-3]`)
-- Arm64EC
-  - Condition flags (`NZCV` register).
-  - Floating-point status (`FPSR` register).

--- a/tests/assembly/asm/aarch64-types.rs
+++ b/tests/assembly/asm/aarch64-types.rs
@@ -6,7 +6,7 @@
 //@ [arm64ec] needs-llvm-components: aarch64
 //@ compile-flags: -Zmerge-functions=disabled
 
-#![feature(no_core, lang_items, rustc_attrs, repr_simd, asm_experimental_arch, f16, f128)]
+#![feature(no_core, lang_items, rustc_attrs, repr_simd, f16, f128)]
 #![crate_type = "rlib"]
 #![no_core]
 #![allow(asm_sub_register, non_camel_case_types)]

--- a/tests/codegen/asm/arm64ec-clobbers.rs
+++ b/tests/codegen/asm/arm64ec-clobbers.rs
@@ -3,7 +3,7 @@
 //@ needs-llvm-components: aarch64
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![feature(no_core, rustc_attrs, lang_items)]
 #![no_core]
 
 #[lang = "sized"]

--- a/tests/ui/asm/aarch64/arm64ec-sve.rs
+++ b/tests/ui/asm/aarch64/arm64ec-sve.rs
@@ -3,7 +3,7 @@
 //@ needs-llvm-components: aarch64
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![feature(no_core, rustc_attrs, lang_items)]
 #![no_core]
 
 // SVE cannot be used for Arm64EC


### PR DESCRIPTION
This stabilizes inline assembly for Arm64EC ("Emulation Compatible").

Corresponding reference PR: https://github.com/rust-lang/reference/pull/1653

---

From the requirements of stabilization mentioned in https://github.com/rust-lang/rust/issues/93335

> Each architecture needs to be reviewed before stabilization:

> - It must have clobber_abi.

Done in https://github.com/rust-lang/rust/pull/131332.

> - It must be possible to clobber every register that is normally clobbered by a function call.

This is possible from the time of the initial implementation.

> - Generally review that the exposed register classes make sense.

The registers available in this target are a subset of those available in the AArch64 inline assembly which is already stable.

The following registers cannot be used in Arm64EC compared to AArch64:

- `x13`, `x14`, `x23`, `x24`, `x28` (register class: `reg`)
- `v[16-31]` (register class: `vreg`)
- `p[0-15]`, `ffr` (clobber-only register class `preg`)

These are disallowed by the ABI (see also [abi docs](https://learn.microsoft.com/en-us/cpp/build/arm64ec-windows-abi-conventions?view=msvc-170#register-mapping) for `reg`/`vreg` and https://github.com/rust-lang/rust/pull/131332#issuecomment-2401189142 for `preg`).

Although not listed in the above requirements, preserves_flags is also implemented and the same as AArch64.

---

cc @dpaoliello

r? @Amanieu

@rustbot label O-windows O-AArch64 +A-inline-assembly +T-lang -T-compiler +needs-fcp
