### PR TITLE
[beta] backports

### DIFF
--- a/compiler/rustc_lint/src/non_local_def.rs
+++ b/compiler/rustc_lint/src/non_local_def.rs
@@ -151,9 +151,15 @@ impl<'tcx> LateLintPass<'tcx> for NonLocalDefinitions {
                 //     };
                 // };
                 // ```
+                //
+                // It isn't possible to mix a impl in a module with const-anon, but an item can
+                // be put inside a module and referenced by a impl so we also have to treat the
+                // item parent as transparent to module and for consistency we have to do the same
+                // for impl, otherwise the item-def and impl-def won't have the same parent.
                 let outermost_impl_parent = peel_parent_while(cx.tcx, parent, |tcx, did| {
-                    tcx.def_kind(did) == DefKind::Const
-                        && tcx.opt_item_name(did) == Some(kw::Underscore)
+                    tcx.def_kind(did) == DefKind::Mod
+                        || (tcx.def_kind(did) == DefKind::Const
+                            && tcx.opt_item_name(did) == Some(kw::Underscore))
                 });
 
                 // 2. We check if any of the paths reference a the `impl`-parent.

--- a/library/std/src/sys/thread_local/statik.rs
+++ b/library/std/src/sys/thread_local/statik.rs
@@ -14,12 +14,11 @@ pub macro thread_local_inner {
     (@key $t:ty, const $init:expr) => {{
         const __INIT: $t = $init;
 
+        // NOTE: Please update the shadowing test in `tests/thread.rs` if these types are renamed.
         unsafe {
-            use $crate::thread::LocalKey;
-            use $crate::thread::local_impl::EagerStorage;
-
-            LocalKey::new(|_| {
-                static VAL: EagerStorage<$t> = EagerStorage { value: __INIT };
+            $crate::thread::LocalKey::new(|_| {
+                static VAL: $crate::thread::local_impl::EagerStorage<$t> =
+                    $crate::thread::local_impl::EagerStorage { value: __INIT };
                 &VAL.value
             })
         }

--- a/tests/rustdoc/stability.rs
+++ b/tests/rustdoc/stability.rs
@@ -1,6 +1,8 @@
 #![feature(staged_api)]
+#![feature(rustc_attrs)]
+#![feature(rustdoc_internals)]
 
-#![stable(feature = "rust1", since = "1.0.0")]
+#![stable(feature = "core", since = "1.6.0")]
 
 //@ has stability/index.html
 //@ has - '//ul[@class="item-table"]/li[1]//a' AaStable
@@ -26,7 +28,7 @@ pub struct ZzStable;
 #[unstable(feature = "unstable", issue = "none")]
 pub mod unstable {
     //@ !hasraw stability/unstable/struct.StableInUnstable.html \
-    //      '//span[@class="since"]'
+    //      '//div[@class="main-heading"]//span[@class="since"]'
     //@ has - '//div[@class="stab unstable"]' 'experimental'
     #[stable(feature = "rust1", since = "1.0.0")]
     pub struct StableInUnstable;
@@ -34,52 +36,136 @@ pub mod unstable {
     #[stable(feature = "rust1", since = "1.0.0")]
     pub mod stable_in_unstable {
         //@ !hasraw stability/unstable/stable_in_unstable/struct.Inner.html \
-        //      '//span[@class="since"]'
+        //      '//div[@class="main-heading"]//span[@class="since"]'
         //@ has - '//div[@class="stab unstable"]' 'experimental'
         #[stable(feature = "rust1", since = "1.0.0")]
         pub struct Inner;
+    }
+
+    //@ has stability/struct.AaStable.html \
+    //      '//*[@id="method.foo"]//span[@class="since"]' '2.2.2'
+    impl super::AaStable {
+        #[stable(feature = "rust2", since = "2.2.2")]
+        pub fn foo() {}
+    }
+
+    //@ has stability/unstable/struct.StableInUnstable.html \
+    //      '//*[@id="method.foo"]//span[@class="since"]' '1.0.0'
+    impl StableInUnstable {
+        #[stable(feature = "rust1", since = "1.0.0")]
+        pub fn foo() {}
+    }
+}
+
+#[unstable(feature = "unstable", issue = "none")]
+#[doc(hidden)]
+pub mod unstable_stripped {
+    //@ has stability/struct.AaStable.html \
+    //      '//*[@id="method.foo"]//span[@class="since"]' '2.2.2'
+    impl super::AaStable {
+        #[stable(feature = "rust2", since = "2.2.2")]
+        pub fn foo() {}
     }
 }
 
 #[stable(feature = "rust2", since = "2.2.2")]
 pub mod stable_later {
     //@ has stability/stable_later/struct.StableInLater.html \
-    //      '//span[@class="since"]' '2.2.2'
+    //      '//div[@class="main-heading"]//span[@class="since"]' '2.2.2'
     #[stable(feature = "rust1", since = "1.0.0")]
     pub struct StableInLater;
 
     #[stable(feature = "rust1", since = "1.0.0")]
     pub mod stable_in_later {
         //@ has stability/stable_later/stable_in_later/struct.Inner.html \
-        //      '//span[@class="since"]' '2.2.2'
+        //      '//div[@class="main-heading"]//span[@class="since"]' '2.2.2'
         #[stable(feature = "rust1", since = "1.0.0")]
         pub struct Inner;
     }
 }
 
 #[stable(feature = "rust1", since = "1.0.0")]
-pub mod stable_earlier {
-    //@ has stability/stable_earlier/struct.StableInUnstable.html \
-    //      '//span[@class="since"]' '1.0.0'
+#[rustc_allowed_through_unstable_modules]
+pub mod stable_earlier1 {
+    //@ has stability/stable_earlier1/struct.StableInUnstable.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
+    //@ has - '//*[@id="method.foo"]//span[@class="since"]' '1.0.0'
     #[doc(inline)]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use crate::unstable::StableInUnstable;
 
-    //@ has stability/stable_earlier/stable_in_unstable/struct.Inner.html \
-    //      '//span[@class="since"]' '1.0.0'
+    //@ has stability/stable_earlier1/stable_in_unstable/struct.Inner.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
     #[doc(inline)]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use crate::unstable::stable_in_unstable;
 
-    //@ has stability/stable_earlier/struct.StableInLater.html \
-    //      '//span[@class="since"]' '1.0.0'
+    //@ has stability/stable_earlier1/struct.StableInLater.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
     #[doc(inline)]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use crate::stable_later::StableInLater;
 
-    //@ has stability/stable_earlier/stable_in_later/struct.Inner.html \
-    //      '//span[@class="since"]' '1.0.0'
+    //@ has stability/stable_earlier1/stable_in_later/struct.Inner.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
     #[doc(inline)]
     #[stable(feature = "rust1", since = "1.0.0")]
     pub use crate::stable_later::stable_in_later;
 }
+
+/// These will inherit the crate stability.
+#[stable(feature = "rust1", since = "1.0.0")]
+pub mod stable_earlier2 {
+    //@ has stability/stable_earlier2/struct.StableInUnstable.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.6.0'
+    //@ has - '//*[@id="method.foo"]//span[@class="since"]' '1.0.0'
+    #[doc(inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use crate::unstable::StableInUnstable;
+
+    //@ has stability/stable_earlier2/stable_in_unstable/struct.Inner.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.6.0'
+    #[doc(inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use crate::unstable::stable_in_unstable;
+
+    //@ has stability/stable_earlier2/struct.StableInLater.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.6.0'
+    #[doc(inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use crate::stable_later::StableInLater;
+
+    //@ has stability/stable_earlier2/stable_in_later/struct.Inner.html \
+    //      '//div[@class="main-heading"]//span[@class="since"]' '1.6.0'
+    #[doc(inline)]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    pub use crate::stable_later::stable_in_later;
+}
+
+//@ !hasraw stability/trait.UnstableTraitWithStableMethod.html \
+//      '//div[@class="main-heading"]//span[@class="since"]'
+//@ has - '//*[@id="tymethod.foo"]//span[@class="since"]' '1.0.0'
+//@ has - '//*[@id="method.bar"]//span[@class="since"]' '1.0.0'
+#[unstable(feature = "unstable", issue = "none")]
+pub trait UnstableTraitWithStableMethod {
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn foo();
+    #[stable(feature = "rust1", since = "1.0.0")]
+    fn bar() {}
+}
+
+//@ has stability/primitive.i32.html \
+//      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
+#[rustc_doc_primitive = "i32"]
+//
+/// `i32` is always stable in 1.0, even if you look at it from core.
+#[stable(feature = "rust1", since = "1.0.0")]
+mod prim_i32 {}
+
+//@ has stability/keyword.if.html \
+//      '//div[@class="main-heading"]//span[@class="since"]' '1.0.0'
+#[doc(keyword = "if")]
+//
+/// We currently don't document stability for keywords, but let's test it anyway.
+#[stable(feature = "rust1", since = "1.0.0")]
+mod if_keyword {}

--- a/tests/ui/lint/non-local-defs/convoluted-locals-132427.rs
+++ b/tests/ui/lint/non-local-defs/convoluted-locals-132427.rs
@@ -1,0 +1,64 @@
+// Regression tests for https://github.com/rust-lang/rust/issues/132427
+
+//@ check-pass
+
+// original
+mod auth {
+    const _: () = {
+        pub enum ArbitraryContext {}
+
+        const _: () = {
+            impl ArbitraryContext {}
+        };
+    };
+}
+
+mod z {
+    pub enum ArbitraryContext {}
+
+    const _: () = {
+        const _: () = {
+            impl ArbitraryContext {}
+        };
+    };
+}
+
+const _: () = {
+    mod auth {
+        const _: () = {
+            pub enum ArbitraryContext {}
+
+            const _: () = {
+                impl ArbitraryContext {}
+            };
+        };
+    }
+};
+
+mod a {
+    mod b {
+        const _: () = {
+            pub enum ArbitraryContext {}
+
+            const _: () = {
+                impl ArbitraryContext {}
+            };
+        };
+    }
+}
+
+mod foo {
+    const _: () = {
+        mod auth {
+            const _: () = {
+                pub enum ArbitraryContext {}
+
+                const _: () = {
+                    impl ArbitraryContext {}
+                };
+            };
+        }
+    };
+}
+
+fn main() {}


### PR DESCRIPTION
- rustdoc: skip stability inheritance for some item kinds #132481
- Avoid use imports in thread_local_inner! in static #132101
- Also treat `impl` definition parent as transparent regarding modules #132453
- Revert "Avoid nested replacement ranges" from #129346. #132587

r? cuviper
