### PR TITLE
Properly suggest `E::assoc` when we encounter `E::Variant::assoc`

### DIFF
--- a/tests/ui/enum/assoc-fn-call-on-variant.rs
+++ b/tests/ui/enum/assoc-fn-call-on-variant.rs
@@ -1,0 +1,15 @@
+#[derive(Default)]
+enum E {
+    A {},
+    B {},
+    #[default]
+    C,
+}
+
+impl E {
+    fn f() {}
+}
+
+fn main() {
+    E::A::f(); //~ ERROR failed to resolve: `A` is a variant, not a module
+}

--- a/tests/ui/enum/assoc-fn-call-on-variant.stderr
+++ b/tests/ui/enum/assoc-fn-call-on-variant.stderr
@@ -6,7 +6,7 @@ LL |     E::A::f();
    |
 help: there is an enum variant `E::A`; try using the variant's enum
    |
-LL |     E();
+LL |     E::f();
    |     ~
 
 error: aborting due to 1 previous error

--- a/tests/ui/enum/assoc-fn-call-on-variant.stderr
+++ b/tests/ui/enum/assoc-fn-call-on-variant.stderr
@@ -1,0 +1,14 @@
+error[E0433]: failed to resolve: `A` is a variant, not a module
+  --> $DIR/assoc-fn-call-on-variant.rs:14:8
+   |
+LL |     E::A::f();
+   |        ^ `A` is a variant, not a module
+   |
+help: there is an enum variant `E::A`; try using the variant's enum
+   |
+LL |     E();
+   |     ~
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/resolve/resolve-variant-assoc-item.stderr
+++ b/tests/ui/resolve/resolve-variant-assoc-item.stderr
@@ -6,7 +6,7 @@ LL |     E::V::associated_item;
    |
 help: there is an enum variant `E::V`; try using the variant's enum
    |
-LL |     E;
+LL |     E::associated_item;
    |     ~
 
 error[E0433]: failed to resolve: `V` is a variant, not a module
@@ -16,10 +16,6 @@ LL |     V::associated_item;
    |     ^ `V` is a variant, not a module
    |
 help: there is an enum variant `E::V`; try using the variant's enum
-   |
-LL |     E;
-   |     ~
-help: an enum with a similar name exists
    |
 LL |     E::associated_item;
    |     ~


### PR DESCRIPTION
Use the right span when encountering an enum variant followed by an associated item so we don't lose the associated item in the resulting code.
    
Do not suggest the thing twice, once as a removal of the associated item and a second time as a typo suggestion.