### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_feature/src/tests.rs
+++ b/compiler/rustc_feature/src/tests.rs
@@ -18,6 +18,16 @@ fn rustc_bootstrap_parsing() {
     assert!(!is_bootstrap("x,y,z", Some("a")));
     assert!(!is_bootstrap("x,y,z", None));
 
-    // this is technically a breaking change, but there are no stability guarantees for RUSTC_BOOTSTRAP
+    // `RUSTC_BOOTSTRAP=0` is not recognized.
     assert!(!is_bootstrap("0", None));
+
+    // `RUSTC_BOOTSTRAP=-1` is force-stable, no unstable features allowed.
+    let is_force_stable = |krate| {
+        std::env::set_var("RUSTC_BOOTSTRAP", "-1");
+        matches!(UnstableFeatures::from_environment(krate), UnstableFeatures::Disallow)
+    };
+    assert!(is_force_stable(None));
+    // Does not support specifying any crate.
+    assert!(is_force_stable(Some("x")));
+    assert!(is_force_stable(Some("x,y,z")));
 }

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -54,7 +54,7 @@ pub struct EnabledLangFeature {
     pub stable_since: Option<Symbol>,
 }
 
-/// Information abhout an enabled library feature.
+/// Information about an enabled library feature.
 #[derive(Debug, Copy, Clone)]
 pub struct EnabledLibFeature {
     pub gate_name: Symbol,

--- a/compiler/rustc_hir_analysis/messages.ftl
+++ b/compiler/rustc_hir_analysis/messages.ftl
@@ -448,6 +448,11 @@ hir_analysis_rpitit_refined = impl trait in impl method signature does not match
     .note = add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
     .feedback_note = we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
 
+hir_analysis_rpitit_refined_lifetimes = impl trait in impl method captures fewer lifetimes than in trait
+    .suggestion = modify the `use<..>` bound to capture the same lifetimes that the trait does
+    .note = add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+    .feedback_note = we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+
 hir_analysis_self_in_impl_self =
     `Self` is not valid in the self type of an impl block
     .note = replace `Self` with a different type

--- a/compiler/rustc_hir_analysis/src/errors.rs
+++ b/compiler/rustc_hir_analysis/src/errors.rs
@@ -1153,6 +1153,16 @@ pub(crate) struct ReturnPositionImplTraitInTraitRefined<'tcx> {
     pub return_ty: Ty<'tcx>,
 }
 
+#[derive(LintDiagnostic)]
+#[diag(hir_analysis_rpitit_refined_lifetimes)]
+#[note]
+#[note(hir_analysis_feedback_note)]
+pub(crate) struct ReturnPositionImplTraitInTraitRefinedLifetimes {
+    #[suggestion(applicability = "maybe-incorrect", code = "{suggestion}")]
+    pub suggestion_span: Span,
+    pub suggestion: String,
+}
+
 #[derive(Diagnostic)]
 #[diag(hir_analysis_inherent_ty_outside, code = E0390)]
 #[help]

--- a/tests/incremental/hygiene/load_cached_hygiene.rs
+++ b/tests/incremental/hygiene/load_cached_hygiene.rs
@@ -7,7 +7,7 @@
 //    This causes hygiene information to be saved to the incr cache.
 // 2. One function is the foreign crate is modified. This causes the
 //    optimized mir for an unmodified function to be loaded from the
-//@    incremental cache and written out to the crate metadata.
+//    incremental cache and written out to the crate metadata.
 // 3. In the process of loading and writing out this function's MIR,
 //    we load hygiene information from the incremental cache and
 //    write it to our metadata.

--- a/tests/rustdoc-js/trailing.js
+++ b/tests/rustdoc-js/trailing.js
@@ -1,0 +1,7 @@
+// exact-check
+const EXPECTED = {
+    'query': 'inner::',
+    'others': [
+        { 'path': 'trailing::inner', 'name': 'function' },
+    ],
+}

--- a/tests/rustdoc-js/trailing.rs
+++ b/tests/rustdoc-js/trailing.rs
@@ -1,0 +1,3 @@
+pub mod inner {
+    pub fn function() {}
+}

--- a/tests/ui/bootstrap/rustc_bootstap.force_stable.stderr
+++ b/tests/ui/bootstrap/rustc_bootstap.force_stable.stderr
@@ -1,0 +1,10 @@
+error: the option `Z` is only accepted on the nightly compiler
+
+help: consider switching to a nightly toolchain: `rustup default nightly`
+
+note: selecting a toolchain with `+toolchain` arguments require a rustup proxy; see <https://rust-lang.github.io/rustup/concepts/index.html>
+
+note: for more information about Rust's stability policy, see <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>
+
+error: 1 nightly option were parsed
+

--- a/tests/ui/bootstrap/rustc_bootstap.rs
+++ b/tests/ui/bootstrap/rustc_bootstap.rs
@@ -1,0 +1,47 @@
+//! Check `RUSTC_BOOTSTRAP`'s behavior in relation to feature stability and what rustc considers
+//! itself to be (stable vs non-stable ).
+//!
+//! `RUSTC_BOOTSTRAP` accepts:
+//!
+//! - `1`: cheat, allow usage of unstable features even if rustc thinks it is a stable compiler.
+//! - `x,y,z`: comma-delimited list of crates.
+//! - `-1`: force rustc to think it is a stable compiler.
+
+// ignore-tidy-linelength
+
+//@ revisions: default_nightly cheat cheat_single_crate cheat_multi_crate force_stable invalid_zero invalid_junk
+//@ only-nightly
+
+//@[default_nightly] unset-rustc-env:RUSTC_BOOTSTRAP
+//@[default_nightly] check-pass
+
+// For a nightly compiler, this is same as `default_nightly` as if `RUSTC_BOOTSTRAP` was unset.
+//@[invalid_zero] rustc-env:RUSTC_BOOTSTRAP=0
+//@[invalid_zero] check-pass
+
+// Invalid values are silently discarded, same as `default_nightly`, i.e. as if `RUSTC_BOOTSTRAP`
+// was unset.
+//@[invalid_junk] rustc-env:RUSTC_BOOTSTRAP=*
+//@[invalid_junk] check-pass
+
+//@[cheat] rustc-env:RUSTC_BOOTSTRAP=1
+//@[cheat] check-pass
+
+//@[cheat_single_crate] rustc-env:RUSTC_BOOTSTRAP=x
+//@[cheat_single_crate] check-pass
+
+//@[cheat_multi_crate] rustc-env:RUSTC_BOOTSTRAP=x,y,z
+//@[cheat_multi_crate] check-pass
+
+// Note: compiletest passes some `-Z` flags to the compiler for ui testing purposes, so here we
+// instead abuse the fact that `-Z unstable-options` is also part of rustc's stability story and is
+// also affected by `RUSTC_BOOTSTRAP`.
+//@[force_stable] rustc-env:RUSTC_BOOTSTRAP=-1
+//@[force_stable] compile-flags: -Z unstable-options
+//@[force_stable] regex-error-pattern: error: the option `Z` is only accepted on the nightly compiler
+
+#![crate_type = "lib"]
+
+// Note: `rustc_attrs` is a perma-unstable internal feature that is unlikely to change, which is
+// used as a proxy to check `RUSTC_BOOTSTRAP` versus stability checking logic.
+#![feature(rustc_attrs)]

--- a/tests/ui/coercion/unboxing-needing-parenthases-issue-132924.rs
+++ b/tests/ui/coercion/unboxing-needing-parenthases-issue-132924.rs
@@ -1,0 +1,18 @@
+//@ check-fail
+fn main() {
+    let x = Box::new(Some(1));
+
+    let test: Option<i32> = x;
+    //~^ ERROR mismatched types
+    let x = Box::new(Some(1));
+    let test: Option<i32> = { x as Box<Option<i32>> };
+    //~^ ERROR mismatched types
+
+    let x = Box::new(Some(1));
+    let test: Option<i32> = if true { x as Box<Option<i32>> } else { None };
+    //~^ ERROR mismatched types
+
+    let x = std::rc::Rc::new(Some(1));
+    let test: Option<i32> = x as std::rc::Rc<Option<i32>>;
+    //~^ ERROR mismatched types
+}

--- a/tests/ui/coercion/unboxing-needing-parenthases-issue-132924.stderr
+++ b/tests/ui/coercion/unboxing-needing-parenthases-issue-132924.stderr
@@ -1,0 +1,59 @@
+error[E0308]: mismatched types
+  --> $DIR/unboxing-needing-parenthases-issue-132924.rs:5:29
+   |
+LL |     let test: Option<i32> = x;
+   |               -----------   ^ expected `Option<i32>`, found `Box<Option<{integer}>>`
+   |               |
+   |               expected due to this
+   |
+   = note: expected enum `Option<i32>`
+            found struct `Box<Option<{integer}>>`
+help: consider unboxing the value
+   |
+LL |     let test: Option<i32> = *x;
+   |                             +
+
+error[E0308]: mismatched types
+  --> $DIR/unboxing-needing-parenthases-issue-132924.rs:8:31
+   |
+LL |     let test: Option<i32> = { x as Box<Option<i32>> };
+   |                               ^^^^^^^^^^^^^^^^^^^^^ expected `Option<i32>`, found `Box<Option<i32>>`
+   |
+   = note: expected enum `Option<_>`
+            found struct `Box<Option<_>>`
+help: consider unboxing the value
+   |
+LL |     let test: Option<i32> = { *(x as Box<Option<i32>>) };
+   |                               ++                     +
+
+error[E0308]: mismatched types
+  --> $DIR/unboxing-needing-parenthases-issue-132924.rs:12:39
+   |
+LL |     let test: Option<i32> = if true { x as Box<Option<i32>> } else { None };
+   |                                       ^^^^^^^^^^^^^^^^^^^^^ expected `Option<i32>`, found `Box<Option<i32>>`
+   |
+   = note: expected enum `Option<_>`
+            found struct `Box<Option<_>>`
+help: consider unboxing the value
+   |
+LL |     let test: Option<i32> = if true { *(x as Box<Option<i32>>) } else { None };
+   |                                       ++                     +
+
+error[E0308]: mismatched types
+  --> $DIR/unboxing-needing-parenthases-issue-132924.rs:16:29
+   |
+LL |     let test: Option<i32> = x as std::rc::Rc<Option<i32>>;
+   |               -----------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Option<i32>`, found `Rc<Option<i32>>`
+   |               |
+   |               expected due to this
+   |
+   = note: expected enum `Option<_>`
+            found struct `Rc<Option<_>>`
+help: consider dereferencing the type
+   |
+LL |     let test: Option<i32> = *(x as std::rc::Rc<Option<i32>>);
+   |                             ++                             +
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/impl-trait/in-trait/refine-captures.rs
+++ b/tests/ui/impl-trait/in-trait/refine-captures.rs
@@ -1,0 +1,36 @@
+#![feature(precise_capturing_in_traits)]
+
+trait LifetimeParam<'a> {
+    fn test() -> impl Sized;
+}
+// Refining via capturing fewer lifetimes than the trait definition.
+impl<'a> LifetimeParam<'a> for i32 {
+    fn test() -> impl Sized + use<> {}
+    //~^ WARN impl trait in impl method captures fewer lifetimes than in trait
+}
+// If the lifetime is substituted, then we don't refine anything.
+impl LifetimeParam<'static> for u32 {
+    fn test() -> impl Sized + use<> {}
+    // Ok
+}
+
+trait TypeParam<T> {
+    fn test() -> impl Sized;
+}
+// Indirectly capturing a lifetime param through a type param substitution.
+impl<'a> TypeParam<&'a ()> for i32 {
+    fn test() -> impl Sized + use<> {}
+    //~^ WARN impl trait in impl method captures fewer lifetimes than in trait
+}
+// Two of them, but only one is captured...
+impl<'a, 'b> TypeParam<(&'a (), &'b ())> for u32 {
+    fn test() -> impl Sized + use<'b> {}
+    //~^ WARN impl trait in impl method captures fewer lifetimes than in trait
+}
+// What if we don't capture a type param? That should be an error otherwise.
+impl<T> TypeParam<T> for u64 {
+    fn test() -> impl Sized + use<> {}
+    //~^ ERROR `impl Trait` must mention all type parameters in scope in `use<...>`
+}
+
+fn main() {}

--- a/tests/ui/impl-trait/in-trait/refine-captures.stderr
+++ b/tests/ui/impl-trait/in-trait/refine-captures.stderr
@@ -1,0 +1,52 @@
+warning: impl trait in impl method captures fewer lifetimes than in trait
+  --> $DIR/refine-captures.rs:8:31
+   |
+LL |     fn test() -> impl Sized + use<> {}
+   |                               ^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+   = note: `#[warn(refining_impl_trait_internal)]` on by default
+help: modify the `use<..>` bound to capture the same lifetimes that the trait does
+   |
+LL |     fn test() -> impl Sized + use<'a> {}
+   |                               ~~~~~~~
+
+warning: impl trait in impl method captures fewer lifetimes than in trait
+  --> $DIR/refine-captures.rs:22:31
+   |
+LL |     fn test() -> impl Sized + use<> {}
+   |                               ^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: modify the `use<..>` bound to capture the same lifetimes that the trait does
+   |
+LL |     fn test() -> impl Sized + use<'a> {}
+   |                               ~~~~~~~
+
+warning: impl trait in impl method captures fewer lifetimes than in trait
+  --> $DIR/refine-captures.rs:27:31
+   |
+LL |     fn test() -> impl Sized + use<'b> {}
+   |                               ^^^^^^^
+   |
+   = note: add `#[allow(refining_impl_trait)]` if it is intended for this to be part of the public API of this crate
+   = note: we are soliciting feedback, see issue #121718 <https://github.com/rust-lang/rust/issues/121718> for more information
+help: modify the `use<..>` bound to capture the same lifetimes that the trait does
+   |
+LL |     fn test() -> impl Sized + use<'a, 'b> {}
+   |                               ~~~~~~~~~~~
+
+error: `impl Trait` must mention all type parameters in scope in `use<...>`
+  --> $DIR/refine-captures.rs:32:18
+   |
+LL | impl<T> TypeParam<T> for u64 {
+   |      - type parameter is implicitly captured by this `impl Trait`
+LL |     fn test() -> impl Sized + use<> {}
+   |                  ^^^^^^^^^^^^^^^^^^
+   |
+   = note: currently, all type parameters are required to be mentioned in the precise captures list
+
+error: aborting due to 1 previous error; 3 warnings emitted
+

--- a/tests/ui/moves/moved-value-on-as-ref-arg.fixed
+++ b/tests/ui/moves/moved-value-on-as-ref-arg.fixed
@@ -18,8 +18,8 @@ impl AsMut<Bar> for Bar {
 
 fn foo<T: AsRef<Bar>>(_: T) {}
 fn qux<T: AsMut<Bar>>(_: T) {}
-fn bat<T: Borrow<T>>(_: T) {}
-fn baz<T: BorrowMut<T>>(_: T) {}
+fn bat<T: Borrow<Bar>>(_: T) {}
+fn baz<T: BorrowMut<Bar>>(_: T) {}
 
 pub fn main() {
     let bar = Bar;

--- a/tests/ui/moves/moved-value-on-as-ref-arg.rs
+++ b/tests/ui/moves/moved-value-on-as-ref-arg.rs
@@ -18,8 +18,8 @@ impl AsMut<Bar> for Bar {
 
 fn foo<T: AsRef<Bar>>(_: T) {}
 fn qux<T: AsMut<Bar>>(_: T) {}
-fn bat<T: Borrow<T>>(_: T) {}
-fn baz<T: BorrowMut<T>>(_: T) {}
+fn bat<T: Borrow<Bar>>(_: T) {}
+fn baz<T: BorrowMut<Bar>>(_: T) {}
 
 pub fn main() {
     let bar = Bar;

--- a/tests/ui/moves/region-var-in-moved-ty-issue-133118.rs
+++ b/tests/ui/moves/region-var-in-moved-ty-issue-133118.rs
@@ -1,0 +1,25 @@
+//! regression test for #133118
+
+pub trait Alpha {
+    fn y(self) -> usize;
+}
+
+pub trait Beta {
+    type Gamma;
+    fn gamma(&self) -> Self::Gamma;
+}
+
+pub fn a<T: Alpha>(_x: T) -> usize {
+    todo!();
+}
+
+pub fn x<B>(beta: &B) -> usize
+where
+    for<'a> &'a B: Beta,
+    for<'a> <&'a B as Beta>::Gamma: Alpha,
+{
+    let g1 = beta.gamma();
+    a(g1) + a(g1) //~ ERROR use of moved value: `g1` [E0382]
+}
+
+pub fn main() {}

--- a/tests/ui/moves/region-var-in-moved-ty-issue-133118.stderr
+++ b/tests/ui/moves/region-var-in-moved-ty-issue-133118.stderr
@@ -1,0 +1,21 @@
+error[E0382]: use of moved value: `g1`
+  --> $DIR/region-var-in-moved-ty-issue-133118.rs:22:15
+   |
+LL |     let g1 = beta.gamma();
+   |         -- move occurs because `g1` has type `<&B as Beta>::Gamma`, which does not implement the `Copy` trait
+LL |     a(g1) + a(g1)
+   |       --      ^^ value used here after move
+   |       |
+   |       value moved here
+   |
+note: consider changing this parameter type in function `a` to borrow instead if owning the value isn't necessary
+  --> $DIR/region-var-in-moved-ty-issue-133118.rs:12:24
+   |
+LL | pub fn a<T: Alpha>(_x: T) -> usize {
+   |        -               ^ this parameter takes ownership of the value
+   |        |
+   |        in this function
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0382`.

--- a/tests/ui/parser/suggest-static-for-global-var-mut.rs
+++ b/tests/ui/parser/suggest-static-for-global-var-mut.rs
@@ -1,0 +1,5 @@
+let mut _data = vec![1,2,3];
+//~^ ERROR expected item, found keyword `let`
+
+fn main() {
+}

--- a/tests/ui/parser/suggest-static-for-global-var-mut.stderr
+++ b/tests/ui/parser/suggest-static-for-global-var-mut.stderr
@@ -1,12 +1,10 @@
 error: expected item, found keyword `let`
-  --> $DIR/suggest-const-for-global-var.rs:1:1
+  --> $DIR/suggest-static-for-global-var-mut.rs:1:1
    |
-LL | let X: i32 = 12;
-   | ^^^
-   | |
-   | `let` cannot be used for global variables
-   | help: consider using `static` or `const` instead of `let`
+LL | let mut _data = vec![1,2,3];
+   | ^^^ `let` cannot be used for global variables
    |
+   = help: consider using `static` and a `Mutex` instead of `let mut`
    = note: for a full list of items that can appear in modules, see <https://doc.rust-lang.org/reference/items.html>
 
 error: aborting due to 1 previous error

--- a/tests/ui/symbol-names/basic.rs
+++ b/tests/ui/symbol-names/basic.rs
@@ -1,7 +1,7 @@
 //@ build-fail
 //@ revisions: legacy v0
 //@[legacy]compile-flags: -Z unstable-options -C symbol-mangling-version=legacy
-    //@[v0]compile-flags: -C symbol-mangling-version=v0
+//@[v0]compile-flags: -C symbol-mangling-version=v0
 
 #![feature(rustc_attrs)]
 

--- a/tests/ui/symbol-names/impl1.rs
+++ b/tests/ui/symbol-names/impl1.rs
@@ -1,7 +1,7 @@
 //@ build-fail
 //@ revisions: legacy v0
 //@[legacy]compile-flags: -Z unstable-options -C symbol-mangling-version=legacy
-    //@[v0]compile-flags: -C symbol-mangling-version=v0
+//@[v0]compile-flags: -C symbol-mangling-version=v0
 //@[legacy]normalize-stderr-test: "h[\w]{16}E?\)" -> "<SYMBOL_HASH>)"
 
 #![feature(auto_traits, rustc_attrs)]

--- a/tests/ui/symbol-names/issue-60925.rs
+++ b/tests/ui/symbol-names/issue-60925.rs
@@ -1,7 +1,7 @@
 //@ build-fail
 //@ revisions: legacy v0
 //@[legacy]compile-flags: -Z unstable-options -C symbol-mangling-version=legacy
-    //@[v0]compile-flags: -C symbol-mangling-version=v0
+//@[v0]compile-flags: -C symbol-mangling-version=v0
 
 #![feature(rustc_attrs)]
 


### PR DESCRIPTION
Successful merges:

 - #132795 (Check `use<..>` in RPITIT for refinement)
 - #132944 (add parentheses when unboxing suggestion needed)
 - #132993 (Make rustc consider itself a stable compiler when `RUSTC_BOOTSTRAP=-1`)
 - #133130 (`suggest_borrow_generic_arg`: instantiate clauses properly)
 - #133133 (rustdoc-search: add standalone trailing `::` test)
 - #133143 (Diagnostics for let mut in item context)
 - #133147 (Fixup some test directives)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=132795,132944,132993,133130,133133,133143,133147)
<!-- homu-ignore:end -->