### PR TITLE
Dont consider predicates that may hold as impossible in `is_impossible_associated_item`

### DIFF
--- a/tests/rustdoc/impossible-default.rs
+++ b/tests/rustdoc/impossible-default.rs
@@ -18,3 +18,11 @@ pub trait Foo {
 pub struct Bar([u8]);
 
 impl Foo for Bar {}
+
+//@ has foo/struct.Generic.html '//*[@id="method.needs_sized"]//h4[@class="code-header"]' \
+// "fn needs_sized"
+//@ has foo/struct.Generic.html '//*[@id="method.no_needs_sized"]//h4[@class="code-header"]' \
+// "fn no_needs_sized"
+pub struct Generic<T: ?Sized>(T);
+
+impl<T: ?Sized> Foo for Generic<T> {}


### PR DESCRIPTION
Use infer vars to account for ambiguities when considering if methods are impossible to instantiate for a given self type. Also while we're at it, let's use the new trait solver instead of `evaluate` since this is used in rustdoc.

r? lcnr
Fixes #131839