### PR TITLE
bump sccache for linux x86_64 to allow caching while PGO'd

### DIFF
--- a/src/ci/docker/scripts/sccache.sh
+++ b/src/ci/docker/scripts/sccache.sh
@@ -6,10 +6,11 @@ set -ex
 
 case "$(uname -m)" in
     x86_64)
-        url="https://ci-mirrors.rust-lang.org/rustc/2021-08-24-sccache-v0.2.15-x86_64-unknown-linux-musl"
+        url="https://ci-mirrors.rust-lang.org/rustc/2022-12-08-sccache-v0.3.3-x86_64-unknown-linux-musl"
         ;;
     aarch64)
-        url="https://ci-mirrors.rust-lang.org/rustc/2021-08-25-sccache-v0.2.15-aarch64-unknown-linux-musl"
+        # no aarch64 release for 0.3.3, so use this
+        url="https://ci-mirrors.rust-lang.org/rustc/2022-11-13-sccache-v0.3.1-aarch64-unknown-linux-musl"
         ;;
     *)
         echo "unsupported architecture: $(uname -m)"

--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -279,5 +279,6 @@ if [ "$RUN_CHECK_WITH_PARALLEL_QUERIES" != "" ]; then
 fi
 
 echo "::group::sccache stats"
+sccache --version || true
 sccache --show-stats || true
 echo "::endgroup::"


### PR DESCRIPTION
This bumps sccache for linux-only jobs to allow sccache work with PGO https://github.com/mozilla/sccache/pull/952

<strike>This is improvement: 2h05m -> 1h44m (from 1 run) for `dist-x86_64-linux` https://github.com/rust-lang/rust/pull/133033#issuecomment-2478817764</strike>

Why still use old release? Commit with improvement was old, so i used some release around. In future, more recent versions can be tested to see if there any improvements, while this one already gives one.

aarch64 update shouldn't change much, as there no PGO used.

For other OSes i will create separate PRs later.

r? infra