### PR TITLE
Reword resolve errors caused by likely missing crate in dep tree

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0433.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0433.md
@@ -19,7 +19,7 @@ If you've expected to use a crate name:
 
 ```compile_fail
 use ferris_wheel::BigO;
-// error: failed to resolve: use of undeclared crate or module `ferris_wheel`
+// error: failed to resolve: use of undeclared module or unlinked crate
 ```
 
 Make sure the crate has been added as a dependency in `Cargo.toml`.

--- a/compiler/rustc_resolve/src/diagnostics.rs
+++ b/compiler/rustc_resolve/src/diagnostics.rs
@@ -24,6 +24,7 @@ use rustc_session::lint::builtin::{
     MACRO_EXPANDED_MACRO_EXPORTS_ACCESSED_BY_ABSOLUTE_PATHS,
 };
 use rustc_session::lint::{AmbiguityErrorDiag, BuiltinLintDiag};
+use rustc_session::utils::was_invoked_from_cargo;
 use rustc_span::edit_distance::find_best_match_for_name;
 use rustc_span::edition::Edition;
 use rustc_span::hygiene::MacroKind;
@@ -809,7 +810,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                     }
                     err.multipart_suggestion(msg, suggestions, applicability);
                 }
-
                 if let Some(ModuleOrUniformRoot::Module(module)) = module
                     && let Some(module) = module.opt_def_id()
                     && let Some(segment) = segment
@@ -2044,13 +2044,23 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 (format!("`_` is not a valid crate or module name"), None)
             } else if self.tcx.sess.is_rust_2015() {
                 (
-                    format!("you might be missing crate `{ident}`"),
+                    format!("use of unresolved module or unlinked crate `{ident}`"),
                     Some((
                         vec![(
                             self.current_crate_outer_attr_insert_span,
                             format!("extern crate {ident};\n"),
                         )],
-                        format!("consider importing the `{ident}` crate"),
+                        if was_invoked_from_cargo() {
+                            format!(
+                                "if you wanted to use a crate named `{ident}`, use `cargo add {ident}` \
+                             to add it to your `Cargo.toml` and import it in your code",
+                            )
+                        } else {
+                            format!(
+                                "you might be missing a crate named `{ident}`, add it to your \
+                                 project and import it in your code",
+                            )
+                        },
                         Applicability::MaybeIncorrect,
                     )),
                 )
@@ -2229,7 +2239,25 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 let descr = binding.res().descr();
                 (format!("{descr} `{ident}` is not a crate or module"), suggestion)
             } else {
-                (format!("use of undeclared crate or module `{ident}`"), suggestion)
+                let suggestion = if suggestion.is_some() {
+                    suggestion
+                } else if was_invoked_from_cargo() {
+                    Some((
+                        vec![],
+                        format!(
+                            "if you wanted to use a crate named `{ident}`, use `cargo add {ident}` \
+                             to add it to your `Cargo.toml`",
+                        ),
+                        Applicability::MaybeIncorrect,
+                    ))
+                } else {
+                    Some((
+                        vec![],
+                        format!("you might be missing a crate named `{ident}`",),
+                        Applicability::MaybeIncorrect,
+                    ))
+                };
+                (format!("use of unresolved module or unlinked crate `{ident}`"), suggestion)
             }
         }
     }

--- a/src/tools/miri/tests/fail/rustc-error2.rs
+++ b/src/tools/miri/tests/fail/rustc-error2.rs
@@ -4,7 +4,7 @@ struct Struct<T>(T);
 impl<T> std::ops::Deref for Struct<T> {
     type Target = dyn Fn(T);
     fn deref(&self) -> &assert_mem_uninitialized_valid::Target {
-        //~^ERROR: undeclared crate or module
+        //~^ERROR: use of unresolved module or unlinked crate
         unimplemented!()
     }
 }

--- a/src/tools/miri/tests/fail/rustc-error2.stderr
+++ b/src/tools/miri/tests/fail/rustc-error2.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `assert_mem_uninitialized_valid`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `assert_mem_uninitialized_valid`
   --> tests/fail/rustc-error2.rs:LL:CC
    |
 LL |     fn deref(&self) -> &assert_mem_uninitialized_valid::Target {
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `assert_mem_uninitialized_valid`
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `assert_mem_uninitialized_valid`
+   |
+   = help: you might be missing a crate named `assert_mem_uninitialized_valid`
 
 error: aborting due to 1 previous error
 

--- a/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
+++ b/tests/rustdoc-ui/ice-unresolved-import-100241.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `inner`
   --> $DIR/ice-unresolved-import-100241.rs:9:13
    |
 LL |     pub use inner::S;
-   |             ^^^^^ you might be missing crate `inner`
+   |             ^^^^^ use of unresolved module or unlinked crate `inner`
    |
-help: consider importing the `inner` crate
+help: you might be missing a crate named `inner`, add it to your project and import it in your code
    |
 LL + extern crate inner;
    |

--- a/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.stderr
+++ b/tests/rustdoc-ui/intra-doc/unresolved-import-recovery.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: you might be missing crate `unresolved_crate`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved_crate`
   --> $DIR/unresolved-import-recovery.rs:3:5
    |
 LL | use unresolved_crate::module::Name;
-   |     ^^^^^^^^^^^^^^^^ you might be missing crate `unresolved_crate`
+   |     ^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved_crate`
    |
-help: consider importing the `unresolved_crate` crate
+help: you might be missing a crate named `unresolved_crate`, add it to your project and import it in your code
    |
 LL + extern crate unresolved_crate;
    |

--- a/tests/rustdoc-ui/issues/issue-61732.rs
+++ b/tests/rustdoc-ui/issues/issue-61732.rs
@@ -1,4 +1,4 @@
 // This previously triggered an ICE.
 
 pub(in crate::r#mod) fn main() {}
-//~^ ERROR failed to resolve: you might be missing crate `r#mod`
+//~^ ERROR failed to resolve: use of unresolved module or unlinked crate `r#mod`

--- a/tests/rustdoc-ui/issues/issue-61732.stderr
+++ b/tests/rustdoc-ui/issues/issue-61732.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: you might be missing crate `r#mod`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `r#mod`
   --> $DIR/issue-61732.rs:3:15
    |
 LL | pub(in crate::r#mod) fn main() {}
-   |               ^^^^^ you might be missing crate `r#mod`
+   |               ^^^^^ use of unresolved module or unlinked crate `r#mod`
    |
-help: consider importing the `r#mod` crate
+help: you might be missing a crate named `r#mod`, add it to your project and import it in your code
    |
 LL + extern crate r#mod;
    |

--- a/tests/ui/attributes/check-builtin-attr-ice.stderr
+++ b/tests/ui/attributes/check-builtin-attr-ice.stderr
@@ -1,20 +1,20 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `should_panic`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `should_panic`
   --> $DIR/check-builtin-attr-ice.rs:43:7
    |
 LL |     #[should_panic::skip]
-   |       ^^^^^^^^^^^^ use of undeclared crate or module `should_panic`
+   |       ^^^^^^^^^^^^ use of unresolved module or unlinked crate `should_panic`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `should_panic`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `should_panic`
   --> $DIR/check-builtin-attr-ice.rs:47:7
    |
 LL |     #[should_panic::a::b::c]
-   |       ^^^^^^^^^^^^ use of undeclared crate or module `should_panic`
+   |       ^^^^^^^^^^^^ use of unresolved module or unlinked crate `should_panic`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `deny`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `deny`
   --> $DIR/check-builtin-attr-ice.rs:55:7
    |
 LL |     #[deny::skip]
-   |       ^^^^ use of undeclared crate or module `deny`
+   |       ^^^^ use of unresolved module or unlinked crate `deny`
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/attributes/check-cfg_attr-ice.stderr
+++ b/tests/ui/attributes/check-cfg_attr-ice.stderr
@@ -17,83 +17,83 @@ LL |         #[cfg_attr::no_such_thing]
    = help: add `#![feature(stmt_expr_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:52:3
    |
 LL | #[cfg_attr::no_such_thing]
-   |   ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:55:7
    |
 LL |     #[cfg_attr::no_such_thing]
-   |       ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |       ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:57:17
    |
 LL |     GiveYouUp(#[cfg_attr::no_such_thing] u8),
-   |                 ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |                 ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:64:11
    |
 LL |         #[cfg_attr::no_such_thing]
-   |           ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |           ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:41:7
    |
 LL |     #[cfg_attr::no_such_thing]
-   |       ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |       ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:43:15
    |
 LL |     fn from(#[cfg_attr::no_such_thing] any_other_guy: AnyOtherGuy) -> This {
-   |               ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |               ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:45:11
    |
 LL |         #[cfg_attr::no_such_thing]
-   |           ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |           ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:32:3
    |
 LL | #[cfg_attr::no_such_thing]
-   |   ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:24:3
    |
 LL | #[cfg_attr::no_such_thing]
-   |   ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:27:7
    |
 LL |     #[cfg_attr::no_such_thing]
-   |       ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |       ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:16:3
    |
 LL | #[cfg_attr::no_such_thing]
-   |   ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:19:7
    |
 LL |     #[cfg_attr::no_such_thing]
-   |       ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |       ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `cfg_attr`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `cfg_attr`
   --> $DIR/check-cfg_attr-ice.rs:12:3
    |
 LL | #[cfg_attr::no_such_thing]
-   |   ^^^^^^^^ use of undeclared crate or module `cfg_attr`
+   |   ^^^^^^^^ use of unresolved module or unlinked crate `cfg_attr`
 
 error: aborting due to 15 previous errors
 

--- a/tests/ui/attributes/field-attributes-vis-unresolved.stderr
+++ b/tests/ui/attributes/field-attributes-vis-unresolved.stderr
@@ -1,21 +1,21 @@
-error[E0433]: failed to resolve: you might be missing crate `nonexistent`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistent`
   --> $DIR/field-attributes-vis-unresolved.rs:17:12
    |
 LL |     pub(in nonexistent) field: u8
-   |            ^^^^^^^^^^^ you might be missing crate `nonexistent`
+   |            ^^^^^^^^^^^ use of unresolved module or unlinked crate `nonexistent`
    |
-help: consider importing the `nonexistent` crate
+help: you might be missing a crate named `nonexistent`, add it to your project and import it in your code
    |
 LL + extern crate nonexistent;
    |
 
-error[E0433]: failed to resolve: you might be missing crate `nonexistent`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistent`
   --> $DIR/field-attributes-vis-unresolved.rs:22:12
    |
 LL |     pub(in nonexistent) u8
-   |            ^^^^^^^^^^^ you might be missing crate `nonexistent`
+   |            ^^^^^^^^^^^ use of unresolved module or unlinked crate `nonexistent`
    |
-help: consider importing the `nonexistent` crate
+help: you might be missing a crate named `nonexistent`, add it to your project and import it in your code
    |
 LL + extern crate nonexistent;
    |

--- a/tests/ui/coherence/conflicting-impl-with-err.stderr
+++ b/tests/ui/coherence/conflicting-impl-with-err.stderr
@@ -1,14 +1,18 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `nope`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nope`
   --> $DIR/conflicting-impl-with-err.rs:4:11
    |
 LL | impl From<nope::Thing> for Error {
-   |           ^^^^ use of undeclared crate or module `nope`
+   |           ^^^^ use of unresolved module or unlinked crate `nope`
+   |
+   = help: you might be missing a crate named `nope`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `nope`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nope`
   --> $DIR/conflicting-impl-with-err.rs:5:16
    |
 LL |     fn from(_: nope::Thing) -> Self {
-   |                ^^^^ use of undeclared crate or module `nope`
+   |                ^^^^ use of unresolved module or unlinked crate `nope`
+   |
+   = help: you might be missing a crate named `nope`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/delegation/bad-resolve.rs
+++ b/tests/ui/delegation/bad-resolve.rs
@@ -40,7 +40,7 @@ impl Trait for S {
 }
 
 mod prefix {}
-reuse unresolved_prefix::{a, b, c}; //~ ERROR use of undeclared crate or module `unresolved_prefix`
+reuse unresolved_prefix::{a, b, c}; //~ ERROR use of unresolved module or unlinked crate
 reuse prefix::{self, super, crate}; //~ ERROR `crate` in paths can only be used in start position
 
 fn main() {}

--- a/tests/ui/delegation/bad-resolve.stderr
+++ b/tests/ui/delegation/bad-resolve.stderr
@@ -81,11 +81,13 @@ LL |     type Type;
 LL | impl Trait for S {
    | ^^^^^^^^^^^^^^^^ missing `Type` in implementation
 
-error[E0433]: failed to resolve: use of undeclared crate or module `unresolved_prefix`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved_prefix`
   --> $DIR/bad-resolve.rs:43:7
    |
 LL | reuse unresolved_prefix::{a, b, c};
-   |       ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `unresolved_prefix`
+   |       ^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved_prefix`
+   |
+   = help: you might be missing a crate named `unresolved_prefix`
 
 error[E0433]: failed to resolve: `crate` in paths can only be used in start position
   --> $DIR/bad-resolve.rs:44:29

--- a/tests/ui/delegation/glob-bad-path.rs
+++ b/tests/ui/delegation/glob-bad-path.rs
@@ -5,7 +5,7 @@ trait Trait {}
 struct S;
 
 impl Trait for u8 {
-    reuse unresolved::*; //~ ERROR failed to resolve: use of undeclared crate or module `unresolved`
+    reuse unresolved::*; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `unresolved`
     reuse S::*; //~ ERROR expected trait, found struct `S`
 }
 

--- a/tests/ui/delegation/glob-bad-path.stderr
+++ b/tests/ui/delegation/glob-bad-path.stderr
@@ -4,11 +4,11 @@ error: expected trait, found struct `S`
 LL |     reuse S::*;
    |           ^ not a trait
 
-error[E0433]: failed to resolve: use of undeclared crate or module `unresolved`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `unresolved`
   --> $DIR/glob-bad-path.rs:8:11
    |
 LL |     reuse unresolved::*;
-   |           ^^^^^^^^^^ use of undeclared crate or module `unresolved`
+   |           ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/error-codes/E0432.stderr
+++ b/tests/ui/error-codes/E0432.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `something`
   --> $DIR/E0432.rs:1:5
    |
 LL | use something::Foo;
-   |     ^^^^^^^^^ you might be missing crate `something`
+   |     ^^^^^^^^^ use of unresolved module or unlinked crate `something`
    |
-help: consider importing the `something` crate
+help: you might be missing a crate named `something`, add it to your project and import it in your code
    |
 LL + extern crate something;
    |

--- a/tests/ui/extern-flag/multiple-opts.stderr
+++ b/tests/ui/extern-flag/multiple-opts.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `somedep`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `somedep`
   --> $DIR/multiple-opts.rs:19:5
    |
 LL |     somedep::somefun();
-   |     ^^^^^^^ use of undeclared crate or module `somedep`
+   |     ^^^^^^^ use of unresolved module or unlinked crate `somedep`
+   |
+   = help: you might be missing a crate named `somedep`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/extern-flag/noprelude.stderr
+++ b/tests/ui/extern-flag/noprelude.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `somedep`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `somedep`
   --> $DIR/noprelude.rs:6:5
    |
 LL |     somedep::somefun();
-   |     ^^^^^^^ use of undeclared crate or module `somedep`
+   |     ^^^^^^^ use of unresolved module or unlinked crate `somedep`
+   |
+   = help: you might be missing a crate named `somedep`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/foreign/stashed-issue-121451.rs
+++ b/tests/ui/foreign/stashed-issue-121451.rs
@@ -1,4 +1,4 @@
 extern "C" fn _f() -> libc::uintptr_t {}
-//~^ ERROR failed to resolve: use of undeclared crate or module `libc`
+//~^ ERROR failed to resolve
 
 fn main() {}

--- a/tests/ui/foreign/stashed-issue-121451.stderr
+++ b/tests/ui/foreign/stashed-issue-121451.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `libc`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `libc`
   --> $DIR/stashed-issue-121451.rs:1:23
    |
 LL | extern "C" fn _f() -> libc::uintptr_t {}
-   |                       ^^^^ use of undeclared crate or module `libc`
+   |                       ^^^^ use of unresolved module or unlinked crate `libc`
+   |
+   = help: you might be missing a crate named `libc`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.rs
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.rs
@@ -10,7 +10,7 @@ macro a() {
     mod u {
         // Late resolution.
         fn f() { my_core::mem::drop(0); }
-        //~^ ERROR failed to resolve: use of undeclared crate or module `my_core`
+        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `my_core`
     }
 }
 
@@ -23,7 +23,7 @@ mod v {
 mod u {
     // Late resolution.
     fn f() { my_core::mem::drop(0); }
-    //~^ ERROR failed to resolve: use of undeclared crate or module `my_core`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `my_core`
 }
 
 fn main() {}

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.stderr
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail-2018.stderr
@@ -15,25 +15,27 @@ LL | a!();
    |
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `my_core`
   --> $DIR/extern-prelude-from-opaque-fail-2018.rs:12:18
    |
 LL |         fn f() { my_core::mem::drop(0); }
-   |                  ^^^^^^^ use of undeclared crate or module `my_core`
+   |                  ^^^^^^^ use of unresolved module or unlinked crate `my_core`
 ...
 LL | a!();
    | ---- in this macro invocation
    |
+   = help: you might be missing a crate named `my_core`
    = help: consider importing this module:
            std::mem
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `my_core`
   --> $DIR/extern-prelude-from-opaque-fail-2018.rs:25:14
    |
 LL |     fn f() { my_core::mem::drop(0); }
-   |              ^^^^^^^ use of undeclared crate or module `my_core`
+   |              ^^^^^^^ use of unresolved module or unlinked crate `my_core`
    |
+   = help: you might be missing a crate named `my_core`
 help: consider importing this module
    |
 LL +     use std::mem;

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail.rs
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail.rs
@@ -10,7 +10,7 @@ macro a() {
     mod u {
         // Late resolution.
         fn f() { my_core::mem::drop(0); }
-        //~^ ERROR failed to resolve: use of undeclared crate or module `my_core`
+        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `my_core`
     }
 }
 
@@ -23,7 +23,7 @@ mod v {
 mod u {
     // Late resolution.
     fn f() { my_core::mem::drop(0); }
-    //~^ ERROR failed to resolve: use of undeclared crate or module `my_core`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `my_core`
 }
 
 fn main() {}

--- a/tests/ui/hygiene/extern-prelude-from-opaque-fail.stderr
+++ b/tests/ui/hygiene/extern-prelude-from-opaque-fail.stderr
@@ -15,25 +15,27 @@ LL | a!();
    |
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `my_core`
   --> $DIR/extern-prelude-from-opaque-fail.rs:12:18
    |
 LL |         fn f() { my_core::mem::drop(0); }
-   |                  ^^^^^^^ use of undeclared crate or module `my_core`
+   |                  ^^^^^^^ use of unresolved module or unlinked crate `my_core`
 ...
 LL | a!();
    | ---- in this macro invocation
    |
+   = help: you might be missing a crate named `my_core`
    = help: consider importing this module:
            my_core::mem
    = note: this error originates in the macro `a` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `my_core`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `my_core`
   --> $DIR/extern-prelude-from-opaque-fail.rs:25:14
    |
 LL |     fn f() { my_core::mem::drop(0); }
-   |              ^^^^^^^ use of undeclared crate or module `my_core`
+   |              ^^^^^^^ use of unresolved module or unlinked crate `my_core`
    |
+   = help: you might be missing a crate named `my_core`
 help: consider importing this module
    |
 LL +     use my_core::mem;

--- a/tests/ui/impl-trait/issue-72911.stderr
+++ b/tests/ui/impl-trait/issue-72911.stderr
@@ -1,14 +1,18 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
   --> $DIR/issue-72911.rs:11:33
    |
 LL | fn gather_from_file(dir_entry: &foo::MissingItem) -> impl Iterator<Item = Lint> {
-   |                                 ^^^ use of undeclared crate or module `foo`
+   |                                 ^^^ use of unresolved module or unlinked crate `foo`
+   |
+   = help: you might be missing a crate named `foo`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
   --> $DIR/issue-72911.rs:16:41
    |
 LL | fn lint_files() -> impl Iterator<Item = foo::MissingItem> {
-   |                                         ^^^ use of undeclared crate or module `foo`
+   |                                         ^^^ use of unresolved module or unlinked crate `foo`
+   |
+   = help: you might be missing a crate named `foo`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/stashed-diag-issue-121504.rs
+++ b/tests/ui/impl-trait/stashed-diag-issue-121504.rs
@@ -4,7 +4,7 @@ trait MyTrait {
     async fn foo(self) -> (Self, i32);
 }
 
-impl MyTrait for xyz::T { //~ ERROR failed to resolve: use of undeclared crate or module `xyz`
+impl MyTrait for xyz::T { //~ ERROR failed to resolve: use of unresolved module or unlinked crate `xyz`
     async fn foo(self, key: i32) -> (u32, i32) {
         (self, key)
     }

--- a/tests/ui/impl-trait/stashed-diag-issue-121504.stderr
+++ b/tests/ui/impl-trait/stashed-diag-issue-121504.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `xyz`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `xyz`
   --> $DIR/stashed-diag-issue-121504.rs:7:18
    |
 LL | impl MyTrait for xyz::T {
-   |                  ^^^ use of undeclared crate or module `xyz`
+   |                  ^^^ use of unresolved module or unlinked crate `xyz`
+   |
+   = help: you might be missing a crate named `xyz`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/imports/extern-prelude-extern-crate-fail.rs
+++ b/tests/ui/imports/extern-prelude-extern-crate-fail.rs
@@ -7,7 +7,7 @@ mod n {
 
 mod m {
     fn check() {
-        two_macros::m!(); //~ ERROR failed to resolve: use of undeclared crate or module `two_macros`
+        two_macros::m!(); //~ ERROR failed to resolve: use of unresolved module or unlinked crate `two_macros`
     }
 }
 

--- a/tests/ui/imports/extern-prelude-extern-crate-fail.stderr
+++ b/tests/ui/imports/extern-prelude-extern-crate-fail.stderr
@@ -9,11 +9,11 @@ LL | define_std_as_non_existent!();
    |
    = note: this error originates in the macro `define_std_as_non_existent` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0433]: failed to resolve: use of undeclared crate or module `two_macros`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `two_macros`
   --> $DIR/extern-prelude-extern-crate-fail.rs:10:9
    |
 LL |         two_macros::m!();
-   |         ^^^^^^^^^^ use of undeclared crate or module `two_macros`
+   |         ^^^^^^^^^^ use of unresolved module or unlinked crate `two_macros`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/imports/import-from-missing-star-2.stderr
+++ b/tests/ui/imports/import-from-missing-star-2.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star-2.rs:2:9
    |
 LL |     use spam::*;
-   |         ^^^^ you might be missing crate `spam`
+   |         ^^^^ use of unresolved module or unlinked crate `spam`
    |
-help: consider importing the `spam` crate
+help: you might be missing a crate named `spam`, add it to your project and import it in your code
    |
 LL + extern crate spam;
    |

--- a/tests/ui/imports/import-from-missing-star-3.stderr
+++ b/tests/ui/imports/import-from-missing-star-3.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star-3.rs:2:9
    |
 LL |     use spam::*;
-   |         ^^^^ you might be missing crate `spam`
+   |         ^^^^ use of unresolved module or unlinked crate `spam`
    |
-help: consider importing the `spam` crate
+help: you might be missing a crate named `spam`, add it to your project and import it in your code
    |
 LL + extern crate spam;
    |
@@ -13,9 +13,9 @@ error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star-3.rs:27:13
    |
 LL |         use spam::*;
-   |             ^^^^ you might be missing crate `spam`
+   |             ^^^^ use of unresolved module or unlinked crate `spam`
    |
-help: consider importing the `spam` crate
+help: you might be missing a crate named `spam`, add it to your project and import it in your code
    |
 LL + extern crate spam;
    |

--- a/tests/ui/imports/import-from-missing-star.stderr
+++ b/tests/ui/imports/import-from-missing-star.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `spam`
   --> $DIR/import-from-missing-star.rs:1:5
    |
 LL | use spam::*;
-   |     ^^^^ you might be missing crate `spam`
+   |     ^^^^ use of unresolved module or unlinked crate `spam`
    |
-help: consider importing the `spam` crate
+help: you might be missing a crate named `spam`, add it to your project and import it in your code
    |
 LL + extern crate spam;
    |

--- a/tests/ui/imports/import3.stderr
+++ b/tests/ui/imports/import3.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `main`
   --> $DIR/import3.rs:2:5
    |
 LL | use main::bar;
-   |     ^^^^ you might be missing crate `main`
+   |     ^^^^ use of unresolved module or unlinked crate `main`
    |
-help: consider importing the `main` crate
+help: you might be missing a crate named `main`, add it to your project and import it in your code
    |
 LL + extern crate main;
    |

--- a/tests/ui/imports/issue-109343.stderr
+++ b/tests/ui/imports/issue-109343.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `unresolved`
   --> $DIR/issue-109343.rs:4:9
    |
 LL | pub use unresolved::f;
-   |         ^^^^^^^^^^ you might be missing crate `unresolved`
+   |         ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
    |
-help: consider importing the `unresolved` crate
+help: you might be missing a crate named `unresolved`, add it to your project and import it in your code
    |
 LL + extern crate unresolved;
    |

--- a/tests/ui/imports/issue-1697.rs
+++ b/tests/ui/imports/issue-1697.rs
@@ -2,7 +2,7 @@
 
 use unresolved::*;
 //~^ ERROR unresolved import `unresolved` [E0432]
-//~| NOTE you might be missing crate `unresolved`
-//~| HELP consider importing the `unresolved` crate
+//~| NOTE use of unresolved module or unlinked crate `unresolved`
+//~| HELP you might be missing a crate named `unresolved`
 
 fn main() {}

--- a/tests/ui/imports/issue-1697.stderr
+++ b/tests/ui/imports/issue-1697.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `unresolved`
   --> $DIR/issue-1697.rs:3:5
    |
 LL | use unresolved::*;
-   |     ^^^^^^^^^^ you might be missing crate `unresolved`
+   |     ^^^^^^^^^^ use of unresolved module or unlinked crate `unresolved`
    |
-help: consider importing the `unresolved` crate
+help: you might be missing a crate named `unresolved`, add it to your project and import it in your code
    |
 LL + extern crate unresolved;
    |

--- a/tests/ui/imports/issue-33464.stderr
+++ b/tests/ui/imports/issue-33464.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `abc`
   --> $DIR/issue-33464.rs:3:5
    |
 LL | use abc::one_el;
-   |     ^^^ you might be missing crate `abc`
+   |     ^^^ use of unresolved module or unlinked crate `abc`
    |
-help: consider importing the `abc` crate
+help: you might be missing a crate named `abc`, add it to your project and import it in your code
    |
 LL + extern crate abc;
    |
@@ -13,9 +13,9 @@ error[E0432]: unresolved import `abc`
   --> $DIR/issue-33464.rs:5:5
    |
 LL | use abc::{a, bbb, cccccc};
-   |     ^^^ you might be missing crate `abc`
+   |     ^^^ use of unresolved module or unlinked crate `abc`
    |
-help: consider importing the `abc` crate
+help: you might be missing a crate named `abc`, add it to your project and import it in your code
    |
 LL + extern crate abc;
    |
@@ -24,9 +24,9 @@ error[E0432]: unresolved import `a_very_long_name`
   --> $DIR/issue-33464.rs:7:5
    |
 LL | use a_very_long_name::{el, el2};
-   |     ^^^^^^^^^^^^^^^^ you might be missing crate `a_very_long_name`
+   |     ^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `a_very_long_name`
    |
-help: consider importing the `a_very_long_name` crate
+help: you might be missing a crate named `a_very_long_name`, add it to your project and import it in your code
    |
 LL + extern crate a_very_long_name;
    |

--- a/tests/ui/imports/issue-36881.stderr
+++ b/tests/ui/imports/issue-36881.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `issue_36881_aux`
   --> $DIR/issue-36881.rs:5:9
    |
 LL |     use issue_36881_aux::Foo;
-   |         ^^^^^^^^^^^^^^^ you might be missing crate `issue_36881_aux`
+   |         ^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `issue_36881_aux`
    |
-help: consider importing the `issue_36881_aux` crate
+help: you might be missing a crate named `issue_36881_aux`, add it to your project and import it in your code
    |
 LL + extern crate issue_36881_aux;
    |

--- a/tests/ui/imports/issue-37887.stderr
+++ b/tests/ui/imports/issue-37887.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `test`
   --> $DIR/issue-37887.rs:3:9
    |
 LL |     use test::*;
-   |         ^^^^ you might be missing crate `test`
+   |         ^^^^ use of unresolved module or unlinked crate `test`
    |
-help: consider importing the `test` crate
+help: you might be missing a crate named `test`, add it to your project and import it in your code
    |
 LL + extern crate test;
    |

--- a/tests/ui/imports/issue-53269.stderr
+++ b/tests/ui/imports/issue-53269.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `nonexistent_module`
   --> $DIR/issue-53269.rs:6:9
    |
 LL |     use nonexistent_module::mac;
-   |         ^^^^^^^^^^^^^^^^^^ you might be missing crate `nonexistent_module`
+   |         ^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `nonexistent_module`
    |
-help: consider importing the `nonexistent_module` crate
+help: you might be missing a crate named `nonexistent_module`, add it to your project and import it in your code
    |
 LL + extern crate nonexistent_module;
    |

--- a/tests/ui/imports/issue-55457.stderr
+++ b/tests/ui/imports/issue-55457.stderr
@@ -11,9 +11,9 @@ error[E0432]: unresolved import `non_existent`
   --> $DIR/issue-55457.rs:2:5
    |
 LL | use non_existent::non_existent;
-   |     ^^^^^^^^^^^^ you might be missing crate `non_existent`
+   |     ^^^^^^^^^^^^ use of unresolved module or unlinked crate `non_existent`
    |
-help: consider importing the `non_existent` crate
+help: you might be missing a crate named `non_existent`, add it to your project and import it in your code
    |
 LL + extern crate non_existent;
    |

--- a/tests/ui/imports/issue-81413.stderr
+++ b/tests/ui/imports/issue-81413.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `doesnt_exist`
   --> $DIR/issue-81413.rs:7:9
    |
 LL | pub use doesnt_exist::*;
-   |         ^^^^^^^^^^^^ you might be missing crate `doesnt_exist`
+   |         ^^^^^^^^^^^^ use of unresolved module or unlinked crate `doesnt_exist`
    |
-help: consider importing the `doesnt_exist` crate
+help: you might be missing a crate named `doesnt_exist`, add it to your project and import it in your code
    |
 LL + extern crate doesnt_exist;
    |

--- a/tests/ui/imports/tool-mod-child.rs
+++ b/tests/ui/imports/tool-mod-child.rs
@@ -1,7 +1,7 @@
 use clippy::a; //~ ERROR unresolved import `clippy`
-use clippy::a::b; //~ ERROR failed to resolve: you might be missing crate `clippy`
+use clippy::a::b; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `clippy`
 
 use rustdoc::a; //~ ERROR unresolved import `rustdoc`
-use rustdoc::a::b; //~ ERROR failed to resolve: you might be missing crate `rustdoc`
+use rustdoc::a::b; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `rustdoc`
 
 fn main() {}

--- a/tests/ui/imports/tool-mod-child.stderr
+++ b/tests/ui/imports/tool-mod-child.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: you might be missing crate `clippy`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `clippy`
   --> $DIR/tool-mod-child.rs:2:5
    |
 LL | use clippy::a::b;
-   |     ^^^^^^ you might be missing crate `clippy`
+   |     ^^^^^^ use of unresolved module or unlinked crate `clippy`
    |
-help: consider importing the `clippy` crate
+help: you might be missing a crate named `clippy`, add it to your project and import it in your code
    |
 LL + extern crate clippy;
    |
@@ -13,20 +13,20 @@ error[E0432]: unresolved import `clippy`
   --> $DIR/tool-mod-child.rs:1:5
    |
 LL | use clippy::a;
-   |     ^^^^^^ you might be missing crate `clippy`
+   |     ^^^^^^ use of unresolved module or unlinked crate `clippy`
    |
-help: consider importing the `clippy` crate
+help: you might be missing a crate named `clippy`, add it to your project and import it in your code
    |
 LL + extern crate clippy;
    |
 
-error[E0433]: failed to resolve: you might be missing crate `rustdoc`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rustdoc`
   --> $DIR/tool-mod-child.rs:5:5
    |
 LL | use rustdoc::a::b;
-   |     ^^^^^^^ you might be missing crate `rustdoc`
+   |     ^^^^^^^ use of unresolved module or unlinked crate `rustdoc`
    |
-help: consider importing the `rustdoc` crate
+help: you might be missing a crate named `rustdoc`, add it to your project and import it in your code
    |
 LL + extern crate rustdoc;
    |
@@ -35,9 +35,9 @@ error[E0432]: unresolved import `rustdoc`
   --> $DIR/tool-mod-child.rs:4:5
    |
 LL | use rustdoc::a;
-   |     ^^^^^^^ you might be missing crate `rustdoc`
+   |     ^^^^^^^ use of unresolved module or unlinked crate `rustdoc`
    |
-help: consider importing the `rustdoc` crate
+help: you might be missing a crate named `rustdoc`, add it to your project and import it in your code
    |
 LL + extern crate rustdoc;
    |

--- a/tests/ui/imports/unresolved-imports-used.stderr
+++ b/tests/ui/imports/unresolved-imports-used.stderr
@@ -14,9 +14,9 @@ error[E0432]: unresolved import `foo`
   --> $DIR/unresolved-imports-used.rs:11:5
    |
 LL | use foo::bar;
-   |     ^^^ you might be missing crate `foo`
+   |     ^^^ use of unresolved module or unlinked crate `foo`
    |
-help: consider importing the `foo` crate
+help: you might be missing a crate named `foo`, add it to your project and import it in your code
    |
 LL + extern crate foo;
    |
@@ -25,9 +25,9 @@ error[E0432]: unresolved import `baz`
   --> $DIR/unresolved-imports-used.rs:12:5
    |
 LL | use baz::*;
-   |     ^^^ you might be missing crate `baz`
+   |     ^^^ use of unresolved module or unlinked crate `baz`
    |
-help: consider importing the `baz` crate
+help: you might be missing a crate named `baz`, add it to your project and import it in your code
    |
 LL + extern crate baz;
    |
@@ -36,9 +36,9 @@ error[E0432]: unresolved import `foo2`
   --> $DIR/unresolved-imports-used.rs:14:5
    |
 LL | use foo2::bar2;
-   |     ^^^^ you might be missing crate `foo2`
+   |     ^^^^ use of unresolved module or unlinked crate `foo2`
    |
-help: consider importing the `foo2` crate
+help: you might be missing a crate named `foo2`, add it to your project and import it in your code
    |
 LL + extern crate foo2;
    |
@@ -47,9 +47,9 @@ error[E0432]: unresolved import `baz2`
   --> $DIR/unresolved-imports-used.rs:15:5
    |
 LL | use baz2::*;
-   |     ^^^^ you might be missing crate `baz2`
+   |     ^^^^ use of unresolved module or unlinked crate `baz2`
    |
-help: consider importing the `baz2` crate
+help: you might be missing a crate named `baz2`, add it to your project and import it in your code
    |
 LL + extern crate baz2;
    |

--- a/tests/ui/issues/issue-33293.rs
+++ b/tests/ui/issues/issue-33293.rs
@@ -1,6 +1,6 @@
 fn main() {
     match 0 {
         aaa::bbb(_) => ()
-        //~^ ERROR failed to resolve: use of undeclared crate or module `aaa`
+        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `aaa`
     };
 }

--- a/tests/ui/issues/issue-33293.stderr
+++ b/tests/ui/issues/issue-33293.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `aaa`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `aaa`
   --> $DIR/issue-33293.rs:3:9
    |
 LL |         aaa::bbb(_) => ()
-   |         ^^^ use of undeclared crate or module `aaa`
+   |         ^^^ use of unresolved module or unlinked crate `aaa`
+   |
+   = help: you might be missing a crate named `aaa`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/keyword/extern/keyword-extern-as-identifier-use.stderr
+++ b/tests/ui/keyword/extern/keyword-extern-as-identifier-use.stderr
@@ -13,9 +13,9 @@ error[E0432]: unresolved import `r#extern`
   --> $DIR/keyword-extern-as-identifier-use.rs:1:5
    |
 LL | use extern::foo;
-   |     ^^^^^^ you might be missing crate `r#extern`
+   |     ^^^^^^ use of unresolved module or unlinked crate `r#extern`
    |
-help: consider importing the `r#extern` crate
+help: you might be missing a crate named `r#extern`, add it to your project and import it in your code
    |
 LL + extern crate r#extern;
    |

--- a/tests/ui/macros/builtin-prelude-no-accidents.rs
+++ b/tests/ui/macros/builtin-prelude-no-accidents.rs
@@ -2,7 +2,7 @@
 // because macros with the same names are in prelude.
 
 fn main() {
-    env::current_dir; //~ ERROR use of undeclared crate or module `env`
-    type A = panic::PanicInfo; //~ ERROR use of undeclared crate or module `panic`
-    type B = vec::Vec<u8>; //~ ERROR use of undeclared crate or module `vec`
+    env::current_dir; //~ ERROR use of unresolved module or unlinked crate `env`
+    type A = panic::PanicInfo; //~ ERROR use of unresolved module or unlinked crate `panic`
+    type B = vec::Vec<u8>; //~ ERROR use of unresolved module or unlinked crate `vec`
 }

--- a/tests/ui/macros/builtin-prelude-no-accidents.stderr
+++ b/tests/ui/macros/builtin-prelude-no-accidents.stderr
@@ -1,31 +1,34 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `env`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `env`
   --> $DIR/builtin-prelude-no-accidents.rs:5:5
    |
 LL |     env::current_dir;
-   |     ^^^ use of undeclared crate or module `env`
+   |     ^^^ use of unresolved module or unlinked crate `env`
    |
+   = help: you might be missing a crate named `env`
 help: consider importing this module
    |
 LL + use std::env;
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `panic`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `panic`
   --> $DIR/builtin-prelude-no-accidents.rs:6:14
    |
 LL |     type A = panic::PanicInfo;
-   |              ^^^^^ use of undeclared crate or module `panic`
+   |              ^^^^^ use of unresolved module or unlinked crate `panic`
    |
+   = help: you might be missing a crate named `panic`
 help: consider importing this module
    |
 LL + use std::panic;
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `vec`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `vec`
   --> $DIR/builtin-prelude-no-accidents.rs:7:14
    |
 LL |     type B = vec::Vec<u8>;
-   |              ^^^ use of undeclared crate or module `vec`
+   |              ^^^ use of unresolved module or unlinked crate `vec`
    |
+   = help: you might be missing a crate named `vec`
 help: consider importing this module
    |
 LL + use std::vec;

--- a/tests/ui/macros/macro-inner-attributes.rs
+++ b/tests/ui/macros/macro-inner-attributes.rs
@@ -15,6 +15,6 @@ test!(b,
 #[rustc_dummy]
 fn main() {
     a::bar();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `a`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `a`
     b::bar();
 }

--- a/tests/ui/macros/macro-inner-attributes.stderr
+++ b/tests/ui/macros/macro-inner-attributes.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `a`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `a`
   --> $DIR/macro-inner-attributes.rs:17:5
    |
 LL |     a::bar();
-   |     ^ use of undeclared crate or module `a`
+   |     ^ use of unresolved module or unlinked crate `a`
    |
 help: there is a crate or module with a similar name
    |

--- a/tests/ui/macros/macro_path_as_generic_bound.stderr
+++ b/tests/ui/macros/macro_path_as_generic_bound.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `m`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `m`
   --> $DIR/macro_path_as_generic_bound.rs:7:6
    |
 LL | foo!(m::m2::A);
-   |      ^ use of undeclared crate or module `m`
+   |      ^ use of unresolved module or unlinked crate `m`
+   |
+   = help: you might be missing a crate named `m`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/macros/meta-item-absolute-path.stderr
+++ b/tests/ui/macros/meta-item-absolute-path.stderr
@@ -1,14 +1,14 @@
-error[E0433]: failed to resolve: you might be missing crate `Absolute`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `Absolute`
   --> $DIR/meta-item-absolute-path.rs:1:12
    |
 LL | #[derive(::Absolute)]
-   |            ^^^^^^^^ you might be missing crate `Absolute`
+   |            ^^^^^^^^ use of unresolved module or unlinked crate `Absolute`
 
-error[E0433]: failed to resolve: you might be missing crate `Absolute`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `Absolute`
   --> $DIR/meta-item-absolute-path.rs:1:12
    |
 LL | #[derive(::Absolute)]
-   |            ^^^^^^^^ you might be missing crate `Absolute`
+   |            ^^^^^^^^ use of unresolved module or unlinked crate `Absolute`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 

--- a/tests/ui/mir/issue-121103.rs
+++ b/tests/ui/mir/issue-121103.rs
@@ -1,3 +1,3 @@
 fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}
-//~^ ERROR failed to resolve: use of undeclared crate or module `lib2`
-//~| ERROR failed to resolve: use of undeclared crate or module `lib2`
+//~^ ERROR failed to resolve: use of unresolved module or unlinked crate `lib2`
+//~| ERROR failed to resolve: use of unresolved module or unlinked crate `lib2`

--- a/tests/ui/mir/issue-121103.stderr
+++ b/tests/ui/mir/issue-121103.stderr
@@ -1,14 +1,18 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `lib2`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `lib2`
   --> $DIR/issue-121103.rs:1:38
    |
 LL | fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}
-   |                                      ^^^^ use of undeclared crate or module `lib2`
+   |                                      ^^^^ use of unresolved module or unlinked crate `lib2`
+   |
+   = help: you might be missing a crate named `lib2`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `lib2`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `lib2`
   --> $DIR/issue-121103.rs:1:13
    |
 LL | fn main(_: <lib2::GenericType<42> as lib2::TypeFn>::Output) {}
-   |             ^^^^ use of undeclared crate or module `lib2`
+   |             ^^^^ use of unresolved module or unlinked crate `lib2`
+   |
+   = help: you might be missing a crate named `lib2`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/modules_and_files_visibility/mod_file_disambig.rs
+++ b/tests/ui/modules_and_files_visibility/mod_file_disambig.rs
@@ -2,5 +2,5 @@ mod mod_file_disambig_aux; //~ ERROR file for module `mod_file_disambig_aux` fou
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);
-    //~^ ERROR failed to resolve: use of undeclared crate or module `mod_file_aux`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
 }

--- a/tests/ui/modules_and_files_visibility/mod_file_disambig.stderr
+++ b/tests/ui/modules_and_files_visibility/mod_file_disambig.stderr
@@ -6,11 +6,13 @@ LL | mod mod_file_disambig_aux;
    |
    = help: delete or rename one of them to remove the ambiguity
 
-error[E0433]: failed to resolve: use of undeclared crate or module `mod_file_aux`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
   --> $DIR/mod_file_disambig.rs:4:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);
-   |                ^^^^^^^^^^^^ use of undeclared crate or module `mod_file_aux`
+   |                ^^^^^^^^^^^^ use of unresolved module or unlinked crate `mod_file_aux`
+   |
+   = help: you might be missing a crate named `mod_file_aux`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/const-param-decl-on-type-instead-of-impl.rs
+++ b/tests/ui/parser/const-param-decl-on-type-instead-of-impl.rs
@@ -11,5 +11,5 @@ fn banana(a: <T<const N: usize>>::BAR) {}
 fn chaenomeles() {
     path::path::Struct::<const N: usize>()
     //~^ ERROR unexpected `const` parameter declaration
-    //~| ERROR failed to resolve: use of undeclared crate or module `path`
+    //~| ERROR failed to resolve: use of unresolved module or unlinked crate `path`
 }

--- a/tests/ui/parser/const-param-decl-on-type-instead-of-impl.stderr
+++ b/tests/ui/parser/const-param-decl-on-type-instead-of-impl.stderr
@@ -21,11 +21,13 @@ error: unexpected `const` parameter declaration
 LL |     path::path::Struct::<const N: usize>()
    |                          ^^^^^^^^^^^^^^ expected a `const` expression, not a parameter declaration
 
-error[E0433]: failed to resolve: use of undeclared crate or module `path`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `path`
   --> $DIR/const-param-decl-on-type-instead-of-impl.rs:12:5
    |
 LL |     path::path::Struct::<const N: usize>()
-   |     ^^^^ use of undeclared crate or module `path`
+   |     ^^^^ use of unresolved module or unlinked crate `path`
+   |
+   = help: you might be missing a crate named `path`
 
 error[E0412]: cannot find type `T` in this scope
   --> $DIR/const-param-decl-on-type-instead-of-impl.rs:8:15

--- a/tests/ui/parser/dyn-trait-compatibility.rs
+++ b/tests/ui/parser/dyn-trait-compatibility.rs
@@ -1,7 +1,7 @@
 type A0 = dyn;
 //~^ ERROR cannot find type `dyn` in this scope
 type A1 = dyn::dyn;
-//~^ ERROR use of undeclared crate or module `dyn`
+//~^ ERROR use of unresolved module or unlinked crate `dyn`
 type A2 = dyn<dyn, dyn>;
 //~^ ERROR cannot find type `dyn` in this scope
 //~| ERROR cannot find type `dyn` in this scope

--- a/tests/ui/parser/dyn-trait-compatibility.stderr
+++ b/tests/ui/parser/dyn-trait-compatibility.stderr
@@ -40,11 +40,13 @@ error[E0412]: cannot find type `dyn` in this scope
 LL | type A3 = dyn<<dyn as dyn>::dyn>;
    |                ^^^ not found in this scope
 
-error[E0433]: failed to resolve: use of undeclared crate or module `dyn`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `dyn`
   --> $DIR/dyn-trait-compatibility.rs:3:11
    |
 LL | type A1 = dyn::dyn;
-   |           ^^^ use of undeclared crate or module `dyn`
+   |           ^^^ use of unresolved module or unlinked crate `dyn`
+   |
+   = help: you might be missing a crate named `dyn`
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/parser/mod_file_not_exist.rs
+++ b/tests/ui/parser/mod_file_not_exist.rs
@@ -5,5 +5,6 @@ mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);
-    //~^ ERROR failed to resolve: use of undeclared crate or module `mod_file_aux`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
+    //~| HELP you might be missing a crate named `mod_file_aux`
 }

--- a/tests/ui/parser/mod_file_not_exist.stderr
+++ b/tests/ui/parser/mod_file_not_exist.stderr
@@ -7,11 +7,13 @@ LL | mod not_a_real_file;
    = help: to create the module `not_a_real_file`, create file "$DIR/not_a_real_file.rs" or "$DIR/not_a_real_file/mod.rs"
    = note: if there is a `mod not_a_real_file` elsewhere in the crate already, import it with `use crate::...` instead
 
-error[E0433]: failed to resolve: use of undeclared crate or module `mod_file_aux`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
   --> $DIR/mod_file_not_exist.rs:7:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);
-   |                ^^^^^^^^^^^^ use of undeclared crate or module `mod_file_aux`
+   |                ^^^^^^^^^^^^ use of unresolved module or unlinked crate `mod_file_aux`
+   |
+   = help: you might be missing a crate named `mod_file_aux`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/parser/mod_file_not_exist_windows.rs
+++ b/tests/ui/parser/mod_file_not_exist_windows.rs
@@ -5,5 +5,6 @@ mod not_a_real_file; //~ ERROR file not found for module `not_a_real_file`
 
 fn main() {
     assert_eq!(mod_file_aux::bar(), 10);
-    //~^ ERROR failed to resolve: use of undeclared crate or module `mod_file_aux`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
+    //~| HELP you might be missing a crate named `mod_file_aux`
 }

--- a/tests/ui/parser/mod_file_not_exist_windows.stderr
+++ b/tests/ui/parser/mod_file_not_exist_windows.stderr
@@ -7,11 +7,13 @@ LL | mod not_a_real_file;
    = help: to create the module `not_a_real_file`, create file "$DIR/not_a_real_file.rs" or "$DIR/not_a_real_file/mod.rs"
    = note: if there is a `mod not_a_real_file` elsewhere in the crate already, import it with `use crate::...` instead
 
-error[E0433]: failed to resolve: use of undeclared crate or module `mod_file_aux`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `mod_file_aux`
   --> $DIR/mod_file_not_exist_windows.rs:7:16
    |
 LL |     assert_eq!(mod_file_aux::bar(), 10);
-   |                ^^^^^^^^^^^^ use of undeclared crate or module `mod_file_aux`
+   |                ^^^^^^^^^^^^ use of unresolved module or unlinked crate `mod_file_aux`
+   |
+   = help: you might be missing a crate named `mod_file_aux`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/privacy/restricted/test.rs
+++ b/tests/ui/privacy/restricted/test.rs
@@ -47,6 +47,6 @@ fn main() {
 }
 
 mod pathological {
-    pub(in bad::path) mod m1 {} //~ ERROR failed to resolve: you might be missing crate `bad`
+    pub(in bad::path) mod m1 {} //~ ERROR failed to resolve: use of unresolved module or unlinked crate `bad`
     pub(in foo) mod m2 {} //~ ERROR visibilities can only be restricted to ancestor modules
 }

--- a/tests/ui/privacy/restricted/test.stderr
+++ b/tests/ui/privacy/restricted/test.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: you might be missing crate `bad`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `bad`
   --> $DIR/test.rs:50:12
    |
 LL |     pub(in bad::path) mod m1 {}
-   |            ^^^ you might be missing crate `bad`
+   |            ^^^ use of unresolved module or unlinked crate `bad`
    |
-help: consider importing the `bad` crate
+help: you might be missing a crate named `bad`, add it to your project and import it in your code
    |
 LL + extern crate bad;
    |

--- a/tests/ui/resolve/112590-2.stderr
+++ b/tests/ui/resolve/112590-2.stderr
@@ -14,12 +14,13 @@ LL -         let _: Vec<i32> = super::foo::baf::baz::MyVec::new();
 LL +         let _: Vec<i32> = MyVec::new();
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `fox`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `fox`
   --> $DIR/112590-2.rs:18:27
    |
 LL |         let _: Vec<i32> = fox::bar::baz::MyVec::new();
-   |                           ^^^ use of undeclared crate or module `fox`
+   |                           ^^^ use of unresolved module or unlinked crate `fox`
    |
+   = help: you might be missing a crate named `fox`
 help: consider importing this struct through its public re-export
    |
 LL +     use foo::bar::baz::MyVec;
@@ -30,12 +31,13 @@ LL -         let _: Vec<i32> = fox::bar::baz::MyVec::new();
 LL +         let _: Vec<i32> = MyVec::new();
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `vec`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `vec`
   --> $DIR/112590-2.rs:24:15
    |
 LL |     type _B = vec::Vec::<u8>;
-   |               ^^^ use of undeclared crate or module `vec`
+   |               ^^^ use of unresolved module or unlinked crate `vec`
    |
+   = help: you might be missing a crate named `vec`
 help: consider importing this module
    |
 LL + use std::vec;
@@ -57,14 +59,16 @@ LL -     let _t = std::sync_error::atomic::AtomicBool::new(true);
 LL +     let _t = AtomicBool::new(true);
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `vec`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `vec`
   --> $DIR/112590-2.rs:23:24
    |
 LL |     let _t: Vec<i32> = vec::new();
    |                        ^^^
    |                        |
-   |                        use of undeclared crate or module `vec`
+   |                        use of unresolved module or unlinked crate `vec`
    |                        help: a struct with a similar name exists (notice the capitalization): `Vec`
+   |
+   = help: you might be missing a crate named `vec`
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/resolve/bad-module.rs
+++ b/tests/ui/resolve/bad-module.rs
@@ -1,7 +1,7 @@
 fn main() {
     let foo = thing::len(Vec::new());
-    //~^ ERROR failed to resolve: use of undeclared crate or module `thing`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `thing`
 
     let foo = foo::bar::baz();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `foo`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `foo`
 }

--- a/tests/ui/resolve/bad-module.stderr
+++ b/tests/ui/resolve/bad-module.stderr
@@ -1,14 +1,18 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
   --> $DIR/bad-module.rs:5:15
    |
 LL |     let foo = foo::bar::baz();
-   |               ^^^ use of undeclared crate or module `foo`
+   |               ^^^ use of unresolved module or unlinked crate `foo`
+   |
+   = help: you might be missing a crate named `foo`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `thing`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `thing`
   --> $DIR/bad-module.rs:2:15
    |
 LL |     let foo = thing::len(Vec::new());
-   |               ^^^^^ use of undeclared crate or module `thing`
+   |               ^^^^^ use of unresolved module or unlinked crate `thing`
+   |
+   = help: you might be missing a crate named `thing`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/resolve/editions-crate-root-2015.rs
+++ b/tests/ui/resolve/editions-crate-root-2015.rs
@@ -2,10 +2,10 @@
 
 mod inner {
     fn global_inner(_: ::nonexistant::Foo) {
-        //~^ ERROR failed to resolve: you might be missing crate `nonexistant`
+        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `nonexistant`
     }
     fn crate_inner(_: crate::nonexistant::Foo) {
-        //~^ ERROR failed to resolve: you might be missing crate `nonexistant`
+        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `nonexistant`
     }
 
     fn bare_global(_: ::nonexistant) {

--- a/tests/ui/resolve/editions-crate-root-2015.stderr
+++ b/tests/ui/resolve/editions-crate-root-2015.stderr
@@ -1,21 +1,21 @@
-error[E0433]: failed to resolve: you might be missing crate `nonexistant`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistant`
   --> $DIR/editions-crate-root-2015.rs:4:26
    |
 LL |     fn global_inner(_: ::nonexistant::Foo) {
-   |                          ^^^^^^^^^^^ you might be missing crate `nonexistant`
+   |                          ^^^^^^^^^^^ use of unresolved module or unlinked crate `nonexistant`
    |
-help: consider importing the `nonexistant` crate
+help: you might be missing a crate named `nonexistant`, add it to your project and import it in your code
    |
 LL + extern crate nonexistant;
    |
 
-error[E0433]: failed to resolve: you might be missing crate `nonexistant`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistant`
   --> $DIR/editions-crate-root-2015.rs:7:30
    |
 LL |     fn crate_inner(_: crate::nonexistant::Foo) {
-   |                              ^^^^^^^^^^^ you might be missing crate `nonexistant`
+   |                              ^^^^^^^^^^^ use of unresolved module or unlinked crate `nonexistant`
    |
-help: consider importing the `nonexistant` crate
+help: you might be missing a crate named `nonexistant`, add it to your project and import it in your code
    |
 LL + extern crate nonexistant;
    |

--- a/tests/ui/resolve/export-fully-qualified-2018.rs
+++ b/tests/ui/resolve/export-fully-qualified-2018.rs
@@ -5,7 +5,7 @@
 // want to change eventually.
 
 mod foo {
-    pub fn bar() { foo::baz(); } //~ ERROR failed to resolve: use of undeclared crate or module `foo`
+    pub fn bar() { foo::baz(); } //~ ERROR failed to resolve: use of unresolved module or unlinked crate `foo`
 
     fn baz() { }
 }

--- a/tests/ui/resolve/export-fully-qualified-2018.stderr
+++ b/tests/ui/resolve/export-fully-qualified-2018.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
   --> $DIR/export-fully-qualified-2018.rs:8:20
    |
 LL |     pub fn bar() { foo::baz(); }
-   |                    ^^^ use of undeclared crate or module `foo`
+   |                    ^^^ use of unresolved module or unlinked crate `foo`
+   |
+   = help: you might be missing a crate named `foo`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/export-fully-qualified.rs
+++ b/tests/ui/resolve/export-fully-qualified.rs
@@ -5,7 +5,7 @@
 // want to change eventually.
 
 mod foo {
-    pub fn bar() { foo::baz(); } //~ ERROR failed to resolve: use of undeclared crate or module `foo`
+    pub fn bar() { foo::baz(); } //~ ERROR failed to resolve: use of unresolved module or unlinked crate `foo`
 
     fn baz() { }
 }

--- a/tests/ui/resolve/export-fully-qualified.stderr
+++ b/tests/ui/resolve/export-fully-qualified.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
   --> $DIR/export-fully-qualified.rs:8:20
    |
 LL |     pub fn bar() { foo::baz(); }
-   |                    ^^^ use of undeclared crate or module `foo`
+   |                    ^^^ use of unresolved module or unlinked crate `foo`
+   |
+   = help: you might be missing a crate named `foo`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/extern-prelude-fail.stderr
+++ b/tests/ui/resolve/extern-prelude-fail.stderr
@@ -2,20 +2,20 @@ error[E0432]: unresolved import `extern_prelude`
   --> $DIR/extern-prelude-fail.rs:7:9
    |
 LL |     use extern_prelude::S;
-   |         ^^^^^^^^^^^^^^ you might be missing crate `extern_prelude`
+   |         ^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `extern_prelude`
    |
-help: consider importing the `extern_prelude` crate
+help: you might be missing a crate named `extern_prelude`, add it to your project and import it in your code
    |
 LL + extern crate extern_prelude;
    |
 
-error[E0433]: failed to resolve: you might be missing crate `extern_prelude`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `extern_prelude`
   --> $DIR/extern-prelude-fail.rs:8:15
    |
 LL |     let s = ::extern_prelude::S;
-   |               ^^^^^^^^^^^^^^ you might be missing crate `extern_prelude`
+   |               ^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `extern_prelude`
    |
-help: consider importing the `extern_prelude` crate
+help: you might be missing a crate named `extern_prelude`, add it to your project and import it in your code
    |
 LL + extern crate extern_prelude;
    |

--- a/tests/ui/resolve/issue-101749-2.rs
+++ b/tests/ui/resolve/issue-101749-2.rs
@@ -12,5 +12,5 @@ fn main() {
     let rect = Rectangle::new(3, 4);
     // `area` is not implemented for `Rectangle`, so this should not suggest
     let _ = rect::area();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `rect`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `rect`
 }

--- a/tests/ui/resolve/issue-101749-2.stderr
+++ b/tests/ui/resolve/issue-101749-2.stderr
@@ -1,8 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `rect`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rect`
   --> $DIR/issue-101749-2.rs:14:13
    |
 LL |     let _ = rect::area();
-   |             ^^^^ use of undeclared crate or module `rect`
+   |             ^^^^ use of unresolved module or unlinked crate `rect`
+   |
+   = help: you might be missing a crate named `rect`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/resolve/issue-101749.fixed
+++ b/tests/ui/resolve/issue-101749.fixed
@@ -15,5 +15,5 @@ impl Rectangle {
 fn main() {
     let rect = Rectangle::new(3, 4);
     let _ = rect.area();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `rect`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `rect`
 }

--- a/tests/ui/resolve/issue-101749.rs
+++ b/tests/ui/resolve/issue-101749.rs
@@ -15,5 +15,5 @@ impl Rectangle {
 fn main() {
     let rect = Rectangle::new(3, 4);
     let _ = rect::area();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `rect`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `rect`
 }

--- a/tests/ui/resolve/issue-101749.stderr
+++ b/tests/ui/resolve/issue-101749.stderr
@@ -1,9 +1,10 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `rect`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `rect`
   --> $DIR/issue-101749.rs:17:13
    |
 LL |     let _ = rect::area();
-   |             ^^^^ use of undeclared crate or module `rect`
+   |             ^^^^ use of unresolved module or unlinked crate `rect`
    |
+   = help: you might be missing a crate named `rect`
 help: you may have meant to call an instance method
    |
 LL |     let _ = rect.area();

--- a/tests/ui/resolve/issue-82865.rs
+++ b/tests/ui/resolve/issue-82865.rs
@@ -2,7 +2,7 @@
 
 #![feature(decl_macro)]
 
-use x::y::z; //~ ERROR: failed to resolve: you might be missing crate `x`
+use x::y::z; //~ ERROR: failed to resolve: use of unresolved module or unlinked crate `x`
 
 macro mac () {
     Box::z //~ ERROR: no function or associated item

--- a/tests/ui/resolve/issue-82865.stderr
+++ b/tests/ui/resolve/issue-82865.stderr
@@ -1,10 +1,10 @@
-error[E0433]: failed to resolve: you might be missing crate `x`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `x`
   --> $DIR/issue-82865.rs:5:5
    |
 LL | use x::y::z;
-   |     ^ you might be missing crate `x`
+   |     ^ use of unresolved module or unlinked crate `x`
    |
-help: consider importing the `x` crate
+help: you might be missing a crate named `x`, add it to your project and import it in your code
    |
 LL + extern crate x;
    |

--- a/tests/ui/resolve/resolve-bad-visibility.stderr
+++ b/tests/ui/resolve/resolve-bad-visibility.stderr
@@ -16,24 +16,24 @@ error[E0742]: visibilities can only be restricted to ancestor modules
 LL | pub(in std::vec) struct F;
    |        ^^^^^^^^
 
-error[E0433]: failed to resolve: you might be missing crate `nonexistent`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `nonexistent`
   --> $DIR/resolve-bad-visibility.rs:7:8
    |
 LL | pub(in nonexistent) struct G;
-   |        ^^^^^^^^^^^ you might be missing crate `nonexistent`
+   |        ^^^^^^^^^^^ use of unresolved module or unlinked crate `nonexistent`
    |
-help: consider importing the `nonexistent` crate
+help: you might be missing a crate named `nonexistent`, add it to your project and import it in your code
    |
 LL + extern crate nonexistent;
    |
 
-error[E0433]: failed to resolve: you might be missing crate `too_soon`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `too_soon`
   --> $DIR/resolve-bad-visibility.rs:8:8
    |
 LL | pub(in too_soon) struct H;
-   |        ^^^^^^^^ you might be missing crate `too_soon`
+   |        ^^^^^^^^ use of unresolved module or unlinked crate `too_soon`
    |
-help: consider importing the `too_soon` crate
+help: you might be missing a crate named `too_soon`, add it to your project and import it in your code
    |
 LL + extern crate too_soon;
    |

--- a/tests/ui/resolve/typo-suggestion-mistyped-in-path.rs
+++ b/tests/ui/resolve/typo-suggestion-mistyped-in-path.rs
@@ -29,8 +29,8 @@ fn main() {
     //~| NOTE use of undeclared type `Struc`
 
     modul::foo();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `modul`
-    //~| NOTE use of undeclared crate or module `modul`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `modul`
+    //~| NOTE use of unresolved module or unlinked crate `modul`
 
     module::Struc::foo();
     //~^ ERROR failed to resolve: could not find `Struc` in `module`

--- a/tests/ui/resolve/typo-suggestion-mistyped-in-path.stderr
+++ b/tests/ui/resolve/typo-suggestion-mistyped-in-path.stderr
@@ -30,11 +30,11 @@ LL |     Struc::foo();
    |     use of undeclared type `Struc`
    |     help: a struct with a similar name exists: `Struct`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `modul`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `modul`
   --> $DIR/typo-suggestion-mistyped-in-path.rs:31:5
    |
 LL |     modul::foo();
-   |     ^^^^^ use of undeclared crate or module `modul`
+   |     ^^^^^ use of unresolved module or unlinked crate `modul`
    |
 help: there is a crate or module with a similar name
    |

--- a/tests/ui/rfcs/rfc-2126-extern-absolute-paths/non-existent-1.stderr
+++ b/tests/ui/rfcs/rfc-2126-extern-absolute-paths/non-existent-1.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `xcrate`
   --> $DIR/non-existent-1.rs:3:5
    |
 LL | use xcrate::S;
-   |     ^^^^^^ use of undeclared crate or module `xcrate`
+   |     ^^^^^^ use of unresolved module or unlinked crate `xcrate`
+   |
+   = help: you might be missing a crate named `xcrate`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rust-2018/unresolved-asterisk-imports.stderr
+++ b/tests/ui/rust-2018/unresolved-asterisk-imports.stderr
@@ -2,7 +2,9 @@ error[E0432]: unresolved import `not_existing_crate`
   --> $DIR/unresolved-asterisk-imports.rs:3:5
    |
 LL | use not_existing_crate::*;
-   |     ^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `not_existing_crate`
+   |     ^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `not_existing_crate`
+   |
+   = help: you might be missing a crate named `not_existing_crate`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/suggestions/crate-or-module-typo.rs
+++ b/tests/ui/suggestions/crate-or-module-typo.rs
@@ -1,6 +1,6 @@
 //@ edition:2018
 
-use st::cell::Cell; //~ ERROR failed to resolve: use of undeclared crate or module `st`
+use st::cell::Cell; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `st`
 
 mod bar {
     pub fn bar() { bar::baz(); } //~ ERROR failed to resolve: function `bar` is not a crate or module
@@ -11,7 +11,7 @@ mod bar {
 use bas::bar; //~ ERROR unresolved import `bas`
 
 struct Foo {
-    bar: st::cell::Cell<bool> //~ ERROR failed to resolve: use of undeclared crate or module `st`
+    bar: st::cell::Cell<bool> //~ ERROR failed to resolve: use of unresolved module or unlinked crate `st`
 }
 
 fn main() {}

--- a/tests/ui/suggestions/crate-or-module-typo.stderr
+++ b/tests/ui/suggestions/crate-or-module-typo.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `st`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `st`
   --> $DIR/crate-or-module-typo.rs:3:5
    |
 LL | use st::cell::Cell;
-   |     ^^ use of undeclared crate or module `st`
+   |     ^^ use of unresolved module or unlinked crate `st`
    |
 help: there is a crate or module with a similar name
    |
@@ -13,18 +13,18 @@ error[E0432]: unresolved import `bas`
   --> $DIR/crate-or-module-typo.rs:11:5
    |
 LL | use bas::bar;
-   |     ^^^ use of undeclared crate or module `bas`
+   |     ^^^ use of unresolved module or unlinked crate `bas`
    |
 help: there is a crate or module with a similar name
    |
 LL | use bar::bar;
    |     ~~~
 
-error[E0433]: failed to resolve: use of undeclared crate or module `st`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `st`
   --> $DIR/crate-or-module-typo.rs:14:10
    |
 LL |     bar: st::cell::Cell<bool>
-   |          ^^ use of undeclared crate or module `st`
+   |          ^^ use of unresolved module or unlinked crate `st`
    |
 help: there is a crate or module with a similar name
    |

--- a/tests/ui/suggestions/issue-112590-suggest-import.rs
+++ b/tests/ui/suggestions/issue-112590-suggest-import.rs
@@ -1,8 +1,8 @@
 pub struct S;
 
-impl fmt::Debug for S { //~ ERROR failed to resolve: use of undeclared crate or module `fmt`
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result { //~ ERROR failed to resolve: use of undeclared crate or module `fmt`
-        //~^ ERROR failed to resolve: use of undeclared crate or module `fmt`
+impl fmt::Debug for S { //~ ERROR failed to resolve: use of unresolved module or unlinked crate `fmt`
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result { //~ ERROR failed to resolve: use of unresolved module or unlinked crate `fmt`
+        //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `fmt`
         Ok(())
     }
 }

--- a/tests/ui/suggestions/issue-112590-suggest-import.stderr
+++ b/tests/ui/suggestions/issue-112590-suggest-import.stderr
@@ -1,31 +1,34 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `fmt`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `fmt`
   --> $DIR/issue-112590-suggest-import.rs:3:6
    |
 LL | impl fmt::Debug for S {
-   |      ^^^ use of undeclared crate or module `fmt`
+   |      ^^^ use of unresolved module or unlinked crate `fmt`
    |
+   = help: you might be missing a crate named `fmt`
 help: consider importing this module
    |
 LL + use std::fmt;
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `fmt`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `fmt`
   --> $DIR/issue-112590-suggest-import.rs:4:28
    |
 LL |     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-   |                            ^^^ use of undeclared crate or module `fmt`
+   |                            ^^^ use of unresolved module or unlinked crate `fmt`
    |
+   = help: you might be missing a crate named `fmt`
 help: consider importing this module
    |
 LL + use std::fmt;
    |
 
-error[E0433]: failed to resolve: use of undeclared crate or module `fmt`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `fmt`
   --> $DIR/issue-112590-suggest-import.rs:4:51
    |
 LL |     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-   |                                                   ^^^ use of undeclared crate or module `fmt`
+   |                                                   ^^^ use of unresolved module or unlinked crate `fmt`
    |
+   = help: you might be missing a crate named `fmt`
 help: consider importing this module
    |
 LL + use std::fmt;

--- a/tests/ui/suggestions/undeclared-module-alloc.rs
+++ b/tests/ui/suggestions/undeclared-module-alloc.rs
@@ -1,5 +1,5 @@
 //@ edition:2018
 
-use alloc::rc::Rc; //~ ERROR failed to resolve: use of undeclared crate or module `alloc`
+use alloc::rc::Rc; //~ ERROR failed to resolve: use of unresolved module or unlinked crate `alloc`
 
 fn main() {}

--- a/tests/ui/suggestions/undeclared-module-alloc.stderr
+++ b/tests/ui/suggestions/undeclared-module-alloc.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `alloc`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `alloc`
   --> $DIR/undeclared-module-alloc.rs:3:5
    |
 LL | use alloc::rc::Rc;
-   |     ^^^^^ use of undeclared crate or module `alloc`
+   |     ^^^^^ use of unresolved module or unlinked crate `alloc`
    |
    = help: add `extern crate alloc` to use the `alloc` crate
 

--- a/tests/ui/tool-attributes/unknown-tool-name.rs
+++ b/tests/ui/tool-attributes/unknown-tool-name.rs
@@ -1,2 +1,2 @@
-#[foo::bar] //~ ERROR failed to resolve: use of undeclared crate or module `foo`
+#[foo::bar] //~ ERROR failed to resolve: use of unresolved module or unlinked crate `foo`
 fn main() {}

--- a/tests/ui/tool-attributes/unknown-tool-name.stderr
+++ b/tests/ui/tool-attributes/unknown-tool-name.stderr
@@ -1,8 +1,8 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `foo`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `foo`
   --> $DIR/unknown-tool-name.rs:1:3
    |
 LL | #[foo::bar]
-   |   ^^^ use of undeclared crate or module `foo`
+   |   ^^^ use of unresolved module or unlinked crate `foo`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/typeck/issue-120856.rs
+++ b/tests/ui/typeck/issue-120856.rs
@@ -1,5 +1,5 @@
 pub type Archived<T> = <m::Alias as n::Trait>::Archived;
-//~^ ERROR failed to resolve: use of undeclared crate or module `m`
-//~| ERROR failed to resolve: use of undeclared crate or module `n`
+//~^ ERROR failed to resolve: use of unresolved module or unlinked crate `m`
+//~| ERROR failed to resolve: use of unresolved module or unlinked crate `n`
 
 fn main() {}

--- a/tests/ui/typeck/issue-120856.stderr
+++ b/tests/ui/typeck/issue-120856.stderr
@@ -1,20 +1,24 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `n`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `n`
   --> $DIR/issue-120856.rs:1:37
    |
 LL | pub type Archived<T> = <m::Alias as n::Trait>::Archived;
    |                                     ^
    |                                     |
-   |                                     use of undeclared crate or module `n`
+   |                                     use of unresolved module or unlinked crate `n`
    |                                     help: a trait with a similar name exists: `Fn`
+   |
+   = help: you might be missing a crate named `n`
 
-error[E0433]: failed to resolve: use of undeclared crate or module `m`
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `m`
   --> $DIR/issue-120856.rs:1:25
    |
 LL | pub type Archived<T> = <m::Alias as n::Trait>::Archived;
    |                         ^
    |                         |
-   |                         use of undeclared crate or module `m`
+   |                         use of unresolved module or unlinked crate `m`
    |                         help: a type parameter with a similar name exists: `T`
+   |
+   = help: you might be missing a crate named `m`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/typeck/path-to-method-sugg-unresolved-expr.cargo-invoked.stderr
+++ b/tests/ui/typeck/path-to-method-sugg-unresolved-expr.cargo-invoked.stderr
@@ -1,0 +1,11 @@
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `page_size`
+  --> $DIR/path-to-method-sugg-unresolved-expr.rs:5:21
+   |
+LL |     let page_size = page_size::get();
+   |                     ^^^^^^^^^ use of unresolved module or unlinked crate `page_size`
+   |
+   = help: if you wanted to use a crate named `page_size`, use `cargo add page_size` to add it to your `Cargo.toml`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/typeck/path-to-method-sugg-unresolved-expr.only-rustc.stderr
+++ b/tests/ui/typeck/path-to-method-sugg-unresolved-expr.only-rustc.stderr
@@ -1,0 +1,11 @@
+error[E0433]: failed to resolve: use of unresolved module or unlinked crate `page_size`
+  --> $DIR/path-to-method-sugg-unresolved-expr.rs:5:21
+   |
+LL |     let page_size = page_size::get();
+   |                     ^^^^^^^^^ use of unresolved module or unlinked crate `page_size`
+   |
+   = help: you might be missing a crate named `page_size`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/typeck/path-to-method-sugg-unresolved-expr.rs
+++ b/tests/ui/typeck/path-to-method-sugg-unresolved-expr.rs
@@ -1,4 +1,10 @@
+//@ revisions: only-rustc cargo-invoked
+//@[only-rustc] unset-rustc-env:CARGO_CRATE_NAME
+//@[cargo-invoked] rustc-env:CARGO_CRATE_NAME=foo
 fn main() {
     let page_size = page_size::get();
-    //~^ ERROR failed to resolve: use of undeclared crate or module `page_size`
+    //~^ ERROR failed to resolve: use of unresolved module or unlinked crate `page_size`
+    //~| NOTE use of unresolved module or unlinked crate `page_size`
+    //@[cargo-invoked]~^^^ HELP if you wanted to use a crate named `page_size`, use `cargo add
+    //@[only-rustc]~^^^^ HELP you might be missing a crate named `page_size`
 }

--- a/tests/ui/typeck/path-to-method-sugg-unresolved-expr.stderr
+++ b/tests/ui/typeck/path-to-method-sugg-unresolved-expr.stderr
@@ -1,9 +1,0 @@
-error[E0433]: failed to resolve: use of undeclared crate or module `page_size`
-  --> $DIR/path-to-method-sugg-unresolved-expr.rs:2:21
-   |
-LL |     let page_size = page_size::get();
-   |                     ^^^^^^^^^ use of undeclared crate or module `page_size`
-
-error: aborting due to 1 previous error
-
-For more information about this error, try `rustc --explain E0433`.

--- a/tests/ui/unresolved/unresolved-asterisk-imports.stderr
+++ b/tests/ui/unresolved/unresolved-asterisk-imports.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `not_existing_crate`
   --> $DIR/unresolved-asterisk-imports.rs:1:5
    |
 LL | use not_existing_crate::*;
-   |     ^^^^^^^^^^^^^^^^^^ you might be missing crate `not_existing_crate`
+   |     ^^^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `not_existing_crate`
    |
-help: consider importing the `not_existing_crate` crate
+help: you might be missing a crate named `not_existing_crate`, add it to your project and import it in your code
    |
 LL + extern crate not_existing_crate;
    |

--- a/tests/ui/unresolved/unresolved-import.rs
+++ b/tests/ui/unresolved/unresolved-import.rs
@@ -1,7 +1,7 @@
 use foo::bar;
 //~^ ERROR unresolved import `foo` [E0432]
-//~| NOTE you might be missing crate `foo`
-//~| HELP consider importing the `foo` crate
+//~| NOTE use of unresolved module or unlinked crate `foo`
+//~| HELP you might be missing a crate named `foo`
 //~| SUGGESTION extern crate foo;
 
 use bar::Baz as x;

--- a/tests/ui/unresolved/unresolved-import.stderr
+++ b/tests/ui/unresolved/unresolved-import.stderr
@@ -2,9 +2,9 @@ error[E0432]: unresolved import `foo`
   --> $DIR/unresolved-import.rs:1:5
    |
 LL | use foo::bar;
-   |     ^^^ you might be missing crate `foo`
+   |     ^^^ use of unresolved module or unlinked crate `foo`
    |
-help: consider importing the `foo` crate
+help: you might be missing a crate named `foo`, add it to your project and import it in your code
    |
 LL + extern crate foo;
    |


### PR DESCRIPTION
Reword label and add `help`:

```
error[E0432]: unresolved import `some_novel_crate`
 --> f704.rs:1:5
  |
1 | use some_novel_crate::Type;
  |     ^^^^^^^^^^^^^^^^ use of unresolved module or unlinked crate `some_novel_crate`
  |
  = help: if you wanted to use a crate named `some_novel_crate`, use `cargo add some_novel_crate` to add it to your `Cargo.toml`
```

Fix #133137.