### PR TITLE
Tweak type diff highlighting when the same type is on both sides

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -864,6 +864,8 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 let path1 = self.tcx.def_path_str(did1);
                 let path2 = self.tcx.def_path_str(did2);
                 if did1 == did2 {
+                    let path1 = self.tcx.item_name(did1).to_string();
+                    let path2 = self.tcx.item_name(did2).to_string();
                     // Easy case. Replace same types with `_` to shorten the output and highlight
                     // the differing ones.
                     //     let x: Foo<Bar, Qux> = y::<Foo<Quz, Qux>>();

--- a/tests/ui/higher-ranked/higher-ranked-lifetime-equality.stderr
+++ b/tests/ui/higher-ranked/higher-ranked-lifetime-equality.stderr
@@ -4,8 +4,8 @@ error[E0308]: mismatched types
 LL |     let foo: Foo<Two> = foo;
    |                         ^^^ one type is more general than the other
    |
-   = note: expected struct `my_api::Foo<for<'a, 'b> fn(&'a (), &'b ())>`
-              found struct `my_api::Foo<for<'a> fn(&'a (), &'a ())>`
+   = note: expected struct `Foo<for<'a, 'b> fn(&'a (), &'b ())>`
+              found struct `Foo<for<'a> fn(&'a (), &'a ())>`
 
 error[E0308]: mismatched types
   --> $DIR/higher-ranked-lifetime-equality.rs:34:25
@@ -13,8 +13,8 @@ error[E0308]: mismatched types
 LL |     let foo: Foo<Two> = foo;
    |                         ^^^ one type is more general than the other
    |
-   = note: expected struct `my_api::Foo<for<'a, 'b> fn(&'a (), &'b ())>`
-              found struct `my_api::Foo<for<'a> fn(&'a (), &'a ())>`
+   = note: expected struct `Foo<for<'a, 'b> fn(&'a (), &'b ())>`
+              found struct `Foo<for<'a> fn(&'a (), &'a ())>`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
+++ b/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
@@ -7,8 +7,8 @@ LL |     type Foo = impl PartialEq<(Foo, i32)>;
 LL |         fn eq(&self, _other: &(Foo, i32)) -> bool {
    |                              ^^^^^^^^^^^ expected `a::Bar`, found opaque type
    |
-   = note: expected signature `fn(&a::Bar, &(a::Bar, _)) -> _`
-              found signature `fn(&a::Bar, &(a::Foo, _)) -> _`
+   = note: expected signature `fn(&Bar, &(a::Bar, _)) -> _`
+              found signature `fn(&Bar, &(a::Foo, _)) -> _`
 help: change the parameter type to match the trait
    |
 LL |         fn eq(&self, _other: &(a::Bar, i32)) -> bool {
@@ -44,8 +44,8 @@ LL |     type Foo = impl PartialEq<(Foo, i32)>;
 LL |         fn eq(&self, _other: &(Bar, i32)) -> bool {
    |                              ^^^^^^^^^^^ expected opaque type, found `b::Bar`
    |
-   = note: expected signature `fn(&b::Bar, &(b::Foo, _)) -> _`
-              found signature `fn(&b::Bar, &(b::Bar, _)) -> _`
+   = note: expected signature `fn(&Bar, &(b::Foo, _)) -> _`
+              found signature `fn(&Bar, &(b::Bar, _)) -> _`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
   --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:25:12
    |

--- a/tests/ui/proc-macro/proc-macro-abi.stderr
+++ b/tests/ui/proc-macro/proc-macro-abi.stderr
@@ -4,8 +4,8 @@ error: function-like proc macro has incorrect signature
 LL | pub extern "C" fn abi(a: TokenStream) -> TokenStream {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "C" fn
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `extern "C" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `extern "C" fn(TokenStream) -> TokenStream`
 
 error: function-like proc macro has incorrect signature
   --> $DIR/proc-macro-abi.rs:17:1
@@ -13,8 +13,8 @@ error: function-like proc macro has incorrect signature
 LL | pub extern "system" fn abi2(a: TokenStream) -> TokenStream {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "system" fn
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `extern "system" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `extern "system" fn(TokenStream) -> TokenStream`
 
 error: function-like proc macro has incorrect signature
   --> $DIR/proc-macro-abi.rs:23:1
@@ -22,8 +22,8 @@ error: function-like proc macro has incorrect signature
 LL | pub extern fn abi3(a: TokenStream) -> TokenStream {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "C" fn
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `extern "C" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
+   = note: expected signature `fn(TokenStream) -> TokenStream`
+              found signature `extern "C" fn(TokenStream) -> TokenStream`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/proc-macro/signature-proc-macro-attribute.stderr
+++ b/tests/ui/proc-macro/signature-proc-macro-attribute.stderr
@@ -4,8 +4,8 @@ error: attribute proc macro has incorrect signature
 LL | pub fn bad_input(input: String) -> TokenStream {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of function parameters
    |
-   = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(std::string::String) -> proc_macro::TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> TokenStream`
+              found signature `fn(std::string::String) -> TokenStream`
 
 error: attribute proc macro has incorrect signature
   --> $DIR/signature-proc-macro-attribute.rs:16:1
@@ -31,8 +31,8 @@ error: attribute proc macro has incorrect signature
 LL | pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
    |                                                    ^^^^^^ incorrect number of function parameters
    |
-   = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> proc_macro::TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream, proc_macro::TokenStream) -> TokenStream`
+              found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> TokenStream`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/proc-macro/signature-proc-macro-derive.stderr
+++ b/tests/ui/proc-macro/signature-proc-macro-derive.stderr
@@ -4,8 +4,8 @@ error: derive proc macro has incorrect signature
 LL | pub fn bad_input(input: String) -> TokenStream {
    |                         ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(std::string::String) -> proc_macro::TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream) -> TokenStream`
+              found signature `fn(std::string::String) -> TokenStream`
 
 error: derive proc macro has incorrect signature
   --> $DIR/signature-proc-macro-derive.rs:16:42
@@ -13,8 +13,8 @@ error: derive proc macro has incorrect signature
 LL | pub fn bad_output(input: TokenStream) -> String {
    |                                          ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(proc_macro::TokenStream) -> std::string::String`
+   = note: expected signature `fn(TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(TokenStream) -> std::string::String`
 
 error: derive proc macro has incorrect signature
   --> $DIR/signature-proc-macro-derive.rs:22:30
@@ -31,8 +31,8 @@ error: derive proc macro has incorrect signature
 LL | pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
    |                                    ^^^^^^^^^^^ incorrect number of function parameters
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> proc_macro::TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream) -> TokenStream`
+              found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> TokenStream`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/proc-macro/signature-proc-macro.stderr
+++ b/tests/ui/proc-macro/signature-proc-macro.stderr
@@ -4,8 +4,8 @@ error: function-like proc macro has incorrect signature
 LL | pub fn bad_input(input: String) -> TokenStream {
    |                         ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(std::string::String) -> proc_macro::TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream) -> TokenStream`
+              found signature `fn(std::string::String) -> TokenStream`
 
 error: function-like proc macro has incorrect signature
   --> $DIR/signature-proc-macro.rs:16:42
@@ -13,8 +13,8 @@ error: function-like proc macro has incorrect signature
 LL | pub fn bad_output(input: TokenStream) -> String {
    |                                          ^^^^^^ expected `proc_macro::TokenStream`, found `std::string::String`
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(proc_macro::TokenStream) -> std::string::String`
+   = note: expected signature `fn(TokenStream) -> proc_macro::TokenStream`
+              found signature `fn(TokenStream) -> std::string::String`
 
 error: function-like proc macro has incorrect signature
   --> $DIR/signature-proc-macro.rs:22:30
@@ -31,8 +31,8 @@ error: function-like proc macro has incorrect signature
 LL | pub fn too_many(a: TokenStream, b: TokenStream, c: String) -> TokenStream {
    |                                    ^^^^^^^^^^^ incorrect number of function parameters
    |
-   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
-              found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> proc_macro::TokenStream`
+   = note: expected signature `fn(proc_macro::TokenStream) -> TokenStream`
+              found signature `fn(proc_macro::TokenStream, proc_macro::TokenStream, std::string::String) -> TokenStream`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/range/issue-73553-misinterp-range-literal.stderr
+++ b/tests/ui/range/issue-73553-misinterp-range-literal.stderr
@@ -6,8 +6,8 @@ LL |     demo(tell(1)..tell(10));
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected reference `&std::ops::Range<_>`
-                 found struct `std::ops::Range<_>`
+   = note: expected reference `&Range<_>`
+                 found struct `Range<_>`
 note: function defined here
   --> $DIR/issue-73553-misinterp-range-literal.rs:3:4
    |
@@ -26,8 +26,8 @@ LL |     demo(1..10);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: expected reference `&std::ops::Range<usize>`
-                 found struct `std::ops::Range<{integer}>`
+   = note: expected reference `&Range<usize>`
+                 found struct `Range<{integer}>`
 note: function defined here
   --> $DIR/issue-73553-misinterp-range-literal.rs:3:4
    |

--- a/tests/ui/regions/resolve-re-error-ice.stderr
+++ b/tests/ui/regions/resolve-re-error-ice.stderr
@@ -14,8 +14,8 @@ note: ...so that the method type is compatible with trait
    |
 LL |     fn key_set(&self) -> Subject<'a, Keys<K, V>, (), R> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   = note: expected `fn(&Subject<'_, _, _, _>) -> Subject<'_, std::collections::hash_map::Keys<'_, _, _>, _, _>`
-              found `fn(&Subject<'_, _, _, _>) -> Subject<'a, std::collections::hash_map::Keys<'_, _, _>, _, _>`
+   = note: expected `fn(&Subject<'_, _, _, _>) -> Subject<'_, Keys<'_, _, _>, _, _>`
+              found `fn(&Subject<'_, _, _, _>) -> Subject<'a, Keys<'_, _, _>, _, _>`
 note: but, the lifetime must be valid for the lifetime `'a` as defined here...
   --> $DIR/resolve-re-error-ice.rs:10:6
    |


### PR DESCRIPTION
When highlighting type comparisons, if both sides are for the same type, we use only the type name instead of the full def path. This is beneficial when we are dealing with longer, more complex types where it is easy to lose track of where we are, so reducing the verbosity a bit in an element that doesn't contribute to the users' understanding is a net positive.