### PR TITLE
fix(x): fix a regex used to find python executable

### DIFF
--- a/x
+++ b/x
@@ -36,7 +36,7 @@ for SEARCH_PYTHON in py python3 python python2; do
     fi
 done
 
-python=$(bash -c "compgen -c python" | grep '^python[2-3]\.[0-9]\+$' | head -n1)
+python=$(bash -c "compgen -c python" | grep '^python[2-3]\.[0-9]+$' | head -n1)
 if ! [ "$python" = "" ]; then
     exec "$python" "$xpy" "$@"
 fi


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Isn't the regex `^python[2-3]\.[0-9]\+$` wrong? It doesn't match, for example, with `python2.8`. There should be a plus sign at the end for a match, like `python2.8+`. I think `[0-9]+` is meant here instead of `[0-9]\+`. In that case a string like `python2.8` would match. This wasn't noticed because the script probably find and run the Python executable before this line.