### PR TITLE
Revert diagnostics hack to fix ICE 132920

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1804,24 +1804,6 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 StringPart::highlighted("cargo tree".to_string()),
                 StringPart::normal("` to explore your dependency tree".to_string()),
             ]);
-
-            // FIXME: this is a giant hack for the benefit of this specific diagnostic. Because
-            // we're so nested in method calls before the error gets emitted, bubbling a single bit
-            // flag informing the top level caller to stop adding extra detail to the diagnostic,
-            // would actually be harder to follow. So we do something naughty here: we consume the
-            // diagnostic, emit it and leave in its place a "delayed bug" that will continue being
-            // modified but won't actually be printed to end users. This *is not ideal*, but allows
-            // us to reduce the verbosity of an error that is already quite verbose and increase its
-            // specificity. Below we modify the main message as well, in a way that *could* break if
-            // the implementation of Diagnostics change significantly, but that would be caught with
-            // a make test failure when this diagnostic is tested.
-            err.primary_message(format!(
-                "{} because the trait comes from a different crate version",
-                err.messages[0].0.as_str().unwrap(),
-            ));
-            let diag = err.clone();
-            err.downgrade_to_delayed_bug();
-            self.tcx.dcx().emit_diagnostic(diag);
             return true;
         }
 

--- a/tests/run-make/diagnostics-traits-from-duplicate-crates/minibevy.rs
+++ b/tests/run-make/diagnostics-traits-from-duplicate-crates/minibevy.rs
@@ -1,0 +1,2 @@
+pub trait Resource {}
+pub struct Ray2d;

--- a/tests/run-make/diagnostics-traits-from-duplicate-crates/minirapier.rs
+++ b/tests/run-make/diagnostics-traits-from-duplicate-crates/minirapier.rs
@@ -1,0 +1,1 @@
+pub type Ray = minibevy::Ray2d;

--- a/tests/run-make/diagnostics-traits-from-duplicate-crates/repro.rs
+++ b/tests/run-make/diagnostics-traits-from-duplicate-crates/repro.rs
@@ -1,0 +1,14 @@
+extern crate minibevy;
+extern crate minirapier;
+
+use minibevy::Resource;
+use minirapier::Ray;
+
+fn insert_resource<R: Resource>(_resource: R) {}
+
+struct Res;
+impl Resource for Res {}
+
+fn main() {
+    insert_resource(Res.into());
+}

--- a/tests/run-make/diagnostics-traits-from-duplicate-crates/rmake.rs
+++ b/tests/run-make/diagnostics-traits-from-duplicate-crates/rmake.rs
@@ -1,0 +1,45 @@
+// Non-regression test for issue #132920 where multiple versions of the same crate are present in
+// the dependency graph, and an unexpected error in a dependent crate caused an ICE in the
+// unsatisfied bounds diagnostics for traits present in multiple crate versions.
+//
+// Setup:
+// - two versions of the same crate: minibevy_a and minibevy_b
+// - minirapier: depends on minibevy_a
+// - repro: depends on minirapier and minibevy_b
+
+use run_make_support::rustc;
+
+fn main() {
+    // Prepare dependencies, mimicking a check build with cargo.
+    rustc()
+        .input("minibevy.rs")
+        .crate_name("minibevy")
+        .crate_type("lib")
+        .emit("metadata")
+        .metadata("a")
+        .extra_filename("-a")
+        .run();
+    rustc()
+        .input("minibevy.rs")
+        .crate_name("minibevy")
+        .crate_type("lib")
+        .emit("metadata")
+        .metadata("b")
+        .extra_filename("-b")
+        .run();
+    rustc()
+        .input("minirapier.rs")
+        .crate_name("minirapier")
+        .crate_type("lib")
+        .emit("metadata")
+        .extern_("minibevy", "libminibevy-a.rmeta")
+        .run();
+
+    // Building the main crate used to ICE here when printing the `type annotations needed` error.
+    rustc()
+        .input("repro.rs")
+        .extern_("minibevy", "libminibevy-b.rmeta")
+        .extern_("minirapier", "libminirapier.rmeta")
+        .run_fail()
+        .assert_stderr_not_contains("error: the compiler unexpectedly panicked. this is a bug");
+}


### PR DESCRIPTION
This reverts 8a568d9f15453cbfe5d6f45fa5f5bb32e58b93ed from #128849 to fix the diagnostics ICE in #132920.

The hack mentioned in that commit was supposed to be tailored to E277, but that codepath is used actually shared with other errors, e.g. at least the E283 from the linked issue. 

We may have to eat the slightly worse diagnostics until a non-hacky way to make this error less verbose is implemented (or I guess a different hack specializing even more to E277's structure). 

Sorry @estebank 🙏. I can close this if you'd prefer to fix it in a different way.

Since it seems unexpected that #128849 would impact the repro, here's how the error used to look before that PR.

```console
warning: unused import: `minirapier::Ray`
 --> src/main.rs:2:5
  |
2 | use minirapier::Ray;
  |     ^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

error[E0283]: type annotations needed
  --> src/main.rs:10:5
   |
10 |     insert_resource(Res.into());
   |     ^^^^^^^^^^^^^^^ ---------- type must be known at this point
   |     |
   |     cannot infer type of the type parameter `R` declared on the function `insert_resource`
   |
   = note: cannot satisfy `_: Resource`
   = help: the trait `Resource` is implemented for `Res`
note: required by a bound in `insert_resource`
  --> src/main.rs:4:23
   |
4  | fn insert_resource<R: Resource>(_resource: R) {}
   |                       ^^^^^^^^ required by this bound in `insert_resource`
help: consider specifying the generic argument
   |
10 |     insert_resource::<R>(Res.into());
   |                    +++++
help: consider removing this method call, as the receiver has type `Res` and `Res: Resource` trivially holds
   |
10 -     insert_resource(Res.into());
10 +     insert_resource(Res);
```

And how it looks now without the ICE.

```console
warning: unused import: `minirapier::Ray`
 --> src/main.rs:2:5
  |
2 | use minirapier::Ray;
  |     ^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

error[E0283]: type annotations needed
  --> src/main.rs:10:5
   |
10 |     insert_resource(Res.into());
   |     ^^^^^^^^^^^^^^^ ---------- type must be known at this point
   |     |
   |     cannot infer type of the type parameter `R` declared on the function `insert_resource`
   |
   = note: cannot satisfy `_: Resource`
note: there are multiple different versions of crate `minibevy` in the dependency graph
  --> /home/lqd/rust/tmp/minimization/issue-132920/rustc-ice-version-conflict/minibevy_b/src/lib.rs:1:1
   |
1  | pub trait Resource {}
   | ^^^^^^^^^^^^^^^^^^ this is the required trait
   |
  ::: src/main.rs:1:5
   |
1  | use minibevy::Resource;
   |     -------- one version of crate `minibevy` is used here, as a direct dependency of the current crate
2  | use minirapier::Ray;
   |     ---------- one version of crate `minibevy` is used here, as a dependency of crate `minirapier`
   |
  ::: /home/lqd/rust/tmp/minimization/issue-132920/rustc-ice-version-conflict/minibevy_a/src/lib.rs:1:1
   |
1  | pub trait Resource {}
   | ------------------ this is the found trait
   = help: you can use `cargo tree` to explore your dependency tree
note: required by a bound in `insert_resource`
  --> src/main.rs:4:23
   |
4  | fn insert_resource<R: Resource>(_resource: R) {}
   |                       ^^^^^^^^ required by this bound in `insert_resource`
help: consider specifying the generic argument
   |
10 |     insert_resource::<R>(Res.into());
   |                    +++++
help: consider removing this method call, as the receiver has type `Res` and `Res: Resource` trivially holds
   |
10 -     insert_resource(Res.into());
10 +     insert_resource(Res);
   |
```

The improvements from #128849 are still present and the note about the trait coming from the 2 versions of bevy is more explanatory/helpful than before, albeit a bit verbosely.

Fixes #132920.