### PR TITLE
Reject raw lifetime followed by `'`, like regular lifetimes do

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -715,7 +715,17 @@ impl Cursor<'_> {
             self.bump();
             self.bump();
             self.eat_while(is_id_continue);
-            return RawLifetime;
+            match self.first() {
+                '\'' => {
+                    // Check if after skipping literal contents we've met a closing
+                    // single quote (which means that user attempted to create a
+                    // string with single quotes).
+                    self.bump();
+                    let kind = Char { terminated: true };
+                    return Literal { kind, suffix_start: self.pos_within_token() };
+                }
+                _ => return RawLifetime,
+            }
         }
 
         // Either a lifetime or a character literal with

--- a/tests/ui/lifetimes/raw/immediately-followed-by-lt.rs
+++ b/tests/ui/lifetimes/raw/immediately-followed-by-lt.rs
@@ -1,0 +1,14 @@
+//@ edition: 2021
+
+// Make sure we reject the case where a raw lifetime is immediately followed by another
+// lifetime. This reserves a modest amount of space for changing lexing to, for example,
+// delay rejection of overlong char literals like `'r#long'id`.
+
+macro_rules! w {
+    ($($tt:tt)*) => {}
+}
+
+w!('r#long'id);
+//~^ ERROR character literal may only contain one codepoint
+
+fn main() {}

--- a/tests/ui/lifetimes/raw/immediately-followed-by-lt.stderr
+++ b/tests/ui/lifetimes/raw/immediately-followed-by-lt.stderr
@@ -1,0 +1,13 @@
+error: character literal may only contain one codepoint
+  --> $DIR/immediately-followed-by-lt.rs:11:4
+   |
+LL | w!('r#long'id);
+   |    ^^^^^^^^
+   |
+help: if you meant to write a string literal, use double quotes
+   |
+LL | w!("r#long"id);
+   |    ~      ~
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
See comment. We want to reject cases like `'r#long'id`, which currently gets interpreted as a raw lifetime (`'r#long`) followed by a lifetime (`'id`). This could have alternative lexes, such as an overlong char literal (`'r#long'`) followed by an identifier (`id`). To avoid committing to this in any case, let's reject the whole thing.

@mattheww, is this what you were looking for in https://github.com/rust-lang/reference/pull/1603#issuecomment-2339237325? I'd say ignore the details about the specific error message (the fact that this gets reinterpreted as a char literal is 🤷), just that because this causes a lexer error we're effectively saving syntactical space like you wanted.