### PR TITLE
Rollup of 5 pull requests

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -503,8 +503,8 @@
 # Set this to "if-unchanged" if you are working on `src/tools`, `tests` or `library` (on CI, `library`
 # changes triggers in-tree compiler build) to speed up the build process.
 #
-# Set this to `true` to download unconditionally.
-#download-rustc = false
+# Set this to `true` to always download or `false` to always use the in-tree compiler.
+#download-rustc = "if-unchanged"
 
 # Number of codegen units to use for each compiler invocation. A value of 0
 # means "the number of cores on this machine", and 1+ is passed through to the

--- a/src/bootstrap/src/core/build_steps/clean.rs
+++ b/src/bootstrap/src/core/build_steps/clean.rs
@@ -226,6 +226,8 @@ where
         Err(ref e) if e.kind() == ErrorKind::PermissionDenied => {
             let m = t!(path.symlink_metadata());
             let mut p = m.permissions();
+            // this os not unix, so clippy gives FP
+            #[expect(clippy::permissions_set_readonly_false)]
             p.set_readonly(false);
             t!(fs::set_permissions(path, p));
             f(path).unwrap_or_else(|e| {

--- a/src/bootstrap/src/core/build_steps/clippy.rs
+++ b/src/bootstrap/src/core/build_steps/clippy.rs
@@ -66,7 +66,7 @@ fn lint_args(builder: &Builder<'_>, config: &LintConfig, ignored_rules: &[&str])
 /// We need to keep the order of the given clippy lint rules before passing them.
 /// Since clap doesn't offer any useful interface for this purpose out of the box,
 /// we have to handle it manually.
-fn get_clippy_rules_in_order(all_args: &[String], config: &LintConfig) -> Vec<String> {
+pub fn get_clippy_rules_in_order(all_args: &[String], config: &LintConfig) -> Vec<String> {
     let mut result = vec![];
 
     for (prefix, item) in
@@ -86,11 +86,11 @@ fn get_clippy_rules_in_order(all_args: &[String], config: &LintConfig) -> Vec<St
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct LintConfig {
-    allow: Vec<String>,
-    warn: Vec<String>,
-    deny: Vec<String>,
-    forbid: Vec<String>,
+pub struct LintConfig {
+    pub allow: Vec<String>,
+    pub warn: Vec<String>,
+    pub deny: Vec<String>,
+    pub forbid: Vec<String>,
 }
 
 impl LintConfig {

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -839,6 +839,7 @@ impl<'a> Builder<'a> {
                 clippy::RustInstaller,
                 clippy::TestFloatParse,
                 clippy::Tidy,
+                clippy::CI,
             ),
             Kind::Check | Kind::Fix => describe!(
                 check::Std,

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 
 use super::flags::Flags;
 use super::{ChangeIdWrapper, Config, RUSTC_IF_UNCHANGED_ALLOWED_PATHS};
-use crate::core::build_steps::clippy::get_clippy_rules_in_order;
+use crate::core::build_steps::clippy::{LintConfig, get_clippy_rules_in_order};
 use crate::core::build_steps::llvm;
 use crate::core::config::{LldMode, Target, TargetSelection, TomlConfig};
 
@@ -309,9 +309,10 @@ fn order_of_clippy_rules() {
     ];
     let config = Config::parse(Flags::parse(&args));
 
-    let actual = match &config.cmd {
+    let actual = match config.cmd.clone() {
         crate::Subcommand::Clippy { allow, deny, warn, forbid, .. } => {
-            get_clippy_rules_in_order(&args, &allow, &deny, &warn, &forbid)
+            let cfg = LintConfig { allow, deny, warn, forbid };
+            get_clippy_rules_in_order(&args, &cfg)
         }
         _ => panic!("invalid subcommand"),
     };
@@ -332,9 +333,10 @@ fn clippy_rule_separate_prefix() {
         vec!["clippy".to_string(), "-A clippy:all".to_string(), "-W clippy::style".to_string()];
     let config = Config::parse(Flags::parse(&args));
 
-    let actual = match &config.cmd {
+    let actual = match config.cmd.clone() {
         crate::Subcommand::Clippy { allow, deny, warn, forbid, .. } => {
-            get_clippy_rules_in_order(&args, &allow, &deny, &warn, &forbid)
+            let cfg = LintConfig { allow, deny, warn, forbid };
+            get_clippy_rules_in_order(&args, &cfg)
         }
         _ => panic!("invalid subcommand"),
     };

--- a/src/bootstrap/src/utils/helpers.rs
+++ b/src/bootstrap/src/utils/helpers.rs
@@ -145,7 +145,7 @@ pub fn symlink_dir(config: &Config, original: &Path, link: &Path) -> io::Result<
 
     #[cfg(windows)]
     fn symlink_dir_inner(target: &Path, junction: &Path) -> io::Result<()> {
-        junction::create(&target, &junction)
+        junction::create(target, junction)
     }
 }
 

--- a/src/ci/docker/host-x86_64/mingw-check/Dockerfile
+++ b/src/ci/docker/host-x86_64/mingw-check/Dockerfile
@@ -50,9 +50,7 @@ ENV SCRIPT \
            python3 ../x.py check --stage 0 --set build.optimized-compiler-builtins=false core alloc std --target=aarch64-unknown-linux-gnu,i686-pc-windows-msvc,i686-unknown-linux-gnu,x86_64-apple-darwin,x86_64-pc-windows-gnu,x86_64-pc-windows-msvc && \
            /scripts/check-default-config-profiles.sh && \
            python3 ../x.py check --target=i686-pc-windows-gnu --host=i686-pc-windows-gnu && \
-           python3 ../x.py clippy bootstrap -Dwarnings && \
-           python3 ../x.py clippy library -Aclippy::all -Dclippy::correctness && \
-           python3 ../x.py clippy compiler -Aclippy::all -Dclippy::correctness -Dclippy::clone_on_ref_ptr && \
+           python3 ../x.py clippy ci && \
            python3 ../x.py build --stage 0 src/tools/build-manifest && \
            python3 ../x.py test --stage 0 src/tools/compiletest && \
            python3 ../x.py test --stage 0 core alloc std test proc_macro && \

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1107,6 +1107,25 @@ class RoaringBitmapBits {
 }
 
 /**
+ * A prefix tree, used for name-based search.
+ *
+ * This data structure is used to drive prefix matches,
+ * such as matching the query "link" to `LinkedList`,
+ * and Lev-distance matches, such as matching the
+ * query "hahsmap" to `HashMap`. Substring matches,
+ * such as "list" to `LinkedList`, are done with a
+ * tailTable that deep-links into this trie.
+ *
+ * children
+ * : A [sparse array] of subtrees. The array index
+ *   is a charCode.
+ *
+ *   [sparse array]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/
+ *     Indexed_collections#sparse_arrays
+ *
+ * matches
+ * : A list of search index IDs for this node.
+ *
  * @typedef {{
  *     children: [NameTrie],
  *     matches: [number],

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -1160,9 +1160,6 @@ class NameTrie {
                 for (const entry of tailTable.get(tail)) {
                     entry.searchSubstringPrefix(name, 3, results);
                 }
-            } else {
-                console.log(tailTable);
-                console.log(tail);
             }
         }
         return [...results];

--- a/tests/rustdoc-js-std/deduplication.js
+++ b/tests/rustdoc-js-std/deduplication.js
@@ -5,6 +5,5 @@ const EXPECTED = {
     'others': [
         { 'path': 'std::f32', 'name': 'is_nan' },
         { 'path': 'std::f64', 'name': 'is_nan' },
-        { 'path': 'std::option::Option', 'name': 'is_none' },
     ],
 };

--- a/tests/rustdoc-js-std/path-maxeditdistance.js
+++ b/tests/rustdoc-js-std/path-maxeditdistance.js
@@ -3,16 +3,8 @@ const FILTER_CRATE = "std";
 const EXPECTED = [
     {
         query: 'vec::intoiterator',
-        others: [
-            // trait std::iter::IntoIterator is not the first result
-            { 'path': 'std::vec', 'name': 'IntoIter' },
-            { 'path': 'std::vec::Vec', 'name': 'into_iter' },
-            { 'path': 'std::vec::Drain', 'name': 'into_iter' },
-            { 'path': 'std::vec::IntoIter', 'name': 'into_iter' },
-            { 'path': 'std::vec::ExtractIf', 'name': 'into_iter' },
-            { 'path': 'std::vec::Splice', 'name': 'into_iter' },
-            { 'path': 'std::collections::vec_deque::VecDeque', 'name': 'into_iter' },
-        ],
+        // trait std::iter::IntoIterator is not the first result
+        others: [],
     },
     {
         query: 'vec::iter',

--- a/tests/rustdoc-js/non-english-identifier.js
+++ b/tests/rustdoc-js/non-english-identifier.js
@@ -133,22 +133,34 @@ const EXPECTED = [
                 path: "non_english_identifier",
                 href: "../non_english_identifier/trait.加法.html",
                 desc: "Add"
-            },
-            {
-                name: "中文名称的加法宏",
-                path: "non_english_identifier",
-                href: "../non_english_identifier/macro.中文名称的加法宏.html",
-            },
-            {
-                name: "中文名称的加法API",
-                path: "non_english_identifier",
-                href: "../non_english_identifier/fn.中文名称的加法API.html",
             }],
         in_args: [{
             name: "加上",
             path: "non_english_identifier::加法",
             href: "../non_english_identifier/trait.加法.html#tymethod.加上",
         }],
+        returned: [],
+    },
+    { // levensthein and substring checking only kick in at three characters
+        query: '加法宏',
+        others: [
+            {
+                name: "中文名称的加法宏",
+                path: "non_english_identifier",
+                href: "../non_english_identifier/macro.中文名称的加法宏.html",
+            }],
+        in_args: [],
+        returned: [],
+    },
+    { // levensthein and substring checking only kick in at three characters
+        query: '加法A',
+        others: [
+            {
+                name: "中文名称的加法API",
+                path: "non_english_identifier",
+                href: "../non_english_identifier/fn.中文名称的加法API.html",
+            }],
+        in_args: [],
         returned: [],
     },
     { // Extensive type-based search is still buggy, experimental & work-in-progress.

--- a/tests/rustdoc-js/path-maxeditdistance.js
+++ b/tests/rustdoc-js/path-maxeditdistance.js
@@ -14,21 +14,38 @@ const EXPECTED = [
         ],
     },
     {
-        // swap br/rb; that's edit distance 2, where maxPathEditDistance = 3 (11 / 3)
+        // swap br/rb; that's edit distance 1, where maxPathEditDistance = 2
         'query': 'arbacadarba::hocuspocusprestidigitation',
         'others': [
             { 'path': 'abracadabra', 'name': 'HocusPocusPrestidigitation' },
         ],
     },
     {
-        // truncate 5 chars, where maxEditDistance = 7 (21 / 3)
-        'query': 'abracadarba::hocusprestidigitation',
+        // swap p/o o/p, that's also edit distance 1
+        'query': 'abracadabra::hocusopcusprestidigitation',
         'others': [
             { 'path': 'abracadabra', 'name': 'HocusPocusPrestidigitation' },
         ],
     },
     {
-        // truncate 9 chars, where maxEditDistance = 5 (17 / 3)
+        // swap p/o o/p and gi/ig, that's edit distance 2
+        'query': 'abracadabra::hocusopcusprestidiigtation',
+        'others': [
+            { 'path': 'abracadabra', 'name': 'HocusPocusPrestidigitation' },
+        ],
+    },
+    {
+        // swap p/o o/p, gi/ig, and ti/it, that's edit distance 3 and not shown (we stop at 2)
+        'query': 'abracadabra::hocusopcusprestidiigtaiton',
+        'others': [],
+    },
+    {
+        // truncate 5 chars, where maxEditDistance = 2
+        'query': 'abracadarba::hocusprestidigitation',
+        'others': [],
+    },
+    {
+        // truncate 9 chars, where maxEditDistance = 2
         'query': 'abracadarba::hprestidigitation',
         'others': [],
     },

--- a/tests/rustdoc-js/prototype.js
+++ b/tests/rustdoc-js/prototype.js
@@ -9,7 +9,9 @@ const EXPECTED = [
     },
     {
         'query': '__proto__',
-        'others': [],
+        'others': [
+            {"path": "", "name": "prototype"},
+        ],
         'returned': [],
         'in_args': [],
     },

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/closure-origin-multi-variant-diagnostics.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/closure-origin-multi-variant-diagnostics.stderr
@@ -11,10 +11,6 @@ note: closure cannot be moved more than once as it is not `Copy` due to moving t
    |
 LL |         if let MultiVariant::Point(ref mut x, _) = point {
    |                                                    ^^^^^
-help: consider mutably borrowing `c`
-   |
-LL |     let a = &mut c;
-   |             ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/closure-origin-single-variant-diagnostics.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/closure-origin-single-variant-diagnostics.stderr
@@ -11,10 +11,6 @@ note: closure cannot be moved more than once as it is not `Copy` due to moving t
    |
 LL |         let SingleVariant::Point(ref mut x, _) = point;
    |                                                  ^^^^^
-help: consider mutably borrowing `c`
-   |
-LL |     let b = &mut c;
-   |             ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/closure-origin-struct-diagnostics.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/closure-origin-struct-diagnostics.stderr
@@ -11,10 +11,6 @@ note: closure cannot be moved more than once as it is not `Copy` due to moving t
    |
 LL |         x.y.a += 1;
    |         ^^^^^
-help: consider mutably borrowing `hello`
-   |
-LL |     let b = &mut hello;
-   |             ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/closure-origin-tuple-diagnostics-1.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/closure-origin-tuple-diagnostics-1.stderr
@@ -11,10 +11,6 @@ note: closure cannot be moved more than once as it is not `Copy` due to moving t
    |
 LL |         x.0 += 1;
    |         ^^^
-help: consider mutably borrowing `hello`
-   |
-LL |     let b = &mut hello;
-   |             ++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/moves/auxiliary/suggest-borrow-for-generic-arg-aux.rs
+++ b/tests/ui/moves/auxiliary/suggest-borrow-for-generic-arg-aux.rs
@@ -1,23 +1,20 @@
 //! auxiliary definitons for suggest-borrow-for-generic-arg.rs, to ensure the suggestion works on
 //! functions defined in other crates.
 
-use std::borrow::{Borrow, BorrowMut};
-use std::convert::{AsMut, AsRef};
-pub struct Bar;
+use std::io::{self, Read, Write};
+use std::iter::Sum;
 
-impl AsRef<Bar> for Bar {
-    fn as_ref(&self) -> &Bar {
-        self
-    }
+pub fn write_stuff<W: Write>(mut writer: W) -> io::Result<()> {
+    writeln!(writer, "stuff")
 }
 
-impl AsMut<Bar> for Bar {
-    fn as_mut(&mut self) -> &mut Bar {
-        self
-    }
+pub fn read_and_discard<R: Read>(mut reader: R) -> io::Result<()> {
+    let mut buf = Vec::new();
+    reader.read_to_end(&mut buf).map(|_| ())
 }
 
-pub fn foo<T: AsRef<Bar>>(_: T) {}
-pub fn qux<T: AsMut<Bar>>(_: T) {}
-pub fn bat<T: Borrow<T>>(_: T) {}
-pub fn baz<T: BorrowMut<T>>(_: T) {}
+pub fn sum_three<I: IntoIterator>(iter: I) -> <I as IntoIterator>::Item
+    where <I as IntoIterator>::Item: Sum
+{
+    iter.into_iter().take(3).sum()
+}

--- a/tests/ui/moves/auxiliary/suggest-borrow-for-generic-arg-aux.rs
+++ b/tests/ui/moves/auxiliary/suggest-borrow-for-generic-arg-aux.rs
@@ -1,0 +1,23 @@
+//! auxiliary definitons for suggest-borrow-for-generic-arg.rs, to ensure the suggestion works on
+//! functions defined in other crates.
+
+use std::borrow::{Borrow, BorrowMut};
+use std::convert::{AsMut, AsRef};
+pub struct Bar;
+
+impl AsRef<Bar> for Bar {
+    fn as_ref(&self) -> &Bar {
+        self
+    }
+}
+
+impl AsMut<Bar> for Bar {
+    fn as_mut(&mut self) -> &mut Bar {
+        self
+    }
+}
+
+pub fn foo<T: AsRef<Bar>>(_: T) {}
+pub fn qux<T: AsMut<Bar>>(_: T) {}
+pub fn bat<T: Borrow<T>>(_: T) {}
+pub fn baz<T: BorrowMut<T>>(_: T) {}

--- a/tests/ui/moves/borrow-closures-instead-of-move.rs
+++ b/tests/ui/moves/borrow-closures-instead-of-move.rs
@@ -1,4 +1,4 @@
-fn takes_fn(f: impl Fn()) { //~ HELP if `impl Fn()` implemented `Clone`
+fn takes_fn(f: impl Fn()) {
     loop {
         takes_fnonce(f);
         //~^ ERROR use of moved value

--- a/tests/ui/moves/borrow-closures-instead-of-move.stderr
+++ b/tests/ui/moves/borrow-closures-instead-of-move.stderr
@@ -8,21 +8,6 @@ LL |     loop {
 LL |         takes_fnonce(f);
    |                      ^ value moved here, in previous iteration of loop
    |
-note: consider changing this parameter type in function `takes_fnonce` to borrow instead if owning the value isn't necessary
-  --> $DIR/borrow-closures-instead-of-move.rs:34:20
-   |
-LL | fn takes_fnonce(_: impl FnOnce()) {}
-   |    ------------    ^^^^^^^^^^^^^ this parameter takes ownership of the value
-   |    |
-   |    in this function
-help: if `impl Fn()` implemented `Clone`, you could clone the value
-  --> $DIR/borrow-closures-instead-of-move.rs:1:16
-   |
-LL | fn takes_fn(f: impl Fn()) {
-   |                ^^^^^^^^^ consider constraining this type parameter with `Clone`
-LL |     loop {
-LL |         takes_fnonce(f);
-   |                      - you could clone this value
 help: consider borrowing `f`
    |
 LL |         takes_fnonce(&f);
@@ -40,13 +25,6 @@ LL |         takes_fnonce(m);
 LL |     takes_fnonce(m);
    |                  ^ value used here after move
    |
-note: consider changing this parameter type in function `takes_fnonce` to borrow instead if owning the value isn't necessary
-  --> $DIR/borrow-closures-instead-of-move.rs:34:20
-   |
-LL | fn takes_fnonce(_: impl FnOnce()) {}
-   |    ------------    ^^^^^^^^^^^^^ this parameter takes ownership of the value
-   |    |
-   |    in this function
 help: if `impl FnMut()` implemented `Clone`, you could clone the value
   --> $DIR/borrow-closures-instead-of-move.rs:9:20
    |

--- a/tests/ui/moves/moved-value-on-as-ref-arg.stderr
+++ b/tests/ui/moves/moved-value-on-as-ref-arg.stderr
@@ -8,7 +8,7 @@ LL |     foo(bar);
 LL |     let _baa = bar;
    |                ^^^ value used here after move
    |
-help: borrow the value to avoid moving it
+help: consider borrowing `bar`
    |
 LL |     foo(&bar);
    |         +
@@ -31,7 +31,7 @@ LL | struct Bar;
 ...
 LL |     qux(bar);
    |         --- you could clone this value
-help: borrow the value to avoid moving it
+help: consider mutably borrowing `bar`
    |
 LL |     qux(&mut bar);
    |         ++++
@@ -46,7 +46,7 @@ LL |     bat(bar);
 LL |     let _baa = bar;
    |                ^^^ value used here after move
    |
-help: borrow the value to avoid moving it
+help: consider borrowing `bar`
    |
 LL |     bat(&bar);
    |         +
@@ -69,7 +69,7 @@ LL | struct Bar;
 ...
 LL |     baz(bar);
    |         --- you could clone this value
-help: borrow the value to avoid moving it
+help: consider mutably borrowing `bar`
    |
 LL |     baz(&mut bar);
    |         ++++

--- a/tests/ui/moves/moves-based-on-type-no-recursive-stack-closure.stderr
+++ b/tests/ui/moves/moves-based-on-type-no-recursive-stack-closure.stderr
@@ -24,10 +24,6 @@ LL | fn conspirator<F>(mut f: F) where F: FnMut(&mut R, bool) {
    |                ^ consider constraining this type parameter with `Clone`
 LL |     let mut r = R {c: Box::new(f)};
    |                                - you could clone this value
-help: consider mutably borrowing `f`
-   |
-LL |     let mut r = R {c: Box::new(&mut f)};
-   |                                ++++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/moves/suggest-borrow-for-generic-arg.fixed
+++ b/tests/ui/moves/suggest-borrow-for-generic-arg.fixed
@@ -1,0 +1,22 @@
+//! Test suggetions to borrow generic arguments instead of moving when all predicates hold after
+//! substituting in the reference type.
+//@ run-rustfix
+//@ aux-build:suggest-borrow-for-generic-arg-aux.rs
+
+#![allow(unused_mut)]
+extern crate suggest_borrow_for_generic_arg_aux as aux;
+
+pub fn main() {
+    let bar = aux::Bar;
+    aux::foo(&bar); //~ HELP borrow the value
+    let _baa = bar; //~ ERROR use of moved value
+    let mut bar = aux::Bar;
+    aux::qux(&mut bar); //~ HELP borrow the value
+    let _baa = bar; //~ ERROR use of moved value
+    let bar = aux::Bar;
+    aux::bat(&bar); //~ HELP borrow the value
+    let _baa = bar; //~ ERROR use of moved value
+    let mut bar = aux::Bar;
+    aux::baz(&mut bar); //~ HELP borrow the value
+    let _baa = bar; //~ ERROR use of moved value
+}

--- a/tests/ui/moves/suggest-borrow-for-generic-arg.fixed
+++ b/tests/ui/moves/suggest-borrow-for-generic-arg.fixed
@@ -1,22 +1,46 @@
-//! Test suggetions to borrow generic arguments instead of moving when all predicates hold after
-//! substituting in the reference type.
+//! Test suggetions to borrow generic arguments instead of moving. Tests for other instances of this
+//! can be found in `moved-value-on-as-ref-arg.rs` and `borrow-closures-instead-of-move.rs`
 //@ run-rustfix
-//@ aux-build:suggest-borrow-for-generic-arg-aux.rs
+//@ aux-crate:aux=suggest-borrow-for-generic-arg-aux.rs
+//@ edition: 2021
 
 #![allow(unused_mut)]
-extern crate suggest_borrow_for_generic_arg_aux as aux;
+use std::io::{self, Write};
 
-pub fn main() {
-    let bar = aux::Bar;
-    aux::foo(&bar); //~ HELP consider borrowing `bar`
-    let _baa = bar; //~ ERROR use of moved value
-    let mut bar = aux::Bar;
-    aux::qux(&mut bar); //~ HELP consider mutably borrowing `bar`
-    let _baa = bar; //~ ERROR use of moved value
-    let bar = aux::Bar;
-    aux::bat(&bar); //~ HELP consider borrowing `bar`
-    let _baa = bar; //~ ERROR use of moved value
-    let mut bar = aux::Bar;
-    aux::baz(&mut bar); //~ HELP consider mutably borrowing `bar`
-    let _baa = bar; //~ ERROR use of moved value
+// test for `std::io::Write` (#131413)
+fn test_write() -> io::Result<()> {
+    let mut stdout = io::stdout();
+    aux::write_stuff(&stdout)?; //~ HELP consider borrowing `stdout`
+    writeln!(stdout, "second line")?; //~ ERROR borrow of moved value: `stdout`
+
+    let mut buf = Vec::new();
+    aux::write_stuff(&mut buf.clone())?; //~ HELP consider mutably borrowing `buf`
+    //~^ HELP consider cloning the value
+    writeln!(buf, "second_line") //~ ERROR borrow of moved value: `buf`
+}
+
+/// test for `std::io::Read` (#131413)
+fn test_read() -> io::Result<()> {
+    let stdin = io::stdin();
+    aux::read_and_discard(&stdin)?; //~ HELP consider borrowing `stdin`
+    aux::read_and_discard(stdin)?; //~ ERROR use of moved value: `stdin`
+
+    let mut bytes = std::collections::VecDeque::from([1, 2, 3, 4, 5, 6]);
+    aux::read_and_discard(&mut bytes.clone())?; //~ HELP consider mutably borrowing `bytes`
+    //~^ HELP consider cloning the value
+    aux::read_and_discard(bytes) //~ ERROR use of moved value: `bytes`
+}
+
+/// test that suggestions work with projection types in the callee's signature
+fn test_projections() {
+    let mut iter = [1, 2, 3, 4, 5, 6].into_iter();
+    let _six: usize = aux::sum_three(&mut iter.clone()); //~ HELP consider mutably borrowing `iter`
+    //~^ HELP consider cloning the value
+    let _fifteen: usize = aux::sum_three(iter); //~ ERROR use of moved value: `iter`
+}
+
+fn main() {
+    test_write().unwrap();
+    test_read().unwrap();
+    test_projections();
 }

--- a/tests/ui/moves/suggest-borrow-for-generic-arg.fixed
+++ b/tests/ui/moves/suggest-borrow-for-generic-arg.fixed
@@ -8,15 +8,15 @@ extern crate suggest_borrow_for_generic_arg_aux as aux;
 
 pub fn main() {
     let bar = aux::Bar;
-    aux::foo(&bar); //~ HELP borrow the value
+    aux::foo(&bar); //~ HELP consider borrowing `bar`
     let _baa = bar; //~ ERROR use of moved value
     let mut bar = aux::Bar;
-    aux::qux(&mut bar); //~ HELP borrow the value
+    aux::qux(&mut bar); //~ HELP consider mutably borrowing `bar`
     let _baa = bar; //~ ERROR use of moved value
     let bar = aux::Bar;
-    aux::bat(&bar); //~ HELP borrow the value
+    aux::bat(&bar); //~ HELP consider borrowing `bar`
     let _baa = bar; //~ ERROR use of moved value
     let mut bar = aux::Bar;
-    aux::baz(&mut bar); //~ HELP borrow the value
+    aux::baz(&mut bar); //~ HELP consider mutably borrowing `bar`
     let _baa = bar; //~ ERROR use of moved value
 }

--- a/tests/ui/moves/suggest-borrow-for-generic-arg.rs
+++ b/tests/ui/moves/suggest-borrow-for-generic-arg.rs
@@ -8,15 +8,15 @@ extern crate suggest_borrow_for_generic_arg_aux as aux;
 
 pub fn main() {
     let bar = aux::Bar;
-    aux::foo(bar); //~ HELP borrow the value
+    aux::foo(bar); //~ HELP consider borrowing `bar`
     let _baa = bar; //~ ERROR use of moved value
     let mut bar = aux::Bar;
-    aux::qux(bar); //~ HELP borrow the value
+    aux::qux(bar); //~ HELP consider mutably borrowing `bar`
     let _baa = bar; //~ ERROR use of moved value
     let bar = aux::Bar;
-    aux::bat(bar); //~ HELP borrow the value
+    aux::bat(bar); //~ HELP consider borrowing `bar`
     let _baa = bar; //~ ERROR use of moved value
     let mut bar = aux::Bar;
-    aux::baz(bar); //~ HELP borrow the value
+    aux::baz(bar); //~ HELP consider mutably borrowing `bar`
     let _baa = bar; //~ ERROR use of moved value
 }

--- a/tests/ui/moves/suggest-borrow-for-generic-arg.rs
+++ b/tests/ui/moves/suggest-borrow-for-generic-arg.rs
@@ -1,0 +1,22 @@
+//! Test suggetions to borrow generic arguments instead of moving when all predicates hold after
+//! substituting in the reference type.
+//@ run-rustfix
+//@ aux-build:suggest-borrow-for-generic-arg-aux.rs
+
+#![allow(unused_mut)]
+extern crate suggest_borrow_for_generic_arg_aux as aux;
+
+pub fn main() {
+    let bar = aux::Bar;
+    aux::foo(bar); //~ HELP borrow the value
+    let _baa = bar; //~ ERROR use of moved value
+    let mut bar = aux::Bar;
+    aux::qux(bar); //~ HELP borrow the value
+    let _baa = bar; //~ ERROR use of moved value
+    let bar = aux::Bar;
+    aux::bat(bar); //~ HELP borrow the value
+    let _baa = bar; //~ ERROR use of moved value
+    let mut bar = aux::Bar;
+    aux::baz(bar); //~ HELP borrow the value
+    let _baa = bar; //~ ERROR use of moved value
+}

--- a/tests/ui/moves/suggest-borrow-for-generic-arg.rs
+++ b/tests/ui/moves/suggest-borrow-for-generic-arg.rs
@@ -1,22 +1,46 @@
-//! Test suggetions to borrow generic arguments instead of moving when all predicates hold after
-//! substituting in the reference type.
+//! Test suggetions to borrow generic arguments instead of moving. Tests for other instances of this
+//! can be found in `moved-value-on-as-ref-arg.rs` and `borrow-closures-instead-of-move.rs`
 //@ run-rustfix
-//@ aux-build:suggest-borrow-for-generic-arg-aux.rs
+//@ aux-crate:aux=suggest-borrow-for-generic-arg-aux.rs
+//@ edition: 2021
 
 #![allow(unused_mut)]
-extern crate suggest_borrow_for_generic_arg_aux as aux;
+use std::io::{self, Write};
 
-pub fn main() {
-    let bar = aux::Bar;
-    aux::foo(bar); //~ HELP consider borrowing `bar`
-    let _baa = bar; //~ ERROR use of moved value
-    let mut bar = aux::Bar;
-    aux::qux(bar); //~ HELP consider mutably borrowing `bar`
-    let _baa = bar; //~ ERROR use of moved value
-    let bar = aux::Bar;
-    aux::bat(bar); //~ HELP consider borrowing `bar`
-    let _baa = bar; //~ ERROR use of moved value
-    let mut bar = aux::Bar;
-    aux::baz(bar); //~ HELP consider mutably borrowing `bar`
-    let _baa = bar; //~ ERROR use of moved value
+// test for `std::io::Write` (#131413)
+fn test_write() -> io::Result<()> {
+    let mut stdout = io::stdout();
+    aux::write_stuff(stdout)?; //~ HELP consider borrowing `stdout`
+    writeln!(stdout, "second line")?; //~ ERROR borrow of moved value: `stdout`
+
+    let mut buf = Vec::new();
+    aux::write_stuff(buf)?; //~ HELP consider mutably borrowing `buf`
+    //~^ HELP consider cloning the value
+    writeln!(buf, "second_line") //~ ERROR borrow of moved value: `buf`
+}
+
+/// test for `std::io::Read` (#131413)
+fn test_read() -> io::Result<()> {
+    let stdin = io::stdin();
+    aux::read_and_discard(stdin)?; //~ HELP consider borrowing `stdin`
+    aux::read_and_discard(stdin)?; //~ ERROR use of moved value: `stdin`
+
+    let mut bytes = std::collections::VecDeque::from([1, 2, 3, 4, 5, 6]);
+    aux::read_and_discard(bytes)?; //~ HELP consider mutably borrowing `bytes`
+    //~^ HELP consider cloning the value
+    aux::read_and_discard(bytes) //~ ERROR use of moved value: `bytes`
+}
+
+/// test that suggestions work with projection types in the callee's signature
+fn test_projections() {
+    let mut iter = [1, 2, 3, 4, 5, 6].into_iter();
+    let _six: usize = aux::sum_three(iter); //~ HELP consider mutably borrowing `iter`
+    //~^ HELP consider cloning the value
+    let _fifteen: usize = aux::sum_three(iter); //~ ERROR use of moved value: `iter`
+}
+
+fn main() {
+    test_write().unwrap();
+    test_read().unwrap();
+    test_projections();
 }

--- a/tests/ui/moves/suggest-borrow-for-generic-arg.stderr
+++ b/tests/ui/moves/suggest-borrow-for-generic-arg.stderr
@@ -1,0 +1,63 @@
+error[E0382]: use of moved value: `bar`
+  --> $DIR/suggest-borrow-for-generic-arg.rs:12:16
+   |
+LL |     let bar = aux::Bar;
+   |         --- move occurs because `bar` has type `Bar`, which does not implement the `Copy` trait
+LL |     aux::foo(bar);
+   |              --- value moved here
+LL |     let _baa = bar;
+   |                ^^^ value used here after move
+   |
+help: borrow the value to avoid moving it
+   |
+LL |     aux::foo(&bar);
+   |              +
+
+error[E0382]: use of moved value: `bar`
+  --> $DIR/suggest-borrow-for-generic-arg.rs:15:16
+   |
+LL |     let mut bar = aux::Bar;
+   |         ------- move occurs because `bar` has type `Bar`, which does not implement the `Copy` trait
+LL |     aux::qux(bar);
+   |              --- value moved here
+LL |     let _baa = bar;
+   |                ^^^ value used here after move
+   |
+help: borrow the value to avoid moving it
+   |
+LL |     aux::qux(&mut bar);
+   |              ++++
+
+error[E0382]: use of moved value: `bar`
+  --> $DIR/suggest-borrow-for-generic-arg.rs:18:16
+   |
+LL |     let bar = aux::Bar;
+   |         --- move occurs because `bar` has type `Bar`, which does not implement the `Copy` trait
+LL |     aux::bat(bar);
+   |              --- value moved here
+LL |     let _baa = bar;
+   |                ^^^ value used here after move
+   |
+help: borrow the value to avoid moving it
+   |
+LL |     aux::bat(&bar);
+   |              +
+
+error[E0382]: use of moved value: `bar`
+  --> $DIR/suggest-borrow-for-generic-arg.rs:21:16
+   |
+LL |     let mut bar = aux::Bar;
+   |         ------- move occurs because `bar` has type `Bar`, which does not implement the `Copy` trait
+LL |     aux::baz(bar);
+   |              --- value moved here
+LL |     let _baa = bar;
+   |                ^^^ value used here after move
+   |
+help: borrow the value to avoid moving it
+   |
+LL |     aux::baz(&mut bar);
+   |              ++++
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/moves/suggest-borrow-for-generic-arg.stderr
+++ b/tests/ui/moves/suggest-borrow-for-generic-arg.stderr
@@ -8,7 +8,7 @@ LL |     aux::foo(bar);
 LL |     let _baa = bar;
    |                ^^^ value used here after move
    |
-help: borrow the value to avoid moving it
+help: consider borrowing `bar`
    |
 LL |     aux::foo(&bar);
    |              +
@@ -23,7 +23,7 @@ LL |     aux::qux(bar);
 LL |     let _baa = bar;
    |                ^^^ value used here after move
    |
-help: borrow the value to avoid moving it
+help: consider mutably borrowing `bar`
    |
 LL |     aux::qux(&mut bar);
    |              ++++
@@ -38,7 +38,7 @@ LL |     aux::bat(bar);
 LL |     let _baa = bar;
    |                ^^^ value used here after move
    |
-help: borrow the value to avoid moving it
+help: consider borrowing `bar`
    |
 LL |     aux::bat(&bar);
    |              +
@@ -53,7 +53,7 @@ LL |     aux::baz(bar);
 LL |     let _baa = bar;
    |                ^^^ value used here after move
    |
-help: borrow the value to avoid moving it
+help: consider mutably borrowing `bar`
    |
 LL |     aux::baz(&mut bar);
    |              ++++

--- a/tests/ui/moves/suggest-borrow-for-generic-arg.stderr
+++ b/tests/ui/moves/suggest-borrow-for-generic-arg.stderr
@@ -1,63 +1,93 @@
-error[E0382]: use of moved value: `bar`
-  --> $DIR/suggest-borrow-for-generic-arg.rs:12:16
+error[E0382]: borrow of moved value: `stdout`
+  --> $DIR/suggest-borrow-for-generic-arg.rs:14:14
    |
-LL |     let bar = aux::Bar;
-   |         --- move occurs because `bar` has type `Bar`, which does not implement the `Copy` trait
-LL |     aux::foo(bar);
-   |              --- value moved here
-LL |     let _baa = bar;
-   |                ^^^ value used here after move
+LL |     let mut stdout = io::stdout();
+   |         ---------- move occurs because `stdout` has type `Stdout`, which does not implement the `Copy` trait
+LL |     aux::write_stuff(stdout)?;
+   |                      ------ value moved here
+LL |     writeln!(stdout, "second line")?;
+   |              ^^^^^^ value borrowed here after move
    |
-help: consider borrowing `bar`
+help: consider borrowing `stdout`
    |
-LL |     aux::foo(&bar);
-   |              +
+LL |     aux::write_stuff(&stdout)?;
+   |                      +
 
-error[E0382]: use of moved value: `bar`
-  --> $DIR/suggest-borrow-for-generic-arg.rs:15:16
+error[E0382]: borrow of moved value: `buf`
+  --> $DIR/suggest-borrow-for-generic-arg.rs:19:14
    |
-LL |     let mut bar = aux::Bar;
-   |         ------- move occurs because `bar` has type `Bar`, which does not implement the `Copy` trait
-LL |     aux::qux(bar);
-   |              --- value moved here
-LL |     let _baa = bar;
-   |                ^^^ value used here after move
+LL |     let mut buf = Vec::new();
+   |         ------- move occurs because `buf` has type `Vec<u8>`, which does not implement the `Copy` trait
+LL |     aux::write_stuff(buf)?;
+   |                      --- value moved here
+LL |
+LL |     writeln!(buf, "second_line")
+   |              ^^^ value borrowed here after move
    |
-help: consider mutably borrowing `bar`
+help: consider mutably borrowing `buf`
    |
-LL |     aux::qux(&mut bar);
-   |              ++++
+LL |     aux::write_stuff(&mut buf)?;
+   |                      ++++
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |     aux::write_stuff(buf.clone())?;
+   |                         ++++++++
 
-error[E0382]: use of moved value: `bar`
-  --> $DIR/suggest-borrow-for-generic-arg.rs:18:16
+error[E0382]: use of moved value: `stdin`
+  --> $DIR/suggest-borrow-for-generic-arg.rs:26:27
    |
-LL |     let bar = aux::Bar;
-   |         --- move occurs because `bar` has type `Bar`, which does not implement the `Copy` trait
-LL |     aux::bat(bar);
-   |              --- value moved here
-LL |     let _baa = bar;
-   |                ^^^ value used here after move
+LL |     let stdin = io::stdin();
+   |         ----- move occurs because `stdin` has type `Stdin`, which does not implement the `Copy` trait
+LL |     aux::read_and_discard(stdin)?;
+   |                           ----- value moved here
+LL |     aux::read_and_discard(stdin)?;
+   |                           ^^^^^ value used here after move
    |
-help: consider borrowing `bar`
+help: consider borrowing `stdin`
    |
-LL |     aux::bat(&bar);
-   |              +
+LL |     aux::read_and_discard(&stdin)?;
+   |                           +
 
-error[E0382]: use of moved value: `bar`
-  --> $DIR/suggest-borrow-for-generic-arg.rs:21:16
+error[E0382]: use of moved value: `bytes`
+  --> $DIR/suggest-borrow-for-generic-arg.rs:31:27
    |
-LL |     let mut bar = aux::Bar;
-   |         ------- move occurs because `bar` has type `Bar`, which does not implement the `Copy` trait
-LL |     aux::baz(bar);
-   |              --- value moved here
-LL |     let _baa = bar;
-   |                ^^^ value used here after move
+LL |     let mut bytes = std::collections::VecDeque::from([1, 2, 3, 4, 5, 6]);
+   |         --------- move occurs because `bytes` has type `VecDeque<u8>`, which does not implement the `Copy` trait
+LL |     aux::read_and_discard(bytes)?;
+   |                           ----- value moved here
+LL |
+LL |     aux::read_and_discard(bytes)
+   |                           ^^^^^ value used here after move
    |
-help: consider mutably borrowing `bar`
+help: consider mutably borrowing `bytes`
    |
-LL |     aux::baz(&mut bar);
-   |              ++++
+LL |     aux::read_and_discard(&mut bytes)?;
+   |                           ++++
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |     aux::read_and_discard(bytes.clone())?;
+   |                                ++++++++
 
-error: aborting due to 4 previous errors
+error[E0382]: use of moved value: `iter`
+  --> $DIR/suggest-borrow-for-generic-arg.rs:39:42
+   |
+LL |     let mut iter = [1, 2, 3, 4, 5, 6].into_iter();
+   |         -------- move occurs because `iter` has type `std::array::IntoIter<usize, 6>`, which does not implement the `Copy` trait
+LL |     let _six: usize = aux::sum_three(iter);
+   |                                      ---- value moved here
+LL |
+LL |     let _fifteen: usize = aux::sum_three(iter);
+   |                                          ^^^^ value used here after move
+   |
+help: consider mutably borrowing `iter`
+   |
+LL |     let _six: usize = aux::sum_three(&mut iter);
+   |                                      ++++
+help: consider cloning the value if the performance cost is acceptable
+   |
+LL |     let _six: usize = aux::sum_three(iter.clone());
+   |                                          ++++++++
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/not-copy-closure.stderr
+++ b/tests/ui/not-copy-closure.stderr
@@ -11,10 +11,6 @@ note: closure cannot be moved more than once as it is not `Copy` due to moving t
    |
 LL |         a += 1;
    |         ^
-help: consider mutably borrowing `hello`
-   |
-LL |     let b = &mut hello;
-   |             ++++
 
 error: aborting due to 1 previous error
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -977,6 +977,7 @@ contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
 users_on_vacation = [
     "jyn514",
     "oli-obk",
+    "onur-ozkan",
 ]
 
 [assign.adhoc_groups]


### PR DESCRIPTION
Successful merges:

 - #132172 (borrowck diagnostics: suggest borrowing function inputs in generic positions)
 - #132649 (add ./x clippy ci)
 - #133005 (rustdoc: use a trie for name-based search)
 - #133034 (update download-rustc comments and default)
 - #133036 (add myself into `users_on_vacation` on triagebot)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=132172,132649,133005,133034,133036)
<!-- homu-ignore:end -->