### PR TITLE
Add lint against (some) interior mutable consts

### DIFF
--- a/compiler/rustc_codegen_cranelift/patches/0027-stdlib-128bit-atomic-operations.patch
+++ b/compiler/rustc_codegen_cranelift/patches/0027-stdlib-128bit-atomic-operations.patch
@@ -46,7 +46,7 @@ index bf2b6d59f88..d5ccce03bbf 100644
  
  #[cfg(target_pointer_width = "16")]
  impl_atomic_primitive!(AtomicIsize(isize), size("ptr"), align(2));
-@@ -3585,44 +3585,6 @@ pub const fn as_ptr(&self) -> *mut $int_type {
+@@ -3585,46 +3585,6 @@ pub const fn as_ptr(&self) -> *mut $int_type {
      8,
      u64 AtomicU64
  }
@@ -63,6 +63,7 @@ index bf2b6d59f88..d5ccce03bbf 100644
 -    rustc_const_unstable(feature = "integer_atomics", issue = "99069"),
 -    rustc_const_unstable(feature = "integer_atomics", issue = "99069"),
 -    rustc_diagnostic_item = "AtomicI128",
+-    cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
 -    "i128",
 -    "#![feature(integer_atomics)]\n\n",
 -    atomic_min, atomic_max,
@@ -82,6 +83,7 @@ index bf2b6d59f88..d5ccce03bbf 100644
 -    rustc_const_unstable(feature = "integer_atomics", issue = "99069"),
 -    rustc_const_unstable(feature = "integer_atomics", issue = "99069"),
 -    rustc_diagnostic_item = "AtomicU128",
+-    cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
 -    "u128",
 -    "#![feature(integer_atomics)]\n\n",
 -    atomic_umin, atomic_umax,

--- a/compiler/rustc_feature/src/builtin_attrs.rs
+++ b/compiler/rustc_feature/src/builtin_attrs.rs
@@ -949,6 +949,10 @@ pub static BUILTIN_ATTRIBUTES: &[BuiltinAttribute] = &[
         "`#[rustc_no_implicit_autorefs]` is used to mark functions for which an autoref to the dereference of a raw pointer should not be used as an argument."
     ),
     rustc_attr!(
+        rustc_significant_interior_mutable_type, Normal, template!(Word), ErrorFollowing, EncodeCrossCrate::Yes,
+        "#[rustc_significant_interior_mutable_type] is used to mark type that are significant interior mutable types."
+    ),
+    rustc_attr!(
         rustc_coherence_is_core, AttributeType::CrateLevel, template!(Word), ErrorFollowing, EncodeCrossCrate::No,
         "#![rustc_coherence_is_core] allows inherent methods on builtin types, only intended to be used in `core`."
     ),

--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -436,6 +436,14 @@ lint_incomplete_include =
 
 lint_inner_macro_attribute_unstable = inner macro attributes are unstable
 
+lint_interior_mutable_consts = interior mutability in `const` items have no effect on the `const` item itself
+    .label = `{$ty_name}` is an interior mutable type
+    .temporary = each usage of a `const` item creates a new temporary
+    .never_original = only the temporaries and never the original `const` item `{$const_name}` will be modified
+    .suggestion_inline_const = for use as an initializer, consider using an inline-const `const {"{"} /* ... */ {"}"}` at the usage site instead
+    .suggestion_static = for a shared instance of `{$const_name}`, consider using a `static` item instead
+    .suggestion_expect = alternatively consider expecting the lint
+
 lint_invalid_asm_label_binary = avoid using labels containing only the digits `0` and `1` in inline assembly
     .label = use a different label that doesn't start with `0` or `1`
     .help = start numbering with `2` instead

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -1940,6 +1940,55 @@ pub(crate) enum UnpredictableFunctionPointerComparisonsSuggestion<'a, 'tcx> {
     },
 }
 
+#[derive(LintDiagnostic)]
+#[diag(lint_interior_mutable_consts)]
+#[note(lint_temporary)]
+#[note(lint_never_original)]
+#[help(lint_suggestion_inline_const)]
+pub(crate) struct InteriorMutableConstsDiag {
+    pub ty_name: Ident,
+    pub const_name: Ident,
+    #[label]
+    pub ty_span: Span,
+    #[subdiagnostic]
+    pub sugg_static: InteriorMutableConstsSuggestionStatic,
+    #[subdiagnostic]
+    pub sugg_expect: InteriorMutableConstsSuggestionExpect,
+}
+
+#[derive(Subdiagnostic)]
+pub(crate) enum InteriorMutableConstsSuggestionStatic {
+    #[suggestion(
+        lint_suggestion_static,
+        code = "{before}static ",
+        style = "verbose",
+        applicability = "maybe-incorrect"
+    )]
+    Spanful {
+        #[primary_span]
+        const_: Span,
+        before: &'static str,
+    },
+    #[help(lint_suggestion_static)]
+    Spanless,
+}
+
+#[derive(Subdiagnostic)]
+pub(crate) enum InteriorMutableConstsSuggestionExpect {
+    #[suggestion(
+        lint_suggestion_expect,
+        code = "#[expect(interior_mutable_consts, reason = \"...\")] ",
+        style = "verbose",
+        applicability = "maybe-incorrect"
+    )]
+    Spanful {
+        #[primary_span]
+        span: Span,
+    },
+    #[help(lint_suggestion_expect)]
+    Spanless,
+}
+
 pub(crate) struct ImproperCTypes<'a> {
     pub ty: Ty<'a>,
     pub desc: &'a str,

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -182,6 +182,9 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                         [sym::rustc_no_implicit_autorefs, ..] => {
                             self.check_applied_to_fn_or_method(hir_id, attr, span, target)
                         }
+                        [sym::rustc_significant_interior_mutable_type, ..] => {
+                            self.check_rustc_significant_interior_mutable_type(attr, span, target)
+                        }
                         [sym::rustc_never_returns_null_ptr, ..] => {
                             self.check_applied_to_fn_or_method(hir_id, attr, span, target)
                         }
@@ -1824,6 +1827,24 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 defn_span: span,
                 on_crate: hir_id == CRATE_HIR_ID,
             });
+        }
+    }
+
+    /// Checks if `#[rustc_significant_interior_mutable_type]` is applied to a struct, enum, union, or trait.
+    fn check_rustc_significant_interior_mutable_type(
+        &self,
+        attr: &Attribute,
+        span: Span,
+        target: Target,
+    ) {
+        match target {
+            Target::Struct | Target::Enum | Target::Union => {}
+            _ => {
+                self.dcx().emit_err(errors::AttrShouldBeAppliedToStructEnum {
+                    attr_span: attr.span(),
+                    span,
+                });
+            }
         }
     }
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -109,6 +109,15 @@ pub(crate) struct AttrShouldBeAppliedToFn {
 }
 
 #[derive(Diagnostic)]
+#[diag(passes_should_be_applied_to_struct_enum)]
+pub(crate) struct AttrShouldBeAppliedToStructEnum {
+    #[primary_span]
+    pub attr_span: Span,
+    #[label]
+    pub span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(passes_should_be_applied_to_fn, code = E0739)]
 pub(crate) struct TrackedCallerWrongLocation {
     #[primary_span]

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1862,6 +1862,7 @@ symbols! {
         rustc_regions,
         rustc_reservation_impl,
         rustc_serialize,
+        rustc_significant_interior_mutable_type,
         rustc_skip_during_method_dispatch,
         rustc_specialization_trait,
         rustc_std_internal_symbol,

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -308,6 +308,7 @@ pub use once::OnceCell;
 #[stable(feature = "rust1", since = "1.0.0")]
 #[repr(transparent)]
 #[rustc_pub_transparent]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct Cell<T: ?Sized> {
     value: UnsafeCell<T>,
 }
@@ -718,6 +719,7 @@ impl<T, const N: usize> Cell<[T; N]> {
 /// See the [module-level documentation](self) for more.
 #[rustc_diagnostic_item = "RefCell"]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct RefCell<T: ?Sized> {
     borrow: Cell<BorrowFlag>,
     // Stores the location of the earliest currently active borrow.
@@ -2067,6 +2069,7 @@ impl<T: ?Sized + fmt::Display> fmt::Display for RefMut<'_, T> {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[repr(transparent)]
 #[rustc_pub_transparent]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct UnsafeCell<T: ?Sized> {
     value: T,
 }

--- a/library/core/src/cell/lazy.rs
+++ b/library/core/src/cell/lazy.rs
@@ -35,6 +35,7 @@ enum State<T, F> {
 /// //   92
 /// ```
 #[stable(feature = "lazy_cell", since = "1.80.0")]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct LazyCell<T, F = fn() -> T> {
     state: UnsafeCell<State<T, F>>,
 }

--- a/library/core/src/cell/once.rs
+++ b/library/core/src/cell/once.rs
@@ -32,6 +32,7 @@ use crate::{fmt, mem};
 /// assert!(cell.get().is_some());
 /// ```
 #[stable(feature = "once_cell", since = "1.70.0")]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct OnceCell<T> {
     // Invariant: written to at most once.
     inner: UnsafeCell<Option<T>>,

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -504,6 +504,7 @@ pub enum Ordering {
     note = "the `new` function is now preferred",
     suggestion = "AtomicBool::new(false)"
 )]
+#[cfg_attr(not(bootstrap), expect(interior_mutable_consts))]
 pub const ATOMIC_BOOL_INIT: AtomicBool = AtomicBool::new(false);
 
 #[cfg(target_has_atomic_load_store = "8")]
@@ -3788,6 +3789,7 @@ macro_rules! atomic_int_ptr_sized {
             note = "the `new` function is now preferred",
             suggestion = "AtomicIsize::new(0)",
         )]
+        #[cfg_attr(not(bootstrap), expect(interior_mutable_consts))]
         pub const ATOMIC_ISIZE_INIT: AtomicIsize = AtomicIsize::new(0);
 
         /// An [`AtomicUsize`] initialized to `0`.
@@ -3798,6 +3800,7 @@ macro_rules! atomic_int_ptr_sized {
             note = "the `new` function is now preferred",
             suggestion = "AtomicUsize::new(0)",
         )]
+        #[cfg_attr(not(bootstrap), expect(interior_mutable_consts))]
         pub const ATOMIC_USIZE_INIT: AtomicUsize = AtomicUsize::new(0);
     )* };
 }

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -361,6 +361,7 @@ const EMULATE_ATOMIC_BOOL: bool =
 #[cfg(target_has_atomic_load_store = "8")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "AtomicBool"]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 #[repr(C, align(1))]
 pub struct AtomicBool {
     v: UnsafeCell<u8>,
@@ -390,6 +391,7 @@ unsafe impl Sync for AtomicBool {}
 #[cfg(target_has_atomic_load_store = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_diagnostic_item = "AtomicPtr"]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 #[cfg_attr(target_pointer_width = "16", repr(C, align(2)))]
 #[cfg_attr(target_pointer_width = "32", repr(C, align(4)))]
 #[cfg_attr(target_pointer_width = "64", repr(C, align(8)))]
@@ -2484,6 +2486,7 @@ macro_rules! atomic_int {
      $const_stable_new:meta,
      $const_stable_into_inner:meta,
      $diagnostic_item:meta,
+     $interior_mut_item:meta,
      $s_int_type:literal,
      $extra_feature:expr,
      $min_fn:ident, $max_fn:ident,
@@ -2521,6 +2524,7 @@ macro_rules! atomic_int {
         /// [module-level documentation]: crate::sync::atomic
         #[$stable]
         #[$diagnostic_item]
+        #[$interior_mut_item]
         #[repr(C, align($align))]
         pub struct $atomic_type {
             v: UnsafeCell<$int_type>,
@@ -3544,6 +3548,7 @@ atomic_int! {
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     rustc_const_stable(feature = "const_atomic_into_inner", since = "1.79.0"),
     rustc_diagnostic_item = "AtomicI8",
+    cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
     "i8",
     "",
     atomic_min, atomic_max,
@@ -3563,6 +3568,7 @@ atomic_int! {
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     rustc_const_stable(feature = "const_atomic_into_inner", since = "1.79.0"),
     rustc_diagnostic_item = "AtomicU8",
+    cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
     "u8",
     "",
     atomic_umin, atomic_umax,
@@ -3582,6 +3588,7 @@ atomic_int! {
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     rustc_const_stable(feature = "const_atomic_into_inner", since = "1.79.0"),
     rustc_diagnostic_item = "AtomicI16",
+    cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
     "i16",
     "",
     atomic_min, atomic_max,
@@ -3601,6 +3608,7 @@ atomic_int! {
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     rustc_const_stable(feature = "const_atomic_into_inner", since = "1.79.0"),
     rustc_diagnostic_item = "AtomicU16",
+    cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
     "u16",
     "",
     atomic_umin, atomic_umax,
@@ -3620,6 +3628,7 @@ atomic_int! {
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     rustc_const_stable(feature = "const_atomic_into_inner", since = "1.79.0"),
     rustc_diagnostic_item = "AtomicI32",
+    cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
     "i32",
     "",
     atomic_min, atomic_max,
@@ -3639,6 +3648,7 @@ atomic_int! {
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     rustc_const_stable(feature = "const_atomic_into_inner", since = "1.79.0"),
     rustc_diagnostic_item = "AtomicU32",
+    cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
     "u32",
     "",
     atomic_umin, atomic_umax,
@@ -3658,6 +3668,7 @@ atomic_int! {
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     rustc_const_stable(feature = "const_atomic_into_inner", since = "1.79.0"),
     rustc_diagnostic_item = "AtomicI64",
+    cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
     "i64",
     "",
     atomic_min, atomic_max,
@@ -3677,6 +3688,7 @@ atomic_int! {
     rustc_const_stable(feature = "const_integer_atomics", since = "1.34.0"),
     rustc_const_stable(feature = "const_atomic_into_inner", since = "1.79.0"),
     rustc_diagnostic_item = "AtomicU64",
+    cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
     "u64",
     "",
     atomic_umin, atomic_umax,
@@ -3696,6 +3708,7 @@ atomic_int! {
     rustc_const_unstable(feature = "integer_atomics", issue = "99069"),
     rustc_const_unstable(feature = "integer_atomics", issue = "99069"),
     rustc_diagnostic_item = "AtomicI128",
+    cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
     "i128",
     "#![feature(integer_atomics)]\n\n",
     atomic_min, atomic_max,
@@ -3715,6 +3728,7 @@ atomic_int! {
     rustc_const_unstable(feature = "integer_atomics", issue = "99069"),
     rustc_const_unstable(feature = "integer_atomics", issue = "99069"),
     rustc_diagnostic_item = "AtomicU128",
+    cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
     "u128",
     "#![feature(integer_atomics)]\n\n",
     atomic_umin, atomic_umax,
@@ -3738,6 +3752,7 @@ macro_rules! atomic_int_ptr_sized {
             rustc_const_stable(feature = "const_ptr_sized_atomics", since = "1.24.0"),
             rustc_const_stable(feature = "const_atomic_into_inner", since = "1.79.0"),
             rustc_diagnostic_item = "AtomicIsize",
+            cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
             "isize",
             "",
             atomic_min, atomic_max,
@@ -3757,6 +3772,7 @@ macro_rules! atomic_int_ptr_sized {
             rustc_const_stable(feature = "const_ptr_sized_atomics", since = "1.24.0"),
             rustc_const_stable(feature = "const_atomic_into_inner", since = "1.79.0"),
             rustc_diagnostic_item = "AtomicUsize",
+            cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type),
             "usize",
             "",
             atomic_umin, atomic_umax,

--- a/library/coretests/tests/cell.rs
+++ b/library/coretests/tests/cell.rs
@@ -456,6 +456,7 @@ fn refcell_format() {
 }
 
 #[allow(dead_code)]
+#[cfg_attr(not(bootstrap), allow(interior_mutable_consts))]
 fn const_cells() {
     const UNSAFE_CELL: UnsafeCell<i32> = UnsafeCell::new(3);
     const _: i32 = UNSAFE_CELL.into_inner();

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -230,6 +230,7 @@ use crate::ops::Index;
 ///     Mutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
 ///
 /// // HashMaps using LazyLock to retain random seeding
+/// # #[cfg_attr(not(bootstrap), allow(interior_mutable_consts))]
 /// const RANDOM_EMPTY_MAP: LazyLock<HashMap<String, Vec<i32>>> =
 ///     LazyLock::new(HashMap::new);
 /// static RANDOM_MAP: LazyLock<Mutex<HashMap<String, Vec<i32>>>> =

--- a/library/std/src/sync/barrier.rs
+++ b/library/std/src/sync/barrier.rs
@@ -26,6 +26,7 @@ use crate::sync::{Condvar, Mutex};
 /// });
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct Barrier {
     lock: Mutex<BarrierState>,
     cvar: Condvar,

--- a/library/std/src/sync/lazy_lock.rs
+++ b/library/std/src/sync/lazy_lock.rs
@@ -62,6 +62,7 @@ union Data<T, F> {
 /// }
 /// ```
 #[stable(feature = "lazy_cell", since = "1.80.0")]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct LazyLock<T, F = fn() -> T> {
     // FIXME(nonpoison_once): if possible, switch to nonpoison version once it is available
     once: Once,

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -103,6 +103,7 @@ use crate::sync::Once;
 ///
 /// ```
 #[stable(feature = "once_cell", since = "1.70.0")]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct OnceLock<T> {
     // FIXME(nonpoison_once): switch to nonpoison version once it is available
     once: Once,

--- a/library/std/src/sync/poison/condvar.rs
+++ b/library/std/src/sync/poison/condvar.rs
@@ -106,6 +106,7 @@ impl WaitTimeoutResult {
 /// }
 /// ```
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct Condvar {
     inner: sys::Condvar,
 }

--- a/library/std/src/sync/poison/mutex.rs
+++ b/library/std/src/sync/poison/mutex.rs
@@ -172,6 +172,7 @@ use crate::sys::sync as sys;
 ///
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "Mutex")]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct Mutex<T: ?Sized> {
     inner: sys::Mutex,
     poison: poison::Flag,

--- a/library/std/src/sync/poison/once.rs
+++ b/library/std/src/sync/poison/once.rs
@@ -71,6 +71,7 @@ pub(crate) enum ExclusiveState {
     note = "the `Once::new()` function is now preferred",
     suggestion = "Once::new()"
 )]
+#[cfg_attr(not(bootstrap), expect(interior_mutable_consts))]
 pub const ONCE_INIT: Once = Once::new();
 
 impl Once {

--- a/library/std/src/sync/poison/once.rs
+++ b/library/std/src/sync/poison/once.rs
@@ -32,6 +32,7 @@ use crate::sys::sync as sys;
 /// [`OnceLock<T>`]: crate::sync::OnceLock
 /// [`LazyLock<T, F>`]: crate::sync::LazyLock
 #[stable(feature = "rust1", since = "1.0.0")]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct Once {
     inner: sys::Once,
 }

--- a/library/std/src/sync/poison/rwlock.rs
+++ b/library/std/src/sync/poison/rwlock.rs
@@ -77,6 +77,7 @@ use crate::sys::sync as sys;
 /// [`Mutex`]: super::Mutex
 #[stable(feature = "rust1", since = "1.0.0")]
 #[cfg_attr(not(test), rustc_diagnostic_item = "RwLock")]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct RwLock<T: ?Sized> {
     inner: sys::RwLock,
     poison: poison::Flag,

--- a/library/std/src/sync/reentrant_lock.rs
+++ b/library/std/src/sync/reentrant_lock.rs
@@ -80,6 +80,7 @@ use crate::thread::{ThreadId, current_id};
 // we don't need to further synchronize the TID accesses, so they can be regular 64-bit
 // non-atomic accesses.
 #[unstable(feature = "reentrant_lock", issue = "121440")]
+#[cfg_attr(not(bootstrap), rustc_significant_interior_mutable_type)]
 pub struct ReentrantLock<T: ?Sized> {
     mutex: sys::Mutex,
     owner: Tid,

--- a/library/std/src/sys/thread_local/native/mod.rs
+++ b/library/std/src/sys/thread_local/native/mod.rs
@@ -55,6 +55,7 @@ pub macro thread_local_inner {
 
     // Used to generate the `LocalKey` value for const-initialized thread locals.
     (@key $t:ty, const $init:expr) => {{
+        #[allow(unknown_lints, interior_mutable_consts)] // cfg(bootstrap) for unknown_lints
         const __INIT: $t = $init;
 
         unsafe {

--- a/src/tools/clippy/tests/ui/borrow_interior_mutable_const.rs
+++ b/src/tools/clippy/tests/ui/borrow_interior_mutable_const.rs
@@ -7,7 +7,7 @@
     const_item_mutation,
     unconditional_panic
 )]
-
+#![allow(interior_mutable_consts)]
 use core::cell::{Cell, UnsafeCell};
 use core::ops::{Deref, Index};
 

--- a/src/tools/clippy/tests/ui/declare_interior_mutable_const.rs
+++ b/src/tools/clippy/tests/ui/declare_interior_mutable_const.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::declare_interior_mutable_const)]
 #![allow(clippy::missing_const_for_thread_local)]
-
+#![allow(interior_mutable_consts)]
 use core::cell::{Cell, RefCell, UnsafeCell};
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ptr;

--- a/tests/ui/consts/issue-17718.rs
+++ b/tests/ui/consts/issue-17718.rs
@@ -1,5 +1,6 @@
 //@ run-pass
 #![allow(dead_code)]
+#![allow(interior_mutable_consts)]
 //@ aux-build:issue-17718-aux.rs
 
 extern crate issue_17718_aux as other;

--- a/tests/ui/lint/interior-mutable-types-in-consts-not-sync.rs
+++ b/tests/ui/lint/interior-mutable-types-in-consts-not-sync.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+
+use std::cell::{Cell, RefCell, UnsafeCell, LazyCell, OnceCell};
+
+const A: Cell<i32> = Cell::new(0);
+//~^ WARN interior mutability in `const` item
+const B: RefCell<i32> = RefCell::new(0);
+//~^ WARN interior mutability in `const` item
+const C: UnsafeCell<i32> = UnsafeCell::new(0);
+//~^ WARN interior mutability in `const` item
+const D: LazyCell<i32> = LazyCell::new(|| 0);
+//~^ WARN interior mutability in `const` item
+const E: OnceCell<i32> = OnceCell::new();
+//~^ WARN interior mutability in `const` item
+
+fn main() {}

--- a/tests/ui/lint/interior-mutable-types-in-consts-not-sync.stderr
+++ b/tests/ui/lint/interior-mutable-types-in-consts-not-sync.stderr
@@ -1,0 +1,108 @@
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts-not-sync.rs:5:1
+   |
+LL | const A: Cell<i32> = Cell::new(0);
+   | ^^^^^^^^^---------^^^^^^^^^^^^^^^^
+   |          |
+   |          `Cell` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `A` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+   = note: `#[warn(interior_mutable_consts)]` on by default
+help: for a shared instance of `A`, consider using a `static` item instead
+   |
+LL - const A: Cell<i32> = Cell::new(0);
+LL + static A: Cell<i32> = Cell::new(0);
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const A: Cell<i32> = Cell::new(0);
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts-not-sync.rs:7:1
+   |
+LL | const B: RefCell<i32> = RefCell::new(0);
+   | ^^^^^^^^^------------^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `RefCell` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `B` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `B`, consider using a `static` item instead
+   |
+LL - const B: RefCell<i32> = RefCell::new(0);
+LL + static B: RefCell<i32> = RefCell::new(0);
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const B: RefCell<i32> = RefCell::new(0);
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts-not-sync.rs:9:1
+   |
+LL | const C: UnsafeCell<i32> = UnsafeCell::new(0);
+   | ^^^^^^^^^---------------^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `UnsafeCell` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `C` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `C`, consider using a `static` item instead
+   |
+LL - const C: UnsafeCell<i32> = UnsafeCell::new(0);
+LL + static C: UnsafeCell<i32> = UnsafeCell::new(0);
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const C: UnsafeCell<i32> = UnsafeCell::new(0);
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts-not-sync.rs:11:1
+   |
+LL | const D: LazyCell<i32> = LazyCell::new(|| 0);
+   | ^^^^^^^^^-------------^^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `LazyCell` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `D` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `D`, consider using a `static` item instead
+   |
+LL - const D: LazyCell<i32> = LazyCell::new(|| 0);
+LL + static D: LazyCell<i32> = LazyCell::new(|| 0);
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const D: LazyCell<i32> = LazyCell::new(|| 0);
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts-not-sync.rs:13:1
+   |
+LL | const E: OnceCell<i32> = OnceCell::new();
+   | ^^^^^^^^^-------------^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `OnceCell` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `E` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `E`, consider using a `static` item instead
+   |
+LL - const E: OnceCell<i32> = OnceCell::new();
+LL + static E: OnceCell<i32> = OnceCell::new();
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const E: OnceCell<i32> = OnceCell::new();
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: 5 warnings emitted
+

--- a/tests/ui/lint/interior-mutable-types-in-consts.rs
+++ b/tests/ui/lint/interior-mutable-types-in-consts.rs
@@ -1,0 +1,44 @@
+//@ check-pass
+
+#![feature(reentrant_lock)]
+
+use std::sync::{Once, Barrier, Condvar, LazyLock, Mutex, OnceLock, ReentrantLock, RwLock};
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicI32, AtomicU32};
+
+const A: Once = Once::new();
+//~^ WARN interior mutability in `const` items
+const B: Barrier = Barrier::new(0);
+//~^ WARN interior mutability in `const` items
+const C: Condvar = Condvar::new();
+//~^ WARN interior mutability in `const` items
+const D: LazyLock<i32> = LazyLock::new(|| 0);
+//~^ WARN interior mutability in `const` items
+const E: Mutex<i32> = Mutex::new(0);
+//~^ WARN interior mutability in `const` items
+const F: OnceLock<i32> = OnceLock::new();
+//~^ WARN interior mutability in `const` items
+const G: ReentrantLock<i32> = ReentrantLock::new(0);
+//~^ WARN interior mutability in `const` items
+const H: RwLock<i32> = RwLock::new(0);
+//~^ WARN interior mutability in `const` items
+const I: AtomicBool = AtomicBool::new(false);
+//~^ WARN interior mutability in `const` items
+const J: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
+//~^ WARN interior mutability in `const` items
+const K: AtomicI32 = AtomicI32::new(0);
+//~^ WARN interior mutability in `const` items
+const L: AtomicU32 = AtomicU32::new(0);
+//~^ WARN interior mutability in `const` items
+
+pub(crate) const X: Once = Once::new();
+//~^ WARN interior mutability in `const` items
+
+fn main() {
+    const Z: Once = Once::new();
+    //~^ WARN interior mutability in `const` items
+}
+
+struct S;
+impl S {
+    const Z: Once = Once::new(); // not a const-item
+}

--- a/tests/ui/lint/interior-mutable-types-in-consts.stderr
+++ b/tests/ui/lint/interior-mutable-types-in-consts.stderr
@@ -1,0 +1,297 @@
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:8:1
+   |
+LL | const A: Once = Once::new();
+   | ^^^^^^^^^----^^^^^^^^^^^^^^^
+   |          |
+   |          `Once` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `A` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+   = note: `#[warn(interior_mutable_consts)]` on by default
+help: for a shared instance of `A`, consider using a `static` item instead
+   |
+LL - const A: Once = Once::new();
+LL + static A: Once = Once::new();
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const A: Once = Once::new();
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:10:1
+   |
+LL | const B: Barrier = Barrier::new(0);
+   | ^^^^^^^^^-------^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `Barrier` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `B` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `B`, consider using a `static` item instead
+   |
+LL - const B: Barrier = Barrier::new(0);
+LL + static B: Barrier = Barrier::new(0);
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const B: Barrier = Barrier::new(0);
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:12:1
+   |
+LL | const C: Condvar = Condvar::new();
+   | ^^^^^^^^^-------^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `Condvar` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `C` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `C`, consider using a `static` item instead
+   |
+LL - const C: Condvar = Condvar::new();
+LL + static C: Condvar = Condvar::new();
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const C: Condvar = Condvar::new();
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:14:1
+   |
+LL | const D: LazyLock<i32> = LazyLock::new(|| 0);
+   | ^^^^^^^^^-------------^^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `LazyLock` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `D` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `D`, consider using a `static` item instead
+   |
+LL - const D: LazyLock<i32> = LazyLock::new(|| 0);
+LL + static D: LazyLock<i32> = LazyLock::new(|| 0);
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const D: LazyLock<i32> = LazyLock::new(|| 0);
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:16:1
+   |
+LL | const E: Mutex<i32> = Mutex::new(0);
+   | ^^^^^^^^^----------^^^^^^^^^^^^^^^^^
+   |          |
+   |          `Mutex` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `E` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `E`, consider using a `static` item instead
+   |
+LL - const E: Mutex<i32> = Mutex::new(0);
+LL + static E: Mutex<i32> = Mutex::new(0);
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const E: Mutex<i32> = Mutex::new(0);
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:18:1
+   |
+LL | const F: OnceLock<i32> = OnceLock::new();
+   | ^^^^^^^^^-------------^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `OnceLock` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `F` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `F`, consider using a `static` item instead
+   |
+LL - const F: OnceLock<i32> = OnceLock::new();
+LL + static F: OnceLock<i32> = OnceLock::new();
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const F: OnceLock<i32> = OnceLock::new();
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:20:1
+   |
+LL | const G: ReentrantLock<i32> = ReentrantLock::new(0);
+   | ^^^^^^^^^------------------^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `ReentrantLock` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `G` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `G`, consider using a `static` item instead
+   |
+LL - const G: ReentrantLock<i32> = ReentrantLock::new(0);
+LL + static G: ReentrantLock<i32> = ReentrantLock::new(0);
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const G: ReentrantLock<i32> = ReentrantLock::new(0);
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:22:1
+   |
+LL | const H: RwLock<i32> = RwLock::new(0);
+   | ^^^^^^^^^-----------^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `RwLock` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `H` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `H`, consider using a `static` item instead
+   |
+LL - const H: RwLock<i32> = RwLock::new(0);
+LL + static H: RwLock<i32> = RwLock::new(0);
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const H: RwLock<i32> = RwLock::new(0);
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:24:1
+   |
+LL | const I: AtomicBool = AtomicBool::new(false);
+   | ^^^^^^^^^----------^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `AtomicBool` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `I` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `I`, consider using a `static` item instead
+   |
+LL - const I: AtomicBool = AtomicBool::new(false);
+LL + static I: AtomicBool = AtomicBool::new(false);
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const I: AtomicBool = AtomicBool::new(false);
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:26:1
+   |
+LL | const J: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
+   | ^^^^^^^^^--------------^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `AtomicPtr` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `J` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `J`, consider using a `static` item instead
+   |
+LL - const J: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
+LL + static J: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const J: AtomicPtr<i32> = AtomicPtr::new(std::ptr::null_mut());
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:28:1
+   |
+LL | const K: AtomicI32 = AtomicI32::new(0);
+   | ^^^^^^^^^---------^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `AtomicI32` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `K` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `K`, consider using a `static` item instead
+   |
+LL - const K: AtomicI32 = AtomicI32::new(0);
+LL + static K: AtomicI32 = AtomicI32::new(0);
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const K: AtomicI32 = AtomicI32::new(0);
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:30:1
+   |
+LL | const L: AtomicU32 = AtomicU32::new(0);
+   | ^^^^^^^^^---------^^^^^^^^^^^^^^^^^^^^^
+   |          |
+   |          `AtomicU32` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `L` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `L`, consider using a `static` item instead
+   |
+LL - const L: AtomicU32 = AtomicU32::new(0);
+LL + static L: AtomicU32 = AtomicU32::new(0);
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] const L: AtomicU32 = AtomicU32::new(0);
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:33:1
+   |
+LL | pub(crate) const X: Once = Once::new();
+   | ^^^^^^^^^^^^^^^^^^^^----^^^^^^^^^^^^^^^
+   |                     |
+   |                     `Once` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `X` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `X`, consider using a `static` item instead
+   |
+LL - pub(crate) const X: Once = Once::new();
+LL + pub(crate) static X: Once = Once::new();
+   |
+help: alternatively consider expecting the lint
+   |
+LL | #[expect(interior_mutable_consts, reason = "...")] pub(crate) const X: Once = Once::new();
+   | ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: interior mutability in `const` items have no effect on the `const` item itself
+  --> $DIR/interior-mutable-types-in-consts.rs:37:5
+   |
+LL |     const Z: Once = Once::new();
+   |     ^^^^^^^^^----^^^^^^^^^^^^^^^
+   |              |
+   |              `Once` is an interior mutable type
+   |
+   = note: each usage of a `const` item creates a new temporary
+   = note: only the temporaries and never the original `const` item `Z` will be modified
+   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
+help: for a shared instance of `Z`, consider using a `static` item instead
+   |
+LL -     const Z: Once = Once::new();
+LL +     static Z: Once = Once::new();
+   |
+help: alternatively consider expecting the lint
+   |
+LL |     #[expect(interior_mutable_consts, reason = "...")] const Z: Once = Once::new();
+   |     ++++++++++++++++++++++++++++++++++++++++++++++++++
+
+warning: 14 warnings emitted
+


### PR DESCRIPTION
## `interior_mutable_consts`

*warn-by-default*

The `interior_mutable_consts` lint detects instance where const-items have a interior mutable type, which silently does nothing.

### Example

```rust
use std::sync::Once;

// SAFETY: should only be call once
unsafe extern "C" fn ffi_init() { /* ... */ }

const A: Once = Once::new(); // using `A` will always creates temporaries and
                             // never modify it-self on use, should be a
                             // static-item instead

fn init() {
    A.call_once(|| unsafe {
        ffi_init();  // unsound, as the `call_once` is on a temporary
                     // and not on a shared variable
    })
}
```

```text
warning: interior mutability in `const` items have no effect on the `const` item itself
  --> $DIR/interior-mutable-types-in-consts.rs:8:1
   |
LL | const A: Once = Once::new();
   | ^^^^^^^^^----^^^^^^^^^^^^^^^
   |          |
   |          `Once` is an interior mutable type
   |
   = note: each usage of a `const` item creates a new temporary
   = note: only the temporaries and never the original `const` item `A` will be modified
   = help: for use as an initializer, consider using an inline-const `const { /* ... */ }` at the usage site instead
   = note: `#[warn(interior_mutable_consts)]` on by default
help: for a shared instance of `A`, consider using a `static` item instead
   |
LL - const A: Once = Once::new();
LL + static A: Once = Once::new();
   |
help: alternatively consider expecting the lint
   |
LL | #[expect(interior_mutable_consts, reason = "...")] const A: Once = Once::new();
   | ++++++++++++++++++++++++++++++++++++++++++++++++++

```

### Explanation

Using a const-item with an interior mutable type has no effect as const-item are essentially inlined wherever they are used, meaning that they are copied directly into the relevant context when used rendering modification through interior mutability ineffective across usage of that const-item.

The current implementation of this lint only warns on significant `std` and `core` interior mutable types, like `Once`, `AtomicI32`, ... this is done out of prudence and may be extended in the future.

----

It should be noted that the lint in not immunized against false-positives in particular when those immutable const-items are used as "init" const for const arrays (i.e. `[INIT; 10]`), which is why the lint recommends inline-const instead.

It should also be noted that this is NOT an uplift of the more general [`clippy::declare_interior_mutable_const`](https://rust-lang.github.io/rust-clippy/master/index.html#/declare_interior_mutable_const) lint, which works for all interior mutable types, but has even more false-positives than the currently proposed lint.

A simple [Github Search](https://github.com/search?q=lang%3Arust+%2F%28%3F-i%29const+%5Ba-zA-Z0-9_%5D*%3A+Once%2F&type=code) reveals many instance where the user probably wanted to use a `static`-item instead.

----

@rustbot labels +I-lang-nominated +T-lang -S-waiting-on-review
cc @AngelicosPhosphoros @kupiakos
r? compiler

Fixes [IRLO - Forbidding creation of constant mutexes, etc](https://internals.rust-lang.org/t/forbidding-creation-of-constant-mutexes-etc/19005)
Fixes https://github.com/rust-lang/rust/issues/132028
Fixes https://github.com/rust-lang/rust/issues/40543
