### PR TITLE
Stabilize let chains in the 2024 edition

### DIFF
--- a/tests/mir-opt/building/logical_or_in_conditional.rs
+++ b/tests/mir-opt/building/logical_or_in_conditional.rs
@@ -1,6 +1,6 @@
 // skip-filecheck
 //@ compile-flags: -Z validate-mir
-#![feature(let_chains)]
+//@ edition: 2024
 struct Droppy(u8);
 impl Drop for Droppy {
     fn drop(&mut self) {

--- a/tests/mir-opt/building/logical_or_in_conditional.test_complex.built.after.mir
+++ b/tests/mir-opt/building/logical_or_in_conditional.test_complex.built.after.mir
@@ -19,7 +19,7 @@ fn test_complex() -> () {
     bb0: {
         StorageLive(_1);
         StorageLive(_2);
-        _2 = E::f() -> [return: bb1, unwind: bb34];
+        _2 = E::f() -> [return: bb1, unwind: bb35];
     }
 
     bb1: {
@@ -42,7 +42,7 @@ fn test_complex() -> () {
 
     bb5: {
         StorageLive(_4);
-        _4 = always_true() -> [return: bb6, unwind: bb34];
+        _4 = always_true() -> [return: bb6, unwind: bb35];
     }
 
     bb6: {
@@ -64,7 +64,7 @@ fn test_complex() -> () {
     }
 
     bb9: {
-        drop(_7) -> [return: bb11, unwind: bb34];
+        drop(_7) -> [return: bb11, unwind: bb35];
     }
 
     bb10: {
@@ -78,7 +78,7 @@ fn test_complex() -> () {
     }
 
     bb12: {
-        drop(_7) -> [return: bb13, unwind: bb34];
+        drop(_7) -> [return: bb13, unwind: bb35];
     }
 
     bb13: {
@@ -98,7 +98,7 @@ fn test_complex() -> () {
     }
 
     bb15: {
-        drop(_10) -> [return: bb17, unwind: bb34];
+        drop(_10) -> [return: bb17, unwind: bb35];
     }
 
     bb16: {
@@ -113,11 +113,12 @@ fn test_complex() -> () {
 
     bb18: {
         _1 = const ();
+        StorageDead(_2);
         goto -> bb22;
     }
 
     bb19: {
-        drop(_10) -> [return: bb20, unwind: bb34];
+        drop(_10) -> [return: bb20, unwind: bb35];
     }
 
     bb20: {
@@ -127,6 +128,7 @@ fn test_complex() -> () {
     }
 
     bb21: {
+        StorageDead(_2);
         _1 = const ();
         goto -> bb22;
     }
@@ -135,10 +137,9 @@ fn test_complex() -> () {
         StorageDead(_8);
         StorageDead(_5);
         StorageDead(_4);
-        StorageDead(_2);
         StorageDead(_1);
         StorageLive(_11);
-        _11 = always_true() -> [return: bb23, unwind: bb34];
+        _11 = always_true() -> [return: bb23, unwind: bb35];
     }
 
     bb23: {
@@ -146,7 +147,7 @@ fn test_complex() -> () {
     }
 
     bb24: {
-        goto -> bb32;
+        goto -> bb33;
     }
 
     bb25: {
@@ -155,7 +156,7 @@ fn test_complex() -> () {
 
     bb26: {
         StorageLive(_12);
-        _12 = E::f() -> [return: bb27, unwind: bb34];
+        _12 = E::f() -> [return: bb27, unwind: bb35];
     }
 
     bb27: {
@@ -178,21 +179,26 @@ fn test_complex() -> () {
 
     bb31: {
         _0 = const ();
-        goto -> bb33;
+        StorageDead(_12);
+        goto -> bb34;
     }
 
     bb32: {
-        _0 = const ();
+        StorageDead(_12);
         goto -> bb33;
     }
 
     bb33: {
+        _0 = const ();
+        goto -> bb34;
+    }
+
+    bb34: {
         StorageDead(_11);
-        StorageDead(_12);
         return;
     }
 
-    bb34 (cleanup): {
+    bb35 (cleanup): {
         resume;
     }
 }

--- a/tests/ui/deriving/auxiliary/malicious-macro.rs
+++ b/tests/ui/deriving/auxiliary/malicious-macro.rs
@@ -1,4 +1,4 @@
-#![feature(let_chains)]
+//@ edition: 2024
 
 extern crate proc_macro;
 

--- a/tests/ui/drop/drop-order-comparisons.e2021.fixed
+++ b/tests/ui/drop/drop-order-comparisons.e2021.fixed
@@ -24,7 +24,7 @@
 //@ [e2024] edition: 2024
 //@ run-pass
 
-#![feature(let_chains)]
+#![cfg_attr(e2021, feature(let_chains))]
 #![cfg_attr(e2021, warn(rust_2024_compatibility))]
 
 fn t_bindings() {

--- a/tests/ui/drop/drop-order-comparisons.rs
+++ b/tests/ui/drop/drop-order-comparisons.rs
@@ -24,7 +24,7 @@
 //@ [e2024] edition: 2024
 //@ run-pass
 
-#![feature(let_chains)]
+#![cfg_attr(e2021, feature(let_chains))]
 #![cfg_attr(e2021, warn(rust_2024_compatibility))]
 
 fn t_bindings() {

--- a/tests/ui/drop/drop_order.rs
+++ b/tests/ui/drop/drop_order.rs
@@ -2,9 +2,10 @@
 //@ compile-flags: -Z validate-mir
 //@ revisions: edition2021 edition2024
 //@ [edition2021] edition: 2021
+//@ [edition2024] compile-flags: -Z lint-mir
 //@ [edition2024] edition: 2024
 
-#![feature(let_chains)]
+#![cfg_attr(edition2021, feature(let_chains))]
 
 use std::cell::RefCell;
 use std::convert::TryInto;

--- a/tests/ui/drop/drop_order_if_let_rescope.rs
+++ b/tests/ui/drop/drop_order_if_let_rescope.rs
@@ -1,8 +1,6 @@
 //@ run-pass
 //@ edition:2024
-//@ compile-flags: -Z validate-mir
-
-#![feature(let_chains)]
+//@ compile-flags: -Z validate-mir -Z lint-mir
 
 use std::cell::RefCell;
 use std::convert::TryInto;

--- a/tests/ui/drop/issue-100276.rs
+++ b/tests/ui/drop/issue-100276.rs
@@ -1,6 +1,11 @@
 //@ check-pass
 //@ compile-flags: -Z validate-mir
-#![feature(let_chains)]
+//@ revisions: edition2021 edition2024
+//@ [edition2021] edition: 2021
+//@ [edition2024] compile-flags: -Z lint-mir
+//@ [edition2024] edition: 2024
+
+#![cfg_attr(edition2021, feature(let_chains))]
 
 fn let_chains(entry: std::io::Result<std::fs::DirEntry>) {
     if let Ok(entry) = entry

--- a/tests/ui/expr/if/attrs/let-chains-attr.rs
+++ b/tests/ui/expr/if/attrs/let-chains-attr.rs
@@ -1,6 +1,5 @@
 //@ check-pass
-
-#![feature(let_chains)]
+//@ edition:2024
 
 #[cfg(false)]
 fn foo() {

--- a/tests/ui/lint/issue-121070-let-range.rs
+++ b/tests/ui/lint/issue-121070-let-range.rs
@@ -1,6 +1,6 @@
 //@ check-pass
+//@ edition:2024
 
-#![feature(let_chains)]
 #![allow(irrefutable_let_patterns)]
 fn main() {
     let _a = 0..1;

--- a/tests/ui/mir/issue-99852.rs
+++ b/tests/ui/mir/issue-99852.rs
@@ -1,6 +1,6 @@
 //@ check-pass
 //@ compile-flags: -Z validate-mir
-#![feature(let_chains)]
+//@ edition: 2024
 
 fn lambda<T, U>() -> U
 where

--- a/tests/ui/mir/mir_let_chains_drop_order.rs
+++ b/tests/ui/mir/mir_let_chains_drop_order.rs
@@ -6,7 +6,7 @@
 
 // See `mir_drop_order.rs` for more information
 
-#![feature(let_chains)]
+#![cfg_attr(edition2021, feature(let_chains))]
 #![allow(irrefutable_let_patterns)]
 
 use std::cell::RefCell;

--- a/tests/ui/parser/brace-in-let-chain.rs
+++ b/tests/ui/parser/brace-in-let-chain.rs
@@ -1,6 +1,6 @@
 // issue #117766
+//@ edition: 2024
 
-#![feature(let_chains)]
 fn main() {
     if let () = ()
         && let () = () {

--- a/tests/ui/parser/deli-ident-issue-1.rs
+++ b/tests/ui/parser/deli-ident-issue-1.rs
@@ -1,4 +1,4 @@
-#![feature(let_chains)]
+//@ edition: 2024
 trait Demo {}
 
 impl dyn Demo {

--- a/tests/ui/parser/issues/issue-103381.fixed
+++ b/tests/ui/parser/issues/issue-103381.fixed
@@ -1,6 +1,6 @@
+//@ edition: 2024
 //@ run-rustfix
 
-#![feature(let_chains)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
 #![allow(irrefutable_let_patterns)]

--- a/tests/ui/parser/issues/issue-103381.rs
+++ b/tests/ui/parser/issues/issue-103381.rs
@@ -1,6 +1,6 @@
+//@ edition: 2024
 //@ run-rustfix
 
-#![feature(let_chains)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
 #![allow(irrefutable_let_patterns)]

--- a/tests/ui/parser/semi-in-let-chain.rs
+++ b/tests/ui/parser/semi-in-let-chain.rs
@@ -1,6 +1,5 @@
 // Issue #117720
-
-#![feature(let_chains)]
+//@ edition: 2024
 
 fn main() {
     if let () = ()

--- a/tests/ui/parser/semi-in-let-chain.stderr
+++ b/tests/ui/parser/semi-in-let-chain.stderr
@@ -1,11 +1,11 @@
 error: expected `{`, found `;`
-  --> $DIR/semi-in-let-chain.rs:7:23
+  --> $DIR/semi-in-let-chain.rs:6:23
    |
 LL |         && let () = ();
    |                       ^ expected `{`
    |
 note: you likely meant to continue parsing the let-chain starting here
-  --> $DIR/semi-in-let-chain.rs:8:9
+  --> $DIR/semi-in-let-chain.rs:7:9
    |
 LL |         && let () = ()
    |         ^^^^^^
@@ -16,13 +16,13 @@ LL +         && let () = ()
    |
 
 error: expected `{`, found `;`
-  --> $DIR/semi-in-let-chain.rs:15:20
+  --> $DIR/semi-in-let-chain.rs:14:20
    |
 LL |         && () == ();
    |                    ^ expected `{`
    |
 note: the `if` expression is missing a block after this condition
-  --> $DIR/semi-in-let-chain.rs:14:8
+  --> $DIR/semi-in-let-chain.rs:13:8
    |
 LL |       if let () = ()
    |  ________^
@@ -30,13 +30,13 @@ LL | |         && () == ();
    | |___________________^
 
 error: expected `{`, found `;`
-  --> $DIR/semi-in-let-chain.rs:23:20
+  --> $DIR/semi-in-let-chain.rs:22:20
    |
 LL |         && () == ();
    |                    ^ expected `{`
    |
 note: you likely meant to continue parsing the let-chain starting here
-  --> $DIR/semi-in-let-chain.rs:24:9
+  --> $DIR/semi-in-let-chain.rs:23:9
    |
 LL |         && let () = ()
    |         ^^^^^^

--- a/tests/ui/rfcs/rfc-0000-never_patterns/diverges-not.rs
+++ b/tests/ui/rfcs/rfc-0000-never_patterns/diverges-not.rs
@@ -1,5 +1,5 @@
+//@ edition: 2024
 #![feature(never_patterns)]
-#![feature(let_chains)]
 #![allow(incomplete_features)]
 #![deny(unreachable_patterns)]
 

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.rs
@@ -15,11 +15,9 @@ fn _if_let_guard() {
 
         () if true && let 0 = 1 => {}
         //~^ ERROR `if let` guards are experimental
-        //~| ERROR `let` expressions in this position are unstable
 
         () if let 0 = 1 && true => {}
         //~^ ERROR `if let` guards are experimental
-        //~| ERROR `let` expressions in this position are unstable
 
         () if (let 0 = 1) && true => {}
         //~^ ERROR expected expression, found `let` statement
@@ -33,8 +31,6 @@ fn _if_let_guard() {
 
         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
         //~^ ERROR `if let` guards are experimental
-        //~| ERROR `let` expressions in this position are unstable
-        //~| ERROR `let` expressions in this position are unstable
         //~| ERROR expected expression, found `let` statement
         //~| ERROR expected expression, found `let` statement
         //~| ERROR expected expression, found `let` statement
@@ -42,7 +38,6 @@ fn _if_let_guard() {
 
         () if let Range { start: _, end: _ } = (true..true) && false => {}
         //~^ ERROR `if let` guards are experimental
-        //~| ERROR `let` expressions in this position are unstable
 
         _ => {}
     }

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/feature-gate.stderr
@@ -25,98 +25,98 @@ LL |         () if (((let 0 = 1))) => {}
    |                  ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:24:16
+  --> $DIR/feature-gate.rs:22:16
    |
 LL |         () if (let 0 = 1) && true => {}
    |                ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:24:16
+  --> $DIR/feature-gate.rs:22:16
    |
 LL |         () if (let 0 = 1) && true => {}
    |                ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:27:24
+  --> $DIR/feature-gate.rs:25:24
    |
 LL |         () if true && (let 0 = 1) => {}
    |                        ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:27:24
+  --> $DIR/feature-gate.rs:25:24
    |
 LL |         () if true && (let 0 = 1) => {}
    |                        ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:30:16
+  --> $DIR/feature-gate.rs:28:16
    |
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    |                ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:30:16
+  --> $DIR/feature-gate.rs:28:16
    |
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    |                ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:30:31
+  --> $DIR/feature-gate.rs:28:31
    |
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    |                               ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:30:31
+  --> $DIR/feature-gate.rs:28:31
    |
 LL |         () if (let 0 = 1) && (let 0 = 1) => {}
    |                               ^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:34:42
+  --> $DIR/feature-gate.rs:32:42
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                          ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:34:42
+  --> $DIR/feature-gate.rs:32:42
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:34:55
+  --> $DIR/feature-gate.rs:32:55
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                                       ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:34:42
+  --> $DIR/feature-gate.rs:32:42
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:34:68
+  --> $DIR/feature-gate.rs:32:68
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                                                    ^^^^^^^^^
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 note: `let`s wrapped in parentheses are not supported in a context with let chains
-  --> $DIR/feature-gate.rs:34:42
+  --> $DIR/feature-gate.rs:32:42
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:60:16
+  --> $DIR/feature-gate.rs:55:16
    |
 LL |     use_expr!((let 0 = 1 && 0 == 0));
    |                ^^^
@@ -124,7 +124,7 @@ LL |     use_expr!((let 0 = 1 && 0 == 0));
    = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:60:16
+  --> $DIR/feature-gate.rs:55:16
    |
 LL |     use_expr!((let 0 = 1 && 0 == 0));
    |                ^^^
@@ -133,7 +133,7 @@ LL |     use_expr!((let 0 = 1 && 0 == 0));
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:63:16
+  --> $DIR/feature-gate.rs:58:16
    |
 LL |     use_expr!((let 0 = 1));
    |                ^^^
@@ -141,7 +141,7 @@ LL |     use_expr!((let 0 = 1));
    = note: only supported directly in conditions of `if` and `while` expressions
 
 error: expected expression, found `let` statement
-  --> $DIR/feature-gate.rs:63:16
+  --> $DIR/feature-gate.rs:58:16
    |
 LL |     use_expr!((let 0 = 1));
    |                ^^^
@@ -150,7 +150,7 @@ LL |     use_expr!((let 0 = 1));
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: no rules expected keyword `let`
-  --> $DIR/feature-gate.rs:72:15
+  --> $DIR/feature-gate.rs:67:15
    |
 LL |     macro_rules! use_expr {
    |     --------------------- when calling this macro
@@ -159,7 +159,7 @@ LL |     use_expr!(let 0 = 1);
    |               ^^^ no rules expected this token in macro call
    |
 note: while trying to match meta-variable `$e:expr`
-  --> $DIR/feature-gate.rs:53:10
+  --> $DIR/feature-gate.rs:48:10
    |
 LL |         ($e:expr) => {
    |          ^^^^^^^
@@ -187,7 +187,7 @@ LL |         () if true && let 0 = 1 => {}
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:20:12
+  --> $DIR/feature-gate.rs:19:12
    |
 LL |         () if let 0 = 1 && true => {}
    |            ^^^^^^^^^^^^^^^^^^^^
@@ -198,7 +198,7 @@ LL |         () if let 0 = 1 && true => {}
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:34:12
+  --> $DIR/feature-gate.rs:32:12
    |
 LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -209,7 +209,7 @@ LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:43:12
+  --> $DIR/feature-gate.rs:39:12
    |
 LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -220,7 +220,7 @@ LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
 error[E0658]: `if let` guards are experimental
-  --> $DIR/feature-gate.rs:68:12
+  --> $DIR/feature-gate.rs:63:12
    |
 LL |         () if let 0 = 1 => {}
    |            ^^^^^^^^^^^^
@@ -230,56 +230,6 @@ LL |         () if let 0 = 1 => {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:16:23
-   |
-LL |         () if true && let 0 = 1 => {}
-   |                       ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:20:15
-   |
-LL |         () if let 0 = 1 && true => {}
-   |               ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:34:15
-   |
-LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |               ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:34:28
-   |
-LL |         () if let 0 = 1 && let 1 = 2 && (let 2 = 3 && let 3 = 4 && let 4 = 5) => {}
-   |                            ^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/feature-gate.rs:43:15
-   |
-LL |         () if let Range { start: _, end: _ } = (true..true) && false => {}
-   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error: aborting due to 25 previous errors
+error: aborting due to 20 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/macro-expanded.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/macro-expanded.rs
@@ -1,7 +1,6 @@
 // Expression macros can't expand to a let match guard.
 
 #![feature(if_let_guard)]
-#![feature(let_chains)]
 
 macro_rules! m {
     ($e:expr) => { let Some(x) = $e }

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/macro-expanded.stderr
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/macro-expanded.stderr
@@ -1,5 +1,5 @@
 error: expected expression, found `let` statement
-  --> $DIR/macro-expanded.rs:7:20
+  --> $DIR/macro-expanded.rs:6:20
    |
 LL |     ($e:expr) => { let Some(x) = $e }
    |                    ^^^

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let-chain.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let-chain.rs
@@ -1,5 +1,5 @@
+//@ edition: 2024
 #![feature(if_let_guard)]
-#![feature(let_chains)]
 #![allow(irrefutable_let_patterns)]
 
 fn same_pattern(c: bool) {

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/parens.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/parens.rs
@@ -1,7 +1,7 @@
+//@ edition: 2024
 // Parenthesised let "expressions" are not allowed in guards
 
 #![feature(if_let_guard)]
-#![feature(let_chains)]
 
 #[cfg(false)]
 fn un_cfged() {

--- a/tests/ui/rfcs/rfc-2294-if-let-guard/shadowing.rs
+++ b/tests/ui/rfcs/rfc-2294-if-let-guard/shadowing.rs
@@ -1,8 +1,8 @@
 // Check shadowing in if let guards works as expected.
 //@ check-pass
+//@ edition: 2024
 
 #![feature(if_let_guard)]
-#![feature(let_chains)]
 
 fn main() {
     let x: Option<Option<i32>> = Some(Some(6));

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ast-lowering-does-not-wrap-let-chains.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ast-lowering-does-not-wrap-let-chains.rs
@@ -1,6 +1,6 @@
 //@ run-pass
+//@ edition: 2024
 
-#![feature(let_chains)]
 #![allow(irrefutable_let_patterns)]
 
 fn main() {

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.rs
@@ -1,4 +1,4 @@
-#![feature(let_chains)]
+//@ edition: 2024
 
 fn let_or_guard(x: Result<Option<i32>, ()>) {
     match x {

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/auxiliary/macro-in-2021.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/auxiliary/macro-in-2021.rs
@@ -1,0 +1,26 @@
+//@ edition: 2021
+
+#[macro_export]
+macro_rules! make_if {
+    (($($tt:tt)*) { $body:expr } { $else:expr }) => {{
+        if $($tt)* {
+            $body
+        } else {
+            $else
+        }
+    }};
+    (let ($expr:expr) { $body:expr } { $else:expr }) => {{
+        if let None = $expr {
+            $body
+        } else {
+            $else
+        }
+    }};
+    (let ($expr:expr) let ($expr2:expr) { $body:expr } { $else:expr }) => {{
+        if let None = $expr && let None = $expr2 {
+            $body
+        } else {
+            $else
+        }
+    }};
+}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/auxiliary/macro-in-2024.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/auxiliary/macro-in-2024.rs
@@ -1,0 +1,26 @@
+//@ edition: 2024
+
+#[macro_export]
+macro_rules! make_if {
+    (($($tt:tt)*) { $body:expr } { $else:expr }) => {{
+        if $($tt)* {
+            $body
+        } else {
+            $else
+        }
+    }};
+    (let ($expr:expr) { $body:expr } { $else:expr }) => {{
+        if let None = $expr {
+            $body
+        } else {
+            $else
+        }
+    }};
+    (let ($expr:expr) let ($expr2:expr) { $body:expr } { $else:expr }) => {{
+        if let None = $expr && let None = $expr2 {
+            $body
+        } else {
+            $else
+        }
+    }};
+}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/edition-gate-macro-error.edition2021.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/edition-gate-macro-error.edition2021.stderr
@@ -1,0 +1,65 @@
+error[E0658]: `let` expressions in this position are unstable
+  --> $DIR/edition-gate-macro-error.rs:19:30
+   |
+LL |     macro_in_2021::make_if!((let Some(0) = None && let Some(0) = None) { never!() } { never!() });
+   |                              ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `let` expressions in this position are unstable
+  --> $DIR/edition-gate-macro-error.rs:19:52
+   |
+LL |     macro_in_2021::make_if!((let Some(0) = None && let Some(0) = None) { never!() } { never!() });
+   |                                                    ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `let` expressions in this position are unstable
+  --> $DIR/edition-gate-macro-error.rs:22:5
+   |
+LL |     macro_in_2021::make_if!(let (Some(0)) let (Some(0)) { never!() } { never!() });
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: this error originates in the macro `macro_in_2021::make_if` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0658]: `let` expressions in this position are unstable
+  --> $DIR/edition-gate-macro-error.rs:22:5
+   |
+LL |     macro_in_2021::make_if!(let (Some(0)) let (Some(0)) { never!() } { never!() });
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: this error originates in the macro `macro_in_2021::make_if` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0658]: `let` expressions in this position are unstable
+  --> $DIR/edition-gate-macro-error.rs:26:30
+   |
+LL |     macro_in_2024::make_if!((let Some(0) = None && let Some(0) = None) { never!() } { never!() });
+   |                              ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `let` expressions in this position are unstable
+  --> $DIR/edition-gate-macro-error.rs:26:52
+   |
+LL |     macro_in_2024::make_if!((let Some(0) = None && let Some(0) = None) { never!() } { never!() });
+   |                                                    ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 6 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/edition-gate-macro-error.edition2024.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/edition-gate-macro-error.edition2024.stderr
@@ -1,0 +1,45 @@
+error[E0658]: `let` expressions in this position are unstable
+  --> $DIR/edition-gate-macro-error.rs:19:30
+   |
+LL |     macro_in_2021::make_if!((let Some(0) = None && let Some(0) = None) { never!() } { never!() });
+   |                              ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `let` expressions in this position are unstable
+  --> $DIR/edition-gate-macro-error.rs:19:52
+   |
+LL |     macro_in_2021::make_if!((let Some(0) = None && let Some(0) = None) { never!() } { never!() });
+   |                                                    ^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: `let` expressions in this position are unstable
+  --> $DIR/edition-gate-macro-error.rs:22:5
+   |
+LL |     macro_in_2021::make_if!(let (Some(0)) let (Some(0)) { never!() } { never!() });
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: this error originates in the macro `macro_in_2021::make_if` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0658]: `let` expressions in this position are unstable
+  --> $DIR/edition-gate-macro-error.rs:22:5
+   |
+LL |     macro_in_2021::make_if!(let (Some(0)) let (Some(0)) { never!() } { never!() });
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
+   = help: add `#![feature(let_chains)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = note: this error originates in the macro `macro_in_2021::make_if` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/edition-gate-macro-error.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/edition-gate-macro-error.rs
@@ -1,0 +1,30 @@
+//@ revisions: edition2021 edition2024
+//@ compile-flags: -Z lint-mir -Z validate-mir
+//@ [edition2021] edition: 2021
+//@ [edition2024] edition: 2024
+//@ aux-build:macro-in-2021.rs
+//@ aux-build:macro-in-2024.rs
+
+use std::unreachable as never;
+
+// Compiletest doesn't specify the needed --extern flags to make `extern crate` unneccessary
+extern crate macro_in_2021;
+extern crate macro_in_2024;
+
+fn main() {
+    // Gated on both 2021 and 2024 if the `if` comes from a 2021 macro
+    // Gated only on 2021 if the `if` comes from a 2024 macro
+    // No gating if both the `if` and the chain are from a 2024 macro
+
+    macro_in_2021::make_if!((let Some(0) = None && let Some(0) = None) { never!() } { never!() });
+    //~^ ERROR `let` expressions in this position are unstable
+    //~| ERROR `let` expressions in this position are unstable
+    macro_in_2021::make_if!(let (Some(0)) let (Some(0)) { never!() } { never!() });
+    //~^ ERROR `let` expressions in this position are unstable
+    //~| ERROR `let` expressions in this position are unstable
+
+    macro_in_2024::make_if!((let Some(0) = None && let Some(0) = None) { never!() } { never!() });
+    //[edition2021]~^ ERROR `let` expressions in this position are unstable
+    //[edition2021]~| ERROR `let` expressions in this position are unstable
+    macro_in_2024::make_if!(let (Some(0)) let (Some(0)) { never!() } { never!() });
+}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/edition-gate-macro.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/edition-gate-macro.rs
@@ -1,0 +1,76 @@
+//@ revisions: edition2021 edition2024
+//@ compile-flags: -Z lint-mir -Z validate-mir
+//@ [edition2021] edition: 2021
+//@ [edition2024] edition: 2024
+//@ aux-build:macro-in-2021.rs
+//@ aux-build:macro-in-2024.rs
+//@ run-pass
+
+#![allow(dead_code)]
+
+use std::unreachable as never;
+use std::cell::RefCell;
+use std::convert::TryInto;
+
+// Compiletest doesn't specify the needed --extern flags to make `extern crate` unneccessary
+extern crate macro_in_2021;
+extern crate macro_in_2024;
+
+#[derive(Default)]
+struct DropOrderCollector(RefCell<Vec<u32>>);
+
+struct LoudDrop<'a>(&'a DropOrderCollector, u32);
+
+impl Drop for LoudDrop<'_> {
+    fn drop(&mut self) {
+        println!("{}", self.1);
+        self.0.0.borrow_mut().push(self.1);
+    }
+}
+
+impl DropOrderCollector {
+    fn print(&self, n: u32) {
+        println!("{n}");
+        self.0.borrow_mut().push(n)
+    }
+    fn some_loud(&self, n: u32) -> Option<LoudDrop> {
+        Some(LoudDrop(self, n))
+    }
+
+    #[track_caller]
+    fn validate(self) {
+        assert!(
+            self.0
+                .into_inner()
+                .into_iter()
+                .enumerate()
+                .all(|(idx, item)| idx + 1 == item.try_into().unwrap())
+        );
+    }
+    fn with_macro_2021(self) {
+        // Edition 2021 drop behaviour
+        macro_in_2021::make_if!((let None = self.some_loud(2)) { never!() } {self.print(1) });
+        macro_in_2021::make_if!(let (self.some_loud(4)) { never!() } { self.print(3) });
+        self.validate();
+    }
+    fn with_macro_2024(self) {
+        // Edition 2024 drop behaviour
+        macro_in_2024::make_if!((let None = self.some_loud(1)) { never!() } { self.print(2) });
+        macro_in_2024::make_if!(let (self.some_loud(3)) { never!() } { self.print(4) });
+        self.validate();
+    }
+}
+
+fn main() {
+    // 2021 drop order if it's a 2021 macro creating the `if`
+    // 2024 drop order if it's a 2024 macro creating the `if`
+
+    // Compare this with edition-gate-macro-error.rs: We want to avoid exposing 2021 drop order,
+    // because it can create bad MIR (issue #104843)
+    // This test doesn't contain any let chains at all: it should be understood
+    // in combination with `edition-gate-macro-error.rs`
+
+    DropOrderCollector::default().with_macro_2021();
+    DropOrderCollector::default().with_macro_2024();
+
+}

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/ensure-that-let-else-does-not-interact-with-let-chains.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/ensure-that-let-else-does-not-interact-with-let-chains.rs
@@ -1,4 +1,4 @@
-#![feature(let_chains)]
+//@ edition: 2024
 
 fn main() {
     let opt = Some(1i32);

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/issue-90722.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/issue-90722.rs
@@ -1,6 +1,5 @@
 //@ check-pass
-
-#![feature(let_chains)]
+//@ edition: 2024
 
 fn main() {
     let x = Some(vec!["test"]);

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/issue-92145.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/issue-92145.rs
@@ -1,6 +1,5 @@
 //@ check-pass
-
-#![feature(let_chains)]
+//@ edition:2024
 
 fn main() {
     let opt = Some("foo bar");

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/issue-93150.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/issue-93150.rs
@@ -2,7 +2,6 @@ fn main() {
     match true {
         _ if let true = true && true => {}
         //~^ ERROR `if let` guards are
-        //~| ERROR `let` expressions in this
         _ => {}
     }
 }

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/issue-93150.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/issue-93150.stderr
@@ -9,16 +9,6 @@ LL |         _ if let true = true && true => {}
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
    = help: you can write `if matches!(<expr>, <pattern>)` instead of `if let <pattern> = <expr>`
 
-error[E0658]: `let` expressions in this position are unstable
-  --> $DIR/issue-93150.rs:3:14
-   |
-LL |         _ if let true = true && true => {}
-   |              ^^^^^^^^^^^^^^^
-   |
-   = note: see issue #53667 <https://github.com/rust-lang/rust/issues/53667> for more information
-   = help: add `#![feature(let_chains)]` to the crate attributes to enable
-   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/issue-99938.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/issue-99938.rs
@@ -1,6 +1,7 @@
 //@ compile-flags: -Zvalidate-mir -C opt-level=3
 //@ build-pass
-#![feature(let_chains)]
+//@ edition: 2024
+
 struct TupleIter<T, I: Iterator<Item = T>> {
     inner: I,
 }

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/temporary-early-drop.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/temporary-early-drop.rs
@@ -3,7 +3,6 @@
 //@ edition: 2024
 //@ check-pass
 
-#![feature(let_chains)]
 #![allow(irrefutable_let_patterns)]
 
 struct Pd;

--- a/tests/ui/unpretty/expanded-exhaustive.rs
+++ b/tests/ui/unpretty/expanded-exhaustive.rs
@@ -12,7 +12,6 @@
 #![feature(dyn_star)]
 #![feature(explicit_tail_calls)]
 #![feature(gen_blocks)]
-#![feature(let_chains)]
 #![feature(more_qualified_paths)]
 #![feature(never_patterns)]
 #![feature(never_type)]

--- a/tests/ui/unpretty/expanded-exhaustive.stdout
+++ b/tests/ui/unpretty/expanded-exhaustive.stdout
@@ -13,7 +13,6 @@
 #![feature(dyn_star)]
 #![feature(explicit_tail_calls)]
 #![feature(gen_blocks)]
-#![feature(let_chains)]
 #![feature(more_qualified_paths)]
 #![feature(never_patterns)]
 #![feature(never_type)]

--- a/tests/ui/unpretty/expanded-interpolation.rs
+++ b/tests/ui/unpretty/expanded-interpolation.rs
@@ -1,6 +1,6 @@
 //@ compile-flags: -Zunpretty=expanded
+//@ edition:2024
 //@ check-pass
-//@ edition: 2015
 
 // This test covers the AST pretty-printer's insertion of parentheses in some
 // macro metavariable edge cases. Synthetic parentheses (i.e. not appearing in
@@ -8,7 +8,6 @@
 // Rust syntax. We also test negative cases: the pretty-printer should not be
 // synthesizing parentheses indiscriminately; only where necessary.
 
-#![feature(let_chains)]
 #![feature(if_let_guard)]
 
 macro_rules! expr {

--- a/tests/ui/unpretty/expanded-interpolation.stdout
+++ b/tests/ui/unpretty/expanded-interpolation.stdout
@@ -1,8 +1,7 @@
 #![feature(prelude_import)]
-#![no_std]
 //@ compile-flags: -Zunpretty=expanded
+//@ edition:2024
 //@ check-pass
-//@ edition: 2015
 
 // This test covers the AST pretty-printer's insertion of parentheses in some
 // macro metavariable edge cases. Synthetic parentheses (i.e. not appearing in
@@ -10,10 +9,9 @@
 // Rust syntax. We also test negative cases: the pretty-printer should not be
 // synthesizing parentheses indiscriminately; only where necessary.
 
-#![feature(let_chains)]
 #![feature(if_let_guard)]
 #[prelude_import]
-use ::std::prelude::rust_2015::*;
+use std::prelude::rust_2024::*;
 #[macro_use]
 extern crate std;
 


### PR DESCRIPTION
# Stabilization report

This proposes the stabilization of `let_chains` ([tracking issue], [RFC 2497]) in the [2024 edition] of Rust.

[tracking issue]: https://github.com/rust-lang/rust/issues/53667
[RFC 2497]: https://github.com/rust-lang/rfcs/pull/2497
[2024 edition]: https://doc.rust-lang.org/nightly/edition-guide/rust-2024/index.html

## What is being stabilized

The ability to `&&`-chain `let` statements inside `if` and `while` is being stabilized, allowing intermixture with boolean expressions. The patterns inside the `let` sub-expressions can be irrefutable or refutable.

```Rust
struct FnCall<'a> {
    fn_name: &'a str,
    args: Vec<i32>,
}

fn is_legal_ident(s: &str) -> bool {
    s.chars()
        .all(|c| ('a'..='z').contains(&c) || ('A'..='Z').contains(&c))
}

impl<'a> FnCall<'a> {
    fn parse(s: &'a str) -> Option<Self> {
        if let Some((fn_name, after_name)) = s.split_once("(")
            && !fn_name.is_empty()
            && is_legal_ident(fn_name)
            && let Some((args_str, "")) = after_name.rsplit_once(")")
        {
            let args = args_str
                .split(',')
                .map(|arg| arg.parse())
                .collect::<Result<Vec<_>, _>>();
            args.ok().map(|args| FnCall { fn_name, args })
        } else {
            None
        }
    }
    fn exec(&self) -> Option<i32> {
        let iter = self.args.iter().copied();
        match self.fn_name {
            "sum" => Some(iter.sum()),
            "max" => iter.max(),
            "min" => iter.min(),
            _ => None,
        }
    }
}

fn main() {
    println!("{:?}", FnCall::parse("sum(1,2,3)").unwrap().exec());
    println!("{:?}", FnCall::parse("max(4,5)").unwrap().exec());
}
```

The feature will only be stabilized for the 2024 edition and future editions. Users of past editions will get an error with a hint to update the edition.

closes rust-lang/rust#53667

## Why 2024 edition?

Rust generally tries to ship new features to all editions. So even the oldest editions receive the newest features. However, sometimes a feature requires a breaking change so much that offering the feature without the breaking change makes no sense. This occurs rarely, but has happened in the 2018 edition already with `async` and `await` syntax. It required an edition boundary in order for `async`/`await` to become keywords, and the entire feature foots on those keywords.

In the instance of let chains, the issue is the drop order of `if let` chains. If we want `if let` chains to be compatible with `if let`, drop order makes it hard for us to [generate correct MIR]. It would be strange to have different behaviour for `if let ... {}` and `if true && let ... {}`. So it's better to [stay consistent with `if let`].

In edition 2024, [drop order changes] have been introduced to make `if let` temporaries be lived more shortly. These changes also affected `if let` chains. These changes make sense even if you don't take the `if let` chains MIR generation problem into account. But if we want to use them as the solution to the MIR generation problem, we need to restrict let chains to edition 2024 and beyond: for let chains, it's not just a change towards more sensible behaviour, but one required for correct function.

[generate correct MIR]: https://github.com/rust-lang/rust/issues/104843
[stay consistent with `if let`]: https://github.com/rust-lang/rust/pull/103293#issuecomment-1293408574
[drop order changes]: https://github.com/rust-lang/rust/issues/124085

## Introduction considerations

As edition 2024 is very new, this stabilization PR only makes it possible to use let chains on 2024 without that feature gate, it doesn't mark that feature gate as stable/removed. I would propose to continue offering the `let_chains` feature (behind a feature gate) for a limited time (maybe 3 months after stabilization?) on older editions to allow nightly users to adopt edition 2024 at their own pace. After that, the feature gate shall be marked as *stabilized*, not removed, and replaced by an error on editions 2021 and below.

## Implementation history

* History from before March 14, 2022 can be found in the [original stabilization PR] that was reverted.
* https://github.com/rust-lang/rust/pull/94927
* https://github.com/rust-lang/rust/pull/94951
* https://github.com/rust-lang/rust/pull/94974
* https://github.com/rust-lang/rust/pull/95008
* https://github.com/rust-lang/rust/pull/97295
* https://github.com/rust-lang/rust/pull/98633
* https://github.com/rust-lang/rust/pull/99731
* https://github.com/rust-lang/rust/pull/102394
* https://github.com/rust-lang/rust/pull/100526
* https://github.com/rust-lang/rust/pull/100538
* https://github.com/rust-lang/rust/pull/102998
* https://github.com/rust-lang/rust/pull/103405
* https://github.com/rust-lang/rust/pull/103293
* https://github.com/rust-lang/rust/pull/107251
* https://github.com/rust-lang/rust/pull/110568
* https://github.com/rust-lang/rust/pull/115677
* https://github.com/rust-lang/rust/pull/117743
* https://github.com/rust-lang/rust/pull/117770
* https://github.com/rust-lang/rust/pull/118191
* https://github.com/rust-lang/rust/pull/119554
* https://github.com/rust-lang/rust/pull/129394
* https://github.com/rust-lang/rust/pull/132828
* https://github.com/rust-lang/reference/pull/1179
* https://github.com/rust-lang/reference/pull/1251
* https://github.com/rust-lang/rustfmt/pull/5910

[original stabilization PR]: https://github.com/rust-lang/rust/pull/94927

## Adoption history

### In the compiler

* History before March 14, 2022 can be found in the [original stabilization PR].
* https://github.com/rust-lang/rust/pull/115983
* https://github.com/rust-lang/rust/pull/116549
* https://github.com/rust-lang/rust/pull/116688

### Outside of the compiler

* https://github.com/rust-lang/rust-clippy/pull/11750
* [rspack](https://github.com/web-infra-dev/rspack)
* [risingwave](https://github.com/risingwavelabs/risingwave)
* [dylint](https://github.com/trailofbits/dylint)
* [convex-backend](https://github.com/get-convex/convex-backend)
* [tikv](https://github.com/tikv/tikv)
* [Daft](https://github.com/Eventual-Inc/Daft)
* [greptimedb](https://github.com/GreptimeTeam/greptimedb)

## Tests

<details>

### Intentional restrictions

[`partially-macro-expanded.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2294-if-let-guard/partially-macro-expanded.rs), [`macro-expanded.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2294-if-let-guard/macro-expanded.rs): it is possible to use macros to expand to both the pattern and the expression inside a let chain, but not to the entire `let pat = expr` operand.
[`parens.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2294-if-let-guard/parens.rs): `if (let pat = expr)` is not allowed in chains
[`ensure-that-let-else-does-not-interact-with-let-chains.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2497-if-let-chains/ensure-that-let-else-does-not-interact-with-let-chains.rs): `let...else` doesn't support chaining.

### Overlap with match guards

[`move-guard-if-let-chain.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2294-if-let-guard/move-guard-if-let-chain.rs): test for the `use moved value` error working well in match guards. could maybe be extended with let chains that have more than one `let`
[`shadowing.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2294-if-let-guard/shadowing.rs): shadowing in if let guards works as expected
[`ast-validate-guards.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2497-if-let-chains/ast-validate-guards.rs): let chains in match guards require the match guards feature gate

### Simple cases from the early days

PR rust-lang/rust#88642 has added some tests with very simple usages of `let else`, mostly as regression tests to early bugs.

[`then-else-blocks.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2497-if-let-chains/then-else-blocks.rs)
[`ast-lowering-does-not-wrap-let-chains.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2497-if-let-chains/ast-lowering-does-not-wrap-let-chains.rs)
[`issue-90722.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2497-if-let-chains/issue-90722.rs)
[`issue-92145.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2497-if-let-chains/issue-92145.rs)

### Drop order/MIR scoping tests

[`issue-100276.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/drop/issue-100276.rs): let expressions on RHS aren't terminating scopes
[`drop_order.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/drop/drop_order.rs): exhaustive temporary drop order test for various Rust constructs, including let chains
[`scope.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2294-if-let-guard/scope.rs): match guard scoping test
[`drop-scope.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2294-if-let-guard/drop-scope.rs): another match guard scoping test, ensuring that temporaries in if-let guards live for the arm
[`drop_order_if_let_rescope.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/drop/drop_order_if_let_rescope.rs): if let rescoping on edition 2024, including chains
[`mir_let_chains_drop_order.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/mir/mir_let_chains_drop_order.rs): comprehensive drop order test for let chains, distinguishes editions 2021 and 2024.
[`issue-99938.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2497-if-let-chains/issue-99938.rs), [`issue-99852.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/mir/issue-99852.rs) both bad MIR ICEs fixed by rust-lang/rust#102394

### Linting

[`irrefutable-lets.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2497-if-let-chains/irrefutable-lets.rs): trailing and leading irrefutable let patterns get linted for, others don't. The lint is turned off for `else if`.
[`issue-121070-let-range.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/lint/issue-121070-let-range.rs): regression test for false positive of the unused parens lint, precedence requires the `()`s here

### Parser: intentional restrictions

[`disallowed-positions.rs`](https://github.com/rust-lang/rust/blob/2128d8df0e858edcbe6a0861bac948b88b7fabc3/tests/ui/rfcs/rfc-2497-if-let-chains/disallowed-positions.rs): `let` in expression context is rejected everywhere except at the top level
[`invalid-let-in-a-valid-let-context.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-2497-if-let-chains/invalid-let-in-a-valid-let-context.rs): nested `let` is not allowed (let's are no legal expressions just because they are allowed in `if` and `while`).

### Parser: recovery

[`issue-103381.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/parser/issues/issue-103381.rs): Graceful recovery of incorrect chaining of `if` and `if let`
[`semi-in-let-chain.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/parser/semi-in-let-chain.rs): Ensure that stray `;`s in let chains give nice errors (`if_chain!` users might be accustomed to `;`s)
[`deli-ident-issue-1.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/parser/deli-ident-issue-1.rs), [`brace-in-let-chain.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/parser/brace-in-let-chain.rs): Ensure that stray unclosed `{`s in let chains give nice errors and hints

### Misc

[`conflicting_bindings.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/pattern/usefulness/conflicting_bindings.rs): the conflicting bindings check also works in let chains. Personally, I'd extend it to chains with multiple let's as well.
[`let-chains-attr.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/expr/if/attrs/let-chains-attr.rs): attributes work on let chains

### Tangential tests with `#![feature(let_chains)]`

[`if-let.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/coverage/branch/if-let.rs): MC/DC coverage tests for let chains
[`logical_or_in_conditional.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/mir-opt/building/logical_or_in_conditional.rs): not really about let chains, more about dropping/scoping behaviour of `||`
[`stringify.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/macros/stringify.rs): exhaustive test of the `stringify` macro
[`expanded-interpolation.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/unpretty/expanded-interpolation.rs), [`expanded-exhaustive.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/unpretty/expanded-exhaustive.rs): Exhaustive test of `-Zunpretty`
[`diverges-not.rs`](https://github.com/rust-lang/rust/blob/4adafcf40aa6064d2bbcb44bc1a50b3b1e86e5e0/tests/ui/rfcs/rfc-0000-never_patterns/diverges-not.rs): Never type, mostly tangential to let chains

</details>

## Possible future work

* There is proposals to allow `if let Pat(bindings) = expr {}` to be written as `if expr is Pat(bindings) {}` ([RFC 3573]). `if let` chains are a natural extension of the already existing `if let` syntax, and I'd argue orthogonal towards `is` syntax.
  * https://github.com/rust-lang/lang-team/issues/297
* One could have similar chaining inside `let ... else` statements. There is no proposed RFC for this however, nor is it implemented on nightly.
* Match guards have the `if` keyword as well, but on stable Rust, they don't support `let`. The functionality is available via an unstable feature ([`if_let_guard` tracking issue]). Stabilization of let chains affects this feature in so far as match guards containing let chains now only need the `if_let_guard` feature gate be present instead of also the `let_chains` feature (NOTE: this PR doesn't implement this simplification, it's left for future work).

[RFC 3573]: https://github.com/rust-lang/rfcs/pull/3573
[`if_let_guard` tracking issue]: https://github.com/rust-lang/rust/issues/51114

## Open questions / blockers

- [x] bad recovery if you don't put a `let` (I don't think this is a blocker): [#117977](https://github.com/rust-lang/rust/issues/117977)
- [x] An instance where a temporary lives shorter than with nested ifs, breaking compilation: [#103476](https://github.com/rust-lang/rust/issues/103476). Personally I don't think this is a blocker either, as it's an edge case. Edit: turns out to not reproduce in edition 2025 any more, due to let rescoping. regression test added in rust-lang/rust#133093
- [x] One should probably extend the tests for `move-guard-if-let-chain.rs` and `conflicting_bindings.rs` to have chains with multiple let's: done in 133093
- [x] Parsing rejection tests: addressed by https://github.com/rust-lang/rust/pull/132828
- [x] [Style](https://rust-lang.zulipchat.com/#narrow/channel/346005-t-style/topic/let.20chains.20stabilization.20and.20formatting): https://github.com/rust-lang/rust/pull/139456
- [x] https://github.com/rust-lang/rust/issues/86730 explicitly mentions `let_else`. I think we can live with `let pat = expr` not evaluating as `expr` for macro_rules macros, especially given that `let pat = expr` is not a legal expression anywhere except inside `if` and `while`.
- [x] Documentation in the reference: https://github.com/rust-lang/reference/pull/1740
- [x] Add chapter to the Rust 2024 [edition guide]: https://github.com/rust-lang/edition-guide/pull/337
- [x] Resolve open questions on desired drop order.

[original reference PR]: https://github.com/rust-lang/reference/pull/1179
[edition guide]: https://github.com/rust-lang/edition-guide
