### PR TITLE
On argument position `impl Trait<A>` where `A` is not found, hide useles error

### DIFF
--- a/tests/ui/impl-trait/resolve-error-in-impl-trait-fn-argument.rs
+++ b/tests/ui/impl-trait/resolve-error-in-impl-trait-fn-argument.rs
@@ -1,0 +1,9 @@
+// Ensure that we don't emit an E0270 for "`impl AsRef<Path>: AsRef<Path>` not satisfied".
+
+fn foo(filename: impl AsRef<Path>) { //~ ERROR cannot find type `Path` in this scope
+    std::fs::write(filename, "hello").unwrap();
+}
+
+fn main() {
+    foo("/tmp/hello");
+}

--- a/tests/ui/impl-trait/resolve-error-in-impl-trait-fn-argument.stderr
+++ b/tests/ui/impl-trait/resolve-error-in-impl-trait-fn-argument.stderr
@@ -1,0 +1,14 @@
+error[E0412]: cannot find type `Path` in this scope
+  --> $DIR/resolve-error-in-impl-trait-fn-argument.rs:3:29
+   |
+LL | fn foo(filename: impl AsRef<Path>) {
+   |                             ^^^^ not found in this scope
+   |
+help: consider importing this struct
+   |
+LL + use std::path::Path;
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0412`.


### PR DESCRIPTION
When given

```rust
fn foo(filename: impl AsRef<NonExistent>) {
    std::fs::write(filename, "hello").unwrap();
}
```

Emit only an error about `NonExistent`, and avoid an error complaining that `impl AsRef<NonExistent>: AsRef<NonExistent>` is not satisfied.

By making the `res` corresponding to the `impl AsRef<NonExistent>` type paremeter be `Res::Err`, E0277 (and others) errors are silenced.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
