### PR TITLE
Prefer `pub(super)` in `unreachable_pub` lint suggestion

### DIFF
--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -254,7 +254,8 @@ impl<'a> LintDiagnostic<'a, ()> for BuiltinUngatedAsyncFnTrackCaller<'_> {
 #[diag(lint_builtin_unreachable_pub)]
 pub(crate) struct BuiltinUnreachablePub<'a> {
     pub what: &'a str,
-    #[suggestion(code = "pub(crate)")]
+    pub new_vis: &'a str,
+    #[suggestion(code = "{new_vis}")]
     pub suggestion: (Span, Applicability),
     #[help]
     pub help: bool,

--- a/tests/ui/lint/unreachable_pub.fixed
+++ b/tests/ui/lint/unreachable_pub.fixed
@@ -7,12 +7,12 @@
 
 mod private_mod {
     // non-leaked `pub` items in private module should be linted
-    pub use std::fmt; //~ WARNING unreachable_pub
-    pub use std::env::{Args}; // braced-use has different item spans than unbraced
+    pub(crate) use std::fmt; //~ WARNING unreachable_pub
+    pub(crate) use std::env::{Args}; // braced-use has different item spans than unbraced
     //~^ WARNING unreachable_pub
 
     // we lint on struct definition
-    pub struct Hydrogen { //~ WARNING unreachable_pub
+    pub(crate) struct Hydrogen { //~ WARNING unreachable_pub
         // but not on fields, even if they are `pub` as putting `pub(crate)`
         // it would clutter the source code for little value
         pub neutrons: usize,
@@ -23,7 +23,7 @@ mod private_mod {
     }
     impl Hydrogen {
         // impls, too
-        pub fn count_neutrons(&self) -> usize { self.neutrons } //~ WARNING unreachable_pub
+        pub(crate) fn count_neutrons(&self) -> usize { self.neutrons } //~ WARNING unreachable_pub
         pub(crate) fn count_electrons(&self) -> usize { self.electrons }
     }
     impl Clone for Hydrogen {
@@ -32,49 +32,49 @@ mod private_mod {
         }
     }
 
-    pub enum Helium {} //~ WARNING unreachable_pub
-    pub union Lithium { c1: usize, c2: u8 } //~ WARNING unreachable_pub
-    pub fn beryllium() {} //~ WARNING unreachable_pub
-    pub trait Boron {} //~ WARNING unreachable_pub
-    pub const CARBON: usize = 1; //~ WARNING unreachable_pub
-    pub static NITROGEN: usize = 2; //~ WARNING unreachable_pub
-    pub type Oxygen = bool; //~ WARNING unreachable_pub
+    pub(crate) enum Helium {} //~ WARNING unreachable_pub
+    pub(crate) union Lithium { c1: usize, c2: u8 } //~ WARNING unreachable_pub
+    pub(crate) fn beryllium() {} //~ WARNING unreachable_pub
+    pub(crate) trait Boron {} //~ WARNING unreachable_pub
+    pub(crate) const CARBON: usize = 1; //~ WARNING unreachable_pub
+    pub(crate) static NITROGEN: usize = 2; //~ WARNING unreachable_pub
+    pub(crate) type Oxygen = bool; //~ WARNING unreachable_pub
 
     macro_rules! define_empty_struct_with_visibility {
         ($visibility: vis, $name: ident) => { $visibility struct $name {} }
         //~^ WARNING unreachable_pub
     }
-    define_empty_struct_with_visibility!(pub, Fluorine);
+    define_empty_struct_with_visibility!(pub(crate), Fluorine);
 
     extern "C" {
-        pub fn catalyze() -> bool; //~ WARNING unreachable_pub
+        pub(crate) fn catalyze() -> bool; //~ WARNING unreachable_pub
     }
 
     mod private_in_private {
-        pub enum Helium {} //~ WARNING unreachable_pub
-        pub fn beryllium() {} //~ WARNING unreachable_pub
+        pub(super) enum Helium {} //~ WARNING unreachable_pub
+        pub(super) fn beryllium() {} //~ WARNING unreachable_pub
     }
 
     pub(crate) mod crate_in_private {
-        pub const CARBON: usize = 1; //~ WARNING unreachable_pub
+        pub(crate) const CARBON: usize = 1; //~ WARNING unreachable_pub
     }
 
-    pub mod pub_in_private { //~ WARNING unreachable_pub
-        pub static NITROGEN: usize = 2; //~ WARNING unreachable_pub
+    pub(crate) mod pub_in_private { //~ WARNING unreachable_pub
+        pub(crate) static NITROGEN: usize = 2; //~ WARNING unreachable_pub
     }
 
     fn foo() {
         const {
-            pub struct Foo; //~ WARNING unreachable_pub
+            pub(crate) struct Foo; //~ WARNING unreachable_pub
         };
     }
 
     enum Weird {
         Variant = {
-            pub struct Foo; //~ WARNING unreachable_pub
+            pub(crate) struct Foo; //~ WARNING unreachable_pub
 
             mod tmp {
-                pub struct Bar; //~ WARNING unreachable_pub
+                pub(crate) struct Bar; //~ WARNING unreachable_pub
             }
 
             let _ = tmp::Bar;
@@ -83,11 +83,11 @@ mod private_mod {
         },
     }
 
-    pub use fpu_precision::set_precision; //~ WARNING unreachable_pub
+    pub(crate) use fpu_precision::set_precision; //~ WARNING unreachable_pub
 
     mod fpu_precision {
-        pub fn set_precision<T>() {} //~ WARNING unreachable_pub
-        pub fn set_micro_precision<T>() {} //~ WARNING unreachable_pub
+        pub(crate) fn set_precision<T>() {} //~ WARNING unreachable_pub
+        pub(super) fn set_micro_precision<T>() {} //~ WARNING unreachable_pub
     }
 
     // items leaked through signatures (see `get_neon` below) are OK

--- a/tests/ui/lint/unreachable_pub.stderr
+++ b/tests/ui/lint/unreachable_pub.stderr
@@ -1,5 +1,5 @@
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:8:13
+  --> $DIR/unreachable_pub.rs:10:13
    |
 LL |     pub use std::fmt;
    |     ---     ^^^^^^^^
@@ -8,13 +8,13 @@ LL |     pub use std::fmt;
    |
    = help: or consider exporting it for use by other crates
 note: the lint level is defined here
-  --> $DIR/unreachable_pub.rs:4:9
+  --> $DIR/unreachable_pub.rs:6:9
    |
 LL | #![warn(unreachable_pub)]
    |         ^^^^^^^^^^^^^^^
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:9:24
+  --> $DIR/unreachable_pub.rs:11:24
    |
 LL |     pub use std::env::{Args}; // braced-use has different item spans than unbraced
    |     ---                ^^^^
@@ -24,7 +24,7 @@ LL |     pub use std::env::{Args}; // braced-use has different item spans than u
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:13:5
+  --> $DIR/unreachable_pub.rs:15:5
    |
 LL |     pub struct Hydrogen {
    |     ---^^^^^^^^^^^^^^^^
@@ -34,7 +34,7 @@ LL |     pub struct Hydrogen {
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:24:9
+  --> $DIR/unreachable_pub.rs:26:9
    |
 LL |         pub fn count_neutrons(&self) -> usize { self.neutrons }
    |         ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -42,7 +42,7 @@ LL |         pub fn count_neutrons(&self) -> usize { self.neutrons }
    |         help: consider restricting its visibility: `pub(crate)`
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:33:5
+  --> $DIR/unreachable_pub.rs:35:5
    |
 LL |     pub enum Helium {}
    |     ---^^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL |     pub enum Helium {}
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:34:5
+  --> $DIR/unreachable_pub.rs:36:5
    |
 LL |     pub union Lithium { c1: usize, c2: u8 }
    |     ---^^^^^^^^^^^^^^
@@ -62,7 +62,7 @@ LL |     pub union Lithium { c1: usize, c2: u8 }
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:35:5
+  --> $DIR/unreachable_pub.rs:37:5
    |
 LL |     pub fn beryllium() {}
    |     ---^^^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |     pub fn beryllium() {}
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:36:5
+  --> $DIR/unreachable_pub.rs:38:5
    |
 LL |     pub trait Boron {}
    |     ---^^^^^^^^^^^^
@@ -82,7 +82,7 @@ LL |     pub trait Boron {}
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:37:5
+  --> $DIR/unreachable_pub.rs:39:5
    |
 LL |     pub const CARBON: usize = 1;
    |     ---^^^^^^^^^^^^^^^^^^^^
@@ -92,7 +92,7 @@ LL |     pub const CARBON: usize = 1;
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:38:5
+  --> $DIR/unreachable_pub.rs:40:5
    |
 LL |     pub static NITROGEN: usize = 2;
    |     ---^^^^^^^^^^^^^^^^^^^^^^^
@@ -102,7 +102,7 @@ LL |     pub static NITROGEN: usize = 2;
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:39:5
+  --> $DIR/unreachable_pub.rs:41:5
    |
 LL |     pub type Oxygen = bool;
    |     ---^^^^^^^^^^^^
@@ -112,7 +112,7 @@ LL |     pub type Oxygen = bool;
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:42:47
+  --> $DIR/unreachable_pub.rs:44:47
    |
 LL |         ($visibility: vis, $name: ident) => { $visibility struct $name {} }
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -127,7 +127,7 @@ LL |     define_empty_struct_with_visibility!(pub, Fluorine);
    = note: this warning originates in the macro `define_empty_struct_with_visibility` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:48:9
+  --> $DIR/unreachable_pub.rs:50:9
    |
 LL |         pub fn catalyze() -> bool;
    |         ---^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,5 +136,115 @@ LL |         pub fn catalyze() -> bool;
    |
    = help: or consider exporting it for use by other crates
 
-warning: 13 warnings emitted
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:62:5
+   |
+LL |     pub mod pub_in_private {
+   |     ---^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:68:13
+   |
+LL |             pub struct Foo;
+   |             ---^^^^^^^^^^^
+   |             |
+   |             help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:74:13
+   |
+LL |             pub struct Foo;
+   |             ---^^^^^^^^^^^
+   |             |
+   |             help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:86:13
+   |
+LL |     pub use fpu_precision::set_precision;
+   |     ---     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:54:9
+   |
+LL |         pub enum Helium {}
+   |         ---^^^^^^^^^^^^
+   |         |
+   |         help: consider restricting its visibility: `pub(super)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:55:9
+   |
+LL |         pub fn beryllium() {}
+   |         ---^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider restricting its visibility: `pub(super)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:59:9
+   |
+LL |         pub const CARBON: usize = 1;
+   |         ---^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:63:9
+   |
+LL |         pub static NITROGEN: usize = 2;
+   |         ---^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:77:17
+   |
+LL |                 pub struct Bar;
+   |                 ---^^^^^^^^^^^
+   |                 |
+   |                 help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:89:9
+   |
+LL |         pub fn set_precision<T>() {}
+   |         ---^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:90:9
+   |
+LL |         pub fn set_micro_precision<T>() {}
+   |         ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider restricting its visibility: `pub(super)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: 24 warnings emitted
 


### PR DESCRIPTION
This PR updates the `unreachable_pub` lint suggestion to prefer `pub(super)` instead of `pub(crate)` when possible.

cc @petrochenkov
r? @nnethercote