### PR TITLE
Rollup of 4 pull requests

### DIFF
--- a/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
+++ b/compiler/rustc_codegen_cranelift/src/intrinsics/mod.rs
@@ -1264,6 +1264,7 @@ fn codegen_regular_intrinsic_call<'tcx>(
 
         sym::cold_path => {
             // This is a no-op. The intrinsic is just a hint to the optimizer.
+            // We still have an impl here to avoid it being turned into a call.
         }
 
         // Unimplemented intrinsics must have a fallback body. The fallback body is obtained

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -417,9 +417,6 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
                 // These just return their argument
                 self.copy_op(&args[0], dest)?;
             }
-            sym::cold_path => {
-                // This is a no-op. The intrinsic is just a hint to the optimizer.
-            }
             sym::raw_eq => {
                 let result = self.raw_eq_intrinsic(&args[0], &args[1])?;
                 self.write_scalar(result, dest)?;

--- a/config.example.toml
+++ b/config.example.toml
@@ -81,7 +81,7 @@
 # Indicates whether the LLVM plugin is enabled or not
 #plugins = false
 
-# Wheter to build Enzyme as AutoDiff backend.
+# Whether to build Enzyme as AutoDiff backend.
 #enzyme = false
 
 # Whether to build LLVM with support for it's gpu offload runtime.

--- a/tests/ui/auxiliary/pub-and-stability.rs
+++ b/tests/ui/auxiliary/pub-and-stability.rs
@@ -5,8 +5,8 @@
 // The basic stability pattern in this file has four cases:
 // 1. no stability attribute at all
 // 2. a stable attribute (feature "unit_test")
-// 3. an unstable attribute that unit test declares (feature "unstable_declared")
-// 4. an unstable attribute that unit test fails to declare (feature "unstable_undeclared")
+// 3. an unstable attribute that unit test enables (feature "unstable_declared")
+// 4. an unstable attribute that unit test fails to enable (feature "unstable_undeclared")
 //
 // This file also covers four kinds of visibility: private,
 // pub(module), pub(crate), and pub.

--- a/tests/ui/explore-issue-38412.rs
+++ b/tests/ui/explore-issue-38412.rs
@@ -1,9 +1,9 @@
 //@ aux-build:pub-and-stability.rs
 
-// A big point of this test is that we *declare* `unstable_declared`,
-// but do *not* declare `unstable_undeclared`. This way we can check
-// that the compiler is letting in uses of declared feature-gated
-// stuff but still rejecting uses of undeclared feature-gated stuff.
+// A big point of this test is that we *enable* `unstable_declared`,
+// but do *not* enable `unstable_undeclared`. This way we can check
+// that the compiler is letting in uses of enabled feature-gated
+// stuff but still rejecting uses of disabled feature-gated stuff.
 #![feature(unstable_declared)]
 
 extern crate pub_and_stability;

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -367,21 +367,22 @@ trigger_files = [
 
 [autolabel."T-bootstrap"]
 trigger_files = [
-    "x.py",
-    "x",
-    "x.ps1",
+    "Cargo.toml",
+    "configure",
+    "config.example.toml",
     "src/bootstrap",
+    "src/build_helper",
     "src/tools/rust-installer",
     "src/tools/x",
-    "configure",
-    "Cargo.toml",
-    "config.example.toml",
     "src/stage0",
     "src/tools/compiletest",
     "src/tools/tidy",
     "src/tools/rustdoc-gui-test",
     "src/tools/libcxx-version",
     "src/tools/rustc-perf-wrapper",
+    "x.py",
+    "x",
+    "x.ps1"
 ]
 
 [autolabel."T-infra"]

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -236,7 +236,21 @@ trigger_files = [
     "compiler",
 
     # Tests
+    "tests/assembly",
+    "tests/auxiliary",
+    "tests/codegen",
+    "tests/codegen-units",
+    "tests/COMPILER_TESTS.md",
+    "tests/coverage",
+    "tests/coverage-run-rustdoc",
+    "tests/crashes",
+    "tests/debuginfo",
+    "tests/incremental",
+    "tests/mir-opt",
+    "tests/pretty",
+    "tests/run-make",
     "tests/ui",
+    "tests/ui-fulldeps",
 ]
 exclude_labels = [
     "T-*",


### PR DESCRIPTION
Successful merges:

 - #133156 (typo in config.example.toml)
 - #133157 (stability: remove skip_stability_check_due_to_privacy)
 - #133163 (remove pointless cold_path impl in interpreter)
 - #133169 (Update autolabels for T-compiler and T-bootstrap)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=133156,133157,133163,133169)
<!-- homu-ignore:end -->