### PR TITLE
Implement suggestion for never type fallback lints

### DIFF
--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -215,6 +215,7 @@ pub(crate) enum SuggestAnnotation {
     Unit(Span),
     Path(Span),
     Local(Span),
+    Turbo(Span, usize, usize),
 }
 
 #[derive(Clone)]
@@ -244,6 +245,16 @@ impl Subdiagnostic for SuggestAnnotations {
                 SuggestAnnotation::Local(span) => {
                     suggestions.push((span, ": ()".to_string()));
                 }
+                SuggestAnnotation::Turbo(span, n_args, idx) => suggestions.push((
+                    span,
+                    format!(
+                        "::<{}>",
+                        (0..n_args)
+                            .map(|i| if i == idx { "()" } else { "_" })
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                    ),
+                )),
             }
         }
 

--- a/compiler/rustc_hir_typeck/src/errors.rs
+++ b/compiler/rustc_hir_typeck/src/errors.rs
@@ -214,6 +214,7 @@ pub(crate) struct DependencyOnUnitNeverTypeFallback<'tcx> {
 pub(crate) enum SuggestAnnotation {
     Unit(Span),
     Path(Span),
+    Local(Span),
 }
 
 #[derive(Clone)]
@@ -239,6 +240,9 @@ impl Subdiagnostic for SuggestAnnotations {
                 SuggestAnnotation::Path(span) => {
                     suggestions.push((span.shrink_to_lo(), "<() as ".to_string()));
                     suggestions.push((span.shrink_to_hi(), ">".to_string()));
+                }
+                SuggestAnnotation::Local(span) => {
+                    suggestions.push((span, ": ()".to_string()));
                 }
             }
         }

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
@@ -13,6 +13,10 @@ note: in edition 2024, the requirement `!: Default` will fail
 LL |         true => Default::default(),
    |                 ^^^^^^^^^^^^^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         true => <() as Default>::default(),
+   |                 ++++++        +
 
 warning: this function depends on never type fallback being `()`
   --> $DIR/never-type-fallback-breaking.rs:27:1

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
@@ -32,6 +32,10 @@ note: in edition 2024, the requirement `!: Default` will fail
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^
+help: use `()` annotations to avoid fallback changes
+   |
+LL |     deserialize::<()>()?;
+   |                ++++++
 
 warning: 2 warnings emitted
 

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
@@ -15,8 +15,8 @@ LL |         true => Default::default(),
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
 help: use `()` annotations to avoid fallback changes
    |
-LL |         true => <() as Default>::default(),
-   |                 ++++++        +
+LL |     let x: () = match true {
+   |          ++++
 
 warning: this function depends on never type fallback being `()`
   --> $DIR/never-type-fallback-breaking.rs:27:1

--- a/tests/ui/never_type/defaulted-never-note.nofallback.stderr
+++ b/tests/ui/never_type/defaulted-never-note.nofallback.stderr
@@ -13,6 +13,10 @@ note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will f
 LL |     foo(_x);
    |         ^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+help: use `()` annotations to avoid fallback changes
+   |
+LL |     let _x: () = return;
+   |           ++++
 
 warning: 1 warning emitted
 

--- a/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
+++ b/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
@@ -13,6 +13,10 @@ note: in edition 2024, the requirement `!: Default` will fail
 LL |         false => <_>::default(),
    |                   ^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         false => <()>::default(),
+   |                   ~~
 
 warning: this function depends on never type fallback being `()`
   --> $DIR/dependency-on-fallback-to-unit.rs:19:1

--- a/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
+++ b/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
@@ -32,6 +32,10 @@ note: in edition 2024, the requirement `!: Default` will fail
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^
+help: use `()` annotations to avoid fallback changes
+   |
+LL |     deserialize::<()>()?;
+   |                ++++++
 
 warning: 2 warnings emitted
 

--- a/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
@@ -15,8 +15,8 @@ LL |         x = UnitDefault::default();
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
 help: use `()` annotations to avoid fallback changes
    |
-LL |         x = <() as UnitDefault>::default();
-   |             ++++++            +
+LL |     let x: ();
+   |          ++++
 
 warning: this function depends on never type fallback being `()`
   --> $DIR/diverging-fallback-control-flow.rs:42:1
@@ -34,8 +34,8 @@ LL |         x = UnitDefault::default();
    |             ^^^^^^^^^^^^^^^^^^^^^^
 help: use `()` annotations to avoid fallback changes
    |
-LL |         x = <() as UnitDefault>::default();
-   |             ++++++            +
+LL |     let x: ();
+   |          ++++
 
 warning: 2 warnings emitted
 

--- a/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
@@ -13,6 +13,10 @@ note: in edition 2024, the requirement `!: UnitDefault` will fail
 LL |         x = UnitDefault::default();
    |             ^^^^^^^^^^^^^^^^^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         x = <() as UnitDefault>::default();
+   |             ++++++            +
 
 warning: this function depends on never type fallback being `()`
   --> $DIR/diverging-fallback-control-flow.rs:42:1
@@ -28,6 +32,10 @@ note: in edition 2024, the requirement `!: UnitDefault` will fail
    |
 LL |         x = UnitDefault::default();
    |             ^^^^^^^^^^^^^^^^^^^^^^
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         x = <() as UnitDefault>::default();
+   |             ++++++            +
 
 warning: 2 warnings emitted
 

--- a/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
@@ -13,6 +13,10 @@ note: in edition 2024, the requirement `!: Test` will fail
 LL |     unconstrained_arg(return);
    |                       ^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+help: use `()` annotations to avoid fallback changes
+   |
+LL |     unconstrained_arg::<()>(return);
+   |                      ++++++
 
 warning: 1 warning emitted
 

--- a/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
@@ -13,6 +13,10 @@ note: in edition 2024, the requirement `!: UnitReturn` will fail
 LL |     let _ = if true { unconstrained_return() } else { panic!() };
    |                       ^^^^^^^^^^^^^^^^^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+help: use `()` annotations to avoid fallback changes
+   |
+LL |     let _: () = if true { unconstrained_return() } else { panic!() };
+   |          ++++
 
 warning: 1 warning emitted
 

--- a/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
+++ b/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
@@ -13,6 +13,10 @@ note: in edition 2024, the requirement `!: Bar` will fail
 LL |     foo(|| panic!());
    |     ^^^^^^^^^^^^^^^^
    = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
+help: use `()` annotations to avoid fallback changes
+   |
+LL |     foo::<(), _>(|| panic!());
+   |        +++++++++
 
 warning: 1 warning emitted
 

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
@@ -8,6 +8,10 @@ LL |         unsafe { mem::zeroed() }
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         unsafe { mem::zeroed::<()>() }
+   |                             ++++++
 
 warning: never type fallback affects this call to an `unsafe` function
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:30:13
@@ -18,6 +22,10 @@ LL |             core::mem::transmute(Zst)
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
+help: use `()` annotations to avoid fallback changes
+   |
+LL |             core::mem::transmute::<_, ()>(Zst)
+   |                                 +++++++++
 
 warning: never type fallback affects this union access
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:47:18
@@ -38,6 +46,10 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         unsafe { *ptr::from_ref(&()).cast::<()>() }
+   |                                          ++++++
 
 warning: never type fallback affects this call to an `unsafe` function
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:79:18
@@ -48,6 +60,10 @@ LL |         unsafe { internally_create(x) }
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         unsafe { internally_create::<()>(x) }
+   |                                   ++++++
 
 warning: never type fallback affects this call to an `unsafe` function
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:97:18
@@ -58,6 +74,10 @@ LL |         unsafe { zeroed() }
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         let zeroed = mem::zeroed::<()>;
+   |                                 ++++++
 
 warning: never type fallback affects this `unsafe` function
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:92:22
@@ -68,6 +88,10 @@ LL |         let zeroed = mem::zeroed;
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         let zeroed = mem::zeroed::<()>;
+   |                                 ++++++
 
 warning: never type fallback affects this `unsafe` function
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:115:17
@@ -78,6 +102,10 @@ LL |         let f = internally_create;
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         let f = internally_create::<()>;
+   |                                  ++++++
 
 warning: never type fallback affects this call to an `unsafe` method
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:140:13

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
@@ -102,6 +102,10 @@ LL |         msg_send!();
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `()` annotations to avoid fallback changes
+   |
+LL |             match send_message::<() /* ?0 */>() {
+   |                                  ~~
 
 warning: 10 warnings emitted
 

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
@@ -102,6 +102,10 @@ LL |         msg_send!();
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use `()` annotations to avoid fallback changes
+   |
+LL |             match send_message::<() /* ?0 */>() {
+   |                                  ~~
 
 warning: the type `!` does not permit zero-initialization
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:13:18

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
@@ -8,6 +8,10 @@ LL |         unsafe { mem::zeroed() }
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         unsafe { mem::zeroed::<()>() }
+   |                             ++++++
 
 error: never type fallback affects this call to an `unsafe` function
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:30:13
@@ -18,6 +22,10 @@ LL |             core::mem::transmute(Zst)
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
+help: use `()` annotations to avoid fallback changes
+   |
+LL |             core::mem::transmute::<_, ()>(Zst)
+   |                                 +++++++++
 
 error: never type fallback affects this union access
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:47:18
@@ -38,6 +46,10 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         unsafe { *ptr::from_ref(&()).cast::<()>() }
+   |                                          ++++++
 
 error: never type fallback affects this call to an `unsafe` function
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:79:18
@@ -48,6 +60,10 @@ LL |         unsafe { internally_create(x) }
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         unsafe { internally_create::<()>(x) }
+   |                                   ++++++
 
 error: never type fallback affects this call to an `unsafe` function
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:97:18
@@ -58,6 +74,10 @@ LL |         unsafe { zeroed() }
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         let zeroed = mem::zeroed::<()>;
+   |                                 ++++++
 
 error: never type fallback affects this `unsafe` function
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:92:22
@@ -68,6 +88,10 @@ LL |         let zeroed = mem::zeroed;
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         let zeroed = mem::zeroed::<()>;
+   |                                 ++++++
 
 error: never type fallback affects this `unsafe` function
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:115:17
@@ -78,6 +102,10 @@ LL |         let f = internally_create;
    = warning: this will change its meaning in a future release!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
+help: use `()` annotations to avoid fallback changes
+   |
+LL |         let f = internally_create::<()>;
+   |                                  ++++++
 
 error: never type fallback affects this call to an `unsafe` method
   --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:140:13


### PR DESCRIPTION
r? @WaffleLapkin 

Just opening this up for vibes; it's not done yet. I'd still like to make this suggestable in a few more cases before merge:
- [x] Try to annotate `_` -> `()`
- [x] Try to annotate local variables if they're un-annotated: `let x = ...` -> `let x: () = ...`
- [x] Try to annotate the self type of a `Trait::method()` -> `<() as Trait>::method()`.

The only other case we may want to suggest is a missing turbofish, like `f()` -> `f::<()>()`. That may be possible, but seems overly annoying.

This partly addresses https://github.com/rust-lang/rust/issues/132358; the other half of fixing that would be to make the error message a bit better, perhaps just special casing the `?` operator 🤔 I don't think I'll do that part.