### PR TITLE
Postpone `-Z input-stats` til all source is parsed

### DIFF
--- a/compiler/rustc_expand/src/expand.rs
+++ b/compiler/rustc_expand/src/expand.rs
@@ -432,6 +432,14 @@ impl<'a, 'b> MacroExpander<'a, 'b> {
         let (mut fragment_with_placeholders, mut invocations) =
             self.collect_invocations(input_fragment, &[]);
 
+        if matches!(fragment_with_placeholders, AstFragment::Crate(_))
+            && self.cx.sess.opts.unstable_opts.input_stats
+        {
+            let mut counter = rustc_ast_passes::node_count::NodeCounter::new();
+            fragment_with_placeholders.visit_with(&mut counter);
+            eprintln!("Pre-expansion node count:  {}", counter.count);
+        }
+
         // Optimization: if we resolve all imports now,
         // we'll be able to immediately resolve most of imported macros.
         self.resolve_imports();

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -54,11 +54,6 @@ pub(crate) fn parse<'a>(sess: &'a Session) -> Result<ast::Crate> {
         })
         .map_err(|parse_error| parse_error.emit())?;
 
-    if sess.opts.unstable_opts.input_stats {
-        eprintln!("Lines of code:             {}", sess.source_map().count_lines());
-        eprintln!("Pre-expansion node count:  {}", count_nodes(&krate));
-    }
-
     if let Some(ref s) = sess.opts.unstable_opts.show_span {
         rustc_ast_passes::show_span::run(sess.dcx(), s, &krate);
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Currently `-Z input-stats` is fairly misleading, because its "lines of code" and "pre-expansion node count" only measure the crate root, and no other source files in the crate. So, before this PR:

```
$ git clone https://github.com/BurntSushi/ripgrep
$ cd ripgrep
$ cargo +nightly rustc -- -Z input-stats
...
Lines of code:             483
Pre-expansion node count:  2386
Post-expansion node count: 63844
```

This PR is an attempt to make the flag a bit more useful, by printing the first node count only after parsing all source files in the crate. I also removed the "lines of code" measurement entirely, because I couldn't figure out an easy way to give it the correct behavior, and it's also easy to do without `rustc`, e.g. with `git ls-files`. So, after this PR:

```
$ cargo +stage1 rustc -- -Z input-stats
Pre-expansion node count:  40297
Post-expansion node count: 63844
```

At first I was also trying to do the same thing for `-Z hir-stats`, since that flag similarly prints pre-expansion stats for the AST:

https://github.com/rust-lang/rust/blob/8adb4b30f40e6fbd21dc1ba26c3301c7eeb6de3c/compiler/rustc_interface/src/passes.rs#L66-L68

However, I then realized that this would be much less trivial, because that `hir_stats` module lives in the `rustc_passes` crate, which depends on the `rustc_expand` crate:

https://github.com/rust-lang/rust/blob/8adb4b30f40e6fbd21dc1ba26c3301c7eeb6de3c/compiler/rustc_passes/Cargo.toml#L14

And I wasn't sure if it would make sense to move that module to a different crate, or if so, which crate to move it to. But I'm happy to do that if I should.