### PR TITLE
SolverDelegate add assoc type for Infcx

### DIFF
--- a/compiler/rustc_next_trait_solver/src/delegate.rs
+++ b/compiler/rustc_next_trait_solver/src/delegate.rs
@@ -4,9 +4,8 @@ use rustc_type_ir::fold::TypeFoldable;
 use rustc_type_ir::solve::{Certainty, Goal, NoSolution, SolverMode};
 use rustc_type_ir::{self as ty, InferCtxtLike, Interner};
 
-pub trait SolverDelegate:
-    Deref<Target: InferCtxtLike<Interner = <Self as SolverDelegate>::Interner>> + Sized
-{
+pub trait SolverDelegate: Deref<Target = <Self as SolverDelegate>::Infcx> + Sized {
+    type Infcx: InferCtxtLike<Interner = <Self as SolverDelegate>::Interner>;
     type Interner: Interner;
     fn cx(&self) -> Self::Interner {
         (**self).cx()

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -36,6 +36,7 @@ impl<'tcx> Deref for SolverDelegate<'tcx> {
 }
 
 impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<'tcx> {
+    type Infcx = InferCtxt<'tcx>;
     type Interner = TyCtxt<'tcx>;
 
     fn cx(&self) -> TyCtxt<'tcx> {


### PR DESCRIPTION
makes writing trait bounds on it a lot nicer going forward.

r? @compiler-errors 
