### PR TITLE
Add more mailmap entries

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -48,6 +48,7 @@ Andrew Poelstra <asp11@sfu.ca> <apoelstra@wpsoftware.net>
 Anhad Singh <andypythonappdeveloper@gmail.com>
 Antoine Plaskowski <antoine.plaskowski@epitech.eu>
 Anton Löfgren <anton.lofgren@gmail.com> <alofgren@op5.com>
+apiraino <apiraino@users.noreply.github.com> <apiraino@protonmail.com>
 Araam Borhanian <avborhanian@gmail.com>
 Araam Borhanian <avborhanian@gmail.com> <dobbybabee@gmail.com>
 Areski Belaid <areski@gmail.com> areski <areski@gmail.com>
@@ -62,7 +63,10 @@ Austin Seipp <mad.one@gmail.com> <as@hacks.yi.org>
 Ayaz Hafiz <ayaz.hafiz.1@gmail.com>
 Aydin Kim <ladinjin@hanmail.net> aydin.kim <aydin.kim@samsung.com>
 Ayush Mishra <ayushmishra2005@gmail.com>
+Ashley Mannix <kodraus@hey.com> <ashleymannix@live.com.au>
 asrar <aszenz@gmail.com>
+b-naber <bn263@gmx.de>
+b-naber <bn263@gmx.de> <b_naber@gmx.de>
 BaoshanPang <pangbw@gmail.com>
 Barosl Lee <vcs@barosl.com> Barosl LEE <github@barosl.com>
 Bastian Kersting <bastian@cmbt.de>
@@ -98,6 +102,8 @@ Caleb Cartwright <caleb.cartwright@outlook.com>
 Caleb Jones <code@calebjones.net>
 Noah Lev <camelidcamel@gmail.com>
 Noah Lev <camelidcamel@gmail.com> <37223377+camelid@users.noreply.github.com>
+Catherine <catherine3.flores@gmail.com>
+Catherine <catherine3.flores@gmail.com> <catherine.3.flores@gmail.com>
 cameron1024 <cameron.studdstreet@gmail.com>
 Camille Gillot <gillot.camille@gmail.com>
 Carl-Anton Ingmarsson <mail@carlanton.se> <ca.ingmarsson@gmail.com>
@@ -133,11 +139,13 @@ Clement Miao <clementmiao@gmail.com>
 Clément Renault <renault.cle@gmail.com>
 Cliff Dyer <jcd@sdf.org>
 Clinton Ryan <clint.ryan3@gmail.com>
+Taylor Cramer <cramertaylorj@gmail.com> <cramertj@google.com>
 ember arlynx <ember@lunar.town> <corey@octayn.net>
 Crazycolorz5 <Crazycolorz5@gmail.com>
 csmoe <35686186+csmoe@users.noreply.github.com>
 Cyryl Płotnicki <cyplo@cyplo.net>
 Damien Schoof <damien.schoof@gmail.com>
+Dan Gohman <dev@sunfishcode.online> <sunfish@mozilla.com>
 Dan Robertson <danlrobertson89@gmail.com>
 Daniel Campoverde <alx741@riseup.net>
 Daniel J Rollins <drollins@financialforce.com>
@@ -179,10 +187,14 @@ Eduardo Bautista <me@eduardobautista.com> <=>
 Eduardo Bautista <me@eduardobautista.com> <mail@eduardobautista.com>
 Eduardo Broto <ebroto@tutanota.com>
 Edward Shen <code@eddie.sh> <xes@meta.com>
+Jacob Finkelman <eh2406@wayne.edu>
+Jacob Finkelman <eh2406@wayne.edu> <YeomanYaacov@gmail.com>
 Elliott Slaughter <elliottslaughter@gmail.com> <eslaughter@mozilla.com>
 Elly Fong-Jones <elly@leptoquark.net>
 Eric Holk <eric.holk@gmail.com> <eholk@cs.indiana.edu>
 Eric Holk <eric.holk@gmail.com> <eholk@mozilla.com>
+Eric Holk <eric.holk@gmail.com> <eric@theincredibleholk.org>
+Eric Holk <eric.holk@gmail.com> <ericholk@microsoft.com>
 Eric Holmes <eric@ejholmes.net>
 Eric Reed <ecreed@cs.washington.edu> <ereed@mozilla.com>
 Erick Tryzelaar <erick.tryzelaar@gmail.com> <etryzelaar@iqt.org>
@@ -206,6 +218,7 @@ Felix S. Klock II <pnkfelix@pnkfx.org> <pnkfelix@mozilla.com>
 Félix Saparelli <felix@passcod.name>
 Flaper Fesp <flaper87@gmail.com>
 Florian Berger <fbergr@gmail.com>
+Florian Gilcher <florian.gilcher@asquera.de> <flo@andersground.net>
 Florian Wilkens <mrfloya_github@outlook.com> Florian Wilkens <floya@live.de>
 François Mockers <mockersf@gmail.com>
 Frank Steffahn <fdsteffahn@gmail.com> <frank.steffahn@stu.uni-kiel.de>
@@ -240,6 +253,8 @@ Herman J. Radtke III <herman@hermanradtke.com> Herman J. Radtke III <hermanradtk
 Hirochika Matsumoto <git@hkmatsumoto.com> <matsujika@gmail.com>
 Hrvoje Nikšić <hniksic@gmail.com>
 Hsiang-Cheng Yang <rick68@users.noreply.github.com>
+Huon Wilson <dbau.pp@gmail.com>
+Huon Wilson <dbau.pp@gmail.com> <wilson.huon@gmail.com>
 Ian Jackson <ijackson@chiark.greenend.org.uk> <ian.jackson@citrix.com>
 Ian Jackson <ijackson@chiark.greenend.org.uk> <ijackson+github@slimy.greenend.org.uk>
 Ian Jackson <ijackson@chiark.greenend.org.uk> <iwj@xenproject.org>
@@ -252,9 +267,13 @@ ivan tkachenko <me@ratijas.tk>
 J. J. Weber <jjweber@gmail.com>
 Jack Huey <jack.huey@umassmed.edu> <jackh726@gmail.com>
 Jacob <jacob.macritchie@gmail.com>
+Jacob Hoffman-Andrews <rust@hoffman-andrews.com> <github@hoffman-andrews.com>
 Jacob Greenfield <xales@naveria.com>
 Jacob Pratt <jacob@jhpratt.dev> <the.z.cuber@gmail.com>
 Jacob Pratt <jacob@jhpratt.dev> <jacopratt@tesla.com>
+Jake Goulding <jake.goulding@integer32.com>
+Jake Goulding <jake.goulding@integer32.com> <jake.goulding@gmail.com> 
+Jake Goulding <jake.goulding@integer32.com> <shepmaster@mac.com>
 Jake Vossen <jake@vossen.dev>
 Jakob Degen <jakob.e.degen@gmail.com> <jakob@degen.com>
 Jakob Lautrup Nysom <jako3047@gmail.com>
@@ -287,6 +306,7 @@ Jerry Hardee <hardeejj9@gmail.com>
 Jesús Rubio <jesusprubio@gmail.com>
 Jethro Beekman <github@jbeekman.nl>
 Jian Zeng <knight42@mail.ustc.edu.cn>
+Jieyou Xu <jieyouxu@outlook.com>
 Jieyou Xu <jieyouxu@outlook.com> <39484203+jieyouxu@users.noreply.github.com>
 Jihyun Yu <j.yu@navercorp.com> <yjh0502@gmail.com>
 Jihyun Yu <j.yu@navercorp.com> jihyun <jihyun@nablecomm.com>
@@ -322,9 +342,12 @@ Josh Holmer <jholmer.in@gmail.com>
 Josh Stone <cuviper@gmail.com> <jistone@redhat.com>
 Josh Stone <cuviper@gmail.com> <jistone@fedoraproject.org>
 Julia Ryan <juliaryan3.14@gmail.com> <josephryan3.14@gmail.com>
+Jubilee Young <workingjubilee@gmail.com> <46493976+workingjubilee@users.noreply.github.com>
+Jubilee Young <workingjubilee@gmail.com>
 Julian Knodt <julianknodt@gmail.com>
 jumbatm <jumbatm@gmail.com> <30644300+jumbatm@users.noreply.github.com>
 Junyoung Cho <june0.cho@samsung.com>
+Jynn Nelson <github@jyn.dev> <rust@jyn.dev>
 Jynn Nelson <github@jyn.dev> <jyn514@gmail.com>
 Jynn Nelson <github@jyn.dev> <joshua@yottadb.com>
 Jynn Nelson <github@jyn.dev> <jyn.nelson@redjack.com>
@@ -385,12 +408,14 @@ Marcell Pardavi <marcell.pardavi@gmail.com>
 Marcus Klaas de Vries <mail@marcusklaas.nl>
 Margaret Meyerhofer <mmeyerho@andrew.cmu.edu> <mmeyerho@andrew>
 Mark Mansi <markm@cs.wisc.edu>
+Mark Mansi <markm@cs.wisc.edu> <m.mim95@gmail.com>
 Mark Rousskov <mark.simulacrum@gmail.com>
 Mark Sinclair <mark.edward.x@gmail.com>
 Mark Sinclair <mark.edward.x@gmail.com> =Mark Sinclair <=125axel125@gmail.com>
 Markus Legner <markus@legner.ch>
 Markus Westerlind <marwes91@gmail.com> Markus <marwes91@gmail.com>
 Martin Carton <cartonmartin+git@gmail.com>
+Martin Carton <cartonmartin+git@gmail.com> <cartonmartin@gmail.com>
 Martin Habovštiak <martin.habovstiak@gmail.com>
 Martin Hafskjold Thoresen <martinhath@gmail.com>
 Martin Nordholts <martin.nordholts@codetale.se> <enselic@gmail.com>
@@ -415,6 +440,7 @@ Melody Horn <melody@boringcactus.com> <mathphreak@gmail.com>
 Mendes <pedro.mendes.26@gmail.com>
 mental <m3nta1@yahoo.com>
 mibac138 <5672750+mibac138@users.noreply.github.com>
+Michael Howell <michael@notriddle.com> <notriddle+rust-mod@protonmail.com>
 Michael Williams <m.t.williams@live.com>
 Michael Woerister <michaelwoerister@posteo> <michaelwoerister@gmail>
 Michael Woerister <michaelwoerister@posteo> <michaelwoerister@gmail.com>
@@ -431,6 +457,7 @@ Ms2ger <ms2ger@gmail.com> <Ms2ger@gmail.com>
 msizanoen1 <qtmlabs@protonmail.com>
 Mukilan Thiagarajan <mukilanthiagarajan@gmail.com>
 Nadrieril Feneanar <Nadrieril@users.noreply.github.com>
+Nadrieril Feneanar <Nadrieril@users.noreply.github.com> <nadrieril+rust@gmail.com>
 Nadrieril Feneanar <Nadrieril@users.noreply.github.com> <nadrieril+git@gmail.com>
 NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm@gmail.com>
 NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm+github@gmail.com>
@@ -447,15 +474,23 @@ Nicholas Bishop <nbishop@nbishop.net> <nicholasbishop@gmail.com>
 Nicholas Bishop <nbishop@nbishop.net> <nicholasbishop@google.com>
 Nicholas Nethercote <n.nethercote@gmail.com> <nnethercote@apple.com>
 Nicholas Nethercote <n.nethercote@gmail.com> <nnethercote@mozilla.com>
+Nick Cameron <nrc@ncameron.org> <ncameron@mozilla.com>
+Nick Fitzgerald <fitzgen@gmail.com> <nfitzgerald@mozilla.com>
 Nick Platt <platt.nicholas@gmail.com>
 Niclas Schwarzlose <15schnic@gmail.com>
 Nicolas Abram <abramlujan@gmail.com>
 Nicole Mazzuca <npmazzuca@gmail.com>
+Niko Matsakis <rust@nikomatsakis.com>
+Niko Matsakis <rust@nikomatsakis.com> <niko@alum.mit.edu>
+Noratrieb <48135649+Noratrieb@users.noreply.github.com>
 Noratrieb <48135649+Noratrieb@users.noreply.github.com> <48135649+Nilstrieb@users.noreply.github.com>
 Noratrieb <48135649+Noratrieb@users.noreply.github.com> <nilstrieb@gmail.com>
+Noratrieb <48135649+Noratrieb@users.noreply.github.com> <rust@noratrieb.dev>
 Noratrieb <48135649+Noratrieb@users.noreply.github.com> <nora@noratrieb.dev>
 Nif Ward <nif.ward@gmail.com>
 Nika Layzell <nika@thelayzells.com> <michael@thelayzells.com>
+Nikita Popov <nikita.ppv@gmail.com>
+Nikita Popov <nikita.ppv@gmail.com> <npopov@redhat.com>
 NODA Kai <nodakai@gmail.com>
 Oğuz Ağcayazı <oguz.agcayazi@gmail.com> <oguz.agcayazi@gmail.com>
 Oğuz Ağcayazı <oguz.agcayazi@gmail.com> <ouz.agz@gmail.com>
@@ -516,6 +551,7 @@ Ricky Hosfelt <ricky@hosfelt.io>
 Ritiek Malhotra <ritiekmalhotra123@gmail.com>
 Rob Arnold <robarnold@cs.cmu.edu>
 Rob Arnold <robarnold@cs.cmu.edu> Rob Arnold <robarnold@68-26-94-7.pools.spcsdns.net>
+Robert Collins <robertc@robertcollins.net> <robertc+rust@robertcollins.net>
 Robert Foss <dev@robertfoss.se> robertfoss <dev@robertfoss.se>
 Robert Gawdzik <rgawdzik@hotmail.com> Robert Gawdzik ☢ <rgawdzik@hotmail.com>
 Robert Habermeier <rphmeier@gmail.com>
@@ -554,6 +590,11 @@ Simonas Kazlauskas <git@kazlauskas.me> Simonas Kazlauskas <github@kazlauskas.me>
 Simonas Kazlauskas <git@kazlauskas.me> <simonas+t-compiler@kazlauskas.me>
 Siva Prasad <sivaauturic@gmail.com>
 Smittyvb <me@smitop.com>
+Sophia June Turner <547158+sophiajt@users.noreply.github.com>
+Sophia June Turner <547158+sophiajt@users.noreply.github.com> <547158+jntrnr@users.noreply.github.com>
+Sophia June Turner <547158+sophiajt@users.noreply.github.com> <jonathandturner@users.noreply.github.com>
+Sophia June Turner <547158+sophiajt@users.noreply.github.com> <jturner@mozilla.com>
+Sophia June Turner <547158+sophiajt@users.noreply.github.com> <jonathan.d.turner@gmail.com>
 Srinivas Reddy Thatiparthy <thatiparthysreenivas@gmail.com>
 Stanislav Tkach <stanislav.tkach@gmail.com>
 startling <tdixon51793@gmail.com>
@@ -586,8 +627,10 @@ Tim Diekmann <t.diekmann.3dv@gmail.com>
 Tim Hutt <tdhutt@gmail.com>
 Tim JIANG <p90eri@gmail.com>
 Tim Joseph Dumol <tim@timdumol.com>
+Tim Neumann <mail@timnn.me> <timnn@google.com>
 Timothy Maloney <tmaloney@pdx.edu>
 Tomas Koutsky <tomas@stepnivlk.net>
+Tomasz Miąsko <tomasz.miasko@gmail.com>
 Torsten Weber <TorstenWeber12@gmail.com>
 Torsten Weber <TorstenWeber12@gmail.com> <torstenweber12@gmail.com>
 Trevor Gross <tmgross@umich.edu> <t.gross35@gmail.com>
@@ -607,7 +650,7 @@ Valerii Lashmanov <vflashm@gmail.com>
 Vitali Haravy <HumaneProgrammer@gmail.com> Vitali Haravy <humaneprogrammer@gmail.com>
 Vitaly Shukela <vi0oss@gmail.com>
 Waffle Lapkin <waffle.lapkin@gmail.com>
-Waffle Lapkin <waffle.lapkin@tasking.com>
+Waffle Lapkin <waffle.lapkin@gmail.com> <waffle.lapkin@tasking.com>
 Wesley Wiser <wwiser@gmail.com> <wesleywiser@microsoft.com>
 whitequark <whitequark@whitequark.org>
 William Ting <io@williamting.com> <william.h.ting@gmail.com>


### PR DESCRIPTION
If you have been pinged: I'm adding a mailmap entry for you to keep thanks.rust-lang.org working properly.

**I have picked the canonical address mostly arbitrarily. If you want a different one as the canonical address, please tell me here**.

<details>
<summary>more details on the change</summary>

builds on top of #132471, this containing the less obvious changes that add new canonical email addresses instead of just adding new current ones.

The people updated in this commit have contributed under different email
addresses than the ones they have used in rust-lang/team.
https://github.com/rust-lang/thanks/pull/53 will use team data for thanks reviewers, which requires this to be in
sync.
Therefore, I have updated many of the people that I've noticed being
duplicated after the change.

</details>




I'm adding a novel entry for you: @apiraino @KodrAus @cramertj @sunfishcode @Eh2406 @skade @huonw @jsha @shepmaster @workingjubilee @rbtcollins  @nrc @fitzgen @sophiajt @tmiasko @notriddle @TimNN @WaffleLapkin 

