### PR TITLE
Remove erroneous statement in repeat_n documentation that was obsoleted by the same version repeat_n was stabilized

### DIFF
--- a/library/core/src/iter/sources/repeat_n.rs
+++ b/library/core/src/iter/sources/repeat_n.rs
@@ -8,9 +8,7 @@ use crate::num::NonZero;
 /// The `repeat_n()` function repeats a single value exactly `n` times.
 ///
 /// This is very similar to using [`repeat()`] with [`Iterator::take()`],
-/// but there are two differences:
-/// - `repeat_n()` can return the original value, rather than always cloning.
-/// - `repeat_n()` produces an [`ExactSizeIterator`].
+/// but `repeat_n()` can return the original value, rather than always cloning.
 ///
 /// [`repeat()`]: crate::iter::repeat
 ///


### PR DESCRIPTION
Remove statement that `std::iter::repeat_n(element, count)` is different from `std::iter::repeat(element).take(count)` because its return type implements std::iter::ExactSizeIterator.

This would’ve been true if 994e712162af1d568a1751c32626478f2c613cc2 and 3dca90946f612f73b64f6c17ecb82a520a1d8da1 didn't add `impl<T: Clone> std::iter::ExactSizeIterator for std::iter::Take<std::iter::Repeat<T>>` (library/core/src/iter/adapters/take.rs:364).

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
