### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/library/std/src/os/nuttx/raw.rs
+++ b/library/std/src/os/nuttx/raw.rs
@@ -1,4 +1,4 @@
-//! rtems raw type definitions
+//! NuttX raw type definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
 #![deprecated(

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -115,7 +115,12 @@ RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --release-channel=$RUST_RELEASE_CHANNE
 if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.remap-debuginfo"
-  RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --debuginfo-level-std=1"
+
+  if [ "$DEPLOY_ALT" != "" ]; then
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --debuginfo-level=2"
+  else
+    RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --debuginfo-level-std=1"
+  fi
 
   if [ "$NO_LLVM_ASSERTIONS" = "1" ]; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --disable-llvm-assertions"

--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -120,6 +120,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "incremental",
     "known-bug",
     "llvm-cov-flags",
+    "max-llvm-major-version",
     "min-cdb-version",
     "min-gdb-version",
     "min-lldb-version",

--- a/src/tools/compiletest/src/header.rs
+++ b/src/tools/compiletest/src/header.rs
@@ -1547,6 +1547,20 @@ fn ignore_llvm(config: &Config, line: &str) -> IgnoreDecision {
                 };
             }
         } else if let Some(version_string) =
+            config.parse_name_value_directive(line, "max-llvm-major-version")
+        {
+            let max_version = extract_llvm_version(&version_string);
+            // Ignore if actual major version is larger than the maximum required major version.
+            if actual_version.major > max_version.major {
+                return IgnoreDecision::Ignore {
+                    reason: format!(
+                        "ignored when the LLVM version ({actual_version}) is newer than major\
+                        version {}",
+                        max_version.major
+                    ),
+                };
+            }
+        } else if let Some(version_string) =
             config.parse_name_value_directive(line, "min-system-llvm-version")
         {
             let min_version = extract_llvm_version(&version_string);

--- a/src/tools/compiletest/src/header/tests.rs
+++ b/src/tools/compiletest/src/header/tests.rs
@@ -299,6 +299,15 @@ fn llvm_version() {
 
     let config: Config = cfg().llvm_version("10.6.2").build();
     assert!(!check_ignore(&config, "//@ exact-llvm-major-version: 10"));
+
+    let config: Config = cfg().llvm_version("19.0.0").build();
+    assert!(!check_ignore(&config, "//@ max-llvm-major-version: 19"));
+
+    let config: Config = cfg().llvm_version("19.1.2").build();
+    assert!(!check_ignore(&config, "//@ max-llvm-major-version: 19"));
+
+    let config: Config = cfg().llvm_version("20.0.0").build();
+    assert!(check_ignore(&config, "//@ max-llvm-major-version: 19"));
 }
 
 #[test]

--- a/src/tools/tidy/src/known_bug.rs
+++ b/src/tools/tidy/src/known_bug.rs
@@ -6,8 +6,22 @@ use crate::walk::*;
 
 pub fn check(filepath: &Path, bad: &mut bool) {
     walk(filepath, |path, _is_dir| filter_not_rust(path), &mut |entry, contents| {
-        let file = entry.path();
-        if !contents.lines().any(|line| line.starts_with("//@ known-bug: ")) {
+        let file: &Path = entry.path();
+
+        // files in "auxiliary" do not need to crash by themselves
+        let test_path_segments =
+            file.iter().map(|s| s.to_string_lossy().into()).collect::<Vec<String>>();
+        let test_path_segments_str =
+            test_path_segments.iter().map(|s| s.as_str()).collect::<Vec<&str>>();
+
+        if !matches!(test_path_segments_str[..], [
+            ..,
+            "tests",
+            "crashes",
+            "auxiliary",
+            _aux_file_rs
+        ]) && !contents.lines().any(|line| line.starts_with("//@ known-bug: "))
+        {
             tidy_error!(
                 bad,
                 "{} crash/ice test does not have a \"//@ known-bug: \" directive",

--- a/tests/assembly/riscv-soft-abi-with-float-features.rs
+++ b/tests/assembly/riscv-soft-abi-with-float-features.rs
@@ -2,7 +2,7 @@
 //@ compile-flags: --target riscv64imac-unknown-none-elf -Ctarget-feature=+f,+d
 //@ needs-llvm-components: riscv
 //@ revisions: LLVM-PRE-20 LLVM-POST-20
-//@ [LLVM-PRE-20] ignore-llvm-version: 20 - 99
+//@ [LLVM-PRE-20] max-llvm-major-version: 19
 //@ [LLVM-POST-20] min-llvm-version: 20
 
 #![feature(no_core, lang_items, f16)]

--- a/tests/assembly/x86_64-cmp.rs
+++ b/tests/assembly/x86_64-cmp.rs
@@ -1,7 +1,7 @@
 //@ revisions: DEBUG LLVM-PRE-20-OPTIM LLVM-20-OPTIM
 //@ [DEBUG] compile-flags: -C opt-level=0
 //@ [LLVM-PRE-20-OPTIM] compile-flags: -C opt-level=3
-//@ [LLVM-PRE-20-OPTIM] ignore-llvm-version: 20 - 99
+//@ [LLVM-PRE-20-OPTIM] max-llvm-major-version: 19
 //@ [LLVM-20-OPTIM] compile-flags: -C opt-level=3
 //@ [LLVM-20-OPTIM] min-llvm-version: 20
 //@ assembly-output: emit-asm

--- a/tests/codegen/branch-protection-old-llvm.rs
+++ b/tests/codegen/branch-protection-old-llvm.rs
@@ -7,7 +7,7 @@
 //@ [LEAF] compile-flags: -Z branch-protection=pac-ret,leaf
 //@ [BKEY] compile-flags: -Z branch-protection=pac-ret,b-key
 //@ compile-flags: --target aarch64-unknown-linux-gnu
-//@ ignore-llvm-version: 19 - 99
+//@ max-llvm-major-version: 18
 
 #![crate_type = "lib"]
 #![feature(no_core, lang_items)]

--- a/tests/codegen/call-metadata.rs
+++ b/tests/codegen/call-metadata.rs
@@ -2,7 +2,7 @@
 // scalar value.
 
 //@ compile-flags: -O -C no-prepopulate-passes
-//@ ignore-llvm-version: 19 - 99
+//@ max-llvm-major-version: 18
 
 #![crate_type = "lib"]
 

--- a/tests/codegen/integer-cmp.rs
+++ b/tests/codegen/integer-cmp.rs
@@ -3,7 +3,7 @@
 
 //@ revisions: llvm-pre-20 llvm-20
 //@ [llvm-20] min-llvm-version: 20
-//@ [llvm-pre-20] ignore-llvm-version: 20 - 99
+//@ [llvm-pre-20] max-llvm-major-version: 19
 //@ compile-flags: -C opt-level=3
 
 #![crate_type = "lib"]

--- a/tests/ui/asan-odr-win/asan_odr_windows.rs
+++ b/tests/ui/asan-odr-win/asan_odr_windows.rs
@@ -1,0 +1,18 @@
+//! Check that crates can be linked together with `-Z sanitizer=address` on msvc.
+//! See <https://github.com/rust-lang/rust/issues/124390>.
+
+//@ run-pass
+//@ compile-flags:-Zsanitizer=address
+//@ aux-build: asan_odr_win-2.rs
+//@ only-windows-msvc
+
+extern crate othercrate;
+
+fn main() {
+    let result = std::panic::catch_unwind(|| {
+        println!("hello!");
+    });
+    assert!(result.is_ok());
+
+    othercrate::exposed_func();
+}

--- a/tests/ui/asan-odr-win/auxiliary/asan_odr_win-2.rs
+++ b/tests/ui/asan-odr-win/auxiliary/asan_odr_win-2.rs
@@ -1,0 +1,11 @@
+//@ no-prefer-dynamic
+//@ compile-flags: -Z sanitizer=address
+#![crate_name = "othercrate"]
+#![crate_type = "rlib"]
+
+pub fn exposed_func() {
+    let result = std::panic::catch_unwind(|| {
+        println!("hello!");
+    });
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
Successful merges:

 - #132010 (ci: Enable full `debuginfo-level=2` in `DEPLOY_ALT`)
 - #132310 (compiletest: add `max-llvm-major-version` directive)
 - #132773 (PassWrapper: disable UseOdrIndicator for Asan Win32)
 - #133013 (compiletest: known-bug / crashes: allow for an "auxiliary" directory to contain files that do not have a "known-bug" directive)
 - #133027 (Fix a copy-paste issue in the NuttX raw type definition)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=132010,132310,132773,133013,133027)
<!-- homu-ignore:end -->