### PR TITLE
Rollup of 3 pull requests

### DIFF
--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -45,6 +45,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                     | asm::InlineAsmArch::X86_64
                     | asm::InlineAsmArch::Arm
                     | asm::InlineAsmArch::AArch64
+                    | asm::InlineAsmArch::Arm64EC
                     | asm::InlineAsmArch::RiscV32
                     | asm::InlineAsmArch::RiscV64
                     | asm::InlineAsmArch::LoongArch64

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -254,7 +254,8 @@ impl<'a> LintDiagnostic<'a, ()> for BuiltinUngatedAsyncFnTrackCaller<'_> {
 #[diag(lint_builtin_unreachable_pub)]
 pub(crate) struct BuiltinUnreachablePub<'a> {
     pub what: &'a str,
-    #[suggestion(code = "pub(crate)")]
+    pub new_vis: &'a str,
+    #[suggestion(code = "{new_vis}")]
     pub suggestion: (Span, Applicability),
     #[help]
     pub help: bool,

--- a/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
+++ b/src/doc/unstable-book/src/language-features/asm-experimental-arch.md
@@ -18,7 +18,6 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 - MSP430
 - M68k
 - CSKY
-- Arm64EC
 - SPARC
 
 ## Register classes
@@ -53,9 +52,6 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | CSKY         | `freg`         | `f[0-31]`                          | `f`                  |
 | SPARC        | `reg`          | `r[2-29]`                          | `r`                  |
 | SPARC        | `yreg`         | `y`                                | Only clobbers        |
-| Arm64EC      | `reg`          | `x[0-12]`, `x[15-22]`, `x[25-27]`, `x30` | `r`            |
-| Arm64EC      | `vreg`         | `v[0-15]`                          | `w`                  |
-| Arm64EC      | `vreg_low16`   | `v[0-15]`                          | `x`                  |
 
 > **Notes**:
 > - NVPTX doesn't have a fixed register set, so named registers are not supported.
@@ -92,8 +88,6 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | CSKY         | `freg`                          | None           | `f32`,                                  |
 | SPARC        | `reg`                           | None           | `i8`, `i16`, `i32`, `i64` (SPARC64 only) |
 | SPARC        | `yreg`                          | N/A            | Only clobbers                           |
-| Arm64EC      | `reg`                           | None           | `i8`, `i16`, `i32`, `f32`, `i64`, `f64` |
-| Arm64EC      | `vreg`                          | None           | `i8`, `i16`, `i32`, `f32`, `i64`, `f64`, <br> `i8x8`, `i16x4`, `i32x2`, `i64x1`, `f32x2`, `f64x1`, <br> `i8x16`, `i16x8`, `i32x4`, `i64x2`, `f32x4`, `f64x2` |
 
 ## Register aliases
 
@@ -134,12 +128,6 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | SPARC        | `r[8-15]`     | `o[0-7]`  |
 | SPARC        | `r[16-23]`    | `l[0-7]`  |
 | SPARC        | `r[24-31]`    | `i[0-7]`  |
-| Arm64EC      | `x[0-30]`     | `w[0-30]` |
-| Arm64EC      | `x29`         | `fp`      |
-| Arm64EC      | `x30`         | `lr`      |
-| Arm64EC      | `sp`          | `wsp`     |
-| Arm64EC      | `xzr`         | `wzr`     |
-| Arm64EC      | `v[0-15]`     | `b[0-15]`, `h[0-15]`, `s[0-15]`, `d[0-15]`, `q[0-15]` |
 
 > **Notes**:
 > - TI does not mandate a frame pointer for MSP430, but toolchains are allowed
@@ -150,8 +138,8 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | Architecture | Unsupported register                    | Reason                                                                                                                                                                              |
 | ------------ | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | All          | `sp`, `r14`/`o6` (SPARC)                | The stack pointer must be restored to its original value at the end of an asm code block.                                                                                           |
-| All          | `fr` (Hexagon), `fp` (PowerPC), `$fp` (MIPS), `Y` (AVR), `r4` (MSP430), `a6` (M68k), `r30`/`i6` (SPARC), `x29` (Arm64EC) | The frame pointer cannot be used as an input or output.                                            |
-| All          | `r19` (Hexagon), `r29` (PowerPC), `r30` (PowerPC), `x19` (Arm64EC) | These are used internally by LLVM as "base pointer" for functions with complex stack frames.                                                             |
+| All          | `fr` (Hexagon), `fp` (PowerPC), `$fp` (MIPS), `Y` (AVR), `r4` (MSP430), `a6` (M68k), `r30`/`i6` (SPARC) | The frame pointer cannot be used as an input or output.                                                             |
+| All          | `r19` (Hexagon), `r29` (PowerPC), `r30` (PowerPC) | These are used internally by LLVM as "base pointer" for functions with complex stack frames.                                                                              |
 | MIPS         | `$0` or `$zero`                         | This is a constant zero register which can't be modified.                                                                                                                           |
 | MIPS         | `$1` or `$at`                           | Reserved for assembler.                                                                                                                                                             |
 | MIPS         | `$26`/`$k0`, `$27`/`$k1`                | OS-reserved registers.                                                                                                                                                              |
@@ -176,9 +164,6 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | SPARC        | `r5`/`g5`                               | Reserved for system. (SPARC32 only) |
 | SPARC        | `r6`/`g6`, `r7`/`g7`                    | Reserved for system. |
 | SPARC        | `r31`/`i7`                              | Return address cannot be used as inputs or outputs. |
-| Arm64EC      | `xzr`                                   | This is a constant zero register which can't be modified. |
-| Arm64EC      | `x18`                                   | This is an OS-reserved register. |
-| Arm64EC      | `x13`, `x14`, `x23`, `x24`, `x28`, `v[16-31]` | These are AArch64 registers that are not supported for Arm64EC. |
 
 
 ## Template modifiers
@@ -197,16 +182,6 @@ This feature tracks `asm!` and `global_asm!` support for the following architect
 | SPARC        | `reg`          | None     | `%o0`          | None          |
 | CSKY         | `reg`          | None     | `r0`           | None          |
 | CSKY         | `freg`         | None     | `f0`           | None          |
-| Arm64EC      | `reg`          | None     | `x0`           | `x`           |
-| Arm64EC      | `reg`          | `w`      | `w0`           | `w`           |
-| Arm64EC      | `reg`          | `x`      | `x0`           | `x`           |
-| Arm64EC      | `vreg`         | None     | `v0`           | None          |
-| Arm64EC      | `vreg`         | `v`      | `v0`           | None          |
-| Arm64EC      | `vreg`         | `b`      | `b0`           | `b`           |
-| Arm64EC      | `vreg`         | `h`      | `h0`           | `h`           |
-| Arm64EC      | `vreg`         | `s`      | `s0`           | `s`           |
-| Arm64EC      | `vreg`         | `d`      | `d0`           | `d`           |
-| Arm64EC      | `vreg`         | `q`      | `q0`           | `q`           |
 
 # Flags covered by `preserves_flags`
 
@@ -220,6 +195,3 @@ These flags registers must be restored upon exiting the asm block if the `preser
 - SPARC
   - Integer condition codes (`icc` and `xcc`)
   - Floating-point condition codes (`fcc[0-3]`)
-- Arm64EC
-  - Condition flags (`NZCV` register).
-  - Floating-point status (`FPSR` register).

--- a/tests/assembly/asm/aarch64-types.rs
+++ b/tests/assembly/asm/aarch64-types.rs
@@ -6,7 +6,7 @@
 //@ [arm64ec] needs-llvm-components: aarch64
 //@ compile-flags: -Zmerge-functions=disabled
 
-#![feature(no_core, lang_items, rustc_attrs, repr_simd, asm_experimental_arch, f16, f128)]
+#![feature(no_core, lang_items, rustc_attrs, repr_simd, f16, f128)]
 #![crate_type = "rlib"]
 #![no_core]
 #![allow(asm_sub_register, non_camel_case_types)]

--- a/tests/codegen/asm/arm64ec-clobbers.rs
+++ b/tests/codegen/asm/arm64ec-clobbers.rs
@@ -3,7 +3,7 @@
 //@ needs-llvm-components: aarch64
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![feature(no_core, rustc_attrs, lang_items)]
 #![no_core]
 
 #[lang = "sized"]

--- a/tests/ui/asm/aarch64/arm64ec-sve.rs
+++ b/tests/ui/asm/aarch64/arm64ec-sve.rs
@@ -3,7 +3,7 @@
 //@ needs-llvm-components: aarch64
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![feature(no_core, rustc_attrs, lang_items)]
 #![no_core]
 
 // SVE cannot be used for Arm64EC

--- a/tests/ui/lint/unreachable_pub.fixed
+++ b/tests/ui/lint/unreachable_pub.fixed
@@ -7,12 +7,12 @@
 
 mod private_mod {
     // non-leaked `pub` items in private module should be linted
-    pub use std::fmt; //~ WARNING unreachable_pub
-    pub use std::env::{Args}; // braced-use has different item spans than unbraced
+    pub(crate) use std::fmt; //~ WARNING unreachable_pub
+    pub(crate) use std::env::{Args}; // braced-use has different item spans than unbraced
     //~^ WARNING unreachable_pub
 
     // we lint on struct definition
-    pub struct Hydrogen { //~ WARNING unreachable_pub
+    pub(crate) struct Hydrogen { //~ WARNING unreachable_pub
         // but not on fields, even if they are `pub` as putting `pub(crate)`
         // it would clutter the source code for little value
         pub neutrons: usize,
@@ -23,7 +23,7 @@ mod private_mod {
     }
     impl Hydrogen {
         // impls, too
-        pub fn count_neutrons(&self) -> usize { self.neutrons } //~ WARNING unreachable_pub
+        pub(crate) fn count_neutrons(&self) -> usize { self.neutrons } //~ WARNING unreachable_pub
         pub(crate) fn count_electrons(&self) -> usize { self.electrons }
     }
     impl Clone for Hydrogen {
@@ -32,49 +32,49 @@ mod private_mod {
         }
     }
 
-    pub enum Helium {} //~ WARNING unreachable_pub
-    pub union Lithium { c1: usize, c2: u8 } //~ WARNING unreachable_pub
-    pub fn beryllium() {} //~ WARNING unreachable_pub
-    pub trait Boron {} //~ WARNING unreachable_pub
-    pub const CARBON: usize = 1; //~ WARNING unreachable_pub
-    pub static NITROGEN: usize = 2; //~ WARNING unreachable_pub
-    pub type Oxygen = bool; //~ WARNING unreachable_pub
+    pub(crate) enum Helium {} //~ WARNING unreachable_pub
+    pub(crate) union Lithium { c1: usize, c2: u8 } //~ WARNING unreachable_pub
+    pub(crate) fn beryllium() {} //~ WARNING unreachable_pub
+    pub(crate) trait Boron {} //~ WARNING unreachable_pub
+    pub(crate) const CARBON: usize = 1; //~ WARNING unreachable_pub
+    pub(crate) static NITROGEN: usize = 2; //~ WARNING unreachable_pub
+    pub(crate) type Oxygen = bool; //~ WARNING unreachable_pub
 
     macro_rules! define_empty_struct_with_visibility {
         ($visibility: vis, $name: ident) => { $visibility struct $name {} }
         //~^ WARNING unreachable_pub
     }
-    define_empty_struct_with_visibility!(pub, Fluorine);
+    define_empty_struct_with_visibility!(pub(crate), Fluorine);
 
     extern "C" {
-        pub fn catalyze() -> bool; //~ WARNING unreachable_pub
+        pub(crate) fn catalyze() -> bool; //~ WARNING unreachable_pub
     }
 
     mod private_in_private {
-        pub enum Helium {} //~ WARNING unreachable_pub
-        pub fn beryllium() {} //~ WARNING unreachable_pub
+        pub(super) enum Helium {} //~ WARNING unreachable_pub
+        pub(super) fn beryllium() {} //~ WARNING unreachable_pub
     }
 
     pub(crate) mod crate_in_private {
-        pub const CARBON: usize = 1; //~ WARNING unreachable_pub
+        pub(crate) const CARBON: usize = 1; //~ WARNING unreachable_pub
     }
 
-    pub mod pub_in_private { //~ WARNING unreachable_pub
-        pub static NITROGEN: usize = 2; //~ WARNING unreachable_pub
+    pub(crate) mod pub_in_private { //~ WARNING unreachable_pub
+        pub(crate) static NITROGEN: usize = 2; //~ WARNING unreachable_pub
     }
 
     fn foo() {
         const {
-            pub struct Foo; //~ WARNING unreachable_pub
+            pub(crate) struct Foo; //~ WARNING unreachable_pub
         };
     }
 
     enum Weird {
         Variant = {
-            pub struct Foo; //~ WARNING unreachable_pub
+            pub(crate) struct Foo; //~ WARNING unreachable_pub
 
             mod tmp {
-                pub struct Bar; //~ WARNING unreachable_pub
+                pub(crate) struct Bar; //~ WARNING unreachable_pub
             }
 
             let _ = tmp::Bar;
@@ -83,11 +83,11 @@ mod private_mod {
         },
     }
 
-    pub use fpu_precision::set_precision; //~ WARNING unreachable_pub
+    pub(crate) use fpu_precision::set_precision; //~ WARNING unreachable_pub
 
     mod fpu_precision {
-        pub fn set_precision<T>() {} //~ WARNING unreachable_pub
-        pub fn set_micro_precision<T>() {} //~ WARNING unreachable_pub
+        pub(crate) fn set_precision<T>() {} //~ WARNING unreachable_pub
+        pub(super) fn set_micro_precision<T>() {} //~ WARNING unreachable_pub
     }
 
     // items leaked through signatures (see `get_neon` below) are OK

--- a/tests/ui/lint/unreachable_pub.stderr
+++ b/tests/ui/lint/unreachable_pub.stderr
@@ -1,5 +1,5 @@
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:8:13
+  --> $DIR/unreachable_pub.rs:10:13
    |
 LL |     pub use std::fmt;
    |     ---     ^^^^^^^^
@@ -8,13 +8,13 @@ LL |     pub use std::fmt;
    |
    = help: or consider exporting it for use by other crates
 note: the lint level is defined here
-  --> $DIR/unreachable_pub.rs:4:9
+  --> $DIR/unreachable_pub.rs:6:9
    |
 LL | #![warn(unreachable_pub)]
    |         ^^^^^^^^^^^^^^^
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:9:24
+  --> $DIR/unreachable_pub.rs:11:24
    |
 LL |     pub use std::env::{Args}; // braced-use has different item spans than unbraced
    |     ---                ^^^^
@@ -24,7 +24,7 @@ LL |     pub use std::env::{Args}; // braced-use has different item spans than u
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:13:5
+  --> $DIR/unreachable_pub.rs:15:5
    |
 LL |     pub struct Hydrogen {
    |     ---^^^^^^^^^^^^^^^^
@@ -34,7 +34,7 @@ LL |     pub struct Hydrogen {
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:24:9
+  --> $DIR/unreachable_pub.rs:26:9
    |
 LL |         pub fn count_neutrons(&self) -> usize { self.neutrons }
    |         ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -42,7 +42,7 @@ LL |         pub fn count_neutrons(&self) -> usize { self.neutrons }
    |         help: consider restricting its visibility: `pub(crate)`
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:33:5
+  --> $DIR/unreachable_pub.rs:35:5
    |
 LL |     pub enum Helium {}
    |     ---^^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL |     pub enum Helium {}
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:34:5
+  --> $DIR/unreachable_pub.rs:36:5
    |
 LL |     pub union Lithium { c1: usize, c2: u8 }
    |     ---^^^^^^^^^^^^^^
@@ -62,7 +62,7 @@ LL |     pub union Lithium { c1: usize, c2: u8 }
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:35:5
+  --> $DIR/unreachable_pub.rs:37:5
    |
 LL |     pub fn beryllium() {}
    |     ---^^^^^^^^^^^^^^^
@@ -72,7 +72,7 @@ LL |     pub fn beryllium() {}
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:36:5
+  --> $DIR/unreachable_pub.rs:38:5
    |
 LL |     pub trait Boron {}
    |     ---^^^^^^^^^^^^
@@ -82,7 +82,7 @@ LL |     pub trait Boron {}
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:37:5
+  --> $DIR/unreachable_pub.rs:39:5
    |
 LL |     pub const CARBON: usize = 1;
    |     ---^^^^^^^^^^^^^^^^^^^^
@@ -92,7 +92,7 @@ LL |     pub const CARBON: usize = 1;
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:38:5
+  --> $DIR/unreachable_pub.rs:40:5
    |
 LL |     pub static NITROGEN: usize = 2;
    |     ---^^^^^^^^^^^^^^^^^^^^^^^
@@ -102,7 +102,7 @@ LL |     pub static NITROGEN: usize = 2;
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:39:5
+  --> $DIR/unreachable_pub.rs:41:5
    |
 LL |     pub type Oxygen = bool;
    |     ---^^^^^^^^^^^^
@@ -112,7 +112,7 @@ LL |     pub type Oxygen = bool;
    = help: or consider exporting it for use by other crates
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:42:47
+  --> $DIR/unreachable_pub.rs:44:47
    |
 LL |         ($visibility: vis, $name: ident) => { $visibility struct $name {} }
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -127,7 +127,7 @@ LL |     define_empty_struct_with_visibility!(pub, Fluorine);
    = note: this warning originates in the macro `define_empty_struct_with_visibility` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 warning: unreachable `pub` item
-  --> $DIR/unreachable_pub.rs:48:9
+  --> $DIR/unreachable_pub.rs:50:9
    |
 LL |         pub fn catalyze() -> bool;
    |         ---^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,5 +136,115 @@ LL |         pub fn catalyze() -> bool;
    |
    = help: or consider exporting it for use by other crates
 
-warning: 13 warnings emitted
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:62:5
+   |
+LL |     pub mod pub_in_private {
+   |     ---^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:68:13
+   |
+LL |             pub struct Foo;
+   |             ---^^^^^^^^^^^
+   |             |
+   |             help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:74:13
+   |
+LL |             pub struct Foo;
+   |             ---^^^^^^^^^^^
+   |             |
+   |             help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:86:13
+   |
+LL |     pub use fpu_precision::set_precision;
+   |     ---     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     |
+   |     help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:54:9
+   |
+LL |         pub enum Helium {}
+   |         ---^^^^^^^^^^^^
+   |         |
+   |         help: consider restricting its visibility: `pub(super)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:55:9
+   |
+LL |         pub fn beryllium() {}
+   |         ---^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider restricting its visibility: `pub(super)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:59:9
+   |
+LL |         pub const CARBON: usize = 1;
+   |         ---^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:63:9
+   |
+LL |         pub static NITROGEN: usize = 2;
+   |         ---^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:77:17
+   |
+LL |                 pub struct Bar;
+   |                 ---^^^^^^^^^^^
+   |                 |
+   |                 help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:89:9
+   |
+LL |         pub fn set_precision<T>() {}
+   |         ---^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider restricting its visibility: `pub(crate)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: unreachable `pub` item
+  --> $DIR/unreachable_pub.rs:90:9
+   |
+LL |         pub fn set_micro_precision<T>() {}
+   |         ---^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |         |
+   |         help: consider restricting its visibility: `pub(super)`
+   |
+   = help: or consider exporting it for use by other crates
+
+warning: 24 warnings emitted
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -972,6 +972,7 @@ warn_non_default_branch = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
 users_on_vacation = [
     "fmease",
+    "jieyouxu",
     "jyn514",
     "oli-obk",
 ]


### PR DESCRIPTION
Successful merges:

 - #131781 (Stabilize Arm64EC inline assembly)
 - #132426 (Prefer `pub(super)` in `unreachable_pub` lint suggestion)
 - #132866 (Break from review rotation)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131781,132426,132866)
<!-- homu-ignore:end -->