### PR TITLE
Revert #126024 "Do not use global caches if opaque types can be defined"

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -2362,17 +2362,18 @@ impl<'tcx> SelectionContext<'_, 'tcx> {
             }
 
             ty::Alias(ty::Opaque, ty::AliasTy { def_id, args, .. }) => {
-                if self.infcx.can_define_opaque_ty(def_id) {
-                    unreachable!()
-                } else {
-                    // We can resolve the `impl Trait` to its concrete type,
-                    // which enforces a DAG between the functions requiring
-                    // the auto trait bounds in question.
-                    match self.tcx().type_of_opaque(def_id) {
-                        Ok(ty) => t.rebind(vec![ty.instantiate(self.tcx(), args)]),
-                        Err(_) => {
-                            return Err(SelectionError::OpaqueTypeAutoTraitLeakageUnknown(def_id));
-                        }
+                // FIXME(new-solver): because we're still using the global cache
+                // when defining opaque types, we can reach here, but shouldn't.
+                // The test `type-alias-impl-trait/reveal_local.rs` is an
+                // example.
+
+                // We can resolve the `impl Trait` to its concrete type,
+                // which enforces a DAG between the functions requiring
+                // the auto trait bounds in question.
+                match self.tcx().type_of_opaque(def_id) {
+                    Ok(ty) => t.rebind(vec![ty.instantiate(self.tcx(), args)]),
+                    Err(_) => {
+                        return Err(SelectionError::OpaqueTypeAutoTraitLeakageUnknown(def_id));
                     }
                 }
             }

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1492,9 +1492,13 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
             // it's not worth going to more trouble to increase the
             // hit-rate, I don't think.
             TypingMode::Coherence => false,
-            // Avoid using the global cache when we're defining opaque types
-            // as their hidden type may impact the result of candidate selection.
-            TypingMode::Analysis { defining_opaque_types } => defining_opaque_types.is_empty(),
+            // FIXME(new-solver): This is incorrect, we should not be using the
+            // global cache when we're defining opaque types, as their hidden
+            // type may impact the result of candidate selection. This is still
+            // a theoretical possibility, however, and we have no example of
+            // actual unsoundness it can trigger. Until then, not using the
+            // cache is too big of a compile-time regression.
+            TypingMode::Analysis { .. } => true,
             // The global cache is only used if there are no opaque types in
             // the defining scope or we're outside of analysis.
             //

--- a/tests/ui/consts/const-promoted-opaque.rs
+++ b/tests/ui/consts/const-promoted-opaque.rs
@@ -30,7 +30,7 @@ const BAR: () = {
 };
 
 const BAZ: &Foo = &FOO;
-//[atomic]~^ ERROR: constants cannot refer to interior mutable data
+//[string,atomic]~^ ERROR: constants cannot refer to interior mutable data
 
 fn main() {
     let _: &'static _ = &FOO;

--- a/tests/ui/consts/const-promoted-opaque.string.stderr
+++ b/tests/ui/consts/const-promoted-opaque.string.stderr
@@ -7,6 +7,12 @@ LL |
 LL | };
    | - value is dropped here
 
+error[E0492]: constants cannot refer to interior mutable data
+  --> $DIR/const-promoted-opaque.rs:32:19
+   |
+LL | const BAZ: &Foo = &FOO;
+   |                   ^^^^ this borrow of an interior mutable value may end up in the final value
+
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/const-promoted-opaque.rs:36:26
    |
@@ -18,7 +24,7 @@ LL |
 LL | }
    | - temporary value is freed at the end of this statement
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0493, E0716.
-For more information about an error, try `rustc --explain E0493`.
+Some errors have detailed explanations: E0492, E0493, E0716.
+For more information about an error, try `rustc --explain E0492`.

--- a/tests/ui/type-alias-impl-trait/reveal_local.rs
+++ b/tests/ui/type-alias-impl-trait/reveal_local.rs
@@ -20,7 +20,7 @@ fn not_gooder() -> Foo {
     // while we could know this from the hidden type, it would
     // need extra roundabout logic to support it.
     is_send::<Foo>();
-    //~^ ERROR: type annotations needed: cannot satisfy `Foo: Send`
+    //~^ ERROR: cannot check whether the hidden type of `reveal_local[9507]::Foo::{opaque#0}` satisfies auto traits
 
     x
 }

--- a/tests/ui/type-alias-impl-trait/reveal_local.stderr
+++ b/tests/ui/type-alias-impl-trait/reveal_local.stderr
@@ -16,13 +16,18 @@ note: required by a bound in `is_send`
 LL | fn is_send<T: Send>() {}
    |               ^^^^ required by this bound in `is_send`
 
-error[E0283]: type annotations needed: cannot satisfy `Foo: Send`
+error: cannot check whether the hidden type of `reveal_local[9507]::Foo::{opaque#0}` satisfies auto traits
   --> $DIR/reveal_local.rs:22:15
    |
 LL |     is_send::<Foo>();
    |               ^^^
    |
-   = note: cannot satisfy `Foo: Send`
+   = note: fetching the hidden types of an opaque inside of the defining scope is not supported. You can try moving the opaque type and the item that actually registers a hidden type into a new submodule
+note: opaque type is declared here
+  --> $DIR/reveal_local.rs:5:12
+   |
+LL | type Foo = impl Debug;
+   |            ^^^^^^^^^^
 note: required by a bound in `is_send`
   --> $DIR/reveal_local.rs:7:15
    |
@@ -31,4 +36,3 @@ LL | fn is_send<T: Send>() {}
 
 error: aborting due to 2 previous errors
 
-For more information about this error, try `rustc --explain E0283`.


### PR DESCRIPTION
This PR prepares a revert of #126024 as discussed on zulip, because of its regressions to compilation times vs unclear soundness fix. Opening as draft for discussion between @compiler-errors and @lcnr.

---

#126024 didn't fix the ICE in https://github.com/rust-lang/rust/issues/119272 ([proof](https://rust.godbolt.org/z/GxWK4x9Kj)). Enabling the new solver in coherence did fix both the codegen ICE and incorrectly accepting the code in the first place. 

It seems the theoretical unsoundness fixed in #126024 didn't yet have an MCVE showcasing the issue, and didn't have tests. The correct fix is in principle to use the new solver. 

However, that is not happening soon and until then #126024 has a big impact on compile-times in some cases:
- as seen in [this zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/144729-t-types/topic/Fuchsia.20Build.20Time.20Regression): fuchsia is seeing a 10x regression on the `starnix_core` crate with #126024.
- similarly, as seen in #132064: it looks like one crate is making the entire project build 6-7x slower in 1.82.0. It seemed likely that people would encounter the same behavior when #126024 landed on stable
- even the [post-merge perf results](https://github.com/rust-lang/rust/pull/126024#issuecomment-2248358134) showed significant regressions on a popular crate (`hyper`). Some of the PR's effects should be seen by a large number of people but thankfully they're not always as dramatic as the previous 2 cases.

---

I didn't add the crash test for #119272 back, and the  `auto-traits/opaque_type_candidate_selection.rs` test was deleted in #130654. I assume the latter was because there already was coverage for such a case, but if not I can add that test back, updated for `-Znext-solver=coherence`. <sub>I don't have an MCVE for #132064 but *if needed*, I could try to minimize it.</sub>

Fixes #132064.

