### PR TITLE
link: remove unused if check

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1105,15 +1105,14 @@ fn link_natively(
         // Many illumos systems will have both the native 'strip' utility and
         // the GNU one. Use the native version explicitly and do not rely on
         // what's in the path.
-        //
-        // If cross-compiling and there is not a native version, then use
-        // `llvm-strip` and hope.
-        let stripcmd = if !sess.host.is_like_solaris { "rust-objcopy" } else { "/usr/bin/strip" };
         match strip {
             // Always preserve the symbol table (-x).
-            Strip::Debuginfo => {
-                strip_symbols_with_external_utility(sess, stripcmd, out_filename, Some("-x"))
-            }
+            Strip::Debuginfo => strip_symbols_with_external_utility(
+                sess,
+                "/usr/bin/strip",
+                out_filename,
+                Some("-x"),
+            ),
             // Strip::Symbols is handled via the --strip-all linker option.
             Strip::Symbols => {}
             Strip::None => {}


### PR DESCRIPTION
The enclosing check already ensured we're on an is_like_solaris path, so this inner `if` will always be false. Inlined the local variable into its only use, but preserved the comment at the top of the block because it seems like it's still relevant.

I noticed this while sorting out a CI failure that ended up being identical to #132719.

cc @jieyouxu (author of #131405)
cc @albertlarsan68 (co-reviewed https://github.com/rust-lang/rust/pull/131405)