### PR TITLE
Add `f16` and `f128` to `invalid_nan_comparison`

### DIFF
--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -204,7 +204,10 @@ fn lint_nan<'tcx>(
                     return false;
                 };
 
-                matches!(cx.tcx.get_diagnostic_name(def_id), Some(sym::f32_nan | sym::f64_nan))
+                matches!(
+                    cx.tcx.get_diagnostic_name(def_id),
+                    Some(sym::f16_nan | sym::f32_nan | sym::f64_nan | sym::f128_nan)
+                )
             }
             _ => false,
         }

--- a/tests/ui/lint/invalid-nan-comparison-suggestion.fixed
+++ b/tests/ui/lint/invalid-nan-comparison-suggestion.fixed
@@ -1,7 +1,15 @@
 //@ check-pass
 //@ run-rustfix
 
+#![feature(f16, f128)]
+
 fn main() {
+    let x = 5f16;
+    let _ = x.is_nan();
+    //~^ WARN incorrect NaN comparison
+    let _ = !x.is_nan();
+    //~^ WARN incorrect NaN comparison
+
     let x = 5f32;
     let _ = x.is_nan();
     //~^ WARN incorrect NaN comparison
@@ -9,6 +17,12 @@ fn main() {
     //~^ WARN incorrect NaN comparison
 
     let x = 5f64;
+    let _ = x.is_nan();
+    //~^ WARN incorrect NaN comparison
+    let _ = !x.is_nan();
+    //~^ WARN incorrect NaN comparison
+
+    let x = 5f128;
     let _ = x.is_nan();
     //~^ WARN incorrect NaN comparison
     let _ = !x.is_nan();

--- a/tests/ui/lint/invalid-nan-comparison-suggestion.rs
+++ b/tests/ui/lint/invalid-nan-comparison-suggestion.rs
@@ -1,7 +1,15 @@
 //@ check-pass
 //@ run-rustfix
 
+#![feature(f16, f128)]
+
 fn main() {
+    let x = 5f16;
+    let _ = x == f16::NAN;
+    //~^ WARN incorrect NaN comparison
+    let _ = x != f16::NAN;
+    //~^ WARN incorrect NaN comparison
+
     let x = 5f32;
     let _ = x == f32::NAN;
     //~^ WARN incorrect NaN comparison
@@ -12,6 +20,12 @@ fn main() {
     let _ = x == f64::NAN;
     //~^ WARN incorrect NaN comparison
     let _ = x != f64::NAN;
+    //~^ WARN incorrect NaN comparison
+
+    let x = 5f128;
+    let _ = x == f128::NAN;
+    //~^ WARN incorrect NaN comparison
+    let _ = x != f128::NAN;
     //~^ WARN incorrect NaN comparison
 
     let b = &2.3f32;

--- a/tests/ui/lint/invalid-nan-comparison-suggestion.stderr
+++ b/tests/ui/lint/invalid-nan-comparison-suggestion.stderr
@@ -1,10 +1,34 @@
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison-suggestion.rs:6:13
+  --> $DIR/invalid-nan-comparison-suggestion.rs:8:13
+   |
+LL |     let _ = x == f16::NAN;
+   |             ^^^^^^^^^^^^^
+   |
+   = note: `#[warn(invalid_nan_comparisons)]` on by default
+help: use `f32::is_nan()` or `f64::is_nan()` instead
+   |
+LL -     let _ = x == f16::NAN;
+LL +     let _ = x.is_nan();
+   |
+
+warning: incorrect NaN comparison, NaN cannot be directly compared to itself
+  --> $DIR/invalid-nan-comparison-suggestion.rs:10:13
+   |
+LL |     let _ = x != f16::NAN;
+   |             ^^^^^^^^^^^^^
+   |
+help: use `f32::is_nan()` or `f64::is_nan()` instead
+   |
+LL -     let _ = x != f16::NAN;
+LL +     let _ = !x.is_nan();
+   |
+
+warning: incorrect NaN comparison, NaN cannot be directly compared to itself
+  --> $DIR/invalid-nan-comparison-suggestion.rs:14:13
    |
 LL |     let _ = x == f32::NAN;
    |             ^^^^^^^^^^^^^
    |
-   = note: `#[warn(invalid_nan_comparisons)]` on by default
 help: use `f32::is_nan()` or `f64::is_nan()` instead
    |
 LL -     let _ = x == f32::NAN;
@@ -12,7 +36,7 @@ LL +     let _ = x.is_nan();
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison-suggestion.rs:8:13
+  --> $DIR/invalid-nan-comparison-suggestion.rs:16:13
    |
 LL |     let _ = x != f32::NAN;
    |             ^^^^^^^^^^^^^
@@ -24,7 +48,7 @@ LL +     let _ = !x.is_nan();
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison-suggestion.rs:12:13
+  --> $DIR/invalid-nan-comparison-suggestion.rs:20:13
    |
 LL |     let _ = x == f64::NAN;
    |             ^^^^^^^^^^^^^
@@ -36,7 +60,7 @@ LL +     let _ = x.is_nan();
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison-suggestion.rs:14:13
+  --> $DIR/invalid-nan-comparison-suggestion.rs:22:13
    |
 LL |     let _ = x != f64::NAN;
    |             ^^^^^^^^^^^^^
@@ -48,7 +72,31 @@ LL +     let _ = !x.is_nan();
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison-suggestion.rs:18:8
+  --> $DIR/invalid-nan-comparison-suggestion.rs:26:13
+   |
+LL |     let _ = x == f128::NAN;
+   |             ^^^^^^^^^^^^^^
+   |
+help: use `f32::is_nan()` or `f64::is_nan()` instead
+   |
+LL -     let _ = x == f128::NAN;
+LL +     let _ = x.is_nan();
+   |
+
+warning: incorrect NaN comparison, NaN cannot be directly compared to itself
+  --> $DIR/invalid-nan-comparison-suggestion.rs:28:13
+   |
+LL |     let _ = x != f128::NAN;
+   |             ^^^^^^^^^^^^^^
+   |
+help: use `f32::is_nan()` or `f64::is_nan()` instead
+   |
+LL -     let _ = x != f128::NAN;
+LL +     let _ = !x.is_nan();
+   |
+
+warning: incorrect NaN comparison, NaN cannot be directly compared to itself
+  --> $DIR/invalid-nan-comparison-suggestion.rs:32:8
    |
 LL |     if b != &f32::NAN {}
    |        ^^^^^^^^^^^^^^
@@ -60,7 +108,7 @@ LL +     if !b.is_nan() {}
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison-suggestion.rs:22:8
+  --> $DIR/invalid-nan-comparison-suggestion.rs:36:8
    |
 LL |     if b != { &f32::NAN } {}
    |        ^^^^^^^^^^^^^^^^^^
@@ -72,7 +120,7 @@ LL +     if !b.is_nan() {}
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison-suggestion.rs:26:9
+  --> $DIR/invalid-nan-comparison-suggestion.rs:40:9
    |
 LL | /         b != {
 LL | |
@@ -87,7 +135,7 @@ LL +         !b.is_nan();
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison-suggestion.rs:35:13
+  --> $DIR/invalid-nan-comparison-suggestion.rs:49:13
    |
 LL |     let _ = nan!() == number!();
    |             ^^^^^^^^^^^^^^^^^^^
@@ -99,7 +147,7 @@ LL +     let _ = number!().is_nan();
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison-suggestion.rs:37:13
+  --> $DIR/invalid-nan-comparison-suggestion.rs:51:13
    |
 LL |     let _ = number!() != nan!();
    |             ^^^^^^^^^^^^^^^^^^^
@@ -110,5 +158,5 @@ LL -     let _ = number!() != nan!();
 LL +     let _ = !number!().is_nan();
    |
 
-warning: 9 warnings emitted
+warning: 13 warnings emitted
 

--- a/tests/ui/lint/invalid-nan-comparison.rs
+++ b/tests/ui/lint/invalid-nan-comparison.rs
@@ -1,12 +1,37 @@
 //@ check-pass
 
+#![feature(f16, f128)]
+
 fn main() {
+    f16();
     f32();
     f64();
+    f128();
 }
 
 const TEST: bool = 5f32 == f32::NAN;
 //~^ WARN incorrect NaN comparison
+
+fn f16() {
+    macro_rules! number { () => { 5f16 }; }
+    let x = number!();
+    x == f16::NAN;
+    //~^ WARN incorrect NaN comparison
+    x != f16::NAN;
+    //~^ WARN incorrect NaN comparison
+    x < f16::NAN;
+    //~^ WARN incorrect NaN comparison
+    x > f16::NAN;
+    //~^ WARN incorrect NaN comparison
+    x <= f16::NAN;
+    //~^ WARN incorrect NaN comparison
+    x >= f16::NAN;
+    //~^ WARN incorrect NaN comparison
+    number!() == f16::NAN;
+    //~^ WARN incorrect NaN comparison
+    f16::NAN != number!();
+    //~^ WARN incorrect NaN comparison
+}
 
 fn f32() {
     macro_rules! number { () => { 5f32 }; }
@@ -47,5 +72,26 @@ fn f64() {
     number!() == f64::NAN;
     //~^ WARN incorrect NaN comparison
     f64::NAN != number!();
+    //~^ WARN incorrect NaN comparison
+}
+
+fn f128() {
+    macro_rules! number { () => { 5f128 }; }
+    let x = number!();
+    x == f128::NAN;
+    //~^ WARN incorrect NaN comparison
+    x != f128::NAN;
+    //~^ WARN incorrect NaN comparison
+    x < f128::NAN;
+    //~^ WARN incorrect NaN comparison
+    x > f128::NAN;
+    //~^ WARN incorrect NaN comparison
+    x <= f128::NAN;
+    //~^ WARN incorrect NaN comparison
+    x >= f128::NAN;
+    //~^ WARN incorrect NaN comparison
+    number!() == f128::NAN;
+    //~^ WARN incorrect NaN comparison
+    f128::NAN != number!();
     //~^ WARN incorrect NaN comparison
 }

--- a/tests/ui/lint/invalid-nan-comparison.stderr
+++ b/tests/ui/lint/invalid-nan-comparison.stderr
@@ -1,5 +1,5 @@
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison.rs:8:20
+  --> $DIR/invalid-nan-comparison.rs:12:20
    |
 LL | const TEST: bool = 5f32 == f32::NAN;
    |                    ^^^^^^^^^^^^^^^^
@@ -12,7 +12,79 @@ LL + const TEST: bool = 5f32.is_nan();
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison.rs:14:5
+  --> $DIR/invalid-nan-comparison.rs:18:5
+   |
+LL |     x == f16::NAN;
+   |     ^^^^^^^^^^^^^
+   |
+help: use `f32::is_nan()` or `f64::is_nan()` instead
+   |
+LL -     x == f16::NAN;
+LL +     x.is_nan();
+   |
+
+warning: incorrect NaN comparison, NaN cannot be directly compared to itself
+  --> $DIR/invalid-nan-comparison.rs:20:5
+   |
+LL |     x != f16::NAN;
+   |     ^^^^^^^^^^^^^
+   |
+help: use `f32::is_nan()` or `f64::is_nan()` instead
+   |
+LL -     x != f16::NAN;
+LL +     !x.is_nan();
+   |
+
+warning: incorrect NaN comparison, NaN is not orderable
+  --> $DIR/invalid-nan-comparison.rs:22:5
+   |
+LL |     x < f16::NAN;
+   |     ^^^^^^^^^^^^
+
+warning: incorrect NaN comparison, NaN is not orderable
+  --> $DIR/invalid-nan-comparison.rs:24:5
+   |
+LL |     x > f16::NAN;
+   |     ^^^^^^^^^^^^
+
+warning: incorrect NaN comparison, NaN is not orderable
+  --> $DIR/invalid-nan-comparison.rs:26:5
+   |
+LL |     x <= f16::NAN;
+   |     ^^^^^^^^^^^^^
+
+warning: incorrect NaN comparison, NaN is not orderable
+  --> $DIR/invalid-nan-comparison.rs:28:5
+   |
+LL |     x >= f16::NAN;
+   |     ^^^^^^^^^^^^^
+
+warning: incorrect NaN comparison, NaN cannot be directly compared to itself
+  --> $DIR/invalid-nan-comparison.rs:30:5
+   |
+LL |     number!() == f16::NAN;
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `f32::is_nan()` or `f64::is_nan()` instead
+   |
+LL -     number!() == f16::NAN;
+LL +     number!().is_nan();
+   |
+
+warning: incorrect NaN comparison, NaN cannot be directly compared to itself
+  --> $DIR/invalid-nan-comparison.rs:32:5
+   |
+LL |     f16::NAN != number!();
+   |     ^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `f32::is_nan()` or `f64::is_nan()` instead
+   |
+LL -     f16::NAN != number!();
+LL +     !number!().is_nan();
+   |
+
+warning: incorrect NaN comparison, NaN cannot be directly compared to itself
+  --> $DIR/invalid-nan-comparison.rs:39:5
    |
 LL |     x == f32::NAN;
    |     ^^^^^^^^^^^^^
@@ -24,7 +96,7 @@ LL +     x.is_nan();
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison.rs:16:5
+  --> $DIR/invalid-nan-comparison.rs:41:5
    |
 LL |     x != f32::NAN;
    |     ^^^^^^^^^^^^^
@@ -36,31 +108,31 @@ LL +     !x.is_nan();
    |
 
 warning: incorrect NaN comparison, NaN is not orderable
-  --> $DIR/invalid-nan-comparison.rs:18:5
+  --> $DIR/invalid-nan-comparison.rs:43:5
    |
 LL |     x < f32::NAN;
    |     ^^^^^^^^^^^^
 
 warning: incorrect NaN comparison, NaN is not orderable
-  --> $DIR/invalid-nan-comparison.rs:20:5
+  --> $DIR/invalid-nan-comparison.rs:45:5
    |
 LL |     x > f32::NAN;
    |     ^^^^^^^^^^^^
 
 warning: incorrect NaN comparison, NaN is not orderable
-  --> $DIR/invalid-nan-comparison.rs:22:5
+  --> $DIR/invalid-nan-comparison.rs:47:5
    |
 LL |     x <= f32::NAN;
    |     ^^^^^^^^^^^^^
 
 warning: incorrect NaN comparison, NaN is not orderable
-  --> $DIR/invalid-nan-comparison.rs:24:5
+  --> $DIR/invalid-nan-comparison.rs:49:5
    |
 LL |     x >= f32::NAN;
    |     ^^^^^^^^^^^^^
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison.rs:26:5
+  --> $DIR/invalid-nan-comparison.rs:51:5
    |
 LL |     number!() == f32::NAN;
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -72,7 +144,7 @@ LL +     number!().is_nan();
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison.rs:28:5
+  --> $DIR/invalid-nan-comparison.rs:53:5
    |
 LL |     f32::NAN != number!();
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -84,7 +156,7 @@ LL +     !number!().is_nan();
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison.rs:35:5
+  --> $DIR/invalid-nan-comparison.rs:60:5
    |
 LL |     x == f64::NAN;
    |     ^^^^^^^^^^^^^
@@ -96,7 +168,7 @@ LL +     x.is_nan();
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison.rs:37:5
+  --> $DIR/invalid-nan-comparison.rs:62:5
    |
 LL |     x != f64::NAN;
    |     ^^^^^^^^^^^^^
@@ -108,31 +180,31 @@ LL +     !x.is_nan();
    |
 
 warning: incorrect NaN comparison, NaN is not orderable
-  --> $DIR/invalid-nan-comparison.rs:39:5
+  --> $DIR/invalid-nan-comparison.rs:64:5
    |
 LL |     x < f64::NAN;
    |     ^^^^^^^^^^^^
 
 warning: incorrect NaN comparison, NaN is not orderable
-  --> $DIR/invalid-nan-comparison.rs:41:5
+  --> $DIR/invalid-nan-comparison.rs:66:5
    |
 LL |     x > f64::NAN;
    |     ^^^^^^^^^^^^
 
 warning: incorrect NaN comparison, NaN is not orderable
-  --> $DIR/invalid-nan-comparison.rs:43:5
+  --> $DIR/invalid-nan-comparison.rs:68:5
    |
 LL |     x <= f64::NAN;
    |     ^^^^^^^^^^^^^
 
 warning: incorrect NaN comparison, NaN is not orderable
-  --> $DIR/invalid-nan-comparison.rs:45:5
+  --> $DIR/invalid-nan-comparison.rs:70:5
    |
 LL |     x >= f64::NAN;
    |     ^^^^^^^^^^^^^
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison.rs:47:5
+  --> $DIR/invalid-nan-comparison.rs:72:5
    |
 LL |     number!() == f64::NAN;
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -144,7 +216,7 @@ LL +     number!().is_nan();
    |
 
 warning: incorrect NaN comparison, NaN cannot be directly compared to itself
-  --> $DIR/invalid-nan-comparison.rs:49:5
+  --> $DIR/invalid-nan-comparison.rs:74:5
    |
 LL |     f64::NAN != number!();
    |     ^^^^^^^^^^^^^^^^^^^^^
@@ -155,5 +227,77 @@ LL -     f64::NAN != number!();
 LL +     !number!().is_nan();
    |
 
-warning: 17 warnings emitted
+warning: incorrect NaN comparison, NaN cannot be directly compared to itself
+  --> $DIR/invalid-nan-comparison.rs:81:5
+   |
+LL |     x == f128::NAN;
+   |     ^^^^^^^^^^^^^^
+   |
+help: use `f32::is_nan()` or `f64::is_nan()` instead
+   |
+LL -     x == f128::NAN;
+LL +     x.is_nan();
+   |
+
+warning: incorrect NaN comparison, NaN cannot be directly compared to itself
+  --> $DIR/invalid-nan-comparison.rs:83:5
+   |
+LL |     x != f128::NAN;
+   |     ^^^^^^^^^^^^^^
+   |
+help: use `f32::is_nan()` or `f64::is_nan()` instead
+   |
+LL -     x != f128::NAN;
+LL +     !x.is_nan();
+   |
+
+warning: incorrect NaN comparison, NaN is not orderable
+  --> $DIR/invalid-nan-comparison.rs:85:5
+   |
+LL |     x < f128::NAN;
+   |     ^^^^^^^^^^^^^
+
+warning: incorrect NaN comparison, NaN is not orderable
+  --> $DIR/invalid-nan-comparison.rs:87:5
+   |
+LL |     x > f128::NAN;
+   |     ^^^^^^^^^^^^^
+
+warning: incorrect NaN comparison, NaN is not orderable
+  --> $DIR/invalid-nan-comparison.rs:89:5
+   |
+LL |     x <= f128::NAN;
+   |     ^^^^^^^^^^^^^^
+
+warning: incorrect NaN comparison, NaN is not orderable
+  --> $DIR/invalid-nan-comparison.rs:91:5
+   |
+LL |     x >= f128::NAN;
+   |     ^^^^^^^^^^^^^^
+
+warning: incorrect NaN comparison, NaN cannot be directly compared to itself
+  --> $DIR/invalid-nan-comparison.rs:93:5
+   |
+LL |     number!() == f128::NAN;
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `f32::is_nan()` or `f64::is_nan()` instead
+   |
+LL -     number!() == f128::NAN;
+LL +     number!().is_nan();
+   |
+
+warning: incorrect NaN comparison, NaN cannot be directly compared to itself
+  --> $DIR/invalid-nan-comparison.rs:95:5
+   |
+LL |     f128::NAN != number!();
+   |     ^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use `f32::is_nan()` or `f64::is_nan()` instead
+   |
+LL -     f128::NAN != number!();
+LL +     !number!().is_nan();
+   |
+
+warning: 33 warnings emitted
 


### PR DESCRIPTION
Currently `f32_nan` and `f64_nan` are used to provide the `invalid_nan_comparison` lint. Since we have `f16_nan` and `f128_nan`, hook these up so the new float types get the same lints.