### PR TITLE
Use a separate dir for r-a builds consistently in helix config

### DIFF
--- a/src/etc/rust_analyzer_helix.toml
+++ b/src/etc/rust_analyzer_helix.toml
@@ -1,3 +1,12 @@
+# This config uses a separate build directory for rust-analyzer,
+# so that r-a's checks don't block user `x` commands and vice-verse.
+# R-a's build directory is located in `build/rust-analyzer`.
+#
+# To build rustfmt and proc macro server for r-a run the following command:
+# ```
+# x b proc-macro-srv-cli rustfmt --stage 0 --build-dir build/rust-analyzer
+# ```
+
 [language-server.rust-analyzer.config]
 linkedProjects = [
     "Cargo.toml",
@@ -17,16 +26,18 @@ overrideCommand = [
     "x.py",
     "check",
     "--json-output",
+    "--build-dir",
+    "build/rust-analyzer",
 ]
 
 [language-server.rust-analyzer.config.rustfmt]
 overrideCommand = [
-    "build-rust-analyzer/host/rustfmt/bin/rustfmt",
+    "build/rust-analyzer/host/rustfmt/bin/rustfmt",
     "--edition=2021"
 ]
 
 [language-server.rust-analyzer.config.procMacro]
-server = "build-rust-analyzer/host/stage0/libexec/rust-analyzer-proc-macro-srv"
+server = "build/rust-analyzer/host/stage0/libexec/rust-analyzer-proc-macro-srv"
 enable = true
 
 [language-server.rust-analyzer.config.rustc]
@@ -47,4 +58,6 @@ overrideCommand = [
     "x.py",
     "check",
     "--json-output",
+    "--build-dir",
+    "build/rust-analyzer",
 ]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

r? @jieyouxu
cc @mrkajetanp

Previously config used `build-rust-analyzer` for rustfmt and proc macros server, while not using it for actual `x check` commands.

This PR:
- Replaces the build dir with `build/rust-analyzer`
  - This is just my preference
  - Although I do think this is the nicest option: the directory is already git-ignored, `rm -fr ./build` removes everything, etc
- Uses said directory with the `x check` commands in helix r-a config
- Adds instructions on how to build rustfmt and proc macro server to the config

As of note, this is not what other configs do (like vscode's), however this _is_ what I would actually suggest to people (and what I'm actually using).