### PR TITLE
Avoid using imports in thread_local_inner! in static

### DIFF
--- a/library/std/src/sys/thread_local/statik.rs
+++ b/library/std/src/sys/thread_local/statik.rs
@@ -14,12 +14,11 @@ pub macro thread_local_inner {
     (@key $t:ty, const $init:expr) => {{
         const __INIT: $t = $init;
 
+        // NOTE: Please update the shadowing test in `tests/thread.rs` if these types are renamed.
         unsafe {
-            use $crate::thread::LocalKey;
-            use $crate::thread::local_impl::EagerStorage;
-
-            LocalKey::new(|_| {
-                static VAL: EagerStorage<$t> = EagerStorage { value: __INIT };
+            $crate::thread::LocalKey::new(|_| {
+                static VAL: $crate::thread::local_impl::EagerStorage<$t> =
+                    $crate::thread::local_impl::EagerStorage { value: __INIT };
                 &VAL.value
             })
         }


### PR DESCRIPTION
Fixes #131863 for wasm targets

All other macros were done in #131866, but this sub module is missed.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

r? @jieyouxu 
