### PR TITLE
Use Hacker's Delight impl in `i64::midpoint` instead of wide `i128` impl

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -429,7 +429,7 @@ impl i64 {
         from_xe_bytes_doc = "",
         bound_condition = "",
     }
-    midpoint_impl! { i64, i128, signed }
+    midpoint_impl! { i64, signed }
 }
 
 impl i128 {
@@ -530,7 +530,7 @@ impl isize {
         from_xe_bytes_doc = usize_isize_from_xe_bytes_doc!(),
         bound_condition = " on 64-bit targets",
     }
-    midpoint_impl! { isize, i128, signed }
+    midpoint_impl! { isize, signed }
 }
 
 /// If the 6th bit is set ascii is lower case.


### PR DESCRIPTION
This PR switches `i64::midpoint` and (`isize::midpoint` where `isize == i64`) to using our Hacker's Delight impl instead of wide `i128` implementation.

As LLVM seems to be outperformed by the complexity of signed 128-bits number compared to our Hacker's Delight implementation.[^1]

It doesn't seems like it's an improvement for the other sizes[^2], so we let them with the wide implementation.

[^1]: https://rust.godbolt.org/z/ravE75EYj
[^2]: https://rust.godbolt.org/z/fzr171zKh

r? libs
