### PR TITLE
Fix missing submodule in `./x vendor`

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -1026,7 +1026,7 @@ impl Step for PlainSourceTarball {
             let mut cmd = command(&builder.initial_cargo);
             cmd.arg("vendor").arg("--versioned-dirs");
 
-            for p in default_paths_to_vendor(builder) {
+            for (p, _) in default_paths_to_vendor(builder) {
                 cmd.arg("--sync").arg(p);
             }
 

--- a/src/bootstrap/src/core/build_steps/vendor.rs
+++ b/src/bootstrap/src/core/build_steps/vendor.rs
@@ -4,24 +4,26 @@ use crate::core::build_steps::tool::SUBMODULES_FOR_RUSTBOOK;
 use crate::core::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::utils::exec::command;
 
-/// List of default paths used for vendoring for `x vendor` and dist tarballs.
-pub fn default_paths_to_vendor(builder: &Builder<'_>) -> Vec<PathBuf> {
-    let mut paths = vec![];
-    for p in [
-        "src/tools/cargo/Cargo.toml",
-        "src/tools/rust-analyzer/Cargo.toml",
-        "compiler/rustc_codegen_cranelift/Cargo.toml",
-        "compiler/rustc_codegen_gcc/Cargo.toml",
-        "library/Cargo.toml",
-        "src/bootstrap/Cargo.toml",
-        "src/tools/rustbook/Cargo.toml",
-        "src/tools/rustc-perf/Cargo.toml",
-        "src/tools/opt-dist/Cargo.toml",
-    ] {
-        paths.push(builder.src.join(p));
-    }
-
-    paths
+/// Returns the cargo workspaces to vendor for `x vendor` and dist tarballs.
+///
+/// Returns a `Vec` of `(path_to_manifest, submodules_required)` where
+/// `path_to_manifest` is the cargo workspace, and `submodules_required` is
+/// the set of submodules that must be available.
+pub fn default_paths_to_vendor(builder: &Builder<'_>) -> Vec<(PathBuf, Vec<&'static str>)> {
+    [
+        ("src/tools/cargo/Cargo.toml", vec!["src/tools/cargo"]),
+        ("src/tools/rust-analyzer/Cargo.toml", vec![]),
+        ("compiler/rustc_codegen_cranelift/Cargo.toml", vec![]),
+        ("compiler/rustc_codegen_gcc/Cargo.toml", vec![]),
+        ("library/Cargo.toml", vec![]),
+        ("src/bootstrap/Cargo.toml", vec![]),
+        ("src/tools/rustbook/Cargo.toml", SUBMODULES_FOR_RUSTBOOK.into()),
+        ("src/tools/rustc-perf/Cargo.toml", vec!["src/tools/rustc-perf"]),
+        ("src/tools/opt-dist/Cargo.toml", vec![]),
+    ]
+    .into_iter()
+    .map(|(path, submodules)| (builder.src.join(path), submodules))
+    .collect()
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -56,15 +58,16 @@ impl Step for Vendor {
             cmd.arg("--versioned-dirs");
         }
 
+        let to_vendor = default_paths_to_vendor(builder);
         // These submodules must be present for `x vendor` to work.
-        for submodule in
-            SUBMODULES_FOR_RUSTBOOK.iter().chain(["src/tools/cargo", "src/tools/rustc-perf"].iter())
-        {
-            builder.build.require_submodule(submodule, None);
+        for (_, submodules) in &to_vendor {
+            for submodule in submodules {
+                builder.build.require_submodule(submodule, None);
+            }
         }
 
         // Sync these paths by default.
-        for p in default_paths_to_vendor(builder) {
+        for (p, _) in &to_vendor {
             cmd.arg("--sync").arg(p);
         }
 

--- a/src/bootstrap/src/core/build_steps/vendor.rs
+++ b/src/bootstrap/src/core/build_steps/vendor.rs
@@ -57,7 +57,9 @@ impl Step for Vendor {
         }
 
         // These submodules must be present for `x vendor` to work.
-        for submodule in SUBMODULES_FOR_RUSTBOOK.iter().chain(["src/tools/cargo"].iter()) {
+        for submodule in
+            SUBMODULES_FOR_RUSTBOOK.iter().chain(["src/tools/cargo", "src/tools/rustc-perf"].iter())
+        {
             builder.build.require_submodule(submodule, None);
         }
 


### PR DESCRIPTION
The `src/tools/rustc-perf` submodule is needed for vendoring because it is included in the vendor set.

To test this:

1. Get a fresh clone of `rust-lang/rust`
2. `./x vendor`

