### PR TITLE
Recurse into APITs in `impl_trait_overcaptures`

### DIFF
--- a/compiler/rustc_lint/src/impl_trait_overcaptures.rs
+++ b/compiler/rustc_lint/src/impl_trait_overcaptures.rs
@@ -262,7 +262,11 @@ where
             // If it's owned by this function
             && let opaque =
                 self.tcx.hir_node_by_def_id(opaque_def_id).expect_opaque_ty()
-            && let hir::OpaqueTyOrigin::FnReturn { parent, .. } = opaque.origin
+            // We want to recurse into RPITs and async fns, even though the latter
+            // doesn't overcapture on its own, it may mention additional RPITs
+            // in its bounds.
+            && let hir::OpaqueTyOrigin::FnReturn { parent, .. }
+                | hir::OpaqueTyOrigin::AsyncFn { parent, .. } = opaque.origin
             && parent == self.parent_def_id
         {
             let opaque_span = self.tcx.def_span(opaque_def_id);

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024.fixed
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024.fixed
@@ -1,4 +1,5 @@
 //@ run-rustfix
+//@ edition: 2018
 
 #![allow(unused)]
 #![deny(impl_trait_overcaptures)]
@@ -34,6 +35,10 @@ fn apit<T: Sized>(_: &T) -> impl Sized + use<T> {}
 //~| WARN this changes meaning in Rust 2024
 
 fn apit2<U, T: Sized>(_: &T, _: U) -> impl Sized + use<U, T> {}
+//~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
+//~| WARN this changes meaning in Rust 2024
+
+async fn async_fn<'a>(x: &'a ()) -> impl Sized + use<> {}
 //~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
 //~| WARN this changes meaning in Rust 2024
 

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024.rs
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024.rs
@@ -1,4 +1,5 @@
 //@ run-rustfix
+//@ edition: 2018
 
 #![allow(unused)]
 #![deny(impl_trait_overcaptures)]
@@ -34,6 +35,10 @@ fn apit(_: &impl Sized) -> impl Sized {}
 //~| WARN this changes meaning in Rust 2024
 
 fn apit2<U>(_: &impl Sized, _: U) -> impl Sized {}
+//~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
+//~| WARN this changes meaning in Rust 2024
+
+async fn async_fn<'a>(x: &'a ()) -> impl Sized {}
 //~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
 //~| WARN this changes meaning in Rust 2024
 

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024.stderr
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024.stderr
@@ -1,5 +1,5 @@
 error: `impl Sized` will capture more lifetimes than possibly intended in edition 2024
-  --> $DIR/overcaptures-2024.rs:6:29
+  --> $DIR/overcaptures-2024.rs:7:29
    |
 LL | fn named<'a>(x: &'a i32) -> impl Sized { *x }
    |                             ^^^^^^^^^^
@@ -7,13 +7,13 @@ LL | fn named<'a>(x: &'a i32) -> impl Sized { *x }
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
-  --> $DIR/overcaptures-2024.rs:6:10
+  --> $DIR/overcaptures-2024.rs:7:10
    |
 LL | fn named<'a>(x: &'a i32) -> impl Sized { *x }
    |          ^^
    = note: all lifetimes in scope will be captured by `impl Trait`s in edition 2024
 note: the lint level is defined here
-  --> $DIR/overcaptures-2024.rs:4:9
+  --> $DIR/overcaptures-2024.rs:5:9
    |
 LL | #![deny(impl_trait_overcaptures)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^
@@ -23,7 +23,7 @@ LL | fn named<'a>(x: &'a i32) -> impl Sized + use<> { *x }
    |                                        +++++++
 
 error: `impl Sized` will capture more lifetimes than possibly intended in edition 2024
-  --> $DIR/overcaptures-2024.rs:10:25
+  --> $DIR/overcaptures-2024.rs:11:25
    |
 LL | fn implicit(x: &i32) -> impl Sized { *x }
    |                         ^^^^^^^^^^
@@ -31,7 +31,7 @@ LL | fn implicit(x: &i32) -> impl Sized { *x }
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
-  --> $DIR/overcaptures-2024.rs:10:16
+  --> $DIR/overcaptures-2024.rs:11:16
    |
 LL | fn implicit(x: &i32) -> impl Sized { *x }
    |                ^
@@ -42,7 +42,7 @@ LL | fn implicit(x: &i32) -> impl Sized + use<> { *x }
    |                                    +++++++
 
 error: `impl Sized + '_` will capture more lifetimes than possibly intended in edition 2024
-  --> $DIR/overcaptures-2024.rs:16:33
+  --> $DIR/overcaptures-2024.rs:17:33
    |
 LL |     fn hello(&self, x: &i32) -> impl Sized + '_ { self }
    |                                 ^^^^^^^^^^^^^^^
@@ -50,7 +50,7 @@ LL |     fn hello(&self, x: &i32) -> impl Sized + '_ { self }
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
-  --> $DIR/overcaptures-2024.rs:16:24
+  --> $DIR/overcaptures-2024.rs:17:24
    |
 LL |     fn hello(&self, x: &i32) -> impl Sized + '_ { self }
    |                        ^
@@ -61,7 +61,7 @@ LL |     fn hello(&self, x: &i32) -> impl Sized + '_ + use<'_> { self }
    |                                                 +++++++++
 
 error: `impl Sized` will capture more lifetimes than possibly intended in edition 2024
-  --> $DIR/overcaptures-2024.rs:28:47
+  --> $DIR/overcaptures-2024.rs:29:47
    |
 LL | fn hrtb() -> impl for<'a> Higher<'a, Output = impl Sized> {}
    |                                               ^^^^^^^^^^
@@ -69,7 +69,7 @@ LL | fn hrtb() -> impl for<'a> Higher<'a, Output = impl Sized> {}
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
-  --> $DIR/overcaptures-2024.rs:28:23
+  --> $DIR/overcaptures-2024.rs:29:23
    |
 LL | fn hrtb() -> impl for<'a> Higher<'a, Output = impl Sized> {}
    |                       ^^
@@ -80,7 +80,7 @@ LL | fn hrtb() -> impl for<'a> Higher<'a, Output = impl Sized + use<>> {}
    |                                                          +++++++
 
 error: `impl Sized` will capture more lifetimes than possibly intended in edition 2024
-  --> $DIR/overcaptures-2024.rs:32:28
+  --> $DIR/overcaptures-2024.rs:33:28
    |
 LL | fn apit(_: &impl Sized) -> impl Sized {}
    |                            ^^^^^^^^^^
@@ -88,13 +88,13 @@ LL | fn apit(_: &impl Sized) -> impl Sized {}
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
-  --> $DIR/overcaptures-2024.rs:32:12
+  --> $DIR/overcaptures-2024.rs:33:12
    |
 LL | fn apit(_: &impl Sized) -> impl Sized {}
    |            ^
    = note: all lifetimes in scope will be captured by `impl Trait`s in edition 2024
 note: you could use a `use<...>` bound to explicitly specify captures, but argument-position `impl Trait`s are not nameable
-  --> $DIR/overcaptures-2024.rs:32:13
+  --> $DIR/overcaptures-2024.rs:33:13
    |
 LL | fn apit(_: &impl Sized) -> impl Sized {}
    |             ^^^^^^^^^^
@@ -104,7 +104,7 @@ LL | fn apit<T: Sized>(_: &T) -> impl Sized + use<T> {}
    |        ++++++++++     ~                ++++++++
 
 error: `impl Sized` will capture more lifetimes than possibly intended in edition 2024
-  --> $DIR/overcaptures-2024.rs:36:38
+  --> $DIR/overcaptures-2024.rs:37:38
    |
 LL | fn apit2<U>(_: &impl Sized, _: U) -> impl Sized {}
    |                                      ^^^^^^^^^^
@@ -112,13 +112,13 @@ LL | fn apit2<U>(_: &impl Sized, _: U) -> impl Sized {}
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
 note: specifically, this lifetime is in scope but not mentioned in the type's bounds
-  --> $DIR/overcaptures-2024.rs:36:16
+  --> $DIR/overcaptures-2024.rs:37:16
    |
 LL | fn apit2<U>(_: &impl Sized, _: U) -> impl Sized {}
    |                ^
    = note: all lifetimes in scope will be captured by `impl Trait`s in edition 2024
 note: you could use a `use<...>` bound to explicitly specify captures, but argument-position `impl Trait`s are not nameable
-  --> $DIR/overcaptures-2024.rs:36:17
+  --> $DIR/overcaptures-2024.rs:37:17
    |
 LL | fn apit2<U>(_: &impl Sized, _: U) -> impl Sized {}
    |                 ^^^^^^^^^^
@@ -127,5 +127,24 @@ help: use the precise capturing `use<...>` syntax to make the captures explicit
 LL | fn apit2<U, T: Sized>(_: &T, _: U) -> impl Sized + use<U, T> {}
    |           ++++++++++      ~                      +++++++++++
 
-error: aborting due to 6 previous errors
+error: `impl Sized` will capture more lifetimes than possibly intended in edition 2024
+  --> $DIR/overcaptures-2024.rs:41:37
+   |
+LL | async fn async_fn<'a>(x: &'a ()) -> impl Sized {}
+   |                                     ^^^^^^^^^^
+   |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+note: specifically, this lifetime is in scope but not mentioned in the type's bounds
+  --> $DIR/overcaptures-2024.rs:41:19
+   |
+LL | async fn async_fn<'a>(x: &'a ()) -> impl Sized {}
+   |                   ^^
+   = note: all lifetimes in scope will be captured by `impl Trait`s in edition 2024
+help: use the precise capturing `use<...>` syntax to make the captures explicit
+   |
+LL | async fn async_fn<'a>(x: &'a ()) -> impl Sized + use<> {}
+   |                                                +++++++
+
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION
We were previously not detecting cases where an RPIT was located in the return type of an async function, leading to underfiring of the `impl_trait_overcaptures`. This PR does this recursion properly now.

cc https://github.com/rust-lang/rust/issues/132809