### PR TITLE
style-guide: Only use the new binop heuristic for assignments

### DIFF
--- a/src/doc/style-guide/src/editions.md
+++ b/src/doc/style-guide/src/editions.md
@@ -40,8 +40,9 @@ include:
   of a delimited expression, delimited expressions are generally combinable,
   regardless of the number of members. Previously only applied with exactly
   one member (except for closures with explicit blocks).
-- When line-breaking a binary operator, if the first operand spans multiple
-  lines, use the base indentation of the last line.
+- When line-breaking an assignment operator, if the left-hand side spans
+  multiple lines, use the base indentation of the last line of the left-hand
+  side to indent the right-hand side.
 - Miscellaneous `rustfmt` bugfixes.
 - Use version-sort (sort `x8`, `x16`, `x32`, `x64`, `x128` in that order).
 - Change "ASCIIbetical" sort to Unicode-aware "non-lowercase before lowercase".

--- a/src/doc/style-guide/src/expressions.md
+++ b/src/doc/style-guide/src/expressions.md
@@ -328,9 +328,9 @@ foo_bar
 Prefer line-breaking at an assignment operator (either `=` or `+=`, etc.) rather
 than at other binary operators.
 
-If line-breaking at a binary operator (including assignment operators) where the
-first operand spans multiple lines, use the base indentation of the *last*
-line of the first operand, and indent relative to that:
+If line-breaking an assignment operator where the left-hand side spans multiple
+lines, use the base indentation of the *last* line of the left-hand side, and
+indent the right-hand side relative to that:
 
 ```rust
 impl SomeType {
@@ -340,12 +340,6 @@ impl SomeType {
             .expect("thing must exist")
             .extra_info =
                 long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
-
-        self.array[array_index as usize]
-            .as_mut()
-            .expect("thing must exist")
-            .extra_info
-                + long_long_long_long_long_long_long_long_long_long_long_long_long_long_long;
 
         self.array[array_index as usize]
             .as_mut()


### PR DESCRIPTION
This avoids pathological cases where chains of binops get progressively
deeper.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
