### PR TITLE
Gate async fn trait bound modifier on `async_trait_bounds`

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -516,6 +516,11 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
         "async closures are unstable",
         "to use an async block, remove the `||`: `async {`"
     );
+    gate_all!(
+        async_trait_bounds,
+        "`async` trait bounds are unstable",
+        "use the desugared name of the async trait, such as `AsyncFn`"
+    );
     gate_all!(async_for_loop, "`for await` loops are experimental");
     gate_all!(
         closure_lifetime_binder,

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -394,6 +394,8 @@ declare_features! (
     (unstable, async_fn_track_caller, "1.73.0", Some(110011)),
     /// Allows `for await` loops.
     (unstable, async_for_loop, "1.77.0", Some(118898)),
+    /// Allows `async` trait bound modifier.
+    (unstable, async_trait_bounds, "CURRENT_RUSTC_VERSION", Some(62290)),
     /// Allows using C-variadics.
     (unstable, c_variadic, "1.34.0", Some(44930)),
     /// Allows the use of `#[cfg(<true/false>)]`.

--- a/compiler/rustc_parse/src/parser/ty.rs
+++ b/compiler/rustc_parse/src/parser/ty.rs
@@ -940,7 +940,7 @@ impl<'a> Parser<'a> {
         let asyncness = if self.token.uninterpolated_span().at_least_rust_2018()
             && self.eat_keyword(kw::Async)
         {
-            self.psess.gated_spans.gate(sym::async_closure, self.prev_token.span);
+            self.psess.gated_spans.gate(sym::async_trait_bounds, self.prev_token.span);
             BoundAsyncness::Async(self.prev_token.span)
         } else if self.may_recover()
             && self.token.uninterpolated_span().is_rust_2015()
@@ -951,7 +951,7 @@ impl<'a> Parser<'a> {
                 span: self.prev_token.span,
                 help: HelpUseLatestEdition::new(),
             });
-            self.psess.gated_spans.gate(sym::async_closure, self.prev_token.span);
+            self.psess.gated_spans.gate(sym::async_trait_bounds, self.prev_token.span);
             BoundAsyncness::Async(self.prev_token.span)
         } else {
             BoundAsyncness::Normal

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -468,6 +468,7 @@ symbols! {
         async_for_loop,
         async_iterator,
         async_iterator_poll_next,
+        async_trait_bounds,
         atomic,
         atomic_mod,
         atomics,

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -794,7 +794,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     closure_def_id,
                     found_kind,
                     expected_kind,
-                    "async ",
+                    "Async",
                 );
                 self.note_obligation_cause(&mut err, &obligation);
                 self.point_at_returns_when_relevant(&mut err, &obligation);

--- a/src/tools/miri/tests/pass/async-closure-captures.rs
+++ b/src/tools/miri/tests/pass/async-closure-captures.rs
@@ -1,6 +1,6 @@
 // Same as rustc's `tests/ui/async-await/async-closures/captures.rs`, keep in sync
 
-#![feature(async_closure, noop_waker)]
+#![feature(async_closure, noop_waker, async_trait_bounds)]
 
 use std::future::Future;
 use std::pin::pin;

--- a/src/tools/miri/tests/pass/async-closure-drop.rs
+++ b/src/tools/miri/tests/pass/async-closure-drop.rs
@@ -1,4 +1,4 @@
-#![feature(async_closure, noop_waker, async_fn_traits)]
+#![feature(async_closure, noop_waker, async_trait_bounds)]
 
 use std::future::Future;
 use std::pin::pin;

--- a/tests/codegen/async-closure-debug.rs
+++ b/tests/codegen/async-closure-debug.rs
@@ -9,7 +9,7 @@
 
 #![feature(async_closure)]
 
-fn async_closure_test(upvar: &str) -> impl async Fn() + '_ {
+fn async_closure_test(upvar: &str) -> impl AsyncFn() + '_ {
     async move || {
         let hello = String::from("hello");
         println!("{hello}, {upvar}");

--- a/tests/coverage/async_closure.cov-map
+++ b/tests/coverage/async_closure.cov-map
@@ -1,19 +1,19 @@
 Function name: async_closure::call_once::<async_closure::main::{closure#0}>
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 07, 01, 00, 2c]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 07, 01, 00, 2b]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 7, 1) to (start + 0, 44)
+- Code(Counter(0)) at (prev + 7, 1) to (start + 0, 43)
 Highest counter ID seen: c0
 
 Function name: async_closure::call_once::<async_closure::main::{closure#0}>::{closure#0}
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 07, 2c, 01, 0e, 05, 02, 01, 00, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 07, 2b, 01, 0e, 05, 02, 01, 00, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 7, 44) to (start + 1, 14)
+- Code(Counter(0)) at (prev + 7, 43) to (start + 1, 14)
 - Code(Counter(1)) at (prev + 2, 1) to (start + 0, 2)
 Highest counter ID seen: c1
 

--- a/tests/coverage/async_closure.coverage
+++ b/tests/coverage/async_closure.coverage
@@ -4,7 +4,7 @@
    LL|       |//@ aux-build: executor.rs
    LL|       |extern crate executor;
    LL|       |
-   LL|      1|async fn call_once(f: impl async FnOnce()) {
+   LL|      1|async fn call_once(f: impl AsyncFnOnce()) {
    LL|      1|    f().await;
    LL|      1|}
    LL|       |

--- a/tests/coverage/async_closure.rs
+++ b/tests/coverage/async_closure.rs
@@ -4,7 +4,7 @@
 //@ aux-build: executor.rs
 extern crate executor;
 
-async fn call_once(f: impl async FnOnce()) {
+async fn call_once(f: impl AsyncFnOnce()) {
     f().await;
 }
 

--- a/tests/crashes/124020.rs
+++ b/tests/crashes/124020.rs
@@ -1,7 +1,7 @@
 //@ known-bug: #124020
 //@ compile-flags: -Zpolymorphize=on --edition=2018 --crate-type=lib
 
-#![feature(async_closure, noop_waker, async_fn_traits)]
+#![feature(async_closure, noop_waker, async_trait_bounds)]
 
 use std::future::Future;
 use std::pin::pin;
@@ -19,7 +19,7 @@ pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
     }
 }
 
-async fn call_once(f: impl async FnOnce(DropMe)) {
+async fn call_once(f: impl AsyncFnOnce(DropMe)) {
     f(DropMe("world")).await;
 }
 

--- a/tests/ui/async-await/async-closures/async-fn-mut-for-async-fn.rs
+++ b/tests/ui/async-await/async-closures/async-fn-mut-for-async-fn.rs
@@ -10,7 +10,7 @@ fn main() {
     block_on::block_on(async {
         let x = async || {};
 
-        async fn needs_async_fn_mut(mut x: impl async FnMut()) {
+        async fn needs_async_fn_mut(mut x: impl AsyncFnMut()) {
             x().await;
         }
         needs_async_fn_mut(x).await;

--- a/tests/ui/async-await/async-closures/async-fn-once-for-async-fn.rs
+++ b/tests/ui/async-await/async-closures/async-fn-once-for-async-fn.rs
@@ -8,7 +8,7 @@ extern crate block_on;
 
 fn main() {
     block_on::block_on(async {
-        async fn needs_async_fn_once(x: impl async FnOnce()) {
+        async fn needs_async_fn_once(x: impl AsyncFnOnce()) {
             x().await;
         }
 

--- a/tests/ui/async-await/async-closures/auxiliary/foreign.rs
+++ b/tests/ui/async-await/async-closures/auxiliary/foreign.rs
@@ -2,6 +2,6 @@
 
 #![feature(async_closure)]
 
-pub fn closure() -> impl async Fn() {
+pub fn closure() -> impl AsyncFn() {
     async || { /* Don't really need to do anything here. */ }
 }

--- a/tests/ui/async-await/async-closures/body-check-on-non-fnmut.rs
+++ b/tests/ui/async-await/async-closures/body-check-on-non-fnmut.rs
@@ -11,7 +11,7 @@ extern crate block_on;
 
 async fn empty() {}
 
-pub async fn call_once<F: async FnOnce()>(f: F) {
+pub async fn call_once<F: AsyncFnOnce()>(f: F) {
     f().await;
 }
 

--- a/tests/ui/async-await/async-closures/box-deref-in-debuginfo.rs
+++ b/tests/ui/async-await/async-closures/box-deref-in-debuginfo.rs
@@ -16,7 +16,7 @@ impl Trait for (i32,) {
     }
 }
 
-async fn call_once(f: impl async FnOnce()) {
+async fn call_once(f: impl AsyncFnOnce()) {
     f().await;
 }
 

--- a/tests/ui/async-await/async-closures/brand.rs
+++ b/tests/ui/async-await/async-closures/brand.rs
@@ -13,7 +13,7 @@ struct S;
 struct B<'b>(PhantomData<&'b mut &'b mut ()>);
 
 impl S {
-    async fn q<F: async Fn(B<'_>)>(self, f: F) {
+    async fn q<F: AsyncFn(B<'_>)>(self, f: F) {
         f(B(PhantomData)).await;
     }
 }

--- a/tests/ui/async-await/async-closures/captures.rs
+++ b/tests/ui/async-await/async-closures/captures.rs
@@ -13,11 +13,11 @@ fn main() {
     block_on::block_on(async_main());
 }
 
-async fn call<T>(f: &impl async Fn() -> T) -> T {
+async fn call<T>(f: &impl AsyncFn() -> T) -> T {
     f().await
 }
 
-async fn call_once<T>(f: impl async FnOnce() -> T) -> T {
+async fn call_once<T>(f: impl AsyncFnOnce() -> T) -> T {
     f().await
 }
 
@@ -80,7 +80,7 @@ async fn async_main() {
         call_once(c).await;
     }
 
-    fn force_fnonce<T>(f: impl async FnOnce() -> T) -> impl async FnOnce() -> T {
+    fn force_fnonce<T>(f: impl AsyncFnOnce() -> T) -> impl AsyncFnOnce() -> T {
         f
     }
 

--- a/tests/ui/async-await/async-closures/clone-closure.rs
+++ b/tests/ui/async-await/async-closures/clone-closure.rs
@@ -7,7 +7,7 @@
 
 extern crate block_on;
 
-async fn for_each(f: impl async FnOnce(&str) + Clone) {
+async fn for_each(f: impl AsyncFnOnce(&str) + Clone) {
     f.clone()("world").await;
     f.clone()("world2").await;
 }

--- a/tests/ui/async-await/async-closures/constrained-but-no-upvars-yet.rs
+++ b/tests/ui/async-await/async-closures/constrained-but-no-upvars-yet.rs
@@ -6,7 +6,7 @@
 
 #![feature(async_closure)]
 
-fn constrain<T: async FnOnce()>(t: T) -> T {
+fn constrain<T: AsyncFnOnce()>(t: T) -> T {
     t
 }
 
@@ -14,7 +14,7 @@ fn call_once<T>(f: impl FnOnce() -> T) -> T {
     f()
 }
 
-async fn async_call_once<T>(f: impl async FnOnce() -> T) -> T {
+async fn async_call_once<T>(f: impl AsyncFnOnce() -> T) -> T {
     f().await
 }
 

--- a/tests/ui/async-await/async-closures/debuginfo-by-move-body.rs
+++ b/tests/ui/async-await/async-closures/debuginfo-by-move-body.rs
@@ -7,7 +7,7 @@
 
 extern crate block_on;
 
-async fn call_once(f: impl async FnOnce()) {
+async fn call_once(f: impl AsyncFnOnce()) {
     f().await;
 }
 

--- a/tests/ui/async-await/async-closures/drop.rs
+++ b/tests/ui/async-await/async-closures/drop.rs
@@ -16,7 +16,7 @@ impl Drop for DropMe {
     }
 }
 
-async fn call_once(f: impl async FnOnce()) {
+async fn call_once(f: impl AsyncFnOnce()) {
     println!("before call");
     let fut = Box::pin(f());
     println!("after call");

--- a/tests/ui/async-await/async-closures/fn-exception-target-features.rs
+++ b/tests/ui/async-await/async-closures/fn-exception-target-features.rs
@@ -10,7 +10,7 @@ use std::future::Future;
 #[target_feature(enable = "sse2")]
 fn target_feature()  -> Pin<Box<dyn Future<Output = ()> + 'static>> { todo!() }
 
-fn test(f: impl async Fn()) {}
+fn test(f: impl AsyncFn()) {}
 
 fn main() {
     test(target_feature); //~ ERROR the trait bound

--- a/tests/ui/async-await/async-closures/fn-exception-target-features.stderr
+++ b/tests/ui/async-await/async-closures/fn-exception-target-features.stderr
@@ -9,8 +9,8 @@ LL |     test(target_feature);
 note: required by a bound in `test`
   --> $DIR/fn-exception-target-features.rs:13:17
    |
-LL | fn test(f: impl async Fn()) {}
-   |                 ^^^^^^^^^^ required by this bound in `test`
+LL | fn test(f: impl AsyncFn()) {}
+   |                 ^^^^^^^^^ required by this bound in `test`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/async-closures/fn-exception.rs
+++ b/tests/ui/async-await/async-closures/fn-exception.rs
@@ -13,7 +13,7 @@ unsafe extern "C" {
     pub safe fn abi() -> Pin<Box<dyn Future<Output = ()> + 'static>>;
 }
 
-fn test(f: impl async Fn()) {}
+fn test(f: impl AsyncFn()) {}
 
 fn main() {
     test(unsafety); //~ ERROR the trait bound

--- a/tests/ui/async-await/async-closures/fn-exception.stderr
+++ b/tests/ui/async-await/async-closures/fn-exception.stderr
@@ -9,8 +9,8 @@ LL |     test(unsafety);
 note: required by a bound in `test`
   --> $DIR/fn-exception.rs:16:17
    |
-LL | fn test(f: impl async Fn()) {}
-   |                 ^^^^^^^^^^ required by this bound in `test`
+LL | fn test(f: impl AsyncFn()) {}
+   |                 ^^^^^^^^^ required by this bound in `test`
 
 error[E0277]: the trait bound `extern "C" fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {abi}: AsyncFn()` is not satisfied
   --> $DIR/fn-exception.rs:20:10
@@ -23,8 +23,8 @@ LL |     test(abi);
 note: required by a bound in `test`
   --> $DIR/fn-exception.rs:16:17
    |
-LL | fn test(f: impl async Fn()) {}
-   |                 ^^^^^^^^^^ required by this bound in `test`
+LL | fn test(f: impl AsyncFn()) {}
+   |                 ^^^^^^^^^ required by this bound in `test`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/async-await/async-closures/force-move-due-to-inferred-kind.rs
+++ b/tests/ui/async-await/async-closures/force-move-due-to-inferred-kind.rs
@@ -6,7 +6,7 @@
 
 extern crate block_on;
 
-fn force_fnonce<T: async FnOnce()>(t: T) -> T { t }
+fn force_fnonce<T: AsyncFnOnce()>(t: T) -> T { t }
 
 fn main() {
     block_on::block_on(async {

--- a/tests/ui/async-await/async-closures/foreign.rs
+++ b/tests/ui/async-await/async-closures/foreign.rs
@@ -12,7 +12,7 @@ extern crate foreign;
 
 struct NoCopy;
 
-async fn call_once(f: impl async FnOnce()) {
+async fn call_once(f: impl AsyncFnOnce()) {
     f().await;
 }
 

--- a/tests/ui/async-await/async-closures/implements-fnmut.rs
+++ b/tests/ui/async-await/async-closures/implements-fnmut.rs
@@ -1,7 +1,7 @@
 //@ build-pass
 //@ edition: 2021
 
-// Demonstrates that an async closure may implement `FnMut` (not just `async FnMut`!)
+// Demonstrates that an async closure may implement `FnMut` (not just `AsyncFnMut`!)
 // if it has no self-borrows. In this case, `&Ty` is not borrowed from the closure env,
 // since it's fine to reborrow it with its original lifetime. See the doc comment on
 // `should_reborrow_from_env_of_parent_coroutine_closure` for more detail for when we

--- a/tests/ui/async-await/async-closures/inline-body.rs
+++ b/tests/ui/async-await/async-closures/inline-body.rs
@@ -24,7 +24,7 @@ pub fn block_on<T>(fut: impl Future<Output = T>) -> T {
     }
 }
 
-async fn call_once<T>(f: impl async FnOnce() -> T) -> T {
+async fn call_once<T>(f: impl AsyncFnOnce() -> T) -> T {
     f().await
 }
 

--- a/tests/ui/async-await/async-closures/mangle.rs
+++ b/tests/ui/async-await/async-closures/mangle.rs
@@ -13,11 +13,11 @@ use std::future::Future;
 use std::pin::pin;
 use std::task::*;
 
-async fn call_mut(f: &mut impl async FnMut()) {
+async fn call_mut(f: &mut impl AsyncFnMut()) {
     f().await;
 }
 
-async fn call_once(f: impl async FnOnce()) {
+async fn call_once(f: impl AsyncFnOnce()) {
     f().await;
 }
 

--- a/tests/ui/async-await/async-closures/moro-example.rs
+++ b/tests/ui/async-await/async-closures/moro-example.rs
@@ -22,7 +22,7 @@ impl<'scope, 'env: 'scope> Scope<'scope, 'env> {
 
 fn scope_with_closure<'env, B>(_body: B) -> BoxFuture<'env, ()>
 where
-    for<'scope> B: async FnOnce(&'scope Scope<'scope, 'env>),
+    for<'scope> B: AsyncFnOnce(&'scope Scope<'scope, 'env>),
 {
     todo!()
 }

--- a/tests/ui/async-await/async-closures/move-is-async-fn.rs
+++ b/tests/ui/async-await/async-closures/move-is-async-fn.rs
@@ -19,7 +19,7 @@ fn main() {
         is_static(&c);
 
         // Check that `<{async fn} as AsyncFnOnce>::CallOnceFuture` owns its captures.
-        fn call_once<F: async FnOnce()>(f: F) -> F::CallOnceFuture { f() }
+        fn call_once<F: AsyncFnOnce()>(f: F) -> F::CallOnceFuture { f() }
         is_static(&call_once(c));
     });
 }

--- a/tests/ui/async-await/async-closures/mut-ref-reborrow.rs
+++ b/tests/ui/async-await/async-closures/mut-ref-reborrow.rs
@@ -9,7 +9,7 @@
 
 extern crate block_on;
 
-async fn call_once(f: impl async FnOnce()) { f().await; }
+async fn call_once(f: impl AsyncFnOnce()) { f().await; }
 
 pub async fn async_closure(x: &mut i32) {
     let c = async move || {

--- a/tests/ui/async-await/async-closures/no-borrow-from-env.rs
+++ b/tests/ui/async-await/async-closures/no-borrow-from-env.rs
@@ -5,7 +5,7 @@
 
 fn outlives<'a>(_: impl Sized + 'a) {}
 
-async fn call_once(f: impl async FnOnce()) {
+async fn call_once(f: impl AsyncFnOnce()) {
     f().await;
 }
 

--- a/tests/ui/async-await/async-closures/non-copy-arg-does-not-force-inner-move.rs
+++ b/tests/ui/async-await/async-closures/non-copy-arg-does-not-force-inner-move.rs
@@ -6,7 +6,7 @@
 
 extern crate block_on;
 
-fn wrapper(f: impl Fn(String)) -> impl async Fn(String) {
+fn wrapper(f: impl Fn(String)) -> impl AsyncFn(String) {
     async move |s| f(s)
 }
 

--- a/tests/ui/async-await/async-closures/overlapping-projs.rs
+++ b/tests/ui/async-await/async-closures/overlapping-projs.rs
@@ -7,7 +7,7 @@
 
 extern crate block_on;
 
-async fn call_once(f: impl async FnOnce()) {
+async fn call_once(f: impl AsyncFnOnce()) {
     f().await;
 }
 

--- a/tests/ui/async-await/async-closures/precise-captures.rs
+++ b/tests/ui/async-await/async-closures/precise-captures.rs
@@ -5,7 +5,7 @@
 //@ revisions: call call_once force_once
 
 // call - Call the closure regularly.
-// call_once - Call the closure w/ `async FnOnce`, so exercising the by_move shim.
+// call_once - Call the closure w/ `AsyncFnOnce`, so exercising the by_move shim.
 // force_once - Force the closure mode to `FnOnce`, so exercising what was fixed
 //   in <https://github.com/rust-lang/rust/pull/123350>.
 
@@ -20,7 +20,7 @@ macro_rules! call {
 }
 
 #[cfg(call_once)]
-async fn call_once(f: impl async FnOnce()) {
+async fn call_once(f: impl AsyncFnOnce()) {
     f().await
 }
 
@@ -35,7 +35,7 @@ macro_rules! guidance {
 }
 
 #[cfg(force_once)]
-fn infer_fnonce(c: impl async FnOnce()) -> impl async FnOnce() { c }
+fn infer_fnonce(c: impl AsyncFnOnce()) -> impl AsyncFnOnce() { c }
 
 #[cfg(force_once)]
 macro_rules! guidance {

--- a/tests/ui/async-await/async-closures/refd.rs
+++ b/tests/ui/async-await/async-closures/refd.rs
@@ -10,15 +10,15 @@ struct NoCopy;
 
 fn main() {
     block_on::block_on(async {
-        async fn call_once(x: impl async Fn()) { x().await }
+        async fn call_once(x: impl AsyncFn()) { x().await }
 
-        // check that `&{async-closure}` implements `async Fn`.
+        // check that `&{async-closure}` implements `AsyncFn`.
         call_once(&async || {}).await;
 
-        // check that `&{closure}` implements `async Fn`.
+        // check that `&{closure}` implements `AsyncFn`.
         call_once(&|| async {}).await;
 
-        // check that `&fndef` implements `async Fn`.
+        // check that `&fndef` implements `AsyncFn`.
         async fn foo() {}
         call_once(&foo).await;
     });

--- a/tests/ui/async-await/async-closures/signature-deduction.rs
+++ b/tests/ui/async-await/async-closures/signature-deduction.rs
@@ -3,7 +3,7 @@
 
 #![feature(async_closure)]
 
-async fn foo(x: impl async Fn(&str) -> &str) {}
+async fn foo(x: impl AsyncFn(&str) -> &str) {}
 
 fn main() {
     foo(async |x| x);

--- a/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.rs
+++ b/tests/ui/async-await/async-closures/without-precise-captures-we-are-powerless.rs
@@ -8,7 +8,7 @@
 
 fn outlives<'a>(_: impl Sized + 'a) {}
 
-async fn call_once(f: impl async FnOnce()) {
+async fn call_once(f: impl AsyncFnOnce()) {
     f().await;
 }
 

--- a/tests/ui/async-await/async-closures/wrong-fn-kind.rs
+++ b/tests/ui/async-await/async-closures/wrong-fn-kind.rs
@@ -2,7 +2,7 @@
 
 #![feature(async_closure)]
 
-fn needs_async_fn(_: impl async Fn()) {}
+fn needs_async_fn(_: impl AsyncFn()) {}
 
 fn a() {
     let mut x = 1;
@@ -15,7 +15,7 @@ fn a() {
 fn b() {
     let x = String::new();
     needs_async_fn(move || async move {
-        //~^ ERROR expected a closure that implements the `async Fn` trait, but this closure only implements `async FnOnce`
+        //~^ ERROR expected a closure that implements the `AsyncFn` trait, but this closure only implements `AsyncFnOnce`
         println!("{x}");
     });
 }

--- a/tests/ui/async-await/async-closures/wrong-fn-kind.stderr
+++ b/tests/ui/async-await/async-closures/wrong-fn-kind.stderr
@@ -1,29 +1,29 @@
-error[E0525]: expected a closure that implements the `async Fn` trait, but this closure only implements `async FnOnce`
+error[E0525]: expected a closure that implements the `AsyncFn` trait, but this closure only implements `AsyncFnOnce`
   --> $DIR/wrong-fn-kind.rs:17:20
    |
 LL |       needs_async_fn(move || async move {
    |       -------------- -^^^^^^
    |       |              |
-   |  _____|______________this closure implements `async FnOnce`, not `async Fn`
+   |  _____|______________this closure implements `AsyncFnOnce`, not `AsyncFn`
    | |     |
    | |     required by a bound introduced by this call
 LL | |
 LL | |         println!("{x}");
-   | |                    - closure is `async FnOnce` because it moves the variable `x` out of its environment
+   | |                    - closure is `AsyncFnOnce` because it moves the variable `x` out of its environment
 LL | |     });
-   | |_____- the requirement to implement `async Fn` derives from here
+   | |_____- the requirement to implement `AsyncFn` derives from here
    |
 note: required by a bound in `needs_async_fn`
   --> $DIR/wrong-fn-kind.rs:5:27
    |
-LL | fn needs_async_fn(_: impl async Fn()) {}
-   |                           ^^^^^^^^^^ required by this bound in `needs_async_fn`
+LL | fn needs_async_fn(_: impl AsyncFn()) {}
+   |                           ^^^^^^^^^ required by this bound in `needs_async_fn`
 
 error[E0596]: cannot borrow `x` as mutable, as it is a captured variable in a `Fn` closure
   --> $DIR/wrong-fn-kind.rs:9:20
    |
-LL | fn needs_async_fn(_: impl async Fn()) {}
-   |                      --------------- change this to accept `FnMut` instead of `Fn`
+LL | fn needs_async_fn(_: impl AsyncFn()) {}
+   |                      -------------- change this to accept `FnMut` instead of `Fn`
 ...
 LL |     needs_async_fn(async || {
    |     -------------- ^^^^^^^^

--- a/tests/ui/async-await/async-fn/dyn-pos.rs
+++ b/tests/ui/async-await/async-fn/dyn-pos.rs
@@ -2,7 +2,7 @@
 
 #![feature(async_closure)]
 
-fn foo(x: &dyn async Fn()) {}
+fn foo(x: &dyn AsyncFn()) {}
 //~^ ERROR the trait `AsyncFnMut` cannot be made into an object
 
 fn main() {}

--- a/tests/ui/async-await/async-fn/dyn-pos.stderr
+++ b/tests/ui/async-await/async-fn/dyn-pos.stderr
@@ -1,8 +1,8 @@
 error[E0038]: the trait `AsyncFnMut` cannot be made into an object
   --> $DIR/dyn-pos.rs:5:16
    |
-LL | fn foo(x: &dyn async Fn()) {}
-   |                ^^^^^^^^^^ `AsyncFnMut` cannot be made into an object
+LL | fn foo(x: &dyn AsyncFn()) {}
+   |                ^^^^^^^^^ `AsyncFnMut` cannot be made into an object
    |
 note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/ops/async_function.rs:LL:COL

--- a/tests/ui/async-await/async-fn/edition-2015.rs
+++ b/tests/ui/async-await/async-fn/edition-2015.rs
@@ -1,8 +1,8 @@
 fn foo(x: impl async Fn()) -> impl async Fn() { x }
 //~^ ERROR `async` trait bounds are only allowed in Rust 2018 or later
 //~| ERROR `async` trait bounds are only allowed in Rust 2018 or later
-//~| ERROR async closures are unstable
-//~| ERROR async closures are unstable
+//~| ERROR `async` trait bounds are unstable
+//~| ERROR `async` trait bounds are unstable
 //~| ERROR use of unstable library feature `async_closure`
 //~| ERROR use of unstable library feature `async_closure`
 

--- a/tests/ui/async-await/async-fn/edition-2015.stderr
+++ b/tests/ui/async-await/async-fn/edition-2015.stderr
@@ -16,27 +16,27 @@ LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
-error[E0658]: async closures are unstable
+error[E0658]: `async` trait bounds are unstable
   --> $DIR/edition-2015.rs:1:16
    |
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    |                ^^^^^
    |
    = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
-   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+   = help: add `#![feature(async_trait_bounds)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: to use an async block, remove the `||`: `async {`
+   = help: use the desugared name of the async trait, such as `AsyncFn`
 
-error[E0658]: async closures are unstable
+error[E0658]: `async` trait bounds are unstable
   --> $DIR/edition-2015.rs:1:36
    |
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    |                                    ^^^^^
    |
    = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
-   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+   = help: add `#![feature(async_trait_bounds)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: to use an async block, remove the `||`: `async {`
+   = help: use the desugared name of the async trait, such as `AsyncFn`
 
 error[E0658]: use of unstable library feature `async_closure`
   --> $DIR/edition-2015.rs:1:42

--- a/tests/ui/async-await/async-fn/higher-ranked-async-fn.rs
+++ b/tests/ui/async-await/async-fn/higher-ranked-async-fn.rs
@@ -15,7 +15,7 @@ async fn f(arg: &i32) {}
 
 async fn func<F>(f: F)
 where
-    F: for<'a> async Fn(&'a i32),
+    F: for<'a> AsyncFn(&'a i32),
 {
     let x: i32 = 0;
     f(&x).await;

--- a/tests/ui/async-await/async-fn/impl-trait.rs
+++ b/tests/ui/async-await/async-fn/impl-trait.rs
@@ -3,13 +3,13 @@
 
 #![feature(async_closure, type_alias_impl_trait)]
 
-type Tait = impl async Fn();
+type Tait = impl AsyncFn();
 fn tait() -> Tait {
     || async {}
 }
 
-fn foo(x: impl async Fn()) -> impl async Fn() { x }
+fn foo(x: impl AsyncFn()) -> impl AsyncFn() { x }
 
-fn param<T: async Fn()>() {}
+fn param<T: AsyncFn()>() {}
 
 fn main() {}

--- a/tests/ui/async-await/async-fn/mbe-async-trait-bound-theoretical-regression.rs
+++ b/tests/ui/async-await/async-fn/mbe-async-trait-bound-theoretical-regression.rs
@@ -13,9 +13,9 @@ macro_rules! demo {
 }
 
 demo! { impl async Trait }
-//~^ ERROR async closures are unstable
+//~^ ERROR `async` trait bounds are unstable
 
 demo! { dyn async Trait }
-//~^ ERROR async closures are unstable
+//~^ ERROR `async` trait bounds are unstable
 
 fn main() {}

--- a/tests/ui/async-await/async-fn/mbe-async-trait-bound-theoretical-regression.stderr
+++ b/tests/ui/async-await/async-fn/mbe-async-trait-bound-theoretical-regression.stderr
@@ -20,27 +20,27 @@ LL | demo! { dyn async Trait }
    |
    = note: this error originates in the macro `demo` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0658]: async closures are unstable
+error[E0658]: `async` trait bounds are unstable
   --> $DIR/mbe-async-trait-bound-theoretical-regression.rs:15:14
    |
 LL | demo! { impl async Trait }
    |              ^^^^^
    |
    = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
-   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+   = help: add `#![feature(async_trait_bounds)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: to use an async block, remove the `||`: `async {`
+   = help: use the desugared name of the async trait, such as `AsyncFn`
 
-error[E0658]: async closures are unstable
+error[E0658]: `async` trait bounds are unstable
   --> $DIR/mbe-async-trait-bound-theoretical-regression.rs:18:13
    |
 LL | demo! { dyn async Trait }
    |             ^^^^^
    |
    = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
-   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+   = help: add `#![feature(async_trait_bounds)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: to use an async block, remove the `||`: `async {`
+   = help: use the desugared name of the async trait, such as `AsyncFn`
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/async-await/async-fn/not-a-trait.rs
+++ b/tests/ui/async-await/async-fn/not-a-trait.rs
@@ -1,6 +1,6 @@
 //@ edition:2018
 
-#![feature(async_closure)]
+#![feature(async_trait_bounds)]
 
 struct S;
 

--- a/tests/ui/async-await/async-fn/project.rs
+++ b/tests/ui/async-await/async-fn/project.rs
@@ -6,7 +6,9 @@
 
 #![feature(async_closure, unboxed_closures, async_fn_traits)]
 
-fn project<F: async Fn<()>>(_: F) -> Option<F::Output> { None }
+use std::ops::AsyncFn;
+
+fn project<F: AsyncFn<()>>(_: F) -> Option<F::Output> { None }
 
 fn main() {
     let x: Option<i32> = project(|| async { 1i32 });

--- a/tests/ui/async-await/async-fn/sugar.rs
+++ b/tests/ui/async-await/async-fn/sugar.rs
@@ -1,7 +1,7 @@
 //@ edition: 2021
 //@ check-pass
 
-#![feature(async_closure)]
+#![feature(async_closure, async_trait_bounds)]
 
 async fn foo() {}
 

--- a/tests/ui/async-await/async-fn/trait-bounds-in-macro.rs
+++ b/tests/ui/async-await/async-fn/trait-bounds-in-macro.rs
@@ -6,7 +6,7 @@ macro_rules! x {
 
 x! {
     async fn foo() -> impl async Fn() { }
-    //~^ ERROR async closures are unstable
+    //~^ ERROR `async` trait bounds are unstable
 }
 
 fn main() {}

--- a/tests/ui/async-await/async-fn/trait-bounds-in-macro.stderr
+++ b/tests/ui/async-await/async-fn/trait-bounds-in-macro.stderr
@@ -1,13 +1,13 @@
-error[E0658]: async closures are unstable
+error[E0658]: `async` trait bounds are unstable
   --> $DIR/trait-bounds-in-macro.rs:8:28
    |
 LL |     async fn foo() -> impl async Fn() { }
    |                            ^^^^^
    |
    = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
-   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+   = help: add `#![feature(async_trait_bounds)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: to use an async block, remove the `||`: `async {`
+   = help: use the desugared name of the async trait, such as `AsyncFn`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/async-fn/wrong-trait.rs
+++ b/tests/ui/async-await/async-fn/wrong-trait.rs
@@ -1,6 +1,6 @@
 //@ edition:2018
 
-#![feature(async_closure)]
+#![feature(async_trait_bounds)]
 
 trait Foo {}
 

--- a/tests/ui/feature-gates/feature-gate-async-trait-bounds.rs
+++ b/tests/ui/feature-gates/feature-gate-async-trait-bounds.rs
@@ -1,0 +1,7 @@
+//@ edition: 2021
+
+fn test(_: impl async Fn()) {}
+//~^ ERROR `async` trait bounds are unstable
+//~| ERROR use of unstable library feature `async_closure`
+
+fn main() {}

--- a/tests/ui/feature-gates/feature-gate-async-trait-bounds.stderr
+++ b/tests/ui/feature-gates/feature-gate-async-trait-bounds.stderr
@@ -1,0 +1,24 @@
+error[E0658]: `async` trait bounds are unstable
+  --> $DIR/feature-gate-async-trait-bounds.rs:3:17
+   |
+LL | fn test(_: impl async Fn()) {}
+   |                 ^^^^^
+   |
+   = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
+   = help: add `#![feature(async_trait_bounds)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: use the desugared name of the async trait, such as `AsyncFn`
+
+error[E0658]: use of unstable library feature `async_closure`
+  --> $DIR/feature-gate-async-trait-bounds.rs:3:23
+   |
+LL | fn test(_: impl async Fn()) {}
+   |                       ^^^^
+   |
+   = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
+   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/impl-trait/precise-capturing/bound-modifiers.rs
+++ b/tests/ui/impl-trait/precise-capturing/bound-modifiers.rs
@@ -7,7 +7,7 @@ fn polarity() -> impl Sized + ?use<> {}
 fn asyncness() -> impl Sized + async use<> {}
 //~^ ERROR expected identifier, found keyword `use`
 //~| ERROR cannot find trait `r#use` in this scope
-//~| ERROR async closures are unstable
+//~| ERROR `async` trait bounds are unstable
 
 fn constness() -> impl Sized + const use<> {}
 //~^ ERROR expected identifier, found keyword `use`

--- a/tests/ui/impl-trait/precise-capturing/bound-modifiers.stderr
+++ b/tests/ui/impl-trait/precise-capturing/bound-modifiers.stderr
@@ -46,16 +46,16 @@ error[E0405]: cannot find trait `r#use` in this scope
 LL | fn binder() -> impl Sized + for<'a> use<> {}
    |                                     ^^^ not found in this scope
 
-error[E0658]: async closures are unstable
+error[E0658]: `async` trait bounds are unstable
   --> $DIR/bound-modifiers.rs:7:32
    |
 LL | fn asyncness() -> impl Sized + async use<> {}
    |                                ^^^^^
    |
    = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
-   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+   = help: add `#![feature(async_trait_bounds)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: to use an async block, remove the `||`: `async {`
+   = help: use the desugared name of the async trait, such as `AsyncFn`
 
 error[E0658]: const trait impls are experimental
   --> $DIR/bound-modifiers.rs:12:32

--- a/tests/ui/parser/bad-recover-kw-after-impl.rs
+++ b/tests/ui/parser/bad-recover-kw-after-impl.rs
@@ -12,6 +12,6 @@ macro_rules! impl_primitive {
 
 impl_primitive!(impl async);
 //~^ ERROR expected identifier, found `<eof>`
-//~| ERROR async closures are unstable
+//~| ERROR `async` trait bounds are unstable
 
 fn main() {}

--- a/tests/ui/parser/bad-recover-kw-after-impl.stderr
+++ b/tests/ui/parser/bad-recover-kw-after-impl.stderr
@@ -7,16 +7,16 @@ LL |     ($ty:ty) => {
 LL | impl_primitive!(impl async);
    |                      ^^^^^ expected identifier
 
-error[E0658]: async closures are unstable
+error[E0658]: `async` trait bounds are unstable
   --> $DIR/bad-recover-kw-after-impl.rs:13:22
    |
 LL | impl_primitive!(impl async);
    |                      ^^^^^
    |
    = note: see issue #62290 <https://github.com/rust-lang/rust/issues/62290> for more information
-   = help: add `#![feature(async_closure)]` to the crate attributes to enable
+   = help: add `#![feature(async_trait_bounds)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-   = help: to use an async block, remove the `||`: `async {`
+   = help: use the desugared name of the async trait, such as `AsyncFn`
 
 error: aborting due to 2 previous errors
 


### PR DESCRIPTION
This PR moves `async Fn()` trait bounds into a new feature gate: `feature(async_trait_bounds)`. The general vibe is that we will most likely stabilize the `feature(async_closure)` *without* the `async Fn()` trait bound modifier, so we need to gate that separately. 

We're trying to work on the general vision of `async` trait bound modifier general in: https://github.com/rust-lang/rfcs/pull/3710, however that RFC still needs more time for consensus to converge, and we've decided that the value that users get from calling the bound `async Fn()` is *not really* worth blocking landing async closures in general.