### PR TITLE
Fix validation when lowering `?` trait bounds

### DIFF
--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -168,12 +168,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             match hir_bound {
                 hir::GenericBound::Trait(poly_trait_ref) => {
                     let hir::TraitBoundModifiers { constness, polarity } = poly_trait_ref.modifiers;
-                    let polarity = match polarity {
-                        rustc_ast::BoundPolarity::Positive => ty::PredicatePolarity::Positive,
-                        rustc_ast::BoundPolarity::Negative(_) => ty::PredicatePolarity::Negative,
-                        rustc_ast::BoundPolarity::Maybe(_) => continue,
-                    };
-
                     let _ = self.lower_poly_trait_ref(
                         &poly_trait_ref.trait_ref,
                         poly_trait_ref.span,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
@@ -51,7 +51,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 &trait_bound.trait_ref,
                 trait_bound.span,
                 hir::BoundConstness::Never,
-                ty::PredicatePolarity::Positive,
+                hir::BoundPolarity::Positive,
                 dummy_self,
                 &mut bounds,
                 PredicateFilter::SelfOnly,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -659,7 +659,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
         trait_ref: &hir::TraitRef<'tcx>,
         span: Span,
         constness: hir::BoundConstness,
-        polarity: ty::PredicatePolarity,
+        polarity: hir::BoundPolarity,
         self_ty: Ty<'tcx>,
         bounds: &mut Bounds<'tcx>,
         predicate_filter: PredicateFilter,
@@ -680,6 +680,15 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             trait_segment,
             Some(self_ty),
         );
+
+        let polarity = match polarity {
+            rustc_ast::BoundPolarity::Positive => ty::PredicatePolarity::Positive,
+            rustc_ast::BoundPolarity::Negative(_) => ty::PredicatePolarity::Negative,
+            rustc_ast::BoundPolarity::Maybe(_) => {
+                // No-op.
+                return arg_count;
+            }
+        };
 
         if let hir::BoundConstness::Always(span) | hir::BoundConstness::Maybe(span) = constness
             && !self.tcx().is_const_trait(trait_def_id)

--- a/tests/ui/impl-trait/precise-capturing/bound-modifiers.rs
+++ b/tests/ui/impl-trait/precise-capturing/bound-modifiers.rs
@@ -3,8 +3,6 @@
 fn polarity() -> impl Sized + ?use<> {}
 //~^ ERROR expected identifier, found keyword `use`
 //~| ERROR cannot find trait `r#use` in this scope
-//~| WARN relaxing a default bound only does something for `?Sized`
-//~| WARN relaxing a default bound only does something for `?Sized`
 
 fn asyncness() -> impl Sized + async use<> {}
 //~^ ERROR expected identifier, found keyword `use`

--- a/tests/ui/impl-trait/precise-capturing/bound-modifiers.stderr
+++ b/tests/ui/impl-trait/precise-capturing/bound-modifiers.stderr
@@ -5,19 +5,19 @@ LL | fn polarity() -> impl Sized + ?use<> {}
    |                                ^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `use`
-  --> $DIR/bound-modifiers.rs:9:38
+  --> $DIR/bound-modifiers.rs:7:38
    |
 LL | fn asyncness() -> impl Sized + async use<> {}
    |                                      ^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `use`
-  --> $DIR/bound-modifiers.rs:14:38
+  --> $DIR/bound-modifiers.rs:12:38
    |
 LL | fn constness() -> impl Sized + const use<> {}
    |                                      ^^^ expected identifier, found keyword
 
 error: expected identifier, found keyword `use`
-  --> $DIR/bound-modifiers.rs:19:37
+  --> $DIR/bound-modifiers.rs:17:37
    |
 LL | fn binder() -> impl Sized + for<'a> use<> {}
    |                                     ^^^ expected identifier, found keyword
@@ -29,25 +29,25 @@ LL | fn polarity() -> impl Sized + ?use<> {}
    |                                ^^^ not found in this scope
 
 error[E0405]: cannot find trait `r#use` in this scope
-  --> $DIR/bound-modifiers.rs:9:38
+  --> $DIR/bound-modifiers.rs:7:38
    |
 LL | fn asyncness() -> impl Sized + async use<> {}
    |                                      ^^^ not found in this scope
 
 error[E0405]: cannot find trait `r#use` in this scope
-  --> $DIR/bound-modifiers.rs:14:38
+  --> $DIR/bound-modifiers.rs:12:38
    |
 LL | fn constness() -> impl Sized + const use<> {}
    |                                      ^^^ not found in this scope
 
 error[E0405]: cannot find trait `r#use` in this scope
-  --> $DIR/bound-modifiers.rs:19:37
+  --> $DIR/bound-modifiers.rs:17:37
    |
 LL | fn binder() -> impl Sized + for<'a> use<> {}
    |                                     ^^^ not found in this scope
 
 error[E0658]: async closures are unstable
-  --> $DIR/bound-modifiers.rs:9:32
+  --> $DIR/bound-modifiers.rs:7:32
    |
 LL | fn asyncness() -> impl Sized + async use<> {}
    |                                ^^^^^
@@ -58,7 +58,7 @@ LL | fn asyncness() -> impl Sized + async use<> {}
    = help: to use an async block, remove the `||`: `async {`
 
 error[E0658]: const trait impls are experimental
-  --> $DIR/bound-modifiers.rs:14:32
+  --> $DIR/bound-modifiers.rs:12:32
    |
 LL | fn constness() -> impl Sized + const use<> {}
    |                                ^^^^^
@@ -67,21 +67,7 @@ LL | fn constness() -> impl Sized + const use<> {}
    = help: add `#![feature(const_trait_impl)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
-  --> $DIR/bound-modifiers.rs:3:31
-   |
-LL | fn polarity() -> impl Sized + ?use<> {}
-   |                               ^^^^^^
-
-warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
-  --> $DIR/bound-modifiers.rs:3:31
-   |
-LL | fn polarity() -> impl Sized + ?use<> {}
-   |                               ^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: aborting due to 10 previous errors; 2 warnings emitted
+error: aborting due to 10 previous errors
 
 Some errors have detailed explanations: E0405, E0658.
 For more information about an error, try `rustc --explain E0405`.

--- a/tests/ui/issues/issue-37534.rs
+++ b/tests/ui/issues/issue-37534.rs
@@ -1,6 +1,5 @@
 struct Foo<T: ?Hash> {}
 //~^ ERROR expected trait, found derive macro `Hash`
-//~^^ ERROR parameter `T` is never used
-//~^^^ WARN relaxing a default bound only does something for `?Sized`
+//~| WARN relaxing a default bound only does something for `?Sized`
 
 fn main() {}

--- a/tests/ui/issues/issue-37534.stderr
+++ b/tests/ui/issues/issue-37534.stderr
@@ -15,15 +15,6 @@ warning: relaxing a default bound only does something for `?Sized`; all other tr
 LL | struct Foo<T: ?Hash> {}
    |               ^^^^^
 
-error[E0392]: type parameter `T` is never used
-  --> $DIR/issue-37534.rs:1:12
-   |
-LL | struct Foo<T: ?Hash> {}
-   |            ^ unused type parameter
-   |
-   = help: consider removing `T`, referring to it in a field, or using a marker such as `PhantomData`
+error: aborting due to 1 previous error; 1 warning emitted
 
-error: aborting due to 2 previous errors; 1 warning emitted
-
-Some errors have detailed explanations: E0392, E0404.
-For more information about an error, try `rustc --explain E0392`.
+For more information about this error, try `rustc --explain E0404`.

--- a/tests/ui/trait-bounds/maybe-bound-generics-deny.rs
+++ b/tests/ui/trait-bounds/maybe-bound-generics-deny.rs
@@ -1,0 +1,4 @@
+fn uwu<T: ?Sized<i32>>() {}
+//~^ ERROR trait takes 0 generic arguments but 1 generic argument was supplied
+
+fn main() {}

--- a/tests/ui/trait-bounds/maybe-bound-generics-deny.stderr
+++ b/tests/ui/trait-bounds/maybe-bound-generics-deny.stderr
@@ -1,0 +1,11 @@
+error[E0107]: trait takes 0 generic arguments but 1 generic argument was supplied
+  --> $DIR/maybe-bound-generics-deny.rs:1:12
+   |
+LL | fn uwu<T: ?Sized<i32>>() {}
+   |            ^^^^^----- help: remove the unnecessary generics
+   |            |
+   |            expected 0 generic arguments
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0107`.

--- a/tests/ui/trait-bounds/maybe-bound-has-path-args.rs
+++ b/tests/ui/trait-bounds/maybe-bound-has-path-args.rs
@@ -1,0 +1,7 @@
+trait Trait {}
+
+fn test<T: ?self::<i32>::Trait>() {}
+//~^ ERROR type arguments are not allowed on this type
+//~| WARN relaxing a default bound only does something for `?Sized`
+
+fn main() {}

--- a/tests/ui/trait-bounds/maybe-bound-has-path-args.stderr
+++ b/tests/ui/trait-bounds/maybe-bound-has-path-args.stderr
@@ -1,0 +1,17 @@
+warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
+  --> $DIR/maybe-bound-has-path-args.rs:3:12
+   |
+LL | fn test<T: ?self::<i32>::Trait>() {}
+   |            ^^^^^^^^^^^^^^^^^^^
+
+error[E0109]: type arguments are not allowed on this type
+  --> $DIR/maybe-bound-has-path-args.rs:3:20
+   |
+LL | fn test<T: ?self::<i32>::Trait>() {}
+   |             ----   ^^^ type argument not allowed
+   |             |
+   |             not allowed on this type
+
+error: aborting due to 1 previous error; 1 warning emitted
+
+For more information about this error, try `rustc --explain E0109`.

--- a/tests/ui/trait-bounds/maybe-bound-with-assoc.rs
+++ b/tests/ui/trait-bounds/maybe-bound-with-assoc.rs
@@ -1,0 +1,12 @@
+trait HasAssoc {
+    type Assoc;
+}
+fn hasassoc<T: ?HasAssoc<Assoc = ()>>() {}
+//~^ WARN relaxing a default bound
+
+trait NoAssoc {}
+fn noassoc<T: ?NoAssoc<Missing = ()>>() {}
+//~^ WARN relaxing a default bound
+//~| ERROR associated type `Missing` not found for `NoAssoc`
+
+fn main() {}

--- a/tests/ui/trait-bounds/maybe-bound-with-assoc.stderr
+++ b/tests/ui/trait-bounds/maybe-bound-with-assoc.stderr
@@ -1,0 +1,21 @@
+warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
+  --> $DIR/maybe-bound-with-assoc.rs:4:16
+   |
+LL | fn hasassoc<T: ?HasAssoc<Assoc = ()>>() {}
+   |                ^^^^^^^^^^^^^^^^^^^^^
+
+warning: relaxing a default bound only does something for `?Sized`; all other traits are not bound by default
+  --> $DIR/maybe-bound-with-assoc.rs:8:15
+   |
+LL | fn noassoc<T: ?NoAssoc<Missing = ()>>() {}
+   |               ^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0220]: associated type `Missing` not found for `NoAssoc`
+  --> $DIR/maybe-bound-with-assoc.rs:8:24
+   |
+LL | fn noassoc<T: ?NoAssoc<Missing = ()>>() {}
+   |                        ^^^^^^^ associated type `Missing` not found
+
+error: aborting due to 1 previous error; 2 warnings emitted
+
+For more information about this error, try `rustc --explain E0220`.


### PR DESCRIPTION
Pass the unlowered (`rustc_hir`) polarity to `lower_poly_trait_ref`. 

This allows us to actually *validate* that generic args are actually valid on `?Trait` paths. This actually regressed in #113671 because that PR changed the behavior where we were inadvertently re-lowering paths as `BoundPolarity::Positive`, which was also coincidentally the only place we were enforcing the generics on `?Trait` paths were correct.
