### PR TITLE
tweak attributes for const panic macro

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -2965,14 +2965,35 @@ pub(crate) macro const_eval_select {
             $(#[$compiletime_attr:meta])* $compiletime:block
         else
             $(#[$runtime_attr:meta])* $runtime:block
+    ) => {
+        // Use the `noinline` arm, after adding explicit `inline` attributes
+        $crate::intrinsics::const_eval_select!(
+            @capture { $($arg : $ty = $val),* } $(-> $ret)? :
+            #[noinline]
+            if const
+                #[inline] // prevent codegen on this function
+                $(#[$compiletime_attr])*
+                $compiletime
+            else
+                #[inline] // avoid the overhead of an extra fn call
+                $(#[$runtime_attr])*
+                $runtime
+        )
+    },
+    // With a leading #[noinline], we don't add inline attributes
+    (
+        @capture { $($arg:ident : $ty:ty = $val:expr),* $(,)? } $( -> $ret:ty )? :
+        #[noinline]
+        if const
+            $(#[$compiletime_attr:meta])* $compiletime:block
+        else
+            $(#[$runtime_attr:meta])* $runtime:block
     ) => {{
-        #[inline] // avoid the overhead of an extra fn call
         $(#[$runtime_attr])*
         fn runtime($($arg: $ty),*) $( -> $ret )? {
             $runtime
         }
 
-        #[inline] // prevent codegen on this function
         $(#[$compiletime_attr])*
         const fn compiletime($($arg: $ty),*) $( -> $ret )? {
             // Don't warn if one of the arguments is unused.

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1268,8 +1268,9 @@ impl f128 {
             min <= max,
             "min > max, or either was NaN",
             "min > max, or either was NaN. min = {min:?}, max = {max:?}",
-            min: f128,
-            max: f128,
+            // FIXME(f16_f128): Passed by-ref to avoid codegen crashes
+            min: &f128 = &min,
+            max: &f128 = &max,
         );
 
         if self < min {

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1243,8 +1243,9 @@ impl f16 {
             min <= max,
             "min > max, or either was NaN",
             "min > max, or either was NaN. min = {min:?}, max = {max:?}",
-            min: f16,
-            max: f16,
+            // FIXME(f16_f128): Passed by-ref to avoid codegen crashes
+            min: &f16 = &min,
+            max: &f16 = &max,
         );
 
         if self < min {


### PR DESCRIPTION
Let's do some random mutations of this macro to see if that can re-gain the perf lost in https://github.com/rust-lang/rust/pull/132542.