### PR TITLE
compiletest: Add ``exact-llvm-major-version`` directive

### DIFF
--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -25,6 +25,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "dont-check-failure-status",
     "edition",
     "error-pattern",
+    "exact-llvm-major-version",
     "exec-env",
     "failure-status",
     "filecheck-flags",

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -1588,12 +1588,12 @@ fn ignore_llvm(config: &Config, line: &str) -> IgnoreDecision {
         } else if let Some(version_string) =
             config.parse_name_value_directive(line, "exact-llvm-major-version")
         {
-            // Syntax is "only-llvm-major-version: <version>"
+            // Syntax is "exact-llvm-major-version: <version>"
             let version = extract_llvm_version(&version_string);
-            if actual_version.major > version.major || actual_version.major < version.major {
+            if actual_version.major != version.major {
                 return IgnoreDecision::Ignore {
                     reason: format!(
-                        "ignored when the LLVM major version is {}, but it should be {}",
+                        "ignored when the actual LLVM major version is {}, but the test only targets major version {}",
                         actual_version.major, version.major
                     ),
                 };

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -1585,6 +1585,19 @@ fn ignore_llvm(config: &Config, line: &str) -> IgnoreDecision {
                     };
                 }
             }
+        } else if let Some(version_string) =
+            config.parse_name_value_directive(line, "exact-llvm-major-version")
+        {
+            // Syntax is "only-llvm-major-version: <version>"
+            let version = extract_llvm_version(&version_string);
+            if actual_version.major > version.major || actual_version.major < version.major {
+                return IgnoreDecision::Ignore {
+                    reason: format!(
+                        "ignored when the LLVM major version is {}, but it should be {}",
+                        actual_version.major, version.major
+                    ),
+                };
+            }
         }
     }
     IgnoreDecision::Continue

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -284,6 +284,15 @@ fn llvm_version() {
 
     let config: Config = cfg().llvm_version("10.0.0").build();
     assert!(!check_ignore(&config, "//@ min-llvm-version: 9.0"));
+
+    let config: Config = cfg().llvm_version("10.0.0").build();
+    assert!(check_ignore(&config, "//@ exact-llvm-major-version: 9.0"));
+
+    let config: Config = cfg().llvm_version("9.0.0").build();
+    assert!(check_ignore(&config, "//@ exact-llvm-major-version: 10.0"));
+
+    let config: Config = cfg().llvm_version("10.0.0").build();
+    assert!(!check_ignore(&config, "//@ exact-llvm-major-version: 10.0"));
 }
 
 #[test]

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -293,6 +293,12 @@ fn llvm_version() {
 
     let config: Config = cfg().llvm_version("10.0.0").build();
     assert!(!check_ignore(&config, "//@ exact-llvm-major-version: 10.0"));
+
+    let config: Config = cfg().llvm_version("10.0.0").build();
+    assert!(!check_ignore(&config, "//@ exact-llvm-major-version: 10"));
+
+    let config: Config = cfg().llvm_version("10.6.2").build();
+    assert!(!check_ignore(&config, "//@ exact-llvm-major-version: 10"));
 }
 
 #[test]

--- a/tests/codegen/try_question_mark_nop.rs
+++ b/tests/codegen/try_question_mark_nop.rs
@@ -2,8 +2,7 @@
 //@ only-x86_64
 // FIXME: Remove the `min-llvm-version`.
 //@ revisions: NINETEEN TWENTY
-//@[NINETEEN] min-llvm-version: 19
-//@[NINETEEN] ignore-llvm-version: 20-99
+//@[NINETEEN] exact-llvm-major-version: 19
 //@[TWENTY] min-llvm-version: 20
 //@ min-llvm-version: 19
 


### PR DESCRIPTION
Now contributors don't need to use  `min-llvm-version: X` + `ignore-llvm-version: X+1 - 99`, so they can simply use `exact-llvm-major-version: X`

To be honest, I didn't find any usages of that hack other than the one mentioned in the issue.  ( `tests/codegen/try_question_mark_nop.rs`)
Closes #132348.

rustc-dev-guide PR for `//@ exact-llvm-major-version`: https://github.com/rust-lang/rustc-dev-guide/pull/2135

r? jieyouxu
