### PR TITLE
Do not filter empty lint passes & re-do CTFE pass

### DIFF
--- a/compiler/rustc_lint/src/late.rs
+++ b/compiler/rustc_lint/src/late.rs
@@ -422,6 +422,9 @@ fn late_lint_crate<'tcx>(tcx: TyCtxt<'tcx>) {
         .into_iter()
         .filter(|pass| {
             let lints = (**pass).get_lints();
+            // Lintless passes are always in
+            lints.is_empty() ||
+            // If the pass doesn't have a single needed lint, omit it
             !lints.iter().all(|lint| lints_that_dont_need_to_run.contains(&LintId::of(lint)))
         })
         .collect();

--- a/src/tools/clippy/clippy_lints/src/ctfe.rs
+++ b/src/tools/clippy/clippy_lints/src/ctfe.rs
@@ -1,29 +1,16 @@
 use rustc_hir::def_id::LocalDefId;
 use rustc_hir::intravisit::FnKind;
 use rustc_hir::{Body, FnDecl};
-use rustc_lint::Level::Deny;
-use rustc_lint::{LateContext, LateLintPass, Lint};
+use rustc_lint::{LateContext, LateLintPass};
 use rustc_session::declare_lint_pass;
 use rustc_span::Span;
 
-/// Ensures that Constant-time Function Evaluation is being done (specifically, MIR lint passes).
-/// As Clippy deactivates codegen, this lint ensures that CTFE (used in hard errors) is still ran.
-pub static CLIPPY_CTFE: &Lint = &Lint {
-    name: &"clippy::CLIPPY_CTFE",
-    default_level: Deny,
-    desc: "Ensure CTFE is being made",
-    edition_lint_opts: None,
-    report_in_external_macro: true,
-    future_incompatible: None,
-    is_externally_loaded: true,
-    crate_level_only: false,
-    eval_always: true,
-    ..Lint::default_fields_for_macro()
-};
 
-// No static CLIPPY_CTFE_INFO because we want this lint to be invisible
-
-declare_lint_pass! { ClippyCtfe => [CLIPPY_CTFE] }
+declare_lint_pass! {
+    /// Ensures that Constant-time Function Evaluation is being done (specifically, MIR lint passes).
+    /// As Clippy deactivates codegen, this lint ensures that CTFE (used in hard errors) is still ran.
+    ClippyCtfe => []
+}
 
 impl<'tcx> LateLintPass<'tcx> for ClippyCtfe {
     fn check_fn(


### PR DESCRIPTION
Some structs implement `LintPass` without having a `Lint` associated with them #125116 broke that behaviour by filtering them out. This PR ensures that lintless passes are not filtered out. 