### PR TITLE
Known-bug test for `keyword_idents` lint not propagating to other files

### DIFF
--- a/tests/ui/lint/keyword-idents/auxiliary/multi_file_submod.rs
+++ b/tests/ui/lint/keyword-idents/auxiliary/multi_file_submod.rs
@@ -1,0 +1,10 @@
+// Submodule file used by test `../multi-file.rs`.
+
+// Keywords reserved from Rust 2018:
+fn async() {}
+fn await() {}
+fn try() {}
+fn dyn() {}
+
+// Keywords reserved from Rust 2024:
+fn gen() {}

--- a/tests/ui/lint/keyword-idents/multi-file.rs
+++ b/tests/ui/lint/keyword-idents/multi-file.rs
@@ -1,0 +1,14 @@
+#![deny(keyword_idents)] // Should affect the submodule, but doesn't.
+//@ edition: 2015
+//@ known-bug: #132218
+//@ check-pass (known bug; should be check-fail)
+
+// Because `keyword_idents_2018` and `keyword_idents_2024` are pre-expansion
+// lints, configuring them via lint attributes doesn't propagate to submodules
+// in other files.
+// <https://github.com/rust-lang/rust/issues/132218>
+
+#[path = "./auxiliary/multi_file_submod.rs"]
+mod multi_file_submod;
+
+fn main() {}


### PR DESCRIPTION
Known-bug test for `keyword_idents` lint not propagating to other files when configured via attribute (#132218).