### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -32,14 +32,12 @@
 //!
 //! Once you are familiar with the contents of the standard library you may
 //! begin to find the verbosity of the prose distracting. At this stage in your
-//! development you may want to press the <code>
-//! <svg style="width:0.75rem;height:0.75rem" viewBox="0 0 12 12"
-//! stroke="currentColor" fill="none">
-//! <path d="M2,2l4,4l4,-4M2,6l4,4l4,-4"/></svg> Summary</code> button near the
-//! top of the page to collapse it into a more skimmable view.
+//! development you may want to press the
+//! "<svg style="width:0.75rem;height:0.75rem" viewBox="0 0 12 12" stroke="currentColor" fill="none"><path d="M2,2l4,4l4,-4M2,6l4,4l4,-4"/></svg>&nbsp;Summary"
+//! button near the top of the page to collapse it into a more skimmable view.
 //!
 //! While you are looking at the top of the page, also notice the
-//! <code>source</code> link. Rust's API documentation comes with the source
+//! "Source" link. Rust's API documentation comes with the source
 //! code and you are encouraged to read it. The standard library source is
 //! generally high quality and a peek behind the curtains is
 //! often enlightening.

--- a/tests/crashes/README.md
+++ b/tests/crashes/README.md
@@ -8,7 +8,7 @@ A test will "pass" if rustc exits with something other than 1 or 0.
 
 When adding crashes from https://github.com/rust-lang/rust/issues, the
 issue number should be noted in the file name (12345.rs should suffice)
-and perhaps also inside the file via `//@ known-bug #4321`
+and also inside the file via `//@ known-bug #4321` if possible.
 
 If you happen to fix one of the crashes, please move it to a fitting
 subdirectory in `tests/ui` and give it a meaningful name.
@@ -21,3 +21,5 @@ to the description of your pull request will ensure the
 corresponding tickets will be closed automatically upon merge.
 The ticket ids can be found in the file name or the `known-bug` annotation
 inside the testfile.
+
+Please do not re-report any crashes that you find here!


### PR DESCRIPTION
Successful merges:

 - #132617 (Fix an extra newline in rendered std doc)
 - #132698 (Remove unneeded fields in `scrape_examples::FindCalls`)
 - #132700 (add note not to re-report crashes from `crashes` tests)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=132617,132698,132700)
<!-- homu-ignore:end -->