### PR TITLE
Improve fidelity of `rustc-crates-on-stable` test

### DIFF
--- a/tests/run-make/rustc-crates-on-stable/rmake.rs
+++ b/tests/run-make/rustc-crates-on-stable/rmake.rs
@@ -4,13 +4,18 @@
 use run_make_support::{cargo, rustc_path, source_root};
 
 fn main() {
-    // Use the stage0 beta cargo for the compilation (it shouldn't really matter which cargo we use)
+    // NOTE: in the following cargo invocation, make sure that no unstable cargo flags are used! We
+    // want to check that the listed compiler crates here can compile on the stable channel. We
+    // can't really just "ask" a stage1 cargo to pretend that it is a stable cargo, because other
+    // compiler crates are part of the same workspace, which necessarily requires that they can use
+    // unstable features and experimental editions (like edition 2024).
     cargo()
-        // Ensure `proc-macro2`'s nightly detection is disabled
+        // Ensure `proc-macro2`'s nightly detection is disabled: its build script avoids using
+        // nightly features when `RUSTC_STAGE` is set.
         .env("RUSTC_STAGE", "0")
         .env("RUSTC", rustc_path())
-        // We want to disallow all nightly features to simulate a stable build
-        .env("RUSTFLAGS", "-Zallow-features=")
+        // This forces the underlying rustc to think it is a stable rustc.
+        .env("RUSTC_BOOTSTRAP", "-1")
         .arg("build")
         .arg("--manifest-path")
         .arg(source_root().join("Cargo.toml"))


### PR DESCRIPTION
Use `RUSTC_BOOTSTRAP=-1` to make the underlying `rustc` think it is a stable `rustc`, *really* making sure that these compiler crates can be compiled on the stable channel.

cc @Kobzol who suggested this in https://github.com/rust-lang/rust/pull/132993#issuecomment-2482714452, thanks!

You can tell this works because if I keep `.env("RUSTFLAGS", "-Zallow-features=")`, the underlying rustc thinks it is very stable and thus rejects the unstable `-Zallow-features` flag.

```
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `X:\repos\rust\build\x86_64-pc-windows-msvc\stage1\bin\rustc.exe - --crate-name ___ --print=file-names -Zallow-features= --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg` (exit code: 1)
  --- stderr
  error: the option `Z` is only accepted on the nightly compiler
```

r? compiler