### PR TITLE
ci: use free runner in dist-i686-msvc

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -465,7 +465,7 @@ auto:
       SCRIPT: python x.py dist bootstrap --include-default-paths
       DIST_REQUIRE_ALL_TOOLS: 1
       CODEGEN_BACKENDS: llvm,cranelift
-    <<: *job-windows-8c
+    <<: *job-windows
 
   - image: dist-aarch64-msvc
     env:


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->

I already tried this in https://github.com/rust-lang/rust/pull/132316#issuecomment-2444763685 and I thought this would take too long. However, the slowness was due to llvm cache not being hit.
Instead, we need to compare timings with an llvm cache hit.
So now I'm trying again.
<!-- homu-ignore:end -->


try-job: dist-i686-msvc