### PR TITLE
Add `PeekableIterator` trait

### DIFF
--- a/library/core/src/iter/mod.rs
+++ b/library/core/src/iter/mod.rs
@@ -448,6 +448,8 @@ pub use self::traits::FusedIterator;
 pub use self::traits::InPlaceIterable;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::traits::Iterator;
+#[unstable(feature = "peekable_iterator", issue = "132973")]
+pub use self::traits::PeekableIterator;
 #[unstable(issue = "none", feature = "trusted_fused")]
 pub use self::traits::TrustedFused;
 #[unstable(feature = "trusted_len", issue = "37572")]

--- a/library/core/src/iter/range.rs
+++ b/library/core/src/iter/range.rs
@@ -1,5 +1,6 @@
 use super::{
-    FusedIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce, TrustedStep,
+    FusedIterator, PeekableIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce,
+    TrustedStep,
 };
 use crate::ascii::Char as AsciiChar;
 use crate::mem;
@@ -908,6 +909,18 @@ impl<A: Step> Iterator for ops::Range<A> {
         // Additionally Self: TrustedRandomAccess is only implemented for Copy types
         // which means even repeated reads of the same index would be safe.
         unsafe { Step::forward_unchecked(self.start.clone(), idx) }
+    }
+}
+
+#[unstable(feature = "peekable_iterator", issue = "132973")]
+impl<A: Step> PeekableIterator for ops::Range<A> {
+    type PeekedItem<'b>
+        = &'b A
+    where
+        Self: 'b;
+
+    fn peek(&self) -> Option<Self::PeekedItem<'_>> {
+        if self.start < self.end { Some(&self.start) } else { None }
     }
 }
 

--- a/library/core/src/iter/traits/mod.rs
+++ b/library/core/src/iter/traits/mod.rs
@@ -4,6 +4,7 @@ mod double_ended;
 mod exact_size;
 mod iterator;
 mod marker;
+mod peekable;
 mod unchecked_iterator;
 
 #[unstable(issue = "none", feature = "inplace_iteration")]
@@ -12,6 +13,8 @@ pub use self::marker::InPlaceIterable;
 pub use self::marker::TrustedFused;
 #[unstable(feature = "trusted_step", issue = "85731")]
 pub use self::marker::TrustedStep;
+#[unstable(feature = "peekable_iterator", issue = "132973")]
+pub use self::peekable::PeekableIterator;
 pub(crate) use self::unchecked_iterator::UncheckedIterator;
 #[stable(feature = "rust1", since = "1.0.0")]
 pub use self::{

--- a/library/core/src/iter/traits/peekable.rs
+++ b/library/core/src/iter/traits/peekable.rs
@@ -1,0 +1,116 @@
+use core::borrow::Borrow;
+
+/// An iterator with a `peek()` that returns an optional reference to the next
+/// element.
+#[unstable(feature = "peekable_iterator", issue = "132973")]
+pub trait PeekableIterator: Iterator {
+    /// The type of the item being peeked.
+    type PeekedItem<'b>: Borrow<Self::Item> + 'b
+    where
+        Self: 'b;
+
+    /// Returns a reference to the next() value without advancing the iterator.
+    ///
+    /// Like [`next`], if there is a value, it is wrapped in a `Some(T)`.
+    /// But if the iteration is over, `None` is returned.
+    ///
+    /// [`next`]: Iterator::next
+    ///
+    /// Because `peek()` returns a reference, and many iterators iterate over
+    /// references, there can be a possibly confusing situation where the
+    /// return value is a double reference. You can see this effect in the
+    /// examples below.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// #![feature(peekable_iterator)]
+    /// # use std::iter::PeekableIterator;
+    ///
+    /// let xs = [1, 2, 3];
+    ///
+    /// let mut iter = xs.iter();
+    ///
+    /// // peek() lets us see into the future
+    /// assert_eq!(iter.peek(), Some(&1));
+    /// assert_eq!(iter.next(), Some(&1));
+    ///
+    /// assert_eq!(iter.next(), Some(&2));
+    ///
+    /// // The iterator does not advance even if we `peek` multiple times
+    /// assert_eq!(iter.peek(), Some(&3));
+    /// assert_eq!(iter.peek(), Some(&3));
+    ///
+    /// assert_eq!(iter.next(), Some(&3));
+    ///
+    /// // After the iterator is finished, so is `peek()`
+    /// assert_eq!(iter.peek(), None);
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    fn peek(&self) -> Option<Self::PeekedItem<'_>>;
+
+    /// Consume and return the next value of this iterator if a condition is true.
+    ///
+    /// If `func` returns `true` for the next value of this iterator, consume and return it.
+    /// Otherwise, return `None`.
+    ///
+    /// # Examples
+    /// Consume a number if it's equal to 0.
+    /// ```
+    /// #![feature(peekable_iterator)]
+    /// # use std::iter::PeekableIterator;
+    ///
+    /// let mut iter = 0..5;
+    /// // The first item of the iterator is 0; consume it.
+    /// assert_eq!(iter.next_if(|&x| x == 0), Some(0));
+    /// // The next item returned is now 1, so `next_if` will return `None`.
+    /// assert_eq!(iter.next_if(|&x| x == 0), None);
+    /// // `next_if` saves the value of the next item if it was not equal to `expected`.
+    /// assert_eq!(iter.next(), Some(1));
+    /// ```
+    ///
+    /// Consume any number less than 10.
+    /// ```
+    /// #![feature(peekable_iterator)]
+    /// # use std::iter::PeekableIterator;
+    ///
+    /// let mut iter = 1..20;
+    /// // Consume all numbers less than 10
+    /// while iter.next_if(|&x| x < 10).is_some() {}
+    /// // The next value returned will be 10
+    /// assert_eq!(iter.next(), Some(10));
+    /// ```
+    fn next_if(&mut self, func: impl FnOnce(&Self::Item) -> bool) -> Option<Self::Item> {
+        match self.peek() {
+            Some(matched) if func(matched.borrow()) => (),
+            _ => return None,
+        };
+        self.next()
+    }
+
+    /// Consume and return the next item if it is equal to `expected`.
+    ///
+    /// # Example
+    /// Consume a number if it's equal to 0.
+    /// ```
+    /// #![feature(peekable_iterator)]
+    /// # use std::iter::PeekableIterator;
+    ///
+    /// let mut iter = 0..5;
+    /// // The first item of the iterator is 0; consume it.
+    /// assert_eq!(iter.next_if_eq(&0), Some(0));
+    /// // The next item returned is now 1, so `next_if` will return `None`.
+    /// assert_eq!(iter.next_if_eq(&0), None);
+    /// // `next_if_eq` saves the value of the next item if it was not equal to `expected`.
+    /// assert_eq!(iter.next(), Some(1));
+    /// ```
+    fn next_if_eq<T>(&mut self, expected: &T) -> Option<Self::Item>
+    where
+        Self::Item: PartialEq<T>,
+        T: ?Sized,
+    {
+        self.next_if(|next| next == expected)
+    }
+}

--- a/library/core/src/iter/traits/peekable.rs
+++ b/library/core/src/iter/traits/peekable.rs
@@ -16,11 +16,6 @@ pub trait PeekableIterator: Iterator {
     ///
     /// [`next`]: Iterator::next
     ///
-    /// Because `peek()` returns a reference, and many iterators iterate over
-    /// references, there can be a possibly confusing situation where the
-    /// return value is a double reference. You can see this effect in the
-    /// examples below.
-    ///
     /// # Examples
     ///
     /// Basic usage:
@@ -51,7 +46,7 @@ pub trait PeekableIterator: Iterator {
     /// ```
     fn peek(&self) -> Option<Self::PeekedItem<'_>>;
 
-    /// Consume and return the next value of this iterator if a condition is true.
+    /// Consumes and return the next value of this iterator if a condition is true.
     ///
     /// If `func` returns `true` for the next value of this iterator, consume and return it.
     /// Otherwise, return `None`.
@@ -90,7 +85,7 @@ pub trait PeekableIterator: Iterator {
         self.next()
     }
 
-    /// Consume and return the next item if it is equal to `expected`.
+    /// Consumes and return the next item if it is equal to `expected`.
     ///
     /// # Example
     /// Consume a number if it's equal to 0.

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -6,7 +6,8 @@ mod macros;
 use super::{from_raw_parts, from_raw_parts_mut};
 use crate::hint::assert_unchecked;
 use crate::iter::{
-    FusedIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce, UncheckedIterator,
+    FusedIterator, PeekableIterator, TrustedLen, TrustedRandomAccess, TrustedRandomAccessNoCoerce,
+    UncheckedIterator,
 };
 use crate::marker::PhantomData;
 use crate::mem::{self, SizedTypeProperties};

--- a/library/core/src/slice/iter/macros.rs
+++ b/library/core/src/slice/iter/macros.rs
@@ -445,6 +445,23 @@ macro_rules! iterator {
             }
         }
 
+        #[unstable(feature = "peekable_iterator", issue = "132973")]
+        impl<'a, T> PeekableIterator for $name<'a, T> {
+            type PeekedItem<'b> = Self::Item where Self: 'b;
+
+            #[inline]
+            fn peek(&self) -> Option<Self::Item> {
+                if len!(self) == 0 {
+                    None
+                } else {
+                    // SAFETY: `len!(self) > 0`
+                    unsafe {
+                        Some(& $( $mut_ )? *self.ptr.as_ptr())
+                    }
+                }
+            }
+        }
+
         #[stable(feature = "default_iters", since = "1.70.0")]
         impl<T> Default for $name<'_, T> {
             /// Creates an empty slice iterator.

--- a/library/core/tests/iter/traits/mod.rs
+++ b/library/core/tests/iter/traits/mod.rs
@@ -1,4 +1,5 @@
 mod accum;
 mod double_ended;
 mod iterator;
+mod peekable;
 mod step;

--- a/library/core/tests/iter/traits/peekable.rs
+++ b/library/core/tests/iter/traits/peekable.rs
@@ -1,0 +1,61 @@
+// use core::iter::*;
+
+// FIXME: need to implement PeekableIterator for Cloned
+// #[test]
+// fn test_peekable_iterator() {
+//     let xs = vec![0, 1, 2, 3, 4, 5];
+
+//     let mut it = xs.iter().cloned();
+//     assert_eq!(it.len(), 6);
+//     assert_eq!(it.peek().unwrap(), &0);
+//     assert_eq!(it.len(), 6);
+//     assert_eq!(it.next().unwrap(), 0);
+//     assert_eq!(it.len(), 5);
+//     assert_eq!(it.next().unwrap(), 1);
+//     assert_eq!(it.len(), 4);
+//     assert_eq!(it.next().unwrap(), 2);
+//     assert_eq!(it.len(), 3);
+//     assert_eq!(it.peek().unwrap(), &3);
+//     assert_eq!(it.len(), 3);
+//     assert_eq!(it.peek().unwrap(), &3);
+//     assert_eq!(it.len(), 3);
+//     assert_eq!(it.next().unwrap(), 3);
+//     assert_eq!(it.len(), 2);
+//     assert_eq!(it.next().unwrap(), 4);
+//     assert_eq!(it.len(), 1);
+//     assert_eq!(it.peek().unwrap(), &5);
+//     assert_eq!(it.len(), 1);
+//     assert_eq!(it.next().unwrap(), 5);
+//     assert_eq!(it.len(), 0);
+//     assert!(it.peek().is_none());
+//     assert_eq!(it.len(), 0);
+//     assert!(it.next().is_none());
+//     assert_eq!(it.len(), 0);
+
+//     let mut it = xs.iter().cloned();
+//     assert_eq!(it.len(), 6);
+//     assert_eq!(it.peek().unwrap(), &0);
+//     assert_eq!(it.len(), 6);
+//     assert_eq!(it.next_back().unwrap(), 5);
+//     assert_eq!(it.len(), 5);
+//     assert_eq!(it.next_back().unwrap(), 4);
+//     assert_eq!(it.len(), 4);
+//     assert_eq!(it.next_back().unwrap(), 3);
+//     assert_eq!(it.len(), 3);
+//     assert_eq!(it.peek().unwrap(), &0);
+//     assert_eq!(it.len(), 3);
+//     assert_eq!(it.peek().unwrap(), &0);
+//     assert_eq!(it.len(), 3);
+//     assert_eq!(it.next_back().unwrap(), 2);
+//     assert_eq!(it.len(), 2);
+//     assert_eq!(it.next_back().unwrap(), 1);
+//     assert_eq!(it.len(), 1);
+//     assert_eq!(it.peek().unwrap(), &0);
+//     assert_eq!(it.len(), 1);
+//     assert_eq!(it.next_back().unwrap(), 0);
+//     assert_eq!(it.len(), 0);
+//     assert!(it.peek().is_none());
+//     assert_eq!(it.len(), 0);
+//     assert!(it.next_back().is_none());
+//     assert_eq!(it.len(), 0);
+// }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Adds the `PeekableIterator` trait (tracking issue: #132973) and implementations for `slice::Iter` and `ops::Range`.

I tried to implement it for `Cloned`, but I couldn’t get the types and lifetimes to line up, so the unit test at `library/core/tests/iter/traits/peekable.rs` is not yet compilable.