### PR TITLE
coverage: Regression test for inlining into an uninstrumented crate

### DIFF
--- a/tests/coverage/auxiliary/inline_mixed_helper.rs
+++ b/tests/coverage/auxiliary/inline_mixed_helper.rs
@@ -1,0 +1,13 @@
+//@ edition: 2021
+//@ compile-flags: -Cinstrument-coverage=on
+
+#[inline]
+pub fn inline_me() {}
+
+#[inline(never)]
+pub fn no_inlining_please() {}
+
+pub fn generic<T>() {}
+
+// FIXME(#132436): Even though this doesn't ICE, it still produces coverage
+// reports that undercount the affected code.

--- a/tests/coverage/inline_mixed.rs
+++ b/tests/coverage/inline_mixed.rs
@@ -1,0 +1,19 @@
+//@ edition: 2021
+//@ compile-flags: -Cinstrument-coverage=off
+//@ ignore-coverage-run
+//@ aux-crate: inline_mixed_helper=inline_mixed_helper.rs
+
+// Regression test for <https://github.com/rust-lang/rust/pull/132395>.
+// Various forms of cross-crate inlining can cause coverage statements to be
+// inlined into crates that are being built without coverage instrumentation.
+// At the very least, we need to not ICE when that happens.
+
+fn main() {
+    inline_mixed_helper::inline_me();
+    inline_mixed_helper::no_inlining_please();
+    inline_mixed_helper::generic::<u32>();
+}
+
+// FIXME(#132437): We currently don't test this in coverage-run mode, because
+// whether or not it produces a `.profraw` file appears to differ between
+// platforms.


### PR DESCRIPTION
Regression test for #132395, after I was able to figure out a simple way to reproduce it. See also #132436.

In addition to confirming that there is no ICE, this test also demonstrates that the affected code is undercounted, because executing the inlined copy doesn't increment coverage counters.