### PR TITLE
Print unsafety of attribute in AST pretty print

### DIFF
--- a/compiler/rustc_ast_pretty/src/pprust/state.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state.rs
@@ -627,6 +627,13 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
 
     fn print_attr_item(&mut self, item: &ast::AttrItem, span: Span) {
         self.ibox(0);
+        match item.unsafety {
+            ast::Safety::Unsafe(_) => {
+                self.word("unsafe");
+                self.popen();
+            }
+            ast::Safety::Default | ast::Safety::Safe(_) => {}
+        }
         match &item.args {
             AttrArgs::Delimited(DelimArgs { dspan: _, delim, tokens }) => self.print_mac_common(
                 Some(MacHeader::Path(&item.path)),
@@ -654,6 +661,10 @@ pub trait PrintState<'a>: std::ops::Deref<Target = pp::Printer> + std::ops::Dere
                 let token_str = self.meta_item_lit_to_string(lit);
                 self.word(token_str);
             }
+        }
+        match item.unsafety {
+            ast::Safety::Unsafe(_) => self.pclose(),
+            ast::Safety::Default | ast::Safety::Safe(_) => {}
         }
         self.end();
     }

--- a/tests/ui/unpretty/unsafe-attr.rs
+++ b/tests/ui/unpretty/unsafe-attr.rs
@@ -1,0 +1,11 @@
+//@ compile-flags: -Zunpretty=normal
+//@ check-pass
+
+#[no_mangle]
+extern "C" fn foo() {}
+
+#[unsafe(no_mangle)]
+extern "C" fn bar() {}
+
+#[cfg_attr(FALSE, unsafe(no_mangle))]
+extern "C" fn zoo() {}

--- a/tests/ui/unpretty/unsafe-attr.stdout
+++ b/tests/ui/unpretty/unsafe-attr.stdout
@@ -4,7 +4,7 @@
 #[no_mangle]
 extern "C" fn foo() {}
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 extern "C" fn bar() {}
 
 #[cfg_attr(FALSE, unsafe(no_mangle))]

--- a/tests/ui/unpretty/unsafe-attr.stdout
+++ b/tests/ui/unpretty/unsafe-attr.stdout
@@ -1,0 +1,11 @@
+//@ compile-flags: -Zunpretty=normal
+//@ check-pass
+
+#[no_mangle]
+extern "C" fn foo() {}
+
+#[no_mangle]
+extern "C" fn bar() {}
+
+#[cfg_attr(FALSE, unsafe(no_mangle))]
+extern "C" fn zoo() {}


### PR DESCRIPTION
This PR fixes the AST pretty print, which was missing the unsafety for unsafe attributes.

Related to https://github.com/rust-lang/rust/pull/131558#discussion_r1807736204