### PR TITLE
Make sure `type_param_predicates` resolves correctly for RPITIT

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -764,6 +764,16 @@ pub(super) fn type_param_predicates<'tcx>(
     tcx: TyCtxt<'tcx>,
     (item_def_id, def_id, assoc_name): (LocalDefId, LocalDefId, Ident),
 ) -> ty::EarlyBinder<'tcx, &'tcx [(ty::Clause<'tcx>, Span)]> {
+    match tcx.opt_rpitit_info(item_def_id.to_def_id()) {
+        Some(ty::ImplTraitInTraitData::Trait { opaque_def_id, .. }) => {
+            return tcx.type_param_predicates((opaque_def_id.expect_local(), def_id, assoc_name));
+        }
+        Some(ty::ImplTraitInTraitData::Impl { .. }) => {
+            unreachable!("should not be lowering bounds on RPITIT in impl")
+        }
+        None => {}
+    }
+
     use rustc_hir::*;
     use rustc_middle::ty::Ty;
 

--- a/tests/ui/impl-trait/in-trait/shorthand-projection-in-rpitit-bound.rs
+++ b/tests/ui/impl-trait/in-trait/shorthand-projection-in-rpitit-bound.rs
@@ -1,0 +1,13 @@
+//@ check-pass
+
+// Ensure that we can resolve a shorthand projection in an item bound in an RPITIT.
+
+pub trait Bar {
+    type Foo;
+}
+
+pub trait Baz {
+    fn boom<X: Bar>() -> impl Bar<Foo = X::Foo>;
+}
+
+fn main() {}


### PR DESCRIPTION
After #132194, we end up lowering the item bounds for an RPITIT in an `ItemCtxt` whose def id is the *synthetic GAT*, not the opaque type from the HIR.

This means that when we're resolving a shorthand projection like `T::Assoc`, we call the `type_param_predicates` function with the `item_def_id` of the *GAT* and not the opaque. That function operates on the HIR, and is not designed to work with the `Node::Synthetic` that gets fed for items synthesized by the compiler...

This PR reuses the trick we use elsewhere in lowering, where we intercept whether an item comes from RPITIT lowering, and forwards the query off to the correct item.

Fixes #132372