### PR TITLE
More tests for non-exhaustive C-like enums in FFI

### DIFF
--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/improper_ctypes/auxiliary/types.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/improper_ctypes/auxiliary/types.rs
@@ -38,3 +38,9 @@ pub enum NonExhaustiveCLikeEnum {
     Four = 4,
     Five = 5,
 }
+
+#[repr(C)]
+pub struct NormalStructWithNonExhaustiveCLikeEnum {
+    one: u8,
+    two: NonExhaustiveCLikeEnum,
+}

--- a/tests/ui/rfcs/rfc-2008-non-exhaustive/improper_ctypes/extern_crate_improper.rs
+++ b/tests/ui/rfcs/rfc-2008-non-exhaustive/improper_ctypes/extern_crate_improper.rs
@@ -8,7 +8,7 @@ extern crate types;
 
 use types::{
     NonExhaustiveCLikeEnum, NonExhaustiveEnum, NonExhaustiveVariants,
-    NormalStruct, TupleStruct, UnitStruct,
+    NormalStruct, TupleStruct, UnitStruct, NormalStructWithNonExhaustiveCLikeEnum
 };
 
 extern "C" {
@@ -27,6 +27,9 @@ extern "C" {
 // These should pass without remark, as they're C-compatible, despite being "non-exhaustive".
 extern "C" {
     pub fn non_exhaustive_c_compat_enum(_: NonExhaustiveCLikeEnum);
+    pub fn non_exhaustive_c_compat_enum_ret() -> *mut NonExhaustiveCLikeEnum;
+    pub fn struct_w_non_exhaustive_c_like_enum(_: NormalStructWithNonExhaustiveCLikeEnum);
+    pub fn struct_w_non_exhaustive_c_like_enum_ret() -> *mut NormalStructWithNonExhaustiveCLikeEnum;
 }
 
 fn main() {}


### PR DESCRIPTION
Add a few more tests for the `improper_ctypes` lint as found with the [varnish-rs](https://github.com/gquintard/varnish-rs) project.

This follows up on #116831, fixed in #116863 by @workingjubilee - I have been seeing these fail with the bindgen-generated non-exhaustive enums inside other structs. Seems the issue does not exist in the primary branch, so this PR just makes sure more cases are covered for the future.