### PR TITLE
shave 150ms off bootstrap

### DIFF
--- a/src/bootstrap/src/utils/channel.rs
+++ b/src/bootstrap/src/utils/channel.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 use super::helpers;
 use crate::Build;
-use crate::utils::helpers::{output, t};
+use crate::utils::helpers::{start_process, t};
 
 #[derive(Clone, Default)]
 pub enum GitInfo {
@@ -56,7 +56,7 @@ impl GitInfo {
         }
 
         // Ok, let's scrape some info
-        let ver_date = output(
+        let ver_date = start_process(
             helpers::git(Some(dir))
                 .arg("log")
                 .arg("-1")
@@ -65,14 +65,14 @@ impl GitInfo {
                 .as_command_mut(),
         );
         let ver_hash =
-            output(helpers::git(Some(dir)).arg("rev-parse").arg("HEAD").as_command_mut());
-        let short_ver_hash = output(
+            start_process(helpers::git(Some(dir)).arg("rev-parse").arg("HEAD").as_command_mut());
+        let short_ver_hash = start_process(
             helpers::git(Some(dir)).arg("rev-parse").arg("--short=9").arg("HEAD").as_command_mut(),
         );
         GitInfo::Present(Some(Info {
-            commit_date: ver_date.trim().to_string(),
-            sha: ver_hash.trim().to_string(),
-            short_sha: short_ver_hash.trim().to_string(),
+            commit_date: ver_date().trim().to_string(),
+            sha: ver_hash().trim().to_string(),
+            short_sha: short_ver_hash().trim().to_string(),
         }))
     }
 


### PR DESCRIPTION
This starts `git` commands inside `GitInfo`and the submodule updates in parallel. Git should already perform internal locking in cases where it needs to serialize a modification.


```
OLD
Benchmark #1: ./x check core
  Time (mean ± σ):     608.7 ms ±   4.4 ms    [User: 368.3 ms, System: 455.1 ms]
  Range (min … max):   602.3 ms … 618.8 ms    10 runs

NEW
Benchmark #1: ./x check core
  Time (mean ± σ):     462.8 ms ±   2.6 ms    [User: 350.2 ms, System: 485.1 ms]
  Range (min … max):   457.5 ms … 465.6 ms    10 runs
```

This should help with the rust-analyzer setup which issues many individual `./x check` calls. There's more that could be done but these were the lowest-hanging fruits that I saw.