### PR TITLE
better test for const HashMap; remove const_hash leftovers

### DIFF
--- a/library/core/src/hash/sip.rs
+++ b/library/core/src/hash/sip.rs
@@ -147,9 +147,8 @@ impl SipHasher {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
-    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     #[must_use]
-    pub const fn new() -> SipHasher {
+    pub fn new() -> SipHasher {
         SipHasher::new_with_keys(0, 0)
     }
 
@@ -157,9 +156,8 @@ impl SipHasher {
     #[inline]
     #[stable(feature = "rust1", since = "1.0.0")]
     #[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
-    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     #[must_use]
-    pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher {
+    pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher {
         SipHasher(SipHasher24 { hasher: Hasher::new_with_keys(key0, key1) })
     }
 }
@@ -169,8 +167,7 @@ impl SipHasher13 {
     #[inline]
     #[unstable(feature = "hashmap_internals", issue = "none")]
     #[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
-    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
-    pub const fn new() -> SipHasher13 {
+    pub fn new() -> SipHasher13 {
         SipHasher13::new_with_keys(0, 0)
     }
 
@@ -178,8 +175,7 @@ impl SipHasher13 {
     #[inline]
     #[unstable(feature = "hashmap_internals", issue = "none")]
     #[deprecated(since = "1.13.0", note = "use `std::hash::DefaultHasher` instead")]
-    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
-    pub const fn new_with_keys(key0: u64, key1: u64) -> SipHasher13 {
+    pub fn new_with_keys(key0: u64, key1: u64) -> SipHasher13 {
         SipHasher13 { hasher: Hasher::new_with_keys(key0, key1) }
     }
 }

--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -122,7 +122,6 @@
 #![feature(const_eval_select)]
 #![feature(const_exact_div)]
 #![feature(const_float_methods)]
-#![feature(const_hash)]
 #![feature(const_heap)]
 #![feature(const_nonnull_new)]
 #![feature(const_num_midpoint)]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -20,7 +20,6 @@
 #![feature(const_bigint_helper_methods)]
 #![feature(const_black_box)]
 #![feature(const_eval_select)]
-#![feature(const_hash)]
 #![feature(const_heap)]
 #![feature(const_nonnull_new)]
 #![feature(const_num_midpoint)]

--- a/library/std/src/hash/random.rs
+++ b/library/std/src/hash/random.rs
@@ -105,9 +105,8 @@ impl DefaultHasher {
     #[stable(feature = "hashmap_default_hasher", since = "1.13.0")]
     #[inline]
     #[allow(deprecated)]
-    #[rustc_const_unstable(feature = "const_hash", issue = "104061")]
     #[must_use]
-    pub const fn new() -> DefaultHasher {
+    pub fn new() -> DefaultHasher {
         DefaultHasher(SipHasher13::new_with_keys(0, 0))
     }
 }

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -328,6 +328,7 @@
 // Library features (core):
 // tidy-alphabetical-start
 #![feature(array_chunks)]
+#![feature(build_hasher_default_const_new)]
 #![feature(c_str_module)]
 #![feature(char_internals)]
 #![feature(clone_to_uninit)]

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -416,7 +416,6 @@
 // Only for const-ness:
 // tidy-alphabetical-start
 #![feature(const_collections_with_hasher)]
-#![feature(const_hash)]
 #![feature(thread_local_internals)]
 // tidy-alphabetical-end
 //


### PR DESCRIPTION
The existing `const_with_hasher` test is kind of silly since the HashMap it constructs can never contain any elements. So this adjusts the test to construct a usable HashMap, which is a bit non-trivial since the default hash builder cannot be built in `const`. `BuildHasherDefault::new()` helps but is unstable (https://github.com/rust-lang/rust/issues/123197), so we also have a test that does not involve that type.

The second commit removes the last remnants of https://github.com/rust-lang/rust/issues/104061, since they aren't actually useful -- without const traits, you can't do any hashing in `const`.

Cc @rust-lang/libs-api @rust-lang/wg-const-eval 
Closes #104061
Related to https://github.com/rust-lang/rust/issues/102575