### PR TITLE
Use CLOCK_BOOTTIME for Instant in Fuchsia/Android

### DIFF
--- a/library/std/src/sys/pal/unix/time.rs
+++ b/library/std/src/sys/pal/unix/time.rs
@@ -271,7 +271,11 @@ impl Instant {
         // we preserve this value domain out of an abundance of caution.
         #[cfg(target_vendor = "apple")]
         const clock_id: libc::clockid_t = libc::CLOCK_UPTIME_RAW;
-        #[cfg(not(target_vendor = "apple"))]
+        // Instant is intended to progress forward during periods of suspension
+        // in both Android and Fuchsia, and therefore uses CLOCK_BOOTTIME.
+        #[cfg(any(target_os = "android", target_os = "fuchsia"))]
+        const clock_id: libc::clockid_t = libc::CLOCK_BOOTTIME;
+        #[cfg(not(any(target_vendor = "apple", target_os = "fuchsia", target_os = "android")))]
         const clock_id: libc::clockid_t = libc::CLOCK_MONOTONIC;
         Instant { t: Timespec::now(clock_id) }
     }

--- a/library/std/src/time.rs
+++ b/library/std/src/time.rs
@@ -115,6 +115,8 @@ use crate::sys_common::{FromInner, IntoInner};
 /// | SOLID     | `get_tim`                                                            |
 /// | WASI      | [__wasi_clock_time_get (Monotonic Clock)]                            |
 /// | Windows   | [QueryPerformanceCounter]                                            |
+/// | Android   | [clock_gettime (Boottime Clock)]                                     |
+/// | Fuchsia   | [zx_clock_get_boot]                                                  |
 ///
 /// [currently]: crate::io#platform-specific-behavior
 /// [QueryPerformanceCounter]: https://docs.microsoft.com/en-us/windows/win32/api/profileapi/nf-profileapi-queryperformancecounter
@@ -122,6 +124,8 @@ use crate::sys_common::{FromInner, IntoInner};
 /// [timekeeping in SGX]: https://edp.fortanix.com/docs/concepts/rust-std/#codestdtimecode
 /// [__wasi_clock_time_get (Monotonic Clock)]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#clock_time_get
 /// [clock_gettime (Monotonic Clock)]: https://linux.die.net/man/3/clock_gettime
+/// [clock_gettime (Boottime Clock)]: https://linux.die.net/man/2/clock_gettime
+/// [zx_clock_get_boot]: https://fuchsia.dev/reference/syscalls/clock_get_boot
 ///
 /// **Disclaimer:** These system calls might change over time.
 ///


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/132331)*

Fuchsia and Android both want Instants to progress during periods of suspension, and thus must use CLOCK_BOOTTIME as the backing reference clock.

r? @tmandry 
