### PR TITLE
Add XTENSA_ALLOWED_FEATURES to supported_target_features

### DIFF
--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -541,6 +541,7 @@ impl super::spec::Target {
             "csky" => CSKY_ALLOWED_FEATURES,
             "loongarch64" => LOONGARCH_ALLOWED_FEATURES,
             "s390x" => IBMZ_ALLOWED_FEATURES,
+            "xtensa" => XTENSA_ALLOWED_FEATURES,
             _ => &[],
         }
     }


### PR DESCRIPTION
Without this, `target_arch = "xtensa"` doesn't work.
