### PR TITLE
stability: remove skip_stability_check_due_to_privacy

### DIFF
--- a/tests/ui/auxiliary/pub-and-stability.rs
+++ b/tests/ui/auxiliary/pub-and-stability.rs
@@ -5,8 +5,8 @@
 // The basic stability pattern in this file has four cases:
 // 1. no stability attribute at all
 // 2. a stable attribute (feature "unit_test")
-// 3. an unstable attribute that unit test declares (feature "unstable_declared")
-// 4. an unstable attribute that unit test fails to declare (feature "unstable_undeclared")
+// 3. an unstable attribute that unit test enables (feature "unstable_declared")
+// 4. an unstable attribute that unit test fails to enable (feature "unstable_undeclared")
 //
 // This file also covers four kinds of visibility: private,
 // pub(module), pub(crate), and pub.

--- a/tests/ui/explore-issue-38412.rs
+++ b/tests/ui/explore-issue-38412.rs
@@ -1,9 +1,9 @@
 //@ aux-build:pub-and-stability.rs
 
-// A big point of this test is that we *declare* `unstable_declared`,
-// but do *not* declare `unstable_undeclared`. This way we can check
-// that the compiler is letting in uses of declared feature-gated
-// stuff but still rejecting uses of undeclared feature-gated stuff.
+// A big point of this test is that we *enable* `unstable_declared`,
+// but do *not* enable `unstable_undeclared`. This way we can check
+// that the compiler is letting in uses of enabled feature-gated
+// stuff but still rejecting uses of disabled feature-gated stuff.
 #![feature(unstable_declared)]
 
 extern crate pub_and_stability;


### PR DESCRIPTION
This was added in https://github.com/rust-lang/rust/pull/38689 to deal with https://github.com/rust-lang/rust/issues/38412. However, even after removing the check, the relevant tests still pass. Let's see if CI finds any other tests that rely on this. If not, it seems like logic elsewhere in the compiler changed so this is not required any more.