### PR TITLE
Port most of `--print=target-cpus` to Rust

### DIFF
--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2204,7 +2204,7 @@ unsafe extern "C" {
         Desc: &mut *const c_char,
     );
 
-    pub fn LLVMRustGetHostCPUName(len: *mut usize) -> *const c_char;
+    pub fn LLVMRustGetHostCPUName(LenOut: &mut size_t) -> *const u8;
 
     // This function makes copies of pointed to data, so the data's lifetime may end after this
     // function returns.

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -2190,12 +2190,8 @@ unsafe extern "C" {
 
     pub fn LLVMRustHasFeature(T: &TargetMachine, s: *const c_char) -> bool;
 
-    pub fn LLVMRustPrintTargetCPUs(
-        T: &TargetMachine,
-        cpu: *const c_char,
-        print: unsafe extern "C" fn(out: *mut c_void, string: *const c_char, len: usize),
-        out: *mut c_void,
-    );
+    #[allow(improper_ctypes)]
+    pub(crate) fn LLVMRustPrintTargetCPUs(TM: &TargetMachine, OutStr: &RustString);
     pub fn LLVMRustGetTargetFeaturesCount(T: &TargetMachine) -> size_t;
     pub fn LLVMRustGetTargetFeature(
         T: &TargetMachine,

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -382,9 +382,9 @@ extern "C" void LLVMRustGetTargetFeature(LLVMTargetMachineRef TM, size_t Index,
   *Desc = Feat.Desc;
 }
 
-extern "C" const char *LLVMRustGetHostCPUName(size_t *len) {
+extern "C" const char *LLVMRustGetHostCPUName(size_t *OutLen) {
   StringRef Name = sys::getHostCPUName();
-  *len = Name.size();
+  *OutLen = Name.size();
   return Name.data();
 }
 

--- a/tests/run-make/print-target-cpus-native/rmake.rs
+++ b/tests/run-make/print-target-cpus-native/rmake.rs
@@ -1,0 +1,39 @@
+//@ ignore-cross-compile
+//@ needs-llvm-components: aarch64 x86
+// FIXME(#132514): Is needs-llvm-components actually necessary for this test?
+
+use run_make_support::{assert_contains_regex, rfs, rustc, target};
+
+// Test that when querying `--print=target-cpus` for a target with the same
+// architecture as the host, the first CPU is "native" with a suitable remark.
+
+fn main() {
+    let expected = r"^Available CPUs for this target:
+    native +- Select the CPU of the current host \(currently [^ )]+\)\.
+";
+
+    // Without an explicit target.
+    rustc().print("target-cpus").run().assert_stdout_contains_regex(expected);
+
+    // With an explicit target that happens to be the host.
+    let host = target(); // Because of ignore-cross-compile, assume host == target.
+    rustc().print("target-cpus").target(host).run().assert_stdout_contains_regex(expected);
+
+    // With an explicit output path.
+    rustc().print("target-cpus=./xyzzy.txt").run().assert_stdout_equals("");
+    assert_contains_regex(rfs::read_to_string("./xyzzy.txt"), expected);
+
+    // Now try some cross-target queries with the same arch as the host.
+    // (Specify multiple targets so that at least one of them is not the host.)
+    let cross_targets: &[&str] = if cfg!(target_arch = "aarch64") {
+        &["aarch64-unknown-linux-gnu", "aarch64-apple-darwin"]
+    } else if cfg!(target_arch = "x86_64") {
+        &["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"]
+    } else {
+        &[]
+    };
+    for target in cross_targets {
+        println!("Trying target: {target}");
+        rustc().print("target-cpus").target(target).run().assert_stdout_contains_regex(expected);
+    }
+}


### PR DESCRIPTION
The logic and formatting needed by `--print=target-cpus` has historically been carried out in C++ code. Originally it used `printf` to write directly to the console, but later it switched over to writing to a `std::ostringstream` and then passing its buffer to a callback function pointer.

This PR replaces that C++ code with a very simple function that writes a list of CPU names to a `&RustString`, with the rest of the logic and formatting being handled by ordinary safe Rust code.