### PR TITLE
[illumos] use pipe2 to create anonymous pipes

### DIFF
--- a/library/std/src/sys/pal/unix/pipe.rs
+++ b/library/std/src/sys/pal/unix/pipe.rs
@@ -23,6 +23,7 @@ pub fn anon_pipe() -> io::Result<(AnonPipe, AnonPipe)> {
             target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "hurd",
+            target_os = "illumos",
             target_os = "linux",
             target_os = "netbsd",
             target_os = "openbsd",


### PR DESCRIPTION
pipe2 allows the newly-created pipe to atomically be CLOEXEC.

pipe2 was added to illumos a long time ago:
https://github.com/illumos/illumos-gate/commit/5dbfd19ad5fcc2b779f40f80fa05c1bd28fd0b4e. I've verified that this change passes all of std's tests on illumos.