### PR TITLE
Also emit ICE dump files on stable rustc

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -1337,9 +1337,6 @@ fn ice_path_with_config(config: Option<&UnstableOptions>) -> &'static Option<Pat
     }
 
     ICE_PATH.get_or_init(|| {
-        if !rustc_feature::UnstableFeatures::from_environment(None).is_nightly_build() {
-            return None;
-        }
         let mut path = match std::env::var_os("RUSTC_ICE") {
             Some(s) => {
                 if s == "0" {

--- a/tests/run-make/dump-ice-to-disk/rmake.rs
+++ b/tests/run-make/dump-ice-to-disk/rmake.rs
@@ -23,7 +23,7 @@
 //! - An attempt is made to re-enable this test on `i686-mingw` (by removing `ignore-windows`). If
 //!   this test is still flakey, please restore the `ignore-windows` directive.
 
-//@ ignore-windows
+//@ ignore-windows-gnu
 //FIXME(#128911): still flakey on i686-mingw.
 
 use std::cell::OnceCell;


### PR DESCRIPTION
**BLOCKED: waiting on MCP https://github.com/rust-lang/compiler-team/issues/809**

See [On nightly, dump ICE backtraces to disk #108714][nightly-ice] where originally we made it nightly-only in case there was some problems with the ICE dumping infra breaking stable users. However, a good amount of time has since passed (Jun 2023 when #108714 was merged vs Nov 2024 when this PR ws opened). It was waiting for cargo gc work, but the timeline of that is unclear so imo should not block this.

Also note that ICE dumping is perma-unstable behavior, so if this somehow is problematic it is very easy to revert.

This `run-make` test was flaky on windows-gnu but not msvc cc #128911.

Closes #132245.

## Unresolved concerns

- [ ] Check-on-save can dump ICE files to the crate multiple times, can we figure out somewhere to place the ICE files that are not so disruptive?

[nightly-ice]: https://github.com/rust-lang/rust/pull/108714