### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -1082,7 +1082,7 @@ impl<T, A: Allocator> LinkedList<T, A> {
 
     /// Retains only the elements specified by the predicate.
     ///
-    /// In other words, remove all elements `e` for which `f(&e)` returns false.
+    /// In other words, remove all elements `e` for which `f(&mut e)` returns false.
     /// This method operates in place, visiting each element exactly once in the
     /// original order, and preserves the order of the retained elements.
     ///

--- a/library/alloc/src/collections/vec_deque/mod.rs
+++ b/library/alloc/src/collections/vec_deque/mod.rs
@@ -2122,7 +2122,7 @@ impl<T, A: Allocator> VecDeque<T, A> {
 
     /// Retains only the elements specified by the predicate.
     ///
-    /// In other words, remove all elements `e` for which `f(&e)` returns false.
+    /// In other words, remove all elements `e` for which `f(&mut e)` returns false.
     /// This method operates in place, visiting each element exactly once in the
     /// original order, and preserves the order of the retained elements.
     ///

--- a/library/core/src/iter/sources/repeat_n.rs
+++ b/library/core/src/iter/sources/repeat_n.rs
@@ -8,9 +8,7 @@ use crate::num::NonZero;
 /// The `repeat_n()` function repeats a single value exactly `n` times.
 ///
 /// This is very similar to using [`repeat()`] with [`Iterator::take()`],
-/// but there are two differences:
-/// - `repeat_n()` can return the original value, rather than always cloning.
-/// - `repeat_n()` produces an [`ExactSizeIterator`].
+/// but `repeat_n()` can return the original value, rather than always cloning.
 ///
 /// [`repeat()`]: crate::iter::repeat
 ///

--- a/library/std/tests/thread.rs
+++ b/library/std/tests/thread.rs
@@ -39,6 +39,29 @@ fn thread_local_containing_const_statements() {
 }
 
 #[test]
+fn thread_local_hygeiene() {
+    // Previously `thread_local_inner!` had use imports for `LocalKey`, `Storage`, `EagerStorage`
+    // and `LazyStorage`. The use imports will shadow a user-provided type or type alias if the
+    // user-provided type or type alias has the same name. Make sure that this does not happen. See
+    // <https://github.com/rust-lang/rust/issues/131863>.
+    //
+    // NOTE: if the internal implementation details change (i.e. get renamed), this test should be
+    // updated.
+
+    #![allow(dead_code)]
+    type LocalKey = ();
+    type Storage = ();
+    type LazyStorage = ();
+    type EagerStorage = ();
+    thread_local! {
+        static A: LocalKey = const { () };
+        static B: Storage = const { () };
+        static C: LazyStorage = const { () };
+        static D: EagerStorage = const { () };
+    }
+}
+
+#[test]
 // Include an ignore list on purpose, so that new platforms don't miss it
 #[cfg_attr(
     any(


### PR DESCRIPTION
Successful merges:

 - #131809 (Fix predicate signatures in retain_mut docs)
 - #131858 (Remove outdated documentation for `repeat_n`)
 - #131866 (Avoid use imports in `thread_local_inner!`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131809,131858,131866)
<!-- homu-ignore:end -->