### PR TITLE
only use generic info when ty var belong it in orphan check

### DIFF
--- a/compiler/rustc_hir_analysis/src/coherence/orphan.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/orphan.rs
@@ -554,12 +554,12 @@ impl<'cx, 'tcx> TypeFolder<TyCtxt<'tcx>> for TyVarReplacer<'cx, 'tcx> {
             return ty.super_fold_with(self);
         };
         let origin = self.infcx.type_var_origin(vid);
-        if let Some(def_id) = origin.param_def_id {
+        if let Some(def_id) = origin.param_def_id
+            && let Some(index) = self.generics.param_def_id_to_index.get(&def_id)
+        {
             // The generics of an `impl` don't have a parent, we can index directly.
-            let index = self.generics.param_def_id_to_index[&def_id];
-            let name = self.generics.own_params[index as usize].name;
-
-            Ty::new_param(self.infcx.tcx, index, name)
+            let name = self.generics.own_params[*index as usize].name;
+            Ty::new_param(self.infcx.tcx, *index, name)
         } else {
             ty
         }

--- a/tests/ui/coherence/impl-for-assoc-with-ty-var.rs
+++ b/tests/ui/coherence/impl-for-assoc-with-ty-var.rs
@@ -1,0 +1,21 @@
+//@ aux-build:coherence_lib.rs
+
+// issue#132826
+
+extern crate coherence_lib;
+
+use coherence_lib::{Pair, Remote, Remote1};
+
+trait MyTrait {
+    type Item;
+}
+
+impl<M> MyTrait for Pair<M, M> {
+    type Item = Pair<M, M>;
+}
+
+impl<K> Remote for <Pair<K, K> as MyTrait>::Item {}
+//~^ ERROR: the type parameter `K` is not constrained by the impl trait, self type, or predicates
+//~| ERROR: only traits defined in the current crate can be implemented for arbitrary types
+
+fn main() {}

--- a/tests/ui/coherence/impl-for-assoc-with-ty-var.stderr
+++ b/tests/ui/coherence/impl-for-assoc-with-ty-var.stderr
@@ -1,0 +1,22 @@
+error[E0207]: the type parameter `K` is not constrained by the impl trait, self type, or predicates
+  --> $DIR/impl-for-assoc-with-ty-var.rs:17:6
+   |
+LL | impl<K> Remote for <Pair<K, K> as MyTrait>::Item {}
+   |      ^ unconstrained type parameter
+
+error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
+  --> $DIR/impl-for-assoc-with-ty-var.rs:17:1
+   |
+LL | impl<K> Remote for <Pair<K, K> as MyTrait>::Item {}
+   | ^^^^^^^^^^^^^^^^^^^-----------------------------
+   |                    |
+   |                    `Pair` is not defined in the current crate
+   |
+   = note: impl doesn't have any local type before any uncovered type parameters
+   = note: for more information see https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules
+   = note: define and implement a trait or new type instead
+
+error: aborting due to 2 previous errors
+
+Some errors have detailed explanations: E0117, E0207.
+For more information about an error, try `rustc --explain E0117`.


### PR DESCRIPTION
Fixes #132826

This issue is caused by incorrect usage of a type variable. I will use the following example to illustrate:

```rs
// foregin.rs
pub trait ForeignTrait {}
pub struct ForeignType<T>(pub T);

// lib.rs
extern crate foregin;
use foreign_crate::{ForeignType, ForeignTrait};

trait MyTrait {
    type Item;
}

impl<M> MyTrait for ForeignType<M> { // `impl#0`
    type Item = ForeignType<M>;
}

impl<K> ForeignTrait for <ForeignType<K> as MyTrait>::Item {} // `impl#1`
```

When we check the orphan rule for `impl#1`, we create two type variables: `ty_var(K)` and `ty_var(M)`, which come from `impl#1` and `impl#0` respectively. After normalizing `<ForeignType<K> as MyTrait>::Item`, it returns `ty_var(M)`, which is then used to find the generics information of `impl#1`, causing a panic due to it not being found.

So naturally, I think there are three ways to solve this issue:

- Try to instantiate `ty_var(M)` into `ty_var(K)` since their relationship is similar to that of a parameter and an argument. And then we can use `ty_var(K)` as the correct key for the generic.
-  During type folding, find the correct type variable among all those that have an equality relation with ty_var(M). The pseudocode might be:

```rs
fn fold_ty() {
  //...
  let vid = [vid, all_eq_relations_of(vid)]
          .find(|ty| 
              generics.param_def_id_to_index.contains(ty.origin.param_def_id))
          .unwrap();
   // ....
}
```
- The final approach, as shown in this PR, is to use the generics information only if the type variable belongs to this set of generics. I chose this method because the above methods are too complex, and this approach can easily resolve the issue.

r? @fmease