### PR TITLE
Do not run test where it cannot run

### DIFF
--- a/library/core/tests/lazy.rs
+++ b/library/core/tests/lazy.rs
@@ -114,6 +114,7 @@ fn lazy_type_inference() {
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 #[should_panic = "LazyCell instance has previously been poisoned"]
 fn lazy_force_mut_panic() {
     let mut lazy = LazyCell::<String>::new(|| panic!());


### PR DESCRIPTION
This was seen on Ferrocene, where we have a custom test target that does not have unwind support
