### PR TITLE
Derive `Copy` and `Hash` for `IntErrorKind`

### DIFF
--- a/library/core/src/num/error.rs
+++ b/library/core/src/num/error.rs
@@ -79,7 +79,7 @@ pub struct ParseIntError {
 /// # }
 /// ```
 #[stable(feature = "int_error_matching", since = "1.55.0")]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
 #[non_exhaustive]
 pub enum IntErrorKind {
     /// Value being parsed is empty.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This PR derives `Copy` and `Hash` for `IntErrorKind` to make it easier to work with. (see #131826)

I think an argument could be made to also derive `PartialOrd` + `Ord` as well given that other error kinds in the std like [`io::ErrorKind`](https://doc.rust-lang.org/src/std/io/error.rs.html#212-428) do this. Granted these seem much less useful for errors.

Fixes https://github.com/rust-lang/rust/issues/131826