### PR TITLE
Add `must_use` to `CommandExt::exec`

### DIFF
--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -154,6 +154,7 @@ pub trait CommandExt: Sealed {
     /// required to gracefully handle errors it is recommended to use the
     /// cross-platform `spawn` instead.
     #[stable(feature = "process_exec2", since = "1.9.0")]
+    #[must_use]
     fn exec(&mut self) -> io::Error;
 
     /// Set executable argument

--- a/tests/ui/command/command-exec.rs
+++ b/tests/ui/command/command-exec.rs
@@ -26,23 +26,23 @@ fn main() {
             }
 
             "exec-test2" => {
-                Command::new("/path/to/nowhere").exec();
+                let _ = Command::new("/path/to/nowhere").exec();
                 println!("passed");
             }
 
             "exec-test3" => {
-                Command::new(&me).arg("bad\0").exec();
+                let _ = Command::new(&me).arg("bad\0").exec();
                 println!("passed");
             }
 
             "exec-test4" => {
-                Command::new(&me).current_dir("/path/to/nowhere").exec();
+                let _ = Command::new(&me).current_dir("/path/to/nowhere").exec();
                 println!("passed");
             }
 
             "exec-test5" => {
                 env::set_var("VARIABLE", "ABC");
-                Command::new("definitely-not-a-real-binary").env("VARIABLE", "XYZ").exec();
+                let _ =  Command::new("definitely-not-a-real-binary").env("VARIABLE", "XYZ").exec();
                 assert_eq!(env::var("VARIABLE").unwrap(), "ABC");
                 println!("passed");
             }


### PR DESCRIPTION
[CommandExt::exec](https://fburl.com/0qhpo7nu) returns a `std::io::Error` in the case exec fails, but its not currently marked as `must_use` making it easy to accidentally ignore it.

This PR adds the `must_use` attributed here as i think it fits the definition in the guide of [When to add #[must_use]](https://std-dev-guide.rust-lang.org/policy/must-use.html#when-to-add-must_use)