### PR TITLE
Fix #131977 parens mangled in shared mut static lint suggestion

### DIFF
--- a/tests/ui/statics/static-mut-shared-parens.rs
+++ b/tests/ui/statics/static-mut-shared-parens.rs
@@ -1,0 +1,13 @@
+//Missing paren in diagnostic msg: https://github.com/rust-lang/rust/issues/131977
+//@check-pass
+
+
+static mut TEST: usize = 0;
+
+fn main() {
+    let _ = unsafe { (&TEST) as *const usize };
+    //~^WARN creating a shared reference to mutable static is discouraged
+
+    let _ = unsafe { ((&mut TEST)) as *const usize };
+    //~^WARN creating a mutable reference to mutable static is discouraged
+}

--- a/tests/ui/statics/static-mut-shared-parens.stderr
+++ b/tests/ui/statics/static-mut-shared-parens.stderr
@@ -1,0 +1,29 @@
+warning: creating a shared reference to mutable static is discouraged
+  --> $DIR/static-mut-shared-parens.rs:8:22
+   |
+LL |     let _ = unsafe { (&TEST) as *const usize };
+   |                      ^^^^^^^ shared reference to mutable static
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
+   = note: `#[warn(static_mut_refs)]` on by default
+help: use `&raw const` instead to create a raw pointer
+   |
+LL |     let _ = unsafe { (&raw const TEST) as *const usize };
+   |                       ~~~~~~~~~~
+
+warning: creating a mutable reference to mutable static is discouraged
+  --> $DIR/static-mut-shared-parens.rs:11:22
+   |
+LL |     let _ = unsafe { ((&mut TEST)) as *const usize };
+   |                      ^^^^^^^^^^^^^ mutable reference to mutable static
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
+help: use `&raw mut` instead to create a raw pointer
+   |
+LL |     let _ = unsafe { ((&raw mut TEST)) as *const usize };
+   |                        ~~~~~~~~
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
Resolves #131977 for static mut references after discussion with 
Esteban & Jieyou on [t-compiler/help](https://rust-lang.zulipchat.com/#narrow/channel/182449-t-compiler.2Fhelp/topic/linting.20with.20parens.20in.20the.20HIR).

This doesn't do anything to change the underlying issue if there are other expressions that generate lint suggestions which need to be applied within parentheses.

