### PR TITLE
Don't exclude relnotes from `needs-triage` label

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -451,7 +451,6 @@ new_issue = true
 exclude_labels = [
     "C-tracking-issue",
     "A-diagnostics",
-    "relnotes-tracking-issue",
 ]
 
 [autolabel."WG-trait-system-refactor"]


### PR DESCRIPTION
So initially we *didn't* exclude `needs-triage` label, then we did exclude them in #132825 as sometimes the `needs-triage` is redundant. However, I think they are probably worth double-checking because often some of the labels are only accurate/relevant for the *implementation* PR, but not for the purposes of the relnotes tracking issue. Furthermore, sometimes relevant team labels can be removed. So to make it less likely for relnotes to slip through, I think we should still label relnotes-tracking-issues with `needs-triage`.

cc https://rust-lang.zulipchat.com/#narrow/channel/241545-t-release/topic/Please.20CC.20lang

r? release
