### PR TITLE
[experiment] null-terminate track_caller strings

### DIFF
--- a/compiler/rustc_const_eval/src/util/caller_location.rs
+++ b/compiler/rustc_const_eval/src/util/caller_location.rs
@@ -19,14 +19,9 @@ fn alloc_caller_location<'tcx>(
     let loc_details = ecx.tcx.sess.opts.unstable_opts.location_detail;
     // This can fail if rustc runs out of memory right here. Trying to emit an error would be
     // pointless, since that would require allocating more memory than these short strings.
-    let file = if loc_details.file {
-        ecx.allocate_str(filename.as_str(), MemoryKind::CallerLocation, Mutability::Not).unwrap()
-    } else {
-        // FIXME: This creates a new allocation each time. It might be preferable to
-        // perform this allocation only once, and re-use the `MPlaceTy`.
-        // See https://github.com/rust-lang/rust/pull/89920#discussion_r730012398
-        ecx.allocate_str("<redacted>", MemoryKind::CallerLocation, Mutability::Not).unwrap()
-    };
+    let filename = if loc_details.file { filename.as_str() } else { "<redacted>" };
+    let file =
+        ecx.allocate_str_with_null(filename, MemoryKind::CallerLocation, Mutability::Not).unwrap();
     let file = file.map_provenance(CtfeProvenance::as_immutable);
     let line = if loc_details.line { Scalar::from_u32(line) } else { Scalar::from_u32(0) };
     let col = if loc_details.column { Scalar::from_u32(col) } else { Scalar::from_u32(0) };

--- a/compiler/rustc_middle/src/mir/interpret/allocation.rs
+++ b/compiler/rustc_middle/src/mir/interpret/allocation.rs
@@ -294,6 +294,24 @@ impl<Prov: Provenance, Bytes: AllocBytes> Allocation<Prov, (), Bytes> {
         Allocation::from_bytes(slice, Align::ONE, Mutability::Not)
     }
 
+    pub fn from_bytes_byte_aligned_immutable_with_null<'a>(
+        slice: impl Into<Cow<'a, [u8]>>,
+    ) -> Self {
+        let slice = slice.into();
+        let len = slice.len() + 1;
+        let size = Size::from_bytes(len);
+        let mut bytes = Bytes::zeroed(size, Align::ONE).unwrap();
+        bytes[..slice.len()].copy_from_slice(&slice);
+        Self {
+            bytes,
+            provenance: ProvenanceMap::new(),
+            init_mask: InitMask::new(size, true),
+            align: Align::ONE,
+            mutability: Mutability::Not,
+            extra: (),
+        }
+    }
+
     fn uninit_inner<R>(size: Size, align: Align, fail: impl FnOnce() -> R) -> Result<Self, R> {
         // We raise an error if we cannot create the allocation on the host.
         // This results in an error that can happen non-deterministically, since the memory

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1462,6 +1462,13 @@ impl<'tcx> TyCtxt<'tcx> {
         self.reserve_and_set_memory_dedup(alloc, salt)
     }
 
+    pub fn allocate_bytes_dedup_with_null(self, bytes: &[u8], salt: usize) -> interpret::AllocId {
+        // Create an allocation that just contains these bytes.
+        let alloc = interpret::Allocation::from_bytes_byte_aligned_immutable_with_null(bytes);
+        let alloc = self.mk_const_alloc(alloc);
+        self.reserve_and_set_memory_dedup(alloc, salt)
+    }
+
     /// Returns a range of the start/end indices specified with the
     /// `rustc_layout_scalar_valid_range` attribute.
     // FIXME(eddyb) this is an awkward spot for this method, maybe move it?


### PR DESCRIPTION
Trying to evaluate the compile-time/binary size impact of doing this. I suspect it's not measurable, but good to check.

The implementation here is kind of bad. I tried doing two strategies at once and it went predictably.

r? ghost