### PR TITLE
replace manual time convertions with std ones, comptime time format parsing

### DIFF
--- a/compiler/rustc_driver_impl/Cargo.toml
+++ b/compiler/rustc_driver_impl/Cargo.toml
@@ -49,7 +49,7 @@ rustc_trait_selection = { path = "../rustc_trait_selection" }
 rustc_ty_utils = { path = "../rustc_ty_utils" }
 serde_json = "1.0.59"
 shlex = "1.0"
-time = { version = "0.3.36", default-features = false, features = ["alloc", "formatting", "parsing", "macros"] }
+time = { version = "0.3.36", default-features = false, features = ["alloc", "formatting", "macros"] }
 tracing = { version = "0.1.35" }
 # tidy-alphabetical-end
 

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -64,6 +64,7 @@ use rustc_span::source_map::FileLoader;
 use rustc_target::json::ToJson;
 use rustc_target::spec::{Target, TargetTuple};
 use time::OffsetDateTime;
+use time::macros::format_description;
 use tracing::trace;
 
 #[allow(unused_macros)]
@@ -1356,8 +1357,7 @@ fn ice_path_with_config(config: Option<&UnstableOptions>) -> &'static Option<Pat
         let file_now = now
             .format(
                 // Don't use a standard datetime format because Windows doesn't support `:` in paths
-                &time::format_description::parse("[year]-[month]-[day]T[hour]_[minute]_[second]")
-                    .unwrap(),
+                &format_description!("[year]-[month]-[day]T[hour]_[minute]_[second]"),
             )
             .unwrap_or_default();
         let pid = std::process::id();

--- a/compiler/rustc_query_system/src/dep_graph/graph.rs
+++ b/compiler/rustc_query_system/src/dep_graph/graph.rs
@@ -1098,7 +1098,7 @@ impl<D: Deps> CurrentDepGraph<D> {
         use std::time::{SystemTime, UNIX_EPOCH};
 
         let duration = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-        let nanos = duration.as_secs() * 1_000_000_000 + duration.subsec_nanos() as u64;
+        let nanos = duration.as_nanos();
         let mut stable_hasher = StableHasher::new();
         nanos.hash(&mut stable_hasher);
         let anon_id_seed = stable_hasher.finish();


### PR DESCRIPTION
First commit replaces few manual time conversions with std ones, second makes parsing of time format at compiletime.