### PR TITLE
Enforce that raw lifetimes must be valid raw identifiers

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -77,6 +77,8 @@ parse_box_syntax_removed_suggestion = use `Box::new()` instead
 
 parse_cannot_be_raw_ident = `{$ident}` cannot be a raw identifier
 
+parse_cannot_be_raw_lifetime = `{$ident}` cannot be a raw lifetime
+
 parse_catch_after_try = keyword `catch` cannot follow a `try` block
     .help = try using `match` on the result of the `try` block instead
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2019,6 +2019,14 @@ pub(crate) struct CannotBeRawIdent {
 }
 
 #[derive(Diagnostic)]
+#[diag(parse_cannot_be_raw_lifetime)]
+pub(crate) struct CannotBeRawLifetime {
+    #[primary_span]
+    pub span: Span,
+    pub ident: Symbol,
+}
+
+#[derive(Diagnostic)]
 #[diag(parse_keyword_lifetime)]
 pub(crate) struct KeywordLifetime {
     #[primary_span]

--- a/tests/ui/lifetimes/raw/raw-lt-invalid-raw-id.rs
+++ b/tests/ui/lifetimes/raw/raw-lt-invalid-raw-id.rs
@@ -1,0 +1,20 @@
+//@ edition: 2021
+
+// Reject raw lifetimes with identifier parts that wouldn't be valid raw identifiers.
+
+macro_rules! w {
+    ($tt:tt) => {};
+}
+
+w!('r#_);
+//~^ ERROR `_` cannot be a raw lifetime
+w!('r#self);
+//~^ ERROR `self` cannot be a raw lifetime
+w!('r#super);
+//~^ ERROR `super` cannot be a raw lifetime
+w!('r#Self);
+//~^ ERROR `Self` cannot be a raw lifetime
+w!('r#crate);
+//~^ ERROR `crate` cannot be a raw lifetime
+
+fn main() {}

--- a/tests/ui/lifetimes/raw/raw-lt-invalid-raw-id.stderr
+++ b/tests/ui/lifetimes/raw/raw-lt-invalid-raw-id.stderr
@@ -1,0 +1,32 @@
+error: `_` cannot be a raw lifetime
+  --> $DIR/raw-lt-invalid-raw-id.rs:9:4
+   |
+LL | w!('r#_);
+   |    ^^^^
+
+error: `self` cannot be a raw lifetime
+  --> $DIR/raw-lt-invalid-raw-id.rs:11:4
+   |
+LL | w!('r#self);
+   |    ^^^^^^^
+
+error: `super` cannot be a raw lifetime
+  --> $DIR/raw-lt-invalid-raw-id.rs:13:4
+   |
+LL | w!('r#super);
+   |    ^^^^^^^^
+
+error: `Self` cannot be a raw lifetime
+  --> $DIR/raw-lt-invalid-raw-id.rs:15:4
+   |
+LL | w!('r#Self);
+   |    ^^^^^^^
+
+error: `crate` cannot be a raw lifetime
+  --> $DIR/raw-lt-invalid-raw-id.rs:17:4
+   |
+LL | w!('r#crate);
+   |    ^^^^^^^^
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
Make sure that the identifier part of a raw lifetime is a valid raw identifier. This precludes `'r#_` and all module segment paths for now.

I don't believe this is compelling to support. This was raised by @ehuss in https://github.com/rust-lang/reference/pull/1603#discussion_r1822726753 (well, specifically the `'r#_` case), but I don't see why we shouldn't just make it consistent with raw identifiers.