### PR TITLE
Querify should_codegen_locally

### DIFF
--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1662,6 +1662,11 @@ rustc_queries! {
         separate_provide_extern
     }
 
+    query should_codegen_locally_slow(key: ty::Instance<'tcx>) -> bool {
+        desc { "checking whether `{}` should be linked to or lowered", key }
+        cache_on_disk_if { true }
+    }
+
     /// Returns the upstream crate that exports drop-glue for the given
     /// type (`args` is expected to be a single-item list containing the
     /// type one wants drop-glue for).


### PR DESCRIPTION
I think this has a very strong interaction with https://github.com/rust-lang/rust/pull/132566, and may not be justifiable without that PR, so marking this as blocked until that is merged.