### PR TITLE
ignore an occasionally-failing test in Miri

### DIFF
--- a/library/std/src/sync/rwlock/tests.rs
+++ b/library/std/src/sync/rwlock/tests.rs
@@ -550,6 +550,9 @@ fn test_downgrade_observe() {
 }
 
 #[test]
+// FIXME: On macOS we use a provenance-incorrect implementation and Miri catches that issue.
+// See <https://github.com/rust-lang/rust/issues/121950> for details.
+#[cfg_attr(all(miri, target_os = "macos"), ignore)]
 fn test_downgrade_atomic() {
     const NEW_VALUE: i32 = -1;
 


### PR DESCRIPTION
This is like https://github.com/rust-lang/rust/pull/128640, the test [sometimes](https://github.com/rust-lang/rust/pull/133189) fails due to https://github.com/rust-lang/rust/issues/121950.