### PR TITLE
Trim whitespace in RemoveLet primary span

### DIFF
--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -650,8 +650,9 @@ pub(crate) struct LeftArrowOperator {
 #[diag(parse_remove_let)]
 pub(crate) struct RemoveLet {
     #[primary_span]
-    #[suggestion(applicability = "machine-applicable", code = "", style = "verbose")]
     pub span: Span,
+    #[suggestion(applicability = "machine-applicable", code = "", style = "verbose")]
+    pub suggestion: Span,
 }
 
 #[derive(Diagnostic)]

--- a/compiler/rustc_parse/src/parser/pat.rs
+++ b/compiler/rustc_parse/src/parser/pat.rs
@@ -685,7 +685,7 @@ impl<'a> Parser<'a> {
             self.bump();
             // Trim extra space after the `let`
             let span = lo.with_hi(self.token.span.lo());
-            self.dcx().emit_err(RemoveLet { span });
+            self.dcx().emit_err(RemoveLet { span: lo, suggestion: span });
             lo = self.token.span;
         }
 

--- a/tests/ui/parser/unnecessary-let.fixed
+++ b/tests/ui/parser/unnecessary-let.fixed
@@ -1,12 +1,12 @@
 //@ run-rustfix
 
 fn main() {
-    for let _x of [1, 2, 3] {}
+    for _x in [1, 2, 3] {}
     //~^ ERROR expected pattern, found `let`
     //~| ERROR missing `in` in `for` loop
 
     match 1 {
-        let 1 => {}
+        1 => {}
         //~^ ERROR expected pattern, found `let`
         _ => {}
     }

--- a/tests/ui/parser/unnecessary-let.stderr
+++ b/tests/ui/parser/unnecessary-let.stderr
@@ -1,31 +1,31 @@
 error: expected pattern, found `let`
-  --> $DIR/unnecessary-let.rs:2:9
+  --> $DIR/unnecessary-let.rs:4:9
    |
-LL |     for let x of [1, 2, 3] {}
-   |         ^^^^
+LL |     for let _x of [1, 2, 3] {}
+   |         ^^^
    |
 help: remove the unnecessary `let` keyword
    |
-LL -     for let x of [1, 2, 3] {}
-LL +     for x of [1, 2, 3] {}
+LL -     for let _x of [1, 2, 3] {}
+LL +     for _x of [1, 2, 3] {}
    |
 
 error: missing `in` in `for` loop
-  --> $DIR/unnecessary-let.rs:2:15
+  --> $DIR/unnecessary-let.rs:4:16
    |
-LL |     for let x of [1, 2, 3] {}
-   |               ^^
+LL |     for let _x of [1, 2, 3] {}
+   |                ^^
    |
 help: try using `in` here instead
    |
-LL |     for let x in [1, 2, 3] {}
-   |               ~~
+LL |     for let _x in [1, 2, 3] {}
+   |                ~~
 
 error: expected pattern, found `let`
-  --> $DIR/unnecessary-let.rs:7:9
+  --> $DIR/unnecessary-let.rs:9:9
    |
 LL |         let 1 => {}
-   |         ^^^^
+   |         ^^^
    |
 help: remove the unnecessary `let` keyword
    |


### PR DESCRIPTION
Separate `RemoveLet` span into primary span for `let` and removal suggestion span for `let `, so that primary span does not include whitespace.

Fixes: #133031

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
