### PR TITLE
perf experiment: disable large-move-check

### DIFF
--- a/compiler/rustc_monomorphize/messages.ftl
+++ b/compiler/rustc_monomorphize/messages.ftl
@@ -4,11 +4,6 @@ monomorphize_couldnt_dump_mono_stats =
 monomorphize_encountered_error_while_instantiating =
     the above error was encountered while instantiating `{$formatted_item}`
 
-monomorphize_large_assignments =
-    moving {$size} bytes
-    .label = value moved from here
-    .note = The current maximum size is {$limit}, but it can be customized with the move_size_limit attribute: `#![move_size_limit = "..."]`
-
 monomorphize_no_optimized_mir =
     missing optimized MIR for an item in the crate `{$crate_name}`
     .note = missing optimized MIR for this item (was the crate `{$crate_name}` compiled with `--emit=metadata`?)

--- a/compiler/rustc_monomorphize/src/collector/move_check.rs
+++ b/compiler/rustc_monomorphize/src/collector/move_check.rs
@@ -153,3 +153,17 @@ fn build_skip_move_check_fns(tcx: TyCtxt<'_>) -> Vec<DefId> {
         })
         .collect::<Vec<_>>()
 }
+
+fn assoc_fn_of_type<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId, fn_ident: Ident) -> Option<DefId> {
+    for impl_def_id in tcx.inherent_impls(def_id) {
+        if let Some(new) = tcx.associated_items(impl_def_id).find_by_name_and_kind(
+            tcx,
+            fn_ident,
+            AssocKind::Fn,
+            def_id,
+        ) {
+            return Some(new.def_id);
+        }
+    }
+    None
+}

--- a/compiler/rustc_monomorphize/src/errors.rs
+++ b/compiler/rustc_monomorphize/src/errors.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use rustc_errors::{Diag, DiagCtxtHandle, Diagnostic, EmissionGuarantee, Level};
-use rustc_macros::{Diagnostic, LintDiagnostic};
+use rustc_macros::Diagnostic;
 use rustc_span::{Span, Symbol};
 
 use crate::fluent_generated as fluent;
@@ -48,16 +48,6 @@ impl<G: EmissionGuarantee> Diagnostic<'_, G> for UnusedGenericParamsHint {
         }
         diag
     }
-}
-
-#[derive(LintDiagnostic)]
-#[diag(monomorphize_large_assignments)]
-#[note]
-pub(crate) struct LargeAssignmentsLint {
-    #[label]
-    pub span: Span,
-    pub size: u64,
-    pub limit: u64,
 }
 
 #[derive(Diagnostic)]


### PR DESCRIPTION
This is to figure out whether it's worth moving this check into a query, like we are doing for another mono-time check in https://github.com/rust-lang/rust/pull/132173.