### PR TITLE
[AIX] Add crate "unwind" to link with libunwind

### DIFF
--- a/tests/ui/extern-flag/auxiliary/panic_handler.rs
+++ b/tests/ui/extern-flag/auxiliary/panic_handler.rs
@@ -1,14 +1,10 @@
-#![feature(lang_items)]
+#![feature(lang_items, panic_unwind)]
 #![no_std]
 
-// Since `rustc` generally passes `-nodefaultlibs` to the linker,
-// Rust programs link necessary system libraries via `#[link()]`
-// attributes in the `libc` crate. `libc` is a dependency of `std`,
-// but as we are `#![no_std]`, we need to include it manually.
-// Except on windows-msvc.
-#![feature(rustc_private)]
-#[cfg(not(all(windows, target_env = "msvc")))]
-extern crate libc;
+// Since the `unwind` crate is a dependency of the `std` crate, and we have
+// `#![no_std]`, the unwinder is not included in the link command by default.
+// We need to include crate `unwind` manually.
+extern crate unwind;
 
 #[panic_handler]
 pub fn begin_panic_handler(_info: &core::panic::PanicInfo<'_>) -> ! {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
The Rust on IBM AIX uses LLVM's `libunwind`. Since crate `unwind` is a dependency of crate `std` and `#![no_std]` is specified in the test case, `libunwind` is not included in the link command by default. As a result, the test case fails to link with the error "Undefined symbol: ._Unwind_Resume" on AIX. This PR explicitly adds crate `unwind` for AIX, along with feature `panic_unwind`, which is required to include the `unwind` crate.