### PR TITLE
Don't suggest `.into_iter()` on iterators

### DIFF
--- a/tests/ui/iterators/iterator-does-not-need-into-iter.rs
+++ b/tests/ui/iterators/iterator-does-not-need-into-iter.rs
@@ -1,0 +1,18 @@
+//! regression test for #127511: don't suggest `.into_iter()` on iterators
+
+trait Missing {}
+trait HasMethod {
+    fn foo(self);
+}
+impl<T: Iterator + Missing> HasMethod for T {
+    fn foo(self) {}
+}
+
+fn get_iter() -> impl Iterator {
+    core::iter::once(())
+}
+
+fn main() {
+    get_iter().foo();
+    //~^ ERROR the method `foo` exists for opaque type `impl Iterator`, but its trait bounds were not satisfied [E0599]
+}

--- a/tests/ui/iterators/iterator-does-not-need-into-iter.stderr
+++ b/tests/ui/iterators/iterator-does-not-need-into-iter.stderr
@@ -1,0 +1,28 @@
+error[E0599]: the method `foo` exists for opaque type `impl Iterator`, but its trait bounds were not satisfied
+  --> $DIR/iterator-does-not-need-into-iter.rs:16:16
+   |
+LL |     get_iter().foo();
+   |                ^^^ method cannot be called on `impl Iterator` due to unsatisfied trait bounds
+   |
+note: the following trait bounds were not satisfied:
+      `&impl Iterator: Iterator`
+      `&impl Iterator: Missing`
+      `&mut impl Iterator: Missing`
+      `impl Iterator: Missing`
+  --> $DIR/iterator-does-not-need-into-iter.rs:7:9
+   |
+LL | impl<T: Iterator + Missing> HasMethod for T {
+   |         ^^^^^^^^   ^^^^^^^  ---------     -
+   |         |          |
+   |         |          unsatisfied trait bound introduced here
+   |         unsatisfied trait bound introduced here
+   = help: items from traits can only be used if the trait is implemented and in scope
+note: `HasMethod` defines an item `foo`, perhaps you need to implement it
+  --> $DIR/iterator-does-not-need-into-iter.rs:4:1
+   |
+LL | trait HasMethod {
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0599`.


### PR DESCRIPTION
This makes the the suggestion to call `.into_iter()` only consider unsatisfied `Iterator` bounds for the receiver type itself. That way, it ignores predicates generated by trying to auto-ref the receiver (the result of which usually won't implement `Iterator`).

Fixes #127511

Unfortunately, the error in that case is still confusing: it labels `Iterator` as an unsatisfied bound because `&impl Iterator: Iterator` can't be satisfied, despite that not being required or helpful. I'd like to handle that in a separate PR. ~~I'm hoping fixing #124802 will fix it too.~~ It doesn't look connected to that issue. Still, I think it'd be clearest to visually distinguish unsatisfied predicates from different attempts at `pick_method`; I'll make a PR for that soon.