### PR TITLE
Mention both release *and* edition breakage for never type lints

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4185,7 +4185,7 @@ declare_lint! {
     Warn,
     "never type fallback affecting unsafe function calls",
     @future_incompatible = FutureIncompatibleInfo {
-        reason: FutureIncompatibilityReason::FutureReleaseSemanticsChange,
+        reason: FutureIncompatibilityReason::EditionAndFutureReleaseError(Edition::Edition2024),
         reference: "issue #123748 <https://github.com/rust-lang/rust/issues/123748>",
     };
     @edition Edition2024 => Deny;
@@ -4239,7 +4239,7 @@ declare_lint! {
     Warn,
     "never type fallback affecting unsafe function calls",
     @future_incompatible = FutureIncompatibleInfo {
-        reason: FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps,
+        reason: FutureIncompatibilityReason::EditionAndFutureReleaseError(Edition::Edition2024),
         reference: "issue #123748 <https://github.com/rust-lang/rust/issues/123748>",
     };
     report_in_external_macro

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -4185,7 +4185,7 @@ declare_lint! {
     Warn,
     "never type fallback affecting unsafe function calls",
     @future_incompatible = FutureIncompatibleInfo {
-        reason: FutureIncompatibilityReason::EditionAndFutureReleaseError(Edition::Edition2024),
+        reason: FutureIncompatibilityReason::EditionAndFutureReleaseSemanticsChange(Edition::Edition2024),
         reference: "issue #123748 <https://github.com/rust-lang/rust/issues/123748>",
     };
     @edition Edition2024 => Deny;

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -381,6 +381,8 @@ pub enum FutureIncompatibilityReason {
     /// hard errors (and the lint removed). Preferably when there is some
     /// confidence that the number of impacted projects is very small (few
     /// should have a broken dependency in their dependency tree).
+    ///
+    /// [`EditionAndFutureReleaseError`]: FutureIncompatibilityReason::EditionAndFutureReleaseError
     FutureReleaseErrorReportInDeps,
     /// Code that changes meaning in some way in a
     /// future release.
@@ -419,6 +421,17 @@ pub enum FutureIncompatibilityReason {
     /// slightly changes the text of the diagnostic, but is otherwise the
     /// same.
     EditionSemanticsChange(Edition),
+    /// This will be an error in the provided edition *and* in a future
+    /// release.
+    ///
+    /// This variant a combination of [`FutureReleaseErrorDontReportInDeps`]
+    /// and [`EditionError`]. This is useful in rare cases when we
+    /// want to have "preview" of a breaking change in an edition, but do a
+    /// breaking change later on all editions anyway.
+    ///
+    /// [`EditionError`]: FutureIncompatibilityReason::EditionError
+    /// [`FutureReleaseErrorDontReportInDeps`]: FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps
+    EditionAndFutureReleaseError(Edition),
     /// A custom reason.
     ///
     /// Choose this variant if the built-in text of the diagnostic of the
@@ -431,9 +444,14 @@ pub enum FutureIncompatibilityReason {
 impl FutureIncompatibilityReason {
     pub fn edition(self) -> Option<Edition> {
         match self {
-            Self::EditionError(e) => Some(e),
-            Self::EditionSemanticsChange(e) => Some(e),
-            _ => None,
+            Self::EditionError(e)
+            | Self::EditionSemanticsChange(e)
+            | Self::EditionAndFutureReleaseError(e) => Some(e),
+
+            FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps
+            | FutureIncompatibilityReason::FutureReleaseErrorReportInDeps
+            | FutureIncompatibilityReason::FutureReleaseSemanticsChange
+            | FutureIncompatibilityReason::Custom(_) => None,
         }
     }
 }

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -432,6 +432,17 @@ pub enum FutureIncompatibilityReason {
     /// [`EditionError`]: FutureIncompatibilityReason::EditionError
     /// [`FutureReleaseErrorDontReportInDeps`]: FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps
     EditionAndFutureReleaseError(Edition),
+    /// This will change meaning in the provided edition *and* in a future
+    /// release.
+    ///
+    /// This variant a combination of [`FutureReleaseSemanticsChange`]
+    /// and [`EditionSemanticsChange`]. This is useful in rare cases when we
+    /// want to have "preview" of a breaking change in an edition, but do a
+    /// breaking change later on all editions anyway.
+    ///
+    /// [`EditionSemanticsChange`]: FutureIncompatibilityReason::EditionSemanticsChange
+    /// [`FutureReleaseSemanticsChange`]: FutureIncompatibilityReason::FutureReleaseSemanticsChange
+    EditionAndFutureReleaseSemanticsChange(Edition),
     /// A custom reason.
     ///
     /// Choose this variant if the built-in text of the diagnostic of the
@@ -446,7 +457,8 @@ impl FutureIncompatibilityReason {
         match self {
             Self::EditionError(e)
             | Self::EditionSemanticsChange(e)
-            | Self::EditionAndFutureReleaseError(e) => Some(e),
+            | Self::EditionAndFutureReleaseError(e)
+            | Self::EditionAndFutureReleaseSemanticsChange(e) => Some(e),
 
             FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps
             | FutureIncompatibilityReason::FutureReleaseErrorReportInDeps

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -388,6 +388,11 @@ pub fn lint_level(
                          it will become a hard error in Rust {edition} and in a future release in all editions!"
                     )
                 }
+                FutureIncompatibilityReason::EditionAndFutureReleaseSemanticsChange(edition) => {
+                    format!(
+                        "this changes meaning in Rust {edition} and in a future release in all editions!"
+                    )
+                }
                 FutureIncompatibilityReason::Custom(reason) => reason.to_owned(),
             };
 

--- a/compiler/rustc_middle/src/lint.rs
+++ b/compiler/rustc_middle/src/lint.rs
@@ -382,6 +382,12 @@ pub fn lint_level(
                 FutureIncompatibilityReason::EditionSemanticsChange(edition) => {
                     format!("this changes meaning in Rust {edition}")
                 }
+                FutureIncompatibilityReason::EditionAndFutureReleaseError(edition) => {
+                    format!(
+                        "this was previously accepted by the compiler but is being phased out; \
+                         it will become a hard error in Rust {edition} and in a future release in all editions!"
+                    )
+                }
                 FutureIncompatibilityReason::Custom(reason) => reason.to_owned(),
             };
 

--- a/tests/ui/delegation/unsupported.rs
+++ b/tests/ui/delegation/unsupported.rs
@@ -10,15 +10,11 @@ mod opaque {
     mod to_reuse {
         use super::Trait;
 
-        pub fn opaque_ret() -> impl Trait { unimplemented!() }
-        //~^ warn: this function depends on never type fallback being `()`
-        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+        pub fn opaque_ret() -> impl Trait { () }
     }
 
     trait ToReuse {
-        fn opaque_ret() -> impl Trait { unimplemented!() }
-        //~^ warn: this function depends on never type fallback being `()`
-        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+        fn opaque_ret() -> impl Trait { () }
     }
 
     // FIXME: Inherited `impl Trait`s create query cycles when used inside trait impls.

--- a/tests/ui/delegation/unsupported.stderr
+++ b/tests/ui/delegation/unsupported.stderr
@@ -1,74 +1,43 @@
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:25:5: 25:24>::{synthetic#0}`
-  --> $DIR/unsupported.rs:26:25
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:21:5: 21:24>::{synthetic#0}`
+  --> $DIR/unsupported.rs:22:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:26:25
+  --> $DIR/unsupported.rs:22:25
    |
 LL |         reuse to_reuse::opaque_ret;
    |                         ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:25:5: 25:24>::{synthetic#0}`, completing the cycle
-note: cycle used when checking that `opaque::<impl at $DIR/unsupported.rs:25:5: 25:24>` is well-formed
-  --> $DIR/unsupported.rs:25:5
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:21:5: 21:24>::{synthetic#0}`, completing the cycle
+note: cycle used when checking that `opaque::<impl at $DIR/unsupported.rs:21:5: 21:24>` is well-formed
+  --> $DIR/unsupported.rs:21:5
    |
 LL |     impl ToReuse for u8 {
    |     ^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
-warning: this function depends on never type fallback being `()`
-  --> $DIR/unsupported.rs:13:9
-   |
-LL |         pub fn opaque_ret() -> impl Trait { unimplemented!() }
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
-   = help: specify the types explicitly
-note: in edition 2024, the requirement `!: opaque::Trait` will fail
-  --> $DIR/unsupported.rs:13:32
-   |
-LL |         pub fn opaque_ret() -> impl Trait { unimplemented!() }
-   |                                ^^^^^^^^^^
-   = note: `#[warn(dependency_on_unit_never_type_fallback)]` on by default
-
-warning: this function depends on never type fallback being `()`
-  --> $DIR/unsupported.rs:19:9
-   |
-LL |         fn opaque_ret() -> impl Trait { unimplemented!() }
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
-   = help: specify the types explicitly
-note: in edition 2024, the requirement `!: opaque::Trait` will fail
-  --> $DIR/unsupported.rs:19:28
-   |
-LL |         fn opaque_ret() -> impl Trait { unimplemented!() }
-   |                            ^^^^^^^^^^
-
-error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:25>::{synthetic#0}`
-  --> $DIR/unsupported.rs:29:24
+error[E0391]: cycle detected when computing type of `opaque::<impl at $DIR/unsupported.rs:24:5: 24:25>::{synthetic#0}`
+  --> $DIR/unsupported.rs:25:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
    |
 note: ...which requires comparing an impl and trait method signature, inferring any hidden `impl Trait` types in the process...
-  --> $DIR/unsupported.rs:29:24
+  --> $DIR/unsupported.rs:25:24
    |
 LL |         reuse ToReuse::opaque_ret;
    |                        ^^^^^^^^^^
-   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:28:5: 28:25>::{synthetic#0}`, completing the cycle
-note: cycle used when checking that `opaque::<impl at $DIR/unsupported.rs:28:5: 28:25>` is well-formed
-  --> $DIR/unsupported.rs:28:5
+   = note: ...which again requires computing type of `opaque::<impl at $DIR/unsupported.rs:24:5: 24:25>::{synthetic#0}`, completing the cycle
+note: cycle used when checking that `opaque::<impl at $DIR/unsupported.rs:24:5: 24:25>` is well-formed
+  --> $DIR/unsupported.rs:24:5
    |
 LL |     impl ToReuse for u16 {
    |     ^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error: recursive delegation is not supported yet
-  --> $DIR/unsupported.rs:42:22
+  --> $DIR/unsupported.rs:38:22
    |
 LL |         pub reuse to_reuse2::foo;
    |                              --- callee defined here
@@ -77,14 +46,14 @@ LL |     reuse to_reuse1::foo;
    |                      ^^^
 
 error[E0283]: type annotations needed
-  --> $DIR/unsupported.rs:52:18
+  --> $DIR/unsupported.rs:48:18
    |
 LL |     reuse Trait::foo;
    |                  ^^^ cannot infer type
    |
    = note: cannot satisfy `_: effects::Trait`
 
-error: aborting due to 4 previous errors; 2 warnings emitted
+error: aborting due to 4 previous errors
 
 Some errors have detailed explanations: E0283, E0391.
 For more information about an error, try `rustc --explain E0283`.

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.fixed
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.fixed
@@ -16,7 +16,7 @@ fn main() {
 
 fn m() {
     //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let x: () = match true {
         true => Default::default(),
         //[e2024]~^ error: the trait bound `!: Default` is not satisfied
@@ -28,7 +28,7 @@ fn m() {
 
 fn q() -> Option<()> {
     //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     fn deserialize<T: Default>() -> Option<T> {
         Some(T::default())
     }
@@ -45,7 +45,7 @@ fn help<'a: 'a, T: Into<()>, U>(_: U) -> Result<T, ()> {
 }
 fn meow() -> Result<(), ()> {
     //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     help::<(), _>(1)?;
     //[e2024]~^ error: the trait bound `(): From<!>` is not satisfied
     Ok(())

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
@@ -4,7 +4,7 @@ warning: this function depends on never type fallback being `()`
 LL | fn m() {
    | ^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
@@ -24,7 +24,7 @@ warning: this function depends on never type fallback being `()`
 LL | fn q() -> Option<()> {
    | ^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
@@ -43,7 +43,7 @@ warning: this function depends on never type fallback being `()`
 LL | fn meow() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `(): From<!>` will fail

--- a/tests/ui/editions/never-type-fallback-breaking.rs
+++ b/tests/ui/editions/never-type-fallback-breaking.rs
@@ -16,7 +16,7 @@ fn main() {
 
 fn m() {
     //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let x = match true {
         true => Default::default(),
         //[e2024]~^ error: the trait bound `!: Default` is not satisfied
@@ -28,7 +28,7 @@ fn m() {
 
 fn q() -> Option<()> {
     //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     fn deserialize<T: Default>() -> Option<T> {
         Some(T::default())
     }
@@ -45,7 +45,7 @@ fn help<'a: 'a, T: Into<()>, U>(_: U) -> Result<T, ()> {
 }
 fn meow() -> Result<(), ()> {
     //[e2021]~^ this function depends on never type fallback being `()`
-    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[e2021]~| this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     help(1)?;
     //[e2024]~^ error: the trait bound `(): From<!>` is not satisfied
     Ok(())

--- a/tests/ui/never_type/defaulted-never-note.nofallback.stderr
+++ b/tests/ui/never_type/defaulted-never-note.nofallback.stderr
@@ -4,7 +4,7 @@ warning: this function depends on never type fallback being `()`
 LL | fn smeg() {
    | ^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will fail

--- a/tests/ui/never_type/defaulted-never-note.rs
+++ b/tests/ui/never_type/defaulted-never-note.rs
@@ -27,7 +27,7 @@ fn foo<T: ImplementedForUnitButNotNever>(_t: T) {}
 //[fallback]~| NOTE required by a bound in `foo`
 fn smeg() {
     //[nofallback]~^ warn: this function depends on never type fallback being `()`
-    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let _x = return;
     foo(_x);
     //[fallback]~^ ERROR the trait bound

--- a/tests/ui/never_type/dependency-on-fallback-to-unit.rs
+++ b/tests/ui/never_type/dependency-on-fallback-to-unit.rs
@@ -7,7 +7,7 @@ fn main() {
 
 fn def() {
     //~^ warn: this function depends on never type fallback being `()`
-    //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     match true {
         false => <_>::default(),
         true => return,
@@ -18,7 +18,7 @@ fn def() {
 // <https://github.com/rust-lang/rust/issues/39216>
 fn question_mark() -> Result<(), ()> {
     //~^ warn: this function depends on never type fallback being `()`
-    //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     deserialize()?;
     Ok(())
 }

--- a/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
+++ b/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
@@ -4,7 +4,7 @@ warning: this function depends on never type fallback being `()`
 LL | fn def() {
    | ^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
@@ -24,7 +24,7 @@ warning: this function depends on never type fallback being `()`
 LL | fn question_mark() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail

--- a/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
@@ -4,7 +4,7 @@ warning: this function depends on never type fallback being `()`
 LL | fn assignment() {
    | ^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
@@ -24,7 +24,7 @@ warning: this function depends on never type fallback being `()`
 LL | fn assignment_rev() {
    | ^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail

--- a/tests/ui/never_type/diverging-fallback-control-flow.rs
+++ b/tests/ui/never_type/diverging-fallback-control-flow.rs
@@ -29,7 +29,7 @@ impl UnitDefault for () {
 
 fn assignment() {
     //[nofallback]~^ warn: this function depends on never type fallback being `()`
-    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let x;
 
     if true {
@@ -41,7 +41,7 @@ fn assignment() {
 
 fn assignment_rev() {
     //[nofallback]~^ warn: this function depends on never type fallback being `()`
-    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     let x;
 
     if true {

--- a/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
@@ -4,7 +4,7 @@ warning: this function depends on never type fallback being `()`
 LL | fn main() {
    | ^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Test` will fail

--- a/tests/ui/never_type/diverging-fallback-no-leak.rs
+++ b/tests/ui/never_type/diverging-fallback-no-leak.rs
@@ -13,7 +13,7 @@ fn unconstrained_arg<T: Test>(_: T) {}
 
 fn main() {
     //[nofallback]~^ warn: this function depends on never type fallback being `()`
-    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
 
     // Here the type variable falls back to `!`,
     // and hence we get a type error.

--- a/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
@@ -4,7 +4,7 @@ warning: this function depends on never type fallback being `()`
 LL | fn main() {
    | ^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitReturn` will fail

--- a/tests/ui/never_type/diverging-fallback-unconstrained-return.rs
+++ b/tests/ui/never_type/diverging-fallback-unconstrained-return.rs
@@ -27,7 +27,7 @@ fn unconstrained_return<T: UnitReturn>() -> T {
 
 fn main() {
     //[nofallback]~^ warn: this function depends on never type fallback being `()`
-    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
 
     // In Ye Olde Days, the `T` parameter of `unconstrained_return`
     // winds up "entangled" with the `!` type that results from

--- a/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
+++ b/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
@@ -4,7 +4,7 @@ warning: this function depends on never type fallback being `()`
 LL | fn main() {
    | ^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Bar` will fail

--- a/tests/ui/never_type/fallback-closure-ret.rs
+++ b/tests/ui/never_type/fallback-closure-ret.rs
@@ -20,6 +20,6 @@ fn foo<R: Bar>(_: impl Fn() -> R) {}
 
 fn main() {
     //[nofallback]~^ warn: this function depends on never type fallback being `()`
-    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //[nofallback]~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     foo(|| panic!());
 }

--- a/tests/ui/never_type/impl_trait_fallback.rs
+++ b/tests/ui/never_type/impl_trait_fallback.rs
@@ -7,6 +7,6 @@ impl T for () {}
 
 fn should_ret_unit() -> impl T {
     //~^ warn: this function depends on never type fallback being `()`
-    //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     panic!()
 }

--- a/tests/ui/never_type/impl_trait_fallback.stderr
+++ b/tests/ui/never_type/impl_trait_fallback.stderr
@@ -4,7 +4,7 @@ warning: this function depends on never type fallback being `()`
 LL | fn should_ret_unit() -> impl T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: T` will fail

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
@@ -4,7 +4,7 @@ warning: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
@@ -19,7 +19,7 @@ warning: never type fallback affects this call to an `unsafe` function
 LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -33,7 +33,7 @@ warning: never type fallback affects this union access
 LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
@@ -43,7 +43,7 @@ warning: never type fallback affects this raw pointer dereference
 LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -57,7 +57,7 @@ warning: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -71,7 +71,7 @@ warning: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -85,7 +85,7 @@ warning: never type fallback affects this `unsafe` function
 LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -99,7 +99,7 @@ warning: never type fallback affects this `unsafe` function
 LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -113,7 +113,7 @@ warning: never type fallback affects this call to an `unsafe` method
 LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
@@ -126,7 +126,7 @@ LL |             match send_message::<_ /* ?0 */>() {
 LL |         msg_send!();
    |         ----------- in this macro invocation
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
@@ -4,7 +4,7 @@ warning: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
@@ -19,7 +19,7 @@ warning: never type fallback affects this call to an `unsafe` function
 LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -33,7 +33,7 @@ warning: never type fallback affects this union access
 LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
@@ -43,7 +43,7 @@ warning: never type fallback affects this raw pointer dereference
 LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -57,7 +57,7 @@ warning: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -71,7 +71,7 @@ warning: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -85,7 +85,7 @@ warning: never type fallback affects this `unsafe` function
 LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -99,7 +99,7 @@ warning: never type fallback affects this `unsafe` function
 LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -113,7 +113,7 @@ warning: never type fallback affects this call to an `unsafe` method
 LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
@@ -126,7 +126,7 @@ LL |             match send_message::<_ /* ?0 */>() {
 LL |         msg_send!();
    |         ----------- in this macro invocation
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
@@ -4,7 +4,7 @@ error: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
@@ -19,7 +19,7 @@ error: never type fallback affects this call to an `unsafe` function
 LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -33,7 +33,7 @@ error: never type fallback affects this union access
 LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
@@ -43,7 +43,7 @@ error: never type fallback affects this raw pointer dereference
 LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -57,7 +57,7 @@ error: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -71,7 +71,7 @@ error: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -85,7 +85,7 @@ error: never type fallback affects this `unsafe` function
 LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -99,7 +99,7 @@ error: never type fallback affects this `unsafe` function
 LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -113,7 +113,7 @@ error: never type fallback affects this call to an `unsafe` method
 LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
@@ -126,7 +126,7 @@ LL |             match send_message::<_ /* ?0 */>() {
 LL |         msg_send!();
    |         ----------- in this macro invocation
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
@@ -4,7 +4,7 @@ error: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
@@ -19,7 +19,7 @@ error: never type fallback affects this call to an `unsafe` function
 LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -33,7 +33,7 @@ error: never type fallback affects this union access
 LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
@@ -43,7 +43,7 @@ error: never type fallback affects this raw pointer dereference
 LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -57,7 +57,7 @@ error: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -71,7 +71,7 @@ error: never type fallback affects this call to an `unsafe` function
 LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -85,7 +85,7 @@ error: never type fallback affects this `unsafe` function
 LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -99,7 +99,7 @@ error: never type fallback affects this `unsafe` function
 LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
@@ -113,7 +113,7 @@ error: never type fallback affects this call to an `unsafe` method
 LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
 
@@ -126,7 +126,7 @@ LL |             match send_message::<_ /* ?0 */>() {
 LL |         msg_send!();
    |         ----------- in this macro invocation
    |
-   = warning: this will change its meaning in a future release!
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the type explicitly
    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.rs
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.rs
@@ -13,7 +13,7 @@ fn _zero() {
         unsafe { mem::zeroed() }
         //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
         //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
-        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+        //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
         //[e2024]~| warning: the type `!` does not permit zero-initialization
     } else {
         return;
@@ -30,7 +30,7 @@ fn _trans() {
             core::mem::transmute(Zst)
             //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
             //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
-            //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+            //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
         }
     } else {
         return;
@@ -47,7 +47,7 @@ fn _union() {
         unsafe { Union { a: () }.b }
         //[e2015]~^ warn: never type fallback affects this union access
         //[e2024]~^^ error: never type fallback affects this union access
-        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+        //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
     } else {
         return;
     };
@@ -58,7 +58,7 @@ fn _deref() {
         unsafe { *ptr::from_ref(&()).cast() }
         //[e2015]~^ warn: never type fallback affects this raw pointer dereference
         //[e2024]~^^ error: never type fallback affects this raw pointer dereference
-        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+        //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
     } else {
         return;
     };
@@ -79,7 +79,7 @@ fn _only_generics() {
         unsafe { internally_create(x) }
         //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
         //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
-        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+        //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
 
         x.unwrap()
     } else {
@@ -92,12 +92,12 @@ fn _stored_function() {
         let zeroed = mem::zeroed;
         //[e2015]~^ warn: never type fallback affects this `unsafe` function
         //[e2024]~^^ error: never type fallback affects this `unsafe` function
-        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+        //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
 
         unsafe { zeroed() }
         //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
         //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
-        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+        //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
     } else {
         return;
     };
@@ -115,7 +115,7 @@ fn _only_generics_stored_function() {
         let f = internally_create;
         //[e2015]~^ warn: never type fallback affects this `unsafe` function
         //[e2024]~^^ error: never type fallback affects this `unsafe` function
-        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+        //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
 
         unsafe { f(x) }
 
@@ -140,7 +140,7 @@ fn _method() {
             S(marker::PhantomData).create_out_of_thin_air()
             //[e2015]~^ warn: never type fallback affects this call to an `unsafe` method
             //[e2024]~^^ error: never type fallback affects this call to an `unsafe` method
-            //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+            //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
         }
     } else {
         return;
@@ -158,7 +158,7 @@ fn _objc() {
             match send_message::<_ /* ?0 */>() {
                 //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
                 //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
-                //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+                //~| warn: this changes meaning in Rust 2024 and in a future release in all editions!
                 Ok(x) => x,
                 Err(_) => loop {},
             }

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.rs
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.rs
@@ -13,7 +13,7 @@ fn _zero() {
         unsafe { mem::zeroed() }
         //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
         //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
-        //~| warn: this will change its meaning in a future release!
+        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
         //[e2024]~| warning: the type `!` does not permit zero-initialization
     } else {
         return;
@@ -30,7 +30,7 @@ fn _trans() {
             core::mem::transmute(Zst)
             //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
             //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
-            //~| warn: this will change its meaning in a future release!
+            //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
         }
     } else {
         return;
@@ -47,7 +47,7 @@ fn _union() {
         unsafe { Union { a: () }.b }
         //[e2015]~^ warn: never type fallback affects this union access
         //[e2024]~^^ error: never type fallback affects this union access
-        //~| warn: this will change its meaning in a future release!
+        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     } else {
         return;
     };
@@ -58,7 +58,7 @@ fn _deref() {
         unsafe { *ptr::from_ref(&()).cast() }
         //[e2015]~^ warn: never type fallback affects this raw pointer dereference
         //[e2024]~^^ error: never type fallback affects this raw pointer dereference
-        //~| warn: this will change its meaning in a future release!
+        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     } else {
         return;
     };
@@ -79,7 +79,7 @@ fn _only_generics() {
         unsafe { internally_create(x) }
         //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
         //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
-        //~| warn: this will change its meaning in a future release!
+        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
 
         x.unwrap()
     } else {
@@ -92,12 +92,12 @@ fn _stored_function() {
         let zeroed = mem::zeroed;
         //[e2015]~^ warn: never type fallback affects this `unsafe` function
         //[e2024]~^^ error: never type fallback affects this `unsafe` function
-        //~| warn: this will change its meaning in a future release!
+        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
 
         unsafe { zeroed() }
         //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
         //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
-        //~| warn: this will change its meaning in a future release!
+        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
     } else {
         return;
     };
@@ -115,7 +115,7 @@ fn _only_generics_stored_function() {
         let f = internally_create;
         //[e2015]~^ warn: never type fallback affects this `unsafe` function
         //[e2024]~^^ error: never type fallback affects this `unsafe` function
-        //~| warn: this will change its meaning in a future release!
+        //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
 
         unsafe { f(x) }
 
@@ -140,7 +140,7 @@ fn _method() {
             S(marker::PhantomData).create_out_of_thin_air()
             //[e2015]~^ warn: never type fallback affects this call to an `unsafe` method
             //[e2024]~^^ error: never type fallback affects this call to an `unsafe` method
-            //~| warn: this will change its meaning in a future release!
+            //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
         }
     } else {
         return;
@@ -158,7 +158,7 @@ fn _objc() {
             match send_message::<_ /* ?0 */>() {
                 //[e2015]~^ warn: never type fallback affects this call to an `unsafe` function
                 //[e2024]~^^ error: never type fallback affects this call to an `unsafe` function
-                //~| warn: this will change its meaning in a future release!
+                //~| warn: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
                 Ok(x) => x,
                 Err(_) => loop {},
             }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This PR makes ~~two changes~~ a change to the never type lints (`dependency_on_unit_never_type_fallback` and `never_type_fallback_flowing_into_unsafe`):
1.  Change the wording of the note to mention that the breaking change will be made in an edition _and_ in a future release
2. ~~Make these warnings be reported in deps (hopefully the lints are matured enough)~~

r? @compiler-errors
cc @ehuss 
closes #132930