### PR TITLE
force-recompile library changes on download-rustc="if-unchanged"

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -497,11 +497,12 @@
 #debug = false
 
 # Whether to download the stage 1 and 2 compilers from CI.
-# This is mostly useful for tools; if you have changes to `compiler/` or `library/` they will be ignored.
+# This is useful if you are working on tools, doc-comments, or library (you will be able to build
+# the standard library without needing to build the compiler).
 #
-# Set this to "if-unchanged" to only download if the compiler and standard library have not been modified.
-# Set this to `true` to download unconditionally. This is useful if you are working on tools, doc-comments,
-# or library (you will be able to build the standard library without needing to build the compiler).
+# Set this to "if-unchanged" to only download if the compiler (and library if running on CI) have
+# not been modified.
+# Set this to `true` to download unconditionally.
 #download-rustc = false
 
 # Number of codegen units to use for each compiler invocation. A value of 0

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -153,7 +153,6 @@ impl Step for Std {
             // NOTE: the beta compiler may generate different artifacts than the downloaded compiler, so
             // its artifacts can't be reused.
             && compiler.stage != 0
-            // This check is specific to testing std itself; see `test::Std` for more details.
             && !self.force_recompile
         {
             let sysroot = builder.ensure(Sysroot { compiler, force_recompile: false });


### PR DESCRIPTION
This makes the download-rustc="if-unchanged" option more functional and useful for library developers.

Implements the second item from [this tracking issue](https://github.com/rust-lang/rust/issues/131744).