### PR TITLE
Default-enable `llvm_tools_enabled` when no `config.toml` is present

### DIFF
--- a/compiler/rustc_codegen_cranelift/scripts/setup_rust_fork.sh
+++ b/compiler/rustc_codegen_cranelift/scripts/setup_rust_fork.sh
@@ -38,6 +38,11 @@ local-rebuild = true
 codegen-backends = ["cranelift"]
 deny-warnings = false
 verbose-tests = false
+# The cg_clif sysroot doesn't contain llvm tools and unless llvm_tools is
+# disabled bootstrap will crash trying to copy llvm tools for the bootstrap
+# compiler.
+llvm_tools = false
+
 EOF
 popd
 

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1255,6 +1255,10 @@ impl Config {
             },
             out: PathBuf::from("build"),
 
+            // This is needed by codegen_ssa on macOS to ship `llvm-objcopy` aliased to
+            // `rust-objcopy` to workaround bad `strip`s on macOS.
+            llvm_tools_enabled: true,
+
             ..Default::default()
         }
     }

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -300,4 +300,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Info,
         summary: "`download-rustc='if-unchanged'` is now a default option for library profile.",
     },
+    ChangeInfo {
+        change_id: 133207,
+        severity: ChangeSeverity::Info,
+        summary: "`rust.llvm-tools` is now enabled by default when no `config.toml` is provided.",
+    },
 ];


### PR DESCRIPTION
Fixes #133195. cc @wesleywiser could you double check if with this patch and no `config.toml` that you can run `./x test tests/ui --stage 1`?

`llvm-objcopy` is usually required by cg_ssa on macOS to workaround bad `strip`s.

cc @bjorn3 I hope this doesn't break cg_clif...

r? bootstrap