### PR TITLE
Re-delay a resolve `bug` related to `Self`-ctor in patterns

### DIFF
--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -3940,12 +3940,12 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
             }
             Res::SelfCtor(_) => {
                 // We resolve `Self` in pattern position as an ident sometimes during recovery,
-                // so delay a bug instead of ICEing. (Note: is this no longer true? We now ICE. If
-                // this triggers, please convert to a delayed bug and add a test.)
-                self.r.dcx().span_bug(
+                // so delay a bug instead of ICEing.
+                self.r.dcx().span_delayed_bug(
                     ident.span,
                     "unexpected `SelfCtor` in pattern, expected identifier"
                 );
+                None
             }
             _ => span_bug!(
                 ident.span,

--- a/tests/ui/pattern/self-ctor-133272.rs
+++ b/tests/ui/pattern/self-ctor-133272.rs
@@ -1,0 +1,21 @@
+//! Regression test for <https://github.com/rust-lang/rust/issues/133272>, where a `ref Self` ctor
+//! makes it possible to hit a `delayed_bug` that was converted into a `span_bug` in
+//! <https://github.com/rust-lang/rust/pull/121208>, and hitting this reveals that we did not have
+//! test coverage for this specific code pattern (heh) previously.
+//!
+//! # References
+//!
+//! - ICE bug report: <https://github.com/rust-lang/rust/issues/133272>.
+//! - Previous PR to change `delayed_bug` -> `span_bug`:
+//!   <https://github.com/rust-lang/rust/pull/121208>
+#![crate_type = "lib"]
+
+struct Foo;
+
+impl Foo {
+    fn fun() {
+        let S { ref Self } = todo!();
+        //~^ ERROR expected identifier, found keyword `Self`
+        //~| ERROR cannot find struct, variant or union type `S` in this scope
+    }
+}

--- a/tests/ui/pattern/self-ctor-133272.stderr
+++ b/tests/ui/pattern/self-ctor-133272.stderr
@@ -1,0 +1,15 @@
+error: expected identifier, found keyword `Self`
+  --> $DIR/self-ctor-133272.rs:17:21
+   |
+LL |         let S { ref Self } = todo!();
+   |                     ^^^^ expected identifier, found keyword
+
+error[E0422]: cannot find struct, variant or union type `S` in this scope
+  --> $DIR/self-ctor-133272.rs:17:13
+   |
+LL |         let S { ref Self } = todo!();
+   |             ^ not found in this scope
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0422`.


### PR DESCRIPTION
For the code pattern reported in <https://github.com/rust-lang/rust/issues/133272>,

```rs
impl Foo {
   fn fun() {
        let S { ref Self } = todo!();
   }
}
```

<https://github.com/rust-lang/rust/pull/121208> converted this to a `span_bug` from a `span_delayed_bug` because this specific self-ctor code pattern lacked test coverage. It turns out this can be hit but we just lacked test coverage, so change it back to a `span_delayed_bug` and add a targeted test case.

Follow-up to #121208, cc @nnethercote (very good exercise to expose our test coverage gaps).
Fixes #133272.
