### PR TITLE
Warn on redundant `--cfg` directive when revisions are used

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -468,7 +468,19 @@ impl<'test> TestCx<'test> {
 
         if let Some(revision) = self.revision {
             let normalized_revision = normalize_revision(revision);
-            cmd.args(&["--cfg", &normalized_revision]);
+            let cfg_arg = ["--cfg", &normalized_revision];
+            let arg = format!("--cfg={normalized_revision}");
+            if self
+                .props
+                .compile_flags
+                .windows(2)
+                .any(|args| args == cfg_arg || args[0] == arg || args[1] == arg)
+            {
+                panic!(
+                    "error: redundant cfg argument `{normalized_revision}` is already created by the revision"
+                );
+            }
+            cmd.args(cfg_arg);
         }
 
         if !self.props.no_auto_check_cfg {

--- a/tests/ui/precondition-checks/layout.rs
+++ b/tests/ui/precondition-checks/layout.rs
@@ -2,8 +2,6 @@
 //@ compile-flags: -Copt-level=3 -Cdebug-assertions=no -Zub-checks=yes
 //@ error-pattern: unsafe precondition(s) violated: Layout::from_size_align_unchecked requires
 //@ revisions: toolarge badalign
-//@[toolarge] compile-flags: --cfg toolarge
-//@[badalign] compile-flags: --cfg badalign
 
 fn main() {
     unsafe {

--- a/tests/ui/sanitizer/cfg.rs
+++ b/tests/ui/sanitizer/cfg.rs
@@ -5,19 +5,19 @@
 //@ revisions: address cfi kcfi leak memory thread
 //@compile-flags: -Ctarget-feature=-crt-static
 //@[address]needs-sanitizer-address
-//@[address]compile-flags: -Zsanitizer=address --cfg address
+//@[address]compile-flags: -Zsanitizer=address
 //@[cfi]needs-sanitizer-cfi
-//@[cfi]compile-flags:     -Zsanitizer=cfi     --cfg cfi
+//@[cfi]compile-flags:     -Zsanitizer=cfi
 //@[cfi]compile-flags:     -Clto -Ccodegen-units=1
 //@[kcfi]needs-llvm-components: x86
-//@[kcfi]compile-flags:    -Zsanitizer=kcfi    --cfg kcfi --target x86_64-unknown-none
+//@[kcfi]compile-flags:    -Zsanitizer=kcfi --target x86_64-unknown-none
 //@[kcfi]compile-flags:    -C panic=abort
 //@[leak]needs-sanitizer-leak
-//@[leak]compile-flags:    -Zsanitizer=leak    --cfg leak
+//@[leak]compile-flags:    -Zsanitizer=leak
 //@[memory]needs-sanitizer-memory
-//@[memory]compile-flags:  -Zsanitizer=memory  --cfg memory
+//@[memory]compile-flags:  -Zsanitizer=memory
 //@[thread]needs-sanitizer-thread
-//@[thread]compile-flags:  -Zsanitizer=thread  --cfg thread
+//@[thread]compile-flags:  -Zsanitizer=thread
 
 #![feature(cfg_sanitize, no_core, lang_items)]
 #![crate_type="lib"]

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.no_std.fixed
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.no_std.fixed
@@ -4,7 +4,7 @@
 // For some reason, Rust 2018 or higher is required to reproduce the bug.
 //@ run-rustfix
 //@ revisions: no_std std
-//@ [no_std]compile-flags: --cfg=no_std -C panic=abort
+//@ [no_std]compile-flags: -C panic=abort
 #![cfg_attr(no_std, no_std)]
 
 use core::num::NonZero;

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.rs
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.rs
@@ -4,7 +4,7 @@
 // For some reason, Rust 2018 or higher is required to reproduce the bug.
 //@ run-rustfix
 //@ revisions: no_std std
-//@ [no_std]compile-flags: --cfg=no_std -C panic=abort
+//@ [no_std]compile-flags: -C panic=abort
 #![cfg_attr(no_std, no_std)]
 
 fn main() {

--- a/tests/ui/suggestions/core-std-import-order-issue-83564.std.fixed
+++ b/tests/ui/suggestions/core-std-import-order-issue-83564.std.fixed
@@ -4,7 +4,7 @@
 // For some reason, Rust 2018 or higher is required to reproduce the bug.
 //@ run-rustfix
 //@ revisions: no_std std
-//@ [no_std]compile-flags: --cfg=no_std -C panic=abort
+//@ [no_std]compile-flags: -C panic=abort
 #![cfg_attr(no_std, no_std)]
 
 use std::num::NonZero;


### PR DESCRIPTION
r? @jieyouxu

Fixes #131390
Not sure of the best way to test this