### PR TITLE
chore(issue-template): fix branch name

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -46,7 +46,7 @@ for larger features an implementation could be broken up into multiple PRs.
 
 [stabilization-guide]: https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#stabilization-pr
 [doc-guide]: https://rustc-dev-guide.rust-lang.org/stabilization_guide.html#documentation-prs
-[nightly-style-procedure]: https://github.com/rust-lang/style-team/blob/master/nightly-style-procedure.md 
+[nightly-style-procedure]: https://github.com/rust-lang/style-team/blob/main/nightly-style-procedure.md 
 [Style Guide]: https://github.com/rust-lang/rust/tree/master/src/doc/style-guide
 
 ### Unresolved Questions


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

It was renamed to "main" from "master".

It might seem not important (actually it is not important) but I think there is no need to see this every time when we clicked this link:

![image](https://github.com/user-attachments/assets/145dc587-c365-47e6-83da-69c17f409f71)

And this way is faster I guess.