### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/library/core/src/array/mod.rs
+++ b/library/core/src/array/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! *[See also the array primitive type](array).*
 
-#![stable(feature = "core_array", since = "1.36.0")]
+#![stable(feature = "core_array", since = "1.35.0")]
 
 use crate::borrow::{Borrow, BorrowMut};
 use crate::cmp::Ordering;
@@ -154,10 +154,11 @@ pub const fn from_mut<T>(s: &mut T) -> &mut [T; 1] {
 
 /// The error type returned when a conversion from a slice to an array fails.
 #[stable(feature = "try_from", since = "1.34.0")]
+#[rustc_allowed_through_unstable_modules]
 #[derive(Debug, Copy, Clone)]
 pub struct TryFromSliceError(());
 
-#[stable(feature = "core_array", since = "1.36.0")]
+#[stable(feature = "core_array", since = "1.35.0")]
 impl fmt::Display for TryFromSliceError {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/core/src/char/mod.rs
+++ b/library/core/src/char/mod.rs
@@ -18,7 +18,7 @@
 //! functions that convert various types to `char`.
 
 #![allow(non_snake_case)]
-#![stable(feature = "core_char", since = "1.2.0")]
+#![stable(feature = "rust1", since = "1.0.0")]
 
 mod convert;
 mod decode;

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -481,7 +481,7 @@ pub mod prelude;
 
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use core::any;
-#[stable(feature = "core_array", since = "1.36.0")]
+#[stable(feature = "core_array", since = "1.35.0")]
 pub use core::array;
 #[unstable(feature = "async_iterator", issue = "79024")]
 pub use core::async_iter;

--- a/library/std/src/sys/pal/windows/mod.rs
+++ b/library/std/src/sys/pal/windows/mod.rs
@@ -38,7 +38,7 @@ cfg_if::cfg_if! {
     }
 }
 
-/// Map a Result<T, WinError> to io::Result<T>.
+/// Map a [`Result<T, WinError>`] to [`io::Result<T>`](crate::io::Result<T>).
 trait IoResult<T> {
     fn io_result(self) -> crate::io::Result<T>;
 }

--- a/library/std/src/sys/thread_local/guard/windows.rs
+++ b/library/std/src/sys/thread_local/guard/windows.rs
@@ -26,7 +26,7 @@
 //! This apparently translates to any callbacks in the ".CRT$XLB" section
 //! being run on certain events.
 //!
-//! So after all that, we use the compiler's #[link_section] feature to place
+//! So after all that, we use the compiler's `#[link_section]` feature to place
 //! a callback pointer into the magic section so it ends up being called.
 //!
 //! # What's up with this callback?

--- a/src/bootstrap/defaults/config.library.toml
+++ b/src/bootstrap/defaults/config.library.toml
@@ -8,6 +8,9 @@ bench-stage = 0
 [rust]
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
+# Download rustc from CI instead of building it from source.
+# For stage > 1 builds, this cuts compile times significantly when there are no changes on "compiler" tree.
+download-rustc = "if-unchanged"
 # Make the compiler and standard library faster to build, at the expense of a ~20% runtime slowdown.
 lto = "off"
 

--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -4,7 +4,7 @@
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
 # Download rustc from CI instead of building it from source.
-# This cuts compile times by almost 60x, but means you can't modify the compiler.
+# For stage > 1 builds, this cuts compile times significantly when there are no changes on "compiler" tree.
 # Using these defaults will download the stage2 compiler (see `download-rustc`
 # setting) and the stage2 toolchain should therefore be used for these defaults.
 download-rustc = "if-unchanged"

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -290,4 +290,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "New option `llvm.offload` to control whether the llvm offload runtime for GPU support is built. Implicitly enables the openmp runtime as dependency.",
     },
+    ChangeInfo {
+        change_id: 132494,
+        severity: ChangeSeverity::Info,
+        summary: "`download-rustc='if-unchanged'` is now a default option for library profile.",
+    },
 ];

--- a/tests/rustdoc/stability.rs
+++ b/tests/rustdoc/stability.rs
@@ -1,6 +1,8 @@
 #![feature(staged_api)]
+#![feature(rustc_attrs)]
+#![feature(rustdoc_internals)]
 
-#![stable(feature = "rust1", since = "1.0.0")]
+#![stable(feature = "core", since = "1.6.0")]
 
 //@ has stability/index.html
 //@ has - '//ul[@class="item-table"]/li[1]//a' AaStable
@@ -26,7 +28,7 @@ pub struct ZzStable;
 #[unstable(feature = "unstable", issue = "none")]
 pub mod unstable {
     //@ !hasraw stability/unstable/struct.StableInUnstable.html \
-    //      '//span[@class="since"]'
+    //      '//div[@class="main-heading"]//span[@class="since"]'
     //@ has - '//div[@class="stab unstable"]' 'experimental'
     #[stable(feature = "rust1", since = "1.0.0")]
     pub struct StableInUnstable;
@@ -34,52 +36,136 @@ pub mod unstable {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub mod stable_in_unstable {
         //@ !hasraw stability/unstable/stable_in_unstable/struct.Inner.html \
-        //      '//span[@class="since"]'
+        //      '//div[@class="main-heading"]//span[@class="since"]'
         //@ has - '//div[@class="stab unstable"]' 'experimental'
         #[stable(feature = "rust1", since = "1.0.0")]
         pub struct Inner;
+    }
+
+    //@ has stability/struct.AaStable.html \
+    //      '//*[@id="method.foo"]//span[@class="since"]' '2.2.2'
+    impl super::AaStable {
+        #[stable(feature = "rust2", since = "2.2.2")]
+        pub fn foo() {}
+    }
+
+    //@ has stability/unstable/struct.StableInUnstable.html \
+    //      '//*[@id="method.foo"]//span[@class="since"]' '1.0.0'
+    impl StableInUnstable {
+        #[stable(feature = "rust1", since = "1.0.0")]
+        pub fn foo() {}
+    }
+}
+
+#[unstable(feature = "unstable", issue = "none")]
+#[doc(hidden)]
+pub mod unstable_stripped {
+    //@ has stability/struct.AaStable.html \
+    //      '//*[@id="method.foo"]//span[@class="since"]' '2.2.2'
+    impl super::AaStable {
+        #[stable(feature = "rust2", since = "2.2.2")]
+        pub fn foo() {}
     }
 }
 
 #[stable(feature = "rust2", since = "2.2.2")]
 pub mod stable_later {
     //@ has stability/stable_later/struct.StableInLater.html \
-    //      '//span[@class="since"]' '2.2.2'
+    //      '//div[@class="main-heading"]//span[@class="since"]' '2.2.2'
     #[stable(feature = "rust1", since = "1.0.0")]
     pub struct StableInLater;
 
     #[stable(feature = "rust1", since = "1.0.0")]
     pub mod stable_in_later {
         //@ has stability/stable_later/stable_in_later/struct.Inner.html \
-        //      '//span[@class="since"]' '2.2.2'
+        //      '//div[@class="main-heading"]//span[@class="since"]' '2.2.2'
         #[stable(feature = "rust1", since = "1.0.0")]
         pub struct Inner;
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub mod stable_earlier {
-    //@ has stability/stable_earlier/struct.StableInUnstable.html \
-    //      '//span[@class="since"]' '1.0.0'
+#[rustc_allowed_through_unstable_modules]
+pub mod stable_earlier1 {
+    //@ has stability/stable_earlier1/struct.StableInUnstable.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
+    //@ has - '//*[@id="method.foo"]//span[@class="since"]' '1.0.0'
     #[doc(inline)]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use crate::unstable::StableInUnstable;
 
-    //@ has stability/stable_earlier/stable_in_unstable/struct.Inner.html \
-    //      '//span[@class="since"]' '1.0.0'
+    //@ has stability/stable_earlier1/stable_in_unstable/struct.Inner.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
     #[doc(inline)]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use crate::unstable::stable_in_unstable;
 
-    //@ has stability/stable_earlier/struct.StableInLater.html \
-    //      '//span[@class="since"]' '1.0.0'
+    //@ has stability/stable_earlier1/struct.StableInLater.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
     #[doc(inline)]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use crate::stable_later::StableInLater;
 
-    //@ has stability/stable_earlier/stable_in_later/struct.Inner.html \
-    //      '//span[@class="since"]' '1.0.0'
+    //@ has stability/stable_earlier1/stable_in_later/struct.Inner.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
     #[doc(inline)]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use crate::stable_later::stable_in_later;
 }
+
+/// These will inherit the crate stability.
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod stable_earlier2 {
+    //@ has stability/stable_earlier2/struct.StableInUnstable.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.6.0'
+    //@ has - '//*[@id="method.foo"]//span[@class="since"]' '1.0.0'
+    #[doc(inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use crate::unstable::StableInUnstable;
+
+    //@ has stability/stable_earlier2/stable_in_unstable/struct.Inner.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.6.0'
+    #[doc(inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use crate::unstable::stable_in_unstable;
+
+    //@ has stability/stable_earlier2/struct.StableInLater.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.6.0'
+    #[doc(inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use crate::stable_later::StableInLater;
+
+    //@ has stability/stable_earlier2/stable_in_later/struct.Inner.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.6.0'
+    #[doc(inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use crate::stable_later::stable_in_later;
+}
+
+//@ !hasraw stability/trait.UnstableTraitWithStableMethod.html \
+//      '//div[@class="main-heading"]//span[@class="since"]'
+//@ has - '//*[@id="tymethod.foo"]//span[@class="since"]' '1.0.0'
+//@ has - '//*[@id="method.bar"]//span[@class="since"]' '1.0.0'
+#[unstable(feature = "unstable", issue = "none")]
+pub trait UnstableTraitWithStableMethod {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn foo();
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn bar() {}
+}
+
+//@ has stability/primitive.i32.html \
+//      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
+#[rustc_doc_primitive = "i32"]
+//
+/// `i32` is always stable in 1.0, even if you look at it from core.
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_i32 {}
+
+//@ has stability/keyword.if.html \
+//      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
+#[doc(keyword = "if")]
+//
+/// We currently don't document stability for keywords, but let's test it anyway.
+#[stable(feature = "rust1", since = "1.0.0")]
+mod if_keyword {}


### PR DESCRIPTION
Successful merges:

 - #132481 (rustdoc: skip stability inheritance for some item kinds)
 - #132482 (library: fix some stability annotations)
 - #132493 (Fix type reference in documents which was being confused with html tags.)
 - #132494 (make `download-rustc="if-unchanged"` default for library profile)
 - #132495 (Remove unintended link)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=132481,132482,132493,132494,132495)
<!-- homu-ignore:end -->