### PR TITLE
Revert #132662 to fix regression on targets without f128 support

### DIFF
--- a/library/core/src/intrinsics/mod.rs
+++ b/library/core/src/intrinsics/mod.rs
@@ -3463,35 +3463,14 @@ pub(crate) macro const_eval_select {
             $(#[$compiletime_attr:meta])* $compiletime:block
         else
             $(#[$runtime_attr:meta])* $runtime:block
-    ) => {
-        // Use the `noinline` arm, after adding explicit `inline` attributes
-        $crate::intrinsics::const_eval_select!(
-            @capture { $($arg : $ty = $val),* } $(-> $ret)? :
-            #[noinline]
-            if const
-                #[inline] // prevent codegen on this function
-                $(#[$compiletime_attr])*
-                $compiletime
-            else
-                #[inline] // avoid the overhead of an extra fn call
-                $(#[$runtime_attr])*
-                $runtime
-        )
-    },
-    // With a leading #[noinline], we don't add inline attributes
-    (
-        @capture { $($arg:ident : $ty:ty = $val:expr),* $(,)? } $( -> $ret:ty )? :
-        #[noinline]
-        if const
-            $(#[$compiletime_attr:meta])* $compiletime:block
-        else
-            $(#[$runtime_attr:meta])* $runtime:block
     ) => {{
+        #[inline] // avoid the overhead of an extra fn call
         $(#[$runtime_attr])*
         fn runtime($($arg: $ty),*) $( -> $ret )? {
             $runtime
         }
 
+        #[inline] // prevent codegen on this function
         $(#[$compiletime_attr])*
         const fn compiletime($($arg: $ty),*) $( -> $ret )? {
             // Don't warn if one of the arguments is unused.

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -1258,9 +1258,8 @@ impl f128 {
             min <= max,
             "min > max, or either was NaN",
             "min > max, or either was NaN. min = {min:?}, max = {max:?}",
-            // FIXME(f16_f128): Passed by-ref to avoid codegen crashes
-            min: &f128 = &min,
-            max: &f128 = &max,
+            min: f128,
+            max: f128,
         );
 
         if self < min {

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -1235,9 +1235,8 @@ impl f16 {
             min <= max,
             "min > max, or either was NaN",
             "min > max, or either was NaN. min = {min:?}, max = {max:?}",
-            // FIXME(f16_f128): Passed by-ref to avoid codegen crashes
-            min: &f16 = &min,
-            max: &f16 = &max,
+            min: f16,
+            max: f16,
         );
 
         if self < min {

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -206,16 +206,15 @@ pub macro const_panic {
         // add the `rustc_allow_const_fn_unstable`. This is okay to do
         // because both variants will panic, just with different messages.
         #[rustc_allow_const_fn_unstable(const_eval_select)]
-        #[inline(always)] // inline the wrapper
+        #[inline(always)]
         #[track_caller]
         #[cfg_attr(bootstrap, rustc_const_stable(feature = "const_panic", since = "CURRENT_RUSTC_VERSION"))]
         const fn do_panic($($arg: $ty),*) -> ! {
             $crate::intrinsics::const_eval_select!(
-                @capture { $($arg: $ty = $arg),* } -> !:
-                #[noinline]
-                if const #[track_caller] #[inline] { // Inline this, to prevent codegen
+                @capture { $($arg: $ty),* } -> !:
+                if const #[track_caller] {
                     $crate::panic!($const_msg)
-                } else #[track_caller] { // Do not inline this, it makes perf worse
+                } else #[track_caller] {
                     $crate::panic!($runtime_msg)
                 }
             )


### PR DESCRIPTION

This reverts #132662.

See https://github.com/rust-lang/rust/issues/133035 for details of the regression.

Fixes #133035

r? @tgross35 @RalfJung