### PR TITLE
Provide placeholder generics for traits in "no method found for type parameter" suggestions

### DIFF
--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(array_windows)]
 #![feature(box_patterns)]
 #![feature(if_let_guard)]
+#![feature(iter_intersperse)]
 #![feature(let_chains)]
 #![feature(never_type)]
 #![feature(try_blocks)]

--- a/tests/ui/suggestions/no-method-found-suggest-trait-args.rs
+++ b/tests/ui/suggestions/no-method-found-suggest-trait-args.rs
@@ -1,0 +1,30 @@
+/// Tests that suggestions to add trait bounds that would enable using a method include appropriate
+/// placeholder arguments for that trait.
+
+trait Trait<I> {
+    fn method(&self) {}
+}
+
+trait Trait2<'a, A, const B: u8, C = (), const D: u8 = 0> {
+    fn method2(&self) {}
+}
+
+fn foo<T>(value: T) {
+    //~^ SUGGESTION : Trait</* I */>
+    //~| SUGGESTION : Trait2</* 'a, A, B */>
+    value.method();
+    //~^ ERROR no method named `method` found for type parameter `T` in the current scope [E0599]
+    value.method2();
+    //~^ ERROR no method named `method2` found for type parameter `T` in the current scope [E0599]
+}
+
+fn bar(value: impl Copy) {
+    //~^ SUGGESTION + Trait</* I */>
+    //~| SUGGESTION + Trait2</* 'a, A, B */>
+    value.method();
+    //~^ ERROR no method named `method` found for type parameter `impl Copy` in the current scope [E0599]
+    value.method2();
+    //~^ ERROR no method named `method2` found for type parameter `impl Copy` in the current scope [E0599]
+}
+
+fn main() {}

--- a/tests/ui/suggestions/no-method-found-suggest-trait-args.stderr
+++ b/tests/ui/suggestions/no-method-found-suggest-trait-args.stderr
@@ -1,0 +1,63 @@
+error[E0599]: no method named `method` found for type parameter `T` in the current scope
+  --> $DIR/no-method-found-suggest-trait-args.rs:15:11
+   |
+LL | fn foo<T>(value: T) {
+   |        - method `method` not found for this type parameter
+...
+LL |     value.method();
+   |           ^^^^^^ method not found in `T`
+   |
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `method`, perhaps you need to restrict type parameter `T` with it:
+   |
+LL | fn foo<T: Trait</* I */>>(value: T) {
+   |         ++++++++++++++++
+
+error[E0599]: no method named `method2` found for type parameter `T` in the current scope
+  --> $DIR/no-method-found-suggest-trait-args.rs:17:11
+   |
+LL | fn foo<T>(value: T) {
+   |        - method `method2` not found for this type parameter
+...
+LL |     value.method2();
+   |           ^^^^^^^ method not found in `T`
+   |
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `method2`, perhaps you need to restrict type parameter `T` with it:
+   |
+LL | fn foo<T: Trait2</* 'a, A, B */>>(value: T) {
+   |         ++++++++++++++++++++++++
+
+error[E0599]: no method named `method` found for type parameter `impl Copy` in the current scope
+  --> $DIR/no-method-found-suggest-trait-args.rs:24:11
+   |
+LL | fn bar(value: impl Copy) {
+   |               --------- method `method` not found for this type parameter
+...
+LL |     value.method();
+   |           ^^^^^^ method not found in `impl Copy`
+   |
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `method`, perhaps you need to restrict type parameter `impl Copy` with it:
+   |
+LL | fn bar(value: impl Copy + Trait</* I */>) {
+   |                         ++++++++++++++++
+
+error[E0599]: no method named `method2` found for type parameter `impl Copy` in the current scope
+  --> $DIR/no-method-found-suggest-trait-args.rs:26:11
+   |
+LL | fn bar(value: impl Copy) {
+   |               --------- method `method2` not found for this type parameter
+...
+LL |     value.method2();
+   |           ^^^^^^^ method not found in `impl Copy`
+   |
+   = help: items from traits can only be used if the type parameter is bounded by the trait
+help: the following trait defines an item `method2`, perhaps you need to restrict type parameter `impl Copy` with it:
+   |
+LL | fn bar(value: impl Copy + Trait2</* 'a, A, B */>) {
+   |                         ++++++++++++++++++++++++
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
In the diagnostics for the error ``no method named `method` found for type parameter `T` in the current scope [E0599]``, the compiler will suggest adding bounds on `T` for traits that define a method named `method`. However, these suggestions didn't include any generic arguments, so applying them would result in a `missing generics for trait` or `missing lifetime specifier` error. This PR adds placeholder arguments to the suggestion in such cases. Specifically, I tried to base the placeholders off of what's done in suggestions for when generics are missing or too few are provided:
- The placeholder for a parameter without a default is the name of the parameter.
- Placeholders are not provided for parameters with defaults.

Placeholder arguments are enclosed in `/*` and `*/`, and the applicability of the suggestion is downgraded to `Applicability::HasPlaceholders` if any placeholders are provided.

Fixes #132407
