### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -162,7 +162,9 @@ pub trait Pattern: Sized {
     }
 
     /// Returns the pattern as utf-8 bytes if possible.
-    fn as_utf8_pattern(&self) -> Option<Utf8Pattern<'_>>;
+    fn as_utf8_pattern(&self) -> Option<Utf8Pattern<'_>> {
+        None
+    }
 }
 /// Result of calling [`Pattern::as_utf8_pattern()`].
 /// Can be used for inspecting the contents of a [`Pattern`] in cases
@@ -675,11 +677,6 @@ impl<C: MultiCharEq> Pattern for MultiCharEqPattern<C> {
     fn into_searcher(self, haystack: &str) -> MultiCharEqSearcher<'_, C> {
         MultiCharEqSearcher { haystack, char_eq: self.0, char_indices: haystack.char_indices() }
     }
-
-    #[inline]
-    fn as_utf8_pattern(&self) -> Option<Utf8Pattern<'_>> {
-        None
-    }
 }
 
 unsafe impl<'a, C: MultiCharEq> Searcher<'a> for MultiCharEqSearcher<'a, C> {
@@ -769,11 +766,6 @@ macro_rules! pattern_methods {
             $t: ReverseSearcher<$a>,
         {
             ($pmap)(self).strip_suffix_of(haystack)
-        }
-
-        #[inline]
-        fn as_utf8_pattern(&self) -> Option<Utf8Pattern<'_>> {
-            None
         }
     };
 }

--- a/library/std/src/random.rs
+++ b/library/std/src/random.rs
@@ -38,7 +38,7 @@ use crate::sys::random as sys;
 /// Vita                   | `arc4random_buf`
 /// Hermit                 | `read_entropy`
 /// Horizon                | `getrandom` shim
-/// Hurd, L4Re, QNX        | `/dev/urandom`
+/// AIX, Hurd, L4Re, QNX   | `/dev/urandom`
 /// Redox                  | `/scheme/rand`
 /// RTEMS                  | [`arc4random_buf`](https://docs.rtems.org/branches/master/bsp-howto/getentropy.html)
 /// SGX                    | [`rdrand`](https://en.wikipedia.org/wiki/RDRAND)

--- a/library/std/src/sys/pal/unix/process/process_unix.rs
+++ b/library/std/src/sys/pal/unix/process/process_unix.rs
@@ -448,7 +448,6 @@ impl Command {
         use core::sync::atomic::{AtomicU8, Ordering};
 
         use crate::mem::MaybeUninit;
-        use crate::sys::weak::weak;
         use crate::sys::{self, cvt_nz, on_broken_pipe_flag_used};
 
         if self.get_gid().is_some()
@@ -462,6 +461,8 @@ impl Command {
 
         cfg_if::cfg_if! {
             if #[cfg(target_os = "linux")] {
+                use crate::sys::weak::weak;
+
                 weak! {
                     fn pidfd_spawnp(
                         *mut libc::c_int,
@@ -575,16 +576,44 @@ impl Command {
             }
         }
 
-        // Solaris, glibc 2.29+, and musl 1.24+ can set a new working directory,
-        // and maybe others will gain this non-POSIX function too. We'll check
-        // for this weak symbol as soon as it's needed, so we can return early
-        // otherwise to do a manual chdir before exec.
-        weak! {
-            fn posix_spawn_file_actions_addchdir_np(
-                *mut libc::posix_spawn_file_actions_t,
-                *const libc::c_char
-            ) -> libc::c_int
+        type PosixSpawnAddChdirFn = unsafe extern "C" fn(
+            *mut libc::posix_spawn_file_actions_t,
+            *const libc::c_char,
+        ) -> libc::c_int;
+
+        /// Get the function pointer for adding a chdir action to a
+        /// `posix_spawn_file_actions_t`, if available, assuming a dynamic libc.
+        ///
+        /// Some platforms can set a new working directory for a spawned process in the
+        /// `posix_spawn` path. This function looks up the function pointer for adding
+        /// such an action to a `posix_spawn_file_actions_t` struct.
+        #[cfg(not(all(target_os = "linux", target_env = "musl")))]
+        fn get_posix_spawn_addchdir() -> Option<PosixSpawnAddChdirFn> {
+            use crate::sys::weak::weak;
+
+            weak! {
+                fn posix_spawn_file_actions_addchdir_np(
+                    *mut libc::posix_spawn_file_actions_t,
+                    *const libc::c_char
+                ) -> libc::c_int
+            }
+
+            posix_spawn_file_actions_addchdir_np.get()
         }
+
+        /// Get the function pointer for adding a chdir action to a
+        /// `posix_spawn_file_actions_t`, if available, on platforms where the function
+        /// is known to exist.
+        ///
+        /// Weak symbol lookup doesn't work with statically linked libcs, so in cases
+        /// where static linking is possible we need to either check for the presence
+        /// of the symbol at compile time or know about it upfront.
+        #[cfg(all(target_os = "linux", target_env = "musl"))]
+        fn get_posix_spawn_addchdir() -> Option<PosixSpawnAddChdirFn> {
+            // Our minimum required musl supports this function, so we can just use it.
+            Some(libc::posix_spawn_file_actions_addchdir_np)
+        }
+
         let addchdir = match self.get_cwd() {
             Some(cwd) => {
                 if cfg!(target_vendor = "apple") {
@@ -597,7 +626,10 @@ impl Command {
                         return Ok(None);
                     }
                 }
-                match posix_spawn_file_actions_addchdir_np.get() {
+                // Check for the availability of the posix_spawn addchdir
+                // function now. If it isn't available, bail and use the
+                // fork/exec path.
+                match get_posix_spawn_addchdir() {
                     Some(f) => Some((f, cwd)),
                     None => return Ok(None),
                 }

--- a/library/std/src/sys/random/mod.rs
+++ b/library/std/src/sys/random/mod.rs
@@ -40,6 +40,7 @@ cfg_if::cfg_if! {
         mod horizon;
         pub use horizon::fill_bytes;
     } else if #[cfg(any(
+        target_os = "aix",
         target_os = "hurd",
         target_os = "l4re",
         target_os = "nto",

--- a/library/std/src/sys/thread_local/statik.rs
+++ b/library/std/src/sys/thread_local/statik.rs
@@ -14,12 +14,11 @@ pub macro thread_local_inner {
     (@key $t:ty, const $init:expr) => {{
         const __INIT: $t = $init;
 
+        // NOTE: Please update the shadowing test in `tests/thread.rs` if these types are renamed.
         unsafe {
-            use $crate::thread::LocalKey;
-            use $crate::thread::local_impl::EagerStorage;
-
-            LocalKey::new(|_| {
-                static VAL: EagerStorage<$t> = EagerStorage { value: __INIT };
+            $crate::thread::LocalKey::new(|_| {
+                static VAL: $crate::thread::local_impl::EagerStorage<$t> =
+                    $crate::thread::local_impl::EagerStorage { value: __INIT };
                 &VAL.value
             })
         }

--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1368,6 +1368,24 @@ impl clean::Impl {
                 write!(f, " -> ")?;
                 fmt_type(&bare_fn.decl.output, f, use_absolute, cx)?;
             }
+        } else if let clean::Type::Path { path } = type_
+            && let Some(generics) = path.generics()
+            && generics.len() == 1
+            && self.kind.is_fake_variadic()
+        {
+            let ty = generics[0];
+            let wrapper = anchor(path.def_id(), path.last(), cx);
+            if f.alternate() {
+                write!(f, "{wrapper:#}&lt;")?;
+            } else {
+                write!(f, "{wrapper}<")?;
+            }
+            self.print_type(ty, f, use_absolute, cx)?;
+            if f.alternate() {
+                write!(f, "&gt;")?;
+            } else {
+                write!(f, ">")?;
+            }
         } else {
             fmt_type(&type_, f, use_absolute, cx)?;
         }

--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -59,7 +59,7 @@ fn disable_error_reporting<F: FnOnce() -> R, R>(f: F) -> R {
     use std::sync::Mutex;
 
     use windows::Win32::System::Diagnostics::Debug::{
-        SEM_NOGPFAULTERRORBOX, SetErrorMode, THREAD_ERROR_MODE,
+        SEM_FAILCRITICALERRORS, SEM_NOGPFAULTERRORBOX, SetErrorMode, THREAD_ERROR_MODE,
     };
 
     static LOCK: Mutex<()> = Mutex::new(());
@@ -67,13 +67,21 @@ fn disable_error_reporting<F: FnOnce() -> R, R>(f: F) -> R {
     // Error mode is a global variable, so lock it so only one thread will change it
     let _lock = LOCK.lock().unwrap();
 
-    // Tell Windows to not show any UI on errors (such as terminating abnormally).
-    // This is important for running tests, since some of them use abnormal
-    // termination by design. This mode is inherited by all child processes.
+    // Tell Windows to not show any UI on errors (such as terminating abnormally). This is important
+    // for running tests, since some of them use abnormal termination by design. This mode is
+    // inherited by all child processes.
+    //
+    // Note that `run-make` tests require `SEM_FAILCRITICALERRORS` in addition to suppress Windows
+    // Error Reporting (WER) error dialogues that come from "critical failures" such as missing
+    // DLLs.
+    //
+    // See <https://github.com/rust-lang/rust/issues/132092> and
+    // <https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-seterrormode?redirectedfrom=MSDN>.
     unsafe {
-        let old_mode = SetErrorMode(SEM_NOGPFAULTERRORBOX); // read inherited flags
+        // read inherited flags
+        let old_mode = SetErrorMode(SEM_NOGPFAULTERRORBOX | SEM_FAILCRITICALERRORS);
         let old_mode = THREAD_ERROR_MODE(old_mode);
-        SetErrorMode(old_mode | SEM_NOGPFAULTERRORBOX);
+        SetErrorMode(old_mode | SEM_NOGPFAULTERRORBOX | SEM_FAILCRITICALERRORS);
         let r = f();
         SetErrorMode(old_mode);
         r

--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::process::{Command, Output, Stdio};
 use std::{env, fs};
 
-use super::{ProcRes, TestCx};
+use super::{ProcRes, TestCx, disable_error_reporting};
 use crate::util::{copy_dir_all, dylib_env_var};
 
 impl TestCx<'_> {
@@ -514,8 +514,8 @@ impl TestCx<'_> {
             }
         }
 
-        let (Output { stdout, stderr, status }, truncated) =
-            self.read2_abbreviated(cmd.spawn().expect("failed to spawn `rmake`"));
+        let proc = disable_error_reporting(|| cmd.spawn().expect("failed to spawn `rmake`"));
+        let (Output { stdout, stderr, status }, truncated) = self.read2_abbreviated(proc);
         if !status.success() {
             let res = ProcRes {
                 status,

--- a/tests/rustdoc/primitive-tuple-variadic.rs
+++ b/tests/rustdoc/primitive-tuple-variadic.rs
@@ -33,3 +33,22 @@ impl<T> Baz<[T; 1]> for (T,) {}
 //@ has - '//section[@id="impl-Baz%3CT%3E-for-(T,)"]/h3' 'impl<T> Baz<T> for (T₁, T₂, …, Tₙ)'
 #[doc(fake_variadic)]
 impl<T> Baz<T> for (T,) {}
+
+pub trait Qux {}
+
+pub struct NewType<T>(T);
+
+//@ has foo/trait.Qux.html
+//@ has - '//section[@id="impl-Qux-for-NewType%3C(T,)%3E"]/h3' 'impl<T> Qux for NewType<(T₁, T₂, …, Tₙ)>'
+#[doc(fake_variadic)]
+impl<T> Qux for NewType<(T,)> {}
+
+//@ has foo/trait.Qux.html
+//@ has - '//section[@id="impl-Qux-for-NewType%3CNewType%3C(T,)%3E%3E"]/h3' 'impl<T> Qux for NewType<NewType<(T₁, T₂, …, Tₙ)>>'
+#[doc(fake_variadic)]
+impl<T> Qux for NewType<NewType<(T,)>> {}
+
+//@ has foo/trait.Qux.html
+//@ has - '//section[@id="impl-Qux-for-NewType%3Cfn(T)+-%3E+Out%3E"]/h3' 'impl<T, Out> Qux for NewType<fn(T₁, T₂, …, Tₙ) -> Out>'
+#[doc(fake_variadic)]
+impl<T, Out> Qux for NewType<fn(T) -> Out> {}


### PR DESCRIPTION
Successful merges:

 - #131851 ([musl] use posix_spawn if a directory change was requested)
 - #132048 (AIX: use /dev/urandom for random implementation )
 - #132093 (compiletest: suppress Windows Error Reporting (WER) for `run-make` tests)
 - #132101 (Avoid using imports in thread_local_inner! in static)
 - #132113 (Provide a default impl for Pattern::as_utf8_pattern)
 - #132115 (rustdoc: Extend fake_variadic to "wrapped" tuples)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131851,132048,132093,132101,132113,132115)
<!-- homu-ignore:end -->