### PR TITLE
Remove `lower_mono_bounds`

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
+++ b/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
@@ -13,6 +13,7 @@ use tracing::{debug, instrument};
 
 use super::ItemCtxt;
 use super::predicates_of::assert_only_contains_predicates_from;
+use crate::bounds::Bounds;
 use crate::hir_ty_lowering::{HirTyLowerer, PredicateFilter};
 
 /// For associated types we include both bounds written on the type
@@ -36,7 +37,8 @@ fn associated_type_bounds<'tcx>(
     );
 
     let icx = ItemCtxt::new(tcx, assoc_item_def_id);
-    let mut bounds = icx.lowerer().lower_mono_bounds(item_ty, hir_bounds, filter);
+    let mut bounds = Bounds::default();
+    icx.lowerer().lower_bounds(item_ty, hir_bounds, &mut bounds, ty::List::empty(), filter);
     // Associated types are implicitly sized unless a `?Sized` bound is found
     icx.lowerer().add_sized_bound(&mut bounds, item_ty, hir_bounds, None, span);
 
@@ -303,7 +305,8 @@ fn opaque_type_bounds<'tcx>(
 ) -> &'tcx [(ty::Clause<'tcx>, Span)] {
     ty::print::with_reduced_queries!({
         let icx = ItemCtxt::new(tcx, opaque_def_id);
-        let mut bounds = icx.lowerer().lower_mono_bounds(item_ty, hir_bounds, filter);
+        let mut bounds = Bounds::default();
+        icx.lowerer().lower_bounds(item_ty, hir_bounds, &mut bounds, ty::List::empty(), filter);
         // Opaque types are implicitly sized unless a `?Sized` bound is found
         icx.lowerer().add_sized_bound(&mut bounds, item_ty, hir_bounds, None, span);
         debug!(?bounds);

--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -267,7 +267,7 @@ fn gather_explicit_predicates_of(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::Gen
                 let mut bounds = Bounds::default();
                 icx.lowerer().lower_poly_bounds(
                     ty,
-                    bound_pred.bounds.iter(),
+                    bound_pred.bounds,
                     &mut bounds,
                     bound_vars,
                     PredicateFilter::All,
@@ -836,7 +836,7 @@ impl<'tcx> ItemCtxt<'tcx> {
             let bound_vars = self.tcx.late_bound_vars(predicate.hir_id);
             self.lowerer().lower_poly_bounds(
                 bound_ty,
-                predicate.bounds.iter(),
+                predicate.bounds,
                 &mut bounds,
                 bound_vars,
                 filter,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -142,7 +142,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     /// There is an implied binder around `param_ty` and `hir_bounds`.
     /// See `lower_poly_trait_ref` for more details.
     #[instrument(level = "debug", skip(self, hir_bounds, bounds))]
-    pub(crate) fn lower_poly_bounds<'hir, I: Iterator<Item = &'hir hir::GenericBound<'tcx>>>(
+    pub(crate) fn lower_poly_bounds<'hir, I: IntoIterator<Item = &'hir hir::GenericBound<'tcx>>>(
         &self,
         param_ty: Ty<'tcx>,
         hir_bounds: I,
@@ -231,7 +231,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 
         self.lower_poly_bounds(
             param_ty,
-            hir_bounds.iter(),
+            hir_bounds,
             &mut bounds,
             ty::List::empty(),
             predicate_filter,
@@ -446,7 +446,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                             Ty::new_alias(tcx, ty::Projection, projection_ty.skip_binder());
                         self.lower_poly_bounds(
                             param_ty,
-                            hir_bounds.iter(),
+                            hir_bounds,
                             bounds,
                             projection_ty.bound_vars(),
                             predicate_filter,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -142,7 +142,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
     /// There is an implied binder around `param_ty` and `hir_bounds`.
     /// See `lower_poly_trait_ref` for more details.
     #[instrument(level = "debug", skip(self, hir_bounds, bounds))]
-    pub(crate) fn lower_poly_bounds<'hir, I: IntoIterator<Item = &'hir hir::GenericBound<'tcx>>>(
+    pub(crate) fn lower_bounds<'hir, I: IntoIterator<Item = &'hir hir::GenericBound<'tcx>>>(
         &self,
         param_ty: Ty<'tcx>,
         hir_bounds: I,
@@ -210,35 +210,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 }
             }
         }
-    }
-
-    /// Lower HIR bounds into `bounds` given the self type `param_ty` and *no* overarching late-bound vars.
-    ///
-    /// ### Example
-    ///
-    /// ```ignore (illustrative)
-    /// fn foo<T: Bar + Baz>() { }
-    /// //     ^  ^^^^^^^^^ hir_bounds
-    /// //     param_ty
-    /// ```
-    pub(crate) fn lower_mono_bounds(
-        &self,
-        param_ty: Ty<'tcx>,
-        hir_bounds: &[hir::GenericBound<'tcx>],
-        predicate_filter: PredicateFilter,
-    ) -> Bounds<'tcx> {
-        let mut bounds = Bounds::default();
-
-        self.lower_poly_bounds(
-            param_ty,
-            hir_bounds,
-            &mut bounds,
-            ty::List::empty(),
-            predicate_filter,
-        );
-        debug!(?bounds);
-
-        bounds
     }
 
     /// Lower an associated item constraint from the HIR into `bounds`.
@@ -444,7 +415,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                         // parameter to have a skipped binder.
                         let param_ty =
                             Ty::new_alias(tcx, ty::Projection, projection_ty.skip_binder());
-                        self.lower_poly_bounds(
+                        self.lower_bounds(
                             param_ty,
                             hir_bounds,
                             bounds,


### PR DESCRIPTION
I'm not convinced about the usefulness of `lower_mono_bounds`, especially since we have *so* many lower-bound-like fns in HIR lowering, so I've just inlined it into its callers.