### PR TITLE
Use backticks instead of single quotes for library feature names in diagnostics

### DIFF
--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -311,8 +311,8 @@ hir_analysis_missing_trait_item_suggestion = implement the missing item: `{$snip
 
 hir_analysis_missing_trait_item_unstable = not all trait items implemented, missing: `{$missing_item_name}`
     .note = default implementation of `{$missing_item_name}` is unstable
-    .some_note = use of unstable library feature '{$feature}': {$reason}
-    .none_note = use of unstable library feature '{$feature}'
+    .some_note = use of unstable library feature `{$feature}`: {$reason}
+    .none_note = use of unstable library feature `{$feature}`
 
 hir_analysis_missing_type_params =
     the type {$parameterCount ->

--- a/compiler/rustc_middle/src/middle/stability.rs
+++ b/compiler/rustc_middle/src/middle/stability.rs
@@ -112,8 +112,8 @@ pub fn report_unstable(
     soft_handler: impl FnOnce(&'static Lint, Span, String),
 ) {
     let msg = match reason {
-        Some(r) => format!("use of unstable library feature '{feature}': {r}"),
-        None => format!("use of unstable library feature '{feature}'"),
+        Some(r) => format!("use of unstable library feature `{feature}`: {r}"),
+        None => format!("use of unstable library feature `{feature}`"),
     };
 
     if is_soft {

--- a/tests/ui-fulldeps/hash-stable-is-unstable.rs
+++ b/tests/ui-fulldeps/hash-stable-is-unstable.rs
@@ -1,24 +1,24 @@
 //@ compile-flags: -Zdeduplicate-diagnostics=yes
 extern crate rustc_data_structures;
-//~^ use of unstable library feature 'rustc_private'
+//~^ use of unstable library feature `rustc_private`
 //~| NOTE: issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
 //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 extern crate rustc_macros;
-//~^ use of unstable library feature 'rustc_private'
+//~^ use of unstable library feature `rustc_private`
 //~| NOTE: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
 //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 extern crate rustc_query_system;
-//~^ use of unstable library feature 'rustc_private'
+//~^ use of unstable library feature `rustc_private`
 //~| NOTE: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
 //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 use rustc_macros::HashStable;
-//~^ use of unstable library feature 'rustc_private'
+//~^ use of unstable library feature `rustc_private`
 //~| NOTE: see issue #27812 <https://github.com/rust-lang/rust/issues/27812> for more information
 //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 #[derive(HashStable)]
-//~^ use of unstable library feature 'rustc_private'
+//~^ use of unstable library feature `rustc_private`
 //~| NOTE: in this expansion of #[derive(HashStable)]
 //~| NOTE: in this expansion of #[derive(HashStable)]
 //~| NOTE: in this expansion of #[derive(HashStable)]

--- a/tests/ui-fulldeps/hash-stable-is-unstable.rs
+++ b/tests/ui-fulldeps/hash-stable-is-unstable.rs
@@ -1,3 +1,4 @@
+//@ ignore-stage1 FIXME: this line can be removed once these new error messages are in stage 0 rustc
 //@ compile-flags: -Zdeduplicate-diagnostics=yes
 extern crate rustc_data_structures;
 //~^ use of unstable library feature `rustc_private`

--- a/tests/ui-fulldeps/hash-stable-is-unstable.stderr
+++ b/tests/ui-fulldeps/hash-stable-is-unstable.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
+error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
   --> $DIR/hash-stable-is-unstable.rs:2:1
    |
 LL | extern crate rustc_data_structures;
@@ -8,7 +8,7 @@ LL | extern crate rustc_data_structures;
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
+error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
   --> $DIR/hash-stable-is-unstable.rs:6:1
    |
 LL | extern crate rustc_macros;
@@ -18,7 +18,7 @@ LL | extern crate rustc_macros;
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
+error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
   --> $DIR/hash-stable-is-unstable.rs:10:1
    |
 LL | extern crate rustc_query_system;
@@ -28,7 +28,7 @@ LL | extern crate rustc_query_system;
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
+error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
   --> $DIR/hash-stable-is-unstable.rs:15:5
    |
 LL | use rustc_macros::HashStable;
@@ -38,7 +38,7 @@ LL | use rustc_macros::HashStable;
    = help: add `#![feature(rustc_private)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
+error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
   --> $DIR/hash-stable-is-unstable.rs:20:10
    |
 LL | #[derive(HashStable)]

--- a/tests/ui-fulldeps/hash-stable-is-unstable.stderr
+++ b/tests/ui-fulldeps/hash-stable-is-unstable.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/hash-stable-is-unstable.rs:2:1
+  --> $DIR/hash-stable-is-unstable.rs:3:1
    |
 LL | extern crate rustc_data_structures;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -9,7 +9,7 @@ LL | extern crate rustc_data_structures;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/hash-stable-is-unstable.rs:6:1
+  --> $DIR/hash-stable-is-unstable.rs:7:1
    |
 LL | extern crate rustc_macros;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL | extern crate rustc_macros;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/hash-stable-is-unstable.rs:10:1
+  --> $DIR/hash-stable-is-unstable.rs:11:1
    |
 LL | extern crate rustc_query_system;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -29,7 +29,7 @@ LL | extern crate rustc_query_system;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/hash-stable-is-unstable.rs:15:5
+  --> $DIR/hash-stable-is-unstable.rs:16:5
    |
 LL | use rustc_macros::HashStable;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL | use rustc_macros::HashStable;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/hash-stable-is-unstable.rs:20:10
+  --> $DIR/hash-stable-is-unstable.rs:21:10
    |
 LL | #[derive(HashStable)]
    |          ^^^^^^^^^^

--- a/tests/ui-fulldeps/pathless-extern-unstable.rs
+++ b/tests/ui-fulldeps/pathless-extern-unstable.rs
@@ -1,3 +1,4 @@
+//@ ignore-stage1 FIXME: this line can be removed once these new error messages are in stage 0 rustc
 //@ edition:2018
 //@ compile-flags:--extern rustc_middle
 

--- a/tests/ui-fulldeps/pathless-extern-unstable.rs
+++ b/tests/ui-fulldeps/pathless-extern-unstable.rs
@@ -4,6 +4,6 @@
 // Test that `--extern rustc_middle` fails with `rustc_private`.
 
 pub use rustc_middle;
-//~^ ERROR use of unstable library feature 'rustc_private'
+//~^ ERROR use of unstable library feature `rustc_private`
 
 fn main() {}

--- a/tests/ui-fulldeps/pathless-extern-unstable.stderr
+++ b/tests/ui-fulldeps/pathless-extern-unstable.stderr
@@ -1,5 +1,5 @@
 error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
-  --> $DIR/pathless-extern-unstable.rs:6:9
+  --> $DIR/pathless-extern-unstable.rs:7:9
    |
 LL | pub use rustc_middle;
    |         ^^^^^^^^^^^^

--- a/tests/ui-fulldeps/pathless-extern-unstable.stderr
+++ b/tests/ui-fulldeps/pathless-extern-unstable.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
+error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
   --> $DIR/pathless-extern-unstable.rs:6:9
    |
 LL | pub use rustc_middle;

--- a/tests/ui/associated-inherent-types/assoc-inherent-unstable.rs
+++ b/tests/ui/associated-inherent-types/assoc-inherent-unstable.rs
@@ -4,6 +4,6 @@
 #![feature(inherent_associated_types)]
 #![allow(incomplete_features)]
 
-type Data = aux::Owner::Data; //~ ERROR use of unstable library feature 'data'
+type Data = aux::Owner::Data; //~ ERROR use of unstable library feature `data`
 
 fn main() {}

--- a/tests/ui/associated-inherent-types/assoc-inherent-unstable.stderr
+++ b/tests/ui/associated-inherent-types/assoc-inherent-unstable.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'data'
+error[E0658]: use of unstable library feature `data`
   --> $DIR/assoc-inherent-unstable.rs:7:13
    |
 LL | type Data = aux::Owner::Data;

--- a/tests/ui/async-await/async-fn/edition-2015.rs
+++ b/tests/ui/async-await/async-fn/edition-2015.rs
@@ -3,7 +3,7 @@ fn foo(x: impl async Fn()) -> impl async Fn() { x }
 //~| ERROR `async` trait bounds are only allowed in Rust 2018 or later
 //~| ERROR async closures are unstable
 //~| ERROR async closures are unstable
-//~| ERROR use of unstable library feature 'async_closure'
-//~| ERROR use of unstable library feature 'async_closure'
+//~| ERROR use of unstable library feature `async_closure`
+//~| ERROR use of unstable library feature `async_closure`
 
 fn main() {}

--- a/tests/ui/async-await/async-fn/edition-2015.stderr
+++ b/tests/ui/async-await/async-fn/edition-2015.stderr
@@ -38,7 +38,7 @@ LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: to use an async block, remove the `||`: `async {`
 
-error[E0658]: use of unstable library feature 'async_closure'
+error[E0658]: use of unstable library feature `async_closure`
   --> $DIR/edition-2015.rs:1:42
    |
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
@@ -48,7 +48,7 @@ LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    = help: add `#![feature(async_closure)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'async_closure'
+error[E0658]: use of unstable library feature `async_closure`
   --> $DIR/edition-2015.rs:1:22
    |
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }

--- a/tests/ui/box/alloc-unstable-fail.rs
+++ b/tests/ui/box/alloc-unstable-fail.rs
@@ -2,5 +2,5 @@ use std::boxed::Box;
 
 fn main() {
     let _boxed: Box<u32, _> = Box::new(10);
-    //~^ ERROR use of unstable library feature 'allocator_api'
+    //~^ ERROR use of unstable library feature `allocator_api`
 }

--- a/tests/ui/box/alloc-unstable-fail.stderr
+++ b/tests/ui/box/alloc-unstable-fail.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'allocator_api'
+error[E0658]: use of unstable library feature `allocator_api`
   --> $DIR/alloc-unstable-fail.rs:4:26
    |
 LL |     let _boxed: Box<u32, _> = Box::new(10);

--- a/tests/ui/conditional-compilation/cfg_accessible-unstable.rs
+++ b/tests/ui/conditional-compilation/cfg_accessible-unstable.rs
@@ -1,2 +1,2 @@
-#[cfg_accessible(std)] //~ ERROR use of unstable library feature 'cfg_accessible'
+#[cfg_accessible(std)] //~ ERROR use of unstable library feature `cfg_accessible`
 fn main() {}

--- a/tests/ui/conditional-compilation/cfg_accessible-unstable.stderr
+++ b/tests/ui/conditional-compilation/cfg_accessible-unstable.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'cfg_accessible': `cfg_accessible` is not fully implemented
+error[E0658]: use of unstable library feature `cfg_accessible`: `cfg_accessible` is not fully implemented
   --> $DIR/cfg_accessible-unstable.rs:1:3
    |
 LL | #[cfg_accessible(std)]

--- a/tests/ui/consts/const-unstable-intrinsic.rs
+++ b/tests/ui/consts/const-unstable-intrinsic.rs
@@ -15,16 +15,16 @@ const fn const_main() {
     let x = 42;
     unsafe {
         unstable_intrinsic::old_way::size_of_val(&x);
-        //~^ERROR: unstable library feature 'unstable'
+        //~^ERROR: unstable library feature `unstable`
         //~|ERROR: cannot call non-const intrinsic
         unstable_intrinsic::old_way::min_align_of_val(&x);
-        //~^ERROR: unstable library feature 'unstable'
+        //~^ERROR: unstable library feature `unstable`
         //~|ERROR: not yet stable as a const intrinsic
         unstable_intrinsic::new_way::size_of_val(&x);
-        //~^ERROR: unstable library feature 'unstable'
+        //~^ERROR: unstable library feature `unstable`
         //~|ERROR: cannot be (indirectly) exposed to stable
         unstable_intrinsic::new_way::min_align_of_val(&x);
-        //~^ERROR: unstable library feature 'unstable'
+        //~^ERROR: unstable library feature `unstable`
         //~|ERROR: not yet stable as a const intrinsic
 
         old_way::size_of_val(&x);

--- a/tests/ui/consts/const-unstable-intrinsic.stderr
+++ b/tests/ui/consts/const-unstable-intrinsic.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable'
+error[E0658]: use of unstable library feature `unstable`
   --> $DIR/const-unstable-intrinsic.rs:17:9
    |
 LL |         unstable_intrinsic::old_way::size_of_val(&x);
@@ -8,7 +8,7 @@ LL |         unstable_intrinsic::old_way::size_of_val(&x);
    = help: add `#![feature(unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable'
+error[E0658]: use of unstable library feature `unstable`
   --> $DIR/const-unstable-intrinsic.rs:20:9
    |
 LL |         unstable_intrinsic::old_way::min_align_of_val(&x);
@@ -18,7 +18,7 @@ LL |         unstable_intrinsic::old_way::min_align_of_val(&x);
    = help: add `#![feature(unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable'
+error[E0658]: use of unstable library feature `unstable`
   --> $DIR/const-unstable-intrinsic.rs:23:9
    |
 LL |         unstable_intrinsic::new_way::size_of_val(&x);
@@ -28,7 +28,7 @@ LL |         unstable_intrinsic::new_way::size_of_val(&x);
    = help: add `#![feature(unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable'
+error[E0658]: use of unstable library feature `unstable`
   --> $DIR/const-unstable-intrinsic.rs:26:9
    |
 LL |         unstable_intrinsic::new_way::min_align_of_val(&x);

--- a/tests/ui/derives/rustc-decodable-issue-123156.stderr
+++ b/tests/ui/derives/rustc-decodable-issue-123156.stderr
@@ -1,5 +1,5 @@
 Future incompatibility report: Future breakage diagnostic:
-warning: use of unstable library feature 'rustc_encodable_decodable': derive macro for `rustc-serialize`; should not be used in new code
+warning: use of unstable library feature `rustc_encodable_decodable`: derive macro for `rustc-serialize`; should not be used in new code
   --> $DIR/rustc-decodable-issue-123156.rs:10:10
    |
 LL | #[derive(RustcDecodable)]

--- a/tests/ui/explore-issue-38412.rs
+++ b/tests/ui/explore-issue-38412.rs
@@ -18,7 +18,7 @@ fn main() {
 
     let Record { a_stable_pub: _, a_unstable_declared_pub: _, a_unstable_undeclared_pub: _, .. } =
         Record::new();
-    //~^^ ERROR use of unstable library feature 'unstable_undeclared'
+    //~^^ ERROR use of unstable library feature `unstable_undeclared`
 
     let r = Record::new();
     let t = Tuple::new();

--- a/tests/ui/explore-issue-38412.stderr
+++ b/tests/ui/explore-issue-38412.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_undeclared'
+error[E0658]: use of unstable library feature `unstable_undeclared`
   --> $DIR/explore-issue-38412.rs:19:63
    |
 LL |     let Record { a_stable_pub: _, a_unstable_declared_pub: _, a_unstable_undeclared_pub: _, .. } =
@@ -8,7 +8,7 @@ LL |     let Record { a_stable_pub: _, a_unstable_declared_pub: _, a_unstable_un
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_undeclared'
+error[E0658]: use of unstable library feature `unstable_undeclared`
   --> $DIR/explore-issue-38412.rs:28:5
    |
 LL |     r.a_unstable_undeclared_pub;
@@ -36,7 +36,7 @@ error[E0616]: field `d_priv` of struct `Record` is private
 LL |     r.d_priv;
    |       ^^^^^^ private field
 
-error[E0658]: use of unstable library feature 'unstable_undeclared'
+error[E0658]: use of unstable library feature `unstable_undeclared`
   --> $DIR/explore-issue-38412.rs:35:5
    |
 LL |     t.2;
@@ -64,7 +64,7 @@ error[E0616]: field `5` of struct `pub_and_stability::Tuple` is private
 LL |     t.5;
    |       ^ private field
 
-error[E0658]: use of unstable library feature 'unstable_undeclared'
+error[E0658]: use of unstable library feature `unstable_undeclared`
   --> $DIR/explore-issue-38412.rs:42:7
    |
 LL |     r.unstable_undeclared_trait_method();
@@ -74,7 +74,7 @@ LL |     r.unstable_undeclared_trait_method();
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_undeclared'
+error[E0658]: use of unstable library feature `unstable_undeclared`
   --> $DIR/explore-issue-38412.rs:46:7
    |
 LL |     r.unstable_undeclared();
@@ -117,7 +117,7 @@ LL |     r.private();
 LL |         fn private(&self) -> i32 { self.d_priv }
    |         ------------------------ private method defined here
 
-error[E0658]: use of unstable library feature 'unstable_undeclared'
+error[E0658]: use of unstable library feature `unstable_undeclared`
   --> $DIR/explore-issue-38412.rs:55:7
    |
 LL |     t.unstable_undeclared_trait_method();
@@ -127,7 +127,7 @@ LL |     t.unstable_undeclared_trait_method();
    = help: add `#![feature(unstable_undeclared)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_undeclared'
+error[E0658]: use of unstable library feature `unstable_undeclared`
   --> $DIR/explore-issue-38412.rs:59:7
    |
 LL |     t.unstable_undeclared();

--- a/tests/ui/feature-gates/bench.rs
+++ b/tests/ui/feature-gates/bench.rs
@@ -1,9 +1,9 @@
 //@ edition:2018
 
-#[bench] //~ ERROR use of unstable library feature 'test'
+#[bench] //~ ERROR use of unstable library feature `test`
          //~| WARN this was previously accepted
 fn bench() {}
 
-use bench as _; //~ ERROR use of unstable library feature 'test'
+use bench as _; //~ ERROR use of unstable library feature `test`
                 //~| WARN this was previously accepted
 fn main() {}

--- a/tests/ui/feature-gates/bench.stderr
+++ b/tests/ui/feature-gates/bench.stderr
@@ -1,4 +1,4 @@
-error: use of unstable library feature 'test': `bench` is a part of custom test frameworks which are unstable
+error: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
   --> $DIR/bench.rs:3:3
    |
 LL | #[bench]
@@ -8,7 +8,7 @@ LL | #[bench]
    = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
    = note: `#[deny(soft_unstable)]` on by default
 
-error: use of unstable library feature 'test': `bench` is a part of custom test frameworks which are unstable
+error: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
   --> $DIR/bench.rs:7:5
    |
 LL | use bench as _;
@@ -20,7 +20,7 @@ LL | use bench as _;
 error: aborting due to 2 previous errors
 
 Future incompatibility report: Future breakage diagnostic:
-error: use of unstable library feature 'test': `bench` is a part of custom test frameworks which are unstable
+error: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
   --> $DIR/bench.rs:3:3
    |
 LL | #[bench]
@@ -31,7 +31,7 @@ LL | #[bench]
    = note: `#[deny(soft_unstable)]` on by default
 
 Future breakage diagnostic:
-error: use of unstable library feature 'test': `bench` is a part of custom test frameworks which are unstable
+error: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
   --> $DIR/bench.rs:7:5
    |
 LL | use bench as _;

--- a/tests/ui/feature-gates/feature-gate-alloc-error-handler.rs
+++ b/tests/ui/feature-gates/feature-gate-alloc-error-handler.rs
@@ -5,7 +5,7 @@
 
 use core::alloc::Layout;
 
-#[alloc_error_handler] //~ ERROR use of unstable library feature 'alloc_error_handler'
+#[alloc_error_handler] //~ ERROR use of unstable library feature `alloc_error_handler`
 fn oom(info: Layout) -> ! {
     loop {}
 }

--- a/tests/ui/feature-gates/feature-gate-alloc-error-handler.stderr
+++ b/tests/ui/feature-gates/feature-gate-alloc-error-handler.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'alloc_error_handler'
+error[E0658]: use of unstable library feature `alloc_error_handler`
   --> $DIR/feature-gate-alloc-error-handler.rs:8:3
    |
 LL | #[alloc_error_handler]

--- a/tests/ui/feature-gates/feature-gate-autodiff-use.has_support.stderr
+++ b/tests/ui/feature-gates/feature-gate-autodiff-use.has_support.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'autodiff'
+error[E0658]: use of unstable library feature `autodiff`
   --> $DIR/feature-gate-autodiff-use.rs:13:3
    |
 LL | #[autodiff(dfoo, Reverse)]
@@ -8,7 +8,7 @@ LL | #[autodiff(dfoo, Reverse)]
    = help: add `#![feature(autodiff)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'autodiff'
+error[E0658]: use of unstable library feature `autodiff`
   --> $DIR/feature-gate-autodiff-use.rs:9:5
    |
 LL | use std::autodiff::autodiff;

--- a/tests/ui/feature-gates/feature-gate-autodiff-use.no_support.stderr
+++ b/tests/ui/feature-gates/feature-gate-autodiff-use.no_support.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'autodiff'
+error[E0658]: use of unstable library feature `autodiff`
   --> $DIR/feature-gate-autodiff-use.rs:13:3
    |
 LL | #[autodiff(dfoo, Reverse)]
@@ -14,7 +14,7 @@ error: this rustc version does not support autodiff
 LL | #[autodiff(dfoo, Reverse)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error[E0658]: use of unstable library feature 'autodiff'
+error[E0658]: use of unstable library feature `autodiff`
   --> $DIR/feature-gate-autodiff-use.rs:9:5
    |
 LL | use std::autodiff::autodiff;

--- a/tests/ui/feature-gates/feature-gate-autodiff-use.rs
+++ b/tests/ui/feature-gates/feature-gate-autodiff-use.rs
@@ -7,11 +7,11 @@
 #![crate_type = "lib"]
 
 use std::autodiff::autodiff;
-//[has_support]~^ ERROR use of unstable library feature 'autodiff'
-//[no_support]~^^ ERROR use of unstable library feature 'autodiff'
+//[has_support]~^ ERROR use of unstable library feature `autodiff`
+//[no_support]~^^ ERROR use of unstable library feature `autodiff`
 
 #[autodiff(dfoo, Reverse)]
-//[has_support]~^ ERROR use of unstable library feature 'autodiff' [E0658]
-//[no_support]~^^ ERROR use of unstable library feature 'autodiff' [E0658]
+//[has_support]~^ ERROR use of unstable library feature `autodiff` [E0658]
+//[no_support]~^^ ERROR use of unstable library feature `autodiff` [E0658]
 //[no_support]~| ERROR this rustc version does not support autodiff
 fn foo() {}

--- a/tests/ui/feature-gates/feature-gate-concat_bytes.rs
+++ b/tests/ui/feature-gates/feature-gate-concat_bytes.rs
@@ -1,4 +1,4 @@
 fn main() {
-    let a = concat_bytes!(b'A', b"BC"); //~ ERROR use of unstable library feature 'concat_bytes'
+    let a = concat_bytes!(b'A', b"BC"); //~ ERROR use of unstable library feature `concat_bytes`
     assert_eq!(a, &[65, 66, 67]);
 }

--- a/tests/ui/feature-gates/feature-gate-concat_bytes.stderr
+++ b/tests/ui/feature-gates/feature-gate-concat_bytes.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'concat_bytes'
+error[E0658]: use of unstable library feature `concat_bytes`
   --> $DIR/feature-gate-concat_bytes.rs:2:13
    |
 LL |     let a = concat_bytes!(b'A', b"BC");

--- a/tests/ui/feature-gates/feature-gate-concat_idents.stderr
+++ b/tests/ui/feature-gates/feature-gate-concat_idents.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` is not stable enough for use and is subject to change
+error[E0658]: use of unstable library feature `concat_idents`: `concat_idents` is not stable enough for use and is subject to change
   --> $DIR/feature-gate-concat_idents.rs:5:13
    |
 LL |     let a = concat_idents!(X, Y_1);
@@ -8,7 +8,7 @@ LL |     let a = concat_idents!(X, Y_1);
    = help: add `#![feature(concat_idents)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` is not stable enough for use and is subject to change
+error[E0658]: use of unstable library feature `concat_idents`: `concat_idents` is not stable enough for use and is subject to change
   --> $DIR/feature-gate-concat_idents.rs:6:13
    |
 LL |     let b = concat_idents!(X, Y_2);

--- a/tests/ui/feature-gates/feature-gate-concat_idents2.stderr
+++ b/tests/ui/feature-gates/feature-gate-concat_idents2.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` is not stable enough for use and is subject to change
+error[E0658]: use of unstable library feature `concat_idents`: `concat_idents` is not stable enough for use and is subject to change
   --> $DIR/feature-gate-concat_idents2.rs:2:5
    |
 LL |     concat_idents!(a, b);

--- a/tests/ui/feature-gates/feature-gate-concat_idents3.stderr
+++ b/tests/ui/feature-gates/feature-gate-concat_idents3.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` is not stable enough for use and is subject to change
+error[E0658]: use of unstable library feature `concat_idents`: `concat_idents` is not stable enough for use and is subject to change
   --> $DIR/feature-gate-concat_idents3.rs:5:20
    |
 LL |     assert_eq!(10, concat_idents!(X, Y_1));
@@ -8,7 +8,7 @@ LL |     assert_eq!(10, concat_idents!(X, Y_1));
    = help: add `#![feature(concat_idents)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'concat_idents': `concat_idents` is not stable enough for use and is subject to change
+error[E0658]: use of unstable library feature `concat_idents`: `concat_idents` is not stable enough for use and is subject to change
   --> $DIR/feature-gate-concat_idents3.rs:6:20
    |
 LL |     assert_eq!(20, concat_idents!(X, Y_2));

--- a/tests/ui/feature-gates/feature-gate-custom_mir.stderr
+++ b/tests/ui/feature-gates/feature-gate-custom_mir.stderr
@@ -7,7 +7,7 @@ LL | #[custom_mir(dialect = "built")]
    = help: add `#![feature(custom_mir)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'custom_mir': MIR is an implementation detail and extremely unstable
+error[E0658]: use of unstable library feature `custom_mir`: MIR is an implementation detail and extremely unstable
   --> $DIR/feature-gate-custom_mir.rs:4:5
    |
 LL | use core::intrinsics::mir::*;
@@ -16,7 +16,7 @@ LL | use core::intrinsics::mir::*;
    = help: add `#![feature(custom_mir)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'custom_mir': MIR is an implementation detail and extremely unstable
+error[E0658]: use of unstable library feature `custom_mir`: MIR is an implementation detail and extremely unstable
   --> $DIR/feature-gate-custom_mir.rs:10:13
    |
 LL |             Return()

--- a/tests/ui/feature-gates/feature-gate-custom_test_frameworks.stderr
+++ b/tests/ui/feature-gates/feature-gate-custom_test_frameworks.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'custom_test_frameworks': custom test frameworks are an unstable feature
+error[E0658]: use of unstable library feature `custom_test_frameworks`: custom test frameworks are an unstable feature
   --> $DIR/feature-gate-custom_test_frameworks.rs:3:3
    |
 LL | #[test_case]

--- a/tests/ui/feature-gates/feature-gate-derive-coerce-pointee.rs
+++ b/tests/ui/feature-gates/feature-gate-derive-coerce-pointee.rs
@@ -1,6 +1,6 @@
-use std::marker::CoercePointee; //~ ERROR use of unstable library feature 'derive_coerce_pointee'
+use std::marker::CoercePointee; //~ ERROR use of unstable library feature `derive_coerce_pointee`
 
-#[derive(CoercePointee)] //~ ERROR use of unstable library feature 'derive_coerce_pointee'
+#[derive(CoercePointee)] //~ ERROR use of unstable library feature `derive_coerce_pointee`
 #[repr(transparent)]
 struct MyPointer<'a, #[pointee] T: ?Sized> {
     ptr: &'a T,

--- a/tests/ui/feature-gates/feature-gate-derive-coerce-pointee.stderr
+++ b/tests/ui/feature-gates/feature-gate-derive-coerce-pointee.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'derive_coerce_pointee'
+error[E0658]: use of unstable library feature `derive_coerce_pointee`
   --> $DIR/feature-gate-derive-coerce-pointee.rs:3:10
    |
 LL | #[derive(CoercePointee)]
@@ -8,7 +8,7 @@ LL | #[derive(CoercePointee)]
    = help: add `#![feature(derive_coerce_pointee)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'derive_coerce_pointee'
+error[E0658]: use of unstable library feature `derive_coerce_pointee`
   --> $DIR/feature-gate-derive-coerce-pointee.rs:1:5
    |
 LL | use std::marker::CoercePointee;

--- a/tests/ui/feature-gates/feature-gate-format_args_nl.stderr
+++ b/tests/ui/feature-gates/feature-gate-format_args_nl.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'format_args_nl': `format_args_nl` is only for internal language use and is subject to change
+error[E0658]: use of unstable library feature `format_args_nl`: `format_args_nl` is only for internal language use and is subject to change
   --> $DIR/feature-gate-format_args_nl.rs:2:5
    |
 LL |     format_args_nl!("");

--- a/tests/ui/feature-gates/feature-gate-log_syntax.stderr
+++ b/tests/ui/feature-gates/feature-gate-log_syntax.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'log_syntax': `log_syntax!` is not stable enough for use and is subject to change
+error[E0658]: use of unstable library feature `log_syntax`: `log_syntax!` is not stable enough for use and is subject to change
   --> $DIR/feature-gate-log_syntax.rs:2:5
    |
 LL |     log_syntax!()

--- a/tests/ui/feature-gates/feature-gate-log_syntax2.stderr
+++ b/tests/ui/feature-gates/feature-gate-log_syntax2.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'log_syntax': `log_syntax!` is not stable enough for use and is subject to change
+error[E0658]: use of unstable library feature `log_syntax`: `log_syntax!` is not stable enough for use and is subject to change
   --> $DIR/feature-gate-log_syntax2.rs:2:22
    |
 LL |     println!("{:?}", log_syntax!());

--- a/tests/ui/feature-gates/feature-gate-naked_functions.rs
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.rs
@@ -1,13 +1,13 @@
 //@ needs-asm-support
 
 use std::arch::naked_asm;
-//~^ ERROR use of unstable library feature 'naked_functions'
+//~^ ERROR use of unstable library feature `naked_functions`
 
 #[naked]
 //~^ the `#[naked]` attribute is an experimental feature
 extern "C" fn naked() {
     naked_asm!("")
-    //~^ ERROR use of unstable library feature 'naked_functions'
+    //~^ ERROR use of unstable library feature `naked_functions`
     //~| ERROR: requires unsafe
 }
 
@@ -15,7 +15,7 @@ extern "C" fn naked() {
 //~^ the `#[naked]` attribute is an experimental feature
 extern "C" fn naked_2() -> isize {
     naked_asm!("")
-    //~^ ERROR use of unstable library feature 'naked_functions'
+    //~^ ERROR use of unstable library feature `naked_functions`
     //~| ERROR: requires unsafe
 }
 

--- a/tests/ui/feature-gates/feature-gate-naked_functions.stderr
+++ b/tests/ui/feature-gates/feature-gate-naked_functions.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'naked_functions'
+error[E0658]: use of unstable library feature `naked_functions`
   --> $DIR/feature-gate-naked_functions.rs:9:5
    |
 LL |     naked_asm!("")
@@ -8,7 +8,7 @@ LL |     naked_asm!("")
    = help: add `#![feature(naked_functions)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'naked_functions'
+error[E0658]: use of unstable library feature `naked_functions`
   --> $DIR/feature-gate-naked_functions.rs:17:5
    |
 LL |     naked_asm!("")
@@ -38,7 +38,7 @@ LL | #[naked]
    = help: add `#![feature(naked_functions)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'naked_functions'
+error[E0658]: use of unstable library feature `naked_functions`
   --> $DIR/feature-gate-naked_functions.rs:3:5
    |
 LL | use std::arch::naked_asm;

--- a/tests/ui/feature-gates/feature-gate-rustc_encodable_decodable.rs
+++ b/tests/ui/feature-gates/feature-gate-rustc_encodable_decodable.rs
@@ -5,11 +5,11 @@ extern crate rustc_serialize; //~ERROR can't find crate for `rustc_serialize`
 
 #[derive(
     RustcEncodable,
-    //~^   ERROR   use of unstable library feature 'rustc_encodable_decodable'
+    //~^   ERROR   use of unstable library feature `rustc_encodable_decodable`
     //~^^  WARNING this was previously accepted by the compiler
     //~^^^ WARNING use of deprecated macro `RustcEncodable`
     RustcDecodable,
-    //~^   ERROR   use of unstable library feature 'rustc_encodable_decodable'
+    //~^   ERROR   use of unstable library feature `rustc_encodable_decodable`
     //~^^  WARNING this was previously accepted by the compiler
     //~^^^ WARNING use of deprecated macro `RustcDecodable`
 )]

--- a/tests/ui/feature-gates/feature-gate-rustc_encodable_decodable.stderr
+++ b/tests/ui/feature-gates/feature-gate-rustc_encodable_decodable.stderr
@@ -6,7 +6,7 @@ LL | extern crate rustc_serialize;
    |
    = help: maybe you need to install the missing components with: `rustup component add rust-src rustc-dev llvm-tools-preview`
 
-error: use of unstable library feature 'rustc_encodable_decodable': derive macro for `rustc-serialize`; should not be used in new code
+error: use of unstable library feature `rustc_encodable_decodable`: derive macro for `rustc-serialize`; should not be used in new code
   --> $DIR/feature-gate-rustc_encodable_decodable.rs:7:5
    |
 LL |     RustcEncodable,
@@ -24,7 +24,7 @@ LL |     RustcEncodable,
    |
    = note: `#[warn(deprecated)]` on by default
 
-error: use of unstable library feature 'rustc_encodable_decodable': derive macro for `rustc-serialize`; should not be used in new code
+error: use of unstable library feature `rustc_encodable_decodable`: derive macro for `rustc-serialize`; should not be used in new code
   --> $DIR/feature-gate-rustc_encodable_decodable.rs:11:5
    |
 LL |     RustcDecodable,
@@ -43,7 +43,7 @@ error: aborting due to 3 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0463`.
 Future incompatibility report: Future breakage diagnostic:
-error: use of unstable library feature 'rustc_encodable_decodable': derive macro for `rustc-serialize`; should not be used in new code
+error: use of unstable library feature `rustc_encodable_decodable`: derive macro for `rustc-serialize`; should not be used in new code
   --> $DIR/feature-gate-rustc_encodable_decodable.rs:7:5
    |
 LL |     RustcEncodable,
@@ -54,7 +54,7 @@ LL |     RustcEncodable,
    = note: `#[deny(soft_unstable)]` on by default
 
 Future breakage diagnostic:
-error: use of unstable library feature 'rustc_encodable_decodable': derive macro for `rustc-serialize`; should not be used in new code
+error: use of unstable library feature `rustc_encodable_decodable`: derive macro for `rustc-serialize`; should not be used in new code
   --> $DIR/feature-gate-rustc_encodable_decodable.rs:11:5
    |
 LL |     RustcDecodable,

--- a/tests/ui/feature-gates/feature-gate-trace_macros.stderr
+++ b/tests/ui/feature-gates/feature-gate-trace_macros.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is not stable enough for use and is subject to change
+error[E0658]: use of unstable library feature `trace_macros`: `trace_macros` is not stable enough for use and is subject to change
   --> $DIR/feature-gate-trace_macros.rs:2:5
    |
 LL |     trace_macros!(true);

--- a/tests/ui/feature-gates/feature-gate-type_ascription.rs
+++ b/tests/ui/feature-gates/feature-gate-type_ascription.rs
@@ -1,5 +1,5 @@
 // Type ascription is unstable
 
 fn main() {
-    let a = type_ascribe!(10, u8); //~ ERROR use of unstable library feature 'type_ascription': placeholder syntax for type ascription
+    let a = type_ascribe!(10, u8); //~ ERROR use of unstable library feature `type_ascription`: placeholder syntax for type ascription
 }

--- a/tests/ui/feature-gates/feature-gate-type_ascription.stderr
+++ b/tests/ui/feature-gates/feature-gate-type_ascription.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'type_ascription': placeholder syntax for type ascription
+error[E0658]: use of unstable library feature `type_ascription`: placeholder syntax for type ascription
   --> $DIR/feature-gate-type_ascription.rs:4:13
    |
 LL |     let a = type_ascribe!(10, u8);

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-method-calls.rs
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-method-calls.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)]
 
 fn foo<F: Fn()>(mut f: F) {
-    f.call(()); //~ ERROR use of unstable library feature 'fn_traits'
-    f.call_mut(()); //~ ERROR use of unstable library feature 'fn_traits'
-    f.call_once(()); //~ ERROR use of unstable library feature 'fn_traits'
+    f.call(()); //~ ERROR use of unstable library feature `fn_traits`
+    f.call_mut(()); //~ ERROR use of unstable library feature `fn_traits`
+    f.call_once(()); //~ ERROR use of unstable library feature `fn_traits`
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-method-calls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-method-calls.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'fn_traits'
+error[E0658]: use of unstable library feature `fn_traits`
   --> $DIR/feature-gate-unboxed-closures-method-calls.rs:4:7
    |
 LL |     f.call(());
@@ -8,7 +8,7 @@ LL |     f.call(());
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'fn_traits'
+error[E0658]: use of unstable library feature `fn_traits`
   --> $DIR/feature-gate-unboxed-closures-method-calls.rs:5:7
    |
 LL |     f.call_mut(());
@@ -18,7 +18,7 @@ LL |     f.call_mut(());
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'fn_traits'
+error[E0658]: use of unstable library feature `fn_traits`
   --> $DIR/feature-gate-unboxed-closures-method-calls.rs:6:7
    |
 LL |     f.call_once(());

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-ufcs-calls.rs
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-ufcs-calls.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)]
 
 fn foo<F: Fn()>(mut f: F) {
-    Fn::call(&f, ()); //~ ERROR use of unstable library feature 'fn_traits'
-    FnMut::call_mut(&mut f, ()); //~ ERROR use of unstable library feature 'fn_traits'
-    FnOnce::call_once(f, ()); //~ ERROR use of unstable library feature 'fn_traits'
+    Fn::call(&f, ()); //~ ERROR use of unstable library feature `fn_traits`
+    FnMut::call_mut(&mut f, ()); //~ ERROR use of unstable library feature `fn_traits`
+    FnOnce::call_once(f, ()); //~ ERROR use of unstable library feature `fn_traits`
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-unboxed-closures-ufcs-calls.stderr
+++ b/tests/ui/feature-gates/feature-gate-unboxed-closures-ufcs-calls.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'fn_traits'
+error[E0658]: use of unstable library feature `fn_traits`
   --> $DIR/feature-gate-unboxed-closures-ufcs-calls.rs:4:5
    |
 LL |     Fn::call(&f, ());
@@ -8,7 +8,7 @@ LL |     Fn::call(&f, ());
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'fn_traits'
+error[E0658]: use of unstable library feature `fn_traits`
   --> $DIR/feature-gate-unboxed-closures-ufcs-calls.rs:5:5
    |
 LL |     FnMut::call_mut(&mut f, ());
@@ -18,7 +18,7 @@ LL |     FnMut::call_mut(&mut f, ());
    = help: add `#![feature(fn_traits)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'fn_traits'
+error[E0658]: use of unstable library feature `fn_traits`
   --> $DIR/feature-gate-unboxed-closures-ufcs-calls.rs:6:5
    |
 LL |     FnOnce::call_once(f, ());

--- a/tests/ui/feature-gates/issue-49983-see-issue-0.stderr
+++ b/tests/ui/feature-gates/issue-49983-see-issue-0.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'ptr_internals': use `NonNull` instead and consider `PhantomData<T>` (if you also use `#[may_dangle]`), `Send`, and/or `Sync`
+error[E0658]: use of unstable library feature `ptr_internals`: use `NonNull` instead and consider `PhantomData<T>` (if you also use `#[may_dangle]`), `Send`, and/or `Sync`
   --> $DIR/issue-49983-see-issue-0.rs:4:30
    |
 LL | #[allow(unused_imports)] use core::ptr::Unique;

--- a/tests/ui/feature-gates/rustc-private.rs
+++ b/tests/ui/feature-gates/rustc-private.rs
@@ -1,5 +1,5 @@
 // gate-test-rustc_private
 
-extern crate cfg_if; //~ ERROR  use of unstable library feature 'rustc_private'
+extern crate cfg_if; //~ ERROR  use of unstable library feature `rustc_private`
 
 fn main() {}

--- a/tests/ui/feature-gates/rustc-private.stderr
+++ b/tests/ui/feature-gates/rustc-private.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'rustc_private': this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
+error[E0658]: use of unstable library feature `rustc_private`: this crate is being loaded from the sysroot, an unstable location; did you mean to load this crate from crates.io via `Cargo.toml` instead?
   --> $DIR/rustc-private.rs:3:1
    |
 LL | extern crate cfg_if;

--- a/tests/ui/feature-gates/trace_macros-gate.stderr
+++ b/tests/ui/feature-gates/trace_macros-gate.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is not stable enough for use and is subject to change
+error[E0658]: use of unstable library feature `trace_macros`: `trace_macros` is not stable enough for use and is subject to change
   --> $DIR/trace_macros-gate.rs:4:5
    |
 LL |     trace_macros!();
@@ -14,7 +14,7 @@ error: trace_macros! accepts only `true` or `false`
 LL |     trace_macros!();
    |     ^^^^^^^^^^^^^^^
 
-error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is not stable enough for use and is subject to change
+error[E0658]: use of unstable library feature `trace_macros`: `trace_macros` is not stable enough for use and is subject to change
   --> $DIR/trace_macros-gate.rs:6:5
    |
 LL |     trace_macros!(true);
@@ -24,7 +24,7 @@ LL |     trace_macros!(true);
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is not stable enough for use and is subject to change
+error[E0658]: use of unstable library feature `trace_macros`: `trace_macros` is not stable enough for use and is subject to change
   --> $DIR/trace_macros-gate.rs:7:5
    |
 LL |     trace_macros!(false);
@@ -34,7 +34,7 @@ LL |     trace_macros!(false);
    = help: add `#![feature(trace_macros)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'trace_macros': `trace_macros` is not stable enough for use and is subject to change
+error[E0658]: use of unstable library feature `trace_macros`: `trace_macros` is not stable enough for use and is subject to change
   --> $DIR/trace_macros-gate.rs:10:26
    |
 LL |         ($x: ident) => { trace_macros!($x) }

--- a/tests/ui/imports/issue-37887.stderr
+++ b/tests/ui/imports/issue-37887.stderr
@@ -9,7 +9,7 @@ help: consider importing the `test` crate
 LL + extern crate test;
    |
 
-error[E0658]: use of unstable library feature 'test'
+error[E0658]: use of unstable library feature `test`
   --> $DIR/issue-37887.rs:2:5
    |
 LL |     extern crate test;

--- a/tests/ui/imports/resolve-other-libc.rs
+++ b/tests/ui/imports/resolve-other-libc.rs
@@ -6,7 +6,7 @@
 // indicates that `libc` was wrongly resolved to `libc` shipped with the
 // compiler:
 //
-//   error[E0658]: use of unstable library feature 'rustc_private': \
+//   error[E0658]: use of unstable library feature `rustc_private`: \
 //           this crate is being loaded from the sysroot
 //
 extern crate libc; //~ ERROR: extern location for libc does not exist: test.rlib

--- a/tests/ui/inference/inference_unstable_forced.stderr
+++ b/tests/ui/inference/inference_unstable_forced.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'ipu_flatten'
+error[E0658]: use of unstable library feature `ipu_flatten`
   --> $DIR/inference_unstable_forced.rs:11:20
    |
 LL |     assert_eq!('x'.ipu_flatten(), 0);

--- a/tests/ui/internal/internal-unstable-noallow.rs
+++ b/tests/ui/internal/internal-unstable-noallow.rs
@@ -4,10 +4,10 @@
 // the // ~ form.
 
 //@ aux-build:internal_unstable.rs
-//@ error-pattern:use of unstable library feature 'function'
-//@ error-pattern:use of unstable library feature 'struct_field'
-//@ error-pattern:use of unstable library feature 'method'
-//@ error-pattern:use of unstable library feature 'struct2_field'
+//@ error-pattern:use of unstable library feature `function`
+//@ error-pattern:use of unstable library feature `struct_field`
+//@ error-pattern:use of unstable library feature `method`
+//@ error-pattern:use of unstable library feature `struct2_field`
 
 #[macro_use]
 extern crate internal_unstable;

--- a/tests/ui/internal/internal-unstable-noallow.stderr
+++ b/tests/ui/internal/internal-unstable-noallow.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'function'
+error[E0658]: use of unstable library feature `function`
   --> $DIR/internal-unstable-noallow.rs:16:5
    |
 LL |     call_unstable_noallow!();
@@ -8,7 +8,7 @@ LL |     call_unstable_noallow!();
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `call_unstable_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0658]: use of unstable library feature 'struct_field'
+error[E0658]: use of unstable library feature `struct_field`
   --> $DIR/internal-unstable-noallow.rs:18:5
    |
 LL |     construct_unstable_noallow!(0);
@@ -18,7 +18,7 @@ LL |     construct_unstable_noallow!(0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `construct_unstable_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0658]: use of unstable library feature 'method'
+error[E0658]: use of unstable library feature `method`
   --> $DIR/internal-unstable-noallow.rs:20:35
    |
 LL |     |x: internal_unstable::Foo| { call_method_noallow!(x) };
@@ -28,7 +28,7 @@ LL |     |x: internal_unstable::Foo| { call_method_noallow!(x) };
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `call_method_noallow` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0658]: use of unstable library feature 'struct2_field'
+error[E0658]: use of unstable library feature `struct2_field`
   --> $DIR/internal-unstable-noallow.rs:22:35
    |
 LL |     |x: internal_unstable::Bar| { access_field_noallow!(x) };

--- a/tests/ui/internal/internal-unstable-thread-local.stderr
+++ b/tests/ui/internal/internal-unstable-thread-local.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'function'
+error[E0658]: use of unstable library feature `function`
   --> $DIR/internal-unstable-thread-local.rs:9:32
    |
 LL | thread_local!(static BAR: () = internal_unstable::unstable());

--- a/tests/ui/internal/internal-unstable.stderr
+++ b/tests/ui/internal/internal-unstable.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'function'
+error[E0658]: use of unstable library feature `function`
   --> $DIR/internal-unstable.rs:48:25
    |
 LL |     pass_through_allow!(internal_unstable::unstable());
@@ -7,7 +7,7 @@ LL |     pass_through_allow!(internal_unstable::unstable());
    = help: add `#![feature(function)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'function'
+error[E0658]: use of unstable library feature `function`
   --> $DIR/internal-unstable.rs:50:27
    |
 LL |     pass_through_noallow!(internal_unstable::unstable());
@@ -16,7 +16,7 @@ LL |     pass_through_noallow!(internal_unstable::unstable());
    = help: add `#![feature(function)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'function'
+error[E0658]: use of unstable library feature `function`
   --> $DIR/internal-unstable.rs:54:22
    |
 LL |     println!("{:?}", internal_unstable::unstable());
@@ -25,7 +25,7 @@ LL |     println!("{:?}", internal_unstable::unstable());
    = help: add `#![feature(function)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'function'
+error[E0658]: use of unstable library feature `function`
   --> $DIR/internal-unstable.rs:56:10
    |
 LL |     bar!(internal_unstable::unstable());
@@ -34,7 +34,7 @@ LL |     bar!(internal_unstable::unstable());
    = help: add `#![feature(function)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'function'
+error[E0658]: use of unstable library feature `function`
   --> $DIR/internal-unstable.rs:18:9
    |
 LL |         internal_unstable::unstable();

--- a/tests/ui/intrinsics/unchecked_math_unstable.stderr
+++ b/tests/ui/intrinsics/unchecked_math_unstable.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'core_intrinsics': intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
+error[E0658]: use of unstable library feature `core_intrinsics`: intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
   --> $DIR/unchecked_math_unstable.rs:4:19
    |
 LL |         let add = std::intrinsics::unchecked_add(x, y);
@@ -7,7 +7,7 @@ LL |         let add = std::intrinsics::unchecked_add(x, y);
    = help: add `#![feature(core_intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'core_intrinsics': intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
+error[E0658]: use of unstable library feature `core_intrinsics`: intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
   --> $DIR/unchecked_math_unstable.rs:5:19
    |
 LL |         let sub = std::intrinsics::unchecked_sub(x, y);
@@ -16,7 +16,7 @@ LL |         let sub = std::intrinsics::unchecked_sub(x, y);
    = help: add `#![feature(core_intrinsics)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'core_intrinsics': intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
+error[E0658]: use of unstable library feature `core_intrinsics`: intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
   --> $DIR/unchecked_math_unstable.rs:6:19
    |
 LL |         let mul = std::intrinsics::unchecked_mul(x, y);

--- a/tests/ui/issues/issue-52489.rs
+++ b/tests/ui/issues/issue-52489.rs
@@ -3,6 +3,6 @@
 //@ compile-flags:--extern issue_52489
 
 use issue_52489;
-//~^ ERROR use of unstable library feature 'issue_52489_unstable'
+//~^ ERROR use of unstable library feature `issue_52489_unstable`
 
 fn main() {}

--- a/tests/ui/issues/issue-52489.stderr
+++ b/tests/ui/issues/issue-52489.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'issue_52489_unstable'
+error[E0658]: use of unstable library feature `issue_52489_unstable`
   --> $DIR/issue-52489.rs:5:5
    |
 LL | use issue_52489;

--- a/tests/ui/layout/thaw-transmute-invalid-enum.rs
+++ b/tests/ui/layout/thaw-transmute-invalid-enum.rs
@@ -2,13 +2,13 @@
 
 mod assert {
     use std::mem::{Assume, TransmuteFrom};
-    //~^ ERROR: use of unstable library feature 'transmutability'
-    //~| ERROR: use of unstable library feature 'transmutability'
+    //~^ ERROR: use of unstable library feature `transmutability`
+    //~| ERROR: use of unstable library feature `transmutability`
 
     pub fn is_transmutable<Src, Dst>()
     where
         Dst: TransmuteFrom<Src>,
-        //~^ ERROR: use of unstable library feature 'transmutability'
+        //~^ ERROR: use of unstable library feature `transmutability`
     {
     }
 }

--- a/tests/ui/layout/thaw-transmute-invalid-enum.stderr
+++ b/tests/ui/layout/thaw-transmute-invalid-enum.stderr
@@ -20,7 +20,7 @@ LL | |     V = 0xFF,
 LL | | }
    | |_- not a struct or union
 
-error[E0658]: use of unstable library feature 'transmutability'
+error[E0658]: use of unstable library feature `transmutability`
   --> $DIR/thaw-transmute-invalid-enum.rs:4:20
    |
 LL |     use std::mem::{Assume, TransmuteFrom};
@@ -30,7 +30,7 @@ LL |     use std::mem::{Assume, TransmuteFrom};
    = help: add `#![feature(transmutability)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'transmutability'
+error[E0658]: use of unstable library feature `transmutability`
   --> $DIR/thaw-transmute-invalid-enum.rs:4:28
    |
 LL |     use std::mem::{Assume, TransmuteFrom};
@@ -40,7 +40,7 @@ LL |     use std::mem::{Assume, TransmuteFrom};
    = help: add `#![feature(transmutability)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'transmutability'
+error[E0658]: use of unstable library feature `transmutability`
   --> $DIR/thaw-transmute-invalid-enum.rs:10:14
    |
 LL |         Dst: TransmuteFrom<Src>,

--- a/tests/ui/lint/expansion-time.rs
+++ b/tests/ui/lint/expansion-time.rs
@@ -11,7 +11,7 @@ macro_rules! m { ($i) => {} } //~ WARN missing fragment specifier
 
 #[warn(soft_unstable)]
 mod benches {
-    #[bench] //~ WARN use of unstable library feature 'test'
+    #[bench] //~ WARN use of unstable library feature `test`
              //~| WARN this was previously accepted
     fn foo() {}
 }

--- a/tests/ui/lint/expansion-time.stderr
+++ b/tests/ui/lint/expansion-time.stderr
@@ -26,7 +26,7 @@ note: the lint level is defined here
 LL | #[warn(missing_fragment_specifier)]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of unstable library feature 'test': `bench` is a part of custom test frameworks which are unstable
+warning: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
   --> $DIR/expansion-time.rs:14:7
    |
 LL |     #[bench]
@@ -70,7 +70,7 @@ LL | #[warn(missing_fragment_specifier)]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
-warning: use of unstable library feature 'test': `bench` is a part of custom test frameworks which are unstable
+warning: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
   --> $DIR/expansion-time.rs:14:7
    |
 LL |     #[bench]

--- a/tests/ui/lint/lint-output-format.stderr
+++ b/tests/ui/lint/lint-output-format.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-output-format.rs:6:1
    |
 LL | extern crate lint_output_format;
@@ -7,7 +7,7 @@ LL | extern crate lint_output_format;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-output-format.rs:7:26
    |
 LL | use lint_output_format::{foo, bar};
@@ -16,7 +16,7 @@ LL | use lint_output_format::{foo, bar};
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-output-format.rs:7:31
    |
 LL | use lint_output_format::{foo, bar};
@@ -25,7 +25,7 @@ LL | use lint_output_format::{foo, bar};
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-output-format.rs:12:14
    |
 LL |     let _y = bar();

--- a/tests/ui/lint/lint-stability-2.rs
+++ b/tests/ui/lint/lint-stability-2.rs
@@ -66,15 +66,15 @@ mod cross_crate {
         <Foo>::trait_unstable(&foo); //~ ERROR use of unstable library feature
 
         foo.method_unstable_text();
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
         Foo::method_unstable_text(&foo);
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
         <Foo>::method_unstable_text(&foo);
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
         foo.trait_unstable_text();
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
         <Foo>::trait_unstable_text(&foo);
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
 
         stable();
         foo.method_stable();
@@ -139,9 +139,9 @@ mod cross_crate {
         foo.trait_unstable(); //~ ERROR use of unstable library feature
         <Foo>::trait_unstable(&foo); //~ ERROR use of unstable library feature
         foo.trait_unstable_text();
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
         <Foo>::trait_unstable_text(&foo);
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
         foo.trait_stable();
         Trait::trait_stable(&foo);
         <Foo>::trait_stable(&foo);
@@ -157,7 +157,7 @@ mod cross_crate {
         //~^ ERROR use of unstable library feature
         foo.trait_unstable(); //~ ERROR use of unstable library feature
         foo.trait_unstable_text();
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
         foo.trait_stable();
     }
 

--- a/tests/ui/lint/lint-stability-2.stderr
+++ b/tests/ui/lint/lint-stability-2.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:40:13
    |
 LL |         foo.method_deprecated_unstable();
@@ -7,7 +7,7 @@ LL |         foo.method_deprecated_unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:42:9
    |
 LL |         Foo::method_deprecated_unstable(&foo);
@@ -16,7 +16,7 @@ LL |         Foo::method_deprecated_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:44:9
    |
 LL |         <Foo>::method_deprecated_unstable(&foo);
@@ -25,7 +25,7 @@ LL |         <Foo>::method_deprecated_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:46:13
    |
 LL |         foo.trait_deprecated_unstable();
@@ -34,7 +34,7 @@ LL |         foo.trait_deprecated_unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:48:9
    |
 LL |         <Foo>::trait_deprecated_unstable(&foo);
@@ -43,7 +43,7 @@ LL |         <Foo>::trait_deprecated_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:51:13
    |
 LL |         foo.method_deprecated_unstable_text();
@@ -52,7 +52,7 @@ LL |         foo.method_deprecated_unstable_text();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:53:9
    |
 LL |         Foo::method_deprecated_unstable_text(&foo);
@@ -61,7 +61,7 @@ LL |         Foo::method_deprecated_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:55:9
    |
 LL |         <Foo>::method_deprecated_unstable_text(&foo);
@@ -70,7 +70,7 @@ LL |         <Foo>::method_deprecated_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:57:13
    |
 LL |         foo.trait_deprecated_unstable_text();
@@ -79,7 +79,7 @@ LL |         foo.trait_deprecated_unstable_text();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:59:9
    |
 LL |         <Foo>::trait_deprecated_unstable_text(&foo);
@@ -88,7 +88,7 @@ LL |         <Foo>::trait_deprecated_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:62:13
    |
 LL |         foo.method_unstable();
@@ -97,7 +97,7 @@ LL |         foo.method_unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:63:9
    |
 LL |         Foo::method_unstable(&foo);
@@ -106,7 +106,7 @@ LL |         Foo::method_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:64:9
    |
 LL |         <Foo>::method_unstable(&foo);
@@ -115,7 +115,7 @@ LL |         <Foo>::method_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:65:13
    |
 LL |         foo.trait_unstable();
@@ -124,7 +124,7 @@ LL |         foo.trait_unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:66:9
    |
 LL |         <Foo>::trait_unstable(&foo);
@@ -133,7 +133,7 @@ LL |         <Foo>::trait_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability-2.rs:68:13
    |
 LL |         foo.method_unstable_text();
@@ -142,7 +142,7 @@ LL |         foo.method_unstable_text();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability-2.rs:70:9
    |
 LL |         Foo::method_unstable_text(&foo);
@@ -151,7 +151,7 @@ LL |         Foo::method_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability-2.rs:72:9
    |
 LL |         <Foo>::method_unstable_text(&foo);
@@ -160,7 +160,7 @@ LL |         <Foo>::method_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability-2.rs:74:13
    |
 LL |         foo.trait_unstable_text();
@@ -169,7 +169,7 @@ LL |         foo.trait_unstable_text();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability-2.rs:76:9
    |
 LL |         <Foo>::trait_unstable_text(&foo);
@@ -178,7 +178,7 @@ LL |         <Foo>::trait_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:131:13
    |
 LL |         foo.trait_deprecated_unstable();
@@ -187,7 +187,7 @@ LL |         foo.trait_deprecated_unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:133:9
    |
 LL |         <Foo>::trait_deprecated_unstable(&foo);
@@ -196,7 +196,7 @@ LL |         <Foo>::trait_deprecated_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:135:13
    |
 LL |         foo.trait_deprecated_unstable_text();
@@ -205,7 +205,7 @@ LL |         foo.trait_deprecated_unstable_text();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:137:9
    |
 LL |         <Foo>::trait_deprecated_unstable_text(&foo);
@@ -214,7 +214,7 @@ LL |         <Foo>::trait_deprecated_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:139:13
    |
 LL |         foo.trait_unstable();
@@ -223,7 +223,7 @@ LL |         foo.trait_unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:140:9
    |
 LL |         <Foo>::trait_unstable(&foo);
@@ -232,7 +232,7 @@ LL |         <Foo>::trait_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability-2.rs:141:13
    |
 LL |         foo.trait_unstable_text();
@@ -241,7 +241,7 @@ LL |         foo.trait_unstable_text();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability-2.rs:143:9
    |
 LL |         <Foo>::trait_unstable_text(&foo);
@@ -250,7 +250,7 @@ LL |         <Foo>::trait_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:154:13
    |
 LL |         foo.trait_deprecated_unstable();
@@ -259,7 +259,7 @@ LL |         foo.trait_deprecated_unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:156:13
    |
 LL |         foo.trait_deprecated_unstable_text();
@@ -268,7 +268,7 @@ LL |         foo.trait_deprecated_unstable_text();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-2.rs:158:13
    |
 LL |         foo.trait_unstable();
@@ -277,7 +277,7 @@ LL |         foo.trait_unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability-2.rs:159:13
    |
 LL |         foo.trait_unstable_text();

--- a/tests/ui/lint/lint-stability-fields.stderr
+++ b/tests/ui/lint/lint-stability-fields.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:56:17
    |
 LL |         let x = Unstable {
@@ -7,7 +7,7 @@ LL |         let x = Unstable {
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:66:13
    |
 LL |         let Unstable {
@@ -16,7 +16,7 @@ LL |         let Unstable {
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:72:13
    |
 LL |         let Unstable
@@ -25,7 +25,7 @@ LL |         let Unstable
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:77:17
    |
 LL |         let x = reexport::Unstable2(1, 2, 3);
@@ -34,7 +34,7 @@ LL |         let x = reexport::Unstable2(1, 2, 3);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:79:17
    |
 LL |         let x = Unstable2(1, 2, 3);
@@ -43,7 +43,7 @@ LL |         let x = Unstable2(1, 2, 3);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:85:13
    |
 LL |         let Unstable2
@@ -52,7 +52,7 @@ LL |         let Unstable2
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:90:13
    |
 LL |         let Unstable2
@@ -61,7 +61,7 @@ LL |         let Unstable2
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:95:17
    |
 LL |         let x = Deprecated {
@@ -70,7 +70,7 @@ LL |         let x = Deprecated {
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:105:13
    |
 LL |         let Deprecated {
@@ -79,7 +79,7 @@ LL |         let Deprecated {
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:111:13
    |
 LL |         let Deprecated
@@ -88,7 +88,7 @@ LL |         let Deprecated
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:115:17
    |
 LL |         let x = Deprecated2(1, 2, 3);
@@ -97,7 +97,7 @@ LL |         let x = Deprecated2(1, 2, 3);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:121:13
    |
 LL |         let Deprecated2
@@ -106,7 +106,7 @@ LL |         let Deprecated2
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:126:13
    |
 LL |         let Deprecated2
@@ -115,7 +115,7 @@ LL |         let Deprecated2
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:21:13
    |
 LL |             override1: 2,
@@ -124,7 +124,7 @@ LL |             override1: 2,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:22:13
    |
 LL |             override2: 3,
@@ -133,7 +133,7 @@ LL |             override2: 3,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:27:17
    |
 LL |         let _ = x.override1;
@@ -142,7 +142,7 @@ LL |         let _ = x.override1;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:28:17
    |
 LL |         let _ = x.override2;
@@ -151,7 +151,7 @@ LL |         let _ = x.override2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:33:13
    |
 LL |             override1: _,
@@ -160,7 +160,7 @@ LL |             override1: _,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:34:13
    |
 LL |             override2: _,
@@ -169,7 +169,7 @@ LL |             override2: _,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:43:17
    |
 LL |         let _ = x.1;
@@ -178,7 +178,7 @@ LL |         let _ = x.1;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:44:17
    |
 LL |         let _ = x.2;
@@ -187,7 +187,7 @@ LL |         let _ = x.2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:48:20
    |
 LL |                    _,
@@ -196,7 +196,7 @@ LL |                    _,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:49:20
    |
 LL |                    _,
@@ -205,7 +205,7 @@ LL |                    _,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:57:13
    |
 LL |             inherit: 1,
@@ -214,7 +214,7 @@ LL |             inherit: 1,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:59:13
    |
 LL |             override2: 3,
@@ -223,7 +223,7 @@ LL |             override2: 3,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:62:17
    |
 LL |         let _ = x.inherit;
@@ -232,7 +232,7 @@ LL |         let _ = x.inherit;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:64:17
    |
 LL |         let _ = x.override2;
@@ -241,7 +241,7 @@ LL |         let _ = x.override2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:67:13
    |
 LL |             inherit: _,
@@ -250,7 +250,7 @@ LL |             inherit: _,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:69:13
    |
 LL |             override2: _
@@ -259,7 +259,7 @@ LL |             override2: _
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:81:17
    |
 LL |         let _ = x.0;
@@ -268,7 +268,7 @@ LL |         let _ = x.0;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:83:17
    |
 LL |         let _ = x.2;
@@ -277,7 +277,7 @@ LL |         let _ = x.2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:86:14
    |
 LL |             (_,
@@ -286,7 +286,7 @@ LL |             (_,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:88:14
    |
 LL |              _)
@@ -295,7 +295,7 @@ LL |              _)
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:96:13
    |
 LL |             inherit: 1,
@@ -304,7 +304,7 @@ LL |             inherit: 1,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:98:13
    |
 LL |             override2: 3,
@@ -313,7 +313,7 @@ LL |             override2: 3,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:101:17
    |
 LL |         let _ = x.inherit;
@@ -322,7 +322,7 @@ LL |         let _ = x.inherit;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:103:17
    |
 LL |         let _ = x.override2;
@@ -331,7 +331,7 @@ LL |         let _ = x.override2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:106:13
    |
 LL |             inherit: _,
@@ -340,7 +340,7 @@ LL |             inherit: _,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:108:13
    |
 LL |             override2: _
@@ -349,7 +349,7 @@ LL |             override2: _
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:117:17
    |
 LL |         let _ = x.0;
@@ -358,7 +358,7 @@ LL |         let _ = x.0;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:119:17
    |
 LL |         let _ = x.2;
@@ -367,7 +367,7 @@ LL |         let _ = x.2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:122:14
    |
 LL |             (_,
@@ -376,7 +376,7 @@ LL |             (_,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability-fields.rs:124:14
    |
 LL |              _)

--- a/tests/ui/lint/lint-stability.rs
+++ b/tests/ui/lint/lint-stability.rs
@@ -61,11 +61,11 @@ mod cross_crate {
         <Foo as Trait>::trait_unstable(&foo); //~ ERROR use of unstable library feature
 
         unstable_text();
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
         Trait::trait_unstable_text(&foo);
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
         <Foo as Trait>::trait_unstable_text(&foo);
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
 
         stable();
         foo.method_stable();
@@ -152,9 +152,9 @@ mod cross_crate {
         Trait::trait_unstable(&foo); //~ ERROR use of unstable library feature
         <Foo as Trait>::trait_unstable(&foo); //~ ERROR use of unstable library feature
         Trait::trait_unstable_text(&foo);
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
         <Foo as Trait>::trait_unstable_text(&foo);
-        //~^ ERROR use of unstable library feature 'unstable_test_feature': text
+        //~^ ERROR use of unstable library feature `unstable_test_feature`: text
         foo.trait_stable();
         Trait::trait_stable(&foo);
         <Foo>::trait_stable(&foo);

--- a/tests/ui/lint/lint-stability.stderr
+++ b/tests/ui/lint/lint-stability.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:17:5
    |
 LL |     extern crate stability_cfg2;
@@ -7,7 +7,7 @@ LL |     extern crate stability_cfg2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:45:9
    |
 LL |         deprecated_unstable();
@@ -16,7 +16,7 @@ LL |         deprecated_unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:47:9
    |
 LL |         Trait::trait_deprecated_unstable(&foo);
@@ -25,7 +25,7 @@ LL |         Trait::trait_deprecated_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:49:9
    |
 LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
@@ -34,7 +34,7 @@ LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:52:9
    |
 LL |         deprecated_unstable_text();
@@ -43,7 +43,7 @@ LL |         deprecated_unstable_text();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:54:9
    |
 LL |         Trait::trait_deprecated_unstable_text(&foo);
@@ -52,7 +52,7 @@ LL |         Trait::trait_deprecated_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:56:9
    |
 LL |         <Foo as Trait>::trait_deprecated_unstable_text(&foo);
@@ -61,7 +61,7 @@ LL |         <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:59:9
    |
 LL |         unstable();
@@ -70,7 +70,7 @@ LL |         unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:60:9
    |
 LL |         Trait::trait_unstable(&foo);
@@ -79,7 +79,7 @@ LL |         Trait::trait_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:61:9
    |
 LL |         <Foo as Trait>::trait_unstable(&foo);
@@ -88,7 +88,7 @@ LL |         <Foo as Trait>::trait_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability.rs:63:9
    |
 LL |         unstable_text();
@@ -97,7 +97,7 @@ LL |         unstable_text();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability.rs:65:9
    |
 LL |         Trait::trait_unstable_text(&foo);
@@ -106,7 +106,7 @@ LL |         Trait::trait_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability.rs:67:9
    |
 LL |         <Foo as Trait>::trait_unstable_text(&foo);
@@ -115,7 +115,7 @@ LL |         <Foo as Trait>::trait_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:99:17
    |
 LL |         let _ = DeprecatedUnstableStruct {
@@ -124,7 +124,7 @@ LL |         let _ = DeprecatedUnstableStruct {
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:103:17
    |
 LL |         let _ = UnstableStruct { i: 0 };
@@ -133,7 +133,7 @@ LL |         let _ = UnstableStruct { i: 0 };
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:107:17
    |
 LL |         let _ = DeprecatedUnstableUnitStruct;
@@ -142,7 +142,7 @@ LL |         let _ = DeprecatedUnstableUnitStruct;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:109:17
    |
 LL |         let _ = UnstableUnitStruct;
@@ -151,7 +151,7 @@ LL |         let _ = UnstableUnitStruct;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:113:17
    |
 LL |         let _ = Enum::DeprecatedUnstableVariant;
@@ -160,7 +160,7 @@ LL |         let _ = Enum::DeprecatedUnstableVariant;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:115:17
    |
 LL |         let _ = Enum::UnstableVariant;
@@ -169,7 +169,7 @@ LL |         let _ = Enum::UnstableVariant;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:119:17
    |
 LL |         let _ = DeprecatedUnstableTupleStruct (1);
@@ -178,7 +178,7 @@ LL |         let _ = DeprecatedUnstableTupleStruct (1);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:121:17
    |
 LL |         let _ = UnstableTupleStruct (1);
@@ -187,7 +187,7 @@ LL |         let _ = UnstableTupleStruct (1);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:130:25
    |
 LL |         macro_test_arg!(deprecated_unstable_text());
@@ -196,7 +196,7 @@ LL |         macro_test_arg!(deprecated_unstable_text());
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:144:9
    |
 LL |         Trait::trait_deprecated_unstable(&foo);
@@ -205,7 +205,7 @@ LL |         Trait::trait_deprecated_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:146:9
    |
 LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
@@ -214,7 +214,7 @@ LL |         <Foo as Trait>::trait_deprecated_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:148:9
    |
 LL |         Trait::trait_deprecated_unstable_text(&foo);
@@ -223,7 +223,7 @@ LL |         Trait::trait_deprecated_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:150:9
    |
 LL |         <Foo as Trait>::trait_deprecated_unstable_text(&foo);
@@ -232,7 +232,7 @@ LL |         <Foo as Trait>::trait_deprecated_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:152:9
    |
 LL |         Trait::trait_unstable(&foo);
@@ -241,7 +241,7 @@ LL |         Trait::trait_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:153:9
    |
 LL |         <Foo as Trait>::trait_unstable(&foo);
@@ -250,7 +250,7 @@ LL |         <Foo as Trait>::trait_unstable(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability.rs:154:9
    |
 LL |         Trait::trait_unstable_text(&foo);
@@ -259,7 +259,7 @@ LL |         Trait::trait_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/lint-stability.rs:156:9
    |
 LL |         <Foo as Trait>::trait_unstable_text(&foo);
@@ -268,7 +268,7 @@ LL |         <Foo as Trait>::trait_unstable_text(&foo);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:172:10
    |
 LL |     impl UnstableTrait for S { }
@@ -277,7 +277,7 @@ LL |     impl UnstableTrait for S { }
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:174:24
    |
 LL |     trait LocalTrait : UnstableTrait { }
@@ -286,7 +286,7 @@ LL |     trait LocalTrait : UnstableTrait { }
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:179:9
    |
 LL |         fn trait_unstable(&self) {}
@@ -295,7 +295,7 @@ LL |         fn trait_unstable(&self) {}
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:184:5
    |
 LL |     extern crate inherited_stability;
@@ -304,7 +304,7 @@ LL |     extern crate inherited_stability;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:185:9
    |
 LL |     use self::inherited_stability::*;
@@ -313,7 +313,7 @@ LL |     use self::inherited_stability::*;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:188:9
    |
 LL |         unstable();
@@ -322,7 +322,7 @@ LL |         unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:191:9
    |
 LL |         stable_mod::unstable();
@@ -331,7 +331,7 @@ LL |         stable_mod::unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:194:9
    |
 LL |         unstable_mod::deprecated();
@@ -340,7 +340,7 @@ LL |         unstable_mod::deprecated();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:195:9
    |
 LL |         unstable_mod::unstable();
@@ -349,7 +349,7 @@ LL |         unstable_mod::unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:197:17
    |
 LL |         let _ = Unstable::UnstableVariant;
@@ -358,7 +358,7 @@ LL |         let _ = Unstable::UnstableVariant;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:198:17
    |
 LL |         let _ = Unstable::StableVariant;
@@ -367,7 +367,7 @@ LL |         let _ = Unstable::StableVariant;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:88:48
    |
 LL |         struct S1<T: TraitWithAssociatedTypes>(T::TypeUnstable);
@@ -376,7 +376,7 @@ LL |         struct S1<T: TraitWithAssociatedTypes>(T::TypeUnstable);
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/lint-stability.rs:92:13
    |
 LL |             TypeUnstable = u8,

--- a/tests/ui/macros/macro-stability.rs
+++ b/tests/ui/macros/macro-stability.rs
@@ -19,10 +19,10 @@ macro local_unstable_modern() {}
 macro_rules! local_deprecated{ () => () }
 
 fn main() {
-    local_unstable!(); //~ ERROR use of unstable library feature 'local_unstable'
-    local_unstable_modern!(); //~ ERROR use of unstable library feature 'local_unstable'
-    unstable_macro!(); //~ ERROR use of unstable library feature 'unstable_macros'
-    // unstable_macro_modern!(); // ERROR use of unstable library feature 'unstable_macros'
+    local_unstable!(); //~ ERROR use of unstable library feature `local_unstable`
+    local_unstable_modern!(); //~ ERROR use of unstable library feature `local_unstable`
+    unstable_macro!(); //~ ERROR use of unstable library feature `unstable_macros`
+    // unstable_macro_modern!(); // ERROR use of unstable library feature `unstable_macros`
 
     deprecated_macro!();
     //~^ WARN use of deprecated macro `deprecated_macro`: deprecation note

--- a/tests/ui/macros/macro-stability.stderr
+++ b/tests/ui/macros/macro-stability.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'local_unstable'
+error[E0658]: use of unstable library feature `local_unstable`
   --> $DIR/macro-stability.rs:22:5
    |
 LL |     local_unstable!();
@@ -7,7 +7,7 @@ LL |     local_unstable!();
    = help: add `#![feature(local_unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'local_unstable'
+error[E0658]: use of unstable library feature `local_unstable`
   --> $DIR/macro-stability.rs:23:5
    |
 LL |     local_unstable_modern!();
@@ -16,7 +16,7 @@ LL |     local_unstable_modern!();
    = help: add `#![feature(local_unstable)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_macros'
+error[E0658]: use of unstable library feature `unstable_macros`
   --> $DIR/macro-stability.rs:24:5
    |
 LL |     unstable_macro!();

--- a/tests/ui/offset-of/offset-of-unstable.stderr
+++ b/tests/ui/offset-of/offset-of-unstable.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/offset-of-unstable.rs:12:9
    |
 LL |         Unstable,
@@ -7,7 +7,7 @@ LL |         Unstable,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/offset-of-unstable.rs:21:9
    |
 LL |         UnstableWithStableFieldType,
@@ -16,7 +16,7 @@ LL |         UnstableWithStableFieldType,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/offset-of-unstable.rs:26:9
    |
 LL |         UnstableWithStableFieldType,
@@ -25,7 +25,7 @@ LL |         UnstableWithStableFieldType,
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/offset-of-unstable.rs:10:5
    |
 LL | /     offset_of!(
@@ -39,7 +39,7 @@ LL | |     );
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/offset-of-unstable.rs:16:5
    |
 LL |     offset_of!(StableWithUnstableField, unstable);
@@ -49,7 +49,7 @@ LL |     offset_of!(StableWithUnstableField, unstable);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/offset-of-unstable.rs:18:5
    |
 LL |     offset_of!(StableWithUnstableFieldType, stable.unstable);
@@ -59,7 +59,7 @@ LL |     offset_of!(StableWithUnstableFieldType, stable.unstable);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/offset-of-unstable.rs:19:5
    |
 LL | /     offset_of!(
@@ -73,7 +73,7 @@ LL | |     );
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = note: this error originates in the macro `offset_of` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/offset-of-unstable.rs:24:5
    |
 LL | /     offset_of!(

--- a/tests/ui/pin-macro/cant_access_internals.rs
+++ b/tests/ui/pin-macro/cant_access_internals.rs
@@ -8,5 +8,5 @@ use core::{
 
 fn main() {
     let mut phantom_pinned = pin!(PhantomPinned);
-    mem::take(phantom_pinned.__pointer); //~ ERROR use of unstable library feature 'unsafe_pin_internals'
+    mem::take(phantom_pinned.__pointer); //~ ERROR use of unstable library feature `unsafe_pin_internals`
 }

--- a/tests/ui/pin-macro/cant_access_internals.stderr
+++ b/tests/ui/pin-macro/cant_access_internals.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unsafe_pin_internals'
+error[E0658]: use of unstable library feature `unsafe_pin_internals`
   --> $DIR/cant_access_internals.rs:11:15
    |
 LL |     mem::take(phantom_pinned.__pointer);

--- a/tests/ui/proc-macro/expand-to-unstable.stderr
+++ b/tests/ui/proc-macro/expand-to-unstable.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'core_intrinsics': intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
+error[E0658]: use of unstable library feature `core_intrinsics`: intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library
   --> $DIR/expand-to-unstable.rs:8:10
    |
 LL | #[derive(Unstable)]

--- a/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/feature-gate.no_gate.stderr
+++ b/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/feature-gate.no_gate.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'structural_match'
+error[E0658]: use of unstable library feature `structural_match`
   --> $DIR/feature-gate.rs:29:6
    |
 LL | impl std::marker::StructuralPartialEq for Foo { }

--- a/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/feature-gate.rs
+++ b/tests/ui/rfcs/rfc-1445-restrict-constants-in-patterns/feature-gate.rs
@@ -27,7 +27,7 @@ fn main() { //[with_gate]~ ERROR fatal error triggered by #[rustc_error]
 }
 
 impl std::marker::StructuralPartialEq for Foo { }
-//[no_gate]~^ ERROR use of unstable library feature 'structural_match'
+//[no_gate]~^ ERROR use of unstable library feature `structural_match`
 
 impl PartialEq<Foo> for Foo {
     fn eq(&self, other: &Self) -> bool {

--- a/tests/ui/stability-attribute/accidental-stable-in-unstable.rs
+++ b/tests/ui/stability-attribute/accidental-stable-in-unstable.rs
@@ -3,7 +3,7 @@ extern crate core;
 
 // Known accidental stabilizations with no known users, slated for un-stabilization
 // fully stable @ core::char::UNICODE_VERSION
-use core::unicode::UNICODE_VERSION; //~ ERROR use of unstable library feature 'unicode_internals'
+use core::unicode::UNICODE_VERSION; //~ ERROR use of unstable library feature `unicode_internals`
 
 // Known accidental stabilizations with known users
 // fully stable @ core::mem::transmute

--- a/tests/ui/stability-attribute/accidental-stable-in-unstable.stderr
+++ b/tests/ui/stability-attribute/accidental-stable-in-unstable.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unicode_internals'
+error[E0658]: use of unstable library feature `unicode_internals`
   --> $DIR/accidental-stable-in-unstable.rs:6:5
    |
 LL | use core::unicode::UNICODE_VERSION;

--- a/tests/ui/stability-attribute/allow-unstable-reexport.rs
+++ b/tests/ui/stability-attribute/allow-unstable-reexport.rs
@@ -20,11 +20,11 @@ pub use lint_stability_reexport::unstable_text;
 // Ensure items which aren't marked as unstable can't re-export unstable items
 #[stable(feature = "lint_stability", since = "1.0.0")]
 pub use lint_stability::unstable as unstable2;
-//~^ ERROR use of unstable library feature 'unstable_test_feature'
+//~^ ERROR use of unstable library feature `unstable_test_feature`
 
 fn main() {
     // Since we didn't enable the feature in this crate, we still can't
     // use these items, even though they're in scope from the `use`s which are now allowed.
-    unstable(); //~ ERROR use of unstable library feature 'unstable_test_feature'
-    unstable_text(); //~ ERROR use of unstable library feature 'unstable_test_feature'
+    unstable(); //~ ERROR use of unstable library feature `unstable_test_feature`
+    unstable_text(); //~ ERROR use of unstable library feature `unstable_test_feature`
 }

--- a/tests/ui/stability-attribute/allow-unstable-reexport.stderr
+++ b/tests/ui/stability-attribute/allow-unstable-reexport.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/allow-unstable-reexport.rs:22:9
    |
 LL | pub use lint_stability::unstable as unstable2;
@@ -7,7 +7,7 @@ LL | pub use lint_stability::unstable as unstable2;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/allow-unstable-reexport.rs:28:5
    |
 LL |     unstable();
@@ -16,7 +16,7 @@ LL |     unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': text
+error[E0658]: use of unstable library feature `unstable_test_feature`: text
   --> $DIR/allow-unstable-reexport.rs:29:5
    |
 LL |     unstable_text();

--- a/tests/ui/stability-attribute/allowed-through-unstable.rs
+++ b/tests/ui/stability-attribute/allowed-through-unstable.rs
@@ -6,4 +6,4 @@
 extern crate allowed_through_unstable_core;
 
 use allowed_through_unstable_core::unstable_module::OldStableTraitAllowedThoughUnstable;
-use allowed_through_unstable_core::unstable_module::NewStableTraitNotAllowedThroughUnstable; //~ ERROR use of unstable library feature 'unstable_test_feature'
+use allowed_through_unstable_core::unstable_module::NewStableTraitNotAllowedThroughUnstable; //~ ERROR use of unstable library feature `unstable_test_feature`

--- a/tests/ui/stability-attribute/allowed-through-unstable.stderr
+++ b/tests/ui/stability-attribute/allowed-through-unstable.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/allowed-through-unstable.rs:9:5
    |
 LL | use allowed_through_unstable_core::unstable_module::NewStableTraitNotAllowedThroughUnstable;

--- a/tests/ui/stability-attribute/default-body-stability-err.stderr
+++ b/tests/ui/stability-attribute/default-body-stability-err.stderr
@@ -5,7 +5,7 @@ LL | impl JustTrait for Type {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: default implementation of `CONSTANT` is unstable
-   = note: use of unstable library feature 'constant_default_body'
+   = note: use of unstable library feature `constant_default_body`
    = help: add `#![feature(constant_default_body)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -16,7 +16,7 @@ LL | impl JustTrait for Type {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: default implementation of `fun` is unstable
-   = note: use of unstable library feature 'fun_default_body'
+   = note: use of unstable library feature `fun_default_body`
    = help: add `#![feature(fun_default_body)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -27,7 +27,7 @@ LL | impl JustTrait for Type {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: default implementation of `fun2` is unstable
-   = note: use of unstable library feature 'fun_default_body': reason
+   = note: use of unstable library feature `fun_default_body`: reason
    = help: add `#![feature(fun_default_body)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
@@ -43,7 +43,7 @@ LL | | }
    | |_^
    |
    = note: default implementation of `eq` is unstable
-   = note: use of unstable library feature 'eq_default_body'
+   = note: use of unstable library feature `eq_default_body`
    = help: add `#![feature(eq_default_body)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 

--- a/tests/ui/stability-attribute/generics-default-stability-trait.rs
+++ b/tests/ui/stability-attribute/generics-default-stability-trait.rs
@@ -13,15 +13,15 @@ impl Trait1 for S {
 
 struct S;
 
-impl Trait1<usize> for S { //~ ERROR use of unstable library feature 'unstable_default'
+impl Trait1<usize> for S { //~ ERROR use of unstable library feature `unstable_default`
     fn foo() -> usize { 0 }
 }
 
-impl Trait1<isize> for S { //~ ERROR use of unstable library feature 'unstable_default'
+impl Trait1<isize> for S { //~ ERROR use of unstable library feature `unstable_default`
     fn foo() -> isize { 0 }
 }
 
-impl Trait2<usize> for S { //~ ERROR use of unstable library feature 'unstable_default'
+impl Trait2<usize> for S { //~ ERROR use of unstable library feature `unstable_default`
     fn foo() -> usize { 0 }
 }
 

--- a/tests/ui/stability-attribute/generics-default-stability-trait.stderr
+++ b/tests/ui/stability-attribute/generics-default-stability-trait.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability-trait.rs:16:13
    |
 LL | impl Trait1<usize> for S {
@@ -7,7 +7,7 @@ LL | impl Trait1<usize> for S {
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability-trait.rs:20:13
    |
 LL | impl Trait1<isize> for S {
@@ -16,7 +16,7 @@ LL | impl Trait1<isize> for S {
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability-trait.rs:24:13
    |
 LL | impl Trait2<usize> for S {

--- a/tests/ui/stability-attribute/generics-default-stability-where.rs
+++ b/tests/ui/stability-attribute/generics-default-stability-where.rs
@@ -4,7 +4,7 @@ extern crate unstable_generic_param;
 
 use unstable_generic_param::*;
 
-impl<T> Trait3<usize> for T where T: Trait2<usize> { //~ ERROR use of unstable library feature 'unstable_default'
+impl<T> Trait3<usize> for T where T: Trait2<usize> { //~ ERROR use of unstable library feature `unstable_default`
 //~^ ERROR `T` must be used as the type parameter for some local type
     fn foo() -> usize { T::foo() }
 }

--- a/tests/ui/stability-attribute/generics-default-stability-where.stderr
+++ b/tests/ui/stability-attribute/generics-default-stability-where.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability-where.rs:7:45
    |
 LL | impl<T> Trait3<usize> for T where T: Trait2<usize> {

--- a/tests/ui/stability-attribute/generics-default-stability.rs
+++ b/tests/ui/stability-attribute/generics-default-stability.rs
@@ -20,12 +20,12 @@ impl Trait3<usize> for S {
 fn main() {
     let _ = S;
 
-    let _: Struct1<isize> = Struct1 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct1<isize> = Struct1 { field: 1 }; //~ ERROR use of unstable library feature `unstable_default`
 
     let _ = STRUCT1; // ok
     let _: Struct1 = STRUCT1; // ok
-    let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature 'unstable_default'
-    let _: Struct1<isize> = Struct1 { field: 0 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct1<usize> = STRUCT1; //~ ERROR use of unstable library feature `unstable_default`
+    let _: Struct1<isize> = Struct1 { field: 0 }; //~ ERROR use of unstable library feature `unstable_default`
 
     // Instability is not enforced for generic type parameters used in public fields.
     // Note how the unstable type default `usize` leaks,
@@ -54,10 +54,10 @@ fn main() {
 
     let _ = STRUCT3;
     let _: Struct3 = STRUCT3; // ok
-    let _: Struct3<isize, usize> = STRUCT3; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct3<isize, usize> = STRUCT3; //~ ERROR use of unstable library feature `unstable_default`
     let _: Struct3<isize> = STRUCT3; // ok
-    let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 }; //~ ERROR use of unstable library feature 'unstable_default'
-    let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 }; //~ ERROR use of unstable library feature `unstable_default`
+    let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 }; //~ ERROR use of unstable library feature `unstable_default`
     let _ = STRUCT3.field1; // ok
     let _: isize = STRUCT3.field1; // ok
     let _ = STRUCT3.field1 + 1; // ok
@@ -81,15 +81,15 @@ fn main() {
     //~^^^ use of deprecated field `unstable_generic_param::Struct4::field`: test [deprecated]
 
     let _ = STRUCT5;
-    let _: Struct5<isize> = Struct5 { field: 1 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct5<isize> = Struct5 { field: 1 }; //~ ERROR use of unstable library feature `unstable_default`
     //~^ use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
     //~^^ use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
     //~^^^ use of deprecated field `unstable_generic_param::Struct5::field`: test [deprecated]
     let _ = STRUCT5;
     let _: Struct5 = STRUCT5; //~ use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
-    let _: Struct5<usize> = STRUCT5; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct5<usize> = STRUCT5; //~ ERROR use of unstable library feature `unstable_default`
     //~^ use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
-    let _: Struct5<isize> = Struct5 { field: 0 }; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Struct5<isize> = Struct5 { field: 0 }; //~ ERROR use of unstable library feature `unstable_default`
     //~^ use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
     //~^^ use of deprecated struct `unstable_generic_param::Struct5`: test [deprecated]
     //~^^^ use of deprecated field `unstable_generic_param::Struct5::field`: test [deprecated]
@@ -97,12 +97,12 @@ fn main() {
     let _: Struct6<isize> = Struct6 { field: 1 }; // ok
     let _: Struct6<isize> = Struct6 { field: 0 }; // ok
 
-    let _: Alias1<isize> = Alias1::Some(1); //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Alias1<isize> = Alias1::Some(1); //~ ERROR use of unstable library feature `unstable_default`
 
     let _ = ALIAS1; // ok
     let _: Alias1 = ALIAS1; // ok
-    let _: Alias1<usize> = ALIAS1; //~ ERROR use of unstable library feature 'unstable_default'
-    let _: Alias1<isize> = Alias1::Some(0); //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Alias1<usize> = ALIAS1; //~ ERROR use of unstable library feature `unstable_default`
+    let _: Alias1<isize> = Alias1::Some(0); //~ ERROR use of unstable library feature `unstable_default`
 
     // Instability is not enforced for generic type parameters used in public fields.
     // Note how the unstable type default `usize` leaks,
@@ -130,10 +130,10 @@ fn main() {
 
     let _ = ALIAS3;
     let _: Alias3 = ALIAS3; // ok
-    let _: Alias3<isize, usize> = ALIAS3; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Alias3<isize, usize> = ALIAS3; //~ ERROR use of unstable library feature `unstable_default`
     let _: Alias3<isize> = ALIAS3; // ok
-    let _: Alias3<isize, isize> = Alias3::Ok(0); //~ ERROR use of unstable library feature 'unstable_default'
-    let _: Alias3<usize, usize> = Alias3::Ok(0); //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Alias3<isize, isize> = Alias3::Ok(0); //~ ERROR use of unstable library feature `unstable_default`
+    let _: Alias3<usize, usize> = Alias3::Ok(0); //~ ERROR use of unstable library feature `unstable_default`
     let _ = ALIAS3.unwrap(); // ok
     let _: isize = ALIAS3.unwrap(); // ok
     let _ = ALIAS3.unwrap() + 1; // ok
@@ -155,26 +155,26 @@ fn main() {
     //~^^ use of deprecated type alias `unstable_generic_param::Alias4`: test [deprecated]
 
     let _ = ALIAS5;
-    let _: Alias5<isize> = Alias5::Some(1); //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Alias5<isize> = Alias5::Some(1); //~ ERROR use of unstable library feature `unstable_default`
     //~^ use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
     //~^^ use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
     let _ = ALIAS5;
     let _: Alias5 = ALIAS5; //~ use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
-    let _: Alias5<usize> = ALIAS5; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Alias5<usize> = ALIAS5; //~ ERROR use of unstable library feature `unstable_default`
     //~^ use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
-    let _: Alias5<isize> = Alias5::Some(0); //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Alias5<isize> = Alias5::Some(0); //~ ERROR use of unstable library feature `unstable_default`
     //~^ use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
     //~^^ use of deprecated type alias `unstable_generic_param::Alias5`: test [deprecated]
 
     let _: Alias6<isize> = Alias6::Some(1); // ok
     let _: Alias6<isize> = Alias6::Some(0); // ok
 
-    let _: Enum1<isize> = Enum1::Some(1); //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Enum1<isize> = Enum1::Some(1); //~ ERROR use of unstable library feature `unstable_default`
 
     let _ = ENUM1; // ok
     let _: Enum1 = ENUM1; // ok
-    let _: Enum1<usize> = ENUM1; //~ ERROR use of unstable library feature 'unstable_default'
-    let _: Enum1<isize> = Enum1::Some(0); //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Enum1<usize> = ENUM1; //~ ERROR use of unstable library feature `unstable_default`
+    let _: Enum1<isize> = Enum1::Some(0); //~ ERROR use of unstable library feature `unstable_default`
 
     // Instability is not enforced for generic type parameters used in public fields.
     // Note how the unstable type default `usize` leaks,
@@ -202,10 +202,10 @@ fn main() {
 
     let _ = ENUM3;
     let _: Enum3 = ENUM3; // ok
-    let _: Enum3<isize, usize> = ENUM3; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Enum3<isize, usize> = ENUM3; //~ ERROR use of unstable library feature `unstable_default`
     let _: Enum3<isize> = ENUM3; // ok
-    let _: Enum3<isize, isize> = Enum3::Ok(0); //~ ERROR use of unstable library feature 'unstable_default'
-    let _: Enum3<usize, usize> = Enum3::Ok(0); //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Enum3<isize, isize> = Enum3::Ok(0); //~ ERROR use of unstable library feature `unstable_default`
+    let _: Enum3<usize, usize> = Enum3::Ok(0); //~ ERROR use of unstable library feature `unstable_default`
     if let Enum3::Ok(x) = ENUM3 {let _ = x;} // ok
     if let Enum3::Ok(x) = ENUM3 {let _: isize = x;} // ok
     if let Enum3::Ok(x) = ENUM3 {let _ = x + 1;} // ok
@@ -227,21 +227,21 @@ fn main() {
     //~^^ use of deprecated enum `unstable_generic_param::Enum4`: test [deprecated]
 
     let _ = ENUM5;
-    let _: Enum5<isize> = Enum5::Some(1); //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Enum5<isize> = Enum5::Some(1); //~ ERROR use of unstable library feature `unstable_default`
     //~^ use of deprecated tuple variant `unstable_generic_param::Enum5::Some`: test [deprecated]
     //~^^ use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
     let _ = ENUM5;
     let _: Enum5 = ENUM5; //~ use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
-    let _: Enum5<usize> = ENUM5; //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Enum5<usize> = ENUM5; //~ ERROR use of unstable library feature `unstable_default`
     //~^ use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
-    let _: Enum5<isize> = Enum5::Some(0); //~ ERROR use of unstable library feature 'unstable_default'
+    let _: Enum5<isize> = Enum5::Some(0); //~ ERROR use of unstable library feature `unstable_default`
     //~^ use of deprecated tuple variant `unstable_generic_param::Enum5::Some`: test [deprecated]
     //~^^ use of deprecated enum `unstable_generic_param::Enum5`: test [deprecated]
 
     let _: Enum6<isize> = Enum6::Some(1); // ok
     let _: Enum6<isize> = Enum6::Some(0); // ok
 
-    let _: Box1<isize, System> = Box1::new(1); //~ ERROR use of unstable library feature 'box_alloc_param'
+    let _: Box1<isize, System> = Box1::new(1); //~ ERROR use of unstable library feature `box_alloc_param`
     let _: Box1<isize> = Box1::new(1); // ok
 
     let _: Box2<isize, System> = Box2::new(1); // ok

--- a/tests/ui/stability-attribute/generics-default-stability.stderr
+++ b/tests/ui/stability-attribute/generics-default-stability.stderr
@@ -216,7 +216,7 @@ warning: use of deprecated enum `unstable_generic_param::Enum5`: test
 LL |     let _: Enum5<isize> = Enum5::Some(0);
    |            ^^^^^
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:23:20
    |
 LL |     let _: Struct1<isize> = Struct1 { field: 1 };
@@ -225,7 +225,7 @@ LL |     let _: Struct1<isize> = Struct1 { field: 1 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:27:20
    |
 LL |     let _: Struct1<usize> = STRUCT1;
@@ -234,7 +234,7 @@ LL |     let _: Struct1<usize> = STRUCT1;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:28:20
    |
 LL |     let _: Struct1<isize> = Struct1 { field: 0 };
@@ -243,7 +243,7 @@ LL |     let _: Struct1<isize> = Struct1 { field: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:57:27
    |
 LL |     let _: Struct3<isize, usize> = STRUCT3;
@@ -252,7 +252,7 @@ LL |     let _: Struct3<isize, usize> = STRUCT3;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:59:27
    |
 LL |     let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 };
@@ -261,7 +261,7 @@ LL |     let _: Struct3<isize, isize> = Struct3 { field1: 0, field2: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:60:27
    |
 LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
@@ -270,7 +270,7 @@ LL |     let _: Struct3<usize, usize> = Struct3 { field1: 0, field2: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:84:20
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 1 };
@@ -279,7 +279,7 @@ LL |     let _: Struct5<isize> = Struct5 { field: 1 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:90:20
    |
 LL |     let _: Struct5<usize> = STRUCT5;
@@ -288,7 +288,7 @@ LL |     let _: Struct5<usize> = STRUCT5;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:92:20
    |
 LL |     let _: Struct5<isize> = Struct5 { field: 0 };
@@ -297,7 +297,7 @@ LL |     let _: Struct5<isize> = Struct5 { field: 0 };
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:100:19
    |
 LL |     let _: Alias1<isize> = Alias1::Some(1);
@@ -306,7 +306,7 @@ LL |     let _: Alias1<isize> = Alias1::Some(1);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:104:19
    |
 LL |     let _: Alias1<usize> = ALIAS1;
@@ -315,7 +315,7 @@ LL |     let _: Alias1<usize> = ALIAS1;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:105:19
    |
 LL |     let _: Alias1<isize> = Alias1::Some(0);
@@ -324,7 +324,7 @@ LL |     let _: Alias1<isize> = Alias1::Some(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:133:26
    |
 LL |     let _: Alias3<isize, usize> = ALIAS3;
@@ -333,7 +333,7 @@ LL |     let _: Alias3<isize, usize> = ALIAS3;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:135:26
    |
 LL |     let _: Alias3<isize, isize> = Alias3::Ok(0);
@@ -342,7 +342,7 @@ LL |     let _: Alias3<isize, isize> = Alias3::Ok(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:136:26
    |
 LL |     let _: Alias3<usize, usize> = Alias3::Ok(0);
@@ -351,7 +351,7 @@ LL |     let _: Alias3<usize, usize> = Alias3::Ok(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:158:19
    |
 LL |     let _: Alias5<isize> = Alias5::Some(1);
@@ -360,7 +360,7 @@ LL |     let _: Alias5<isize> = Alias5::Some(1);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:163:19
    |
 LL |     let _: Alias5<usize> = ALIAS5;
@@ -369,7 +369,7 @@ LL |     let _: Alias5<usize> = ALIAS5;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:165:19
    |
 LL |     let _: Alias5<isize> = Alias5::Some(0);
@@ -378,7 +378,7 @@ LL |     let _: Alias5<isize> = Alias5::Some(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:172:18
    |
 LL |     let _: Enum1<isize> = Enum1::Some(1);
@@ -387,7 +387,7 @@ LL |     let _: Enum1<isize> = Enum1::Some(1);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:176:18
    |
 LL |     let _: Enum1<usize> = ENUM1;
@@ -396,7 +396,7 @@ LL |     let _: Enum1<usize> = ENUM1;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:177:18
    |
 LL |     let _: Enum1<isize> = Enum1::Some(0);
@@ -405,7 +405,7 @@ LL |     let _: Enum1<isize> = Enum1::Some(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:205:25
    |
 LL |     let _: Enum3<isize, usize> = ENUM3;
@@ -414,7 +414,7 @@ LL |     let _: Enum3<isize, usize> = ENUM3;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:207:25
    |
 LL |     let _: Enum3<isize, isize> = Enum3::Ok(0);
@@ -423,7 +423,7 @@ LL |     let _: Enum3<isize, isize> = Enum3::Ok(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:208:25
    |
 LL |     let _: Enum3<usize, usize> = Enum3::Ok(0);
@@ -432,7 +432,7 @@ LL |     let _: Enum3<usize, usize> = Enum3::Ok(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:230:18
    |
 LL |     let _: Enum5<isize> = Enum5::Some(1);
@@ -441,7 +441,7 @@ LL |     let _: Enum5<isize> = Enum5::Some(1);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:235:18
    |
 LL |     let _: Enum5<usize> = ENUM5;
@@ -450,7 +450,7 @@ LL |     let _: Enum5<usize> = ENUM5;
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_default'
+error[E0658]: use of unstable library feature `unstable_default`
   --> $DIR/generics-default-stability.rs:237:18
    |
 LL |     let _: Enum5<isize> = Enum5::Some(0);
@@ -459,7 +459,7 @@ LL |     let _: Enum5<isize> = Enum5::Some(0);
    = help: add `#![feature(unstable_default)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'box_alloc_param'
+error[E0658]: use of unstable library feature `box_alloc_param`
   --> $DIR/generics-default-stability.rs:244:24
    |
 LL |     let _: Box1<isize, System> = Box1::new(1);

--- a/tests/ui/stability-attribute/issue-28075.rs
+++ b/tests/ui/stability-attribute/issue-28075.rs
@@ -7,7 +7,7 @@
 extern crate lint_stability;
 
 use lint_stability::{unstable, deprecated};
-//~^ ERROR use of unstable library feature 'unstable_test_feature'
+//~^ ERROR use of unstable library feature `unstable_test_feature`
 
 fn main() {
 }

--- a/tests/ui/stability-attribute/issue-28075.stderr
+++ b/tests/ui/stability-attribute/issue-28075.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/issue-28075.rs:9:22
    |
 LL | use lint_stability::{unstable, deprecated};

--- a/tests/ui/stability-attribute/issue-28388-3.rs
+++ b/tests/ui/stability-attribute/issue-28388-3.rs
@@ -5,7 +5,7 @@
 extern crate lint_stability;
 
 use lint_stability::UnstableEnum::{};
-//~^ ERROR use of unstable library feature 'unstable_test_feature'
+//~^ ERROR use of unstable library feature `unstable_test_feature`
 use lint_stability::StableEnum::{}; // OK
 
 fn main() {}

--- a/tests/ui/stability-attribute/issue-28388-3.stderr
+++ b/tests/ui/stability-attribute/issue-28388-3.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/issue-28388-3.rs:7:5
    |
 LL | use lint_stability::UnstableEnum::{};

--- a/tests/ui/stability-attribute/stability-attribute-implies-no-feature.rs
+++ b/tests/ui/stability-attribute/stability-attribute-implies-no-feature.rs
@@ -5,9 +5,9 @@
 
 extern crate stability_attribute_implies;
 use stability_attribute_implies::{foo, foobar};
-//~^ ERROR use of unstable library feature 'foobar'
+//~^ ERROR use of unstable library feature `foobar`
 
 fn main() {
     foo(); // no error - stable
-    foobar(); //~ ERROR use of unstable library feature 'foobar'
+    foobar(); //~ ERROR use of unstable library feature `foobar`
 }

--- a/tests/ui/stability-attribute/stability-attribute-implies-no-feature.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-implies-no-feature.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'foobar'
+error[E0658]: use of unstable library feature `foobar`
   --> $DIR/stability-attribute-implies-no-feature.rs:7:40
    |
 LL | use stability_attribute_implies::{foo, foobar};
@@ -8,7 +8,7 @@ LL | use stability_attribute_implies::{foo, foobar};
    = help: add `#![feature(foobar)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'foobar'
+error[E0658]: use of unstable library feature `foobar`
   --> $DIR/stability-attribute-implies-no-feature.rs:12:5
    |
 LL |     foobar();

--- a/tests/ui/stability-attribute/stability-attribute-issue.rs
+++ b/tests/ui/stability-attribute/stability-attribute-issue.rs
@@ -6,7 +6,7 @@ use stability_attribute_issue::*;
 
 fn main() {
     unstable();
-    //~^ ERROR use of unstable library feature 'unstable_test_feature'
+    //~^ ERROR use of unstable library feature `unstable_test_feature`
     unstable_msg();
-    //~^ ERROR use of unstable library feature 'unstable_test_feature': message
+    //~^ ERROR use of unstable library feature `unstable_test_feature`: message
 }

--- a/tests/ui/stability-attribute/stability-attribute-issue.stderr
+++ b/tests/ui/stability-attribute/stability-attribute-issue.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/stability-attribute-issue.rs:8:5
    |
 LL |     unstable();
@@ -8,7 +8,7 @@ LL |     unstable();
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature': message
+error[E0658]: use of unstable library feature `unstable_test_feature`: message
   --> $DIR/stability-attribute-issue.rs:10:5
    |
 LL |     unstable_msg();

--- a/tests/ui/stability-attribute/stable-in-unstable.rs
+++ b/tests/ui/stability-attribute/stable-in-unstable.rs
@@ -13,8 +13,8 @@ extern crate stable_in_unstable_core;
 extern crate stable_in_unstable_std;
 
 mod isolated1 {
-    use stable_in_unstable_core::new_unstable_module; //~ ERROR use of unstable library feature 'unstable_test_feature'
-    use stable_in_unstable_core::new_unstable_module::OldTrait; //~ ERROR use of unstable library feature 'unstable_test_feature'
+    use stable_in_unstable_core::new_unstable_module; //~ ERROR use of unstable library feature `unstable_test_feature`
+    use stable_in_unstable_core::new_unstable_module::OldTrait; //~ ERROR use of unstable library feature `unstable_test_feature`
 }
 
 mod isolated2 {
@@ -26,7 +26,7 @@ mod isolated2 {
 }
 
 mod isolated3 {
-    use stable_in_unstable_core::new_unstable_module::OldTrait; //~ ERROR use of unstable library feature 'unstable_test_feature'
+    use stable_in_unstable_core::new_unstable_module::OldTrait; //~ ERROR use of unstable library feature `unstable_test_feature`
 
     struct LocalType;
 
@@ -36,7 +36,7 @@ mod isolated3 {
 mod isolated4 {
     struct LocalType;
 
-    impl stable_in_unstable_core::new_unstable_module::OldTrait for LocalType {} //~ ERROR use of unstable library feature 'unstable_test_feature'
+    impl stable_in_unstable_core::new_unstable_module::OldTrait for LocalType {} //~ ERROR use of unstable library feature `unstable_test_feature`
 }
 
 mod isolated5 {
@@ -46,9 +46,9 @@ mod isolated5 {
 }
 
 mod isolated6 {
-    use stable_in_unstable_core::new_unstable_module::{OldTrait}; //~ ERROR use of unstable library feature 'unstable_test_feature'
+    use stable_in_unstable_core::new_unstable_module::{OldTrait}; //~ ERROR use of unstable library feature `unstable_test_feature`
 }
 
 mod isolated7 {
-    use stable_in_unstable_core::new_unstable_module::*; //~ ERROR use of unstable library feature 'unstable_test_feature'
+    use stable_in_unstable_core::new_unstable_module::*; //~ ERROR use of unstable library feature `unstable_test_feature`
 }

--- a/tests/ui/stability-attribute/stable-in-unstable.stderr
+++ b/tests/ui/stability-attribute/stable-in-unstable.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/stable-in-unstable.rs:16:9
    |
 LL |     use stable_in_unstable_core::new_unstable_module;
@@ -8,7 +8,7 @@ LL |     use stable_in_unstable_core::new_unstable_module;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/stable-in-unstable.rs:17:9
    |
 LL |     use stable_in_unstable_core::new_unstable_module::OldTrait;
@@ -18,7 +18,7 @@ LL |     use stable_in_unstable_core::new_unstable_module::OldTrait;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/stable-in-unstable.rs:29:9
    |
 LL |     use stable_in_unstable_core::new_unstable_module::OldTrait;
@@ -28,7 +28,7 @@ LL |     use stable_in_unstable_core::new_unstable_module::OldTrait;
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/stable-in-unstable.rs:39:10
    |
 LL |     impl stable_in_unstable_core::new_unstable_module::OldTrait for LocalType {}
@@ -38,7 +38,7 @@ LL |     impl stable_in_unstable_core::new_unstable_module::OldTrait for LocalTy
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/stable-in-unstable.rs:49:56
    |
 LL |     use stable_in_unstable_core::new_unstable_module::{OldTrait};
@@ -48,7 +48,7 @@ LL |     use stable_in_unstable_core::new_unstable_module::{OldTrait};
    = help: add `#![feature(unstable_test_feature)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'unstable_test_feature'
+error[E0658]: use of unstable library feature `unstable_test_feature`
   --> $DIR/stable-in-unstable.rs:53:9
    |
 LL |     use stable_in_unstable_core::new_unstable_module::*;

--- a/tests/ui/stability-attribute/suggest-vec-allocator-api.rs
+++ b/tests/ui/stability-attribute/suggest-vec-allocator-api.rs
@@ -1,9 +1,9 @@
 fn main() {
-    let _: Vec<u8, _> = vec![]; //~ ERROR use of unstable library feature 'allocator_api'
+    let _: Vec<u8, _> = vec![]; //~ ERROR use of unstable library feature `allocator_api`
     #[rustfmt::skip]
     let _: Vec<
         String,
-        _> = vec![]; //~ ERROR use of unstable library feature 'allocator_api'
-    let _ = Vec::<u16, _>::new(); //~ ERROR use of unstable library feature 'allocator_api'
-    let _boxed: Box<u32, _> = Box::new(10); //~ ERROR use of unstable library feature 'allocator_api'
+        _> = vec![]; //~ ERROR use of unstable library feature `allocator_api`
+    let _ = Vec::<u16, _>::new(); //~ ERROR use of unstable library feature `allocator_api`
+    let _boxed: Box<u32, _> = Box::new(10); //~ ERROR use of unstable library feature `allocator_api`
 }

--- a/tests/ui/stability-attribute/suggest-vec-allocator-api.stderr
+++ b/tests/ui/stability-attribute/suggest-vec-allocator-api.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'allocator_api'
+error[E0658]: use of unstable library feature `allocator_api`
   --> $DIR/suggest-vec-allocator-api.rs:2:20
    |
 LL |     let _: Vec<u8, _> = vec![];
@@ -10,7 +10,7 @@ LL |     let _: Vec<u8, _> = vec![];
    = help: add `#![feature(allocator_api)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'allocator_api'
+error[E0658]: use of unstable library feature `allocator_api`
   --> $DIR/suggest-vec-allocator-api.rs:6:9
    |
 LL |         _> = vec![];
@@ -26,7 +26,7 @@ LL +         String,
 LL ~         _)> = vec![];
    |
 
-error[E0658]: use of unstable library feature 'allocator_api'
+error[E0658]: use of unstable library feature `allocator_api`
   --> $DIR/suggest-vec-allocator-api.rs:8:26
    |
 LL |     let _boxed: Box<u32, _> = Box::new(10);
@@ -36,7 +36,7 @@ LL |     let _boxed: Box<u32, _> = Box::new(10);
    = help: add `#![feature(allocator_api)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'allocator_api'
+error[E0658]: use of unstable library feature `allocator_api`
   --> $DIR/suggest-vec-allocator-api.rs:7:24
    |
 LL |     let _ = Vec::<u16, _>::new();

--- a/tests/ui/traits/const-traits/const_derives/derive-const-gate.stderr
+++ b/tests/ui/traits/const-traits/const_derives/derive-const-gate.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'derive_const'
+error[E0658]: use of unstable library feature `derive_const`
   --> $DIR/derive-const-gate.rs:1:3
    |
 LL | #[derive_const(Default)]

--- a/tests/ui/traits/issue-78372.rs
+++ b/tests/ui/traits/issue-78372.rs
@@ -1,8 +1,8 @@
-use std::ops::DispatchFromDyn; //~ ERROR use of unstable library feature 'dispatch_from_dyn'
+use std::ops::DispatchFromDyn; //~ ERROR use of unstable library feature `dispatch_from_dyn`
 struct Smaht<T, MISC>(PhantomData); //~ ERROR cannot find type `PhantomData` in this scope
 impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {} //~ ERROR cannot find type `U` in this scope
 //~^ ERROR cannot find type `MISC` in this scope
-//~| ERROR use of unstable library feature 'dispatch_from_dyn'
+//~| ERROR use of unstable library feature `dispatch_from_dyn`
 //~| ERROR the trait `DispatchFromDyn` may only be implemented for a coercion between structures
 trait Foo: X<u32> {}
 trait X<T> {

--- a/tests/ui/traits/issue-78372.stderr
+++ b/tests/ui/traits/issue-78372.stderr
@@ -37,7 +37,7 @@ help: you might be missing a type parameter
 LL | impl<T, MISC> DispatchFromDyn<Smaht<U, MISC>> for T {}
    |       ++++++
 
-error[E0658]: use of unstable library feature 'dispatch_from_dyn'
+error[E0658]: use of unstable library feature `dispatch_from_dyn`
   --> $DIR/issue-78372.rs:1:5
    |
 LL | use std::ops::DispatchFromDyn;
@@ -46,7 +46,7 @@ LL | use std::ops::DispatchFromDyn;
    = help: add `#![feature(dispatch_from_dyn)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'dispatch_from_dyn'
+error[E0658]: use of unstable library feature `dispatch_from_dyn`
   --> $DIR/issue-78372.rs:3:9
    |
 LL | impl<T> DispatchFromDyn<Smaht<U, MISC>> for T {}

--- a/tests/ui/transmutability/malformed-program-gracefulness/feature-missing.rs
+++ b/tests/ui/transmutability/malformed-program-gracefulness/feature-missing.rs
@@ -3,7 +3,7 @@
 #![crate_type = "lib"]
 
 use std::mem::TransmuteFrom;
-//~^ ERROR use of unstable library feature 'transmutability' [E0658]
+//~^ ERROR use of unstable library feature `transmutability` [E0658]
 
 use std::mem::Assume;
-//~^ ERROR use of unstable library feature 'transmutability' [E0658]
+//~^ ERROR use of unstable library feature `transmutability` [E0658]

--- a/tests/ui/transmutability/malformed-program-gracefulness/feature-missing.stderr
+++ b/tests/ui/transmutability/malformed-program-gracefulness/feature-missing.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'transmutability'
+error[E0658]: use of unstable library feature `transmutability`
   --> $DIR/feature-missing.rs:5:5
    |
 LL | use std::mem::TransmuteFrom;
@@ -8,7 +8,7 @@ LL | use std::mem::TransmuteFrom;
    = help: add `#![feature(transmutability)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'transmutability'
+error[E0658]: use of unstable library feature `transmutability`
   --> $DIR/feature-missing.rs:8:5
    |
 LL | use std::mem::Assume;

--- a/tests/ui/type/pattern_types/feature-gate-pattern_types.rs
+++ b/tests/ui/type/pattern_types/feature-gate-pattern_types.rs
@@ -3,12 +3,12 @@
 use std::pat::pattern_type;
 
 type NonNullU32 = pattern_type!(u32 is 1..);
-//~^ use of unstable library feature 'core_pattern_type'
+//~^ use of unstable library feature `core_pattern_type`
 type Percent = pattern_type!(u32 is 0..=100);
-//~^ use of unstable library feature 'core_pattern_type'
+//~^ use of unstable library feature `core_pattern_type`
 type Negative = pattern_type!(i32 is ..=0);
-//~^ use of unstable library feature 'core_pattern_type'
+//~^ use of unstable library feature `core_pattern_type`
 type Positive = pattern_type!(i32 is 0..);
-//~^ use of unstable library feature 'core_pattern_type'
+//~^ use of unstable library feature `core_pattern_type`
 type Always = pattern_type!(Option<u32> is Some(_));
-//~^ use of unstable library feature 'core_pattern_type'
+//~^ use of unstable library feature `core_pattern_type`

--- a/tests/ui/type/pattern_types/feature-gate-pattern_types.stderr
+++ b/tests/ui/type/pattern_types/feature-gate-pattern_types.stderr
@@ -1,4 +1,4 @@
-error[E0658]: use of unstable library feature 'core_pattern_type'
+error[E0658]: use of unstable library feature `core_pattern_type`
   --> $DIR/feature-gate-pattern_types.rs:5:19
    |
 LL | type NonNullU32 = pattern_type!(u32 is 1..);
@@ -8,7 +8,7 @@ LL | type NonNullU32 = pattern_type!(u32 is 1..);
    = help: add `#![feature(core_pattern_type)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'core_pattern_type'
+error[E0658]: use of unstable library feature `core_pattern_type`
   --> $DIR/feature-gate-pattern_types.rs:7:16
    |
 LL | type Percent = pattern_type!(u32 is 0..=100);
@@ -18,7 +18,7 @@ LL | type Percent = pattern_type!(u32 is 0..=100);
    = help: add `#![feature(core_pattern_type)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'core_pattern_type'
+error[E0658]: use of unstable library feature `core_pattern_type`
   --> $DIR/feature-gate-pattern_types.rs:9:17
    |
 LL | type Negative = pattern_type!(i32 is ..=0);
@@ -28,7 +28,7 @@ LL | type Negative = pattern_type!(i32 is ..=0);
    = help: add `#![feature(core_pattern_type)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'core_pattern_type'
+error[E0658]: use of unstable library feature `core_pattern_type`
   --> $DIR/feature-gate-pattern_types.rs:11:17
    |
 LL | type Positive = pattern_type!(i32 is 0..);
@@ -38,7 +38,7 @@ LL | type Positive = pattern_type!(i32 is 0..);
    = help: add `#![feature(core_pattern_type)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0658]: use of unstable library feature 'core_pattern_type'
+error[E0658]: use of unstable library feature `core_pattern_type`
   --> $DIR/feature-gate-pattern_types.rs:13:15
    |
 LL | type Always = pattern_type!(Option<u32> is Some(_));


### PR DESCRIPTION
This PR changes the text of library feature errors for using unstable or body-unstable items. Displaying library feature names in backticks is consistent with other diagnostics (e.g. those from `rustc_passes`) and with the `reason`s on unstable attributes in the library. Additionally, this simplifies diagnostics when supporting multiple unstable attributes on items (see #131824) since `DiagSymbolList` also displays symbols using backticks.