### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -135,7 +135,7 @@ pub trait Visitor<'ast>: Sized {
     /// or `ControlFlow<T>`.
     type Result: VisitorResult = ();
 
-    fn visit_ident(&mut self, _ident: Ident) -> Self::Result {
+    fn visit_ident(&mut self, _ident: &'ast Ident) -> Self::Result {
         Self::Result::output()
     }
     fn visit_foreign_item(&mut self, i: &'ast ForeignItem) -> Self::Result {
@@ -317,12 +317,12 @@ pub fn walk_local<'a, V: Visitor<'a>>(visitor: &mut V, local: &'a Local) -> V::R
 }
 
 pub fn walk_label<'a, V: Visitor<'a>>(visitor: &mut V, Label { ident }: &'a Label) -> V::Result {
-    visitor.visit_ident(*ident)
+    visitor.visit_ident(ident)
 }
 
 pub fn walk_lifetime<'a, V: Visitor<'a>>(visitor: &mut V, lifetime: &'a Lifetime) -> V::Result {
     let Lifetime { id: _, ident } = lifetime;
-    visitor.visit_ident(*ident)
+    visitor.visit_ident(ident)
 }
 
 pub fn walk_poly_trait_ref<'a, V>(visitor: &mut V, trait_ref: &'a PolyTraitRef) -> V::Result
@@ -429,7 +429,7 @@ impl WalkItemKind for ItemKind {
             }) => {
                 try_visit!(walk_qself(visitor, qself));
                 try_visit!(visitor.visit_path(path, *id));
-                visit_opt!(visitor, visit_ident, *rename);
+                visit_opt!(visitor, visit_ident, rename);
                 visit_opt!(visitor, visit_block, body);
             }
             ItemKind::DelegationMac(box DelegationMac { qself, prefix, suffixes, body }) => {
@@ -437,9 +437,9 @@ impl WalkItemKind for ItemKind {
                 try_visit!(visitor.visit_path(prefix, *id));
                 if let Some(suffixes) = suffixes {
                     for (ident, rename) in suffixes {
-                        visitor.visit_ident(*ident);
+                        visitor.visit_ident(ident);
                         if let Some(rename) = rename {
-                            visitor.visit_ident(*rename);
+                            visitor.visit_ident(rename);
                         }
                     }
                 }
@@ -472,7 +472,7 @@ where
     let Variant { attrs, id: _, span: _, vis, ident, data, disr_expr, is_placeholder: _ } = variant;
     walk_list!(visitor, visit_attribute, attrs);
     try_visit!(visitor.visit_vis(vis));
-    try_visit!(visitor.visit_ident(*ident));
+    try_visit!(visitor.visit_ident(ident));
     try_visit!(visitor.visit_variant_data(data));
     visit_opt!(visitor, visit_variant_discr, disr_expr);
     V::Result::output()
@@ -481,7 +481,7 @@ where
 pub fn walk_expr_field<'a, V: Visitor<'a>>(visitor: &mut V, f: &'a ExprField) -> V::Result {
     let ExprField { attrs, id: _, span: _, ident, expr, is_shorthand: _, is_placeholder: _ } = f;
     walk_list!(visitor, visit_attribute, attrs);
-    try_visit!(visitor.visit_ident(*ident));
+    try_visit!(visitor.visit_ident(ident));
     try_visit!(visitor.visit_expr(expr));
     V::Result::output()
 }
@@ -489,7 +489,7 @@ pub fn walk_expr_field<'a, V: Visitor<'a>>(visitor: &mut V, f: &'a ExprField) ->
 pub fn walk_pat_field<'a, V: Visitor<'a>>(visitor: &mut V, fp: &'a PatField) -> V::Result {
     let PatField { ident, pat, is_shorthand: _, attrs, id: _, span: _, is_placeholder: _ } = fp;
     walk_list!(visitor, visit_attribute, attrs);
-    try_visit!(visitor.visit_ident(*ident));
+    try_visit!(visitor.visit_ident(ident));
     try_visit!(visitor.visit_pat(pat));
     V::Result::output()
 }
@@ -564,7 +564,7 @@ pub fn walk_use_tree<'a, V: Visitor<'a>>(
     match kind {
         UseTreeKind::Simple(rename) => {
             // The extra IDs are handled during AST lowering.
-            visit_opt!(visitor, visit_ident, *rename);
+            visit_opt!(visitor, visit_ident, rename);
         }
         UseTreeKind::Glob => {}
         UseTreeKind::Nested { ref items, span: _ } => {
@@ -581,7 +581,7 @@ pub fn walk_path_segment<'a, V: Visitor<'a>>(
     segment: &'a PathSegment,
 ) -> V::Result {
     let PathSegment { ident, id: _, args } = segment;
-    try_visit!(visitor.visit_ident(*ident));
+    try_visit!(visitor.visit_ident(ident));
     visit_opt!(visitor, visit_generic_args, args);
     V::Result::output()
 }
@@ -627,7 +627,7 @@ pub fn walk_assoc_item_constraint<'a, V: Visitor<'a>>(
     constraint: &'a AssocItemConstraint,
 ) -> V::Result {
     let AssocItemConstraint { id: _, ident, gen_args, kind, span: _ } = constraint;
-    try_visit!(visitor.visit_ident(*ident));
+    try_visit!(visitor.visit_ident(ident));
     visit_opt!(visitor, visit_generic_args, gen_args);
     match kind {
         AssocItemConstraintKind::Equality { term } => match term {
@@ -665,7 +665,7 @@ pub fn walk_pat<'a, V: Visitor<'a>>(visitor: &mut V, pattern: &'a Pat) -> V::Res
             try_visit!(visitor.visit_pat(subpattern));
         }
         PatKind::Ident(_bmode, ident, optional_subpattern) => {
-            try_visit!(visitor.visit_ident(*ident));
+            try_visit!(visitor.visit_ident(ident));
             visit_opt!(visitor, visit_pat, optional_subpattern);
         }
         PatKind::Lit(expression) => try_visit!(visitor.visit_expr(expression)),
@@ -751,7 +751,7 @@ pub fn walk_generic_param<'a, V: Visitor<'a>>(
     let GenericParam { id: _, ident, attrs, bounds, is_placeholder: _, kind, colon_span: _ } =
         param;
     walk_list!(visitor, visit_attribute, attrs);
-    try_visit!(visitor.visit_ident(*ident));
+    try_visit!(visitor.visit_ident(ident));
     walk_list!(visitor, visit_param_bound, bounds, BoundKind::Bound);
     match kind {
         GenericParamKind::Lifetime => (),
@@ -889,7 +889,7 @@ impl WalkItemKind for AssocItemKind {
             }) => {
                 try_visit!(walk_qself(visitor, qself));
                 try_visit!(visitor.visit_path(path, *id));
-                visit_opt!(visitor, visit_ident, *rename);
+                visit_opt!(visitor, visit_ident, rename);
                 visit_opt!(visitor, visit_block, body);
             }
             AssocItemKind::DelegationMac(box DelegationMac { qself, prefix, suffixes, body }) => {
@@ -897,9 +897,9 @@ impl WalkItemKind for AssocItemKind {
                 try_visit!(visitor.visit_path(prefix, id));
                 if let Some(suffixes) = suffixes {
                     for (ident, rename) in suffixes {
-                        visitor.visit_ident(*ident);
+                        visitor.visit_ident(ident);
                         if let Some(rename) = rename {
-                            visitor.visit_ident(*rename);
+                            visitor.visit_ident(rename);
                         }
                     }
                 }
@@ -915,7 +915,7 @@ pub fn walk_assoc_item<'a, V: Visitor<'a>>(
     item: &'a Item<impl WalkItemKind>,
     ctxt: AssocCtxt,
 ) -> V::Result {
-    let &Item { id: _, span: _, ident, ref vis, ref attrs, ref kind, tokens: _ } = item;
+    let Item { id: _, span: _, ident, vis, attrs, kind, tokens: _ } = item;
     walk_list!(visitor, visit_attribute, attrs);
     try_visit!(visitor.visit_vis(vis));
     try_visit!(visitor.visit_ident(ident));
@@ -935,7 +935,7 @@ pub fn walk_field_def<'a, V: Visitor<'a>>(visitor: &mut V, field: &'a FieldDef) 
     let FieldDef { attrs, id: _, span: _, vis, ident, ty, is_placeholder: _ } = field;
     walk_list!(visitor, visit_attribute, attrs);
     try_visit!(visitor.visit_vis(vis));
-    visit_opt!(visitor, visit_ident, *ident);
+    visit_opt!(visitor, visit_ident, ident);
     try_visit!(visitor.visit_ty(ty));
     V::Result::output()
 }
@@ -1017,7 +1017,7 @@ pub fn walk_format_args<'a, V: Visitor<'a>>(visitor: &mut V, fmt: &'a FormatArgs
     for FormatArgument { kind, expr } in arguments.all_args() {
         match kind {
             FormatArgumentKind::Named(ident) | FormatArgumentKind::Captured(ident) => {
-                try_visit!(visitor.visit_ident(*ident))
+                try_visit!(visitor.visit_ident(ident))
             }
             FormatArgumentKind::Normal => {}
         }
@@ -1137,7 +1137,7 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) -> V
         }
         ExprKind::Field(subexpression, ident) => {
             try_visit!(visitor.visit_expr(subexpression));
-            try_visit!(visitor.visit_ident(*ident));
+            try_visit!(visitor.visit_ident(ident));
         }
         ExprKind::Index(main_expression, index_expression, _span) => {
             try_visit!(visitor.visit_expr(main_expression));
@@ -1172,7 +1172,7 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) -> V
         ExprKind::FormatArgs(f) => try_visit!(visitor.visit_format_args(f)),
         ExprKind::OffsetOf(container, fields) => {
             try_visit!(visitor.visit_ty(container));
-            walk_list!(visitor, visit_ident, fields.iter().copied());
+            walk_list!(visitor, visit_ident, fields.iter());
         }
         ExprKind::Yield(optional_expression) => {
             visit_opt!(visitor, visit_expr, optional_expression);

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -249,7 +249,7 @@ impl<'a> AstValidator<'a> {
     }
 
     fn visit_struct_field_def(&mut self, field: &'a FieldDef) {
-        if let Some(ident) = field.ident
+        if let Some(ref ident) = field.ident
             && ident.name == kw::Underscore
         {
             self.visit_vis(&field.vis);
@@ -899,7 +899,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     }
 
                     this.visit_vis(&item.vis);
-                    this.visit_ident(item.ident);
+                    this.visit_ident(&item.ident);
                     let disallowed = matches!(constness, Const::No)
                         .then(|| TildeConstReason::TraitImpl { span: item.span });
                     this.with_tilde_const(disallowed, |this| this.visit_generics(generics));
@@ -953,7 +953,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     }
 
                     this.visit_vis(&item.vis);
-                    this.visit_ident(item.ident);
+                    this.visit_ident(&item.ident);
                     this.with_tilde_const(
                         Some(TildeConstReason::Impl { span: item.span }),
                         |this| this.visit_generics(generics),
@@ -991,7 +991,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 }
 
                 self.visit_vis(&item.vis);
-                self.visit_ident(item.ident);
+                self.visit_ident(&item.ident);
                 let kind =
                     FnKind::Fn(FnCtxt::Free, item.ident, sig, &item.vis, generics, body.as_deref());
                 self.visit_fn(kind, item.span, item.id);
@@ -1058,7 +1058,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     // Equivalent of `visit::walk_item` for `ItemKind::Trait` that inserts a bound
                     // context for the supertraits.
                     this.visit_vis(&item.vis);
-                    this.visit_ident(item.ident);
+                    this.visit_ident(&item.ident);
                     let disallowed = is_const_trait
                         .is_none()
                         .then(|| TildeConstReason::Trait { span: item.span });
@@ -1085,7 +1085,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
             ItemKind::Struct(vdata, generics) => match vdata {
                 VariantData::Struct { fields, .. } => {
                     self.visit_vis(&item.vis);
-                    self.visit_ident(item.ident);
+                    self.visit_ident(&item.ident);
                     self.visit_generics(generics);
                     // Permit `Anon{Struct,Union}` as field type.
                     walk_list!(self, visit_struct_field_def, fields);
@@ -1101,7 +1101,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                 match vdata {
                     VariantData::Struct { fields, .. } => {
                         self.visit_vis(&item.vis);
-                        self.visit_ident(item.ident);
+                        self.visit_ident(&item.ident);
                         self.visit_generics(generics);
                         // Permit `Anon{Struct,Union}` as field type.
                         walk_list!(self, visit_struct_field_def, fields);
@@ -1521,7 +1521,7 @@ impl<'a> Visitor<'a> for AstValidator<'a> {
                     || matches!(sig.header.constness, Const::Yes(_)) =>
             {
                 self.visit_vis(&item.vis);
-                self.visit_ident(item.ident);
+                self.visit_ident(&item.ident);
                 let kind = FnKind::Fn(
                     FnCtxt::Assoc(ctxt),
                     item.ident,

--- a/compiler/rustc_ast_passes/src/node_count.rs
+++ b/compiler/rustc_ast_passes/src/node_count.rs
@@ -16,7 +16,7 @@ impl NodeCounter {
 }
 
 impl<'ast> Visitor<'ast> for NodeCounter {
-    fn visit_ident(&mut self, _ident: Ident) {
+    fn visit_ident(&mut self, _ident: &Ident) {
         self.count += 1;
     }
     fn visit_foreign_item(&mut self, i: &ForeignItem) {

--- a/compiler/rustc_builtin_macros/src/deriving/default.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/default.rs
@@ -222,7 +222,7 @@ impl<'a, 'b> rustc_ast::visit::Visitor<'a> for DetectNonVariantDefaultAttr<'a, '
         rustc_ast::visit::walk_attribute(self, attr);
     }
     fn visit_variant(&mut self, v: &'a rustc_ast::Variant) {
-        self.visit_ident(v.ident);
+        self.visit_ident(&v.ident);
         self.visit_vis(&v.vis);
         self.visit_variant_data(&v.data);
         visit_opt!(self, visit_anon_const, &v.disr_expr);

--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1892,11 +1892,11 @@ impl EarlyLintPass for KeywordIdents {
     fn check_mac(&mut self, cx: &EarlyContext<'_>, mac: &ast::MacCall) {
         self.check_tokens(cx, &mac.args.tokens);
     }
-    fn check_ident(&mut self, cx: &EarlyContext<'_>, ident: Ident) {
+    fn check_ident(&mut self, cx: &EarlyContext<'_>, ident: &Ident) {
         if ident.name.as_str().starts_with('\'') {
             self.check_ident_token(cx, UnderMacro(false), ident.without_first_quote(), "'");
         } else {
-            self.check_ident_token(cx, UnderMacro(false), ident, "");
+            self.check_ident_token(cx, UnderMacro(false), *ident, "");
         }
     }
 }

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -190,7 +190,7 @@ impl<'a, T: EarlyLintPass> ast_visit::Visitor<'a> for EarlyContextAndPass<'a, T>
         ast_visit::walk_ty(self, t);
     }
 
-    fn visit_ident(&mut self, ident: Ident) {
+    fn visit_ident(&mut self, ident: &Ident) {
         lint_callback!(self, check_ident, ident);
     }
 

--- a/compiler/rustc_lint/src/passes.rs
+++ b/compiler/rustc_lint/src/passes.rs
@@ -133,7 +133,7 @@ macro_rules! early_lint_methods {
     ($macro:path, $args:tt) => (
         $macro!($args, [
             fn check_param(a: &rustc_ast::Param);
-            fn check_ident(a: rustc_span::symbol::Ident);
+            fn check_ident(a: &rustc_span::symbol::Ident);
             fn check_crate(a: &rustc_ast::Crate);
             fn check_crate_post(a: &rustc_ast::Crate);
             fn check_item(a: &rustc_ast::Item);

--- a/compiler/rustc_resolve/src/build_reduced_graph.rs
+++ b/compiler/rustc_resolve/src/build_reduced_graph.rs
@@ -1321,7 +1321,7 @@ impl<'a, 'ra, 'tcx> Visitor<'a> for BuildReducedGraphVisitor<'a, 'ra, 'tcx> {
                         // Visit attributes after items for backward compatibility.
                         // This way they can use `macro_rules` defined later.
                         self.visit_vis(&item.vis);
-                        self.visit_ident(item.ident);
+                        self.visit_ident(&item.ident);
                         item.kind.walk(item, AssocCtxt::Trait, self);
                         visit::walk_list!(self, visit_attribute, &item.attrs);
                     }

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -1205,7 +1205,7 @@ impl<'ra: 'ast, 'ast, 'tcx> Visitor<'ast> for LateResolutionVisitor<'_, 'ast, 'r
     }
 
     fn visit_assoc_item_constraint(&mut self, constraint: &'ast AssocItemConstraint) {
-        self.visit_ident(constraint.ident);
+        self.visit_ident(&constraint.ident);
         if let Some(ref gen_args) = constraint.gen_args {
             // Forbid anonymous lifetimes in GAT parameters until proper semantics are decided.
             self.with_lifetime_rib(LifetimeRibKind::AnonymousReportError, |this| {
@@ -4582,7 +4582,7 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
 
     fn resolve_expr_field(&mut self, f: &'ast ExprField, e: &'ast Expr) {
         self.resolve_expr(&f.expr, Some(e));
-        self.visit_ident(f.ident);
+        self.visit_ident(&f.ident);
         walk_list!(self, visit_attribute, f.attrs.iter());
     }
 

--- a/library/alloc/src/collections/binary_heap/tests.rs
+++ b/library/alloc/src/collections/binary_heap/tests.rs
@@ -350,7 +350,7 @@ fn test_drain_forget() {
         mem::forget(it);
     }))
     .unwrap();
-    // Behaviour after leaking is explicitly unspecified and order is arbitrary,
+    // Behavior after leaking is explicitly unspecified and order is arbitrary,
     // so it's fine if these start failing, but probably worth knowing.
     assert!(q.is_empty());
     assert_eq!(a.dropped() + b.dropped() + c.dropped(), 1);
@@ -377,7 +377,7 @@ fn test_drain_sorted_forget() {
         mem::forget(it);
     }))
     .unwrap();
-    // Behaviour after leaking is explicitly unspecified,
+    // Behavior after leaking is explicitly unspecified,
     // so it's fine if these start failing, but probably worth knowing.
     assert_eq!(q.len(), 2);
     assert_eq!(a.dropped(), 0);

--- a/library/alloc/src/collections/btree/map/tests.rs
+++ b/library/alloc/src/collections/btree/map/tests.rs
@@ -1216,7 +1216,7 @@ mod test_extract_if {
         {
             let mut it = map.extract_if(|dummy, _| dummy.query(true));
             catch_unwind(AssertUnwindSafe(|| while it.next().is_some() {})).unwrap_err();
-            // Iterator behaviour after a panic is explicitly unspecified,
+            // Iterator behavior after a panic is explicitly unspecified,
             // so this is just the current implementation:
             let result = catch_unwind(AssertUnwindSafe(|| it.next()));
             assert!(matches!(result, Ok(None)));

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -3075,7 +3075,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     ///
     /// drop(strong);
     /// // But not any more. We can do weak.as_ptr(), but accessing the pointer would lead to
-    /// // undefined behaviour.
+    /// // undefined behavior.
     /// // assert_eq!("hello", unsafe { &*weak.as_ptr() });
     /// ```
     ///

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -804,7 +804,7 @@ impl<T, A: Allocator> Arc<T, A> {
             // observe a non-zero strong count. Therefore we need at least "Release" ordering
             // in order to synchronize with the `compare_exchange_weak` in `Weak::upgrade`.
             //
-            // "Acquire" ordering is not required. When considering the possible behaviours
+            // "Acquire" ordering is not required. When considering the possible behaviors
             // of `data_fn` we only need to look at what it could do with a reference to a
             // non-upgradeable `Weak`:
             // - It can *clone* the `Weak`, increasing the weak reference count.
@@ -2788,7 +2788,7 @@ impl<T: ?Sized, A: Allocator> Weak<T, A> {
     ///
     /// drop(strong);
     /// // But not any more. We can do weak.as_ptr(), but accessing the pointer would lead to
-    /// // undefined behaviour.
+    /// // undefined behavior.
     /// // assert_eq!("hello", unsafe { &*weak.as_ptr() });
     /// ```
     ///

--- a/library/alloc/src/vec/is_zero.rs
+++ b/library/alloc/src/vec/is_zero.rs
@@ -172,7 +172,7 @@ macro_rules! impl_is_zero_option_of_bool {
             fn is_zero(&self) -> bool {
                 // SAFETY: This is *not* a stable layout guarantee, but
                 // inside `core` we're allowed to rely on the current rustc
-                // behaviour that options of bools will be one byte with
+                // behavior that options of bools will be one byte with
                 // no padding, so long as they're nested less than 254 deep.
                 let raw: u8 = unsafe { core::mem::transmute(*self) };
                 raw == 0

--- a/library/core/src/alloc/global.rs
+++ b/library/core/src/alloc/global.rs
@@ -173,7 +173,7 @@ pub unsafe trait GlobalAlloc {
     /// # Safety
     ///
     /// The caller has to ensure that `layout` has non-zero size. Like `alloc`
-    /// zero sized `layout` can result in undefined behaviour.
+    /// zero sized `layout` can result in undefined behavior.
     /// However the allocated block of memory is guaranteed to be initialized.
     ///
     /// # Errors
@@ -234,7 +234,7 @@ pub unsafe trait GlobalAlloc {
     ///   does not overflow `isize` (i.e., the rounded value must be less than or
     ///   equal to `isize::MAX`).
     ///
-    /// If these are not followed, undefined behaviour can result.
+    /// If these are not followed, undefined behavior can result.
     ///
     /// (Extension subtraits might provide more specific bounds on
     /// behavior, e.g., guarantee a sentinel address or a null pointer

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -1221,7 +1221,7 @@ impl<T: ?Sized> RefCell<T> {
     /// Unlike `RefCell::borrow`, this method is unsafe because it does not
     /// return a `Ref`, thus leaving the borrow flag untouched. Mutably
     /// borrowing the `RefCell` while the reference returned by this method
-    /// is alive is undefined behaviour.
+    /// is alive is undefined behavior.
     ///
     /// # Examples
     ///

--- a/library/core/src/cmp.rs
+++ b/library/core/src/cmp.rs
@@ -380,7 +380,7 @@ pub struct AssertParamIsEq<T: Eq + ?Sized> {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[stable(feature = "rust1", since = "1.0.0")]
 // This is a lang item only so that `BinOp::Cmp` in MIR can return it.
-// It has no special behaviour, but does require that the three variants
+// It has no special behavior, but does require that the three variants
 // `Less`/`Equal`/`Greater` remain `-1_i8`/`0_i8`/`+1_i8` respectively.
 #[lang = "Ordering"]
 #[repr(i8)]

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -930,7 +930,7 @@ extern "rust-intrinsic" {
     /// on most platforms.
     /// On Unix, the
     /// process will probably terminate with a signal like `SIGABRT`, `SIGILL`, `SIGTRAP`, `SIGSEGV` or
-    /// `SIGBUS`.  The precise behaviour is not guaranteed and not stable.
+    /// `SIGBUS`.  The precise behavior is not guaranteed and not stable.
     #[rustc_safe_intrinsic]
     #[rustc_nounwind]
     pub fn abort() -> !;
@@ -1384,7 +1384,7 @@ extern "rust-intrinsic" {
 
     /// Like [`transmute`], but even less checked at compile-time: rather than
     /// giving an error for `size_of::<Src>() != size_of::<Dst>()`, it's
-    /// **Undefined Behaviour** at runtime.
+    /// **Undefined Behavior** at runtime.
     ///
     /// Prefer normal `transmute` where possible, for the extra checking, since
     /// both do exactly the same thing at runtime, if they both compile.

--- a/library/core/src/intrinsics/mir.rs
+++ b/library/core/src/intrinsics/mir.rs
@@ -298,7 +298,7 @@ define!(
 );
 define!(
     "mir_unwind_unreachable",
-    /// An unwind action that triggers undefined behaviour.
+    /// An unwind action that triggers undefined behavior.
     fn UnwindUnreachable() -> UnwindActionArg
 );
 define!(

--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -723,7 +723,7 @@ impl<T> MaybeUninit<T> {
     /// this does not constitute a stable guarantee), because the only
     /// requirement the compiler knows about it is that the data pointer must be
     /// non-null. Dropping such a `Vec<T>` however will cause undefined
-    /// behaviour.
+    /// behavior.
     ///
     /// [`assume_init`]: MaybeUninit::assume_init
     /// [`Vec<T>`]: ../../std/vec/struct.Vec.html

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -355,7 +355,7 @@ where
     }
 
     /// Creates a non-zero without checking whether the value is non-zero.
-    /// This results in undefined behaviour if the value is zero.
+    /// This results in undefined behavior if the value is zero.
     ///
     /// # Safety
     ///
@@ -952,9 +952,9 @@ macro_rules! nonzero_integer {
 
             /// Multiplies two non-zero integers together,
             /// assuming overflow cannot occur.
-            /// Overflow is unchecked, and it is undefined behaviour to overflow
+            /// Overflow is unchecked, and it is undefined behavior to overflow
             /// *even if the result would wrap to a non-zero value*.
-            /// The behaviour is undefined as soon as
+            /// The behavior is undefined as soon as
             #[doc = sign_dependent_expr!{
                 $signedness ?
                 if signed {
@@ -1323,9 +1323,9 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
 
         /// Adds an unsigned integer to a non-zero value,
         /// assuming overflow cannot occur.
-        /// Overflow is unchecked, and it is undefined behaviour to overflow
+        /// Overflow is unchecked, and it is undefined behavior to overflow
         /// *even if the result would wrap to a non-zero value*.
-        /// The behaviour is undefined as soon as
+        /// The behavior is undefined as soon as
         #[doc = concat!("`self + rhs > ", stringify!($Int), "::MAX`.")]
         ///
         /// # Examples
@@ -1599,7 +1599,7 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
 
         /// Computes the absolute value of self.
         #[doc = concat!("See [`", stringify!($Int), "::abs`]")]
-        /// for documentation on overflow behaviour.
+        /// for documentation on overflow behavior.
         ///
         /// # Example
         ///
@@ -1878,7 +1878,7 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         /// Negates self, overflowing if this is equal to the minimum value.
         ///
         #[doc = concat!("See [`", stringify!($Int), "::overflowing_neg`]")]
-        /// for documentation on overflow behaviour.
+        /// for documentation on overflow behavior.
         ///
         /// # Example
         ///
@@ -1943,7 +1943,7 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         /// of the type.
         ///
         #[doc = concat!("See [`", stringify!($Int), "::wrapping_neg`]")]
-        /// for documentation on overflow behaviour.
+        /// for documentation on overflow behavior.
         ///
         /// # Example
         ///

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -3086,7 +3086,7 @@ macro_rules! uint_impl {
         /// ```
         #[inline]
         #[unstable(feature = "wrapping_next_power_of_two", issue = "32463",
-                   reason = "needs decision on wrapping behaviour")]
+                   reason = "needs decision on wrapping behavior")]
         #[rustc_const_unstable(feature = "wrapping_next_power_of_two", issue = "32463")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]

--- a/library/core/src/num/wrapping.rs
+++ b/library/core/src/num/wrapping.rs
@@ -1043,7 +1043,7 @@ macro_rules! wrapping_int_impl_unsigned {
             #[must_use = "this returns the result of the operation, \
                           without modifying the original"]
             #[unstable(feature = "wrapping_next_power_of_two", issue = "32463",
-                       reason = "needs decision on wrapping behaviour")]
+                       reason = "needs decision on wrapping behavior")]
             pub fn next_power_of_two(self) -> Self {
                 Wrapping(self.0.wrapping_next_power_of_two())
             }

--- a/library/core/src/ops/deref.rs
+++ b/library/core/src/ops/deref.rs
@@ -15,7 +15,7 @@
 ///
 /// Types that implement `Deref` or `DerefMut` are often called "smart
 /// pointers" and the mechanism of deref coercion has been specifically designed
-/// to facilitate the pointer-like behaviour that name suggests. Often, the
+/// to facilitate the pointer-like behavior that name suggests. Often, the
 /// purpose of a "smart pointer" type is to change the ownership semantics
 /// of a contained value (for example, [`Rc`][rc] or [`Cow`][cow]) or the
 /// storage semantics of a contained value (for example, [`Box`][box]).
@@ -42,7 +42,7 @@
 /// 1. a value of the type transparently behaves like a value of the target
 ///    type;
 /// 1. the implementation of the deref function is cheap; and
-/// 1. users of the type will not be surprised by any deref coercion behaviour.
+/// 1. users of the type will not be surprised by any deref coercion behavior.
 ///
 /// In general, deref traits **should not** be implemented if:
 ///
@@ -185,7 +185,7 @@ impl<T: ?Sized> Deref for &mut T {
 ///
 /// Types that implement `DerefMut` or `Deref` are often called "smart
 /// pointers" and the mechanism of deref coercion has been specifically designed
-/// to facilitate the pointer-like behaviour that name suggests. Often, the
+/// to facilitate the pointer-like behavior that name suggests. Often, the
 /// purpose of a "smart pointer" type is to change the ownership semantics
 /// of a contained value (for example, [`Rc`][rc] or [`Cow`][cow]) or the
 /// storage semantics of a contained value (for example, [`Box`][box]).

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -150,7 +150,7 @@
 //! It is further guaranteed that, for the cases above, one can
 //! [`mem::transmute`] from all valid values of `T` to `Option<T>` and
 //! from `Some::<T>(_)` to `T` (but transmuting `None::<T>` to `T`
-//! is undefined behaviour).
+//! is undefined behavior).
 //!
 //! # Method overview
 //!

--- a/library/core/src/primitive_docs.rs
+++ b/library/core/src/primitive_docs.rs
@@ -100,7 +100,7 @@ mod prim_bool {}
 ///
 /// Both match arms must produce values of type [`u32`], but since `break` never produces a value
 /// at all we know it can never produce a value which isn't a [`u32`]. This illustrates another
-/// behaviour of the `!` type - expressions with type `!` will coerce into any other type.
+/// behavior of the `!` type - expressions with type `!` will coerce into any other type.
 ///
 /// [`u32`]: prim@u32
 /// [`exit`]: ../std/process/fn.exit.html
@@ -134,7 +134,7 @@ mod prim_bool {}
 ///
 /// Since the [`Err`] variant contains a `!`, it can never occur. If the `exhaustive_patterns`
 /// feature is present this means we can exhaustively match on [`Result<T, !>`] by just taking the
-/// [`Ok`] variant. This illustrates another behaviour of `!` - it can be used to "delete" certain
+/// [`Ok`] variant. This illustrates another behavior of `!` - it can be used to "delete" certain
 /// enum variants from generic types like `Result`.
 ///
 /// ## Infinite loops
@@ -351,7 +351,7 @@ mod prim_never {}
 /// ```
 ///
 /// ```no_run
-/// // Undefined behaviour
+/// // Undefined behavior
 /// let _ = unsafe { char::from_u32_unchecked(0x110000) };
 /// ```
 ///
@@ -568,7 +568,7 @@ impl () {}
 /// Instead of coercing a reference to a raw pointer, you can use the macros
 /// [`ptr::addr_of!`] (for `*const T`) and [`ptr::addr_of_mut!`] (for `*mut T`).
 /// These macros allow you to create raw pointers to fields to which you cannot
-/// create a reference (without causing undefined behaviour), such as an
+/// create a reference (without causing undefined behavior), such as an
 /// unaligned field. This might be necessary if packed structs or uninitialized
 /// memory is involved.
 ///
@@ -1453,7 +1453,7 @@ mod prim_usize {}
 /// <code>&[bool]</code> can only point to an allocation containing the integer values `1`
 /// ([`true`](../std/keyword.true.html)) or `0` ([`false`](../std/keyword.false.html)), but
 /// creating a <code>&[bool]</code> that points to an allocation containing
-/// the value `3` causes undefined behaviour.
+/// the value `3` causes undefined behavior.
 /// In fact, <code>[Option]\<&T></code> has the same memory representation as a
 /// nullable but aligned pointer, and can be passed across FFI boundaries as such.
 ///

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -134,7 +134,7 @@
 //! # Provenance
 //!
 //! Pointers are not *simply* an "integer" or "address". For instance, it's uncontroversial
-//! to say that a Use After Free is clearly Undefined Behaviour, even if you "get lucky"
+//! to say that a Use After Free is clearly Undefined Behavior, even if you "get lucky"
 //! and the freed memory gets reallocated before your read/write (in fact this is the
 //! worst-case scenario, UAFs would be much less concerning if this didn't happen!).
 //! As another example, consider that [`wrapping_offset`] is documented to "remember"
@@ -1125,7 +1125,7 @@ pub const unsafe fn swap_nonoverlapping<T>(x: *mut T, y: *mut T, count: usize) {
     unsafe { swap_nonoverlapping_simple_untyped(x, y, count) }
 }
 
-/// Same behaviour and safety conditions as [`swap_nonoverlapping`]
+/// Same behavior and safety conditions as [`swap_nonoverlapping`]
 ///
 /// LLVM can vectorize this (at least it can for the power-of-two-sized types
 /// `swap_nonoverlapping` tries to use) so no need to manually SIMD it.

--- a/library/core/src/str/pattern.rs
+++ b/library/core/src/str/pattern.rs
@@ -57,9 +57,9 @@ use crate::{cmp, fmt};
 /// [`Searcher`] type, which does the actual work of finding
 /// occurrences of the pattern in a string.
 ///
-/// Depending on the type of the pattern, the behaviour of methods like
+/// Depending on the type of the pattern, the behavior of methods like
 /// [`str::find`] and [`str::contains`] can change. The table below describes
-/// some of those behaviours.
+/// some of those behaviors.
 ///
 /// | Pattern type             | Match condition                           |
 /// |--------------------------|-------------------------------------------|

--- a/library/core/tests/num/int_macros.rs
+++ b/library/core/tests/num/int_macros.rs
@@ -113,7 +113,7 @@ macro_rules! int_module {
                 // Rotating these should make no difference
                 //
                 // We test using 124 bits because to ensure that overlong bit shifts do
-                // not cause undefined behaviour. See #10183.
+                // not cause undefined behavior. See #10183.
                 assert_eq_const_safe!(_0.rotate_left(124), _0);
                 assert_eq_const_safe!(_1.rotate_left(124), _1);
                 assert_eq_const_safe!(_0.rotate_right(124), _0);

--- a/library/core/tests/num/uint_macros.rs
+++ b/library/core/tests/num/uint_macros.rs
@@ -79,7 +79,7 @@ macro_rules! uint_module {
                 // Rotating these should make no difference
                 //
                 // We test using 124 bits because to ensure that overlong bit shifts do
-                // not cause undefined behaviour. See #10183.
+                // not cause undefined behavior. See #10183.
                 assert_eq_const_safe!(_0.rotate_left(124), _0);
                 assert_eq_const_safe!(_1.rotate_left(124), _1);
                 assert_eq_const_safe!(_0.rotate_right(124), _0);

--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -76,7 +76,7 @@ impl Symbol {
                 .all(|b| matches!(b, b'_' | b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9'))
     }
 
-    // Mimics the behaviour of `Symbol::can_be_raw` from `rustc_span`
+    // Mimics the behavior of `Symbol::can_be_raw` from `rustc_span`
     fn can_be_raw(string: &str) -> bool {
         match string {
             "_" | "super" | "self" | "Self" | "crate" => false,

--- a/library/std/src/collections/hash/map/tests.rs
+++ b/library/std/src/collections/hash/map/tests.rs
@@ -1098,7 +1098,7 @@ mod test_extract_if {
                 _ => panic!(),
             });
             catch_unwind(AssertUnwindSafe(|| while it.next().is_some() {})).unwrap_err();
-            // Iterator behaviour after a panic is explicitly unspecified,
+            // Iterator behavior after a panic is explicitly unspecified,
             // so this is just the current implementation:
             let result = catch_unwind(AssertUnwindSafe(|| it.next()));
             assert!(result.is_err());

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -618,7 +618,7 @@ impl Error for JoinPathsError {
 ///
 /// # Deprecation
 ///
-/// This function is deprecated because the behaviour on Windows is not correct.
+/// This function is deprecated because the behavior on Windows is not correct.
 /// The 'HOME' environment variable is not standard on Windows, and may not produce
 /// desired results; for instance, under Cygwin or Mingw it will return `/home/you`
 /// when it should return `C:\Users\you`.

--- a/library/std/src/os/unix/fs.rs
+++ b/library/std/src/os/unix/fs.rs
@@ -153,7 +153,7 @@ pub trait FileExt {
     ///
     /// It is possible to inadvertently set this flag, like in the example below.
     /// Therefore, it is important to be vigilant while changing options to mitigate
-    /// unexpected behaviour.
+    /// unexpected behavior.
     ///
     /// ```no_run
     /// use std::fs::File;

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -1167,7 +1167,7 @@ impl FusedIterator for Ancestors<'_> {}
 /// path.push(r"..\otherdir");
 /// path.push("system32");
 ///
-/// The behaviour of `PathBuf` may be changed to a panic on such inputs
+/// The behavior of `PathBuf` may be changed to a panic on such inputs
 /// in the future. [`Extend::extend`] should be used to add multi-part paths.
 #[cfg_attr(not(test), rustc_diagnostic_item = "PathBuf")]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -1409,7 +1409,7 @@ impl PathBuf {
     /// (That is, it will have the same parent.)
     ///
     /// The argument is not sanitized, so can include separators. This
-    /// behaviour may be changed to a panic in the future.
+    /// behavior may be changed to a panic in the future.
     ///
     /// [`self.file_name`]: Path::file_name
     /// [`pop`]: PathBuf::pop

--- a/library/std/src/process.rs
+++ b/library/std/src/process.rs
@@ -119,7 +119,7 @@
 //! when given a `.bat` file as the application to run, it will automatically
 //! convert that into running `cmd.exe /c` with the batch file as the next argument.
 //!
-//! For historical reasons Rust currently preserves this behaviour when using
+//! For historical reasons Rust currently preserves this behavior when using
 //! [`Command::new`], and escapes the arguments according to `cmd.exe` rules.
 //! Due to the complexity of `cmd.exe` argument handling, it might not be
 //! possible to safely escape some special characters, and using them will result
@@ -2318,7 +2318,7 @@ pub fn exit(code: i32) -> ! {
 /// Rust IO buffers (eg, from `BufWriter`) will not be flushed.
 /// Likewise, C stdio buffers will (on most platforms) not be flushed.
 ///
-/// This is in contrast to the default behaviour of [`panic!`] which unwinds
+/// This is in contrast to the default behavior of [`panic!`] which unwinds
 /// the current thread's stack and calls all destructors.
 /// When `panic="abort"` is set, either as an argument to `rustc` or in a
 /// crate's Cargo.toml, [`panic!`] and `abort` are similar. However,

--- a/library/std/src/sync/mpmc/array.rs
+++ b/library/std/src/sync/mpmc/array.rs
@@ -484,7 +484,7 @@ impl<T> Channel<T> {
     ///
     /// # Panicking
     /// If a destructor panics, the remaining messages are leaked, matching the
-    /// behaviour of the unbounded channel.
+    /// behavior of the unbounded channel.
     ///
     /// # Safety
     /// This method must only be called when dropping the last receiver. The

--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -288,7 +288,7 @@ impl Once {
     ///
     /// If this [`Once`] has been poisoned because an initialization closure has
     /// panicked, this method will also panic. Use [`wait_force`](Self::wait_force)
-    /// if this behaviour is not desired.
+    /// if this behavior is not desired.
     #[unstable(feature = "once_wait", issue = "127527")]
     pub fn wait(&self) {
         if !self.inner.is_completed() {

--- a/library/std/src/sys/pal/unix/process/process_fuchsia.rs
+++ b/library/std/src/sys/pal/unix/process/process_fuchsia.rs
@@ -273,7 +273,7 @@ impl ExitStatus {
         // We don't know what someone who calls into_raw() will do with this value, but it should
         // have the conventional Unix representation. Despite the fact that this is not
         // standardised in SuS or POSIX, all Unix systems encode the signal and exit status the
-        // same way. (Ie the WIFEXITED, WEXITSTATUS etc. macros have identical behaviour on every
+        // same way. (Ie the WIFEXITED, WEXITSTATUS etc. macros have identical behavior on every
         // Unix.)
         //
         // The caller of `std::os::unix::into_raw` is probably wanting a Unix exit status, and may

--- a/library/std/src/sys/pal/windows/fs.rs
+++ b/library/std/src/sys/pal/windows/fs.rs
@@ -1159,7 +1159,7 @@ pub fn symlink_inner(original: &Path, link: &Path, dir: bool) -> io::Result<()> 
     // Formerly, symlink creation required the SeCreateSymbolicLink privilege. For the Windows 10
     // Creators Update, Microsoft loosened this to allow unprivileged symlink creation if the
     // computer is in Developer Mode, but SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE must be
-    // added to dwFlags to opt into this behaviour.
+    // added to dwFlags to opt into this behavior.
     let result = cvt(unsafe {
         c::CreateSymbolicLinkW(
             link.as_ptr(),

--- a/library/std/src/sys/pal/windows/process.rs
+++ b/library/std/src/sys/pal/windows/process.rs
@@ -47,7 +47,7 @@ impl EnvKey {
     }
 }
 
-// Comparing Windows environment variable keys[1] are behaviourally the
+// Comparing Windows environment variable keys[1] are behaviorally the
 // composition of two operations[2]:
 //
 // 1. Case-fold both strings. This is done using a language-independent
@@ -338,8 +338,8 @@ impl Command {
 
         // If at least one of stdin, stdout or stderr are set (i.e. are non null)
         // then set the `hStd` fields in `STARTUPINFO`.
-        // Otherwise skip this and allow the OS to apply its default behaviour.
-        // This provides more consistent behaviour between Win7 and Win8+.
+        // Otherwise skip this and allow the OS to apply its default behavior.
+        // This provides more consistent behavior between Win7 and Win8+.
         let is_set = |stdio: &Handle| !stdio.as_raw_handle().is_null();
         if is_set(&stderr) || is_set(&stdout) || is_set(&stdin) {
             si.dwFlags |= c::STARTF_USESTDHANDLES;
@@ -507,7 +507,7 @@ where
     Exists: FnMut(PathBuf) -> Option<Vec<u16>>,
 {
     // 1. Child paths
-    // This is for consistency with Rust's historic behaviour.
+    // This is for consistency with Rust's historic behavior.
     if let Some(paths) = child_paths {
         for path in env::split_paths(paths).filter(|p| !p.as_os_str().is_empty()) {
             if let Some(path) = exists(path) {

--- a/library/std/src/sys/pal/windows/process/tests.rs
+++ b/library/std/src/sys/pal/windows/process/tests.rs
@@ -191,7 +191,7 @@ fn windows_exe_resolver() {
 
     /*
     Some of the following tests may need to be changed if you are deliberately
-    changing the behaviour of `resolve_exe`.
+    changing the behavior of `resolve_exe`.
     */
 
     let empty_paths = || None;

--- a/library/std/src/sys/pal/windows/thread.rs
+++ b/library/std/src/sys/pal/windows/thread.rs
@@ -99,7 +99,7 @@ impl Thread {
         }
         // Attempt to use high-precision sleep (Windows 10, version 1803+).
         // On error fallback to the standard `Sleep` function.
-        // Also preserves the zero duration behaviour of `Sleep`.
+        // Also preserves the zero duration behavior of `Sleep`.
         if dur.is_zero() || high_precision_sleep(dur).is_err() {
             unsafe { c::Sleep(super::dur2timeout(dur)) }
         }

--- a/library/std/src/sys/path/windows/tests.rs
+++ b/library/std/src/sys/path/windows/tests.rs
@@ -119,7 +119,7 @@ fn test_windows_prefix_components() {
 
 /// See #101358.
 ///
-/// Note that the exact behaviour here may change in the future.
+/// Note that the exact behavior here may change in the future.
 /// In which case this test will need to adjusted.
 #[test]
 fn broken_unc_path() {

--- a/library/std/src/sys/random/linux.rs
+++ b/library/std/src/sys/random/linux.rs
@@ -30,7 +30,7 @@
 //! data the system has available at the time.
 //!
 //! So in conclusion, we always want the output of the non-blocking pool, but
-//! may need to wait until it is initalized. The default behaviour of `getrandom`
+//! may need to wait until it is initalized. The default behavior of `getrandom`
 //! is to wait until the non-blocking pool is initialized and then draw from there,
 //! so if `getrandom` is available, we use its default to generate the bytes. For
 //! `HashMap`, however, we need to specify the `GRND_INSECURE` flags, but that
@@ -39,7 +39,7 @@
 //! succeed if the pool is initialized. If it isn't, we fall back to the file
 //! access method.
 //!
-//! The behaviour of `/dev/urandom` is inverse to that of `getrandom`: it always
+//! The behavior of `/dev/urandom` is inverse to that of `getrandom`: it always
 //! yields data, even when the pool is not initialized. For generating `HashMap`
 //! keys, this is not important, so we can use it directly. For secure data
 //! however, we need to wait until initialization, which we can do by `poll`ing

--- a/library/std/src/sys/sync/condvar/pthread.rs
+++ b/library/std/src/sys/sync/condvar/pthread.rs
@@ -66,7 +66,7 @@ impl Drop for AllocatedCondvar {
             // On DragonFly pthread_cond_destroy() returns EINVAL if called on
             // a condvar that was just initialized with
             // libc::PTHREAD_COND_INITIALIZER. Once it is used or
-            // pthread_cond_init() is called, this behaviour no longer occurs.
+            // pthread_cond_init() is called, this behavior no longer occurs.
             debug_assert!(r == 0 || r == libc::EINVAL);
         } else {
             debug_assert_eq!(r, 0);

--- a/library/std/src/sys/sync/mutex/pthread.rs
+++ b/library/std/src/sys/sync/mutex/pthread.rs
@@ -65,7 +65,7 @@ impl Drop for AllocatedMutex {
             // On DragonFly pthread_mutex_destroy() returns EINVAL if called on a
             // mutex that was just initialized with libc::PTHREAD_MUTEX_INITIALIZER.
             // Once it is used (locked/unlocked) or pthread_mutex_init() is called,
-            // this behaviour no longer occurs.
+            // this behavior no longer occurs.
             debug_assert!(r == 0 || r == libc::EINVAL);
         } else {
             debug_assert_eq!(r, 0);
@@ -88,7 +88,7 @@ impl Mutex {
     /// since the `lock` and the lock must have occurred on the current thread.
     ///
     /// # Safety
-    /// Causes undefined behaviour if the mutex is not locked.
+    /// Causes undefined behavior if the mutex is not locked.
     #[inline]
     pub(crate) unsafe fn get_assert_locked(&self) -> *mut libc::pthread_mutex_t {
         unsafe { self.inner.get_unchecked().0.get() }

--- a/library/std/src/sys/sync/once_box.rs
+++ b/library/std/src/sys/sync/once_box.rs
@@ -36,7 +36,7 @@ impl<T> OnceBox<T> {
     /// ```
     ///
     /// # Safety
-    /// This causes undefined behaviour if the assumption above is violated.
+    /// This causes undefined behavior if the assumption above is violated.
     #[inline]
     pub unsafe fn get_unchecked(&self) -> &T {
         unsafe { &*self.ptr.load(Relaxed) }

--- a/library/std/src/sys/sync/rwlock/futex.rs
+++ b/library/std/src/sys/sync/rwlock/futex.rs
@@ -283,7 +283,7 @@ impl RwLock {
         futex_wake(&self.writer_notify)
         // Note that FreeBSD and DragonFlyBSD don't tell us whether they woke
         // up any threads or not, and always return `false` here. That still
-        // results in correct behaviour: it just means readers get woken up as
+        // results in correct behavior: it just means readers get woken up as
         // well in case both readers and writers were waiting.
     }
 

--- a/library/std/src/sys/sync/rwlock/queue.rs
+++ b/library/std/src/sys/sync/rwlock/queue.rs
@@ -8,7 +8,7 @@
 //! * `pthread` is an external library, meaning the fast path of acquiring an
 //! uncontended lock cannot be inlined.
 //! * Some platforms (at least glibc before version 2.25) have buggy implementations
-//! that can easily lead to undefined behaviour in safe Rust code when not properly
+//! that can easily lead to undefined behavior in safe Rust code when not properly
 //! guarded against.
 //! * On some platforms (e.g. macOS), the lock is very slow.
 //!

--- a/library/std/src/sys/sync/thread_parking/darwin.rs
+++ b/library/std/src/sys/sync/thread_parking/darwin.rs
@@ -5,7 +5,7 @@
 //! rejection from the App Store).
 //!
 //! Therefore, we need to look for other synchronization primitives. Luckily, Darwin
-//! supports semaphores, which allow us to implement the behaviour we need with
+//! supports semaphores, which allow us to implement the behavior we need with
 //! only one primitive (as opposed to a mutex-condvar pair). We use the semaphore
 //! provided by libdispatch, as the underlying Mach semaphore is only dubiously
 //! public.

--- a/library/std/src/sys/sync/thread_parking/pthread.rs
+++ b/library/std/src/sys/sync/thread_parking/pthread.rs
@@ -97,7 +97,7 @@ impl Parker {
     /// The constructed parker must never be moved.
     pub unsafe fn new_in_place(parker: *mut Parker) {
         // Use the default mutex implementation to allow for simpler initialization.
-        // This could lead to undefined behaviour when deadlocking. This is avoided
+        // This could lead to undefined behavior when deadlocking. This is avoided
         // by not deadlocking. Note in particular the unlocking operation before any
         // panic, as code after the panic could try to park again.
         (&raw mut (*parker).state).write(AtomicUsize::new(EMPTY));

--- a/library/std/src/sys/sync/thread_parking/windows7.rs
+++ b/library/std/src/sys/sync/thread_parking/windows7.rs
@@ -35,7 +35,7 @@
 // different implementations.
 //
 // Unfortunately, NT Keyed Events are an undocumented Windows API. However:
-// - This API is relatively simple with obvious behaviour, and there are
+// - This API is relatively simple with obvious behavior, and there are
 //   several (unofficial) articles documenting the details. [1]
 // - `parking_lot` has been using this API for years (on Windows versions
 //   before Windows 8). [2] Many big projects extensively use parking_lot,
@@ -43,7 +43,7 @@
 // - It is the underlying API used by Windows SRW locks and Windows critical
 //   sections. [3] [4]
 // - The source code of the implementations of Wine, ReactOs, and Windows XP
-//   are available and match the expected behaviour.
+//   are available and match the expected behavior.
 // - The main risk with an undocumented API is that it might change in the
 //   future. But since we only use it for older versions of Windows, that's not
 //   a problem.

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -878,7 +878,7 @@ pub fn sleep(dur: Duration) {
 ///
 /// # Platform-specific behavior
 ///
-/// This function uses [`sleep`] internally, see its platform-specific behaviour.
+/// This function uses [`sleep`] internally, see its platform-specific behavior.
 ///
 ///
 /// # Examples
@@ -949,7 +949,7 @@ pub fn sleep_until(deadline: Instant) {
 }
 
 /// Used to ensure that `park` and `park_timeout` do not unwind, as that can
-/// cause undefined behaviour if not handled correctly (see #102398 for context).
+/// cause undefined behavior if not handled correctly (see #102398 for context).
 struct PanicGuard;
 
 impl Drop for PanicGuard {

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -178,9 +178,9 @@ pub struct Instant(time::Instant);
 /// system.
 ///
 /// A `SystemTime` does not count leap seconds.
-/// `SystemTime::now()`'s behaviour around a leap second
+/// `SystemTime::now()`'s behavior around a leap second
 /// is the same as the operating system's wall clock.
-/// The precise behaviour near a leap second
+/// The precise behavior near a leap second
 /// (e.g. whether the clock appears to run slow or fast, or stop, or jump)
 /// depends on platform and configuration,
 /// so should not be relied on.

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -47,11 +47,6 @@ source "$ci_dir/shared.sh"
 
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
-# suppress change-tracker warnings on CI
-if [ "$CI" != "" ]; then
-    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set change-id=99999999"
-fi
-
 # If runner uses an incompatible option and `FORCE_CI_RUSTC` is not defined,
 # switch to in-tree rustc.
 if [ "$FORCE_CI_RUSTC" == "" ]; then

--- a/src/tools/clippy/clippy_utils/src/ast_utils/ident_iter.rs
+++ b/src/tools/clippy/clippy_utils/src/ast_utils/ident_iter.rs
@@ -39,7 +39,7 @@ impl From<&Attribute> for IdentIter {
 struct IdentCollector(Vec<Ident>);
 
 impl Visitor<'_> for IdentCollector {
-    fn visit_ident(&mut self, ident: Ident) {
-        self.0.push(ident);
+    fn visit_ident(&mut self, ident: &Ident) {
+        self.0.push(*ident);
     }
 }


### PR DESCRIPTION
Successful merges:

 - #132106 (Pass Ident by reference in ast Visitor)
 - #132130 (remove `change-id` from CI script)
 - #132137 (library: consistently use American spelling for 'behavior')

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=132106,132130,132137)
<!-- homu-ignore:end -->