### PR TITLE
Fix `librustdoc/scrape_examples.rs` formatting

### DIFF
--- a/src/librustdoc/scrape_examples.rs
+++ b/src/librustdoc/scrape_examples.rs
@@ -42,10 +42,16 @@ impl ScrapeExamplesOptions {
                 scrape_tests,
             }),
             (Some(_), false, _) | (None, true, _) => {
-                dcx.fatal("must use --scrape-examples-output-path and --scrape-examples-target-crate together");
+                dcx.fatal(
+                    "must use --scrape-examples-output-path and --scrape-examples-target-crate \
+                     together",
+                );
             }
             (None, false, true) => {
-                dcx.fatal("must use --scrape-examples-output-path and --scrape-examples-target-crate with --scrape-tests");
+                dcx.fatal(
+                    "must use --scrape-examples-output-path and \
+                     --scrape-examples-target-crate with --scrape-tests",
+                );
             }
             (None, false, false) => None,
         }
@@ -163,14 +169,15 @@ where
         };
 
         // If this span comes from a macro expansion, then the source code may not actually show
-        // a use of the given item, so it would be a poor example. Hence, we skip all uses in macros.
+        // a use of the given item, so it would be a poor example. Hence, we skip all uses in
+        // macros.
         if call_span.from_expansion() {
             trace!("Rejecting expr from macro: {call_span:?}");
             return;
         }
 
-        // If the enclosing item has a span coming from a proc macro, then we also don't want to include
-        // the example.
+        // If the enclosing item has a span coming from a proc macro, then we also don't want to
+        // include the example.
         let enclosing_item_span =
             tcx.hir().span_with_body(tcx.hir().get_parent_item(ex.hir_id).into());
         if enclosing_item_span.from_expansion() {
@@ -178,11 +185,12 @@ where
             return;
         }
 
-        // If the enclosing item doesn't actually enclose the call, this means we probably have a weird
-        // macro issue even though the spans aren't tagged as being from an expansion.
+        // If the enclosing item doesn't actually enclose the call, this means we probably have a
+        // weird macro issue even though the spans aren't tagged as being from an expansion.
         if !enclosing_item_span.contains(call_span) {
             warn!(
-                "Attempted to scrape call at [{call_span:?}] whose enclosing item [{enclosing_item_span:?}] doesn't contain the span of the call."
+                "Attempted to scrape call at [{call_span:?}] whose enclosing item \
+                 [{enclosing_item_span:?}] doesn't contain the span of the call."
             );
             return;
         }
@@ -190,7 +198,8 @@ where
         // Similarly for the call w/ the function ident.
         if !call_span.contains(ident_span) {
             warn!(
-                "Attempted to scrape call at [{call_span:?}] whose identifier [{ident_span:?}] was not contained in the span of the call."
+                "Attempted to scrape call at [{call_span:?}] whose identifier [{ident_span:?}] was \
+                 not contained in the span of the call."
             );
             return;
         }
@@ -224,7 +233,8 @@ where
                     Some(url) => url,
                     None => {
                         trace!(
-                            "Rejecting expr ({call_span:?}) whose clean span ({clean_span:?}) cannot be turned into a link"
+                            "Rejecting expr ({call_span:?}) whose clean span ({clean_span:?}) \
+                             cannot be turned into a link"
                         );
                         return;
                     }
@@ -272,7 +282,8 @@ pub(crate) fn run(
         let (cx, _) = Context::init(krate, renderopts, cache, tcx).map_err(|e| e.to_string())?;
 
         // Collect CrateIds corresponding to provided target crates
-        // If two different versions of the crate in the dependency tree, then examples will be collected from both.
+        // If two different versions of the crate in the dependency tree, then examples will be
+        // collected from both.
         let all_crates = tcx
             .crates(())
             .iter()


### PR DESCRIPTION
Still working on the intra-doc link feature. This time I encountered this file and it bothered me a bit so fixing formatting. :3

r? @notriddle