### PR TITLE
stabilize const_pin_2

### DIFF
--- a/library/core/src/lib.rs
+++ b/library/core/src/lib.rs
@@ -120,7 +120,6 @@
 #![feature(const_float_methods)]
 #![feature(const_heap)]
 #![feature(const_nonnull_new)]
-#![feature(const_pin_2)]
 #![feature(const_ptr_is_null)]
 #![feature(const_ptr_sub_ptr)]
 #![feature(const_raw_ptr_comparison)]

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1214,8 +1214,9 @@ impl<Ptr: Deref<Target: Unpin>> Pin<Ptr> {
     /// assert_eq!(*r, 5);
     /// ```
     #[inline(always)]
-    #[rustc_const_unstable(feature = "const_pin_2", issue = "76654")]
+    #[rustc_const_stable(feature = "const_pin", since = "CURRENT_RUSTC_VERSION")]
     #[stable(feature = "pin_into_inner", since = "1.39.0")]
+    #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
     pub const fn into_inner(pin: Pin<Ptr>) -> Ptr {
         pin.__pointer
     }
@@ -1503,8 +1504,9 @@ impl<Ptr: Deref> Pin<Ptr> {
     /// If the underlying data is [`Unpin`], [`Pin::into_inner`] should be used
     /// instead.
     #[inline(always)]
-    #[rustc_const_unstable(feature = "const_pin_2", issue = "76654")]
+    #[rustc_const_stable(feature = "const_pin", since = "CURRENT_RUSTC_VERSION")]
     #[stable(feature = "pin_into_inner", since = "1.39.0")]
+    #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
     pub const unsafe fn into_inner_unchecked(pin: Pin<Ptr>) -> Ptr {
         pin.__pointer
     }

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -21,7 +21,6 @@
 #![feature(const_eval_select)]
 #![feature(const_heap)]
 #![feature(const_nonnull_new)]
-#![feature(const_pin_2)]
 #![feature(const_trait_impl)]
 #![feature(core_intrinsics)]
 #![feature(core_io_borrowed_buf)]


### PR DESCRIPTION
This got split out from const_pin in https://github.com/rust-lang/rust/pull/130136; we can merge them back together since it's still the same release cycle (assuming this lands fast enough).

r? @tgross35 
Fixes https://github.com/rust-lang/rust/issues/76654