### PR TITLE
Added regression test for generics index out of bounds

### DIFF
--- a/tests/ui/traits/ice-index-out-of-bounds-issue-117446.rs
+++ b/tests/ui/traits/ice-index-out-of-bounds-issue-117446.rs
@@ -1,0 +1,24 @@
+//@ check-fail
+//
+// Regression for https://github.com/rust-lang/rust/issues/117446
+
+pub struct Repeated<T>(Vec<T>);
+
+trait Foo<'a> {
+    fn outer<D>() -> Option<()>;
+}
+
+impl<'a, T> Foo<'a> for Repeated<T> {
+    fn outer() -> Option<()> {
+        //~^ ERROR  associated function `outer` has 0 type parameters but its trait declaration has 1 type parameter [E0049]
+        //~^^ ERROR mismatched types [E0308]
+        fn inner<Q>(value: Option<()>) -> Repeated<Q> {
+            match value {
+                _ => Self(unimplemented!()),
+                //~^ ERROR can't reference `Self` constructor from outer item [E0401]
+            }
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/traits/ice-index-out-of-bounds-issue-117446.stderr
+++ b/tests/ui/traits/ice-index-out-of-bounds-issue-117446.stderr
@@ -1,0 +1,33 @@
+error[E0049]: associated function `outer` has 0 type parameters but its trait declaration has 1 type parameter
+  --> $DIR/ice-index-out-of-bounds-issue-117446.rs:12:13
+   |
+LL |     fn outer<D>() -> Option<()>;
+   |              - expected 1 type parameter
+...
+LL |     fn outer() -> Option<()> {
+   |             ^ found 0 type parameters
+
+error[E0308]: mismatched types
+  --> $DIR/ice-index-out-of-bounds-issue-117446.rs:12:19
+   |
+LL |     fn outer() -> Option<()> {
+   |        -----      ^^^^^^^^^^ expected `Option<()>`, found `()`
+   |        |
+   |        implicitly returns `()` as its body has no tail or `return` expression
+   |
+   = note:   expected enum `Option<()>`
+           found unit type `()`
+
+error[E0401]: can't reference `Self` constructor from outer item
+  --> $DIR/ice-index-out-of-bounds-issue-117446.rs:17:22
+   |
+LL | impl<'a, T> Foo<'a> for Repeated<T> {
+   | ----------------------------------- the inner item doesn't inherit generics from this impl, so `Self` is invalid to reference
+...
+LL |                 _ => Self(unimplemented!()),
+   |                      ^^^^ help: replace `Self` with the actual type: `Repeated`
+
+error: aborting due to 3 previous errors
+
+Some errors have detailed explanations: E0049, E0308, E0401.
+For more information about an error, try `rustc --explain E0049`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Added a regression test for  #117446
This ICE was fixed in Rust 1.75 but a regression test was never added.

This PR adds a UI test with a reduced version of the original bug report that does not rely on external crates.
