### PR TITLE
Remove whitespaces on rust-env directives from some test codes

### DIFF
--- a/src/tools/miri/tests/panic/panic1.rs
+++ b/src/tools/miri/tests/panic/panic1.rs
@@ -1,4 +1,4 @@
-//@rustc-env: RUST_BACKTRACE=1
+//@rustc-env:RUST_BACKTRACE=1
 //@compile-flags: -Zmiri-disable-isolation
 
 fn main() {

--- a/src/tools/miri/tests/pass/backtrace/backtrace-global-alloc.rs
+++ b/src/tools/miri/tests/pass/backtrace/backtrace-global-alloc.rs
@@ -1,5 +1,5 @@
 //@compile-flags: -Zmiri-disable-isolation
-//@rustc-env: RUST_BACKTRACE=1
+//@rustc-env:RUST_BACKTRACE=1
 
 use std::alloc::System;
 use std::backtrace::Backtrace;

--- a/src/tools/miri/tests/pass/backtrace/backtrace-std.rs
+++ b/src/tools/miri/tests/pass/backtrace/backtrace-std.rs
@@ -1,5 +1,5 @@
 //@compile-flags: -Zmiri-disable-isolation
-//@rustc-env: RUST_BACKTRACE=1
+//@rustc-env:RUST_BACKTRACE=1
 
 use std::backtrace::Backtrace;
 

--- a/tests/rustdoc-ui/doctest/unparseable-doc-test.rs
+++ b/tests/rustdoc-ui/doctest/unparseable-doc-test.rs
@@ -2,7 +2,7 @@
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101
-//@ rustc-env: RUST_BACKTRACE=0
+//@ rustc-env:RUST_BACKTRACE=0
 
 /// ```rust
 /// let x = 7;

--- a/tests/ui/proc-macro/env.rs
+++ b/tests/ui/proc-macro/env.rs
@@ -1,6 +1,6 @@
 //@ aux-build:env.rs
 //@ run-pass
-//@ rustc-env: THE_CONST=1
+//@ rustc-env:THE_CONST=1
 //@ compile-flags: -Zunstable-options --env-set THE_CONST=12 --env-set ANOTHER=4
 
 #![crate_name = "foo"]


### PR DESCRIPTION
This PR is a part of https://github.com/rust-lang/rust/issues/132990.

{unset-,}{rustc,exec}-env directive shouldn't have whitespace.

NOTE: It looks that those whitespaces don't affect tests because I think those are parsed then added as temporary env vars on command line. Those are parsed by Rust properly.
For example, `SOME_ENV=1  ⌴RUST_TRACEBACK=0 rustdoc src/lib.rs` is equivalent with `SOME_ENV=1 RUST_TRACEBACK=0 rustdoc src/lib.rs`. (Of course for code's consistency, we should use the directives without any whitespaces.)
