### PR TITLE
CI: use free runners for 3 fast windows jobs

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -488,7 +488,7 @@ auto:
       SCRIPT: python x.py dist bootstrap --include-default-paths
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-windows-8c
+    <<: *job-windows
 
   - image: dist-x86_64-mingw
     env:
@@ -501,10 +501,10 @@ auto:
       NO_DOWNLOAD_CI_LLVM: 1
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-windows-8c
+    <<: *job-windows
 
   - image: dist-x86_64-msvc-alt
     env:
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-extended --enable-profiler
       SCRIPT: python x.py dist bootstrap --include-default-paths
-    <<: *job-windows-8c
+    <<: *job-windows


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->

I noticed that some windows jobs running on large runners are significantly faster than the rest of the auto build.

Here's some data based on the latest 97 auto builds:

- Average of these jobs:
  - `dist-i686-mingw`: 88 minutes
  - `dist-x86_64-mingw`: 86 minutes
  - `dist-x86_64-msvc-alt`: 81 minutes
- Minimum duration of the auto builds: 136 minutes (2h 16 min).
- Average duration of the auto build: 155 minutes (2h 35 min).

In this PR I switch these jobs from large runners to free runners, to see if we can save some resources.

Imo if the try builds don't take longer than the average duration of the auto build we could merge this PR.

<!-- homu-ignore:end -->

try-job: dist-i686-msvc
try-job: dist-i686-mingw
try-job: dist-x86_64-mingw
try-job: dist-x86_64-msvc-alt
