### PR TITLE
`#[inline]` integer parsing functions

### DIFF
--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -1433,6 +1433,7 @@ macro_rules! from_str_radix_int_impl {
         #[stable(feature = "rust1", since = "1.0.0")]
         impl FromStr for $t {
             type Err = ParseIntError;
+            #[inline]
             fn from_str(src: &str) -> Result<Self, ParseIntError> {
                 <$t>::from_str_radix(src, 10)
             }
@@ -1505,6 +1506,7 @@ macro_rules! from_str_radix {
             /// ```
             #[stable(feature = "rust1", since = "1.0.0")]
             #[rustc_const_stable(feature = "const_int_from_str", since = "1.82.0")]
+            #[inline]
             pub const fn from_str_radix(src: &str, radix: u32) -> Result<$int_ty, ParseIntError> {
                 use self::IntErrorKind::*;
                 use self::ParseIntError as PIE;
@@ -1649,6 +1651,7 @@ macro_rules! from_str_radix_size_impl {
         /// ```
         #[stable(feature = "rust1", since = "1.0.0")]
         #[rustc_const_stable(feature = "const_int_from_str", since = "1.82.0")]
+        #[inline]
         pub const fn from_str_radix(src: &str, radix: u32) -> Result<$size, ParseIntError> {
             match <$t>::from_str_radix(src, radix) {
                 Ok(x) => Ok(x as $size),


### PR DESCRIPTION
This improves the performance of `str::parse` into integers.

Before:
```
compare          fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ std                         │               │               │               │         │
   ├─ 328920585  10.23 ns      │ 24.8 ns       │ 10.34 ns      │ 10.48 ns      │ 100     │ 25600
   ├─ 3255       8.551 ns      │ 8.59 ns       │ 8.551 ns      │ 8.56 ns       │ 100     │ 25600
   ╰─ 5          7.847 ns      │ 7.887 ns      │ 7.847 ns      │ 7.853 ns      │ 100     │ 25600
```

After:
```
compare          fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ std                         │               │               │               │         │
   ├─ 328920585  8.316 ns      │ 23.7 ns       │ 8.355 ns      │ 8.491 ns      │ 100     │ 25600
   ├─ 3255       4.566 ns      │ 4.588 ns      │ 4.586 ns      │ 4.576 ns      │ 100     │ 51200
   ╰─ 5          2.877 ns      │ 3.697 ns      │ 2.896 ns      │ 2.945 ns      │ 100     │ 102400
```

Benchmark:
```rust
fn std(input: &str) -> Result<u64, ParseIntError> {
    input.parse()
}
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
