### PR TITLE
Implement `~const Destruct` effect goal in the new solver

### DIFF
--- a/compiler/rustc_const_eval/src/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/check_consts/check.rs
@@ -24,7 +24,7 @@ use rustc_span::{Span, Symbol, sym};
 use rustc_trait_selection::traits::{
     Obligation, ObligationCause, ObligationCauseCode, ObligationCtxt,
 };
-use tracing::{debug, instrument, trace};
+use tracing::{instrument, trace};
 
 use super::ops::{self, NonConstOp, Status};
 use super::qualifs::{self, HasMutInterior, NeedsDrop, NeedsNonConstDrop};
@@ -47,7 +47,7 @@ impl<'mir, 'tcx> Qualifs<'mir, 'tcx> {
     /// Returns `true` if `local` is `NeedsDrop` at the given `Location`.
     ///
     /// Only updates the cursor if absolutely necessary
-    fn needs_drop(
+    pub(crate) fn needs_drop(
         &mut self,
         ccx: &'mir ConstCx<'mir, 'tcx>,
         local: Local,
@@ -322,6 +322,14 @@ impl<'mir, 'tcx> Checker<'mir, 'tcx> {
                 );
             }
         }
+    }
+
+    /// Emits an error at the given `span` if an expression cannot be evaluated in the current
+    /// context. This is meant for use in a post-const-checker pass such as the const precise
+    /// live drops lint.
+    pub fn check_op_spanned_post<O: NonConstOp<'tcx>>(mut self, op: O, span: Span) {
+        self.check_op_spanned(op, span);
+        assert!(self.secondary_errors.is_empty());
     }
 
     fn check_static(&mut self, def_id: DefId, span: Span) {
@@ -869,12 +877,13 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                 let mut err_span = self.span;
                 let ty_of_dropped_place = dropped_place.ty(self.body, self.tcx).ty;
 
-                let ty_needs_non_const_drop =
-                    qualifs::NeedsNonConstDrop::in_any_value_of_ty(self.ccx, ty_of_dropped_place);
-
-                debug!(?ty_of_dropped_place, ?ty_needs_non_const_drop);
-
-                if !ty_needs_non_const_drop {
+                let needs_drop = if let Some(local) = dropped_place.as_local() {
+                    self.qualifs.needs_drop(self.ccx, local, location)
+                } else {
+                    qualifs::NeedsDrop::in_any_value_of_ty(self.ccx, ty_of_dropped_place)
+                };
+                // If this type doesn't need a drop at all, then there's nothing to enforce.
+                if !needs_drop {
                     return;
                 }
 
@@ -883,18 +892,17 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                     err_span = self.body.local_decls[local].source_info.span;
                     self.qualifs.needs_non_const_drop(self.ccx, local, location)
                 } else {
-                    true
+                    qualifs::NeedsNonConstDrop::in_any_value_of_ty(self.ccx, ty_of_dropped_place)
                 };
 
-                if needs_non_const_drop {
-                    self.check_op_spanned(
-                        ops::LiveDrop {
-                            dropped_at: Some(terminator.source_info.span),
-                            dropped_ty: ty_of_dropped_place,
-                        },
-                        err_span,
-                    );
-                }
+                self.check_op_spanned(
+                    ops::LiveDrop {
+                        dropped_at: Some(terminator.source_info.span),
+                        dropped_ty: ty_of_dropped_place,
+                        needs_non_const_drop,
+                    },
+                    err_span,
+                );
             }
 
             TerminatorKind::InlineAsm { .. } => self.check_op(ops::InlineAsm),

--- a/compiler/rustc_const_eval/src/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/check_consts/ops.rs
@@ -459,7 +459,7 @@ impl<'tcx> NonConstOp<'tcx> for InlineAsm {
 
 #[derive(Debug)]
 pub(crate) struct LiveDrop<'tcx> {
-    pub dropped_at: Option<Span>,
+    pub dropped_at: Span,
     pub dropped_ty: Ty<'tcx>,
     pub needs_non_const_drop: bool,
 }

--- a/compiler/rustc_const_eval/src/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/check_consts/ops.rs
@@ -461,15 +461,41 @@ impl<'tcx> NonConstOp<'tcx> for InlineAsm {
 pub(crate) struct LiveDrop<'tcx> {
     pub dropped_at: Option<Span>,
     pub dropped_ty: Ty<'tcx>,
+    pub needs_non_const_drop: bool,
 }
 impl<'tcx> NonConstOp<'tcx> for LiveDrop<'tcx> {
+    fn status_in_item(&self, _ccx: &ConstCx<'_, 'tcx>) -> Status {
+        if self.needs_non_const_drop {
+            Status::Forbidden
+        } else {
+            Status::Unstable {
+                gate: sym::const_destruct,
+                gate_already_checked: false,
+                safe_to_expose_on_stable: false,
+                is_function_call: false,
+            }
+        }
+    }
+
     fn build_error(&self, ccx: &ConstCx<'_, 'tcx>, span: Span) -> Diag<'tcx> {
-        ccx.dcx().create_err(errors::LiveDrop {
-            span,
-            dropped_ty: self.dropped_ty,
-            kind: ccx.const_kind(),
-            dropped_at: self.dropped_at,
-        })
+        if self.needs_non_const_drop {
+            ccx.dcx().create_err(errors::LiveDrop {
+                span,
+                dropped_ty: self.dropped_ty,
+                kind: ccx.const_kind(),
+                dropped_at: self.dropped_at,
+            })
+        } else {
+            ccx.tcx.sess.create_feature_err(
+                errors::LiveDrop {
+                    span,
+                    dropped_ty: self.dropped_ty,
+                    kind: ccx.const_kind(),
+                    dropped_at: self.dropped_at,
+                },
+                sym::const_destruct,
+            )
+        }
     }
 }
 

--- a/compiler/rustc_const_eval/src/check_consts/post_drop_elaboration.rs
+++ b/compiler/rustc_const_eval/src/check_consts/post_drop_elaboration.rs
@@ -5,11 +5,7 @@ use rustc_span::symbol::sym;
 use tracing::trace;
 
 use super::ConstCx;
-use super::check::Qualifs;
-use super::ops::{self};
-use super::qualifs::{NeedsNonConstDrop, Qualif};
 use crate::check_consts::check::Checker;
-use crate::check_consts::qualifs::NeedsDrop;
 use crate::check_consts::rustc_allow_const_fn_unstable;
 
 /// Returns `true` if we should use the more precise live drop checker that runs after drop
@@ -46,23 +42,16 @@ pub fn check_live_drops<'tcx>(tcx: TyCtxt<'tcx>, body: &mir::Body<'tcx>) {
         return;
     }
 
-    let mut visitor = CheckLiveDrops { ccx: &ccx, qualifs: Qualifs::default() };
+    // I know it's not great to be creating a new const checker, but I'd
+    // rather use it so we can deduplicate the error emitting logic that
+    // it contains.
+    let mut visitor = CheckLiveDrops { checker: Checker::new(&ccx) };
 
     visitor.visit_body(body);
 }
 
 struct CheckLiveDrops<'mir, 'tcx> {
-    ccx: &'mir ConstCx<'mir, 'tcx>,
-    qualifs: Qualifs<'mir, 'tcx>,
-}
-
-// So we can access `body` and `tcx`.
-impl<'mir, 'tcx> std::ops::Deref for CheckLiveDrops<'mir, 'tcx> {
-    type Target = ConstCx<'mir, 'tcx>;
-
-    fn deref(&self) -> &Self::Target {
-        self.ccx
-    }
+    checker: Checker<'mir, 'tcx>,
 }
 
 impl<'tcx> Visitor<'tcx> for CheckLiveDrops<'_, 'tcx> {
@@ -82,38 +71,10 @@ impl<'tcx> Visitor<'tcx> for CheckLiveDrops<'_, 'tcx> {
 
         match &terminator.kind {
             mir::TerminatorKind::Drop { place: dropped_place, .. } => {
-                let ty_of_dropped_place = dropped_place.ty(self.body, self.tcx).ty;
-
-                let needs_drop = if let Some(local) = dropped_place.as_local() {
-                    self.qualifs.needs_drop(self.ccx, local, location)
-                } else {
-                    NeedsDrop::in_any_value_of_ty(self.ccx, ty_of_dropped_place)
-                };
-                // If this type doesn't need a drop at all, then there's nothing to enforce.
-                if !needs_drop {
-                    return;
-                }
-
-                let mut err_span = terminator.source_info.span;
-
-                let needs_non_const_drop = if let Some(local) = dropped_place.as_local() {
-                    // Use the span where the local was declared as the span of the drop error.
-                    err_span = self.body.local_decls[local].source_info.span;
-                    self.qualifs.needs_non_const_drop(self.ccx, local, location)
-                } else {
-                    NeedsNonConstDrop::in_any_value_of_ty(self.ccx, ty_of_dropped_place)
-                };
-
-                // I know it's not great to be creating a new const checker, but I'd
-                // rather use it so we can deduplicate the error emitting logic that
-                // it contains.
-                Checker::new(self.ccx).check_op_spanned_post(
-                    ops::LiveDrop {
-                        dropped_at: Some(terminator.source_info.span),
-                        dropped_ty: ty_of_dropped_place,
-                        needs_non_const_drop,
-                    },
-                    err_span,
+                self.checker.check_drop_terminator(
+                    *dropped_place,
+                    location,
+                    terminator.source_info.span,
                 );
             }
 

--- a/compiler/rustc_const_eval/src/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/check_consts/qualifs.rs
@@ -306,11 +306,10 @@ where
             return false;
         }
 
-        // This is currently unconditionally true for all qualifs, since we do
-        // not recurse into the pointer of a deref projection, but that may change
-        // in the future. If that changes, each qualif should be required to
-        // specify whether it operates structurally for deref projections, just like
-        // we do for `Qualif::is_structural_in_adt`.
+        // `Deref` currently unconditionally "qualifies" if `in_any_value_of_ty` returns true,
+        // i.e., we treat all qualifs as non-structural for deref projections. Generally,
+        // we can say very little about `*ptr` even if we know that `ptr` satisfies all
+        // sorts of properties.
         if matches!(elem, ProjectionElem::Deref) {
             // We have to assume that this qualifies.
             return true;

--- a/compiler/rustc_const_eval/src/check_consts/qualifs.rs
+++ b/compiler/rustc_const_eval/src/check_consts/qualifs.rs
@@ -175,6 +175,11 @@ impl Qualif for NeedsNonConstDrop {
             return false;
         }
 
+        // If this doesn't need drop at all, then don't select `~const Destruct`.
+        if !ty.needs_drop(cx.tcx, cx.typing_env) {
+            return false;
+        }
+
         // We check that the type is `~const Destruct` since that will verify that
         // the type is both `~const Drop` (if a drop impl exists for the adt), *and*
         // that the components of this type are also `~const Destruct`. This
@@ -203,7 +208,7 @@ impl Qualif for NeedsNonConstDrop {
         // in its value since:
         // 1. The destructor may have `~const` bounds which are not present on the type.
         //   Someone needs to check that those are satisfied.
-        //   While this could be done instead satisfied by checking that the `~const Drop`
+        //   While this could be instead satisfied by checking that the `~const Drop`
         //   impl holds (i.e. replicating part of the `in_any_value_of_ty` logic above),
         //   even in this case, we have another problem, which is,
         // 2. The destructor may *modify* the operand being dropped, so even if we

--- a/compiler/rustc_const_eval/src/errors.rs
+++ b/compiler/rustc_const_eval/src/errors.rs
@@ -411,7 +411,7 @@ pub struct LiveDrop<'tcx> {
     pub kind: ConstContext,
     pub dropped_ty: Ty<'tcx>,
     #[label(const_eval_dropped_at_label)]
-    pub dropped_at: Option<Span>,
+    pub dropped_at: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -426,7 +426,7 @@ declare_features! (
     (unstable, const_async_blocks, "1.53.0", Some(85368)),
     /// Allows `const || {}` closures in const contexts.
     (incomplete, const_closures, "1.68.0", Some(106003)),
-    /// Uwu
+    /// Allows using `~const Destruct` bounds and calling drop impls in const contexts.
     (unstable, const_destruct, "CURRENT_RUSTC_VERSION", Some(133214)),
     /// Allows `for _ in _` loops in const contexts.
     (unstable, const_for, "1.56.0", Some(87575)),

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -426,6 +426,8 @@ declare_features! (
     (unstable, const_async_blocks, "1.53.0", Some(85368)),
     /// Allows `const || {}` closures in const contexts.
     (incomplete, const_closures, "1.68.0", Some(106003)),
+    /// Uwu
+    (unstable, const_destruct, "CURRENT_RUSTC_VERSION", Some(133214)),
     /// Allows `for _ in _` loops in const contexts.
     (unstable, const_for, "1.56.0", Some(87575)),
     /// Be more precise when looking for live drops in a const context.

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -269,13 +269,13 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     );
                 }
                 Adjust::Deref(None) => {
-                    // FIXME(effects): We *could* enforce `&T: ~const Deref` here.
+                    // FIXME(const_trait_impl): We *could* enforce `&T: ~const Deref` here.
                 }
                 Adjust::Pointer(_pointer_coercion) => {
-                    // FIXME(effects): We should probably enforce these.
+                    // FIXME(const_trait_impl): We should probably enforce these.
                 }
                 Adjust::ReborrowPin(_mutability) => {
-                    // FIXME(effects): We could enforce these; they correspond to
+                    // FIXME(const_trait_impl): We could enforce these; they correspond to
                     // `&mut T: DerefMut` tho, so it's kinda moot.
                 }
                 Adjust::Borrow(_) => {

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -384,6 +384,10 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
         self.is_conditionally_const(def_id)
     }
 
+    fn alias_has_const_conditions(self, def_id: DefId) -> bool {
+        self.is_conditionally_const(def_id)
+    }
+
     fn const_conditions(
         self,
         def_id: DefId,
@@ -663,6 +667,7 @@ bidirectional_lang_item_map! {
     CoroutineYield,
     Destruct,
     DiscriminantKind,
+    Drop,
     DynMetadata,
     Fn,
     FnMut,

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -4,7 +4,7 @@
 
 pub mod tls;
 
-use std::assert_matches::assert_matches;
+use std::assert_matches::{assert_matches, debug_assert_matches};
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
@@ -377,14 +377,17 @@ impl<'tcx> Interner for TyCtxt<'tcx> {
     }
 
     fn impl_is_const(self, def_id: DefId) -> bool {
+        debug_assert_matches!(self.def_kind(def_id), DefKind::Impl { of_trait: true });
         self.is_conditionally_const(def_id)
     }
 
     fn fn_is_const(self, def_id: DefId) -> bool {
+        debug_assert_matches!(self.def_kind(def_id), DefKind::Fn | DefKind::AssocFn);
         self.is_conditionally_const(def_id)
     }
 
     fn alias_has_const_conditions(self, def_id: DefId) -> bool {
+        debug_assert_matches!(self.def_kind(def_id), DefKind::AssocTy | DefKind::OpaqueTy);
         self.is_conditionally_const(def_id)
     }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -610,6 +610,7 @@ symbols! {
         const_compare_raw_pointers,
         const_constructor,
         const_deallocate,
+        const_destruct,
         const_eval_limit,
         const_eval_select,
         const_evaluatable_checked,

--- a/compiler/rustc_type_ir/src/inherent.rs
+++ b/compiler/rustc_type_ir/src/inherent.rs
@@ -11,7 +11,7 @@ use rustc_ast_ir::Mutability;
 use crate::elaborate::Elaboratable;
 use crate::fold::{TypeFoldable, TypeSuperFoldable};
 use crate::relate::Relate;
-use crate::solve::Reveal;
+use crate::solve::{AdtDestructorKind, Reveal};
 use crate::visit::{Flags, TypeSuperVisitable, TypeVisitable};
 use crate::{self as ty, CollectAndApply, Interner, UpcastFrom};
 
@@ -537,6 +537,8 @@ pub trait AdtDef<I: Interner>: Copy + Debug + Hash + Eq {
     fn sized_constraint(self, interner: I) -> Option<ty::EarlyBinder<I, I::Ty>>;
 
     fn is_fundamental(self) -> bool;
+
+    fn destructor(self, interner: I) -> Option<AdtDestructorKind>;
 }
 
 pub trait ParamEnv<I: Interner>: Copy + Debug + Hash + Eq + TypeFoldable<I> {

--- a/compiler/rustc_type_ir/src/interner.rs
+++ b/compiler/rustc_type_ir/src/interner.rs
@@ -225,6 +225,7 @@ pub trait Interner:
 
     fn impl_is_const(self, def_id: Self::DefId) -> bool;
     fn fn_is_const(self, def_id: Self::DefId) -> bool;
+    fn alias_has_const_conditions(self, def_id: Self::DefId) -> bool;
     fn const_conditions(
         self,
         def_id: Self::DefId,

--- a/compiler/rustc_type_ir/src/lang_items.rs
+++ b/compiler/rustc_type_ir/src/lang_items.rs
@@ -19,6 +19,7 @@ pub enum TraitSolverLangItem {
     CoroutineYield,
     Destruct,
     DiscriminantKind,
+    Drop,
     DynMetadata,
     Fn,
     FnMut,

--- a/compiler/rustc_type_ir/src/solve/mod.rs
+++ b/compiler/rustc_type_ir/src/solve/mod.rs
@@ -326,3 +326,10 @@ impl MaybeCause {
         }
     }
 }
+
+/// Indicates that a `impl Drop for Adt` is `const` or not.
+#[derive(Debug)]
+pub enum AdtDestructorKind {
+    NotConst,
+    Const,
+}

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -953,7 +953,7 @@ marker_impls! {
 ///
 /// This should be used for `~const` bounds,
 /// as non-const bounds will always hold for every type.
-#[unstable(feature = "const_destruct", issue = "10")]
+#[unstable(feature = "const_destruct", issue = "133214")]
 #[lang = "destruct"]
 #[rustc_on_unimplemented(message = "can't drop `{Self}`", append_const_msg)]
 #[rustc_deny_explicit_impl(implement_via_object = false)]

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -953,7 +953,7 @@ marker_impls! {
 ///
 /// This should be used for `~const` bounds,
 /// as non-const bounds will always hold for every type.
-#[unstable(feature = "const_trait_impl", issue = "67792")]
+#[unstable(feature = "const_destruct", issue = "10")]
 #[lang = "destruct"]
 #[rustc_on_unimplemented(message = "can't drop `{Self}`", append_const_msg)]
 #[rustc_deny_explicit_impl(implement_via_object = false)]

--- a/tests/ui/consts/const-block-const-bound.rs
+++ b/tests/ui/consts/const-block-const-bound.rs
@@ -1,7 +1,7 @@
 //@ known-bug: #103507
 
 #![allow(unused)]
-#![feature(const_trait_impl, negative_impls)]
+#![feature(const_trait_impl, negative_impls, const_destruct)]
 
 use std::marker::Destruct;
 

--- a/tests/ui/consts/const-block-const-bound.stderr
+++ b/tests/ui/consts/const-block-const-bound.stderr
@@ -1,23 +1,3 @@
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/const-block-const-bound.rs:6:5
-   |
-LL | use std::marker::Destruct;
-   |     ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/const-block-const-bound.rs:8:22
-   |
-LL | const fn f<T: ~const Destruct>(x: T) {}
-   |                      ^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: `~const` can only be applied to `#[const_trait]` traits
   --> $DIR/const-block-const-bound.rs:8:15
    |
@@ -40,7 +20,6 @@ LL | const fn f<T: ~const Destruct>(x: T) {}
    |                                |
    |                                the destructor for this type cannot be evaluated in constant functions
 
-error: aborting due to 5 previous errors
+error: aborting due to 3 previous errors
 
-Some errors have detailed explanations: E0493, E0658.
-For more information about an error, try `rustc --explain E0493`.
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/consts/const-block-const-bound.stderr
+++ b/tests/ui/consts/const-block-const-bound.stderr
@@ -1,3 +1,23 @@
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/const-block-const-bound.rs:6:5
+   |
+LL | use std::marker::Destruct;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/const-block-const-bound.rs:8:22
+   |
+LL | const fn f<T: ~const Destruct>(x: T) {}
+   |                      ^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error: `~const` can only be applied to `#[const_trait]` traits
   --> $DIR/const-block-const-bound.rs:8:15
    |
@@ -20,6 +40,7 @@ LL | const fn f<T: ~const Destruct>(x: T) {}
    |                                |
    |                                the destructor for this type cannot be evaluated in constant functions
 
-error: aborting due to 3 previous errors
+error: aborting due to 5 previous errors
 
-For more information about this error, try `rustc --explain E0493`.
+Some errors have detailed explanations: E0493, E0658.
+For more information about an error, try `rustc --explain E0493`.

--- a/tests/ui/consts/const-block-const-bound.stderr
+++ b/tests/ui/consts/const-block-const-bound.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL | use std::marker::Destruct;
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -14,7 +14,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL | const fn f<T: ~const Destruct>(x: T) {}
    |                      ^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 

--- a/tests/ui/consts/control-flow/drop-fail.precise.stderr
+++ b/tests/ui/consts/control-flow/drop-fail.precise.stderr
@@ -1,14 +1,20 @@
 error[E0493]: destructor of `Option<Vec<i32>>` cannot be evaluated at compile-time
-  --> $DIR/drop-fail.rs:8:9
+  --> $DIR/drop-fail.rs:9:9
    |
 LL |     let x = Some(Vec::new());
    |         ^ the destructor for this type cannot be evaluated in constants
+...
+LL | };
+   | - value is dropped here
 
 error[E0493]: destructor of `Option<Vec<i32>>` cannot be evaluated at compile-time
-  --> $DIR/drop-fail.rs:39:9
+  --> $DIR/drop-fail.rs:40:9
    |
 LL |     let mut tmp = None;
    |         ^^^^^^^ the destructor for this type cannot be evaluated in constants
+...
+LL | };
+   | - value is dropped here
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/control-flow/drop-fail.rs
+++ b/tests/ui/consts/control-flow/drop-fail.rs
@@ -1,5 +1,6 @@
 //@ revisions: stock precise
 
+#![feature(const_destruct)]
 #![cfg_attr(precise, feature(const_precise_live_drops))]
 
 // `x` is *not* always moved into the final value and may be dropped inside the initializer.

--- a/tests/ui/consts/control-flow/drop-fail.stock.stderr
+++ b/tests/ui/consts/control-flow/drop-fail.stock.stderr
@@ -1,5 +1,5 @@
 error[E0493]: destructor of `Option<Vec<i32>>` cannot be evaluated at compile-time
-  --> $DIR/drop-fail.rs:8:9
+  --> $DIR/drop-fail.rs:9:9
    |
 LL |     let x = Some(Vec::new());
    |         ^ the destructor for this type cannot be evaluated in constants
@@ -8,7 +8,7 @@ LL | };
    | - value is dropped here
 
 error[E0493]: destructor of `(Vec<i32>,)` cannot be evaluated at compile-time
-  --> $DIR/drop-fail.rs:21:9
+  --> $DIR/drop-fail.rs:22:9
    |
 LL |     let vec_tuple = (Vec::new(),);
    |         ^^^^^^^^^ the destructor for this type cannot be evaluated in constants
@@ -17,7 +17,7 @@ LL | };
    | - value is dropped here
 
 error[E0493]: destructor of `Result<Vec<i32>, Vec<i32>>` cannot be evaluated at compile-time
-  --> $DIR/drop-fail.rs:29:9
+  --> $DIR/drop-fail.rs:30:9
    |
 LL |     let x: Result<_, Vec<i32>> = Ok(Vec::new());
    |         ^ the destructor for this type cannot be evaluated in constants
@@ -26,7 +26,7 @@ LL | };
    | - value is dropped here
 
 error[E0493]: destructor of `Option<Vec<i32>>` cannot be evaluated at compile-time
-  --> $DIR/drop-fail.rs:39:9
+  --> $DIR/drop-fail.rs:40:9
    |
 LL |     let mut tmp = None;
    |         ^^^^^^^ the destructor for this type cannot be evaluated in constants

--- a/tests/ui/consts/drop_zst.stderr
+++ b/tests/ui/consts/drop_zst.stderr
@@ -3,6 +3,8 @@ error[E0493]: destructor of `S` cannot be evaluated at compile-time
    |
 LL |     let s = S;
    |         ^ the destructor for this type cannot be evaluated in constant functions
+LL | }
+   | - value is dropped here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/fn_trait_refs.rs
+++ b/tests/ui/consts/fn_trait_refs.rs
@@ -5,6 +5,7 @@
 #![feature(unboxed_closures)]
 #![feature(const_trait_impl)]
 #![feature(const_cmp)]
+#![feature(const_destruct)]
 
 use std::marker::Destruct;
 

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL | use std::marker::Destruct;
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -14,7 +14,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL |     T: ~const Fn<()> + ~const Destruct,
    |                               ^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -24,7 +24,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |                                  ^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -34,7 +34,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL |     T: ~const Fn<()> + ~const Destruct,
    |                               ^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -44,7 +44,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |                                  ^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -1,53 +1,3 @@
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/fn_trait_refs.rs:9:5
-   |
-LL | use std::marker::Destruct;
-   |     ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/fn_trait_refs.rs:13:31
-   |
-LL |     T: ~const Fn<()> + ~const Destruct,
-   |                               ^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/fn_trait_refs.rs:20:34
-   |
-LL |     T: ~const FnMut<()> + ~const Destruct,
-   |                                  ^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/fn_trait_refs.rs:34:31
-   |
-LL |     T: ~const Fn<()> + ~const Destruct,
-   |                               ^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/fn_trait_refs.rs:48:34
-   |
-LL |     T: ~const FnMut<()> + ~const Destruct,
-   |                                  ^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error[E0635]: unknown feature `const_fn_trait_ref_impls`
   --> $DIR/fn_trait_refs.rs:3:12
    |
@@ -61,19 +11,19 @@ LL | #![feature(const_cmp)]
    |            ^^^^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:13:8
+  --> $DIR/fn_trait_refs.rs:14:8
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
    |        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:13:24
+  --> $DIR/fn_trait_refs.rs:14:24
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
    |                        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:13:8
+  --> $DIR/fn_trait_refs.rs:14:8
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
    |        ^^^^^^
@@ -81,7 +31,7 @@ LL |     T: ~const Fn<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:13:8
+  --> $DIR/fn_trait_refs.rs:14:8
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
    |        ^^^^^^
@@ -89,7 +39,7 @@ LL |     T: ~const Fn<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:13:24
+  --> $DIR/fn_trait_refs.rs:14:24
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
    |                        ^^^^^^
@@ -97,19 +47,19 @@ LL |     T: ~const Fn<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:20:8
+  --> $DIR/fn_trait_refs.rs:21:8
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:20:27
+  --> $DIR/fn_trait_refs.rs:21:27
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |                           ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:20:8
+  --> $DIR/fn_trait_refs.rs:21:8
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |        ^^^^^^
@@ -117,7 +67,7 @@ LL |     T: ~const FnMut<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:20:8
+  --> $DIR/fn_trait_refs.rs:21:8
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |        ^^^^^^
@@ -125,7 +75,7 @@ LL |     T: ~const FnMut<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:20:27
+  --> $DIR/fn_trait_refs.rs:21:27
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |                           ^^^^^^
@@ -133,21 +83,13 @@ LL |     T: ~const FnMut<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:27:8
+  --> $DIR/fn_trait_refs.rs:28:8
    |
 LL |     T: ~const FnOnce<()>,
    |        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:27:8
-   |
-LL |     T: ~const FnOnce<()>,
-   |        ^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
-error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:27:8
+  --> $DIR/fn_trait_refs.rs:28:8
    |
 LL |     T: ~const FnOnce<()>,
    |        ^^^^^^
@@ -155,19 +97,27 @@ LL |     T: ~const FnOnce<()>,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:34:8
+  --> $DIR/fn_trait_refs.rs:28:8
+   |
+LL |     T: ~const FnOnce<()>,
+   |        ^^^^^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: `~const` can only be applied to `#[const_trait]` traits
+  --> $DIR/fn_trait_refs.rs:35:8
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
    |        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:34:24
+  --> $DIR/fn_trait_refs.rs:35:24
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
    |                        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:34:8
+  --> $DIR/fn_trait_refs.rs:35:8
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
    |        ^^^^^^
@@ -175,7 +125,7 @@ LL |     T: ~const Fn<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:34:8
+  --> $DIR/fn_trait_refs.rs:35:8
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
    |        ^^^^^^
@@ -183,7 +133,7 @@ LL |     T: ~const Fn<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:34:24
+  --> $DIR/fn_trait_refs.rs:35:24
    |
 LL |     T: ~const Fn<()> + ~const Destruct,
    |                        ^^^^^^
@@ -191,19 +141,19 @@ LL |     T: ~const Fn<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:48:8
+  --> $DIR/fn_trait_refs.rs:49:8
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |        ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:48:27
+  --> $DIR/fn_trait_refs.rs:49:27
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |                           ^^^^^^
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:48:8
+  --> $DIR/fn_trait_refs.rs:49:8
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |        ^^^^^^
@@ -211,7 +161,7 @@ LL |     T: ~const FnMut<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:48:8
+  --> $DIR/fn_trait_refs.rs:49:8
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |        ^^^^^^
@@ -219,7 +169,7 @@ LL |     T: ~const FnMut<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: `~const` can only be applied to `#[const_trait]` traits
-  --> $DIR/fn_trait_refs.rs:48:27
+  --> $DIR/fn_trait_refs.rs:49:27
    |
 LL |     T: ~const FnMut<()> + ~const Destruct,
    |                           ^^^^^^
@@ -227,7 +177,7 @@ LL |     T: ~const FnMut<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0015]: cannot call non-const operator in constants
-  --> $DIR/fn_trait_refs.rs:70:17
+  --> $DIR/fn_trait_refs.rs:71:17
    |
 LL |         assert!(test_one == (1, 1, 1));
    |                 ^^^^^^^^^^^^^^^^^^^^^
@@ -235,7 +185,7 @@ LL |         assert!(test_one == (1, 1, 1));
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error[E0015]: cannot call non-const operator in constants
-  --> $DIR/fn_trait_refs.rs:73:17
+  --> $DIR/fn_trait_refs.rs:74:17
    |
 LL |         assert!(test_two == (2, 2));
    |                 ^^^^^^^^^^^^^^^^^^
@@ -243,7 +193,7 @@ LL |         assert!(test_two == (2, 2));
    = note: calls in constants are limited to constant functions, tuple structs and tuple variants
 
 error[E0015]: cannot call non-const closure in constant functions
-  --> $DIR/fn_trait_refs.rs:15:5
+  --> $DIR/fn_trait_refs.rs:16:5
    |
 LL |     f()
    |     ^^^
@@ -255,7 +205,7 @@ LL |     T: ~const Fn<()> + ~const Destruct + ~const Fn(),
    |                                        +++++++++++++
 
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
-  --> $DIR/fn_trait_refs.rs:11:23
+  --> $DIR/fn_trait_refs.rs:12:23
    |
 LL | const fn tester_fn<T>(f: T) -> T::Output
    |                       ^ the destructor for this type cannot be evaluated in constant functions
@@ -264,7 +214,7 @@ LL | }
    | - value is dropped here
 
 error[E0015]: cannot call non-const closure in constant functions
-  --> $DIR/fn_trait_refs.rs:22:5
+  --> $DIR/fn_trait_refs.rs:23:5
    |
 LL |     f()
    |     ^^^
@@ -276,7 +226,7 @@ LL |     T: ~const FnMut<()> + ~const Destruct + ~const FnMut(),
    |                                           ++++++++++++++++
 
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
-  --> $DIR/fn_trait_refs.rs:18:27
+  --> $DIR/fn_trait_refs.rs:19:27
    |
 LL | const fn tester_fn_mut<T>(mut f: T) -> T::Output
    |                           ^^^^^ the destructor for this type cannot be evaluated in constant functions
@@ -285,7 +235,7 @@ LL | }
    | - value is dropped here
 
 error[E0015]: cannot call non-const closure in constant functions
-  --> $DIR/fn_trait_refs.rs:29:5
+  --> $DIR/fn_trait_refs.rs:30:5
    |
 LL |     f()
    |     ^^^
@@ -297,7 +247,7 @@ LL |     T: ~const FnOnce<()> + ~const FnOnce(),
    |                          +++++++++++++++++
 
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
-  --> $DIR/fn_trait_refs.rs:32:21
+  --> $DIR/fn_trait_refs.rs:33:21
    |
 LL | const fn test_fn<T>(mut f: T) -> (T::Output, T::Output, T::Output)
    |                     ^^^^^ the destructor for this type cannot be evaluated in constant functions
@@ -306,7 +256,7 @@ LL | }
    | - value is dropped here
 
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
-  --> $DIR/fn_trait_refs.rs:46:25
+  --> $DIR/fn_trait_refs.rs:47:25
    |
 LL | const fn test_fn_mut<T>(mut f: T) -> (T::Output, T::Output)
    |                         ^^^^^ the destructor for this type cannot be evaluated in constant functions
@@ -314,7 +264,7 @@ LL | const fn test_fn_mut<T>(mut f: T) -> (T::Output, T::Output)
 LL | }
    | - value is dropped here
 
-error: aborting due to 39 previous errors
+error: aborting due to 34 previous errors
 
-Some errors have detailed explanations: E0015, E0493, E0635, E0658.
+Some errors have detailed explanations: E0015, E0493, E0635.
 For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -1,3 +1,53 @@
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/fn_trait_refs.rs:9:5
+   |
+LL | use std::marker::Destruct;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/fn_trait_refs.rs:13:31
+   |
+LL |     T: ~const Fn<()> + ~const Destruct,
+   |                               ^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/fn_trait_refs.rs:20:34
+   |
+LL |     T: ~const FnMut<()> + ~const Destruct,
+   |                                  ^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/fn_trait_refs.rs:34:31
+   |
+LL |     T: ~const Fn<()> + ~const Destruct,
+   |                               ^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/fn_trait_refs.rs:48:34
+   |
+LL |     T: ~const FnMut<()> + ~const Destruct,
+   |                                  ^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0635]: unknown feature `const_fn_trait_ref_impls`
   --> $DIR/fn_trait_refs.rs:3:12
    |
@@ -264,7 +314,7 @@ LL | const fn test_fn_mut<T>(mut f: T) -> (T::Output, T::Output)
 LL | }
    | - value is dropped here
 
-error: aborting due to 34 previous errors
+error: aborting due to 39 previous errors
 
-Some errors have detailed explanations: E0015, E0493, E0635.
+Some errors have detailed explanations: E0015, E0493, E0635, E0658.
 For more information about an error, try `rustc --explain E0015`.

--- a/tests/ui/consts/promoted_const_call.stderr
+++ b/tests/ui/consts/promoted_const_call.stderr
@@ -7,25 +7,13 @@ LL | impl const Drop for Panic { fn drop(&mut self) { panic!(); } }
    = note: marking a trait with `#[const_trait]` ensures all default method bodies are `const`
    = note: adding a non-const method body in the future would be a breaking change
 
-error[E0716]: temporary value dropped while borrowed
-  --> $DIR/promoted_const_call.rs:10:26
-   |
-LL |     let _: &'static _ = &id(&Panic);
-   |            ----------    ^^^^^^^^^^ creates a temporary value which is freed while still in use
-   |            |
-   |            type annotation requires that borrow lasts for `'static`
-...
-LL | };
-   | - temporary value is freed at the end of this statement
-
-error[E0716]: temporary value dropped while borrowed
+error[E0493]: destructor of `Panic` cannot be evaluated at compile-time
   --> $DIR/promoted_const_call.rs:10:30
    |
 LL |     let _: &'static _ = &id(&Panic);
-   |            ----------        ^^^^^ - temporary value is freed at the end of this statement
-   |            |                 |
-   |            |                 creates a temporary value which is freed while still in use
-   |            type annotation requires that borrow lasts for `'static`
+   |                              ^^^^^ - value is dropped here
+   |                              |
+   |                              the destructor for this type cannot be evaluated in constants
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call.rs:16:26
@@ -69,6 +57,7 @@ LL |     let _: &'static _ = &&(Panic, 0).1;
 LL | }
    | - temporary value is freed at the end of this statement
 
-error: aborting due to 7 previous errors
+error: aborting due to 6 previous errors
 
-For more information about this error, try `rustc --explain E0716`.
+Some errors have detailed explanations: E0493, E0716.
+For more information about an error, try `rustc --explain E0493`.

--- a/tests/ui/consts/promoted_const_call2.stderr
+++ b/tests/ui/consts/promoted_const_call2.stderr
@@ -22,7 +22,9 @@ error[E0493]: destructor of `String` cannot be evaluated at compile-time
   --> $DIR/promoted_const_call2.rs:4:30
    |
 LL |     let _: &'static _ = &id(&String::new());
-   |                              ^^^^^^^^^^^^^ the destructor for this type cannot be evaluated in constants
+   |                              ^^^^^^^^^^^^^ - value is dropped here
+   |                              |
+   |                              the destructor for this type cannot be evaluated in constants
 
 error[E0716]: temporary value dropped while borrowed
   --> $DIR/promoted_const_call2.rs:11:26

--- a/tests/ui/consts/qualif-indirect-mutation-fail.stderr
+++ b/tests/ui/consts/qualif-indirect-mutation-fail.stderr
@@ -3,6 +3,9 @@ error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
    |
 LL |     let mut x = None;
    |         ^^^^^ the destructor for this type cannot be evaluated in constants
+...
+LL | };
+   | - value is dropped here
 
 error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
@@ -26,6 +29,8 @@ error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
    |
 LL |     let _z = x;
    |         ^^ the destructor for this type cannot be evaluated in constants
+LL | };
+   | - value is dropped here
 
 error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL
@@ -49,42 +54,62 @@ error[E0493]: destructor of `(u32, Option<String>)` cannot be evaluated at compi
    |
 LL |     let mut a: (u32, Option<String>) = (0, None);
    |         ^^^^^ the destructor for this type cannot be evaluated in constant functions
+LL |     let _ = &mut a.1;
+LL | }
+   | - value is dropped here
 
 error[E0493]: destructor of `Option<T>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:34:9
    |
 LL |     let x: Option<T> = None;
    |         ^ the destructor for this type cannot be evaluated in constant functions
+LL |     let _ = x.is_some();
+LL | }
+   | - value is dropped here
 
 error[E0493]: destructor of `Option<T>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:42:9
    |
 LL |     let _y = x;
    |         ^^ the destructor for this type cannot be evaluated in constant functions
+LL | }
+   | - value is dropped here
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:50:9
    |
 LL |     let mut y: Option<String> = None;
    |         ^^^^^ the destructor for this type cannot be evaluated in constant functions
+LL |     std::ptr::addr_of_mut!(y);
+LL | }
+   | - value is dropped here
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:47:9
    |
 LL |     let mut x: Option<String> = None;
    |         ^^^^^ the destructor for this type cannot be evaluated in constant functions
+...
+LL | }
+   | - value is dropped here
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:60:9
    |
 LL |     let y: Option<String> = None;
    |         ^ the destructor for this type cannot be evaluated in constant functions
+LL |     std::ptr::addr_of!(y);
+LL | }
+   | - value is dropped here
 
 error[E0493]: destructor of `Option<String>` cannot be evaluated at compile-time
   --> $DIR/qualif-indirect-mutation-fail.rs:57:9
    |
 LL |     let x: Option<String> = None;
    |         ^ the destructor for this type cannot be evaluated in constant functions
+...
+LL | }
+   | - value is dropped here
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/impl-trait/normalize-tait-in-const.rs
+++ b/tests/ui/impl-trait/normalize-tait-in-const.rs
@@ -1,7 +1,7 @@
 //@ known-bug: #103507
 
 #![feature(type_alias_impl_trait)]
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_destruct)]
 
 use std::marker::Destruct;
 

--- a/tests/ui/traits/const-traits/const-drop-bound.rs
+++ b/tests/ui/traits/const-traits/const-drop-bound.rs
@@ -2,7 +2,7 @@
 // FIXME check-pass
 
 #![feature(const_trait_impl)]
-#![feature(const_precise_live_drops)]
+#![feature(const_precise_live_drops, const_destruct)]
 
 use std::marker::Destruct;
 

--- a/tests/ui/traits/const-traits/const-drop-bound.stderr
+++ b/tests/ui/traits/const-traits/const-drop-bound.stderr
@@ -1,43 +1,3 @@
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/const-drop-bound.rs:7:5
-   |
-LL | use std::marker::Destruct;
-   |     ^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/const-drop-bound.rs:9:68
-   |
-LL | const fn foo<T, E>(res: Result<T, E>) -> Option<T> where E: ~const Destruct {
-   |                                                                    ^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/const-drop-bound.rs:20:15
-   |
-LL |     T: ~const Destruct,
-   |               ^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/const-drop-bound.rs:21:15
-   |
-LL |     E: ~const Destruct,
-   |               ^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: `~const` can only be applied to `#[const_trait]` traits
   --> $DIR/const-drop-bound.rs:9:61
    |
@@ -88,7 +48,6 @@ LL |         Err(_e) => None,
    |             |
    |             the destructor for this type cannot be evaluated in constant functions
 
-error: aborting due to 11 previous errors
+error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0493, E0658.
-For more information about an error, try `rustc --explain E0493`.
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/traits/const-traits/const-drop-bound.stderr
+++ b/tests/ui/traits/const-traits/const-drop-bound.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL | use std::marker::Destruct;
    |     ^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -14,7 +14,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL | const fn foo<T, E>(res: Result<T, E>) -> Option<T> where E: ~const Destruct {
    |                                                                    ^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -24,7 +24,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL |     T: ~const Destruct,
    |               ^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -34,7 +34,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL |     E: ~const Destruct,
    |               ^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 

--- a/tests/ui/traits/const-traits/const-drop-bound.stderr
+++ b/tests/ui/traits/const-traits/const-drop-bound.stderr
@@ -1,3 +1,43 @@
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/const-drop-bound.rs:7:5
+   |
+LL | use std::marker::Destruct;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/const-drop-bound.rs:9:68
+   |
+LL | const fn foo<T, E>(res: Result<T, E>) -> Option<T> where E: ~const Destruct {
+   |                                                                    ^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/const-drop-bound.rs:20:15
+   |
+LL |     T: ~const Destruct,
+   |               ^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/const-drop-bound.rs:21:15
+   |
+LL |     E: ~const Destruct,
+   |               ^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error: `~const` can only be applied to `#[const_trait]` traits
   --> $DIR/const-drop-bound.rs:9:61
    |
@@ -44,8 +84,11 @@ error[E0493]: destructor of `E` cannot be evaluated at compile-time
   --> $DIR/const-drop-bound.rs:12:13
    |
 LL |         Err(_e) => None,
-   |             ^^ the destructor for this type cannot be evaluated in constant functions
+   |             ^^        - value is dropped here
+   |             |
+   |             the destructor for this type cannot be evaluated in constant functions
 
-error: aborting due to 7 previous errors
+error: aborting due to 11 previous errors
 
-For more information about this error, try `rustc --explain E0493`.
+Some errors have detailed explanations: E0493, E0658.
+For more information about an error, try `rustc --explain E0493`.

--- a/tests/ui/traits/const-traits/const-drop-fail-2.rs
+++ b/tests/ui/traits/const-traits/const-drop-fail-2.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #110395
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_destruct)]
 // #![cfg_attr(precise, feature(const_precise_live_drops))]
 
 use std::marker::{Destruct, PhantomData};

--- a/tests/ui/traits/const-traits/const-drop-fail-2.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail-2.stderr
@@ -1,3 +1,23 @@
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/const-drop-fail-2.rs:5:19
+   |
+LL | use std::marker::{Destruct, PhantomData};
+   |                   ^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: use of unstable library feature `const_destruct`
+  --> $DIR/const-drop-fail-2.rs:20:26
+   |
+LL | const fn check<T: ~const Destruct>(_: T) {}
+   |                          ^^^^^^^^
+   |
+   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error: const `impl` for trait `Drop` which is not marked with `#[const_trait]`
   --> $DIR/const-drop-fail-2.rs:39:25
    |
@@ -35,7 +55,7 @@ LL | const fn check<T: ~const Destruct>(_: T) {}
    |                                    |
    |                                    the destructor for this type cannot be evaluated in constant functions
 
-error: aborting due to 5 previous errors
+error: aborting due to 7 previous errors
 
-Some errors have detailed explanations: E0277, E0493.
+Some errors have detailed explanations: E0277, E0493, E0658.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/const-drop-fail-2.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail-2.stderr
@@ -1,23 +1,3 @@
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/const-drop-fail-2.rs:5:19
-   |
-LL | use std::marker::{Destruct, PhantomData};
-   |                   ^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: use of unstable library feature `const_destruct`
-  --> $DIR/const-drop-fail-2.rs:20:26
-   |
-LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                          ^^^^^^^^
-   |
-   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
-   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
 error: const `impl` for trait `Drop` which is not marked with `#[const_trait]`
   --> $DIR/const-drop-fail-2.rs:39:25
    |
@@ -55,7 +35,7 @@ LL | const fn check<T: ~const Destruct>(_: T) {}
    |                                    |
    |                                    the destructor for this type cannot be evaluated in constant functions
 
-error: aborting due to 7 previous errors
+error: aborting due to 5 previous errors
 
-Some errors have detailed explanations: E0277, E0493, E0658.
+Some errors have detailed explanations: E0277, E0493.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/const-drop-fail-2.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail-2.stderr
@@ -4,7 +4,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL | use std::marker::{Destruct, PhantomData};
    |                   ^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -14,7 +14,7 @@ error[E0658]: use of unstable library feature `const_destruct`
 LL | const fn check<T: ~const Destruct>(_: T) {}
    |                          ^^^^^^^^
    |
-   = note: see issue #10 <https://github.com/rust-lang/rust/issues/10> for more information
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
    = help: add `#![feature(const_destruct)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 

--- a/tests/ui/traits/const-traits/const-drop-fail.precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.precise.stderr
@@ -25,7 +25,9 @@ error[E0493]: destructor of `T` cannot be evaluated at compile-time
   --> $DIR/const-drop-fail.rs:23:36
    |
 LL | const fn check<T: ~const Destruct>(_: T) {}
-   |                                    ^ the destructor for this type cannot be evaluated in constant functions
+   |                                    ^      - value is dropped here
+   |                                    |
+   |                                    the destructor for this type cannot be evaluated in constant functions
 
 error[E0080]: evaluation of constant value failed
   --> $SRC_DIR/core/src/ptr/mod.rs:LL:COL

--- a/tests/ui/traits/const-traits/const-drop-fail.rs
+++ b/tests/ui/traits/const-traits/const-drop-fail.rs
@@ -1,7 +1,7 @@
 //@ known-bug: #110395
 
 //@ revisions: stock precise
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_destruct)]
 #![cfg_attr(precise, feature(const_precise_live_drops))]
 
 use std::marker::{Destruct, PhantomData};

--- a/tests/ui/traits/const-traits/const-drop.precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop.precise.stderr
@@ -72,6 +72,12 @@ note: required by a bound in `t::ConstDropWithBound`
 LL |     pub struct ConstDropWithBound<T: const SomeTrait>(pub core::marker::PhantomData<T>);
    |                                      ^^^^^ required by this bound in `ConstDropWithBound`
 
+error[E0493]: destructor of `S<'_>` cannot be evaluated at compile-time
+  --> $DIR/const-drop.rs:23:13
+   |
+LL |     let _ = S(&mut c);
+   |             ^^^^^^^^^ the destructor for this type cannot be evaluated in constant functions
+
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
   --> $DIR/const-drop.rs:18:32
    |
@@ -84,7 +90,7 @@ error[E0277]: the trait bound `T: ~const SomeTrait` is not satisfied
 LL |             T::foo();
    |             ^^^^^^^^
 
-error: aborting due to 10 previous errors
+error: aborting due to 11 previous errors
 
 Some errors have detailed explanations: E0277, E0493.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/const-drop.precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop.precise.stderr
@@ -76,13 +76,17 @@ error[E0493]: destructor of `S<'_>` cannot be evaluated at compile-time
   --> $DIR/const-drop.rs:23:13
    |
 LL |     let _ = S(&mut c);
-   |             ^^^^^^^^^ the destructor for this type cannot be evaluated in constant functions
+   |             ^^^^^^^^^- value is dropped here
+   |             |
+   |             the destructor for this type cannot be evaluated in constant functions
 
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
   --> $DIR/const-drop.rs:18:32
    |
 LL | const fn a<T: ~const Destruct>(_: T) {}
-   |                                ^ the destructor for this type cannot be evaluated in constant functions
+   |                                ^      - value is dropped here
+   |                                |
+   |                                the destructor for this type cannot be evaluated in constant functions
 
 error[E0277]: the trait bound `T: ~const SomeTrait` is not satisfied
   --> $DIR/const-drop.rs:69:13

--- a/tests/ui/traits/const-traits/const-drop.rs
+++ b/tests/ui/traits/const-traits/const-drop.rs
@@ -1,7 +1,7 @@
 // FIXME run-pass
 //@ known-bug: #110395
 //@ revisions: stock precise
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_destruct)]
 #![feature(never_type)]
 #![cfg_attr(precise, feature(const_precise_live_drops))]
 

--- a/tests/ui/traits/const-traits/const-drop.stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop.stock.stderr
@@ -72,6 +72,14 @@ note: required by a bound in `t::ConstDropWithBound`
 LL |     pub struct ConstDropWithBound<T: const SomeTrait>(pub core::marker::PhantomData<T>);
    |                                      ^^^^^ required by this bound in `ConstDropWithBound`
 
+error[E0493]: destructor of `S<'_>` cannot be evaluated at compile-time
+  --> $DIR/const-drop.rs:23:13
+   |
+LL |     let _ = S(&mut c);
+   |             ^^^^^^^^^- value is dropped here
+   |             |
+   |             the destructor for this type cannot be evaluated in constant functions
+
 error[E0493]: destructor of `T` cannot be evaluated at compile-time
   --> $DIR/const-drop.rs:18:32
    |
@@ -86,7 +94,7 @@ error[E0277]: the trait bound `T: ~const SomeTrait` is not satisfied
 LL |             T::foo();
    |             ^^^^^^^^
 
-error: aborting due to 10 previous errors
+error: aborting due to 11 previous errors
 
 Some errors have detailed explanations: E0277, E0493.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/traits/const-traits/effects/auxiliary/minicore.rs
+++ b/tests/ui/traits/const-traits/effects/auxiliary/minicore.rs
@@ -11,7 +11,8 @@
     rustc_attrs,
     fundamental,
     marker_trait_attr,
-    const_trait_impl
+    const_trait_impl,
+    const_destruct,
 )]
 #![allow(internal_features, incomplete_features)]
 #![no_std]

--- a/tests/ui/traits/const-traits/effects/auxiliary/minicore.rs
+++ b/tests/ui/traits/const-traits/effects/auxiliary/minicore.rs
@@ -444,12 +444,12 @@ impl<T: ?Sized> Deref for Ref<'_, T> {
 
 #[lang = "clone"]
 #[rustc_trivial_field_reads]
-// FIXME: #[const_trait]
+#[const_trait]
 pub trait Clone: Sized {
     fn clone(&self) -> Self;
     fn clone_from(&mut self, source: &Self)
     where
-    // FIXME: Self: ~const Destruct,
+    Self: ~const Destruct,
     {
         *self = source.clone()
     }
@@ -458,7 +458,7 @@ pub trait Clone: Sized {
 #[lang = "structural_peq"]
 pub trait StructuralPartialEq {}
 
-// FIXME: const fn drop<T: ~const Destruct>(_: T) {}
+pub const fn drop<T: ~const Destruct>(_: T) {}
 
 #[rustc_intrinsic_must_be_overridden]
 #[rustc_intrinsic]

--- a/tests/ui/traits/const-traits/effects/auxiliary/minicore.rs
+++ b/tests/ui/traits/const-traits/effects/auxiliary/minicore.rs
@@ -12,7 +12,7 @@
     fundamental,
     marker_trait_attr,
     const_trait_impl,
-    const_destruct,
+    const_destruct
 )]
 #![allow(internal_features, incomplete_features)]
 #![no_std]
@@ -450,7 +450,7 @@ pub trait Clone: Sized {
     fn clone(&self) -> Self;
     fn clone_from(&mut self, source: &Self)
     where
-    Self: ~const Destruct,
+        Self: ~const Destruct,
     {
         *self = source.clone()
     }

--- a/tests/ui/traits/const-traits/effects/minicore-drop-fail.rs
+++ b/tests/ui/traits/const-traits/effects/minicore-drop-fail.rs
@@ -1,0 +1,37 @@
+//@ aux-build:minicore.rs
+//@ compile-flags: --crate-type=lib -Znext-solver
+
+#![feature(no_core, const_trait_impl)]
+#![no_std]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+struct Contains<T>(T);
+
+struct NotDropImpl;
+impl Drop for NotDropImpl {
+    fn drop(&mut self) {}
+}
+
+#[const_trait] trait Foo {}
+impl Foo for () {}
+
+struct Conditional<T: Foo>(T);
+impl<T> const Drop for Conditional<T> where T: ~const Foo {
+    fn drop(&mut self) {}
+}
+
+const fn test() {
+    let _ = NotDropImpl;
+    //~^ ERROR destructor of `NotDropImpl` cannot be evaluated at compile-time
+    let _ = Contains(NotDropImpl);
+    //~^ ERROR destructor of `Contains<NotDropImpl>` cannot be evaluated at compile-time
+    let _ = Conditional(());
+    //~^ ERROR destructor of `Conditional<()>` cannot be evaluated at compile-time
+}
+
+const fn drop_arbitrary<T>(_: T) {
+    //~^ ERROR destructor of `T` cannot be evaluated at compile-time
+}

--- a/tests/ui/traits/const-traits/effects/minicore-drop-fail.rs
+++ b/tests/ui/traits/const-traits/effects/minicore-drop-fail.rs
@@ -1,7 +1,7 @@
 //@ aux-build:minicore.rs
 //@ compile-flags: --crate-type=lib -Znext-solver
 
-#![feature(no_core, const_trait_impl)]
+#![feature(no_core, const_trait_impl, const_destruct)]
 #![no_std]
 #![no_core]
 

--- a/tests/ui/traits/const-traits/effects/minicore-drop-fail.stderr
+++ b/tests/ui/traits/const-traits/effects/minicore-drop-fail.stderr
@@ -1,0 +1,36 @@
+error[E0493]: destructor of `NotDropImpl` cannot be evaluated at compile-time
+  --> $DIR/minicore-drop-fail.rs:27:13
+   |
+LL |     let _ = NotDropImpl;
+   |             ^^^^^^^^^^^- value is dropped here
+   |             |
+   |             the destructor for this type cannot be evaluated in constant functions
+
+error[E0493]: destructor of `Contains<NotDropImpl>` cannot be evaluated at compile-time
+  --> $DIR/minicore-drop-fail.rs:29:13
+   |
+LL |     let _ = Contains(NotDropImpl);
+   |             ^^^^^^^^^^^^^^^^^^^^^- value is dropped here
+   |             |
+   |             the destructor for this type cannot be evaluated in constant functions
+
+error[E0493]: destructor of `Conditional<()>` cannot be evaluated at compile-time
+  --> $DIR/minicore-drop-fail.rs:31:13
+   |
+LL |     let _ = Conditional(());
+   |             ^^^^^^^^^^^^^^^- value is dropped here
+   |             |
+   |             the destructor for this type cannot be evaluated in constant functions
+
+error[E0493]: destructor of `T` cannot be evaluated at compile-time
+  --> $DIR/minicore-drop-fail.rs:35:28
+   |
+LL | const fn drop_arbitrary<T>(_: T) {
+   |                            ^ the destructor for this type cannot be evaluated in constant functions
+LL |
+LL | }
+   | - value is dropped here
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/traits/const-traits/effects/minicore-drop-without-feature-gate.no.stderr
+++ b/tests/ui/traits/const-traits/effects/minicore-drop-without-feature-gate.no.stderr
@@ -1,5 +1,5 @@
 error[E0493]: destructor of `ConstDrop` cannot be evaluated at compile-time
-  --> $DIR/minicore-drop-without-feature-gate.rs:23:13
+  --> $DIR/minicore-drop-without-feature-gate.rs:24:13
    |
 LL |     let _ = ConstDrop;
    |             ^^^^^^^^^- value is dropped here

--- a/tests/ui/traits/const-traits/effects/minicore-drop-without-feature-gate.no.stderr
+++ b/tests/ui/traits/const-traits/effects/minicore-drop-without-feature-gate.no.stderr
@@ -1,0 +1,15 @@
+error[E0493]: destructor of `ConstDrop` cannot be evaluated at compile-time
+  --> $DIR/minicore-drop-without-feature-gate.rs:23:13
+   |
+LL |     let _ = ConstDrop;
+   |             ^^^^^^^^^- value is dropped here
+   |             |
+   |             the destructor for this type cannot be evaluated in constant functions
+   |
+   = note: see issue #133214 <https://github.com/rust-lang/rust/issues/133214> for more information
+   = help: add `#![feature(const_destruct)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0493`.

--- a/tests/ui/traits/const-traits/effects/minicore-drop-without-feature-gate.rs
+++ b/tests/ui/traits/const-traits/effects/minicore-drop-without-feature-gate.rs
@@ -2,6 +2,7 @@
 //@ compile-flags: --crate-type=lib -Znext-solver
 //@ revisions: yes no
 //@[yes] check-pass
+// gate-test-const_destruct
 
 #![feature(no_core, const_trait_impl)]
 #![cfg_attr(yes, feature(const_destruct))]

--- a/tests/ui/traits/const-traits/effects/minicore-drop-without-feature-gate.rs
+++ b/tests/ui/traits/const-traits/effects/minicore-drop-without-feature-gate.rs
@@ -1,0 +1,25 @@
+//@ aux-build:minicore.rs
+//@ compile-flags: --crate-type=lib -Znext-solver
+//@ revisions: yes no
+//@[yes] check-pass
+
+#![feature(no_core, const_trait_impl)]
+#![cfg_attr(yes, feature(const_destruct))]
+#![no_std]
+#![no_core]
+
+extern crate minicore;
+use minicore::*;
+
+struct ConstDrop;
+impl const Drop for ConstDrop {
+    fn drop(&mut self) {}
+}
+
+// Make sure that `ConstDrop` can only be dropped when the `const_drop`
+// feature gate is enabled. Otherwise, we should error if there is a drop
+// impl at all.
+const fn test() {
+    let _ = ConstDrop;
+    //[no]~^ ERROR destructor of `ConstDrop` cannot be evaluated at compile-time
+}

--- a/tests/ui/traits/const-traits/issue-92111.rs
+++ b/tests/ui/traits/const-traits/issue-92111.rs
@@ -3,7 +3,7 @@
 //@ known-bug: #110395
 // FIXME check-pass
 
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_destruct)]
 
 use std::marker::Destruct;
 

--- a/tests/ui/traits/next-solver/destruct.rs
+++ b/tests/ui/traits/next-solver/destruct.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: -Znext-solver
 //@ check-pass
 
-#![feature(const_trait_impl)]
+#![feature(const_trait_impl, const_destruct)]
 
 fn foo(_: impl std::marker::Destruct) {}
 


### PR DESCRIPTION
This also fixed a subtle bug/limitation of the `NeedsConstDrop` check. Specifically, the "`Qualif`" API basically treats const drops as totally structural, even though dropping something that has an explicit `Drop` implementation cannot be structurally decomposed. For example:

```rust
#![feature(const_trait_impl)]

#[const_trait] trait Foo {
    fn foo();
}

struct Conditional<T: Foo>(T);

impl Foo for () {
    fn foo() {
        println!("uh oh");
    }
}

impl<T> const Drop for Conditional<T> where T: ~const Foo {
    fn drop(&mut self) {
        T::foo();
    }
}

const FOO: () = {
    let _ = Conditional(());
    //~^ This should error.
};

fn main() {}
```

In this example, when checking if the `Conditional(())` rvalue is const-drop, since `Conditional` has a const destructor, we would previously recurse into the `()` value and determine it has nothing to drop, which means that it is considered to *not* need a const drop -- even though dropping `Conditional(())` would mean evaluating the destructor which relies on that `T: const Foo` bound to hold!

This could be fixed alternatively by banning any const conditions on `const Drop` impls, but that really sucks -- that means that basically no *interesting* const drop impls could be written. We have the capability to totally and intuitively support the right behavior, which I've implemented here.