### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -31,6 +31,7 @@ Alexis Beingessner <a.beingessner@gmail.com>
 Alfie John <alfie@alfie.wtf> Alfie John <alfiej@fastmail.fm>
 Alona Enraght-Moony <code@alona.page> <nixon.emoony@gmail.com>
 Alona Enraght-Moony <code@alona.page> <nixon@caminus.local>
+Alona Enraght-Moony <code@alona.page> <contact@alona.page>
 Amanda Stjerna <mail@amandastjerna.se> <albin.stjerna@gmail.com>
 Amanda Stjerna <mail@amandastjerna.se> <amanda.stjerna@it.uu.se>
 Amos Onn <amosonn@gmail.com>
@@ -75,6 +76,7 @@ Benjamin Jackman <ben@jackman.biz>
 Benoît Cortier <benoit.cortier@fried-world.eu>
 Bheesham Persaud <bheesham123@hotmail.com> Bheesham Persaud <bheesham.persaud@live.ca>
 bjorn3 <17426603+bjorn3@users.noreply.github.com> <bjorn3@users.noreply.github.com>
+bjorn3 <17426603+bjorn3@users.noreply.github.com> <bjorn3_gh@protonmail.com>
 Björn Steinbrink <bsteinbr@gmail.com> <B.Steinbrink@gmx.de>
 blake2-ppc <ulrik.sverdrup@gmail.com> <blake2-ppc>
 blyxyas <blyxyas@gmail.com> Alejandra González <blyxyas@gmail.com>
@@ -172,6 +174,7 @@ Dzmitry Malyshau <kvarkus@gmail.com>
 E. Dunham <edunham@mozilla.com> edunham <edunham@mozilla.com>
 Ed Barnard <eabarnard@gmail.com>
 Eduard-Mihai Burtescu <edy.burt@gmail.com>
+Eduard-Mihai Burtescu <edy.burt@gmail.com> <eddyb@lyken.rs>
 Eduardo Bautista <me@eduardobautista.com> <=>
 Eduardo Bautista <me@eduardobautista.com> <mail@eduardobautista.com>
 Eduardo Broto <ebroto@tutanota.com>
@@ -186,6 +189,7 @@ Erick Tryzelaar <erick.tryzelaar@gmail.com> <etryzelaar@iqt.org>
 Erik Desjardins <erikdesjardins@users.noreply.github.com>
 Erik Jensen <erikjensen@rkjnsn.net>
 Erin Power <xampprocky@gmail.com>
+Erin Power <xampprocky@gmail.com> <xampprocky@icloud.com>
 Erin Power <xampprocky@gmail.com> <theaaronepower@gmail.com>
 Erin Power <xampprocky@gmail.com> <Aaronepower@users.noreply.github.com>
 Esteban Küber <esteban@kuber.com.ar>
@@ -198,6 +202,7 @@ F001 <changchun.fan@qq.com>
 Fabian Kössel <fkjogu@users.noreply.github.com>
 Falco Hirschenberger <falco.hirschenberger@gmail.com> <hirschen@itwm.fhg.de>
 Felix S. Klock II <pnkfelix@pnkfx.org> Felix S Klock II <pnkfelix@pnkfx.org>
+Felix S. Klock II <pnkfelix@pnkfx.org> <pnkfelix@mozilla.com>
 Félix Saparelli <felix@passcod.name>
 Flaper Fesp <flaper87@gmail.com>
 Florian Berger <fbergr@gmail.com>
@@ -245,7 +250,7 @@ Irina Popa <irinagpopa@gmail.com>
 Ivan Ivaschenko <defuz.net@gmail.com>
 ivan tkachenko <me@ratijas.tk>
 J. J. Weber <jjweber@gmail.com>
-Jack Huey <jack.huey@umassmed.edu>
+Jack Huey <jack.huey@umassmed.edu> <jackh726@gmail.com>
 Jacob <jacob.macritchie@gmail.com>
 Jacob Greenfield <xales@naveria.com>
 Jacob Pratt <jacob@jhpratt.dev> <the.z.cuber@gmail.com>
@@ -292,6 +297,7 @@ John Clements <clements@racket-lang.org> <clements@brinckerhoff.org>
 John Hodge <acessdev@gmail.com> John Hodge <tpg@mutabah.net>
 John Hörnvall <trolledwoods@gmail.com>
 John Kåre Alsaker <john.kare.alsaker@gmail.com>
+John Kåre Alsaker <john.kare.alsaker@gmail.com> <zoxc32@gmail.com>
 John Talling <inrustwetrust@users.noreply.github.com>
 John Van Enk <vanenkj@gmail.com>
 Jonas Tepe <jonasprogrammer@gmail.com>
@@ -368,6 +374,7 @@ Lukas Lueg <lukas.lueg@gmail.com>
 Luke Metz <luke.metz@students.olin.edu>
 Luqman Aden <me@luqman.ca> <laden@csclub.uwaterloo.ca>
 Luqman Aden <me@luqman.ca> <laden@mozilla.com>
+Luqman Aden <me@luqman.ca> <rust@luqman.ca>
 Lzu Tao <taolzu@gmail.com>
 Maik Klein <maikklein@googlemail.com>
 Malo Jaffré <jaffre.malo@gmail.com>
@@ -409,6 +416,7 @@ mental <m3nta1@yahoo.com>
 mibac138 <5672750+mibac138@users.noreply.github.com>
 Michael Williams <m.t.williams@live.com>
 Michael Woerister <michaelwoerister@posteo> <michaelwoerister@gmail>
+Michael Woerister <michaelwoerister@posteo> <michaelwoerister@gmail.com>
 Michael Woerister <michaelwoerister@posteo> <michaelwoerister@users.noreply.github.com>
 Michael Woerister <michaelwoerister@posteo> <michaelwoerister@posteo.net>
 Michael Zhang <hmperson1@gmail.com>
@@ -422,6 +430,7 @@ Ms2ger <ms2ger@gmail.com> <Ms2ger@gmail.com>
 msizanoen1 <qtmlabs@protonmail.com>
 Mukilan Thiagarajan <mukilanthiagarajan@gmail.com>
 Nadrieril Feneanar <Nadrieril@users.noreply.github.com>
+Nadrieril Feneanar <Nadrieril@users.noreply.github.com> <nadrieril+git@gmail.com>
 NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm@gmail.com>
 NAKASHIMA, Makoto <makoto.nksm+github@gmail.com> <makoto.nksm+github@gmail.com>
 Nathan Ringo <remexre@gmail.com>
@@ -442,6 +451,8 @@ Niclas Schwarzlose <15schnic@gmail.com>
 Nicolas Abram <abramlujan@gmail.com>
 Nicole Mazzuca <npmazzuca@gmail.com>
 Noratrieb <48135649+Noratrieb@users.noreply.github.com> <48135649+Nilstrieb@users.noreply.github.com>
+Noratrieb <48135649+Noratrieb@users.noreply.github.com> <nilstrieb@gmail.com>
+Noratrieb <48135649+Noratrieb@users.noreply.github.com> <nora@noratrieb.dev>
 Nif Ward <nif.ward@gmail.com>
 Nika Layzell <nika@thelayzells.com> <michael@thelayzells.com>
 NODA Kai <nodakai@gmail.com>
@@ -460,6 +471,7 @@ Oliver Scherer <oli-obk@users.noreply.github.com> <github6541940@oli-obk.de>
 Oliver Scherer <oli-obk@users.noreply.github.com> <public.oliver.schneider@kit.edu>
 Oliver Scherer <oli-obk@users.noreply.github.com> <oliver.schneider@kit.edu>
 Oliver Scherer <oli-obk@users.noreply.github.com> <obk8176014uqher834@olio-obk.de>
+Oliver Scherer <oli-obk@users.noreply.github.com> <rustc-contact@oli-obk.de>
 Oliver Scherer <oli-obk@users.noreply.github.com>
 Onur Özkan <onurozkan.dev@outlook.com> <work@onurozkan.dev>
 Onur Özkan <onurozkan.dev@outlook.com>
@@ -496,6 +508,7 @@ Raphaël Huchet <rap2hpoutre@users.noreply.github.com>
 rChaser53 <tayoshizawa29@gmail.com>
 Rémy Rakic <remy.rakic@gmail.com>
 Rémy Rakic <remy.rakic@gmail.com> <remy.rakic+github@gmail.com>
+Rémy Rakic <remy.rakic@gmail.com> <remy.rakic+rust@gmail.com>
 Renato Riccieri Santos Zannon <renato@rrsz.com.br>
 Richard Diamond <wichard@vitalitystudios.com> <wichard@hahbee.co>
 Ricky Hosfelt <ricky@hosfelt.io>
@@ -525,6 +538,7 @@ Samuel Tardieu <sam@rfc1149.net>
 Santiago Pastorino <spastorino@gmail.com>
 Santiago Pastorino <spastorino@gmail.com> <santiago@wyeworks.com>
 Scott McMurray <scottmcm@users.noreply.github.com>
+Scott McMurray <scottmcm@users.noreply.github.com> <smcmurray@acm.org>
 Scott Olson <scott@solson.me> Scott Olson <scott@scott-olson.org>
 Sean Gillespie <sean.william.g@gmail.com> swgillespie <sean.william.g@gmail.com>
 Seiichi Uchida <seuchida@gmail.com>
@@ -536,6 +550,7 @@ Shyam Sundar B <shyambaskaran@outlook.com>
 Simon Barber-Dueck <sbarberdueck@gmail.com> Simon BD <simon@server>
 Simon Sapin <simon@exyr.org> <simon.sapin@exyr.org>
 Simonas Kazlauskas <git@kazlauskas.me> Simonas Kazlauskas <github@kazlauskas.me>
+Simonas Kazlauskas <git@kazlauskas.me> <simonas+t-compiler@kazlauskas.me>
 Siva Prasad <sivaauturic@gmail.com>
 Smittyvb <me@smitop.com>
 Srinivas Reddy Thatiparthy <thatiparthysreenivas@gmail.com>
@@ -556,6 +571,8 @@ Tatsuyuki Ishi <ishitatsuyuki@gmail.com>
 Tau Gärtli <git@tau.garden> <ruben.schmidmeister@icloud.com>
 Tero Hänninen <lgvz@users.noreply.github.com> Tero Hänninen <tejohann@kapsi.fi>
 The8472 <git@infinite-source.de>
+The8472 <git@infinite-source.de> <the8472.rs@infinite-source.de>
+The8472 <git@infinite-source.de> <the8472@users.noreply.github.com>
 Theo Belaire <theo.belaire@gmail.com> Theo Belaire <tyr.god.of.war.42@gmail.com>
 Theodore Luo Wang <wangtheo662@gmail.com>
 Thiago Pontes <email@thiago.me> thiagopnts <thiagopnts@gmail.com>
@@ -593,7 +610,8 @@ Waffle Lapkin <waffle.lapkin@tasking.com>
 Wesley Wiser <wwiser@gmail.com> <wesleywiser@microsoft.com>
 whitequark <whitequark@whitequark.org>
 William Ting <io@williamting.com> <william.h.ting@gmail.com>
-Wim Looman <wim@nemo157.com>
+Wim Looman <wim@nemo157.com> <rust-lang@nemo157.com>
+Wim Looman <wim@nemo157.com> <git@nemo157.com>
 Without Boats <woboats@gmail.com>
 Without Boats <woboats@gmail.com> <boats@mozilla.com>
 Xinye Tao <xy.tao@outlook.com>

--- a/compiler/rustc_codegen_cranelift/src/lib.rs
+++ b/compiler/rustc_codegen_cranelift/src/lib.rs
@@ -40,6 +40,7 @@ use std::sync::Arc;
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::settings::{self, Configurable};
 use rustc_codegen_ssa::CodegenResults;
+use rustc_codegen_ssa::back::versioned_llvm_target;
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_data_structures::profiling::SelfProfilerRef;
 use rustc_errors::ErrorGuaranteed;
@@ -260,7 +261,9 @@ impl CodegenBackend for CraneliftCodegenBackend {
 }
 
 fn target_triple(sess: &Session) -> target_lexicon::Triple {
-    match sess.target.llvm_target.parse() {
+    // FIXME(madsmtm): Use `sess.target.llvm_target` once target-lexicon supports unversioned macOS.
+    // See <https://github.com/bytecodealliance/target-lexicon/pull/113>
+    match versioned_llvm_target(sess).parse() {
         Ok(triple) => triple,
         Err(err) => sess.dcx().fatal(format!("target not recognized: {}", err)),
     }

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -9,6 +9,7 @@ use llvm::{
     LLVMRustLLVMHasZlibCompressionForDebugSymbols, LLVMRustLLVMHasZstdCompressionForDebugSymbols,
 };
 use rustc_codegen_ssa::back::link::ensure_removed;
+use rustc_codegen_ssa::back::versioned_llvm_target;
 use rustc_codegen_ssa::back::write::{
     BitcodeSection, CodegenContext, EmitObj, ModuleConfig, TargetMachineFactoryConfig,
     TargetMachineFactoryFn,
@@ -211,7 +212,7 @@ pub(crate) fn target_machine_factory(
         singlethread = false;
     }
 
-    let triple = SmallCStr::new(&sess.target.llvm_target);
+    let triple = SmallCStr::new(&versioned_llvm_target(sess));
     let cpu = SmallCStr::new(llvm_util::target_cpu(sess));
     let features = CString::new(target_features.join(",")).unwrap();
     let abi = SmallCStr::new(&sess.target.llvm_abiname);

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -3,6 +3,7 @@ use std::cell::{Cell, RefCell};
 use std::ffi::{CStr, c_uint};
 use std::str;
 
+use rustc_codegen_ssa::back::versioned_llvm_target;
 use rustc_codegen_ssa::base::{wants_msvc_seh, wants_wasm_eh};
 use rustc_codegen_ssa::errors as ssa_errors;
 use rustc_codegen_ssa::traits::*;
@@ -177,7 +178,7 @@ pub(crate) unsafe fn create_module<'ll>(
         llvm::LLVMSetDataLayout(llmod, data_layout.as_ptr());
     }
 
-    let llvm_target = SmallCStr::new(&sess.target.llvm_target);
+    let llvm_target = SmallCStr::new(&versioned_llvm_target(sess));
     unsafe {
         llvm::LLVMRustSetNormalizedTarget(llmod, llvm_target.as_ptr());
     }

--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -2,6 +2,12 @@ codegen_ssa_L4Bender_exporting_symbols_unimplemented = exporting symbols not imp
 
 codegen_ssa_add_native_library = failed to add native library {$library_path}: {$error}
 
+codegen_ssa_apple_deployment_target_invalid =
+    failed to parse deployment target specified in {$env_var}: {$error}
+
+codegen_ssa_apple_deployment_target_too_low =
+    deployment target in {$env_var} was set to {$version}, but the minimum supported by `rustc` is {$os_min}
+
 codegen_ssa_apple_sdk_error_sdk_path = failed to get {$sdk_name} SDK path: {$error}
 
 codegen_ssa_archive_build_failure = failed to build archive at `{$path}`: {$error}

--- a/compiler/rustc_codegen_ssa/src/back/apple.rs
+++ b/compiler/rustc_codegen_ssa/src/back/apple.rs
@@ -7,6 +7,22 @@ use rustc_target::spec::Target;
 #[cfg(test)]
 mod tests;
 
+pub(super) fn macho_platform(target: &Target) -> u32 {
+    match (&*target.os, &*target.abi) {
+        ("macos", _) => object::macho::PLATFORM_MACOS,
+        ("ios", "macabi") => object::macho::PLATFORM_MACCATALYST,
+        ("ios", "sim") => object::macho::PLATFORM_IOSSIMULATOR,
+        ("ios", _) => object::macho::PLATFORM_IOS,
+        ("watchos", "sim") => object::macho::PLATFORM_WATCHOSSIMULATOR,
+        ("watchos", _) => object::macho::PLATFORM_WATCHOS,
+        ("tvos", "sim") => object::macho::PLATFORM_TVOSSIMULATOR,
+        ("tvos", _) => object::macho::PLATFORM_TVOS,
+        ("visionos", "sim") => object::macho::PLATFORM_XROSSIMULATOR,
+        ("visionos", _) => object::macho::PLATFORM_XROS,
+        _ => unreachable!("tried to get Mach-O platform for non-Apple target"),
+    }
+}
+
 /// Deployment target or SDK version.
 ///
 /// The size of the numbers in here are limited by Mach-O's `LC_BUILD_VERSION`.

--- a/compiler/rustc_codegen_ssa/src/back/apple.rs
+++ b/compiler/rustc_codegen_ssa/src/back/apple.rs
@@ -1,0 +1,127 @@
+use std::env;
+use std::num::ParseIntError;
+
+use rustc_session::Session;
+use rustc_target::spec::Target;
+
+#[cfg(test)]
+mod tests;
+
+/// Deployment target or SDK version.
+///
+/// The size of the numbers in here are limited by Mach-O's `LC_BUILD_VERSION`.
+type OSVersion = (u16, u8, u8);
+
+/// Parse an OS version triple (SDK version or deployment target).
+fn parse_version(version: &str) -> Result<OSVersion, ParseIntError> {
+    if let Some((major, minor)) = version.split_once('.') {
+        let major = major.parse()?;
+        if let Some((minor, patch)) = minor.split_once('.') {
+            Ok((major, minor.parse()?, patch.parse()?))
+        } else {
+            Ok((major, minor.parse()?, 0))
+        }
+    } else {
+        Ok((version.parse()?, 0, 0))
+    }
+}
+
+/// Minimum operating system versions currently supported by `rustc`.
+fn os_minimum_deployment_target(os: &str) -> OSVersion {
+    // When bumping a version in here, remember to update the platform-support docs too.
+    //
+    // NOTE: The defaults may change in future `rustc` versions, so if you are looking for the
+    // default deployment target, prefer:
+    // ```
+    // $ rustc --print deployment-target
+    // ```
+    match os {
+        "macos" => (10, 12, 0),
+        "ios" => (10, 0, 0),
+        "tvos" => (10, 0, 0),
+        "watchos" => (5, 0, 0),
+        "visionos" => (1, 0, 0),
+        _ => unreachable!("tried to get deployment target for non-Apple platform"),
+    }
+}
+
+/// The deployment target for the given target.
+///
+/// This is similar to `os_minimum_deployment_target`, except that on certain targets it makes sense
+/// to raise the minimum OS version.
+///
+/// This matches what LLVM does, see in part:
+/// <https://github.com/llvm/llvm-project/blob/llvmorg-18.1.8/llvm/lib/TargetParser/Triple.cpp#L1900-L1932>
+fn minimum_deployment_target(target: &Target) -> OSVersion {
+    match (&*target.os, &*target.arch, &*target.abi) {
+        ("macos", "aarch64", _) => (11, 0, 0),
+        ("ios", "aarch64", "macabi") => (14, 0, 0),
+        ("ios", "aarch64", "sim") => (14, 0, 0),
+        ("ios", _, _) if target.llvm_target.starts_with("arm64e") => (14, 0, 0),
+        // Mac Catalyst defaults to 13.1 in Clang.
+        ("ios", _, "macabi") => (13, 1, 0),
+        ("tvos", "aarch64", "sim") => (14, 0, 0),
+        ("watchos", "aarch64", "sim") => (7, 0, 0),
+        (os, _, _) => os_minimum_deployment_target(os),
+    }
+}
+
+/// Name of the environment variable used to fetch the deployment target on the given OS.
+fn deployment_target_env_var(os: &str) -> &'static str {
+    match os {
+        "macos" => "MACOSX_DEPLOYMENT_TARGET",
+        "ios" => "IPHONEOS_DEPLOYMENT_TARGET",
+        "watchos" => "WATCHOS_DEPLOYMENT_TARGET",
+        "tvos" => "TVOS_DEPLOYMENT_TARGET",
+        "visionos" => "XROS_DEPLOYMENT_TARGET",
+        _ => unreachable!("tried to get deployment target env var for non-Apple platform"),
+    }
+}
+
+/// Get the deployment target based on the standard environment variables, or fall back to the
+/// minimum version supported by `rustc`.
+pub fn deployment_target(sess: &Session) -> OSVersion {
+    let min = minimum_deployment_target(&sess.target);
+
+    if let Ok(deployment_target) = env::var(deployment_target_env_var(&sess.target.os)) {
+        match parse_version(&deployment_target) {
+            // It is common that the deployment target is set too low, e.g. on macOS Aarch64 to also
+            // target older x86_64, the user may set a lower deployment target than supported.
+            //
+            // To avoid such issues, we silently raise the deployment target here.
+            // FIXME: We want to show a warning when `version < os_min`.
+            Ok(version) => version.max(min),
+            // FIXME: Report erroneous environment variable to user.
+            Err(_) => min,
+        }
+    } else {
+        // If no deployment target variable is set, default to the minimum found above.
+        min
+    }
+}
+
+pub(super) fn add_version_to_llvm_target(
+    llvm_target: &str,
+    deployment_target: OSVersion,
+) -> String {
+    let mut components = llvm_target.split("-");
+    let arch = components.next().expect("apple target should have arch");
+    let vendor = components.next().expect("apple target should have vendor");
+    let os = components.next().expect("apple target should have os");
+    let environment = components.next();
+    assert_eq!(components.next(), None, "too many LLVM triple components");
+
+    let (major, minor, patch) = deployment_target;
+
+    assert!(
+        !os.contains(|c: char| c.is_ascii_digit()),
+        "LLVM target must not already be versioned"
+    );
+
+    if let Some(env) = environment {
+        // Insert version into OS, before environment
+        format!("{arch}-{vendor}-{os}{major}.{minor}.{patch}-{env}")
+    } else {
+        format!("{arch}-{vendor}-{os}{major}.{minor}.{patch}")
+    }
+}

--- a/compiler/rustc_codegen_ssa/src/back/apple/tests.rs
+++ b/compiler/rustc_codegen_ssa/src/back/apple/tests.rs
@@ -1,0 +1,21 @@
+use super::{add_version_to_llvm_target, parse_version};
+
+#[test]
+fn test_add_version_to_llvm_target() {
+    assert_eq!(
+        add_version_to_llvm_target("aarch64-apple-macosx", (10, 14, 1)),
+        "aarch64-apple-macosx10.14.1"
+    );
+    assert_eq!(
+        add_version_to_llvm_target("aarch64-apple-ios-simulator", (16, 1, 0)),
+        "aarch64-apple-ios16.1.0-simulator"
+    );
+}
+
+#[test]
+fn test_parse_version() {
+    assert_eq!(parse_version("10"), Ok((10, 0, 0)));
+    assert_eq!(parse_version("10.12"), Ok((10, 12, 0)));
+    assert_eq!(parse_version("10.12.6"), Ok((10, 12, 6)));
+    assert_eq!(parse_version("9999.99.99"), Ok((9999, 99, 99)));
+}

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -22,6 +22,8 @@ use rustc_span::sym;
 use rustc_target::abi::Endian;
 use rustc_target::spec::{RelocModel, Target, ef_avr_arch};
 
+use super::apple;
+
 /// The default metadata loader. This is used by cg_llvm and cg_clif.
 ///
 /// # Metadata location
@@ -238,7 +240,7 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
             file.set_macho_cpu_subtype(object::macho::CPU_SUBTYPE_ARM64E);
         }
 
-        file.set_macho_build_version(macho_object_build_version_for_target(&sess.target))
+        file.set_macho_build_version(macho_object_build_version_for_target(sess))
     }
     if binary_format == BinaryFormat::Coff {
         // Disable the default mangler to avoid mangling the special "@feat.00" symbol name.
@@ -392,7 +394,7 @@ pub(crate) fn create_object_file(sess: &Session) -> Option<write::Object<'static
 ///
 /// Since Xcode 15, Apple's LD apparently requires object files to use this load command, so this
 /// returns the `MachOBuildVersion` for the target to do so.
-fn macho_object_build_version_for_target(target: &Target) -> object::write::MachOBuildVersion {
+fn macho_object_build_version_for_target(sess: &Session) -> object::write::MachOBuildVersion {
     /// The `object` crate demands "X.Y.Z encoded in nibbles as xxxx.yy.zz"
     /// e.g. minOS 14.0 = 0x000E0000, or SDK 16.2 = 0x00100200
     fn pack_version((major, minor, patch): (u16, u8, u8)) -> u32 {
@@ -401,8 +403,8 @@ fn macho_object_build_version_for_target(target: &Target) -> object::write::Mach
     }
 
     let platform =
-        rustc_target::spec::current_apple_platform(target).expect("unknown Apple target OS");
-    let min_os = rustc_target::spec::current_apple_deployment_target(target);
+        rustc_target::spec::current_apple_platform(&sess.target).expect("unknown Apple target OS");
+    let min_os = apple::deployment_target(sess);
 
     let mut build_version = object::write::MachOBuildVersion::default();
     build_version.platform = platform;

--- a/compiler/rustc_codegen_ssa/src/back/metadata.rs
+++ b/compiler/rustc_codegen_ssa/src/back/metadata.rs
@@ -402,8 +402,7 @@ fn macho_object_build_version_for_target(sess: &Session) -> object::write::MachO
         (major << 16) | (minor << 8) | patch
     }
 
-    let platform =
-        rustc_target::spec::current_apple_platform(&sess.target).expect("unknown Apple target OS");
+    let platform = apple::macho_platform(&sess.target);
     let min_os = apple::deployment_target(sess);
 
     let mut build_version = object::write::MachOBuildVersion::default();

--- a/compiler/rustc_codegen_ssa/src/back/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/back/mod.rs
@@ -1,3 +1,8 @@
+use std::borrow::Cow;
+
+use rustc_session::Session;
+
+pub mod apple;
 pub mod archive;
 pub(crate) mod command;
 pub mod link;
@@ -7,3 +12,19 @@ pub mod metadata;
 pub(crate) mod rpath;
 pub mod symbol_export;
 pub mod write;
+
+/// The target triple depends on the deployment target, and is required to
+/// enable features such as cross-language LTO, and for picking the right
+/// Mach-O commands.
+///
+/// Certain optimizations also depend on the deployment target.
+pub fn versioned_llvm_target(sess: &Session) -> Cow<'_, str> {
+    if sess.target.is_like_osx {
+        apple::add_version_to_llvm_target(&sess.target.llvm_target, apple::deployment_target(sess))
+            .into()
+    } else {
+        // FIXME(madsmtm): Certain other targets also include a version,
+        // we might want to move that here as well.
+        Cow::Borrowed(&sess.target.llvm_target)
+    }
+}

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 use std::io::Error;
+use std::num::ParseIntError;
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 
@@ -537,6 +538,14 @@ pub enum ExtractBundledLibsError<'a> {
 pub(crate) struct UnsupportedArch<'a> {
     pub arch: &'a str,
     pub os: &'a str,
+}
+
+#[derive(Diagnostic)]
+pub(crate) enum AppleDeploymentTarget {
+    #[diag(codegen_ssa_apple_deployment_target_invalid)]
+    Invalid { env_var: &'static str, error: ParseIntError },
+    #[diag(codegen_ssa_apple_deployment_target_too_low)]
+    TooLow { env_var: &'static str, version: String, os_min: String },
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_codegen_ssa/src/lib.rs
+++ b/compiler/rustc_codegen_ssa/src/lib.rs
@@ -6,6 +6,7 @@
 #![doc(rust_logo)]
 #![feature(assert_matches)]
 #![feature(box_patterns)]
+#![feature(debug_closure_helpers)]
 #![feature(file_buffered)]
 #![feature(if_let_guard)]
 #![feature(let_chains)]

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -33,6 +33,7 @@ use std::time::{Instant, SystemTime};
 use std::{env, str};
 
 use rustc_ast as ast;
+use rustc_codegen_ssa::back::apple;
 use rustc_codegen_ssa::traits::CodegenBackend;
 use rustc_codegen_ssa::{CodegenErrors, CodegenResults};
 use rustc_data_structures::profiling::{
@@ -855,10 +856,8 @@ fn print_crate_info(
                 }
             }
             DeploymentTarget => {
-                use rustc_target::spec::current_apple_deployment_target;
-
                 if sess.target.is_like_osx {
-                    let (major, minor, patch) = current_apple_deployment_target(&sess.target);
+                    let (major, minor, patch) = apple::deployment_target(sess);
                     let patch = if patch != 0 { format!(".{patch}") } else { String::new() };
                     println_info!("deployment_target={major}.{minor}{patch}")
                 } else {

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -857,9 +857,10 @@ fn print_crate_info(
             }
             DeploymentTarget => {
                 if sess.target.is_like_osx {
-                    let (major, minor, patch) = apple::deployment_target(sess);
-                    let patch = if patch != 0 { format!(".{patch}") } else { String::new() };
-                    println_info!("deployment_target={major}.{minor}{patch}")
+                    println_info!(
+                        "deployment_target={}",
+                        apple::pretty_version(apple::deployment_target(sess))
+                    )
                 } else {
                     #[allow(rustc::diagnostic_outside_of_impl)]
                     sess.dcx().fatal("only Apple targets currently support deployment version info")

--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -151,9 +151,15 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                 //     };
                 // };
                 // ```
+                //
+                // It isn't possible to mix a impl in a module with const-anon, but an item can
+                // be put inside a module and referenced by a impl so we also have to treat the
+                // item parent as transparent to module and for consistency we have to do the same
+                // for impl, otherwise the item-def and impl-def won't have the same parent.
                 let outermost_impl_parent = peel_parent_while(cx.tcx, parent, |tcx, did| {
-                    tcx.def_kind(did) == DefKind::Const
-                        && tcx.opt_item_name(did) == Some(kw::Underscore)
+                    tcx.def_kind(did) == DefKind::Mod
+                        || (tcx.def_kind(did) == DefKind::Const
+                            && tcx.opt_item_name(did) == Some(kw::Underscore))
                 });
 
                 // 2. We check if any of the paths reference a the `impl`-parent.

--- a/compiler/rustc_middle/src/ty/error.rs
+++ b/compiler/rustc_middle/src/ty/error.rs
@@ -1,5 +1,7 @@
 use std::borrow::Cow;
+use std::fs::File;
 use std::hash::{DefaultHasher, Hash, Hasher};
+use std::io::{Read, Write};
 use std::path::PathBuf;
 
 use rustc_errors::pluralize;
@@ -250,8 +252,8 @@ impl<'tcx> TyCtxt<'tcx> {
         }
 
         let width = self.sess.diagnostic_width();
-        let length_limit = width.saturating_sub(30);
-        if regular.len() <= width {
+        let length_limit = width / 2;
+        if regular.len() <= width * 2 / 3 {
             return regular;
         }
         let short = self.ty_string_with_limit(ty, length_limit);
@@ -265,7 +267,20 @@ impl<'tcx> TyCtxt<'tcx> {
         *path = Some(path.take().unwrap_or_else(|| {
             self.output_filenames(()).temp_path_ext(&format!("long-type-{hash}.txt"), None)
         }));
-        match std::fs::write(path.as_ref().unwrap(), &format!("{regular}\n")) {
+        let Ok(mut file) =
+            File::options().create(true).read(true).append(true).open(&path.as_ref().unwrap())
+        else {
+            return regular;
+        };
+
+        // Do not write the same type to the file multiple times.
+        let mut contents = String::new();
+        let _ = file.read_to_string(&mut contents);
+        if let Some(_) = contents.lines().find(|line| line == &regular) {
+            return short;
+        }
+
+        match write!(file, "{regular}\n") {
             Ok(_) => short,
             Err(_) => regular,
         }

--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -3,7 +3,7 @@ use std::env;
 
 use crate::spec::{
     Cc, DebuginfoKind, FramePointer, LinkerFlavor, Lld, SplitDebuginfo, StackProbeType, StaticCow,
-    Target, TargetOptions, cvs,
+    TargetOptions, cvs,
 };
 
 #[cfg(test)]
@@ -154,23 +154,6 @@ pub(crate) fn base(
         ..Default::default()
     };
     (opts, unversioned_llvm_target(os, arch, abi), arch.target_arch())
-}
-
-pub fn platform(target: &Target) -> Option<u32> {
-    Some(match (&*target.os, &*target.abi) {
-        ("macos", _) => object::macho::PLATFORM_MACOS,
-        ("ios", "macabi") => object::macho::PLATFORM_MACCATALYST,
-        ("ios", "sim") => object::macho::PLATFORM_IOSSIMULATOR,
-        ("ios", _) => object::macho::PLATFORM_IOS,
-        ("watchos", "sim") => object::macho::PLATFORM_WATCHOSSIMULATOR,
-        ("watchos", _) => object::macho::PLATFORM_WATCHOS,
-        ("tvos", "sim") => object::macho::PLATFORM_TVOSSIMULATOR,
-        ("tvos", _) => object::macho::PLATFORM_TVOS,
-        // FIXME: Upgrade to `object-rs` 0.33+ implementation with visionOS platform definition
-        ("visionos", "sim") => 12,
-        ("visionos", _) => 11,
-        _ => return None,
-    })
 }
 
 /// Generate part of the LLVM target triple.

--- a/compiler/rustc_target/src/spec/base/apple/mod.rs
+++ b/compiler/rustc_target/src/spec/base/apple/mod.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::env;
-use std::num::ParseIntError;
 
 use crate::spec::{
     Cc, DebuginfoKind, FramePointer, LinkerFlavor, Lld, SplitDebuginfo, StackProbeType, StaticCow,
@@ -97,9 +96,8 @@ impl TargetAbi {
     }
 }
 
-/// Get the base target options, LLVM target and `target_arch` from the three
-/// things that uniquely identify Rust's Apple targets: The OS, the
-/// architecture, and the ABI.
+/// Get the base target options, unversioned LLVM target and `target_arch` from the three
+/// things that uniquely identify Rust's Apple targets: The OS, the architecture, and the ABI.
 pub(crate) fn base(
     os: &'static str,
     arch: Arch,
@@ -155,7 +153,7 @@ pub(crate) fn base(
 
         ..Default::default()
     };
-    (opts, llvm_target(os, arch, abi), arch.target_arch())
+    (opts, unversioned_llvm_target(os, arch, abi), arch.target_arch())
 }
 
 pub fn platform(target: &Target) -> Option<u32> {
@@ -175,97 +173,11 @@ pub fn platform(target: &Target) -> Option<u32> {
     })
 }
 
-/// Hack for calling `deployment_target` outside of this module.
-pub fn deployment_target_for_target(target: &Target) -> (u16, u8, u8) {
-    let arch = if target.llvm_target.starts_with("arm64e") {
-        Arch::Arm64e
-    } else if target.arch == "aarch64" {
-        Arch::Arm64
-    } else {
-        // Dummy architecture, only used by `deployment_target` anyhow
-        Arch::X86_64
-    };
-    let abi = match &*target.abi {
-        "macabi" => TargetAbi::MacCatalyst,
-        "sim" => TargetAbi::Simulator,
-        "" => TargetAbi::Normal,
-        abi => unreachable!("invalid abi '{abi}' for Apple target"),
-    };
-    deployment_target(&target.os, arch, abi)
-}
-
-/// Get the deployment target based on the standard environment variables, or
-/// fall back to a sane default.
-fn deployment_target(os: &str, arch: Arch, abi: TargetAbi) -> (u16, u8, u8) {
-    // When bumping a version in here, remember to update the platform-support
-    // docs too.
-    //
-    // NOTE: If you are looking for the default deployment target, prefer
-    // `rustc --print deployment-target`, as the default here may change in
-    // future `rustc` versions.
-
-    // Minimum operating system versions currently supported by `rustc`.
-    let os_min = match os {
-        "macos" => (10, 12, 0),
-        "ios" => (10, 0, 0),
-        "tvos" => (10, 0, 0),
-        "watchos" => (5, 0, 0),
-        "visionos" => (1, 0, 0),
-        _ => unreachable!("tried to get deployment target for non-Apple platform"),
-    };
-
-    // On certain targets it makes sense to raise the minimum OS version.
-    //
-    // This matches what LLVM does, see:
-    // <https://github.com/llvm/llvm-project/blob/llvmorg-18.1.8/llvm/lib/TargetParser/Triple.cpp#L1900-L1932>
-    let min = match (os, arch, abi) {
-        ("macos", Arch::Arm64 | Arch::Arm64e, _) => (11, 0, 0),
-        ("ios", Arch::Arm64 | Arch::Arm64e, TargetAbi::MacCatalyst) => (14, 0, 0),
-        ("ios", Arch::Arm64 | Arch::Arm64e, TargetAbi::Simulator) => (14, 0, 0),
-        ("ios", Arch::Arm64e, TargetAbi::Normal) => (14, 0, 0),
-        // Mac Catalyst defaults to 13.1 in Clang.
-        ("ios", _, TargetAbi::MacCatalyst) => (13, 1, 0),
-        ("tvos", Arch::Arm64 | Arch::Arm64e, TargetAbi::Simulator) => (14, 0, 0),
-        ("watchos", Arch::Arm64 | Arch::Arm64e, TargetAbi::Simulator) => (7, 0, 0),
-        _ => os_min,
-    };
-
-    // The environment variable used to fetch the deployment target.
-    let env_var = match os {
-        "macos" => "MACOSX_DEPLOYMENT_TARGET",
-        "ios" => "IPHONEOS_DEPLOYMENT_TARGET",
-        "watchos" => "WATCHOS_DEPLOYMENT_TARGET",
-        "tvos" => "TVOS_DEPLOYMENT_TARGET",
-        "visionos" => "XROS_DEPLOYMENT_TARGET",
-        _ => unreachable!("tried to get deployment target env var for non-Apple platform"),
-    };
-
-    if let Ok(deployment_target) = env::var(env_var) {
-        match parse_version(&deployment_target) {
-            // It is common that the deployment target is set too low, e.g. on
-            // macOS Aarch64 to also target older x86_64, the user may set a
-            // lower deployment target than supported.
-            //
-            // To avoid such issues, we silently raise the deployment target
-            // here.
-            // FIXME: We want to show a warning when `version < os_min`.
-            Ok(version) => version.max(min),
-            // FIXME: Report erroneous environment variable to user.
-            Err(_) => min,
-        }
-    } else {
-        min
-    }
-}
-
-/// Generate the target triple that we need to pass to LLVM and/or Clang.
-fn llvm_target(os: &str, arch: Arch, abi: TargetAbi) -> StaticCow<str> {
-    // The target triple depends on the deployment target, and is required to
-    // enable features such as cross-language LTO, and for picking the right
-    // Mach-O commands.
-    //
-    // Certain optimizations also depend on the deployment target.
-    let (major, minor, patch) = deployment_target(os, arch, abi);
+/// Generate part of the LLVM target triple.
+///
+/// See `rustc_codegen_ssa::back::versioned_llvm_target` for the full triple passed to LLVM and
+/// Clang.
+fn unversioned_llvm_target(os: &str, arch: Arch, abi: TargetAbi) -> StaticCow<str> {
     let arch = arch.target_name();
     // Convert to the "canonical" OS name used by LLVM:
     // https://github.com/llvm/llvm-project/blob/llvmorg-18.1.8/llvm/lib/TargetParser/Triple.cpp#L236-L282
@@ -282,7 +194,7 @@ fn llvm_target(os: &str, arch: Arch, abi: TargetAbi) -> StaticCow<str> {
         TargetAbi::MacCatalyst => "-macabi",
         TargetAbi::Simulator => "-simulator",
     };
-    format!("{arch}-apple-{os}{major}.{minor}.{patch}{environment}").into()
+    format!("{arch}-apple-{os}{environment}").into()
 }
 
 fn link_env_remove(os: &'static str) -> StaticCow<[StaticCow<str>]> {
@@ -319,22 +231,5 @@ fn link_env_remove(os: &'static str) -> StaticCow<[StaticCow<str>]> {
         // Otherwise if cross-compiling for a different OS/SDK (including Mac Catalyst), remove any part
         // of the linking environment that's wrong and reversed.
         cvs!["MACOSX_DEPLOYMENT_TARGET"]
-    }
-}
-
-/// Parse an OS version triple (SDK version or deployment target).
-///
-/// The size of the returned numbers here are limited by Mach-O's
-/// `LC_BUILD_VERSION`.
-fn parse_version(version: &str) -> Result<(u16, u8, u8), ParseIntError> {
-    if let Some((major, minor)) = version.split_once('.') {
-        let major = major.parse()?;
-        if let Some((minor, patch)) = minor.split_once('.') {
-            Ok((major, minor.parse()?, patch.parse()?))
-        } else {
-            Ok((major, minor.parse()?, 0))
-        }
-    } else {
-        Ok((version.parse()?, 0, 0))
     }
 }

--- a/compiler/rustc_target/src/spec/base/apple/tests.rs
+++ b/compiler/rustc_target/src/spec/base/apple/tests.rs
@@ -1,4 +1,3 @@
-use super::parse_version;
 use crate::spec::targets::{
     aarch64_apple_darwin, aarch64_apple_ios_sim, aarch64_apple_visionos_sim,
     aarch64_apple_watchos_sim, i686_apple_darwin, x86_64_apple_darwin, x86_64_apple_ios,
@@ -39,12 +38,4 @@ fn macos_link_environment_unmodified() {
             "XROS_DEPLOYMENT_TARGET"
         ],);
     }
-}
-
-#[test]
-fn test_parse_version() {
-    assert_eq!(parse_version("10"), Ok((10, 0, 0)));
-    assert_eq!(parse_version("10.12"), Ok((10, 12, 0)));
-    assert_eq!(parse_version("10.12.6"), Ok((10, 12, 6)));
-    assert_eq!(parse_version("9999.99.99"), Ok((9999, 99, 99)));
 }

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -59,10 +59,7 @@ pub mod abi;
 pub mod crt_objects;
 
 mod base;
-pub use base::apple::{
-    deployment_target_for_target as current_apple_deployment_target,
-    platform as current_apple_platform,
-};
+pub use base::apple::platform as current_apple_platform;
 pub use base::avr_gnu::ef_avr_arch;
 
 /// Linker is called through a C/C++ compiler.
@@ -2003,7 +2000,12 @@ impl TargetWarnings {
 /// Every field here must be specified, and has no default value.
 #[derive(PartialEq, Clone, Debug)]
 pub struct Target {
-    /// Target triple to pass to LLVM.
+    /// Unversioned target triple to pass to LLVM.
+    ///
+    /// Target triples can optionally contain an OS version (notably Apple targets), which rustc
+    /// cannot know without querying the environment.
+    ///
+    /// Use `rustc_codegen_ssa::back::versioned_llvm_target` if you need the full LLVM target.
     pub llvm_target: StaticCow<str>,
     /// Metadata about a target, for example the description or tier.
     /// Used for generating target documentation.

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -59,7 +59,6 @@ pub mod abi;
 pub mod crt_objects;
 
 mod base;
-pub use base::apple::platform as current_apple_platform;
 pub use base::avr_gnu::ef_avr_arch;
 
 /// Linker is called through a C/C++ compiler.

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1872,7 +1872,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                         StringPart::normal(" implemented for `"),
                     ]);
                     if types_content.0 == types_content.1 {
-                        msg.push(StringPart::normal(obligation_trait_ref.self_ty().to_string()));
+                        let ty =
+                            self.tcx.short_ty_string(obligation_trait_ref.self_ty(), &mut None);
+                        msg.push(StringPart::normal(ty));
                     } else {
                         msg.extend(types.0.0);
                     }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -2540,12 +2540,16 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             && self.tcx.trait_impls_of(trait_def_id).is_empty()
             && !self.tcx.trait_is_auto(trait_def_id)
             && !self.tcx.trait_is_alias(trait_def_id)
+            && trait_predicate.polarity() == ty::PredicatePolarity::Positive
         {
             err.span_help(
                 self.tcx.def_span(trait_def_id),
                 crate::fluent_generated::trait_selection_trait_has_no_impls,
             );
-        } else if !suggested && !unsatisfied_const {
+        } else if !suggested
+            && !unsatisfied_const
+            && trait_predicate.polarity() == ty::PredicatePolarity::Positive
+        {
             // Can't show anything else useful, try to find similar impls.
             let impl_candidates = self.find_similar_impl_candidates(trait_predicate);
             if !self.report_similar_impl_candidates(

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -328,6 +328,11 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                             }
                         } else if let Some(custom_explanation) = safe_transmute_explanation {
                             err.span_label(span, custom_explanation);
+                        } else if explanation.len() > self.tcx.sess.diagnostic_width() {
+                            // Really long types don't look good as span labels, instead move it
+                            // to a `help`.
+                            err.span_label(span, "unsatisfied trait bound");
+                            err.help(explanation);
                         } else {
                             err.span_label(span, explanation);
                         }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3697,6 +3697,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         err: &mut Diag<'_>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) {
+        if trait_pred.polarity() == ty::PredicatePolarity::Negative {
+            return;
+        }
         let Some(diagnostic_name) = self.tcx.get_diagnostic_name(trait_pred.def_id()) else {
             return;
         };

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3563,17 +3563,34 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 )]);
             }
             ObligationCauseCode::OpaqueReturnType(expr_info) => {
-                if let Some((expr_ty, hir_id)) = expr_info {
-                    let expr_ty = self.tcx.short_ty_string(expr_ty, long_ty_file);
-                    let expr = self.infcx.tcx.hir().expect_expr(hir_id);
-                    err.span_label(
-                        expr.span,
-                        with_forced_trimmed_paths!(format!(
-                            "return type was inferred to be `{expr_ty}` here",
-                        )),
-                    );
-                    suggest_remove_deref(err, &expr);
-                }
+                let (expr_ty, expr) = if let Some((expr_ty, hir_id)) = expr_info {
+                    let expr_ty = tcx.short_ty_string(expr_ty, long_ty_file);
+                    let expr = tcx.hir().expect_expr(hir_id);
+                    (expr_ty, expr)
+                } else if let Some(body_id) = tcx.hir_node_by_def_id(body_id).body_id()
+                    && let body = tcx.hir().body(body_id)
+                    && let hir::ExprKind::Block(block, _) = body.value.kind
+                    && let Some(expr) = block.expr
+                    && let Some(expr_ty) = self
+                        .typeck_results
+                        .as_ref()
+                        .and_then(|typeck| typeck.node_type_opt(expr.hir_id))
+                    && let Some(pred) = predicate.as_clause()
+                    && let ty::ClauseKind::Trait(pred) = pred.kind().skip_binder()
+                    && self.can_eq(param_env, pred.self_ty(), expr_ty)
+                {
+                    let expr_ty = tcx.short_ty_string(expr_ty, long_ty_file);
+                    (expr_ty, expr)
+                } else {
+                    return;
+                };
+                err.span_label(
+                    expr.span,
+                    with_forced_trimmed_paths!(format!(
+                        "return type was inferred to be `{expr_ty}` here",
+                    )),
+                );
+                suggest_remove_deref(err, &expr);
             }
         }
     }

--- a/config.example.toml
+++ b/config.example.toml
@@ -668,8 +668,6 @@
 
 # Flag indicating whether git info will be retrieved from .git automatically.
 # Having the git information can cause a lot of rebuilds during development.
-#
-# FIXME(#76720): this can causes bugs if different compilers reuse the same metadata cache.
 #omit-git-hash = if rust.channel == "dev" { true } else { false }
 
 # Whether to create a source tarball by default when running `x dist`.

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -2169,7 +2169,7 @@ impl str {
     /// Returns a string slice with the prefix removed.
     ///
     /// If the string starts with the pattern `prefix`, returns the substring after the prefix,
-    /// wrapped in `Some`. Unlike `trim_start_matches`, this method removes the prefix exactly once.
+    /// wrapped in `Some`. Unlike [`trim_start_matches`], this method removes the prefix exactly once.
     ///
     /// If the string does not start with `prefix`, returns `None`.
     ///
@@ -2178,6 +2178,7 @@ impl str {
     ///
     /// [`char`]: prim@char
     /// [pattern]: self::pattern
+    /// [`trim_start_matches`]: Self::trim_start_matches
     ///
     /// # Examples
     ///
@@ -2196,7 +2197,7 @@ impl str {
     /// Returns a string slice with the suffix removed.
     ///
     /// If the string ends with the pattern `suffix`, returns the substring before the suffix,
-    /// wrapped in `Some`.  Unlike `trim_end_matches`, this method removes the suffix exactly once.
+    /// wrapped in `Some`.  Unlike [`trim_end_matches`], this method removes the suffix exactly once.
     ///
     /// If the string does not end with `suffix`, returns `None`.
     ///
@@ -2205,6 +2206,7 @@ impl str {
     ///
     /// [`char`]: prim@char
     /// [pattern]: self::pattern
+    /// [`trim_end_matches`]: Self::trim_end_matches
     ///
     /// # Examples
     ///

--- a/library/core/src/str/mod.rs
+++ b/library/core/src/str/mod.rs
@@ -211,13 +211,15 @@ impl str {
         }
     }
 
-    /// Finds the closest `x` not exceeding `index` where `is_char_boundary(x)` is `true`.
+    /// Finds the closest `x` not exceeding `index` where [`is_char_boundary(x)`] is `true`.
     ///
     /// This method can help you truncate a string so that it's still valid UTF-8, but doesn't
     /// exceed a given number of bytes. Note that this is done purely at the character level
     /// and can still visually split graphemes, even though the underlying characters aren't
     /// split. For example, the emoji 🧑‍🔬 (scientist) could be split so that the string only
     /// includes 🧑 (person) instead.
+    ///
+    /// [`is_char_boundary(x)`]: Self::is_char_boundary
     ///
     /// # Examples
     ///
@@ -247,7 +249,7 @@ impl str {
         }
     }
 
-    /// Finds the closest `x` not below `index` where `is_char_boundary(x)` is `true`.
+    /// Finds the closest `x` not below `index` where [`is_char_boundary(x)`] is `true`.
     ///
     /// If `index` is greater than the length of the string, this returns the length of the string.
     ///
@@ -255,7 +257,7 @@ impl str {
     /// for more details.
     ///
     /// [`floor_char_boundary`]: str::floor_char_boundary
-    ///
+    /// [`is_char_boundary(x)`]: Self::is_char_boundary
     ///
     /// # Examples
     ///

--- a/tests/assembly/asm/loongarch-type.rs
+++ b/tests/assembly/asm/loongarch-type.rs
@@ -3,7 +3,7 @@
 //@ compile-flags: -Zmerge-functions=disabled
 //@ needs-llvm-components: loongarch
 
-#![feature(no_core, lang_items, rustc_attrs, asm_experimental_arch)]
+#![feature(no_core, lang_items, rustc_attrs)]
 #![crate_type = "rlib"]
 #![no_core]
 #![allow(asm_sub_register, non_camel_case_types)]

--- a/tests/ui/async-await/async-closures/not-clone-closure.stderr
+++ b/tests/ui/async-await/async-closures/not-clone-closure.stderr
@@ -2,8 +2,9 @@ error[E0277]: the trait bound `NotClonableUpvar: Clone` is not satisfied in `{as
   --> $DIR/not-clone-closure.rs:32:15
    |
 LL |     not_clone.clone();
-   |               ^^^^^ within `{async closure@$DIR/not-clone-closure.rs:29:21: 29:34}`, the trait `Clone` is not implemented for `NotClonableUpvar`
+   |               ^^^^^ unsatisfied trait bound
    |
+   = help: within `{async closure@$DIR/not-clone-closure.rs:29:21: 29:34}`, the trait `Clone` is not implemented for `NotClonableUpvar`
 note: required because it's used within this closure
   --> $DIR/not-clone-closure.rs:29:21
    |

--- a/tests/ui/async-await/async-error-span.stderr
+++ b/tests/ui/async-await/async-error-span.stderr
@@ -3,6 +3,9 @@ error[E0277]: `()` is not a future
    |
 LL | fn get_future() -> impl Future<Output = ()> {
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^ `()` is not a future
+LL |
+LL |     panic!()
+   |     -------- return type was inferred to be `_` here
    |
    = help: the trait `Future` is not implemented for `()`
 

--- a/tests/ui/async-await/coroutine-not-future.rs
+++ b/tests/ui/async-await/coroutine-not-future.rs
@@ -1,4 +1,5 @@
 //@ edition:2018
+//@compile-flags: --diagnostic-width=300
 #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
 
 use std::future::Future;

--- a/tests/ui/async-await/coroutine-not-future.stderr
+++ b/tests/ui/async-await/coroutine-not-future.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `impl Future<Output = ()>: Coroutine<_>` is not satisfied
-  --> $DIR/coroutine-not-future.rs:35:21
+  --> $DIR/coroutine-not-future.rs:36:21
    |
 LL |     takes_coroutine(async_fn());
    |     --------------- ^^^^^^^^^^ the trait `Coroutine<_>` is not implemented for `impl Future<Output = ()>`
@@ -7,13 +7,13 @@ LL |     takes_coroutine(async_fn());
    |     required by a bound introduced by this call
    |
 note: required by a bound in `takes_coroutine`
-  --> $DIR/coroutine-not-future.rs:19:39
+  --> $DIR/coroutine-not-future.rs:20:39
    |
 LL | fn takes_coroutine<ResumeTy>(_g: impl Coroutine<ResumeTy, Yield = (), Return = ()>) {}
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_coroutine`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Coroutine<_>` is not satisfied
-  --> $DIR/coroutine-not-future.rs:37:21
+  --> $DIR/coroutine-not-future.rs:38:21
    |
 LL |     takes_coroutine(returns_async_block());
    |     --------------- ^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine<_>` is not implemented for `impl Future<Output = ()>`
@@ -21,27 +21,27 @@ LL |     takes_coroutine(returns_async_block());
    |     required by a bound introduced by this call
    |
 note: required by a bound in `takes_coroutine`
-  --> $DIR/coroutine-not-future.rs:19:39
+  --> $DIR/coroutine-not-future.rs:20:39
    |
 LL | fn takes_coroutine<ResumeTy>(_g: impl Coroutine<ResumeTy, Yield = (), Return = ()>) {}
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_coroutine`
 
-error[E0277]: the trait bound `{async block@$DIR/coroutine-not-future.rs:39:21: 39:26}: Coroutine<_>` is not satisfied
-  --> $DIR/coroutine-not-future.rs:39:21
+error[E0277]: the trait bound `{async block@$DIR/coroutine-not-future.rs:40:21: 40:26}: Coroutine<_>` is not satisfied
+  --> $DIR/coroutine-not-future.rs:40:21
    |
 LL |     takes_coroutine(async {});
-   |     --------------- ^^^^^^^^ the trait `Coroutine<_>` is not implemented for `{async block@$DIR/coroutine-not-future.rs:39:21: 39:26}`
+   |     --------------- ^^^^^^^^ the trait `Coroutine<_>` is not implemented for `{async block@$DIR/coroutine-not-future.rs:40:21: 40:26}`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `takes_coroutine`
-  --> $DIR/coroutine-not-future.rs:19:39
+  --> $DIR/coroutine-not-future.rs:20:39
    |
 LL | fn takes_coroutine<ResumeTy>(_g: impl Coroutine<ResumeTy, Yield = (), Return = ()>) {}
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_coroutine`
 
 error[E0277]: `impl Coroutine<Yield = (), Return = ()>` is not a future
-  --> $DIR/coroutine-not-future.rs:43:18
+  --> $DIR/coroutine-not-future.rs:44:18
    |
 LL |     takes_future(returns_coroutine());
    |     ------------ ^^^^^^^^^^^^^^^^^^^ `impl Coroutine<Yield = (), Return = ()>` is not a future
@@ -50,13 +50,13 @@ LL |     takes_future(returns_coroutine());
    |
    = help: the trait `Future` is not implemented for `impl Coroutine<Yield = (), Return = ()>`
 note: required by a bound in `takes_future`
-  --> $DIR/coroutine-not-future.rs:18:26
+  --> $DIR/coroutine-not-future.rs:19:26
    |
 LL | fn takes_future(_f: impl Future<Output = ()>) {}
    |                          ^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_future`
 
-error[E0277]: `{coroutine@$DIR/coroutine-not-future.rs:47:9: 47:14}` is not a future
-  --> $DIR/coroutine-not-future.rs:47:9
+error[E0277]: `{coroutine@$DIR/coroutine-not-future.rs:48:9: 48:14}` is not a future
+  --> $DIR/coroutine-not-future.rs:48:9
    |
 LL |       takes_future(
    |       ------------ required by a bound introduced by this call
@@ -65,11 +65,11 @@ LL | /         |ctx| {
 LL | |
 LL | |             ctx = yield ();
 LL | |         },
-   | |_________^ `{coroutine@$DIR/coroutine-not-future.rs:47:9: 47:14}` is not a future
+   | |_________^ `{coroutine@$DIR/coroutine-not-future.rs:48:9: 48:14}` is not a future
    |
-   = help: the trait `Future` is not implemented for `{coroutine@$DIR/coroutine-not-future.rs:47:9: 47:14}`
+   = help: the trait `Future` is not implemented for `{coroutine@$DIR/coroutine-not-future.rs:48:9: 48:14}`
 note: required by a bound in `takes_future`
-  --> $DIR/coroutine-not-future.rs:18:26
+  --> $DIR/coroutine-not-future.rs:19:26
    |
 LL | fn takes_future(_f: impl Future<Output = ()>) {}
    |                          ^^^^^^^^^^^^^^^^^^^ required by this bound in `takes_future`

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_bad.stderr
@@ -20,10 +20,11 @@ error[E0277]: `{closure@$DIR/const_param_ty_bad.rs:8:11: 8:13}` can't be used as
   --> $DIR/const_param_ty_bad.rs:8:11
    |
 LL |     check(|| {});
-   |     ----- ^^^^^ the trait `UnsizedConstParamTy` is not implemented for closure `{closure@$DIR/const_param_ty_bad.rs:8:11: 8:13}`
+   |     ----- ^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+   = help: the trait `UnsizedConstParamTy` is not implemented for closure `{closure@$DIR/const_param_ty_bad.rs:8:11: 8:13}`
 note: required by a bound in `check`
   --> $DIR/const_param_ty_bad.rs:4:18
    |

--- a/tests/ui/const-generics/associated-type-bound-fail.stderr
+++ b/tests/ui/const-generics/associated-type-bound-fail.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `u16: Bar<N>` is not satisfied
 LL |     type Assoc = u16;
    |                  ^^^ the trait `Bar<N>` is not implemented for `u16`
    |
-   = help: the trait `Bar<3>` is implemented for `u16`
+   = help: the trait `Bar<N>` is not implemented for `u16`
+           but trait `Bar<3>` is implemented for it
 note: required by a bound in `Foo::Assoc`
   --> $DIR/associated-type-bound-fail.rs:4:17
    |

--- a/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
+++ b/tests/ui/const-generics/defaults/rp_impl_trait_fail.stderr
@@ -18,7 +18,8 @@ LL |
 LL |     1_u32
    |     ----- return type was inferred to be `u32` here
    |
-   = help: the trait `Traitor<N, 2>` is implemented for `u32`
+   = help: the trait `Traitor<N, N>` is not implemented for `u32`
+           but trait `Traitor<N, 2>` is implemented for it
 
 error[E0277]: the trait bound `u64: Traitor` is not satisfied
   --> $DIR/rp_impl_trait_fail.rs:21:13
@@ -29,7 +30,8 @@ LL |
 LL |     1_u64
    |     ----- return type was inferred to be `u64` here
    |
-   = help: the trait `Traitor<1, 2>` is implemented for `u64`
+   = help: the trait `Traitor<1, 1>` is not implemented for `u64`
+           but trait `Traitor<1, 2>` is implemented for it
 
 error[E0284]: type annotations needed
   --> $DIR/rp_impl_trait_fail.rs:28:5

--- a/tests/ui/const-generics/defaults/trait_objects_fail.stderr
+++ b/tests/ui/const-generics/defaults/trait_objects_fail.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `u32: Trait` is not satisfied
 LL |     foo(&10_u32);
    |         ^^^^^^^ the trait `Trait` is not implemented for `u32`
    |
-   = help: the trait `Trait<2>` is implemented for `u32`
+   = help: the trait `Trait<12>` is not implemented for `u32`
+           but trait `Trait<2>` is implemented for it
    = note: required for the cast from `&u32` to `&dyn Trait`
 
 error[E0277]: the trait bound `bool: Traitor<_>` is not satisfied
@@ -13,7 +14,8 @@ error[E0277]: the trait bound `bool: Traitor<_>` is not satisfied
 LL |     bar(&true);
    |         ^^^^^ the trait `Traitor<_>` is not implemented for `bool`
    |
-   = help: the trait `Traitor<2, 3>` is implemented for `bool`
+   = help: the trait `Traitor<_, _>` is not implemented for `bool`
+           but trait `Traitor<2, 3>` is implemented for it
    = note: required for the cast from `&bool` to `&dyn Traitor<_>`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/const-generics/defaults/wfness.stderr
+++ b/tests/ui/const-generics/defaults/wfness.stderr
@@ -10,7 +10,8 @@ error[E0277]: the trait bound `(): Trait<2>` is not satisfied
 LL |     (): Trait<N>;
    |         ^^^^^^^^ the trait `Trait<2>` is not implemented for `()`
    |
-   = help: the trait `Trait<3>` is implemented for `()`
+   = help: the trait `Trait<2>` is not implemented for `()`
+           but trait `Trait<3>` is implemented for it
 
 error[E0277]: the trait bound `(): Trait<1>` is not satisfied
   --> $DIR/wfness.rs:18:13
@@ -18,7 +19,8 @@ error[E0277]: the trait bound `(): Trait<1>` is not satisfied
 LL | fn foo() -> DependentDefaultWfness {
    |             ^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<1>` is not implemented for `()`
    |
-   = help: the trait `Trait<3>` is implemented for `()`
+   = help: the trait `Trait<1>` is not implemented for `()`
+           but trait `Trait<3>` is implemented for it
 note: required by a bound in `WhereClause`
   --> $DIR/wfness.rs:8:9
    |

--- a/tests/ui/const-generics/occurs-check/unused-substs-1.stderr
+++ b/tests/ui/const-generics/occurs-check/unused-substs-1.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `A<_>: Bar<_>` is not satisfied
 LL |     let _ = A;
    |             ^ the trait `Bar<_>` is not implemented for `A<_>`
    |
-   = help: the trait `Bar<_>` is implemented for `A<{ 6 + 1 }>`
+   = help: the trait `Bar<_>` is not implemented for `A<_>`
+           but it is implemented for `A<{ 6 + 1 }>`
 note: required by a bound in `A`
   --> $DIR/unused-substs-1.rs:9:11
    |

--- a/tests/ui/coroutine/arg-count-mismatch-on-unit-input.stderr
+++ b/tests/ui/coroutine/arg-count-mismatch-on-unit-input.stderr
@@ -5,7 +5,10 @@ LL | fn foo() -> impl Coroutine<u8> {
    |             ^^^^^^^^^^^^^^^^^^ expected due to this
 ...
 LL |     |_: ()| {}
-   |     ------- found signature defined here
+   |     ----------
+   |     |
+   |     found signature defined here
+   |     return type was inferred to be `{coroutine@$DIR/arg-count-mismatch-on-unit-input.rs:8:5: 8:12}` here
    |
    = note: expected coroutine signature `fn(u8) -> _`
               found coroutine signature `fn(()) -> _`

--- a/tests/ui/coroutine/clone-impl.rs
+++ b/tests/ui/coroutine/clone-impl.rs
@@ -1,6 +1,7 @@
 // gate-test-coroutine_clone
 // Verifies that non-static coroutines can be cloned/copied if all their upvars and locals held
 // across awaits can be cloned/copied.
+//@compile-flags: --diagnostic-width=300
 
 #![feature(coroutines, coroutine_clone, stmt_expr_attributes)]
 

--- a/tests/ui/coroutine/clone-impl.stderr
+++ b/tests/ui/coroutine/clone-impl.stderr
@@ -1,76 +1,76 @@
-error[E0277]: the trait bound `Vec<u32>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}`
-  --> $DIR/clone-impl.rs:49:5
+error[E0277]: the trait bound `Vec<u32>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:44:5: 44:12}`
+  --> $DIR/clone-impl.rs:50:5
    |
 LL |     move || {
-   |     ------- within this `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}`
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:44:5: 44:12}`
 ...
 LL |     check_copy(&gen_clone_0);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}`, the trait `Copy` is not implemented for `Vec<u32>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:44:5: 44:12}`, the trait `Copy` is not implemented for `Vec<u32>`
    |
 note: captured value does not implement `Copy`
-  --> $DIR/clone-impl.rs:47:14
+  --> $DIR/clone-impl.rs:48:14
    |
 LL |         drop(clonable_0);
    |              ^^^^^^^^^^ has type `Vec<u32>` which does not implement `Copy`
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:89:18
+  --> $DIR/clone-impl.rs:90:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `Vec<char>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}`
-  --> $DIR/clone-impl.rs:49:5
+error[E0277]: the trait bound `Vec<char>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:44:5: 44:12}`
+  --> $DIR/clone-impl.rs:50:5
    |
 LL |     move || {
-   |     ------- within this `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}`
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:44:5: 44:12}`
 ...
 LL |     check_copy(&gen_clone_0);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:43:5: 43:12}`, the trait `Copy` is not implemented for `Vec<char>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:44:5: 44:12}`, the trait `Copy` is not implemented for `Vec<char>`
    |
 note: coroutine does not implement `Copy` as this value is used across a yield
-  --> $DIR/clone-impl.rs:45:9
+  --> $DIR/clone-impl.rs:46:9
    |
 LL |         let v = vec!['a'];
    |             - has type `Vec<char>` which does not implement `Copy`
 LL |         yield;
    |         ^^^^^ yield occurs here, with `v` maybe used later
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:89:18
+  --> $DIR/clone-impl.rs:90:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `Vec<u32>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}`
-  --> $DIR/clone-impl.rs:70:5
+error[E0277]: the trait bound `Vec<u32>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:59:5: 59:12}`
+  --> $DIR/clone-impl.rs:71:5
    |
 LL |     move || {
-   |     ------- within this `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}`
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:59:5: 59:12}`
 ...
 LL |     check_copy(&gen_clone_1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}`, the trait `Copy` is not implemented for `Vec<u32>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:59:5: 59:12}`, the trait `Copy` is not implemented for `Vec<u32>`
    |
 note: captured value does not implement `Copy`
-  --> $DIR/clone-impl.rs:68:14
+  --> $DIR/clone-impl.rs:69:14
    |
 LL |         drop(clonable_1);
    |              ^^^^^^^^^^ has type `Vec<u32>` which does not implement `Copy`
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:89:18
+  --> $DIR/clone-impl.rs:90:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `Vec<char>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}`
-  --> $DIR/clone-impl.rs:70:5
+error[E0277]: the trait bound `Vec<char>: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:59:5: 59:12}`
+  --> $DIR/clone-impl.rs:71:5
    |
 LL |     move || {
-   |     ------- within this `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}`
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:59:5: 59:12}`
 ...
 LL |     check_copy(&gen_clone_1);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:58:5: 58:12}`, the trait `Copy` is not implemented for `Vec<char>`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:59:5: 59:12}`, the trait `Copy` is not implemented for `Vec<char>`
    |
 note: coroutine does not implement `Copy` as this value is used across a yield
-  --> $DIR/clone-impl.rs:64:9
+  --> $DIR/clone-impl.rs:65:9
    |
 LL |         let v = vec!['a'];
    |             - has type `Vec<char>` which does not implement `Copy`
@@ -78,27 +78,27 @@ LL |         let v = vec!['a'];
 LL |         yield;
    |         ^^^^^ yield occurs here, with `v` maybe used later
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:89:18
+  --> $DIR/clone-impl.rs:90:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `NonClone: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}`
-  --> $DIR/clone-impl.rs:83:5
+error[E0277]: the trait bound `NonClone: Copy` is not satisfied in `{coroutine@$DIR/clone-impl.rs:80:5: 80:12}`
+  --> $DIR/clone-impl.rs:84:5
    |
 LL |     move || {
-   |     ------- within this `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}`
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:80:5: 80:12}`
 ...
 LL |     check_copy(&gen_non_clone);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}`, the trait `Copy` is not implemented for `NonClone`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:80:5: 80:12}`, the trait `Copy` is not implemented for `NonClone`
    |
 note: captured value does not implement `Copy`
-  --> $DIR/clone-impl.rs:81:14
+  --> $DIR/clone-impl.rs:82:14
    |
 LL |         drop(non_clonable);
    |              ^^^^^^^^^^^^ has type `NonClone` which does not implement `Copy`
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl.rs:89:18
+  --> $DIR/clone-impl.rs:90:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
@@ -108,22 +108,22 @@ LL + #[derive(Copy)]
 LL | struct NonClone;
    |
 
-error[E0277]: the trait bound `NonClone: Clone` is not satisfied in `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}`
-  --> $DIR/clone-impl.rs:85:5
+error[E0277]: the trait bound `NonClone: Clone` is not satisfied in `{coroutine@$DIR/clone-impl.rs:80:5: 80:12}`
+  --> $DIR/clone-impl.rs:86:5
    |
 LL |     move || {
-   |     ------- within this `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}`
+   |     ------- within this `{coroutine@$DIR/clone-impl.rs:80:5: 80:12}`
 ...
 LL |     check_clone(&gen_non_clone);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:79:5: 79:12}`, the trait `Clone` is not implemented for `NonClone`
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `{coroutine@$DIR/clone-impl.rs:80:5: 80:12}`, the trait `Clone` is not implemented for `NonClone`
    |
 note: captured value does not implement `Clone`
-  --> $DIR/clone-impl.rs:81:14
+  --> $DIR/clone-impl.rs:82:14
    |
 LL |         drop(non_clonable);
    |              ^^^^^^^^^^^^ has type `NonClone` which does not implement `Clone`
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl.rs:90:19
+  --> $DIR/clone-impl.rs:91:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`

--- a/tests/ui/coroutine/gen_block_is_coro.stderr
+++ b/tests/ui/coroutine/gen_block_is_coro.stderr
@@ -3,18 +3,24 @@ error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:7:5: 7:8}: C
    |
 LL | fn foo() -> impl Coroutine<Yield = u32, Return = ()> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:7:5: 7:8}`
+LL |     gen { yield 42 }
+   |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_coro.rs:7:5: 7:8}` here
 
 error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:11:5: 11:8}: Coroutine` is not satisfied
   --> $DIR/gen_block_is_coro.rs:10:13
    |
 LL | fn bar() -> impl Coroutine<Yield = i64, Return = ()> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:11:5: 11:8}`
+LL |     gen { yield 42 }
+   |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_coro.rs:11:5: 11:8}` here
 
 error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:15:5: 15:8}: Coroutine` is not satisfied
   --> $DIR/gen_block_is_coro.rs:14:13
    |
 LL | fn baz() -> impl Coroutine<Yield = i32, Return = ()> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:15:5: 15:8}`
+LL |     gen { yield 42 }
+   |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_coro.rs:15:5: 15:8}` here
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/coroutine/gen_block_is_no_future.stderr
+++ b/tests/ui/coroutine/gen_block_is_no_future.stderr
@@ -3,6 +3,8 @@ error[E0277]: `{gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:8}` is not a fut
    |
 LL | fn foo() -> impl std::future::Future {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^ `{gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:8}` is not a future
+LL |     gen { yield 42 }
+   |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:8}` here
    |
    = help: the trait `Future` is not implemented for `{gen block@$DIR/gen_block_is_no_future.rs:5:5: 5:8}`
 

--- a/tests/ui/coroutine/issue-105084.rs
+++ b/tests/ui/coroutine/issue-105084.rs
@@ -1,3 +1,4 @@
+//@compile-flags: --diagnostic-width=300
 #![feature(coroutines)]
 #![feature(coroutine_clone)]
 #![feature(coroutine_trait)]

--- a/tests/ui/coroutine/issue-105084.stderr
+++ b/tests/ui/coroutine/issue-105084.stderr
@@ -1,8 +1,8 @@
 error[E0382]: borrow of moved value: `g`
-  --> $DIR/issue-105084.rs:38:14
+  --> $DIR/issue-105084.rs:39:14
    |
 LL |     let mut g = #[coroutine]
-   |         ----- move occurs because `g` has type `{coroutine@$DIR/issue-105084.rs:15:5: 15:7}`, which does not implement the `Copy` trait
+   |         ----- move occurs because `g` has type `{coroutine@$DIR/issue-105084.rs:16:5: 16:7}`, which does not implement the `Copy` trait
 ...
 LL |     let mut h = copy(g);
    |                      - value moved here
@@ -11,7 +11,7 @@ LL |     Pin::new(&mut g).resume(());
    |              ^^^^^^ value borrowed here after move
    |
 note: consider changing this parameter type in function `copy` to borrow instead if owning the value isn't necessary
-  --> $DIR/issue-105084.rs:9:21
+  --> $DIR/issue-105084.rs:10:21
    |
 LL | fn copy<T: Copy>(x: T) -> T {
    |    ----             ^ this parameter takes ownership of the value
@@ -22,17 +22,17 @@ help: consider cloning the value if the performance cost is acceptable
 LL |     let mut h = copy(g.clone());
    |                       ++++++++
 
-error[E0277]: the trait bound `Box<(i32, ())>: Copy` is not satisfied in `{coroutine@$DIR/issue-105084.rs:15:5: 15:7}`
-  --> $DIR/issue-105084.rs:32:17
+error[E0277]: the trait bound `Box<(i32, ())>: Copy` is not satisfied in `{coroutine@$DIR/issue-105084.rs:16:5: 16:7}`
+  --> $DIR/issue-105084.rs:33:17
    |
 LL |     || {
-   |     -- within this `{coroutine@$DIR/issue-105084.rs:15:5: 15:7}`
+   |     -- within this `{coroutine@$DIR/issue-105084.rs:16:5: 16:7}`
 ...
 LL |     let mut h = copy(g);
-   |                 ^^^^^^^ within `{coroutine@$DIR/issue-105084.rs:15:5: 15:7}`, the trait `Copy` is not implemented for `Box<(i32, ())>`
+   |                 ^^^^^^^ within `{coroutine@$DIR/issue-105084.rs:16:5: 16:7}`, the trait `Copy` is not implemented for `Box<(i32, ())>`
    |
 note: coroutine does not implement `Copy` as this value is used across a yield
-  --> $DIR/issue-105084.rs:22:22
+  --> $DIR/issue-105084.rs:23:22
    |
 LL |         Box::new((5, yield));
    |         -------------^^^^^--
@@ -40,7 +40,7 @@ LL |         Box::new((5, yield));
    |         |            yield occurs here, with `Box::new((5, yield))` maybe used later
    |         has type `Box<(i32, ())>` which does not implement `Copy`
 note: required by a bound in `copy`
-  --> $DIR/issue-105084.rs:9:12
+  --> $DIR/issue-105084.rs:10:12
    |
 LL | fn copy<T: Copy>(x: T) -> T {
    |            ^^^^ required by this bound in `copy`

--- a/tests/ui/coroutine/issue-88653.rs
+++ b/tests/ui/coroutine/issue-88653.rs
@@ -14,6 +14,7 @@ fn foo(bar: bool) -> impl Coroutine<(bool,)> {
     #[coroutine]
     |bar| {
         //~^ NOTE: found signature defined here
+        //~| NOTE: return type was inferred to be
         if bar {
             yield bar;
         }

--- a/tests/ui/coroutine/issue-88653.stderr
+++ b/tests/ui/coroutine/issue-88653.stderr
@@ -1,11 +1,21 @@
 error[E0631]: type mismatch in coroutine arguments
   --> $DIR/issue-88653.rs:8:22
    |
-LL | fn foo(bar: bool) -> impl Coroutine<(bool,)> {
-   |                      ^^^^^^^^^^^^^^^^^^^^^^^ expected due to this
+LL |   fn foo(bar: bool) -> impl Coroutine<(bool,)> {
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^ expected due to this
 ...
-LL |     |bar| {
-   |     ----- found signature defined here
+LL |       |bar| {
+   |       -----
+   |       |
+   |  _____found signature defined here
+   | |
+LL | |
+LL | |
+LL | |         if bar {
+LL | |             yield bar;
+LL | |         }
+LL | |     }
+   | |_____- return type was inferred to be `{coroutine@$DIR/issue-88653.rs:15:5: 15:10}` here
    |
    = note: expected coroutine signature `fn((bool,)) -> _`
               found coroutine signature `fn(bool) -> _`

--- a/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.current.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.current.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `&str: AsExpression<Integer>` is not satisfied
 LL |     SelectInt.check("bar");
    |               ^^^^^ the trait `AsExpression<Integer>` is not implemented for `&str`
    |
-   = help: the trait `AsExpression<Text>` is implemented for `&str`
+   = help: the trait `AsExpression<Integer>` is not implemented for `&str`
+           but trait `AsExpression<Text>` is implemented for it
    = help: for that trait implementation, expected `Text`, found `Integer`
 
 error: aborting due to 1 previous error

--- a/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.next.stderr
+++ b/tests/ui/diagnostic_namespace/do_not_recommend/as_expression.next.stderr
@@ -22,7 +22,8 @@ error[E0277]: the trait bound `&str: AsExpression<Integer>` is not satisfied
 LL |     SelectInt.check("bar");
    |               ^^^^^ the trait `AsExpression<Integer>` is not implemented for `&str`
    |
-   = help: the trait `AsExpression<Text>` is implemented for `&str`
+   = help: the trait `AsExpression<Integer>` is not implemented for `&str`
+           but trait `AsExpression<Text>` is implemented for it
    = help: for that trait implementation, expected `Text`, found `Integer`
 
 error[E0271]: type mismatch resolving `<SelectInt as Expression>::SqlType == Text`

--- a/tests/ui/generic-const-items/unsatisfied-bounds.stderr
+++ b/tests/ui/generic-const-items/unsatisfied-bounds.stderr
@@ -16,7 +16,8 @@ error[E0277]: the trait bound `Infallible: From<()>` is not satisfied
 LL |     let () = K::<()>;
    |                  ^^ the trait `From<()>` is not implemented for `Infallible`
    |
-   = help: the trait `From<!>` is implemented for `Infallible`
+   = help: the trait `From<()>` is not implemented for `Infallible`
+           but trait `From<!>` is implemented for it
    = help: for that trait implementation, expected `!`, found `()`
 note: required by a bound in `K`
   --> $DIR/unsatisfied-bounds.rs:12:17
@@ -48,7 +49,8 @@ error[E0277]: the trait bound `Infallible: From<()>` is not satisfied
 LL |     let _ = <() as Trait<&'static str>>::B::<()>;
    |                                              ^^ the trait `From<()>` is not implemented for `Infallible`
    |
-   = help: the trait `From<!>` is implemented for `Infallible`
+   = help: the trait `From<()>` is not implemented for `Infallible`
+           but trait `From<!>` is implemented for it
    = help: for that trait implementation, expected `!`, found `()`
 note: required by a bound in `Trait::B`
   --> $DIR/unsatisfied-bounds.rs:21:21

--- a/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
+++ b/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
@@ -1,4 +1,4 @@
-<svg width="1104px" height="362px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1104px" height="398px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -31,33 +31,37 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">the trait `Bar&lt;i32&gt;` is not implemented for `Struct`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     Struct</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Bar&lt;</tspan><tspan class="fg-magenta bold">i32</tspan><tspan>&gt;` </tspan><tspan class="fg-magenta bold">is not</tspan><tspan> implemented for `Struct`</tspan>
+    <tspan x="10px" y="136px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>     </tspan><tspan class="fg-ansi256-012 bold">------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">return type was inferred to be `Struct` here</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>           but trait `Bar&lt;</tspan><tspan class="fg-magenta bold">()</tspan><tspan>&gt;` </tspan><tspan class="fg-magenta bold">is</tspan><tspan> implemented for it</tspan>
+    <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: for that trait implementation, expected `</tspan><tspan class="fg-magenta bold">()</tspan><tspan>`, found `</tspan><tspan class="fg-magenta bold">i32</tspan><tspan>`</tspan>
+    <tspan x="10px" y="172px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Bar&lt;</tspan><tspan class="fg-magenta bold">i32</tspan><tspan>&gt;` </tspan><tspan class="fg-magenta bold">is not</tspan><tspan> implemented for `Struct`</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required for `Struct` to implement `Foo&lt;i32&gt;`</tspan>
+    <tspan x="10px" y="190px"><tspan>           but trait `Bar&lt;</tspan><tspan class="fg-magenta bold">()</tspan><tspan>&gt;` </tspan><tspan class="fg-magenta bold">is</tspan><tspan> implemented for it</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/highlight-difference-between-expected-trait-and-found-trait.rs:11:12</tspan>
+    <tspan x="10px" y="208px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: for that trait implementation, expected `</tspan><tspan class="fg-magenta bold">()</tspan><tspan>`, found `</tspan><tspan class="fg-magenta bold">i32</tspan><tspan>`</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required for `Struct` to implement `Foo&lt;i32&gt;`</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> impl&lt;T, K&gt; Foo&lt;K&gt; for T where T: Bar&lt;K&gt;</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/highlight-difference-between-expected-trait-and-found-trait.rs:11:12</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>            </tspan><tspan class="fg-ansi256-010 bold">^^^^^^</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^</tspan><tspan>          </tspan><tspan class="fg-ansi256-012 bold">------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">unsatisfied trait bound introduced here</tspan>
+    <tspan x="10px" y="262px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="280px">
+    <tspan x="10px" y="280px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> impl&lt;T, K&gt; Foo&lt;K&gt; for T where T: Bar&lt;K&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-ansi256-009 bold">error</tspan><tspan class="bold">: aborting due to 1 previous error</tspan>
+    <tspan x="10px" y="298px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>            </tspan><tspan class="fg-ansi256-010 bold">^^^^^^</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^</tspan><tspan>          </tspan><tspan class="fg-ansi256-012 bold">------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">unsatisfied trait bound introduced here</tspan>
 </tspan>
     <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="bold">For more information about this error, try `rustc --explain E0277`.</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-ansi256-009 bold">error</tspan><tspan class="bold">: aborting due to 1 previous error</tspan>
 </tspan>
     <tspan x="10px" y="352px">
+</tspan>
+    <tspan x="10px" y="370px"><tspan class="bold">For more information about this error, try `rustc --explain E0277`.</tspan>
+</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
   </text>
 

--- a/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
+++ b/tests/ui/impl-trait/diagnostics/highlight-difference-between-expected-trait-and-found-trait.svg
@@ -1,4 +1,4 @@
-<svg width="1104px" height="344px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1104px" height="362px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -33,29 +33,31 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Bar&lt;()&gt;` </tspan><tspan class="fg-magenta bold">is</tspan><tspan> implemented for `Struct`</tspan>
+    <tspan x="10px" y="136px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Bar&lt;</tspan><tspan class="fg-magenta bold">i32</tspan><tspan>&gt;` </tspan><tspan class="fg-magenta bold">is not</tspan><tspan> implemented for `Struct`</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: for that trait implementation, expected `</tspan><tspan class="fg-magenta bold">()</tspan><tspan>`, found `</tspan><tspan class="fg-magenta bold">i32</tspan><tspan>`</tspan>
+    <tspan x="10px" y="154px"><tspan>           but trait `Bar&lt;</tspan><tspan class="fg-magenta bold">()</tspan><tspan>&gt;` </tspan><tspan class="fg-magenta bold">is</tspan><tspan> implemented for it</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required for `Struct` to implement `Foo&lt;i32&gt;`</tspan>
+    <tspan x="10px" y="172px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: for that trait implementation, expected `</tspan><tspan class="fg-magenta bold">()</tspan><tspan>`, found `</tspan><tspan class="fg-magenta bold">i32</tspan><tspan>`</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/highlight-difference-between-expected-trait-and-found-trait.rs:11:12</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required for `Struct` to implement `Foo&lt;i32&gt;`</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/highlight-difference-between-expected-trait-and-found-trait.rs:11:12</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> impl&lt;T, K&gt; Foo&lt;K&gt; for T where T: Bar&lt;K&gt;</tspan>
+    <tspan x="10px" y="226px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>            </tspan><tspan class="fg-ansi256-010 bold">^^^^^^</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^</tspan><tspan>          </tspan><tspan class="fg-ansi256-012 bold">------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">unsatisfied trait bound introduced here</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> impl&lt;T, K&gt; Foo&lt;K&gt; for T where T: Bar&lt;K&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="262px">
+    <tspan x="10px" y="262px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>            </tspan><tspan class="fg-ansi256-010 bold">^^^^^^</tspan><tspan>     </tspan><tspan class="fg-ansi256-010 bold">^</tspan><tspan>          </tspan><tspan class="fg-ansi256-012 bold">------</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">unsatisfied trait bound introduced here</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan class="fg-ansi256-009 bold">error</tspan><tspan class="bold">: aborting due to 1 previous error</tspan>
+    <tspan x="10px" y="280px">
 </tspan>
-    <tspan x="10px" y="298px">
+    <tspan x="10px" y="298px"><tspan class="fg-ansi256-009 bold">error</tspan><tspan class="bold">: aborting due to 1 previous error</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="bold">For more information about this error, try `rustc --explain E0277`.</tspan>
+    <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px">
+    <tspan x="10px" y="334px"><tspan class="bold">For more information about this error, try `rustc --explain E0277`.</tspan>
+</tspan>
+    <tspan x="10px" y="352px">
 </tspan>
   </text>
 

--- a/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
+++ b/tests/ui/impl-trait/in-trait/return-dont-satisfy-bounds.stderr
@@ -32,7 +32,8 @@ LL |     fn foo<F2: Foo<u8>>(self) -> impl Foo<u8> {
 LL |         self
    |         ---- return type was inferred to be `Bar` here
    |
-   = help: the trait `Foo<char>` is implemented for `Bar`
+   = help: the trait `Foo<u8>` is not implemented for `Bar`
+           but trait `Foo<char>` is implemented for it
    = help: for that trait implementation, expected `char`, found `u8`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/impl-trait/issue-55872-1.stderr
+++ b/tests/ui/impl-trait/issue-55872-1.stderr
@@ -12,6 +12,9 @@ error[E0277]: the trait bound `S: Copy` is not satisfied in `(S, T)`
    |
 LL |     fn foo<T: Default>() -> Self::E {
    |                             ^^^^^^^ within `(S, T)`, the trait `Copy` is not implemented for `S`
+...
+LL |         (S::default(), T::default())
+   |         ---------------------------- return type was inferred to be `(S, T)` here
    |
    = note: required because it appears within the type `(S, T)`
 help: consider further restricting this bound
@@ -24,6 +27,9 @@ error[E0277]: the trait bound `T: Copy` is not satisfied in `(S, T)`
    |
 LL |     fn foo<T: Default>() -> Self::E {
    |                             ^^^^^^^ within `(S, T)`, the trait `Copy` is not implemented for `T`
+...
+LL |         (S::default(), T::default())
+   |         ---------------------------- return type was inferred to be `(S, T)` here
    |
    = note: required because it appears within the type `(S, T)`
 help: consider further restricting this bound

--- a/tests/ui/impl-trait/issue-55872-3.stderr
+++ b/tests/ui/impl-trait/issue-55872-3.stderr
@@ -3,6 +3,9 @@ error[E0277]: the trait bound `{async block@$DIR/issue-55872-3.rs:15:9: 15:14}: 
    |
 LL |     fn foo<T>() -> Self::E {
    |                    ^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/issue-55872-3.rs:15:9: 15:14}`
+LL |
+LL |         async {}
+   |         -------- return type was inferred to be `{async block@$DIR/issue-55872-3.rs:15:9: 15:14}` here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/impl-trait/issues/issue-62742.stderr
+++ b/tests/ui/impl-trait/issues/issue-62742.stderr
@@ -29,7 +29,8 @@ error[E0277]: the trait bound `RawImpl<_>: Raw<_>` is not satisfied
 LL |     WrongImpl::foo(0i32);
    |     ^^^^^^^^^ the trait `Raw<_>` is not implemented for `RawImpl<_>`
    |
-   = help: the trait `Raw<[_]>` is implemented for `RawImpl<_>`
+   = help: the trait `Raw<_>` is not implemented for `RawImpl<_>`
+           but trait `Raw<[_]>` is implemented for it
 note: required by a bound in `SafeImpl`
   --> $DIR/issue-62742.rs:33:35
    |
@@ -67,7 +68,8 @@ error[E0277]: the trait bound `RawImpl<()>: Raw<()>` is not satisfied
 LL |     WrongImpl::<()>::foo(0i32);
    |     ^^^^^^^^^^^^^^^ the trait `Raw<()>` is not implemented for `RawImpl<()>`
    |
-   = help: the trait `Raw<[()]>` is implemented for `RawImpl<()>`
+   = help: the trait `Raw<()>` is not implemented for `RawImpl<()>`
+           but trait `Raw<[()]>` is implemented for it
    = help: for that trait implementation, expected `[()]`, found `()`
 note: required by a bound in `SafeImpl`
   --> $DIR/issue-62742.rs:33:35

--- a/tests/ui/impl-trait/nested-rpit-hrtb.stderr
+++ b/tests/ui/impl-trait/nested-rpit-hrtb.stderr
@@ -83,7 +83,8 @@ error[E0277]: the trait bound `for<'a> &'a (): Qux<'b>` is not satisfied
 LL | fn one_hrtb_mention_fn_trait_param_uses<'b>() -> impl for<'a> Bar<'a, Assoc = impl Qux<'b>> {}
    |                                                                               ^^^^^^^^^^^^ the trait `for<'a> Qux<'b>` is not implemented for `&'a ()`
    |
-   = help: the trait `Qux<'_>` is implemented for `()`
+   = help: the trait `Qux<'b>` is not implemented for `&'a ()`
+           but trait `Qux<'_>` is implemented for `()`
    = help: for that trait implementation, expected `()`, found `&'a ()`
 
 error: implementation of `Bar` is not general enough
@@ -101,7 +102,8 @@ error[E0277]: the trait bound `for<'a, 'b> &'a (): Qux<'b>` is not satisfied
 LL | fn two_htrb_trait_param_uses() -> impl for<'a> Bar<'a, Assoc = impl for<'b> Qux<'b>> {}
    |                                                                ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a, 'b> Qux<'b>` is not implemented for `&'a ()`
    |
-   = help: the trait `Qux<'_>` is implemented for `()`
+   = help: the trait `Qux<'b>` is not implemented for `&'a ()`
+           but trait `Qux<'_>` is implemented for `()`
    = help: for that trait implementation, expected `()`, found `&'a ()`
 
 error: aborting due to 9 previous errors

--- a/tests/ui/impl-trait/nested_impl_trait.stderr
+++ b/tests/ui/impl-trait/nested_impl_trait.stderr
@@ -46,7 +46,9 @@ error[E0277]: the trait bound `impl Debug: From<impl Into<u32>>` is not satisfie
   --> $DIR/nested_impl_trait.rs:6:46
    |
 LL | fn bad_in_ret_position(x: impl Into<u32>) -> impl Into<impl Debug> { x }
-   |                                              ^^^^^^^^^^^^^^^^^^^^^ the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
+   |                                              ^^^^^^^^^^^^^^^^^^^^^   - return type was inferred to be `impl Into<u32>` here
+   |                                              |
+   |                                              the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
    |
    = help: the trait `Into<U>` is implemented for `T`
    = note: required for `impl Into<u32>` to implement `Into<impl Debug>`
@@ -55,7 +57,9 @@ error[E0277]: the trait bound `impl Debug: From<impl Into<u32>>` is not satisfie
   --> $DIR/nested_impl_trait.rs:19:34
    |
 LL |     fn bad(x: impl Into<u32>) -> impl Into<impl Debug> { x }
-   |                                  ^^^^^^^^^^^^^^^^^^^^^ the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
+   |                                  ^^^^^^^^^^^^^^^^^^^^^   - return type was inferred to be `impl Into<u32>` here
+   |                                  |
+   |                                  the trait `From<impl Into<u32>>` is not implemented for `impl Debug`
    |
    = help: the trait `Into<U>` is implemented for `T`
    = note: required for `impl Into<u32>` to implement `Into<impl Debug>`

--- a/tests/ui/impl-trait/opaque-cast-field-access-in-future.stderr
+++ b/tests/ui/impl-trait/opaque-cast-field-access-in-future.stderr
@@ -3,6 +3,9 @@ error[E0283]: type annotations needed
    |
 LL | fn run() -> Foo<impl Future<Output = ()>> {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type
+LL |
+LL |     loop {}
+   |     ------- return type was inferred to be `!` here
    |
    = note: cannot satisfy `_: Future`
 

--- a/tests/ui/impl-trait/projection-mismatch-in-impl-where-clause.stderr
+++ b/tests/ui/impl-trait/projection-mismatch-in-impl-where-clause.stderr
@@ -3,6 +3,9 @@ error[E0271]: type mismatch resolving `<() as Super>::Assoc == ()`
    |
 LL | fn test() -> impl Test {
    |              ^^^^^^^^^ type mismatch resolving `<() as Super>::Assoc == ()`
+LL |
+LL |     ()
+   |     -- return type was inferred to be `()` here
    |
 note: expected this to be `()`
   --> $DIR/projection-mismatch-in-impl-where-clause.rs:6:18

--- a/tests/ui/indexing/index-help.stderr
+++ b/tests/ui/indexing/index-help.stderr
@@ -5,7 +5,8 @@ LL |     x[0i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `i32`
-   = help: the trait `SliceIndex<[{integer}]>` is implemented for `usize`
+   = help: the trait `SliceIndex<[{integer}]>` is not implemented for `i32`
+           but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i32`
    = note: required for `Vec<{integer}>` to implement `Index<i32>`
 

--- a/tests/ui/indexing/index-help.stderr
+++ b/tests/ui/indexing/index-help.stderr
@@ -5,7 +5,6 @@ LL |     x[0i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `i32`
-   = help: the trait `SliceIndex<[{integer}]>` is not implemented for `i32`
            but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i32`
    = note: required for `Vec<{integer}>` to implement `Index<i32>`

--- a/tests/ui/indexing/indexing-requires-a-uint.stderr
+++ b/tests/ui/indexing/indexing-requires-a-uint.stderr
@@ -5,7 +5,8 @@ LL |     [0][0u8];
    |         ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `u8`
-   = help: the trait `SliceIndex<[{integer}]>` is implemented for `usize`
+   = help: the trait `SliceIndex<[{integer}]>` is not implemented for `u8`
+           but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u8`
    = note: required for `[{integer}]` to implement `Index<u8>`
    = note: 1 redundant requirement hidden

--- a/tests/ui/indexing/indexing-requires-a-uint.stderr
+++ b/tests/ui/indexing/indexing-requires-a-uint.stderr
@@ -5,7 +5,6 @@ LL |     [0][0u8];
    |         ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `u8`
-   = help: the trait `SliceIndex<[{integer}]>` is not implemented for `u8`
            but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u8`
    = note: required for `[{integer}]` to implement `Index<u8>`

--- a/tests/ui/indexing/point-at-index-for-obligation-failure.stderr
+++ b/tests/ui/indexing/point-at-index-for-obligation-failure.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `String: Borrow<&str>` is not satisfied
 LL |         &s
    |         ^^ the trait `Borrow<&str>` is not implemented for `String`
    |
-   = help: the trait `Borrow<str>` is implemented for `String`
+   = help: the trait `Borrow<&_>` is not implemented for `String`
+           but trait `Borrow<_>` is implemented for it
    = help: for that trait implementation, expected `str`, found `&str`
    = note: required for `HashMap<String, String>` to implement `Index<&&str>`
 

--- a/tests/ui/integral-indexing.stderr
+++ b/tests/ui/integral-indexing.stderr
@@ -5,7 +5,6 @@ LL |     v[3u8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `u8`
-   = help: the trait `SliceIndex<[isize]>` is not implemented for `u8`
            but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u8`
    = note: required for `Vec<isize>` to implement `Index<u8>`
@@ -16,7 +15,6 @@ error[E0277]: the type `[isize]` cannot be indexed by `i8`
 LL |     v[3i8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[isize]>` is not implemented for `i8`
    = help: the trait `SliceIndex<[isize]>` is not implemented for `i8`
            but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i8`
@@ -29,7 +27,6 @@ LL |     v[3u32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `u32`
-   = help: the trait `SliceIndex<[isize]>` is not implemented for `u32`
            but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u32`
    = note: required for `Vec<isize>` to implement `Index<u32>`
@@ -40,7 +37,6 @@ error[E0277]: the type `[isize]` cannot be indexed by `i32`
 LL |     v[3i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[isize]>` is not implemented for `i32`
    = help: the trait `SliceIndex<[isize]>` is not implemented for `i32`
            but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i32`
@@ -53,7 +49,6 @@ LL |     s.as_bytes()[3u8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `u8`
-   = help: the trait `SliceIndex<[u8]>` is not implemented for `u8`
            but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u8`
    = note: required for `[u8]` to implement `Index<u8>`
@@ -64,7 +59,6 @@ error[E0277]: the type `[u8]` cannot be indexed by `i8`
 LL |     s.as_bytes()[3i8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[u8]>` is not implemented for `i8`
    = help: the trait `SliceIndex<[u8]>` is not implemented for `i8`
            but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i8`
@@ -77,7 +71,6 @@ LL |     s.as_bytes()[3u32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `u32`
-   = help: the trait `SliceIndex<[u8]>` is not implemented for `u32`
            but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u32`
    = note: required for `[u8]` to implement `Index<u32>`
@@ -88,7 +81,6 @@ error[E0277]: the type `[u8]` cannot be indexed by `i32`
 LL |     s.as_bytes()[3i32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[u8]>` is not implemented for `i32`
    = help: the trait `SliceIndex<[u8]>` is not implemented for `i32`
            but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i32`

--- a/tests/ui/integral-indexing.stderr
+++ b/tests/ui/integral-indexing.stderr
@@ -5,7 +5,8 @@ LL |     v[3u8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `u8`
-   = help: the trait `SliceIndex<[isize]>` is implemented for `usize`
+   = help: the trait `SliceIndex<[isize]>` is not implemented for `u8`
+           but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u8`
    = note: required for `Vec<isize>` to implement `Index<u8>`
 
@@ -16,7 +17,8 @@ LL |     v[3i8];
    |       ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `i8`
-   = help: the trait `SliceIndex<[isize]>` is implemented for `usize`
+   = help: the trait `SliceIndex<[isize]>` is not implemented for `i8`
+           but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i8`
    = note: required for `Vec<isize>` to implement `Index<i8>`
 
@@ -27,7 +29,8 @@ LL |     v[3u32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `u32`
-   = help: the trait `SliceIndex<[isize]>` is implemented for `usize`
+   = help: the trait `SliceIndex<[isize]>` is not implemented for `u32`
+           but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u32`
    = note: required for `Vec<isize>` to implement `Index<u32>`
 
@@ -38,7 +41,8 @@ LL |     v[3i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[isize]>` is not implemented for `i32`
-   = help: the trait `SliceIndex<[isize]>` is implemented for `usize`
+   = help: the trait `SliceIndex<[isize]>` is not implemented for `i32`
+           but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i32`
    = note: required for `Vec<isize>` to implement `Index<i32>`
 
@@ -49,7 +53,8 @@ LL |     s.as_bytes()[3u8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `u8`
-   = help: the trait `SliceIndex<[u8]>` is implemented for `usize`
+   = help: the trait `SliceIndex<[u8]>` is not implemented for `u8`
+           but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u8`
    = note: required for `[u8]` to implement `Index<u8>`
 
@@ -60,7 +65,8 @@ LL |     s.as_bytes()[3i8];
    |                  ^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `i8`
-   = help: the trait `SliceIndex<[u8]>` is implemented for `usize`
+   = help: the trait `SliceIndex<[u8]>` is not implemented for `i8`
+           but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i8`
    = note: required for `[u8]` to implement `Index<i8>`
 
@@ -71,7 +77,8 @@ LL |     s.as_bytes()[3u32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `u32`
-   = help: the trait `SliceIndex<[u8]>` is implemented for `usize`
+   = help: the trait `SliceIndex<[u8]>` is not implemented for `u32`
+           but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `u32`
    = note: required for `[u8]` to implement `Index<u32>`
 
@@ -82,7 +89,8 @@ LL |     s.as_bytes()[3i32];
    |                  ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[u8]>` is not implemented for `i32`
-   = help: the trait `SliceIndex<[u8]>` is implemented for `usize`
+   = help: the trait `SliceIndex<[u8]>` is not implemented for `i32`
+           but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i32`
    = note: required for `[u8]` to implement `Index<i32>`
 

--- a/tests/ui/issues/issue-34334.stderr
+++ b/tests/ui/issues/issue-34334.stderr
@@ -18,7 +18,6 @@ LL |     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_rece
    |                                                                                       ^^^^^^^ value of type `Vec<(u32, _, _)>` cannot be built from `std::iter::Iterator<Item=()>`
    |
    = help: the trait `FromIterator<()>` is not implemented for `Vec<(u32, _, _)>`
-   = help: the trait `FromIterator<()>` is not implemented for `Vec<(u32, _, _)>`
            but trait `FromIterator<(u32, _, _)>` is implemented for it
    = help: for that trait implementation, expected `(u32, _, _)`, found `()`
 note: the method call chain might not have had the expected associated types

--- a/tests/ui/issues/issue-34334.stderr
+++ b/tests/ui/issues/issue-34334.stderr
@@ -18,7 +18,8 @@ LL |     let sr2: Vec<(u32, _, _)> = sr.iter().map(|(faction, th_sender, th_rece
    |                                                                                       ^^^^^^^ value of type `Vec<(u32, _, _)>` cannot be built from `std::iter::Iterator<Item=()>`
    |
    = help: the trait `FromIterator<()>` is not implemented for `Vec<(u32, _, _)>`
-   = help: the trait `FromIterator<(u32, _, _)>` is implemented for `Vec<(u32, _, _)>`
+   = help: the trait `FromIterator<()>` is not implemented for `Vec<(u32, _, _)>`
+           but trait `FromIterator<(u32, _, _)>` is implemented for it
    = help: for that trait implementation, expected `(u32, _, _)`, found `()`
 note: the method call chain might not have had the expected associated types
   --> $DIR/issue-34334.rs:5:43

--- a/tests/ui/issues/issue-45801.stderr
+++ b/tests/ui/issues/issue-45801.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `Params: Plugin<i32>` is not satisfied
 LL |     req.get_ref::<Params>();
    |         ^^^^^^^ the trait `Plugin<i32>` is not implemented for `Params`
    |
-   = help: the trait `Plugin<Foo>` is implemented for `Params`
+   = help: the trait `Plugin<i32>` is not implemented for `Params`
+           but trait `Plugin<Foo>` is implemented for it
    = help: for that trait implementation, expected `Foo`, found `i32`
 
 error: aborting due to 1 previous error

--- a/tests/ui/issues/issue-66923-show-error-for-correct-call.stderr
+++ b/tests/ui/issues/issue-66923-show-error-for-correct-call.stderr
@@ -5,7 +5,8 @@ LL |     let x2: Vec<f64> = x1.into_iter().collect();
    |                                       ^^^^^^^ value of type `Vec<f64>` cannot be built from `std::iter::Iterator<Item=&f64>`
    |
    = help: the trait `FromIterator<&f64>` is not implemented for `Vec<f64>`
-   = help: the trait `FromIterator<f64>` is implemented for `Vec<f64>`
+   = help: the trait `FromIterator<&_>` is not implemented for `Vec<f64>`
+           but trait `FromIterator<_>` is implemented for it
    = help: for that trait implementation, expected `f64`, found `&f64`
 note: the method call chain might not have had the expected associated types
   --> $DIR/issue-66923-show-error-for-correct-call.rs:8:27
@@ -26,7 +27,8 @@ LL |     let x3 = x1.into_iter().collect::<Vec<f64>>();
    |                             required by a bound introduced by this call
    |
    = help: the trait `FromIterator<&f64>` is not implemented for `Vec<f64>`
-   = help: the trait `FromIterator<f64>` is implemented for `Vec<f64>`
+   = help: the trait `FromIterator<&_>` is not implemented for `Vec<f64>`
+           but trait `FromIterator<_>` is implemented for it
    = help: for that trait implementation, expected `f64`, found `&f64`
 note: the method call chain might not have had the expected associated types
   --> $DIR/issue-66923-show-error-for-correct-call.rs:12:17

--- a/tests/ui/issues/issue-66923-show-error-for-correct-call.stderr
+++ b/tests/ui/issues/issue-66923-show-error-for-correct-call.stderr
@@ -4,7 +4,6 @@ error[E0277]: a value of type `Vec<f64>` cannot be built from an iterator over e
 LL |     let x2: Vec<f64> = x1.into_iter().collect();
    |                                       ^^^^^^^ value of type `Vec<f64>` cannot be built from `std::iter::Iterator<Item=&f64>`
    |
-   = help: the trait `FromIterator<&f64>` is not implemented for `Vec<f64>`
    = help: the trait `FromIterator<&_>` is not implemented for `Vec<f64>`
            but trait `FromIterator<_>` is implemented for it
    = help: for that trait implementation, expected `f64`, found `&f64`
@@ -26,7 +25,6 @@ LL |     let x3 = x1.into_iter().collect::<Vec<f64>>();
    |                             |
    |                             required by a bound introduced by this call
    |
-   = help: the trait `FromIterator<&f64>` is not implemented for `Vec<f64>`
    = help: the trait `FromIterator<&_>` is not implemented for `Vec<f64>`
            but trait `FromIterator<_>` is implemented for it
    = help: for that trait implementation, expected `f64`, found `&f64`

--- a/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
@@ -7,7 +7,8 @@ LL |     i.collect()
    |       ^^^^^^^ value of type `Vec<X>` cannot be built from `std::iter::Iterator<Item=&X>`
    |
    = help: the trait `FromIterator<&X>` is not implemented for `Vec<X>`
-   = help: the trait `FromIterator<X>` is implemented for `Vec<X>`
+   = help: the trait `FromIterator<&_>` is not implemented for `Vec<X>`
+           but trait `FromIterator<_>` is implemented for it
    = help: for that trait implementation, expected `X`, found `&X`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:5:26
@@ -124,7 +125,8 @@ LL |     let g: Vec<i32> = f.collect();
    |                         ^^^^^^^ value of type `Vec<i32>` cannot be built from `std::iter::Iterator<Item=()>`
    |
    = help: the trait `FromIterator<()>` is not implemented for `Vec<i32>`
-   = help: the trait `FromIterator<i32>` is implemented for `Vec<i32>`
+   = help: the trait `FromIterator<()>` is not implemented for `Vec<i32>`
+           but trait `FromIterator<i32>` is implemented for it
    = help: for that trait implementation, expected `i32`, found `()`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain-fixable.rs:32:15

--- a/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain-fixable.stderr
@@ -6,7 +6,6 @@ LL |     let i = i.map(|x| x.clone());
 LL |     i.collect()
    |       ^^^^^^^ value of type `Vec<X>` cannot be built from `std::iter::Iterator<Item=&X>`
    |
-   = help: the trait `FromIterator<&X>` is not implemented for `Vec<X>`
    = help: the trait `FromIterator<&_>` is not implemented for `Vec<X>`
            but trait `FromIterator<_>` is implemented for it
    = help: for that trait implementation, expected `X`, found `&X`
@@ -124,7 +123,6 @@ error[E0277]: a value of type `Vec<i32>` cannot be built from an iterator over e
 LL |     let g: Vec<i32> = f.collect();
    |                         ^^^^^^^ value of type `Vec<i32>` cannot be built from `std::iter::Iterator<Item=()>`
    |
-   = help: the trait `FromIterator<()>` is not implemented for `Vec<i32>`
    = help: the trait `FromIterator<()>` is not implemented for `Vec<i32>`
            but trait `FromIterator<i32>` is implemented for it
    = help: for that trait implementation, expected `i32`, found `()`

--- a/tests/ui/iterators/invalid-iterator-chain.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain.stderr
@@ -6,7 +6,6 @@ LL |     let i = i.map(|x| x.clone());
 LL |     i.collect()
    |       ^^^^^^^ value of type `Vec<X>` cannot be built from `std::iter::Iterator<Item=&X>`
    |
-   = help: the trait `FromIterator<&X>` is not implemented for `Vec<X>`
    = help: the trait `FromIterator<&_>` is not implemented for `Vec<X>`
            but trait `FromIterator<_>` is implemented for it
    = help: for that trait implementation, expected `X`, found `&X`
@@ -181,7 +180,6 @@ error[E0277]: a value of type `Vec<i32>` cannot be built from an iterator over e
 LL |     let g: Vec<i32> = f.collect();
    |                         ^^^^^^^ value of type `Vec<i32>` cannot be built from `std::iter::Iterator<Item=()>`
    |
-   = help: the trait `FromIterator<()>` is not implemented for `Vec<i32>`
    = help: the trait `FromIterator<()>` is not implemented for `Vec<i32>`
            but trait `FromIterator<i32>` is implemented for it
    = help: for that trait implementation, expected `i32`, found `()`

--- a/tests/ui/iterators/invalid-iterator-chain.stderr
+++ b/tests/ui/iterators/invalid-iterator-chain.stderr
@@ -7,7 +7,8 @@ LL |     i.collect()
    |       ^^^^^^^ value of type `Vec<X>` cannot be built from `std::iter::Iterator<Item=&X>`
    |
    = help: the trait `FromIterator<&X>` is not implemented for `Vec<X>`
-   = help: the trait `FromIterator<X>` is implemented for `Vec<X>`
+   = help: the trait `FromIterator<&_>` is not implemented for `Vec<X>`
+           but trait `FromIterator<_>` is implemented for it
    = help: for that trait implementation, expected `X`, found `&X`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:4:26
@@ -181,7 +182,8 @@ LL |     let g: Vec<i32> = f.collect();
    |                         ^^^^^^^ value of type `Vec<i32>` cannot be built from `std::iter::Iterator<Item=()>`
    |
    = help: the trait `FromIterator<()>` is not implemented for `Vec<i32>`
-   = help: the trait `FromIterator<i32>` is implemented for `Vec<i32>`
+   = help: the trait `FromIterator<()>` is not implemented for `Vec<i32>`
+           but trait `FromIterator<i32>` is implemented for it
    = help: for that trait implementation, expected `i32`, found `()`
 note: the method call chain might not have had the expected associated types
   --> $DIR/invalid-iterator-chain.rs:44:15

--- a/tests/ui/lifetimes/lifetime-elision-return-type-trait.stderr
+++ b/tests/ui/lifetimes/lifetime-elision-return-type-trait.stderr
@@ -3,6 +3,9 @@ error[E0277]: the trait bound `Result<(), _>: Future` is not satisfied
    |
 LL | fn foo() -> impl Future<Item=(), Error=Box<dyn Error>> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Future` is not implemented for `Result<(), _>`
+LL |
+LL |     Ok(())
+   |     ------ return type was inferred to be `Result<(), _>` here
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/lifetime-elision-return-type-trait.rs:1:1

--- a/tests/ui/lint/issue-106991.stderr
+++ b/tests/ui/lint/issue-106991.stderr
@@ -3,6 +3,9 @@ error[E0271]: expected `foo` to be a fn item that returns `i32`, but it returns 
    |
 LL | fn bar() -> impl Iterator<Item = i32> {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `i32`, found `()`
+...
+LL |     x.iter_mut().map(foo)
+   |     --------------------- return type was inferred to be `Map<std::slice::IterMut<'_, Vec<u8>>, for<'a> fn(&'a mut Vec<u8>) {foo}>` here
    |
    = note: required for `Map<std::slice::IterMut<'_, Vec<u8>>, for<'a> fn(&'a mut Vec<u8>) {foo}>` to implement `Iterator`
 

--- a/tests/ui/lint/non-local-defs/convoluted-locals-132427.rs
+++ b/tests/ui/lint/non-local-defs/convoluted-locals-132427.rs
@@ -1,0 +1,64 @@
+// Regression tests for https://github.com/rust-lang/rust/issues/132427
+
+//@ check-pass
+
+// original
+mod auth {
+    const _: () = {
+        pub enum ArbitraryContext {}
+
+        const _: () = {
+            impl ArbitraryContext {}
+        };
+    };
+}
+
+mod z {
+    pub enum ArbitraryContext {}
+
+    const _: () = {
+        const _: () = {
+            impl ArbitraryContext {}
+        };
+    };
+}
+
+const _: () = {
+    mod auth {
+        const _: () = {
+            pub enum ArbitraryContext {}
+
+            const _: () = {
+                impl ArbitraryContext {}
+            };
+        };
+    }
+};
+
+mod a {
+    mod b {
+        const _: () = {
+            pub enum ArbitraryContext {}
+
+            const _: () = {
+                impl ArbitraryContext {}
+            };
+        };
+    }
+}
+
+mod foo {
+    const _: () = {
+        mod auth {
+            const _: () = {
+                pub enum ArbitraryContext {}
+
+                const _: () = {
+                    impl ArbitraryContext {}
+                };
+            };
+        }
+    };
+}
+
+fn main() {}

--- a/tests/ui/never_type/from_infer_breaking_with_unit_fallback.unit.stderr
+++ b/tests/ui/never_type/from_infer_breaking_with_unit_fallback.unit.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `E: From<()>` is not satisfied
 LL |     <E as From<_>>::from(never); // Should the inference fail?
    |      ^ the trait `From<()>` is not implemented for `E`
    |
-   = help: the trait `From<!>` is implemented for `E`
+   = help: the trait `From<()>` is not implemented for `E`
+           but trait `From<!>` is implemented for it
    = help: for that trait implementation, expected `!`, found `()`
 
 error: aborting due to 1 previous error

--- a/tests/ui/never_type/impl_trait_fallback2.stderr
+++ b/tests/ui/never_type/impl_trait_fallback2.stderr
@@ -3,6 +3,9 @@ error[E0277]: the trait bound `(): T` is not satisfied
    |
 LL | fn should_ret_unit() -> impl T {
    |                         ^^^^^^ the trait `T` is not implemented for `()`
+LL |
+LL |     panic!()
+   |     -------- return type was inferred to be `_` here
    |
    = help: the trait `T` is implemented for `i32`
 
@@ -11,6 +14,9 @@ error[E0277]: the trait bound `(): T` is not satisfied
    |
 LL | fn a() -> Foo {
    |           ^^^ the trait `T` is not implemented for `()`
+LL |
+LL |     panic!()
+   |     -------- return type was inferred to be `_` here
    |
    = help: the trait `T` is implemented for `i32`
 

--- a/tests/ui/never_type/impl_trait_fallback3.stderr
+++ b/tests/ui/never_type/impl_trait_fallback3.stderr
@@ -3,6 +3,9 @@ error[E0277]: the trait bound `(): T` is not satisfied
    |
 LL | fn a() -> Foo {
    |           ^^^ the trait `T` is not implemented for `()`
+...
+LL |     panic!()
+   |     -------- return type was inferred to be `_` here
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/impl_trait_fallback3.rs:5:1

--- a/tests/ui/never_type/impl_trait_fallback4.stderr
+++ b/tests/ui/never_type/impl_trait_fallback4.stderr
@@ -3,6 +3,9 @@ error[E0277]: the trait bound `(): T` is not satisfied
    |
 LL | fn foo() -> impl T {
    |             ^^^^^^ the trait `T` is not implemented for `()`
+LL |
+LL |     panic!()
+   |     -------- return type was inferred to be `_` here
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/impl_trait_fallback4.rs:3:1

--- a/tests/ui/never_type/never-value-fallback-issue-66757.nofallback.stderr
+++ b/tests/ui/never_type/never-value-fallback-issue-66757.nofallback.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `E: From<()>` is not satisfied
 LL |     <E as From<_>>::from(never);
    |      ^ the trait `From<()>` is not implemented for `E`
    |
-   = help: the trait `From<!>` is implemented for `E`
+   = help: the trait `From<()>` is not implemented for `E`
+           but trait `From<!>` is implemented for it
    = help: for that trait implementation, expected `!`, found `()`
 
 error: aborting due to 1 previous error

--- a/tests/ui/on-unimplemented/impl-substs.stderr
+++ b/tests/ui/on-unimplemented/impl-substs.stderr
@@ -7,7 +7,8 @@ LL |     Foo::<usize>::foo((1i32, 1i32, 1i32));
    |     required by a bound introduced by this call
    |
    = help: the trait `Foo<usize>` is not implemented for `(i32, i32, i32)`
-   = help: the trait `Foo<i32>` is implemented for `(i32, i32, i32)`
+   = help: the trait `Foo<usize>` is not implemented for `(i32, i32, i32)`
+           but trait `Foo<i32>` is implemented for it
    = help: for that trait implementation, expected `i32`, found `usize`
 
 error: aborting due to 1 previous error

--- a/tests/ui/on-unimplemented/impl-substs.stderr
+++ b/tests/ui/on-unimplemented/impl-substs.stderr
@@ -7,7 +7,6 @@ LL |     Foo::<usize>::foo((1i32, 1i32, 1i32));
    |     required by a bound introduced by this call
    |
    = help: the trait `Foo<usize>` is not implemented for `(i32, i32, i32)`
-   = help: the trait `Foo<usize>` is not implemented for `(i32, i32, i32)`
            but trait `Foo<i32>` is implemented for it
    = help: for that trait implementation, expected `i32`, found `usize`
 

--- a/tests/ui/on-unimplemented/on-impl.stderr
+++ b/tests/ui/on-unimplemented/on-impl.stderr
@@ -7,7 +7,8 @@ LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
    |     required by a bound introduced by this call
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the trait `Index<usize>` is implemented for `[i32]`
+   = help: the trait `Index<u32>` is not implemented for `[i32]`
+           but trait `Index<usize>` is implemented for it
    = help: for that trait implementation, expected `usize`, found `u32`
 
 error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
@@ -17,7 +18,8 @@ LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the trait `Index<usize>` is implemented for `[i32]`
+   = help: the trait `Index<u32>` is not implemented for `[i32]`
+           but trait `Index<usize>` is implemented for it
    = help: for that trait implementation, expected `usize`, found `u32`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/on-unimplemented/on-impl.stderr
+++ b/tests/ui/on-unimplemented/on-impl.stderr
@@ -7,7 +7,6 @@ LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
    |     required by a bound introduced by this call
    |
    = help: the trait `Index<u32>` is not implemented for `[i32]`
-   = help: the trait `Index<u32>` is not implemented for `[i32]`
            but trait `Index<usize>` is implemented for it
    = help: for that trait implementation, expected `usize`, found `u32`
 
@@ -17,7 +16,6 @@ error[E0277]: the trait bound `[i32]: Index<u32>` is not satisfied
 LL |     Index::<u32>::index(&[1, 2, 3] as &[i32], 2u32);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ a usize is required to index into a slice
    |
-   = help: the trait `Index<u32>` is not implemented for `[i32]`
    = help: the trait `Index<u32>` is not implemented for `[i32]`
            but trait `Index<usize>` is implemented for it
    = help: for that trait implementation, expected `usize`, found `u32`

--- a/tests/ui/on-unimplemented/slice-index.stderr
+++ b/tests/ui/on-unimplemented/slice-index.stderr
@@ -5,7 +5,8 @@ LL |     x[1i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[i32]>` is not implemented for `i32`
-   = help: the trait `SliceIndex<[i32]>` is implemented for `usize`
+   = help: the trait `SliceIndex<[i32]>` is not implemented for `i32`
+           but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i32`
    = note: required for `[i32]` to implement `Index<i32>`
 

--- a/tests/ui/on-unimplemented/slice-index.stderr
+++ b/tests/ui/on-unimplemented/slice-index.stderr
@@ -5,7 +5,6 @@ LL |     x[1i32];
    |       ^^^^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[i32]>` is not implemented for `i32`
-   = help: the trait `SliceIndex<[i32]>` is not implemented for `i32`
            but it is implemented for `usize`
    = help: for that trait implementation, expected `usize`, found `i32`
    = note: required for `[i32]` to implement `Index<i32>`

--- a/tests/ui/str/str-idx.stderr
+++ b/tests/ui/str/str-idx.stderr
@@ -7,7 +7,8 @@ LL |     let _: u8 = s[4];
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the trait `SliceIndex<[_]>` is implemented for `usize`
+   = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
+           but trait `SliceIndex<[_]>` is implemented for `usize`
    = help: for that trait implementation, expected `[_]`, found `str`
    = note: required for `str` to implement `Index<{integer}>`
 
@@ -22,7 +23,8 @@ LL |     let _ = s.get(4);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the trait `SliceIndex<[_]>` is implemented for `usize`
+   = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
+           but trait `SliceIndex<[_]>` is implemented for `usize`
    = help: for that trait implementation, expected `[_]`, found `str`
 note: required by a bound in `core::str::<impl str>::get`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
@@ -38,7 +40,8 @@ LL |     let _ = s.get_unchecked(4);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the trait `SliceIndex<[_]>` is implemented for `usize`
+   = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
+           but trait `SliceIndex<[_]>` is implemented for `usize`
    = help: for that trait implementation, expected `[_]`, found `str`
 note: required by a bound in `core::str::<impl str>::get_unchecked`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL

--- a/tests/ui/str/str-idx.stderr
+++ b/tests/ui/str/str-idx.stderr
@@ -4,7 +4,6 @@ error[E0277]: the type `str` cannot be indexed by `{integer}`
 LL |     let _: u8 = s[4];
    |                   ^ string indices are ranges of `usize`
    |
-   = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
@@ -20,7 +19,6 @@ LL |     let _ = s.get(4);
    |               |
    |               required by a bound introduced by this call
    |
-   = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
@@ -37,7 +35,6 @@ LL |     let _ = s.get_unchecked(4);
    |               |
    |               required by a bound introduced by this call
    |
-   = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -31,7 +31,6 @@ LL |     s[1usize] = bot();
    |       ^^^^^^ string indices are ranges of `usize`
    |
    = help: the trait `SliceIndex<str>` is not implemented for `usize`
-   = help: the trait `SliceIndex<str>` is not implemented for `usize`
            but trait `SliceIndex<[_]>` is implemented for it
    = help: for that trait implementation, expected `[_]`, found `str`
    = note: required for `str` to implement `Index<usize>`
@@ -44,7 +43,6 @@ LL |     s.get_mut(1);
    |       |
    |       required by a bound introduced by this call
    |
-   = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
@@ -61,7 +59,6 @@ LL |     s.get_unchecked_mut(1);
    |       |
    |       required by a bound introduced by this call
    |
-   = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`

--- a/tests/ui/str/str-mut-idx.stderr
+++ b/tests/ui/str/str-mut-idx.stderr
@@ -31,7 +31,8 @@ LL |     s[1usize] = bot();
    |       ^^^^^^ string indices are ranges of `usize`
    |
    = help: the trait `SliceIndex<str>` is not implemented for `usize`
-   = help: the trait `SliceIndex<[_]>` is implemented for `usize`
+   = help: the trait `SliceIndex<str>` is not implemented for `usize`
+           but trait `SliceIndex<[_]>` is implemented for it
    = help: for that trait implementation, expected `[_]`, found `str`
    = note: required for `str` to implement `Index<usize>`
 
@@ -46,7 +47,8 @@ LL |     s.get_mut(1);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the trait `SliceIndex<[_]>` is implemented for `usize`
+   = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
+           but trait `SliceIndex<[_]>` is implemented for `usize`
    = help: for that trait implementation, expected `[_]`, found `str`
 note: required by a bound in `core::str::<impl str>::get_mut`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL
@@ -62,7 +64,8 @@ LL |     s.get_unchecked_mut(1);
    = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
    = note: you can use `.chars().nth()` or `.bytes().nth()`
            for more information, see chapter 8 in The Book: <https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings>
-   = help: the trait `SliceIndex<[_]>` is implemented for `usize`
+   = help: the trait `SliceIndex<str>` is not implemented for `{integer}`
+           but trait `SliceIndex<[_]>` is implemented for `usize`
    = help: for that trait implementation, expected `[_]`, found `str`
 note: required by a bound in `core::str::<impl str>::get_unchecked_mut`
   --> $SRC_DIR/core/src/str/mod.rs:LL:COL

--- a/tests/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
+++ b/tests/ui/suggestions/fn-ctor-passed-as-arg-where-it-should-have-been-called.stderr
@@ -20,10 +20,11 @@ error[E0277]: the trait bound `{closure@$DIR/fn-ctor-passed-as-arg-where-it-shou
   --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:19:9
    |
 LL |     bar(closure);
-   |     --- ^^^^^^^ the trait `T` is not implemented for closure `{closure@$DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:18:19: 18:21}`
+   |     --- ^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+   = help: the trait `T` is not implemented for closure `{closure@$DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:18:19: 18:21}`
 note: required by a bound in `bar`
   --> $DIR/fn-ctor-passed-as-arg-where-it-should-have-been-called.rs:14:16
    |

--- a/tests/ui/suggestions/issue-101623.stderr
+++ b/tests/ui/suggestions/issue-101623.stderr
@@ -7,7 +7,8 @@ LL |     Trait::do_stuff({ fun(&mut *inner) });
    |     |               the trait `Trait<'_>` is not implemented for `*mut ()`
    |     required by a bound introduced by this call
    |
-   = help: the trait `Trait<'_>` is implemented for `()`
+   = help: the trait `Trait<'_>` is not implemented for `*mut ()`
+           but it is implemented for `()`
    = help: for that trait implementation, expected `()`, found `*mut ()`
 
 error: aborting due to 1 previous error

--- a/tests/ui/suggestions/issue-84973-blacklist.rs
+++ b/tests/ui/suggestions/issue-84973-blacklist.rs
@@ -1,5 +1,6 @@
 // Checks that certain traits for which we don't want to suggest borrowing
 // are blacklisted and don't cause the suggestion to be issued.
+//@compile-flags: --diagnostic-width=300
 
 #![feature(coroutines)]
 

--- a/tests/ui/suggestions/issue-84973-blacklist.stderr
+++ b/tests/ui/suggestions/issue-84973-blacklist.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `String: Copy` is not satisfied
-  --> $DIR/issue-84973-blacklist.rs:15:12
+  --> $DIR/issue-84973-blacklist.rs:16:12
    |
 LL |     f_copy("".to_string());
    |     ------ ^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `String`
@@ -7,7 +7,7 @@ LL |     f_copy("".to_string());
    |     required by a bound introduced by this call
    |
 note: required by a bound in `f_copy`
-  --> $DIR/issue-84973-blacklist.rs:6:14
+  --> $DIR/issue-84973-blacklist.rs:7:14
    |
 LL | fn f_copy<T: Copy>(t: T) {}
    |              ^^^^ required by this bound in `f_copy`
@@ -18,7 +18,7 @@ LL +     f_copy("");
    |
 
 error[E0277]: the trait bound `S: Clone` is not satisfied
-  --> $DIR/issue-84973-blacklist.rs:16:13
+  --> $DIR/issue-84973-blacklist.rs:17:13
    |
 LL |     f_clone(S);
    |     ------- ^ the trait `Clone` is not implemented for `S`
@@ -26,7 +26,7 @@ LL |     f_clone(S);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `f_clone`
-  --> $DIR/issue-84973-blacklist.rs:7:15
+  --> $DIR/issue-84973-blacklist.rs:8:15
    |
 LL | fn f_clone<T: Clone>(t: T) {}
    |               ^^^^^ required by this bound in `f_clone`
@@ -36,24 +36,24 @@ LL + #[derive(Clone)]
 LL | struct S;
    |
 
-error[E0277]: `{static coroutine@$DIR/issue-84973-blacklist.rs:17:26: 17:35}` cannot be unpinned
-  --> $DIR/issue-84973-blacklist.rs:17:26
+error[E0277]: `{static coroutine@$DIR/issue-84973-blacklist.rs:18:26: 18:35}` cannot be unpinned
+  --> $DIR/issue-84973-blacklist.rs:18:26
    |
 LL |     f_unpin(#[coroutine] static || { yield; });
-   |     -------              ^^^^^^^^^^^^^^^^^^^^ the trait `Unpin` is not implemented for `{static coroutine@$DIR/issue-84973-blacklist.rs:17:26: 17:35}`
+   |     -------              ^^^^^^^^^^^^^^^^^^^^ the trait `Unpin` is not implemented for `{static coroutine@$DIR/issue-84973-blacklist.rs:18:26: 18:35}`
    |     |
    |     required by a bound introduced by this call
    |
    = note: consider using the `pin!` macro
            consider using `Box::pin` if you need to access the pinned value outside of the current scope
 note: required by a bound in `f_unpin`
-  --> $DIR/issue-84973-blacklist.rs:8:15
+  --> $DIR/issue-84973-blacklist.rs:9:15
    |
 LL | fn f_unpin<T: Unpin>(t: T) {}
    |               ^^^^^ required by this bound in `f_unpin`
 
 error[E0277]: the size for values of type `dyn Fn()` cannot be known at compilation time
-  --> $DIR/issue-84973-blacklist.rs:22:13
+  --> $DIR/issue-84973-blacklist.rs:23:13
    |
 LL |     f_sized(*ref_cl);
    |     ------- ^^^^^^^ doesn't have a size known at compile-time
@@ -62,7 +62,7 @@ LL |     f_sized(*ref_cl);
    |
    = help: the trait `Sized` is not implemented for `dyn Fn()`
 note: required by a bound in `f_sized`
-  --> $DIR/issue-84973-blacklist.rs:9:15
+  --> $DIR/issue-84973-blacklist.rs:10:15
    |
 LL | fn f_sized<T: Sized>(t: T) {}
    |               ^^^^^ required by this bound in `f_sized`
@@ -73,7 +73,7 @@ LL +     f_sized(ref_cl);
    |
 
 error[E0277]: `Rc<{integer}>` cannot be sent between threads safely
-  --> $DIR/issue-84973-blacklist.rs:27:12
+  --> $DIR/issue-84973-blacklist.rs:28:12
    |
 LL |     f_send(rc);
    |     ------ ^^ `Rc<{integer}>` cannot be sent between threads safely
@@ -82,7 +82,7 @@ LL |     f_send(rc);
    |
    = help: the trait `Send` is not implemented for `Rc<{integer}>`
 note: required by a bound in `f_send`
-  --> $DIR/issue-84973-blacklist.rs:10:14
+  --> $DIR/issue-84973-blacklist.rs:11:14
    |
 LL | fn f_send<T: Send>(t: T) {}
    |              ^^^^ required by this bound in `f_send`

--- a/tests/ui/suggestions/suggest-dereferencing-index.stderr
+++ b/tests/ui/suggestions/suggest-dereferencing-index.stderr
@@ -5,7 +5,8 @@ LL |     let one_item_please: i32 = [1, 2, 3][i];
    |                                          ^ slice indices are of type `usize` or ranges of `usize`
    |
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `&usize`
-   = help: the trait `SliceIndex<[{integer}]>` is implemented for `usize`
+   = help: the trait `SliceIndex<[{integer}]>` is not implemented for `&_`
+           but it is implemented for `_`
    = help: for that trait implementation, expected `usize`, found `&usize`
    = note: required for `[{integer}]` to implement `Index<&usize>`
    = note: 1 redundant requirement hidden

--- a/tests/ui/suggestions/suggest-dereferencing-index.stderr
+++ b/tests/ui/suggestions/suggest-dereferencing-index.stderr
@@ -4,7 +4,6 @@ error[E0277]: the type `[{integer}]` cannot be indexed by `&usize`
 LL |     let one_item_please: i32 = [1, 2, 3][i];
    |                                          ^ slice indices are of type `usize` or ranges of `usize`
    |
-   = help: the trait `SliceIndex<[{integer}]>` is not implemented for `&usize`
    = help: the trait `SliceIndex<[{integer}]>` is not implemented for `&_`
            but it is implemented for `_`
    = help: for that trait implementation, expected `usize`, found `&usize`

--- a/tests/ui/traits/coercion-generic-bad.stderr
+++ b/tests/ui/traits/coercion-generic-bad.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `Struct: Trait<isize>` is not satisfied
 LL |     let s: Box<dyn Trait<isize>> = Box::new(Struct { person: "Fred" });
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<isize>` is not implemented for `Struct`
    |
-   = help: the trait `Trait<&'static str>` is implemented for `Struct`
+   = help: the trait `Trait<isize>` is not implemented for `Struct`
+           but trait `Trait<&'static str>` is implemented for it
    = help: for that trait implementation, expected `&'static str`, found `isize`
    = note: required for the cast from `Box<Struct>` to `Box<dyn Trait<isize>>`
 

--- a/tests/ui/traits/fn-pointer/bare-fn-no-impl-fn-ptr-99875.stderr
+++ b/tests/ui/traits/fn-pointer/bare-fn-no-impl-fn-ptr-99875.stderr
@@ -20,10 +20,11 @@ error[E0277]: the trait bound `{closure@$DIR/bare-fn-no-impl-fn-ptr-99875.rs:14:
   --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:14:11
    |
 LL |     takes(|_: Argument| -> Return { todo!() });
-   |     ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for closure `{closure@$DIR/bare-fn-no-impl-fn-ptr-99875.rs:14:11: 14:34}`
+   |     ----- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+   = help: the trait `Trait` is not implemented for closure `{closure@$DIR/bare-fn-no-impl-fn-ptr-99875.rs:14:11: 14:34}`
    = help: the trait `Trait` is implemented for fn pointer `fn(Argument) -> Return`
 note: required by a bound in `takes`
   --> $DIR/bare-fn-no-impl-fn-ptr-99875.rs:9:18

--- a/tests/ui/traits/negative-bounds/on-unimplemented.stderr
+++ b/tests/ui/traits/negative-bounds/on-unimplemented.stderr
@@ -6,12 +6,6 @@ LL | fn hello() -> impl !Foo {
 LL |
 LL |     NotFoo
    |     ------ return type was inferred to be `NotFoo` here
-   |
-help: this trait has no implementations, consider adding one
-  --> $DIR/on-unimplemented.rs:4:1
-   |
-LL | trait Foo {}
-   | ^^^^^^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/negative-bounds/simple.stderr
+++ b/tests/ui/traits/negative-bounds/simple.stderr
@@ -28,7 +28,8 @@ error[E0277]: the trait bound `Copyable: !Copy` is not satisfied
 LL |     not_copy::<Copyable>();
    |                ^^^^^^^^ the trait bound `Copyable: !Copy` is not satisfied
    |
-   = help: the trait `Copy` is implemented for `Copyable`
+   = help: the trait `Copy` is not implemented for `Copyable`
+           but trait `Copy` is implemented for it
 note: required by a bound in `not_copy`
   --> $DIR/simple.rs:3:16
    |

--- a/tests/ui/traits/negative-bounds/simple.stderr
+++ b/tests/ui/traits/negative-bounds/simple.stderr
@@ -28,18 +28,11 @@ error[E0277]: the trait bound `Copyable: !Copy` is not satisfied
 LL |     not_copy::<Copyable>();
    |                ^^^^^^^^ the trait bound `Copyable: !Copy` is not satisfied
    |
-   = help: the trait `Copy` is not implemented for `Copyable`
-           but trait `Copy` is implemented for it
 note: required by a bound in `not_copy`
   --> $DIR/simple.rs:3:16
    |
 LL | fn not_copy<T: !Copy>() {}
    |                ^^^^^ required by this bound in `not_copy`
-help: consider annotating `Copyable` with `#[derive(Copy)]`
-   |
-LL + #[derive(Copy)]
-LL | struct Copyable;
-   |
 
 error[E0277]: the trait bound `NotNecessarilyCopyable: !Copy` is not satisfied
   --> $DIR/simple.rs:37:16
@@ -52,11 +45,6 @@ note: required by a bound in `not_copy`
    |
 LL | fn not_copy<T: !Copy>() {}
    |                ^^^^^ required by this bound in `not_copy`
-help: consider annotating `NotNecessarilyCopyable` with `#[derive(Copy)]`
-   |
-LL + #[derive(Copy)]
-LL | struct NotNecessarilyCopyable;
-   |
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/transmutability/assoc-bound.stderr
+++ b/tests/ui/transmutability/assoc-bound.stderr
@@ -2,8 +2,9 @@ error[E0277]: the trait bound `<T as A>::AssocA: TransmuteFrom<(), Assume { alig
   --> $DIR/assoc-bound.rs:16:19
    |
 LL |     type AssocB = T::AssocA;
-   |                   ^^^^^^^^^ the trait `TransmuteFrom<(), Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `<T as A>::AssocA`
+   |                   ^^^^^^^^^ unsatisfied trait bound
    |
+   = help: the trait `TransmuteFrom<(), Assume { alignment: false, lifetimes: false, safety: false, validity: false }>` is not implemented for `<T as A>::AssocA`
 note: required by a bound in `B::AssocB`
   --> $DIR/assoc-bound.rs:9:18
    |

--- a/tests/ui/try-block/try-block-bad-type.stderr
+++ b/tests/ui/try-block/try-block-bad-type.stderr
@@ -7,7 +7,8 @@ LL |         Err("")?;
    |         this can't be annotated with `?` because it has type `Result<_, &str>`
    |
    = note: the question mark operation (`?`) implicitly performs a conversion on the error value using the `From` trait
-   = help: the trait `From<Infallible>` is implemented for `TryFromSliceError`
+   = help: the trait `From<&str>` is not implemented for `TryFromSliceError`
+           but trait `From<Infallible>` is implemented for it
    = help: for that trait implementation, expected `Infallible`, found `&str`
    = note: required for `Result<u32, TryFromSliceError>` to implement `FromResidual<Result<Infallible, &str>>`
 

--- a/tests/ui/try-trait/bad-interconversion.stderr
+++ b/tests/ui/try-trait/bad-interconversion.stderr
@@ -67,7 +67,6 @@ LL |     ControlFlow::Continue(Err("hello")?)
    |                                       ^ this `?` produces `Result<Infallible, &str>`, which is incompatible with `ControlFlow<String>`
    |
    = help: the trait `FromResidual<Result<Infallible, &str>>` is not implemented for `ControlFlow<String>`
-   = help: the trait `FromResidual<Result<Infallible, &str>>` is not implemented for `ControlFlow<String>`
            but trait `FromResidual<ControlFlow<String, Infallible>>` is implemented for it
    = help: for that trait implementation, expected `ControlFlow<String, Infallible>`, found `Result<Infallible, &str>`
 
@@ -80,7 +79,6 @@ LL |     Some(3)?;
    |            ^ this `?` produces `Option<Infallible>`, which is incompatible with `ControlFlow<u64>`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `ControlFlow<u64>`
-   = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `ControlFlow<u64>`
            but trait `FromResidual<ControlFlow<u64, Infallible>>` is implemented for it
    = help: for that trait implementation, expected `ControlFlow<u64, Infallible>`, found `Option<Infallible>`
 
@@ -92,7 +90,6 @@ LL | fn control_flow_to_control_flow() -> ControlFlow<i64> {
 LL |     ControlFlow::Break(4_u8)?;
    |                             ^ this `?` produces `ControlFlow<u8, Infallible>`, which is incompatible with `ControlFlow<i64>`
    |
-   = help: the trait `FromResidual<ControlFlow<u8, Infallible>>` is not implemented for `ControlFlow<i64>`
    = note: unlike `Result`, there's no `From`-conversion performed for `ControlFlow`
    = help: the trait `FromResidual<ControlFlow<u8, _>>` is not implemented for `ControlFlow<i64>`
            but trait `FromResidual<ControlFlow<i64, _>>` is implemented for it

--- a/tests/ui/try-trait/bad-interconversion.stderr
+++ b/tests/ui/try-trait/bad-interconversion.stderr
@@ -67,7 +67,8 @@ LL |     ControlFlow::Continue(Err("hello")?)
    |                                       ^ this `?` produces `Result<Infallible, &str>`, which is incompatible with `ControlFlow<String>`
    |
    = help: the trait `FromResidual<Result<Infallible, &str>>` is not implemented for `ControlFlow<String>`
-   = help: the trait `FromResidual<ControlFlow<String, Infallible>>` is implemented for `ControlFlow<String>`
+   = help: the trait `FromResidual<Result<Infallible, &str>>` is not implemented for `ControlFlow<String>`
+           but trait `FromResidual<ControlFlow<String, Infallible>>` is implemented for it
    = help: for that trait implementation, expected `ControlFlow<String, Infallible>`, found `Result<Infallible, &str>`
 
 error[E0277]: the `?` operator can only be used on `ControlFlow`s in a function that returns `ControlFlow`
@@ -79,7 +80,8 @@ LL |     Some(3)?;
    |            ^ this `?` produces `Option<Infallible>`, which is incompatible with `ControlFlow<u64>`
    |
    = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `ControlFlow<u64>`
-   = help: the trait `FromResidual<ControlFlow<u64, Infallible>>` is implemented for `ControlFlow<u64>`
+   = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `ControlFlow<u64>`
+           but trait `FromResidual<ControlFlow<u64, Infallible>>` is implemented for it
    = help: for that trait implementation, expected `ControlFlow<u64, Infallible>`, found `Option<Infallible>`
 
 error[E0277]: the `?` operator in a function that returns `ControlFlow<B, _>` can only be used on other `ControlFlow<B, _>`s (with the same Break type)
@@ -92,7 +94,8 @@ LL |     ControlFlow::Break(4_u8)?;
    |
    = help: the trait `FromResidual<ControlFlow<u8, Infallible>>` is not implemented for `ControlFlow<i64>`
    = note: unlike `Result`, there's no `From`-conversion performed for `ControlFlow`
-   = help: the trait `FromResidual<ControlFlow<i64, Infallible>>` is implemented for `ControlFlow<i64>`
+   = help: the trait `FromResidual<ControlFlow<u8, _>>` is not implemented for `ControlFlow<i64>`
+           but trait `FromResidual<ControlFlow<i64, _>>` is implemented for it
    = help: for that trait implementation, expected `i64`, found `u8`
 
 error: aborting due to 8 previous errors

--- a/tests/ui/type-alias-impl-trait/constrain_in_projection.current.stderr
+++ b/tests/ui/type-alias-impl-trait/constrain_in_projection.current.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `Foo: Trait<Bar>` is not satisfied
 LL |     let x = <Foo as Trait<Bar>>::Assoc::default();
    |              ^^^ the trait `Trait<Bar>` is not implemented for `Foo`
    |
-   = help: the trait `Trait<()>` is implemented for `Foo`
+   = help: the trait `Trait<Bar>` is not implemented for `Foo`
+           but trait `Trait<()>` is implemented for it
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/fallback.stderr
+++ b/tests/ui/type-alias-impl-trait/fallback.stderr
@@ -4,7 +4,10 @@ error[E0283]: type annotations needed
 LL | fn unconstrained_foo() -> Wrapper<Foo> {
    |                           ------------ type must be known at this point
 LL |     Wrapper::Second
-   |     ^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the enum `Wrapper`
+   |     ^^^^^^^^^^^^^^^
+   |     |
+   |     cannot infer type of the type parameter `T` declared on the enum `Wrapper`
+   |     return type was inferred to be `Wrapper<_>` here
    |
    = note: cannot satisfy `_: Copy`
 help: consider specifying the generic argument

--- a/tests/ui/type-alias-impl-trait/nested-tait-inference.current.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-tait-inference.current.stderr
@@ -7,7 +7,8 @@ LL | fn foo() -> impl Foo<FooX> {
 LL |     ()
    |     -- return type was inferred to be `()` here
    |
-   = help: the trait `Foo<()>` is implemented for `()`
+   = help: the trait `Foo<FooX>` is not implemented for `()`
+           but trait `Foo<()>` is implemented for it
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/non-lifetime-binder-in-constraint.stderr
+++ b/tests/ui/type-alias-impl-trait/non-lifetime-binder-in-constraint.stderr
@@ -17,6 +17,9 @@ error[E0277]: the trait bound `{integer}: Trait<()>` is not satisfied
    |
 LL | fn produce() -> impl for<T> Trait<(), Assoc = impl Trait<T>> {
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait<()>` is not implemented for `{integer}`
+...
+LL |     16
+   |     -- return type was inferred to be `{integer}` here
    |
 help: this trait has no implementations, consider adding one
   --> $DIR/non-lifetime-binder-in-constraint.rs:4:1

--- a/tests/ui/type-alias-impl-trait/self-referential-2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-2.current.stderr
@@ -7,7 +7,6 @@ LL |     42_i32
    |     ------ return type was inferred to be `i32` here
    |
    = help: the trait `PartialEq<Foo>` is not implemented for `i32`
-   = help: the trait `PartialEq<Foo>` is not implemented for `i32`
            but trait `PartialEq<i32>` is implemented for it
 
 error: aborting due to 1 previous error

--- a/tests/ui/type-alias-impl-trait/self-referential-2.current.stderr
+++ b/tests/ui/type-alias-impl-trait/self-referential-2.current.stderr
@@ -7,7 +7,8 @@ LL |     42_i32
    |     ------ return type was inferred to be `i32` here
    |
    = help: the trait `PartialEq<Foo>` is not implemented for `i32`
-   = help: the trait `PartialEq` is implemented for `i32`
+   = help: the trait `PartialEq<Foo>` is not implemented for `i32`
+           but trait `PartialEq<i32>` is implemented for it
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/suggest-similar-impls-for-root-obligation.stderr
+++ b/tests/ui/typeck/suggest-similar-impls-for-root-obligation.stderr
@@ -4,7 +4,8 @@ error[E0277]: the trait bound `((),): Into<Bar>` is not satisfied
 LL |     let _: Bar = ((),).into();
    |                        ^^^^ the trait `Foo<'_>` is not implemented for `((),)`
    |
-   = help: the trait `Foo<'_>` is implemented for `()`
+   = help: the trait `Foo<'_>` is not implemented for `((),)`
+           but it is implemented for `()`
    = help: for that trait implementation, expected `()`, found `((),)`
 note: required for `Bar` to implement `From<((),)>`
   --> $DIR/suggest-similar-impls-for-root-obligation.rs:7:22

--- a/tests/ui/where-clauses/higher-ranked-fn-type.verbose.stderr
+++ b/tests/ui/where-clauses/higher-ranked-fn-type.verbose.stderr
@@ -2,8 +2,9 @@ error[E0277]: the trait bound `for<Region(BrNamed(DefId(0:6 ~ higher_ranked_fn_t
   --> $DIR/higher-ranked-fn-type.rs:20:5
    |
 LL |     called()
-   |     ^^^^^^^^ the trait `for<Region(BrNamed(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b), 'b))> Foo` is not implemented for `fn(&'^1_0.Named(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b), "'b") ())`
+   |     ^^^^^^^^ unsatisfied trait bound
    |
+   = help: the trait `for<Region(BrNamed(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b), 'b))> Foo` is not implemented for `fn(&'^1_0.Named(DefId(0:6 ~ higher_ranked_fn_type[9e51]::called::'b), "'b") ())`
 help: this trait has no implementations, consider adding one
   --> $DIR/higher-ranked-fn-type.rs:6:1
    |


### PR DESCRIPTION
Successful merges:

 - #131037 (Move versioned Apple LLVM targets from `rustc_target` to `rustc_codegen_ssa`)
 - #132147 (Tweak E0277 output when a candidate is available)
 - #132398 (Add a couple of intra-doc links to str)
 - #132453 (Also treat `impl` definition parent as transparent regarding modules)
 - #132457 (Remove needless #![feature(asm_experimental_arch)] from loongarch64 inline assembly test)
 - #132465 (refactor(config): remove FIXME statement in comment of `omit-git-hash`)
 - #132471 (Add a bunch of mailmap entries)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131037,132147,132398,132453,132457,132465,132471)
<!-- homu-ignore:end -->