### PR TITLE
Deduplicate some error+lint diagnostic structs

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -468,13 +468,21 @@ fn emit_orphan_check_error<'tcx>(
                 let name = tcx.item_name(param_def_id);
 
                 reported.get_or_insert(match local_ty {
-                    Some(local_type) => tcx.dcx().emit_err(errors::TyParamFirstLocal {
-                        span,
-                        note: (),
-                        param: name,
-                        local_type,
-                    }),
-                    None => tcx.dcx().emit_err(errors::TyParamSome { span, note: (), param: name }),
+                    Some(local_type) => tcx
+                        .dcx()
+                        .create_err(errors::TyParamFirstLocal {
+                            label: span,
+                            note: (),
+                            param: name,
+                            local_type,
+                        })
+                        .with_span(span)
+                        .emit(),
+                    None => tcx
+                        .dcx()
+                        .create_err(errors::TyParamSome { label: span, note: (), param: name })
+                        .with_span(span)
+                        .emit(),
                 });
             }
             reported.unwrap() // FIXME(fmease): This is very likely reachable.
@@ -498,13 +506,13 @@ fn lint_uncovered_ty_params<'tcx>(
                 UNCOVERED_PARAM_IN_PROJECTION,
                 hir_id,
                 span,
-                errors::TyParamFirstLocalLint { span, note: (), param: name, local_type },
+                errors::TyParamFirstLocal { label: span, note: (), param: name, local_type },
             ),
             None => tcx.emit_node_span_lint(
                 UNCOVERED_PARAM_IN_PROJECTION,
                 hir_id,
                 span,
-                errors::TyParamSomeLint { span, note: (), param: name },
+                errors::TyParamSome { label: span, note: (), param: name },
             ),
         };
     }

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1379,51 +1379,24 @@ pub(crate) struct CrossCrateTraitsDefined {
     pub traits: String,
 }
 
-// FIXME(fmease): Deduplicate:
-
-#[derive(Diagnostic)]
+#[derive(Diagnostic, LintDiagnostic)]
 #[diag(hir_analysis_ty_param_first_local, code = E0210)]
 #[note]
 pub(crate) struct TyParamFirstLocal<'tcx> {
-    #[primary_span]
     #[label]
-    pub span: Span,
+    pub label: Span,
     #[note(hir_analysis_case_note)]
     pub note: (),
     pub param: Symbol,
     pub local_type: Ty<'tcx>,
 }
 
-#[derive(LintDiagnostic)]
-#[diag(hir_analysis_ty_param_first_local, code = E0210)]
-#[note]
-pub(crate) struct TyParamFirstLocalLint<'tcx> {
-    #[label]
-    pub span: Span,
-    #[note(hir_analysis_case_note)]
-    pub note: (),
-    pub param: Symbol,
-    pub local_type: Ty<'tcx>,
-}
-
-#[derive(Diagnostic)]
+#[derive(Diagnostic, LintDiagnostic)]
 #[diag(hir_analysis_ty_param_some, code = E0210)]
 #[note]
 pub(crate) struct TyParamSome {
-    #[primary_span]
     #[label]
-    pub span: Span,
-    #[note(hir_analysis_only_note)]
-    pub note: (),
-    pub param: Symbol,
-}
-
-#[derive(LintDiagnostic)]
-#[diag(hir_analysis_ty_param_some, code = E0210)]
-#[note]
-pub(crate) struct TyParamSomeLint {
-    #[label]
-    pub span: Span,
+    pub label: Span,
     #[note(hir_analysis_only_note)]
     pub note: (),
     pub param: Symbol,

--- a/compiler/rustc_hir_analysis/src/lib.rs
+++ b/compiler/rustc_hir_analysis/src/lib.rs
@@ -62,6 +62,7 @@ This API is completely unstable and subject to change.
 #![doc(html_root_url = "https://doc.rust-lang.org/nightly/nightly-rustc/")]
 #![doc(rust_logo)]
 #![feature(assert_matches)]
+#![feature(decl_macro)]
 #![feature(if_let_guard)]
 #![feature(iter_intersperse)]
 #![feature(let_chains)]

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -670,20 +670,9 @@ pub(crate) enum SuggestBoxingForReturnImplTrait {
     },
 }
 
-#[derive(Diagnostic)]
+#[derive(Diagnostic, LintDiagnostic)]
 #[diag(hir_typeck_self_ctor_from_outer_item, code = E0401)]
 pub(crate) struct SelfCtorFromOuterItem {
-    #[primary_span]
-    pub span: Span,
-    #[label]
-    pub impl_span: Span,
-    #[subdiagnostic]
-    pub sugg: Option<ReplaceWithName>,
-}
-
-#[derive(LintDiagnostic)]
-#[diag(hir_typeck_self_ctor_from_outer_item)]
-pub(crate) struct SelfCtorFromOuterItemLint {
     #[label]
     pub impl_span: Span,
     #[subdiagnostic]

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1140,22 +1140,17 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     span: path_span,
                     name: self.tcx.item_name(def.did()).to_ident_string(),
                 });
+                let diag =
+                    errors::SelfCtorFromOuterItem { impl_span: tcx.def_span(impl_def_id), sugg };
                 if ty.raw.has_param() {
-                    let guar = self.dcx().emit_err(errors::SelfCtorFromOuterItem {
-                        span: path_span,
-                        impl_span: tcx.def_span(impl_def_id),
-                        sugg,
-                    });
+                    let guar = self.dcx().create_err(diag).with_span(path_span).emit();
                     return (Ty::new_error(self.tcx, guar), res);
                 } else {
                     self.tcx.emit_node_span_lint(
                         SELF_CONSTRUCTOR_FROM_OUTER_ITEM,
                         hir_id,
                         path_span,
-                        errors::SelfCtorFromOuterItemLint {
-                            impl_span: tcx.def_span(impl_def_id),
-                            sugg,
-                        },
+                        diag,
                     );
                 }
             }

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -560,16 +560,9 @@ pub(crate) struct ReprIdent {
     pub span: Span,
 }
 
-#[derive(Diagnostic)]
+#[derive(Diagnostic, LintDiagnostic)]
 #[diag(passes_repr_conflicting, code = E0566)]
-pub(crate) struct ReprConflicting {
-    #[primary_span]
-    pub hint_spans: Vec<Span>,
-}
-
-#[derive(LintDiagnostic)]
-#[diag(passes_repr_conflicting, code = E0566)]
-pub(crate) struct ReprConflictingLint;
+pub(crate) struct ReprConflicting;
 
 #[derive(Diagnostic)]
 #[diag(passes_used_static)]

--- a/tests/ui/self/self-ctor-nongeneric.stderr
+++ b/tests/ui/self/self-ctor-nongeneric.stderr
@@ -1,4 +1,4 @@
-warning: can't reference `Self` constructor from outer item
+warning[E0401]: can't reference `Self` constructor from outer item
   --> $DIR/self-ctor-nongeneric.rs:8:23
    |
 LL | impl S0 {
@@ -11,7 +11,7 @@ LL |         const C: S0 = Self(0);
    = note: for more information, see issue #124186 <https://github.com/rust-lang/rust/issues/124186>
    = note: `#[warn(self_constructor_from_outer_item)]` on by default
 
-warning: can't reference `Self` constructor from outer item
+warning[E0401]: can't reference `Self` constructor from outer item
   --> $DIR/self-ctor-nongeneric.rs:12:13
    |
 LL | impl S0 {
@@ -25,3 +25,4 @@ LL |             Self(0)
 
 warning: 2 warnings emitted
 
+For more information about this error, try `rustc --explain E0401`.


### PR DESCRIPTION
The first commit consolidates pairs of diagnostic structs that essentially represent the same diagnostic but were separated because one "cannot really" derive both `Diagnostic` and `LintDiagnostic` at the same time. Well, it's possible but only if you don't use `#[primary_span]` (see #125169). So, in this PR we don't (and use `Diag::with_span` in the non-lint case) contrary to https://github.com/rust-lang/rust/pull/125208/commits/775527e808e915d4f6d8adfd6365becd7e656302 from #125208.

Deduplicates: `TyParamFirstLocal{,Lint}`, `TyParamSome{,Lint}`, `SelfCtorFromOuterItem{,Lint}`, `ConflictingRepr{,Lint}`.
Doesn't deduplicate `BuiltinEllipsisInclusiveRangePatterns{,Lint}` because it looks a bit more involved (tho I haven't really tried).

The second commit isn't really serious. I should probably just drop it, it's not worth it (DRY fallacy).

---

This PR is a vibes check, I'm fine with closing it if you don't like it.