### PR TITLE
Fix enum_glob_use in rustc_lexer

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -34,8 +34,14 @@ mod tests;
 
 use unicode_properties::UnicodeEmoji;
 
-use self::LiteralKind::*;
-use self::TokenKind::*;
+use self::LiteralKind::{Byte, ByteStr, CStr, Char, Float, Int, RawByteStr, RawCStr, RawStr, Str};
+use self::TokenKind::{
+    And, At, Bang, BlockComment, Caret, CloseBrace, CloseBracket, CloseParen, Colon, Comma, Dollar,
+    Dot, Eq as TokenKindEq, Gt, Ident, InvalidIdent, InvalidPrefix, Lifetime, LineComment, Literal,
+    Lt, Minus, OpenBrace, OpenBracket, OpenParen, Or, Percent, Plus, Pound, Question, RawIdent,
+    RawLifetime, Semi, Slash, Star, Tilde, Unknown, UnknownPrefix, UnknownPrefixLifetime,
+    Whitespace,
+};
 pub use crate::cursor::Cursor;
 use crate::cursor::EOF_CHAR;
 
@@ -442,7 +448,7 @@ impl Cursor<'_> {
             '?' => Question,
             ':' => Colon,
             '$' => Dollar,
-            '=' => Eq,
+            '=' => TokenKindEq,
             '!' => Bang,
             '<' => Lt,
             '>' => Gt,

--- a/compiler/rustc_lexer/src/unescape.rs
+++ b/compiler/rustc_lexer/src/unescape.rs
@@ -4,7 +4,7 @@
 use std::ops::Range;
 use std::str::Chars;
 
-use Mode::*;
+use Mode::{Byte, ByteStr, CStr, Char, RawByteStr, RawCStr, RawStr, Str};
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Hi,

This PR fixes the following clippy warnings

```
warning: usage of wildcard import for enum variants
 --> compiler/rustc_lexer/src/unescape.rs:7:5
  |
7 | use Mode::*;
  |     ^^^^^^^ help: try: `Mode::{Byte, ByteStr, CStr, Char, RawByteStr, RawCStr, RawStr, Str}`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_glob_use
  = note: requested on the command line with `-W clippy::enum-glob-use`

warning: usage of wildcard import for enum variants
  --> compiler/rustc_lexer/src/lib.rs:37:5
   |
37 | use self::LiteralKind::*;
   |     ^^^^^^^^^^^^^^^^^^^^ help: try: `self::LiteralKind::{Byte, ByteStr, CStr, Char, Float, Int, RawByteStr, RawCStr, RawStr, Str}`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_glob_use

warning: usage of wildcard import for enum variants
  --> compiler/rustc_lexer/src/lib.rs:38:5
   |
38 | use self::TokenKind::*;
   |     ^^^^^^^^^^^^^^^^^^ help: try: `self::TokenKind::{And, At, Bang, BlockComment, Caret, CloseBrace, CloseBracket, CloseParen, Colon, Comma, Dollar, Dot, Eq, Gt, Ident, InvalidIdent, InvalidPrefix, Lifetime, LineComment, Literal, Lt, Minus, OpenBrace, OpenBracket, OpenParen, Or, Percent, Plus, Pound, Question, RawIdent, RawLifetime, Semi, Slash, Star, Tilde, Unknown, UnknownPrefix, UnknownPrefixLifetime, Whitespace}`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_glob_use
```

Best regards,
Michal
