### PR TITLE
find the generic container rather than simply looking up for the assoc with const arg

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/type_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/type_of.rs
@@ -175,19 +175,13 @@ fn const_arg_anon_type_of<'tcx>(tcx: TyCtxt<'tcx>, arg_hir_id: HirId, span: Span
         // arm would handle this.
         //
         // I believe this match arm is only needed for GAT but I am not 100% sure - BoxyUwU
-        Node::Ty(hir_ty @ hir::Ty { kind: TyKind::Path(QPath::TypeRelative(_, segment)), .. }) => {
+        Node::Ty(hir_ty @ hir::Ty { kind: TyKind::Path(QPath::TypeRelative(ty, segment)), .. }) => {
             // Find the Item containing the associated type so we can create an ItemCtxt.
             // Using the ItemCtxt lower the HIR for the unresolved assoc type into a
             // ty which is a fully resolved projection.
             // For the code example above, this would mean lowering `Self::Assoc<3>`
             // to a ty::Alias(ty::Projection, `<Self as Foo>::Assoc<3>`).
-            let item_def_id = tcx
-                .hir()
-                .parent_owner_iter(arg_hir_id)
-                .find(|(_, node)| matches!(node, OwnerNode::Item(_)))
-                .unwrap()
-                .0
-                .def_id;
+            let item_def_id = tcx.hir().get_parent_item(ty.hir_id).def_id;
             let ty = ItemCtxt::new(tcx, item_def_id).lower_ty(hir_ty);
 
             // Iterate through the generics of the projection to find the one that corresponds to

--- a/tests/ui/traits/bound/unknown-assoc-with-const-arg.rs
+++ b/tests/ui/traits/bound/unknown-assoc-with-const-arg.rs
@@ -1,0 +1,20 @@
+// issue#132534
+
+trait X {
+    fn a<T>() -> T::unknown<{}> {}
+    //~^ ERROR: associated type `unknown` not found for `T`
+    //~| ERROR: associated type `unknown` not found for `T`
+}
+
+trait Y {
+    fn a() -> NOT_EXIST::unknown<{}> {}
+    //~^ ERROR: failed to resolve: use of undeclared type `NOT_EXIST`
+}
+
+trait Z<T> {
+    fn a() -> T::unknown<{}> {}
+    //~^ ERROR: associated type `unknown` not found for `T`
+    //~| ERROR: associated type `unknown` not found for `T`
+}
+
+fn main() {}

--- a/tests/ui/traits/bound/unknown-assoc-with-const-arg.stderr
+++ b/tests/ui/traits/bound/unknown-assoc-with-const-arg.stderr
@@ -1,0 +1,38 @@
+error[E0220]: associated type `unknown` not found for `T`
+  --> $DIR/unknown-assoc-with-const-arg.rs:4:21
+   |
+LL |     fn a<T>() -> T::unknown<{}> {}
+   |                     ^^^^^^^ associated type `unknown` not found
+
+error[E0220]: associated type `unknown` not found for `T`
+  --> $DIR/unknown-assoc-with-const-arg.rs:15:18
+   |
+LL |     fn a() -> T::unknown<{}> {}
+   |                  ^^^^^^^ associated type `unknown` not found
+
+error[E0220]: associated type `unknown` not found for `T`
+  --> $DIR/unknown-assoc-with-const-arg.rs:4:21
+   |
+LL |     fn a<T>() -> T::unknown<{}> {}
+   |                     ^^^^^^^ associated type `unknown` not found
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0220]: associated type `unknown` not found for `T`
+  --> $DIR/unknown-assoc-with-const-arg.rs:15:18
+   |
+LL |     fn a() -> T::unknown<{}> {}
+   |                  ^^^^^^^ associated type `unknown` not found
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0433]: failed to resolve: use of undeclared type `NOT_EXIST`
+  --> $DIR/unknown-assoc-with-const-arg.rs:10:15
+   |
+LL |     fn a() -> NOT_EXIST::unknown<{}> {}
+   |               ^^^^^^^^^ use of undeclared type `NOT_EXIST`
+
+error: aborting due to 5 previous errors
+
+Some errors have detailed explanations: E0220, E0433.
+For more information about an error, try `rustc --explain E0220`.


### PR DESCRIPTION
Fixes #132534

This issue is caused by mismatched generic parameters. Previously, it tried to find `T` in `trait X`, but after this change, it will find `T` in `fn a`.

r? @compiler-errors  as this assertion was introduced by you.