### PR TITLE
query/plumbing: adjust comment to reality

### DIFF
--- a/compiler/rustc_middle/src/query/plumbing.rs
+++ b/compiler/rustc_middle/src/query/plumbing.rs
@@ -319,7 +319,7 @@ macro_rules! define_callbacks {
 
                 pub type Storage<'tcx> = <$($K)* as keys::Key>::Cache<Erase<$V>>;
 
-                // Ensure that keys grow no larger than 72 bytes by accident.
+                // Ensure that keys grow no larger than 80 bytes by accident.
                 // Increase this limit if necessary, but do try to keep the size low if possible
                 #[cfg(target_pointer_width = "64")]
                 const _: () = {


### PR DESCRIPTION
The limit for the query key size got changed recently in https://github.com/rust-lang/rust/commit/f51ec110a714fea09105586b26c7f8e6a2a57018 but the comment was not updated.

Though maybe it is time to intern `CanonicalTypeOpAscribeUserTypeGoal` rather than copying it everywhere?

r? @lcnr 