### PR TITLE
rustdoc-search: case-sensitive only when capitals are used

### DIFF
--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2500,6 +2500,7 @@ class DocSearch {
         const sortResults = async(results, typeInfo, preferredCrate) => {
             const userQuery = parsedQuery.userQuery;
             const normalizedUserQuery = parsedQuery.userQuery.toLowerCase();
+            const isMixedCase = normalizedUserQuery !== userQuery;
             const result_list = [];
             for (const result of results.values()) {
                 result.item = this.searchIndex[result.id];
@@ -2511,10 +2512,12 @@ class DocSearch {
                 let a, b;
 
                 // sort by exact case-sensitive match
-                a = (aaa.item.name !== userQuery);
-                b = (bbb.item.name !== userQuery);
-                if (a !== b) {
-                    return a - b;
+                if (isMixedCase) {
+                    a = (aaa.item.name !== userQuery);
+                    b = (bbb.item.name !== userQuery);
+                    if (a !== b) {
+                        return a - b;
+                    }
                 }
 
                 // sort by exact match with regard to the last word (mismatch goes later)

--- a/tests/rustdoc-js-std/write.js
+++ b/tests/rustdoc-js-std/write.js
@@ -1,0 +1,24 @@
+const EXPECTED = [
+    {
+        'query': 'write',
+        'others': [
+            { 'path': 'std::fmt', 'name': 'write' },
+            { 'path': 'std::fs', 'name': 'write' },
+            { 'path': 'std::ptr', 'name': 'write' },
+            { 'path': 'std::fmt', 'name': 'Write' },
+            { 'path': 'std::io', 'name': 'Write' },
+            { 'path': 'std::hash::Hasher', 'name': 'write' },
+        ],
+    },
+    {
+        'query': 'Write',
+        'others': [
+            { 'path': 'std::fmt', 'name': 'Write' },
+            { 'path': 'std::io', 'name': 'Write' },
+            { 'path': 'std::fmt', 'name': 'write' },
+            { 'path': 'std::fs', 'name': 'write' },
+            { 'path': 'std::ptr', 'name': 'write' },
+            { 'path': 'std::hash::Hasher', 'name': 'write' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/case.js
+++ b/tests/rustdoc-js/case.js
@@ -1,0 +1,17 @@
+const EXPECTED = [
+    {
+        'query': 'Foo',
+        'others': [
+            { 'path': 'case', 'name': 'Foo', 'desc': 'Docs for Foo' },
+            { 'path': 'case', 'name': 'foo', 'desc': 'Docs for foo' },
+        ],
+    },
+    {
+        'query': 'foo',
+        'others': [
+            // https://github.com/rust-lang/rust/issues/133017
+            { 'path': 'case', 'name': 'Foo', 'desc': 'Docs for Foo' },
+            { 'path': 'case', 'name': 'foo', 'desc': 'Docs for foo' },
+        ],
+    },
+];

--- a/tests/rustdoc-js/case.rs
+++ b/tests/rustdoc-js/case.rs
@@ -1,0 +1,7 @@
+#![allow(nonstandard_style)]
+
+/// Docs for Foo
+pub struct Foo;
+
+/// Docs for foo
+pub struct foo;


### PR DESCRIPTION
This is the "smartcase" behavior, described by vim and dtolnay.

Fixes https://github.com/rust-lang/rust/issues/133017