### PR TITLE
rustdoc-search: add standalone trailing `::` test

### DIFF
--- a/tests/rustdoc-js/trailing.js
+++ b/tests/rustdoc-js/trailing.js
@@ -1,0 +1,7 @@
+// exact-check
+const EXPECTED = {
+    'query': 'inner::',
+    'others': [
+        { 'path': 'trailing::inner', 'name': 'function' },
+    ],
+}

--- a/tests/rustdoc-js/trailing.rs
+++ b/tests/rustdoc-js/trailing.rs
@@ -1,0 +1,3 @@
+pub mod inner {
+    pub fn function() {}
+}


### PR DESCRIPTION
Follow up for #132569

r? @GuillaumeGomez 