### PR TITLE
Clean middle generics using paren sugar if trait has `#[rustc_paren_sugar]`

### DIFF
--- a/src/librustdoc/clean/utils.rs
+++ b/src/librustdoc/clean/utils.rs
@@ -206,7 +206,7 @@ fn clean_middle_generic_args_with_constraints<'tcx>(
 ) -> GenericArgs {
     let args = clean_middle_generic_args(cx, ty_args.map_bound(|args| &args[..]), has_self, did);
 
-    if cx.tcx.fn_trait_kind_from_def_id(did).is_some() {
+    if cx.tcx.is_trait(did) && cx.tcx.trait_def(did).paren_sugar {
         let ty = ty_args
             .iter()
             .nth(if has_self { 1 } else { 0 })

--- a/tests/rustdoc/inline_cross/assoc_item_trait_bounds.rs
+++ b/tests/rustdoc/inline_cross/assoc_item_trait_bounds.rs
@@ -22,6 +22,7 @@ extern crate assoc_item_trait_bounds as aux;
 //@ has - '//*[@id="associatedtype.Out12"]' "type Out12: for<'w> Helper<B<'w> = Cow<'w, str>, A<'w> = bool>"
 //@ has - '//*[@id="associatedtype.Out13"]' "type Out13: for<'fst, 'snd> Aid<'snd, Result<'fst> = &'fst mut str>"
 //@ has - '//*[@id="associatedtype.Out14"]' "type Out14<P: Copy + Eq, Q: ?Sized>"
+//@ has - '//*[@id="associatedtype.Out15"]' "type Out15: AsyncFnMut(i32) -> bool"
 //
 // Snapshots:
 // Check that we don't render any where-clauses for the following associated types since

--- a/tests/rustdoc/inline_cross/auxiliary/assoc_item_trait_bounds.rs
+++ b/tests/rustdoc/inline_cross/auxiliary/assoc_item_trait_bounds.rs
@@ -1,3 +1,7 @@
+#![feature(async_closure)]
+
+use std::ops::AsyncFnMut;
+
 pub trait Main {
     type Item;
 
@@ -16,6 +20,7 @@ pub trait Main {
     type Out12: for<'w> Helper<B<'w> = std::borrow::Cow<'w, str>, A<'w> = bool>;
     type Out13: for<'fst, 'snd> Aid<'snd, Result<'fst> = &'fst mut str>;
     type Out14<P: Copy + Eq, Q: ?Sized>;
+    type Out15: AsyncFnMut(i32) -> bool;
 
     fn make<F>(_: F, _: impl FnMut(&str) -> bool)
     where


### PR DESCRIPTION
That is to say, generalize the `Fn()` paren sugar handling to *any* trait that is marked with `rustc_paren_sugar`. This means that `AsyncFn` is also covered here.

r? fmease