### PR TITLE
simplify force-recompile logic for "library"

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -135,7 +135,7 @@ impl Step for Std {
                 !t!(helpers::git(Some(&builder.src))
                     .args(["diff-index", "--quiet", &closest_merge_commit])
                     .arg("--")
-                    .arg(builder.src.join("library"))
+                    .arg("library")
                     .as_command_mut()
                     .status())
                 .success()

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -15,7 +15,6 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::{env, fs, str};
 
-use build_helper::git::get_closest_merge_commit;
 use serde_derive::Deserialize;
 
 use crate::core::build_steps::tool::SourceType;
@@ -27,7 +26,7 @@ use crate::core::builder::{
 use crate::core::config::{DebuginfoLevel, LlvmLibunwind, RustcLto, TargetSelection};
 use crate::utils::exec::command;
 use crate::utils::helpers::{
-    self, exe, get_clang_cl_resource_dir, is_debug_info, is_dylib, symlink_dir, t, up_to_date,
+    exe, get_clang_cl_resource_dir, is_debug_info, is_dylib, symlink_dir, t, up_to_date,
 };
 use crate::{CLang, Compiler, DependencyType, GitRepo, LLVM_TOOLS, Mode};
 
@@ -125,23 +124,9 @@ impl Step for Std {
         // Force compilation of the standard library from source if the `library` is modified. This allows
         // library team to compile the standard library without needing to compile the compiler with
         // the `rust.download-rustc=true` option.
-        let force_recompile =
-            if builder.rust_info().is_managed_git_subrepository() && builder.download_rustc() {
-                let closest_merge_commit =
-                    get_closest_merge_commit(Some(&builder.src), &builder.config.git_config(), &[])
-                        .unwrap();
-
-                // Check if `library` has changes (returns false otherwise)
-                !t!(helpers::git(Some(&builder.src))
-                    .args(["diff-index", "--quiet", &closest_merge_commit])
-                    .arg("--")
-                    .arg("library")
-                    .as_command_mut()
-                    .status())
-                .success()
-            } else {
-                false
-            };
+        let force_recompile = builder.rust_info().is_managed_git_subrepository()
+            && builder.download_rustc()
+            && builder.config.last_modified_commit(&["library"], "download-rustc", true).is_none();
 
         run.builder.ensure(Std {
             compiler: run.builder.compiler(run.builder.top_stage, run.build_triple()),

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2871,14 +2871,7 @@ impl Config {
 
         // Warn if there were changes to the compiler or standard library since the ancestor commit.
         let mut git = helpers::git(Some(&self.src));
-        git.args(["diff-index", "--quiet", &commit, "--"]);
-
-        // Handle running from a directory other than the top level
-        let top_level = &self.src;
-
-        for path in modified_paths {
-            git.arg(top_level.join(path));
-        }
+        git.args(["diff-index", "--quiet", &commit, "--"]).args(modified_paths);
 
         let has_changes = !t!(git.as_command_mut().status()).success();
         if has_changes {

--- a/src/bootstrap/src/lib.rs
+++ b/src/bootstrap/src/lib.rs
@@ -541,7 +541,7 @@ impl Build {
         }
         let output = helpers::git(Some(&self.src))
             .args(["config", "--file"])
-            .arg(self.config.src.join(".gitmodules"))
+            .arg(".gitmodules")
             .args(["--get-regexp", "path"])
             .run_capture(self)
             .stdout();


### PR DESCRIPTION
It’s kind of self-explanatory when looking at it commit by commit.