### PR TITLE
[core/fmt] Replace checked slice indexing by unchecked to support panic-free code

### DIFF
--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -88,8 +88,9 @@ unsafe trait GenericRadix: Sized {
                 };
             }
         }
-        // SAFETY: `curr` is initialized to `buf.len()` and is only decremented,
-        // so it is always in bounds.
+        // SAFETY: `curr` is initialized to `buf.len()` and is only decremented, so it can't overflow. It is
+        // decremented exactly once for each digit. Since u128 is the widest fixed width integer format dupported,
+        // the maximum number of digits (bits) is 128 for base-2, so `curr` won't underflow as well.
         let buf = unsafe { buf.get_unchecked(curr..) };
         // SAFETY: The only chars in `buf` are created by `Self::digit` which are assumed to be
         // valid UTF-8

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -88,7 +88,9 @@ unsafe trait GenericRadix: Sized {
                 };
             }
         }
-        let buf = &buf[curr..];
+        // SAFETY: `curr` is initialized to `buf.len()` and is only decremented,
+        // so it is always in bounds.
+        let buf = unsafe { buf.get_unchecked(curr..) };
         // SAFETY: The only chars in `buf` are created by `Self::digit` which are assumed to be
         // valid UTF-8
         let buf = unsafe {

--- a/library/core/src/fmt/num.rs
+++ b/library/core/src/fmt/num.rs
@@ -89,7 +89,7 @@ unsafe trait GenericRadix: Sized {
             }
         }
         // SAFETY: `curr` is initialized to `buf.len()` and is only decremented, so it can't overflow. It is
-        // decremented exactly once for each digit. Since u128 is the widest fixed width integer format dupported,
+        // decremented exactly once for each digit. Since u128 is the widest fixed width integer format supported,
         // the maximum number of digits (bits) is 128 for base-2, so `curr` won't underflow as well.
         let buf = unsafe { buf.get_unchecked(curr..) };
         // SAFETY: The only chars in `buf` are created by `Self::digit` which are assumed to be


### PR DESCRIPTION
Fixes #126425

Replace the potentially panicking `[]` indexing with `get_unchecked()` to prevent linking with panic-related code.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
