### PR TITLE
test: Add test for trait in FQS cast, issue #98565

### DIFF
--- a/tests/ui/traits/fully-qualified-syntax-cast.rs
+++ b/tests/ui/traits/fully-qualified-syntax-cast.rs
@@ -1,0 +1,15 @@
+// Regression test for #98565: Provide diagnostics when the user uses
+// the built-in type `str` in a cast where a trait is expected.
+
+trait Foo {
+    fn foo(&self);
+}
+
+impl Foo for String {
+    fn foo(&self) {
+        <Self as str>::trim(self);
+        //~^ ERROR expected trait, found builtin type `str`
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/fully-qualified-syntax-cast.stderr
+++ b/tests/ui/traits/fully-qualified-syntax-cast.stderr
@@ -1,0 +1,9 @@
+error[E0404]: expected trait, found builtin type `str`
+  --> $DIR/fully-qualified-syntax-cast.rs:10:18
+   |
+LL |         <Self as str>::trim(self);
+   |                  ^^^ not a trait
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0404`.


### PR DESCRIPTION
Closes #98565 by adding a test to check for diagnostics when the built-in type `str` is used in a cast where a trait is expected.