### PR TITLE
Enable XRay instrumentation for LoongArch Linux targets

### DIFF
--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
@@ -23,6 +23,7 @@ pub(crate) fn target() -> Target {
                 | SanitizerSet::LEAK
                 | SanitizerSet::MEMORY
                 | SanitizerSet::THREAD,
+            supports_xray: true,
             direct_access_external_data: Some(false),
             ..base::linux_gnu::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_musl.rs
@@ -24,6 +24,7 @@ pub(crate) fn target() -> Target {
                 | SanitizerSet::LEAK
                 | SanitizerSet::MEMORY
                 | SanitizerSet::THREAD,
+            supports_xray: true,
             direct_access_external_data: Some(false),
             ..base::linux_musl::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
@@ -22,6 +22,7 @@ pub(crate) fn target() -> Target {
                 | SanitizerSet::LEAK
                 | SanitizerSet::MEMORY
                 | SanitizerSet::THREAD,
+            supports_xray: true,
             direct_access_external_data: Some(false),
             ..base::linux_ohos::opts()
         },


### PR DESCRIPTION
Enable XRay instrumentation for `loongarch64-unknown-linux-{gnu, musl, ohos}` targets.