### PR TITLE
CI: rfl: use rust-next temporary commit

### DIFF
--- a/src/ci/docker/scripts/rfl-build.sh
+++ b/src/ci/docker/scripts/rfl-build.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-LINUX_VERSION=v6.12-rc2
+LINUX_VERSION=28e848386b92645f93b9f2fdba5882c3ca7fb3e2
 
 # Build rustc, rustdoc, cargo, clippy-driver and rustfmt
 ../x.py build --stage 2 library rustdoc clippy rustfmt


### PR DESCRIPTION
Commit c95bbb59a9b22f9b838b15d28319185c1c884329 within rust-next contains some changes required to be compatible with upcoming arbitraty self types work. Roll RFL CI forward to the latest rust-next to include that work.

Related:
https://github.com/rust-lang/rust/pull/130225
https://github.com/rust-lang/rust/issues/44874

r? @ojeda 

try-job: x86_64-rust-for-linux