### PR TITLE
Make `Ty::primitive_symbol` recognize `str`

### DIFF
--- a/compiler/rustc_middle/src/ty/sty.rs
+++ b/compiler/rustc_middle/src/ty/sty.rs
@@ -1933,6 +1933,7 @@ impl<'tcx> Ty<'tcx> {
                 ty::UintTy::U64 => Some(sym::u64),
                 ty::UintTy::U128 => Some(sym::u128),
             },
+            ty::Str => Some(sym::str),
             _ => None,
         }
     }

--- a/tests/ui/mismatched_types/similar_paths_primitive.rs
+++ b/tests/ui/mismatched_types/similar_paths_primitive.rs
@@ -1,10 +1,14 @@
 #![allow(non_camel_case_types)]
 
 struct bool;
+struct str;
 
 fn foo(_: bool) {}
+fn bar(_: &str) {}
 
 fn main() {
     foo(true);
+    //~^ ERROR mismatched types [E0308]
+    bar("hello");
     //~^ ERROR mismatched types [E0308]
 }

--- a/tests/ui/mismatched_types/similar_paths_primitive.stderr
+++ b/tests/ui/mismatched_types/similar_paths_primitive.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/similar_paths_primitive.rs:8:9
+  --> $DIR/similar_paths_primitive.rs:10:9
    |
 LL |     foo(true);
    |     --- ^^^^ expected `bool`, found a different `bool`
@@ -14,11 +14,32 @@ note: `bool` is defined in the current crate
 LL | struct bool;
    | ^^^^^^^^^^^
 note: function defined here
-  --> $DIR/similar_paths_primitive.rs:5:4
+  --> $DIR/similar_paths_primitive.rs:6:4
    |
 LL | fn foo(_: bool) {}
    |    ^^^ -------
 
-error: aborting due to 1 previous error
+error[E0308]: mismatched types
+  --> $DIR/similar_paths_primitive.rs:12:9
+   |
+LL |     bar("hello");
+   |     --- ^^^^^^^ expected `str`, found a different `str`
+   |     |
+   |     arguments to this function are incorrect
+   |
+   = note: str and `str` have similar names, but are actually distinct types
+   = note: str is a primitive defined by the language
+note: `str` is defined in the current crate
+  --> $DIR/similar_paths_primitive.rs:4:1
+   |
+LL | struct str;
+   | ^^^^^^^^^^
+note: function defined here
+  --> $DIR/similar_paths_primitive.rs:7:4
+   |
+LL | fn bar(_: &str) {}
+   |    ^^^ -------
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Make `Ty::primitive_symbol` recognize `str`, which makes `str` eligible for the "expected primitive, found local type" (and vice versa) [diagnostic](https://github.com/rust-lang/rust/blob/master/compiler/rustc_trait_selection/src/error_reporting/infer/mod.rs#L1430-L1437) that already exists for other primitives.

<details><summary> diagnostic difference</summary>


```rs
#[allow(non_camel_case_types)]
struct str;

fn foo() {
    let _: &str = "hello";
    let _: &core::primitive::str = &str;
}
```

`rustc --crate-type lib --edition 2021 a.rs`

Current nightly:

```rs
error[E0308]: mismatched types
 --> a.rs:5:19
  |
5 |     let _: &str = "hello";
  |            ----   ^^^^^^^ expected `str`, found a different `str`
  |            |
  |            expected due to this
  |
  = note: expected reference `&str`
             found reference `&'static str`

error[E0308]: mismatched types
 --> a.rs:6:36
  |
6 |     let _: &core::primitive::str = &str;
  |            ---------------------   ^^^^ expected `str`, found a different `str`
  |            |
  |            expected due to this
  |
  = note: expected reference `&str` (`str`)
             found reference `&str` (`str`)

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0308`.
```

With this patch:

```rs
error[E0308]: mismatched types
 --> a.rs:5:19
  |
5 |     let _: &str = "hello";
  |            ----   ^^^^^^^ expected `str`, found a different `str`
  |            |
  |            expected due to this
  |
  = note: str and `str` have similar names, but are actually distinct types
  = note: str is a primitive defined by the language
note: `str` is defined in the current crate
 --> a.rs:2:1
  |
2 | struct str;
  | ^^^^^^^^^^

error[E0308]: mismatched types
 --> a.rs:6:36
  |
6 |     let _: &core::primitive::str = &str;
  |            ---------------------   ^^^^ expected `str`, found a different `str`
  |            |
  |            expected due to this
  |
  = note: str and `str` have similar names, but are actually distinct types
  = note: str is a primitive defined by the language
note: `str` is defined in the current crate
 --> a.rs:2:1
  |
2 | struct str;
  | ^^^^^^^^^^

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0308`.
```

</details>
