### PR TITLE
Add nul-terminated filename for #[track_caller]

### DIFF
--- a/compiler/rustc_const_eval/src/util/caller_location.rs
+++ b/compiler/rustc_const_eval/src/util/caller_location.rs
@@ -28,7 +28,7 @@ fn alloc_caller_location<'tcx>(
         // FIXME: This creates a new allocation each time. It might be preferable to
         // perform this allocation only once, and re-use the `MPlaceTy`.
         // See https://github.com/rust-lang/rust/pull/89920#discussion_r730012398
-        ecx.allocate_str("<redacted>", MemoryKind::CallerLocation, Mutability::Not).unwrap()
+        ecx.allocate_str("<redacted>\0", MemoryKind::CallerLocation, Mutability::Not).unwrap()
     };
     let file = file.map_provenance(CtfeProvenance::as_immutable);
     let line = if loc_details.line { Scalar::from_u32(line) } else { Scalar::from_u32(0) };

--- a/compiler/rustc_const_eval/src/util/caller_location.rs
+++ b/compiler/rustc_const_eval/src/util/caller_location.rs
@@ -20,7 +20,10 @@ fn alloc_caller_location<'tcx>(
     // This can fail if rustc runs out of memory right here. Trying to emit an error would be
     // pointless, since that would require allocating more memory than these short strings.
     let file = if loc_details.file {
-        ecx.allocate_str(filename.as_str(), MemoryKind::CallerLocation, Mutability::Not).unwrap()
+        let mut name = filename.as_str().to_string();
+        name.push('\0');
+
+        ecx.allocate_str(&name, MemoryKind::CallerLocation, Mutability::Not).unwrap()
     } else {
         // FIXME: This creates a new allocation each time. It might be preferable to
         // perform this allocation only once, and re-use the `MPlaceTy`.

--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -1,7 +1,6 @@
-use crate::fmt;
-
 #[cfg(not(bootstrap))]
 use crate::ffi::CStr;
+use crate::fmt;
 
 /// A struct containing information about the location of a panic.
 ///

--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -145,7 +145,7 @@ impl<'a> Location<'a> {
 
         #[cfg(debug_assertions)]
         if !matches!(s.as_bytes().last(), Some(0)) {
-            panic!("filename is not nul terminated");
+            panic!("filename is not nul-terminated");
         }
 
         // SAFETY: The string contains a nul-byte, so the length is at least one.
@@ -220,11 +220,6 @@ impl<'a> Location<'a> {
     #[cfg(not(bootstrap))]
     pub fn file_with_nul(&self) -> &CStr {
         let file_with_nul = self.file_with_nul.as_bytes();
-
-        #[cfg(debug_assertions)]
-        if !matches!(file_with_nul.last(), Some(0)) {
-            panic!("filename is not nul terminated");
-        }
 
         // SAFETY: This struct is only ever constructed by the compiler, which always inserts a
         // nul-terminator in this string.

--- a/library/core/src/panic/location.rs
+++ b/library/core/src/panic/location.rs
@@ -1,5 +1,8 @@
 use crate::fmt;
 
+#[cfg(not(bootstrap))]
+use crate::ffi::CStr;
+
 /// A struct containing information about the location of a panic.
 ///
 /// This structure is created by [`PanicHookInfo::location()`] and [`PanicInfo::location()`].
@@ -32,7 +35,11 @@ use crate::fmt;
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 pub struct Location<'a> {
-    file: &'a str,
+    // When not bootstrapping the compiler, it is an invariant that the last byte of this string
+    // slice is a nul-byte.
+    //
+    // When bootstrapping the compiler, this string may be missing the nul-terminator.
+    file_with_nul: &'a str,
     line: u32,
     col: u32,
 }
@@ -127,7 +134,30 @@ impl<'a> Location<'a> {
     #[rustc_const_stable(feature = "const_location_fields", since = "1.79.0")]
     #[inline]
     pub const fn file(&self) -> &str {
-        self.file
+        // String slicing in const is very hard, see:
+        // <https://users.rust-lang.org/t/slicing-strings-in-const/119836>
+
+        let s = self.file_with_nul;
+
+        #[cfg(bootstrap)]
+        if !matches!(s.as_bytes().last(), Some(0)) {
+            return s;
+        }
+
+        #[cfg(debug_assertions)]
+        if !matches!(s.as_bytes().last(), Some(0)) {
+            panic!("filename is not nul terminated");
+        }
+
+        // SAFETY: The string contains a nul-byte, so the length is at least one.
+        let len = unsafe { s.len().unchecked_sub(1) };
+
+        // SAFETY: `s.as_ptr()` is valid for `len+1` bytes, so it is valid for `len` bytes.
+        let file = unsafe { core::slice::from_raw_parts(s.as_ptr(), len) };
+
+        // SAFETY: This is valid utf-8 because the original string is valid utf-8 and the last
+        // character was a nul-byte, so removing it does not cut a codepoint in half.
+        unsafe { core::str::from_utf8_unchecked(file) }
     }
 
     /// Returns the line number from which the panic originated.
@@ -179,17 +209,27 @@ impl<'a> Location<'a> {
     pub const fn column(&self) -> u32 {
         self.col
     }
-}
 
-#[unstable(
-    feature = "panic_internals",
-    reason = "internal details of the implementation of the `panic!` and related macros",
-    issue = "none"
-)]
-impl<'a> Location<'a> {
-    #[doc(hidden)]
-    pub const fn internal_constructor(file: &'a str, line: u32, col: u32) -> Self {
-        Location { file, line, col }
+    /// Returns the name of the source file from which the panic originated as a nul-terminated
+    /// string.
+    ///
+    /// This function is like [`Location::file`], except that it returns a nul-terminated string. It
+    /// is mainly useful for passing the filename into C or C++ code.
+    #[must_use]
+    #[inline]
+    #[unstable(feature = "panic_file_with_nul", issue = "none")]
+    #[cfg(not(bootstrap))]
+    pub fn file_with_nul(&self) -> &CStr {
+        let file_with_nul = self.file_with_nul.as_bytes();
+
+        #[cfg(debug_assertions)]
+        if !matches!(file_with_nul.last(), Some(0)) {
+            panic!("filename is not nul terminated");
+        }
+
+        // SAFETY: This struct is only ever constructed by the compiler, which always inserts a
+        // nul-terminator in this string.
+        unsafe { CStr::from_bytes_with_nul_unchecked(file_with_nul) }
     }
 }
 
@@ -197,6 +237,6 @@ impl<'a> Location<'a> {
 impl fmt::Display for Location<'_> {
     #[inline]
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(formatter, "{}:{}:{}", self.file, self.line, self.col)
+        write!(formatter, "{}:{}:{}", self.file(), self.line, self.col)
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/131828)*
<!-- homu-ignore:end -->

ACP: [Add nul-terminated version of core::panic::Location::file](https://github.com/rust-lang/libs-team/issues/466)

When using `#[track_caller]` you can get the filename of the caller using `Location::caller().file()`. We would like to utilize this in the Linux kernel to implement a Rust equivalent of the following utility:
```c
/**
 * might_sleep - annotation for functions that can sleep
 *
 * this macro will print a stack trace if it is executed in an atomic
 * context (spinlock, irq-handler, ...). Additional sections where blocking is
 * not allowed can be annotated with non_block_start() and non_block_end()
 * pairs.
 *
 * This is a useful debugging help to be able to catch problems early and not
 * be bitten later when the calling function happens to sleep when it is not
 * supposed to.
 */
#define might_sleep() do { __might_sleep(__FILE__, __LINE__); might_resched(); } while (0)
```
It's essentially an assertion that crashes the kernel if a function is used in the wrong context. The filename and line number is used in the error message when it fails. Unfortunately, the `__might_sleep` function requires the filename to be a nul-terminated string. Thus, extend `Location` with a function that returns the filename as a `&CStr`.

Note that unlike with things like the `file!()` macro, it's impossible for us to do this ourselves statically. Copying the filename into another string to nul-terminate it is not a great solution because we need to create the string even if the assertion doesn't fail, as the assertion happens on the C side.

For more context, please see [zulip] and [the Linux kernel mailing list][lkml]. This is one of [RfL's wanted features in core](https://github.com/Rust-for-Linux/linux/issues/514).

cc @ojeda @Urgau 

[zulip]: https://rust-lang.zulipchat.com/#narrow/stream/425075-rust-for-linux/topic/Caller.20location.20with.20nul-terminated.20filename/near/477164522
[lkml]: https://lore.kernel.org/rust-for-linux/CAH5fLgjk5koTwMOcdsnQjTVWQehjCDPoD2M3KboGZsxigKdMfA@mail.gmail.com/