### PR TITLE
chore(style): sync submodule exclusion list between tidy and rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -26,8 +26,6 @@ ignore = [
     "/tests/ui-fulldeps/",            # Some are whitespace-sensitive (e.g. `// ~ERROR` comments).
 
     # Do not format submodules.
-    # FIXME: sync submodule list with tidy/bootstrap/etc
-    # tidy/src/walk.rs:filter_dirs
     "library/backtrace",
     "library/portable-simd",
     "library/stdarch",
@@ -41,6 +39,7 @@ ignore = [
     "src/llvm-project",
     "src/tools/cargo",
     "src/tools/clippy",
+    "src/tools/enzyme",
     "src/tools/miri",
     "src/tools/rust-analyzer",
     "src/tools/rustc-perf",

--- a/src/tools/tidy/src/walk.rs
+++ b/src/tools/tidy/src/walk.rs
@@ -7,7 +7,6 @@ use ignore::DirEntry;
 
 /// The default directory filter.
 pub fn filter_dirs(path: &Path) -> bool {
-    // FIXME: sync submodule exclusion list with rustfmt.toml
     // bootstrap/etc
     let skip = [
         "tidy-test-file",


### PR DESCRIPTION
As asked in the FIXME comments

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
