### PR TITLE
AIX: use /dev/urandom for random implementation 

### DIFF
--- a/library/std/src/random.rs
+++ b/library/std/src/random.rs
@@ -38,7 +38,7 @@ use crate::sys::random as sys;
 /// Vita                   | `arc4random_buf`
 /// Hermit                 | `read_entropy`
 /// Horizon                | `getrandom` shim
-/// Hurd, L4Re, QNX        | `/dev/urandom`
+/// AIX, Hurd, L4Re, QNX   | `/dev/urandom`
 /// Redox                  | `/scheme/rand`
 /// RTEMS                  | [`arc4random_buf`](https://docs.rtems.org/branches/master/bsp-howto/getentropy.html)
 /// SGX                    | [`rdrand`](https://en.wikipedia.org/wiki/RDRAND)

--- a/library/std/src/sys/random/mod.rs
+++ b/library/std/src/sys/random/mod.rs
@@ -40,6 +40,7 @@ cfg_if::cfg_if! {
         mod horizon;
         pub use horizon::fill_bytes;
     } else if #[cfg(any(
+        target_os = "aix",
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",


### PR DESCRIPTION
On AIX, we can poll `/dev/urandom` for cryptographically secure random output to implement `fill_bytes` because we don't have equivalent syscalls like other platforms. https://www.ibm.com/docs/en/aix/7.3?topic=files-random-urandom-devices


