### PR TITLE
Opt out TaKO8Ki from review rotation for now

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -997,7 +997,6 @@ compiler = [
     "@oli-obk",
     "@petrochenkov",
     "@pnkfelix",
-    "@TaKO8Ki",
     "@wesleywiser",
 ]
 libs = [
@@ -1048,7 +1047,6 @@ diagnostics = [
     "@davidtwco",
     "@estebank",
     "@oli-obk",
-    "@TaKO8Ki",
     "@chenyukang",
 ]
 parser = [


### PR DESCRIPTION
Hi @TaKO8Ki, I'm opting you out from compiler/diagnostics review rotation for now because I *think* you're very busy recently. Please feel free to re-add yourself (or close this PR) whenever you have more time / feel like it.