### PR TITLE
CI: use free runners for x86_64-gnu-tools and x86_64-rust-for-linux

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -232,7 +232,7 @@ auto:
   # Tests integration with Rust for Linux.
   # Builds stage 1 compiler and tries to compile a few RfL examples with it.
   - image: x86_64-rust-for-linux
-    <<: *job-linux-8c
+    <<: *job-linux-4c
 
   - image: x86_64-gnu
     <<: *job-linux-4c
@@ -280,7 +280,7 @@ auto:
   - image: x86_64-gnu-tools
     env:
       DEPLOY_TOOLSTATES_JSON: toolstates-linux.json
-    <<: *job-linux-8c
+    <<: *job-linux-4c
 
   ####################
   #  macOS Builders  #


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->

Similar to https://github.com/rust-lang/rust/pull/132316

I noticed that some jobs running on large runners are significantly faster than the rest of the auto build.

Here's some data based on the latest 97 auto builds:

- Average of these jobs:
  - `x86_64-gnu-tools`: 64 minutes
  - `x86_64-rust-for-linux`: 33 minutes
- Minimum duration of the auto builds: 136 minutes (2h 16 min).
- Average duration of the auto build: 155 minutes (2h 35 min).

In this PR I switch these jobs from large runners to free runners, to see if we can save some resources.

Imo if the try builds don't take longer than the average duration of the auto build we could merge this PR.


<!-- homu-ignore:end -->

try-job: x86_64-gnu-tools
try-job: x86_64-rust-for-linux
