### PR TITLE
Update compiler_builtins to 0.1.137 and pin it

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "compiler_builtins"
-version = "0.1.136"
+version = "0.1.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ccee9dd499d7ada4c81533382ce87e88c52b0676c7320b2e617d29e1bb3a3f"
+checksum = "12ca24dd460d0e3d28cc55e2d6a1bfe84e03577bc9e43b2d96d86ccd26ab7b91"
 dependencies = [
  "cc",
  "rustc-std-workspace-core",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 core = { path = "../core" }
-compiler_builtins = { version = "0.1.136", features = ['rustc-dep-of-std'] }
+compiler_builtins = { version = "=0.1.137", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = { version = "1.0", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }
 core = { path = "../core", public = true }
-compiler_builtins = { version = "0.1.136" }
+compiler_builtins = { version = "=0.1.137" }
 unwind = { path = "../unwind" }
 hashbrown = { version = "0.15", default-features = false, features = [
     'rustc-dep-of-std',


### PR DESCRIPTION
This updates to a new version of builtins that includes [1], which was the last blocker to us enabling `f128` tests on all platforms 🎉.

With this update, also change to pinning the version with `=` rather than using the default carat versioning. This is meant to ensure that `compiler-builtins` does not get updated as part of the weekly `Cargo.lock` update, since updates to this crate need to be intentional: changes to rust-lang/rust and rust-lang/compiler-builtins sometimes need to be kept in lockstep, unlike most dependencies, and sometimes these updates can be problematic.

[1]: https://github.com/rust-lang/compiler-builtins/pull/624