### PR TITLE
Return slices with 'data lifetime in BorrowedBuf

### DIFF
--- a/library/core/src/io/borrowed_buf.rs
+++ b/library/core/src/io/borrowed_buf.rs
@@ -90,7 +90,7 @@ impl<'data> BorrowedBuf<'data> {
 
     /// Returns a shared reference to the filled portion of the buffer.
     #[inline]
-    pub fn filled(&self) -> &[u8] {
+    pub fn filled(&self) -> &'data [u8] {
         // SAFETY: We only slice the filled part of the buffer, which is always valid
         unsafe {
             let buf = self.buf.get_unchecked(..self.filled);
@@ -100,7 +100,7 @@ impl<'data> BorrowedBuf<'data> {
 
     /// Returns a mutable reference to the filled portion of the buffer.
     #[inline]
-    pub fn filled_mut(&mut self) -> &mut [u8] {
+    pub fn filled_mut(&mut self) -> &'data mut [u8] {
         // SAFETY: We only slice the filled part of the buffer, which is always valid
         unsafe {
             let buf = self.buf.get_unchecked_mut(..self.filled);


### PR DESCRIPTION
Tracking issue: https://github.com/rust-lang/rust/issues/117693

Seems like an oversight? I don't think there's any reason to limit the lifetime of the filled buffer... fixing this enables the following style of use case:

```rust
pub fn direct_file_name(
    buf: &mut [MaybeUninit<u8>; DIRECT_FILE_NAME_LEN + 1],
    to: RingKind,
    index: u32,
) -> DirectFileNameToken<()> {
    let mut buf = BorrowedBuf::from(buf.as_mut_slice());
    write!(buf.unfilled(), "{:0>13}\0", composite_id(to, index)).unwrap();
    DirectFileNameToken(buf.filled_mut(), PhantomData) // Doesn't compile!
}
```