### PR TITLE
CI: switch 7 linux jobs to free runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,11 +110,7 @@ jobs:
       # less disk space.
       - name: free up disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
-        if: contains(matrix.os, 'ubuntu')
-        with:
-          # Removing packages with APT saves ~5 GiB, but takes several
-          # minutes (and potentially removes important packages).
-          large-packages: false
+        if: matrix.free_disk
 
       # Rust Log Analyzer can't currently detect the PR number of a GitHub
       # Actions build on its own, so a hint in the log message is needed to

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -6,6 +6,8 @@ runners:
 
   - &job-linux-4c
     os: ubuntu-20.04
+    # Free some disk space to avoid running out of space during the build.
+    free_disk: true
     <<: *base-job
 
   # Large runner used mainly for its bigger disk capacity
@@ -135,7 +137,7 @@ auto:
   - image: dist-aarch64-linux
     env:
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-linux-4c-largedisk
+    <<: *job-linux-4c
 
   - image: dist-android
     <<: *job-linux-4c
@@ -156,28 +158,28 @@ auto:
     <<: *job-linux-4c
 
   - image: dist-loongarch64-linux
-    <<: *job-linux-4c-largedisk
+    <<: *job-linux-4c
 
   - image: dist-loongarch64-musl
-    <<: *job-linux-4c-largedisk
+    <<: *job-linux-4c
 
   - image: dist-ohos
     <<: *job-linux-4c
 
   - image: dist-powerpc-linux
-    <<: *job-linux-4c-largedisk
+    <<: *job-linux-4c
 
   - image: dist-powerpc64-linux
-    <<: *job-linux-4c-largedisk
+    <<: *job-linux-4c
 
   - image: dist-powerpc64le-linux
-    <<: *job-linux-4c-largedisk
+    <<: *job-linux-4c
 
   - image: dist-riscv64-linux
     <<: *job-linux-4c
 
   - image: dist-s390x-linux
-    <<: *job-linux-4c-largedisk
+    <<: *job-linux-4c
 
   - image: dist-various-1
     <<: *job-linux-4c


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
`ubuntu-20.04-4core-16gb` is a large runner and we only use it because of it's larger disk space.
Let's see if we can remove it by cleaning more disk space.

Additionally, at the moment every ubuntu image runs the `jlumbroso/free-disk-space` action. This is a waste of time for large runners that don't need to clean space. This PR changes this behavior to only run this action on free runners which don't have enough space to run the CI.

- [x] test that actions without the free_disk flag work

<details><summary><b>Jobs to test</b></summary>
Jobs that have the 4 core large runner on `master` (to test to check if we can move them to free runners):

- dist-aarch64-linux
- dist-loongarch64-linux
- dist-loongarch64-musl
- dist-powerpc-linux
- dist-powerpc64-linux
- dist-powerpc64le-linux
- dist-s390x-linux
- x86_64-gnu-debug

Jobs that have the free runner on `master` (to test to check if cleaning large packages takes too much time):

- arm-android
- armhf-gnu
- dist-android
- dist-armhf-linux
- dist-armv7-linux
- dist-i586-gnu-i586-i686-musl
- dist-i686-linux
- dist-ohos
- dist-riscv64-linux
- dist-various-1
- dist-various-2
- dist-x86_64-freebsd
- dist-x86_64-illumos
- dist-x86_64-netbsd
- mingw-check
- test-various
- x86_64-rust-for-linux
- x86_64-gnu
- x86_64-gnu-stable
- x86_64-gnu-aux
- x86_64-gnu-nopt
- x86_64-gnu-tools
</details>
<!-- homu-ignore:end -->

try-job: x86_64-gnu-aux
try-job: x86_64-gnu-nopt
try-job: x86_64-gnu-tools
