### PR TITLE
unix: Relax escaping in `Debug` impl on `Command`

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -285,6 +285,7 @@
 #![feature(cfg_target_thread_local)]
 #![feature(cfi_encoding)]
 #![feature(concat_idents)]
+#![feature(debug_closure_helpers)]
 #![feature(decl_macro)]
 #![feature(deprecated_suggestion)]
 #![feature(doc_cfg)]

--- a/library/std/src/process/tests.rs
+++ b/library/std/src/process/tests.rs
@@ -552,7 +552,7 @@ fn debug_print() {
 
     let mut command = Command::new("some-boring-name");
 
-    assert_eq!(format!("{command:?}"), format!(r#""some-boring-name""#));
+    assert_eq!(format!("{command:?}"), format!("some-boring-name"));
 
     assert_eq!(
         format!("{command:#?}"),
@@ -568,7 +568,7 @@ fn debug_print() {
 
     command.args(&["1", "2", "3"]);
 
-    assert_eq!(format!("{command:?}"), format!(r#""some-boring-name" "1" "2" "3""#));
+    assert_eq!(format!("{command:?}"), format!("some-boring-name 1 2 3"));
 
     assert_eq!(
         format!("{command:#?}"),
@@ -587,10 +587,7 @@ fn debug_print() {
 
     crate::os::unix::process::CommandExt::arg0(&mut command, "exciting-name");
 
-    assert_eq!(
-        format!("{command:?}"),
-        format!(r#"["some-boring-name"] "exciting-name" "1" "2" "3""#)
-    );
+    assert_eq!(format!("{command:?}"), format!("[some-boring-name] exciting-name 1 2 3"));
 
     assert_eq!(
         format!("{command:#?}"),
@@ -609,10 +606,7 @@ fn debug_print() {
 
     let mut command_with_env_and_cwd = Command::new("boring-name");
     command_with_env_and_cwd.current_dir("/some/path").env("FOO", "bar");
-    assert_eq!(
-        format!("{command_with_env_and_cwd:?}"),
-        r#"cd "/some/path" && FOO="bar" "boring-name""#
-    );
+    assert_eq!(format!("{command_with_env_and_cwd:?}"), "cd /some/path && FOO=bar boring-name");
     assert_eq!(
         format!("{command_with_env_and_cwd:#?}"),
         format!(
@@ -638,7 +632,7 @@ fn debug_print() {
 
     let mut command_with_removed_env = Command::new("boring-name");
     command_with_removed_env.env_remove("FOO").env_remove("BAR");
-    assert_eq!(format!("{command_with_removed_env:?}"), r#"env -u BAR -u FOO "boring-name""#);
+    assert_eq!(format!("{command_with_removed_env:?}"), "env -u BAR -u FOO boring-name");
     assert_eq!(
         format!("{command_with_removed_env:#?}"),
         format!(
@@ -660,7 +654,7 @@ fn debug_print() {
 
     let mut command_with_cleared_env = Command::new("boring-name");
     command_with_cleared_env.env_clear().env("BAR", "val").env_remove("FOO");
-    assert_eq!(format!("{command_with_cleared_env:?}"), r#"env -i BAR="val" "boring-name""#);
+    assert_eq!(format!("{command_with_cleared_env:?}"), "env -i BAR=val boring-name");
     assert_eq!(
         format!("{command_with_cleared_env:#?}"),
         format!(

--- a/tests/run-make/link-args-order/rmake.rs
+++ b/tests/run-make/link-args-order/rmake.rs
@@ -13,17 +13,19 @@ fn main() {
         .linker_flavor(linker)
         .link_arg("a")
         .link_args("b c")
-        .link_args("d e")
-        .link_arg("f")
+        .link_arg("d e")
+        .link_args("f g")
+        .link_arg("h")
         .run_fail()
-        .assert_stderr_contains(r#""a" "b" "c" "d" "e" "f""#);
+        .assert_stderr_contains(r#"a b c "d e" f g h"#);
     rustc()
         .input("empty.rs")
         .linker_flavor(linker)
         .arg("-Zpre-link-arg=a")
         .arg("-Zpre-link-args=b c")
-        .arg("-Zpre-link-args=d e")
-        .arg("-Zpre-link-arg=f")
+        .arg("-Zpre-link-arg=d e")
+        .arg("-Zpre-link-args=f g")
+        .arg("-Zpre-link-arg=h")
         .run_fail()
-        .assert_stderr_contains(r#""a" "b" "c" "d" "e" "f""#);
+        .assert_stderr_contains(r#"a b c "d e" f g h"#);
 }

--- a/tests/run-make/link-dedup/rmake.rs
+++ b/tests/run-make/link-dedup/rmake.rs
@@ -31,9 +31,9 @@ fn needle_from_libs(libs: &[&str]) -> String {
     let mut needle = String::new();
     for lib in libs {
         if is_msvc() {
-            let _ = needle.write_fmt(format_args!(r#""{lib}.lib" "#));
+            let _ = needle.write_fmt(format_args!("{lib}.lib "));
         } else {
-            let _ = needle.write_fmt(format_args!(r#""-l{lib}" "#));
+            let _ = needle.write_fmt(format_args!("-l{lib} "));
         }
     }
     needle.pop(); // remove trailing space

--- a/tests/run-make/pass-linker-flags-flavor/rmake.rs
+++ b/tests/run-make/pass-linker-flags-flavor/rmake.rs
@@ -72,8 +72,8 @@ fn main() {
         .stdout_utf8();
 
     let no_verbatim = regex::Regex::new("l1.*-Wl,a1.*l2.*-Wl,a2.*d1.*-Wl,a3").unwrap();
-    let one_verbatim = regex::Regex::new(r#"l1.*"a1".*l2.*-Wl,a2.*d1.*-Wl,a3"#).unwrap();
-    let ld = regex::Regex::new(r#"l1.*"a1".*l2.*"a2".*d1.*"a3""#).unwrap();
+    let one_verbatim = regex::Regex::new("l1.*a1.*l2.*-Wl,a2.*d1.*-Wl,a3").unwrap();
+    let ld = regex::Regex::new("l1.*a1.*l2.*a2.*d1.*a3").unwrap();
 
     assert!(no_verbatim.is_match(&out_gnu));
     assert!(no_verbatim.is_match(&out_att_gnu));


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/132484)*
<!-- homu-ignore:end -->

The `Debug` output of `Command` is very useful for showing to the user the command that was executed when something went wrong. This is done for example by `rustc` when invoking an external tool like the linker fails.

It is also overly verbose, since everything is quoted, which makes it harder to read. Instead, we now first check if we're reasonably sure that an argument is simple enough that using it in the shell wouldn't need quoting, and then output it without quotes if possible.

An example of output before could look like this:

    PATH="/a:/b" "cc" "foo.o" "-target" "arm64-apple-darwin11.0" "some path with spaces"

Now it looks like this:

    PATH=/a:/b cc foo.o -target arm64-apple-darwin11.0 "some path with spaces"

This is naturally a behavioural change, but I believe it's allowed by [the docs](https://doc.rust-lang.org/std/process/struct.Command.html#impl-Debug-for-Command).

r? libs