### PR TITLE
make `download-rustc="if-unchanged"` default for library profile

### DIFF
--- a/src/bootstrap/defaults/config.library.toml
+++ b/src/bootstrap/defaults/config.library.toml
@@ -8,6 +8,9 @@ bench-stage = 0
 [rust]
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
+# Download rustc from CI instead of building it from source.
+# For stage > 1 builds, this cuts compile times significantly when there are no changes on "compiler" tree.
+download-rustc = "if-unchanged"
 # Make the compiler and standard library faster to build, at the expense of a ~20% runtime slowdown.
 lto = "off"
 

--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -4,7 +4,7 @@
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
 # Download rustc from CI instead of building it from source.
-# This cuts compile times by almost 60x, but means you can't modify the compiler.
+# For stage > 1 builds, this cuts compile times significantly when there are no changes on "compiler" tree.
 # Using these defaults will download the stage2 compiler (see `download-rustc`
 # setting) and the stage2 toolchain should therefore be used for these defaults.
 download-rustc = "if-unchanged"

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -290,4 +290,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "New option `llvm.offload` to control whether the llvm offload runtime for GPU support is built. Implicitly enables the openmp runtime as dependency.",
     },
+    ChangeInfo {
+        change_id: 132494,
+        severity: ChangeSeverity::Info,
+        summary: "`download-rustc='if-unchanged'` is now a default option for library profile.",
+    },
 ];


### PR DESCRIPTION
Since `download-rustc` is tested on CI and https://github.com/rust-lang/rust/pull/132267 makes it effective for library development, we can now make it default for the library profile.

Implements the 3rd item from [this tracking issue](https://github.com/rust-lang/rust/issues/131744).