### PR TITLE
do not remove `.cargo` directory

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1092,9 +1092,6 @@ class RustBuild(object):
             if not os.path.exists(cargo_dir):
                 eprint('ERROR: vendoring required, but .cargo/config does not exist.')
                 raise Exception("{} not found".format(cargo_dir))
-        else:
-            if os.path.exists(cargo_dir):
-                shutil.rmtree(cargo_dir)
 
 def parse_args(args):
     """Parse the command line arguments that the python script needs."""


### PR DESCRIPTION
If vendoring isn't used bootstrap removes `.cargo` directory, which prevents developers from setting certain options in the `.cargo/config.toml` file. This was introduced in https://github.com/rust-lang/rust/pull/97513 (specifically in [this commit](https://github.com/rust-lang/rust/pull/97513/commits/345eb14f6c841cd38e76a5b0bbf99e1b94a90d40)). Also, since https://github.com/rust-lang/rust/pull/123942, vendoring is now possible even in git sources, which means we shouldn't remove `.cargo` directory in git sources anymore.