### PR TITLE
HashStable for rustc_feature::Features: stop hashing compile-time constant

### DIFF
--- a/compiler/rustc_query_system/src/ich/impls_syntax.rs
+++ b/compiler/rustc_query_system/src/ich/impls_syntax.rs
@@ -111,13 +111,8 @@ impl<'a> HashStable<StableHashingContext<'a>> for SourceFile {
 impl<'tcx> HashStable<StableHashingContext<'tcx>> for rustc_feature::Features {
     fn hash_stable(&self, hcx: &mut StableHashingContext<'tcx>, hasher: &mut StableHasher) {
         // Unfortunately we cannot exhaustively list fields here, since the
-        // struct is macro generated.
+        // struct has private fields (to ensure its invariant is maintained)
         self.enabled_lang_features().hash_stable(hcx, hasher);
         self.enabled_lib_features().hash_stable(hcx, hasher);
-
-        // FIXME: why do we hash something that is a compile-time constant?
-        for feature in rustc_feature::UNSTABLE_LANG_FEATURES.iter() {
-            feature.name.hash_stable(hcx, hasher);
-        }
     }
 }


### PR DESCRIPTION
It seems like back in https://github.com/rust-lang/rust/commit/542bc75deaaf4e84dcd7a196685bc1a1cb100d32 this was added as "hash the boolean value of each lang feature", but then in https://github.com/rust-lang/rust/commit/1487bd6a174f813967ffff6b3334b4fe296f1f30 this got split into first hashing a sequence of `bool`s (representing all the features) and then hashing all the feature names... but the list of feature names is a compile-time constant, so it seems entirely unnecessary to hash them?

Cc @Mark-Simulacrum who wrote the second of the commits mentioned above.
Cc @nnethercote 