### PR TITLE
Remove unnecessary pub enum glob-imports from `rustc_middle::ty`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -816,7 +816,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                     ) {
                         match captured_place.info.capture_kind {
                             ty::UpvarCapture::ByRef(
-                                ty::BorrowKind::MutBorrow | ty::BorrowKind::UniqueImmBorrow,
+                                ty::BorrowKind::Mutable | ty::BorrowKind::UniqueImmutable,
                             ) => {
                                 capture_reason = format!("mutable borrow of `{upvar}`");
                             }

--- a/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_errors.rs
@@ -189,7 +189,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
     /// Returns `true` if a closure is inferred to be an `FnMut` closure.
     fn is_closure_fn_mut(&self, fr: RegionVid) -> bool {
         if let Some(ty::ReLateParam(late_param)) = self.to_error_region(fr).as_deref()
-            && let ty::BoundRegionKind::BrEnv = late_param.bound_region
+            && let ty::BoundRegionKind::ClosureEnv = late_param.bound_region
             && let DefiningTy::Closure(_, args) = self.regioncx.universal_regions().defining_ty
         {
             return args.as_closure().kind() == ty::ClosureKind::FnMut;

--- a/compiler/rustc_borrowck/src/diagnostics/region_name.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/region_name.rs
@@ -301,7 +301,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
             }
 
             ty::ReLateParam(late_param) => match late_param.bound_region {
-                ty::BoundRegionKind::BrNamed(region_def_id, name) => {
+                ty::BoundRegionKind::Named(region_def_id, name) => {
                     // Get the span to point to, even if we don't use the name.
                     let span = tcx.hir().span_if_local(region_def_id).unwrap_or(DUMMY_SP);
                     debug!(
@@ -332,7 +332,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
                     }
                 }
 
-                ty::BoundRegionKind::BrEnv => {
+                ty::BoundRegionKind::ClosureEnv => {
                     let def_ty = self.regioncx.universal_regions().defining_ty;
 
                     let closure_kind = match def_ty {
@@ -369,7 +369,7 @@ impl<'tcx> MirBorrowckCtxt<'_, '_, 'tcx> {
                     })
                 }
 
-                ty::BoundRegionKind::BrAnon => None,
+                ty::BoundRegionKind::Anon => None,
             },
 
             ty::ReBound(..)

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1375,9 +1375,9 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
 
                     let region_ctxt_fn = || {
                         let reg_info = match br.kind {
-                            ty::BoundRegionKind::BrAnon => sym::anon,
-                            ty::BoundRegionKind::BrNamed(_, name) => name,
-                            ty::BoundRegionKind::BrEnv => sym::env,
+                            ty::BoundRegionKind::Anon => sym::anon,
+                            ty::BoundRegionKind::Named(_, name) => name,
+                            ty::BoundRegionKind::ClosureEnv => sym::env,
                         };
 
                         RegionCtxt::LateBound(reg_info)

--- a/compiler/rustc_borrowck/src/type_check/relate_tys.rs
+++ b/compiler/rustc_borrowck/src/type_check/relate_tys.rs
@@ -271,9 +271,9 @@ impl<'a, 'b, 'tcx> NllTypeRelating<'a, 'b, 'tcx> {
             .placeholder_region(self.type_checker.infcx, placeholder);
 
         let reg_info = match placeholder.bound.kind {
-            ty::BoundRegionKind::BrAnon => sym::anon,
-            ty::BoundRegionKind::BrNamed(_, name) => name,
-            ty::BoundRegionKind::BrEnv => sym::env,
+            ty::BoundRegionKind::Anon => sym::anon,
+            ty::BoundRegionKind::Named(_, name) => name,
+            ty::BoundRegionKind::ClosureEnv => sym::env,
         };
 
         if cfg!(debug_assertions) {

--- a/compiler/rustc_borrowck/src/universal_regions.rs
+++ b/compiler/rustc_borrowck/src/universal_regions.rs
@@ -696,14 +696,13 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
                 let closure_sig = args.as_closure().sig();
                 let inputs_and_output = closure_sig.inputs_and_output();
                 let bound_vars = tcx.mk_bound_variable_kinds_from_iter(
-                    inputs_and_output
-                        .bound_vars()
-                        .iter()
-                        .chain(iter::once(ty::BoundVariableKind::Region(ty::BrEnv))),
+                    inputs_and_output.bound_vars().iter().chain(iter::once(
+                        ty::BoundVariableKind::Region(ty::BoundRegionKind::ClosureEnv),
+                    )),
                 );
                 let br = ty::BoundRegion {
                     var: ty::BoundVar::from_usize(bound_vars.len() - 1),
-                    kind: ty::BrEnv,
+                    kind: ty::BoundRegionKind::ClosureEnv,
                 };
                 let env_region = ty::Region::new_bound(tcx, ty::INNERMOST, br);
                 let closure_ty = tcx.closure_env_ty(
@@ -751,15 +750,13 @@ impl<'cx, 'tcx> UniversalRegionsBuilder<'cx, 'tcx> {
             DefiningTy::CoroutineClosure(def_id, args) => {
                 assert_eq!(self.mir_def.to_def_id(), def_id);
                 let closure_sig = args.as_coroutine_closure().coroutine_closure_sig();
-                let bound_vars = tcx.mk_bound_variable_kinds_from_iter(
-                    closure_sig
-                        .bound_vars()
-                        .iter()
-                        .chain(iter::once(ty::BoundVariableKind::Region(ty::BrEnv))),
-                );
+                let bound_vars =
+                    tcx.mk_bound_variable_kinds_from_iter(closure_sig.bound_vars().iter().chain(
+                        iter::once(ty::BoundVariableKind::Region(ty::BoundRegionKind::ClosureEnv)),
+                    ));
                 let br = ty::BoundRegion {
                     var: ty::BoundVar::from_usize(bound_vars.len() - 1),
-                    kind: ty::BrEnv,
+                    kind: ty::BoundRegionKind::ClosureEnv,
                 };
                 let env_region = ty::Region::new_bound(tcx, ty::INNERMOST, br);
                 let closure_kind = args.as_coroutine_closure().kind();

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -710,7 +710,7 @@ pub fn check_tied_features(
 /// applied to the method prototype.
 fn should_inherit_track_caller(tcx: TyCtxt<'_>, def_id: DefId) -> bool {
     if let Some(impl_item) = tcx.opt_associated_item(def_id)
-        && let ty::AssocItemContainer::ImplContainer = impl_item.container
+        && let ty::AssocItemContainer::Impl = impl_item.container
         && let Some(trait_item) = impl_item.trait_item_def_id
     {
         return tcx.codegen_fn_attrs(trait_item).flags.intersects(CodegenFnAttrFlags::TRACK_CALLER);

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -2244,7 +2244,7 @@ fn param_env_with_gat_bounds<'tcx>(
                     .into()
                 }
                 GenericParamDefKind::Lifetime => {
-                    let kind = ty::BoundRegionKind::BrNamed(param.def_id, param.name);
+                    let kind = ty::BoundRegionKind::Named(param.def_id, param.name);
                     let bound_var = ty::BoundVariableKind::Region(kind);
                     bound_vars.push(bound_var);
                     ty::Region::new_bound(tcx, ty::INNERMOST, ty::BoundRegion {

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -1189,8 +1189,8 @@ fn compare_self_type<'tcx>(
 
     let self_string = |method: ty::AssocItem| {
         let untransformed_self_ty = match method.container {
-            ty::ImplContainer => impl_trait_ref.self_ty(),
-            ty::TraitContainer => tcx.types.self_param,
+            ty::AssocItemContainer::Impl => impl_trait_ref.self_ty(),
+            ty::AssocItemContainer::Trait => tcx.types.self_param,
         };
         let self_arg_ty = tcx.fn_sig(method.def_id).instantiate_identity().input(0);
         let param_env = ty::ParamEnv::reveal_all();
@@ -2224,10 +2224,8 @@ fn param_env_with_gat_bounds<'tcx>(
 
     for impl_ty in impl_tys_to_install {
         let trait_ty = match impl_ty.container {
-            ty::AssocItemContainer::TraitContainer => impl_ty,
-            ty::AssocItemContainer::ImplContainer => {
-                tcx.associated_item(impl_ty.trait_item_def_id.unwrap())
-            }
+            ty::AssocItemContainer::Trait => impl_ty,
+            ty::AssocItemContainer::Impl => tcx.associated_item(impl_ty.trait_item_def_id.unwrap()),
         };
 
         let mut bound_vars: smallvec::SmallVec<[ty::BoundVariableKind; 8]> =

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -178,19 +178,19 @@ pub fn check_intrinsic_type(
     let name_str = intrinsic_name.as_str();
 
     let bound_vars = tcx.mk_bound_variable_kinds(&[
-        ty::BoundVariableKind::Region(ty::BrAnon),
-        ty::BoundVariableKind::Region(ty::BrAnon),
-        ty::BoundVariableKind::Region(ty::BrEnv),
+        ty::BoundVariableKind::Region(ty::BoundRegionKind::Anon),
+        ty::BoundVariableKind::Region(ty::BoundRegionKind::Anon),
+        ty::BoundVariableKind::Region(ty::BoundRegionKind::ClosureEnv),
     ]);
     let mk_va_list_ty = |mutbl| {
         tcx.lang_items().va_list().map(|did| {
             let region = ty::Region::new_bound(tcx, ty::INNERMOST, ty::BoundRegion {
                 var: ty::BoundVar::ZERO,
-                kind: ty::BrAnon,
+                kind: ty::BoundRegionKind::Anon,
             });
             let env_region = ty::Region::new_bound(tcx, ty::INNERMOST, ty::BoundRegion {
                 var: ty::BoundVar::from_u32(2),
-                kind: ty::BrEnv,
+                kind: ty::BoundRegionKind::ClosureEnv,
             });
             let va_list_ty = tcx.type_of(did).instantiate(tcx, &[region.into()]);
             (Ty::new_ref(tcx, env_region, va_list_ty, mutbl), va_list_ty)
@@ -509,7 +509,8 @@ pub fn check_intrinsic_type(
                 );
                 let discriminant_def_id = assoc_items[0];
 
-                let br = ty::BoundRegion { var: ty::BoundVar::ZERO, kind: ty::BrAnon };
+                let br =
+                    ty::BoundRegion { var: ty::BoundVar::ZERO, kind: ty::BoundRegionKind::Anon };
                 (
                     1,
                     0,
@@ -573,10 +574,14 @@ pub fn check_intrinsic_type(
             }
 
             sym::raw_eq => {
-                let br = ty::BoundRegion { var: ty::BoundVar::ZERO, kind: ty::BrAnon };
+                let br =
+                    ty::BoundRegion { var: ty::BoundVar::ZERO, kind: ty::BoundRegionKind::Anon };
                 let param_ty_lhs =
                     Ty::new_imm_ref(tcx, ty::Region::new_bound(tcx, ty::INNERMOST, br), param(0));
-                let br = ty::BoundRegion { var: ty::BoundVar::from_u32(1), kind: ty::BrAnon };
+                let br = ty::BoundRegion {
+                    var: ty::BoundVar::from_u32(1),
+                    kind: ty::BoundRegionKind::Anon,
+                };
                 let param_ty_rhs =
                     Ty::new_imm_ref(tcx, ty::Region::new_bound(tcx, ty::INNERMOST, br), param(0));
                 (1, 0, vec![param_ty_lhs, param_ty_rhs], tcx.types.bool)

--- a/compiler/rustc_hir_analysis/src/check/wfcheck.rs
+++ b/compiler/rustc_hir_analysis/src/check/wfcheck.rs
@@ -1048,8 +1048,10 @@ fn check_associated_item(
             .coherent_trait(tcx.parent(item.trait_item_def_id.unwrap_or(item_id.into())))?;
 
         let self_ty = match item.container {
-            ty::TraitContainer => tcx.types.self_param,
-            ty::ImplContainer => tcx.type_of(item.container_id(tcx)).instantiate_identity(),
+            ty::AssocItemContainer::Trait => tcx.types.self_param,
+            ty::AssocItemContainer::Impl => {
+                tcx.type_of(item.container_id(tcx)).instantiate_identity()
+            }
         };
 
         match item.kind {
@@ -1072,7 +1074,7 @@ fn check_associated_item(
                 check_method_receiver(wfcx, hir_sig, item, self_ty)
             }
             ty::AssocKind::Type => {
-                if let ty::AssocItemContainer::TraitContainer = item.container {
+                if let ty::AssocItemContainer::Trait = item.container {
                     check_associated_type_bounds(wfcx, item, span)
                 }
                 if item.defaultness(tcx).has_value() {

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -634,7 +634,7 @@ fn get_new_lifetime_name<'tcx>(
         .collect_referenced_late_bound_regions(poly_trait_ref)
         .into_iter()
         .filter_map(|lt| {
-            if let ty::BoundRegionKind::BrNamed(_, name) = lt {
+            if let ty::BoundRegionKind::Named(_, name) = lt {
                 Some(name.as_str().to_string())
             } else {
                 None

--- a/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
+++ b/compiler/rustc_hir_analysis/src/collect/resolve_bound_vars.rs
@@ -322,7 +322,7 @@ fn late_arg_as_bound_arg<'tcx>(
     let name = tcx.item_name(def_id);
     match param.kind {
         GenericParamKind::Lifetime { .. } => {
-            ty::BoundVariableKind::Region(ty::BrNamed(def_id, name))
+            ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id, name))
         }
         GenericParamKind::Type { .. } => {
             ty::BoundVariableKind::Ty(ty::BoundTyKind::Param(def_id, name))
@@ -337,7 +337,7 @@ fn late_arg_as_bound_arg<'tcx>(
 fn generic_param_def_as_bound_arg(param: &ty::GenericParamDef) -> ty::BoundVariableKind {
     match param.kind {
         ty::GenericParamDefKind::Lifetime => {
-            ty::BoundVariableKind::Region(ty::BoundRegionKind::BrNamed(param.def_id, param.name))
+            ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(param.def_id, param.name))
         }
         ty::GenericParamDefKind::Type { .. } => {
             ty::BoundVariableKind::Ty(ty::BoundTyKind::Param(param.def_id, param.name))

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -644,7 +644,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 ty::GenericParamDefKind::Lifetime => {
                     ty::Region::new_bound(tcx, ty::INNERMOST, ty::BoundRegion {
                         var: ty::BoundVar::from_usize(num_bound_vars),
-                        kind: ty::BoundRegionKind::BrNamed(param.def_id, param.name),
+                        kind: ty::BoundRegionKind::Named(param.def_id, param.name),
                     })
                     .into()
                 }
@@ -830,8 +830,8 @@ impl<'tcx> TypeVisitor<TyCtxt<'tcx>> for GenericParamAndBoundVarCollector<'_, 't
             }
             ty::ReBound(db, br) if db >= self.depth => {
                 self.vars.insert(match br.kind {
-                    ty::BrNamed(def_id, name) => (def_id, name),
-                    ty::BrAnon | ty::BrEnv => {
+                    ty::BoundRegionKind::Named(def_id, name) => (def_id, name),
+                    ty::BoundRegionKind::Anon | ty::BoundRegionKind::ClosureEnv => {
                         let guar = self
                             .cx
                             .dcx()

--- a/compiler/rustc_hir_typeck/src/check.rs
+++ b/compiler/rustc_hir_typeck/src/check.rs
@@ -194,21 +194,21 @@ fn check_panic_info_fn(tcx: TyCtxt<'_>, fn_id: LocalDefId, fn_sig: ty::FnSig<'_>
     let panic_info_ty = tcx.type_of(panic_info_did).instantiate(tcx, &[ty::GenericArg::from(
         ty::Region::new_bound(tcx, ty::INNERMOST, ty::BoundRegion {
             var: ty::BoundVar::from_u32(1),
-            kind: ty::BrAnon,
+            kind: ty::BoundRegionKind::Anon,
         }),
     )]);
     let panic_info_ref_ty = Ty::new_imm_ref(
         tcx,
         ty::Region::new_bound(tcx, ty::INNERMOST, ty::BoundRegion {
             var: ty::BoundVar::ZERO,
-            kind: ty::BrAnon,
+            kind: ty::BoundRegionKind::Anon,
         }),
         panic_info_ty,
     );
 
     let bounds = tcx.mk_bound_variable_kinds(&[
-        ty::BoundVariableKind::Region(ty::BrAnon),
-        ty::BoundVariableKind::Region(ty::BrAnon),
+        ty::BoundVariableKind::Region(ty::BoundRegionKind::Anon),
+        ty::BoundVariableKind::Region(ty::BoundRegionKind::Anon),
     ]);
     let expected_sig = ty::Binder::bind_with_vars(
         tcx.mk_fn_sig([panic_info_ref_ty], tcx.types.never, false, fn_sig.safety, ExternAbi::Rust),

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -1025,7 +1025,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 let container_id = assoc_item.container_id(tcx);
                 debug!(?def_id, ?container, ?container_id);
                 match container {
-                    ty::TraitContainer => {
+                    ty::AssocItemContainer::Trait => {
                         if let Err(e) = callee::check_legal_trait_for_method_call(
                             tcx,
                             path_span,
@@ -1037,7 +1037,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             self.set_tainted_by_errors(e);
                         }
                     }
-                    ty::ImplContainer => {
+                    ty::AssocItemContainer::Impl => {
                         if segments.len() == 1 {
                             // `<T>::assoc` will end up here, and so
                             // can `T::assoc`. If this came from an

--- a/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/suggestions.rs
@@ -1796,7 +1796,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 false,
                 |did| {
                     let assoc_item = self.tcx.associated_item(did);
-                    assoc_item.container == ty::AssocItemContainer::TraitContainer
+                    assoc_item.container == ty::AssocItemContainer::Trait
                         && assoc_item.container_id(self.tcx) == clone_trait_did
                 },
             )

--- a/compiler/rustc_hir_typeck/src/lib.rs
+++ b/compiler/rustc_hir_typeck/src/lib.rs
@@ -239,7 +239,7 @@ fn infer_type_if_missing<'tcx>(fcx: &FnCtxt<'_, 'tcx>, node: Node<'tcx>) -> Opti
     let expected_type = if let Some(&hir::Ty { kind: hir::TyKind::Infer, span, .. }) = node.ty() {
         if let Some(item) = tcx.opt_associated_item(def_id.into())
             && let ty::AssocKind::Const = item.kind
-            && let ty::ImplContainer = item.container
+            && let ty::AssocItemContainer::Impl = item.container
             && let Some(trait_item_def_id) = item.trait_item_def_id
         {
             let impl_def_id = item.container_id(tcx);

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -480,7 +480,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ProbeScope::Single(def_id) => {
                     let item = self.tcx.associated_item(def_id);
                     // FIXME(fn_delegation): Delegation to inherent methods is not yet supported.
-                    assert_eq!(item.container, AssocItemContainer::TraitContainer);
+                    assert_eq!(item.container, AssocItemContainer::Trait);
 
                     let trait_def_id = self.tcx.parent(def_id);
                     let trait_span = self.tcx.def_span(trait_def_id);
@@ -1406,7 +1406,7 @@ impl<'tcx> Pick<'tcx> {
                         tcx.def_path_str(self.item.def_id),
                     ));
                 }
-                (ty::AssocKind::Const, ty::AssocItemContainer::TraitContainer) => {
+                (ty::AssocKind::Const, ty::AssocItemContainer::Trait) => {
                     let def_id = self.item.container_id(tcx);
                     lint.span_suggestion(
                         span,

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -381,7 +381,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             let closure_env_region: ty::Region<'_> =
                 ty::Region::new_bound(self.tcx, ty::INNERMOST, ty::BoundRegion {
                     var: ty::BoundVar::ZERO,
-                    kind: ty::BoundRegionKind::BrEnv,
+                    kind: ty::BoundRegionKind::ClosureEnv,
                 });
 
             let num_args = args
@@ -441,7 +441,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                         rustc_abi::ExternAbi::Rust,
                     ),
                     self.tcx.mk_bound_variable_kinds(&[ty::BoundVariableKind::Region(
-                        ty::BoundRegionKind::BrEnv,
+                        ty::BoundRegionKind::ClosureEnv,
                     )]),
                 ),
             );

--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -44,8 +44,8 @@ use rustc_middle::hir::place::{Place, PlaceBase, PlaceWithHirId, Projection, Pro
 use rustc_middle::mir::FakeReadCause;
 use rustc_middle::traits::ObligationCauseCode;
 use rustc_middle::ty::{
-    self, ClosureSizeProfileData, Ty, TyCtxt, TypeVisitableExt as _, TypeckResults, UpvarArgs,
-    UpvarCapture,
+    self, BorrowKind, ClosureSizeProfileData, Ty, TyCtxt, TypeVisitableExt as _, TypeckResults,
+    UpvarArgs, UpvarCapture,
 };
 use rustc_middle::{bug, span_bug};
 use rustc_session::lint;
@@ -646,7 +646,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                     },
 
                     ty::UpvarCapture::ByRef(
-                        ty::BorrowKind::MutBorrow | ty::BorrowKind::UniqueImmBorrow,
+                        ty::BorrowKind::Mutable | ty::BorrowKind::UniqueImmutable,
                     ) => {
                         match closure_kind {
                             ty::ClosureKind::Fn => {
@@ -1681,7 +1681,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 ty::UpvarCapture::ByValue
             }
             hir::CaptureBy::Value { .. } | hir::CaptureBy::Ref => {
-                ty::UpvarCapture::ByRef(ty::ImmBorrow)
+                ty::UpvarCapture::ByRef(BorrowKind::Immutable)
             }
         }
     }
@@ -1869,7 +1869,7 @@ fn should_reborrow_from_env_of_parent_coroutine_closure<'tcx>(
             Some(Projection { kind: ProjectionKind::Deref, .. })
         ))
         // (2.)
-        || matches!(child_capture.info.capture_kind, UpvarCapture::ByRef(ty::BorrowKind::MutBorrow))
+        || matches!(child_capture.info.capture_kind, UpvarCapture::ByRef(ty::BorrowKind::Mutable))
 }
 
 /// Truncate the capture so that the place being borrowed is in accordance with RFC 1240,
@@ -1984,7 +1984,7 @@ impl<'tcx> euv::Delegate<'tcx> for InferBorrowKind<'tcx> {
 
         // We need to restrict Fake Read precision to avoid fake reading unsafe code,
         // such as deref of a raw pointer.
-        let dummy_capture_kind = ty::UpvarCapture::ByRef(ty::BorrowKind::ImmBorrow);
+        let dummy_capture_kind = ty::UpvarCapture::ByRef(ty::BorrowKind::Immutable);
 
         let (place, _) = restrict_capture_precision(place.place.clone(), dummy_capture_kind);
 
@@ -2025,7 +2025,7 @@ impl<'tcx> euv::Delegate<'tcx> for InferBorrowKind<'tcx> {
 
         // Raw pointers don't inherit mutability
         if place_with_id.place.deref_tys().any(Ty::is_unsafe_ptr) {
-            capture_kind = ty::UpvarCapture::ByRef(ty::BorrowKind::ImmBorrow);
+            capture_kind = ty::UpvarCapture::ByRef(ty::BorrowKind::Immutable);
         }
 
         self.capture_information.push((place, ty::CaptureInfo {
@@ -2037,7 +2037,7 @@ impl<'tcx> euv::Delegate<'tcx> for InferBorrowKind<'tcx> {
 
     #[instrument(skip(self), level = "debug")]
     fn mutate(&mut self, assignee_place: &PlaceWithHirId<'tcx>, diag_expr_id: HirId) {
-        self.borrow(assignee_place, diag_expr_id, ty::BorrowKind::MutBorrow);
+        self.borrow(assignee_place, diag_expr_id, ty::BorrowKind::Mutable);
     }
 }
 
@@ -2331,16 +2331,16 @@ fn determine_capture_info(
             (ty::UpvarCapture::ByRef(ref_a), ty::UpvarCapture::ByRef(ref_b)) => {
                 match (ref_a, ref_b) {
                     // Take LHS:
-                    (ty::UniqueImmBorrow | ty::MutBorrow, ty::ImmBorrow)
-                    | (ty::MutBorrow, ty::UniqueImmBorrow) => capture_info_a,
+                    (BorrowKind::UniqueImmutable | BorrowKind::Mutable, BorrowKind::Immutable)
+                    | (BorrowKind::Mutable, BorrowKind::UniqueImmutable) => capture_info_a,
 
                     // Take RHS:
-                    (ty::ImmBorrow, ty::UniqueImmBorrow | ty::MutBorrow)
-                    | (ty::UniqueImmBorrow, ty::MutBorrow) => capture_info_b,
+                    (BorrowKind::Immutable, BorrowKind::UniqueImmutable | BorrowKind::Mutable)
+                    | (BorrowKind::UniqueImmutable, BorrowKind::Mutable) => capture_info_b,
 
-                    (ty::ImmBorrow, ty::ImmBorrow)
-                    | (ty::UniqueImmBorrow, ty::UniqueImmBorrow)
-                    | (ty::MutBorrow, ty::MutBorrow) => {
+                    (BorrowKind::Immutable, BorrowKind::Immutable)
+                    | (BorrowKind::UniqueImmutable, BorrowKind::UniqueImmutable)
+                    | (BorrowKind::Mutable, BorrowKind::Mutable) => {
                         bug!("Expected unequal capture kinds");
                     }
                 }
@@ -2367,12 +2367,12 @@ fn truncate_place_to_len_and_update_capture_kind<'tcx>(
     // Note that if the place contained Deref of a raw pointer it would've not been MutBorrow, so
     // we don't need to worry about that case here.
     match curr_mode {
-        ty::UpvarCapture::ByRef(ty::BorrowKind::MutBorrow) => {
+        ty::UpvarCapture::ByRef(ty::BorrowKind::Mutable) => {
             for i in len..place.projections.len() {
                 if place.projections[i].kind == ProjectionKind::Deref
                     && is_mut_ref(place.ty_before_projection(i))
                 {
-                    *curr_mode = ty::UpvarCapture::ByRef(ty::BorrowKind::UniqueImmBorrow);
+                    *curr_mode = ty::UpvarCapture::ByRef(ty::BorrowKind::UniqueImmutable);
                     break;
                 }
             }

--- a/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
+++ b/compiler/rustc_infer/src/infer/canonical/canonicalizer.rs
@@ -753,7 +753,7 @@ impl<'cx, 'tcx> Canonicalizer<'cx, 'tcx> {
         r: ty::Region<'tcx>,
     ) -> ty::Region<'tcx> {
         let var = self.canonical_var(info, r.into());
-        let br = ty::BoundRegion { var, kind: ty::BrAnon };
+        let br = ty::BoundRegion { var, kind: ty::BoundRegionKind::Anon };
         ty::Region::new_bound(self.cx(), self.binder_index, br)
     }
 

--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -154,7 +154,7 @@ fn check_fn(tcx: TyCtxt<'_>, parent_def_id: LocalDefId) {
     }
 
     for bound_var in sig.bound_vars() {
-        let ty::BoundVariableKind::Region(ty::BoundRegionKind::BrNamed(def_id, name)) = bound_var
+        let ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id, name)) = bound_var
         else {
             span_bug!(tcx.def_span(parent_def_id), "unexpected non-lifetime binder on fn sig");
         };
@@ -215,7 +215,7 @@ where
         for arg in t.bound_vars() {
             let arg: ty::BoundVariableKind = arg;
             match arg {
-                ty::BoundVariableKind::Region(ty::BoundRegionKind::BrNamed(def_id, ..))
+                ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id, ..))
                 | ty::BoundVariableKind::Ty(ty::BoundTyKind::Param(def_id, _)) => {
                     added.push(def_id);
                     let unique = self.in_scope_parameters.insert(def_id, ParamKind::Late);
@@ -318,7 +318,7 @@ where
                         ParamKind::Free(def_id, name) => ty::Region::new_late_param(
                             self.tcx,
                             self.parent_def_id.to_def_id(),
-                            ty::BoundRegionKind::BrNamed(def_id, name),
+                            ty::BoundRegionKind::Named(def_id, name),
                         ),
                         // Totally ignore late bound args from binders.
                         ParamKind::Late => return true,
@@ -489,11 +489,11 @@ fn extract_def_id_from_arg<'tcx>(
             ty::ReEarlyParam(ebr) => generics.region_param(ebr, tcx).def_id,
             ty::ReBound(
                 _,
-                ty::BoundRegion { kind: ty::BoundRegionKind::BrNamed(def_id, ..), .. },
+                ty::BoundRegion { kind: ty::BoundRegionKind::Named(def_id, ..), .. },
             )
             | ty::ReLateParam(ty::LateParamRegion {
                 scope: _,
-                bound_region: ty::BoundRegionKind::BrNamed(def_id, ..),
+                bound_region: ty::BoundRegionKind::Named(def_id, ..),
             }) => def_id,
             _ => unreachable!(),
         },
@@ -558,11 +558,11 @@ impl<'tcx> TypeRelation<TyCtxt<'tcx>> for FunctionalVariances<'tcx> {
             ty::ReEarlyParam(ebr) => self.generics.region_param(ebr, self.tcx).def_id,
             ty::ReBound(
                 _,
-                ty::BoundRegion { kind: ty::BoundRegionKind::BrNamed(def_id, ..), .. },
+                ty::BoundRegion { kind: ty::BoundRegionKind::Named(def_id, ..), .. },
             )
             | ty::ReLateParam(ty::LateParamRegion {
                 scope: _,
-                bound_region: ty::BoundRegionKind::BrNamed(def_id, ..),
+                bound_region: ty::BoundRegionKind::Named(def_id, ..),
             }) => def_id,
             _ => {
                 return Ok(a);

--- a/compiler/rustc_lint/src/nonstandard_style.rs
+++ b/compiler/rustc_lint/src/nonstandard_style.rs
@@ -26,8 +26,8 @@ pub(crate) enum MethodLateContext {
 pub(crate) fn method_context(cx: &LateContext<'_>, id: LocalDefId) -> MethodLateContext {
     let item = cx.tcx.associated_item(id);
     match item.container {
-        ty::TraitContainer => MethodLateContext::TraitAutoImpl,
-        ty::ImplContainer => match cx.tcx.impl_trait_ref(item.container_id(cx.tcx)) {
+        ty::AssocItemContainer::Trait => MethodLateContext::TraitAutoImpl,
+        ty::AssocItemContainer::Impl => match cx.tcx.impl_trait_ref(item.container_id(cx.tcx)) {
             Some(_) => MethodLateContext::TraitImpl,
             None => MethodLateContext::PlainImpl,
         },

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1203,8 +1203,8 @@ fn should_encode_type(tcx: TyCtxt<'_>, def_id: LocalDefId, def_kind: DefKind) ->
         DefKind::AssocTy => {
             let assoc_item = tcx.associated_item(def_id);
             match assoc_item.container {
-                ty::AssocItemContainer::ImplContainer => true,
-                ty::AssocItemContainer::TraitContainer => assoc_item.defaultness(tcx).has_value(),
+                ty::AssocItemContainer::Impl => true,
+                ty::AssocItemContainer::Trait => assoc_item.defaultness(tcx).has_value(),
             }
         }
         DefKind::TyParam => {
@@ -1336,7 +1336,7 @@ fn should_encode_const(def_kind: DefKind) -> bool {
 
 fn should_encode_fn_impl_trait_in_trait<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> bool {
     if let Some(assoc_item) = tcx.opt_associated_item(def_id)
-        && assoc_item.container == ty::AssocItemContainer::TraitContainer
+        && assoc_item.container == ty::AssocItemContainer::Trait
         && assoc_item.kind == ty::AssocKind::Fn
     {
         true
@@ -1649,7 +1649,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
         self.tables.assoc_container.set_some(def_id.index, item.container);
 
         match item.container {
-            AssocItemContainer::TraitContainer => {
+            AssocItemContainer::Trait => {
                 if let ty::AssocKind::Type = item.kind {
                     self.encode_explicit_item_bounds(def_id);
                     self.encode_explicit_item_super_predicates(def_id);
@@ -1659,7 +1659,7 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                     }
                 }
             }
-            AssocItemContainer::ImplContainer => {
+            AssocItemContainer::Impl => {
                 if let Some(trait_item_def_id) = item.trait_item_def_id {
                     self.tables.trait_item_def_id.set_some(def_id.index, trait_item_def_id.into());
                 }

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -223,8 +223,8 @@ fixed_size_enum! {
 
 fixed_size_enum! {
     ty::AssocItemContainer {
-        ( TraitContainer )
-        ( ImplContainer  )
+        ( Trait )
+        ( Impl  )
     }
 }
 

--- a/compiler/rustc_middle/src/mir/query.rs
+++ b/compiler/rustc_middle/src/mir/query.rs
@@ -317,7 +317,10 @@ impl<'tcx> ClosureOutlivesSubjectTy<'tcx> {
     pub fn bind(tcx: TyCtxt<'tcx>, ty: Ty<'tcx>) -> Self {
         let inner = tcx.fold_regions(ty, |r, depth| match r.kind() {
             ty::ReVar(vid) => {
-                let br = ty::BoundRegion { var: ty::BoundVar::new(vid.index()), kind: ty::BrAnon };
+                let br = ty::BoundRegion {
+                    var: ty::BoundVar::new(vid.index()),
+                    kind: ty::BoundRegionKind::Anon,
+                };
                 ty::Region::new_bound(tcx, depth, br)
             }
             _ => bug!("unexpected region in ClosureOutlivesSubjectTy: {r:?}"),

--- a/compiler/rustc_middle/src/ty/assoc.rs
+++ b/compiler/rustc_middle/src/ty/assoc.rs
@@ -10,8 +10,8 @@ use crate::ty;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, HashStable, Hash, Encodable, Decodable)]
 pub enum AssocItemContainer {
-    TraitContainer,
-    ImplContainer,
+    Trait,
+    Impl,
 }
 
 /// Information about an associated item
@@ -63,16 +63,16 @@ impl AssocItem {
     #[inline]
     pub fn trait_container(&self, tcx: TyCtxt<'_>) -> Option<DefId> {
         match self.container {
-            AssocItemContainer::ImplContainer => None,
-            AssocItemContainer::TraitContainer => Some(tcx.parent(self.def_id)),
+            AssocItemContainer::Impl => None,
+            AssocItemContainer::Trait => Some(tcx.parent(self.def_id)),
         }
     }
 
     #[inline]
     pub fn impl_container(&self, tcx: TyCtxt<'_>) -> Option<DefId> {
         match self.container {
-            AssocItemContainer::ImplContainer => Some(tcx.parent(self.def_id)),
-            AssocItemContainer::TraitContainer => None,
+            AssocItemContainer::Impl => Some(tcx.parent(self.def_id)),
+            AssocItemContainer::Trait => None,
         }
     }
 

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -1059,7 +1059,7 @@ impl<'tcx> CommonLifetimes<'tcx> {
                     .map(|v| {
                         mk(ty::ReBound(ty::DebruijnIndex::from(i), ty::BoundRegion {
                             var: ty::BoundVar::from(v),
-                            kind: ty::BrAnon,
+                            kind: ty::BoundRegionKind::Anon,
                         }))
                     })
                     .collect()
@@ -1982,7 +1982,10 @@ impl<'tcx> TyCtxt<'tcx> {
                 region = self.map_opaque_lifetime_to_parent_lifetime(def_id);
                 continue;
             }
-            break (scope, ty::BrNamed(def_id.into(), self.item_name(def_id.into())));
+            break (
+                scope,
+                ty::BoundRegionKind::Named(def_id.into(), self.item_name(def_id.into())),
+            );
         };
 
         let is_impl_item = match self.hir_node_by_def_id(suitable_region_binding_scope) {
@@ -3091,7 +3094,7 @@ impl<'tcx> TyCtxt<'tcx> {
                     return ty::Region::new_late_param(
                         self,
                         new_parent.to_def_id(),
-                        ty::BoundRegionKind::BrNamed(
+                        ty::BoundRegionKind::Named(
                             lbv.to_def_id(),
                             self.item_name(lbv.to_def_id()),
                         ),

--- a/compiler/rustc_middle/src/ty/fold.rs
+++ b/compiler/rustc_middle/src/ty/fold.rs
@@ -399,7 +399,7 @@ impl<'tcx> TyCtxt<'tcx> {
                 let index = entry.index();
                 let var = ty::BoundVar::from_usize(index);
                 let kind = entry
-                    .or_insert_with(|| ty::BoundVariableKind::Region(ty::BrAnon))
+                    .or_insert_with(|| ty::BoundVariableKind::Region(ty::BoundRegionKind::Anon))
                     .expect_region();
                 let br = ty::BoundRegion { var, kind };
                 ty::Region::new_bound(self.tcx, ty::INNERMOST, br)

--- a/compiler/rustc_middle/src/ty/instance.rs
+++ b/compiler/rustc_middle/src/ty/instance.rs
@@ -690,7 +690,7 @@ impl<'tcx> Instance<'tcx> {
                         && !matches!(
                             tcx.opt_associated_item(def),
                             Some(ty::AssocItem {
-                                container: ty::AssocItemContainer::TraitContainer,
+                                container: ty::AssocItemContainer::Trait,
                                 ..
                             })
                         )

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -55,9 +55,7 @@ use tracing::{debug, instrument};
 pub use vtable::*;
 use {rustc_ast as ast, rustc_attr as attr, rustc_hir as hir};
 
-pub use self::AssocItemContainer::*;
 pub use self::BorrowKind::*;
-pub use self::IntVarValue::*;
 pub use self::closure::{
     BorrowKind, CAPTURE_STRUCT_LOCAL, CaptureInfo, CapturedPlace, ClosureTypeInfo,
     MinCaptureInformationMap, MinCaptureList, RootVariableMinCaptureList, UpvarCapture, UpvarId,
@@ -2074,7 +2072,7 @@ impl<'tcx> TyCtxt<'tcx> {
         let Some(item) = self.opt_associated_item(def_id) else {
             return false;
         };
-        if item.container != ty::AssocItemContainer::ImplContainer {
+        if item.container != ty::AssocItemContainer::Impl {
             return false;
         }
 

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -55,7 +55,6 @@ use tracing::{debug, instrument};
 pub use vtable::*;
 use {rustc_ast as ast, rustc_attr as attr, rustc_hir as hir};
 
-pub use self::BorrowKind::*;
 pub use self::closure::{
     BorrowKind, CAPTURE_STRUCT_LOCAL, CaptureInfo, CapturedPlace, ClosureTypeInfo,
     MinCaptureInformationMap, MinCaptureList, RootVariableMinCaptureList, UpvarCapture, UpvarId,

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -49,10 +49,6 @@ pub use rustc_session::lint::RegisteredTools;
 use rustc_span::hygiene::MacroKind;
 use rustc_span::symbol::{Ident, Symbol, kw, sym};
 use rustc_span::{ExpnId, ExpnKind, Span};
-pub use rustc_type_ir::ConstKind::{
-    Bound as BoundCt, Error as ErrorCt, Expr as ExprCt, Infer as InferCt, Param as ParamCt,
-    Placeholder as PlaceholderCt, Unevaluated, Value,
-};
 pub use rustc_type_ir::relate::VarianceDiagInfo;
 pub use rustc_type_ir::*;
 use tracing::{debug, instrument};

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -84,7 +84,6 @@ pub use self::predicate::{
     RegionOutlivesPredicate, SubtypePredicate, ToPolyTraitRef, TraitPredicate, TraitRef,
     TypeOutlivesPredicate,
 };
-pub use self::region::BoundRegionKind::*;
 pub use self::region::{
     BoundRegion, BoundRegionKind, EarlyParamRegion, LateParamRegion, Region, RegionKind, RegionVid,
 };
@@ -895,7 +894,7 @@ impl rustc_type_ir::inherent::PlaceholderLike for PlaceholderRegion {
     }
 
     fn new(ui: UniverseIndex, var: BoundVar) -> Self {
-        Placeholder { universe: ui, bound: BoundRegion { var, kind: BoundRegionKind::BrAnon } }
+        Placeholder { universe: ui, bound: BoundRegion { var, kind: BoundRegionKind::Anon } }
     }
 }
 

--- a/compiler/rustc_middle/src/ty/print/pretty.rs
+++ b/compiler/rustc_middle/src/ty/print/pretty.rs
@@ -2483,7 +2483,7 @@ impl<'tcx> FmtPrinter<'_, 'tcx> {
             | ty::RePlaceholder(ty::Placeholder {
                 bound: ty::BoundRegion { kind: br, .. }, ..
             }) => {
-                if let ty::BrNamed(_, name) = br
+                if let ty::BoundRegionKind::Named(_, name) = br
                     && br.is_named()
                 {
                     p!(write("{}", name));
@@ -2569,7 +2569,7 @@ impl<'a, 'tcx> ty::TypeFolder<TyCtxt<'tcx>> for RegionFolder<'a, 'tcx> {
                 // If this is an anonymous placeholder, don't rename. Otherwise, in some
                 // async fns, we get a `for<'r> Send` bound
                 match kind {
-                    ty::BrAnon | ty::BrEnv => r,
+                    ty::BoundRegionKind::Anon | ty::BoundRegionKind::ClosureEnv => r,
                     _ => {
                         // Index doesn't matter, since this is just for naming and these never get bound
                         let br = ty::BoundRegion { var: ty::BoundVar::ZERO, kind };
@@ -2688,12 +2688,13 @@ impl<'tcx> FmtPrinter<'_, 'tcx> {
                             binder_level_idx: ty::DebruijnIndex,
                             br: ty::BoundRegion| {
                 let (name, kind) = match br.kind {
-                    ty::BrAnon | ty::BrEnv => {
+                    ty::BoundRegionKind::Anon | ty::BoundRegionKind::ClosureEnv => {
                         let name = next_name(self);
 
                         if let Some(lt_idx) = lifetime_idx {
                             if lt_idx > binder_level_idx {
-                                let kind = ty::BrNamed(CRATE_DEF_ID.to_def_id(), name);
+                                let kind =
+                                    ty::BoundRegionKind::Named(CRATE_DEF_ID.to_def_id(), name);
                                 return ty::Region::new_bound(
                                     tcx,
                                     ty::INNERMOST,
@@ -2702,14 +2703,14 @@ impl<'tcx> FmtPrinter<'_, 'tcx> {
                             }
                         }
 
-                        (name, ty::BrNamed(CRATE_DEF_ID.to_def_id(), name))
+                        (name, ty::BoundRegionKind::Named(CRATE_DEF_ID.to_def_id(), name))
                     }
-                    ty::BrNamed(def_id, kw::UnderscoreLifetime | kw::Empty) => {
+                    ty::BoundRegionKind::Named(def_id, kw::UnderscoreLifetime | kw::Empty) => {
                         let name = next_name(self);
 
                         if let Some(lt_idx) = lifetime_idx {
                             if lt_idx > binder_level_idx {
-                                let kind = ty::BrNamed(def_id, name);
+                                let kind = ty::BoundRegionKind::Named(def_id, name);
                                 return ty::Region::new_bound(
                                     tcx,
                                     ty::INNERMOST,
@@ -2718,9 +2719,9 @@ impl<'tcx> FmtPrinter<'_, 'tcx> {
                             }
                         }
 
-                        (name, ty::BrNamed(def_id, name))
+                        (name, ty::BoundRegionKind::Named(def_id, name))
                     }
-                    ty::BrNamed(_, name) => {
+                    ty::BoundRegionKind::Named(_, name) => {
                         if let Some(lt_idx) = lifetime_idx {
                             if lt_idx > binder_level_idx {
                                 let kind = br.kind;

--- a/compiler/rustc_middle/src/ty/structural_impls.rs
+++ b/compiler/rustc_middle/src/ty/structural_impls.rs
@@ -62,15 +62,15 @@ impl<'tcx> fmt::Debug for ty::adjustment::Adjustment<'tcx> {
 impl fmt::Debug for ty::BoundRegionKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            ty::BrAnon => write!(f, "BrAnon"),
-            ty::BrNamed(did, name) => {
+            ty::BoundRegionKind::Anon => write!(f, "BrAnon"),
+            ty::BoundRegionKind::Named(did, name) => {
                 if did.is_crate_root() {
                     write!(f, "BrNamed({name})")
                 } else {
                     write!(f, "BrNamed({did:?}, {name})")
                 }
             }
-            ty::BrEnv => write!(f, "BrEnv"),
+            ty::BoundRegionKind::ClosureEnv => write!(f, "BrEnv"),
         }
     }
 }

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -735,8 +735,11 @@ impl<'tcx> TyCtxt<'tcx> {
                 let ty = self.fold_regions(decl.ty, |re, debruijn| {
                     assert_eq!(re, self.lifetimes.re_erased);
                     let var = ty::BoundVar::from_usize(vars.len());
-                    vars.push(ty::BoundVariableKind::Region(ty::BrAnon));
-                    ty::Region::new_bound(self, debruijn, ty::BoundRegion { var, kind: ty::BrAnon })
+                    vars.push(ty::BoundVariableKind::Region(ty::BoundRegionKind::Anon));
+                    ty::Region::new_bound(self, debruijn, ty::BoundRegion {
+                        var,
+                        kind: ty::BoundRegionKind::Anon,
+                    })
                 });
                 ty::EarlyBinder::bind(ty::Binder::bind_with_vars(
                     ty,

--- a/compiler/rustc_middle/src/util/call_kind.rs
+++ b/compiler/rustc_middle/src/util/call_kind.rs
@@ -72,8 +72,8 @@ pub fn call_kind<'tcx>(
     let parent = tcx.opt_associated_item(method_did).and_then(|assoc| {
         let container_id = assoc.container_id(tcx);
         match assoc.container {
-            AssocItemContainer::ImplContainer => tcx.trait_id_of_impl(container_id),
-            AssocItemContainer::TraitContainer => Some(container_id),
+            AssocItemContainer::Impl => tcx.trait_id_of_impl(container_id),
+            AssocItemContainer::Trait => Some(container_id),
         }
     });
 

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -1185,11 +1185,11 @@ impl<'tcx> Cx<'tcx> {
             ty::UpvarCapture::ByValue => captured_place_expr,
             ty::UpvarCapture::ByRef(upvar_borrow) => {
                 let borrow_kind = match upvar_borrow {
-                    ty::BorrowKind::ImmBorrow => BorrowKind::Shared,
-                    ty::BorrowKind::UniqueImmBorrow => {
+                    ty::BorrowKind::Immutable => BorrowKind::Shared,
+                    ty::BorrowKind::UniqueImmutable => {
                         BorrowKind::Mut { kind: mir::MutBorrowKind::ClosureCapture }
                     }
-                    ty::BorrowKind::MutBorrow => {
+                    ty::BorrowKind::Mutable => {
                         BorrowKind::Mut { kind: mir::MutBorrowKind::Default }
                     }
                 };

--- a/compiler/rustc_smir/src/rustc_internal/internal.rs
+++ b/compiler/rustc_smir/src/rustc_internal/internal.rs
@@ -335,12 +335,12 @@ impl RustcInternal for BoundVariableKind {
                 ),
             }),
             BoundVariableKind::Region(kind) => rustc_ty::BoundVariableKind::Region(match kind {
-                BoundRegionKind::BrAnon => rustc_ty::BoundRegionKind::BrAnon,
-                BoundRegionKind::BrNamed(def, symbol) => rustc_ty::BoundRegionKind::BrNamed(
+                BoundRegionKind::BrAnon => rustc_ty::BoundRegionKind::Anon,
+                BoundRegionKind::BrNamed(def, symbol) => rustc_ty::BoundRegionKind::Named(
                     def.0.internal(tables, tcx),
                     Symbol::intern(symbol),
                 ),
-                BoundRegionKind::BrEnv => rustc_ty::BoundRegionKind::BrEnv,
+                BoundRegionKind::BrEnv => rustc_ty::BoundRegionKind::ClosureEnv,
             }),
             BoundVariableKind::Const => rustc_ty::BoundVariableKind::Const,
         }

--- a/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
@@ -243,11 +243,11 @@ impl<'tcx> Stable<'tcx> for ty::BoundRegionKind {
         use stable_mir::ty::BoundRegionKind;
 
         match self {
-            ty::BoundRegionKind::BrAnon => BoundRegionKind::BrAnon,
-            ty::BoundRegionKind::BrNamed(def_id, symbol) => {
+            ty::BoundRegionKind::Anon => BoundRegionKind::BrAnon,
+            ty::BoundRegionKind::Named(def_id, symbol) => {
                 BoundRegionKind::BrNamed(tables.br_named_def(*def_id), symbol.to_string())
             }
-            ty::BoundRegionKind::BrEnv => BoundRegionKind::BrEnv,
+            ty::BoundRegionKind::ClosureEnv => BoundRegionKind::BrEnv,
         }
     }
 }

--- a/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/ty.rs
@@ -418,7 +418,7 @@ pub(crate) fn mir_const_from_ty_const<'tcx>(
     ty: Ty<'tcx>,
 ) -> stable_mir::ty::MirConst {
     let kind = match ty_const.kind() {
-        ty::Value(ty, val) => {
+        ty::ConstKind::Value(ty, val) => {
             let val = match val {
                 ty::ValTree::Leaf(scalar) => ty::ValTree::Leaf(scalar),
                 ty::ValTree::Branch(branch) => {
@@ -435,19 +435,19 @@ pub(crate) fn mir_const_from_ty_const<'tcx>(
                 ))
             }
         }
-        ty::ParamCt(param) => stable_mir::ty::ConstantKind::Param(param.stable(tables)),
-        ty::ErrorCt(_) => unreachable!(),
-        ty::InferCt(_) => unreachable!(),
-        ty::BoundCt(_, _) => unimplemented!(),
-        ty::PlaceholderCt(_) => unimplemented!(),
-        ty::Unevaluated(uv) => {
+        ty::ConstKind::Param(param) => stable_mir::ty::ConstantKind::Param(param.stable(tables)),
+        ty::ConstKind::Error(_) => unreachable!(),
+        ty::ConstKind::Infer(_) => unreachable!(),
+        ty::ConstKind::Bound(_, _) => unimplemented!(),
+        ty::ConstKind::Placeholder(_) => unimplemented!(),
+        ty::ConstKind::Unevaluated(uv) => {
             stable_mir::ty::ConstantKind::Unevaluated(stable_mir::ty::UnevaluatedConst {
                 def: tables.const_def(uv.def),
                 args: uv.args.stable(tables),
                 promoted: None,
             })
         }
-        ty::ExprCt(_) => unimplemented!(),
+        ty::ConstKind::Expr(_) => unimplemented!(),
     };
     let stable_ty = tables.intern_ty(ty);
     let id = tables.intern_mir_const(mir::Const::Ty(ty, ty_const));
@@ -459,7 +459,7 @@ impl<'tcx> Stable<'tcx> for ty::Const<'tcx> {
 
     fn stable(&self, tables: &mut Tables<'_>) -> Self::T {
         let kind = match self.kind() {
-            ty::Value(ty, val) => {
+            ty::ConstKind::Value(ty, val) => {
                 let val = match val {
                     ty::ValTree::Leaf(scalar) => ty::ValTree::Leaf(scalar),
                     ty::ValTree::Branch(branch) => {
@@ -478,16 +478,16 @@ impl<'tcx> Stable<'tcx> for ty::Const<'tcx> {
                     )
                 }
             }
-            ty::ParamCt(param) => stable_mir::ty::TyConstKind::Param(param.stable(tables)),
-            ty::Unevaluated(uv) => stable_mir::ty::TyConstKind::Unevaluated(
+            ty::ConstKind::Param(param) => stable_mir::ty::TyConstKind::Param(param.stable(tables)),
+            ty::ConstKind::Unevaluated(uv) => stable_mir::ty::TyConstKind::Unevaluated(
                 tables.const_def(uv.def),
                 uv.args.stable(tables),
             ),
-            ty::ErrorCt(_) => unreachable!(),
-            ty::InferCt(_) => unreachable!(),
-            ty::BoundCt(_, _) => unimplemented!(),
-            ty::PlaceholderCt(_) => unimplemented!(),
-            ty::ExprCt(_) => unimplemented!(),
+            ty::ConstKind::Error(_) => unreachable!(),
+            ty::ConstKind::Infer(_) => unreachable!(),
+            ty::ConstKind::Bound(_, _) => unimplemented!(),
+            ty::ConstKind::Placeholder(_) => unimplemented!(),
+            ty::ConstKind::Expr(_) => unimplemented!(),
         };
         let id = tables.intern_ty_const(tables.tcx.lift(*self).unwrap());
         stable_mir::ty::TyConst::new(kind, id)

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -568,7 +568,7 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
 
             // We may still encounter unevaluated consts due to the printing
             // logic sometimes passing identity-substituted impl headers.
-            ty::Unevaluated(ty::UnevaluatedConst { def, args, .. }) => {
+            ty::ConstKind::Unevaluated(ty::UnevaluatedConst { def, args, .. }) => {
                 return self.print_def_path(def, args);
             }
 

--- a/compiler/rustc_symbol_mangling/src/v0.rs
+++ b/compiler/rustc_symbol_mangling/src/v0.rs
@@ -290,7 +290,7 @@ impl<'tcx> Printer<'tcx> for SymbolMangler<'tcx> {
 
             // Bound lifetimes use indices starting at 1,
             // see `BinderLevel` for more details.
-            ty::ReBound(debruijn, ty::BoundRegion { var, kind: ty::BrAnon }) => {
+            ty::ReBound(debruijn, ty::BoundRegion { var, kind: ty::BoundRegionKind::Anon }) => {
                 let binder = &self.binders[self.binders.len() - 1 - debruijn.index()];
                 let depth = binder.lifetime_depths.start + var.as_u32();
 

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/find_anon_type.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/find_anon_type.rs
@@ -100,7 +100,10 @@ impl<'tcx> Visitor<'tcx> for FindNestedTypeVisitor<'tcx> {
                     // Find the index of the named region that was part of the
                     // error. We will then search the function parameters for a bound
                     // region at the right depth with the same index
-                    (Some(rbv::ResolvedArg::EarlyBound(id)), ty::BrNamed(def_id, _)) => {
+                    (
+                        Some(rbv::ResolvedArg::EarlyBound(id)),
+                        ty::BoundRegionKind::Named(def_id, _),
+                    ) => {
                         debug!("EarlyBound id={:?} def_id={:?}", id, def_id);
                         if id.to_def_id() == def_id {
                             return ControlFlow::Break(arg);
@@ -112,7 +115,7 @@ impl<'tcx> Visitor<'tcx> for FindNestedTypeVisitor<'tcx> {
                     // region at the right depth with the same index
                     (
                         Some(rbv::ResolvedArg::LateBound(debruijn_index, _, id)),
-                        ty::BrNamed(def_id, _),
+                        ty::BoundRegionKind::Named(def_id, _),
                     ) => {
                         debug!(
                             "FindNestedTypeVisitor::visit_ty: LateBound depth = {:?}",
@@ -191,14 +194,17 @@ impl<'tcx> Visitor<'tcx> for TyPathVisitor<'tcx> {
     fn visit_lifetime(&mut self, lifetime: &hir::Lifetime) -> Self::Result {
         match (self.tcx.named_bound_var(lifetime.hir_id), self.bound_region) {
             // the lifetime of the TyPath!
-            (Some(rbv::ResolvedArg::EarlyBound(id)), ty::BrNamed(def_id, _)) => {
+            (Some(rbv::ResolvedArg::EarlyBound(id)), ty::BoundRegionKind::Named(def_id, _)) => {
                 debug!("EarlyBound id={:?} def_id={:?}", id, def_id);
                 if id.to_def_id() == def_id {
                     return ControlFlow::Break(());
                 }
             }
 
-            (Some(rbv::ResolvedArg::LateBound(debruijn_index, _, id)), ty::BrNamed(def_id, _)) => {
+            (
+                Some(rbv::ResolvedArg::LateBound(debruijn_index, _, id)),
+                ty::BoundRegionKind::Named(def_id, _),
+            ) => {
                 debug!("FindNestedTypeVisitor::visit_ty: LateBound depth = {:?}", debruijn_index,);
                 debug!("id={:?}", id);
                 debug!("def_id={:?}", def_id);

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/named_anon_conflict.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/named_anon_conflict.rs
@@ -60,7 +60,7 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
         let is_impl_item = region_info.is_impl_item;
 
         match br {
-            ty::BrNamed(_, kw::UnderscoreLifetime) | ty::BrAnon => {}
+            ty::BoundRegionKind::Named(_, kw::UnderscoreLifetime) | ty::BoundRegionKind::Anon => {}
             _ => {
                 /* not an anonymous region */
                 debug!("try_report_named_anon_conflict: not an anonymous region");

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_relation.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/placeholder_relation.rs
@@ -29,16 +29,16 @@ impl<'tcx> NiceRegionError<'_, 'tcx> {
             )) => {
                 let span = *span;
                 let (sub_span, sub_symbol) = match sub_name {
-                    ty::BrNamed(def_id, symbol) => {
+                    ty::BoundRegionKind::Named(def_id, symbol) => {
                         (Some(self.tcx().def_span(def_id)), Some(symbol))
                     }
-                    ty::BrAnon | ty::BrEnv => (None, None),
+                    ty::BoundRegionKind::Anon | ty::BoundRegionKind::ClosureEnv => (None, None),
                 };
                 let (sup_span, sup_symbol) = match sup_name {
-                    ty::BrNamed(def_id, symbol) => {
+                    ty::BoundRegionKind::Named(def_id, symbol) => {
                         (Some(self.tcx().def_span(def_id)), Some(symbol))
                     }
-                    ty::BrAnon | ty::BrEnv => (None, None),
+                    ty::BoundRegionKind::Anon | ty::BoundRegionKind::ClosureEnv => (None, None),
                 };
                 let diag = match (sub_span, sup_span, sub_symbol, sup_symbol) {
                     (Some(sub_span), Some(sup_span), Some(&sub_symbol), Some(&sup_symbol)) => {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/static_impl_trait.rs
@@ -59,11 +59,11 @@ impl<'a, 'tcx> NiceRegionError<'a, 'tcx> {
                     let simple_ident = param.param.pat.simple_ident();
 
                     let (has_impl_path, impl_path) = match ctxt.assoc_item.container {
-                        AssocItemContainer::TraitContainer => {
+                        AssocItemContainer::Trait => {
                             let id = ctxt.assoc_item.container_id(tcx);
                             (true, tcx.def_path_str(id))
                         }
-                        AssocItemContainer::ImplContainer => (false, String::new()),
+                        AssocItemContainer::Impl => (false, String::new()),
                     };
 
                     let mut err = self.tcx().dcx().create_err(ButCallingIntroduces {

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/util.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/nice_region_error/util.rs
@@ -46,7 +46,7 @@ pub fn find_param_with_region<'tcx>(
         ty::ReLateParam(late_param) => (late_param.scope, late_param.bound_region),
         ty::ReEarlyParam(ebr) => {
             let region_def = tcx.generics_of(generic_param_scope).region_param(ebr, tcx).def_id;
-            (tcx.parent(region_def), ty::BoundRegionKind::BrNamed(region_def, ebr.name))
+            (tcx.parent(region_def), ty::BoundRegionKind::Named(region_def, ebr.name))
         }
         _ => return None, // not a free region
     };

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -993,7 +993,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
     fn report_inference_failure(&self, var_origin: RegionVariableOrigin) -> Diag<'_> {
         let br_string = |br: ty::BoundRegionKind| {
             let mut s = match br {
-                ty::BrNamed(_, name) => name.to_string(),
+                ty::BoundRegionKind::Named(_, name) => name.to_string(),
                 _ => String::new(),
             };
             if !s.is_empty() {
@@ -1103,7 +1103,7 @@ fn msg_span_from_named_region<'tcx>(
                 ("the anonymous lifetime defined here".to_string(), Some(ty.span))
             } else {
                 match fr.bound_region {
-                    ty::BoundRegionKind::BrNamed(param_def_id, name) => {
+                    ty::BoundRegionKind::Named(param_def_id, name) => {
                         let span = tcx.def_span(param_def_id);
                         let text = if name == kw::UnderscoreLifetime {
                             "the anonymous lifetime as defined here".to_string()
@@ -1112,7 +1112,7 @@ fn msg_span_from_named_region<'tcx>(
                         };
                         (text, Some(span))
                     }
-                    ty::BrAnon => (
+                    ty::BoundRegionKind::Anon => (
                         "the anonymous lifetime as defined here".to_string(),
                         Some(tcx.def_span(generic_param_scope)),
                     ),
@@ -1125,11 +1125,11 @@ fn msg_span_from_named_region<'tcx>(
         }
         ty::ReStatic => ("the static lifetime".to_owned(), alt_span),
         ty::RePlaceholder(ty::PlaceholderRegion {
-            bound: ty::BoundRegion { kind: ty::BoundRegionKind::BrNamed(def_id, name), .. },
+            bound: ty::BoundRegion { kind: ty::BoundRegionKind::Named(def_id, name), .. },
             ..
         }) => (format!("the lifetime `{name}` as defined here"), Some(tcx.def_span(def_id))),
         ty::RePlaceholder(ty::PlaceholderRegion {
-            bound: ty::BoundRegion { kind: ty::BoundRegionKind::BrAnon, .. },
+            bound: ty::BoundRegion { kind: ty::BoundRegionKind::Anon, .. },
             ..
         }) => ("an anonymous lifetime".to_owned(), None),
         _ => bug!("{:?}", region),

--- a/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
+++ b/compiler/rustc_trait_selection/src/errors/note_and_explain.rs
@@ -48,7 +48,7 @@ impl<'a> DescriptionCtx<'a> {
                 } else {
                     let scope = fr.scope.expect_local();
                     match fr.bound_region {
-                        ty::BoundRegionKind::BrNamed(_, name) => {
+                        ty::BoundRegionKind::Named(_, name) => {
                             let span = if let Some(param) = tcx
                                 .hir()
                                 .get_generics(scope)
@@ -64,7 +64,7 @@ impl<'a> DescriptionCtx<'a> {
                                 (Some(span), "as_defined", name.to_string())
                             }
                         }
-                        ty::BrAnon => {
+                        ty::BoundRegionKind::Anon => {
                             let span = Some(tcx.def_span(scope));
                             (span, "defined_here", String::new())
                         }

--- a/compiler/rustc_trait_selection/src/traits/coherence.rs
+++ b/compiler/rustc_trait_selection/src/traits/coherence.rs
@@ -540,7 +540,7 @@ fn plug_infer_with_placeholders<'tcx>(
                                 universe: self.universe,
                                 bound: ty::BoundRegion {
                                     var: self.next_var(),
-                                    kind: ty::BoundRegionKind::BrAnon,
+                                    kind: ty::BoundRegionKind::Anon,
                                 },
                             }),
                         )

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -624,9 +624,8 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                         debug!("equating consts:\nc1= {:?}\nc2= {:?}", c1, c2);
 
                         use rustc_hir::def::DefKind;
-                        use ty::Unevaluated;
                         match (c1.kind(), c2.kind()) {
-                            (Unevaluated(a), Unevaluated(b))
+                            (ty::ConstKind::Unevaluated(a), ty::ConstKind::Unevaluated(b))
                                 if a.def == b.def && tcx.def_kind(a.def) == DefKind::AssocConst =>
                             {
                                 if let Ok(new_obligations) = infcx
@@ -644,7 +643,8 @@ impl<'a, 'tcx> ObligationProcessor for FulfillProcessor<'a, 'tcx> {
                                     ));
                                 }
                             }
-                            (_, Unevaluated(_)) | (Unevaluated(_), _) => (),
+                            (_, ty::ConstKind::Unevaluated(_))
+                            | (ty::ConstKind::Unevaluated(_), _) => (),
                             (_, _) => {
                                 if let Ok(new_obligations) = infcx
                                     .at(&obligation.cause, obligation.param_env)

--- a/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/confirmation.rs
@@ -660,7 +660,7 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                             .into()
                         }
                         GenericParamDefKind::Lifetime => {
-                            let kind = ty::BoundRegionKind::BrNamed(param.def_id, param.name);
+                            let kind = ty::BoundRegionKind::Named(param.def_id, param.name);
                             let bound_var = ty::BoundVariableKind::Region(kind);
                             bound_vars.push(bound_var);
                             ty::Region::new_bound(tcx, ty::INNERMOST, ty::BoundRegion {

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -3183,7 +3183,7 @@ fn bind_coroutine_hidden_types_above<'tcx>(
                         ty::ReErased => {
                             let br = ty::BoundRegion {
                                 var: ty::BoundVar::from_u32(counter),
-                                kind: ty::BrAnon,
+                                kind: ty::BoundRegionKind::Anon,
                             };
                             counter += 1;
                             ty::Region::new_bound(tcx, current_depth, br)
@@ -3196,9 +3196,11 @@ fn bind_coroutine_hidden_types_above<'tcx>(
             bty.instantiate(tcx, args)
         })
         .collect();
-    let bound_vars =
-        tcx.mk_bound_variable_kinds_from_iter(bound_vars.iter().chain(
-            (num_bound_variables..counter).map(|_| ty::BoundVariableKind::Region(ty::BrAnon)),
-        ));
+    let bound_vars = tcx.mk_bound_variable_kinds_from_iter(
+        bound_vars.iter().chain(
+            (num_bound_variables..counter)
+                .map(|_| ty::BoundVariableKind::Region(ty::BoundRegionKind::Anon)),
+        ),
+    );
     ty::Binder::bind_with_vars(hidden_types, bound_vars)
 }

--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -890,9 +890,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                         );
 
                         use rustc_hir::def::DefKind;
-                        use ty::Unevaluated;
                         match (c1.kind(), c2.kind()) {
-                            (Unevaluated(a), Unevaluated(b))
+                            (ty::ConstKind::Unevaluated(a), ty::ConstKind::Unevaluated(b))
                                 if a.def == b.def && tcx.def_kind(a.def) == DefKind::AssocConst =>
                             {
                                 if let Ok(InferOk { obligations, value: () }) = self
@@ -912,7 +911,8 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
                                     );
                                 }
                             }
-                            (_, Unevaluated(_)) | (Unevaluated(_), _) => (),
+                            (_, ty::ConstKind::Unevaluated(_))
+                            | (ty::ConstKind::Unevaluated(_), _) => (),
                             (_, _) => {
                                 if let Ok(InferOk { obligations, value: () }) = self
                                     .infcx

--- a/compiler/rustc_ty_utils/src/abi.rs
+++ b/compiler/rustc_ty_utils/src/abi.rs
@@ -76,12 +76,13 @@ fn fn_sig_for_fn_abi<'tcx>(
         ty::Closure(def_id, args) => {
             let sig = args.as_closure().sig();
 
-            let bound_vars = tcx.mk_bound_variable_kinds_from_iter(
-                sig.bound_vars().iter().chain(iter::once(ty::BoundVariableKind::Region(ty::BrEnv))),
-            );
+            let bound_vars =
+                tcx.mk_bound_variable_kinds_from_iter(sig.bound_vars().iter().chain(iter::once(
+                    ty::BoundVariableKind::Region(ty::BoundRegionKind::ClosureEnv),
+                )));
             let br = ty::BoundRegion {
                 var: ty::BoundVar::from_usize(bound_vars.len() - 1),
-                kind: ty::BoundRegionKind::BrEnv,
+                kind: ty::BoundRegionKind::ClosureEnv,
             };
             let env_region = ty::Region::new_bound(tcx, ty::INNERMOST, br);
             let env_ty = tcx.closure_env_ty(
@@ -105,12 +106,13 @@ fn fn_sig_for_fn_abi<'tcx>(
         ty::CoroutineClosure(def_id, args) => {
             let coroutine_ty = Ty::new_coroutine_closure(tcx, def_id, args);
             let sig = args.as_coroutine_closure().coroutine_closure_sig();
-            let bound_vars = tcx.mk_bound_variable_kinds_from_iter(
-                sig.bound_vars().iter().chain(iter::once(ty::BoundVariableKind::Region(ty::BrEnv))),
-            );
+            let bound_vars =
+                tcx.mk_bound_variable_kinds_from_iter(sig.bound_vars().iter().chain(iter::once(
+                    ty::BoundVariableKind::Region(ty::BoundRegionKind::ClosureEnv),
+                )));
             let br = ty::BoundRegion {
                 var: ty::BoundVar::from_usize(bound_vars.len() - 1),
-                kind: ty::BoundRegionKind::BrEnv,
+                kind: ty::BoundRegionKind::ClosureEnv,
             };
             let env_region = ty::Region::new_bound(tcx, ty::INNERMOST, br);
             // When this `CoroutineClosure` comes from a `ConstructCoroutineInClosureShim`,
@@ -161,11 +163,11 @@ fn fn_sig_for_fn_abi<'tcx>(
             let sig = args.as_coroutine().sig();
 
             let bound_vars = tcx.mk_bound_variable_kinds_from_iter(iter::once(
-                ty::BoundVariableKind::Region(ty::BrEnv),
+                ty::BoundVariableKind::Region(ty::BoundRegionKind::ClosureEnv),
             ));
             let br = ty::BoundRegion {
                 var: ty::BoundVar::from_usize(bound_vars.len() - 1),
-                kind: ty::BoundRegionKind::BrEnv,
+                kind: ty::BoundRegionKind::ClosureEnv,
             };
 
             let env_ty = Ty::new_mut_ref(tcx, ty::Region::new_bound(tcx, ty::INNERMOST, br), ty);

--- a/compiler/rustc_ty_utils/src/assoc.rs
+++ b/compiler/rustc_ty_utils/src/assoc.rs
@@ -140,7 +140,7 @@ fn associated_item_from_trait_item_ref(trait_item_ref: &hir::TraitItemRef) -> ty
         kind,
         def_id: owner_id.to_def_id(),
         trait_item_def_id: Some(owner_id.to_def_id()),
-        container: ty::TraitContainer,
+        container: ty::AssocItemContainer::Trait,
         fn_has_self_parameter: has_self,
         opt_rpitit_info: None,
     }
@@ -159,7 +159,7 @@ fn associated_item_from_impl_item_ref(impl_item_ref: &hir::ImplItemRef) -> ty::A
         kind,
         def_id: def_id.to_def_id(),
         trait_item_def_id: impl_item_ref.trait_item_def_id,
-        container: ty::ImplContainer,
+        container: ty::AssocItemContainer::Impl,
         fn_has_self_parameter: has_self,
         opt_rpitit_info: None,
     }
@@ -267,7 +267,7 @@ fn associated_type_for_impl_trait_in_trait(
         kind: ty::AssocKind::Type,
         def_id,
         trait_item_def_id: None,
-        container: ty::TraitContainer,
+        container: ty::AssocItemContainer::Trait,
         fn_has_self_parameter: false,
         opt_rpitit_info: Some(ImplTraitInTraitData::Trait {
             fn_def_id: fn_def_id.to_def_id(),
@@ -319,7 +319,7 @@ fn associated_type_for_impl_trait_in_impl(
         kind: ty::AssocKind::Type,
         def_id,
         trait_item_def_id: Some(trait_assoc_def_id),
-        container: ty::ImplContainer,
+        container: ty::AssocItemContainer::Impl,
         fn_has_self_parameter: false,
         opt_rpitit_info: Some(ImplTraitInTraitData::Impl { fn_def_id: impl_fn_def_id.to_def_id() }),
     });

--- a/compiler/rustc_ty_utils/src/ty.rs
+++ b/compiler/rustc_ty_utils/src/ty.rs
@@ -135,7 +135,7 @@ fn param_env(tcx: TyCtxt<'_>, def_id: DefId) -> ty::ParamEnv<'_> {
 
     if tcx.def_kind(def_id) == DefKind::AssocFn
         && let assoc_item = tcx.associated_item(def_id)
-        && assoc_item.container == ty::AssocItemContainer::TraitContainer
+        && assoc_item.container == ty::AssocItemContainer::Trait
         && assoc_item.defaultness(tcx).has_value()
     {
         let sig = tcx.fn_sig(def_id).instantiate_identity();

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -304,7 +304,9 @@ pub(crate) fn clean_middle_region(region: ty::Region<'_>) -> Option<Lifetime> {
     match *region {
         ty::ReStatic => Some(Lifetime::statik()),
         _ if !region.has_name() => None,
-        ty::ReBound(_, ty::BoundRegion { kind: ty::BrNamed(_, name), .. }) => Some(Lifetime(name)),
+        ty::ReBound(_, ty::BoundRegion { kind: ty::BoundRegionKind::Named(_, name), .. }) => {
+            Some(Lifetime(name))
+        }
         ty::ReEarlyParam(ref data) => Some(Lifetime(data.name)),
         ty::ReBound(..)
         | ty::ReLateParam(..)
@@ -1896,7 +1898,9 @@ fn clean_trait_object_lifetime_bound<'tcx>(
     match *region {
         ty::ReStatic => Some(Lifetime::statik()),
         ty::ReEarlyParam(region) if region.name != kw::Empty => Some(Lifetime(region.name)),
-        ty::ReBound(_, ty::BoundRegion { kind: ty::BrNamed(_, name), .. }) if name != kw::Empty => {
+        ty::ReBound(_, ty::BoundRegion { kind: ty::BoundRegionKind::Named(_, name), .. })
+            if name != kw::Empty =>
+        {
             Some(Lifetime(name))
         }
         ty::ReEarlyParam(_)
@@ -2141,7 +2145,7 @@ pub(crate) fn clean_middle_ty<'tcx>(
                 .iter()
                 .flat_map(|pred| pred.bound_vars())
                 .filter_map(|var| match var {
-                    ty::BoundVariableKind::Region(ty::BrNamed(def_id, name))
+                    ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id, name))
                         if name != kw::UnderscoreLifetime =>
                     {
                         Some(GenericParamDef::lifetime(def_id, name))
@@ -3118,7 +3122,7 @@ fn clean_bound_vars(bound_vars: &ty::List<ty::BoundVariableKind>) -> Vec<Generic
     bound_vars
         .into_iter()
         .filter_map(|var| match var {
-            ty::BoundVariableKind::Region(ty::BrNamed(def_id, name))
+            ty::BoundVariableKind::Region(ty::BoundRegionKind::Named(def_id, name))
                 if name != kw::UnderscoreLifetime =>
             {
                 Some(GenericParamDef::lifetime(def_id, name))

--- a/src/librustdoc/clean/mod.rs
+++ b/src/librustdoc/clean/mod.rs
@@ -1317,8 +1317,8 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
             simplify::move_bounds_to_generic_parameters(&mut generics);
 
             let provided = match assoc_item.container {
-                ty::ImplContainer => true,
-                ty::TraitContainer => tcx.defaultness(assoc_item.def_id).has_value(),
+                ty::AssocItemContainer::Impl => true,
+                ty::AssocItemContainer::Trait => tcx.defaultness(assoc_item.def_id).has_value(),
             };
             if provided {
                 AssocConstItem(Box::new(Constant {
@@ -1335,10 +1335,10 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
 
             if assoc_item.fn_has_self_parameter {
                 let self_ty = match assoc_item.container {
-                    ty::ImplContainer => {
+                    ty::AssocItemContainer::Impl => {
                         tcx.type_of(assoc_item.container_id(tcx)).instantiate_identity()
                     }
-                    ty::TraitContainer => tcx.types.self_param,
+                    ty::AssocItemContainer::Trait => tcx.types.self_param,
                 };
                 let self_arg_ty =
                     tcx.fn_sig(assoc_item.def_id).instantiate_identity().input(0).skip_binder();
@@ -1355,13 +1355,13 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
             }
 
             let provided = match assoc_item.container {
-                ty::ImplContainer => true,
-                ty::TraitContainer => assoc_item.defaultness(tcx).has_value(),
+                ty::AssocItemContainer::Impl => true,
+                ty::AssocItemContainer::Trait => assoc_item.defaultness(tcx).has_value(),
             };
             if provided {
                 let defaultness = match assoc_item.container {
-                    ty::ImplContainer => Some(assoc_item.defaultness(tcx)),
-                    ty::TraitContainer => None,
+                    ty::AssocItemContainer::Impl => Some(assoc_item.defaultness(tcx)),
+                    ty::AssocItemContainer::Trait => None,
                 };
                 MethodItem(item, defaultness)
             } else {
@@ -1392,7 +1392,7 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
             }
 
             let mut predicates = tcx.explicit_predicates_of(assoc_item.def_id).predicates;
-            if let ty::TraitContainer = assoc_item.container {
+            if let ty::AssocItemContainer::Trait = assoc_item.container {
                 let bounds = tcx.explicit_item_bounds(assoc_item.def_id).iter_identity_copied();
                 predicates = tcx.arena.alloc_from_iter(bounds.chain(predicates.iter().copied()));
             }
@@ -1403,7 +1403,7 @@ pub(crate) fn clean_middle_assoc_item(assoc_item: &ty::AssocItem, cx: &mut DocCo
                 });
             simplify::move_bounds_to_generic_parameters(&mut generics);
 
-            if let ty::TraitContainer = assoc_item.container {
+            if let ty::AssocItemContainer::Trait = assoc_item.container {
                 // Move bounds that are (likely) directly attached to the associated type
                 // from the where-clause to the associated type.
                 // There is no guarantee that this is what the user actually wrote but we have

--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -703,8 +703,8 @@ impl Item {
             | TyMethodItem(..) | MethodItem(..) => {
                 let assoc_item = tcx.associated_item(def_id);
                 let is_trait_item = match assoc_item.container {
-                    ty::TraitContainer => true,
-                    ty::ImplContainer => {
+                    ty::AssocItemContainer::Trait => true,
+                    ty::AssocItemContainer::Impl => {
                         // Trait impl items always inherit the impl's visibility --
                         // we don't want to show `pub`.
                         tcx.impl_trait_ref(tcx.parent(assoc_item.def_id)).is_some()

--- a/src/tools/clippy/clippy_lints/src/loops/mut_range_bound.rs
+++ b/src/tools/clippy/clippy_lints/src/loops/mut_range_bound.rs
@@ -80,7 +80,7 @@ impl<'tcx> Delegate<'tcx> for MutatePairDelegate<'_, 'tcx> {
     fn consume(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
 
     fn borrow(&mut self, cmt: &PlaceWithHirId<'tcx>, diag_expr_id: HirId, bk: ty::BorrowKind) {
-        if bk == ty::BorrowKind::MutBorrow {
+        if bk == ty::BorrowKind::Mutable {
             if let PlaceBase::Local(id) = cmt.place.base {
                 if Some(id) == self.hir_id_low && !BreakAfterExprVisitor::is_found(self.cx, diag_expr_id) {
                     self.span_low = Some(self.cx.tcx.hir().span(diag_expr_id));

--- a/src/tools/clippy/clippy_lints/src/missing_inline.rs
+++ b/src/tools/clippy/clippy_lints/src/missing_inline.rs
@@ -2,6 +2,7 @@ use clippy_utils::diagnostics::span_lint;
 use rustc_ast::ast;
 use rustc_hir as hir;
 use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_middle::ty::AssocItemContainer;
 use rustc_session::declare_lint_pass;
 use rustc_span::{Span, sym};
 
@@ -138,7 +139,6 @@ impl<'tcx> LateLintPass<'tcx> for MissingInline {
     }
 
     fn check_impl_item(&mut self, cx: &LateContext<'tcx>, impl_item: &'tcx hir::ImplItem<'_>) {
-        use rustc_middle::ty::{ImplContainer, TraitContainer};
         if rustc_middle::lint::in_external_macro(cx.sess(), impl_item.span) || is_executable_or_proc_macro(cx) {
             return;
         }
@@ -156,8 +156,8 @@ impl<'tcx> LateLintPass<'tcx> for MissingInline {
         let assoc_item = cx.tcx.associated_item(impl_item.owner_id);
         let container_id = assoc_item.container_id(cx.tcx);
         let trait_def_id = match assoc_item.container {
-            TraitContainer => Some(container_id),
-            ImplContainer => cx.tcx.impl_trait_ref(container_id).map(|t| t.skip_binder().def_id),
+            AssocItemContainer::Trait => Some(container_id),
+            AssocItemContainer::Impl => cx.tcx.impl_trait_ref(container_id).map(|t| t.skip_binder().def_id),
         };
 
         if let Some(trait_def_id) = trait_def_id {

--- a/src/tools/clippy/clippy_lints/src/needless_pass_by_ref_mut.rs
+++ b/src/tools/clippy/clippy_lints/src/needless_pass_by_ref_mut.rs
@@ -417,8 +417,8 @@ impl<'tcx> euv::Delegate<'tcx> for MutablyUsedVariablesCtxt<'tcx> {
             // a closure, it'll return this variant whereas if you have just an index access, it'll
             // return `ImmBorrow`. So if there is "Unique" and it's a mutable reference, we add it
             // to the mutably used variables set.
-            if borrow == ty::BorrowKind::MutBorrow
-                || (borrow == ty::BorrowKind::UniqueImmBorrow && base_ty.ref_mutability() == Some(Mutability::Mut))
+            if borrow == ty::BorrowKind::Mutable
+                || (borrow == ty::BorrowKind::UniqueImmutable && base_ty.ref_mutability() == Some(Mutability::Mut))
             {
                 self.add_mutably_used_var(*vid);
             } else if self.is_in_unsafe_block(id) {
@@ -426,7 +426,7 @@ impl<'tcx> euv::Delegate<'tcx> for MutablyUsedVariablesCtxt<'tcx> {
                 // upon!
                 self.add_mutably_used_var(*vid);
             }
-        } else if borrow == ty::ImmBorrow {
+        } else if borrow == ty::BorrowKind::Immutable {
             // If there is an `async block`, it'll contain a call to a closure which we need to
             // go into to ensure all "mutate" checks are found.
             if let Node::Expr(Expr {

--- a/src/tools/clippy/clippy_lints/src/operators/assign_op_pattern.rs
+++ b/src/tools/clippy/clippy_lints/src/operators/assign_op_pattern.rs
@@ -102,7 +102,7 @@ fn imm_borrows_in_expr(cx: &LateContext<'_>, e: &hir::Expr<'_>) -> HirIdSet {
     struct S(HirIdSet);
     impl Delegate<'_> for S {
         fn borrow(&mut self, place: &PlaceWithHirId<'_>, _: HirId, kind: BorrowKind) {
-            if matches!(kind, BorrowKind::ImmBorrow | BorrowKind::UniqueImmBorrow) {
+            if matches!(kind, BorrowKind::Immutable | BorrowKind::UniqueImmutable) {
                 self.0.insert(match place.place.base {
                     PlaceBase::Local(id) => id,
                     PlaceBase::Upvar(id) => id.var_path.hir_id,
@@ -127,7 +127,7 @@ fn mut_borrows_in_expr(cx: &LateContext<'_>, e: &hir::Expr<'_>) -> HirIdSet {
     struct S(HirIdSet);
     impl Delegate<'_> for S {
         fn borrow(&mut self, place: &PlaceWithHirId<'_>, _: HirId, kind: BorrowKind) {
-            if matches!(kind, BorrowKind::MutBorrow) {
+            if matches!(kind, BorrowKind::Mutable) {
                 self.0.insert(match place.place.base {
                     PlaceBase::Local(id) => id,
                     PlaceBase::Upvar(id) => id.var_path.hir_id,

--- a/src/tools/clippy/clippy_lints/src/unwrap.rs
+++ b/src/tools/clippy/clippy_lints/src/unwrap.rs
@@ -217,7 +217,7 @@ fn is_option_as_mut_use(tcx: TyCtxt<'_>, expr_id: HirId) -> bool {
 
 impl<'tcx> Delegate<'tcx> for MutationVisitor<'tcx> {
     fn borrow(&mut self, cat: &PlaceWithHirId<'tcx>, diag_expr_id: HirId, bk: ty::BorrowKind) {
-        if let ty::BorrowKind::MutBorrow = bk
+        if let ty::BorrowKind::Mutable = bk
             && is_potentially_local_place(self.local_id, &cat.place)
             && !is_option_as_mut_use(self.tcx, diag_expr_id)
         {

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -3340,8 +3340,8 @@ pub fn get_path_from_caller_to_method_type<'tcx>(
     let assoc_item = tcx.associated_item(method);
     let def_id = assoc_item.container_id(tcx);
     match assoc_item.container {
-        rustc_ty::TraitContainer => get_path_to_callee(tcx, from, def_id),
-        rustc_ty::ImplContainer => {
+        rustc_ty::AssocItemContainer::Trait => get_path_to_callee(tcx, from, def_id),
+        rustc_ty::AssocItemContainer::Impl => {
             let ty = tcx.type_of(def_id).instantiate_identity();
             get_path_to_ty(tcx, from, ty, args)
         },

--- a/src/tools/clippy/clippy_utils/src/lib.rs
+++ b/src/tools/clippy/clippy_utils/src/lib.rs
@@ -1209,8 +1209,8 @@ pub fn can_move_expr_to_closure<'tcx>(cx: &LateContext<'tcx>, expr: &'tcx Expr<'
                             let capture = match capture.info.capture_kind {
                                 UpvarCapture::ByValue => CaptureKind::Value,
                                 UpvarCapture::ByRef(kind) => match kind {
-                                    BorrowKind::ImmBorrow => CaptureKind::Ref(Mutability::Not),
-                                    BorrowKind::UniqueImmBorrow | BorrowKind::MutBorrow => {
+                                    BorrowKind::Immutable => CaptureKind::Ref(Mutability::Not),
+                                    BorrowKind::UniqueImmutable | BorrowKind::Mutable => {
                                         CaptureKind::Ref(Mutability::Mut)
                                     },
                                 },

--- a/src/tools/clippy/clippy_utils/src/usage.rs
+++ b/src/tools/clippy/clippy_utils/src/usage.rs
@@ -67,7 +67,7 @@ impl<'tcx> Delegate<'tcx> for MutVarsDelegate {
     fn consume(&mut self, _: &PlaceWithHirId<'tcx>, _: HirId) {}
 
     fn borrow(&mut self, cmt: &PlaceWithHirId<'tcx>, _: HirId, bk: ty::BorrowKind) {
-        if bk == ty::BorrowKind::MutBorrow {
+        if bk == ty::BorrowKind::Mutable {
             self.update(cmt);
         }
     }

--- a/tests/ui/closures/2229_closure_analysis/arrays-completely-captured.rs
+++ b/tests/ui/closures/2229_closure_analysis/arrays-completely-captured.rs
@@ -13,10 +13,10 @@ fn main() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         m[0] += 10;
-        //~^ NOTE: Capturing m[] -> MutBorrow
-        //~| NOTE: Min Capture m[] -> MutBorrow
+        //~^ NOTE: Capturing m[] -> Mutable
+        //~| NOTE: Min Capture m[] -> Mutable
         m[1] += 40;
-        //~^ NOTE: Capturing m[] -> MutBorrow
+        //~^ NOTE: Capturing m[] -> Mutable
     };
 
     c();

--- a/tests/ui/closures/2229_closure_analysis/arrays-completely-captured.stderr
+++ b/tests/ui/closures/2229_closure_analysis/arrays-completely-captured.stderr
@@ -20,12 +20,12 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing m[] -> MutBorrow
+note: Capturing m[] -> Mutable
   --> $DIR/arrays-completely-captured.rs:15:9
    |
 LL |         m[0] += 10;
    |         ^
-note: Capturing m[] -> MutBorrow
+note: Capturing m[] -> Mutable
   --> $DIR/arrays-completely-captured.rs:18:9
    |
 LL |         m[1] += 40;
@@ -43,7 +43,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture m[] -> MutBorrow
+note: Min Capture m[] -> Mutable
   --> $DIR/arrays-completely-captured.rs:15:9
    |
 LL |         m[0] += 10;

--- a/tests/ui/closures/2229_closure_analysis/by_value.rs
+++ b/tests/ui/closures/2229_closure_analysis/by_value.rs
@@ -26,8 +26,8 @@ fn big_box() {
         //~^ NOTE: Capturing t[(0, 0),Deref,(0, 0)] -> ByValue
         //~| NOTE: Min Capture t[(0, 0)] -> ByValue
         println!("{} {:?}", t.1, p);
-        //~^ NOTE: Capturing t[(1, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture t[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing t[(1, 0)] -> Immutable
+        //~| NOTE: Min Capture t[(1, 0)] -> Immutable
     };
 
     c();

--- a/tests/ui/closures/2229_closure_analysis/by_value.stderr
+++ b/tests/ui/closures/2229_closure_analysis/by_value.stderr
@@ -25,7 +25,7 @@ note: Capturing t[(0, 0),Deref,(0, 0)] -> ByValue
    |
 LL |         let p = t.0.0;
    |                 ^^^^^
-note: Capturing t[(1, 0)] -> ImmBorrow
+note: Capturing t[(1, 0)] -> Immutable
   --> $DIR/by_value.rs:28:29
    |
 LL |         println!("{} {:?}", t.1, p);
@@ -48,7 +48,7 @@ note: Min Capture t[(0, 0)] -> ByValue
    |
 LL |         let p = t.0.0;
    |                 ^^^^^
-note: Min Capture t[(1, 0)] -> ImmBorrow
+note: Min Capture t[(1, 0)] -> Immutable
   --> $DIR/by_value.rs:28:29
    |
 LL |         println!("{} {:?}", t.1, p);

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-1.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-1.rs
@@ -20,15 +20,15 @@ fn main() {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:
         println!("{:?}", p);
-        //~^ NOTE: Capturing p[] -> ImmBorrow
-        //~| NOTE: Min Capture p[] -> ImmBorrow
+        //~^ NOTE: Capturing p[] -> Immutable
+        //~| NOTE: Min Capture p[] -> Immutable
         println!("{:?}", p.x);
-        //~^ NOTE: Capturing p[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing p[(0, 0)] -> Immutable
 
         println!("{:?}", q.x);
-        //~^ NOTE: Capturing q[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing q[(0, 0)] -> Immutable
         println!("{:?}", q);
-        //~^ NOTE: Capturing q[] -> ImmBorrow
-        //~| NOTE: Min Capture q[] -> ImmBorrow
+        //~^ NOTE: Capturing q[] -> Immutable
+        //~| NOTE: Min Capture q[] -> Immutable
     };
 }

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-1.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-1.stderr
@@ -20,22 +20,22 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing p[] -> ImmBorrow
+note: Capturing p[] -> Immutable
   --> $DIR/capture-analysis-1.rs:22:26
    |
 LL |         println!("{:?}", p);
    |                          ^
-note: Capturing p[(0, 0)] -> ImmBorrow
+note: Capturing p[(0, 0)] -> Immutable
   --> $DIR/capture-analysis-1.rs:25:26
    |
 LL |         println!("{:?}", p.x);
    |                          ^^^
-note: Capturing q[(0, 0)] -> ImmBorrow
+note: Capturing q[(0, 0)] -> Immutable
   --> $DIR/capture-analysis-1.rs:28:26
    |
 LL |         println!("{:?}", q.x);
    |                          ^^^
-note: Capturing q[] -> ImmBorrow
+note: Capturing q[] -> Immutable
   --> $DIR/capture-analysis-1.rs:30:26
    |
 LL |         println!("{:?}", q);
@@ -53,12 +53,12 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture p[] -> ImmBorrow
+note: Min Capture p[] -> Immutable
   --> $DIR/capture-analysis-1.rs:22:26
    |
 LL |         println!("{:?}", p);
    |                          ^
-note: Min Capture q[] -> ImmBorrow
+note: Min Capture q[] -> Immutable
   --> $DIR/capture-analysis-1.rs:30:26
    |
 LL |         println!("{:?}", q);

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-2.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-2.rs
@@ -22,7 +22,7 @@ fn main() {
         //~^ NOTE: Capturing p[(0, 0)] -> ByValue
         //~| NOTE: p[] captured as ByValue here
         println!("{:?}", p);
-        //~^ NOTE: Capturing p[] -> ImmBorrow
+        //~^ NOTE: Capturing p[] -> Immutable
         //~| NOTE: Min Capture p[] -> ByValue
         //~| NOTE: p[] used here
     };

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-2.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-2.stderr
@@ -25,7 +25,7 @@ note: Capturing p[(0, 0)] -> ByValue
    |
 LL |         let _x = p.x;
    |                  ^^^
-note: Capturing p[] -> ImmBorrow
+note: Capturing p[] -> Immutable
   --> $DIR/capture-analysis-2.rs:24:26
    |
 LL |         println!("{:?}", p);

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-3.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-3.rs
@@ -27,7 +27,7 @@ fn main() {
         //~^ NOTE: Capturing a[(0, 0),(0, 0)] -> ByValue
         //~| NOTE: a[(0, 0)] captured as ByValue here
         println!("{:?}", a.b);
-        //~^ NOTE: Capturing a[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing a[(0, 0)] -> Immutable
         //~| NOTE: Min Capture a[(0, 0)] -> ByValue
         //~| NOTE: a[(0, 0)] used here
     };

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-3.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-3.stderr
@@ -25,7 +25,7 @@ note: Capturing a[(0, 0),(0, 0)] -> ByValue
    |
 LL |         let _x = a.b.c;
    |                  ^^^^^
-note: Capturing a[(0, 0)] -> ImmBorrow
+note: Capturing a[(0, 0)] -> Immutable
   --> $DIR/capture-analysis-3.rs:29:26
    |
 LL |         println!("{:?}", a.b);

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-4.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-4.rs
@@ -27,6 +27,6 @@ fn main() {
         //~^ NOTE: Capturing a[(0, 0)] -> ByValue
         //~| NOTE: Min Capture a[(0, 0)] -> ByValue
         println!("{:?}", a.b.c);
-        //~^ NOTE: Capturing a[(0, 0),(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing a[(0, 0),(0, 0)] -> Immutable
     };
 }

--- a/tests/ui/closures/2229_closure_analysis/capture-analysis-4.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-analysis-4.stderr
@@ -25,7 +25,7 @@ note: Capturing a[(0, 0)] -> ByValue
    |
 LL |         let _x = a.b;
    |                  ^^^
-note: Capturing a[(0, 0),(0, 0)] -> ImmBorrow
+note: Capturing a[(0, 0),(0, 0)] -> Immutable
   --> $DIR/capture-analysis-4.rs:29:26
    |
 LL |         println!("{:?}", a.b.c);

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.rs
@@ -18,8 +18,8 @@ fn main() {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:
         println!("{}", p.x);
-        //~^ NOTE: Capturing p[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture p[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing p[(0, 0)] -> Immutable
+        //~| NOTE: Min Capture p[(0, 0)] -> Immutable
     };
 
     // `c` should only capture `p.x`, therefore mutating `p.y` is allowed.

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-struct.stderr
@@ -20,7 +20,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing p[(0, 0)] -> ImmBorrow
+note: Capturing p[(0, 0)] -> Immutable
   --> $DIR/capture-disjoint-field-struct.rs:20:24
    |
 LL |         println!("{}", p.x);
@@ -38,7 +38,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture p[(0, 0)] -> ImmBorrow
+note: Min Capture p[(0, 0)] -> Immutable
   --> $DIR/capture-disjoint-field-struct.rs:20:24
    |
 LL |         println!("{}", p.x);

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.rs
@@ -13,8 +13,8 @@ fn main() {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:
         println!("{}", t.0);
-        //~^ NOTE: Capturing t[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture t[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing t[(0, 0)] -> Immutable
+        //~| NOTE: Min Capture t[(0, 0)] -> Immutable
     };
 
     // `c` only captures t.0, therefore mutating t.1 is allowed.

--- a/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-disjoint-field-tuple.stderr
@@ -20,7 +20,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing t[(0, 0)] -> ImmBorrow
+note: Capturing t[(0, 0)] -> Immutable
   --> $DIR/capture-disjoint-field-tuple.rs:15:24
    |
 LL |         println!("{}", t.0);
@@ -38,7 +38,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture t[(0, 0)] -> ImmBorrow
+note: Min Capture t[(0, 0)] -> Immutable
   --> $DIR/capture-disjoint-field-tuple.rs:15:24
    |
 LL |         println!("{}", t.0);

--- a/tests/ui/closures/2229_closure_analysis/capture-enums.rs
+++ b/tests/ui/closures/2229_closure_analysis/capture-enums.rs
@@ -21,14 +21,14 @@ fn multi_variant_enum() {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:
         if let Info::Point(_, _, str) = point {
-            //~^ NOTE: Capturing point[] -> ImmBorrow
+            //~^ NOTE: Capturing point[] -> Immutable
             //~| NOTE: Capturing point[(2, 0)] -> ByValue
             //~| NOTE: Min Capture point[] -> ByValue
             println!("{}", str);
         }
 
         if let Info::Meta(_, v) = meta {
-            //~^ NOTE: Capturing meta[] -> ImmBorrow
+            //~^ NOTE: Capturing meta[] -> Immutable
             //~| NOTE: Capturing meta[(1, 1)] -> ByValue
             //~| NOTE: Min Capture meta[] -> ByValue
             println!("{:?}", v);

--- a/tests/ui/closures/2229_closure_analysis/capture-enums.stderr
+++ b/tests/ui/closures/2229_closure_analysis/capture-enums.stderr
@@ -30,7 +30,7 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Capturing point[] -> ImmBorrow
+note: Capturing point[] -> Immutable
   --> $DIR/capture-enums.rs:23:41
    |
 LL |         if let Info::Point(_, _, str) = point {
@@ -40,7 +40,7 @@ note: Capturing point[(2, 0)] -> ByValue
    |
 LL |         if let Info::Point(_, _, str) = point {
    |                                         ^^^^^
-note: Capturing meta[] -> ImmBorrow
+note: Capturing meta[] -> Immutable
   --> $DIR/capture-enums.rs:30:35
    |
 LL |         if let Info::Meta(_, v) = meta {

--- a/tests/ui/closures/2229_closure_analysis/deep-multilevel-struct.rs
+++ b/tests/ui/closures/2229_closure_analysis/deep-multilevel-struct.rs
@@ -39,13 +39,13 @@ fn main() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         let x = &p.a.p.x;
-        //~^ NOTE: Capturing p[(0, 0),(0, 0),(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing p[(0, 0),(0, 0),(0, 0)] -> Immutable
         p.b.q.y = 9;
-        //~^ NOTE: Capturing p[(1, 0),(1, 0),(1, 0)] -> MutBorrow
-        //~| NOTE: p[] captured as MutBorrow here
+        //~^ NOTE: Capturing p[(1, 0),(1, 0),(1, 0)] -> Mutable
+        //~| NOTE: p[] captured as Mutable here
         println!("{:?}", p);
-        //~^ NOTE: Capturing p[] -> ImmBorrow
-        //~| NOTE: Min Capture p[] -> MutBorrow
+        //~^ NOTE: Capturing p[] -> Immutable
+        //~| NOTE: Min Capture p[] -> Mutable
         //~| NOTE: p[] used here
     };
 }

--- a/tests/ui/closures/2229_closure_analysis/deep-multilevel-struct.stderr
+++ b/tests/ui/closures/2229_closure_analysis/deep-multilevel-struct.stderr
@@ -20,17 +20,17 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing p[(0, 0),(0, 0),(0, 0)] -> ImmBorrow
+note: Capturing p[(0, 0),(0, 0),(0, 0)] -> Immutable
   --> $DIR/deep-multilevel-struct.rs:41:18
    |
 LL |         let x = &p.a.p.x;
    |                  ^^^^^^^
-note: Capturing p[(1, 0),(1, 0),(1, 0)] -> MutBorrow
+note: Capturing p[(1, 0),(1, 0),(1, 0)] -> Mutable
   --> $DIR/deep-multilevel-struct.rs:43:9
    |
 LL |         p.b.q.y = 9;
    |         ^^^^^^^
-note: Capturing p[] -> ImmBorrow
+note: Capturing p[] -> Immutable
   --> $DIR/deep-multilevel-struct.rs:46:26
    |
 LL |         println!("{:?}", p);
@@ -48,11 +48,11 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture p[] -> MutBorrow
+note: Min Capture p[] -> Mutable
   --> $DIR/deep-multilevel-struct.rs:43:9
    |
 LL |         p.b.q.y = 9;
-   |         ^^^^^^^ p[] captured as MutBorrow here
+   |         ^^^^^^^ p[] captured as Mutable here
 ...
 LL |         println!("{:?}", p);
    |                          ^ p[] used here

--- a/tests/ui/closures/2229_closure_analysis/deep-multilevel-tuple.rs
+++ b/tests/ui/closures/2229_closure_analysis/deep-multilevel-tuple.rs
@@ -13,13 +13,13 @@ fn main() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         let x = &t.0.0.0;
-        //~^ NOTE: Capturing t[(0, 0),(0, 0),(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing t[(0, 0),(0, 0),(0, 0)] -> Immutable
         t.1.1.1 = 9;
-        //~^ NOTE: Capturing t[(1, 0),(1, 0),(1, 0)] -> MutBorrow
-        //~| NOTE: t[] captured as MutBorrow here
+        //~^ NOTE: Capturing t[(1, 0),(1, 0),(1, 0)] -> Mutable
+        //~| NOTE: t[] captured as Mutable here
         println!("{:?}", t);
-        //~^ NOTE: Min Capture t[] -> MutBorrow
-        //~| NOTE: Capturing t[] -> ImmBorrow
+        //~^ NOTE: Min Capture t[] -> Mutable
+        //~| NOTE: Capturing t[] -> Immutable
         //~| NOTE: t[] used here
     };
 }

--- a/tests/ui/closures/2229_closure_analysis/deep-multilevel-tuple.stderr
+++ b/tests/ui/closures/2229_closure_analysis/deep-multilevel-tuple.stderr
@@ -20,17 +20,17 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing t[(0, 0),(0, 0),(0, 0)] -> ImmBorrow
+note: Capturing t[(0, 0),(0, 0),(0, 0)] -> Immutable
   --> $DIR/deep-multilevel-tuple.rs:15:18
    |
 LL |         let x = &t.0.0.0;
    |                  ^^^^^^^
-note: Capturing t[(1, 0),(1, 0),(1, 0)] -> MutBorrow
+note: Capturing t[(1, 0),(1, 0),(1, 0)] -> Mutable
   --> $DIR/deep-multilevel-tuple.rs:17:9
    |
 LL |         t.1.1.1 = 9;
    |         ^^^^^^^
-note: Capturing t[] -> ImmBorrow
+note: Capturing t[] -> Immutable
   --> $DIR/deep-multilevel-tuple.rs:20:26
    |
 LL |         println!("{:?}", t);
@@ -48,11 +48,11 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture t[] -> MutBorrow
+note: Min Capture t[] -> Mutable
   --> $DIR/deep-multilevel-tuple.rs:17:9
    |
 LL |         t.1.1.1 = 9;
-   |         ^^^^^^^ t[] captured as MutBorrow here
+   |         ^^^^^^^ t[] captured as Mutable here
 ...
 LL |         println!("{:?}", t);
    |                          ^ t[] used here

--- a/tests/ui/closures/2229_closure_analysis/destructure_patterns.rs
+++ b/tests/ui/closures/2229_closure_analysis/destructure_patterns.rs
@@ -44,9 +44,9 @@ fn structs() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         let Point { x: ref mut x, y: _, id: moved_id } = p;
-        //~^ NOTE: Capturing p[(0, 0)] -> MutBorrow
+        //~^ NOTE: Capturing p[(0, 0)] -> Mutable
         //~| NOTE: Capturing p[(2, 0)] -> ByValue
-        //~| NOTE: Min Capture p[(0, 0)] -> MutBorrow
+        //~| NOTE: Min Capture p[(0, 0)] -> Mutable
         //~| NOTE: Min Capture p[(2, 0)] -> ByValue
 
         println!("{}, {}", x, moved_id);
@@ -65,11 +65,11 @@ fn tuples() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         let (ref mut x, ref ref_str, (moved_s, _)) = t;
-        //~^ NOTE: Capturing t[(0, 0)] -> MutBorrow
-        //~| NOTE: Capturing t[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing t[(0, 0)] -> Mutable
+        //~| NOTE: Capturing t[(1, 0)] -> Immutable
         //~| NOTE: Capturing t[(2, 0),(0, 0)] -> ByValue
-        //~| NOTE: Min Capture t[(0, 0)] -> MutBorrow
-        //~| NOTE: Min Capture t[(1, 0)] -> ImmBorrow
+        //~| NOTE: Min Capture t[(0, 0)] -> Mutable
+        //~| NOTE: Min Capture t[(1, 0)] -> Immutable
         //~| NOTE: Min Capture t[(2, 0),(0, 0)] -> ByValue
 
         println!("{}, {} {}", x, ref_str, moved_s);

--- a/tests/ui/closures/2229_closure_analysis/destructure_patterns.stderr
+++ b/tests/ui/closures/2229_closure_analysis/destructure_patterns.stderr
@@ -86,7 +86,7 @@ LL | |         println!("{}, {}", x, moved_id);
 LL | |     };
    | |_____^
    |
-note: Capturing p[(0, 0)] -> MutBorrow
+note: Capturing p[(0, 0)] -> Mutable
   --> $DIR/destructure_patterns.rs:46:58
    |
 LL |         let Point { x: ref mut x, y: _, id: moved_id } = p;
@@ -109,7 +109,7 @@ LL | |         println!("{}, {}", x, moved_id);
 LL | |     };
    | |_____^
    |
-note: Min Capture p[(0, 0)] -> MutBorrow
+note: Min Capture p[(0, 0)] -> Mutable
   --> $DIR/destructure_patterns.rs:46:58
    |
 LL |         let Point { x: ref mut x, y: _, id: moved_id } = p;
@@ -132,12 +132,12 @@ LL | |         println!("{}, {} {}", x, ref_str, moved_s);
 LL | |     };
    | |_____^
    |
-note: Capturing t[(0, 0)] -> MutBorrow
+note: Capturing t[(0, 0)] -> Mutable
   --> $DIR/destructure_patterns.rs:67:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
-note: Capturing t[(1, 0)] -> ImmBorrow
+note: Capturing t[(1, 0)] -> Immutable
   --> $DIR/destructure_patterns.rs:67:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
@@ -160,12 +160,12 @@ LL | |         println!("{}, {} {}", x, ref_str, moved_s);
 LL | |     };
    | |_____^
    |
-note: Min Capture t[(0, 0)] -> MutBorrow
+note: Min Capture t[(0, 0)] -> Mutable
   --> $DIR/destructure_patterns.rs:67:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;
    |                                                      ^
-note: Min Capture t[(1, 0)] -> ImmBorrow
+note: Min Capture t[(1, 0)] -> Immutable
   --> $DIR/destructure_patterns.rs:67:54
    |
 LL |         let (ref mut x, ref ref_str, (moved_s, _)) = t;

--- a/tests/ui/closures/2229_closure_analysis/feature-gate-capture_disjoint_fields.rs
+++ b/tests/ui/closures/2229_closure_analysis/feature-gate-capture_disjoint_fields.rs
@@ -13,7 +13,7 @@ fn main() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("This uses new capture analyysis to capture s={}", s);
-        //~^ NOTE: Capturing s[] -> ImmBorrow
-        //~| NOTE: Min Capture s[] -> ImmBorrow
+        //~^ NOTE: Capturing s[] -> Immutable
+        //~| NOTE: Min Capture s[] -> Immutable
     };
 }

--- a/tests/ui/closures/2229_closure_analysis/feature-gate-capture_disjoint_fields.stderr
+++ b/tests/ui/closures/2229_closure_analysis/feature-gate-capture_disjoint_fields.stderr
@@ -20,7 +20,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing s[] -> ImmBorrow
+note: Capturing s[] -> Immutable
   --> $DIR/feature-gate-capture_disjoint_fields.rs:15:69
    |
 LL |         println!("This uses new capture analyysis to capture s={}", s);
@@ -38,7 +38,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture s[] -> ImmBorrow
+note: Min Capture s[] -> Immutable
   --> $DIR/feature-gate-capture_disjoint_fields.rs:15:69
    |
 LL |         println!("This uses new capture analyysis to capture s={}", s);

--- a/tests/ui/closures/2229_closure_analysis/filter-on-struct-member.rs
+++ b/tests/ui/closures/2229_closure_analysis/filter-on-struct-member.rs
@@ -24,8 +24,8 @@ impl Data {
             |v| self.filter.allowed(*v),
             //~^ ERROR: First Pass analysis includes:
             //~| ERROR: Min Capture analysis includes:
-            //~| NOTE: Capturing self[Deref,(0, 0)] -> ImmBorrow
-            //~| NOTE: Min Capture self[Deref,(0, 0)] -> ImmBorrow
+            //~| NOTE: Capturing self[Deref,(0, 0)] -> Immutable
+            //~| NOTE: Min Capture self[Deref,(0, 0)] -> Immutable
         );
     }
 }

--- a/tests/ui/closures/2229_closure_analysis/filter-on-struct-member.stderr
+++ b/tests/ui/closures/2229_closure_analysis/filter-on-struct-member.stderr
@@ -4,7 +4,7 @@ error: First Pass analysis includes:
 LL |             |v| self.filter.allowed(*v),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: Capturing self[Deref,(0, 0)] -> ImmBorrow
+note: Capturing self[Deref,(0, 0)] -> Immutable
   --> $DIR/filter-on-struct-member.rs:24:17
    |
 LL |             |v| self.filter.allowed(*v),
@@ -16,7 +16,7 @@ error: Min Capture analysis includes:
 LL |             |v| self.filter.allowed(*v),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: Min Capture self[Deref,(0, 0)] -> ImmBorrow
+note: Min Capture self[Deref,(0, 0)] -> Immutable
   --> $DIR/filter-on-struct-member.rs:24:17
    |
 LL |             |v| self.filter.allowed(*v),

--- a/tests/ui/closures/2229_closure_analysis/issue-87378.rs
+++ b/tests/ui/closures/2229_closure_analysis/issue-87378.rs
@@ -19,8 +19,8 @@ fn main() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
        unsafe { u.value }
-        //~^ NOTE: Capturing u[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture u[] -> ImmBorrow
+        //~^ NOTE: Capturing u[(0, 0)] -> Immutable
+        //~| NOTE: Min Capture u[] -> Immutable
     };
 
     c();

--- a/tests/ui/closures/2229_closure_analysis/issue-87378.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-87378.stderr
@@ -20,7 +20,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing u[(0, 0)] -> ImmBorrow
+note: Capturing u[(0, 0)] -> Immutable
   --> $DIR/issue-87378.rs:21:17
    |
 LL |        unsafe { u.value }
@@ -38,7 +38,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture u[] -> ImmBorrow
+note: Min Capture u[] -> Immutable
   --> $DIR/issue-87378.rs:21:17
    |
 LL |        unsafe { u.value }

--- a/tests/ui/closures/2229_closure_analysis/issue-88476.rs
+++ b/tests/ui/closures/2229_closure_analysis/issue-88476.rs
@@ -24,7 +24,7 @@ pub fn test1() {
     //~| ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{:?}", f.0);
-        //~^ NOTE: Capturing f[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing f[(0, 0)] -> Immutable
         //~| NOTE: Min Capture f[] -> ByValue
     };
 
@@ -52,7 +52,7 @@ fn test2() {
     //~| ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{}", character.hp)
-        //~^ NOTE: Capturing character[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing character[(0, 0)] -> Immutable
         //~| NOTE: Min Capture character[(0, 0)] -> ByValue
     };
 

--- a/tests/ui/closures/2229_closure_analysis/issue-88476.stderr
+++ b/tests/ui/closures/2229_closure_analysis/issue-88476.stderr
@@ -31,7 +31,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing f[(0, 0)] -> ImmBorrow
+note: Capturing f[(0, 0)] -> Immutable
   --> $DIR/issue-88476.rs:26:26
    |
 LL |         println!("{:?}", f.0);
@@ -69,7 +69,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing character[(0, 0)] -> ImmBorrow
+note: Capturing character[(0, 0)] -> Immutable
   --> $DIR/issue-88476.rs:54:24
    |
 LL |         println!("{}", character.hp)

--- a/tests/ui/closures/2229_closure_analysis/match/patterns-capture-analysis.rs
+++ b/tests/ui/closures/2229_closure_analysis/match/patterns-capture-analysis.rs
@@ -13,8 +13,8 @@ fn test_1_should_capture() {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:
         match variant {
-        //~^ NOTE: Capturing variant[] -> ImmBorrow
-        //~| NOTE: Min Capture variant[] -> ImmBorrow
+        //~^ NOTE: Capturing variant[] -> Immutable
+        //~| NOTE: Min Capture variant[] -> Immutable
             Some(_) => {}
             _ => {}
         }
@@ -64,9 +64,9 @@ fn test_6_should_capture_single_variant() {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:
         match variant {
-            //~^ NOTE: Capturing variant[] -> ImmBorrow
-            //~| NOTE: Capturing variant[(0, 0)] -> ImmBorrow
-            //~| NOTE: Min Capture variant[] -> ImmBorrow
+            //~^ NOTE: Capturing variant[] -> Immutable
+            //~| NOTE: Capturing variant[(0, 0)] -> Immutable
+            //~| NOTE: Min Capture variant[] -> Immutable
             SingleVariant::Points(a) => {
                 println!("{:?}", a);
             }
@@ -131,8 +131,8 @@ fn test_5_should_capture_multi_variant() {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:
         match variant {
-        //~^ NOTE: Capturing variant[] -> ImmBorrow
-        //~| NOTE: Min Capture variant[] -> ImmBorrow
+        //~^ NOTE: Capturing variant[] -> Immutable
+        //~| NOTE: Min Capture variant[] -> Immutable
             MVariant::A => {}
             _ => {}
         }
@@ -149,8 +149,8 @@ fn test_7_should_capture_slice_len() {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:
         match slice {
-            //~^ NOTE: Capturing slice[] -> ImmBorrow
-            //~| NOTE: Min Capture slice[] -> ImmBorrow
+            //~^ NOTE: Capturing slice[] -> Immutable
+            //~| NOTE: Min Capture slice[] -> Immutable
             [_,_,_] => {},
             _ => {}
         }
@@ -161,8 +161,8 @@ fn test_7_should_capture_slice_len() {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:
         match slice {
-            //~^ NOTE: Capturing slice[] -> ImmBorrow
-            //~| NOTE: Min Capture slice[] -> ImmBorrow
+            //~^ NOTE: Capturing slice[] -> Immutable
+            //~| NOTE: Min Capture slice[] -> Immutable
             [] => {},
             _ => {}
         }
@@ -173,8 +173,8 @@ fn test_7_should_capture_slice_len() {
     //~^ First Pass analysis includes:
     //~| Min Capture analysis includes:
         match slice {
-            //~^ NOTE: Capturing slice[] -> ImmBorrow
-            //~| NOTE: Min Capture slice[] -> ImmBorrow
+            //~^ NOTE: Capturing slice[] -> Immutable
+            //~| NOTE: Min Capture slice[] -> Immutable
             [_, .. ,_] => {},
             _ => {}
         }

--- a/tests/ui/closures/2229_closure_analysis/match/patterns-capture-analysis.stderr
+++ b/tests/ui/closures/2229_closure_analysis/match/patterns-capture-analysis.stderr
@@ -10,7 +10,7 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Capturing variant[] -> ImmBorrow
+note: Capturing variant[] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:15:15
    |
 LL |         match variant {
@@ -28,7 +28,7 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Min Capture variant[] -> ImmBorrow
+note: Min Capture variant[] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:15:15
    |
 LL |         match variant {
@@ -68,12 +68,12 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Capturing variant[] -> ImmBorrow
+note: Capturing variant[] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:66:15
    |
 LL |         match variant {
    |               ^^^^^^^
-note: Capturing variant[(0, 0)] -> ImmBorrow
+note: Capturing variant[(0, 0)] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:66:15
    |
 LL |         match variant {
@@ -91,7 +91,7 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Min Capture variant[] -> ImmBorrow
+note: Min Capture variant[] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:66:15
    |
 LL |         match variant {
@@ -142,7 +142,7 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Capturing variant[] -> ImmBorrow
+note: Capturing variant[] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:133:15
    |
 LL |         match variant {
@@ -160,7 +160,7 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Min Capture variant[] -> ImmBorrow
+note: Min Capture variant[] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:133:15
    |
 LL |         match variant {
@@ -178,7 +178,7 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Capturing slice[] -> ImmBorrow
+note: Capturing slice[] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:151:15
    |
 LL |         match slice {
@@ -196,7 +196,7 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Min Capture slice[] -> ImmBorrow
+note: Min Capture slice[] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:151:15
    |
 LL |         match slice {
@@ -214,7 +214,7 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Capturing slice[] -> ImmBorrow
+note: Capturing slice[] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:163:15
    |
 LL |         match slice {
@@ -232,7 +232,7 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Min Capture slice[] -> ImmBorrow
+note: Min Capture slice[] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:163:15
    |
 LL |         match slice {
@@ -250,7 +250,7 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Capturing slice[] -> ImmBorrow
+note: Capturing slice[] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:175:15
    |
 LL |         match slice {
@@ -268,7 +268,7 @@ LL | |         }
 LL | |     };
    | |_____^
    |
-note: Min Capture slice[] -> ImmBorrow
+note: Min Capture slice[] -> Immutable
   --> $DIR/patterns-capture-analysis.rs:175:15
    |
 LL |         match slice {

--- a/tests/ui/closures/2229_closure_analysis/move_closure.rs
+++ b/tests/ui/closures/2229_closure_analysis/move_closure.rs
@@ -17,7 +17,7 @@ fn simple_move_closure() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         t.0.0 = "new S".into();
-        //~^ NOTE: Capturing t[(0, 0),(0, 0)] -> MutBorrow
+        //~^ NOTE: Capturing t[(0, 0),(0, 0)] -> Mutable
         //~| NOTE: Min Capture t[(0, 0),(0, 0)] -> ByValue
     };
     c();
@@ -36,7 +36,7 @@ fn simple_ref() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         *ref_s += 10;
-        //~^ NOTE: Capturing ref_s[Deref] -> MutBorrow
+        //~^ NOTE: Capturing ref_s[Deref] -> Mutable
         //~| NOTE: Min Capture ref_s[] -> ByValue
     };
     c();
@@ -58,7 +58,7 @@ fn struct_contains_ref_to_another_struct_1() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         t.0.0 = "new s".into();
-        //~^ NOTE: Capturing t[(0, 0),Deref,(0, 0)] -> MutBorrow
+        //~^ NOTE: Capturing t[(0, 0),Deref,(0, 0)] -> Mutable
         //~| NOTE: Min Capture t[(0, 0)] -> ByValue
     };
 
@@ -82,7 +82,7 @@ fn struct_contains_ref_to_another_struct_2() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         let _t = t.0.0;
-        //~^ NOTE: Capturing t[(0, 0),Deref,(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing t[(0, 0),Deref,(0, 0)] -> Immutable
         //~| NOTE: Min Capture t[(0, 0)] -> ByValue
     };
 
@@ -127,7 +127,7 @@ fn truncate_box_derefs() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         let _t = b.0;
-        //~^ NOTE: Capturing b[Deref,(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing b[Deref,(0, 0)] -> Immutable
         //~| NOTE: Min Capture b[] -> ByValue
     };
 
@@ -144,7 +144,7 @@ fn truncate_box_derefs() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{}", b.0);
-        //~^ NOTE: Capturing b[Deref,(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing b[Deref,(0, 0)] -> Immutable
         //~| NOTE: Min Capture b[] -> ByValue
     };
 
@@ -162,7 +162,7 @@ fn truncate_box_derefs() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{}", t.1.0);
-        //~^ NOTE: Capturing t[(1, 0),Deref,(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing t[(1, 0),Deref,(0, 0)] -> Immutable
         //~| NOTE: Min Capture t[(1, 0)] -> ByValue
     };
 }
@@ -182,7 +182,7 @@ fn box_mut_1() {
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     //~| First Pass analysis includes:
-    //~| NOTE: Capturing box_p_foo[Deref,Deref,(0, 0)] -> MutBorrow
+    //~| NOTE: Capturing box_p_foo[Deref,Deref,(0, 0)] -> Mutable
     //~| Min Capture analysis includes:
     //~| NOTE: Min Capture box_p_foo[] -> ByValue
 }
@@ -200,7 +200,7 @@ fn box_mut_2() {
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     //~| First Pass analysis includes:
-    //~| NOTE: Capturing p_foo[Deref,Deref,(0, 0)] -> MutBorrow
+    //~| NOTE: Capturing p_foo[Deref,Deref,(0, 0)] -> Mutable
     //~| Min Capture analysis includes:
     //~| NOTE: Min Capture p_foo[] -> ByValue
 }
@@ -214,7 +214,7 @@ fn returned_closure_owns_copy_type_data() -> impl Fn() -> i32 {
     //~| NOTE: see issue #15701 <https://github.com/rust-lang/rust/issues/15701>
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     //~| First Pass analysis includes:
-    //~| NOTE: Capturing x[] -> ImmBorrow
+    //~| NOTE: Capturing x[] -> Immutable
     //~| Min Capture analysis includes:
     //~| NOTE: Min Capture x[] -> ByValue
 

--- a/tests/ui/closures/2229_closure_analysis/move_closure.stderr
+++ b/tests/ui/closures/2229_closure_analysis/move_closure.stderr
@@ -114,7 +114,7 @@ error: First Pass analysis includes:
 LL |     let c = #[rustc_capture_analysis] move || x;
    |                                       ^^^^^^^^^
    |
-note: Capturing x[] -> ImmBorrow
+note: Capturing x[] -> Immutable
   --> $DIR/move_closure.rs:212:47
    |
 LL |     let c = #[rustc_capture_analysis] move || x;
@@ -144,7 +144,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing t[(0, 0),(0, 0)] -> MutBorrow
+note: Capturing t[(0, 0),(0, 0)] -> Mutable
   --> $DIR/move_closure.rs:19:9
    |
 LL |         t.0.0 = "new S".into();
@@ -180,7 +180,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing ref_s[Deref] -> MutBorrow
+note: Capturing ref_s[Deref] -> Mutable
   --> $DIR/move_closure.rs:38:9
    |
 LL |         *ref_s += 10;
@@ -216,7 +216,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing t[(0, 0),Deref,(0, 0)] -> MutBorrow
+note: Capturing t[(0, 0),Deref,(0, 0)] -> Mutable
   --> $DIR/move_closure.rs:60:9
    |
 LL |         t.0.0 = "new s".into();
@@ -252,7 +252,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing t[(0, 0),Deref,(0, 0)] -> ImmBorrow
+note: Capturing t[(0, 0),Deref,(0, 0)] -> Immutable
   --> $DIR/move_closure.rs:84:18
    |
 LL |         let _t = t.0.0;
@@ -324,7 +324,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing b[Deref,(0, 0)] -> ImmBorrow
+note: Capturing b[Deref,(0, 0)] -> Immutable
   --> $DIR/move_closure.rs:129:18
    |
 LL |         let _t = b.0;
@@ -360,7 +360,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing b[Deref,(0, 0)] -> ImmBorrow
+note: Capturing b[Deref,(0, 0)] -> Immutable
   --> $DIR/move_closure.rs:146:24
    |
 LL |         println!("{}", b.0);
@@ -396,7 +396,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing t[(1, 0),Deref,(0, 0)] -> ImmBorrow
+note: Capturing t[(1, 0),Deref,(0, 0)] -> Immutable
   --> $DIR/move_closure.rs:164:24
    |
 LL |         println!("{}", t.1.0);
@@ -426,7 +426,7 @@ error: First Pass analysis includes:
 LL |     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: Capturing box_p_foo[Deref,Deref,(0, 0)] -> MutBorrow
+note: Capturing box_p_foo[Deref,Deref,(0, 0)] -> Mutable
   --> $DIR/move_closure.rs:180:47
    |
 LL |     let c = #[rustc_capture_analysis] move || box_p_foo.x += 10;
@@ -450,7 +450,7 @@ error: First Pass analysis includes:
 LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;
    |                                       ^^^^^^^^^^^^^^^^^^^^^
    |
-note: Capturing p_foo[Deref,Deref,(0, 0)] -> MutBorrow
+note: Capturing p_foo[Deref,Deref,(0, 0)] -> Mutable
   --> $DIR/move_closure.rs:198:47
    |
 LL |     let c = #[rustc_capture_analysis] move || p_foo.x += 10;

--- a/tests/ui/closures/2229_closure_analysis/multilevel-path-1.rs
+++ b/tests/ui/closures/2229_closure_analysis/multilevel-path-1.rs
@@ -27,8 +27,8 @@ fn main() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         let wp = &w.p;
-        //~^ NOTE: Capturing w[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture w[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing w[(0, 0)] -> Immutable
+        //~| NOTE: Min Capture w[(0, 0)] -> Immutable
         println!("{}", wp.x);
     };
 

--- a/tests/ui/closures/2229_closure_analysis/multilevel-path-1.stderr
+++ b/tests/ui/closures/2229_closure_analysis/multilevel-path-1.stderr
@@ -20,7 +20,7 @@ LL | |         println!("{}", wp.x);
 LL | |     };
    | |_____^
    |
-note: Capturing w[(0, 0)] -> ImmBorrow
+note: Capturing w[(0, 0)] -> Immutable
   --> $DIR/multilevel-path-1.rs:29:19
    |
 LL |         let wp = &w.p;
@@ -38,7 +38,7 @@ LL | |         println!("{}", wp.x);
 LL | |     };
    | |_____^
    |
-note: Min Capture w[(0, 0)] -> ImmBorrow
+note: Min Capture w[(0, 0)] -> Immutable
   --> $DIR/multilevel-path-1.rs:29:19
    |
 LL |         let wp = &w.p;

--- a/tests/ui/closures/2229_closure_analysis/multilevel-path-2.rs
+++ b/tests/ui/closures/2229_closure_analysis/multilevel-path-2.rs
@@ -22,8 +22,8 @@ fn main() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{}", w.p.x);
-        //~^ NOTE: Capturing w[(0, 0),(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture w[(0, 0),(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing w[(0, 0),(0, 0)] -> Immutable
+        //~| NOTE: Min Capture w[(0, 0),(0, 0)] -> Immutable
     };
 
     // `c` only captures `w.p.x`, therefore it's safe to mutate `w.p.y`.

--- a/tests/ui/closures/2229_closure_analysis/multilevel-path-2.stderr
+++ b/tests/ui/closures/2229_closure_analysis/multilevel-path-2.stderr
@@ -20,7 +20,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing w[(0, 0),(0, 0)] -> ImmBorrow
+note: Capturing w[(0, 0),(0, 0)] -> Immutable
   --> $DIR/multilevel-path-2.rs:24:24
    |
 LL |         println!("{}", w.p.x);
@@ -38,7 +38,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture w[(0, 0),(0, 0)] -> ImmBorrow
+note: Min Capture w[(0, 0),(0, 0)] -> Immutable
   --> $DIR/multilevel-path-2.rs:24:24
    |
 LL |         println!("{}", w.p.x);

--- a/tests/ui/closures/2229_closure_analysis/nested-closure.rs
+++ b/tests/ui/closures/2229_closure_analysis/nested-closure.rs
@@ -24,8 +24,8 @@ fn main() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{}", p.x);
-        //~^ NOTE: Capturing p[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture p[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing p[(0, 0)] -> Immutable
+        //~| NOTE: Min Capture p[(0, 0)] -> Immutable
         let incr = 10;
         let mut c2 = #[rustc_capture_analysis]
         //~^ ERROR: attributes on expressions are experimental
@@ -34,15 +34,15 @@ fn main() {
         || p.y += incr;
         //~^ ERROR: First Pass analysis includes:
         //~| ERROR: Min Capture analysis includes:
-        //~| NOTE: Capturing p[(1, 0)] -> MutBorrow
-        //~| NOTE: Capturing incr[] -> ImmBorrow
-        //~| NOTE: Min Capture p[(1, 0)] -> MutBorrow
-        //~| NOTE: Min Capture incr[] -> ImmBorrow
-        //~| NOTE: Capturing p[(1, 0)] -> MutBorrow
-        //~| NOTE: Min Capture p[(1, 0)] -> MutBorrow
+        //~| NOTE: Capturing p[(1, 0)] -> Mutable
+        //~| NOTE: Capturing incr[] -> Immutable
+        //~| NOTE: Min Capture p[(1, 0)] -> Mutable
+        //~| NOTE: Min Capture incr[] -> Immutable
+        //~| NOTE: Capturing p[(1, 0)] -> Mutable
+        //~| NOTE: Min Capture p[(1, 0)] -> Mutable
         c2();
         println!("{}", p.y);
-        //~^ NOTE: Capturing p[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing p[(1, 0)] -> Immutable
     };
 
     c1();

--- a/tests/ui/closures/2229_closure_analysis/nested-closure.stderr
+++ b/tests/ui/closures/2229_closure_analysis/nested-closure.stderr
@@ -24,12 +24,12 @@ error: First Pass analysis includes:
 LL |         || p.y += incr;
    |         ^^^^^^^^^^^^^^
    |
-note: Capturing p[(1, 0)] -> MutBorrow
+note: Capturing p[(1, 0)] -> Mutable
   --> $DIR/nested-closure.rs:34:12
    |
 LL |         || p.y += incr;
    |            ^^^
-note: Capturing incr[] -> ImmBorrow
+note: Capturing incr[] -> Immutable
   --> $DIR/nested-closure.rs:34:19
    |
 LL |         || p.y += incr;
@@ -41,12 +41,12 @@ error: Min Capture analysis includes:
 LL |         || p.y += incr;
    |         ^^^^^^^^^^^^^^
    |
-note: Min Capture p[(1, 0)] -> MutBorrow
+note: Min Capture p[(1, 0)] -> Mutable
   --> $DIR/nested-closure.rs:34:12
    |
 LL |         || p.y += incr;
    |            ^^^
-note: Min Capture incr[] -> ImmBorrow
+note: Min Capture incr[] -> Immutable
   --> $DIR/nested-closure.rs:34:19
    |
 LL |         || p.y += incr;
@@ -64,17 +64,17 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing p[(0, 0)] -> ImmBorrow
+note: Capturing p[(0, 0)] -> Immutable
   --> $DIR/nested-closure.rs:26:24
    |
 LL |         println!("{}", p.x);
    |                        ^^^
-note: Capturing p[(1, 0)] -> MutBorrow
+note: Capturing p[(1, 0)] -> Mutable
   --> $DIR/nested-closure.rs:34:12
    |
 LL |         || p.y += incr;
    |            ^^^
-note: Capturing p[(1, 0)] -> ImmBorrow
+note: Capturing p[(1, 0)] -> Immutable
   --> $DIR/nested-closure.rs:44:24
    |
 LL |         println!("{}", p.y);
@@ -92,12 +92,12 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture p[(0, 0)] -> ImmBorrow
+note: Min Capture p[(0, 0)] -> Immutable
   --> $DIR/nested-closure.rs:26:24
    |
 LL |         println!("{}", p.x);
    |                        ^^^
-note: Min Capture p[(1, 0)] -> MutBorrow
+note: Min Capture p[(1, 0)] -> Mutable
   --> $DIR/nested-closure.rs:34:12
    |
 LL |         || p.y += incr;

--- a/tests/ui/closures/2229_closure_analysis/optimization/edge_case.rs
+++ b/tests/ui/closures/2229_closure_analysis/optimization/edge_case.rs
@@ -23,8 +23,8 @@ fn foo<'a, 'b>(m: &'a MyStruct<'b>) -> impl FnMut() + 'static {
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     //~| ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
-    //~| NOTE: Capturing m[Deref,(0, 0),Deref,(0, 0)] -> ImmBorrow
-    //~| NOTE: Min Capture m[Deref,(0, 0),Deref] -> ImmBorrow
+    //~| NOTE: Capturing m[Deref,(0, 0),Deref,(0, 0)] -> Immutable
+    //~| NOTE: Min Capture m[Deref,(0, 0),Deref] -> Immutable
     c
 }
 

--- a/tests/ui/closures/2229_closure_analysis/optimization/edge_case.stderr
+++ b/tests/ui/closures/2229_closure_analysis/optimization/edge_case.stderr
@@ -14,7 +14,7 @@ error: First Pass analysis includes:
 LL |     let c = #[rustc_capture_analysis] || drop(&m.a.0);
    |                                       ^^^^^^^^^^^^^^^
    |
-note: Capturing m[Deref,(0, 0),Deref,(0, 0)] -> ImmBorrow
+note: Capturing m[Deref,(0, 0),Deref,(0, 0)] -> Immutable
   --> $DIR/edge_case.rs:20:48
    |
 LL |     let c = #[rustc_capture_analysis] || drop(&m.a.0);
@@ -26,7 +26,7 @@ error: Min Capture analysis includes:
 LL |     let c = #[rustc_capture_analysis] || drop(&m.a.0);
    |                                       ^^^^^^^^^^^^^^^
    |
-note: Min Capture m[Deref,(0, 0),Deref] -> ImmBorrow
+note: Min Capture m[Deref,(0, 0),Deref] -> Immutable
   --> $DIR/edge_case.rs:20:48
    |
 LL |     let c = #[rustc_capture_analysis] || drop(&m.a.0);

--- a/tests/ui/closures/2229_closure_analysis/path-with-array-access.rs
+++ b/tests/ui/closures/2229_closure_analysis/path-with-array-access.rs
@@ -28,7 +28,7 @@ fn main() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{}", pent.points[5].x);
-        //~^ NOTE: Capturing pent[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture pent[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing pent[(0, 0)] -> Immutable
+        //~| NOTE: Min Capture pent[(0, 0)] -> Immutable
     };
 }

--- a/tests/ui/closures/2229_closure_analysis/path-with-array-access.stderr
+++ b/tests/ui/closures/2229_closure_analysis/path-with-array-access.stderr
@@ -20,7 +20,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing pent[(0, 0)] -> ImmBorrow
+note: Capturing pent[(0, 0)] -> Immutable
   --> $DIR/path-with-array-access.rs:30:24
    |
 LL |         println!("{}", pent.points[5].x);
@@ -38,7 +38,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture pent[(0, 0)] -> ImmBorrow
+note: Min Capture pent[(0, 0)] -> Immutable
   --> $DIR/path-with-array-access.rs:30:24
    |
 LL |         println!("{}", pent.points[5].x);

--- a/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs
+++ b/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.rs
@@ -28,17 +28,17 @@ fn test_one() {
         //~^ ERROR: Min Capture analysis includes:
         //~| ERROR
         println!("{:?}", a.0);
-        //~^ NOTE: Min Capture a[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture a[(0, 0)] -> Immutable
         //~| NOTE
         println!("{:?}", a.1);
-        //~^ NOTE: Min Capture a[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture a[(1, 0)] -> Immutable
         //~| NOTE
 
         println!("{:?}", b.0);
-        //~^ NOTE: Min Capture b[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture b[(0, 0)] -> Immutable
         //~| NOTE
         println!("{:?}", b.1);
-        //~^ NOTE: Min Capture b[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture b[(1, 0)] -> Immutable
         //~| NOTE
     };
 }
@@ -55,17 +55,17 @@ fn test_two() {
         //~^ ERROR: Min Capture analysis includes:
         //~| ERROR
         println!("{:?}", a.1);
-        //~^ NOTE: Min Capture a[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture a[(1, 0)] -> Immutable
         //~| NOTE
         println!("{:?}", a.0);
-        //~^ NOTE: Min Capture a[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture a[(0, 0)] -> Immutable
         //~| NOTE
 
         println!("{:?}", b.1);
-        //~^ NOTE: Min Capture b[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture b[(1, 0)] -> Immutable
         //~| NOTE
         println!("{:?}", b.0);
-        //~^ NOTE: Min Capture b[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture b[(0, 0)] -> Immutable
         //~| NOTE
     };
 }
@@ -82,17 +82,17 @@ fn test_three() {
         //~^ ERROR: Min Capture analysis includes:
         //~| ERROR
         println!("{:?}", b.1);
-        //~^ NOTE: Min Capture b[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture b[(1, 0)] -> Immutable
         //~| NOTE
         println!("{:?}", a.1);
-        //~^ NOTE: Min Capture a[(1, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture a[(1, 0)] -> Immutable
         //~| NOTE
         println!("{:?}", a.0);
-        //~^ NOTE: Min Capture a[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture a[(0, 0)] -> Immutable
         //~| NOTE
 
         println!("{:?}", b.0);
-        //~^ NOTE: Min Capture b[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Min Capture b[(0, 0)] -> Immutable
         //~| NOTE
     };
 }

--- a/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.stderr
+++ b/tests/ui/closures/2229_closure_analysis/preserve_field_drop_order.stderr
@@ -40,22 +40,22 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing a[(0, 0)] -> ImmBorrow
+note: Capturing a[(0, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:30:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
-note: Capturing a[(1, 0)] -> ImmBorrow
+note: Capturing a[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:33:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
-note: Capturing b[(0, 0)] -> ImmBorrow
+note: Capturing b[(0, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:37:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
-note: Capturing b[(1, 0)] -> ImmBorrow
+note: Capturing b[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:40:26
    |
 LL |         println!("{:?}", b.1);
@@ -73,22 +73,22 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture a[(0, 0)] -> ImmBorrow
+note: Min Capture a[(0, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:30:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
-note: Min Capture a[(1, 0)] -> ImmBorrow
+note: Min Capture a[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:33:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
-note: Min Capture b[(0, 0)] -> ImmBorrow
+note: Min Capture b[(0, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:37:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
-note: Min Capture b[(1, 0)] -> ImmBorrow
+note: Min Capture b[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:40:26
    |
 LL |         println!("{:?}", b.1);
@@ -106,22 +106,22 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing a[(1, 0)] -> ImmBorrow
+note: Capturing a[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:57:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
-note: Capturing a[(0, 0)] -> ImmBorrow
+note: Capturing a[(0, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:60:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
-note: Capturing b[(1, 0)] -> ImmBorrow
+note: Capturing b[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:64:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
-note: Capturing b[(0, 0)] -> ImmBorrow
+note: Capturing b[(0, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:67:26
    |
 LL |         println!("{:?}", b.0);
@@ -139,22 +139,22 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture a[(0, 0)] -> ImmBorrow
+note: Min Capture a[(0, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:60:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
-note: Min Capture a[(1, 0)] -> ImmBorrow
+note: Min Capture a[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:57:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
-note: Min Capture b[(0, 0)] -> ImmBorrow
+note: Min Capture b[(0, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:67:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
-note: Min Capture b[(1, 0)] -> ImmBorrow
+note: Min Capture b[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:64:26
    |
 LL |         println!("{:?}", b.1);
@@ -172,22 +172,22 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing b[(1, 0)] -> ImmBorrow
+note: Capturing b[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:84:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
-note: Capturing a[(1, 0)] -> ImmBorrow
+note: Capturing a[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:87:26
    |
 LL |         println!("{:?}", a.1);
    |                          ^^^
-note: Capturing a[(0, 0)] -> ImmBorrow
+note: Capturing a[(0, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:90:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
-note: Capturing b[(0, 0)] -> ImmBorrow
+note: Capturing b[(0, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:94:26
    |
 LL |         println!("{:?}", b.0);
@@ -205,22 +205,22 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture b[(0, 0)] -> ImmBorrow
+note: Min Capture b[(0, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:94:26
    |
 LL |         println!("{:?}", b.0);
    |                          ^^^
-note: Min Capture b[(1, 0)] -> ImmBorrow
+note: Min Capture b[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:84:26
    |
 LL |         println!("{:?}", b.1);
    |                          ^^^
-note: Min Capture a[(0, 0)] -> ImmBorrow
+note: Min Capture a[(0, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:90:26
    |
 LL |         println!("{:?}", a.0);
    |                          ^^^
-note: Min Capture a[(1, 0)] -> ImmBorrow
+note: Min Capture a[(1, 0)] -> Immutable
   --> $DIR/preserve_field_drop_order.rs:87:26
    |
 LL |         println!("{:?}", a.1);

--- a/tests/ui/closures/2229_closure_analysis/repr_packed.rs
+++ b/tests/ui/closures/2229_closure_analysis/repr_packed.rs
@@ -19,10 +19,10 @@ fn test_alignment_not_affected() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         let z1: &u8 = &foo.x;
-        //~^ NOTE: Capturing foo[] -> ImmBorrow
+        //~^ NOTE: Capturing foo[] -> Immutable
         let z2: &mut u8 = &mut foo.y;
-        //~^ NOTE: Capturing foo[] -> MutBorrow
-        //~| NOTE: Min Capture foo[] -> MutBorrow
+        //~^ NOTE: Capturing foo[] -> Mutable
+        //~| NOTE: Min Capture foo[] -> Mutable
 
         *z2 = 42;
 
@@ -50,10 +50,10 @@ fn test_alignment_affected() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         let z1: &String = &foo.x;
-        //~^ NOTE: Capturing foo[] -> ImmBorrow
+        //~^ NOTE: Capturing foo[] -> Immutable
         let z2: &mut u16 = &mut foo.y;
-        //~^ NOTE: Capturing foo[] -> MutBorrow
-        //~| NOTE: Min Capture foo[] -> MutBorrow
+        //~^ NOTE: Capturing foo[] -> Mutable
+        //~| NOTE: Min Capture foo[] -> Mutable
 
 
         *z2 = 42;
@@ -86,7 +86,7 @@ fn test_truncation_when_ref_and_move() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{}", foo.x);
-        //~^ NOTE: Capturing foo[] -> ImmBorrow
+        //~^ NOTE: Capturing foo[] -> Immutable
         //~| NOTE: Min Capture foo[] -> ByValue
         //~| NOTE: foo[] used here
         let _z = foo.x;

--- a/tests/ui/closures/2229_closure_analysis/repr_packed.stderr
+++ b/tests/ui/closures/2229_closure_analysis/repr_packed.stderr
@@ -40,12 +40,12 @@ LL | |         println!("({}, {})", z1, z2);
 LL | |     };
    | |_____^
    |
-note: Capturing foo[] -> ImmBorrow
+note: Capturing foo[] -> Immutable
   --> $DIR/repr_packed.rs:21:24
    |
 LL |         let z1: &u8 = &foo.x;
    |                        ^^^^^
-note: Capturing foo[] -> MutBorrow
+note: Capturing foo[] -> Mutable
   --> $DIR/repr_packed.rs:23:32
    |
 LL |         let z2: &mut u8 = &mut foo.y;
@@ -63,7 +63,7 @@ LL | |         println!("({}, {})", z1, z2);
 LL | |     };
    | |_____^
    |
-note: Min Capture foo[] -> MutBorrow
+note: Min Capture foo[] -> Mutable
   --> $DIR/repr_packed.rs:23:32
    |
 LL |         let z2: &mut u8 = &mut foo.y;
@@ -81,12 +81,12 @@ LL | |         println!("({}, {})", z1, z2);
 LL | |     };
    | |_____^
    |
-note: Capturing foo[] -> ImmBorrow
+note: Capturing foo[] -> Immutable
   --> $DIR/repr_packed.rs:52:28
    |
 LL |         let z1: &String = &foo.x;
    |                            ^^^^^
-note: Capturing foo[] -> MutBorrow
+note: Capturing foo[] -> Mutable
   --> $DIR/repr_packed.rs:54:33
    |
 LL |         let z2: &mut u16 = &mut foo.y;
@@ -104,7 +104,7 @@ LL | |         println!("({}, {})", z1, z2);
 LL | |     };
    | |_____^
    |
-note: Min Capture foo[] -> MutBorrow
+note: Min Capture foo[] -> Mutable
   --> $DIR/repr_packed.rs:54:33
    |
 LL |         let z2: &mut u16 = &mut foo.y;
@@ -122,7 +122,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing foo[] -> ImmBorrow
+note: Capturing foo[] -> Immutable
   --> $DIR/repr_packed.rs:88:24
    |
 LL |         println!("{}", foo.x);

--- a/tests/ui/closures/2229_closure_analysis/simple-struct-min-capture.rs
+++ b/tests/ui/closures/2229_closure_analysis/simple-struct-min-capture.rs
@@ -16,7 +16,7 @@ fn main() {
     //
     // Requirements:
     // p.x -> MutBoorrow
-    // p   -> ImmBorrow
+    // p   -> Immutable
     //
     // Requirements met when p is captured via MutBorrow
     //
@@ -28,11 +28,11 @@ fn main() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         p.x += 10;
-        //~^ NOTE: Capturing p[(0, 0)] -> MutBorrow
-        //~| NOTE: p[] captured as MutBorrow here
+        //~^ NOTE: Capturing p[(0, 0)] -> Mutable
+        //~| NOTE: p[] captured as Mutable here
         println!("{:?}", p);
-        //~^ NOTE: Capturing p[] -> ImmBorrow
-        //~| NOTE: Min Capture p[] -> MutBorrow
+        //~^ NOTE: Capturing p[] -> Immutable
+        //~| NOTE: Min Capture p[] -> Mutable
         //~| NOTE: p[] used here
     };
 

--- a/tests/ui/closures/2229_closure_analysis/simple-struct-min-capture.stderr
+++ b/tests/ui/closures/2229_closure_analysis/simple-struct-min-capture.stderr
@@ -20,12 +20,12 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing p[(0, 0)] -> MutBorrow
+note: Capturing p[(0, 0)] -> Mutable
   --> $DIR/simple-struct-min-capture.rs:30:9
    |
 LL |         p.x += 10;
    |         ^^^
-note: Capturing p[] -> ImmBorrow
+note: Capturing p[] -> Immutable
   --> $DIR/simple-struct-min-capture.rs:33:26
    |
 LL |         println!("{:?}", p);
@@ -43,11 +43,11 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture p[] -> MutBorrow
+note: Min Capture p[] -> Mutable
   --> $DIR/simple-struct-min-capture.rs:30:9
    |
 LL |         p.x += 10;
-   |         ^^^ p[] captured as MutBorrow here
+   |         ^^^ p[] captured as Mutable here
 ...
 LL |         println!("{:?}", p);
    |                          ^ p[] used here

--- a/tests/ui/closures/2229_closure_analysis/unsafe_ptr.rs
+++ b/tests/ui/closures/2229_closure_analysis/unsafe_ptr.rs
@@ -30,8 +30,8 @@ fn unsafe_imm() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         println!("{:?}", (*t.0).s);
-        //~^ NOTE: Capturing t[(0, 0),Deref,(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture t[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing t[(0, 0),Deref,(0, 0)] -> Immutable
+        //~| NOTE: Min Capture t[(0, 0)] -> Immutable
     };
 
     c();
@@ -51,8 +51,8 @@ fn unsafe_mut() {
     //~^ ERROR: First Pass analysis includes:
     //~| ERROR: Min Capture analysis includes:
         let x = unsafe { &mut (*p).s };
-        //~^ NOTE: Capturing p[Deref,(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture p[] -> ImmBorrow
+        //~^ NOTE: Capturing p[Deref,(0, 0)] -> Immutable
+        //~| NOTE: Min Capture p[] -> Immutable
         *x = "s".into();
     };
     c();

--- a/tests/ui/closures/2229_closure_analysis/unsafe_ptr.stderr
+++ b/tests/ui/closures/2229_closure_analysis/unsafe_ptr.stderr
@@ -30,7 +30,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing t[(0, 0),Deref,(0, 0)] -> ImmBorrow
+note: Capturing t[(0, 0),Deref,(0, 0)] -> Immutable
   --> $DIR/unsafe_ptr.rs:32:26
    |
 LL |         println!("{:?}", (*t.0).s);
@@ -48,7 +48,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture t[(0, 0)] -> ImmBorrow
+note: Min Capture t[(0, 0)] -> Immutable
   --> $DIR/unsafe_ptr.rs:32:26
    |
 LL |         println!("{:?}", (*t.0).s);
@@ -66,7 +66,7 @@ LL | |         *x = "s".into();
 LL | |     };
    | |_____^
    |
-note: Capturing p[Deref,(0, 0)] -> ImmBorrow
+note: Capturing p[Deref,(0, 0)] -> Immutable
   --> $DIR/unsafe_ptr.rs:53:31
    |
 LL |         let x = unsafe { &mut (*p).s };
@@ -84,7 +84,7 @@ LL | |         *x = "s".into();
 LL | |     };
    | |_____^
    |
-note: Min Capture p[] -> ImmBorrow
+note: Min Capture p[] -> Immutable
   --> $DIR/unsafe_ptr.rs:53:31
    |
 LL |         let x = unsafe { &mut (*p).s };

--- a/tests/ui/closures/2229_closure_analysis/wild_patterns.rs
+++ b/tests/ui/closures/2229_closure_analysis/wild_patterns.rs
@@ -28,8 +28,8 @@ fn wild_struct() {
     //~| ERROR: Min Capture analysis includes:
         // FIXME(arora-aman): Change `_x` to `_`
         let Point { x: _x, y: _ } = p;
-        //~^ NOTE: Capturing p[(0, 0)] -> ImmBorrow
-        //~| NOTE: Min Capture p[(0, 0)] -> ImmBorrow
+        //~^ NOTE: Capturing p[(0, 0)] -> Immutable
+        //~| NOTE: Min Capture p[(0, 0)] -> Immutable
     };
 
     c();

--- a/tests/ui/closures/2229_closure_analysis/wild_patterns.stderr
+++ b/tests/ui/closures/2229_closure_analysis/wild_patterns.stderr
@@ -40,7 +40,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Capturing p[(0, 0)] -> ImmBorrow
+note: Capturing p[(0, 0)] -> Immutable
   --> $DIR/wild_patterns.rs:30:37
    |
 LL |         let Point { x: _x, y: _ } = p;
@@ -58,7 +58,7 @@ LL | |
 LL | |     };
    | |_____^
    |
-note: Min Capture p[(0, 0)] -> ImmBorrow
+note: Min Capture p[(0, 0)] -> Immutable
   --> $DIR/wild_patterns.rs:30:37
    |
 LL |         let Point { x: _x, y: _ } = p;


### PR DESCRIPTION
We used to have an idiom in the compiler where we'd prefix or suffix all the variants of an enum, for example `BoundRegionKind`, with something like `Br`, and then *glob-import* that enum variant directly.

@noratrieb brought this up, and I think that it's easier to read when we just use the normal style `EnumName::Variant`.

This PR is a bit large, but it's just naming.

The only somewhat opinionated change that this PR does is rename `BorrowKind::Imm` to `BorrowKind::Immutable` and same for the other variants. I think these enums are used sparingly enough that the extra length is fine.

r? @noratrieb or reassign