### PR TITLE
Fixup some test directives

### DIFF
--- a/tests/incremental/hygiene/load_cached_hygiene.rs
+++ b/tests/incremental/hygiene/load_cached_hygiene.rs
@@ -7,7 +7,7 @@
 //    This causes hygiene information to be saved to the incr cache.
 // 2. One function is the foreign crate is modified. This causes the
 //    optimized mir for an unmodified function to be loaded from the
-//@    incremental cache and written out to the crate metadata.
+//    incremental cache and written out to the crate metadata.
 // 3. In the process of loading and writing out this function's MIR,
 //    we load hygiene information from the incremental cache and
 //    write it to our metadata.

--- a/tests/ui/symbol-names/basic.rs
+++ b/tests/ui/symbol-names/basic.rs
@@ -1,7 +1,7 @@
 //@ build-fail
 //@ revisions: legacy v0
 //@[legacy]compile-flags: -Z unstable-options -C symbol-mangling-version=legacy
-    //@[v0]compile-flags: -C symbol-mangling-version=v0
+//@[v0]compile-flags: -C symbol-mangling-version=v0
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/symbol-names/impl1.rs
+++ b/tests/ui/symbol-names/impl1.rs
@@ -1,7 +1,7 @@
 //@ build-fail
 //@ revisions: legacy v0
 //@[legacy]compile-flags: -Z unstable-options -C symbol-mangling-version=legacy
-    //@[v0]compile-flags: -C symbol-mangling-version=v0
+//@[v0]compile-flags: -C symbol-mangling-version=v0
 //@[legacy]normalize-stderr-test: "h[\w]{16}E?\)" -> "<SYMBOL_HASH>)"
 
 #![feature(auto_traits, rustc_attrs)]

--- a/tests/ui/symbol-names/issue-60925.rs
+++ b/tests/ui/symbol-names/issue-60925.rs
@@ -1,7 +1,7 @@
 //@ build-fail
 //@ revisions: legacy v0
 //@[legacy]compile-flags: -Z unstable-options -C symbol-mangling-version=legacy
-    //@[v0]compile-flags: -C symbol-mangling-version=v0
+//@[v0]compile-flags: -C symbol-mangling-version=v0
 
 #![feature(rustc_attrs)]
 


### PR DESCRIPTION
- A random comment had somehow been turned into an `//@` directive.
- More dubiously I also removed leading spaces from directives in 3 UI tests for consistency. These are the only rustc tests that use that formatting.

r? @jieyouxu 