### PR TITLE
Update libc to 0.2.161

### DIFF
--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -39,7 +39,7 @@ miniz_oxide = { version = "0.7.0", optional = true, default-features = false }
 addr2line = { version = "0.22.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
-libc = { version = "0.2.159", default-features = false, features = [
+libc = { version = "0.2.161", default-features = false, features = [
     'rustc-dep-of-std',
 ], public = true }
 


### PR DESCRIPTION
The main change is to fix segfaults on 32-bit FreeBSD targets.

Fixes #130677