### PR TITLE
[rustdoc] Fix handling of footnote reference in footnote definition

### DIFF
--- a/tests/rustdoc/footnote-reference-in-footnote-def.rs
+++ b/tests/rustdoc/footnote-reference-in-footnote-def.rs
@@ -1,0 +1,20 @@
+// Checks that footnote references in footnote definitions are correctly generated.
+// Regression test for <https://github.com/rust-lang/rust/issues/131946>.
+
+#![crate_name = "foo"]
+
+//@ has 'foo/index.html'
+//@ has - '//*[@class="docblock"]/p/sup[@id="fnref1"]/a[@href="#fn1"]' '1'
+//@ has - '//li[@id="fn1"]/p' 'meow'
+//@ has - '//li[@id="fn1"]/p/sup[@id="fnref2"]/a[@href="#fn2"]' '2'
+//@ has - '//li[@id="fn1"]//a[@href="#fn2"]' '2'
+//@ has - '//li[@id="fn2"]/p' 'uwu'
+//@ has - '//li[@id="fn2"]/p/sup[@id="fnref1"]/a[@href="#fn1"]' '1'
+//@ has - '//li[@id="fn2"]//a[@href="#fn1"]' '1'
+
+//! # footnote-hell
+//!
+//! Hello [^a].
+//!
+//! [^a]: meow [^b]
+//! [^b]: uwu [^a]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/131946.

We didn't check if we had footnote reference in footnote definition.

r? @notriddle 