### PR TITLE
Fix a copy-paste issue in the NuttX raw type definition

### DIFF
--- a/library/std/src/os/nuttx/raw.rs
+++ b/library/std/src/os/nuttx/raw.rs
@@ -1,4 +1,4 @@
-//! rtems raw type definitions
+//! NuttX raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 #![deprecated(


### PR DESCRIPTION
This file is copied from the rtems as initial implementation, and forgot to change the OS name in the comment.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
