### PR TITLE
do not trust download-rustc=if-unchanged on CI for now

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -179,7 +179,9 @@ else
   fi
 
   if [ "$NO_DOWNLOAD_CI_RUSTC" = "" ]; then
-    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.download-rustc=if-unchanged"
+    # disabled for now, see https://github.com/rust-lang/rust/issues/131658
+    #RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.download-rustc=if-unchanged"
+    true
   fi
 fi
 

--- a/tests/run-make/version-verbose-commit-hash/rmake.rs
+++ b/tests/run-make/version-verbose-commit-hash/rmake.rs
@@ -3,9 +3,6 @@
 // test ensures it will not be broken again.
 // See https://github.com/rust-lang/rust/issues/107094
 
-// FIXME(#132845): temporarily disabled to get revert through
-//@ ignore-test
-
 //@ needs-git-hash
 
 use run_make_support::{bare_rustc, bare_rustdoc, regex};


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/131658.

Once https://github.com/rust-lang/rust/pull/131831 lands this will be unnecessary, but until then, better safe than sorry.

r? @onur-ozkan 
Cc @rust-lang/bootstrap 