### PR TITLE
bootstrap: show diagnostics relative to rustc src dir

### DIFF
--- a/src/bootstrap/bootstrap.py
+++ b/src/bootstrap/bootstrap.py
@@ -1029,7 +1029,8 @@ class RustBuild(object):
             raise Exception("no cargo executable found at `{}`".format(
                 self.cargo()))
         args = [self.cargo(), "build", "--manifest-path",
-                os.path.join(self.rust_root, "src/bootstrap/Cargo.toml")]
+                os.path.join(self.rust_root, "src/bootstrap/Cargo.toml"),
+                "-Zroot-dir="+self.rust_root]
         args.extend("--verbose" for _ in range(self.verbose))
         if self.use_locked_deps:
             args.append("--locked")

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -305,9 +305,10 @@ impl Step for Cargo {
         // those features won't be able to land.
         cargo.env("CARGO_TEST_DISABLE_NIGHTLY", "1");
         cargo.env("PATH", path_for_cargo(builder, compiler));
-        // Cargo's test suite requires configurations from its own `.cargo/config.toml`.
-        // Change to the directory so Cargo can read from it.
-        cargo.current_dir(builder.src.join(Self::CRATE_PATH));
+        // Cargo's test suite uses `CARGO_RUSTC_CURRENT_DIR` to determine the path that `file!` is
+        // relative to. Cargo no longer sets this env var, so we have to do that. This has to be the
+        // same value as `-Zroot-dir`.
+        cargo.env("CARGO_RUSTC_CURRENT_DIR", builder.src.display().to_string());
 
         #[cfg(feature = "build-metrics")]
         builder.metrics.begin_test_suite(

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -703,6 +703,9 @@ impl Builder<'_> {
 
         cargo.arg("-j").arg(self.jobs().to_string());
 
+        // Make cargo emit diagnostics relative to the rustc src dir.
+        cargo.arg(format!("-Zroot-dir={}", self.src.display()));
+
         // FIXME: Temporary fix for https://github.com/rust-lang/cargo/issues/3005
         // Force cargo to output binaries with disambiguating hashes in the name
         let mut metadata = if compiler.stage == 0 {

--- a/tests/ui/extern/extern-types-field-offset.run.stderr
+++ b/tests/ui/extern/extern-types-field-offset.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at core/src/panicking.rs:$LINE:$COL:
+thread 'main' panicked at library/core/src/panicking.rs:$LINE:$COL:
 attempted to compute the size or alignment of extern type `Opaque`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread caused non-unwinding panic. aborting.

--- a/tests/ui/extern/extern-types-size_of_val.align.run.stderr
+++ b/tests/ui/extern/extern-types-size_of_val.align.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at core/src/panicking.rs:$LINE:$COL:
+thread 'main' panicked at library/core/src/panicking.rs:$LINE:$COL:
 attempted to compute the size or alignment of extern type `A`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread caused non-unwinding panic. aborting.

--- a/tests/ui/extern/extern-types-size_of_val.size.run.stderr
+++ b/tests/ui/extern/extern-types-size_of_val.size.run.stderr
@@ -1,4 +1,4 @@
-thread 'main' panicked at core/src/panicking.rs:$LINE:$COL:
+thread 'main' panicked at library/core/src/panicking.rs:$LINE:$COL:
 attempted to compute the size or alignment of extern type `A`
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread caused non-unwinding panic. aborting.

--- a/tests/ui/panics/panic-in-cleanup.run.stderr
+++ b/tests/ui/panics/panic-in-cleanup.run.stderr
@@ -4,6 +4,6 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 thread 'main' panicked at $DIR/panic-in-cleanup.rs:16:9:
 BOOM
 stack backtrace:
-thread 'main' panicked at core/src/panicking.rs:$LINE:$COL:
+thread 'main' panicked at library/core/src/panicking.rs:$LINE:$COL:
 panic in a destructor during cleanup
 thread caused non-unwinding panic. aborting.

--- a/tests/ui/panics/panic-in-ffi.run.stderr
+++ b/tests/ui/panics/panic-in-ffi.run.stderr
@@ -2,7 +2,7 @@ thread 'main' panicked at $DIR/panic-in-ffi.rs:21:5:
 Test
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 Noisy Drop
-thread 'main' panicked at core/src/panicking.rs:$LINE:$COL:
+thread 'main' panicked at library/core/src/panicking.rs:$LINE:$COL:
 panic in a function that cannot unwind
 stack backtrace:
 thread caused non-unwinding panic. aborting.

--- a/tests/ui/process/println-with-broken-pipe.run.stderr
+++ b/tests/ui/process/println-with-broken-pipe.run.stderr
@@ -1,3 +1,3 @@
-thread 'main' panicked at std/src/io/stdio.rs:LL:CC:
+thread 'main' panicked at library/std/src/io/stdio.rs:LL:CC:
 failed printing to stdout: Broken pipe (os error 32)
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/128726

Depends on https://github.com/rust-lang/cargo/pull/14752 propagating to bootstrap cargo