### PR TITLE
Compile `test_num_f128` conditionally on `reliable_f128_math` config

### DIFF
--- a/library/std/src/f128/tests.rs
+++ b/library/std/src/f128/tests.rs
@@ -2,7 +2,10 @@
 #![cfg(reliable_f128)]
 
 use crate::f128::consts;
-use crate::num::{FpCategory as Fp, *};
+use crate::num::FpCategory as Fp;
+#[cfg(reliable_f128_math)]
+use crate::ops::Rem;
+use crate::ops::{Add, Div, Mul, Sub};
 
 // Note these tolerances make sense around zero, but not for more extreme exponents.
 
@@ -53,7 +56,22 @@ macro_rules! assert_f128_biteq {
 
 #[test]
 fn test_num_f128() {
-    test_num(10f128, 2f128);
+    // FIXME(f16_f128): replace with a `test_num` call once the required `fmodl`/`fmodf128`
+    // function is available on all platforms.
+    let ten = 10f128;
+    let two = 2f128;
+    assert_eq!(ten.add(two), ten + two);
+    assert_eq!(ten.sub(two), ten - two);
+    assert_eq!(ten.mul(two), ten * two);
+    assert_eq!(ten.div(two), ten / two);
+}
+
+#[test]
+#[cfg(reliable_f128_math)]
+fn test_num_f128_rem() {
+    let ten = 10f128;
+    let two = 2f128;
+    assert_eq!(ten.rem(two), ten % two);
 }
 
 #[test]


### PR DESCRIPTION
With #132434 merged, our internal SGX CI started failing with:
```
05:27:34   = note: rust-lld: error: undefined symbol: fmodl
05:27:34           >>> referenced by arith.rs:617 (core/src/ops/arith.rs:617)
05:27:34           >>>               /home/jenkins/workspace/rust-sgx-ci/rust/build/x86_64-unknown-linux-gnu/stage1-std/x86_64-fortanix-unknown-sgx/release/deps/std-5d5f11eb008c9091.std.d8141acc61ab7ac8-cgu.10.rcgu.o:(std::num::test_num::h7dd9449f6c01fde8)
05:27:34           >>> did you mean: fmodf
05:27:34           >>> defined in: /home/jenkins/workspace/rust-sgx-ci/rust/build/x86_64-unknown-linux-gnu/stage1-std/x86_64-fortanix-unknown-sgx/release/deps/libcompiler_builtins-0376f439a2ebf305.rlib(compiler_builtins-0376f439a2ebf305.compiler_builtins.c22db39d25d6f802-cgu.148.rcgu.o)
```
This originated from the `test_num_f128` test not having the required conditional compilation. This PR fixes that issue.

cc: @jethrogb, @workingjubilee 