### PR TITLE
Remove myself from mentions inside `tests/ui/check-cfg` directory

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -938,9 +938,6 @@ cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 [mentions."tests/ui/stack-protector"]
 cc = ["@rust-lang/project-exploit-mitigations", "@rcvalle"]
 
-[mentions."tests/ui/check-cfg"]
-cc = ["@Urgau"]
-
 [mentions."compiler/rustc_middle/src/mir/coverage.rs"]
 message = "Some changes occurred in coverage instrumentation."
 cc = ["@Zalathar"]


### PR DESCRIPTION
This PR removes myself from mentions inside `tests/ui/check-cfg` directory.

I'm not sure this particular mention has ever been useful to me, and lately it's been too annoying for me to ignore it.

So remove my-self from it.