### PR TITLE
Allow #[link(kind = "dylib")] without a name

### DIFF
--- a/compiler/rustc_codegen_llvm/src/callee.rs
+++ b/compiler/rustc_codegen_llvm/src/callee.rs
@@ -142,8 +142,7 @@ pub(crate) fn get_fn<'ll, 'tcx>(cx: &CodegenCx<'ll, 'tcx>, instance: Instance<'t
             // MinGW: For backward compatibility we rely on the linker to decide whether it
             // should use dllimport for functions.
             if cx.use_dll_storage_attrs
-                && let Some(library) = tcx.native_library(instance_def_id)
-                && library.kind.is_dllimport()
+                && tcx.is_dllimport(instance_def_id)
                 && !matches!(tcx.sess.target.env.as_ref(), "gnu" | "uclibc")
             {
                 llvm::LLVMSetDLLStorageClass(llfn, llvm::DLLStorageClass::DllImport);

--- a/compiler/rustc_codegen_llvm/src/consts.rs
+++ b/compiler/rustc_codegen_llvm/src/consts.rs
@@ -358,10 +358,7 @@ impl<'ll> CodegenCx<'ll, '_> {
             }
         }
 
-        if self.use_dll_storage_attrs
-            && let Some(library) = self.tcx.native_library(def_id)
-            && library.kind.is_dllimport()
-        {
+        if self.use_dll_storage_attrs && self.tcx.is_dllimport(def_id) {
             // For foreign (native) libs we know the exact storage type to use.
             unsafe {
                 llvm::LLVMSetDLLStorageClass(g, llvm::DLLStorageClass::DllImport);

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -368,6 +368,8 @@ declare_features! (
     (unstable, async_fn_track_caller, "1.73.0", Some(110011)),
     /// Allows `for await` loops.
     (unstable, async_for_loop, "1.77.0", Some(118898)),
+    /// Allows `#[link(kind = "dylib")]` without a library name.
+    (unstable, bare_link_kind, "CURRENT_RUSTC_VERSION", Some(132061)),
     /// Allows using C-variadics.
     (unstable, c_variadic, "1.34.0", Some(44930)),
     /// Allows the use of `#[cfg(<true/false>)]`.

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1820,7 +1820,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
     fn encode_native_libraries(&mut self) -> LazyArray<NativeLib> {
         empty_proc_macro!(self);
         let used_libraries = self.tcx.native_libraries(LOCAL_CRATE);
-        self.lazy_array(used_libraries.iter())
+        self.lazy_array(used_libraries.iter_all_items())
     }
 
     fn encode_foreign_modules(&mut self) -> LazyArray<ForeignModule> {

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -35,7 +35,7 @@ use rustc_query_system::query::{QueryCache, QueryMode, QueryState, try_get_cache
 use rustc_session::Limits;
 use rustc_session::config::{EntryFnType, OptLevel, OutputFilenames, SymbolManglingVersion};
 use rustc_session::cstore::{
-    CrateDepKind, CrateSource, ExternCrate, ForeignModule, LinkagePreference, NativeLib,
+    CrateDepKind, CrateSource, ExternCrate, ForeignModule, LinkagePreference, NativeLib, NativeLibs,
 };
 use rustc_session::lint::LintExpectationId;
 use rustc_span::def_id::LOCAL_CRATE;
@@ -406,7 +406,7 @@ rustc_queries! {
     /// These are assembled from the following places:
     /// - `extern` blocks (depending on their `link` attributes)
     /// - the `libs` (`-l`) option
-    query native_libraries(_: CrateNum) -> &'tcx Vec<NativeLib> {
+    query native_libraries(_: CrateNum) -> &'tcx NativeLibs {
         arena_cache
         desc { "looking up the native libraries of a linked crate" }
         separate_provide_extern
@@ -1744,6 +1744,10 @@ rustc_queries! {
     /// Get the corresponding native library from the `native_libraries` query
     query native_library(def_id: DefId) -> Option<&'tcx NativeLib> {
         desc { |tcx| "getting the native library for `{}`", tcx.def_path_str(def_id) }
+    }
+
+    query is_dllimport(def_id: DefId) -> bool {
+        desc { |tcx| "determining dllimport status of `{}`", tcx.def_path_str(def_id) }
     }
 
     query inherit_sig_for_delegation_item(def_id: LocalDefId) -> &'tcx [Ty<'tcx>] {

--- a/compiler/rustc_session/src/cstore.rs
+++ b/compiler/rustc_session/src/cstore.rs
@@ -88,6 +88,31 @@ impl NativeLib {
     }
 }
 
+#[derive(Debug, HashStable_Generic)]
+pub struct NativeLibs {
+    libs: Vec<NativeLib>,
+}
+impl NativeLibs {
+    pub fn iter(&self) -> impl Iterator<Item = &NativeLib> {
+        // Hide entries without a library name.
+        self.iter_all_items().filter(|l| !l.name.is_empty())
+    }
+
+    pub fn iter_all_items(&self) -> impl Iterator<Item = &NativeLib> {
+        self.libs.iter()
+    }
+}
+impl From<Vec<NativeLib>> for NativeLibs {
+    fn from(libs: Vec<NativeLib>) -> Self {
+        Self { libs }
+    }
+}
+impl FromIterator<NativeLib> for NativeLibs {
+    fn from_iter<T: IntoIterator<Item = NativeLib>>(iter: T) -> Self {
+        Self { libs: FromIterator::from_iter(iter) }
+    }
+}
+
 /// Different ways that the PE Format can decorate a symbol name.
 /// From <https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#import-name-type>
 #[derive(Copy, Clone, Debug, Encodable, Decodable, HashStable_Generic, PartialEq, Eq)]

--- a/compiler/rustc_session/src/utils.rs
+++ b/compiler/rustc_session/src/utils.rs
@@ -70,13 +70,6 @@ impl NativeLibKind {
     pub fn is_statically_included(&self) -> bool {
         matches!(self, NativeLibKind::Static { .. })
     }
-
-    pub fn is_dllimport(&self) -> bool {
-        matches!(
-            self,
-            NativeLibKind::Dylib { .. } | NativeLibKind::RawDylib | NativeLibKind::Unspecified
-        )
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Encodable, Decodable)]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -482,6 +482,7 @@ symbols! {
         avx512f,
         await_macro,
         bang,
+        bare_link_kind,
         begin_panic,
         bench,
         bin,

--- a/tests/ui/extern/auxiliary/bare_link_kind_cdylib.rs
+++ b/tests/ui/extern/auxiliary/bare_link_kind_cdylib.rs
@@ -1,0 +1,4 @@
+#![crate_type = "cdylib"]
+
+#[no_mangle]
+pub static FOO: u32 = 0xFEDCBA98;

--- a/tests/ui/extern/bare_link_kind.rs
+++ b/tests/ui/extern/bare_link_kind.rs
@@ -1,0 +1,19 @@
+//@ run-pass
+//@ aux-build:bare_link_kind_cdylib.rs
+
+#![feature(bare_link_kind)]
+
+#[link(kind = "dylib")]
+extern "C" {
+    static FOO: u32;
+}
+
+#[cfg_attr(not(target_env = "msvc"), link(name = "bare_link_kind_cdylib", kind = "dylib"))]
+#[cfg_attr(target_env = "msvc", link(name = "bare_link_kind_cdylib.dll", kind = "dylib"))]
+extern "C" {}
+
+fn main() {
+    unsafe {
+        assert_eq!(FOO, 0xFEDCBA98);
+    }
+}

--- a/tests/ui/feature-gates/feature-gate-bare-link-kind.rs
+++ b/tests/ui/feature-gates/feature-gate-bare-link-kind.rs
@@ -1,0 +1,6 @@
+#[link(kind = "dylib")] //~ ERROR `#[link]` attribute requires a `name = "string"` argument
+extern "C" {
+    static FOO: u32;
+}
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-bare-link-kind.stderr
+++ b/tests/ui/feature-gates/feature-gate-bare-link-kind.stderr
@@ -1,0 +1,9 @@
+error[E0459]: `#[link]` attribute requires a `name = "string"` argument
+  --> $DIR/feature-gate-bare-link-kind.rs:1:1
+   |
+LL | #[link(kind = "dylib")]
+   | ^^^^^^^^^^^^^^^^^^^^^^^ missing `name` argument
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0459`.


### PR DESCRIPTION
This PR allows `#[link(kind = "dylib")]` without a library name (see the [dllimport RFC](https://rust-lang.github.io/rfcs/1717-dllimport.html) for how this affects `extern {}` blocks).

This will need a lang fcp but I wanted to investigate how feasible this is. I want a bare `kind` to act the same as any other `#[link]` for the purposes of applying (or not) dllimport so the kind gets added to the same `NativeLib` array. However, this then means they need to be filtered out from normal queries. To facilitate this I've added a wrapper type for the `NativeLib` container and a separate query for `is_dllimport`.

try-job: x86_64-msvc
try-job: x86_64-mingw
