### PR TITLE
Re-enable `version-verbose-commit-hash` run-make test

### DIFF
--- a/src/bootstrap/defaults/config.dist.toml
+++ b/src/bootstrap/defaults/config.dist.toml
@@ -11,7 +11,6 @@ extended = true
 # Most users installing from source want to build all parts of the project from source.
 [llvm]
 download-ci-llvm = false
-
 [rust]
 # We have several defaults in bootstrap that depend on whether the channel is `dev` (e.g. `omit-git-hash` and `download-ci-llvm`).
 # Make sure they don't get set when installing from source.

--- a/src/bootstrap/defaults/config.library.toml
+++ b/src/bootstrap/defaults/config.library.toml
@@ -8,6 +8,9 @@ bench-stage = 0
 [rust]
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
+# Download rustc from CI instead of building it from source.
+# For stage > 1 builds, this cuts compile times significantly when there are no changes on "compiler" tree.
+download-rustc = "if-unchanged"
 # Make the compiler and standard library faster to build, at the expense of a ~20% runtime slowdown.
 lto = "off"
 

--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -3,6 +3,11 @@
 [rust]
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
+# Download rustc from CI instead of building it from source.
+# For stage > 1 builds, this cuts compile times significantly when there are no changes on "compiler" tree.
+# Using these defaults will download the stage2 compiler (see `download-rustc`
+# setting) and the stage2 toolchain should therefore be used for these defaults.
+download-rustc = "if-unchanged"
 
 [build]
 # Document with the in-tree rustdoc by default, since `download-rustc` makes it quick to compile.

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1665,25 +1665,9 @@ impl Config {
         let mut debuginfo_level_tools = None;
         let mut debuginfo_level_tests = None;
         let mut optimize = None;
+        let mut omit_git_hash = None;
         let mut lld_enabled = None;
         let mut std_features = None;
-
-        let default = config.channel == "dev";
-        config.omit_git_hash = toml.rust.as_ref().and_then(|r| r.omit_git_hash).unwrap_or(default);
-
-        config.rust_info = GitInfo::new(config.omit_git_hash, &config.src);
-        config.cargo_info = GitInfo::new(config.omit_git_hash, &config.src.join("src/tools/cargo"));
-        config.rust_analyzer_info =
-            GitInfo::new(config.omit_git_hash, &config.src.join("src/tools/rust-analyzer"));
-        config.clippy_info =
-            GitInfo::new(config.omit_git_hash, &config.src.join("src/tools/clippy"));
-        config.miri_info = GitInfo::new(config.omit_git_hash, &config.src.join("src/tools/miri"));
-        config.rustfmt_info =
-            GitInfo::new(config.omit_git_hash, &config.src.join("src/tools/rustfmt"));
-        config.enzyme_info =
-            GitInfo::new(config.omit_git_hash, &config.src.join("src/tools/enzyme"));
-        config.in_tree_llvm_info = GitInfo::new(false, &config.src.join("src/llvm-project"));
-        config.in_tree_gcc_info = GitInfo::new(false, &config.src.join("src/gcc"));
 
         let mut is_user_configured_rust_channel = false;
 
@@ -1715,7 +1699,7 @@ impl Config {
                 verbose_tests,
                 optimize_tests,
                 codegen_tests,
-                omit_git_hash: _, // already handled above
+                omit_git_hash: omit_git_hash_toml,
                 dist_src,
                 save_toolstates,
                 codegen_backends,
@@ -1766,6 +1750,7 @@ impl Config {
             std_features = std_features_toml;
 
             optimize = optimize_toml;
+            omit_git_hash = omit_git_hash_toml;
             config.rust_new_symbol_mangling = new_symbol_mangling;
             set(&mut config.rust_optimize_tests, optimize_tests);
             set(&mut config.codegen_tests, codegen_tests);
@@ -1840,6 +1825,24 @@ impl Config {
         }
 
         config.reproducible_artifacts = flags.reproducible_artifact;
+
+        // rust_info must be set before is_ci_llvm_available() is called.
+        let default = config.channel == "dev";
+        config.omit_git_hash = omit_git_hash.unwrap_or(default);
+        config.rust_info = GitInfo::new(config.omit_git_hash, &config.src);
+
+        config.cargo_info = GitInfo::new(config.omit_git_hash, &config.src.join("src/tools/cargo"));
+        config.rust_analyzer_info =
+            GitInfo::new(config.omit_git_hash, &config.src.join("src/tools/rust-analyzer"));
+        config.clippy_info =
+            GitInfo::new(config.omit_git_hash, &config.src.join("src/tools/clippy"));
+        config.miri_info = GitInfo::new(config.omit_git_hash, &config.src.join("src/tools/miri"));
+        config.rustfmt_info =
+            GitInfo::new(config.omit_git_hash, &config.src.join("src/tools/rustfmt"));
+        config.enzyme_info =
+            GitInfo::new(config.omit_git_hash, &config.src.join("src/tools/enzyme"));
+        config.in_tree_llvm_info = GitInfo::new(false, &config.src.join("src/llvm-project"));
+        config.in_tree_gcc_info = GitInfo::new(false, &config.src.join("src/gcc"));
 
         // We need to override `rust.channel` if it's manually specified when using the CI rustc.
         // This is because if the compiler uses a different channel than the one specified in config.toml,
@@ -2757,19 +2760,9 @@ impl Config {
 
         // If `download-rustc` is not set, default to rebuilding.
         let if_unchanged = match download_rustc {
-            None => self.rust_info.is_managed_git_subrepository(),
-            Some(StringOrBool::Bool(false)) => return None,
+            None | Some(StringOrBool::Bool(false)) => return None,
             Some(StringOrBool::Bool(true)) => false,
-            Some(StringOrBool::String(s)) if s == "if-unchanged" => {
-                if !self.rust_info.is_managed_git_subrepository() {
-                    println!(
-                        "ERROR: `download-rustc=if-unchanged` is only compatible with Git managed sources."
-                    );
-                    crate::exit!(1);
-                }
-
-                true
-            }
+            Some(StringOrBool::String(s)) if s == "if-unchanged" => true,
             Some(StringOrBool::String(other)) => {
                 panic!("unrecognized option for download-rustc: {other}")
             }
@@ -2796,7 +2789,7 @@ impl Config {
                     }
                     println!("ERROR: could not find commit hash for downloading rustc");
                     println!("HELP: maybe your repository history is too shallow?");
-                    println!("HELP: consider setting `rust.download-rustc=false` in config.toml");
+                    println!("HELP: consider disabling `download-rustc`");
                     println!("HELP: or fetch enough history to include one upstream commit");
                     crate::exit!(1);
                 }

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -135,7 +135,6 @@ change-id = 0
 [rust]
 lto = "off"
 deny-warnings = true
-download-rustc=false
 
 [build]
 gdb = "foo"
@@ -201,8 +200,6 @@ runner = "x86_64-runner"
             .collect(),
         "setting dictionary value"
     );
-    assert!(!config.llvm_from_ci);
-    assert!(!config.download_rustc());
 }
 
 #[test]

--- a/tests/run-make/version-verbose-commit-hash/rmake.rs
+++ b/tests/run-make/version-verbose-commit-hash/rmake.rs
@@ -3,9 +3,6 @@
 // test ensures it will not be broken again.
 // See https://github.com/rust-lang/rust/issues/107094
 
-// FIXME(#132845): temporarily disabled to get revert through
-//@ ignore-test
-
 //@ needs-git-hash
 
 use run_make_support::{bare_rustc, bare_rustdoc, regex};

--- a/tests/run-make/version-verbose-commit-hash/rmake.rs
+++ b/tests/run-make/version-verbose-commit-hash/rmake.rs
@@ -3,6 +3,9 @@
 // test ensures it will not be broken again.
 // See https://github.com/rust-lang/rust/issues/107094
 
+// FIXME(#132845): temporarily disabled to get revert through
+//@ ignore-test
+
 //@ needs-git-hash
 
 use run_make_support::{bare_rustc, bare_rustdoc, regex};


### PR DESCRIPTION
**Rebased on top of #132846**.

Re-enable disabled `version-verbose-commit-hash` run-make test; it was disabled in revert PR #132846 to force revert through.

r? @ghost