### PR TITLE
Inline str::repeat

### DIFF
--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -531,6 +531,7 @@ impl str {
     #[rustc_allow_incoherent_impl]
     #[must_use]
     #[stable(feature = "repeat_str", since = "1.16.0")]
+    #[inline]
     pub fn repeat(&self, n: usize) -> String {
         unsafe { String::from_utf8_unchecked(self.as_bytes().repeat(n)) }
     }


### PR DESCRIPTION
`str` is non-generic and `str.repeat()` doesn't get inlined, which makes it use a slower algorithm in case of 1-char repetitions. Equivalent byte slice does get inlined: https://rust.godbolt.org/z/4arvh97r4