### PR TITLE
PassWrapper: disable UseOdrIndicator for Asan Win32

### DIFF
--- a/tests/ui/asan-odr-win/asan_odr_windows.rs
+++ b/tests/ui/asan-odr-win/asan_odr_windows.rs
@@ -1,0 +1,18 @@
+//! Check that crates can be linked together with `-Z sanitizer=address` on msvc.
+//! See <https://github.com/rust-lang/rust/issues/124390>.
+
+//@ run-pass
+//@ compile-flags:-Zsanitizer=address
+//@ aux-build: asan_odr_win-2.rs
+//@ only-windows-msvc
+
+extern crate othercrate;
+
+fn main() {
+    let result = std::panic::catch_unwind(|| {
+        println!("hello!");
+    });
+    assert!(result.is_ok());
+
+    othercrate::exposed_func();
+}

--- a/tests/ui/asan-odr-win/auxiliary/asan_odr_win-2.rs
+++ b/tests/ui/asan-odr-win/auxiliary/asan_odr_win-2.rs
@@ -1,0 +1,11 @@
+//@ no-prefer-dynamic
+//@ compile-flags: -Z sanitizer=address
+#![crate_name = "othercrate"]
+#![crate_type = "rlib"]
+
+pub fn exposed_func() {
+    let result = std::panic::catch_unwind(|| {
+        println!("hello!");
+    });
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
As described in https://reviews.llvm.org/D137227 UseOdrIndicator should be disabled on Windows since link.exe does not support duplicate weak definitions.

Fixes https://github.com/rust-lang/rust/issues/124390.

Credits also belong to @1c3t3a  who worked with me on this.
We are currently testing this on a Windows machine.

