### PR TITLE
Make precise capturing suggestion machine-applicable only if it has no APITs

### DIFF
--- a/compiler/rustc_trait_selection/src/errors.rs
+++ b/compiler/rustc_trait_selection/src/errors.rs
@@ -1907,10 +1907,18 @@ impl Subdiagnostic for AddPreciseCapturingForOvercapture {
         diag: &mut Diag<'_, G>,
         _f: &F,
     ) {
+        let applicability = if self.apit_spans.is_empty() {
+            Applicability::MachineApplicable
+        } else {
+            // If there are APIT that are converted to regular parameters,
+            // then this may make the API turbofishable in ways that were
+            // not intended.
+            Applicability::MaybeIncorrect
+        };
         diag.multipart_suggestion_verbose(
             fluent::trait_selection_precise_capturing_overcaptures,
             self.suggs,
-            Applicability::MaybeIncorrect,
+            applicability,
         );
         if !self.apit_spans.is_empty() {
             diag.span_note(

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024-machine-applicable.fixed
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024-machine-applicable.fixed
@@ -1,0 +1,13 @@
+//@ run-rustfix
+//@ rustfix-only-machine-applicable
+
+// Make sure that simple overcapture suggestions remain machine applicable.
+
+#![allow(unused)]
+#![deny(impl_trait_overcaptures)]
+
+fn named<'a>(x: &'a i32) -> impl Sized + use<> { *x }
+//~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
+//~| WARN this changes meaning in Rust 2024
+
+fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024-machine-applicable.rs
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024-machine-applicable.rs
@@ -1,0 +1,13 @@
+//@ run-rustfix
+//@ rustfix-only-machine-applicable
+
+// Make sure that simple overcapture suggestions remain machine applicable.
+
+#![allow(unused)]
+#![deny(impl_trait_overcaptures)]
+
+fn named<'a>(x: &'a i32) -> impl Sized { *x }
+//~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
+//~| WARN this changes meaning in Rust 2024
+
+fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024-machine-applicable.stderr
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024-machine-applicable.stderr
@@ -1,0 +1,26 @@
+error: `impl Sized` will capture more lifetimes than possibly intended in edition 2024
+  --> $DIR/overcaptures-2024-machine-applicable.rs:9:29
+   |
+LL | fn named<'a>(x: &'a i32) -> impl Sized { *x }
+   |                             ^^^^^^^^^^
+   |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+note: specifically, this lifetime is in scope but not mentioned in the type's bounds
+  --> $DIR/overcaptures-2024-machine-applicable.rs:9:10
+   |
+LL | fn named<'a>(x: &'a i32) -> impl Sized { *x }
+   |          ^^
+   = note: all lifetimes in scope will be captured by `impl Trait`s in edition 2024
+note: the lint level is defined here
+  --> $DIR/overcaptures-2024-machine-applicable.rs:7:9
+   |
+LL | #![deny(impl_trait_overcaptures)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^
+help: use the precise capturing `use<...>` syntax to make the captures explicit
+   |
+LL | fn named<'a>(x: &'a i32) -> impl Sized + use<> { *x }
+   |                                        +++++++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/issues/132932

The only case where this suggestion is not machine-applicable is when we suggest turning arg-position impl trait into type parameters, which may expose type parameters that were not turbofishable before.