### PR TITLE
Introduce `RefCell::{try_replace, try_replace_with, try_swap}`

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -899,6 +899,43 @@ impl<T> RefCell<T> {
         mem::replace(&mut *self.borrow_mut(), t)
     }
 
+    /// Replaces the wrapped value with a new one, returning the old value,
+    /// without deinitializing either one.
+    ///
+    /// This function corresponds to [`std::mem::replace`](../mem/fn.replace.html).
+    ///
+    /// This is the non-panicking variant of [`replace`](#method.replace).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(refcell_try_replace)]
+    /// use std::cell::RefCell;
+    ///
+    /// let cell = RefCell::new(5);
+    ///
+    /// {
+    ///     let borrowed_five = cell.borrow();
+    ///     let replace_result = cell.try_replace(6);
+    ///     assert!(replace_result.is_err());
+    ///     assert_eq!(cell, RefCell::new(5));
+    ///
+    /// }
+    ///
+    /// {
+    ///     let replace_result = cell.try_replace(6);
+    ///     assert!(replace_result.is_ok());
+    ///     assert_eq!(cell, RefCell::new(6));
+    /// }
+    /// ```
+    #[inline]
+    #[unstable(feature = "refcell_try_replace", issue = "none")]
+    #[track_caller]
+    #[rustc_confusables("try_swap")]
+    pub fn try_replace(&self, t: T) -> Result<T, BorrowMutError> {
+        Ok(mem::replace(&mut *self.try_borrow_mut()?, t))
+    }
+
     /// Replaces the wrapped value with a new one computed from `f`, returning
     /// the old value, without deinitializing either one.
     ///
@@ -922,6 +959,42 @@ impl<T> RefCell<T> {
         let mut_borrow = &mut *self.borrow_mut();
         let replacement = f(mut_borrow);
         mem::replace(mut_borrow, replacement)
+    }
+
+    /// Replaces the wrapped value with a new one computed from `f`, returning
+    /// the old value, without deinitializing either one.
+    ///
+    /// This is the non-panicking variant of [`replace_with`](#method.replace_with).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(refcell_try_replace)]
+    /// use std::cell::RefCell;
+    ///
+    /// let cell = RefCell::new(5);
+    ///
+    /// {
+    ///     let borrowed_five = cell.borrow();
+    ///     let replace_result = cell.try_replace_with(|&mut old| old + 1);
+    ///     assert!(replace_result.is_err());
+    ///     assert_eq!(cell, RefCell::new(5));
+    ///
+    /// }
+    ///
+    /// {
+    ///     let replace_result = cell.try_replace_with(|&mut old| old + 1);
+    ///     assert!(replace_result.is_ok());
+    ///     assert_eq!(cell, RefCell::new(6));
+    /// }
+    /// ```
+    #[inline]
+    #[unstable(feature = "refcell_try_replace", issue = "none")]
+    #[track_caller]
+    pub fn try_replace_with<F: FnOnce(&mut T) -> T>(&self, f: F) -> Result<T, BorrowMutError> {
+        let mut_borrow = &mut *self.try_borrow_mut()?;
+        let replacement = f(mut_borrow);
+        Ok(mem::replace(mut_borrow, replacement))
     }
 
     /// Swaps the wrapped value of `self` with the wrapped value of `other`,
@@ -948,6 +1021,52 @@ impl<T> RefCell<T> {
     #[stable(feature = "refcell_swap", since = "1.24.0")]
     pub fn swap(&self, other: &Self) {
         mem::swap(&mut *self.borrow_mut(), &mut *other.borrow_mut())
+    }
+
+    /// Swaps the wrapped value of `self` with the wrapped value of `other`,
+    /// without deinitializing either one.
+    ///
+    /// This function corresponds to [`std::mem::swap`](../mem/fn.swap.html).
+    ///
+    /// This is the non-panicking variant of [`swap`](#method.swap).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(refcell_try_replace)]
+    /// use std::cell::RefCell;
+    ///
+    /// let c = RefCell::new(5);
+    /// let d = RefCell::new(6);
+    ///
+    /// {
+    ///     let borrowed_c = c.borrow();
+    ///     let swap_result = c.try_swap(&d);
+    ///     assert!(swap_result.is_err());
+    ///     assert_eq!(c, RefCell::new(5));
+    ///     assert_eq!(d, RefCell::new(6));
+    /// }
+    ///
+    /// {
+    ///     let borrowed_d = d.borrow();
+    ///     let swap_result = c.try_swap(&d);
+    ///     assert!(swap_result.is_err());
+    ///     assert_eq!(c, RefCell::new(5));
+    ///     assert_eq!(d, RefCell::new(6));
+    /// }
+    ///
+    /// {
+    ///     let swap_result = c.try_swap(&d);
+    ///     assert!(swap_result.is_ok());
+    ///     assert_eq!(c, RefCell::new(6));
+    ///     assert_eq!(d, RefCell::new(5));
+    /// }
+    /// ```
+    #[inline]
+    #[unstable(feature = "refcell_try_replace", issue = "none")]
+    #[track_caller]
+    pub fn try_swap(&self, other: &Self) -> Result<(), BorrowMutError> {
+        Ok(mem::swap(&mut *self.try_borrow_mut()?, &mut *other.try_borrow_mut()?))
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This adds `Result`-based equivalents to `RefCell::replace`, `RefCell::replace_with` and `RefCell::swap`.

This was proposed in https://github.com/rust-lang/rust/issues/54493, and has not gone through an ACP or RFC process.

## Concerns

I believe the design of these functions should be relatively uncontroversial, but their presence at all may be. It's unclear how much these would be used, and they do clutter the documentation of `RefCell`. The main purpose is completeness: offering a `Result`-based method for every panicking `RefCell` method.

Looking at history, RFC-2057 ([PR](https://github.com/rust-lang/rfcs/pull/2057), [rendered](https://rust-lang.github.io/rfcs/2057-refcell-replace.html)), which added `replace` and `swap`, simply didn't address the possibility of `try_replace` and `try_swap`. The author dismissed them as not very useful.

## Error types

https://github.com/rust-lang/rust/issues/54493 proposed adding unique error types for each function. I've opted instead to reuse `BorrowMutError`, matching `try_borrow_unguarded` reusing `BorrowError`.

## Process?

As I haven't gone through the `rust-lang/rust` PR process much yet, I'd love guidance on what to do with this. I figured writing this PR couldn't hurt, but it's unclear whether an ACP or RFC would be best here.

The prior additions of `RefCell::{try_borrow, try_borrow_mut}` and `RefCell::{swap, replace}` both used RFCs, but it's unclear to me if things have changed since then.