### PR TITLE
Remove outdated tidy license fixmes

### DIFF
--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -65,9 +65,6 @@ pub(crate) const WORKSPACES: &[(&str, ExceptionList, Option<(&[&str], &[&str])>,
     ),
     // tidy-alphabetical-start
     ("compiler/rustc_codegen_gcc", EXCEPTIONS_GCC, None, &[]),
-    //("library/backtrace", &[], None), // FIXME uncomment once rust-lang/backtrace#562 has been synced back to the rust repo
-    //("library/portable-simd", &[], None), // FIXME uncomment once rust-lang/portable-simd#363 has been synced back to the rust repo
-    //("library/stdarch", EXCEPTIONS_STDARCH, None), // FIXME uncomment once rust-lang/stdarch#1462 has been synced back to the rust repo
     ("src/bootstrap", EXCEPTIONS_BOOTSTRAP, None, &[]),
     ("src/ci/docker/host-x86_64/test-various/uefi_qemu_test", EXCEPTIONS_UEFI_QEMU_TEST, None, &[]),
     ("src/etc/test-float-parse", EXCEPTIONS, None, &[]),
@@ -115,17 +112,6 @@ const EXCEPTIONS_STDLIB: ExceptionList = &[
     ("fortanix-sgx-abi", "MPL-2.0"), // libstd but only for `sgx` target. FIXME: this dependency violates the documentation comment above.
     // tidy-alphabetical-end
 ];
-
-// FIXME uncomment once rust-lang/stdarch#1462 lands
-/*
-const EXCEPTIONS_STDARCH: ExceptionList = &[
-    // tidy-alphabetical-start
-    ("ryu", "Apache-2.0 OR BSL-1.0"), // BSL is not acceptble, but we use it under Apache-2.0
-    ("wasmparser", "Apache-2.0 WITH LLVM-exception"),
-    ("wasmprinter", "Apache-2.0 WITH LLVM-exception"),
-    // tidy-alphabetical-end
-];
-*/
 
 const EXCEPTIONS_CARGO: ExceptionList = &[
     // tidy-alphabetical-start


### PR DESCRIPTION
~~This PR re-enables license dependency checking for:~~
 - ~~the `backtrace` submodule~~
 - ~~and the `portable-simd` subtree~~

~~The `stdarch` submodule doesn't have a `Cargo.lock` yet so we can't re-enable it.~~

This PR removes outdated tidy license fixmes, https://github.com/rust-lang/rust/pull/132560#issuecomment-2453525276.

r? bootstrap