### PR TITLE
Do not enforce `~const` constness effects in typeck if `rustc_do_not_const_check`

### DIFF
--- a/compiler/rustc_hir_typeck/src/callee.rs
+++ b/compiler/rustc_hir_typeck/src/callee.rs
@@ -851,6 +851,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             return;
         }
 
+        // If we have `rustc_do_not_const_check`, do not check `~const` bounds.
+        if self.tcx.has_attr(self.body_id, sym::rustc_do_not_const_check) {
+            return;
+        }
+
         let host = match self.tcx.hir().body_const_context(self.body_id) {
             Some(hir::ConstContext::Const { .. } | hir::ConstContext::Static(_)) => {
                 ty::HostPolarity::Const

--- a/tests/ui/traits/const-traits/do-not-const-check.rs
+++ b/tests/ui/traits/const-traits/do-not-const-check.rs
@@ -1,5 +1,6 @@
 //@ check-pass
-#![feature(const_trait_impl, rustc_attrs)]
+#![feature(const_trait_impl, rustc_attrs, effects)]
+//~^ WARN the feature `effects` is incomplete
 
 #[const_trait]
 trait IntoIter {

--- a/tests/ui/traits/const-traits/do-not-const-check.stderr
+++ b/tests/ui/traits/const-traits/do-not-const-check.stderr
@@ -1,0 +1,11 @@
+warning: the feature `effects` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/do-not-const-check.rs:2:43
+   |
+LL | #![feature(const_trait_impl, rustc_attrs, effects)]
+   |                                           ^^^^^^^
+   |
+   = note: see issue #102090 <https://github.com/rust-lang/rust/issues/102090> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+warning: 1 warning emitted
+


### PR DESCRIPTION
Fixes a slight inconsistency between HIR and MIR enforcement of `~const` :D

r? @rust-lang/project-const-traits 