### PR TITLE
Use `download-rustc=false` global default, `if-unchanged` for tools and library profiles, and make `rust.debug-assertions=true` inhibit downloading CI rustc

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -496,15 +496,18 @@
 #
 #debug = false
 
-# Whether to download the stage 1 and 2 compilers from CI.
-# This is useful if you are working on tools, doc-comments, or library (you will be able to build
-# the standard library without needing to build the compiler).
+# Whether to download the stage 1 and 2 compilers from CI. This is useful if you
+# are working on tools, doc-comments, or library (you will be able to build the
+# standard library without needing to build the compiler).
 #
-# Set this to "if-unchanged" if you are working on `src/tools`, `tests` or `library` (on CI, `library`
-# changes triggers in-tree compiler build) to speed up the build process.
+# Set this to "if-unchanged" if you are working on `src/tools`, `tests` or
+# `library` (on CI, `library` changes triggers in-tree compiler build) to speed
+# up the build process if you don't need to build a compiler from the latest
+# commit from `master`.
 #
-# Set this to `true` to always download or `false` to always use the in-tree compiler.
-#download-rustc = "if-unchanged"
+# Set this to `true` to always download or `false` to always use the in-tree
+# compiler.
+#download-rustc = false
 
 # Number of codegen units to use for each compiler invocation. A value of 0
 # means "the number of cores on this machine", and 1+ is passed through to the

--- a/src/bootstrap/defaults/config.compiler.toml
+++ b/src/bootstrap/defaults/config.compiler.toml
@@ -19,6 +19,9 @@ lto = "off"
 # Forces frame pointers to be used with `-Cforce-frame-pointers`.
 # This can be helpful for profiling at a small performance cost.
 frame-pointers = true
+# Compiler contributors often want to build rustc even without any changes to
+# e.g. check that it builds locally and check the baseline behavior of a
+# compiler built from latest `master` commit.
 download-rustc = false
 
 [llvm]

--- a/src/bootstrap/defaults/config.dist.toml
+++ b/src/bootstrap/defaults/config.dist.toml
@@ -16,6 +16,7 @@ download-ci-llvm = false
 # We have several defaults in bootstrap that depend on whether the channel is `dev` (e.g. `omit-git-hash` and `download-ci-llvm`).
 # Make sure they don't get set when installing from source.
 channel = "nightly"
+# Never download a rustc, distributions must build a fresh compiler.
 download-rustc = false
 lld = true
 # Build the llvm-bitcode-linker

--- a/src/bootstrap/defaults/config.library.toml
+++ b/src/bootstrap/defaults/config.library.toml
@@ -10,7 +10,9 @@ bench-stage = 0
 incremental = true
 # Make the compiler and standard library faster to build, at the expense of a ~20% runtime slowdown.
 lto = "off"
-download-rustc = false
+# Download rustc by default for library profile if compiler-affecting
+# directories are not modified. For CI this is disabled.
+download-rustc = "if-unchanged"
 
 [llvm]
 # Will download LLVM from CI if available on your platform.

--- a/src/bootstrap/defaults/config.tools.toml
+++ b/src/bootstrap/defaults/config.tools.toml
@@ -3,6 +3,9 @@
 [rust]
 # This greatly increases the speed of rebuilds, especially when there are only minor changes. However, it makes the initial build slightly slower.
 incremental = true
+# Most commonly, tools contributors do not need to modify the compiler, so
+# downloading a CI rustc is a good default for tools profile.
+download-rustc = "if-unchanged"
 
 [build]
 # Document with the in-tree rustdoc by default, since `download-rustc` makes it quick to compile.

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -2786,8 +2786,12 @@ impl Config {
 
         // If `download-rustc` is not set, default to rebuilding.
         let if_unchanged = match download_rustc {
-            None => self.rust_info.is_managed_git_subrepository(),
-            Some(StringOrBool::Bool(false)) => return None,
+            // Globally default for `download-rustc` to `false`, because some contributors don't use
+            // profiles for reasons such as:
+            // - They need to seemlessly switch between compiler/library work.
+            // - They don't want to use compiler profile because they need to override too many
+            //   things and it's easier to not use a profile.
+            None | Some(StringOrBool::Bool(false)) => return None,
             Some(StringOrBool::Bool(true)) => false,
             Some(StringOrBool::String(s)) if s == "if-unchanged" => {
                 if !self.rust_info.is_managed_git_subrepository() {

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -305,4 +305,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "`rust.llvm-tools` is now enabled by default when no `config.toml` is provided.",
     },
+    ChangeInfo {
+        change_id: 133068,
+        severity: ChangeSeverity::Warning,
+        summary: "Revert `rust.download-rustc` global default to `false` and only use `rust.download-rustc = \"if-unchanged\"` default for library and tools profile. As alt CI rustc is built without debug assertions, `rust.debug-assertions = true` will now inhibit downloading CI rustc.",
+    },
 ];

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/Dockerfile
@@ -84,7 +84,10 @@ ENV RUST_CONFIGURE_ARGS \
   --enable-new-symbol-mangling
 
 ENV HOST_TARGET x86_64-unknown-linux-gnu
-ENV FORCE_CI_RUSTC 1
+
+# FIXME(#133381): currently rustc alt builds do *not* have rustc debug
+# assertions enabled! Therefore, we cannot force download CI rustc.
+#ENV FORCE_CI_RUSTC 1
 
 COPY host-x86_64/dist-x86_64-linux/shared.sh /scripts/
 COPY host-x86_64/dist-x86_64-linux/build-gccjit.sh /scripts/


### PR DESCRIPTION
- Use `download-rustc = false` as global default.
    - Use `download-rustc = 'if-unchanged'` for tools and library profiles.
- Make `rust.debug-assertions = true` inhibit downloading CI rustc because alt rustc builds do not yet have rustc debug assertions enabled.

Fixes #133132.

cc discussions: https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/Bootstrap.20breakage
compiler contributors poll: https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/.60download-rustc.20.3D.20'if-unchanged'.60.20for.20.60compiler.60.20profile.3F/near/481877253
library contributors poll: https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/.60download-rustc.20.3D.20.22if-unchanged.22.60.20default.20for.20libs.20profile.3F/near/482607011
cc https://rust-lang.zulipchat.com/#narrow/channel/326414-t-infra.2Fbootstrap/topic/When.20is.20rustc.20built.20with.20debug.20assertions.3F

cc @MarcoIeni since you're working on improving CI job times, sorry, this will definitely regress some CI job times because we're probably lying to ourselves that CI rustc had debug assertions for some time 😅

cc @onur-ozkan for FYI, but since you're on vacation (sorry for the ping),

r? @Kobzol (I *think* you have a bit more context than other bootstrap reviewers?)

