### PR TITLE
Diagnostics for let mut in item context

### DIFF
--- a/tests/ui/parser/suggest-static-for-global-var-mut.rs
+++ b/tests/ui/parser/suggest-static-for-global-var-mut.rs
@@ -1,0 +1,5 @@
+let mut _data = vec![1,2,3];
+//~^ ERROR expected item, found keyword `let`
+
+fn main() {
+}

--- a/tests/ui/parser/suggest-static-for-global-var-mut.stderr
+++ b/tests/ui/parser/suggest-static-for-global-var-mut.stderr
@@ -1,12 +1,10 @@
 error: expected item, found keyword `let`
-  --> $DIR/suggest-const-for-global-var.rs:1:1
+  --> $DIR/suggest-static-for-global-var-mut.rs:1:1
    |
-LL | let X: i32 = 12;
-   | ^^^
-   | |
-   | `let` cannot be used for global variables
-   | help: consider using `static` or `const` instead of `let`
+LL | let mut _data = vec![1,2,3];
+   | ^^^ `let` cannot be used for global variables
    |
+   = help: consider using `static` and a `Mutex` instead of `let mut`
    = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 
 error: aborting due to 1 previous error


### PR DESCRIPTION
The diagnostics for `let` at the top level did not account for `let mut`, which [made the error unclear](https://users.rust-lang.org/t/create-a-vector-of-constants-outside-main/121251/1).

I've made the diagnostic always display a link to valid items. I've added dedicated help for `let mut` case that suggests using a `Mutex` (to steer novice users away from the `static mut` trap). Unfortunately, neither the Rust book, nor libstd docs have dedicated section listing all other types for interior-mutable `static`s.