### PR TITLE
[rustdoc] Do not consider nested functions as main function even if named `main` in doctests

### DIFF
--- a/tests/rustdoc-ui/doctest/nested-main.rs
+++ b/tests/rustdoc-ui/doctest/nested-main.rs
@@ -1,0 +1,24 @@
+//@ check-pass
+//@ compile-flags:--test --test-args=--test-threads=1
+//@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
+
+// Regression test for <https://github.com/rust-lang/rust/issues/131893>.
+// It ensures that if a function called `main` is nested, it will not consider
+// it as the `main` function.
+
+/// ```
+/// fn dox() {
+///     fn main() {}
+/// }
+/// ```
+pub fn foo() {}
+
+// This one ensures that having a nested `main` doesn't prevent the
+// actual `main` function to be detected.
+/// ```
+/// fn main() {
+///     fn main() {}
+/// }
+/// ```
+pub fn foo2() {}

--- a/tests/rustdoc-ui/doctest/nested-main.stdout
+++ b/tests/rustdoc-ui/doctest/nested-main.stdout
@@ -1,0 +1,7 @@
+
+running 2 tests
+test $DIR/nested-main.rs - foo (line 10) ... ok
+test $DIR/nested-main.rs - foo2 (line 19) ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+


### PR DESCRIPTION
Fixes #131893.

If a nested function is called `main`, it is not considered as the entry point of the program. Therefore, doctests should not consider such functions as such either.

r? @notriddle 