### PR TITLE
Collect item bounds for RPITITs from trait where clauses just like associated types

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
+++ b/compiler/rustc_hir_analysis/src/collect/item_bounds.rs
@@ -367,20 +367,8 @@ pub(super) fn explicit_item_bounds_with_filter(
         // a projection self type.
         Some(ty::ImplTraitInTraitData::Trait { opaque_def_id, .. }) => {
             let opaque_ty = tcx.hir_node_by_def_id(opaque_def_id.expect_local()).expect_opaque_ty();
-            let item_ty = Ty::new_projection_from_args(
-                tcx,
-                def_id.to_def_id(),
-                ty::GenericArgs::identity_for_item(tcx, def_id),
-            );
-            let bounds = opaque_type_bounds(
-                tcx,
-                opaque_def_id.expect_local(),
-                opaque_ty.bounds,
-                item_ty,
-                opaque_ty.span,
-                filter,
-            );
-            assert_only_contains_predicates_from(filter, bounds, item_ty);
+            let bounds =
+                associated_type_bounds(tcx, def_id, opaque_ty.bounds, opaque_ty.span, filter);
             return ty::EarlyBinder::bind(bounds);
         }
         Some(ty::ImplTraitInTraitData::Impl { .. }) => span_bug!(

--- a/tests/ui/associated-type-bounds/implied-from-self-where-clause.rs
+++ b/tests/ui/associated-type-bounds/implied-from-self-where-clause.rs
@@ -1,0 +1,21 @@
+// Make sure that, like associated type where clauses on traits, we gather item
+// bounds for RPITITs from RTN where clauses.
+
+//@ check-pass
+
+#![feature(return_type_notation)]
+
+trait Foo
+where
+    Self::method(..): Send,
+{
+    fn method() -> impl Sized;
+}
+
+fn is_send(_: impl Send) {}
+
+fn test<T: Foo>() {
+    is_send(T::method());
+}
+
+fn main() {}


### PR DESCRIPTION
We collect item bounds from trait where clauses for *associated types*, i.e. this:

```rust
trait Foo
where
    Self::Assoc: Send
{
    type Assoc;
}
```

Becomes this:

```rust
trait Foo {
    type Assoc: Send;
}
```

Today, with RPITITs/AFIT and return-type notation, we don't do that, i.e.:

```rust
trait Foo where Self::method(..): Send {
    fn method() -> impl Sized;
}

fn is_send(_: impl Send) {}
fn test<T: Foo>() {
    is_send(T::method());
}
```

...which fails on nightly today.

 Turns out it's super easy to fix this, and we just need to use the `associated_type_bounds` lowering function in `explicit_item_bounds_with_filter`, which has that logic baked in.