### PR TITLE
Opportunistically use more accurate span for proc-macro with bad header

### DIFF
--- a/tests/ui/proc-macro/proc-macro-abi.stderr
+++ b/tests/ui/proc-macro/proc-macro-abi.stderr
@@ -1,26 +1,26 @@
 error: function-like proc macro has incorrect signature
-  --> $DIR/proc-macro-abi.rs:11:1
+  --> $DIR/proc-macro-abi.rs:11:5
    |
 LL | pub extern "C" fn abi(a: TokenStream) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "C" fn
+   |     ^^^^^^^^^^ expected "Rust" fn, found "C" fn
    |
    = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `extern "C" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
 
 error: function-like proc macro has incorrect signature
-  --> $DIR/proc-macro-abi.rs:17:1
+  --> $DIR/proc-macro-abi.rs:17:5
    |
 LL | pub extern "system" fn abi2(a: TokenStream) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "system" fn
+   |     ^^^^^^^^^^^^^^^ expected "Rust" fn, found "system" fn
    |
    = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `extern "system" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
 
 error: function-like proc macro has incorrect signature
-  --> $DIR/proc-macro-abi.rs:23:1
+  --> $DIR/proc-macro-abi.rs:23:5
    |
 LL | pub extern fn abi3(a: TokenStream) -> TokenStream {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected "Rust" fn, found "C" fn
+   |     ^^^^^^ expected "Rust" fn, found "C" fn
    |
    = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `extern "C" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`

--- a/tests/ui/proc-macro/signature.stderr
+++ b/tests/ui/proc-macro/signature.stderr
@@ -1,8 +1,8 @@
 error: derive proc macro has incorrect signature
-  --> $DIR/signature.rs:10:1
+  --> $DIR/signature.rs:10:5
    |
 LL | pub unsafe extern "C" fn foo(a: i32, b: u32) -> u32 {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected safe fn, found unsafe fn
+   |     ^^^^^^ expected safe fn, found unsafe fn
    |
    = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
               found signature `unsafe extern "C" fn(i32, u32) -> u32`


### PR DESCRIPTION
```
error: function-like proc macro has incorrect signature
  --> $DIR/proc-macro-abi.rs:17:5
   |
LL | pub extern "system" fn abi2(a: TokenStream) -> TokenStream {
   |     ^^^^^^^^^^^^^^^ expected "Rust" fn, found "system" fn
   |
   = note: expected signature `fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
              found signature `extern "system" fn(proc_macro::TokenStream) -> proc_macro::TokenStream`
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

We don't track appropriate spans in the HIR because it would make really common types larger for use in really uncommon situations, so instead we look at the snippet for the fn signature and try to find the right substring to point at.