### PR TITLE
[AIX] handle libunwind native_libs

### DIFF
--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -54,6 +54,9 @@ pub fn walk_native_lib_search_dirs<R>(
     // The targets here should be in sync with `copy_third_party_objects` in bootstrap.
     // FIXME: implement `-Clink-self-contained=+/-unwind,+/-sanitizers`, move the shipped libunwind
     // and sanitizers to self-contained directory, and stop adding this search path.
+    // FIXME: On AIX this also has the side-effect of making the list of library search paths
+    // non-empty, which is needed or the linker may decide to record the LIBPATH env, if
+    // defined, as the search path instead of appending the default search paths.
     if sess.target.vendor == "fortanix"
         || sess.target.os == "linux"
         || sess.target.os == "fuchsia"

--- a/compiler/rustc_metadata/src/native_libs.rs
+++ b/compiler/rustc_metadata/src/native_libs.rs
@@ -57,6 +57,7 @@ pub fn walk_native_lib_search_dirs<R>(
     if sess.target.vendor == "fortanix"
         || sess.target.os == "linux"
         || sess.target.os == "fuchsia"
+        || sess.target.is_like_aix
         || sess.target.is_like_osx && !sess.opts.unstable_opts.sanitizer.is_empty()
     {
         f(&sess.target_tlib_path.dir, false)?;

--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -330,7 +330,7 @@ fn copy_third_party_objects(
 
     if target == "x86_64-fortanix-unknown-sgx"
         || builder.config.llvm_libunwind(target) == LlvmLibunwind::InTree
-            && (target.contains("linux") || target.contains("fuchsia"))
+            && (target.contains("linux") || target.contains("fuchsia") || target.contains("aix"))
     {
         let libunwind_path =
             copy_llvm_libunwind(builder, target, &builder.sysroot_target_libdir(*compiler, target));


### PR DESCRIPTION
AIX should follow a similar path here to other libunwind platforms, with regards to system vs in-tree libunwind and the native lib search directories.

Having the right native lib search directories here is also required to get the correct default library search paths, due to some quirks of the AIX linker.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
