### PR TITLE
Do not format generic consts

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -414,6 +414,12 @@ pub struct WhereClause {
     pub span: Span,
 }
 
+impl WhereClause {
+    pub fn is_empty(&self) -> bool {
+        !self.has_where_token && self.predicates.is_empty()
+    }
+}
+
 impl Default for WhereClause {
     fn default() -> WhereClause {
         WhereClause { has_where_token: false, predicates: ThinVec::new(), span: DUMMY_SP }

--- a/src/tools/rustfmt/tests/target/const-generics.rs
+++ b/src/tools/rustfmt/tests/target/const-generics.rs
@@ -1,0 +1,25 @@
+// Make sure we don't mess up the formatting of generic consts
+
+#![feature(generic_const_items)]
+
+const GENERIC<N, const M: usize>: i32 = 0;
+
+const WHERECLAUSE: i32 = 0
+where
+    i32:;
+
+trait Foo {
+    const GENERIC<N, const M: usize>: i32;
+
+    const WHERECLAUSE: i32
+    where
+        i32:;
+}
+
+impl Foo for () {
+    const GENERIC<N, const M: usize>: i32 = 0;
+
+    const WHERECLAUSE: i32 = 0
+    where
+        i32:;
+}


### PR DESCRIPTION
We introduced **nightly support** for generic const items in #113522, but formatting of consts was not modified. Making them format *correctly* is hard, so let's just bail formatting them so we don't accidentally strip their generics and where clauses. This is essentially no-op formatting for generic const items.

r? @calebcartwright or @ytmimi 