### PR TITLE
[rustdoc] Unify variant struct fields margins with struct fields

### DIFF
--- a/src/librustdoc/html/static/css/rustdoc.css
+++ b/src/librustdoc/html/static/css/rustdoc.css
@@ -230,7 +230,7 @@ h4.code-header {
 	padding: 0;
 	white-space: pre-wrap;
 }
-.structfield {
+.structfield, .sub-variant-field {
 	margin: 0.6em 0;
 }
 

--- a/tests/rustdoc-gui/fields.goml
+++ b/tests/rustdoc-gui/fields.goml
@@ -1,6 +1,7 @@
 // This test checks that fields are displayed as expected (one by line) and they are surrounded
 // by margins.
 
+store-value: (margin, "9.6px")
 define-function: (
     "check-fields",
     [path, selector_1, selector_2],
@@ -12,8 +13,8 @@ define-function: (
 
         // Check the margins.
         assert-css: (".structfield.section-header", {
-            "margin-top": "9.6px",
-            "margin-bottom": "9.6px",
+            "margin-top": |margin|,
+            "margin-bottom": |margin|,
             "margin-left": "0px",
             "margin-right": "0px",
         }, ALL)
@@ -41,9 +42,9 @@ store-position: ("#variant\.B\.field\.b", {"y": b_y})
 assert: |a_y| < |b_y|
 
 // Check the margins.
-assert-css: (".sub-variant-field .section-header", {
-    "margin-top": "0px",
-    "margin-bottom": "0px",
-    "margin-left": "0px",
+assert-css: (".sub-variant-field", {
+    "margin-top": |margin|,
+    "margin-bottom": |margin|,
+    "margin-left": "24px",
     "margin-right": "0px",
 }, ALL)


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/rust/pull/132220.

| before | after |
|-|-|
| ![image](https://github.com/user-attachments/assets/d8d8336d-7fe4-45fb-a5a5-36a4023223f5) | ![Screenshot from 2024-10-28 11-17-24](https://github.com/user-attachments/assets/9d0d9633-b857-45b4-9217-7d0d1aa8f770) |

r? @notriddle 