### PR TITLE
remove some unnecessary rustc_allow_const_fn_unstable

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -390,9 +390,6 @@ impl<T> MaybeUninit<T> {
     #[must_use]
     #[rustc_diagnostic_item = "maybe_uninit_zeroed"]
     #[stable(feature = "maybe_uninit", since = "1.36.0")]
-    // These are OK to allow since we do not leak &mut to user-visible API
-    #[rustc_allow_const_fn_unstable(const_mut_refs)]
-    #[rustc_allow_const_fn_unstable(const_ptr_write)]
     #[rustc_const_stable(feature = "const_maybe_uninit_zeroed", since = "1.75.0")]
     pub const fn zeroed() -> MaybeUninit<T> {
         let mut u = MaybeUninit::<T>::uninit();

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1475,7 +1475,6 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         /// ```
         #[unstable(feature = "num_midpoint", issue = "110840")]
         #[rustc_const_unstable(feature = "const_num_midpoint", issue = "110840")]
-        #[rustc_allow_const_fn_unstable(const_num_midpoint)]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -844,7 +844,6 @@ pub const fn from_ref<T: ?Sized>(r: &T) -> *const T {
 #[must_use]
 #[stable(feature = "ptr_from_ref", since = "1.76.0")]
 #[rustc_const_stable(feature = "ptr_from_ref", since = "1.76.0")]
-#[rustc_allow_const_fn_unstable(const_mut_refs)]
 #[rustc_never_returns_null_ptr]
 pub const fn from_mut<T: ?Sized>(r: &mut T) -> *mut T {
     r

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -764,7 +764,6 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_ptr_offset", since = "1.61.0")]
-    #[rustc_allow_const_fn_unstable(const_mut_refs)]
     #[rustc_never_returns_null_ptr]
     #[inline(always)]
     #[must_use]
@@ -1867,7 +1866,6 @@ impl<T> [T] {
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_slice_split_at_not_mut", since = "1.71.0")]
-    #[rustc_allow_const_fn_unstable(split_at_checked)]
     #[inline]
     #[track_caller]
     #[must_use]

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -761,7 +761,6 @@ impl str {
     #[must_use]
     #[stable(feature = "split_at_checked", since = "1.80.0")]
     #[rustc_const_unstable(feature = "const_str_split_at", issue = "131518")]
-    #[rustc_allow_const_fn_unstable(const_is_char_boundary)]
     pub const fn split_at_mut_checked(&mut self, mid: usize) -> Option<(&mut str, &mut str)> {
         // is_char_boundary checks that the index is in [0, .len()]
         if self.is_char_boundary(mid) {


### PR DESCRIPTION
These are either unstable functions that don't need the attribute, or the attribute refers to a feature that is already stable.