### PR TITLE
make UI test OS-agnostic

### DIFF
--- a/tests/ui/structs-enums/enum-rec/issue-17431-6.rs
+++ b/tests/ui/structs-enums/enum-rec/issue-17431-6.rs
@@ -1,8 +1,6 @@
-//@ ignore-apple: cycle error does not appear on apple
+use std::cell::UnsafeCell;
 
-use std::sync::Mutex;
-
-enum Foo { X(Mutex<Option<Foo>>) }
+enum Foo { X(UnsafeCell<Option<Foo>>) }
 //~^ ERROR recursive type `Foo` has infinite size
 //~| ERROR cycle detected
 

--- a/tests/ui/structs-enums/enum-rec/issue-17431-6.stderr
+++ b/tests/ui/structs-enums/enum-rec/issue-17431-6.stderr
@@ -1,18 +1,18 @@
 error[E0072]: recursive type `Foo` has infinite size
-  --> $DIR/issue-17431-6.rs:5:1
+  --> $DIR/issue-17431-6.rs:3:1
    |
-LL | enum Foo { X(Mutex<Option<Foo>>) }
-   | ^^^^^^^^                  --- recursive without indirection
+LL | enum Foo { X(UnsafeCell<Option<Foo>>) }
+   | ^^^^^^^^                       --- recursive without indirection
    |
 help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to break the cycle
    |
-LL | enum Foo { X(Mutex<Option<Box<Foo>>>) }
-   |                           ++++   +
+LL | enum Foo { X(UnsafeCell<Option<Box<Foo>>>) }
+   |                                ++++   +
 
 error[E0391]: cycle detected when computing when `Foo` needs drop
-  --> $DIR/issue-17431-6.rs:5:1
+  --> $DIR/issue-17431-6.rs:3:1
    |
-LL | enum Foo { X(Mutex<Option<Foo>>) }
+LL | enum Foo { X(UnsafeCell<Option<Foo>>) }
    | ^^^^^^^^
    |
    = note: ...which immediately requires computing when `Foo` needs drop again


### PR DESCRIPTION
the internal representation of `std::sync::Mutex` depends on the compilation target. due to this, the compiler produces different number of errors for UI test `issue-17431-6.rs` depending on the compilation target.

for example, when compiling the UI test to an `*-apple-*` or `*-qnx7*` target, the "cycle detected" error is not reported

``` console
$ cat src/lib.rs
use std::sync::Mutex;

enum Foo {
    X(Mutex<Option<Foo>>),
}

impl Foo {
    fn bar(self) {}
}

fn main() {}

$ cargo check --target x86_64-apple-ios 2>&1 | rg '^error\['
error[E0072]: recursive type `Foo` has infinite size
```

whereas rustc produces two errors for other OSes, like Linux, which is what the UI test expects

``` console
$ cargo check --target x86_64-unknown-linux-gnu 2>&1 | rg '^error\['
error[E0072]: recursive type `Foo` has infinite size
error[E0391]: cycle detected when computing when `Foo` needs drop
```

this commit replaces the problematic `Mutex` with `UnsafeCell`, which has the same internal representation regardless of the compilation target. with that change, rustc reports two errors for all compilation targets.

``` console
$ cat src/lib.rs
use std::cell::UnsafeCell;

enum Foo {
    X(UnsafeCell<Option<Foo>>),
}

impl Foo {
    fn bar(self) {}
}

fn main() {}

$ cargo check --target x86_64-apple-ios 2>&1 | rg '^error\['
error[E0072]: recursive type `Foo` has infinite size
error[E0391]: cycle detected when computing when `Foo` needs drop
```

with this change, we can remove the `ignore-apple` directive as the UI test now also passes on apple targets.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
