### PR TITLE
Shorten the `MaybeUninit` `Debug` implementation

### DIFF
--- a/library/core/src/mem/maybe_uninit.rs
+++ b/library/core/src/mem/maybe_uninit.rs
@@ -255,7 +255,11 @@ impl<T: Copy> Clone for MaybeUninit<T> {
 #[stable(feature = "maybe_uninit_debug", since = "1.41.0")]
 impl<T> fmt::Debug for MaybeUninit<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.pad(type_name::<Self>())
+        // NB: there is no `.pad_fmt` so we can't use a simpler `format_args!("MaybeUninit<{..}>").
+        // This needs to be adjusted if `MaybeUninit` moves modules.
+        let full_name = type_name::<Self>();
+        let short_name = full_name.split_once("mem::maybe_uninit::").unwrap().1;
+        f.pad(short_name)
     }
 }
 

--- a/library/core/tests/fmt/mod.rs
+++ b/library/core/tests/fmt/mod.rs
@@ -43,3 +43,10 @@ fn pad_integral_resets() {
 
     assert_eq!(format!("{Bar:<03}"), "1  0051  ");
 }
+
+#[test]
+fn test_maybe_uninit_short() {
+    // Ensure that the trimmed `MaybeUninit` Debug implementation doesn't break
+    let x = core::mem::MaybeUninit::new(0u32);
+    assert_eq!(format!("{x:?}"), "MaybeUninit<u32>");
+}


### PR DESCRIPTION
Currently the `Debug` implementation for `MaybeUninit` winds up being pretty verbose. This struct:

```rust
#[derive(Debug)]
pub struct Foo {
    pub a: u32,
    pub b: &'static str,
    pub c: MaybeUninit<u32>,
    pub d: MaybeUninit<String>,
}
```

Prints as:

    Foo {
        a: 0,
        b: "hello",
        c: core::mem::maybe_uninit::MaybeUninit<u32>,
        d: core::mem::maybe_uninit::MaybeUninit<alloc::string::String>,
    }

The goal is just to be a standin for content so the path prefix doesn't add any useful information. Change the implementation to trim `MaybeUninit`'s leading path, meaning the new result is now:

    Foo {
        a: 0,
        b: "hello",
        c: MaybeUninit<u32>,
        d: MaybeUninit<alloc::string::String>,
    }