### PR TITLE
Fix an extra newline in rendered std doc

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -32,14 +32,12 @@
 //!
 //! Once you are familiar with the contents of the standard library you may
 //! begin to find the verbosity of the prose distracting. At this stage in your
-//! development you may want to press the <code>
-//! <svg style="width:0.75rem;height:0.75rem" viewBox="0 0 12 12"
-//! stroke="currentColor" fill="none">
-//! <path d="M2,2l4,4l4,-4M2,6l4,4l4,-4"/></svg> Summary</code> button near the
-//! top of the page to collapse it into a more skimmable view.
+//! development you may want to press the
+//! "<svg style="width:0.75rem;height:0.75rem" viewBox="0 0 12 12" stroke="currentColor" fill="none"><path d="M2,2l4,4l4,-4M2,6l4,4l4,-4"/></svg>&nbsp;Summary"
+//! button near the top of the page to collapse it into a more skimmable view.
 //!
 //! While you are looking at the top of the page, also notice the
-//! <code>source</code> link. Rust's API documentation comes with the source
+//! "Source" link. Rust's API documentation comes with the source
 //! code and you are encouraged to read it. The standard library source is
 //! generally high quality and a peek behind the curtains is
 //! often enlightening.


### PR DESCRIPTION
Fixes #132564

![17308581942254367500907812250579](https://github.com/user-attachments/assets/9e946c49-c0a6-40ba-ab69-b80fe0e085e1)
(taken from the issue above)

The problem with the formatting is due to that newline between `<code>` and `<svg>`. Any newlines outside of the code (i.e., within elements inside of it) are fine.