### PR TITLE
Align boolean option descriptions in `configure.py`

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -193,7 +193,8 @@ if '--help' in sys.argv or '-h' in sys.argv:
         if option.value:
             print('\t{:30} {}'.format('--{}=VAL'.format(option.name), option.desc))
         else:
-            print('\t{:30} {}'.format('--enable-{}  OR  --disable-{}'.format(option.name, option.name), option.desc))
+            print('\t--enable-{:25} OR --disable-{}'.format(option.name, option.name))
+            print('\t\t' + option.desc)
     print('')
     print('This configure script is a thin configuration shim over the true')
     print('configuration system, `config.toml`. You can explore the comments')


### PR DESCRIPTION
Boolean options are currently printed as
```
Options
        --enable-debug  OR  --disable-debug enables debugging environment; does not affect optimization of bootstrapped code
        --enable-docs  OR  --disable-docs build standard library documentation
        --enable-compiler-docs  OR  --disable-compiler-docs build compiler documentation
        --enable-optimize-tests  OR  --disable-optimize-tests build tests with optimizations
        --enable-verbose-tests  OR  --disable-verbose-tests enable verbose output when running tests
        --enable-ccache  OR  --disable-ccache invoke gcc/clang via ccache to reuse object files between builds
        --enable-sccache  OR  --disable-sccache invoke gcc/clang via sccache to reuse object files between builds
        --enable-local-rust  OR  --disable-local-rust use an installed rustc rather than downloading a snapshot
        --local-rust-root=VAL          set prefix for local rust binary
        --enable-local-rebuild  OR  --disable-local-rebuild assume local-rust matches the current version, for rebuilds; implies local-rust, and is implied if local-rust already matches the current version
```
as of #131117

imo, this is a little difficult to skim. This PR changes this to align the `OR`s and push the description onto a newline:

```
Options
        --enable-debug                     OR --disable-debug
                enables debugging environment; does not affect optimization of bootstrapped code
        --enable-docs                      OR --disable-docs
                build standard library documentation
        --enable-compiler-docs             OR --disable-compiler-docs
                build compiler documentation
        --enable-optimize-tests            OR --disable-optimize-tests
                build tests with optimizations
        --enable-verbose-tests             OR --disable-verbose-tests
                enable verbose output when running tests
        --enable-ccache                    OR --disable-ccache
                invoke gcc/clang via ccache to reuse object files between builds
        --enable-sccache                   OR --disable-sccache
                invoke gcc/clang via sccache to reuse object files between builds
        --enable-local-rust                OR --disable-local-rust
                use an installed rustc rather than downloading a snapshot
        --local-rust-root=VAL          set prefix for local rust binary
        --enable-local-rebuild             OR --disable-local-rebuild
                assume local-rust matches the current version, for rebuilds; implies local-rust, and is implied if local-rust already matches the current version
    ```