### PR TITLE
Allow specifying the ELF TLS ABI

### DIFF
--- a/compiler/rustc_codegen_llvm/src/back/owned_target_machine.rs
+++ b/compiler/rustc_codegen_llvm/src/back/owned_target_machine.rs
@@ -39,6 +39,7 @@ impl OwnedTargetMachine {
         output_obj_file: &CStr,
         debug_info_compression: &CStr,
         use_emulated_tls: bool,
+        enable_tlsdesc: bool,
         args_cstr_buff: &[u8],
     ) -> Result<Self, LlvmError<'static>> {
         assert!(args_cstr_buff.len() > 0);
@@ -71,6 +72,7 @@ impl OwnedTargetMachine {
                 output_obj_file.as_ptr(),
                 debug_info_compression.as_ptr(),
                 use_emulated_tls,
+                enable_tlsdesc,
                 args_cstr_buff.as_ptr() as *const c_char,
                 args_cstr_buff.len(),
             )

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -26,7 +26,7 @@ use rustc_session::config::{
 };
 use rustc_span::InnerSpan;
 use rustc_span::symbol::sym;
-use rustc_target::spec::{CodeModel, RelocModel, SanitizerSet, SplitDebuginfo, TlsModel};
+use rustc_target::spec::{CodeModel, RelocModel, SanitizerSet, SplitDebuginfo, TlsDialect, TlsModel};
 use tracing::debug;
 
 use crate::back::lto::ThinBuffer;
@@ -230,6 +230,8 @@ pub(crate) fn target_machine_factory(
 
     let use_emulated_tls = matches!(sess.tls_model(), TlsModel::Emulated);
 
+    let enable_tlsdesc = matches!(sess.tls_dialect(), TlsDialect::Desc);
+
     // copy the exe path, followed by path all into one buffer
     // null terminating them so we can use them as null terminated strings
     let args_cstr_buff = {
@@ -302,6 +304,7 @@ pub(crate) fn target_machine_factory(
             &output_obj_file,
             &debuginfo_compression,
             use_emulated_tls,
+            enable_tlsdesc,
             &args_cstr_buff,
         )
     })

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -310,6 +310,17 @@ impl CodegenBackend for LlvmCodegenBackend {
                 }
                 writeln!(out).unwrap();
             }
+            PrintKind::TlsDialect => {
+                writeln!(out, "Available TLS dialects:").unwrap();
+                for name in
+                    &["trad", "desc"]
+                {
+                    writeln!(out, "    {name}").unwrap();
+                }
+                writeln!(out).unwrap();
+            }
+
+
             PrintKind::StackProtectorStrategies => {
                 writeln!(
                     out,

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2230,6 +2230,7 @@ unsafe extern "C" {
         OutputObjFile: *const c_char,
         DebugInfoCompression: *const c_char,
         UseEmulatedTls: bool,
+        EnableTlsDesc: bool,
         ArgsCstrBuff: *const c_char,
         ArgsCstrBuffLen: usize,
     ) -> *mut TargetMachine;

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -837,6 +837,7 @@ fn print_crate_info(
             RelocationModels
             | CodeModels
             | TlsModels
+            | TlsDialect
             | TargetCPUs
             | StackProtectorStrategies
             | TargetFeatures => {

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -397,7 +397,7 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
     bool TrapUnreachable, bool Singlethread, bool VerboseAsm,
     bool EmitStackSizeSection, bool RelaxELFRelocations, bool UseInitArray,
     const char *SplitDwarfFile, const char *OutputObjFile,
-    const char *DebugInfoCompression, bool UseEmulatedTls,
+    const char *DebugInfoCompression, bool UseEmulatedTls, bool EnableTLSDESC,
     const char *ArgsCstrBuff, size_t ArgsCstrBuffLen) {
 
   auto OptLevel = fromRust(RustOptLevel);
@@ -456,6 +456,7 @@ extern "C" LLVMTargetMachineRef LLVMRustCreateTargetMachine(
 
 #if LLVM_VERSION_GE(19, 0)
   Options.MCOptions.X86RelaxRelocations = RelaxELFRelocations;
+  Options.EnableTLSDESC = EnableTLSDESC;
 #else
   Options.RelaxELFRelocations = RelaxELFRelocations;
 #endif

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -825,6 +825,7 @@ pub enum PrintKind {
     RelocationModels,
     CodeModels,
     TlsModels,
+    TlsDialect,
     TargetSpec,
     AllTargetSpecs,
     NativeStaticLibs,
@@ -1956,6 +1957,7 @@ fn collect_print_requests(
         ("target-libdir", PrintKind::TargetLibdir),
         ("target-list", PrintKind::TargetList),
         ("target-spec-json", PrintKind::TargetSpec),
+        ("tls-dialect", PrintKind::TlsDialect),
         ("tls-models", PrintKind::TlsModels),
         // tidy-alphabetical-end
     ];
@@ -3018,7 +3020,7 @@ pub(crate) mod dep_tracking {
     use rustc_target::spec::{
         CodeModel, FramePointer, MergeFunctions, OnBrokenPipe, PanicStrategy, RelocModel,
         RelroLevel, SanitizerSet, SplitDebuginfo, StackProtector, SymbolVisibility, TargetTriple,
-        TlsModel, WasmCAbi,
+        TlsDialect, TlsModel, WasmCAbi,
     };
 
     use super::{
@@ -3083,6 +3085,7 @@ pub(crate) mod dep_tracking {
         FramePointer,
         RelocModel,
         CodeModel,
+        TlsDialect,
         TlsModel,
         InstrumentCoverage,
         CoverageOptions,

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -14,7 +14,7 @@ use rustc_span::{RealFileName, SourceFileHashAlgorithm};
 use rustc_target::spec::{
     CodeModel, FramePointer, LinkerFlavorCli, MergeFunctions, OnBrokenPipe, PanicStrategy,
     RelocModel, RelroLevel, SanitizerSet, SplitDebuginfo, StackProtector, SymbolVisibility,
-    TargetTriple, TlsModel, WasmCAbi,
+    TargetTriple, TlsDialect, TlsModel, WasmCAbi,
 };
 
 use crate::config::*;
@@ -427,6 +427,8 @@ mod desc {
         "one of supported code models (`rustc --print code-models`)";
     pub(crate) const parse_tls_model: &str =
         "one of supported TLS models (`rustc --print tls-models`)";
+    pub(crate) const parse_tls_dialect: &str =
+        "one of supported TLS dialects (`rustc --print tls-dialect`)";
     pub(crate) const parse_target_feature: &str = parse_string;
     pub(crate) const parse_terminal_url: &str =
         "either a boolean (`yes`, `no`, `on`, `off`, etc), or `auto`";
@@ -1240,6 +1242,13 @@ mod parse {
     pub(crate) fn parse_tls_model(slot: &mut Option<TlsModel>, v: Option<&str>) -> bool {
         match v.and_then(|s| TlsModel::from_str(s).ok()) {
             Some(tls_model) => *slot = Some(tls_model),
+            _ => return false,
+        }
+        true
+    }
+    pub(crate) fn parse_tls_dialect(slot: &mut Option<TlsDialect>, v: Option<&str>) -> bool {
+        match v.and_then(|s| TlsDialect::from_str(s).ok()) {
+            Some(tls_dialect) => *slot = Some(tls_dialect),
             _ => return false,
         }
         true
@@ -2114,6 +2123,9 @@ written to standard error output)"),
     #[rustc_lint_opt_deny_field_access("use `Session::tls_model` instead of this field")]
     tls_model: Option<TlsModel> = (None, parse_tls_model, [TRACKED],
         "choose the TLS model to use (`rustc --print tls-models` for details)"),
+    #[rustc_lint_opt_deny_field_access("use `Session::tls_model` instead of this field")]
+    tls_dialect: Option<TlsDialect> = (None, parse_tls_dialect, [TRACKED],
+        "choose the TLS dialect to use (`rustc --print tls-dialect` for details)"),
     trace_macros: bool = (false, parse_bool, [UNTRACKED],
         "for every macro invocation, print its name and arguments (default: no)"),
     track_diagnostics: bool = (false, parse_bool, [UNTRACKED],

--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -32,7 +32,7 @@ use rustc_target::asm::InlineAsmArch;
 use rustc_target::spec::{
     CodeModel, DebuginfoKind, PanicStrategy, RelocModel, RelroLevel, SanitizerSet,
     SmallDataThresholdSupport, SplitDebuginfo, StackProtector, SymbolVisibility, Target,
-    TargetTriple, TlsModel,
+    TargetTriple, TlsDialect, TlsModel,
 };
 
 use crate::code_stats::CodeStats;
@@ -765,6 +765,10 @@ impl Session {
 
     pub fn tls_model(&self) -> TlsModel {
         self.opts.unstable_opts.tls_model.unwrap_or(self.target.tls_model)
+    }
+
+    pub fn tls_dialect(&self) -> TlsDialect {
+        self.opts.unstable_opts.tls_dialect.unwrap_or(self.target.tls_dialect)
     }
 
     pub fn direct_access_external_data(&self) -> Option<bool> {

--- a/tests/assembly/auxiliary/tlsdesc_aux.rs
+++ b/tests/assembly/auxiliary/tlsdesc_aux.rs
@@ -1,0 +1,8 @@
+#![crate_type = "lib"]
+
+use std::cell::Cell;
+
+thread_local! {
+#[no_mangle]
+pub static A: Cell<u64> = const { Cell::new(0) };
+}

--- a/tests/assembly/tlsdesc.rs
+++ b/tests/assembly/tlsdesc.rs
@@ -1,0 +1,29 @@
+// Verifies that setting the tls-dialect result sin the correct set of assembly
+// instructions.
+//
+// Note: tls-dialect flags have no changes to LLVM IR, and only affect which
+// instruction sequences are emitted by the LLVM backend. Checking the assembly
+// output is how we test the lowering in LLVM, and is the only way a frontend
+// can determine if its code generation flags are set correctly.
+//
+//@ revisions: x64 x64-trad x64-desc
+//
+//@[x64]      compile-flags: --target=x86_64-unknown-linux-gnu
+//@[x64-trad] compile-flags: --target=x86_64-unknown-linux-gnu -Z tls-dialect=trad
+//@[x64-desc] compile-flags: --target=x86_64-unknown-linux-gnu -Z tls-dialect=desc
+//
+//@ assembly-output: emit-asm
+//@ aux-build:tlsdesc_aux.rs
+
+#![crate_type = "lib"]
+
+extern crate tlsdesc_aux as aux;
+
+#[no_mangle]
+fn get_aux() -> u64 {
+    // x64:      __tls_get_addr
+    // x64-trad: __tls_get_addr
+    // x64-desc: tlsdesc
+    // x64-desc: tlscall
+    aux::A.with(|a| a.get())
+}

--- a/tests/ui/invalid-compile-flags/print.stderr
+++ b/tests/ui/invalid-compile-flags/print.stderr
@@ -1,4 +1,4 @@
 error: unknown print request: `yyyy`
   |
-  = help: valid print requests are: `all-target-specs-json`, `calling-conventions`, `cfg`, `check-cfg`, `code-models`, `crate-name`, `deployment-target`, `file-names`, `link-args`, `native-static-libs`, `relocation-models`, `split-debuginfo`, `stack-protector-strategies`, `sysroot`, `target-cpus`, `target-features`, `target-libdir`, `target-list`, `target-spec-json`, `tls-models`
+  = help: valid print requests are: `all-target-specs-json`, `calling-conventions`, `cfg`, `check-cfg`, `code-models`, `crate-name`, `deployment-target`, `file-names`, `link-args`, `native-static-libs`, `relocation-models`, `split-debuginfo`, `stack-protector-strategies`, `sysroot`, `target-cpus`, `target-features`, `target-libdir`, `target-list`, `target-spec-json`, `tls-dialect`, `tls-models`
 


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/132480)*

TLSDESC is an alternate method of TLS access. It is part of the ELF TLS ABI, and is already commonly used in other toolchains. LLVM supports this for most ELF backends (X86_64, Aarch64, RISC-V). It has always been the default for Aarch64, but support for RISC-V and X86_64 were added before the last LLVM release.

More information on TLSDESC can be found in:
https://android.googlesource.com/platform/bionic/+/HEAD/docs/elf-tls.md or the original RFC:
https://www.fsfla.org/~lxoliva/writeups/TLS/RFC-TLSDESC-ARM.txt

This patch adds a new unstable option `-Z tls-dialect`, which matches the common `-mtls-dialect=` option used in Clang, GCC, and other toolchains. This option only needs to be passed through to LLVM to update the code generation. For targets like Aarch64 that always use TLSDESC, this has no effect. Eventually this flag should probably be stabilized since it is an important part of a program's ABI.

In the future, if LLVM changes its defaults for TLS to enable TLSDESC for a particular platform or architecture, users who do not wish to change can use the new option to select their desired TLS ABI.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
