### PR TITLE
don't stage-off to previous compiler when CI rustc is available

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -1734,13 +1734,15 @@ NOTE: if you're sure you want to do this, please open an issue as to why. In the
             } else {
                 // We need to properly build cargo using the suitable stage compiler.
 
-                // HACK: currently tool stages are off-by-one compared to compiler stages, i.e. if
-                // you give `tool::Cargo` a stage 1 rustc, it will cause stage 2 rustc to be built
-                // and produce a cargo built with stage 2 rustc. To fix this, we need to chop off
-                // the compiler stage by 1 to align with expected `./x test run-make --stage N`
-                // behavior, i.e. we need to pass `N - 1` compiler stage to cargo. See also Miri
-                // which does a similar hack.
-                let compiler = builder.compiler(builder.top_stage - 1, compiler.host);
+                let compiler = builder.download_rustc().then_some(compiler).unwrap_or_else(||
+                    // HACK: currently tool stages are off-by-one compared to compiler stages, i.e. if
+                    // you give `tool::Cargo` a stage 1 rustc, it will cause stage 2 rustc to be built
+                    // and produce a cargo built with stage 2 rustc. To fix this, we need to chop off
+                    // the compiler stage by 1 to align with expected `./x test run-make --stage N`
+                    // behavior, i.e. we need to pass `N - 1` compiler stage to cargo. See also Miri
+                    // which does a similar hack.
+                    builder.compiler(builder.top_stage - 1, compiler.host));
+
                 builder.ensure(tool::Cargo { compiler, target: compiler.host })
             };
 


### PR DESCRIPTION
Resolves the 4th item in [Tracking Issue for download-rustc improvements](https://github.com/rust-lang/rust/issues/131744).