### PR TITLE
Add WASM | WASI | Emscripten groups to triagebot.toml

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -135,6 +135,43 @@ In case it's useful, here are some [instructions] for tackling these sorts of is
 """
 label = "O-rfl"
 
+[ping.wasm]
+alias = ["webassembly"]
+message = """\
+Hey WASM notification group! This issue or PR could use some WebAssembly-specific
+guidance. Could one of you weigh in? Thanks <3
+
+(In case it's useful, here are some [instructions] for tackling these sorts of
+issues).
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/wasm.html
+"""
+label = "O-wasm"
+
+[ping.wasi]
+message = """\
+Hey WASI notification group! This issue or PR could use some WASI-specific guidance.
+Could one of you weigh in? Thanks <3
+
+(In case it's useful, here are some [instructions] for tackling these sorts of
+issues).
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/wasi.html
+"""
+label = "O-wasi"
+
+[ping.emscripten]
+message = """\
+Hey Emscripten notification group! This issue or PR could use some Emscripten-specific
+guidance. Could one of you weigh in? Thanks <3
+
+(In case it's useful, here are some [instructions] for tackling these sorts of
+issues).
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/emscripten.html
+"""
+label = "O-emscripten"
+
 [prioritize]
 label = "I-prioritize"
 


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/compiler-team/issues/799

~~This is blocked on amending the notification group section so that the instructions links point somewhere: https://github.com/rust-lang/rustc-dev-guide/pull/2100~~