### PR TITLE
Stabilize shorter-tail-lifetimes

### DIFF
--- a/compiler/rustc_feature/src/accepted.rs
+++ b/compiler/rustc_feature/src/accepted.rs
@@ -364,6 +364,8 @@ declare_features! (
     (accepted, self_in_typedefs, "1.32.0", Some(49303)),
     /// Allows `Self` struct constructor (RFC 2302).
     (accepted, self_struct_ctor, "1.32.0", Some(51994)),
+    /// Shortern the tail expression lifetime
+    (accepted, shorter_tail_lifetimes, "CURRENT_RUSTC_VERSION", Some(123739)),
     /// Allows using subslice patterns, `[a, .., b]` and `[a, xs @ .., b]`.
     (accepted, slice_patterns, "1.42.0", Some(62254)),
     /// Allows use of `&foo[a..b]` as a slicing syntax.

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -571,8 +571,6 @@ declare_features! (
     (unstable, rust_cold_cc, "1.63.0", Some(97544)),
     /// Allows use of x86 SHA512, SM3 and SM4 target-features and intrinsics
     (unstable, sha512_sm_x86, "1.82.0", Some(126624)),
-    /// Shortern the tail expression lifetime
-    (unstable, shorter_tail_lifetimes, "1.79.0", Some(123739)),
     /// Allows the use of SIMD types in functions declared in `extern` blocks.
     (unstable, simd_ffi, "1.0.0", Some(27731)),
     /// Allows specialization of implementations (RFC 1210).

--- a/compiler/rustc_hir_analysis/src/check/region.rs
+++ b/compiler/rustc_hir_analysis/src/check/region.rs
@@ -167,9 +167,7 @@ fn resolve_block<'tcx>(visitor: &mut RegionResolutionVisitor<'tcx>, blk: &'tcx h
             }
         }
         if let Some(tail_expr) = blk.expr {
-            if visitor.tcx.features().shorter_tail_lifetimes()
-                && blk.span.edition().at_least_rust_2024()
-            {
+            if blk.span.edition().at_least_rust_2024() {
                 visitor.terminating_scopes.insert(tail_expr.hir_id.local_id);
             }
             visitor.visit_expr(tail_expr);

--- a/compiler/rustc_lint/src/tail_expr_drop_order.rs
+++ b/compiler/rustc_lint/src/tail_expr_drop_order.rs
@@ -14,15 +14,14 @@ use rustc_span::edition::Edition;
 use crate::{LateContext, LateLintPass};
 
 declare_lint! {
-    /// The `tail_expr_drop_order` lint looks for those values generated at the tail expression location, that of type
-    /// with a significant `Drop` implementation, such as locks.
-    /// In case there are also local variables of type with significant `Drop` implementation as well,
-    /// this lint warns you of a potential transposition in the drop order.
-    /// Your discretion on the new drop order introduced by Edition 2024 is required.
+    /// The `tail_expr_drop_order` lint looks for those values generated at the tail expression location,
+    /// that runs a custom `Drop` destructor.
+    /// Some of them may be dropped earlier in Edition 2024 that they used to in Edition 2021 and prior.
+    /// This lint detects those cases and provides you information on those values and their custom destructor implementations.
+    /// Your discretion on this information is required.
     ///
     /// ### Example
-    /// ```rust,edition2024
-    /// #![feature(shorter_tail_lifetimes)]
+    /// ```rust,edition2021
     /// #![warn(tail_expr_drop_order)]
     /// struct Droppy(i32);
     /// impl Droppy {
@@ -37,12 +36,12 @@ declare_lint! {
     ///         println!("loud drop {}", self.0);
     ///     }
     /// }
-    /// fn edition_2024() -> i32 {
+    /// fn edition_2021() -> i32 {
     ///     let another_droppy = Droppy(0);
     ///     Droppy(1).get()
     /// }
     /// fn main() {
-    ///     edition_2024();
+    ///     edition_2021();
     /// }
     /// ```
     ///
@@ -137,7 +136,7 @@ impl<'tcx> LateLintPass<'tcx> for TailExprDropOrder {
         _: Span,
         def_id: rustc_span::def_id::LocalDefId,
     ) {
-        if cx.tcx.sess.at_least_rust_2024() && cx.tcx.features().shorter_tail_lifetimes() {
+        if !body.value.span.edition().at_least_rust_2024() {
             Self::check_fn_or_closure(cx, fn_kind, body, def_id);
         }
     }
@@ -185,8 +184,8 @@ impl<'a, 'tcx> Visitor<'tcx> for LintVisitor<'a, 'tcx> {
 
 impl<'a, 'tcx> LintVisitor<'a, 'tcx> {
     fn check_block_inner(&mut self, block: &Block<'tcx>) {
-        if !block.span.at_least_rust_2024() {
-            // We only lint for Edition 2024 onwards
+        if block.span.at_least_rust_2024() {
+            // We only lint up to Edition 2021
             return;
         }
         let Some(tail_expr) = block.expr else { return };

--- a/tests/ui/drop/drop_order.rs
+++ b/tests/ui/drop/drop_order.rs
@@ -105,6 +105,7 @@ impl DropOrderCollector {
             () => self.print(10),
         }
 
+        #[cfg(edition2021)]
         match {
             match self.option_loud_drop(14) {
                 _ => {
@@ -114,6 +115,17 @@ impl DropOrderCollector {
             }
         } {
             _ => self.print(12),
+        }
+        #[cfg(edition2024)]
+        match {
+            match self.option_loud_drop(12) {
+                _ => {
+                    self.print(11);
+                    self.option_loud_drop(14)
+                }
+            }
+        } {
+            _ => self.print(13),
         }
 
         match {

--- a/tests/ui/drop/lint-tail-expr-drop-order-gated.rs
+++ b/tests/ui/drop/lint-tail-expr-drop-order-gated.rs
@@ -1,15 +1,11 @@
-// This test ensures that `tail_expr_drop_order` does not activate in case Edition 2024 is not used
-// or the feature gate `shorter_tail_lifetimes` is disabled.
+// This test is to demonstrate that the lint is gated behind Edition and
+// is triggered only for Edition 2021 and before.
 
-//@ revisions: neither no_feature_gate edition_less_than_2024
 //@ check-pass
-//@ [neither] edition: 2021
-//@ [no_feature_gate] compile-flags: -Z unstable-options
-//@ [no_feature_gate] edition: 2024
-//@ [edition_less_than_2024] edition: 2021
+//@ edition: 2024
+//@ compile-flags: -Z unstable-options
 
 #![deny(tail_expr_drop_order)]
-#![cfg_attr(edition_less_than_2024, feature(shorter_tail_lifetimes))]
 
 struct LoudDropper;
 impl Drop for LoudDropper {

--- a/tests/ui/drop/lint-tail-expr-drop-order.rs
+++ b/tests/ui/drop/lint-tail-expr-drop-order.rs
@@ -1,12 +1,10 @@
-//@ compile-flags: -Z unstable-options
-//@ edition: 2024
+//@ edition: 2021
 
 // Edition 2024 lint for change in drop order at tail expression
 // This lint is to capture potential change in program semantics
 // due to implementation of RFC 3606 <https://github.com/rust-lang/rfcs/pull/3606>
 
 #![deny(tail_expr_drop_order)]
-#![feature(shorter_tail_lifetimes)]
 
 struct LoudDropper;
 impl Drop for LoudDropper {

--- a/tests/ui/drop/lint-tail-expr-drop-order.stderr
+++ b/tests/ui/drop/lint-tail-expr-drop-order.stderr
@@ -1,5 +1,5 @@
 error: these values and local bindings have significant drop implementation that will have a different drop order from that of Edition 2021
-  --> $DIR/lint-tail-expr-drop-order.rs:29:15
+  --> $DIR/lint-tail-expr-drop-order.rs:27:15
    |
 LL |     let x = LoudDropper;
    |         - these values have significant drop implementation and will observe changes in drop order under Edition 2024
@@ -10,13 +10,13 @@ LL |     x.get() + LoudDropper.get()
    = warning: this changes meaning in Rust 2024
    = note: for more information, see issue #123739 <https://github.com/rust-lang/rust/issues/123739>
 note: the lint level is defined here
-  --> $DIR/lint-tail-expr-drop-order.rs:8:9
+  --> $DIR/lint-tail-expr-drop-order.rs:7:9
    |
 LL | #![deny(tail_expr_drop_order)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: these values and local bindings have significant drop implementation that will have a different drop order from that of Edition 2021
-  --> $DIR/lint-tail-expr-drop-order.rs:36:23
+  --> $DIR/lint-tail-expr-drop-order.rs:34:23
    |
 LL |     let x = LoudDropper;
    |         - these values have significant drop implementation and will observe changes in drop order under Edition 2024
@@ -27,7 +27,7 @@ LL |     move || x.get() + LoudDropper.get()
    = note: for more information, see issue #123739 <https://github.com/rust-lang/rust/issues/123739>
 
 error: these values and local bindings have significant drop implementation that will have a different drop order from that of Edition 2021
-  --> $DIR/lint-tail-expr-drop-order.rs:65:19
+  --> $DIR/lint-tail-expr-drop-order.rs:63:19
    |
 LL |         let x = LoudDropper;
    |             - these values have significant drop implementation and will observe changes in drop order under Edition 2024

--- a/tests/ui/drop/tail-expr-drop-order-negative.edition2024.stderr
+++ b/tests/ui/drop/tail-expr-drop-order-negative.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/tail-expr-drop-order-negative.rs:11:15
+  --> $DIR/tail-expr-drop-order-negative.rs:9:15
    |
 LL |     x.replace(std::cell::RefCell::new(123).borrow()).is_some()
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                   - temporary value is freed at the end of this statement

--- a/tests/ui/drop/tail-expr-drop-order-negative.rs
+++ b/tests/ui/drop/tail-expr-drop-order-negative.rs
@@ -3,8 +3,6 @@
 //@ [edition2024] edition: 2024
 //@ [edition2021] check-pass
 
-#![feature(shorter_tail_lifetimes)]
-
 fn why_would_you_do_this() -> bool {
     let mut x = None;
     // Make a temporary `RefCell` and put a `Ref` that borrows it in `x`.

--- a/tests/ui/drop/tail-expr-drop-order.rs
+++ b/tests/ui/drop/tail-expr-drop-order.rs
@@ -4,7 +4,6 @@
 //@ edition: 2024
 //@ run-pass
 
-#![feature(shorter_tail_lifetimes)]
 #![allow(unused_imports)]
 #![allow(dead_code)]
 #![allow(unused_variables)]

--- a/tests/ui/lifetimes/refcell-in-tail-expr.edition2021.stderr
+++ b/tests/ui/lifetimes/refcell-in-tail-expr.edition2021.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `cell` does not live long enough
-  --> $DIR/refcell-in-tail-expr.rs:12:27
+  --> $DIR/refcell-in-tail-expr.rs:10:27
    |
 LL |     let cell = std::cell::RefCell::new(0u8);
    |         ---- binding `cell` declared here

--- a/tests/ui/lifetimes/refcell-in-tail-expr.rs
+++ b/tests/ui/lifetimes/refcell-in-tail-expr.rs
@@ -4,8 +4,6 @@
 //@ [edition2024] compile-flags: -Zunstable-options
 //@ [edition2024] check-pass
 
-#![cfg_attr(edition2024, feature(shorter_tail_lifetimes))]
-
 fn main() {
     let cell = std::cell::RefCell::new(0u8);
 

--- a/tests/ui/lifetimes/shorter-tail-expr-lifetime.edition2021.stderr
+++ b/tests/ui/lifetimes/shorter-tail-expr-lifetime.edition2021.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `c` does not live long enough
-  --> $DIR/shorter-tail-expr-lifetime.rs:10:5
+  --> $DIR/shorter-tail-expr-lifetime.rs:8:5
    |
 LL |     let c = std::cell::RefCell::new("..");
    |         - binding `c` declared here

--- a/tests/ui/lifetimes/shorter-tail-expr-lifetime.rs
+++ b/tests/ui/lifetimes/shorter-tail-expr-lifetime.rs
@@ -3,8 +3,6 @@
 //@ [edition2024] edition: 2024
 //@ [edition2024] run-pass
 
-#![cfg_attr(edition2024, feature(shorter_tail_lifetimes))]
-
 fn f() -> usize {
     let c = std::cell::RefCell::new("..");
     c.borrow().len() //[edition2021]~ ERROR: `c` does not live long enough

--- a/tests/ui/lifetimes/tail-expr-in-nested-expr.rs
+++ b/tests/ui/lifetimes/tail-expr-in-nested-expr.rs
@@ -1,8 +1,6 @@
 //@ edition: 2024
 //@ compile-flags: -Zunstable-options
 
-#![feature(shorter_tail_lifetimes)]
-
 fn main() {
     let _ = { String::new().as_str() }.len();
     //~^ ERROR temporary value dropped while borrowed

--- a/tests/ui/lifetimes/tail-expr-in-nested-expr.stderr
+++ b/tests/ui/lifetimes/tail-expr-in-nested-expr.stderr
@@ -1,5 +1,5 @@
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/tail-expr-in-nested-expr.rs:7:15
+  --> $DIR/tail-expr-in-nested-expr.rs:5:15
    |
 LL |     let _ = { String::new().as_str() }.len();
    |               ^^^^^^^^^^^^^---------

--- a/tests/ui/lifetimes/tail-expr-lock-poisoning.rs
+++ b/tests/ui/lifetimes/tail-expr-lock-poisoning.rs
@@ -4,7 +4,6 @@
 //@ [edition2024] edition: 2024
 //@ run-pass
 //@ needs-unwind
-#![cfg_attr(edition2024, feature(shorter_tail_lifetimes))]
 
 use std::sync::Mutex;
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Close #131445
Tracked by #123739

We found a test case `tests/ui/drop/drop_order.rs` that had not been covered by the change. The test fixture is fixed now with the correct expectation.