### PR TITLE
use verbose for path separator suggestion

### DIFF
--- a/compiler/rustc_resolve/src/late/diagnostics.rs
+++ b/compiler/rustc_resolve/src/late/diagnostics.rs
@@ -1472,7 +1472,7 @@ impl<'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'_, 'ast, 'ra, 'tcx> {
             };
 
             if lhs_span.eq_ctxt(rhs_span) {
-                err.span_suggestion(
+                err.span_suggestion_verbose(
                     lhs_span.between(rhs_span),
                     MESSAGE,
                     "::",

--- a/tests/ui/resolve/issue-100365.stderr
+++ b/tests/ui/resolve/issue-100365.stderr
@@ -2,19 +2,34 @@ error[E0423]: expected value, found trait `Into`
   --> $DIR/issue-100365.rs:2:16
    |
 LL |     let addr = Into::<std::net::IpAddr>.into([127, 0, 0, 1]);
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^- help: use the path separator to refer to an item: `::`
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     let addr = Into::<std::net::IpAddr>::into([127, 0, 0, 1]);
+   |                                        ~~
 
 error[E0423]: expected value, found trait `Into`
   --> $DIR/issue-100365.rs:6:13
    |
 LL |     let _ = Into.into(());
-   |             ^^^^- help: use the path separator to refer to an item: `::`
+   |             ^^^^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     let _ = Into::into(());
+   |                 ~~
 
 error[E0423]: expected value, found trait `Into`
   --> $DIR/issue-100365.rs:10:13
    |
 LL |     let _ = Into::<()>.into;
-   |             ^^^^^^^^^^- help: use the path separator to refer to an item: `::`
+   |             ^^^^^^^^^^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     let _ = Into::<()>::into;
+   |                       ~~
 
 error[E0423]: expected value, found trait `std::iter::Iterator`
   --> $DIR/issue-100365.rs:17:9
@@ -42,12 +57,16 @@ error[E0423]: expected value, found trait `Into`
   --> $DIR/issue-100365.rs:25:9
    |
 LL |         Into::<String>.into("")
-   |         ^^^^^^^^^^^^^^- help: use the path separator to refer to an item: `::`
+   |         ^^^^^^^^^^^^^^
 ...
 LL |     let _ = create!();
    |             --------- in this macro invocation
    |
    = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the path separator to refer to an item
+   |
+LL |         Into::<String>::into("")
+   |                       ~~
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/resolve/issue-22692.stderr
+++ b/tests/ui/resolve/issue-22692.stderr
@@ -2,19 +2,34 @@ error[E0423]: expected value, found struct `String`
   --> $DIR/issue-22692.rs:2:13
    |
 LL |     let _ = String.new();
-   |             ^^^^^^- help: use the path separator to refer to an item: `::`
+   |             ^^^^^^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     let _ = String::new();
+   |                   ~~
 
 error[E0423]: expected value, found struct `String`
   --> $DIR/issue-22692.rs:6:13
    |
 LL |     let _ = String.default;
-   |             ^^^^^^- help: use the path separator to refer to an item: `::`
+   |             ^^^^^^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     let _ = String::default;
+   |                   ~~
 
 error[E0423]: expected value, found struct `Vec`
   --> $DIR/issue-22692.rs:10:13
    |
 LL |     let _ = Vec::<()>.with_capacity(1);
-   |             ^^^^^^^^^- help: use the path separator to refer to an item: `::`
+   |             ^^^^^^^^^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     let _ = Vec::<()>::with_capacity(1);
+   |                      ~~
 
 error[E0423]: expected value, found struct `std::cell::Cell`
   --> $DIR/issue-22692.rs:17:9
@@ -50,23 +65,31 @@ error[E0423]: expected value, found struct `Vec`
   --> $DIR/issue-22692.rs:26:9
    |
 LL |         Vec.new()
-   |         ^^^- help: use the path separator to refer to an item: `::`
+   |         ^^^
 ...
 LL |     let _ = create!(type method);
    |             -------------------- in this macro invocation
    |
    = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the path separator to refer to an item
+   |
+LL |         Vec::new()
+   |            ~~
 
 error[E0423]: expected value, found struct `Vec`
   --> $DIR/issue-22692.rs:31:9
    |
 LL |         Vec.new
-   |         ^^^- help: use the path separator to refer to an item: `::`
+   |         ^^^
 ...
 LL |     let _ = create!(type field);
    |             ------------------- in this macro invocation
    |
    = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the path separator to refer to an item
+   |
+LL |         Vec::new
+   |            ~~
 
 error[E0423]: expected value, found struct `std::cell::Cell`
   --> $DIR/issue-22692.rs:17:9

--- a/tests/ui/resolve/suggest-path-for-tuple-struct.stderr
+++ b/tests/ui/resolve/suggest-path-for-tuple-struct.stderr
@@ -2,13 +2,23 @@ error[E0423]: expected value, found struct `SomeTupleStruct`
   --> $DIR/suggest-path-for-tuple-struct.rs:22:13
    |
 LL |     let _ = SomeTupleStruct.new();
-   |             ^^^^^^^^^^^^^^^- help: use the path separator to refer to an item: `::`
+   |             ^^^^^^^^^^^^^^^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     let _ = SomeTupleStruct::new();
+   |                            ~~
 
 error[E0423]: expected value, found struct `SomeRegularStruct`
   --> $DIR/suggest-path-for-tuple-struct.rs:24:13
    |
 LL |     let _ = SomeRegularStruct.new();
-   |             ^^^^^^^^^^^^^^^^^- help: use the path separator to refer to an item: `::`
+   |             ^^^^^^^^^^^^^^^^^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     let _ = SomeRegularStruct::new();
+   |                              ~~
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
+++ b/tests/ui/resolve/suggest-path-instead-of-mod-dot-item.stderr
@@ -2,19 +2,34 @@ error[E0423]: expected value, found module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:17:5
    |
 LL |     a.I
-   |     ^- help: use the path separator to refer to an item: `::`
+   |     ^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     a::I
+   |      ~~
 
 error[E0423]: expected value, found module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:23:5
    |
 LL |     a.g()
-   |     ^- help: use the path separator to refer to an item: `::`
+   |     ^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     a::g()
+   |      ~~
 
 error[E0423]: expected value, found module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:29:5
    |
 LL |     a.b.J
-   |     ^- help: use the path separator to refer to an item: `::`
+   |     ^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     a::b.J
+   |      ~~
 
 error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:35:5
@@ -38,7 +53,12 @@ error[E0423]: expected value, found module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:42:5
    |
 LL |     a.b.f();
-   |     ^- help: use the path separator to refer to an item: `::`
+   |     ^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     a::b.f();
+   |      ~~
 
 error[E0423]: expected value, found module `a::b`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:46:12
@@ -117,23 +137,31 @@ error[E0423]: expected value, found module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:80:9
    |
 LL |         a.f()
-   |         ^- help: use the path separator to refer to an item: `::`
+   |         ^
 ...
 LL |     let _ = create!(method);
    |             --------------- in this macro invocation
    |
    = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the path separator to refer to an item
+   |
+LL |         a::f()
+   |          ~~
 
 error[E0423]: expected value, found module `a`
   --> $DIR/suggest-path-instead-of-mod-dot-item.rs:85:9
    |
 LL |         a.f
-   |         ^- help: use the path separator to refer to an item: `::`
+   |         ^
 ...
 LL |     let _ = create!(field);
    |             -------------- in this macro invocation
    |
    = note: this error originates in the macro `create` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the path separator to refer to an item
+   |
+LL |         a::f
+   |          ~~
 
 error: aborting due to 13 previous errors
 

--- a/tests/ui/suggestions/assoc-const-as-field.stderr
+++ b/tests/ui/suggestions/assoc-const-as-field.stderr
@@ -2,7 +2,12 @@ error[E0423]: expected value, found struct `Mod::Foo`
   --> $DIR/assoc-const-as-field.rs:11:9
    |
 LL |     foo(Mod::Foo.Bar);
-   |         ^^^^^^^^- help: use the path separator to refer to an item: `::`
+   |         ^^^^^^^^
+   |
+help: use the path separator to refer to an item
+   |
+LL |     foo(Mod::Foo::Bar);
+   |                 ~~
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
A single `-` of suggestion underlining that is adjacent to a much more significant `^^^` underlying of the LHS path component is hard to distinguish. IMO this presents much more cleanly when it's verbose, especially because it's a *replacment* suggestion.

r? estebank