### PR TITLE
Overhaul the `-l` option parser (for linking to native libs)

### DIFF
--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -30,16 +30,17 @@ use rustc_target::spec::{
 };
 use tracing::debug;
 
+pub use crate::config::cfg::{Cfg, CheckCfg, ExpectedValues};
+use crate::config::native_libs::parse_libs;
 use crate::errors::FileWriteFail;
 pub use crate::options::*;
 use crate::search_paths::SearchPath;
-use crate::utils::{CanonicalizedPath, NativeLib, NativeLibKind};
+use crate::utils::CanonicalizedPath;
 use crate::{EarlyDiagCtxt, HashStableContext, Session, filesearch, lint};
 
 mod cfg;
+mod native_libs;
 pub mod sigpipe;
-
-pub use cfg::{Cfg, CheckCfg, ExpectedValues};
 
 /// The different settings that the `-C strip` flag can have.
 #[derive(Clone, Copy, PartialEq, Hash, Debug)]
@@ -2132,143 +2133,6 @@ fn parse_assert_incr_state(
         }
         None => None,
     }
-}
-
-fn parse_native_lib_kind(
-    early_dcx: &EarlyDiagCtxt,
-    matches: &getopts::Matches,
-    kind: &str,
-) -> (NativeLibKind, Option<bool>) {
-    let (kind, modifiers) = match kind.split_once(':') {
-        None => (kind, None),
-        Some((kind, modifiers)) => (kind, Some(modifiers)),
-    };
-
-    let kind = match kind {
-        "static" => NativeLibKind::Static { bundle: None, whole_archive: None },
-        "dylib" => NativeLibKind::Dylib { as_needed: None },
-        "framework" => NativeLibKind::Framework { as_needed: None },
-        "link-arg" => {
-            if !nightly_options::is_unstable_enabled(matches) {
-                let why = if nightly_options::match_is_nightly_build(matches) {
-                    " and only accepted on the nightly compiler"
-                } else {
-                    ", the `-Z unstable-options` flag must also be passed to use it"
-                };
-                early_dcx.early_fatal(format!("library kind `link-arg` is unstable{why}"))
-            }
-            NativeLibKind::LinkArg
-        }
-        _ => early_dcx.early_fatal(format!(
-            "unknown library kind `{kind}`, expected one of: static, dylib, framework, link-arg"
-        )),
-    };
-    match modifiers {
-        None => (kind, None),
-        Some(modifiers) => parse_native_lib_modifiers(early_dcx, kind, modifiers, matches),
-    }
-}
-
-fn parse_native_lib_modifiers(
-    early_dcx: &EarlyDiagCtxt,
-    mut kind: NativeLibKind,
-    modifiers: &str,
-    matches: &getopts::Matches,
-) -> (NativeLibKind, Option<bool>) {
-    let mut verbatim = None;
-    for modifier in modifiers.split(',') {
-        let (modifier, value) = match modifier.strip_prefix(['+', '-']) {
-            Some(m) => (m, modifier.starts_with('+')),
-            None => early_dcx.early_fatal(
-                "invalid linking modifier syntax, expected '+' or '-' prefix \
-                 before one of: bundle, verbatim, whole-archive, as-needed",
-            ),
-        };
-
-        let report_unstable_modifier = || {
-            if !nightly_options::is_unstable_enabled(matches) {
-                let why = if nightly_options::match_is_nightly_build(matches) {
-                    " and only accepted on the nightly compiler"
-                } else {
-                    ", the `-Z unstable-options` flag must also be passed to use it"
-                };
-                early_dcx.early_fatal(format!("linking modifier `{modifier}` is unstable{why}"))
-            }
-        };
-        let assign_modifier = |dst: &mut Option<bool>| {
-            if dst.is_some() {
-                let msg = format!("multiple `{modifier}` modifiers in a single `-l` option");
-                early_dcx.early_fatal(msg)
-            } else {
-                *dst = Some(value);
-            }
-        };
-        match (modifier, &mut kind) {
-            ("bundle", NativeLibKind::Static { bundle, .. }) => assign_modifier(bundle),
-            ("bundle", _) => early_dcx.early_fatal(
-                "linking modifier `bundle` is only compatible with `static` linking kind",
-            ),
-
-            ("verbatim", _) => assign_modifier(&mut verbatim),
-
-            ("whole-archive", NativeLibKind::Static { whole_archive, .. }) => {
-                assign_modifier(whole_archive)
-            }
-            ("whole-archive", _) => early_dcx.early_fatal(
-                "linking modifier `whole-archive` is only compatible with `static` linking kind",
-            ),
-
-            ("as-needed", NativeLibKind::Dylib { as_needed })
-            | ("as-needed", NativeLibKind::Framework { as_needed }) => {
-                report_unstable_modifier();
-                assign_modifier(as_needed)
-            }
-            ("as-needed", _) => early_dcx.early_fatal(
-                "linking modifier `as-needed` is only compatible with \
-                 `dylib` and `framework` linking kinds",
-            ),
-
-            // Note: this error also excludes the case with empty modifier
-            // string, like `modifiers = ""`.
-            _ => early_dcx.early_fatal(format!(
-                "unknown linking modifier `{modifier}`, expected one \
-                     of: bundle, verbatim, whole-archive, as-needed"
-            )),
-        }
-    }
-
-    (kind, verbatim)
-}
-
-fn parse_libs(early_dcx: &EarlyDiagCtxt, matches: &getopts::Matches) -> Vec<NativeLib> {
-    matches
-        .opt_strs("l")
-        .into_iter()
-        .map(|s| {
-            // Parse string of the form "[KIND[:MODIFIERS]=]lib[:new_name]",
-            // where KIND is one of "dylib", "framework", "static", "link-arg" and
-            // where MODIFIERS are a comma separated list of supported modifiers
-            // (bundle, verbatim, whole-archive, as-needed). Each modifier is prefixed
-            // with either + or - to indicate whether it is enabled or disabled.
-            // The last value specified for a given modifier wins.
-            let (name, kind, verbatim) = match s.split_once('=') {
-                None => (s, NativeLibKind::Unspecified, None),
-                Some((kind, name)) => {
-                    let (kind, verbatim) = parse_native_lib_kind(early_dcx, matches, kind);
-                    (name.to_string(), kind, verbatim)
-                }
-            };
-
-            let (name, new_name) = match name.split_once(':') {
-                None => (name, None),
-                Some((name, new_name)) => (name.to_string(), Some(new_name.to_owned())),
-            };
-            if name.is_empty() {
-                early_dcx.early_fatal("library name must not be empty");
-            }
-            NativeLib { name, new_name, kind, verbatim }
-        })
-        .collect()
 }
 
 pub fn parse_externs(

--- a/compiler/rustc_session/src/config/native_libs.rs
+++ b/compiler/rustc_session/src/config/native_libs.rs
@@ -1,140 +1,192 @@
+//! Parser for the `-l` command-line option, which links the generated crate to
+//! a native library.
+//!
+//! (There is also a similar but separate syntax for `#[link]` attributes,
+//! which have their own parser in `rustc_metadata`.)
+
+use rustc_feature::UnstableFeatures;
+
 use crate::EarlyDiagCtxt;
-use crate::config::nightly_options;
+use crate::config::UnstableOptions;
 use crate::utils::{NativeLib, NativeLibKind};
 
-pub(crate) fn parse_libs(early_dcx: &EarlyDiagCtxt, matches: &getopts::Matches) -> Vec<NativeLib> {
-    matches
-        .opt_strs("l")
-        .into_iter()
-        .map(|s| {
-            // Parse string of the form "[KIND[:MODIFIERS]=]lib[:new_name]",
-            // where KIND is one of "dylib", "framework", "static", "link-arg" and
-            // where MODIFIERS are a comma separated list of supported modifiers
-            // (bundle, verbatim, whole-archive, as-needed). Each modifier is prefixed
-            // with either + or - to indicate whether it is enabled or disabled.
-            // The last value specified for a given modifier wins.
-            let (name, kind, verbatim) = match s.split_once('=') {
-                None => (s, NativeLibKind::Unspecified, None),
-                Some((kind, name)) => {
-                    let (kind, verbatim) = parse_native_lib_kind(early_dcx, matches, kind);
-                    (name.to_string(), kind, verbatim)
-                }
-            };
+#[cfg(test)]
+mod tests;
 
-            let (name, new_name) = match name.split_once(':') {
-                None => (name, None),
-                Some((name, new_name)) => (name.to_string(), Some(new_name.to_owned())),
-            };
-            if name.is_empty() {
-                early_dcx.early_fatal("library name must not be empty");
-            }
-            NativeLib { name, new_name, kind, verbatim }
-        })
-        .collect()
+/// Parses all `-l` options.
+pub(crate) fn parse_native_libs(
+    early_dcx: &EarlyDiagCtxt,
+    unstable_opts: &UnstableOptions,
+    unstable_features: UnstableFeatures,
+    matches: &getopts::Matches,
+) -> Vec<NativeLib> {
+    let cx = ParseNativeLibCx {
+        early_dcx,
+        unstable_options_enabled: unstable_opts.unstable_options,
+        is_nightly: unstable_features.is_nightly_build(),
+    };
+    matches.opt_strs("l").into_iter().map(|value| parse_native_lib(&cx, &value)).collect()
 }
 
-fn parse_native_lib_kind(
-    early_dcx: &EarlyDiagCtxt,
-    matches: &getopts::Matches,
-    kind: &str,
-) -> (NativeLibKind, Option<bool>) {
-    let (kind, modifiers) = match kind.split_once(':') {
-        None => (kind, None),
-        Some((kind, modifiers)) => (kind, Some(modifiers)),
-    };
+struct ParseNativeLibCx<'a> {
+    early_dcx: &'a EarlyDiagCtxt,
+    unstable_options_enabled: bool,
+    is_nightly: bool,
+}
 
-    let kind = match kind {
+impl ParseNativeLibCx<'_> {
+    /// If unstable values are not permitted, exits with a fatal error made by
+    /// combining the given strings.
+    fn on_unstable_value(&self, message: &str, if_nightly: &str, if_stable: &str) {
+        if self.unstable_options_enabled {
+            return;
+        }
+
+        let suffix = if self.is_nightly { if_nightly } else { if_stable };
+        self.early_dcx.early_fatal(format!("{message}{suffix}"));
+    }
+}
+
+/// Parses the value of a single `-l` option.
+fn parse_native_lib(cx: &ParseNativeLibCx<'_>, value: &str) -> NativeLib {
+    let NativeLibParts { kind, modifiers, name, new_name } = split_native_lib_value(value);
+
+    let kind = kind.map_or(NativeLibKind::Unspecified, |kind| match kind {
         "static" => NativeLibKind::Static { bundle: None, whole_archive: None },
         "dylib" => NativeLibKind::Dylib { as_needed: None },
         "framework" => NativeLibKind::Framework { as_needed: None },
         "link-arg" => {
-            if !nightly_options::is_unstable_enabled(matches) {
-                let why = if nightly_options::match_is_nightly_build(matches) {
-                    " and only accepted on the nightly compiler"
-                } else {
-                    ", the `-Z unstable-options` flag must also be passed to use it"
-                };
-                early_dcx.early_fatal(format!("library kind `link-arg` is unstable{why}"))
-            }
+            cx.on_unstable_value(
+                "library kind `link-arg` is unstable",
+                ", the `-Z unstable-options` flag must also be passed to use it",
+                " and only accepted on the nightly compiler",
+            );
             NativeLibKind::LinkArg
         }
-        _ => early_dcx.early_fatal(format!(
+        _ => cx.early_dcx.early_fatal(format!(
             "unknown library kind `{kind}`, expected one of: static, dylib, framework, link-arg"
         )),
+    });
+
+    // Provisionally create the result, so that modifiers can modify it.
+    let mut native_lib = NativeLib {
+        name: name.to_owned(),
+        new_name: new_name.map(str::to_owned),
+        kind,
+        verbatim: None,
     };
-    match modifiers {
-        None => (kind, None),
-        Some(modifiers) => parse_native_lib_modifiers(early_dcx, kind, modifiers, matches),
+
+    if let Some(modifiers) = modifiers {
+        // If multiple modifiers are present, they are separated by commas.
+        for modifier in modifiers.split(',') {
+            parse_and_apply_modifier(cx, modifier, &mut native_lib);
+        }
+    }
+
+    if native_lib.name.is_empty() {
+        cx.early_dcx.early_fatal("library name must not be empty");
+    }
+
+    native_lib
+}
+
+/// Parses one of the comma-separated modifiers (prefixed by `+` or `-`), and
+/// modifies `native_lib` appropriately.
+///
+/// Exits with a fatal error if a malformed/unknown/inappropriate modifier is
+/// found.
+fn parse_and_apply_modifier(cx: &ParseNativeLibCx<'_>, modifier: &str, native_lib: &mut NativeLib) {
+    let early_dcx = cx.early_dcx;
+
+    // Split off the leading `+` or `-` into a boolean value.
+    let (modifier, value) = match modifier.split_at_checked(1) {
+        Some(("+", m)) => (m, true),
+        Some(("-", m)) => (m, false),
+        _ => cx.early_dcx.early_fatal(
+            "invalid linking modifier syntax, expected '+' or '-' prefix \
+             before one of: bundle, verbatim, whole-archive, as-needed",
+        ),
+    };
+
+    // Assigns the value (from `+` or `-`) to an empty `Option<bool>`, or emits
+    // a fatal error if the option has already been set.
+    let assign_modifier = |opt_bool: &mut Option<bool>| {
+        if opt_bool.is_some() {
+            let msg = format!("multiple `{modifier}` modifiers in a single `-l` option");
+            early_dcx.early_fatal(msg)
+        }
+        *opt_bool = Some(value);
+    };
+
+    // Check that the modifier is applicable to the native lib kind, and apply it.
+    match (modifier, &mut native_lib.kind) {
+        ("bundle", NativeLibKind::Static { bundle, .. }) => assign_modifier(bundle),
+        ("bundle", _) => early_dcx
+            .early_fatal("linking modifier `bundle` is only compatible with `static` linking kind"),
+
+        ("verbatim", _) => assign_modifier(&mut native_lib.verbatim),
+
+        ("whole-archive", NativeLibKind::Static { whole_archive, .. }) => {
+            assign_modifier(whole_archive)
+        }
+        ("whole-archive", _) => early_dcx.early_fatal(
+            "linking modifier `whole-archive` is only compatible with `static` linking kind",
+        ),
+
+        ("as-needed", NativeLibKind::Dylib { as_needed })
+        | ("as-needed", NativeLibKind::Framework { as_needed }) => {
+            cx.on_unstable_value(
+                "linking modifier `as-needed` is unstable",
+                ", the `-Z unstable-options` flag must also be passed to use it",
+                " and only accepted on the nightly compiler",
+            );
+            assign_modifier(as_needed)
+        }
+        ("as-needed", _) => early_dcx.early_fatal(
+            "linking modifier `as-needed` is only compatible with \
+             `dylib` and `framework` linking kinds",
+        ),
+
+        _ => early_dcx.early_fatal(format!(
+            "unknown linking modifier `{modifier}`, expected one \
+             of: bundle, verbatim, whole-archive, as-needed"
+        )),
     }
 }
 
-fn parse_native_lib_modifiers(
-    early_dcx: &EarlyDiagCtxt,
-    mut kind: NativeLibKind,
-    modifiers: &str,
-    matches: &getopts::Matches,
-) -> (NativeLibKind, Option<bool>) {
-    let mut verbatim = None;
-    for modifier in modifiers.split(',') {
-        let (modifier, value) = match modifier.strip_prefix(['+', '-']) {
-            Some(m) => (m, modifier.starts_with('+')),
-            None => early_dcx.early_fatal(
-                "invalid linking modifier syntax, expected '+' or '-' prefix \
-                 before one of: bundle, verbatim, whole-archive, as-needed",
-            ),
-        };
+#[derive(Debug, PartialEq, Eq)]
+struct NativeLibParts<'a> {
+    kind: Option<&'a str>,
+    modifiers: Option<&'a str>,
+    name: &'a str,
+    new_name: Option<&'a str>,
+}
 
-        let report_unstable_modifier = || {
-            if !nightly_options::is_unstable_enabled(matches) {
-                let why = if nightly_options::match_is_nightly_build(matches) {
-                    " and only accepted on the nightly compiler"
-                } else {
-                    ", the `-Z unstable-options` flag must also be passed to use it"
-                };
-                early_dcx.early_fatal(format!("linking modifier `{modifier}` is unstable{why}"))
-            }
-        };
-        let assign_modifier = |dst: &mut Option<bool>| {
-            if dst.is_some() {
-                let msg = format!("multiple `{modifier}` modifiers in a single `-l` option");
-                early_dcx.early_fatal(msg)
-            } else {
-                *dst = Some(value);
-            }
-        };
-        match (modifier, &mut kind) {
-            ("bundle", NativeLibKind::Static { bundle, .. }) => assign_modifier(bundle),
-            ("bundle", _) => early_dcx.early_fatal(
-                "linking modifier `bundle` is only compatible with `static` linking kind",
-            ),
+/// Splits a string of the form `[KIND[:MODIFIERS]=]NAME[:NEW_NAME]` into those
+/// individual parts. This cannot fail, but the resulting strings require
+/// further validation.
+fn split_native_lib_value(value: &str) -> NativeLibParts<'_> {
+    // Split the initial value into `[KIND=]NAME`.
+    let name = value;
+    let (kind, name) = match name.split_once('=') {
+        Some((prefix, name)) => (Some(prefix), name),
+        None => (None, name),
+    };
 
-            ("verbatim", _) => assign_modifier(&mut verbatim),
+    // Split the kind part, if present, into `KIND[:MODIFIERS]`.
+    let (kind, modifiers) = match kind {
+        Some(kind) => match kind.split_once(':') {
+            Some((kind, modifiers)) => (Some(kind), Some(modifiers)),
+            None => (Some(kind), None),
+        },
+        None => (None, None),
+    };
 
-            ("whole-archive", NativeLibKind::Static { whole_archive, .. }) => {
-                assign_modifier(whole_archive)
-            }
-            ("whole-archive", _) => early_dcx.early_fatal(
-                "linking modifier `whole-archive` is only compatible with `static` linking kind",
-            ),
+    // Split the name part into `NAME[:NEW_NAME]`.
+    let (name, new_name) = match name.split_once(':') {
+        Some((name, new_name)) => (name, Some(new_name)),
+        None => (name, None),
+    };
 
-            ("as-needed", NativeLibKind::Dylib { as_needed })
-            | ("as-needed", NativeLibKind::Framework { as_needed }) => {
-                report_unstable_modifier();
-                assign_modifier(as_needed)
-            }
-            ("as-needed", _) => early_dcx.early_fatal(
-                "linking modifier `as-needed` is only compatible with \
-                 `dylib` and `framework` linking kinds",
-            ),
-
-            // Note: this error also excludes the case with empty modifier
-            // string, like `modifiers = ""`.
-            _ => early_dcx.early_fatal(format!(
-                "unknown linking modifier `{modifier}`, expected one \
-                     of: bundle, verbatim, whole-archive, as-needed"
-            )),
-        }
-    }
-
-    (kind, verbatim)
+    NativeLibParts { kind, modifiers, name, new_name }
 }

--- a/compiler/rustc_session/src/config/native_libs.rs
+++ b/compiler/rustc_session/src/config/native_libs.rs
@@ -1,0 +1,140 @@
+use crate::EarlyDiagCtxt;
+use crate::config::nightly_options;
+use crate::utils::{NativeLib, NativeLibKind};
+
+pub(crate) fn parse_libs(early_dcx: &EarlyDiagCtxt, matches: &getopts::Matches) -> Vec<NativeLib> {
+    matches
+        .opt_strs("l")
+        .into_iter()
+        .map(|s| {
+            // Parse string of the form "[KIND[:MODIFIERS]=]lib[:new_name]",
+            // where KIND is one of "dylib", "framework", "static", "link-arg" and
+            // where MODIFIERS are a comma separated list of supported modifiers
+            // (bundle, verbatim, whole-archive, as-needed). Each modifier is prefixed
+            // with either + or - to indicate whether it is enabled or disabled.
+            // The last value specified for a given modifier wins.
+            let (name, kind, verbatim) = match s.split_once('=') {
+                None => (s, NativeLibKind::Unspecified, None),
+                Some((kind, name)) => {
+                    let (kind, verbatim) = parse_native_lib_kind(early_dcx, matches, kind);
+                    (name.to_string(), kind, verbatim)
+                }
+            };
+
+            let (name, new_name) = match name.split_once(':') {
+                None => (name, None),
+                Some((name, new_name)) => (name.to_string(), Some(new_name.to_owned())),
+            };
+            if name.is_empty() {
+                early_dcx.early_fatal("library name must not be empty");
+            }
+            NativeLib { name, new_name, kind, verbatim }
+        })
+        .collect()
+}
+
+fn parse_native_lib_kind(
+    early_dcx: &EarlyDiagCtxt,
+    matches: &getopts::Matches,
+    kind: &str,
+) -> (NativeLibKind, Option<bool>) {
+    let (kind, modifiers) = match kind.split_once(':') {
+        None => (kind, None),
+        Some((kind, modifiers)) => (kind, Some(modifiers)),
+    };
+
+    let kind = match kind {
+        "static" => NativeLibKind::Static { bundle: None, whole_archive: None },
+        "dylib" => NativeLibKind::Dylib { as_needed: None },
+        "framework" => NativeLibKind::Framework { as_needed: None },
+        "link-arg" => {
+            if !nightly_options::is_unstable_enabled(matches) {
+                let why = if nightly_options::match_is_nightly_build(matches) {
+                    " and only accepted on the nightly compiler"
+                } else {
+                    ", the `-Z unstable-options` flag must also be passed to use it"
+                };
+                early_dcx.early_fatal(format!("library kind `link-arg` is unstable{why}"))
+            }
+            NativeLibKind::LinkArg
+        }
+        _ => early_dcx.early_fatal(format!(
+            "unknown library kind `{kind}`, expected one of: static, dylib, framework, link-arg"
+        )),
+    };
+    match modifiers {
+        None => (kind, None),
+        Some(modifiers) => parse_native_lib_modifiers(early_dcx, kind, modifiers, matches),
+    }
+}
+
+fn parse_native_lib_modifiers(
+    early_dcx: &EarlyDiagCtxt,
+    mut kind: NativeLibKind,
+    modifiers: &str,
+    matches: &getopts::Matches,
+) -> (NativeLibKind, Option<bool>) {
+    let mut verbatim = None;
+    for modifier in modifiers.split(',') {
+        let (modifier, value) = match modifier.strip_prefix(['+', '-']) {
+            Some(m) => (m, modifier.starts_with('+')),
+            None => early_dcx.early_fatal(
+                "invalid linking modifier syntax, expected '+' or '-' prefix \
+                 before one of: bundle, verbatim, whole-archive, as-needed",
+            ),
+        };
+
+        let report_unstable_modifier = || {
+            if !nightly_options::is_unstable_enabled(matches) {
+                let why = if nightly_options::match_is_nightly_build(matches) {
+                    " and only accepted on the nightly compiler"
+                } else {
+                    ", the `-Z unstable-options` flag must also be passed to use it"
+                };
+                early_dcx.early_fatal(format!("linking modifier `{modifier}` is unstable{why}"))
+            }
+        };
+        let assign_modifier = |dst: &mut Option<bool>| {
+            if dst.is_some() {
+                let msg = format!("multiple `{modifier}` modifiers in a single `-l` option");
+                early_dcx.early_fatal(msg)
+            } else {
+                *dst = Some(value);
+            }
+        };
+        match (modifier, &mut kind) {
+            ("bundle", NativeLibKind::Static { bundle, .. }) => assign_modifier(bundle),
+            ("bundle", _) => early_dcx.early_fatal(
+                "linking modifier `bundle` is only compatible with `static` linking kind",
+            ),
+
+            ("verbatim", _) => assign_modifier(&mut verbatim),
+
+            ("whole-archive", NativeLibKind::Static { whole_archive, .. }) => {
+                assign_modifier(whole_archive)
+            }
+            ("whole-archive", _) => early_dcx.early_fatal(
+                "linking modifier `whole-archive` is only compatible with `static` linking kind",
+            ),
+
+            ("as-needed", NativeLibKind::Dylib { as_needed })
+            | ("as-needed", NativeLibKind::Framework { as_needed }) => {
+                report_unstable_modifier();
+                assign_modifier(as_needed)
+            }
+            ("as-needed", _) => early_dcx.early_fatal(
+                "linking modifier `as-needed` is only compatible with \
+                 `dylib` and `framework` linking kinds",
+            ),
+
+            // Note: this error also excludes the case with empty modifier
+            // string, like `modifiers = ""`.
+            _ => early_dcx.early_fatal(format!(
+                "unknown linking modifier `{modifier}`, expected one \
+                     of: bundle, verbatim, whole-archive, as-needed"
+            )),
+        }
+    }
+
+    (kind, verbatim)
+}

--- a/compiler/rustc_session/src/config/native_libs/tests.rs
+++ b/compiler/rustc_session/src/config/native_libs/tests.rs
@@ -1,0 +1,50 @@
+use crate::config::native_libs::{NativeLibParts, split_native_lib_value};
+
+#[test]
+fn split() {
+    // This is a unit test for some implementation details, so consider deleting
+    // it if it gets in the way.
+    use NativeLibParts as P;
+
+    let examples = &[
+        ("", P { kind: None, modifiers: None, name: "", new_name: None }),
+        ("foo", P { kind: None, modifiers: None, name: "foo", new_name: None }),
+        ("foo:", P { kind: None, modifiers: None, name: "foo", new_name: Some("") }),
+        ("foo:bar", P { kind: None, modifiers: None, name: "foo", new_name: Some("bar") }),
+        (":bar", P { kind: None, modifiers: None, name: "", new_name: Some("bar") }),
+        ("kind=foo", P { kind: Some("kind"), modifiers: None, name: "foo", new_name: None }),
+        (":mods=foo", P { kind: Some(""), modifiers: Some("mods"), name: "foo", new_name: None }),
+        (":mods=:bar", P {
+            kind: Some(""),
+            modifiers: Some("mods"),
+            name: "",
+            new_name: Some("bar"),
+        }),
+        ("kind=foo:bar", P {
+            kind: Some("kind"),
+            modifiers: None,
+            name: "foo",
+            new_name: Some("bar"),
+        }),
+        ("kind:mods=foo", P {
+            kind: Some("kind"),
+            modifiers: Some("mods"),
+            name: "foo",
+            new_name: None,
+        }),
+        ("kind:mods=foo:bar", P {
+            kind: Some("kind"),
+            modifiers: Some("mods"),
+            name: "foo",
+            new_name: Some("bar"),
+        }),
+        ("::==::", P { kind: Some(""), modifiers: Some(":"), name: "=", new_name: Some(":") }),
+        ("==::==", P { kind: Some(""), modifiers: None, name: "=", new_name: Some(":==") }),
+    ];
+
+    for &(value, ref expected) in examples {
+        println!("{value:?}");
+        let actual = split_native_lib_value(value);
+        assert_eq!(&actual, expected);
+    }
+}

--- a/tests/ui/feature-gates/feature-gate-link-arg-attribute.in_attr.stderr
+++ b/tests/ui/feature-gates/feature-gate-link-arg-attribute.in_attr.stderr
@@ -1,5 +1,5 @@
 error[E0658]: link kind `link-arg` is unstable
-  --> $DIR/feature-gate-link-arg-attribute.rs:1:15
+  --> $DIR/feature-gate-link-arg-attribute.rs:5:15
    |
 LL | #[link(kind = "link-arg", name = "foo")]
    |               ^^^^^^^^^^

--- a/tests/ui/feature-gates/feature-gate-link-arg-attribute.in_flag.stderr
+++ b/tests/ui/feature-gates/feature-gate-link-arg-attribute.in_flag.stderr
@@ -1,0 +1,2 @@
+error: unknown linking modifier `link-arg`, expected one of: bundle, verbatim, whole-archive, as-needed
+

--- a/tests/ui/feature-gates/feature-gate-link-arg-attribute.rs
+++ b/tests/ui/feature-gates/feature-gate-link-arg-attribute.rs
@@ -1,5 +1,9 @@
+//@ revisions: in_attr in_flag
+//@[in_flag] compile-flags: -l dylib:+link-arg=foo
+
+#[cfg(in_attr)]
 #[link(kind = "link-arg", name = "foo")]
-//~^ ERROR link kind `link-arg` is unstable
+//[in_attr]~^ ERROR link kind `link-arg` is unstable
 extern "C" {}
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-native_link_modifiers_as_needed.in_attr.stderr
+++ b/tests/ui/feature-gates/feature-gate-native_link_modifiers_as_needed.in_attr.stderr
@@ -1,5 +1,5 @@
 error[E0658]: linking modifier `as-needed` is unstable
-  --> $DIR/feature-gate-native_link_modifiers_as_needed.rs:1:50
+  --> $DIR/feature-gate-native_link_modifiers_as_needed.rs:5:50
    |
 LL | #[link(name = "foo", kind = "dylib", modifiers = "+as-needed")]
    |                                                  ^^^^^^^^^^^^

--- a/tests/ui/feature-gates/feature-gate-native_link_modifiers_as_needed.in_flag.stderr
+++ b/tests/ui/feature-gates/feature-gate-native_link_modifiers_as_needed.in_flag.stderr
@@ -1,0 +1,2 @@
+error: linking modifier `as-needed` is unstable and only accepted on the nightly compiler
+

--- a/tests/ui/feature-gates/feature-gate-native_link_modifiers_as_needed.in_flag.stderr
+++ b/tests/ui/feature-gates/feature-gate-native_link_modifiers_as_needed.in_flag.stderr
@@ -1,2 +1,2 @@
-error: linking modifier `as-needed` is unstable and only accepted on the nightly compiler
+error: linking modifier `as-needed` is unstable, the `-Z unstable-options` flag must also be passed to use it
 

--- a/tests/ui/feature-gates/feature-gate-native_link_modifiers_as_needed.rs
+++ b/tests/ui/feature-gates/feature-gate-native_link_modifiers_as_needed.rs
@@ -1,5 +1,9 @@
+//@ revisions: in_attr in_flag
+//@[in_flag] compile-flags: -l dylib:+as-needed=foo
+
+#[cfg(in_attr)]
 #[link(name = "foo", kind = "dylib", modifiers = "+as-needed")]
-//~^ ERROR: linking modifier `as-needed` is unstable
+//[in_attr]~^ ERROR: linking modifier `as-needed` is unstable
 extern "C" {}
 
 fn main() {}

--- a/tests/ui/native-library-link-flags/modifiers-bad.blank.stderr
+++ b/tests/ui/native-library-link-flags/modifiers-bad.blank.stderr
@@ -1,0 +1,2 @@
+error: invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed
+

--- a/tests/ui/native-library-link-flags/modifiers-bad.no-prefix.stderr
+++ b/tests/ui/native-library-link-flags/modifiers-bad.no-prefix.stderr
@@ -1,0 +1,2 @@
+error: invalid linking modifier syntax, expected '+' or '-' prefix before one of: bundle, verbatim, whole-archive, as-needed
+

--- a/tests/ui/native-library-link-flags/modifiers-bad.prefix-only.stderr
+++ b/tests/ui/native-library-link-flags/modifiers-bad.prefix-only.stderr
@@ -1,0 +1,2 @@
+error: unknown linking modifier ``, expected one of: bundle, verbatim, whole-archive, as-needed
+

--- a/tests/ui/native-library-link-flags/modifiers-bad.rs
+++ b/tests/ui/native-library-link-flags/modifiers-bad.rs
@@ -1,0 +1,11 @@
+//@ edition: 2021
+//@ revisions: blank no-prefix prefix-only unknown
+
+//@[blank] compile-flags: -l static:=foo
+//@[no-prefix] compile-flags: -l static:bundle=foo
+//@[prefix-only] compile-flags: -l static:+=foo
+//@[unknown] compile-flags: -l static:+ferris=foo
+
+// Tests various illegal values for the "modifier" part of an `-l` flag.
+
+fn main() {}

--- a/tests/ui/native-library-link-flags/modifiers-bad.unknown.stderr
+++ b/tests/ui/native-library-link-flags/modifiers-bad.unknown.stderr
@@ -1,0 +1,2 @@
+error: unknown linking modifier `ferris`, expected one of: bundle, verbatim, whole-archive, as-needed
+


### PR DESCRIPTION
The current parser for `-l` options has accumulated over time, making it hard to follow. This PR tries to clean it up in several ways.

Key changes:
- This code now gets its own submodule, to slightly reduce clutter in `rustc_session::config`.
- Cleaner division between iterating over multiple `-l` options, and processing each individual one.
- Separate “split” step that breaks up the value string into `[KIND[:MODIFIERS]=]NAME[:NEW_NAME]`, but leaves parsing/validating those parts to later steps.
  - This step also gets its own (disposable) unit test, to make sure it works as expected.
- A context struct reduces the burden of parameter passing, and makes it easier to write error messages that adapt to nightly/stable compilers.
- Fewer calls to `nightly_options` helper functions, because at this point we can get the same information from `UnstableOptions` and `UnstableFeatures` (which are downstream of earlier calls to those helper functions).

There should be no overall change in compiler behaviour.