### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -611,7 +611,7 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
         Err(terr) => {
             let mut diag = struct_span_code_err!(
                 tcx.dcx(),
-                cause.span(),
+                cause.span,
                 E0053,
                 "method `{}` has an incompatible return type for trait",
                 trait_m.name
@@ -1169,7 +1169,7 @@ fn extract_spans_for_error_reporting<'tcx>(
         TypeError::ArgumentMutability(i) | TypeError::ArgumentSorts(ExpectedFound { .. }, i) => {
             (impl_args.nth(i).unwrap(), trait_args.and_then(|mut args| args.nth(i)))
         }
-        _ => (cause.span(), tcx.hir().span_if_local(trait_m.def_id)),
+        _ => (cause.span, tcx.hir().span_if_local(trait_m.def_id)),
     }
 }
 

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -612,7 +612,7 @@ pub fn check_function_signature<'tcx>(
         match err {
             TypeError::ArgumentMutability(i)
             | TypeError::ArgumentSorts(ExpectedFound { .. }, i) => args.nth(i).unwrap(),
-            _ => cause.span(),
+            _ => cause.span,
         }
     }
 

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -168,13 +168,6 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             match hir_bound {
                 hir::GenericBound::Trait(poly_trait_ref) => {
                     let hir::TraitBoundModifiers { constness, polarity } = poly_trait_ref.modifiers;
-                    // FIXME: We could pass these directly into `lower_poly_trait_ref`
-                    // so that we could use these spans in diagnostics within that function...
-                    let constness = match constness {
-                        hir::BoundConstness::Never => None,
-                        hir::BoundConstness::Always(_) => Some(ty::BoundConstness::Const),
-                        hir::BoundConstness::Maybe(_) => Some(ty::BoundConstness::ConstIfConst),
-                    };
                     let polarity = match polarity {
                         rustc_ast::BoundPolarity::Positive => ty::PredicatePolarity::Positive,
                         rustc_ast::BoundPolarity::Negative(_) => ty::PredicatePolarity::Negative,

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/dyn_compatibility.rs
@@ -50,7 +50,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             } = self.lower_poly_trait_ref(
                 &trait_bound.trait_ref,
                 trait_bound.span,
-                None,
+                hir::BoundConstness::Never,
                 ty::PredicatePolarity::Positive,
                 dummy_self,
                 &mut bounds,

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -2027,7 +2027,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                                     }
                                     Err(_) => {
                                         span_bug!(
-                                            cause.span(),
+                                            cause.span,
                                             "subtyping remaining fields of type changing FRU failed: {target_ty} != {fru_ty}: {}::{}",
                                             variant.name,
                                             ident.name,

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -550,7 +550,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
                     // This has/will have errored in wfcheck, which we cannot depend on from here, as typeck on functions
                     // may run before wfcheck if the function is used in const eval.
                     self.dcx().span_delayed_bug(
-                        cause.span(),
+                        cause.span,
                         format!("{self_ty} was a subtype of {method_self_ty} but now is not?"),
                     );
                 }

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -519,6 +519,8 @@ pub struct MatchExpressionArmCause<'tcx> {
     pub prior_arm_span: Span,
     pub scrut_span: Span,
     pub source: hir::MatchSource,
+    // Span of the *whole* match expr
+    pub expr_span: Span,
     pub prior_non_diverging_arms: Vec<Span>,
     // Is the expectation of this match expression an RPIT?
     pub tail_defines_return_position_impl_trait: Option<LocalDefId>,

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -92,16 +92,6 @@ impl<'tcx> ObligationCause<'tcx> {
         ObligationCause { span, body_id: CRATE_DEF_ID, code: Default::default() }
     }
 
-    pub fn span(&self) -> Span {
-        match *self.code() {
-            ObligationCauseCode::MatchExpressionArm(box MatchExpressionArmCause {
-                arm_span,
-                ..
-            }) => arm_span,
-            _ => self.span,
-        }
-    }
-
     #[inline]
     pub fn code(&self) -> &ObligationCauseCode<'tcx> {
         &self.code
@@ -517,12 +507,17 @@ pub struct MatchExpressionArmCause<'tcx> {
     pub prior_arm_block_id: Option<HirId>,
     pub prior_arm_ty: Ty<'tcx>,
     pub prior_arm_span: Span,
+    /// Span of the scrutinee of the match (the matched value).
     pub scrut_span: Span,
+    /// Source of the match, i.e. `match` or a desugaring.
     pub source: hir::MatchSource,
-    // Span of the *whole* match expr
+    /// Span of the *whole* match expr.
     pub expr_span: Span,
+    /// Spans of the previous arms except for those that diverge (i.e. evaluate to `!`).
+    ///
+    /// These are used for pointing out errors that may affect several arms.
     pub prior_non_diverging_arms: Vec<Span>,
-    // Is the expectation of this match expression an RPIT?
+    /// Is the expectation of this match expression an RPIT?
     pub tail_defines_return_position_impl_trait: Option<LocalDefId>,
 }
 

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -622,6 +622,10 @@ passes_remove_fields =
 passes_repr_align_function =
     `repr(align)` attributes on functions are unstable
 
+passes_repr_align_greater_than_target_max =
+    alignment must not be greater than `isize::MAX` bytes
+    .note = `isize::MAX` is {$size} for the current target
+
 passes_repr_conflicting =
     conflicting representation hints
 

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -567,6 +567,15 @@ pub(crate) struct ReprConflicting {
     pub hint_spans: Vec<Span>,
 }
 
+#[derive(Diagnostic)]
+#[diag(passes_repr_align_greater_than_target_max, code = E0589)]
+#[note]
+pub(crate) struct InvalidReprAlignForTarget {
+    #[primary_span]
+    pub span: Span,
+    pub size: u64,
+}
+
 #[derive(LintDiagnostic)]
 #[diag(passes_repr_conflicting, code = E0566)]
 pub(crate) struct ReprConflictingLint;

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -392,7 +392,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         Some(ty) if expected == ty => {
                             let source_map = self.tcx.sess.source_map();
                             err.span_suggestion(
-                                source_map.end_point(cause.span()),
+                                source_map.end_point(cause.span),
                                 "try removing this `?`",
                                 "",
                                 Applicability::MachineApplicable,
@@ -431,7 +431,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             Some(ty) if expected == ty => {
                                 let source_map = self.tcx.sess.source_map();
                                 err.span_suggestion(
-                                    source_map.end_point(cause.span()),
+                                    source_map.end_point(cause.span),
                                     "try removing this `?`",
                                     "",
                                     Applicability::MachineApplicable,
@@ -1149,7 +1149,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         terr: TypeError<'tcx>,
         prefer_label: bool,
     ) {
-        let span = cause.span();
+        let span = cause.span;
 
         // For some types of errors, expected-found does not make
         // sense, so just ignore the values we were given.
@@ -1643,7 +1643,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         terr: TypeError<'tcx>,
     ) -> Vec<TypeErrorAdditionalDiags> {
         let mut suggestions = Vec::new();
-        let span = trace.cause.span();
+        let span = trace.cause.span;
         let values = self.resolve_vars_if_possible(trace.values);
         if let Some((expected, found)) = values.ty() {
             match (expected.kind(), found.kind()) {
@@ -1793,7 +1793,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     ) -> Diag<'a> {
         debug!("report_and_explain_type_error(trace={:?}, terr={:?})", trace, terr);
 
-        let span = trace.cause.span();
+        let span = trace.cause.span;
         let failure_code = trace.cause.as_failure_code_diag(
             terr,
             span,

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs
@@ -412,6 +412,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 source,
                 ref prior_non_diverging_arms,
                 scrut_span,
+                expr_span,
                 ..
             }) => match source {
                 hir::MatchSource::TryDesugar(scrut_hir_id) => {
@@ -460,12 +461,12 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             format!("this and all prior arms are found to be of type `{t}`"),
                         );
                     }
-                    let outer = if any_multiline_arm || !source_map.is_multiline(cause.span) {
+                    let outer = if any_multiline_arm || !source_map.is_multiline(expr_span) {
                         // Cover just `match` and the scrutinee expression, not
                         // the entire match body, to reduce diagram noise.
-                        cause.span.shrink_to_lo().to(scrut_span)
+                        expr_span.shrink_to_lo().to(scrut_span)
                     } else {
-                        cause.span
+                        expr_span
                     };
                     let msg = "`match` arms have incompatible types";
                     err.span_label(outer, msg);

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_error.rs
@@ -237,7 +237,7 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
         expected_args: GenericArgsRef<'tcx>,
         actual_args: GenericArgsRef<'tcx>,
     ) -> Diag<'tcx> {
-        let span = cause.span();
+        let span = cause.span;
 
         let (leading_ellipsis, satisfy_span, where_span, dup_span, def_id) =
             if let ObligationCauseCode::WhereClause(def_id, span)

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2169,6 +2169,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         // First, attempt to add note to this error with an async-await-specific
         // message, and fall back to regular note otherwise.
         if !self.maybe_note_obligation_cause_for_async_await(err, obligation) {
+            let mut long_ty_file = None;
             self.note_obligation_cause_code(
                 obligation.cause.body_id,
                 err,
@@ -2177,7 +2178,15 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 obligation.cause.code(),
                 &mut vec![],
                 &mut Default::default(),
+                &mut long_ty_file,
             );
+            if let Some(file) = long_ty_file {
+                err.note(format!(
+                    "the full name for the type has been written to '{}'",
+                    file.display(),
+                ));
+                err.note("consider using `--verbose` to print the full type name to the console");
+            }
             self.suggest_unsized_bound_if_applicable(err, obligation);
             if let Some(span) = err.span.primary_span()
                 && let Some(mut diag) =

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1835,6 +1835,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     if impl_trait_ref.references_error() {
                         return false;
                     }
+                    let self_ty = impl_trait_ref.self_ty().to_string();
                     err.highlighted_help(vec![
                         StringPart::normal(format!(
                             "the trait `{}` ",
@@ -1842,16 +1843,24 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         )),
                         StringPart::highlighted("is"),
                         StringPart::normal(" implemented for `"),
-                        StringPart::highlighted(impl_trait_ref.self_ty().to_string()),
+                        if let [TypeError::Sorts(_)] = &terrs[..] {
+                            StringPart::normal(self_ty)
+                        } else {
+                            StringPart::highlighted(self_ty)
+                        },
                         StringPart::normal("`"),
                     ]);
 
                     if let [TypeError::Sorts(exp_found)] = &terrs[..] {
                         let exp_found = self.resolve_vars_if_possible(*exp_found);
-                        err.help(format!(
-                            "for that trait implementation, expected `{}`, found `{}`",
-                            exp_found.expected, exp_found.found
-                        ));
+                        err.highlighted_help(vec![
+                            StringPart::normal("for that trait implementation, "),
+                            StringPart::normal("expected `"),
+                            StringPart::highlighted(exp_found.expected.to_string()),
+                            StringPart::normal("`, found `"),
+                            StringPart::highlighted(exp_found.found.to_string()),
+                            StringPart::normal("`"),
+                        ]);
                     }
 
                     true

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/mod.rs
@@ -305,6 +305,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 if let ObligationCauseCode::WhereClause(..)
                 | ObligationCauseCode::WhereClauseInExpr(..) = code
                 {
+                    let mut long_ty_file = None;
                     self.note_obligation_cause_code(
                         error.obligation.cause.body_id,
                         &mut diag,
@@ -313,7 +314,17 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         code,
                         &mut vec![],
                         &mut Default::default(),
+                        &mut long_ty_file,
                     );
+                    if let Some(file) = long_ty_file {
+                        diag.note(format!(
+                            "the full name for the type has been written to '{}'",
+                            file.display(),
+                        ));
+                        diag.note(
+                            "consider using `--verbose` to print the full type name to the console",
+                        );
+                    }
                 }
                 diag.emit()
             }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/overflow.rs
@@ -144,6 +144,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             obligation.cause.span,
             suggest_increasing_limit,
             |err| {
+                let mut long_ty_file = None;
                 self.note_obligation_cause_code(
                     obligation.cause.body_id,
                     err,
@@ -152,7 +153,17 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     obligation.cause.code(),
                     &mut vec![],
                     &mut Default::default(),
+                    &mut long_ty_file,
                 );
+                if let Some(file) = long_ty_file {
+                    err.note(format!(
+                        "the full name for the type has been written to '{}'",
+                        file.display(),
+                    ));
+                    err.note(
+                        "consider using `--verbose` to print the full type name to the console",
+                    );
+                }
             },
         );
     }

--- a/compiler/rustc_trait_selection/src/traits/project.rs
+++ b/compiler/rustc_trait_selection/src/traits/project.rs
@@ -1180,7 +1180,7 @@ fn assemble_candidates_from_impls<'cx, 'tcx>(
                                             selcx.tcx(),
                                             selcx.tcx().require_lang_item(
                                                 LangItem::Sized,
-                                                Some(obligation.cause.span()),
+                                                Some(obligation.cause.span),
                                             ),
                                             [self_ty],
                                         ),
@@ -1600,7 +1600,7 @@ fn confirm_builtin_candidate<'cx, 'tcx>(
                 // exist. Instead, `Pointee<Metadata = ()>` should be a supertrait of `Sized`.
                 let sized_predicate = ty::TraitRef::new(
                     tcx,
-                    tcx.require_lang_item(LangItem::Sized, Some(obligation.cause.span())),
+                    tcx.require_lang_item(LangItem::Sized, Some(obligation.cause.span)),
                     [self_ty],
                 );
                 obligations.push(obligation.with(tcx, sized_predicate));

--- a/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
+++ b/compiler/rustc_trait_selection/src/traits/query/evaluate_obligation.rs
@@ -90,7 +90,7 @@ impl<'tcx> InferCtxt<'tcx> {
             assert!(!self.intercrate);
             let c_pred =
                 self.canonicalize_query(param_env.and(obligation.predicate), &mut _orig_values);
-            self.tcx.at(obligation.cause.span()).evaluate_obligation(c_pred)
+            self.tcx.at(obligation.cause.span).evaluate_obligation(c_pred)
         }
     }
 

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -320,8 +320,9 @@ impl char {
     /// '1'.is_digit(37);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_char_is_digit", issue = "132241")]
     #[inline]
-    pub fn is_digit(self, radix: u32) -> bool {
+    pub const fn is_digit(self, radix: u32) -> bool {
         self.to_digit(radix).is_some()
     }
 

--- a/src/tools/compiletest/src/runtest/run_make.rs
+++ b/src/tools/compiletest/src/runtest/run_make.rs
@@ -329,6 +329,7 @@ impl TestCx<'_> {
             .arg(format!("run_make_support={}", &support_lib_path.to_string_lossy()))
             .arg("--edition=2021")
             .arg(&self.testpaths.file.join("rmake.rs"))
+            .arg("-Cprefer-dynamic")
             // Provide necessary library search paths for rustc.
             .env(dylib_env_var(), &env::join_paths(host_dylib_search_paths).unwrap());
 

--- a/src/tools/run-make-support/Cargo.toml
+++ b/src/tools/run-make-support/Cargo.toml
@@ -13,3 +13,6 @@ gimli = "0.31.0"
 build_helper = { path = "../build_helper" }
 serde_json = "1.0"
 libc = "0.2"
+
+[lib]
+crate-type = ["lib", "dylib"]

--- a/tests/rustdoc-gui/fields.goml
+++ b/tests/rustdoc-gui/fields.goml
@@ -1,13 +1,36 @@
-// This test checks that fields are displayed as expected (one by line).
-go-to: "file://" + |DOC_PATH| + "/test_docs/fields/struct.Struct.html"
-store-position: ("#structfield\.a", {"y": a_y})
-store-position: ("#structfield\.b", {"y": b_y})
-assert: |a_y| < |b_y|
+// This test checks that fields are displayed as expected (one by line) and they are surrounded
+// by margins.
 
-go-to: "file://" + |DOC_PATH| + "/test_docs/fields/union.Union.html"
-store-position: ("#structfield\.a", {"y": a_y})
-store-position: ("#structfield\.b", {"y": b_y})
-assert: |a_y| < |b_y|
+define-function: (
+    "check-fields",
+    [path, selector_1, selector_2],
+    block {
+        go-to: "file://" + |DOC_PATH| + "/test_docs/fields/" + |path|
+        store-position: (|selector_1|, {"y": a_y})
+        store-position: (|selector_2|, {"y": b_y})
+        assert: |a_y| < |b_y|
+
+        // Check the margins.
+        assert-css: (".structfield.section-header", {
+            "margin-top": "9.6px",
+            "margin-bottom": "9.6px",
+            "margin-left": "0px",
+            "margin-right": "0px",
+        }, ALL)
+    }
+)
+
+call-function: ("check-fields", {
+    "path": "struct.Struct.html",
+    "selector_1": "#structfield\.a",
+    "selector_2": "#structfield\.b",
+})
+
+call-function: ("check-fields", {
+    "path": "union.Union.html",
+    "selector_1": "#structfield\.a",
+    "selector_2": "#structfield\.b",
+})
 
 go-to: "file://" + |DOC_PATH| + "/test_docs/fields/enum.Enum.html"
 store-position: ("#variant\.A\.field\.a", {"y": a_y})
@@ -16,3 +39,11 @@ assert: |a_y| < |b_y|
 store-position: ("#variant\.B\.field\.a", {"y": a_y})
 store-position: ("#variant\.B\.field\.b", {"y": b_y})
 assert: |a_y| < |b_y|
+
+// Check the margins.
+assert-css: (".sub-variant-field .section-header", {
+    "margin-top": "0px",
+    "margin-bottom": "0px",
+    "margin-left": "0px",
+    "margin-right": "0px",
+}, ALL)

--- a/tests/rustdoc-gui/struct-fields.goml
+++ b/tests/rustdoc-gui/struct-fields.goml
@@ -1,4 +1,5 @@
-// This test ensures that each field is on its own line (In other words, they have display: block).
+// This test ensures that each field is on its own line (In other words, they have
+// `display: block`).
 go-to: "file://" + |DOC_PATH| + "/test_docs/struct.StructWithPublicUndocumentedFields.html"
 
 store-property: ("//*[@id='structfield.first']", {"offsetTop": first_top})

--- a/tests/ui/consts/const-block-const-bound.stderr
+++ b/tests/ui/consts/const-block-const-bound.stderr
@@ -1,14 +1,14 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-block-const-bound.rs:8:22
+  --> $DIR/const-block-const-bound.rs:8:15
    |
 LL | const fn f<T: ~const Destruct>(x: T) {}
-   |                      ^^^^^^^^
+   |               ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-block-const-bound.rs:8:22
+  --> $DIR/const-block-const-bound.rs:8:15
    |
 LL | const fn f<T: ~const Destruct>(x: T) {}
-   |                      ^^^^^^^^
+   |               ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -11,168 +11,168 @@ LL | #![feature(const_cmp)]
    |            ^^^^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:13:15
+  --> $DIR/fn_trait_refs.rs:13:8
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
-   |               ^^^^^^
+   |        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:13:31
+  --> $DIR/fn_trait_refs.rs:13:24
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
-   |                               ^^^^^^^^
+   |                        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:13:15
+  --> $DIR/fn_trait_refs.rs:13:8
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
-   |               ^^^^^^
+   |        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:13:15
+  --> $DIR/fn_trait_refs.rs:13:8
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
-   |               ^^^^^^
+   |        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:13:31
+  --> $DIR/fn_trait_refs.rs:13:24
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
-   |                               ^^^^^^^^
+   |                        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:20:15
+  --> $DIR/fn_trait_refs.rs:20:8
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
-   |               ^^^^^^^^^
+   |        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:20:34
+  --> $DIR/fn_trait_refs.rs:20:27
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
-   |                                  ^^^^^^^^
+   |                           ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:20:15
+  --> $DIR/fn_trait_refs.rs:20:8
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
-   |               ^^^^^^^^^
+   |        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:20:15
+  --> $DIR/fn_trait_refs.rs:20:8
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
-   |               ^^^^^^^^^
+   |        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:20:34
+  --> $DIR/fn_trait_refs.rs:20:27
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
-   |                                  ^^^^^^^^
+   |                           ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:27:15
+  --> $DIR/fn_trait_refs.rs:27:8
    |
 LL |     T: ~const FnOnce<()>,
-   |               ^^^^^^^^^^
+   |        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:27:15
+  --> $DIR/fn_trait_refs.rs:27:8
    |
 LL |     T: ~const FnOnce<()>,
-   |               ^^^^^^^^^^
+   |        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:27:15
+  --> $DIR/fn_trait_refs.rs:27:8
    |
 LL |     T: ~const FnOnce<()>,
-   |               ^^^^^^^^^^
+   |        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:34:15
+  --> $DIR/fn_trait_refs.rs:34:8
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
-   |               ^^^^^^
+   |        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:34:31
+  --> $DIR/fn_trait_refs.rs:34:24
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
-   |                               ^^^^^^^^
+   |                        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:34:15
+  --> $DIR/fn_trait_refs.rs:34:8
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
-   |               ^^^^^^
+   |        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:34:15
+  --> $DIR/fn_trait_refs.rs:34:8
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
-   |               ^^^^^^
+   |        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:34:31
+  --> $DIR/fn_trait_refs.rs:34:24
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
-   |                               ^^^^^^^^
+   |                        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:48:15
+  --> $DIR/fn_trait_refs.rs:48:8
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
-   |               ^^^^^^^^^
+   |        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:48:34
+  --> $DIR/fn_trait_refs.rs:48:27
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
-   |                                  ^^^^^^^^
+   |                           ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:48:15
+  --> $DIR/fn_trait_refs.rs:48:8
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
-   |               ^^^^^^^^^
+   |        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:48:15
+  --> $DIR/fn_trait_refs.rs:48:8
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
-   |               ^^^^^^^^^
+   |        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:48:34
+  --> $DIR/fn_trait_refs.rs:48:27
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
-   |                                  ^^^^^^^^
+   |                           ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/tests/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -1,14 +1,14 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/unstable-const-fn-in-libcore.rs:19:39
+  --> $DIR/unstable-const-fn-in-libcore.rs:19:32
    |
 LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T>(self, f: F) -> T {
-   |                                       ^^^^^^^^^^^^^
+   |                                ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/unstable-const-fn-in-libcore.rs:19:39
+  --> $DIR/unstable-const-fn-in-libcore.rs:19:32
    |
 LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T>(self, f: F) -> T {
-   |                                       ^^^^^^^^^^^^^
+   |                                ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.rs
+++ b/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.rs
@@ -1,0 +1,20 @@
+//@ only-linux
+//@ compile-flags: --error-format=human --color=always
+//@ error-pattern: the trait bound
+
+trait Foo<T>: Bar<T> {}
+
+trait Bar<T> {}
+
+struct Struct;
+
+impl<T, K> Foo<K> for T where T: Bar<K>
+{}
+
+impl<'a> Bar<()> for Struct {}
+
+fn foo() -> impl Foo<i32> {
+    Struct
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
+++ b/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
@@ -33,9 +33,9 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Bar&lt;()&gt;` </tspan><tspan class="fg-magenta bold">is</tspan><tspan> implemented for `</tspan><tspan class="fg-magenta bold">Struct</tspan><tspan>`</tspan>
+    <tspan x="10px" y="136px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Bar&lt;()&gt;` </tspan><tspan class="fg-magenta bold">is</tspan><tspan> implemented for `Struct`</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: for that trait implementation, expected `()`, found `i32`</tspan>
+    <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: for that trait implementation, expected `</tspan><tspan class="fg-magenta bold">()</tspan><tspan>`, found `</tspan><tspan class="fg-magenta bold">i32</tspan><tspan>`</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required for `Struct` to implement `Foo&lt;i32&gt;`</tspan>
 </tspan>

--- a/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
+++ b/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
@@ -1,0 +1,62 @@
+<svg width="1104px" height="344px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-ansi256-009 { fill: #FF5555 }
+    .fg-ansi256-010 { fill: #55FF55 }
+    .fg-ansi256-012 { fill: #5555FF }
+    .fg-magenta { fill: #AA00AA }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: the trait bound `Struct: Foo&lt;i32&gt;` is not satisfied</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/highlight-difference-between-expected-trait-and-found-trait.rs:16:13</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> fn foo() -&gt; impl Foo&lt;i32&gt; {</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">the trait `Bar&lt;i32&gt;` is not implemented for `Struct`, which is required by `Struct: Foo&lt;i32&gt;`</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Bar&lt;()&gt;` </tspan><tspan class="fg-magenta bold">is</tspan><tspan> implemented for `</tspan><tspan class="fg-magenta bold">Struct</tspan><tspan>`</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: for that trait implementation, expected `()`, found `i32`</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required for `Struct` to implement `Foo&lt;i32&gt;`</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/highlight-difference-between-expected-trait-and-found-trait.rs:11:12</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> impl&lt;T, K&gt; Foo&lt;K&gt; for T where T: Bar&lt;K&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>            </tspan><tspan class="fg-ansi256-010 bold">^^^^^^</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^</tspan><tspan>          </tspan><tspan class="fg-ansi256-012 bold">------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">unsatisfied trait bound introduced here</tspan>
+</tspan>
+    <tspan x="10px" y="262px">
+</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-ansi256-009 bold">error</tspan><tspan class="bold">: aborting due to 1 previous error</tspan>
+</tspan>
+    <tspan x="10px" y="298px">
+</tspan>
+    <tspan x="10px" y="316px"><tspan class="bold">For more information about this error, try `rustc --explain E0277`.</tspan>
+</tspan>
+    <tspan x="10px" y="334px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/ui/impl-trait/normalize-tait-in-const.stderr
+++ b/tests/ui/impl-trait/normalize-tait-in-const.stderr
@@ -1,28 +1,28 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/normalize-tait-in-const.rs:26:42
+  --> $DIR/normalize-tait-in-const.rs:26:35
    |
 LL | const fn with_positive<F: for<'a> ~const Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
-   |                                          ^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/normalize-tait-in-const.rs:26:69
+  --> $DIR/normalize-tait-in-const.rs:26:62
    |
 LL | const fn with_positive<F: for<'a> ~const Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
-   |                                                                     ^^^^^^^^
+   |                                                              ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/normalize-tait-in-const.rs:26:42
+  --> $DIR/normalize-tait-in-const.rs:26:35
    |
 LL | const fn with_positive<F: for<'a> ~const Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
-   |                                          ^^^^^^^^^^^^^^^^^
+   |                                   ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/normalize-tait-in-const.rs:26:69
+  --> $DIR/normalize-tait-in-const.rs:26:62
    |
 LL | const fn with_positive<F: for<'a> ~const Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
-   |                                                                     ^^^^^^^^
+   |                                                              ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/repr/repr_align_greater_usize.msp430.stderr
+++ b/tests/ui/repr/repr_align_greater_usize.msp430.stderr
@@ -1,0 +1,19 @@
+error[E0589]: alignment must not be greater than `isize::MAX` bytes
+  --> $DIR/repr_align_greater_usize.rs:21:8
+   |
+LL | #[repr(align(32768))]
+   |        ^^^^^^^^^^^^
+   |
+   = note: `isize::MAX` is 32767 for the current target
+
+error[E0589]: alignment must not be greater than `isize::MAX` bytes
+  --> $DIR/repr_align_greater_usize.rs:24:8
+   |
+LL | #[repr(align(65536))]
+   |        ^^^^^^^^^^^^
+   |
+   = note: `isize::MAX` is 32767 for the current target
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0589`.

--- a/tests/ui/repr/repr_align_greater_usize.rs
+++ b/tests/ui/repr/repr_align_greater_usize.rs
@@ -1,0 +1,25 @@
+//@ revisions: msp430 aarch32
+//@[msp430] needs-llvm-components: msp430
+//@[msp430] compile-flags: --target=msp430-none-elf
+//@[aarch32] build-pass
+//@[aarch32] needs-llvm-components: arm
+//@[aarch32] compile-flags: --target=thumbv7m-none-eabi
+
+// We should fail to compute alignment for types aligned higher than usize::MAX.
+// We can't handle alignments that require all 32 bits, so this only affects 16-bit.
+
+#![feature(lang_items, no_core)]
+#![no_core]
+#![crate_type = "lib"]
+
+#[lang = "sized"]
+trait Sized {}
+
+#[repr(align(16384))]
+struct Kitten;
+
+#[repr(align(32768))] //[msp430]~ ERROR alignment must not be greater than `isize::MAX`
+struct Cat;
+
+#[repr(align(65536))] //[msp430]~ ERROR alignment must not be greater than `isize::MAX`
+struct BigCat;

--- a/tests/ui/specialization/const_trait_impl.stderr
+++ b/tests/ui/specialization/const_trait_impl.stderr
@@ -1,42 +1,42 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const_trait_impl.rs:34:16
+  --> $DIR/const_trait_impl.rs:34:9
    |
 LL | impl<T: ~const Default> const A for T {
-   |                ^^^^^^^
+   |         ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const_trait_impl.rs:40:16
+  --> $DIR/const_trait_impl.rs:40:9
    |
 LL | impl<T: ~const Default + ~const Sup> const A for T {
-   |                ^^^^^^^
+   |         ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const_trait_impl.rs:46:16
+  --> $DIR/const_trait_impl.rs:46:9
    |
 LL | impl<T: ~const Default + ~const Sub> const A for T {
-   |                ^^^^^^^
+   |         ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const_trait_impl.rs:40:16
+  --> $DIR/const_trait_impl.rs:40:9
    |
 LL | impl<T: ~const Default + ~const Sup> const A for T {
-   |                ^^^^^^^
+   |         ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const_trait_impl.rs:34:16
+  --> $DIR/const_trait_impl.rs:34:9
    |
 LL | impl<T: ~const Default> const A for T {
-   |                ^^^^^^^
+   |         ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const_trait_impl.rs:46:16
+  --> $DIR/const_trait_impl.rs:46:9
    |
 LL | impl<T: ~const Default + ~const Sub> const A for T {
-   |                ^^^^^^^
+   |         ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/assoc-type.stderr
+++ b/tests/ui/traits/const-traits/assoc-type.stderr
@@ -17,7 +17,7 @@ note: required by a bound in `Foo::Bar`
   --> $DIR/assoc-type.rs:32:15
    |
 LL |     type Bar: ~const Add;
-   |               ^^^^^^^^^^ required by this bound in `Foo::Bar`
+   |               ^^^^^^ required by this bound in `Foo::Bar`
 
 error: aborting due to 1 previous error; 1 warning emitted
 

--- a/tests/ui/traits/const-traits/call-generic-in-impl.stderr
+++ b/tests/ui/traits/const-traits/call-generic-in-impl.stderr
@@ -1,14 +1,14 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/call-generic-in-impl.rs:10:16
+  --> $DIR/call-generic-in-impl.rs:10:9
    |
 LL | impl<T: ~const PartialEq> const MyPartialEq for T {
-   |                ^^^^^^^^^
+   |         ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/call-generic-in-impl.rs:10:16
+  --> $DIR/call-generic-in-impl.rs:10:9
    |
 LL | impl<T: ~const PartialEq> const MyPartialEq for T {
-   |                ^^^^^^^^^
+   |         ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/call-generic-method-chain.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-chain.stderr
@@ -17,30 +17,30 @@ LL | impl const PartialEq for S {
    = note: adding a non-const method body in the future would be a breaking change
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/call-generic-method-chain.rs:20:32
+  --> $DIR/call-generic-method-chain.rs:20:25
    |
 LL | const fn equals_self<T: ~const PartialEq>(t: &T) -> bool {
-   |                                ^^^^^^^^^
+   |                         ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/call-generic-method-chain.rs:20:32
+  --> $DIR/call-generic-method-chain.rs:20:25
    |
 LL | const fn equals_self<T: ~const PartialEq>(t: &T) -> bool {
-   |                                ^^^^^^^^^
+   |                         ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/call-generic-method-chain.rs:24:40
+  --> $DIR/call-generic-method-chain.rs:24:33
    |
 LL | const fn equals_self_wrapper<T: ~const PartialEq>(t: &T) -> bool {
-   |                                        ^^^^^^^^^
+   |                                 ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/call-generic-method-chain.rs:24:40
+  --> $DIR/call-generic-method-chain.rs:24:33
    |
 LL | const fn equals_self_wrapper<T: ~const PartialEq>(t: &T) -> bool {
-   |                                        ^^^^^^^^^
+   |                                 ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/call-generic-method-dup-bound.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-dup-bound.stderr
@@ -17,30 +17,30 @@ LL | impl const PartialEq for S {
    = note: adding a non-const method body in the future would be a breaking change
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/call-generic-method-dup-bound.rs:20:44
+  --> $DIR/call-generic-method-dup-bound.rs:20:37
    |
 LL | const fn equals_self<T: PartialEq + ~const PartialEq>(t: &T) -> bool {
-   |                                            ^^^^^^^^^
+   |                                     ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/call-generic-method-dup-bound.rs:20:44
+  --> $DIR/call-generic-method-dup-bound.rs:20:37
    |
 LL | const fn equals_self<T: PartialEq + ~const PartialEq>(t: &T) -> bool {
-   |                                            ^^^^^^^^^
+   |                                     ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/call-generic-method-dup-bound.rs:27:37
+  --> $DIR/call-generic-method-dup-bound.rs:27:30
    |
 LL | const fn equals_self2<T: A + ~const PartialEq>(t: &T) -> bool {
-   |                                     ^^^^^^^^^
+   |                              ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/call-generic-method-dup-bound.rs:27:37
+  --> $DIR/call-generic-method-dup-bound.rs:27:30
    |
 LL | const fn equals_self2<T: A + ~const PartialEq>(t: &T) -> bool {
-   |                                     ^^^^^^^^^
+   |                              ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/call-generic-method-pass.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-pass.stderr
@@ -17,16 +17,16 @@ LL | impl const PartialEq for S {
    = note: adding a non-const method body in the future would be a breaking change
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/call-generic-method-pass.rs:20:32
+  --> $DIR/call-generic-method-pass.rs:20:25
    |
 LL | const fn equals_self<T: ~const PartialEq>(t: &T) -> bool {
-   |                                ^^^^^^^^^
+   |                         ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/call-generic-method-pass.rs:20:32
+  --> $DIR/call-generic-method-pass.rs:20:25
    |
 LL | const fn equals_self<T: ~const PartialEq>(t: &T) -> bool {
-   |                                ^^^^^^^^^
+   |                         ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/const-bounds-non-const-trait.stderr
+++ b/tests/ui/traits/const-traits/const-bounds-non-const-trait.stderr
@@ -13,24 +13,24 @@ error: using `#![feature(effects)]` without enabling next trait solver globally
    = help: use `-Znext-solver` to enable
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-bounds-non-const-trait.rs:6:28
+  --> $DIR/const-bounds-non-const-trait.rs:6:21
    |
 LL | const fn perform<T: ~const NonConst>() {}
-   |                            ^^^^^^^^
+   |                     ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-bounds-non-const-trait.rs:6:28
+  --> $DIR/const-bounds-non-const-trait.rs:6:21
    |
 LL | const fn perform<T: ~const NonConst>() {}
-   |                            ^^^^^^^^
+   |                     ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-bounds-non-const-trait.rs:10:21
+  --> $DIR/const-bounds-non-const-trait.rs:10:15
    |
 LL | fn operate<T: const NonConst>() {}
-   |                     ^^^^^^^^
+   |               ^^^^^
 
 error: aborting due to 4 previous errors; 1 warning emitted
 

--- a/tests/ui/traits/const-traits/const-closure-parse-not-item.stderr
+++ b/tests/ui/traits/const-traits/const-closure-parse-not-item.stderr
@@ -1,14 +1,14 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-parse-not-item.rs:7:32
+  --> $DIR/const-closure-parse-not-item.rs:7:25
    |
 LL | const fn test() -> impl ~const Fn() {
-   |                                ^^^^
+   |                         ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-parse-not-item.rs:7:32
+  --> $DIR/const-closure-parse-not-item.rs:7:25
    |
 LL | const fn test() -> impl ~const Fn() {
-   |                                ^^^^
+   |                         ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/const-closure-trait-method-fail.stderr
+++ b/tests/ui/traits/const-traits/const-closure-trait-method-fail.stderr
@@ -1,14 +1,14 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-trait-method-fail.rs:14:39
+  --> $DIR/const-closure-trait-method-fail.rs:14:32
    |
 LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32>(x: T) -> i32 {
-   |                                       ^^^^^^^^^^^^^^^^^
+   |                                ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-trait-method-fail.rs:14:39
+  --> $DIR/const-closure-trait-method-fail.rs:14:32
    |
 LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32>(x: T) -> i32 {
-   |                                       ^^^^^^^^^^^^^^^^^
+   |                                ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/const-closure-trait-method.stderr
+++ b/tests/ui/traits/const-traits/const-closure-trait-method.stderr
@@ -1,14 +1,14 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-trait-method.rs:14:39
+  --> $DIR/const-closure-trait-method.rs:14:32
    |
 LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32>(x: T) -> i32 {
-   |                                       ^^^^^^^^^^^^^^^^^
+   |                                ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closure-trait-method.rs:14:39
+  --> $DIR/const-closure-trait-method.rs:14:32
    |
 LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32>(x: T) -> i32 {
-   |                                       ^^^^^^^^^^^^^^^^^
+   |                                ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/const-closures.stderr
+++ b/tests/ui/traits/const-traits/const-closures.stderr
@@ -1,56 +1,56 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:8:19
+  --> $DIR/const-closures.rs:8:12
    |
 LL |         F: ~const FnOnce() -> u8,
-   |                   ^^^^^^^^^^^^^^
+   |            ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:9:19
+  --> $DIR/const-closures.rs:9:12
    |
 LL |         F: ~const FnMut() -> u8,
-   |                   ^^^^^^^^^^^^^
+   |            ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:10:19
+  --> $DIR/const-closures.rs:10:12
    |
 LL |         F: ~const Fn() -> u8,
-   |                   ^^^^^^^^^^
+   |            ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:8:19
+  --> $DIR/const-closures.rs:8:12
    |
 LL |         F: ~const FnOnce() -> u8,
-   |                   ^^^^^^^^^^^^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:9:19
+  --> $DIR/const-closures.rs:9:12
    |
 LL |         F: ~const FnMut() -> u8,
-   |                   ^^^^^^^^^^^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:10:19
+  --> $DIR/const-closures.rs:10:12
    |
 LL |         F: ~const Fn() -> u8,
-   |                   ^^^^^^^^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:23:27
+  --> $DIR/const-closures.rs:23:20
    |
 LL | const fn answer<F: ~const Fn() -> u8>(f: &F) -> u8 {
-   |                           ^^^^^^^^^^
+   |                    ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-closures.rs:23:27
+  --> $DIR/const-closures.rs:23:20
    |
 LL | const fn answer<F: ~const Fn() -> u8>(f: &F) -> u8 {
-   |                           ^^^^^^^^^^
+   |                    ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/const-drop-bound.stderr
+++ b/tests/ui/traits/const-traits/const-drop-bound.stderr
@@ -1,42 +1,42 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop-bound.rs:9:68
+  --> $DIR/const-drop-bound.rs:9:61
    |
 LL | const fn foo<T, E>(res: Result<T, E>) -> Option<T> where E: ~const Destruct {
-   |                                                                    ^^^^^^^^
+   |                                                             ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop-bound.rs:9:68
+  --> $DIR/const-drop-bound.rs:9:61
    |
 LL | const fn foo<T, E>(res: Result<T, E>) -> Option<T> where E: ~const Destruct {
-   |                                                                    ^^^^^^^^
+   |                                                             ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop-bound.rs:20:15
+  --> $DIR/const-drop-bound.rs:20:8
    |
 LL |     T: ~const Destruct,
-   |               ^^^^^^^^
+   |        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop-bound.rs:21:15
+  --> $DIR/const-drop-bound.rs:21:8
    |
 LL |     E: ~const Destruct,
-   |               ^^^^^^^^
+   |        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop-bound.rs:20:15
+  --> $DIR/const-drop-bound.rs:20:8
    |
 LL |     T: ~const Destruct,
-   |               ^^^^^^^^
+   |        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop-bound.rs:21:15
+  --> $DIR/const-drop-bound.rs:21:8
    |
 LL |     E: ~const Destruct,
-   |               ^^^^^^^^
+   |        ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/const-drop-fail-2.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail-2.stderr
@@ -8,16 +8,16 @@ LL | impl<T: ~const A> const Drop for ConstDropImplWithNonConstBounds<T> {
    = note: adding a non-const method body in the future would be a breaking change
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop-fail-2.rs:20:26
+  --> $DIR/const-drop-fail-2.rs:20:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                          ^^^^^^^^
+   |                   ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop-fail-2.rs:20:26
+  --> $DIR/const-drop-fail-2.rs:20:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                          ^^^^^^^^
+   |                   ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/const-drop-fail.precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.precise.stderr
@@ -8,16 +8,16 @@ LL | impl const Drop for ConstImplWithDropGlue {
    = note: adding a non-const method body in the future would be a breaking change
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop-fail.rs:23:26
+  --> $DIR/const-drop-fail.rs:23:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                          ^^^^^^^^
+   |                   ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop-fail.rs:23:26
+  --> $DIR/const-drop-fail.rs:23:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                          ^^^^^^^^
+   |                   ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/const-drop-fail.stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.stock.stderr
@@ -8,16 +8,16 @@ LL | impl const Drop for ConstImplWithDropGlue {
    = note: adding a non-const method body in the future would be a breaking change
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop-fail.rs:23:26
+  --> $DIR/const-drop-fail.rs:23:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                          ^^^^^^^^
+   |                   ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop-fail.rs:23:26
+  --> $DIR/const-drop-fail.rs:23:19
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                          ^^^^^^^^
+   |                   ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/const-drop.precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop.precise.stderr
@@ -35,16 +35,16 @@ LL |     impl<T: SomeTrait> const Drop for ConstDropWithNonconstBound<T> {
    = note: adding a non-const method body in the future would be a breaking change
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop.rs:18:22
+  --> $DIR/const-drop.rs:18:15
    |
 LL | const fn a<T: ~const Destruct>(_: T) {}
-   |                      ^^^^^^^^
+   |               ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop.rs:18:22
+  --> $DIR/const-drop.rs:18:15
    |
 LL | const fn a<T: ~const Destruct>(_: T) {}
-   |                      ^^^^^^^^
+   |               ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/const-drop.stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop.stock.stderr
@@ -35,16 +35,16 @@ LL |     impl<T: SomeTrait> const Drop for ConstDropWithNonconstBound<T> {
    = note: adding a non-const method body in the future would be a breaking change
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop.rs:18:22
+  --> $DIR/const-drop.rs:18:15
    |
 LL | const fn a<T: ~const Destruct>(_: T) {}
-   |                      ^^^^^^^^
+   |               ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/const-drop.rs:18:22
+  --> $DIR/const-drop.rs:18:15
    |
 LL | const fn a<T: ~const Destruct>(_: T) {}
-   |                      ^^^^^^^^
+   |               ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/const_derives/derive-const-with-params.stderr
+++ b/tests/ui/traits/const-traits/const_derives/derive-const-with-params.stderr
@@ -23,12 +23,6 @@ LL | #[derive_const(PartialEq)]
    = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/derive-const-with-params.rs:7:16
-   |
-LL | #[derive_const(PartialEq)]
-   |                ^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `PartialEq` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0015]: cannot call non-const operator in constant functions
   --> $DIR/derive-const-with-params.rs:8:23

--- a/tests/ui/traits/const-traits/effects/ice-112822-expected-type-for-param.stderr
+++ b/tests/ui/traits/const-traits/effects/ice-112822-expected-type-for-param.stderr
@@ -23,16 +23,16 @@ error: using `#![feature(effects)]` without enabling next trait solver globally
    = help: use `-Znext-solver` to enable
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/ice-112822-expected-type-for-param.rs:3:32
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:25
    |
 LL | const fn test() -> impl ~const Fn() {
-   |                                ^^^^
+   |                         ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/ice-112822-expected-type-for-param.rs:3:32
+  --> $DIR/ice-112822-expected-type-for-param.rs:3:25
    |
 LL | const fn test() -> impl ~const Fn() {
-   |                                ^^^^
+   |                         ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/effects/spec-effectvar-ice.stderr
+++ b/tests/ui/traits/const-traits/effects/spec-effectvar-ice.stderr
@@ -37,10 +37,10 @@ LL | impl<T> const Foo for T where T: const Specialize {}
    = note: adding a non-const method body in the future would be a breaking change
 
 error: `const` can only be applied to `#[const_trait]` traits
-  --> $DIR/spec-effectvar-ice.rs:14:40
+  --> $DIR/spec-effectvar-ice.rs:14:34
    |
 LL | impl<T> const Foo for T where T: const Specialize {}
-   |                                        ^^^^^^^^^^
+   |                                  ^^^^^
 
 error: specialization impl does not specialize any associated items
   --> $DIR/spec-effectvar-ice.rs:14:1

--- a/tests/ui/traits/const-traits/ice-123664-unexpected-bound-var.stderr
+++ b/tests/ui/traits/const-traits/ice-123664-unexpected-bound-var.stderr
@@ -4,16 +4,16 @@ error: using `#![feature(effects)]` without enabling next trait solver globally
    = help: use `-Znext-solver` to enable
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/ice-123664-unexpected-bound-var.rs:4:34
+  --> $DIR/ice-123664-unexpected-bound-var.rs:4:27
    |
 LL | const fn with_positive<F: ~const Fn()>() {}
-   |                                  ^^^^
+   |                           ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/ice-123664-unexpected-bound-var.rs:4:34
+  --> $DIR/ice-123664-unexpected-bound-var.rs:4:27
    |
 LL | const fn with_positive<F: ~const Fn()>() {}
-   |                                  ^^^^
+   |                           ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/issue-92111.stderr
+++ b/tests/ui/traits/const-traits/issue-92111.stderr
@@ -1,14 +1,14 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/issue-92111.rs:20:22
+  --> $DIR/issue-92111.rs:20:15
    |
 LL | const fn a<T: ~const Destruct>(t: T) {}
-   |                      ^^^^^^^^
+   |               ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/issue-92111.rs:20:22
+  --> $DIR/issue-92111.rs:20:15
    |
 LL | const fn a<T: ~const Destruct>(t: T) {}
-   |                      ^^^^^^^^
+   |               ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/item-bound-entailment-fails.stderr
+++ b/tests/ui/traits/const-traits/item-bound-entailment-fails.stderr
@@ -17,7 +17,7 @@ note: required by a bound in `Foo::Assoc`
   --> $DIR/item-bound-entailment-fails.rs:6:20
    |
 LL |     type Assoc<T>: ~const Bar
-   |                    ^^^^^^^^^^ required by this bound in `Foo::Assoc`
+   |                    ^^^^^^ required by this bound in `Foo::Assoc`
 
 error[E0277]: the trait bound `T: ~const Bar` is not satisfied
   --> $DIR/item-bound-entailment-fails.rs:25:21
@@ -29,7 +29,7 @@ note: required by a bound in `Foo::Assoc`
   --> $DIR/item-bound-entailment-fails.rs:6:20
    |
 LL |     type Assoc<T>: ~const Bar
-   |                    ^^^^^^^^^^ required by this bound in `Foo::Assoc`
+   |                    ^^^^^^ required by this bound in `Foo::Assoc`
 
 error: aborting due to 2 previous errors; 1 warning emitted
 

--- a/tests/ui/traits/const-traits/non-const-op-in-closure-in-const.stderr
+++ b/tests/ui/traits/const-traits/non-const-op-in-closure-in-const.stderr
@@ -1,14 +1,14 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/non-const-op-in-closure-in-const.rs:10:51
+  --> $DIR/non-const-op-in-closure-in-const.rs:10:44
    |
 LL | impl<A, B> const Convert<B> for A where B: ~const From<A> {
-   |                                                   ^^^^^^^
+   |                                            ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/non-const-op-in-closure-in-const.rs:10:51
+  --> $DIR/non-const-op-in-closure-in-const.rs:10:44
    |
 LL | impl<A, B> const Convert<B> for A where B: ~const From<A> {
-   |                                                   ^^^^^^^
+   |                                            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/predicate-entailment-fails.stderr
+++ b/tests/ui/traits/const-traits/predicate-entailment-fails.stderr
@@ -14,7 +14,7 @@ LL |     type Bar<T> where T: ~const Bar;
    |     ----------- definition of `Bar` from trait
 ...
 LL |     type Bar<T> = () where T: const Bar;
-   |                               ^^^^^^^^^ impl has extra requirement `T: const Bar`
+   |                               ^^^^^ impl has extra requirement `T: const Bar`
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/predicate-entailment-fails.rs:18:26
@@ -23,7 +23,7 @@ LL |     fn foo<T>() where T: ~const Bar;
    |     -------------------------------- definition of `foo` from trait
 ...
 LL |     fn foo<T>() where T: const Bar {}
-   |                          ^^^^^^^^^ impl has extra requirement `T: const Bar`
+   |                          ^^^^^ impl has extra requirement `T: const Bar`
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/predicate-entailment-fails.rs:29:31
@@ -32,7 +32,7 @@ LL |     type Bar<T> where T: Bar;
    |     ----------- definition of `Bar` from trait
 ...
 LL |     type Bar<T> = () where T: const Bar;
-   |                               ^^^^^^^^^ impl has extra requirement `T: const Bar`
+   |                               ^^^^^ impl has extra requirement `T: const Bar`
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/predicate-entailment-fails.rs:32:26
@@ -41,7 +41,7 @@ LL |     fn foo<T>() where T: Bar;
    |     ------------------------- definition of `foo` from trait
 ...
 LL |     fn foo<T>() where T: const Bar {}
-   |                          ^^^^^^^^^ impl has extra requirement `T: const Bar`
+   |                          ^^^^^ impl has extra requirement `T: const Bar`
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/predicate-entailment-fails.rs:36:31
@@ -50,7 +50,7 @@ LL |     type Bar<T> where T: Bar;
    |     ----------- definition of `Bar` from trait
 ...
 LL |     type Bar<T> = () where T: ~const Bar;
-   |                               ^^^^^^^^^^ impl has extra requirement `T: ~const Bar`
+   |                               ^^^^^^ impl has extra requirement `T: ~const Bar`
 
 error[E0276]: impl has stricter requirements than trait
   --> $DIR/predicate-entailment-fails.rs:39:26
@@ -59,7 +59,7 @@ LL |     fn foo<T>() where T: Bar;
    |     ------------------------- definition of `foo` from trait
 ...
 LL |     fn foo<T>() where T: ~const Bar {}
-   |                          ^^^^^^^^^^ impl has extra requirement `T: ~const Bar`
+   |                          ^^^^^^ impl has extra requirement `T: ~const Bar`
 
 error: aborting due to 6 previous errors; 1 warning emitted
 

--- a/tests/ui/traits/const-traits/super-traits-fail-2.nn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.nn.stderr
@@ -11,24 +11,24 @@ LL | trait Bar: ~const Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:12:19
+  --> $DIR/super-traits-fail-2.rs:12:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:12:19
+  --> $DIR/super-traits-fail-2.rs:12:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:12:19
+  --> $DIR/super-traits-fail-2.rs:12:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/super-traits-fail-2.ny.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.ny.stderr
@@ -1,38 +1,38 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:12:19
+  --> $DIR/super-traits-fail-2.rs:12:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:12:19
+  --> $DIR/super-traits-fail-2.rs:12:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:12:19
+  --> $DIR/super-traits-fail-2.rs:12:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:12:19
+  --> $DIR/super-traits-fail-2.rs:12:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-2.rs:12:19
+  --> $DIR/super-traits-fail-2.rs:12:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/super-traits-fail-3.nn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.nn.stderr
@@ -11,38 +11,38 @@ LL | trait Bar: ~const Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:14:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:14:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:14:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:22:24
+  --> $DIR/super-traits-fail-3.rs:22:17
    |
 LL | const fn foo<T: ~const Bar>(x: &T) {
-   |                        ^^^
+   |                 ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:22:24
+  --> $DIR/super-traits-fail-3.rs:22:17
    |
 LL | const fn foo<T: ~const Bar>(x: &T) {
-   |                        ^^^
+   |                 ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/super-traits-fail-3.ny.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.ny.stderr
@@ -1,38 +1,38 @@
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:14:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:14:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:14:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:14:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:14:19
+  --> $DIR/super-traits-fail-3.rs:14:12
    |
 LL | trait Bar: ~const Foo {}
-   |                   ^^^
+   |            ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/super-traits-fail-3.yn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.yn.stderr
@@ -11,16 +11,16 @@ LL | trait Bar: ~const Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:22:24
+  --> $DIR/super-traits-fail-3.rs:22:17
    |
 LL | const fn foo<T: ~const Bar>(x: &T) {
-   |                        ^^^
+   |                 ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/super-traits-fail-3.rs:22:24
+  --> $DIR/super-traits-fail-3.rs:22:17
    |
 LL | const fn foo<T: ~const Bar>(x: &T) {
-   |                        ^^^
+   |                 ^^^^^^
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
+++ b/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
@@ -28,7 +28,7 @@ note: required by a bound in `require`
   --> $DIR/unsatisfied-const-trait-bound.rs:8:15
    |
 LL | fn require<T: const Trait>() {}
-   |               ^^^^^^^^^^^ required by this bound in `require`
+   |               ^^^^^ required by this bound in `require`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/wf/wf-dyn-incompat-trait-obj-match.rs
+++ b/tests/ui/wf/wf-dyn-incompat-trait-obj-match.rs
@@ -22,8 +22,8 @@ fn main() {
         Some(()) => &S,
         None => &R,  //~ ERROR E0308
     }
-    let t: &dyn Trait = match opt() { //~ ERROR E0038
+    let t: &dyn Trait = match opt() {
         Some(()) => &S, //~ ERROR E0038
-        None => &R,
+        None => &R, //~ ERROR E0038
     };
 }

--- a/tests/ui/wf/wf-dyn-incompat-trait-obj-match.stderr
+++ b/tests/ui/wf/wf-dyn-incompat-trait-obj-match.stderr
@@ -31,14 +31,10 @@ LL | trait Trait: Sized {}
    = note: required for the cast from `&S` to `&dyn Trait`
 
 error[E0038]: the trait `Trait` cannot be made into an object
-  --> $DIR/wf-dyn-incompat-trait-obj-match.rs:25:25
+  --> $DIR/wf-dyn-incompat-trait-obj-match.rs:27:17
    |
-LL |       let t: &dyn Trait = match opt() {
-   |  _________________________^
-LL | |         Some(()) => &S,
-LL | |         None => &R,
-LL | |     };
-   | |_____^ `Trait` cannot be made into an object
+LL |         None => &R,
+   |                 ^^ `Trait` cannot be made into an object
    |
 note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-dyn-incompat-trait-obj-match.rs:6:14


### PR DESCRIPTION
Successful merges:

 - #131633 (error on alignments greater than `isize::MAX`)
 - #132086 (Tweak E0277 highlighting and "long type" path printing)
 - #132220 (Add GUI regression test for doc struct fields margins)
 - #132225 (Dynamically link run-make support)
 - #132227 (Pass constness with span into lower_poly_trait_ref)
 - #132242 (Support `char::is_digit` in const contexts.)
 - #132243 (Remove `ObligationCause::span()` method)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131633,132086,132220,132225,132227,132242,132243)
<!-- homu-ignore:end -->