### PR TITLE
Optimize `Rc<T>::default`

### DIFF
--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -2312,7 +2312,16 @@ impl<T: Default> Default for Rc<T> {
     /// ```
     #[inline]
     fn default() -> Rc<T> {
-        Rc::new(Default::default())
+        unsafe {
+            Self::from_inner(
+                Box::leak(Box::write(Box::new_uninit(), RcInner {
+                    strong: Cell::new(1),
+                    weak: Cell::new(1),
+                    value: T::default(),
+                }))
+                .into(),
+            )
+        }
     }
 }
 

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -3447,13 +3447,16 @@ impl<T: Default> Default for Arc<T> {
     /// assert_eq!(*x, 0);
     /// ```
     fn default() -> Arc<T> {
-        let x = Box::into_raw(Box::write(Box::new_uninit(), ArcInner {
-            strong: atomic::AtomicUsize::new(1),
-            weak: atomic::AtomicUsize::new(1),
-            data: T::default(),
-        }));
-        // SAFETY: `Box::into_raw` consumes the `Box` and never returns null
-        unsafe { Self::from_inner(NonNull::new_unchecked(x)) }
+        unsafe {
+            Self::from_inner(
+                Box::leak(Box::write(Box::new_uninit(), ArcInner {
+                    strong: atomic::AtomicUsize::new(1),
+                    weak: atomic::AtomicUsize::new(1),
+                    data: T::default(),
+                }))
+                .into(),
+            )
+        }
     }
 }
 

--- a/tests/codegen/placement-new.rs
+++ b/tests/codegen/placement-new.rs
@@ -1,9 +1,11 @@
 //@ compile-flags: -O
+//@ compile-flags: -Zmerge-functions=disabled
 #![crate_type = "lib"]
 
 // Test to check that types with "complex" destructors, but trivial `Default` impls
 // are constructed directly into the allocation in `Box::default` and `Arc::default`.
 
+use std::rc::Rc;
 use std::sync::Arc;
 
 // CHECK-LABEL: @box_default_inplace
@@ -14,6 +16,16 @@ pub fn box_default_inplace() -> Box<(String, String)> {
     // CHECK-NOT: call void @llvm.memcpy
     // CHECK: ret ptr [[BOX]]
     Box::default()
+}
+
+// CHECK-LABEL: @rc_default_inplace
+#[no_mangle]
+pub fn rc_default_inplace() -> Rc<(String, String)> {
+    // CHECK-NOT: alloca
+    // CHECK: [[RC:%.*]] = {{.*}}call {{.*}}__rust_alloc(
+    // CHECK-NOT: call void @llvm.memcpy
+    // CHECK: ret ptr [[RC]]
+    Rc::default()
 }
 
 // CHECK-LABEL: @arc_default_inplace


### PR DESCRIPTION
The missing piece of https://github.com/rust-lang/rust/pull/131460.

Also refactored `Arc<T>::default` by using a safe `NonNull::from(Box::leak(_))` to replace the unnecessarily unsafe call to `NonNull::new_unchecked(Box::into_raw(_))`. The remaining unsafety is coming from `[Rc|Arc]::from_inner`, which is safe from the construction of `[Rc|Arc]Inner`.