### PR TITLE
CI: switch dist-x86_64-musl to free runner

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -205,7 +205,7 @@ auto:
   - image: dist-x86_64-musl
     env:
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-linux-8c
+    <<: *job-linux-4c
 
   - image: dist-x86_64-netbsd
     <<: *job-linux-4c


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->

Similar to https://github.com/rust-lang/rust/pull/132396 and https://github.com/rust-lang/rust/pull/132316

I noticed that some jobs running on large runners are significantly faster than the rest of the auto build.

Here's some data based on the latest 97 auto builds:

- Average of these jobs:
  - `dist-x86_64-musl`: 77 minutes
  - `i686-gnu`: 102 minutes (EDIT: this takes too long)
- Minimum duration of the auto builds: 136 minutes (2h 16 min).
- Average duration of the auto build: 155 minutes (2h 35 min).

<!-- homu-ignore:end -->

try-job: dist-x86_64-musl
