### PR TITLE
CI: increase timeout from 4h to 6h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     defaults:
       run:
         shell: ${{ contains(matrix.os, 'windows') && 'msys2 {0}' || 'bash' }}
-    timeout-minutes: 240
+    timeout-minutes: 360
     env:
       CI_JOB_NAME: ${{ matrix.image }}
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse


### PR DESCRIPTION
Our CI got a bit slower since the last time we [lowered](https://github.com/rust-lang/rust/pull/127648) the timeout, and if e.g. Docker build cache is broken, the timeout can be triggered.

Discussed [here](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/ci.20job.20timings.20stats).