### PR TITLE
Account for `wasm32v1-none` when exporting TLS symbols

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1279,7 +1279,7 @@ impl<'a> WasmLd<'a> {
         let mut wasm_ld = WasmLd { cmd, sess };
         if sess.target_features.contains(&sym::atomics) {
             wasm_ld.link_args(&["--shared-memory", "--max-memory=1073741824", "--import-memory"]);
-            if sess.target.os == "unknown" {
+            if sess.target.os == "unknown" || sess.target.os == "none" {
                 wasm_ld.link_args(&[
                     "--export=__wasm_init_tls",
                     "--export=__tls_size",
@@ -1403,7 +1403,7 @@ impl<'a> Linker for WasmLd<'a> {
         // symbols explicitly passed via the `--export` flags above and hides all
         // others. Various bits and pieces of wasm32-unknown-unknown tooling use
         // this, so be sure these symbols make their way out of the linker as well.
-        if self.sess.target.os == "unknown" {
+        if self.sess.target.os == "unknown" || self.sess.target.os == "none" {
             self.link_args(&["--export=__heap_base", "--export=__data_end"]);
         }
     }


### PR DESCRIPTION
Exporting TLS related symbols was limited to `wasm32-unknown-unknown` because WASI and Emscripten (?) have their own infrastructure to deal with TLS. However, the introduction of `wasm32v1-none` is in the same boat as `wasm32-unknown-unknown`.

This PR adjust the mechanism to account for `wasm32v1-none` as well.

See https://github.com/rust-lang/rust/pull/102385 and https://github.com/rust-lang/rust/pull/102440.

r? @alexcrichton