### PR TITLE
ci: Disable full `debuginfo-level=2` in windows alt job

### DIFF
--- a/src/ci/run.sh
+++ b/src/ci/run.sh
@@ -116,7 +116,7 @@ if [ "$DEPLOY$DEPLOY_ALT" = "1" ]; then
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --enable-llvm-static-stdcpp"
   RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --set rust.remap-debuginfo"
 
-  if [ "$DEPLOY_ALT" != "" ]; then
+  if [ "$DEPLOY_ALT" != "" ] && isLinux; then
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --debuginfo-level=2"
   else
     RUST_CONFIGURE_ARGS="$RUST_CONFIGURE_ARGS --debuginfo-level-std=1"


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)


-->

https://github.com/rust-lang/rust/pull/132010 increased the time of the `dist-x86_64-msvc-alt` job by 1 hour.
As discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/CI.20job.20dist-x86_64-msvc-alt.20is.20slower), we want to set this flag on linux only.
<!-- homu-ignore:end -->

try-job: dist-x86_64-msvc-alt
