### PR TITLE
triagebot: Autolabel rustdoc book

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -212,6 +212,10 @@ trigger_files = [
     "src/tools/rustdoc-gui",
     "src/tools/rustdoc-js",
     "src/tools/rustdoc-themes",
+
+    # Docs
+    "src/doc/rustdoc.md",
+    "src/doc/rustdoc/",
 ]
 exclude_labels = [
     "T-*",


### PR DESCRIPTION
Inspired by #132876 not getting labeled as https://github.com/rust-lang/rust/labels/T-rustdoc

r? @GuillaumeGomez 