### PR TITLE
Use `token_descr` more in error messages

### DIFF
--- a/compiler/rustc_expand/messages.ftl
+++ b/compiler/rustc_expand/messages.ftl
@@ -74,7 +74,7 @@ expand_helper_attribute_name_invalid =
     `{$name}` cannot be a name of derive helper attribute
 
 expand_incomplete_parse =
-    macro expansion ignores token `{$token}` and any following
+    macro expansion ignores {$descr} and any tokens following
     .label = caused by the macro expansion here
     .note = the usage of `{$macro_path}!` is likely invalid in {$kind_name} context
     .suggestion_add_semi = you might be missing a semicolon here

--- a/compiler/rustc_expand/src/errors.rs
+++ b/compiler/rustc_expand/src/errors.rs
@@ -275,7 +275,7 @@ pub(crate) struct UnsupportedKeyValue {
 pub(crate) struct IncompleteParse<'a> {
     #[primary_span]
     pub span: Span,
-    pub token: Cow<'a, str>,
+    pub descr: String,
     #[label]
     pub label_span: Span,
     pub macro_path: &'a ast::Path,

--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -21,6 +21,7 @@ use rustc_errors::PResult;
 use rustc_feature::Features;
 use rustc_parse::parser::{
     AttemptLocalParseRecovery, CommaRecoveryMode, ForceCollect, Parser, RecoverColon, RecoverComma,
+    token_descr,
 };
 use rustc_parse::validate_attr;
 use rustc_session::lint::BuiltinLintDiag;
@@ -1013,7 +1014,7 @@ pub(crate) fn ensure_complete_parse<'a>(
     span: Span,
 ) {
     if parser.token != token::Eof {
-        let token = pprust::token_to_string(&parser.token);
+        let descr = token_descr(&parser.token);
         // Avoid emitting backtrace info twice.
         let def_site_span = parser.token.span.with_ctxt(SyntaxContext::root());
 
@@ -1029,7 +1030,7 @@ pub(crate) fn ensure_complete_parse<'a>(
 
         parser.dcx().emit_err(IncompleteParse {
             span: def_site_span,
-            token,
+            descr,
             label_span: span,
             macro_path,
             kind_name,

--- a/compiler/rustc_expand/src/mbe/diagnostics.rs
+++ b/compiler/rustc_expand/src/mbe/diagnostics.rs
@@ -2,10 +2,9 @@ use std::borrow::Cow;
 
 use rustc_ast::token::{self, Token, TokenKind};
 use rustc_ast::tokenstream::TokenStream;
-use rustc_ast_pretty::pprust;
 use rustc_errors::{Applicability, Diag, DiagCtxtHandle, DiagMessage};
 use rustc_macros::Subdiagnostic;
-use rustc_parse::parser::{Parser, Recovery};
+use rustc_parse::parser::{Parser, Recovery, token_descr};
 use rustc_session::parse::ParseSess;
 use rustc_span::source_map::SourceMap;
 use rustc_span::symbol::Ident;
@@ -336,17 +335,11 @@ pub(super) fn annotate_doc_comment(err: &mut Diag<'_>, sm: &SourceMap, span: Spa
 /// other tokens, this is "unexpected token...".
 pub(super) fn parse_failure_msg(tok: &Token, expected_token: Option<&Token>) -> Cow<'static, str> {
     if let Some(expected_token) = expected_token {
-        Cow::from(format!(
-            "expected `{}`, found `{}`",
-            pprust::token_to_string(expected_token),
-            pprust::token_to_string(tok),
-        ))
+        Cow::from(format!("expected {}, found {}", token_descr(expected_token), token_descr(tok)))
     } else {
         match tok.kind {
             token::Eof => Cow::from("unexpected end of macro invocation"),
-            _ => {
-                Cow::from(format!("no rules expected the token `{}`", pprust::token_to_string(tok)))
-            }
+            _ => Cow::from(format!("no rules expected {}", token_descr(tok))),
         }
     }
 }

--- a/compiler/rustc_expand/src/mbe/macro_parser.rs
+++ b/compiler/rustc_expand/src/mbe/macro_parser.rs
@@ -78,11 +78,10 @@ use std::rc::Rc;
 pub(crate) use NamedMatch::*;
 pub(crate) use ParseResult::*;
 use rustc_ast::token::{self, DocComment, NonterminalKind, Token};
-use rustc_ast_pretty::pprust;
 use rustc_data_structures::fx::FxHashMap;
 use rustc_errors::ErrorGuaranteed;
 use rustc_lint_defs::pluralize;
-use rustc_parse::parser::{ParseNtResult, Parser};
+use rustc_parse::parser::{ParseNtResult, Parser, token_descr};
 use rustc_span::Span;
 use rustc_span::symbol::{Ident, MacroRulesNormalizedIdent};
 
@@ -150,7 +149,7 @@ impl Display for MatcherLoc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             MatcherLoc::Token { token } | MatcherLoc::SequenceSep { separator: token } => {
-                write!(f, "`{}`", pprust::token_to_string(token))
+                write!(f, "{}", token_descr(token))
             }
             MatcherLoc::MetaVarDecl { bind, kind, .. } => {
                 write!(f, "meta-variable `${bind}")?;

--- a/compiler/rustc_parse/src/parser/mod.rs
+++ b/compiler/rustc_parse/src/parser/mod.rs
@@ -424,7 +424,7 @@ impl TokenDescription {
     }
 }
 
-pub(super) fn token_descr(token: &Token) -> String {
+pub fn token_descr(token: &Token) -> String {
     let name = pprust::token_to_string(token).to_string();
 
     let kind = match (TokenDescription::from_token(token), &token.kind) {

--- a/tests/ui/array-slice-vec/vec-macro-with-comma-only.rs
+++ b/tests/ui/array-slice-vec/vec-macro-with-comma-only.rs
@@ -1,3 +1,3 @@
 pub fn main() {
-    vec![,]; //~ ERROR no rules expected the token `,`
+    vec![,]; //~ ERROR no rules expected `,`
 }

--- a/tests/ui/array-slice-vec/vec-macro-with-comma-only.stderr
+++ b/tests/ui/array-slice-vec/vec-macro-with-comma-only.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `,`
+error: no rules expected `,`
   --> $DIR/vec-macro-with-comma-only.rs:2:10
    |
 LL |     vec![,];

--- a/tests/ui/editions/edition-keywords-2015-2015-parsing.rs
+++ b/tests/ui/editions/edition-keywords-2015-2015-parsing.rs
@@ -13,8 +13,8 @@ pub fn check_async() {
     let mut r#async = 1; // OK
 
     r#async = consumes_async!(async); // OK
-    r#async = consumes_async!(r#async); //~ ERROR no rules expected the token `r#async`
-    r#async = consumes_async_raw!(async); //~ ERROR no rules expected the token `async`
+    r#async = consumes_async!(r#async); //~ ERROR no rules expected `r#async`
+    r#async = consumes_async_raw!(async); //~ ERROR no rules expected `async`
     r#async = consumes_async_raw!(r#async); // OK
 
     if passes_ident!(async) == 1 {} // OK

--- a/tests/ui/editions/edition-keywords-2015-2015-parsing.stderr
+++ b/tests/ui/editions/edition-keywords-2015-2015-parsing.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `r#async`
+error: no rules expected `r#async`
   --> $DIR/edition-keywords-2015-2015-parsing.rs:16:31
    |
 LL |     r#async = consumes_async!(r#async);
@@ -10,7 +10,7 @@ note: while trying to match `async`
 LL |     (async) => (1)
    |      ^^^^^
 
-error: no rules expected the token `async`
+error: no rules expected `async`
   --> $DIR/edition-keywords-2015-2015-parsing.rs:17:35
    |
 LL |     r#async = consumes_async_raw!(async);

--- a/tests/ui/editions/edition-keywords-2015-2018-parsing.rs
+++ b/tests/ui/editions/edition-keywords-2015-2018-parsing.rs
@@ -13,8 +13,8 @@ pub fn check_async() {
     let mut r#async = 1; // OK
 
     r#async = consumes_async!(async); // OK
-    r#async = consumes_async!(r#async); //~ ERROR no rules expected the token `r#async`
-    r#async = consumes_async_raw!(async); //~ ERROR no rules expected the token `async`
+    r#async = consumes_async!(r#async); //~ ERROR no rules expected `r#async`
+    r#async = consumes_async_raw!(async); //~ ERROR no rules expected `async`
     r#async = consumes_async_raw!(r#async); // OK
 
     if passes_ident!(async) == 1 {} // OK

--- a/tests/ui/editions/edition-keywords-2015-2018-parsing.stderr
+++ b/tests/ui/editions/edition-keywords-2015-2018-parsing.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `r#async`
+error: no rules expected `r#async`
   --> $DIR/edition-keywords-2015-2018-parsing.rs:16:31
    |
 LL |     r#async = consumes_async!(r#async);
@@ -10,7 +10,7 @@ note: while trying to match `async`
 LL |     (async) => (1)
    |      ^^^^^
 
-error: no rules expected the token `async`
+error: no rules expected `async`
   --> $DIR/edition-keywords-2015-2018-parsing.rs:17:35
    |
 LL |     r#async = consumes_async_raw!(async);

--- a/tests/ui/editions/edition-keywords-2018-2015-parsing.rs
+++ b/tests/ui/editions/edition-keywords-2018-2015-parsing.rs
@@ -17,8 +17,8 @@ pub fn check_async() {
     let mut r#async = 1; // OK
 
     r#async = consumes_async!(async); // OK
-    r#async = consumes_async!(r#async); //~ ERROR no rules expected the token `r#async`
-    r#async = consumes_async_raw!(async); //~ ERROR no rules expected the token `async`
+    r#async = consumes_async!(r#async); //~ ERROR no rules expected `r#async`
+    r#async = consumes_async_raw!(async); //~ ERROR no rules expected keyword `async`
     r#async = consumes_async_raw!(r#async); // OK
 
     if passes_ident!(async) == 1 {} // FIXME: Edition hygiene bug, async here is 2018 and reserved

--- a/tests/ui/editions/edition-keywords-2018-2015-parsing.stderr
+++ b/tests/ui/editions/edition-keywords-2018-2015-parsing.stderr
@@ -20,19 +20,19 @@ help: escape `async` to use it as an identifier
 LL |     module::r#async();
    |             ++
 
-error: no rules expected the token `r#async`
+error: no rules expected `r#async`
   --> $DIR/edition-keywords-2018-2015-parsing.rs:20:31
    |
 LL |     r#async = consumes_async!(r#async);
    |                               ^^^^^^^ no rules expected this token in macro call
    |
-note: while trying to match `async`
+note: while trying to match keyword `async`
   --> $DIR/auxiliary/edition-kw-macro-2015.rs:17:6
    |
 LL |     (async) => (1)
    |      ^^^^^
 
-error: no rules expected the token `async`
+error: no rules expected keyword `async`
   --> $DIR/edition-keywords-2018-2015-parsing.rs:21:35
    |
 LL |     r#async = consumes_async_raw!(async);

--- a/tests/ui/editions/edition-keywords-2018-2018-parsing.rs
+++ b/tests/ui/editions/edition-keywords-2018-2018-parsing.rs
@@ -24,8 +24,8 @@ pub fn check_async() {
     let mut r#async = 1; // OK
 
     r#async = consumes_async!(async); // OK
-    r#async = consumes_async!(r#async); //~ ERROR no rules expected the token `r#async`
-    r#async = consumes_async_raw!(async); //~ ERROR no rules expected the token `async`
+    r#async = consumes_async!(r#async); //~ ERROR no rules expected `r#async`
+    r#async = consumes_async_raw!(async); //~ ERROR no rules expected keyword `async`
     r#async = consumes_async_raw!(r#async); // OK
 
     if passes_ident!(async) == 1 {} // FIXME: Edition hygiene bug, async here is 2018 and reserved

--- a/tests/ui/editions/edition-keywords-2018-2018-parsing.stderr
+++ b/tests/ui/editions/edition-keywords-2018-2018-parsing.stderr
@@ -20,19 +20,19 @@ help: escape `async` to use it as an identifier
 LL |     module::r#async();
    |             ++
 
-error: no rules expected the token `r#async`
+error: no rules expected `r#async`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:27:31
    |
 LL |     r#async = consumes_async!(r#async);
    |                               ^^^^^^^ no rules expected this token in macro call
    |
-note: while trying to match `async`
+note: while trying to match keyword `async`
   --> $DIR/auxiliary/edition-kw-macro-2018.rs:17:6
    |
 LL |     (async) => (1)
    |      ^^^^^
 
-error: no rules expected the token `async`
+error: no rules expected keyword `async`
   --> $DIR/edition-keywords-2018-2018-parsing.rs:28:35
    |
 LL |     r#async = consumes_async_raw!(async);

--- a/tests/ui/fail-simple.rs
+++ b/tests/ui/fail-simple.rs
@@ -1,3 +1,3 @@
 fn main() {
-    panic!(@); //~ ERROR no rules expected the token `@`
+    panic!(@); //~ ERROR no rules expected `@`
 }

--- a/tests/ui/fail-simple.stderr
+++ b/tests/ui/fail-simple.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `@`
+error: no rules expected `@`
   --> $DIR/fail-simple.rs:2:12
    |
 LL |     panic!(@);

--- a/tests/ui/macros/assert-trailing-junk.with-generic-asset.stderr
+++ b/tests/ui/macros/assert-trailing-junk.with-generic-asset.stderr
@@ -10,7 +10,7 @@ error: expected one of `,`, `.`, `?`, or an operator, found `some`
 LL |     assert!(true some extra junk);
    |                  ^^^^ expected one of `,`, `.`, `?`, or an operator
 
-error: no rules expected the token `blah`
+error: no rules expected `blah`
   --> $DIR/assert-trailing-junk.rs:15:30
    |
 LL |     assert!(true, "whatever" blah);
@@ -28,7 +28,7 @@ LL |     assert!(true "whatever" blah);
    |                 |
    |                 help: try adding a comma
 
-error: no rules expected the token `blah`
+error: no rules expected `blah`
   --> $DIR/assert-trailing-junk.rs:18:29
    |
 LL |     assert!(true "whatever" blah);

--- a/tests/ui/macros/assert-trailing-junk.without-generic-asset.stderr
+++ b/tests/ui/macros/assert-trailing-junk.without-generic-asset.stderr
@@ -10,7 +10,7 @@ error: expected one of `,`, `.`, `?`, or an operator, found `some`
 LL |     assert!(true some extra junk);
    |                  ^^^^ expected one of `,`, `.`, `?`, or an operator
 
-error: no rules expected the token `blah`
+error: no rules expected `blah`
   --> $DIR/assert-trailing-junk.rs:15:30
    |
 LL |     assert!(true, "whatever" blah);
@@ -28,7 +28,7 @@ LL |     assert!(true "whatever" blah);
    |                 |
    |                 help: try adding a comma
 
-error: no rules expected the token `blah`
+error: no rules expected `blah`
   --> $DIR/assert-trailing-junk.rs:18:29
    |
 LL |     assert!(true "whatever" blah);

--- a/tests/ui/macros/best-failure.rs
+++ b/tests/ui/macros/best-failure.rs
@@ -2,7 +2,7 @@ macro_rules! number {
     (neg false, $self:ident) => { $self };
     ($signed:tt => $ty:ty;) => {
         number!(neg $signed, $self);
-        //~^ ERROR no rules expected the token `$`
+        //~^ ERROR no rules expected `$`
     };
 }
 

--- a/tests/ui/macros/best-failure.stderr
+++ b/tests/ui/macros/best-failure.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `$`
+error: no rules expected `$`
   --> $DIR/best-failure.rs:4:30
    |
 LL | macro_rules! number {

--- a/tests/ui/macros/expr_2021_inline_const.edi2021.stderr
+++ b/tests/ui/macros/expr_2021_inline_const.edi2021.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `const`
+error: no rules expected keyword `const`
   --> $DIR/expr_2021_inline_const.rs:23:12
    |
 LL | macro_rules! m2021 {
@@ -13,7 +13,7 @@ note: while trying to match meta-variable `$e:expr_2021`
 LL |     ($e:expr_2021) => {
    |      ^^^^^^^^^^^^
 
-error: no rules expected the token `const`
+error: no rules expected keyword `const`
   --> $DIR/expr_2021_inline_const.rs:24:12
    |
 LL | macro_rules! m2024 {

--- a/tests/ui/macros/expr_2021_inline_const.edi2024.stderr
+++ b/tests/ui/macros/expr_2021_inline_const.edi2024.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `const`
+error: no rules expected keyword `const`
   --> $DIR/expr_2021_inline_const.rs:23:12
    |
 LL | macro_rules! m2021 {

--- a/tests/ui/macros/expr_2021_inline_const.rs
+++ b/tests/ui/macros/expr_2021_inline_const.rs
@@ -20,8 +20,8 @@ macro_rules! test {
 }
 
 fn main() {
-    m2021!(const { 1 }); //~ ERROR: no rules expected the token `const`
-    m2024!(const { 1 }); //[edi2021]~ ERROR: no rules expected the token `const`
+    m2021!(const { 1 }); //~ ERROR: no rules expected keyword `const`
+    m2024!(const { 1 }); //[edi2021]~ ERROR: no rules expected keyword `const`
 
     test!(expr);
 }

--- a/tests/ui/macros/expr_2024_underscore_expr.edi2021.stderr
+++ b/tests/ui/macros/expr_2024_underscore_expr.edi2021.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `_`
+error: no rules expected reserved identifier `_`
   --> $DIR/expr_2024_underscore_expr.rs:19:12
    |
 LL | macro_rules! m2021 {
@@ -13,7 +13,7 @@ note: while trying to match meta-variable `$e:expr_2021`
 LL |     ($e:expr_2021) => {
    |      ^^^^^^^^^^^^
 
-error: no rules expected the token `_`
+error: no rules expected reserved identifier `_`
   --> $DIR/expr_2024_underscore_expr.rs:20:12
    |
 LL | macro_rules! m2024 {

--- a/tests/ui/macros/expr_2024_underscore_expr.edi2024.stderr
+++ b/tests/ui/macros/expr_2024_underscore_expr.edi2024.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `_`
+error: no rules expected reserved identifier `_`
   --> $DIR/expr_2024_underscore_expr.rs:19:12
    |
 LL | macro_rules! m2021 {

--- a/tests/ui/macros/expr_2024_underscore_expr.rs
+++ b/tests/ui/macros/expr_2024_underscore_expr.rs
@@ -16,6 +16,6 @@ macro_rules! m2024 {
 }
 
 fn main() {
-    m2021!(_); //~ ERROR: no rules expected the token `_`
-    m2024!(_); //[edi2021]~ ERROR: no rules expected the token `_`
+    m2021!(_); //~ ERROR: no rules expected reserved identifier `_`
+    m2024!(_); //[edi2021]~ ERROR: no rules expected reserved identifier `_`
 }

--- a/tests/ui/macros/issue-118786.rs
+++ b/tests/ui/macros/issue-118786.rs
@@ -5,7 +5,7 @@
 macro_rules! make_macro {
     ($macro_name:tt) => {
         macro_rules! $macro_name {
-        //~^ ERROR macro expansion ignores token `{` and any following
+        //~^ ERROR macro expansion ignores `{` and any tokens following
         //~| ERROR cannot find macro `macro_rules` in this scope
         //~| put a macro name here
             () => {}

--- a/tests/ui/macros/issue-118786.stderr
+++ b/tests/ui/macros/issue-118786.stderr
@@ -13,7 +13,7 @@ help: add a semicolon
 LL |         macro_rules! $macro_name; {
    |                                 +
 
-error: macro expansion ignores token `{` and any following
+error: macro expansion ignores `{` and any tokens following
   --> $DIR/issue-118786.rs:7:34
    |
 LL |         macro_rules! $macro_name {

--- a/tests/ui/macros/issue-30007.rs
+++ b/tests/ui/macros/issue-30007.rs
@@ -1,5 +1,5 @@
 macro_rules! t {
-    () => ( String ; );     //~ ERROR macro expansion ignores token `;`
+    () => ( String ; );     //~ ERROR macro expansion ignores `;`
 }
 
 fn main() {

--- a/tests/ui/macros/issue-30007.stderr
+++ b/tests/ui/macros/issue-30007.stderr
@@ -1,4 +1,4 @@
-error: macro expansion ignores token `;` and any following
+error: macro expansion ignores `;` and any tokens following
   --> $DIR/issue-30007.rs:2:20
    |
 LL |     () => ( String ; );

--- a/tests/ui/macros/issue-54441.rs
+++ b/tests/ui/macros/issue-54441.rs
@@ -1,6 +1,6 @@
 macro_rules! m {
     () => {
-        let //~ ERROR macro expansion ignores token `let` and any following
+        let //~ ERROR macro expansion ignores keyword `let` and any tokens following
     };
 }
 

--- a/tests/ui/macros/issue-54441.stderr
+++ b/tests/ui/macros/issue-54441.stderr
@@ -1,4 +1,4 @@
-error: macro expansion ignores token `let` and any following
+error: macro expansion ignores keyword `let` and any tokens following
   --> $DIR/issue-54441.rs:3:9
    |
 LL |         let

--- a/tests/ui/macros/macro-at-most-once-rep-2015.rs
+++ b/tests/ui/macros/macro-at-most-once-rep-2015.rs
@@ -22,21 +22,21 @@ macro_rules! barstar {
 pub fn main() {
     foo!();
     foo!(a);
-    foo!(a?); //~ ERROR no rules expected the token `?`
-    foo!(a?a); //~ ERROR no rules expected the token `?`
-    foo!(a?a?a); //~ ERROR no rules expected the token `?`
+    foo!(a?); //~ ERROR no rules expected `?`
+    foo!(a?a); //~ ERROR no rules expected `?`
+    foo!(a?a?a); //~ ERROR no rules expected `?`
 
     barplus!(); //~ERROR unexpected end of macro invocation
     barplus!(a); //~ERROR unexpected end of macro invocation
-    barplus!(a?); //~ ERROR no rules expected the token `?`
-    barplus!(a?a); //~ ERROR no rules expected the token `?`
+    barplus!(a?); //~ ERROR no rules expected `?`
+    barplus!(a?a); //~ ERROR no rules expected `?`
     barplus!(a+);
     barplus!(+);
 
     barstar!(); //~ERROR unexpected end of macro invocation
     barstar!(a); //~ERROR unexpected end of macro invocation
-    barstar!(a?); //~ ERROR no rules expected the token `?`
-    barstar!(a?a); //~ ERROR no rules expected the token `?`
+    barstar!(a?); //~ ERROR no rules expected `?`
+    barstar!(a?a); //~ ERROR no rules expected `?`
     barstar!(a*);
     barstar!(*);
 }

--- a/tests/ui/macros/macro-at-most-once-rep-2015.stderr
+++ b/tests/ui/macros/macro-at-most-once-rep-2015.stderr
@@ -4,7 +4,7 @@ error: the `?` macro repetition operator does not take a separator
 LL |     ($(a),?) => {};
    |          ^
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:25:11
    |
 LL | macro_rules! foo {
@@ -15,7 +15,7 @@ LL |     foo!(a?);
    |
    = note: while trying to match sequence end
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:26:11
    |
 LL | macro_rules! foo {
@@ -26,7 +26,7 @@ LL |     foo!(a?a);
    |
    = note: while trying to match sequence end
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:27:11
    |
 LL | macro_rules! foo {
@@ -67,7 +67,7 @@ note: while trying to match `+`
 LL |     ($(a)?+) => {}; // ok. matches "a+" and "+"
    |           ^
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:31:15
    |
 LL | macro_rules! barplus {
@@ -82,7 +82,7 @@ note: while trying to match `+`
 LL |     ($(a)?+) => {}; // ok. matches "a+" and "+"
    |           ^
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:32:15
    |
 LL | macro_rules! barplus {
@@ -127,7 +127,7 @@ note: while trying to match `*`
 LL |     ($(a)?*) => {}; // ok. matches "a*" and "*"
    |           ^
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:38:15
    |
 LL | macro_rules! barstar {
@@ -142,7 +142,7 @@ note: while trying to match `*`
 LL |     ($(a)?*) => {}; // ok. matches "a*" and "*"
    |           ^
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2015.rs:39:15
    |
 LL | macro_rules! barstar {

--- a/tests/ui/macros/macro-at-most-once-rep-2018.rs
+++ b/tests/ui/macros/macro-at-most-once-rep-2018.rs
@@ -22,21 +22,21 @@ macro_rules! barstar {
 pub fn main() {
     foo!();
     foo!(a);
-    foo!(a?); //~ ERROR no rules expected the token `?`
-    foo!(a?a); //~ ERROR no rules expected the token `?`
-    foo!(a?a?a); //~ ERROR no rules expected the token `?`
+    foo!(a?); //~ ERROR no rules expected `?`
+    foo!(a?a); //~ ERROR no rules expected `?`
+    foo!(a?a?a); //~ ERROR no rules expected `?`
 
     barplus!(); //~ERROR unexpected end of macro invocation
     barplus!(a); //~ERROR unexpected end of macro invocation
-    barplus!(a?); //~ ERROR no rules expected the token `?`
-    barplus!(a?a); //~ ERROR no rules expected the token `?`
+    barplus!(a?); //~ ERROR no rules expected `?`
+    barplus!(a?a); //~ ERROR no rules expected `?`
     barplus!(a+);
     barplus!(+);
 
     barstar!(); //~ERROR unexpected end of macro invocation
     barstar!(a); //~ERROR unexpected end of macro invocation
-    barstar!(a?); //~ ERROR no rules expected the token `?`
-    barstar!(a?a); //~ ERROR no rules expected the token `?`
+    barstar!(a?); //~ ERROR no rules expected `?`
+    barstar!(a?a); //~ ERROR no rules expected `?`
     barstar!(a*);
     barstar!(*);
 }

--- a/tests/ui/macros/macro-at-most-once-rep-2018.stderr
+++ b/tests/ui/macros/macro-at-most-once-rep-2018.stderr
@@ -4,7 +4,7 @@ error: the `?` macro repetition operator does not take a separator
 LL |     ($(a),?) => {};
    |          ^
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:25:11
    |
 LL | macro_rules! foo {
@@ -15,7 +15,7 @@ LL |     foo!(a?);
    |
    = note: while trying to match sequence end
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:26:11
    |
 LL | macro_rules! foo {
@@ -26,7 +26,7 @@ LL |     foo!(a?a);
    |
    = note: while trying to match sequence end
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:27:11
    |
 LL | macro_rules! foo {
@@ -67,7 +67,7 @@ note: while trying to match `+`
 LL |     ($(a)?+) => {}; // ok. matches "a+" and "+"
    |           ^
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:31:15
    |
 LL | macro_rules! barplus {
@@ -82,7 +82,7 @@ note: while trying to match `+`
 LL |     ($(a)?+) => {}; // ok. matches "a+" and "+"
    |           ^
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:32:15
    |
 LL | macro_rules! barplus {
@@ -127,7 +127,7 @@ note: while trying to match `*`
 LL |     ($(a)?*) => {}; // ok. matches "a*" and "*"
    |           ^
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:38:15
    |
 LL | macro_rules! barstar {
@@ -142,7 +142,7 @@ note: while trying to match `*`
 LL |     ($(a)?*) => {}; // ok. matches "a*" and "*"
    |           ^
 
-error: no rules expected the token `?`
+error: no rules expected `?`
   --> $DIR/macro-at-most-once-rep-2018.rs:39:15
    |
 LL | macro_rules! barstar {

--- a/tests/ui/macros/macro-context.rs
+++ b/tests/ui/macros/macro-context.rs
@@ -1,9 +1,9 @@
 // (typeof used because it's surprisingly hard to find an unparsed token after a stmt)
 macro_rules! m {
     () => ( i ; typeof );   //~ ERROR expected expression, found reserved keyword `typeof`
-                            //~| ERROR macro expansion ignores token `typeof`
-                            //~| ERROR macro expansion ignores token `;`
-                            //~| ERROR macro expansion ignores token `;`
+                            //~| ERROR macro expansion ignores reserved keyword `typeof`
+                            //~| ERROR macro expansion ignores `;`
+                            //~| ERROR macro expansion ignores `;`
                             //~| ERROR cannot find type `i` in this scope
                             //~| ERROR cannot find value `i` in this scope
                             //~| WARN trailing semicolon in macro

--- a/tests/ui/macros/macro-context.stderr
+++ b/tests/ui/macros/macro-context.stderr
@@ -1,4 +1,4 @@
-error: macro expansion ignores token `;` and any following
+error: macro expansion ignores `;` and any tokens following
   --> $DIR/macro-context.rs:3:15
    |
 LL |     () => ( i ; typeof );
@@ -9,7 +9,7 @@ LL |     let a: m!();
    |
    = note: the usage of `m!` is likely invalid in type context
 
-error: macro expansion ignores token `typeof` and any following
+error: macro expansion ignores reserved keyword `typeof` and any tokens following
   --> $DIR/macro-context.rs:3:17
    |
 LL |     () => ( i ; typeof );
@@ -20,7 +20,7 @@ LL |     let i = m!();
    |
    = note: the usage of `m!` is likely invalid in expression context
 
-error: macro expansion ignores token `;` and any following
+error: macro expansion ignores `;` and any tokens following
   --> $DIR/macro-context.rs:3:15
    |
 LL |     () => ( i ; typeof );

--- a/tests/ui/macros/macro-in-expression-context.fixed
+++ b/tests/ui/macros/macro-in-expression-context.fixed
@@ -11,7 +11,7 @@ macro_rules! foo {
         //~| NOTE `#[warn(semicolon_in_expressions_from_macros)]` on by default
         assert_eq!("B", "B");
     }
-    //~^^ ERROR macro expansion ignores token `assert_eq` and any following
+    //~^^ ERROR macro expansion ignores `assert_eq` and any tokens following
     //~| NOTE the usage of `foo!` is likely invalid in expression context
 }
 

--- a/tests/ui/macros/macro-in-expression-context.rs
+++ b/tests/ui/macros/macro-in-expression-context.rs
@@ -11,7 +11,7 @@ macro_rules! foo {
         //~| NOTE `#[warn(semicolon_in_expressions_from_macros)]` on by default
         assert_eq!("B", "B");
     }
-    //~^^ ERROR macro expansion ignores token `assert_eq` and any following
+    //~^^ ERROR macro expansion ignores `assert_eq` and any tokens following
     //~| NOTE the usage of `foo!` is likely invalid in expression context
 }
 

--- a/tests/ui/macros/macro-in-expression-context.stderr
+++ b/tests/ui/macros/macro-in-expression-context.stderr
@@ -1,4 +1,4 @@
-error: macro expansion ignores token `assert_eq` and any following
+error: macro expansion ignores `assert_eq` and any tokens following
   --> $DIR/macro-in-expression-context.rs:12:9
    |
 LL |         assert_eq!("B", "B");

--- a/tests/ui/macros/macro-non-lifetime.rs
+++ b/tests/ui/macros/macro-non-lifetime.rs
@@ -4,5 +4,5 @@ macro_rules! m { ($x:lifetime) => { } }
 
 fn main() {
     m!(a);
-    //~^ ERROR no rules expected the token `a`
+    //~^ ERROR no rules expected `a`
 }

--- a/tests/ui/macros/macro-non-lifetime.stderr
+++ b/tests/ui/macros/macro-non-lifetime.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `a`
+error: no rules expected `a`
   --> $DIR/macro-non-lifetime.rs:6:8
    |
 LL | macro_rules! m { ($x:lifetime) => { } }

--- a/tests/ui/macros/missing-comma.rs
+++ b/tests/ui/macros/missing-comma.rs
@@ -19,16 +19,16 @@ fn main() {
     println!("{}" a);
     //~^ ERROR expected `,`, found `a`
     foo!(a b);
-    //~^ ERROR no rules expected the token `b`
+    //~^ ERROR no rules expected `b`
     foo!(a, b, c, d e);
-    //~^ ERROR no rules expected the token `e`
+    //~^ ERROR no rules expected `e`
     foo!(a, b, c d, e);
-    //~^ ERROR no rules expected the token `d`
+    //~^ ERROR no rules expected `d`
     foo!(a, b, c d e);
-    //~^ ERROR no rules expected the token `d`
+    //~^ ERROR no rules expected `d`
     bar!(Level::Error, );
     //~^ ERROR unexpected end of macro invocation
     check!(<str as Debug>::fmt, "fmt");
     check!(<str as Debug>::fmt, "fmt",);
-    //~^ ERROR no rules expected the token `,`
+    //~^ ERROR no rules expected `,`
 }

--- a/tests/ui/macros/missing-comma.stderr
+++ b/tests/ui/macros/missing-comma.stderr
@@ -4,7 +4,7 @@ error: expected `,`, found `a`
 LL |     println!("{}" a);
    |                   ^ expected `,`
 
-error: no rules expected the token `b`
+error: no rules expected `b`
   --> $DIR/missing-comma.rs:21:12
    |
 LL | macro_rules! foo {
@@ -21,7 +21,7 @@ note: while trying to match meta-variable `$a:ident`
 LL |     ($a:ident) => ();
    |      ^^^^^^^^
 
-error: no rules expected the token `e`
+error: no rules expected `e`
   --> $DIR/missing-comma.rs:23:21
    |
 LL | macro_rules! foo {
@@ -38,7 +38,7 @@ note: while trying to match meta-variable `$d:ident`
 LL |     ($a:ident, $b:ident, $c:ident, $d:ident) => ();
    |                                    ^^^^^^^^
 
-error: no rules expected the token `d`
+error: no rules expected `d`
   --> $DIR/missing-comma.rs:25:18
    |
 LL | macro_rules! foo {
@@ -55,7 +55,7 @@ note: while trying to match meta-variable `$c:ident`
 LL |     ($a:ident, $b:ident, $c:ident) => ();
    |                          ^^^^^^^^
 
-error: no rules expected the token `d`
+error: no rules expected `d`
   --> $DIR/missing-comma.rs:27:18
    |
 LL | macro_rules! foo {
@@ -85,7 +85,7 @@ note: while trying to match meta-variable `$arg:tt`
 LL |     ($lvl:expr, $($arg:tt)+) => {}
    |                   ^^^^^^^
 
-error: no rules expected the token `,`
+error: no rules expected `,`
   --> $DIR/missing-comma.rs:32:38
    |
 LL | macro_rules! check {

--- a/tests/ui/macros/nonterminal-matching.rs
+++ b/tests/ui/macros/nonterminal-matching.rs
@@ -16,7 +16,7 @@ macro complex_nonterminal($nt_item: item) {
         struct S;
     }
 
-    n!(a $nt_item b); //~ ERROR no rules expected the token `enum E {}`
+    n!(a $nt_item b); //~ ERROR no rules expected item `enum E {}`
 }
 
 simple_nonterminal!(a, 'a, (x, y, z)); // OK
@@ -29,10 +29,10 @@ macro_rules! foo {
     (ident $x:ident) => { bar!(ident $x); };
     (lifetime $x:lifetime) => { bar!(lifetime $x); };
     (tt $x:tt) => { bar!(tt $x); };
-    (expr $x:expr) => { bar!(expr $x); }; //~ ERROR: no rules expected the token `3`
-    (literal $x:literal) => { bar!(literal $x); }; //~ ERROR: no rules expected the token `4`
-    (path $x:path) => { bar!(path $x); }; //~ ERROR: no rules expected the token `a::b::c`
-    (stmt $x:stmt) => { bar!(stmt $x); }; //~ ERROR: no rules expected the token `let abc = 0`
+    (expr $x:expr) => { bar!(expr $x); }; //~ ERROR: no rules expected expression `3`
+    (literal $x:literal) => { bar!(literal $x); }; //~ ERROR: no rules expected literal `4`
+    (path $x:path) => { bar!(path $x); }; //~ ERROR: no rules expected path `a::b::c`
+    (stmt $x:stmt) => { bar!(stmt $x); }; //~ ERROR: no rules expected statement `let abc = 0`
 }
 
 macro_rules! bar {

--- a/tests/ui/macros/nonterminal-matching.stderr
+++ b/tests/ui/macros/nonterminal-matching.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `enum E {}`
+error: no rules expected item `enum E {}`
   --> $DIR/nonterminal-matching.rs:19:10
    |
 LL |     macro n(a $nt_item b) {
@@ -10,7 +10,7 @@ LL |     n!(a $nt_item b);
 LL | complex_nonterminal!(enum E {});
    | ------------------------------- in this macro invocation
    |
-note: while trying to match `enum E {}`
+note: while trying to match item `enum E {}`
   --> $DIR/nonterminal-matching.rs:15:15
    |
 LL |     macro n(a $nt_item b) {
@@ -23,7 +23,7 @@ LL | complex_nonterminal!(enum E {});
    = help: try using `:tt` instead in the macro definition
    = note: this error originates in the macro `complex_nonterminal` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: no rules expected the token `3`
+error: no rules expected expression `3`
   --> $DIR/nonterminal-matching.rs:32:35
    |
 LL |     (expr $x:expr) => { bar!(expr $x); };
@@ -45,7 +45,7 @@ LL |     (expr 3) => {};
    = help: try using `:tt` instead in the macro definition
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: no rules expected the token `4`
+error: no rules expected literal `4`
   --> $DIR/nonterminal-matching.rs:33:44
    |
 LL |     (literal $x:literal) => { bar!(literal $x); };
@@ -67,7 +67,7 @@ LL |     (literal 4) => {};
    = help: try using `:tt` instead in the macro definition
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: no rules expected the token `a::b::c`
+error: no rules expected path `a::b::c`
   --> $DIR/nonterminal-matching.rs:34:35
    |
 LL |     (path $x:path) => { bar!(path $x); };
@@ -89,7 +89,7 @@ LL |     (path a::b::c) => {};
    = help: try using `:tt` instead in the macro definition
    = note: this error originates in the macro `foo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: no rules expected the token `let abc = 0`
+error: no rules expected statement `let abc = 0`
   --> $DIR/nonterminal-matching.rs:35:35
    |
 LL |     (stmt $x:stmt) => { bar!(stmt $x); };
@@ -101,7 +101,7 @@ LL | macro_rules! bar {
 LL | foo!(stmt let abc = 0);
    | ---------------------- in this macro invocation
    |
-note: while trying to match `let`
+note: while trying to match keyword `let`
   --> $DIR/nonterminal-matching.rs:45:11
    |
 LL |     (stmt let abc = 0) => {};

--- a/tests/ui/macros/syntax-error-recovery.rs
+++ b/tests/ui/macros/syntax-error-recovery.rs
@@ -10,7 +10,7 @@ macro_rules! values {
     };
 }
 //~^^^^^ ERROR expected one of `(`, `,`, `=`, `{`, or `}`, found type `(String)`
-//~| ERROR macro expansion ignores token `(String)` and any following
+//~| ERROR macro expansion ignores type `(String)` and any tokens following
 
 values!(STRING(1) as (String) => cfg(test),);
 //~^ ERROR expected one of `!` or `::`, found `<eof>`

--- a/tests/ui/macros/syntax-error-recovery.stderr
+++ b/tests/ui/macros/syntax-error-recovery.stderr
@@ -10,7 +10,7 @@ LL | values!(STRING(1) as (String) => cfg(test),);
    = help: enum variants can be `Variant`, `Variant = <integer>`, `Variant(Type, ..., TypeN)` or `Variant { fields: Types }`
    = note: this error originates in the macro `values` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: macro expansion ignores token `(String)` and any following
+error: macro expansion ignores type `(String)` and any tokens following
   --> $DIR/syntax-error-recovery.rs:7:26
    |
 LL |                 $token $($inner)? = $value,

--- a/tests/ui/macros/trace_faulty_macros.stderr
+++ b/tests/ui/macros/trace_faulty_macros.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `bcd`
+error: no rules expected `bcd`
   --> $DIR/trace_faulty_macros.rs:7:26
    |
 LL | macro_rules! my_faulty_macro {

--- a/tests/ui/offset-of/offset-of-arg-count.rs
+++ b/tests/ui/offset-of/offset-of-arg-count.rs
@@ -3,7 +3,7 @@ use std::mem::offset_of;
 fn main() {
     offset_of!(NotEnoughArguments); //~ ERROR unexpected end of macro invocation
     offset_of!(NotEnoughArgumentsWithAComma, ); //~ ERROR unexpected end of macro invocation
-    offset_of!(Container, field, too many arguments); //~ ERROR no rules expected the token `too`
+    offset_of!(Container, field, too many arguments); //~ ERROR no rules expected `too`
     offset_of!(S, f); // compiles fine
     offset_of!(S, f,); // also compiles fine
     offset_of!(S, f.); //~ ERROR unexpected token: `)`

--- a/tests/ui/offset-of/offset-of-arg-count.stderr
+++ b/tests/ui/offset-of/offset-of-arg-count.stderr
@@ -16,7 +16,7 @@ LL |     offset_of!(NotEnoughArgumentsWithAComma, );
 note: while trying to match meta-variable `$fields:expr`
   --> $SRC_DIR/core/src/mem/mod.rs:LL:COL
 
-error: no rules expected the token `too`
+error: no rules expected `too`
   --> $DIR/offset-of-arg-count.rs:6:34
    |
 LL |     offset_of!(Container, field, too many arguments);

--- a/tests/ui/offset-of/offset-of-tuple.stderr
+++ b/tests/ui/offset-of/offset-of-tuple.stderr
@@ -76,7 +76,7 @@ error: suffixes on a tuple index are invalid
 LL |     offset_of!((u8, u8), 1_u8);
    |                          ^^^^ invalid suffix `u8`
 
-error: no rules expected the token `+`
+error: no rules expected `+`
   --> $DIR/offset-of-tuple.rs:11:26
    |
 LL |     offset_of!((u8, u8), +1);

--- a/tests/ui/or-patterns/or-patterns-syntactic-fail-2018.rs
+++ b/tests/ui/or-patterns/or-patterns-syntactic-fail-2018.rs
@@ -9,5 +9,5 @@ macro_rules! accept_pat {
     ($p:pat) => {};
 }
 
-accept_pat!(p | q); //~ ERROR no rules expected the token `|`
-accept_pat!(|p| q); //~ ERROR no rules expected the token `|`
+accept_pat!(p | q); //~ ERROR no rules expected `|`
+accept_pat!(|p| q); //~ ERROR no rules expected `|`

--- a/tests/ui/or-patterns/or-patterns-syntactic-fail-2018.stderr
+++ b/tests/ui/or-patterns/or-patterns-syntactic-fail-2018.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `|`
+error: no rules expected `|`
   --> $DIR/or-patterns-syntactic-fail-2018.rs:12:15
    |
 LL | macro_rules! accept_pat {
@@ -13,7 +13,7 @@ note: while trying to match meta-variable `$p:pat`
 LL |     ($p:pat) => {};
    |      ^^^^^^
 
-error: no rules expected the token `|`
+error: no rules expected `|`
   --> $DIR/or-patterns-syntactic-fail-2018.rs:13:13
    |
 LL | macro_rules! accept_pat {

--- a/tests/ui/parser/macro/macro-doc-comments-1.rs
+++ b/tests/ui/parser/macro/macro-doc-comments-1.rs
@@ -4,6 +4,6 @@ macro_rules! outer {
 
 outer! {
     //! Inner
-} //~^ ERROR no rules expected the token `!`
+} //~^ ERROR no rules expected `!`
 
 fn main() { }

--- a/tests/ui/parser/macro/macro-doc-comments-1.stderr
+++ b/tests/ui/parser/macro/macro-doc-comments-1.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `!`
+error: no rules expected `!`
   --> $DIR/macro-doc-comments-1.rs:6:5
    |
 LL | macro_rules! outer {

--- a/tests/ui/parser/macro/macro-doc-comments-2.rs
+++ b/tests/ui/parser/macro/macro-doc-comments-2.rs
@@ -4,6 +4,6 @@ macro_rules! inner {
 
 inner! {
     /// Outer
-} //~^ ERROR no rules expected the token `[`
+} //~^ ERROR no rules expected `[`
 
 fn main() { }

--- a/tests/ui/parser/macro/macro-doc-comments-2.stderr
+++ b/tests/ui/parser/macro/macro-doc-comments-2.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `[`
+error: no rules expected `[`
   --> $DIR/macro-doc-comments-2.rs:6:5
    |
 LL | macro_rules! inner {

--- a/tests/ui/parser/macro/macro-expand-to-match-arm.rs
+++ b/tests/ui/parser/macro/macro-expand-to-match-arm.rs
@@ -1,7 +1,7 @@
 macro_rules! arm {
     ($pattern:pat => $block:block) => {
         $pattern => $block
-        //~^ ERROR macro expansion ignores token `=>` and any following
+        //~^ ERROR macro expansion ignores `=>` and any tokens following
         //~| NOTE the usage of `arm!` is likely invalid in pattern context
         //~| NOTE macros cannot expand to match arms
     };

--- a/tests/ui/parser/macro/macro-expand-to-match-arm.stderr
+++ b/tests/ui/parser/macro/macro-expand-to-match-arm.stderr
@@ -1,4 +1,4 @@
-error: macro expansion ignores token `=>` and any following
+error: macro expansion ignores `=>` and any tokens following
   --> $DIR/macro-expand-to-match-arm.rs:3:18
    |
 LL |         $pattern => $block

--- a/tests/ui/parser/macro/macro-incomplete-parse.rs
+++ b/tests/ui/parser/macro/macro-incomplete-parse.rs
@@ -2,7 +2,7 @@ macro_rules! ignored_item {
     () => {
         fn foo() {}
         fn bar() {}
-        , //~ ERROR macro expansion ignores token `,`
+        , //~ ERROR macro expansion ignores `,`
     }
 }
 
@@ -13,7 +13,7 @@ macro_rules! ignored_expr {
 }
 
 macro_rules! ignored_pat {
-    () => ( 1, 2 ) //~ ERROR macro expansion ignores token `,`
+    () => ( 1, 2 ) //~ ERROR macro expansion ignores `,`
 }
 
 ignored_item!();

--- a/tests/ui/parser/macro/macro-incomplete-parse.stderr
+++ b/tests/ui/parser/macro/macro-incomplete-parse.stderr
@@ -1,4 +1,4 @@
-error: macro expansion ignores token `,` and any following
+error: macro expansion ignores `,` and any tokens following
   --> $DIR/macro-incomplete-parse.rs:5:9
    |
 LL |         ,
@@ -20,7 +20,7 @@ LL |     ignored_expr!();
    |
    = note: this error originates in the macro `ignored_expr` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: macro expansion ignores token `,` and any following
+error: macro expansion ignores `,` and any tokens following
   --> $DIR/macro-incomplete-parse.rs:16:14
    |
 LL |     () => ( 1, 2 )

--- a/tests/ui/parser/macro/trait-non-item-macros.rs
+++ b/tests/ui/parser/macro/trait-non-item-macros.rs
@@ -1,7 +1,7 @@
 macro_rules! bah {
     ($a:expr) => {
         $a
-    }; //~^ ERROR macro expansion ignores token `2` and any following
+    }; //~^ ERROR macro expansion ignores expression `2` and any tokens following
 }
 
 trait Bar {

--- a/tests/ui/parser/macro/trait-non-item-macros.stderr
+++ b/tests/ui/parser/macro/trait-non-item-macros.stderr
@@ -1,4 +1,4 @@
-error: macro expansion ignores token `2` and any following
+error: macro expansion ignores expression `2` and any tokens following
   --> $DIR/trait-non-item-macros.rs:3:9
    |
 LL |         $a

--- a/tests/ui/proc-macro/attr-invalid-exprs.rs
+++ b/tests/ui/proc-macro/attr-invalid-exprs.rs
@@ -13,7 +13,7 @@ fn main() {
     //~^ ERROR expected expression, found end of macro arguments
 
     let _ = #[duplicate] "Hello, world!";
-    //~^ ERROR macro expansion ignores token `,` and any following
+    //~^ ERROR macro expansion ignores `,` and any tokens following
 
     let _ = {
         #[no_output]
@@ -22,7 +22,7 @@ fn main() {
 
     let _ = {
         #[duplicate]
-        //~^ ERROR macro expansion ignores token `,` and any following
+        //~^ ERROR macro expansion ignores `,` and any tokens following
         "Hello, world!"
     };
 }

--- a/tests/ui/proc-macro/attr-invalid-exprs.stderr
+++ b/tests/ui/proc-macro/attr-invalid-exprs.stderr
@@ -4,7 +4,7 @@ error: expected expression, found end of macro arguments
 LL |     let _ = #[no_output] "Hello, world!";
    |             ^^^^^^^^^^^^
 
-error: macro expansion ignores token `,` and any following
+error: macro expansion ignores `,` and any tokens following
   --> $DIR/attr-invalid-exprs.rs:15:13
    |
 LL |     let _ = #[duplicate] "Hello, world!";
@@ -16,7 +16,7 @@ help: you might be missing a semicolon here
 LL |     let _ = #[duplicate]; "Hello, world!";
    |                         +
 
-error: macro expansion ignores token `,` and any following
+error: macro expansion ignores `,` and any tokens following
   --> $DIR/attr-invalid-exprs.rs:24:9
    |
 LL |         #[duplicate]

--- a/tests/ui/proc-macro/expand-expr.rs
+++ b/tests/ui/proc-macro/expand-expr.rs
@@ -114,8 +114,8 @@ expand_expr_fail!(echo_pm!($)); //~ ERROR: expected expression, found `$`
 
 // We get errors reported and recover during macro expansion if the macro
 // doesn't produce a valid expression.
-expand_expr_is!("string", echo_tts!("string"; hello)); //~ ERROR: macro expansion ignores token `hello` and any following
-expand_expr_is!("string", echo_pm!("string"; hello)); //~ ERROR: macro expansion ignores token `;` and any following
+expand_expr_is!("string", echo_tts!("string"; hello)); //~ ERROR: macro expansion ignores `hello` and any tokens following
+expand_expr_is!("string", echo_pm!("string"; hello)); //~ ERROR: macro expansion ignores `;` and any tokens following
 
 // For now, fail if a non-literal expression is expanded.
 expand_expr_fail!(arbitrary_expression() + "etc");

--- a/tests/ui/proc-macro/expand-expr.stderr
+++ b/tests/ui/proc-macro/expand-expr.stderr
@@ -22,7 +22,7 @@ error: expected expression, found `$`
 LL | expand_expr_fail!(echo_pm!($));
    |                            ^ expected expression
 
-error: macro expansion ignores token `hello` and any following
+error: macro expansion ignores `hello` and any tokens following
   --> $DIR/expand-expr.rs:117:47
    |
 LL | expand_expr_is!("string", echo_tts!("string"; hello));
@@ -34,7 +34,7 @@ help: you might be missing a semicolon here
 LL | expand_expr_is!("string", echo_tts!("string"; hello););
    |                                                     +
 
-error: macro expansion ignores token `;` and any following
+error: macro expansion ignores `;` and any tokens following
   --> $DIR/expand-expr.rs:118:44
    |
 LL | expand_expr_is!("string", echo_pm!("string"; hello));

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.rs
@@ -68,7 +68,7 @@ fn _macros() {
         _ => {}
     }
     use_expr!(let 0 = 1);
-    //~^ ERROR no rules expected the token `let`
+    //~^ ERROR no rules expected keyword `let`
 }
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
@@ -131,7 +131,7 @@ LL |     use_expr!((let 0 = 1));
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
-error: no rules expected the token `let`
+error: no rules expected keyword `let`
   --> $DIR/feature-gate.rs:70:15
    |
 LL |     macro_rules! use_expr {

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/feature-gate.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/feature-gate.rs
@@ -54,7 +54,7 @@ fn _macros() {
     #[cfg(FALSE)] (let 0 = 1);
     //~^ ERROR expected expression, found `let` statement
     use_expr!(let 0 = 1);
-    //~^ ERROR no rules expected the token `let`
+    //~^ ERROR no rules expected keyword `let`
 }
 
 fn main() {}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/feature-gate.stderr
@@ -14,7 +14,7 @@ LL |     noop_expr!((let 0 = 1));
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
-error: no rules expected the token `let`
+error: no rules expected keyword `let`
   --> $DIR/feature-gate.rs:56:15
    |
 LL |     macro_rules! use_expr {

--- a/tests/ui/underscore-ident-matcher.rs
+++ b/tests/ui/underscore-ident-matcher.rs
@@ -5,5 +5,5 @@ macro_rules! identity {
 }
 
 fn main() {
-    let identity!(_) = 10; //~ ERROR no rules expected the token `_`
+    let identity!(_) = 10; //~ ERROR no rules expected reserved identifier `_`
 }

--- a/tests/ui/underscore-ident-matcher.stderr
+++ b/tests/ui/underscore-ident-matcher.stderr
@@ -1,4 +1,4 @@
-error: no rules expected the token `_`
+error: no rules expected reserved identifier `_`
   --> $DIR/underscore-ident-matcher.rs:8:19
    |
 LL | macro_rules! identity {


### PR DESCRIPTION
This is the first two commits from #124141, put into their own PR to get things rolling. Commit messages have the details.

r? @estebank
cc @petrochenkov 