### PR TITLE
tests: Fix the SIMD FFI tests with certain x86 configuration

### DIFF
--- a/tests/run-make/simd-ffi/simd.rs
+++ b/tests/run-make/simd-ffi/simd.rs
@@ -25,7 +25,7 @@ pub struct i32x4([i32; 4]);
 
 extern "C" {
     // _mm_sll_epi32
-    #[cfg(any(target_arch = "x86", target_arch = "x86-64"))]
+    #[cfg(all(any(target_arch = "x86", target_arch = "x86-64"), target_feature = "sse2"))]
     #[link_name = "llvm.x86.sse2.psll.d"]
     fn integer(a: i32x4, b: i32x4) -> i32x4;
 
@@ -42,7 +42,7 @@ extern "C" {
     // we still get type checking, but not as detailed as (ab)using
     // LLVM.
     #[cfg(not(any(
-        target_arch = "x86",
+        all(target_arch = "x86", target_feature = "sse2"),
         target_arch = "x86-64",
         target_arch = "arm",
         target_arch = "aarch64"

--- a/tests/run-make/simd-ffi/simd.rs
+++ b/tests/run-make/simd-ffi/simd.rs
@@ -38,15 +38,13 @@ extern "C" {
     #[link_name = "llvm.aarch64.neon.maxs.v4i32"]
     fn integer(a: i32x4, b: i32x4) -> i32x4;
 
-    // just some substitute foreign symbol, not an LLVM intrinsic; so
-    // we still get type checking, but not as detailed as (ab)using
-    // LLVM.
+    // Use a generic LLVM intrinsic to do type checking on other platforms
     #[cfg(not(any(
-        all(target_arch = "x86", target_feature = "sse2"),
-        target_arch = "x86-64",
+        all(any(target_arch = "x86", target_arch = "x86-64"), target_feature = "sse2"),
         target_arch = "arm",
         target_arch = "aarch64"
     )))]
+    #[link_name = "llvm.smax.v4i32"]
     fn integer(a: i32x4, b: i32x4) -> i32x4;
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This pull request fixes the SIMD FFI tests with certain x86 configurations by gating the SSE2 intrinsic behind the `sse2` feature gate. A generic LLVM intrinsic that is easy to un-fuse on those platforms is added to compensate for those platforms. 