### PR TITLE
remove pointless cold_path impl in interpreter

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -1264,6 +1264,7 @@ fn codegen_regular_intrinsic_call<'tcx>(
 
         sym::cold_path => {
             // This is a no-op. The intrinsic is just a hint to the optimizer.
+            // We still have an impl here to avoid it being turned into a call.
         }
 
         // Unimplemented intrinsics must have a fallback body. The fallback body is obtained

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -417,9 +417,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 // These just return their argument
                 self.copy_op(&args[0], dest)?;
             }
-            sym::cold_path => {
-                // This is a no-op. The intrinsic is just a hint to the optimizer.
-            }
             sym::raw_eq => {
                 let result = self.raw_eq_intrinsic(&args[0], &args[1])?;
                 self.write_scalar(result, dest)?;


### PR DESCRIPTION
This has a fallback impl so the interpreter impl is not needed.

r? @saethlin 