### PR TITLE
xous: sync: remove `rustc_const_stable` attribute on Condvar and Mutex new()

### DIFF
--- a/library/std/src/sys/sync/condvar/xous.rs
+++ b/library/std/src/sys/sync/condvar/xous.rs
@@ -20,7 +20,6 @@ unsafe impl Sync for Condvar {}
 
 impl Condvar {
     #[inline]
-    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
     pub const fn new() -> Condvar {
         Condvar { counter: AtomicUsize::new(0), timed_out: AtomicUsize::new(0) }
     }

--- a/library/std/src/sys/sync/mutex/xous.rs
+++ b/library/std/src/sys/sync/mutex/xous.rs
@@ -24,7 +24,6 @@ pub struct Mutex {
 
 impl Mutex {
     #[inline]
-    #[rustc_const_stable(feature = "const_locks", since = "1.63.0")]
     pub const fn new() -> Mutex {
         Mutex { locked: AtomicUsize::new(0), contended: AtomicBool::new(false) }
     }


### PR DESCRIPTION
These functions had `#[rustc_const_stable(feature = "const_locks", since = "1.63.0")]` on them because they were originally taken from `no_threads`. with d066dfd these no longer compile. Since other platforms do not have this attribute, remove it. This fixes the build for Xous.