### PR TITLE
Apple: Fix direct linking with +verbatim

### DIFF
--- a/tests/run-make/native-link-modifier-verbatim-linker/rmake.rs
+++ b/tests/run-make/native-link-modifier-verbatim-linker/rmake.rs
@@ -3,9 +3,6 @@
 // This test is the same as native-link-modifier-rustc, but without rlibs.
 // See https://github.com/rust-lang/rust/issues/99425
 
-//@ ignore-apple
-// Reason: linking fails due to the unusual ".ext" staticlib name.
-
 use run_make_support::rustc;
 
 fn main() {


### PR DESCRIPTION
Linking with `+verbatim` somewhat worked before, but only when the library was included as part of an rlib.

Fixes https://github.com/rust-lang/rust/issues/132264.

CC @petrochenkov, since you've worked on `+verbatim` before.

@rustbot label O-apple A-linkage

try-job: aarch64-apple
try-job: x86_64-apple-2