### PR TITLE
minor `*dyn` cast cleanup

### DIFF
--- a/tests/ui/cast/ptr-to-trait-obj-drop-principal.rs
+++ b/tests/ui/cast/ptr-to-trait-obj-drop-principal.rs
@@ -1,0 +1,21 @@
+//! Test that non-coercion casts aren't allowed to drop the principal,
+//! because they cannot modify the pointer metadata.
+//!
+//! We test this in a const context to guard against UB if this is allowed
+//! in the future.
+
+trait Trait {}
+impl Trait for () {}
+
+struct Wrapper<T: ?Sized>(T);
+
+const OBJECT: *const (dyn Trait + Send) = &();
+
+// coercions are allowed
+const _: *const dyn Send = OBJECT as _;
+
+// casts are **not** allowed
+const _: *const Wrapper<dyn Send> = OBJECT as _;
+//~^ ERROR casting `*const (dyn Trait + Send + 'static)` as `*const Wrapper<dyn Send>` is invalid
+
+fn main() {}

--- a/tests/ui/cast/ptr-to-trait-obj-drop-principal.stderr
+++ b/tests/ui/cast/ptr-to-trait-obj-drop-principal.stderr
@@ -1,0 +1,11 @@
+error[E0606]: casting `*const (dyn Trait + Send + 'static)` as `*const Wrapper<dyn Send>` is invalid
+  --> $DIR/ptr-to-trait-obj-drop-principal.rs:18:37
+   |
+LL | const _: *const Wrapper<dyn Send> = OBJECT as _;
+   |                                     ^^^^^^^^^^^
+   |
+   = note: the trait objects may have different vtables
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0606`.


### PR DESCRIPTION
Small follow-up to https://github.com/rust-lang/rust/pull/130234 to remove a redundant check and clean up comments. No functional changes.

Also, explain why casts cannot drop the principal even though coercions can, and add a test because apparently we didn't have one already.

r? @WaffleLapkin or @compiler-errors