### PR TITLE
Remove my ping for rustdoc/clean/types.rs

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -725,9 +725,6 @@ please modify the tool then regenerate the library source file with the tool
 instead of editing the library source file manually.
 """
 
-[mentions."src/librustdoc/clean/types.rs"]
-cc = ["@camelid"]
-
 [mentions."src/librustdoc/html/static"]
 message = "Some changes occurred in HTML/CSS/JS."
 cc = [


### PR DESCRIPTION
It was useful at one time, but now it just causes notification noise.

<!-- homu-ignore:start -->
r? @Mark-Simulacrum
<!-- homu-ignore:end -->