### PR TITLE
Handle infer vars in anon consts on stable

### DIFF
--- a/compiler/rustc_middle/src/mir/consts.rs
+++ b/compiler/rustc_middle/src/mir/consts.rs
@@ -325,6 +325,9 @@ impl<'tcx> Const<'tcx> {
 
                 match c.kind() {
                     ConstKind::Value(ty, val) => Ok(tcx.valtree_to_const_val((ty, val))),
+                    ConstKind::Expr(_) => {
+                        bug!("Normalization of `ty::ConstKind::Expr` is unimplemented")
+                    }
                     _ => Err(tcx.dcx().delayed_bug("Unevaluated `ty::Const` in MIR body").into()),
                 }
             }

--- a/tests/ui/const-generics/failing_goal_with_repeat_expr_anon_const.rs
+++ b/tests/ui/const-generics/failing_goal_with_repeat_expr_anon_const.rs
@@ -1,0 +1,21 @@
+// Regression test for #132955 checking that we handle anon consts with
+// inference variables in their generic arguments correctly.
+//
+// This arose via diagnostics where we would have some failing goal such
+// as `[u8; AnonConst<Self>]: PartialEq<Self::A>`, then as part of diagnostics
+// we would replace all generic parameters with inference vars which would yield
+// a self type of `[u8; AnonConst<?x>]` and then attempt to normalize `AnonConst<?x>`.
+
+pub trait T {
+    type A;
+    const P: Self::A;
+
+    fn a() {
+        [0u8; std::mem::size_of::<Self::A>()] == Self::P;
+        //~^ ERROR: can't compare
+        //~| ERROR: constant expression depends on a generic parameter
+        //~| ERROR: constant expression depends on a generic parameter
+    }
+}
+
+fn main() {}

--- a/tests/ui/const-generics/failing_goal_with_repeat_expr_anon_const.stderr
+++ b/tests/ui/const-generics/failing_goal_with_repeat_expr_anon_const.stderr
@@ -1,0 +1,31 @@
+error: constant expression depends on a generic parameter
+  --> $DIR/failing_goal_with_repeat_expr_anon_const.rs:14:15
+   |
+LL |         [0u8; std::mem::size_of::<Self::A>()] == Self::P;
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: constant expression depends on a generic parameter
+  --> $DIR/failing_goal_with_repeat_expr_anon_const.rs:14:47
+   |
+LL |         [0u8; std::mem::size_of::<Self::A>()] == Self::P;
+   |                                               ^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error[E0277]: can't compare `[u8; std::mem::size_of::<Self::A>()]` with `<Self as T>::A`
+  --> $DIR/failing_goal_with_repeat_expr_anon_const.rs:14:47
+   |
+LL |         [0u8; std::mem::size_of::<Self::A>()] == Self::P;
+   |                                               ^^ no implementation for `[u8; std::mem::size_of::<Self::A>()] == <Self as T>::A`
+   |
+   = help: the trait `PartialEq<<Self as T>::A>` is not implemented for `[u8; std::mem::size_of::<Self::A>()]`
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | pub trait T where [u8; std::mem::size_of::<Self::A>()]: PartialEq<<Self as T>::A> {
+   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #132955

Diagnostics will sometimes try to replace generic parameters with inference variables in failing goals. This means that if we have some failing goal with an array repeat expr count anon const in it, we will wind up with some `ty::ConstKind::Unevaluated(anon_const_def, [?x])` during diagnostics which will then ICE if we do not handle inference variables correctly on stable when normalizing type system consts.

r? @compiler-errors 