### PR TITLE
Fix code HTML items making big blocks if too long

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -959,7 +959,7 @@ pre, .rustdoc.src .example-wrap, .example-wrap .src-line-numbers {
 	background: var(--table-alt-row-background-color);
 }
 
-.docblock .stab, .docblock-short .stab {
+.docblock .stab, .docblock-short .stab, .docblock p code {
 	display: inline-block;
 }
 

--- a/tests/rustdoc-gui/check-stab-in-docblock.goml
+++ b/tests/rustdoc-gui/check-stab-in-docblock.goml
@@ -1,5 +1,5 @@
 // This test checks that using `.stab` attributes in `.docblock` elements doesn't
-// create scrollable paragraphs.
+// create scrollable paragraphs and is correctly displayed (not making weird blocks).
 go-to: "file://" + |DOC_PATH| + "/test_docs/index.html"
 // Needs the text to be display to check for scrollable content.
 show-text: true
@@ -30,4 +30,16 @@ store-property: (".top-doc .docblock p:nth-of-type(3)", {
 assert-property: (
     ".top-doc .docblock p:nth-of-type(3)",
     {"scrollHeight": |clientHeight|, "scrollWidth": |clientWidth|},
+)
+
+// Ensure that `<code>` elements in code don't make big blocks.
+compare-elements-size-near: (
+    "#reexport\.TheStdReexport > code",
+    ".docblock p span[data-span='1']",
+    {"height": 1},
+)
+compare-elements-size-near: (
+    "#reexport\.TheStdReexport > code",
+    ".docblock p span[data-span='2']",
+    {"height": 1},
 )

--- a/tests/rustdoc-gui/docblock-big-code-mobile.goml
+++ b/tests/rustdoc-gui/docblock-big-code-mobile.goml
@@ -1,13 +1,15 @@
 // If we have a long `<code>`, we need to ensure that it'll be fully displayed on mobile, meaning
 // that it'll be on two lines.
+
 emulate: "iPhone 8" // it has the following size: (375, 667)
 go-to: "file://" + |DOC_PATH| + "/test_docs/long_code_block/index.html"
-// We now check that the block is on two lines:
 show-text: true // We need to enable text draw to be able to have the "real" size
+
+// We now check that the block is on two lines:
 // Little explanations for this test: if the text wasn't displayed on two lines, it would take
-// around 20px (which is the font size).
-assert-property: (".docblock p > code", {"offsetHeight": "44"})
+// around 24px (which is the font size).
+assert-size: (".docblock p > code", {"height": 48})
 
 // Same check, but where the long code block is also a link
 go-to: "file://" + |DOC_PATH| + "/test_docs/long_code_block_link/index.html"
-assert-property: (".docblock p > a > code", {"offsetHeight": "44"})
+assert-size: (".docblock p > a > code", {"height": 48})


### PR DESCRIPTION
Encountered this bug randomly where `code` item in docblocks would look like this:

![Screenshot from 2024-10-26 15-44-46](https://github.com/user-attachments/assets/a9c1df9d-5007-49eb-a7dd-a2c381b2511e)

With this fix it looks like this:

![image](https://github.com/user-attachments/assets/ea918595-5434-4781-b68c-6abd38689365)

r? @notriddle 