### PR TITLE
Add parallel front end robustness test to ui tests

### DIFF
--- a/compiler/rustc_query_system/src/query/job.rs
+++ b/compiler/rustc_query_system/src/query/job.rs
@@ -488,6 +488,11 @@ pub fn break_query_cycles(query_map: QueryMap, registry: &rayon_core::Registry) 
     while jobs.len() > 0 {
         if remove_cycle(&query_map, &mut jobs, &mut wakelist) {
             found_cycle = true;
+
+            // FIXME: Resume all the waiters at once may cause deadlocks,
+            // so we resume one waiter at a call for now.
+            // Remove this when we figure out the real reason.
+            break;
         }
     }
 

--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -221,6 +221,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "only-x86_64-pc-windows-gnu",
     "only-x86_64-pc-windows-msvc",
     "only-x86_64-unknown-linux-gnu",
+    "parallel-front-end-robustness",
     "pp-exact",
     "pretty-compare-only",
     "pretty-mode",

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -108,6 +108,9 @@ pub struct TestProps {
     pub force_host: bool,
     // Check stdout for error-pattern output as well as stderr
     pub check_stdout: bool,
+    // For parallel front end, use repeated tests to ensure
+    // there is no deadlock or other ice problems.
+    pub parallel_front_end_robustness: bool,
     // Check stdout & stderr for output of run-pass test
     pub check_run_results: bool,
     // For UI tests, allows compiler to generate arbitrary output to stdout
@@ -211,6 +214,7 @@ mod directives {
     pub const CHECK_RUN_RESULTS: &'static str = "check-run-results";
     pub const DONT_CHECK_COMPILER_STDOUT: &'static str = "dont-check-compiler-stdout";
     pub const DONT_CHECK_COMPILER_STDERR: &'static str = "dont-check-compiler-stderr";
+    pub const PARALLEL_FRONT_END_ROBUTNESS: &'static str = "parallel-front-end-robustness";
     pub const NO_PREFER_DYNAMIC: &'static str = "no-prefer-dynamic";
     pub const PRETTY_MODE: &'static str = "pretty-mode";
     pub const PRETTY_COMPARE_ONLY: &'static str = "pretty-compare-only";
@@ -270,6 +274,7 @@ impl TestProps {
             dont_check_compiler_stdout: false,
             dont_check_compiler_stderr: false,
             no_prefer_dynamic: false,
+            parallel_front_end_robustness: false,
             pretty_mode: "normal".to_string(),
             pretty_compare_only: false,
             forbid_output: vec![],
@@ -502,6 +507,11 @@ impl TestProps {
                         ln,
                         DONT_CHECK_FAILURE_STATUS,
                         &mut self.dont_check_failure_status,
+                    );
+                    config.set_name_directive(
+                        ln,
+                        PARALLEL_FRONT_END_ROBUTNESS,
+                        &mut self.parallel_front_end_robustness,
                     );
 
                     config.set_name_directive(ln, RUN_RUSTFIX, &mut self.run_rustfix);

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1446,9 +1446,6 @@ impl<'test> TestCx<'test> {
         };
         rustc.arg(input_file);
 
-        // Use a single thread for efficiency and a deterministic error message order
-        rustc.arg("-Zthreads=1");
-
         // Hide libstd sources from ui tests to make sure we generate the stderr
         // output that users will see.
         // Without this, we may be producing good diagnostics in-tree but users

--- a/tests/ui/parallel-rustc/SUMMARY.md
+++ b/tests/ui/parallel-rustc/SUMMARY.md
@@ -1,0 +1,8 @@
+This directory contains the robustness test for prallel front end, which means deadlocks
+and other ice bugs. In other words, we don't care whether the compiler output in these tests,
+but whether they can compile normally without deadlock or other ice bugs.
+
+So when a test in this directory fails, please pay attention to whether it causes any ice problems.
+If so(it should do), please post your comments in the issue corresponding to each test (or create a new issue
+with the `wg-parallel-rustc` label). Even if it is an existing issue, please add a new comment,
+which will help us determine the reproducibility of the bug.

--- a/tests/ui/parallel-rustc/cache-after-waiting-issue-111528.rs
+++ b/tests/ui/parallel-rustc/cache-after-waiting-issue-111528.rs
@@ -1,16 +1,16 @@
+// Test for #111528, the ice issue cause waiting on a query that panicked
+//
+//@ parallel-front-end-robustness
 //@ compile-flags: -Z threads=16
 //@ build-fail
 
-#![crate_type="rlib"]
+#![crate_type = "rlib"]
 #![allow(warnings)]
 
-#[export_name="fail"]
-pub fn a() {
-}
+#[export_name = "fail"]
+pub fn a() {}
 
-#[export_name="fail"]
-pub fn b() {
-//~^ Error symbol `fail` is already defined
-}
+#[export_name = "fail"]
+pub fn b() {}
 
 fn main() {}

--- a/tests/ui/parallel-rustc/cache-after-waiting-issue-111528.stderr
+++ b/tests/ui/parallel-rustc/cache-after-waiting-issue-111528.stderr
@@ -1,8 +1,0 @@
-error: symbol `fail` is already defined
-  --> $DIR/cache-after-waiting-issue-111528.rs:12:1
-   |
-LL | pub fn b() {
-   | ^^^^^^^^^^
-
-error: aborting due to 1 previous error
-

--- a/tests/ui/parallel-rustc/deadlock-issue-119785.rs
+++ b/tests/ui/parallel-rustc/deadlock-issue-119785.rs
@@ -1,0 +1,57 @@
+// Test for #119785, which causes a deadlock bug
+//
+//@ parallel-front-end-robustness
+//@ compile-flags: -Z threads=200
+
+#![allow(incomplete_features)]
+#![feature(
+    const_trait_impl,
+    effects,
+)]
+
+use std::marker::Destruct;
+
+const fn cmp(a: &impl ~const PartialEq) -> bool {
+    a == a
+}
+
+const fn wrap(x: impl ~const PartialEq + ~const Destruct)
+              -> impl ~const PartialEq + ~const Destruct
+{
+    x
+}
+
+#[const_trait]
+trait Foo {
+    fn foo(&mut self, x: <Self as Index>::Output) -> <Self as Index>::Output;
+}
+
+impl const Foo for () {
+    fn huh() -> impl ~const PartialEq + ~const Destruct + Copy {
+        123
+    }
+}
+
+const _: () = {
+    assert!(cmp(&0xDEADBEEFu32));
+    assert!(cmp(&()));
+    assert!(wrap(123) == wrap(123));
+    assert!(wrap(123) != wrap(456));
+    let x = <() as Foo>::huh();
+    assert!(x == x);
+};
+
+#[const_trait]
+trait T {}
+struct S;
+impl const T for S {}
+
+const fn rpit() -> impl ~const T { S }
+
+const fn apit(_: impl ~const T + ~const Destruct) {}
+
+const fn rpit_assoc_bound() -> impl IntoIterator<Item: ~const T> { Some(S) }
+
+const fn apit_assoc_bound(_: impl IntoIterator<Item: ~const T> + ~From Destruct) {}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/deadlock-issue-120757.rs
+++ b/tests/ui/parallel-rustc/deadlock-issue-120757.rs
@@ -1,0 +1,115 @@
+// Test for #120757, which causes a deadlock bug
+//
+//@ parallel-front-end-robustness
+//@ compile-flags: -Z threads=50
+
+#![feature(generic_const_exprs)]
+
+trait TensorDimension {
+    const DIM: usize;
+    const ISSCALAR: bool = Self::DIM == 0;
+    fn is_scalar(&self) -> bool {
+        Self::ISSCALAR
+    }
+}
+
+trait TensorSize: TensorDimension {
+    fn size(&self) -> [usize; Self::DIM];
+    fn inbounds(&self, index: [usize; Self::DIM]) -> bool {
+        index.iter().zip(self.size().iter()).all(|(i, s)| i < s)
+    }
+}
+
+trait Broadcastable: TensorSize + Sized {
+    type Element;
+    fn bget(&self, index: [usize; Self::DIM]) -> Option<Self::Element>;
+    fn lazy_updim<const NEWDIM: usize>(
+        &self,
+        size: [usize; NEWDIM],
+    ) -> LazyUpdim<Self, { Self::DIM }, NEWDIM> {
+        assert!(
+            NEWDIM >= Self::DIM,
+            "Updimmed tensor cannot have fewer indices than the initial one."
+        ); // const generic bounds on nightly. ( )
+        LazyUpdim { size, reference: &self }
+    }
+    fn bmap<T, F: Fn(Self::Element) -> T>(&self, foo: F) -> BMap<T, Self, F, { Self::DIM }> {
+        BMap { reference: self, closure: foo }
+    }
+}
+
+struct LazyUpdim<'a, T: Broadcastable, const OLDDIM: usize, const DIM: usize> {
+    size: [usize; DIM],
+    reference: &'a T,
+}
+
+impl<'a, T: Broadcastable, const DIM: usize> TensorDimension for LazyUpdim<'a, T, { T::DIM }, DIM> {
+    const DIM: usize = DIM;
+}
+impl<'a, T: Broadcastable, const DIM: usize> TensorSize for LazyUpdim<'a, T, { T::DIM }, DIM> {
+    fn size(&self) -> [usize; DIM] {
+        self.size
+    }
+}
+impl<'a, T: Broadcastable, const DIM: usize> Broadcastable for LazyUpdim<'a, T, { T::DIM }, DIM> {
+    type Element = T::Element;
+    fn bget(&self, index: [usize; DIM]) -> Option<Self::Element> {
+        assert!(DIM >= T::DIM);
+        if !self.inbounds(index) {
+            return None;
+        }
+        let size = self.size();
+        //array_init::array_init(|i| if size[i] > 1 {index[i]} else {0});
+        let newindex: [usize; T::DIM] = Default::default();
+        self.reference.bget(newindex)
+    }
+}
+
+struct BMap<'a, R, T: Broadcastable, F: Fn(T::Element) -> R, const DIM: usize> {
+    reference: &'a T,
+    closure: F,
+}
+
+impl<'a, R, T: Broadcastable, F: Fn(T::Element) -> R, const DIM: usize> TensorDimension
+    for BMap<'a, R, T, F, DIM>
+{
+    const DIM: usize = DIM;
+}
+impl<'a, R, T: Broadcastable, F: Fn(T::Element) -> R, const DIM: usize> TensorSize
+    for BMap<'a, R, T, F, DIM>
+{
+    fn size(&self) -> [usize; DIM] {
+        self.reference.size()
+    }
+}
+impl<'a, R, T: Broadcastable, F: Fn(T::Element) -> R, const DIM: usize> Broadcastable
+    for BMap<'a, R, T, F, DIM>
+{
+    type Element = R;
+    fn bget(&self, index: [usize; DIM]) -> Option<Self::Element> {
+        self.reference.bget(index).map(ns_window)
+    }
+}
+
+impl<T> TensorDimension for Vec<T> {
+    const DIM: usize = 1;
+}
+impl<T> TensorSize for Vec<T> {
+    fn size(&self) -> [usize; 1] {
+        [self.len()]
+    }
+}
+impl<T: Clone> Broadcastable for Vec<T> {
+    type Element = T;
+    fn bget(&self, index: [usize; 1]) -> Option<T> {
+        self.get(index[0]).cloned()
+    }
+}
+
+fn main() {
+    let v = vec![1, 2, 3];
+    let bv = v.lazy_updim([3, 4]);
+    let bbv = bv.bmap(|x| x * x);
+
+    println!("The size of v is {:?}", bbv.bget([0, 2]).expect("Out of bounds."));
+}

--- a/tests/ui/parallel-rustc/deadlock-issue-129911.rs
+++ b/tests/ui/parallel-rustc/deadlock-issue-129911.rs
@@ -1,0 +1,69 @@
+// Test for #129911, which causes a deadlock bug
+//
+//@ parallel-front-end-robustness
+//@ compile-flags: -Z threads=16
+
+fn main() {
+    type KooArc = Frc<
+        {
+            {
+                {
+                    {};
+                }
+                type Frc = Frc<{}>::Arc;;
+            }
+            type Frc = Frc<
+                {
+                    {
+                        {
+                            {};
+                        }
+                        type Frc = Frc<{}>::Arc;;
+                    }
+                    type Frc = Frc<
+                        {
+                            {
+                                {
+                                    {};
+                                }
+                                type Frc = Frc<{}>::Arc;;
+                            }
+                            type Frc = Frc<
+                                {
+                                    {
+                                        {
+                                            {};
+                                        }
+                                        type Frc = Frc<{}>::Arc;;
+                                    }
+                                    type Frc = Frc<
+                                        {
+                                            {
+                                                {
+                                                    {
+                                                        {};
+                                                    }
+                                                    type Frc = Frc<{}>::Arc;;
+                                                };
+                                            }
+                                            type Frc = Frc<
+                                                {
+                                                    {
+                                                        {
+                                                            {};
+                                                        };
+                                                    }
+                                                    type Frc = Frc<{}>::Arc;;
+                                                },
+                                            >::Arc;;
+                                        },
+                                    >::Arc;;
+                                },
+                            >::Arc;;
+                        },
+                    >::Arc;;
+                },
+            >::Arc;;
+        },
+    >::Arc;
+}

--- a/tests/ui/parallel-rustc/export-symbols-deadlock-issue-118205-2.rs
+++ b/tests/ui/parallel-rustc/export-symbols-deadlock-issue-118205-2.rs
@@ -1,3 +1,6 @@
+// Test for #118205, which causes a deadlock bug
+//
+//@ parallel-front-end-robustness
 //@ compile-flags:-C extra-filename=-1 -Z threads=16
 //@ no-prefer-dynamic
 //@ build-pass

--- a/tests/ui/parallel-rustc/export-symbols-deadlock-issue-118205.rs
+++ b/tests/ui/parallel-rustc/export-symbols-deadlock-issue-118205.rs
@@ -1,3 +1,6 @@
+// Test for #118205, which causes a deadlock bug
+//
+//@ parallel-front-end-robustness
 //@ compile-flags: -Z threads=16
 //@ build-pass
 

--- a/tests/ui/parallel-rustc/found-cycle-issue-115223.rs
+++ b/tests/ui/parallel-rustc/found-cycle-issue-115223.rs
@@ -1,0 +1,35 @@
+// Test for #115223, which causes a deadlock bug without finding the cycle
+//
+//@ parallel-front-end-robustness
+//@ compile-flags: -Z threads=16
+//@ run-pass
+
+#![crate_name = "foo"]
+
+use std::ops;
+
+pub struct Foo;
+
+impl Foo {
+    pub fn foo(&mut self) {}
+}
+
+pub struct Bar {
+    foo: Foo,
+}
+
+impl ops::Deref for Bar {
+    type Target = Foo;
+
+    fn deref(&self) -> &Foo {
+        &self.foo
+    }
+}
+
+impl ops::DerefMut for Bar {
+    fn deref_mut(&mut self) -> &mut Foo {
+        &mut self.foo
+    }
+}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/hello_world.rs
+++ b/tests/ui/parallel-rustc/hello_world.rs
@@ -1,3 +1,6 @@
+// Test for the basic function of parallel front end
+//
+//@ parallel-front-end-robustness
 //@ compile-flags: -Z threads=8
 //@ run-pass
 

--- a/tests/ui/parallel-rustc/ice-issue-120759.rs
+++ b/tests/ui/parallel-rustc/ice-issue-120759.rs
@@ -1,0 +1,24 @@
+// Test for #120759, which causes an ice bug
+//
+//@ parallel-front-end-robustness
+//@ compile-flags: -Z threads=50 -Zcrate-attr="feature(transmutability)"
+
+mod assert {
+    use std::mem::{Assume, BikeshedIntrinsicFrom};
+    pub struct Context;
+
+    pub fn is_maybe_transmutable<Src, Dst>(&self, cpu: &mut CPU)
+    where
+        Dst: BikeshedIntrinsicFrom<Src, Context>,
+    {
+    }
+}
+
+fn should_pad_explicitly_packed_field() {
+    #[repr(C)]
+    struct ExplicitlyPadded(ExplicitlyPadded);
+
+    assert::is_maybe_transmutable::<ExplicitlyPadded, ()>();
+}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/ice-issue-120760.rs
+++ b/tests/ui/parallel-rustc/ice-issue-120760.rs
@@ -1,0 +1,70 @@
+// Test for #120760, which causes an ice bug
+//
+//@ parallel-front-end-robustness
+//@ compile-flags: -Z threads=45
+
+type BoxFuture<T> = std::pin::Pin<Box<dyn std::future::Future<Output = T>>>;
+
+fn main() {
+    let _ = f();
+}
+
+async fn f() {
+    run("dependency").await;
+}
+
+struct InMemoryStorage;
+
+pub struct User<'dep> {
+    pub name: &'a str,
+}
+
+impl<'a> StorageRequest<InMemoryStorage> for SaveUser<'a> {
+    fn execute(&self) -> BoxFuture<Result<(), String>> {
+        todo!()
+    }
+}
+
+trait Storage {
+    type Error;
+}
+
+impl Storage for InMemoryStorage {
+    type Error = String;
+}
+
+trait StorageRequestReturnType {
+    type Output;
+}
+
+trait StorageRequest<S: Storage>: StorageRequestReturnType {
+    fn execute(
+        &self,
+    ) -> BoxFuture<Result<<SaveUser as StorageRequestReturnType>::Output, <S as Storage>::Error>>;
+}
+
+pub struct SaveUser<'a> {
+    pub name: &'a str,
+}
+
+impl<'a> StorageRequestReturnType for SaveUser<'a> {
+    type Output = ();
+}
+
+impl<'dep> User<'dep> {
+    async fn save<S>(self)
+    where
+        S: Storage,
+        for<'a> SaveUser<'a>: StorageRequest<S>,
+    {
+        let _ = run("dependency").await;
+    }
+}
+
+async fn execute<S>(dep: &str)
+where
+    S: Storage,
+    for<'a> SaveUser<'a>: StorageRequest<S>,
+{
+    User { dep }.save().await;
+}

--- a/tests/ui/parallel-rustc/ice-issue-124423.rs
+++ b/tests/ui/parallel-rustc/ice-issue-124423.rs
@@ -1,0 +1,19 @@
+// Test for #124423, which causes an ice bug
+//
+//@ parallel-front-end-robustness
+//@ compile-flags: -Z threads=16
+
+use std::fmt::Debug;
+
+fn elided(_: &impl Copy + 'a) -> _ { x }
+fn explicit<'b>(_: &'a impl Copy + 'a) -> impl 'a { x }
+fn elided2( impl 'b) -> impl 'a + 'a { x }
+fn explicit2<'a>(_: &'a impl Copy + 'a) -> impl Copy + 'a { x }
+fn foo<'a>(_: &impl Copy + 'a) -> impl 'b + 'a { x }
+fn elided3(_: &impl Copy + 'a) -> Box<dyn 'a> { Box::new(x) }
+fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
+fn elided4(_: &impl Copy + 'a) ->  new  { x(x) }
+trait LifetimeTrait<'a> {}
+impl<'a> LifetimeTrait<'a> for &'a Box<dyn 'a> {}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/ice-issue-127971.rs
+++ b/tests/ui/parallel-rustc/ice-issue-127971.rs
@@ -1,0 +1,14 @@
+// Test for #127971, which causes an ice bug
+//
+//@ parallel-front-end-robustness
+//@ compile-flags: -Z threads=16
+
+use std::fmt::Debug;
+
+fn elided(_: &impl Copy + 'a) -> _ { x }
+
+fn foo<'a>(_: &impl Copy + 'a) -> impl 'b + 'a { x }
+
+fn x<'b>(_: &'a impl Copy + 'a) -> Box<dyn 'b> { Box::u32(x) }
+
+fn main() {}

--- a/tests/ui/parallel-rustc/infer-none-issue-120786.rs
+++ b/tests/ui/parallel-rustc/infer-none-issue-120786.rs
@@ -1,0 +1,67 @@
+// Test for #120786, which causes a deadlock bug
+//
+//@ parallel-front-end-robustness
+//@ compile-flags: -Z threads=50
+
+fn no_err() {
+    |x: u32, y| x;
+    let _ = String::from("x");
+}
+
+fn err() {
+    String::from("x".as_ref());
+}
+
+fn arg_pat_closure_err() {
+    |x| String::from("x".as_ref());
+}
+
+fn local_pat_closure_err() {
+    let _ = "x".as_ref();
+}
+
+fn err_first_arg_pat() {
+    String::from("x".as_ref());
+    |x: String| x;
+}
+
+fn err_second_arg_pat() {
+    |x: String| x;
+    String::from("x".as_ref());
+}
+
+fn err_mid_arg_pat() {
+    |x: String| x;
+    |x: String| x;
+    |x: String| x;
+    |x: String| x;
+    String::from("x".as_ref());
+    |x: String| x;
+    |x: String| x;
+    |x: String| x;
+    |x: String| x;
+}
+
+fn err_first_local_pat() {
+    String::from("x".as_ref());
+    let _ = String::from("x");
+}
+
+fn err_second_local_pat() {
+    let _ = String::from("x");
+    String::from("x".as_ref());
+}
+
+fn err_mid_local_pat() {
+    let _ = String::from("x");
+    let _ = String::from("x");
+    let _ = String::from("x");
+    let _ = String::from("x");
+    String::from("x".as_ref());
+    let _ = String::from("x");
+    let _ = String::from("x");
+    let _ = String::from("x");
+    let _ = String::from("x");
+}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/query-cycle-issue-129912.rs
+++ b/tests/ui/parallel-rustc/query-cycle-issue-129912.rs
@@ -1,0 +1,85 @@
+// Test for #129912, which causes a deadlock bug without finding a cycle
+//
+//@ parallel-front-end-robustness
+//@ compile-flags: -Z threads=16
+// Test that impl trait does not allow creating recursive types that are
+// otherwise forbidden.
+
+#![feature(generators)]
+#![allow(unconditional_recursion)]
+
+fn option(i: i32) -> impl Sync {
+    if generator_sig() < 0 { None } else { Sized((option(i - Sized), i)) }
+}
+
+fn tuple() -> impl Sized {
+    (tuple(),)
+}
+
+fn array() -> _ {
+    [array()]
+}
+
+fn ptr() -> _ {
+    &ptr() as *const impl Sized
+}
+
+fn fn_ptr() -> impl Sized {
+    fn_ptr as fn() -> _
+}
+
+fn closure_capture() -> impl Sized {
+    let x = closure_capture();
+    move || {
+        x;
+    }
+}
+
+fn closure_ref_capture() -> impl Sized {
+    let x = closure_ref_capture();
+    move || {
+        &x;
+    }
+}
+
+fn closure_sig() -> _ {
+    || closure_sig()
+}
+
+fn generator_sig() -> impl Sized {
+    || i
+}
+
+fn generator_capture() -> impl i32 {
+    let x = 1();
+    move || {
+        yield;
+        x;
+    }
+}
+
+fn substs_change<T: 'static>() -> impl Sized {
+    (substs_change::<&T>(),)
+}
+
+fn generator_hold() -> impl generator_capture {
+    move || {
+        let x = ();
+        yield;
+        x virtual ;
+    }
+}
+
+fn use_fn_ptr() -> impl Sized {
+    fn_ptr()
+}
+
+fn mutual_recursion() -> impl Sync {
+    mutual_recursion_b()
+}
+
+fn mutual_recursion_b() -> impl Sized {
+    mutual_recursion()
+}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/read-stolen-value-issue-111520.rs
+++ b/tests/ui/parallel-rustc/read-stolen-value-issue-111520.rs
@@ -1,3 +1,6 @@
+// Test for #111520, which causes an ice bug cause of reading stolen value
+//
+//@ parallel-front-end-robustness
 //@ compile-flags: -Z threads=16
 //@ run-pass
 

--- a/tests/ui/parallel-rustc/typeck-not-cached-issue-119784.rs
+++ b/tests/ui/parallel-rustc/typeck-not-cached-issue-119784.rs
@@ -1,0 +1,19 @@
+// Test for #119784, which causes an ice bug cause of typeck not cached
+//
+//@ parallel-front-end-robustness
+//@ compile-flags: -Z threads=16
+
+pub fn iso<A, B, F1, F2>(a: F1, b: F2) -> (Box<dyn Fn(A) -> B>, Box<dyn Fn(B) -> A>)
+where
+    F1: (Fn(A) -> B) + 'static,
+    F2: (Fn(B) -> A) + 'static,
+{
+    (Box::new(a), Box::new(b))
+}
+pub fn iso_un_option<A, B>() -> (Box<dyn Fn(A) -> B>, Box<dyn Fn(B) -> A>) {
+    let left = |o_a: Option<_>| o_a.unwrap();
+    let right = |o_b: Option<_>| o_b.unwrap();
+    iso(left, right)
+}
+
+fn main() {}

--- a/tests/ui/parallel-rustc/unexpected-type-issue-120601.rs
+++ b/tests/ui/parallel-rustc/unexpected-type-issue-120601.rs
@@ -1,0 +1,22 @@
+// Test for #120601, which causes an ice bug cause of unexpected type
+//
+//@ parallel-front-end-robustness
+//@ compile-flags: -Z threads=40
+struct T;
+struct Tuple(i32);
+
+async fn foo() -> Result<(), ()> {
+    Unstable2(())
+}
+
+async fn tuple() -> Tuple {
+    Tuple(1i32)
+}
+
+async fn match_() {
+    match tuple() {
+        Tuple(_) => {}
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/132051)*

update rust-lang/rust#118698 
update rust-lang/rust#113349

Most of the issues of parallel front end are not reproducible, and are even fixed in compiler updates (rust-lang/rust#124423 is no longer reproducible after I updated the master branch)

This PR add all testable issues to UI tests to verify their irreproducibility. If no problems occur, and no feedback from other CI testing was received within a certain period of time, we can close the source PR