### PR TITLE
Liberate `aarch64-gnu-debug` from the shackles of `--test-args=clang`

### DIFF
--- a/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
+++ b/src/ci/docker/host-aarch64/aarch64-gnu-debug/Dockerfile
@@ -55,4 +55,4 @@ ENV RUST_CONFIGURE_ARGS \
 
 ENV SCRIPT \
   python3 ../x.py --stage 2 build && \
-  python3 ../x.py --stage 2 test tests/run-make --test-args clang
+  python3 ../x.py --stage 2 test tests/run-make

--- a/src/tools/run-make-support/src/external_deps/c_build.rs
+++ b/src/tools/run-make-support/src/external_deps/c_build.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::artifact_names::{dynamic_lib_name, static_lib_name};
-use crate::external_deps::cc::{cc, cxx};
+use crate::external_deps::c_cxx_compiler::{cc, cxx};
 use crate::external_deps::llvm::llvm_ar;
 use crate::path_helpers::path;
 use crate::targets::{is_darwin, is_msvc, is_windows};

--- a/src/tools/run-make-support/src/external_deps/c_cxx_compiler/cc.rs
+++ b/src/tools/run-make-support/src/external_deps/c_cxx_compiler/cc.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use crate::command::Command;
-use crate::{env_var, is_msvc, is_windows, uname};
+use crate::{env_var, is_msvc};
 
 /// Construct a new platform-specific C compiler invocation.
 ///
@@ -125,101 +125,5 @@ impl Cc {
             self.cmd.arg("-O3");
         }
         self
-    }
-}
-
-/// `EXTRACFLAGS`
-pub fn extra_c_flags() -> Vec<&'static str> {
-    // Adapted from tools.mk (trimmed):
-    //
-    // ```makefile
-    // ifdef IS_WINDOWS
-    //     ifdef IS_MSVC
-    //         EXTRACFLAGS := ws2_32.lib userenv.lib advapi32.lib bcrypt.lib ntdll.lib synchronization.lib
-    //     else
-    //         EXTRACFLAGS := -lws2_32 -luserenv -lbcrypt -lntdll -lsynchronization
-    //     endif
-    // else
-    //     ifeq ($(UNAME),Darwin)
-    //         EXTRACFLAGS := -lresolv
-    //     else
-    //         ifeq ($(UNAME),FreeBSD)
-    //             EXTRACFLAGS := -lm -lpthread -lgcc_s
-    //         else
-    //             ifeq ($(UNAME),SunOS)
-    //                 EXTRACFLAGS := -lm -lpthread -lposix4 -lsocket -lresolv
-    //             else
-    //                 ifeq ($(UNAME),OpenBSD)
-    //                     EXTRACFLAGS := -lm -lpthread -lc++abi
-    //                 else
-    //                     EXTRACFLAGS := -lm -lrt -ldl -lpthread
-    //                 endif
-    //             endif
-    //         endif
-    //     endif
-    // endif
-    // ```
-
-    if is_windows() {
-        if is_msvc() {
-            vec![
-                "ws2_32.lib",
-                "userenv.lib",
-                "advapi32.lib",
-                "bcrypt.lib",
-                "ntdll.lib",
-                "synchronization.lib",
-            ]
-        } else {
-            vec!["-lws2_32", "-luserenv", "-lbcrypt", "-lntdll", "-lsynchronization"]
-        }
-    } else {
-        match uname() {
-            n if n.contains("Darwin") => vec!["-lresolv"],
-            n if n.contains("FreeBSD") => vec!["-lm", "-lpthread", "-lgcc_s"],
-            n if n.contains("SunOS") => {
-                vec!["-lm", "-lpthread", "-lposix4", "-lsocket", "-lresolv"]
-            }
-            n if n.contains("OpenBSD") => vec!["-lm", "-lpthread", "-lc++abi"],
-            _ => vec!["-lm", "-lrt", "-ldl", "-lpthread"],
-        }
-    }
-}
-
-/// `EXTRACXXFLAGS`
-pub fn extra_cxx_flags() -> Vec<&'static str> {
-    // Adapted from tools.mk (trimmed):
-    //
-    // ```makefile
-    // ifdef IS_WINDOWS
-    //     ifdef IS_MSVC
-    //     else
-    //         EXTRACXXFLAGS := -lstdc++
-    //     endif
-    // else
-    //     ifeq ($(UNAME),Darwin)
-    //         EXTRACXXFLAGS := -lc++
-    //     else
-    //         ifeq ($(UNAME),FreeBSD)
-    //         else
-    //             ifeq ($(UNAME),SunOS)
-    //             else
-    //                 ifeq ($(UNAME),OpenBSD)
-    //                 else
-    //                     EXTRACXXFLAGS := -lstdc++
-    //                 endif
-    //             endif
-    //         endif
-    //     endif
-    // endif
-    // ```
-    if is_windows() {
-        if is_msvc() { vec![] } else { vec!["-lstdc++"] }
-    } else {
-        match &uname()[..] {
-            "Darwin" => vec!["-lc++"],
-            "FreeBSD" | "SunOS" | "OpenBSD" => vec![],
-            _ => vec!["-lstdc++"],
-        }
     }
 }

--- a/src/tools/run-make-support/src/external_deps/c_cxx_compiler/extras.rs
+++ b/src/tools/run-make-support/src/external_deps/c_cxx_compiler/extras.rs
@@ -1,0 +1,97 @@
+use crate::{is_msvc, is_windows, uname};
+
+/// `EXTRACFLAGS`
+pub fn extra_c_flags() -> Vec<&'static str> {
+    // Adapted from tools.mk (trimmed):
+    //
+    // ```makefile
+    // ifdef IS_WINDOWS
+    //     ifdef IS_MSVC
+    //         EXTRACFLAGS := ws2_32.lib userenv.lib advapi32.lib bcrypt.lib ntdll.lib synchronization.lib
+    //     else
+    //         EXTRACFLAGS := -lws2_32 -luserenv -lbcrypt -lntdll -lsynchronization
+    //     endif
+    // else
+    //     ifeq ($(UNAME),Darwin)
+    //         EXTRACFLAGS := -lresolv
+    //     else
+    //         ifeq ($(UNAME),FreeBSD)
+    //             EXTRACFLAGS := -lm -lpthread -lgcc_s
+    //         else
+    //             ifeq ($(UNAME),SunOS)
+    //                 EXTRACFLAGS := -lm -lpthread -lposix4 -lsocket -lresolv
+    //             else
+    //                 ifeq ($(UNAME),OpenBSD)
+    //                     EXTRACFLAGS := -lm -lpthread -lc++abi
+    //                 else
+    //                     EXTRACFLAGS := -lm -lrt -ldl -lpthread
+    //                 endif
+    //             endif
+    //         endif
+    //     endif
+    // endif
+    // ```
+
+    if is_windows() {
+        if is_msvc() {
+            vec![
+                "ws2_32.lib",
+                "userenv.lib",
+                "advapi32.lib",
+                "bcrypt.lib",
+                "ntdll.lib",
+                "synchronization.lib",
+            ]
+        } else {
+            vec!["-lws2_32", "-luserenv", "-lbcrypt", "-lntdll", "-lsynchronization"]
+        }
+    } else {
+        match uname() {
+            n if n.contains("Darwin") => vec!["-lresolv"],
+            n if n.contains("FreeBSD") => vec!["-lm", "-lpthread", "-lgcc_s"],
+            n if n.contains("SunOS") => {
+                vec!["-lm", "-lpthread", "-lposix4", "-lsocket", "-lresolv"]
+            }
+            n if n.contains("OpenBSD") => vec!["-lm", "-lpthread", "-lc++abi"],
+            _ => vec!["-lm", "-lrt", "-ldl", "-lpthread"],
+        }
+    }
+}
+
+/// `EXTRACXXFLAGS`
+pub fn extra_cxx_flags() -> Vec<&'static str> {
+    // Adapted from tools.mk (trimmed):
+    //
+    // ```makefile
+    // ifdef IS_WINDOWS
+    //     ifdef IS_MSVC
+    //     else
+    //         EXTRACXXFLAGS := -lstdc++
+    //     endif
+    // else
+    //     ifeq ($(UNAME),Darwin)
+    //         EXTRACXXFLAGS := -lc++
+    //     else
+    //         ifeq ($(UNAME),FreeBSD)
+    //         else
+    //             ifeq ($(UNAME),SunOS)
+    //             else
+    //                 ifeq ($(UNAME),OpenBSD)
+    //                 else
+    //                     EXTRACXXFLAGS := -lstdc++
+    //                 endif
+    //             endif
+    //         endif
+    //     endif
+    // endif
+    // ```
+    if is_windows() {
+        if is_msvc() { vec![] } else { vec!["-lstdc++"] }
+    } else {
+        match &uname()[..] {
+            "Darwin" => vec!["-lc++"],
+            "FreeBSD" | "SunOS" | "OpenBSD" => vec![],
+            _ => vec!["-lstdc++"],
+        }
+    }
+}

--- a/src/tools/run-make-support/src/external_deps/c_cxx_compiler/gcc.rs
+++ b/src/tools/run-make-support/src/external_deps/c_cxx_compiler/gcc.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 
 use crate::command::Command;
-use crate::env_var;
 
 /// Construct a gcc invocation.
 ///
@@ -23,15 +22,11 @@ crate::macros::impl_common_helpers!(Gcc);
 impl Gcc {
     /// Construct a `gcc` invocation. This assumes that *a* suitable `gcc` is available in the
     /// environment.
+    ///
+    /// Note that this does **not** prepopulate the `gcc` invocation with `CC_DEFAULT_FLAGS`.
     #[track_caller]
     pub fn new() -> Self {
-        let mut cmd = Command::new("gcc");
-
-        let default_cflags = env_var("CC_DEFAULT_FLAGS");
-        for flag in default_cflags.split(char::is_whitespace) {
-            cmd.arg(flag);
-        }
-
+        let cmd = Command::new("gcc");
         Self { cmd }
     }
 

--- a/src/tools/run-make-support/src/external_deps/c_cxx_compiler/gcc.rs
+++ b/src/tools/run-make-support/src/external_deps/c_cxx_compiler/gcc.rs
@@ -1,0 +1,71 @@
+use std::path::Path;
+
+use crate::command::Command;
+use crate::env_var;
+
+/// Construct a gcc invocation.
+///
+/// WARNING: This assumes *a* `gcc` exists in the environment and is suitable for use.
+#[track_caller]
+pub fn gcc() -> Gcc {
+    Gcc::new()
+}
+
+/// A specific `gcc`.
+#[derive(Debug)]
+#[must_use]
+pub struct Gcc {
+    cmd: Command,
+}
+
+crate::macros::impl_common_helpers!(Gcc);
+
+impl Gcc {
+    /// Construct a `gcc` invocation. This assumes that *a* suitable `gcc` is available in the
+    /// environment.
+    #[track_caller]
+    pub fn new() -> Self {
+        let mut cmd = Command::new("gcc");
+
+        let default_cflags = env_var("CC_DEFAULT_FLAGS");
+        for flag in default_cflags.split(char::is_whitespace) {
+            cmd.arg(flag);
+        }
+
+        Self { cmd }
+    }
+
+    /// Specify path of the input file.
+    pub fn input<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+        self.cmd.arg(path.as_ref());
+        self
+    }
+
+    /// Adds directories to the list that the linker searches for libraries.
+    /// Equivalent to `-L`.
+    pub fn library_search_path<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+        self.cmd.arg("-L");
+        self.cmd.arg(path.as_ref());
+        self
+    }
+
+    /// Specify `-o`.
+    pub fn out_exe(&mut self, name: &str) -> &mut Self {
+        self.cmd.arg("-o");
+        self.cmd.arg(name);
+        self
+    }
+
+    /// Specify path of the output binary.
+    pub fn output<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+        self.cmd.arg("-o");
+        self.cmd.arg(path.as_ref());
+        self
+    }
+
+    /// Optimize the output at `-O3`.
+    pub fn optimize(&mut self) -> &mut Self {
+        self.cmd.arg("-O3");
+        self
+    }
+}

--- a/src/tools/run-make-support/src/external_deps/c_cxx_compiler/mod.rs
+++ b/src/tools/run-make-support/src/external_deps/c_cxx_compiler/mod.rs
@@ -1,0 +1,7 @@
+mod cc;
+mod extras;
+mod gcc;
+
+pub use cc::*;
+pub use extras::*;
+pub use gcc::*;

--- a/src/tools/run-make-support/src/external_deps/mod.rs
+++ b/src/tools/run-make-support/src/external_deps/mod.rs
@@ -2,8 +2,8 @@
 //! such as `cc` or `python`.
 
 pub mod c_build;
+pub mod c_cxx_compiler;
 pub mod cargo;
-pub mod cc;
 pub mod clang;
 pub mod htmldocck;
 pub mod llvm;

--- a/src/tools/run-make-support/src/lib.rs
+++ b/src/tools/run-make-support/src/lib.rs
@@ -46,10 +46,10 @@ pub use wasmparser;
 // tidy-alphabetical-end
 
 // Re-exports of external dependencies.
-pub use external_deps::{c_build, cc, clang, htmldocck, llvm, python, rustc, rustdoc};
+pub use external_deps::{c_build, c_cxx_compiler, clang, htmldocck, llvm, python, rustc, rustdoc};
 
 // These rely on external dependencies.
-pub use cc::{cc, cxx, extra_c_flags, extra_cxx_flags, Cc};
+pub use c_cxx_compiler::{Cc, Gcc, cc, cxx, extra_c_flags, extra_cxx_flags, gcc};
 pub use c_build::{
     build_native_dynamic_lib, build_native_static_lib, build_native_static_lib_cxx,
     build_native_static_lib_optimized,

--- a/tests/run-make/mte-ffi/rmake.rs
+++ b/tests/run-make/mte-ffi/rmake.rs
@@ -1,14 +1,12 @@
-// Tests that MTE tags and values stored in the top byte of a pointer (TBI) are
-// preserved across FFI boundaries (C <-> Rust).
-// This test does not require MTE: whilst the test will use MTE if available, if it is not,
-// arbitrary tag bits are set using TBI.
+//! Tests that MTE tags and values stored in the top byte of a pointer (TBI) are preserved across
+//! FFI boundaries (C <-> Rust). This test does not require MTE: whilst the test will use MTE if
+//! available, if it is not, arbitrary tag bits are set using TBI.
 
-// This test is only valid for AArch64.
-// The linker must be explicitly specified when cross-compiling, so it is limited to
-// `aarch64-unknown-linux-gnu`.
 //@ only-aarch64-unknown-linux-gnu
+// Reason: this test is only valid for AArch64 with `gcc`. The linker must be explicitly specified
+// when cross-compiling, so it is limited to `aarch64-unknown-linux-gnu`.
 
-use run_make_support::{cc, dynamic_lib_name, extra_c_flags, run, rustc, target};
+use run_make_support::{dynamic_lib_name, extra_c_flags, gcc, run, rustc, target};
 
 fn main() {
     run_test("int");
@@ -29,7 +27,8 @@ fn run_test(variant: &str) {
         .target(target())
         .linker("aarch64-linux-gnu-gcc")
         .run();
-    cc().input(format!("bar_{variant}.c"))
+    gcc()
+        .input(format!("bar_{variant}.c"))
         .input(dynamic_lib_name("foo"))
         .out_exe("test")
         .args(&flags)


### PR DESCRIPTION
### Changes

- Drop `--test-args=clang` from `aarch64-gnu-debug` so run-make tests that are `//@ needs-force-clang-based-tests` no longer only run if their test name contains `clang` (which is a very cool footgun).
- Reorganize run-make-suport library slightly to accommodate a raw gcc invocation.
- Fix `tests/run-make/mte-ffi/rmake.rs` to use `gcc` instead of *a* c compiler.


try-job: aarch64-gnu
try-job: aarch64-gnu-debug