### PR TITLE
make char::is_whitespace unstably const

### DIFF
--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -320,7 +320,7 @@ impl char {
     /// '1'.is_digit(37);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
-    #[rustc_const_unstable(feature = "const_char_is_digit", issue = "132241")]
+    #[rustc_const_unstable(feature = "const_char_classify", issue = "132241")]
     #[inline]
     pub const fn is_digit(self, radix: u32) -> bool {
         self.to_digit(radix).is_some()
@@ -856,8 +856,9 @@ impl char {
     /// ```
     #[must_use]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[rustc_const_unstable(feature = "const_char_classify", issue = "132241")]
     #[inline]
-    pub fn is_whitespace(self) -> bool {
+    pub const fn is_whitespace(self) -> bool {
         match self {
             ' ' | '\x09'..='\x0d' => true,
             c => c > '\x7f' && unicode::White_Space(c),

--- a/library/core/src/unicode/unicode_data.rs
+++ b/library/core/src/unicode/unicode_data.rs
@@ -575,7 +575,7 @@ pub mod white_space {
         0, 0, 0, 0, 0, 0, 0, 0, 0,
     ];
     #[inline]
-    pub fn lookup(c: char) -> bool {
+    pub const fn lookup(c: char) -> bool {
         match c as u32 >> 8 {
             0 => WHITESPACE_MAP[c as usize & 0xff] & 1 != 0,
             22 => c as u32 == 0x1680,

--- a/src/tools/unicode-table-generator/src/cascading_map.rs
+++ b/src/tools/unicode-table-generator/src/cascading_map.rs
@@ -65,7 +65,7 @@ impl RawEmitter {
         self.bytes_used += 256;
 
         writeln!(&mut self.file, "#[inline]").unwrap();
-        writeln!(&mut self.file, "pub fn lookup(c: char) -> bool {{").unwrap();
+        writeln!(&mut self.file, "pub const fn lookup(c: char) -> bool {{").unwrap();
         writeln!(&mut self.file, "    match c as u32 >> 8 {{").unwrap();
         for arm in arms {
             writeln!(&mut self.file, "        {},", arm).unwrap();


### PR DESCRIPTION
I am adding this to the existing https://github.com/rust-lang/rust/issues/132241 feature gate, since `is_digit` and `is_whitespace` seem similar enough that one can group them together.