### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -274,8 +274,12 @@ pub(crate) unsafe fn create_module<'ll>(
         }
     }
 
-    // Control Flow Guard is currently only supported by the MSVC linker on Windows.
-    if sess.target.is_like_msvc {
+    // Control Flow Guard is currently only supported by MSVC and LLVM on Windows.
+    if sess.target.is_like_msvc
+        || (sess.target.options.os == "windows"
+            && sess.target.options.env == "gnu"
+            && sess.target.options.abi == "llvm")
+    {
         match sess.opts.cg.control_flow_guard {
             CFGuard::Disabled => {}
             CFGuard::NoChecks => {

--- a/compiler/rustc_middle/src/mir/consts.rs
+++ b/compiler/rustc_middle/src/mir/consts.rs
@@ -325,6 +325,9 @@ impl<'tcx> Const<'tcx> {
 
                 match c.kind() {
                     ConstKind::Value(ty, val) => Ok(tcx.valtree_to_const_val((ty, val))),
+                    ConstKind::Expr(_) => {
+                        bug!("Normalization of `ty::ConstKind::Expr` is unimplemented")
+                    }
                     _ => Err(tcx.dcx().delayed_bug("Unevaluated `ty::Const` in MIR body").into()),
                 }
             }

--- a/compiler/rustc_monomorphize/messages.ftl
+++ b/compiler/rustc_monomorphize/messages.ftl
@@ -1,11 +1,18 @@
 monomorphize_abi_error_disabled_vector_type_call =
-  ABI error: this function call uses a vector type that requires the `{$required_feature}` target feature, which is not enabled in the caller
+  this function call uses a SIMD vector type that (with the chosen ABI) requires the `{$required_feature}` target feature, which is not enabled in the caller
   .label = function called here
   .help = consider enabling it globally (`-C target-feature=+{$required_feature}`) or locally (`#[target_feature(enable="{$required_feature}")]`)
 monomorphize_abi_error_disabled_vector_type_def =
-  ABI error: this function definition uses a vector type that requires the `{$required_feature}` target feature, which is not enabled
+  this function definition uses a SIMD vector type that (with the chosen ABI) requires the `{$required_feature}` target feature, which is not enabled
   .label = function defined here
   .help = consider enabling it globally (`-C target-feature=+{$required_feature}`) or locally (`#[target_feature(enable="{$required_feature}")]`)
+
+monomorphize_abi_error_unsupported_vector_type_call =
+  this function call uses a SIMD vector type that is not currently supported with the chosen ABI
+  .label = function called here
+monomorphize_abi_error_unsupported_vector_type_def =
+  this function definition uses a SIMD vector type that is not currently supported with the chosen ABI
+  .label = function defined here
 
 monomorphize_couldnt_dump_mono_stats =
     unexpected error occurred while dumping monomorphization stats: {$error}

--- a/compiler/rustc_monomorphize/src/errors.rs
+++ b/compiler/rustc_monomorphize/src/errors.rs
@@ -110,3 +110,17 @@ pub(crate) struct AbiErrorDisabledVectorTypeCall<'a> {
     pub span: Span,
     pub required_feature: &'a str,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(monomorphize_abi_error_unsupported_vector_type_def)]
+pub(crate) struct AbiErrorUnsupportedVectorTypeDef {
+    #[label]
+    pub span: Span,
+}
+
+#[derive(LintDiagnostic)]
+#[diag(monomorphize_abi_error_unsupported_vector_type_call)]
+pub(crate) struct AbiErrorUnsupportedVectorTypeCall {
+    #[label]
+    pub span: Span,
+}

--- a/compiler/rustc_target/src/target_features.rs
+++ b/compiler/rustc_target/src/target_features.rs
@@ -586,8 +586,19 @@ pub fn all_rust_features() -> impl Iterator<Item = (&'static str, Stability)> {
 // certain size to have their "proper" ABI on each architecture.
 // Note that they must be kept sorted by vector size.
 const X86_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] =
-    &[(128, "sse"), (256, "avx"), (512, "avx512f")];
+    &[(128, "sse"), (256, "avx"), (512, "avx512f")]; // FIXME: might need changes for AVX10.
 const AARCH64_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "neon")];
+
+// We might want to add "helium" too.
+const ARM_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "neon")];
+
+const POWERPC_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "altivec")];
+const WASM_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "simd128")];
+const S390X_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[(128, "vector")];
+const RISCV_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] =
+    &[/*(64, "zvl64b"), */ (128, "v")];
+// Always warn on SPARC, as the necessary target features cannot be enabled in Rust at the moment.
+const SPARC_FEATURES_FOR_CORRECT_VECTOR_ABI: &'static [(u64, &'static str)] = &[/*(128, "vis")*/];
 
 impl super::spec::Target {
     pub fn rust_target_features(&self) -> &'static [(&'static str, Stability, ImpliedFeatures)] {
@@ -613,8 +624,15 @@ impl super::spec::Target {
     pub fn features_for_correct_vector_abi(&self) -> Option<&'static [(u64, &'static str)]> {
         match &*self.arch {
             "x86" | "x86_64" => Some(X86_FEATURES_FOR_CORRECT_VECTOR_ABI),
-            "aarch64" => Some(AARCH64_FEATURES_FOR_CORRECT_VECTOR_ABI),
-            // FIXME: add support for non-tier1 architectures
+            "aarch64" | "arm64ec" => Some(AARCH64_FEATURES_FOR_CORRECT_VECTOR_ABI),
+            "arm" => Some(ARM_FEATURES_FOR_CORRECT_VECTOR_ABI),
+            "powerpc" | "powerpc64" => Some(POWERPC_FEATURES_FOR_CORRECT_VECTOR_ABI),
+            "loongarch64" => Some(&[]), // on-stack ABI, so we complain about all by-val vectors
+            "riscv32" | "riscv64" => Some(RISCV_FEATURES_FOR_CORRECT_VECTOR_ABI),
+            "wasm32" | "wasm64" => Some(WASM_FEATURES_FOR_CORRECT_VECTOR_ABI),
+            "s390x" => Some(S390X_FEATURES_FOR_CORRECT_VECTOR_ABI),
+            "sparc" | "sparc64" => Some(SPARC_FEATURES_FOR_CORRECT_VECTOR_ABI),
+            // FIXME: add support for non-tier2 architectures
             _ => None,
         }
     }

--- a/library/core/src/char/methods.rs
+++ b/library/core/src/char/methods.rs
@@ -301,7 +301,7 @@ impl char {
     ///
     /// # Panics
     ///
-    /// Panics if given a radix larger than 36.
+    /// Panics if given a radix smaller than 2 or larger than 36.
     ///
     /// # Examples
     ///
@@ -318,6 +318,13 @@ impl char {
     /// ```should_panic
     /// // this panics
     /// '1'.is_digit(37);
+    /// ```
+    ///
+    /// Passing a small radix, causing a panic:
+    ///
+    /// ```should_panic
+    /// // this panics
+    /// '1'.is_digit(1);
     /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_unstable(feature = "const_char_classify", issue = "132241")]
@@ -345,7 +352,7 @@ impl char {
     ///
     /// # Panics
     ///
-    /// Panics if given a radix larger than 36.
+    /// Panics if given a radix smaller than 2 or larger than 36.
     ///
     /// # Examples
     ///
@@ -369,24 +376,35 @@ impl char {
     /// // this panics
     /// let _ = '1'.to_digit(37);
     /// ```
+    /// Passing a small radix, causing a panic:
+    ///
+    /// ```should_panic
+    /// // this panics
+    /// let _ = '1'.to_digit(1);
+    /// ```
     #[stable(feature = "rust1", since = "1.0.0")]
     #[rustc_const_stable(feature = "const_char_convert", since = "1.67.0")]
     #[must_use = "this returns the result of the operation, \
                   without modifying the original"]
     #[inline]
     pub const fn to_digit(self, radix: u32) -> Option<u32> {
-        // If not a digit, a number greater than radix will be created.
-        let mut digit = (self as u32).wrapping_sub('0' as u32);
-        if radix > 10 {
-            assert!(radix <= 36, "to_digit: radix is too high (maximum 36)");
-            if digit < 10 {
-                return Some(digit);
-            }
-            // Force the 6th bit to be set to ensure ascii is lower case.
-            digit = (self as u32 | 0b10_0000).wrapping_sub('a' as u32).saturating_add(10);
-        }
+        assert!(
+            radix >= 2 && radix <= 36,
+            "to_digit: invalid radix -- radix must be in the range 2 to 36 inclusive"
+        );
+        // check radix to remove letter handling code when radix is a known constant
+        let value = if self > '9' && radix > 10 {
+            // convert ASCII letters to lowercase
+            let lower = self as u32 | 0x20;
+            // convert an ASCII letter to the corresponding value,
+            // non-letters convert to values > 36
+            lower.wrapping_sub('a' as u32) as u64 + 10
+        } else {
+            // convert digit to value, non-digits wrap to values > 36
+            (self as u32).wrapping_sub('0' as u32) as u64
+        };
         // FIXME(const-hack): once then_some is const fn, use it here
-        if digit < radix { Some(digit) } else { None }
+        if value < radix as u64 { Some(value as u32) } else { None }
     }
 
     /// Returns an iterator that yields the hexadecimal Unicode escape of a

--- a/src/ci/docker/run.sh
+++ b/src/ci/docker/run.sh
@@ -96,7 +96,9 @@ if [ -f "$docker_dir/$image/Dockerfile" ]; then
     docker --version
 
     REGISTRY=ghcr.io
-    REGISTRY_USERNAME=${GITHUB_REPOSITORY_OWNER:-rust-lang-ci}
+    # Hardcode username to reuse cache between auto and pr jobs
+    # FIXME: should be changed after move from rust-lang-ci
+    REGISTRY_USERNAME=rust-lang-ci
     # Tag used to push the final Docker image, so that it can be pulled by e.g. rustup
     IMAGE_TAG=${REGISTRY}/${REGISTRY_USERNAME}/rust-ci:${cksum}
     # Tag used to cache the Docker build

--- a/tests/ui/const-generics/failing_goal_with_repeat_expr_anon_const.rs
+++ b/tests/ui/const-generics/failing_goal_with_repeat_expr_anon_const.rs
@@ -1,0 +1,21 @@
+// Regression test for #132955 checking that we handle anon consts with
+// inference variables in their generic arguments correctly.
+//
+// This arose via diagnostics where we would have some failing goal such
+// as `[u8; AnonConst<Self>]: PartialEq<Self::A>`, then as part of diagnostics
+// we would replace all generic parameters with inference vars which would yield
+// a self type of `[u8; AnonConst<?x>]` and then attempt to normalize `AnonConst<?x>`.
+
+pub trait T {
+    type A;
+    const P: Self::A;
+
+    fn a() {
+        [0u8; std::mem::size_of::<Self::A>()] == Self::P;
+        //~^ ERROR: can't compare
+        //~| ERROR: constant expression depends on a generic parameter
+        //~| ERROR: constant expression depends on a generic parameter
+    }
+}
+
+fn main() {}

--- a/tests/ui/const-generics/failing_goal_with_repeat_expr_anon_const.stderr
+++ b/tests/ui/const-generics/failing_goal_with_repeat_expr_anon_const.stderr
@@ -1,0 +1,31 @@
+error: constant expression depends on a generic parameter
+  --> $DIR/failing_goal_with_repeat_expr_anon_const.rs:14:15
+   |
+LL |         [0u8; std::mem::size_of::<Self::A>()] == Self::P;
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error: constant expression depends on a generic parameter
+  --> $DIR/failing_goal_with_repeat_expr_anon_const.rs:14:47
+   |
+LL |         [0u8; std::mem::size_of::<Self::A>()] == Self::P;
+   |                                               ^^
+   |
+   = note: this may fail depending on what value the parameter takes
+
+error[E0277]: can't compare `[u8; std::mem::size_of::<Self::A>()]` with `<Self as T>::A`
+  --> $DIR/failing_goal_with_repeat_expr_anon_const.rs:14:47
+   |
+LL |         [0u8; std::mem::size_of::<Self::A>()] == Self::P;
+   |                                               ^^ no implementation for `[u8; std::mem::size_of::<Self::A>()] == <Self as T>::A`
+   |
+   = help: the trait `PartialEq<<Self as T>::A>` is not implemented for `[u8; std::mem::size_of::<Self::A>()]`
+help: consider introducing a `where` clause, but there might be an alternative better way to express this requirement
+   |
+LL | pub trait T where [u8; std::mem::size_of::<Self::A>()]: PartialEq<<Self as T>::A> {
+   |             +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/simd-abi-checks-empty-list.rs
+++ b/tests/ui/simd-abi-checks-empty-list.rs
@@ -1,0 +1,19 @@
+//@ needs-llvm-components: sparc
+//@ compile-flags: --target=sparc-unknown-none-elf --crate-type=rlib
+//@ build-pass
+//@ ignore-pass (test emits codegen-time warnings)
+#![no_core]
+#![feature(no_core, lang_items, repr_simd)]
+#![allow(improper_ctypes_definitions)]
+#[lang = "sized"]
+trait Sized {}
+
+#[lang = "copy"]
+trait Copy {}
+
+#[repr(simd)]
+pub struct SimdVec([i32; 4]);
+
+pub extern "C" fn pass_by_vec(_: SimdVec) {}
+//~^ this function definition uses a SIMD vector type that is not currently supported with the chosen ABI
+//~| WARNING this was previously accepted by the compiler

--- a/tests/ui/simd-abi-checks-empty-list.stderr
+++ b/tests/ui/simd-abi-checks-empty-list.stderr
@@ -1,0 +1,12 @@
+warning: this function definition uses a SIMD vector type that is not currently supported with the chosen ABI
+  --> $DIR/simd-abi-checks-empty-list.rs:17:1
+   |
+LL | pub extern "C" fn pass_by_vec(_: SimdVec) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function defined here
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
+   = note: `#[warn(abi_unsupported_vector_types)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/simd-abi-checks.rs
+++ b/tests/ui/simd-abi-checks.rs
@@ -12,19 +12,19 @@ use std::arch::x86_64::*;
 struct Wrapper(__m256);
 
 unsafe extern "C" fn w(_: Wrapper) {
-    //~^ ABI error: this function definition uses a vector type that requires the `avx` target feature, which is not enabled
+    //~^ this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
     //~| WARNING this was previously accepted by the compiler
     todo!()
 }
 
 unsafe extern "C" fn f(_: __m256) {
-    //~^ ABI error: this function definition uses a vector type that requires the `avx` target feature, which is not enabled
+    //~^ this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
     //~| WARNING this was previously accepted by the compiler
     todo!()
 }
 
 unsafe extern "C" fn g() -> __m256 {
-    //~^ ABI error: this function definition uses a vector type that requires the `avx` target feature, which is not enabled
+    //~^ this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
     //~| WARNING this was previously accepted by the compiler
     todo!()
 }
@@ -53,16 +53,16 @@ unsafe fn test() {
 fn main() {
     unsafe {
         f(g());
-        //~^ WARNING ABI error: this function call uses a vector type that requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING ABI error: this function call uses a vector type that requires the `avx` target feature, which is not enabled in the caller
+        //~^ WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+        //~| WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
         //~| WARNING this was previously accepted by the compiler
         //~| WARNING this was previously accepted by the compiler
     }
 
     unsafe {
         gavx(favx());
-        //~^ WARNING ABI error: this function call uses a vector type that requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING ABI error: this function call uses a vector type that requires the `avx` target feature, which is not enabled in the caller
+        //~^ WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+        //~| WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
         //~| WARNING this was previously accepted by the compiler
         //~| WARNING this was previously accepted by the compiler
     }
@@ -73,8 +73,8 @@ fn main() {
 
     unsafe {
         w(Wrapper(g()));
-        //~^ WARNING ABI error: this function call uses a vector type that requires the `avx` target feature, which is not enabled in the caller
-        //~| WARNING ABI error: this function call uses a vector type that requires the `avx` target feature, which is not enabled in the caller
+        //~^ WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
+        //~| WARNING this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
         //~| WARNING this was previously accepted by the compiler
         //~| WARNING this was previously accepted by the compiler
     }

--- a/tests/ui/simd-abi-checks.stderr
+++ b/tests/ui/simd-abi-checks.stderr
@@ -1,4 +1,4 @@
-warning: ABI error: this function call uses a vector type that requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:55:11
    |
 LL |         f(g());
@@ -9,7 +9,7 @@ LL |         f(g());
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
    = note: `#[warn(abi_unsupported_vector_types)]` on by default
 
-warning: ABI error: this function call uses a vector type that requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:55:9
    |
 LL |         f(g());
@@ -19,7 +19,7 @@ LL |         f(g());
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: ABI error: this function call uses a vector type that requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:63:14
    |
 LL |         gavx(favx());
@@ -29,7 +29,7 @@ LL |         gavx(favx());
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: ABI error: this function call uses a vector type that requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:63:9
    |
 LL |         gavx(favx());
@@ -39,7 +39,7 @@ LL |         gavx(favx());
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: ABI error: this function call uses a vector type that requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:75:19
    |
 LL |         w(Wrapper(g()));
@@ -49,7 +49,7 @@ LL |         w(Wrapper(g()));
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: ABI error: this function call uses a vector type that requires the `avx` target feature, which is not enabled in the caller
+warning: this function call uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled in the caller
   --> $DIR/simd-abi-checks.rs:75:9
    |
 LL |         w(Wrapper(g()));
@@ -59,7 +59,7 @@ LL |         w(Wrapper(g()));
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: ABI error: this function definition uses a vector type that requires the `avx` target feature, which is not enabled
+warning: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
   --> $DIR/simd-abi-checks.rs:26:1
    |
 LL | unsafe extern "C" fn g() -> __m256 {
@@ -69,7 +69,7 @@ LL | unsafe extern "C" fn g() -> __m256 {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: ABI error: this function definition uses a vector type that requires the `avx` target feature, which is not enabled
+warning: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
   --> $DIR/simd-abi-checks.rs:20:1
    |
 LL | unsafe extern "C" fn f(_: __m256) {
@@ -79,7 +79,7 @@ LL | unsafe extern "C" fn f(_: __m256) {
    = note: for more information, see issue #116558 <https://github.com/rust-lang/rust/issues/116558>
    = help: consider enabling it globally (`-C target-feature=+avx`) or locally (`#[target_feature(enable="avx")]`)
 
-warning: ABI error: this function definition uses a vector type that requires the `avx` target feature, which is not enabled
+warning: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `avx` target feature, which is not enabled
   --> $DIR/simd-abi-checks.rs:14:1
    |
 LL | unsafe extern "C" fn w(_: Wrapper) {

--- a/tests/ui/sse-abi-checks.rs
+++ b/tests/ui/sse-abi-checks.rs
@@ -19,6 +19,6 @@ pub struct SseVector([i64; 2]);
 
 #[no_mangle]
 pub unsafe extern "C" fn f(_: SseVector) {
-    //~^ ABI error: this function definition uses a vector type that requires the `sse` target feature, which is not enabled
+    //~^ this function definition uses a SIMD vector type that (with the chosen ABI) requires the `sse` target feature, which is not enabled
     //~| WARNING this was previously accepted by the compiler
 }

--- a/tests/ui/sse-abi-checks.stderr
+++ b/tests/ui/sse-abi-checks.stderr
@@ -1,4 +1,4 @@
-warning: ABI error: this function definition uses a vector type that requires the `sse` target feature, which is not enabled
+warning: this function definition uses a SIMD vector type that (with the chosen ABI) requires the `sse` target feature, which is not enabled
   --> $DIR/sse-abi-checks.rs:21:1
    |
 LL | pub unsafe extern "C" fn f(_: SseVector) {


### PR DESCRIPTION
Successful merges:

 - #132709 (optimize char::to_digit and assert radix is at least 2)
 - #132842 (ABI checks: add support for tier2 arches)
 - #132965 (allow CFGuard on windows-gnullvm)
 - #132967 (fix REGISTRY_USERNAME to reuse cache between auto and pr jobs)
 - #132971 (Handle infer vars in anon consts on stable)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=132709,132842,132965,132967,132971)
<!-- homu-ignore:end -->