### PR TITLE
[DO NOT MERGE] can `x86_64-gnu-debug` even run the full `run-make` test suite? Answer: no

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-debug/Dockerfile
@@ -54,4 +54,4 @@ ENV RUST_CONFIGURE_ARGS \
 
 ENV SCRIPT \
   python3 ../x.py --stage 2 build && \
-  python3 ../x.py --stage 2 test tests/run-make --test-args clang
+  python3 ../x.py --stage 2 test tests/run-make


### PR DESCRIPTION
r? @ghost

try-job: x86_64-gnu-debug