### PR TITLE
Make sure that we suggest turbofishing the right type arg for never suggestion

### DIFF
--- a/compiler/rustc_hir_typeck/src/fallback.rs
+++ b/compiler/rustc_hir_typeck/src/fallback.rs
@@ -621,7 +621,11 @@ impl<'tcx> AnnotateUnitFallbackVisitor<'_, 'tcx> {
                 .iter()
                 .filter(|arg| matches!(arg.unpack(), ty::GenericArgKind::Type(_)))
                 .count();
-            for (idx, arg) in args.iter().enumerate() {
+            for (idx, arg) in args
+                .iter()
+                .filter(|arg| matches!(arg.unpack(), ty::GenericArgKind::Type(_)))
+                .enumerate()
+            {
                 if let Some(ty) = arg.as_type()
                     && let Some(vid) = self.fcx.root_vid(ty)
                     && self.reachable_vids.contains(&vid)

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.fixed
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.fixed
@@ -17,7 +17,7 @@ fn main() {
 fn m() {
     //[e2021]~^ this function depends on never type fallback being `()`
     //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    let x = match true {
+    let x: () = match true {
         true => Default::default(),
         //[e2024]~^ error: the trait bound `!: Default` is not satisfied
         false => panic!("..."),
@@ -33,7 +33,7 @@ fn q() -> Option<()> {
         Some(T::default())
     }
 
-    deserialize()?;
+    deserialize::<()>()?;
     //[e2024]~^ error: the trait bound `!: Default` is not satisfied
 
     None
@@ -46,7 +46,7 @@ fn help<'a: 'a, T: Into<()>, U>(_: U) -> Result<T, ()> {
 fn meow() -> Result<(), ()> {
     //[e2021]~^ this function depends on never type fallback being `()`
     //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-    help(1)?;
+    help::<(), _>(1)?;
     //[e2024]~^ error: the trait bound `(): From<!>` is not satisfied
     Ok(())
 }

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
@@ -1,5 +1,5 @@
 warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:15:1
+  --> $DIR/never-type-fallback-breaking.rs:17:1
    |
 LL | fn m() {
    | ^^^^^^
@@ -8,7 +8,7 @@ LL | fn m() {
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/never-type-fallback-breaking.rs:19:17
+  --> $DIR/never-type-fallback-breaking.rs:21:17
    |
 LL |         true => Default::default(),
    |                 ^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     let x: () = match true {
    |          ++++
 
 warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:27:1
+  --> $DIR/never-type-fallback-breaking.rs:29:1
    |
 LL | fn q() -> Option<()> {
    | ^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL | fn q() -> Option<()> {
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/never-type-fallback-breaking.rs:34:5
+  --> $DIR/never-type-fallback-breaking.rs:36:5
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^
@@ -37,5 +37,24 @@ help: use `()` annotations to avoid fallback changes
 LL |     deserialize::<()>()?;
    |                ++++++
 
-warning: 2 warnings emitted
+warning: this function depends on never type fallback being `()`
+  --> $DIR/never-type-fallback-breaking.rs:46:1
+   |
+LL | fn meow() -> Result<(), ()> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the types explicitly
+note: in edition 2024, the requirement `(): From<!>` will fail
+  --> $DIR/never-type-fallback-breaking.rs:49:5
+   |
+LL |     help(1)?;
+   |     ^^^^^^^
+help: use `()` annotations to avoid fallback changes
+   |
+LL |     help::<(), _>(1)?;
+   |         +++++++++
+
+warning: 3 warnings emitted
 

--- a/tests/ui/editions/never-type-fallback-breaking.e2024.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2024.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `!: Default` is not satisfied
-  --> $DIR/never-type-fallback-breaking.rs:19:17
+  --> $DIR/never-type-fallback-breaking.rs:21:17
    |
 LL |         true => Default::default(),
    |                 ^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `!`
@@ -8,7 +8,7 @@ LL |         true => Default::default(),
    = help: did you intend to use the type `()` here instead?
 
 error[E0277]: the trait bound `!: Default` is not satisfied
-  --> $DIR/never-type-fallback-breaking.rs:34:5
+  --> $DIR/never-type-fallback-breaking.rs:36:5
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^ the trait `Default` is not implemented for `!`
@@ -16,11 +16,34 @@ LL |     deserialize()?;
    = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: did you intend to use the type `()` here instead?
 note: required by a bound in `deserialize`
-  --> $DIR/never-type-fallback-breaking.rs:30:23
+  --> $DIR/never-type-fallback-breaking.rs:32:23
    |
 LL |     fn deserialize<T: Default>() -> Option<T> {
    |                       ^^^^^^^ required by this bound in `deserialize`
 
-error: aborting due to 2 previous errors
+error[E0277]: the trait bound `(): From<!>` is not satisfied
+  --> $DIR/never-type-fallback-breaking.rs:49:5
+   |
+LL |     help(1)?;
+   |     ^^^^^^^ the trait `From<!>` is not implemented for `()`
+   |
+   = help: the following other types implement trait `From<T>`:
+             `(T, T)` implements `From<[T; 2]>`
+             `(T, T, T)` implements `From<[T; 3]>`
+             `(T, T, T, T)` implements `From<[T; 4]>`
+             `(T, T, T, T, T)` implements `From<[T; 5]>`
+             `(T, T, T, T, T, T)` implements `From<[T; 6]>`
+             `(T, T, T, T, T, T, T)` implements `From<[T; 7]>`
+             `(T, T, T, T, T, T, T, T)` implements `From<[T; 8]>`
+             `(T, T, T, T, T, T, T, T, T)` implements `From<[T; 9]>`
+           and 4 others
+   = note: required for `!` to implement `Into<()>`
+note: required by a bound in `help`
+  --> $DIR/never-type-fallback-breaking.rs:43:20
+   |
+LL | fn help<'a: 'a, T: Into<()>, U>(_: U) -> Result<T, ()> {
+   |                    ^^^^^^^^ required by this bound in `help`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
I had a bug where rust would suggest the wrong arg to turbofish `()` if there were any early-bound lifetimes...

r? WaffleLapkin