### PR TITLE
Update grammar in wasm-c-abi's compiler flag documentation

### DIFF
--- a/src/doc/unstable-book/src/compiler-flags/wasm-c-abi.md
+++ b/src/doc/unstable-book/src/compiler-flags/wasm-c-abi.md
@@ -3,8 +3,8 @@
 This option controls whether Rust uses the spec-compliant C ABI when compiling
 for the `wasm32-unknown-unknown` target.
 
-This makes it possible to be ABI-compatible with all other spec-compliant Wasm
-like Rusts `wasm32-wasip1`.
+This makes it possible to be ABI-compatible with all other spec-compliant Wasm targets
+like `wasm32-wasip1`.
 
 This compiler flag is perma-unstable, as it will be enabled by default in the
 future with no option to fall back to the old non-spec-compliant ABI.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This PR adjusts the grammar of the `wasm-c-abi` compiler flag documentation. See the inline comments within the PR for details.
