### PR TITLE
Add a test case for #131164

### DIFF
--- a/tests/run-make/rust-lld-link-script-provide/main.rs
+++ b/tests/run-make/rust-lld-link-script-provide/main.rs
@@ -1,0 +1,7 @@
+#[no_mangle]
+fn foo() {}
+
+#[no_mangle]
+fn bar() {}
+
+fn main() {}

--- a/tests/run-make/rust-lld-link-script-provide/rmake.rs
+++ b/tests/run-make/rust-lld-link-script-provide/rmake.rs
@@ -1,0 +1,18 @@
+// This test ensures that the “symbol not found” error does not occur
+// when the symbols in the `PROVIDE` of the link script can be eliminated.
+// This is a regression test for #131164.
+
+//@ needs-rust-lld
+//@ only-x86_64-unknown-linux-gnu
+
+use run_make_support::rustc;
+
+fn main() {
+    rustc()
+        .input("main.rs")
+        .arg("-Zlinker-features=+lld")
+        .arg("-Clink-self-contained=+linker")
+        .arg("-Zunstable-options")
+        .link_arg("-Tscript.t")
+        .run();
+}

--- a/tests/run-make/rust-lld-link-script-provide/script.t
+++ b/tests/run-make/rust-lld-link-script-provide/script.t
@@ -1,0 +1,1 @@
+PROVIDE(foo = bar);


### PR DESCRIPTION
The upstream has already been fixed, but it won't be backported to LLVM 19.

r? jieyouxu or compiler

try-job: x86_64-gnu-stable