### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,0 @@
-if nix flake show path:./src/tools/nix-dev-shell &> /dev/null; then
-  use flake path:./src/tools/nix-dev-shell
-fi

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+if nix flake show path:./src/tools/nix-dev-shell &> /dev/null; then
+  use flake path:./src/tools/nix-dev-shell
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ build/
 /src/tools/x/target
 # Created by default with `src/ci/docker/run.sh`
 /obj/
+# Created by nix dev shell / .envrc
+src/tools/nix-dev-shell/flake.lock
 
 ## ICE reports
 rustc-ice-*.txt

--- a/.mailmap
+++ b/.mailmap
@@ -256,6 +256,7 @@ Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakub.bukaj@yahoo.com>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakub@jakub.cc>
 Jakub Adam Wieczorek <jakub.adam.wieczorek@gmail.com> <jakubw@jakubw.net>
+Jakub Beránek <berykubik@gmail.com> <jakub.beranek@vsb.cz>
 James [Undefined] <tpzker@thepuzzlemaker.info>
 James Deng <cnjamesdeng@gmail.com> <cnJamesDeng@gmail.com>
 James Hinshelwood <jameshinshelwood1@gmail.com> <james.hinshelwood@bigpayme.com>

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -490,8 +490,8 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
     assert(ArgsCstrBuff[ArgsCstrBuffLen - 1] == '\0');
     auto Arg0 = std::string(ArgsCstrBuff);
     buffer_offset = Arg0.size() + 1;
-    auto ArgsCppStr =
-        std::string(ArgsCstrBuff + buffer_offset, ArgsCstrBuffLen - buffer_offset);
+    auto ArgsCppStr = std::string(ArgsCstrBuff + buffer_offset,
+                                  ArgsCstrBuffLen - buffer_offset);
     auto i = 0;
     while (i != std::string::npos) {
       i = ArgsCppStr.find('\0', i + 1);

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -491,12 +491,12 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
     auto Arg0 = std::string(ArgsCstrBuff);
     buffer_offset = Arg0.size() + 1;
     auto ArgsCppStr =
-        std::string(ArgsCstrBuff + buffer_offset, ArgsCstrBuffLen - 1);
+        std::string(ArgsCstrBuff + buffer_offset, ArgsCstrBuffLen - buffer_offset);
     auto i = 0;
     while (i != std::string::npos) {
       i = ArgsCppStr.find('\0', i + 1);
       if (i != std::string::npos)
-        ArgsCppStr.replace(i, i + 1, " ");
+        ArgsCppStr.replace(i, 1, " ");
     }
     Options.MCOptions.Argv0 = Arg0;
     Options.MCOptions.CommandlineArgs = ArgsCppStr;

--- a/compiler/rustc_next_trait_solver/src/delegate.rs
+++ b/compiler/rustc_next_trait_solver/src/delegate.rs
@@ -4,9 +4,8 @@ use rustc_type_ir::fold::TypeFoldable;
 use rustc_type_ir::solve::{Certainty, Goal, NoSolution, SolverMode};
 use rustc_type_ir::{self as ty, InferCtxtLike, Interner};
 
-pub trait SolverDelegate:
-    Deref<Target: InferCtxtLike<Interner = <Self as SolverDelegate>::Interner>> + Sized
-{
+pub trait SolverDelegate: Deref<Target = <Self as SolverDelegate>::Infcx> + Sized {
+    type Infcx: InferCtxtLike<Interner = <Self as SolverDelegate>::Interner>;
     type Interner: Interner;
     fn cx(&self) -> Self::Interner {
         (**self).cx()

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
@@ -23,6 +23,7 @@ pub(crate) fn target() -> Target {
                 | SanitizerSet::LEAK
                 | SanitizerSet::MEMORY
                 | SanitizerSet::THREAD,
+            supports_xray: true,
             direct_access_external_data: Some(false),
             ..base::linux_gnu::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_musl.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_musl.rs
@@ -24,6 +24,7 @@ pub(crate) fn target() -> Target {
                 | SanitizerSet::LEAK
                 | SanitizerSet::MEMORY
                 | SanitizerSet::THREAD,
+            supports_xray: true,
             direct_access_external_data: Some(false),
             ..base::linux_musl::opts()
         },

--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
+++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_ohos.rs
@@ -22,6 +22,7 @@ pub(crate) fn target() -> Target {
                 | SanitizerSet::LEAK
                 | SanitizerSet::MEMORY
                 | SanitizerSet::THREAD,
+            supports_xray: true,
             direct_access_external_data: Some(false),
             ..base::linux_ohos::opts()
         },

--- a/compiler/rustc_trait_selection/src/solve/delegate.rs
+++ b/compiler/rustc_trait_selection/src/solve/delegate.rs
@@ -36,6 +36,7 @@ impl<'tcx> Deref for SolverDelegate<'tcx> {
 }
 
 impl<'tcx> rustc_next_trait_solver::delegate::SolverDelegate for SolverDelegate<'tcx> {
+    type Infcx = InferCtxt<'tcx>;
     type Interner = TyCtxt<'tcx>;
 
     fn cx(&self) -> TyCtxt<'tcx> {

--- a/library/core/tests/lazy.rs
+++ b/library/core/tests/lazy.rs
@@ -114,6 +114,7 @@ fn lazy_type_inference() {
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 #[should_panic = "LazyCell instance has previously been poisoned"]
 fn lazy_force_mut_panic() {
     let mut lazy = LazyCell::<String>::new(|| panic!());

--- a/library/std/src/os/unix/process.rs
+++ b/library/std/src/os/unix/process.rs
@@ -154,6 +154,7 @@ pub trait CommandExt: Sealed {
     /// required to gracefully handle errors it is recommended to use the
     /// cross-platform `spawn` instead.
     #[stable(feature = "process_exec2", since = "1.9.0")]
+    #[must_use]
     fn exec(&mut self) -> io::Error;
 
     /// Set executable argument

--- a/src/tools/nix-dev-shell/envrc-flake
+++ b/src/tools/nix-dev-shell/envrc-flake
@@ -1,0 +1,8 @@
+# If you want to use this as an .envrc file to create a shell with necessery components 
+# to develop rustc, use the following command in the root of the rusr checkout:
+#	
+# ln -s ./src/tools/nix-dev-shell/envrc-flake ./.envrc && echo .envrc >> .git/info/exclude
+
+if nix flake show path:./src/tools/nix-dev-shell &> /dev/null; then
+  use flake path:./src/tools/nix-dev-shell
+fi

--- a/src/tools/nix-dev-shell/envrc-shell
+++ b/src/tools/nix-dev-shell/envrc-shell
@@ -1,0 +1,7 @@
+# If you want to use this as an .envrc file to create a shell with necessery components 
+# to develop rustc, use the following command in the root of the rusr checkout:
+#	
+# ln -s ./src/tools/nix-dev-shell/envrc-shell ./.envrc && echo .envrc >> .git/info/exclude
+
+use nix ./src/tools/nix-dev-shell/shell.nix
+  

--- a/src/tools/nix-dev-shell/flake.nix
+++ b/src/tools/nix-dev-shell/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "rustc dev shell";
+
+  inputs = {
+    nixpkgs.url      = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url  = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+	flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        x = import ./x { inherit pkgs; };
+      in
+      {
+        devShells.default = with pkgs; mkShell {
+          name = "rustc-dev-shell";
+          nativeBuildInputs = with pkgs; [
+            binutils cmake ninja pkg-config python3 git curl cacert patchelf nix
+          ];
+          buildInputs = with pkgs; [
+            openssl glibc.out glibc.static x
+          ];
+          # Avoid creating text files for ICEs.
+          RUSTC_ICE = "0";
+          # Provide `libstdc++.so.6` for the self-contained lld.
+          LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [
+            stdenv.cc.cc.lib
+          ]}";
+        };
+      }
+    );
+}

--- a/src/tools/nix-dev-shell/shell.nix
+++ b/src/tools/nix-dev-shell/shell.nix
@@ -1,0 +1,19 @@
+{ pkgs ? import <nixpkgs> {} }:
+let 
+  x = import ./x { inherit pkgs; };
+in
+pkgs.mkShell {
+  name = "rustc";
+  nativeBuildInputs = with pkgs; [
+    binutils cmake ninja pkg-config python3 git curl cacert patchelf nix
+  ];
+  buildInputs = with pkgs; [
+    openssl glibc.out glibc.static x
+  ];
+  # Avoid creating text files for ICEs.
+  RUSTC_ICE = "0";
+  # Provide `libstdc++.so.6` for the self-contained lld.
+  LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [
+    stdenv.cc.cc.lib
+  ]}";
+}

--- a/src/tools/nix-dev-shell/x/default.nix
+++ b/src/tools/nix-dev-shell/x/default.nix
@@ -1,0 +1,22 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+pkgs.stdenv.mkDerivation {
+  name = "x";
+
+  src = ./x.rs;
+  dontUnpack = true;
+
+  nativeBuildInputs = with pkgs; [ rustc ];
+
+  buildPhase = ''
+    PYTHON=${pkgs.lib.getExe pkgs.python3} rustc -Copt-level=3 --crate-name x $src --out-dir $out/bin
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Helper for rust-lang/rust x.py";
+    homepage = "https://github.com/rust-lang/rust/blob/master/src/tools/x";
+    license = licenses.mit;
+    mainProgram = "x";
+  };
+}

--- a/src/tools/nix-dev-shell/x/x.rs
+++ b/src/tools/nix-dev-shell/x/x.rs
@@ -1,0 +1,50 @@
+// git clone https://github.com/rust-lang/rust/blob/0ea7ddcc35a2fcaa5da8a7dcfc118c9fb4a63b95/src/tools/x/src/main.rs
+// patched to stop doing python probing, stop the probe, please dont, i have a python
+//! Run bootstrap from any subdirectory of a rust compiler checkout.
+//!
+//! We prefer `exec`, to avoid adding an extra process in the process tree.
+//! However, since `exec` isn't available on Windows, we indirect through
+//! `exec_or_status`, which will call `exec` on unix and `status` on Windows.
+//!
+//! We use `powershell.exe x.ps1` on Windows, and `sh -c x` on Unix, those are
+//! the ones that call `x.py`. We use `sh -c` on Unix, because it is a standard.
+//! We also don't use `pwsh` on Windows, because it is not installed by default;
+
+use std::env;
+use std::os::unix::process::CommandExt;
+use std::process::{self, Command};
+
+fn main() {
+    match env::args().skip(1).next().as_deref() {
+        Some("--wrapper-version") => {
+            println!("0.1.0");
+            return;
+        }
+        _ => {}
+    }
+    let current = match env::current_dir() {
+        Ok(dir) => dir,
+        Err(err) => {
+            eprintln!("Failed to get current directory: {err}");
+            process::exit(1);
+        }
+    };
+
+    for dir in current.ancestors() {
+        let candidate = dir.join("x.py");
+        if candidate.exists() {
+            let mut cmd = Command::new(env!("PYTHON"));
+            cmd.arg(dir.join("x.py"));
+            cmd.args(env::args().skip(1)).current_dir(dir);
+
+            let error = cmd.exec();
+            eprintln!("Failed to invoke `{:?}`: {}", cmd, error);
+        }
+    }
+
+    eprintln!(
+        "x.py not found. Please run inside of a checkout of `https://github.com/rust-lang/rust`."
+    );
+
+    process::exit(1);
+}

--- a/tests/ui/command/command-exec.rs
+++ b/tests/ui/command/command-exec.rs
@@ -26,23 +26,23 @@ fn main() {
             }
 
             "exec-test2" => {
-                Command::new("/path/to/nowhere").exec();
+                let _ = Command::new("/path/to/nowhere").exec();
                 println!("passed");
             }
 
             "exec-test3" => {
-                Command::new(&me).arg("bad\0").exec();
+                let _ = Command::new(&me).arg("bad\0").exec();
                 println!("passed");
             }
 
             "exec-test4" => {
-                Command::new(&me).current_dir("/path/to/nowhere").exec();
+                let _ = Command::new(&me).current_dir("/path/to/nowhere").exec();
                 println!("passed");
             }
 
             "exec-test5" => {
                 env::set_var("VARIABLE", "ABC");
-                Command::new("definitely-not-a-real-binary").env("VARIABLE", "XYZ").exec();
+                let _ =  Command::new("definitely-not-a-real-binary").env("VARIABLE", "XYZ").exec();
                 assert_eq!(env::var("VARIABLE").unwrap(), "ABC");
                 println!("passed");
             }


### PR DESCRIPTION
Successful merges:

 - #129620 (Provide a more convinient way of developing rustc on NixOS)
 - #131805 (rustc_llvm: Fix flattened CLI args)
 - #131818 (Enable XRay instrumentation for LoongArch Linux targets)
 - #131825 (SolverDelegate add assoc type for Infcx)
 - #131833 (Add `must_use` to `CommandExt::exec`)
 - #131835 (Do not run test where it cannot run)
 - #131844 (Add mailmap entry for kobzol)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=129620,131805,131818,131825,131833,131835,131844)
<!-- homu-ignore:end -->