### PR TITLE
Reduce dependence on the target name

### DIFF
--- a/compiler/rustc_codegen_gcc/src/consts.rs
+++ b/compiler/rustc_codegen_gcc/src/consts.rs
@@ -146,7 +146,7 @@ impl<'gcc, 'tcx> StaticCodegenMethods for CodegenCx<'gcc, 'tcx> {
 
         // Wasm statics with custom link sections get special treatment as they
         // go into custom sections of the wasm executable.
-        if self.tcx.sess.opts.target_triple.tuple().starts_with("wasm32") {
+        if self.tcx.sess.target.is_like_wasm {
             if let Some(_section) = attrs.link_section {
                 unimplemented!();
             }

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -85,11 +85,7 @@ pub fn link_binary(
         }
 
         if invalid_output_for_target(sess, crate_type) {
-            bug!(
-                "invalid output type `{:?}` for target os `{}`",
-                crate_type,
-                sess.opts.target_triple
-            );
+            bug!("invalid output type `{:?}` for target `{}`", crate_type, sess.opts.target_triple);
         }
 
         sess.time("link_binary_check_files_are_writeable", || {
@@ -996,6 +992,7 @@ fn link_natively(
                         && (code < 1000 || code > 9999)
                     {
                         let is_vs_installed = windows_registry::find_vs_version().is_ok();
+                        // FIXME(cc-rs#1265) pass only target arch to find_tool()
                         let has_linker = windows_registry::find_tool(
                             sess.opts.target_triple.tuple(),
                             "link.exe",

--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -47,6 +47,7 @@ pub(crate) fn get_linker<'a>(
     self_contained: bool,
     target_cpu: &'a str,
 ) -> Box<dyn Linker + 'a> {
+    // FIXME(cc-rs#1265) pass only target arch to find_tool()
     let msvc_tool = windows_registry::find_tool(sess.opts.target_triple.tuple(), "link.exe");
 
     // If our linker looks like a batch script on Windows then to execute this

--- a/compiler/rustc_codegen_ssa/src/back/write.rs
+++ b/compiler/rustc_codegen_ssa/src/back/write.rs
@@ -345,6 +345,8 @@ pub struct CodegenContext<B: WriteBackendMethods> {
     pub is_pe_coff: bool,
     pub target_can_use_split_dwarf: bool,
     pub target_arch: String,
+    pub target_is_like_osx: bool,
+    pub target_is_like_aix: bool,
     pub split_debuginfo: rustc_target::spec::SplitDebuginfo,
     pub split_dwarf_kind: rustc_session::config::SplitDwarfKind,
 
@@ -1195,6 +1197,8 @@ fn start_executing_work<B: ExtraBackendMethods>(
         is_pe_coff: tcx.sess.target.is_like_windows,
         target_can_use_split_dwarf: tcx.sess.target_can_use_split_dwarf(),
         target_arch: tcx.sess.target.arch.to_string(),
+        target_is_like_osx: tcx.sess.target.is_like_osx,
+        target_is_like_aix: tcx.sess.target.is_like_aix,
         split_debuginfo: tcx.sess.split_debuginfo(),
         split_dwarf_kind: tcx.sess.opts.unstable_opts.split_dwarf_kind,
         parallel: backend.supports_parallel() && !sess.opts.unstable_opts.no_parallel_backend,

--- a/compiler/rustc_target/src/spec/mod.rs
+++ b/compiler/rustc_target/src/spec/mod.rs
@@ -1595,11 +1595,10 @@ macro_rules! supported_targets {
         pub const TARGETS: &[&str] = &[$($tuple),+];
 
         fn load_builtin(target: &str) -> Option<Target> {
-            let mut t = match target {
+            let t = match target {
                 $( $tuple => targets::$module::target(), )+
                 _ => return None,
             };
-            t.is_builtin = true;
             debug!("got builtin target: {:?}", t);
             Some(t)
         }
@@ -2128,9 +2127,6 @@ type StaticCow<T> = Cow<'static, T>;
 /// through `Deref` impls.
 #[derive(PartialEq, Clone, Debug)]
 pub struct TargetOptions {
-    /// Whether the target is built-in or loaded from a custom target specification.
-    pub is_builtin: bool,
-
     /// Used as the `target_endian` `cfg` variable. Defaults to little endian.
     pub endian: Endian,
     /// Width of c_int type. Defaults to "32".
@@ -2606,7 +2602,6 @@ impl Default for TargetOptions {
     /// incomplete, and if used for compilation, will certainly not work.
     fn default() -> TargetOptions {
         TargetOptions {
-            is_builtin: false,
             endian: Endian::Little,
             c_int_width: "32".into(),
             os: "none".into(),
@@ -3349,7 +3344,6 @@ impl Target {
             }
         }
 
-        key!(is_builtin, bool);
         key!(c_int_width = "target-c-int-width");
         key!(c_enum_min_bits, Option<u64>); // if None, matches c_int_width
         key!(os);
@@ -3462,10 +3456,6 @@ impl Target {
         key!(entry_abi, Conv)?;
         key!(supports_xray, bool);
 
-        if base.is_builtin {
-            // This can cause unfortunate ICEs later down the line.
-            return Err("may not set is_builtin for targets not built-in".into());
-        }
         base.update_from_cli();
 
         // Each field should have been read using `Json::remove` so any keys remaining are unused.
@@ -3635,7 +3625,6 @@ impl ToJson for Target {
         target_val!(arch);
         target_val!(data_layout);
 
-        target_option_val!(is_builtin);
         target_option_val!(endian, "target-endian");
         target_option_val!(c_int_width, "target-c-int-width");
         target_option_val!(os);

--- a/tests/run-make/target-specs/definitely-not-builtin-target.json
+++ b/tests/run-make/target-specs/definitely-not-builtin-target.json
@@ -1,7 +1,0 @@
-{
-  "arch": "x86_64",
-  "is-builtin": true,
-  "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
-  "llvm-target": "x86_64-unknown-unknown-gnu",
-  "target-pointer-width": "64"
-}

--- a/tests/run-make/target-specs/rmake.rs
+++ b/tests/run-make/target-specs/rmake.rs
@@ -54,11 +54,6 @@ fn main() {
         .run();
     rustc()
         .input("foo.rs")
-        .target("definitely-not-builtin-target")
-        .run_fail()
-        .assert_stderr_contains("may not set is_builtin");
-    rustc()
-        .input("foo.rs")
         .target("endianness-mismatch")
         .run_fail()
         .assert_stderr_contains(r#""data-layout" claims architecture is little-endian"#);


### PR DESCRIPTION
The target name can be anything with custom target specs. Matching on fields inside the target spec is much more robust than matching on the target name.

Also remove the unused is_builtin target spec field.