### PR TITLE
rustdoc: make doctest span tweak a 2024 edition change

### DIFF
--- a/tests/rustdoc-ui/doctest/auxiliary/extern_macros_2024.rs
+++ b/tests/rustdoc-ui/doctest/auxiliary/extern_macros_2024.rs
@@ -1,0 +1,10 @@
+//@ edition:2024
+//@ compile-flags:-Z unstable-options
+#![crate_name="extern_macros"]
+#[macro_export]
+macro_rules! attrs_on_struct {
+    ( $( #[$attr:meta] )* ) => {
+        $( #[$attr] )*
+        pub struct ExpandedStruct;
+    }
+}

--- a/tests/rustdoc-ui/doctest/auxiliary/relative-dir.md
+++ b/tests/rustdoc-ui/doctest/auxiliary/relative-dir.md
@@ -1,0 +1,3 @@
+```rust
+let x = include_bytes!("relative-dir-empty-file");
+```

--- a/tests/rustdoc-ui/doctest/doctest-output-include-fail.rs
+++ b/tests/rustdoc-ui/doctest/doctest-output-include-fail.rs
@@ -1,4 +1,5 @@
-//@ compile-flags:--test --test-args=--test-threads=1
+//@ edition:2024
+//@ compile-flags:--test --test-args=--test-threads=1 -Z unstable-options
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101

--- a/tests/rustdoc-ui/doctest/doctest-output.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-output.edition2015.stdout
@@ -1,0 +1,8 @@
+
+running 3 tests
+test $DIR/doctest-output.rs - (line 12) ... ok
+test $DIR/doctest-output.rs - ExpandedStruct (line 28) ... ok
+test $DIR/doctest-output.rs - foo::bar (line 22) ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/doctest/doctest-output.edition2024.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-output.edition2024.stdout
@@ -1,0 +1,8 @@
+
+running 3 tests
+test $DIR/doctest-output.rs - (line 12) ... ok
+test $DIR/doctest-output.rs - ExpandedStruct (line 28) ... ok
+test $DIR/doctest-output.rs - foo::bar (line 22) ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/doctest/doctest-output.rs
+++ b/tests/rustdoc-ui/doctest/doctest-output.rs
@@ -1,6 +1,10 @@
-//@ edition:2018
-//@ aux-build:extern_macros.rs
-//@ compile-flags:--test --test-args=--test-threads=1
+//@ revisions: edition2015 edition2024
+//@[edition2015]edition:2015
+//@[edition2015]aux-build:extern_macros.rs
+//@[edition2015]compile-flags:--test --test-args=--test-threads=1
+//@[edition2024]edition:2015
+//@[edition2024]aux-build:extern_macros.rs
+//@[edition2024]compile-flags:--test --test-args=--test-threads=1 -Z unstable-options
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ check-pass

--- a/tests/rustdoc-ui/doctest/doctest-output.stdout
+++ b/tests/rustdoc-ui/doctest/doctest-output.stdout
@@ -1,8 +1,0 @@
-
-running 3 tests
-test $DIR/doctest-output.rs - (line 8) ... ok
-test $DIR/doctest-output.rs - ExpandedStruct (line 25) ... ok
-test $DIR/doctest-output.rs - foo::bar (line 18) ... ok
-
-test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
-

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
@@ -1,12 +1,12 @@
 
 running 1 test
-test $DIR/relative-path-include-bytes-132203.rs - (line 17) ... FAILED
+test $DIR/relative-path-include-bytes-132203.rs - (line 18) ... FAILED
 
 failures:
 
----- $DIR/relative-path-include-bytes-132203.rs - (line 17) stdout ----
+---- $DIR/relative-path-include-bytes-132203.rs - (line 18) stdout ----
 error: couldn't read `$DIR/relative-dir-empty-file`: No such file or directory (os error 2)
-  --> $DIR/relative-path-include-bytes-132203.rs:18:9
+  --> $DIR/relative-path-include-bytes-132203.rs:19:9
    |
 LL | let x = include_bytes!("relative-dir-empty-file");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -18,7 +18,7 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/relative-path-include-bytes-132203.rs - (line 17)
+    $DIR/relative-path-include-bytes-132203.rs - (line 18)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2015.stdout
@@ -1,0 +1,24 @@
+
+running 1 test
+test $DIR/relative-path-include-bytes-132203.rs - (line 17) ... FAILED
+
+failures:
+
+---- $DIR/relative-path-include-bytes-132203.rs - (line 17) stdout ----
+error: couldn't read `$DIR/relative-dir-empty-file`: No such file or directory (os error 2)
+  --> $DIR/relative-path-include-bytes-132203.rs:18:9
+   |
+LL | let x = include_bytes!("relative-dir-empty-file");
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+
+failures:
+    $DIR/relative-path-include-bytes-132203.rs - (line 17)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2024.stdout
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.edition2024.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test $DIR/auxiliary/relative-dir.md - (line 1) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
@@ -1,3 +1,4 @@
+//@ ignore-windows
 //@ revisions: edition2015 edition2024
 //@[edition2015]edition:2015
 //@[edition2015]check-fail

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
@@ -1,0 +1,17 @@
+//@ revisions: edition2015 edition2024
+//@[edition2015]edition:2015
+//@[edition2015]check-fail
+//@[edition2015]failure-status: 101
+//@[edition2015]compile-flags:--test --test-args=--test-threads=1
+//@[edition2024]edition:2024
+//@[edition2024]check-pass
+//@[edition2024]compile-flags:--test --test-args=--test-threads=1 -Z unstable-options
+//@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
+
+// https://github.com/rust-lang/rust/issues/132203
+// This version, because it's edition2024, passes thanks to the new
+// relative path. The edition2015 version fails, because paths are
+// resolved relative to the rs file instead of relative to the md file.
+
+#![doc=include_str!("auxiliary/relative-dir.md")]


### PR DESCRIPTION
Fixes #132203

This is a compatibility hack, because I think the new behavior is better. When an A `include_str!` B, and B `include_str!` C, the path to C should be resolved relative to B, not A. That's how `include!` itself works, so that's how `include_str!` with should work.
