### PR TITLE
Early exit from MIR cost computation if we reach the threshold.

### DIFF
--- a/compiler/rustc_mir_transform/src/inline.rs
+++ b/compiler/rustc_mir_transform/src/inline.rs
@@ -526,6 +526,15 @@ impl<'tcx> Inliner<'tcx> {
                 continue;
             }
 
+            let cost = checker.cost();
+            if cost > threshold {
+                debug!(
+                    "NOT inlining {:?} [cost lower bound={} > threshold={}], early exit",
+                    callsite, cost, threshold
+                );
+                return Err("cost above threshold");
+            }
+
             let blk = &callee_body.basic_blocks[bb];
             checker.visit_basic_block_data(bb, blk);
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

r? saethlin
