### PR TITLE
macOS: Document the difference between Clang's `-darwin` and `-macosx` targets

### DIFF
--- a/src/doc/rustc/src/platform-support/apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/apple-darwin.md
@@ -52,5 +52,10 @@ Cross-compilation of these targets are supported using Clang, but may require
 Xcode or the macOS SDK (`MacOSX.sdk`) to be available to compile C code and
 to link.
 
+The Clang target is suffixed with `-macosx`. Clang's `-darwin` target refers
+to Darwin platforms in general (macOS/iOS/tvOS/watchOS/visionOS), and requires
+the `-mmacosx-version-min=...`, `-miphoneos-version-min=...` or similar flags
+to disambiguate.
+
 The path to the SDK can be passed to `rustc` using the common `SDKROOT`
 environment variable.


### PR DESCRIPTION
`rustc`'s `*-apple-darwin` targets are badly named (they should've been called `*-apple-macos`), and this causes confusion wrt. the similarly named but somewhat incompatible Clang targets.

So let's document the difference to at least make things a _little_ easier on our users.

@rustbot label O-macos  A-docs 