### PR TITLE
Fix suggestions when returning a bare trait from an async fn.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,6 +3365,7 @@ dependencies = [
  "rustc_fluent_macro",
  "rustc_graphviz",
  "rustc_hir",
+ "rustc_hir_analysis",
  "rustc_index",
  "rustc_infer",
  "rustc_lexer",

--- a/compiler/rustc_borrowck/Cargo.toml
+++ b/compiler/rustc_borrowck/Cargo.toml
@@ -13,6 +13,7 @@ rustc_errors = { path = "../rustc_errors" }
 rustc_fluent_macro = { path = "../rustc_fluent_macro" }
 rustc_graphviz = { path = "../rustc_graphviz" }
 rustc_hir = { path = "../rustc_hir" }
+rustc_hir_analysis = { path = "../rustc_hir_analysis" }
 rustc_index = { path = "../rustc_index" }
 rustc_infer = { path = "../rustc_infer" }
 rustc_lexer = { path = "../rustc_lexer" }

--- a/tests/ui/traits/suggest-impl-on-bare-trait-return.rs
+++ b/tests/ui/traits/suggest-impl-on-bare-trait-return.rs
@@ -1,0 +1,8 @@
+//@ edition:2021
+trait Trait {}
+
+async fn fun() -> Trait {  //~ ERROR expected a type, found a trait
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui/traits/suggest-impl-on-bare-trait-return.stderr
+++ b/tests/ui/traits/suggest-impl-on-bare-trait-return.stderr
@@ -1,0 +1,18 @@
+error[E0782]: expected a type, found a trait
+  --> $DIR/suggest-impl-on-bare-trait-return.rs:4:13
+   |
+LL | fn fun() -> Trait {
+   |             ^^^^^
+   |
+help: use `impl Trait` to return an opaque type, as long as you return a single underlying type
+   |
+LL | fn fun() -> impl Trait {
+   |             ++++
+help: alternatively, you can return an owned trait object
+   |
+LL | fn fun() -> Box<dyn Trait> {
+   |             +++++++      +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0782`.


### PR DESCRIPTION
Don't assume we always return a trait object and suggest the dyn keyword. Suggest adding impl instead.

fixes #131661

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
