### PR TITLE
Fix AIX libc call char type from i8 to u8

### DIFF
--- a/compiler/rustc_session/src/filesearch.rs
+++ b/compiler/rustc_session/src/filesearch.rs
@@ -84,7 +84,7 @@ fn current_dll_path() -> Result<PathBuf, String> {
         loop {
             if libc::loadquery(
                 libc::L_GETINFO,
-                buffer.as_mut_ptr() as *mut i8,
+                buffer.as_mut_ptr() as *mut u8,
                 (std::mem::size_of::<libc::ld_info>() * buffer.len()) as u32,
             ) >= 0
             {


### PR DESCRIPTION
There was an update to AIX `libc` default char type from `i8 -> u8`, we should reflect that on the call site to satisfy the type checker.

https://github.com/rust-lang/libc/blame/81f0cd3d9715e579c92063f78d0d14da85a31dd1/src/unix/aix/mod.rs#L1