### PR TITLE
Remove `Waker::waker` from 1.82 relnotes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -123,7 +123,6 @@ Stabilized APIs
 These APIs are now stable in const contexts:
 
 - [`std::task::Waker::from_raw`](https://doc.rust-lang.org/nightly/std/task/struct.Waker.html#method.from_raw)
-- [`std::task::Waker::waker`](https://doc.rust-lang.org/nightly/std/task/struct.Waker.html#method.from_raw)
 - [`std::task::Context::from_waker`](https://doc.rust-lang.org/nightly/std/task/struct.Context.html#method.from_waker)
 - [`std::task::Context::waker`](https://doc.rust-lang.org/nightly/std/task/struct.Context.html#method.waker)
 - [`$integer::from_str_radix`](https://doc.rust-lang.org/nightly/std/primitive.u32.html#method.from_str_radix)


### PR DESCRIPTION
This was noticed in <https://github.com/rust-lang/blog.rust-lang.org/pull/1415#pullrequestreview-2371307666>.