### PR TITLE
Make `RUSTC_BOOTSTRAP` read the crate name from `CARGO_CRATE_NAME`

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -1211,9 +1211,7 @@ pub fn handle_options(early_dcx: &EarlyDiagCtxt, args: &[String]) -> Option<geto
     if args.is_empty() {
         // user did not write `-v` nor `-Z unstable-options`, so do not
         // include that extra information.
-        let nightly_build =
-            rustc_feature::UnstableFeatures::from_environment(None).is_nightly_build();
-        usage(false, false, nightly_build);
+        usage(false, false, nightly_options::is_nightly_build());
         return None;
     }
 
@@ -1265,7 +1263,7 @@ pub fn handle_options(early_dcx: &EarlyDiagCtxt, args: &[String]) -> Option<geto
     if matches.opt_present("h") || matches.opt_present("help") {
         // Only show unstable options in --help if we accept unstable options.
         let unstable_enabled = nightly_options::is_unstable_enabled(&matches);
-        let nightly_build = nightly_options::match_is_nightly_build(&matches);
+        let nightly_build = nightly_options::is_nightly_build();
         usage(matches.opt_present("verbose"), unstable_enabled, nightly_build);
         return None;
     }
@@ -1337,7 +1335,7 @@ fn ice_path_with_config(config: Option<&UnstableOptions>) -> &'static Option<Pat
     }
 
     ICE_PATH.get_or_init(|| {
-        if !rustc_feature::UnstableFeatures::from_environment(None).is_nightly_build() {
+        if !nightly_options::is_nightly_build() {
             return None;
         }
         let mut path = match std::env::var_os("RUSTC_ICE") {
@@ -1493,7 +1491,7 @@ fn report_ice(
         dcx.emit_note(session_diagnostics::IceBugReport { bug_report_url });
 
         // Only emit update nightly hint for users on nightly builds.
-        if rustc_feature::UnstableFeatures::from_environment(None).is_nightly_build() {
+        if nightly_options::is_nightly_build() {
             dcx.emit_note(session_diagnostics::UpdateNightlyNote);
         }
     }

--- a/compiler/rustc_feature/src/tests.rs
+++ b/compiler/rustc_feature/src/tests.rs
@@ -3,8 +3,9 @@ use std::env;
 use super::UnstableFeatures;
 
 fn unstable_features(rustc_bootstrap: &str, crate_name: Option<&str>) -> UnstableFeatures {
-    UnstableFeatures::from_environment_inner(crate_name, |name| match name {
+    UnstableFeatures::from_environment_inner(|name| match name {
         "RUSTC_BOOTSTRAP" => Ok(rustc_bootstrap.to_owned()),
+        "CARGO_CRATE_NAME" => crate_name.map(str::to_owned).ok_or(env::VarError::NotPresent),
         _ => Err(env::VarError::NotPresent),
     })
 }
@@ -21,6 +22,7 @@ fn rustc_bootstrap_parsing() {
     // RUSTC_BOOTSTRAP allows multiple comma-delimited crates
     assert!(is_bootstrap("x,y,z", Some("x")));
     assert!(is_bootstrap("x,y,z", Some("y")));
+    assert!(is_bootstrap("x,y-utils", Some("y_utils")));
     // Crate that aren't specified do not get unstable features
     assert!(!is_bootstrap("x", Some("a")));
     assert!(!is_bootstrap("x,y,z", Some("a")));

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1825,7 +1825,7 @@ pub fn parse_crate_edition(early_dcx: &EarlyDiagCtxt, matches: &getopts::Matches
     };
 
     if !edition.is_stable() && !nightly_options::is_unstable_enabled(matches) {
-        let is_nightly = nightly_options::match_is_nightly_build(matches);
+        let is_nightly = nightly_options::is_nightly_build();
         let msg = if !is_nightly {
             format!(
                 "the crate requires edition {edition}, but the latest edition supported by this Rust version is {LATEST_STABLE_EDITION}"
@@ -2510,7 +2510,7 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
     let debuginfo_compression = unstable_opts.debuginfo_compression;
 
     let crate_name = matches.opt_str("crate-name");
-    let unstable_features = UnstableFeatures::from_environment(crate_name.as_deref());
+    let unstable_features = UnstableFeatures::from_environment();
     // Parse any `-l` flags, which link to native libraries.
     let libs = parse_native_libs(early_dcx, &unstable_opts, unstable_features, matches);
 

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -40,6 +40,7 @@ use crate::{EarlyDiagCtxt, HashStableContext, Session, filesearch, lint};
 
 mod cfg;
 mod native_libs;
+pub mod nightly_options;
 pub mod sigpipe;
 
 /// The different settings that the `-C strip` flag can have.
@@ -2687,77 +2688,6 @@ pub fn parse_crate_types_from_list(list_list: Vec<String>) -> Result<Vec<CrateTy
     }
 
     Ok(crate_types)
-}
-
-pub mod nightly_options {
-    use rustc_feature::UnstableFeatures;
-
-    use super::{OptionStability, RustcOptGroup};
-    use crate::EarlyDiagCtxt;
-
-    pub fn is_unstable_enabled(matches: &getopts::Matches) -> bool {
-        match_is_nightly_build(matches)
-            && matches.opt_strs("Z").iter().any(|x| *x == "unstable-options")
-    }
-
-    pub fn match_is_nightly_build(matches: &getopts::Matches) -> bool {
-        is_nightly_build(matches.opt_str("crate-name").as_deref())
-    }
-
-    fn is_nightly_build(krate: Option<&str>) -> bool {
-        UnstableFeatures::from_environment(krate).is_nightly_build()
-    }
-
-    pub fn check_nightly_options(
-        early_dcx: &EarlyDiagCtxt,
-        matches: &getopts::Matches,
-        flags: &[RustcOptGroup],
-    ) {
-        let has_z_unstable_option = matches.opt_strs("Z").iter().any(|x| *x == "unstable-options");
-        let really_allows_unstable_options = match_is_nightly_build(matches);
-        let mut nightly_options_on_stable = 0;
-
-        for opt in flags.iter() {
-            if opt.stability == OptionStability::Stable {
-                continue;
-            }
-            if !matches.opt_present(opt.name) {
-                continue;
-            }
-            if opt.name != "Z" && !has_z_unstable_option {
-                early_dcx.early_fatal(format!(
-                    "the `-Z unstable-options` flag must also be passed to enable \
-                         the flag `{}`",
-                    opt.name
-                ));
-            }
-            if really_allows_unstable_options {
-                continue;
-            }
-            match opt.stability {
-                OptionStability::Unstable => {
-                    nightly_options_on_stable += 1;
-                    let msg = format!(
-                        "the option `{}` is only accepted on the nightly compiler",
-                        opt.name
-                    );
-                    let _ = early_dcx.early_err(msg);
-                }
-                OptionStability::Stable => {}
-            }
-        }
-        if nightly_options_on_stable > 0 {
-            early_dcx
-                .early_help("consider switching to a nightly toolchain: `rustup default nightly`");
-            early_dcx.early_note("selecting a toolchain with `+toolchain` arguments require a rustup proxy; see <https://rust-lang.github.io/rustup/concepts/index.html>");
-            early_dcx.early_note("for more information about Rust's stability policy, see <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>");
-            early_dcx.early_fatal(format!(
-                "{} nightly option{} were parsed",
-                nightly_options_on_stable,
-                if nightly_options_on_stable > 1 { "s" } else { "" }
-            ));
-        }
-    }
 }
 
 impl fmt::Display for CrateType {

--- a/compiler/rustc_session/src/config/nightly_options.rs
+++ b/compiler/rustc_session/src/config/nightly_options.rs
@@ -1,0 +1,64 @@
+use rustc_feature::UnstableFeatures;
+
+use crate::EarlyDiagCtxt;
+use crate::config::{OptionStability, RustcOptGroup};
+
+pub fn is_unstable_enabled(matches: &getopts::Matches) -> bool {
+    match_is_nightly_build(matches)
+        && matches.opt_strs("Z").iter().any(|x| *x == "unstable-options")
+}
+
+pub fn match_is_nightly_build(matches: &getopts::Matches) -> bool {
+    is_nightly_build(matches.opt_str("crate-name").as_deref())
+}
+
+fn is_nightly_build(krate: Option<&str>) -> bool {
+    UnstableFeatures::from_environment(krate).is_nightly_build()
+}
+
+pub fn check_nightly_options(
+    early_dcx: &EarlyDiagCtxt,
+    matches: &getopts::Matches,
+    flags: &[RustcOptGroup],
+) {
+    let has_z_unstable_option = matches.opt_strs("Z").iter().any(|x| *x == "unstable-options");
+    let really_allows_unstable_options = match_is_nightly_build(matches);
+    let mut nightly_options_on_stable = 0;
+
+    for opt in flags.iter() {
+        if opt.stability == OptionStability::Stable {
+            continue;
+        }
+        if !matches.opt_present(opt.name) {
+            continue;
+        }
+        if opt.name != "Z" && !has_z_unstable_option {
+            early_dcx.early_fatal(format!(
+                "the `-Z unstable-options` flag must also be passed to enable the flag `{}`",
+                opt.name
+            ));
+        }
+        if really_allows_unstable_options {
+            continue;
+        }
+        match opt.stability {
+            OptionStability::Unstable => {
+                nightly_options_on_stable += 1;
+                let msg =
+                    format!("the option `{}` is only accepted on the nightly compiler", opt.name);
+                let _ = early_dcx.early_err(msg);
+            }
+            OptionStability::Stable => {}
+        }
+    }
+    if nightly_options_on_stable > 0 {
+        early_dcx.early_help("consider switching to a nightly toolchain: `rustup default nightly`");
+        early_dcx.early_note("selecting a toolchain with `+toolchain` arguments require a rustup proxy; see <https://rust-lang.github.io/rustup/concepts/index.html>");
+        early_dcx.early_note("for more information about Rust's stability policy, see <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>");
+        early_dcx.early_fatal(format!(
+            "{} nightly option{} were parsed",
+            nightly_options_on_stable,
+            if nightly_options_on_stable > 1 { "s" } else { "" }
+        ));
+    }
+}

--- a/compiler/rustc_session/src/config/nightly_options.rs
+++ b/compiler/rustc_session/src/config/nightly_options.rs
@@ -4,16 +4,11 @@ use crate::EarlyDiagCtxt;
 use crate::config::{OptionStability, RustcOptGroup};
 
 pub fn is_unstable_enabled(matches: &getopts::Matches) -> bool {
-    match_is_nightly_build(matches)
-        && matches.opt_strs("Z").iter().any(|x| *x == "unstable-options")
+    is_nightly_build() && matches.opt_strs("Z").iter().any(|x| *x == "unstable-options")
 }
 
-pub fn match_is_nightly_build(matches: &getopts::Matches) -> bool {
-    is_nightly_build(matches.opt_str("crate-name").as_deref())
-}
-
-fn is_nightly_build(krate: Option<&str>) -> bool {
-    UnstableFeatures::from_environment(krate).is_nightly_build()
+pub fn is_nightly_build() -> bool {
+    UnstableFeatures::from_environment().is_nightly_build()
 }
 
 pub fn check_nightly_options(
@@ -22,7 +17,7 @@ pub fn check_nightly_options(
     flags: &[RustcOptGroup],
 ) {
     let has_z_unstable_option = matches.opt_strs("Z").iter().any(|x| *x == "unstable-options");
-    let really_allows_unstable_options = match_is_nightly_build(matches);
+    let really_allows_unstable_options = is_nightly_build();
     let mut nightly_options_on_stable = 0;
 
     for opt in flags.iter() {

--- a/compiler/rustc_session/src/parse.rs
+++ b/compiler/rustc_session/src/parse.rs
@@ -251,7 +251,7 @@ impl ParseSess {
     pub fn with_dcx(dcx: DiagCtxt, source_map: Lrc<SourceMap>) -> Self {
         Self {
             dcx,
-            unstable_features: UnstableFeatures::from_environment(None),
+            unstable_features: UnstableFeatures::from_environment(),
             config: Cfg::default(),
             check_config: CheckCfg::default(),
             edition: ExpnId::root().expn_data().edition,

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -409,7 +409,7 @@ impl Options {
                 println_condition(p.condition);
             }
 
-            if nightly_options::match_is_nightly_build(matches) {
+            if nightly_options::is_nightly_build() {
                 println!("\nPasses run with `--show-coverage`:");
                 for p in passes::COVERAGE_PASSES {
                     print!("{:>20}", p.pass.name);
@@ -653,7 +653,7 @@ impl Options {
             &matches.opt_strs("html-after-content"),
             &matches.opt_strs("markdown-before-content"),
             &matches.opt_strs("markdown-after-content"),
-            nightly_options::match_is_nightly_build(matches),
+            nightly_options::is_nightly_build(),
             dcx,
             &mut id_map,
             edition,
@@ -775,8 +775,7 @@ impl Options {
         let with_examples = matches.opt_strs("with-examples");
         let call_locations = crate::scrape_examples::load_call_locations(with_examples, dcx);
 
-        let unstable_features =
-            rustc_feature::UnstableFeatures::from_environment(crate_name.as_deref());
+        let unstable_features = rustc_feature::UnstableFeatures::from_environment();
         let options = Options {
             bin_crate,
             proc_macro_crate,

--- a/src/librustdoc/core.rs
+++ b/src/librustdoc/core.rs
@@ -260,7 +260,7 @@ pub(crate) fn create_config(
         cg: codegen_options,
         externs,
         target_triple: target,
-        unstable_features: UnstableFeatures::from_environment(crate_name.as_deref()),
+        unstable_features: UnstableFeatures::from_environment(),
         actually_rustdoc: true,
         resolve_doc_links,
         unstable_opts,


### PR DESCRIPTION
Background: In addition to the fixed values `1` and `-1`, `RUSTC_BOOTSTRAP` also accepts a comma-separated list of crate names, and only force-enables unstable functionality if the current crate name is in that list.

This is not actually used for bootstrapping the compiler. Instead, it exists so that when cargo sees a third-party crate trying to set `RUSTC_BOOTSTRAP` in build.rs, cargo can suggest a somewhat less horrifying alternative. See #77802 for more context.

---

The current implementation works by requiring every stable/nightly check to also pass an optional crate name, which is obtained by scanning `&getopts::Matches` for the `--crate-name` option. This creates extra mess and complexity at every call site, just for this one niche use-case, and doesn't even work for crate names that have been set in some other way.

---

As long as per-crate `RUSTC_BOOTSTRAP` exists, there is no truly satisfactory way to implement it. However, we can encapsulate some of the mess by getting the crate name from `CARGO_CRATE_NAME`, instead of getting it from the command-line.

This is a cargo-specific hack, but I think that's acceptable. We're dealing with `RUSTC_BOOTSTRAP`, which is already well outside the boundaries of what's “supported”, so what's important is that the cargo use-case that motivated this mess in the first place continues to work. And if someone out there is using `RUSTC_BOOTSTRAP` with a non-cargo build system, it's likely that their build system will let them set it to `1` on a per-crate basis anyway.