### PR TITLE
Remove unintended link

### DIFF
--- a/library/std/src/sys/thread_local/guard/windows.rs
+++ b/library/std/src/sys/thread_local/guard/windows.rs
@@ -26,7 +26,7 @@
 //! This apparently translates to any callbacks in the ".CRT$XLB" section
 //! being run on certain events.
 //!
-//! So after all that, we use the compiler's #[link_section] feature to place
+//! So after all that, we use the compiler's `#[link_section]` feature to place
 //! a callback pointer into the magic section so it ends up being called.
 //!
 //! # What's up with this callback?


### PR DESCRIPTION
Since `#[link_section]` is enclosed in braces, it was being confused with a link during docs compilation.

This caused compilation to fail when running `x dist` since it emitted a warning regarding broken links.