### PR TITLE
Add --diagnostic-width to some tests failing after 1a0c5021838

### DIFF
--- a/tests/ui/coroutine/clone-impl-async.rs
+++ b/tests/ui/coroutine/clone-impl-async.rs
@@ -1,4 +1,5 @@
 //@ edition:2021
+//@compile-flags: --diagnostic-width=300
 // gate-test-coroutine_clone
 // Verifies that feature(coroutine_clone) doesn't allow async blocks to be cloned/copied.
 

--- a/tests/ui/coroutine/clone-impl-async.stderr
+++ b/tests/ui/coroutine/clone-impl-async.stderr
@@ -1,89 +1,89 @@
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:12:27: 12:32}: Copy` is not satisfied
-  --> $DIR/clone-impl-async.rs:17:16
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:13:27: 13:32}: Copy` is not satisfied
+  --> $DIR/clone-impl-async.rs:18:16
    |
 LL |     check_copy(&inner_non_clone);
-   |     ---------- ^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:12:27: 12:32}`
+   |     ---------- ^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:13:27: 13:32}`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-async.rs:69:18
+  --> $DIR/clone-impl-async.rs:70:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:12:27: 12:32}: Clone` is not satisfied
-  --> $DIR/clone-impl-async.rs:19:17
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:13:27: 13:32}: Clone` is not satisfied
+  --> $DIR/clone-impl-async.rs:20:17
    |
 LL |     check_clone(&inner_non_clone);
-   |     ----------- ^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:12:27: 12:32}`
+   |     ----------- ^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:13:27: 13:32}`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-async.rs:70:19
+  --> $DIR/clone-impl-async.rs:71:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`
 
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:23:27: 23:37}: Copy` is not satisfied
-  --> $DIR/clone-impl-async.rs:26:16
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:24:27: 24:37}: Copy` is not satisfied
+  --> $DIR/clone-impl-async.rs:27:16
    |
 LL |     check_copy(&outer_non_clone);
-   |     ---------- ^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:23:27: 23:37}`
+   |     ---------- ^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:24:27: 24:37}`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-async.rs:69:18
+  --> $DIR/clone-impl-async.rs:70:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:23:27: 23:37}: Clone` is not satisfied
-  --> $DIR/clone-impl-async.rs:28:17
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:24:27: 24:37}: Clone` is not satisfied
+  --> $DIR/clone-impl-async.rs:29:17
    |
 LL |     check_clone(&outer_non_clone);
-   |     ----------- ^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:23:27: 23:37}`
+   |     ----------- ^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:24:27: 24:37}`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-async.rs:70:19
+  --> $DIR/clone-impl-async.rs:71:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`
 
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:31:28: 31:38}: Copy` is not satisfied
-  --> $DIR/clone-impl-async.rs:32:16
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:32:28: 32:38}: Copy` is not satisfied
+  --> $DIR/clone-impl-async.rs:33:16
    |
 LL |     check_copy(&maybe_copy_clone);
-   |     ---------- ^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:31:28: 31:38}`
+   |     ---------- ^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/clone-impl-async.rs:32:28: 32:38}`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-async.rs:69:18
+  --> $DIR/clone-impl-async.rs:70:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:31:28: 31:38}: Clone` is not satisfied
-  --> $DIR/clone-impl-async.rs:34:17
+error[E0277]: the trait bound `{async block@$DIR/clone-impl-async.rs:32:28: 32:38}: Clone` is not satisfied
+  --> $DIR/clone-impl-async.rs:35:17
    |
 LL |     check_clone(&maybe_copy_clone);
-   |     ----------- ^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:31:28: 31:38}`
+   |     ----------- ^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `{async block@$DIR/clone-impl-async.rs:32:28: 32:38}`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-async.rs:70:19
+  --> $DIR/clone-impl-async.rs:71:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Copy` is not satisfied
-  --> $DIR/clone-impl-async.rs:38:16
+  --> $DIR/clone-impl-async.rs:39:16
    |
 LL |     check_copy(&inner_non_clone_fn);
    |     ---------- ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `impl Future<Output = ()>`
@@ -91,13 +91,13 @@ LL |     check_copy(&inner_non_clone_fn);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-async.rs:69:18
+  --> $DIR/clone-impl-async.rs:70:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Clone` is not satisfied
-  --> $DIR/clone-impl-async.rs:40:17
+  --> $DIR/clone-impl-async.rs:41:17
    |
 LL |     check_clone(&inner_non_clone_fn);
    |     ----------- ^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `impl Future<Output = ()>`
@@ -105,13 +105,13 @@ LL |     check_clone(&inner_non_clone_fn);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-async.rs:70:19
+  --> $DIR/clone-impl-async.rs:71:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Copy` is not satisfied
-  --> $DIR/clone-impl-async.rs:44:16
+  --> $DIR/clone-impl-async.rs:45:16
    |
 LL |     check_copy(&outer_non_clone_fn);
    |     ---------- ^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `impl Future<Output = ()>`
@@ -119,13 +119,13 @@ LL |     check_copy(&outer_non_clone_fn);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-async.rs:69:18
+  --> $DIR/clone-impl-async.rs:70:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Clone` is not satisfied
-  --> $DIR/clone-impl-async.rs:46:17
+  --> $DIR/clone-impl-async.rs:47:17
    |
 LL |     check_clone(&outer_non_clone_fn);
    |     ----------- ^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `impl Future<Output = ()>`
@@ -133,13 +133,13 @@ LL |     check_clone(&outer_non_clone_fn);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-async.rs:70:19
+  --> $DIR/clone-impl-async.rs:71:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Copy` is not satisfied
-  --> $DIR/clone-impl-async.rs:50:16
+  --> $DIR/clone-impl-async.rs:51:16
    |
 LL |     check_copy(&maybe_copy_clone_fn);
    |     ---------- ^^^^^^^^^^^^^^^^^^^^ the trait `Copy` is not implemented for `impl Future<Output = ()>`
@@ -147,13 +147,13 @@ LL |     check_copy(&maybe_copy_clone_fn);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-async.rs:69:18
+  --> $DIR/clone-impl-async.rs:70:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
 error[E0277]: the trait bound `impl Future<Output = ()>: Clone` is not satisfied
-  --> $DIR/clone-impl-async.rs:52:17
+  --> $DIR/clone-impl-async.rs:53:17
    |
 LL |     check_clone(&maybe_copy_clone_fn);
    |     ----------- ^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `impl Future<Output = ()>`
@@ -161,7 +161,7 @@ LL |     check_clone(&maybe_copy_clone_fn);
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-async.rs:70:19
+  --> $DIR/clone-impl-async.rs:71:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`

--- a/tests/ui/coroutine/clone-impl-static.rs
+++ b/tests/ui/coroutine/clone-impl-static.rs
@@ -1,3 +1,4 @@
+//@compile-flags: --diagnostic-width=300
 // gate-test-coroutine_clone
 // Verifies that static coroutines cannot be cloned/copied.
 

--- a/tests/ui/coroutine/clone-impl-static.stderr
+++ b/tests/ui/coroutine/clone-impl-static.stderr
@@ -1,27 +1,27 @@
-error[E0277]: the trait bound `{static coroutine@$DIR/clone-impl-static.rs:8:5: 8:19}: Copy` is not satisfied
-  --> $DIR/clone-impl-static.rs:11:16
+error[E0277]: the trait bound `{static coroutine@$DIR/clone-impl-static.rs:9:5: 9:19}: Copy` is not satisfied
+  --> $DIR/clone-impl-static.rs:12:16
    |
 LL |     check_copy(&gen);
-   |     ---------- ^^^^ the trait `Copy` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:8:5: 8:19}`
+   |     ---------- ^^^^ the trait `Copy` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:9:5: 9:19}`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_copy`
-  --> $DIR/clone-impl-static.rs:17:18
+  --> $DIR/clone-impl-static.rs:18:18
    |
 LL | fn check_copy<T: Copy>(_x: &T) {}
    |                  ^^^^ required by this bound in `check_copy`
 
-error[E0277]: the trait bound `{static coroutine@$DIR/clone-impl-static.rs:8:5: 8:19}: Clone` is not satisfied
-  --> $DIR/clone-impl-static.rs:13:17
+error[E0277]: the trait bound `{static coroutine@$DIR/clone-impl-static.rs:9:5: 9:19}: Clone` is not satisfied
+  --> $DIR/clone-impl-static.rs:14:17
    |
 LL |     check_clone(&gen);
-   |     ----------- ^^^^ the trait `Clone` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:8:5: 8:19}`
+   |     ----------- ^^^^ the trait `Clone` is not implemented for `{static coroutine@$DIR/clone-impl-static.rs:9:5: 9:19}`
    |     |
    |     required by a bound introduced by this call
    |
 note: required by a bound in `check_clone`
-  --> $DIR/clone-impl-static.rs:18:19
+  --> $DIR/clone-impl-static.rs:19:19
    |
 LL | fn check_clone<T: Clone>(_x: &T) {}
    |                   ^^^^^ required by this bound in `check_clone`

--- a/tests/ui/coroutine/gen_block_is_coro.rs
+++ b/tests/ui/coroutine/gen_block_is_coro.rs
@@ -1,4 +1,4 @@
-//@compile-flags: --edition 2024 -Zunstable-options
+//@compile-flags: --edition 2024 -Zunstable-options --diagnostic-width=300
 #![feature(coroutines, coroutine_trait, gen_blocks)]
 
 use std::ops::Coroutine;

--- a/tests/ui/impl-trait/issue-55872-3.rs
+++ b/tests/ui/impl-trait/issue-55872-3.rs
@@ -1,4 +1,5 @@
 //@ edition:2018
+//@compile-flags: --diagnostic-width=300
 
 #![feature(impl_trait_in_assoc_type)]
 

--- a/tests/ui/impl-trait/issue-55872-3.stderr
+++ b/tests/ui/impl-trait/issue-55872-3.stderr
@@ -1,11 +1,11 @@
-error[E0277]: the trait bound `{async block@$DIR/issue-55872-3.rs:15:9: 15:14}: Copy` is not satisfied
-  --> $DIR/issue-55872-3.rs:13:20
+error[E0277]: the trait bound `{async block@$DIR/issue-55872-3.rs:16:9: 16:14}: Copy` is not satisfied
+  --> $DIR/issue-55872-3.rs:14:20
    |
 LL |     fn foo<T>() -> Self::E {
-   |                    ^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/issue-55872-3.rs:15:9: 15:14}`
+   |                    ^^^^^^^ the trait `Copy` is not implemented for `{async block@$DIR/issue-55872-3.rs:16:9: 16:14}`
 LL |
 LL |         async {}
-   |         -------- return type was inferred to be `{async block@$DIR/issue-55872-3.rs:15:9: 15:14}` here
+   |         -------- return type was inferred to be `{async block@$DIR/issue-55872-3.rs:16:9: 16:14}` here
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/not-clone-closure.rs
+++ b/tests/ui/not-clone-closure.rs
@@ -1,3 +1,4 @@
+//@compile-flags: --diagnostic-width=300
 // Check that closures do not implement `Clone` if their environment is not `Clone`.
 
 struct S(i32);

--- a/tests/ui/not-clone-closure.stderr
+++ b/tests/ui/not-clone-closure.stderr
@@ -1,14 +1,14 @@
-error[E0277]: the trait bound `S: Clone` is not satisfied in `{closure@$DIR/not-clone-closure.rs:7:17: 7:24}`
-  --> $DIR/not-clone-closure.rs:11:23
+error[E0277]: the trait bound `S: Clone` is not satisfied in `{closure@$DIR/not-clone-closure.rs:8:17: 8:24}`
+  --> $DIR/not-clone-closure.rs:12:23
    |
 LL |     let hello = move || {
-   |                 ------- within this `{closure@$DIR/not-clone-closure.rs:7:17: 7:24}`
+   |                 ------- within this `{closure@$DIR/not-clone-closure.rs:8:17: 8:24}`
 ...
 LL |     let hello = hello.clone();
-   |                       ^^^^^ within `{closure@$DIR/not-clone-closure.rs:7:17: 7:24}`, the trait `Clone` is not implemented for `S`
+   |                       ^^^^^ within `{closure@$DIR/not-clone-closure.rs:8:17: 8:24}`, the trait `Clone` is not implemented for `S`
    |
 note: required because it's used within this closure
-  --> $DIR/not-clone-closure.rs:7:17
+  --> $DIR/not-clone-closure.rs:8:17
    |
 LL |     let hello = move || {
    |                 ^^^^^^^


### PR DESCRIPTION
Otherwise the tests would fail depending on the execution environment.