### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_lint/src/internal.rs
+++ b/compiler/rustc_lint/src/internal.rs
@@ -427,7 +427,7 @@ declare_tool_lint! {
     /// More details on translatable diagnostics can be found
     /// [here](https://rustc-dev-guide.rust-lang.org/diagnostics/translation.html).
     pub rustc::UNTRANSLATABLE_DIAGNOSTIC,
-    Deny,
+    Allow,
     "prevent creation of diagnostics which cannot be translated",
     report_in_external_macro: true
 }
@@ -440,7 +440,7 @@ declare_tool_lint! {
     /// More details on diagnostics implementations can be found
     /// [here](https://rustc-dev-guide.rust-lang.org/diagnostics/diagnostic-structs.html).
     pub rustc::DIAGNOSTIC_OUTSIDE_OF_IMPL,
-    Deny,
+    Allow,
     "prevent diagnostic creation outside of `Diagnostic`/`Subdiagnostic`/`LintDiagnostic` impls",
     report_in_external_macro: true
 }

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -634,6 +634,26 @@ impl<T> From<T> for OnceLock<T> {
 
 #[stable(feature = "once_cell", since = "1.70.0")]
 impl<T: PartialEq> PartialEq for OnceLock<T> {
+    /// Equality for two `OnceLock`s.
+    ///
+    /// Two `OnceLock`s are equal if they either both contain values and their
+    /// values are equal, or if neither contains a value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::OnceLock;
+    ///
+    /// let five = OnceLock::new();
+    /// five.set(5).unwrap();
+    ///
+    /// let also_five = OnceLock::new();
+    /// also_five.set(5).unwrap();
+    ///
+    /// assert!(five == also_five);
+    ///
+    /// assert!(OnceLock::<u32>::new() == OnceLock::<u32>::new());
+    /// ```
     #[inline]
     fn eq(&self, other: &OnceLock<T>) -> bool {
         self.get() == other.get()

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -135,6 +135,43 @@ In case it's useful, here are some [instructions] for tackling these sorts of is
 """
 label = "O-rfl"
 
+[ping.wasm]
+alias = ["webassembly"]
+message = """\
+Hey WASM notification group! This issue or PR could use some WebAssembly-specific
+guidance. Could one of you weigh in? Thanks <3
+
+(In case it's useful, here are some [instructions] for tackling these sorts of
+issues).
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/wasm.html
+"""
+label = "O-wasm"
+
+[ping.wasi]
+message = """\
+Hey WASI notification group! This issue or PR could use some WASI-specific guidance.
+Could one of you weigh in? Thanks <3
+
+(In case it's useful, here are some [instructions] for tackling these sorts of
+issues).
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/wasi.html
+"""
+label = "O-wasi"
+
+[ping.emscripten]
+message = """\
+Hey Emscripten notification group! This issue or PR could use some Emscripten-specific
+guidance. Could one of you weigh in? Thanks <3
+
+(In case it's useful, here are some [instructions] for tackling these sorts of
+issues).
+
+[instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/emscripten.html
+"""
+label = "O-emscripten"
+
 [prioritize]
 label = "I-prioritize"
 


### PR DESCRIPTION
Successful merges:

 - #131875 (Add WASM | WASI | Emscripten groups to triagebot.toml)
 - #132019 (Document `PartialEq` impl for `OnceLock`)
 - #132182 (Downgrade `untranslatable_diagnostic` and `diagnostic_outside_of_impl` to `allow`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131875,132019,132182)
<!-- homu-ignore:end -->