### PR TITLE
bootstrap: add quoting support to avoid splitting

### DIFF
--- a/src/bootstrap/configure.py
+++ b/src/bootstrap/configure.py
@@ -3,6 +3,7 @@
 # ignore-tidy-linelength
 
 from __future__ import absolute_import, division, print_function
+import shlex
 import sys
 import os
 rust_dir = os.path.dirname(os.path.abspath(__file__))
@@ -288,8 +289,9 @@ def build(known_args):
 
 def set(key, value, config):
     if isinstance(value, list):
-        # Remove empty values, which value.split(',') tends to generate.
-        value = [v for v in value if v]
+        # Remove empty values, which value.split(',') tends to generate and
+        # replace single quotes for double quotes to ensure correct parsing.
+        value = [v.replace('\'', '"') for v in value if v]
 
     s = "{:20} := {}".format(key, value)
     if len(s) < 70 or VERBOSE:
@@ -298,7 +300,13 @@ def set(key, value, config):
         p(s[:70] + " ...")
 
     arr = config
-    parts = key.split('.')
+
+    # Split `key` on periods using shell semantics.
+    lexer = shlex.shlex(key, posix=True)
+    lexer.whitespace = "."
+    lexer.wordchars += "-"
+    parts = list(lexer)
+
     for i, part in enumerate(parts):
         if i == len(parts) - 1:
             if is_value_list(part) and isinstance(value, str):


### PR DESCRIPTION
With this change, it is now possible to pass quotes to the configure script, such as

`./configure.py --set=target.\"thumbv8m.main-none-eabi\".linker=/linker`
or
`./configure.py '--set=target."thumbv8m.main-none-eabi".linker=/linker'`

, which will treat `thumbv8.main-none-eabi` as a whole part. Currently, the string would be split into two elements: `thumbv8`, and `main-none-eabi`.

The approach taken is to perform custom splitting instead of using `str.split()` and then repairing the split. Also, There are numerous corner cases not handled: the custom split doesn't differentiate between single quotes or double quotes, so it is perfectly possible to pass `./configure.py --set=target.\"thumbv8m.main-none-eabi\'.linker=/linker` and the behaviour would be the same as with all double quotes or single quotes.

As for the code, i'm unsure on whether to delimit strings with double or single quotes. I've seen both single quotes and double quotes used to delimit strings, like in 
```py
err("Option '{}' provided more than once".format(key))
```
and this a handful of lines down:
```py
if option.name == 'sccache':
    set('llvm.ccache', 'sccache', config)
```
Please advise on the wanted one.

Fixes #130602

r? @onur-ozkan

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Thanks in advance for the feedback!