### PR TITLE
`suggest_borrow_generic_arg`: instantiate clauses properly

### DIFF
--- a/tests/ui/moves/moved-value-on-as-ref-arg.fixed
+++ b/tests/ui/moves/moved-value-on-as-ref-arg.fixed
@@ -18,8 +18,8 @@ impl AsMut<Bar> for Bar {
 
 fn foo<T: AsRef<Bar>>(_: T) {}
 fn qux<T: AsMut<Bar>>(_: T) {}
-fn bat<T: Borrow<T>>(_: T) {}
-fn baz<T: BorrowMut<T>>(_: T) {}
+fn bat<T: Borrow<Bar>>(_: T) {}
+fn baz<T: BorrowMut<Bar>>(_: T) {}
 
 pub fn main() {
     let bar = Bar;

--- a/tests/ui/moves/moved-value-on-as-ref-arg.rs
+++ b/tests/ui/moves/moved-value-on-as-ref-arg.rs
@@ -18,8 +18,8 @@ impl AsMut<Bar> for Bar {
 
 fn foo<T: AsRef<Bar>>(_: T) {}
 fn qux<T: AsMut<Bar>>(_: T) {}
-fn bat<T: Borrow<T>>(_: T) {}
-fn baz<T: BorrowMut<T>>(_: T) {}
+fn bat<T: Borrow<Bar>>(_: T) {}
+fn baz<T: BorrowMut<Bar>>(_: T) {}
 
 pub fn main() {
     let bar = Bar;

--- a/tests/ui/moves/region-var-in-moved-ty-issue-133118.rs
+++ b/tests/ui/moves/region-var-in-moved-ty-issue-133118.rs
@@ -1,0 +1,25 @@
+//! regression test for #133118
+
+pub trait Alpha {
+    fn y(self) -> usize;
+}
+
+pub trait Beta {
+    type Gamma;
+    fn gamma(&self) -> Self::Gamma;
+}
+
+pub fn a<T: Alpha>(_x: T) -> usize {
+    todo!();
+}
+
+pub fn x<B>(beta: &B) -> usize
+where
+    for<'a> &'a B: Beta,
+    for<'a> <&'a B as Beta>::Gamma: Alpha,
+{
+    let g1 = beta.gamma();
+    a(g1) + a(g1) //~ ERROR use of moved value: `g1` [E0382]
+}
+
+pub fn main() {}

--- a/tests/ui/moves/region-var-in-moved-ty-issue-133118.stderr
+++ b/tests/ui/moves/region-var-in-moved-ty-issue-133118.stderr
@@ -1,0 +1,21 @@
+error[E0382]: use of moved value: `g1`
+  --> $DIR/region-var-in-moved-ty-issue-133118.rs:22:15
+   |
+LL |     let g1 = beta.gamma();
+   |         -- move occurs because `g1` has type `<&B as Beta>::Gamma`, which does not implement the `Copy` trait
+LL |     a(g1) + a(g1)
+   |       --      ^^ value used here after move
+   |       |
+   |       value moved here
+   |
+note: consider changing this parameter type in function `a` to borrow instead if owning the value isn't necessary
+  --> $DIR/region-var-in-moved-ty-issue-133118.rs:12:24
+   |
+LL | pub fn a<T: Alpha>(_x: T) -> usize {
+   |        -               ^ this parameter takes ownership of the value
+   |        |
+   |        in this function
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0382`.


### PR DESCRIPTION
This simplifies and fixes the way `suggest_borrow_generic_arg` instantiates callees' predicates when testing them to see if a moved argument can instead be borrowed. Previously, it would ICE if the moved argument's type included a region variable, since it was getting passed to a call of `EarlyBinder::instantiate`. This makes the instantiation much more straightforward, which also fixes the ICE.

Fixes #133118

This also modifies `tests/ui/moves/moved-value-on-as-ref-arg.rs` to have more useful bounds on the tests for suggestions to borrow `Borrow` and `BorrowMut` arguments. With its old tautological `T: BorrowMut<T>` bound, this fix would make it suggest a shared borrow for that argument.