### PR TITLE
Add bad-reg inline assembly ui test for RISC-V and s390x

### DIFF
--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -6,6 +6,7 @@
 //!
 //! - `minicore` is **only** intended for `core` items, and the stubs should match the actual `core`
 //!   items.
+//! - Becareful of adding new features and things that are only available for a subset of targets.
 //!
 //! # References
 //!
@@ -13,8 +14,9 @@
 //! <https://github.com/rust-lang/rust/blob/c0b5cc9003f6464c11ae1c0662c6a7e06f6f5cab/compiler/rustc_codegen_cranelift/example/mini_core.rs>.
 // ignore-tidy-linelength
 
-#![feature(no_core, lang_items, rustc_attrs)]
+#![feature(no_core, lang_items, rustc_attrs, decl_macro)]
 #![allow(unused, improper_ctypes_definitions, internal_features)]
+#![feature(asm_experimental_arch)]
 #![no_std]
 #![no_core]
 
@@ -37,7 +39,9 @@ impl<T: ?Sized> LegacyReceiver for &mut T {}
 #[lang = "copy"]
 pub trait Copy: Sized {}
 
-impl_marker_trait!(Copy => [ bool, char, isize, usize, i8, i16, i32, i64, u8, u16, u32, u64 ]);
+impl_marker_trait!(
+    Copy => [ bool, char, isize, usize, i8, i16, i32, i64, u8, u16, u32, u64, f32, f64 ]
+);
 impl<'a, T: ?Sized> Copy for &'a T {}
 impl<T: ?Sized> Copy for *const T {}
 impl<T: ?Sized> Copy for *mut T {}
@@ -69,4 +73,9 @@ impl<T: Copy + ?Sized> Copy for ManuallyDrop<T> {}
 #[repr(transparent)]
 pub struct UnsafeCell<T: ?Sized> {
     value: T,
+}
+
+#[rustc_builtin_macro]
+pub macro asm("assembly template", $(operands,)* $(options($(option),*))?) {
+    /* compiler built-in */
 }

--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -6,7 +6,7 @@
 //!
 //! - `minicore` is **only** intended for `core` items, and the stubs should match the actual `core`
 //!   items.
-//! - Becareful of adding new features and things that are only available for a subset of targets.
+//! - Be careful of adding new features and things that are only available for a subset of targets.
 //!
 //! # References
 //!

--- a/tests/ui/asm/riscv/bad-reg.riscv32e.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32e.stderr
@@ -1,191 +1,191 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:100:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: cannot use register `x16`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("x16") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x17`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:51:18
    |
 LL |         asm!("", out("x17") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x18`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:53:18
    |
 LL |         asm!("", out("x18") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x19`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:55:18
    |
 LL |         asm!("", out("x19") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x20`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:54:18
+  --> $DIR/bad-reg.rs:57:18
    |
 LL |         asm!("", out("x20") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x21`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:56:18
+  --> $DIR/bad-reg.rs:59:18
    |
 LL |         asm!("", out("x21") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x22`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:58:18
+  --> $DIR/bad-reg.rs:61:18
    |
 LL |         asm!("", out("x22") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x23`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:60:18
+  --> $DIR/bad-reg.rs:63:18
    |
 LL |         asm!("", out("x23") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x24`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:62:18
+  --> $DIR/bad-reg.rs:65:18
    |
 LL |         asm!("", out("x24") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x25`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:64:18
+  --> $DIR/bad-reg.rs:67:18
    |
 LL |         asm!("", out("x25") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x26`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:66:18
+  --> $DIR/bad-reg.rs:69:18
    |
 LL |         asm!("", out("x26") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x27`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:68:18
+  --> $DIR/bad-reg.rs:71:18
    |
 LL |         asm!("", out("x27") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x28`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:70:18
+  --> $DIR/bad-reg.rs:73:18
    |
 LL |         asm!("", out("x28") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x29`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:72:18
+  --> $DIR/bad-reg.rs:75:18
    |
 LL |         asm!("", out("x29") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x30`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:74:18
+  --> $DIR/bad-reg.rs:77:18
    |
 LL |         asm!("", out("x30") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x31`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:76:18
+  --> $DIR/bad-reg.rs:79:18
    |
 LL |         asm!("", out("x31") _);
    |                  ^^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:80:26
+  --> $DIR/bad-reg.rs:83:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:82:26
+  --> $DIR/bad-reg.rs:85:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:84:26
+  --> $DIR/bad-reg.rs:87:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:87:26
+  --> $DIR/bad-reg.rs:90:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:94:27
+  --> $DIR/bad-reg.rs:97:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -193,7 +193,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:28
+  --> $DIR/bad-reg.rs:100:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -201,7 +201,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:35
+  --> $DIR/bad-reg.rs:103:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32e.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32e.stderr
@@ -1,0 +1,212 @@
+error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:40:18
+   |
+LL |         asm!("", out("s1") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:42:18
+   |
+LL |         asm!("", out("fp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:44:18
+   |
+LL |         asm!("", out("sp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:46:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:48:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:50:18
+   |
+LL |         asm!("", out("tp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:52:18
+   |
+LL |         asm!("", out("zero") _);
+   |                  ^^^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:103:18
+   |
+LL |         asm!("", in("v0") x);
+   |                  ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:106:18
+   |
+LL |         asm!("", out("v0") x);
+   |                  ^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:109:26
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                          ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:112:26
+   |
+LL |         asm!("/* {} */", out(vreg) _);
+   |                          ^^^^^^^^^^^
+
+error: cannot use register `x16`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:55:18
+   |
+LL |         asm!("", out("x16") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x17`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:57:18
+   |
+LL |         asm!("", out("x17") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x18`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:59:18
+   |
+LL |         asm!("", out("x18") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x19`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:61:18
+   |
+LL |         asm!("", out("x19") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x20`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:63:18
+   |
+LL |         asm!("", out("x20") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x21`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:65:18
+   |
+LL |         asm!("", out("x21") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x22`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:67:18
+   |
+LL |         asm!("", out("x22") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x23`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:69:18
+   |
+LL |         asm!("", out("x23") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x24`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:71:18
+   |
+LL |         asm!("", out("x24") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x25`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:73:18
+   |
+LL |         asm!("", out("x25") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x26`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:75:18
+   |
+LL |         asm!("", out("x26") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x27`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:77:18
+   |
+LL |         asm!("", out("x27") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x28`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:79:18
+   |
+LL |         asm!("", out("x28") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x29`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:81:18
+   |
+LL |         asm!("", out("x29") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x30`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:83:18
+   |
+LL |         asm!("", out("x30") _);
+   |                  ^^^^^^^^^^^^
+
+error: cannot use register `x31`: register can't be used with the `e` target feature
+  --> $DIR/bad-reg.rs:85:18
+   |
+LL |         asm!("", out("x31") _);
+   |                  ^^^^^^^^^^^^
+
+error: register class `freg` requires at least one of the following target features: d, f
+  --> $DIR/bad-reg.rs:89:26
+   |
+LL |         asm!("/* {} */", in(freg) f);
+   |                          ^^^^^^^^^^
+
+error: register class `freg` requires at least one of the following target features: d, f
+  --> $DIR/bad-reg.rs:91:26
+   |
+LL |         asm!("/* {} */", out(freg) _);
+   |                          ^^^^^^^^^^^
+
+error: register class `freg` requires at least one of the following target features: d, f
+  --> $DIR/bad-reg.rs:93:26
+   |
+LL |         asm!("/* {} */", in(freg) d);
+   |                          ^^^^^^^^^^
+
+error: register class `freg` requires at least one of the following target features: d, f
+  --> $DIR/bad-reg.rs:96:26
+   |
+LL |         asm!("/* {} */", out(freg) d);
+   |                          ^^^^^^^^^^^
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:103:27
+   |
+LL |         asm!("", in("v0") x);
+   |                           ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:106:28
+   |
+LL |         asm!("", out("v0") x);
+   |                            ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:109:35
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                                   ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: aborting due to 34 previous errors
+

--- a/tests/ui/asm/riscv/bad-reg.riscv32e.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32e.stderr
@@ -1,191 +1,191 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:109:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:112:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: cannot use register `x16`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("x16") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x17`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("x17") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x18`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:59:18
+  --> $DIR/bad-reg.rs:50:18
    |
 LL |         asm!("", out("x18") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x19`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:61:18
+  --> $DIR/bad-reg.rs:52:18
    |
 LL |         asm!("", out("x19") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x20`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:63:18
+  --> $DIR/bad-reg.rs:54:18
    |
 LL |         asm!("", out("x20") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x21`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:65:18
+  --> $DIR/bad-reg.rs:56:18
    |
 LL |         asm!("", out("x21") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x22`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:67:18
+  --> $DIR/bad-reg.rs:58:18
    |
 LL |         asm!("", out("x22") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x23`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:69:18
+  --> $DIR/bad-reg.rs:60:18
    |
 LL |         asm!("", out("x23") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x24`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:71:18
+  --> $DIR/bad-reg.rs:62:18
    |
 LL |         asm!("", out("x24") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x25`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:73:18
+  --> $DIR/bad-reg.rs:64:18
    |
 LL |         asm!("", out("x25") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x26`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:75:18
+  --> $DIR/bad-reg.rs:66:18
    |
 LL |         asm!("", out("x26") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x27`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:77:18
+  --> $DIR/bad-reg.rs:68:18
    |
 LL |         asm!("", out("x27") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x28`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:79:18
+  --> $DIR/bad-reg.rs:70:18
    |
 LL |         asm!("", out("x28") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x29`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:81:18
+  --> $DIR/bad-reg.rs:72:18
    |
 LL |         asm!("", out("x29") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x30`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:83:18
+  --> $DIR/bad-reg.rs:74:18
    |
 LL |         asm!("", out("x30") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x31`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:85:18
+  --> $DIR/bad-reg.rs:76:18
    |
 LL |         asm!("", out("x31") _);
    |                  ^^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:89:26
+  --> $DIR/bad-reg.rs:80:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:91:26
+  --> $DIR/bad-reg.rs:82:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:93:26
+  --> $DIR/bad-reg.rs:84:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:96:26
+  --> $DIR/bad-reg.rs:87:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -193,7 +193,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:106:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -201,7 +201,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32gc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32gc.stderr
@@ -1,71 +1,71 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:100:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:94:27
+  --> $DIR/bad-reg.rs:97:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -73,7 +73,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:28
+  --> $DIR/bad-reg.rs:100:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -81,7 +81,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:35
+  --> $DIR/bad-reg.rs:103:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32gc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32gc.stderr
@@ -1,0 +1,92 @@
+error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:40:18
+   |
+LL |         asm!("", out("s1") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:42:18
+   |
+LL |         asm!("", out("fp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:44:18
+   |
+LL |         asm!("", out("sp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:46:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:48:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:50:18
+   |
+LL |         asm!("", out("tp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:52:18
+   |
+LL |         asm!("", out("zero") _);
+   |                  ^^^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:103:18
+   |
+LL |         asm!("", in("v0") x);
+   |                  ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:106:18
+   |
+LL |         asm!("", out("v0") x);
+   |                  ^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:109:26
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                          ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:112:26
+   |
+LL |         asm!("/* {} */", out(vreg) _);
+   |                          ^^^^^^^^^^^
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:103:27
+   |
+LL |         asm!("", in("v0") x);
+   |                           ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:106:28
+   |
+LL |         asm!("", out("v0") x);
+   |                            ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:109:35
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                                   ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: aborting due to 14 previous errors
+

--- a/tests/ui/asm/riscv/bad-reg.riscv32gc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32gc.stderr
@@ -1,71 +1,71 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:109:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:112:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -73,7 +73,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:106:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -81,7 +81,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32i.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32i.stderr
@@ -1,0 +1,116 @@
+error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:40:18
+   |
+LL |         asm!("", out("s1") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:42:18
+   |
+LL |         asm!("", out("fp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:44:18
+   |
+LL |         asm!("", out("sp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:46:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:48:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:50:18
+   |
+LL |         asm!("", out("tp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:52:18
+   |
+LL |         asm!("", out("zero") _);
+   |                  ^^^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:103:18
+   |
+LL |         asm!("", in("v0") x);
+   |                  ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:106:18
+   |
+LL |         asm!("", out("v0") x);
+   |                  ^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:109:26
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                          ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:112:26
+   |
+LL |         asm!("/* {} */", out(vreg) _);
+   |                          ^^^^^^^^^^^
+
+error: register class `freg` requires at least one of the following target features: d, f
+  --> $DIR/bad-reg.rs:89:26
+   |
+LL |         asm!("/* {} */", in(freg) f);
+   |                          ^^^^^^^^^^
+
+error: register class `freg` requires at least one of the following target features: d, f
+  --> $DIR/bad-reg.rs:91:26
+   |
+LL |         asm!("/* {} */", out(freg) _);
+   |                          ^^^^^^^^^^^
+
+error: register class `freg` requires at least one of the following target features: d, f
+  --> $DIR/bad-reg.rs:93:26
+   |
+LL |         asm!("/* {} */", in(freg) d);
+   |                          ^^^^^^^^^^
+
+error: register class `freg` requires at least one of the following target features: d, f
+  --> $DIR/bad-reg.rs:96:26
+   |
+LL |         asm!("/* {} */", out(freg) d);
+   |                          ^^^^^^^^^^^
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:103:27
+   |
+LL |         asm!("", in("v0") x);
+   |                           ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:106:28
+   |
+LL |         asm!("", out("v0") x);
+   |                            ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:109:35
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                                   ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: aborting due to 18 previous errors
+

--- a/tests/ui/asm/riscv/bad-reg.riscv32i.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32i.stderr
@@ -1,95 +1,95 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:109:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:112:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:89:26
+  --> $DIR/bad-reg.rs:80:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:91:26
+  --> $DIR/bad-reg.rs:82:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:93:26
+  --> $DIR/bad-reg.rs:84:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:96:26
+  --> $DIR/bad-reg.rs:87:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -97,7 +97,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:106:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -105,7 +105,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32i.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32i.stderr
@@ -1,95 +1,95 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:100:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:80:26
+  --> $DIR/bad-reg.rs:83:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:82:26
+  --> $DIR/bad-reg.rs:85:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:84:26
+  --> $DIR/bad-reg.rs:87:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:87:26
+  --> $DIR/bad-reg.rs:90:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:94:27
+  --> $DIR/bad-reg.rs:97:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -97,7 +97,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:28
+  --> $DIR/bad-reg.rs:100:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -105,7 +105,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:35
+  --> $DIR/bad-reg.rs:103:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32imafc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32imafc.stderr
@@ -1,71 +1,71 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:109:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:112:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: `d` target feature is not enabled
-  --> $DIR/bad-reg.rs:93:35
+  --> $DIR/bad-reg.rs:84:35
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                                   ^
@@ -73,7 +73,7 @@ LL |         asm!("/* {} */", in(freg) d);
    = note: this is required to use type `f64` with register class `freg`
 
 error: `d` target feature is not enabled
-  --> $DIR/bad-reg.rs:96:36
+  --> $DIR/bad-reg.rs:87:36
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                                    ^
@@ -81,7 +81,7 @@ LL |         asm!("/* {} */", out(freg) d);
    = note: this is required to use type `f64` with register class `freg`
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -89,7 +89,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:106:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -97,7 +97,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32imafc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32imafc.stderr
@@ -1,0 +1,108 @@
+error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:40:18
+   |
+LL |         asm!("", out("s1") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:42:18
+   |
+LL |         asm!("", out("fp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:44:18
+   |
+LL |         asm!("", out("sp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:46:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:48:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:50:18
+   |
+LL |         asm!("", out("tp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:52:18
+   |
+LL |         asm!("", out("zero") _);
+   |                  ^^^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:103:18
+   |
+LL |         asm!("", in("v0") x);
+   |                  ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:106:18
+   |
+LL |         asm!("", out("v0") x);
+   |                  ^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:109:26
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                          ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:112:26
+   |
+LL |         asm!("/* {} */", out(vreg) _);
+   |                          ^^^^^^^^^^^
+
+error: `d` target feature is not enabled
+  --> $DIR/bad-reg.rs:93:35
+   |
+LL |         asm!("/* {} */", in(freg) d);
+   |                                   ^
+   |
+   = note: this is required to use type `f64` with register class `freg`
+
+error: `d` target feature is not enabled
+  --> $DIR/bad-reg.rs:96:36
+   |
+LL |         asm!("/* {} */", out(freg) d);
+   |                                    ^
+   |
+   = note: this is required to use type `f64` with register class `freg`
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:103:27
+   |
+LL |         asm!("", in("v0") x);
+   |                           ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:106:28
+   |
+LL |         asm!("", out("v0") x);
+   |                            ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:109:35
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                                   ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: aborting due to 16 previous errors
+

--- a/tests/ui/asm/riscv/bad-reg.riscv32imafc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32imafc.stderr
@@ -1,71 +1,71 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:100:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: `d` target feature is not enabled
-  --> $DIR/bad-reg.rs:84:35
+  --> $DIR/bad-reg.rs:87:35
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                                   ^
@@ -73,7 +73,7 @@ LL |         asm!("/* {} */", in(freg) d);
    = note: this is required to use type `f64` with register class `freg`
 
 error: `d` target feature is not enabled
-  --> $DIR/bad-reg.rs:87:36
+  --> $DIR/bad-reg.rs:90:36
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                                    ^
@@ -81,7 +81,7 @@ LL |         asm!("/* {} */", out(freg) d);
    = note: this is required to use type `f64` with register class `freg`
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:94:27
+  --> $DIR/bad-reg.rs:97:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -89,7 +89,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:28
+  --> $DIR/bad-reg.rs:100:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -97,7 +97,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:35
+  --> $DIR/bad-reg.rs:103:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv64gc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64gc.stderr
@@ -1,71 +1,71 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:100:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:94:27
+  --> $DIR/bad-reg.rs:97:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -73,7 +73,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:28
+  --> $DIR/bad-reg.rs:100:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -81,7 +81,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:35
+  --> $DIR/bad-reg.rs:103:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv64gc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64gc.stderr
@@ -1,0 +1,92 @@
+error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:40:18
+   |
+LL |         asm!("", out("s1") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:42:18
+   |
+LL |         asm!("", out("fp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:44:18
+   |
+LL |         asm!("", out("sp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:46:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:48:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:50:18
+   |
+LL |         asm!("", out("tp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:52:18
+   |
+LL |         asm!("", out("zero") _);
+   |                  ^^^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:103:18
+   |
+LL |         asm!("", in("v0") x);
+   |                  ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:106:18
+   |
+LL |         asm!("", out("v0") x);
+   |                  ^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:109:26
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                          ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:112:26
+   |
+LL |         asm!("/* {} */", out(vreg) _);
+   |                          ^^^^^^^^^^^
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:103:27
+   |
+LL |         asm!("", in("v0") x);
+   |                           ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:106:28
+   |
+LL |         asm!("", out("v0") x);
+   |                            ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:109:35
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                                   ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: aborting due to 14 previous errors
+

--- a/tests/ui/asm/riscv/bad-reg.riscv64gc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64gc.stderr
@@ -1,71 +1,71 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:109:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:112:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -73,7 +73,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:106:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -81,7 +81,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv64imac.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64imac.stderr
@@ -1,0 +1,116 @@
+error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:40:18
+   |
+LL |         asm!("", out("s1") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:42:18
+   |
+LL |         asm!("", out("fp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:44:18
+   |
+LL |         asm!("", out("sp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:46:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:48:18
+   |
+LL |         asm!("", out("gp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:50:18
+   |
+LL |         asm!("", out("tp") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:52:18
+   |
+LL |         asm!("", out("zero") _);
+   |                  ^^^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:103:18
+   |
+LL |         asm!("", in("v0") x);
+   |                  ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:106:18
+   |
+LL |         asm!("", out("v0") x);
+   |                  ^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:109:26
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                          ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:112:26
+   |
+LL |         asm!("/* {} */", out(vreg) _);
+   |                          ^^^^^^^^^^^
+
+error: register class `freg` requires at least one of the following target features: d, f
+  --> $DIR/bad-reg.rs:89:26
+   |
+LL |         asm!("/* {} */", in(freg) f);
+   |                          ^^^^^^^^^^
+
+error: register class `freg` requires at least one of the following target features: d, f
+  --> $DIR/bad-reg.rs:91:26
+   |
+LL |         asm!("/* {} */", out(freg) _);
+   |                          ^^^^^^^^^^^
+
+error: register class `freg` requires at least one of the following target features: d, f
+  --> $DIR/bad-reg.rs:93:26
+   |
+LL |         asm!("/* {} */", in(freg) d);
+   |                          ^^^^^^^^^^
+
+error: register class `freg` requires at least one of the following target features: d, f
+  --> $DIR/bad-reg.rs:96:26
+   |
+LL |         asm!("/* {} */", out(freg) d);
+   |                          ^^^^^^^^^^^
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:103:27
+   |
+LL |         asm!("", in("v0") x);
+   |                           ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:106:28
+   |
+LL |         asm!("", out("v0") x);
+   |                            ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:109:35
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                                   ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: aborting due to 18 previous errors
+

--- a/tests/ui/asm/riscv/bad-reg.riscv64imac.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64imac.stderr
@@ -1,95 +1,95 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:18
+  --> $DIR/bad-reg.rs:94:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:109:26
+  --> $DIR/bad-reg.rs:100:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:112:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:89:26
+  --> $DIR/bad-reg.rs:80:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:91:26
+  --> $DIR/bad-reg.rs:82:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:93:26
+  --> $DIR/bad-reg.rs:84:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:96:26
+  --> $DIR/bad-reg.rs:87:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:27
+  --> $DIR/bad-reg.rs:94:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -97,7 +97,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:106:28
+  --> $DIR/bad-reg.rs:97:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -105,7 +105,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:35
+  --> $DIR/bad-reg.rs:100:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv64imac.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64imac.stderr
@@ -1,95 +1,95 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:31:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:35:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:37:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:39:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:41:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:43:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:18
+  --> $DIR/bad-reg.rs:97:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:100:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:26
+  --> $DIR/bad-reg.rs:103:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:80:26
+  --> $DIR/bad-reg.rs:83:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:82:26
+  --> $DIR/bad-reg.rs:85:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:84:26
+  --> $DIR/bad-reg.rs:87:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:87:26
+  --> $DIR/bad-reg.rs:90:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:94:27
+  --> $DIR/bad-reg.rs:97:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -97,7 +97,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:28
+  --> $DIR/bad-reg.rs:100:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -105,7 +105,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:35
+  --> $DIR/bad-reg.rs:103:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.rs
+++ b/tests/ui/asm/riscv/bad-reg.rs
@@ -14,6 +14,9 @@
 //@[riscv64gc] compile-flags: --target riscv64gc-unknown-linux-gnu
 //@[riscv64gc] needs-llvm-components: riscv
 
+// Unlike riscv32e-registers.rs, this tests if the rustc can reject invalid registers
+// usage in the asm! API (in, out, inout, etc.).
+
 #![crate_type = "lib"]
 #![feature(no_core, rustc_attrs)]
 #![feature(asm_experimental_arch)]

--- a/tests/ui/asm/riscv/bad-reg.rs
+++ b/tests/ui/asm/riscv/bad-reg.rs
@@ -1,0 +1,115 @@
+//@ revisions: riscv32i riscv32imafc riscv32gc riscv32e riscv64imac riscv64gc
+//@[riscv32i] compile-flags: --target riscv32i-unknown-none-elf
+//@[riscv32i] needs-llvm-components: riscv
+//@[riscv32imafc] compile-flags: --target riscv32imafc-unknown-none-elf
+//@[riscv32imafc] needs-llvm-components: riscv
+//@[riscv32gc] compile-flags: --target riscv32gc-unknown-linux-gnu
+//@[riscv32gc] needs-llvm-components: riscv
+//@[riscv32e] compile-flags: --target riscv32e-unknown-none-elf
+//@[riscv32e] needs-llvm-components: riscv
+//@[riscv64imac] compile-flags: --target riscv64imac-unknown-none-elf
+//@[riscv64imac] needs-llvm-components: riscv
+//@[riscv64gc] compile-flags: --target riscv64gc-unknown-linux-gnu
+//@[riscv64gc] needs-llvm-components: riscv
+//@ needs-asm-support
+
+#![crate_type = "rlib"]
+#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "copy"]
+trait Copy {}
+
+impl Copy for i32 {}
+impl Copy for f32 {}
+impl Copy for f64 {}
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+
+fn f() {
+    let mut x = 0;
+    let mut f = 0.0_f32;
+    let mut d = 0.0_f64;
+    unsafe {
+        // Unsupported registers
+        asm!("", out("s1") _);
+        //~^ ERROR invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
+        asm!("", out("fp") _);
+        //~^ ERROR invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
+        asm!("", out("sp") _);
+        //~^ ERROR invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
+        asm!("", out("gp") _);
+        //~^ ERROR invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+        asm!("", out("gp") _);
+        //~^ ERROR invalid register `gp`: the global pointer cannot be used as an operand for inline asm
+        asm!("", out("tp") _);
+        //~^ ERROR invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
+        asm!("", out("zero") _);
+        //~^ ERROR invalid register `zero`: the zero register cannot be used as an operand for inline asm
+
+        asm!("", out("x16") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x17") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x18") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x19") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x20") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x21") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x22") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x23") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x24") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x25") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x26") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x27") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x28") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x29") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x30") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+        asm!("", out("x31") _);
+        //[riscv32e]~^ ERROR register can't be used with the `e` target feature
+
+        asm!("", out("f0") _); // ok
+        asm!("/* {} */", in(freg) f);
+        //[riscv32i,riscv32e,riscv64imac]~^ ERROR register class `freg` requires at least one of the following target features: d, f
+        asm!("/* {} */", out(freg) _);
+        //[riscv32i,riscv32e,riscv64imac]~^ ERROR register class `freg` requires at least one of the following target features: d, f
+        asm!("/* {} */", in(freg) d);
+        //[riscv32i,riscv32e,riscv64imac]~^ ERROR register class `freg` requires at least one of the following target features: d, f
+        //[riscv32imafc]~^^ ERROR `d` target feature is not enabled
+        asm!("/* {} */", out(freg) d);
+        //[riscv32i,riscv32e,riscv64imac]~^ ERROR register class `freg` requires at least one of the following target features: d, f
+        //[riscv32imafc]~^^ ERROR `d` target feature is not enabled
+
+        // Clobber-only registers
+        // vreg
+        asm!("", out("v0") _); // ok
+        asm!("", in("v0") x);
+        //~^ ERROR can only be used as a clobber
+        //~| ERROR type `i32` cannot be used with this register class
+        asm!("", out("v0") x);
+        //~^ ERROR can only be used as a clobber
+        //~| ERROR type `i32` cannot be used with this register class
+        asm!("/* {} */", in(vreg) x);
+        //~^ ERROR can only be used as a clobber
+        //~| ERROR type `i32` cannot be used with this register class
+        asm!("/* {} */", out(vreg) _);
+        //~^ ERROR can only be used as a clobber
+    }
+}

--- a/tests/ui/asm/riscv/bad-reg.rs
+++ b/tests/ui/asm/riscv/bad-reg.rs
@@ -1,3 +1,5 @@
+//@ add-core-stubs
+//@ needs-asm-support
 //@ revisions: riscv32i riscv32imafc riscv32gc riscv32e riscv64imac riscv64gc
 //@[riscv32i] compile-flags: --target riscv32i-unknown-none-elf
 //@[riscv32i] needs-llvm-components: riscv
@@ -11,25 +13,14 @@
 //@[riscv64imac] needs-llvm-components: riscv
 //@[riscv64gc] compile-flags: --target riscv64gc-unknown-linux-gnu
 //@[riscv64gc] needs-llvm-components: riscv
-//@ needs-asm-support
 
-#![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![crate_type = "lib"]
+#![feature(no_core, rustc_attrs)]
+#![feature(asm_experimental_arch)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for i32 {}
-impl Copy for f32 {}
-impl Copy for f64 {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+extern crate minicore;
+use minicore::*;
 
 fn f() {
     let mut x = 0;

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32e.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32e.stderr
@@ -1,5 +1,5 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:43:11
+  --> $DIR/riscv32e-registers.rs:46:11
    |
 LL |     asm!("li x16, 0");
    |           ^
@@ -11,7 +11,7 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:46:11
+  --> $DIR/riscv32e-registers.rs:49:11
    |
 LL |     asm!("li x17, 0");
    |           ^
@@ -23,7 +23,7 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:49:11
+  --> $DIR/riscv32e-registers.rs:52:11
    |
 LL |     asm!("li x18, 0");
    |           ^
@@ -35,7 +35,7 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:52:11
+  --> $DIR/riscv32e-registers.rs:55:11
    |
 LL |     asm!("li x19, 0");
    |           ^
@@ -47,7 +47,7 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:55:11
+  --> $DIR/riscv32e-registers.rs:58:11
    |
 LL |     asm!("li x20, 0");
    |           ^
@@ -59,7 +59,7 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:61:11
    |
 LL |     asm!("li x21, 0");
    |           ^
@@ -71,7 +71,7 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:64:11
    |
 LL |     asm!("li x22, 0");
    |           ^
@@ -83,7 +83,7 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:67:11
    |
 LL |     asm!("li x23, 0");
    |           ^
@@ -95,7 +95,7 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:70:11
    |
 LL |     asm!("li x24, 0");
    |           ^
@@ -107,7 +107,7 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:73:11
    |
 LL |     asm!("li x25, 0");
    |           ^
@@ -119,7 +119,7 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:76:11
    |
 LL |     asm!("li x26, 0");
    |           ^
@@ -131,7 +131,7 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:79:11
    |
 LL |     asm!("li x27, 0");
    |           ^
@@ -143,7 +143,7 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:82:11
    |
 LL |     asm!("li x28, 0");
    |           ^
@@ -155,7 +155,7 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:85:11
    |
 LL |     asm!("li x29, 0");
    |           ^
@@ -167,7 +167,7 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:88:11
    |
 LL |     asm!("li x30, 0");
    |           ^
@@ -179,7 +179,7 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:91:11
    |
 LL |     asm!("li x31, 0");
    |           ^

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32em.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32em.stderr
@@ -1,5 +1,5 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:43:11
+  --> $DIR/riscv32e-registers.rs:46:11
    |
 LL |     asm!("li x16, 0");
    |           ^
@@ -11,7 +11,7 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:46:11
+  --> $DIR/riscv32e-registers.rs:49:11
    |
 LL |     asm!("li x17, 0");
    |           ^
@@ -23,7 +23,7 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:49:11
+  --> $DIR/riscv32e-registers.rs:52:11
    |
 LL |     asm!("li x18, 0");
    |           ^
@@ -35,7 +35,7 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:52:11
+  --> $DIR/riscv32e-registers.rs:55:11
    |
 LL |     asm!("li x19, 0");
    |           ^
@@ -47,7 +47,7 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:55:11
+  --> $DIR/riscv32e-registers.rs:58:11
    |
 LL |     asm!("li x20, 0");
    |           ^
@@ -59,7 +59,7 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:61:11
    |
 LL |     asm!("li x21, 0");
    |           ^
@@ -71,7 +71,7 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:64:11
    |
 LL |     asm!("li x22, 0");
    |           ^
@@ -83,7 +83,7 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:67:11
    |
 LL |     asm!("li x23, 0");
    |           ^
@@ -95,7 +95,7 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:70:11
    |
 LL |     asm!("li x24, 0");
    |           ^
@@ -107,7 +107,7 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:73:11
    |
 LL |     asm!("li x25, 0");
    |           ^
@@ -119,7 +119,7 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:76:11
    |
 LL |     asm!("li x26, 0");
    |           ^
@@ -131,7 +131,7 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:79:11
    |
 LL |     asm!("li x27, 0");
    |           ^
@@ -143,7 +143,7 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:82:11
    |
 LL |     asm!("li x28, 0");
    |           ^
@@ -155,7 +155,7 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:85:11
    |
 LL |     asm!("li x29, 0");
    |           ^
@@ -167,7 +167,7 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:88:11
    |
 LL |     asm!("li x30, 0");
    |           ^
@@ -179,7 +179,7 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:91:11
    |
 LL |     asm!("li x31, 0");
    |           ^

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32emc.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32emc.stderr
@@ -1,5 +1,5 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:43:11
+  --> $DIR/riscv32e-registers.rs:46:11
    |
 LL |     asm!("li x16, 0");
    |           ^
@@ -11,7 +11,7 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:46:11
+  --> $DIR/riscv32e-registers.rs:49:11
    |
 LL |     asm!("li x17, 0");
    |           ^
@@ -23,7 +23,7 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:49:11
+  --> $DIR/riscv32e-registers.rs:52:11
    |
 LL |     asm!("li x18, 0");
    |           ^
@@ -35,7 +35,7 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:52:11
+  --> $DIR/riscv32e-registers.rs:55:11
    |
 LL |     asm!("li x19, 0");
    |           ^
@@ -47,7 +47,7 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:55:11
+  --> $DIR/riscv32e-registers.rs:58:11
    |
 LL |     asm!("li x20, 0");
    |           ^
@@ -59,7 +59,7 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:61:11
    |
 LL |     asm!("li x21, 0");
    |           ^
@@ -71,7 +71,7 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:64:11
    |
 LL |     asm!("li x22, 0");
    |           ^
@@ -83,7 +83,7 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:67:11
    |
 LL |     asm!("li x23, 0");
    |           ^
@@ -95,7 +95,7 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:70:11
    |
 LL |     asm!("li x24, 0");
    |           ^
@@ -107,7 +107,7 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:73:11
    |
 LL |     asm!("li x25, 0");
    |           ^
@@ -119,7 +119,7 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:76:11
    |
 LL |     asm!("li x26, 0");
    |           ^
@@ -131,7 +131,7 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:79:11
    |
 LL |     asm!("li x27, 0");
    |           ^
@@ -143,7 +143,7 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:82:11
    |
 LL |     asm!("li x28, 0");
    |           ^
@@ -155,7 +155,7 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:85:11
    |
 LL |     asm!("li x29, 0");
    |           ^
@@ -167,7 +167,7 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:88:11
    |
 LL |     asm!("li x30, 0");
    |           ^
@@ -179,7 +179,7 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:91:11
    |
 LL |     asm!("li x31, 0");
    |           ^

--- a/tests/ui/asm/riscv/riscv32e-registers.rs
+++ b/tests/ui/asm/riscv/riscv32e-registers.rs
@@ -11,6 +11,9 @@
 //@ [riscv32emc] needs-llvm-components: riscv
 //@ [riscv32emc] compile-flags: --target=riscv32emc-unknown-none-elf
 
+// Unlike bad-reg.rs, this tests if the assembler can reject invalid registers
+// usage in assembly code.
+
 #![no_core]
 #![feature(no_core, lang_items, rustc_attrs)]
 

--- a/tests/ui/asm/s390x/bad-reg.rs
+++ b/tests/ui/asm/s390x/bad-reg.rs
@@ -1,23 +1,16 @@
+//@ add-core-stubs
+//@ needs-asm-support
 //@ revisions: s390x
 //@[s390x] compile-flags: --target s390x-unknown-linux-gnu
 //@[s390x] needs-llvm-components: systemz
-//@ needs-asm-support
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![feature(no_core, rustc_attrs)]
+#![feature(asm_experimental_arch)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for i32 {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+extern crate minicore;
+use minicore::*;
 
 fn f() {
     let mut x = 0;

--- a/tests/ui/asm/s390x/bad-reg.rs
+++ b/tests/ui/asm/s390x/bad-reg.rs
@@ -1,0 +1,135 @@
+//@ revisions: s390x
+//@[s390x] compile-flags: --target s390x-unknown-linux-gnu
+//@[s390x] needs-llvm-components: systemz
+//@ needs-asm-support
+
+#![crate_type = "rlib"]
+#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![no_core]
+
+#[lang = "sized"]
+trait Sized {}
+#[lang = "copy"]
+trait Copy {}
+
+impl Copy for i32 {}
+
+#[rustc_builtin_macro]
+macro_rules! asm {
+    () => {};
+}
+
+fn f() {
+    let mut x = 0;
+    unsafe {
+        // Unsupported registers
+        asm!("", out("r11") _);
+        //~^ ERROR invalid register `r11`: The frame pointer cannot be used as an operand for inline asm
+        asm!("", out("r15") _);
+        //~^ ERROR invalid register `r15`: The stack pointer cannot be used as an operand for inline asm
+        asm!("", out("c0") _);
+        //~^ ERROR invalid register `c0`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c1") _);
+        //~^ ERROR invalid register `c1`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c2") _);
+        //~^ ERROR invalid register `c2`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c3") _);
+        //~^ ERROR invalid register `c3`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c4") _);
+        //~^ ERROR invalid register `c4`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c5") _);
+        //~^ ERROR invalid register `c5`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c6") _);
+        //~^ ERROR invalid register `c6`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c7") _);
+        //~^ ERROR invalid register `c7`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c8") _);
+        //~^ ERROR invalid register `c8`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c9") _);
+        //~^ ERROR invalid register `c9`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c10") _);
+        //~^ ERROR invalid register `c10`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c11") _);
+        //~^ ERROR invalid register `c11`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c12") _);
+        //~^ ERROR invalid register `c12`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c13") _);
+        //~^ ERROR invalid register `c13`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c14") _);
+        //~^ ERROR invalid register `c14`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("c15") _);
+        //~^ ERROR invalid register `c15`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+        asm!("", out("a0") _);
+        //~^ ERROR invalid register `a0`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
+        asm!("", out("a1") _);
+        //~^ ERROR invalid register `a1`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
+
+        // Clobber-only registers
+        // areg
+        asm!("", out("a2") _); // ok
+        asm!("", in("a2") x);
+        //~^ ERROR can only be used as a clobber
+        //~| ERROR type `i32` cannot be used with this register class
+        asm!("", out("a2") x);
+        //~^ ERROR can only be used as a clobber
+        //~| ERROR type `i32` cannot be used with this register class
+        asm!("/* {} */", in(areg) x);
+        //~^ ERROR can only be used as a clobber
+        //~| ERROR type `i32` cannot be used with this register class
+        asm!("/* {} */", out(areg) _);
+        //~^ ERROR can only be used as a clobber
+
+        // vreg
+        asm!("", out("v0") _); // ok
+        // FIXME: will be supported in https://github.com/rust-lang/rust/pull/131664
+        asm!("", in("v0") x);
+        //~^ ERROR can only be used as a clobber
+        //~| ERROR type `i32` cannot be used with this register class
+        asm!("", out("v0") x);
+        //~^ ERROR can only be used as a clobber
+        //~| ERROR type `i32` cannot be used with this register class
+        asm!("/* {} */", in(vreg) x);
+        //~^ ERROR can only be used as a clobber
+        //~| ERROR type `i32` cannot be used with this register class
+        asm!("/* {} */", out(vreg) _);
+        //~^ ERROR can only be used as a clobber
+
+        // Overlapping registers
+        // vreg/freg
+        asm!("", out("v0") _, out("f0") _);
+        //~^ ERROR register `f0` conflicts with register `v0`
+        asm!("", out("v1") _, out("f1") _);
+        //~^ ERROR register `f1` conflicts with register `v1`
+        asm!("", out("v2") _, out("f2") _);
+        //~^ ERROR register `f2` conflicts with register `v2`
+        asm!("", out("v3") _, out("f3") _);
+        //~^ ERROR register `f3` conflicts with register `v3`
+        asm!("", out("v4") _, out("f4") _);
+        //~^ ERROR register `f4` conflicts with register `v4`
+        asm!("", out("v5") _, out("f5") _);
+        //~^ ERROR register `f5` conflicts with register `v5`
+        asm!("", out("v6") _, out("f6") _);
+        //~^ ERROR register `f6` conflicts with register `v6`
+        asm!("", out("v7") _, out("f7") _);
+        //~^ ERROR register `f7` conflicts with register `v7`
+        asm!("", out("v8") _, out("f8") _);
+        //~^ ERROR register `f8` conflicts with register `v8`
+        asm!("", out("v9") _, out("f9") _);
+        //~^ ERROR register `f9` conflicts with register `v9`
+        asm!("", out("v10") _, out("f10") _);
+        //~^ ERROR register `f10` conflicts with register `v10`
+        asm!("", out("v11") _, out("f11") _);
+        //~^ ERROR register `f11` conflicts with register `v11`
+        asm!("", out("v12") _, out("f12") _);
+        //~^ ERROR register `f12` conflicts with register `v12`
+        asm!("", out("v13") _, out("f13") _);
+        //~^ ERROR register `f13` conflicts with register `v13`
+        asm!("", out("v14") _, out("f14") _);
+        //~^ ERROR register `f14` conflicts with register `v14`
+        asm!("", out("v15") _, out("f15") _);
+        //~^ ERROR register `f15` conflicts with register `v15`
+        // no %f16
+        asm!("", out("v16") _, out("f16") _);
+        //~^ ERROR invalid register `f16`: unknown register
+    }
+}

--- a/tests/ui/asm/s390x/bad-reg.s390x.stderr
+++ b/tests/ui/asm/s390x/bad-reg.s390x.stderr
@@ -1,0 +1,352 @@
+error: invalid register `r11`: The frame pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:26:18
+   |
+LL |         asm!("", out("r11") _);
+   |                  ^^^^^^^^^^^^
+
+error: invalid register `r15`: The stack pointer cannot be used as an operand for inline asm
+  --> $DIR/bad-reg.rs:28:18
+   |
+LL |         asm!("", out("r15") _);
+   |                  ^^^^^^^^^^^^
+
+error: invalid register `c0`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:30:18
+   |
+LL |         asm!("", out("c0") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `c1`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:32:18
+   |
+LL |         asm!("", out("c1") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `c2`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:34:18
+   |
+LL |         asm!("", out("c2") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `c3`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:36:18
+   |
+LL |         asm!("", out("c3") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `c4`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:38:18
+   |
+LL |         asm!("", out("c4") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `c5`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:40:18
+   |
+LL |         asm!("", out("c5") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `c6`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:42:18
+   |
+LL |         asm!("", out("c6") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `c7`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:44:18
+   |
+LL |         asm!("", out("c7") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `c8`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:46:18
+   |
+LL |         asm!("", out("c8") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `c9`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:48:18
+   |
+LL |         asm!("", out("c9") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `c10`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:50:18
+   |
+LL |         asm!("", out("c10") _);
+   |                  ^^^^^^^^^^^^
+
+error: invalid register `c11`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:52:18
+   |
+LL |         asm!("", out("c11") _);
+   |                  ^^^^^^^^^^^^
+
+error: invalid register `c12`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:54:18
+   |
+LL |         asm!("", out("c12") _);
+   |                  ^^^^^^^^^^^^
+
+error: invalid register `c13`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:56:18
+   |
+LL |         asm!("", out("c13") _);
+   |                  ^^^^^^^^^^^^
+
+error: invalid register `c14`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:58:18
+   |
+LL |         asm!("", out("c14") _);
+   |                  ^^^^^^^^^^^^
+
+error: invalid register `c15`: control registers are reserved by the kernel and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:60:18
+   |
+LL |         asm!("", out("c15") _);
+   |                  ^^^^^^^^^^^^
+
+error: invalid register `a0`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:62:18
+   |
+LL |         asm!("", out("a0") _);
+   |                  ^^^^^^^^^^^
+
+error: invalid register `a1`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
+  --> $DIR/bad-reg.rs:64:18
+   |
+LL |         asm!("", out("a1") _);
+   |                  ^^^^^^^^^^^
+
+error: register class `areg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:70:18
+   |
+LL |         asm!("", in("a2") x);
+   |                  ^^^^^^^^^^
+
+error: register class `areg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:73:18
+   |
+LL |         asm!("", out("a2") x);
+   |                  ^^^^^^^^^^^
+
+error: register class `areg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:76:26
+   |
+LL |         asm!("/* {} */", in(areg) x);
+   |                          ^^^^^^^^^^
+
+error: register class `areg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:79:26
+   |
+LL |         asm!("/* {} */", out(areg) _);
+   |                          ^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:85:18
+   |
+LL |         asm!("", in("v0") x);
+   |                  ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:88:18
+   |
+LL |         asm!("", out("v0") x);
+   |                  ^^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:91:26
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                          ^^^^^^^^^^
+
+error: register class `vreg` can only be used as a clobber, not as an input or output
+  --> $DIR/bad-reg.rs:94:26
+   |
+LL |         asm!("/* {} */", out(vreg) _);
+   |                          ^^^^^^^^^^^
+
+error: register `f0` conflicts with register `v0`
+  --> $DIR/bad-reg.rs:99:31
+   |
+LL |         asm!("", out("v0") _, out("f0") _);
+   |                  -----------  ^^^^^^^^^^^ register `f0`
+   |                  |
+   |                  register `v0`
+
+error: register `f1` conflicts with register `v1`
+  --> $DIR/bad-reg.rs:101:31
+   |
+LL |         asm!("", out("v1") _, out("f1") _);
+   |                  -----------  ^^^^^^^^^^^ register `f1`
+   |                  |
+   |                  register `v1`
+
+error: register `f2` conflicts with register `v2`
+  --> $DIR/bad-reg.rs:103:31
+   |
+LL |         asm!("", out("v2") _, out("f2") _);
+   |                  -----------  ^^^^^^^^^^^ register `f2`
+   |                  |
+   |                  register `v2`
+
+error: register `f3` conflicts with register `v3`
+  --> $DIR/bad-reg.rs:105:31
+   |
+LL |         asm!("", out("v3") _, out("f3") _);
+   |                  -----------  ^^^^^^^^^^^ register `f3`
+   |                  |
+   |                  register `v3`
+
+error: register `f4` conflicts with register `v4`
+  --> $DIR/bad-reg.rs:107:31
+   |
+LL |         asm!("", out("v4") _, out("f4") _);
+   |                  -----------  ^^^^^^^^^^^ register `f4`
+   |                  |
+   |                  register `v4`
+
+error: register `f5` conflicts with register `v5`
+  --> $DIR/bad-reg.rs:109:31
+   |
+LL |         asm!("", out("v5") _, out("f5") _);
+   |                  -----------  ^^^^^^^^^^^ register `f5`
+   |                  |
+   |                  register `v5`
+
+error: register `f6` conflicts with register `v6`
+  --> $DIR/bad-reg.rs:111:31
+   |
+LL |         asm!("", out("v6") _, out("f6") _);
+   |                  -----------  ^^^^^^^^^^^ register `f6`
+   |                  |
+   |                  register `v6`
+
+error: register `f7` conflicts with register `v7`
+  --> $DIR/bad-reg.rs:113:31
+   |
+LL |         asm!("", out("v7") _, out("f7") _);
+   |                  -----------  ^^^^^^^^^^^ register `f7`
+   |                  |
+   |                  register `v7`
+
+error: register `f8` conflicts with register `v8`
+  --> $DIR/bad-reg.rs:115:31
+   |
+LL |         asm!("", out("v8") _, out("f8") _);
+   |                  -----------  ^^^^^^^^^^^ register `f8`
+   |                  |
+   |                  register `v8`
+
+error: register `f9` conflicts with register `v9`
+  --> $DIR/bad-reg.rs:117:31
+   |
+LL |         asm!("", out("v9") _, out("f9") _);
+   |                  -----------  ^^^^^^^^^^^ register `f9`
+   |                  |
+   |                  register `v9`
+
+error: register `f10` conflicts with register `v10`
+  --> $DIR/bad-reg.rs:119:32
+   |
+LL |         asm!("", out("v10") _, out("f10") _);
+   |                  ------------  ^^^^^^^^^^^^ register `f10`
+   |                  |
+   |                  register `v10`
+
+error: register `f11` conflicts with register `v11`
+  --> $DIR/bad-reg.rs:121:32
+   |
+LL |         asm!("", out("v11") _, out("f11") _);
+   |                  ------------  ^^^^^^^^^^^^ register `f11`
+   |                  |
+   |                  register `v11`
+
+error: register `f12` conflicts with register `v12`
+  --> $DIR/bad-reg.rs:123:32
+   |
+LL |         asm!("", out("v12") _, out("f12") _);
+   |                  ------------  ^^^^^^^^^^^^ register `f12`
+   |                  |
+   |                  register `v12`
+
+error: register `f13` conflicts with register `v13`
+  --> $DIR/bad-reg.rs:125:32
+   |
+LL |         asm!("", out("v13") _, out("f13") _);
+   |                  ------------  ^^^^^^^^^^^^ register `f13`
+   |                  |
+   |                  register `v13`
+
+error: register `f14` conflicts with register `v14`
+  --> $DIR/bad-reg.rs:127:32
+   |
+LL |         asm!("", out("v14") _, out("f14") _);
+   |                  ------------  ^^^^^^^^^^^^ register `f14`
+   |                  |
+   |                  register `v14`
+
+error: register `f15` conflicts with register `v15`
+  --> $DIR/bad-reg.rs:129:32
+   |
+LL |         asm!("", out("v15") _, out("f15") _);
+   |                  ------------  ^^^^^^^^^^^^ register `f15`
+   |                  |
+   |                  register `v15`
+
+error: invalid register `f16`: unknown register
+  --> $DIR/bad-reg.rs:132:32
+   |
+LL |         asm!("", out("v16") _, out("f16") _);
+   |                                ^^^^^^^^^^^^
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:70:27
+   |
+LL |         asm!("", in("a2") x);
+   |                           ^
+   |
+   = note: register class `areg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:73:28
+   |
+LL |         asm!("", out("a2") x);
+   |                            ^
+   |
+   = note: register class `areg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:76:35
+   |
+LL |         asm!("/* {} */", in(areg) x);
+   |                                   ^
+   |
+   = note: register class `areg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:85:27
+   |
+LL |         asm!("", in("v0") x);
+   |                           ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:88:28
+   |
+LL |         asm!("", out("v0") x);
+   |                            ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: type `i32` cannot be used with this register class
+  --> $DIR/bad-reg.rs:91:35
+   |
+LL |         asm!("/* {} */", in(vreg) x);
+   |                                   ^
+   |
+   = note: register class `vreg` supports these types: 
+
+error: aborting due to 51 previous errors
+

--- a/tests/ui/asm/s390x/bad-reg.s390x.stderr
+++ b/tests/ui/asm/s390x/bad-reg.s390x.stderr
@@ -1,173 +1,173 @@
 error: invalid register `r11`: The frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:26:18
+  --> $DIR/bad-reg.rs:19:18
    |
 LL |         asm!("", out("r11") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r15`: The stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:28:18
+  --> $DIR/bad-reg.rs:21:18
    |
 LL |         asm!("", out("r15") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c0`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:30:18
+  --> $DIR/bad-reg.rs:23:18
    |
 LL |         asm!("", out("c0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c1`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:32:18
+  --> $DIR/bad-reg.rs:25:18
    |
 LL |         asm!("", out("c1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c2`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:27:18
    |
 LL |         asm!("", out("c2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c3`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:29:18
    |
 LL |         asm!("", out("c3") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c4`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:31:18
    |
 LL |         asm!("", out("c4") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c5`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("c5") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c6`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("c6") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c7`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("c7") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c8`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("c8") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c9`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("c9") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `c10`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:50:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("c10") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c11`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:52:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("c11") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c12`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:54:18
+  --> $DIR/bad-reg.rs:47:18
    |
 LL |         asm!("", out("c12") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c13`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:56:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("c13") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c14`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:58:18
+  --> $DIR/bad-reg.rs:51:18
    |
 LL |         asm!("", out("c14") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `c15`: control registers are reserved by the kernel and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:60:18
+  --> $DIR/bad-reg.rs:53:18
    |
 LL |         asm!("", out("c15") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `a0`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:62:18
+  --> $DIR/bad-reg.rs:55:18
    |
 LL |         asm!("", out("a0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `a1`: a0 and a1 are reserved for system use and cannot be used as operands for inline asm
-  --> $DIR/bad-reg.rs:64:18
+  --> $DIR/bad-reg.rs:57:18
    |
 LL |         asm!("", out("a1") _);
    |                  ^^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:70:18
+  --> $DIR/bad-reg.rs:63:18
    |
 LL |         asm!("", in("a2") x);
    |                  ^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:73:18
+  --> $DIR/bad-reg.rs:66:18
    |
 LL |         asm!("", out("a2") x);
    |                  ^^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:76:26
+  --> $DIR/bad-reg.rs:69:26
    |
 LL |         asm!("/* {} */", in(areg) x);
    |                          ^^^^^^^^^^
 
 error: register class `areg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:79:26
+  --> $DIR/bad-reg.rs:72:26
    |
 LL |         asm!("/* {} */", out(areg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:85:18
+  --> $DIR/bad-reg.rs:78:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:88:18
+  --> $DIR/bad-reg.rs:81:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:91:26
+  --> $DIR/bad-reg.rs:84:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:94:26
+  --> $DIR/bad-reg.rs:87:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: register `f0` conflicts with register `v0`
-  --> $DIR/bad-reg.rs:99:31
+  --> $DIR/bad-reg.rs:92:31
    |
 LL |         asm!("", out("v0") _, out("f0") _);
    |                  -----------  ^^^^^^^^^^^ register `f0`
@@ -175,7 +175,7 @@ LL |         asm!("", out("v0") _, out("f0") _);
    |                  register `v0`
 
 error: register `f1` conflicts with register `v1`
-  --> $DIR/bad-reg.rs:101:31
+  --> $DIR/bad-reg.rs:94:31
    |
 LL |         asm!("", out("v1") _, out("f1") _);
    |                  -----------  ^^^^^^^^^^^ register `f1`
@@ -183,7 +183,7 @@ LL |         asm!("", out("v1") _, out("f1") _);
    |                  register `v1`
 
 error: register `f2` conflicts with register `v2`
-  --> $DIR/bad-reg.rs:103:31
+  --> $DIR/bad-reg.rs:96:31
    |
 LL |         asm!("", out("v2") _, out("f2") _);
    |                  -----------  ^^^^^^^^^^^ register `f2`
@@ -191,7 +191,7 @@ LL |         asm!("", out("v2") _, out("f2") _);
    |                  register `v2`
 
 error: register `f3` conflicts with register `v3`
-  --> $DIR/bad-reg.rs:105:31
+  --> $DIR/bad-reg.rs:98:31
    |
 LL |         asm!("", out("v3") _, out("f3") _);
    |                  -----------  ^^^^^^^^^^^ register `f3`
@@ -199,7 +199,7 @@ LL |         asm!("", out("v3") _, out("f3") _);
    |                  register `v3`
 
 error: register `f4` conflicts with register `v4`
-  --> $DIR/bad-reg.rs:107:31
+  --> $DIR/bad-reg.rs:100:31
    |
 LL |         asm!("", out("v4") _, out("f4") _);
    |                  -----------  ^^^^^^^^^^^ register `f4`
@@ -207,7 +207,7 @@ LL |         asm!("", out("v4") _, out("f4") _);
    |                  register `v4`
 
 error: register `f5` conflicts with register `v5`
-  --> $DIR/bad-reg.rs:109:31
+  --> $DIR/bad-reg.rs:102:31
    |
 LL |         asm!("", out("v5") _, out("f5") _);
    |                  -----------  ^^^^^^^^^^^ register `f5`
@@ -215,7 +215,7 @@ LL |         asm!("", out("v5") _, out("f5") _);
    |                  register `v5`
 
 error: register `f6` conflicts with register `v6`
-  --> $DIR/bad-reg.rs:111:31
+  --> $DIR/bad-reg.rs:104:31
    |
 LL |         asm!("", out("v6") _, out("f6") _);
    |                  -----------  ^^^^^^^^^^^ register `f6`
@@ -223,7 +223,7 @@ LL |         asm!("", out("v6") _, out("f6") _);
    |                  register `v6`
 
 error: register `f7` conflicts with register `v7`
-  --> $DIR/bad-reg.rs:113:31
+  --> $DIR/bad-reg.rs:106:31
    |
 LL |         asm!("", out("v7") _, out("f7") _);
    |                  -----------  ^^^^^^^^^^^ register `f7`
@@ -231,7 +231,7 @@ LL |         asm!("", out("v7") _, out("f7") _);
    |                  register `v7`
 
 error: register `f8` conflicts with register `v8`
-  --> $DIR/bad-reg.rs:115:31
+  --> $DIR/bad-reg.rs:108:31
    |
 LL |         asm!("", out("v8") _, out("f8") _);
    |                  -----------  ^^^^^^^^^^^ register `f8`
@@ -239,7 +239,7 @@ LL |         asm!("", out("v8") _, out("f8") _);
    |                  register `v8`
 
 error: register `f9` conflicts with register `v9`
-  --> $DIR/bad-reg.rs:117:31
+  --> $DIR/bad-reg.rs:110:31
    |
 LL |         asm!("", out("v9") _, out("f9") _);
    |                  -----------  ^^^^^^^^^^^ register `f9`
@@ -247,7 +247,7 @@ LL |         asm!("", out("v9") _, out("f9") _);
    |                  register `v9`
 
 error: register `f10` conflicts with register `v10`
-  --> $DIR/bad-reg.rs:119:32
+  --> $DIR/bad-reg.rs:112:32
    |
 LL |         asm!("", out("v10") _, out("f10") _);
    |                  ------------  ^^^^^^^^^^^^ register `f10`
@@ -255,7 +255,7 @@ LL |         asm!("", out("v10") _, out("f10") _);
    |                  register `v10`
 
 error: register `f11` conflicts with register `v11`
-  --> $DIR/bad-reg.rs:121:32
+  --> $DIR/bad-reg.rs:114:32
    |
 LL |         asm!("", out("v11") _, out("f11") _);
    |                  ------------  ^^^^^^^^^^^^ register `f11`
@@ -263,7 +263,7 @@ LL |         asm!("", out("v11") _, out("f11") _);
    |                  register `v11`
 
 error: register `f12` conflicts with register `v12`
-  --> $DIR/bad-reg.rs:123:32
+  --> $DIR/bad-reg.rs:116:32
    |
 LL |         asm!("", out("v12") _, out("f12") _);
    |                  ------------  ^^^^^^^^^^^^ register `f12`
@@ -271,7 +271,7 @@ LL |         asm!("", out("v12") _, out("f12") _);
    |                  register `v12`
 
 error: register `f13` conflicts with register `v13`
-  --> $DIR/bad-reg.rs:125:32
+  --> $DIR/bad-reg.rs:118:32
    |
 LL |         asm!("", out("v13") _, out("f13") _);
    |                  ------------  ^^^^^^^^^^^^ register `f13`
@@ -279,7 +279,7 @@ LL |         asm!("", out("v13") _, out("f13") _);
    |                  register `v13`
 
 error: register `f14` conflicts with register `v14`
-  --> $DIR/bad-reg.rs:127:32
+  --> $DIR/bad-reg.rs:120:32
    |
 LL |         asm!("", out("v14") _, out("f14") _);
    |                  ------------  ^^^^^^^^^^^^ register `f14`
@@ -287,7 +287,7 @@ LL |         asm!("", out("v14") _, out("f14") _);
    |                  register `v14`
 
 error: register `f15` conflicts with register `v15`
-  --> $DIR/bad-reg.rs:129:32
+  --> $DIR/bad-reg.rs:122:32
    |
 LL |         asm!("", out("v15") _, out("f15") _);
    |                  ------------  ^^^^^^^^^^^^ register `f15`
@@ -295,13 +295,13 @@ LL |         asm!("", out("v15") _, out("f15") _);
    |                  register `v15`
 
 error: invalid register `f16`: unknown register
-  --> $DIR/bad-reg.rs:132:32
+  --> $DIR/bad-reg.rs:125:32
    |
 LL |         asm!("", out("v16") _, out("f16") _);
    |                                ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:70:27
+  --> $DIR/bad-reg.rs:63:27
    |
 LL |         asm!("", in("a2") x);
    |                           ^
@@ -309,7 +309,7 @@ LL |         asm!("", in("a2") x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:73:28
+  --> $DIR/bad-reg.rs:66:28
    |
 LL |         asm!("", out("a2") x);
    |                            ^
@@ -317,7 +317,7 @@ LL |         asm!("", out("a2") x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:76:35
+  --> $DIR/bad-reg.rs:69:35
    |
 LL |         asm!("/* {} */", in(areg) x);
    |                                   ^
@@ -325,7 +325,7 @@ LL |         asm!("/* {} */", in(areg) x);
    = note: register class `areg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:85:27
+  --> $DIR/bad-reg.rs:78:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -333,7 +333,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:88:28
+  --> $DIR/bad-reg.rs:81:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -341,7 +341,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:91:35
+  --> $DIR/bad-reg.rs:84:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/131341#discussion_r1826555431

> Btw, such unsupported registers are present in most architectures, but only aarch64/arm64ec, x86_64, and not yet merged [sparc/sparc64](https://github.com/rust-lang/rust/pull/132472/files#diff-02aebda3376c2b020265137f9ce2c387669ca5cfecd7d60494275c2387db5114) (and powerpc/powerpc64 by this PR) currently have ui tests for them.  I plan to add tests for other arches later.


Starting with RISC-V and s390x, which I'm familiar with and relatively easy to check for correctness.

(Relevant rustc code are supported_types/def_regs/overlapping_regs in [compiler/rustc_target/src/asm/riscv.rs](https://github.com/rust-lang/rust/blob/588a4203508ed7c76750c96b482641261630ed36/compiler/rustc_target/src/asm/riscv.rs) and [compiler/rustc_target/src/asm/s390x.rs](https://github.com/rust-lang/rust/blob/588a4203508ed7c76750c96b482641261630ed36/compiler/rustc_target/src/asm/s390x.rs).)

r? workingjubilee

@rustbot label +A-inline-assembly

