### PR TITLE
Also treat `impl` definition parent as transparent regarding modules

### DIFF
--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -151,9 +151,15 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                 //     };
                 // };
                 // ```
+                //
+                // It isn't possible to mix a impl in a module with const-anon, but an item can
+                // be put inside a module and referenced by a impl so we also have to treat the
+                // item parent as transparent to module and for consistency we have to do the same
+                // for impl, otherwise the item-def and impl-def won't have the same parent.
                 let outermost_impl_parent = peel_parent_while(cx.tcx, parent, |tcx, did| {
-                    tcx.def_kind(did) == DefKind::Const
-                        && tcx.opt_item_name(did) == Some(kw::Underscore)
+                    tcx.def_kind(did) == DefKind::Mod
+                        || (tcx.def_kind(did) == DefKind::Const
+                            && tcx.opt_item_name(did) == Some(kw::Underscore))
                 });
 
                 // 2. We check if any of the paths reference a the `impl`-parent.

--- a/tests/ui/lint/non-local-defs/convoluted-locals-132427.rs
+++ b/tests/ui/lint/non-local-defs/convoluted-locals-132427.rs
@@ -1,0 +1,64 @@
+// Regression tests for https://github.com/rust-lang/rust/issues/132427
+
+//@ check-pass
+
+// original
+mod auth {
+    const _: () = {
+        pub enum ArbitraryContext {}
+
+        const _: () = {
+            impl ArbitraryContext {}
+        };
+    };
+}
+
+mod z {
+    pub enum ArbitraryContext {}
+
+    const _: () = {
+        const _: () = {
+            impl ArbitraryContext {}
+        };
+    };
+}
+
+const _: () = {
+    mod auth {
+        const _: () = {
+            pub enum ArbitraryContext {}
+
+            const _: () = {
+                impl ArbitraryContext {}
+            };
+        };
+    }
+};
+
+mod a {
+    mod b {
+        const _: () = {
+            pub enum ArbitraryContext {}
+
+            const _: () = {
+                impl ArbitraryContext {}
+            };
+        };
+    }
+}
+
+mod foo {
+    const _: () = {
+        mod auth {
+            const _: () = {
+                pub enum ArbitraryContext {}
+
+                const _: () = {
+                    impl ArbitraryContext {}
+                };
+            };
+        }
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
This PR changes the `non_local_definitions` lint logic to also consider `impl` definition parent as transparent regarding modules.

See tests and explanation in the changes.

@rustbot label +L-non_local_definitions
Fixes *(after beta-backport)* #132427
cc @leighmcculloch
r? @jieyouxu
