### PR TITLE
Suggest fixing typos and let bindings at the same time

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -894,10 +894,13 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
 
             // If the trait has a single item (which wasn't matched by the algorithm), suggest it
             let suggestion = self.get_single_associated_item(path, &source, is_expected);
-            if !self.r.add_typo_suggestion(err, suggestion, ident_span) {
-                fallback = !self.let_binding_suggestion(err, ident_span);
-            }
+            self.r.add_typo_suggestion(err, suggestion, ident_span);
         }
+
+        if self.let_binding_suggestion(err, ident_span) {
+            fallback = false;
+        }
+
         fallback
     }
 

--- a/tests/ui/error-festival.stderr
+++ b/tests/ui/error-festival.stderr
@@ -2,7 +2,16 @@ error[E0425]: cannot find value `y` in this scope
   --> $DIR/error-festival.rs:14:5
    |
 LL |     y = 2;
-   |     ^ help: a local variable with a similar name exists: `x`
+   |     ^
+   |
+help: a local variable with a similar name exists
+   |
+LL |     x = 2;
+   |     ~
+help: you might have meant to introduce a new binding
+   |
+LL |     let y = 2;
+   |     +++
 
 error[E0603]: constant `FOO` is private
   --> $DIR/error-festival.rs:22:10

--- a/tests/ui/suggestions/suggest-let-and-typo-issue-132483.rs
+++ b/tests/ui/suggestions/suggest-let-and-typo-issue-132483.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let x1 = 0;
+    x2 = 1;
+    //~^ ERROR E0425
+    other_val = 2;
+    //~^ ERROR E0425
+}

--- a/tests/ui/suggestions/suggest-let-and-typo-issue-132483.stderr
+++ b/tests/ui/suggestions/suggest-let-and-typo-issue-132483.stderr
@@ -1,0 +1,29 @@
+error[E0425]: cannot find value `x2` in this scope
+  --> $DIR/suggest-let-and-typo-issue-132483.rs:3:5
+   |
+LL |     x2 = 1;
+   |     ^^
+   |
+help: a local variable with a similar name exists
+   |
+LL |     x1 = 1;
+   |     ~~
+help: you might have meant to introduce a new binding
+   |
+LL |     let x2 = 1;
+   |     +++
+
+error[E0425]: cannot find value `other_val` in this scope
+  --> $DIR/suggest-let-and-typo-issue-132483.rs:5:5
+   |
+LL |     other_val = 2;
+   |     ^^^^^^^^^
+   |
+help: you might have meant to introduce a new binding
+   |
+LL |     let other_val = 2;
+   |     +++
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0425`.


### PR DESCRIPTION
Fixes #132483

Currently, a suggestion for adding a let binding won't be shown if we suggest fixing a typo. This changes that behavior to always show both, if possible. Essentially, this turns the suggestion from
```rust
error[E0425]: cannot find value `x2` in this scope
 --> src/main.rs:4:5
  |
4 |     x2 = 2;
  |     ^^ help: a local variable with a similar name exists: `x1`

For more information about this error, try `rustc --explain E0425`.
```

to
```rust
error[E0425]: cannot find value `x2` in this scope
 --> src/main.rs:4:5
  |
4 |     x2 = 2;
  |     ^^
  |
help: a local variable with a similar name exists
  |
4 |     x1 = 2;
  |     ~~
help: you might have meant to introduce a new binding
  |
4 |     let x2 = 2;
  |     +++

For more information about this error, try `rustc --explain E0425`.
```

for the following code:
```rust
fn main() {
    let x1 = 1;
    x2 = 2;
}
```

The original behavior only shows the suggestion for a let binding if a typo suggestion wasn't already displayed. However, this falls apart in the cases like the one above where we have multiple similar variables. I don't think it makes sense to hide this suggestion if there's a similar variable, since that defeats the purpose of this suggestion in that case (it's meant to help those coming from languages like Python).