### PR TITLE
CI: split x86_64-mingw job

### DIFF
--- a/src/bootstrap/mk/Makefile.in
+++ b/src/bootstrap/mk/Makefile.in
@@ -108,11 +108,13 @@ ci-msvc: ci-msvc-py ci-msvc-ps1
 
 ## MingW native builders
 
-# test both x and bootstrap entrypoints
+# Set of tests that should represent half of the time of the test suite.
+# Used to split tests across multiple CI runners.
+# Test both x and bootstrap entrypoints.
 ci-mingw-x:
-	$(Q)$(CFG_SRC_DIR)/x test --stage 2 tidy
+	$(Q)$(CFG_SRC_DIR)/x test --stage 2 --skip=compiler --skip=src
 ci-mingw-bootstrap:
-	$(Q)$(BOOTSTRAP) test --stage 2 --skip tidy
+	$(Q)$(BOOTSTRAP) test --stage 2 --skip=tests --skip=coverage-map --skip=coverage-run --skip=library --skip=tidyselftest
 ci-mingw: ci-mingw-x ci-mingw-bootstrap
 
 .PHONY: dist

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -439,14 +439,24 @@ auto:
       NO_DOWNLOAD_CI_LLVM: 1
     <<: *job-windows-8c
 
-  - image: x86_64-mingw
+  # x86_64-mingw is split into two jobs to run tests in parallel.
+  - image: x86_64-mingw-1
     env:
-      SCRIPT: make ci-mingw
+      SCRIPT: make ci-mingw-x
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
       # We are intentionally allowing an old toolchain on this builder (and that's
       # incompatible with LLVM downloads today).
       NO_DOWNLOAD_CI_LLVM: 1
-    <<: *job-windows-8c
+    <<: *job-windows
+
+  - image: x86_64-mingw-2
+    env:
+      SCRIPT: make ci-mingw-bootstrap
+      RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-gnu
+      # We are intentionally allowing an old toolchain on this builder (and that's
+      # incompatible with LLVM downloads today).
+      NO_DOWNLOAD_CI_LLVM: 1
+    <<: *job-windows
 
   - image: dist-x86_64-msvc
     env:

--- a/src/ci/shared.sh
+++ b/src/ci/shared.sh
@@ -53,7 +53,8 @@ function isLinux {
 }
 
 function isKnownToBeMingwBuild {
-    isGitHubActions && [[ "${CI_JOB_NAME}" == *mingw ]]
+    # CI_JOB_NAME must end with "mingw" and optionally `-N` to be considered a MinGW build.
+    isGitHubActions && [[ "${CI_JOB_NAME}" =~ mingw(-[0-9]+)?$ ]]
 }
 
 function isCiBranch {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->

Split the x86_64-mingw job in two to move it to free runners and reduce the use of large runners in CI.
<!-- homu-ignore:end -->

try-job: x86_64-mingw-1
try-job: x86_64-mingw-2
