### PR TITLE
Make rustc consider itself a stable compiler when `RUSTC_BOOTSTRAP=-1`

### DIFF
--- a/compiler/rustc_feature/src/tests.rs
+++ b/compiler/rustc_feature/src/tests.rs
@@ -18,6 +18,16 @@ fn rustc_bootstrap_parsing() {
     assert!(!is_bootstrap("x,y,z", Some("a")));
     assert!(!is_bootstrap("x,y,z", None));
 
-    // this is technically a breaking change, but there are no stability guarantees for RUSTC_BOOTSTRAP
+    // `RUSTC_BOOTSTRAP=0` is not recognized.
     assert!(!is_bootstrap("0", None));
+
+    // `RUSTC_BOOTSTRAP=-1` is force-stable, no unstable features allowed.
+    let is_force_stable = |krate| {
+        std::env::set_var("RUSTC_BOOTSTRAP", "-1");
+        matches!(UnstableFeatures::from_environment(krate), UnstableFeatures::Disallow)
+    };
+    assert!(is_force_stable(None));
+    // Does not support specifying any crate.
+    assert!(is_force_stable(Some("x")));
+    assert!(is_force_stable(Some("x,y,z")));
 }

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -54,7 +54,7 @@ pub struct EnabledLangFeature {
     pub stable_since: Option<Symbol>,
 }
 
-/// Information abhout an enabled library feature.
+/// Information about an enabled library feature.
 #[derive(Debug, Copy, Clone)]
 pub struct EnabledLibFeature {
     pub gate_name: Symbol,

--- a/tests/ui/bootstrap/rustc_bootstap.force_stable.stderr
+++ b/tests/ui/bootstrap/rustc_bootstap.force_stable.stderr
@@ -1,0 +1,10 @@
+error: the option `Z` is only accepted on the nightly compiler
+
+help: consider switching to a nightly toolchain: `rustup default nightly`
+
+note: selecting a toolchain with `+toolchain` arguments require a rustup proxy; see <https://rust-lang.github.io/rustup/concepts/index.html>
+
+note: for more information about Rust's stability policy, see <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>
+
+error: 1 nightly option were parsed
+

--- a/tests/ui/bootstrap/rustc_bootstap.rs
+++ b/tests/ui/bootstrap/rustc_bootstap.rs
@@ -1,0 +1,47 @@
+//! Check `RUSTC_BOOTSTRAP`'s behavior in relation to feature stability and what rustc considers
+//! itself to be (stable vs non-stable ).
+//!
+//! `RUSTC_BOOTSTRAP` accepts:
+//!
+//! - `1`: cheat, allow usage of unstable features even if rustc thinks it is a stable compiler.
+//! - `x,y,z`: comma-delimited list of crates.
+//! - `-1`: force rustc to think it is a stable compiler.
+
+// ignore-tidy-linelength
+
+//@ revisions: default_nightly cheat cheat_single_crate cheat_multi_crate force_stable invalid_zero invalid_junk
+//@ only-nightly
+
+//@[default_nightly] unset-rustc-env:RUSTC_BOOTSTRAP
+//@[default_nightly] check-pass
+
+// For a nightly compiler, this is same as `default_nightly` as if `RUSTC_BOOTSTRAP` was unset.
+//@[invalid_zero] rustc-env:RUSTC_BOOTSTRAP=0
+//@[invalid_zero] check-pass
+
+// Invalid values are silently discarded, same as `default_nightly`, i.e. as if `RUSTC_BOOTSTRAP`
+// was unset.
+//@[invalid_junk] rustc-env:RUSTC_BOOTSTRAP=*
+//@[invalid_junk] check-pass
+
+//@[cheat] rustc-env:RUSTC_BOOTSTRAP=1
+//@[cheat] check-pass
+
+//@[cheat_single_crate] rustc-env:RUSTC_BOOTSTRAP=x
+//@[cheat_single_crate] check-pass
+
+//@[cheat_multi_crate] rustc-env:RUSTC_BOOTSTRAP=x,y,z
+//@[cheat_multi_crate] check-pass
+
+// Note: compiletest passes some `-Z` flags to the compiler for ui testing purposes, so here we
+// instead abuse the fact that `-Z unstable-options` is also part of rustc's stability story and is
+// also affected by `RUSTC_BOOTSTRAP`.
+//@[force_stable] rustc-env:RUSTC_BOOTSTRAP=-1
+//@[force_stable] compile-flags: -Z unstable-options
+//@[force_stable] regex-error-pattern: error: the option `Z` is only accepted on the nightly compiler
+
+#![crate_type = "lib"]
+
+// Note: `rustc_attrs` is a perma-unstable internal feature that is unlikely to change, which is
+// used as a proxy to check `RUSTC_BOOTSTRAP` versus stability checking logic.
+#![feature(rustc_attrs)]


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rust/issues/123404 to allow test writers to specify `//@ rustc-env:RUSTC_BOOTSTRAP=-1` to have a given rustc consider itself a stable rustc. This is only intended for testing usages.

I did not use `RUSTC_BOOTSTRAP=0` because that can be confusing, i.e. one might think that means "not bootstrapping", but "forcing a given rustc to consider itself a stable compiler" is a different use case.

I also added a specific test to check `RUSTC_BOOTSTRAP`'s various values and how that interacts with rustc's stability story w.r.t. features and cli flags.

Noticed when trying to write a test for enabling ICE file dumping on stable.

Dunno if this needs a compiler FCP or MCP, but I can file an MCP or ask someone to start an FCP if needed. Note that `RUSTC_BOOTSTRAP` is a perma-unstable env var and has no stability guarantees (heh) whatsoever. This does not affect bootstrapping because bootstrap never sets `RUSTC_BOOTSTRAP=-1`. If someone does set that when bootstrapping, it is considered PEBKAC.

Accompanying dev-guide PR: https://github.com/rust-lang/rustc-dev-guide/pull/2136

cc @estebank and @rust-lang/wg-diagnostics for FYI

