### PR TITLE
Remove attributes from generics in built-in derive macros

### DIFF
--- a/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
+++ b/compiler/rustc_builtin_macros/src/deriving/generic/mod.rs
@@ -680,6 +680,12 @@ impl<'a> TraitDef<'a> {
                     param_clone
                 }
             })
+            .map(|mut param| {
+                // Remove all attributes, because there might be helper attributes
+                // from other macros that will not be valid in the expanded implementation.
+                param.attrs.clear();
+                param
+            })
             .collect();
 
         // and similarly for where clauses

--- a/tests/ui/proc-macro/auxiliary/helper-attr.rs
+++ b/tests/ui/proc-macro/auxiliary/helper-attr.rs
@@ -1,0 +1,12 @@
+//@ force-host
+//@ no-prefer-dynamic
+
+#![crate_type = "proc-macro"]
+
+extern crate proc_macro;
+
+// Doesn't do anything, but has a helper attribute.
+#[proc_macro_derive(WithHelperAttr, attributes(x))]
+pub fn derive(_input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    proc_macro::TokenStream::new()
+}

--- a/tests/ui/proc-macro/helper-attr-builtin-derive.rs
+++ b/tests/ui/proc-macro/helper-attr-builtin-derive.rs
@@ -1,0 +1,19 @@
+// This test checks that helper attributes of a derive proc macro can be used together with
+// other built-in derive macros.
+// issue: rust-lang/rust#132561
+//@ check-pass
+//@ aux-build:helper-attr.rs
+//@ edition:2021
+
+#[macro_use]
+extern crate helper_attr;
+
+use helper_attr::WithHelperAttr;
+
+#[derive(WithHelperAttr, Debug, Clone, PartialEq)]
+struct MyStruct<#[x] 'a, #[x] const A: usize, #[x] B> {
+    #[x]
+    field: &'a [B; A],
+}
+
+fn main() {}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
Related issue #132561 

Removes all attributes from generics in the expanded implementations of built-in derive macros.