### PR TITLE
add rustc std workspace crate sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3197,6 +3197,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5c9f15eec8235d7cb775ee6f81891db79b98fd54ba1ad8fae565b88ef1ae4e2"
 
 [[package]]
+name = "rustc-std-workspace-alloc"
+version = "1.0.1"
+
+[[package]]
+name = "rustc-std-workspace-core"
+version = "1.0.1"
+
+[[package]]
+name = "rustc-std-workspace-std"
+version = "1.0.1"
+
+[[package]]
 name = "rustc_abi"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ resolver = "2"
 members = [
   "compiler/rustc",
   "src/etc/test-float-parse",
+  "src/rustc-std-workspace/rustc-std-workspace-core",
+  "src/rustc-std-workspace/rustc-std-workspace-alloc",
+  "src/rustc-std-workspace/rustc-std-workspace-std",
   "src/rustdoc-json-types",
   "src/tools/build_helper",
   "src/tools/cargotest",

--- a/library/rustc-std-workspace-core/README.md
+++ b/library/rustc-std-workspace-core/README.md
@@ -27,3 +27,6 @@ it'll look like
 
 when Cargo invokes the compiler, satisfying the implicit `extern crate core`
 directive injected by the compiler.
+
+The sources for the crates.io version can be found in
+[`src/rustc-std-workspace`](../../src/rustc-std-workspace).

--- a/src/rustc-std-workspace/README.md
+++ b/src/rustc-std-workspace/README.md
@@ -1,0 +1,4 @@
+See `library/rustc-std-workspace-core/README.md` for context.
+
+These are the crates.io versions of these crates, as opposed to the versions
+in `library` which are the ones used inside the rustc workspace.

--- a/src/rustc-std-workspace/README.md
+++ b/src/rustc-std-workspace/README.md
@@ -1,4 +1,4 @@
-See `library/rustc-std-workspace-core/README.md` for context.
+See [`library/rustc-std-workspace-core/README.md`](../../library/rustc-std-workspace-core/README.md) for context.
 
 These are the crates.io versions of these crates, as opposed to the versions
 in `library` which are the ones used inside the rustc workspace.

--- a/src/rustc-std-workspace/rustc-std-workspace-alloc/Cargo.toml
+++ b/src/rustc-std-workspace/rustc-std-workspace-alloc/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rustc-std-workspace-alloc"
+version = "1.0.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2018"
+license = 'MIT/Apache-2.0'
+description = 'workspace hack'
+
+[dependencies]

--- a/src/rustc-std-workspace/rustc-std-workspace-alloc/Cargo.toml
+++ b/src/rustc-std-workspace/rustc-std-workspace-alloc/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "rustc-std-workspace-alloc"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2018"
+edition = "2021"
 license = 'MIT/Apache-2.0'
-description = 'workspace hack'
+description = """
+crate for integration of crates.io crates into rust-lang/rust standard library workspace
+"""
 
-[dependencies]
+repository = "https://github.com/rust-lang/rust/tree/master/src/rustc-std-workspace"

--- a/src/rustc-std-workspace/rustc-std-workspace-alloc/src/lib.rs
+++ b/src/rustc-std-workspace/rustc-std-workspace-alloc/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+extern crate alloc as the_alloc;
+pub use the_alloc::*;

--- a/src/rustc-std-workspace/rustc-std-workspace-core/Cargo.toml
+++ b/src/rustc-std-workspace/rustc-std-workspace-core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rustc-std-workspace-core"
+version = "1.0.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+license = "MIT/Apache-2.0"
+description = """
+Explicitly empty crate for rust-lang/rust integration
+"""
+
+[dependencies]

--- a/src/rustc-std-workspace/rustc-std-workspace-core/Cargo.toml
+++ b/src/rustc-std-workspace/rustc-std-workspace-core/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "rustc-std-workspace-core"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2021"
 license = "MIT/Apache-2.0"
 description = """
-Explicitly empty crate for rust-lang/rust integration
+crate for integration of crates.io crates into rust-lang/rust standard library workspace
 """
 
-[dependencies]
+repository = "https://github.com/rust-lang/rust/tree/master/src/rustc-std-workspace"

--- a/src/rustc-std-workspace/rustc-std-workspace-core/src/lib.rs
+++ b/src/rustc-std-workspace/rustc-std-workspace-core/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+extern crate core as the_core;
+pub use the_core::*;

--- a/src/rustc-std-workspace/rustc-std-workspace-std/Cargo.toml
+++ b/src/rustc-std-workspace/rustc-std-workspace-std/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rustc-std-workspace-std"
+version = "1.0.1"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+license = "MIT/Apache-2.0"
+description = "Workaround for rustbuild"
+
+[lib]
+name = "std"
+

--- a/src/rustc-std-workspace/rustc-std-workspace-std/Cargo.toml
+++ b/src/rustc-std-workspace/rustc-std-workspace-std/Cargo.toml
@@ -2,9 +2,10 @@
 name = "rustc-std-workspace-std"
 version = "1.0.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+edition = "2021"
 license = "MIT/Apache-2.0"
-description = "Workaround for rustbuild"
+description = """
+crate for integration of crates.io crates into rust-lang/rust standard library workspace
+"""
 
-[lib]
-name = "std"
-
+repository = "https://github.com/rust-lang/rust/tree/master/src/rustc-std-workspace"

--- a/src/rustc-std-workspace/rustc-std-workspace-std/src/lib.rs
+++ b/src/rustc-std-workspace/rustc-std-workspace-std/src/lib.rs
@@ -1,0 +1,1 @@
+pub use std::*;


### PR DESCRIPTION
This adds the sources for the crates listed at https://crates.io/search?q=rustc-std-workspace in this repo. The first commit adds the original sources as downloaded from crates.io (with `Cargo.toml.orig` moved back over `Cargo.toml`), and adds a README explaining what this is about. The 2nd commit updates the sources to make the core and alloc crates re-exports of the "actual" core and alloc crates, as was already the case with `std`, and also adds a `repository` link to the manifest so one can figure out where to find these crates.

I bumped the version for the core and alloc crates in the hope that the new versions can be published on crates.io shortly after this PR lands.

See [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/rustc-std-workspace-core.20crate.20is.20empty) for a bit more context.

r? @Amanieu 