### PR TITLE
[beta] backports

### DIFF
--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -77,6 +77,8 @@ parse_box_syntax_removed_suggestion = use `Box::new()` instead
 
 parse_cannot_be_raw_ident = `{$ident}` cannot be a raw identifier
 
+parse_cannot_be_raw_lifetime = `{$ident}` cannot be a raw lifetime
+
 parse_catch_after_try = keyword `catch` cannot follow a `try` block
     .help = try using `match` on the result of the `try` block instead
 

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2019,6 +2019,14 @@ pub(crate) struct CannotBeRawIdent {
 }
 
 #[derive(Diagnostic)]
+#[diag(parse_cannot_be_raw_lifetime)]
+pub(crate) struct CannotBeRawLifetime {
+    #[primary_span]
+    pub span: Span,
+    pub ident: Symbol,
+}
+
+#[derive(Diagnostic)]
 #[diag(parse_keyword_lifetime)]
 pub(crate) struct KeywordLifetime {
     #[primary_span]

--- a/tests/debuginfo/numeric-types.rs
+++ b/tests/debuginfo/numeric-types.rs
@@ -3,8 +3,11 @@
 //@ ignore-windows-gnu: #128981
 
 // Note: u128 visualization was not supported in 10.0.22621.3233 but was fixed in 10.0.26100.2161.
-// FIXME(jieyouxu): triple-check if this annotation works properly in CI, because it seems to
-// ignore the test locally for me.
+
+// FIXME(#133107): this is temporarily marked as `only-64bit` because of course 32-bit msvc has
+// a different integer width and thus underlying integer type display. Only marked as such to
+// unblock the tree.
+//@ only-64bit
 //@ min-cdb-version: 10.0.26100.2161
 
 // Tests the visualizations for `NonZero<T>`, `Wrapping<T>` and

--- a/tests/debuginfo/numeric-types.rs
+++ b/tests/debuginfo/numeric-types.rs
@@ -2,6 +2,11 @@
 
 //@ ignore-windows-gnu: #128981
 
+// Note: u128 visualization was not supported in 10.0.22621.3233 but was fixed in 10.0.26100.2161.
+// FIXME(jieyouxu): triple-check if this annotation works properly in CI, because it seems to
+// ignore the test locally for me.
+//@ min-cdb-version: 10.0.26100.2161
+
 // Tests the visualizations for `NonZero<T>`, `Wrapping<T>` and
 // `Atomic{Bool,I8,I16,I32,I64,Isize,U8,U16,U32,U64,Usize}` located in `libcore.natvis`.
 
@@ -48,8 +53,8 @@
 // cdb-check:nz_u64           : 0x64 [Type: core::num::nonzero::NonZero<u64>]
 // cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZero<u64>]
 
-// 128-bit integers don't seem to work in CDB
 // cdb-command: dx nz_u128
+// cdb-check:nz_u128          : 111 [Type: core::num::nonzero::NonZero<u128>]
 // cdb-check:    [<Raw View>]     [Type: core::num::nonzero::NonZero<u128>]
 
 // cdb-command: dx nz_usize
@@ -58,101 +63,99 @@
 
 // cdb-command: dx w_i8
 // cdb-check:w_i8             : 10 [Type: core::num::wrapping::Wrapping<i8>]
-// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<i8>]
+// cdb-check:    [+0x000] __0              : 10 [Type: char]
 
 // cdb-command: dx w_i16
 // cdb-check:w_i16            : 20 [Type: core::num::wrapping::Wrapping<i16>]
-// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<i16>]
+// cdb-check:    [+0x000] __0              : 20 [Type: short]
 
 // cdb-command: dx w_i32
 // cdb-check:w_i32            : 30 [Type: core::num::wrapping::Wrapping<i32>]
-// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<i32>]
+// cdb-check:    [+0x000] __0              : 30 [Type: int]
 
 // cdb-command: dx w_i64
 // cdb-check:w_i64            : 40 [Type: core::num::wrapping::Wrapping<i64>]
-// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<i64>]
+// cdb-check:    [+0x000] __0              : 40 [Type: __int64]
 
-// 128-bit integers don't seem to work in CDB
 // cdb-command: dx w_i128
-// cdb-check:w_i128           [Type: core::num::wrapping::Wrapping<i128>]
-// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<i128>]
+// cdb-check:w_i128           : 50 [Type: core::num::wrapping::Wrapping<i128>]
+// cdb-check:    [+0x000] __0              : 50 [Type: i128]
 
 // cdb-command: dx w_isize
 // cdb-check:w_isize          : 60 [Type: core::num::wrapping::Wrapping<isize>]
-// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<isize>]
+// cdb-check:    [+0x000] __0              : 60 [Type: __int64]
 
 // cdb-command: dx w_u8
 // cdb-check:w_u8             : 0x46 [Type: core::num::wrapping::Wrapping<u8>]
-// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<u8>]
+// cdb-check:    [+0x000] __0              : 0x46 [Type: unsigned char]
 
 // cdb-command: dx w_u16
 // cdb-check:w_u16            : 0x50 [Type: core::num::wrapping::Wrapping<u16>]
-// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<u16>]
+// cdb-check:    [+0x000] __0              : 0x50 [Type: unsigned short]
 
 // cdb-command: dx w_u32
 // cdb-check:w_u32            : 0x5a [Type: core::num::wrapping::Wrapping<u32>]
-// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<u32>]
+// cdb-check:    [+0x000] __0              : 0x5a [Type: unsigned int]
 
 // cdb-command: dx w_u64
 // cdb-check:w_u64            : 0x64 [Type: core::num::wrapping::Wrapping<u64>]
-// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<u64>]
+// cdb-check:    [+0x000] __0              : 0x64 [Type: unsigned __int64]
 
-// 128-bit integers don't seem to work in CDB
 // cdb-command: dx w_u128
-// cdb-check:w_u128           [Type: core::num::wrapping::Wrapping<u128>]
-// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<u128>]
+// cdb-check:w_u128           : 110 [Type: core::num::wrapping::Wrapping<u128>]
+// cdb-check:    [+0x000] __0              : 110 [Type: u128]
 
 // cdb-command: dx w_usize
 // cdb-check:w_usize          : 0x78 [Type: core::num::wrapping::Wrapping<usize>]
-// cdb-check:    [<Raw View>]     [Type: core::num::wrapping::Wrapping<usize>]
+// cdb-check:    [+0x000] __0              : 0x78 [Type: unsigned __int64]
 
 // cdb-command: dx a_bool_t
 // cdb-check:a_bool_t         : true [Type: core::sync::atomic::AtomicBool]
-// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicBool]
+// cdb-check:    [+0x000] v                : 0x1 [Type: core::cell::UnsafeCell<u8>]
 
 // cdb-command: dx a_bool_f
 // cdb-check:a_bool_f         : false [Type: core::sync::atomic::AtomicBool]
-// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicBool]
+// cdb-check:    [+0x000] v                : 0x0 [Type: core::cell::UnsafeCell<u8>]
 
 // cdb-command: dx a_i8
 // cdb-check:a_i8             : 2 [Type: core::sync::atomic::AtomicI8]
-// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicI8]
+// cdb-check:    [+0x000] v                : 2 [Type: core::cell::UnsafeCell<i8>]
 
 // cdb-command: dx a_i16
 // cdb-check:a_i16            : 4 [Type: core::sync::atomic::AtomicI16]
-// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicI16]
+// cdb-check:    [+0x000] v                : 4 [Type: core::cell::UnsafeCell<i16>]
 
 // cdb-command: dx a_i32
 // cdb-check:a_i32            : 8 [Type: core::sync::atomic::AtomicI32]
-// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicI32]
+// cdb-check:    [+0x000] v                : 8 [Type: core::cell::UnsafeCell<i32>]
 
 // cdb-command: dx a_i64
 // cdb-check:a_i64            : 16 [Type: core::sync::atomic::AtomicI64]
-// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicI64]
+// cdb-check:    [+0x000] v                : 16 [Type: core::cell::UnsafeCell<i64>]
 
 // cdb-command: dx a_isize
 // cdb-check:a_isize          : 32 [Type: core::sync::atomic::AtomicIsize]
-// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicIsize]
+// cdb-check:    [+0x000] v                : 32 [Type: core::cell::UnsafeCell<isize>]
 
 // cdb-command: dx a_u8
 // cdb-check:a_u8             : 0x40 [Type: core::sync::atomic::AtomicU8]
-// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicU8]
+// cdb-check:    [+0x000] v                : 0x40 [Type: core::cell::UnsafeCell<u8>]
 
 // cdb-command: dx a_u16
 // cdb-check:a_u16            : 0x80 [Type: core::sync::atomic::AtomicU16]
-// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicU16]
+// cdb-check:    [+0x000] v                : 0x80 [Type: core::cell::UnsafeCell<u16>]
 
 // cdb-command: dx a_u32
 // cdb-check:a_u32            : 0x100 [Type: core::sync::atomic::AtomicU32]
-// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicU32]
+// cdb-check:    [+0x000] v                : 0x100 [Type: core::cell::UnsafeCell<u32>]
 
 // cdb-command: dx a_u64
 // cdb-check:a_u64            : 0x200 [Type: core::sync::atomic::AtomicU64]
-// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicU64]
+// cdb-check:    [+0x000] v                : 0x200 [Type: core::cell::UnsafeCell<u64>]
 
 // cdb-command: dx a_usize
 // cdb-check:a_usize          : 0x400 [Type: core::sync::atomic::AtomicUsize]
-// cdb-check:    [<Raw View>]     [Type: core::sync::atomic::AtomicUsize]
+// cdb-check:    [+0x000] v                : 0x400 [Type: core::cell::UnsafeCell<usize>]
 
 
 // === GDB TESTS ===================================================================================

--- a/tests/debuginfo/range-types.rs
+++ b/tests/debuginfo/range-types.rs
@@ -1,7 +1,10 @@
 // Testing the display of range types in cdb.
 
-// cdb-only
-//@ min-cdb-version: 10.0.18317.1001
+//@ only-cdb
+
+// FIXME(jieyouxu): triple check in CI if the directive actually works
+//@ min-cdb-version: 10.0.26100.2161
+
 //@ compile-flags:-g
 
 // === CDB TESTS ==================================================================================
@@ -10,23 +13,26 @@
 
 // cdb-command: dx r1,d
 // cdb-check:r1,d             : (3..5) [Type: core::ops::range::Range<i32>]
-// cdb-check:    [<Raw View>]     [Type: core::ops::range::Range<i32>]
+// cdb-check:    [+0x000] start            : 3 [Type: int]
+// cdb-check:    [+0x004] end              : 5 [Type: int]
 
 // cdb-command: dx r2,d
 // cdb-check:r2,d             : (2..) [Type: core::ops::range::RangeFrom<i32>]
-// cdb-check:    [<Raw View>]     [Type: core::ops::range::RangeFrom<i32>]
+// cdb-check:    [+0x000] start            : 2 [Type: int]
 
 // cdb-command: dx r3,d
 // cdb-check:r3,d             : (1..=4) [Type: core::ops::range::RangeInclusive<i32>]
-// cdb-check:    [<Raw View>]     [Type: core::ops::range::RangeInclusive<i32>]
+// cdb-check:    [+0x000] start            : 1 [Type: int]
+// cdb-check:    [+0x004] end              : 4 [Type: int]
+// cdb-check:    [+0x008] exhausted        : false [Type: bool]
 
 // cdb-command: dx r4,d
 // cdb-check:r4,d             : (..10) [Type: core::ops::range::RangeTo<i32>]
-// cdb-check:    [<Raw View>]     [Type: core::ops::range::RangeTo<i32>]
+// cdb-check:    [+0x000] end              : 10 [Type: int]
 
 // cdb-command: dx r5,d
 // cdb-check:r5,d             : (..=3) [Type: core::ops::range::RangeToInclusive<i32>]
-// cdb-check:    [<Raw View>]     [Type: core::ops::range::RangeToInclusive<i32>]
+// cdb-check:    [+0x000] end              : 3 [Type: int]
 
 // cdb-command: dx r6,d
 // cdb-check:r6,d             [Type: core::ops::range::RangeFull]

--- a/tests/debuginfo/unit-type.rs
+++ b/tests/debuginfo/unit-type.rs
@@ -1,5 +1,8 @@
 //@ compile-flags:-g
 
+// FIXME(jieyouxu): triple check if this works in CI
+//@ min-cdb-version: 10.0.26100.2161
+
 // === GDB TESTS ===================================================================================
 
 // gdb-command: run
@@ -26,18 +29,18 @@
 // cdb-check: Breakpoint 0 hit
 
 // cdb-command: dx _ref
-// cdb-check: _ref             : 0x[...] : () [Type: tuple$<> *]
+// cdb-check: _ref             : 0x[...] [Type: tuple$<> *]
 
 // cdb-command: dx _ptr
-// cdb-check: _ptr             : 0x[...] : () [Type: tuple$<> *]
+// cdb-check: _ptr             : 0x[...] [Type: tuple$<> *]
 
 // cdb-command: dx _local
-// cdb-check: _local           : () [Type: tuple$<>]
+// cdb-check: _local           [Type: tuple$<>]
 
 // cdb-command: dx _field,d
 // cdb-check: _field,d         [Type: unit_type::_TypeContainingUnitField]
 // cdb-check:     [+0x[...]] _a               : 123 [Type: unsigned int]
-// cdb-check:     [+0x[...]] _unit            : () [Type: tuple$<>]
+// cdb-check:     [+0x[...]] _unit            [Type: tuple$<>]
 // cdb-check:     [+0x[...]] _b               : 456 [Type: unsigned __int64]
 
 // Check that we can cast "void pointers" to their actual type in the debugger

--- a/tests/ui/lifetimes/raw/raw-lt-invalid-raw-id.rs
+++ b/tests/ui/lifetimes/raw/raw-lt-invalid-raw-id.rs
@@ -1,0 +1,20 @@
+//@ edition: 2021
+
+// Reject raw lifetimes with identifier parts that wouldn't be valid raw identifiers.
+
+macro_rules! w {
+    ($tt:tt) => {};
+}
+
+w!('r#_);
+//~^ ERROR `_` cannot be a raw lifetime
+w!('r#self);
+//~^ ERROR `self` cannot be a raw lifetime
+w!('r#super);
+//~^ ERROR `super` cannot be a raw lifetime
+w!('r#Self);
+//~^ ERROR `Self` cannot be a raw lifetime
+w!('r#crate);
+//~^ ERROR `crate` cannot be a raw lifetime
+
+fn main() {}

--- a/tests/ui/lifetimes/raw/raw-lt-invalid-raw-id.stderr
+++ b/tests/ui/lifetimes/raw/raw-lt-invalid-raw-id.stderr
@@ -1,0 +1,32 @@
+error: `_` cannot be a raw lifetime
+  --> $DIR/raw-lt-invalid-raw-id.rs:9:4
+   |
+LL | w!('r#_);
+   |    ^^^^
+
+error: `self` cannot be a raw lifetime
+  --> $DIR/raw-lt-invalid-raw-id.rs:11:4
+   |
+LL | w!('r#self);
+   |    ^^^^^^^
+
+error: `super` cannot be a raw lifetime
+  --> $DIR/raw-lt-invalid-raw-id.rs:13:4
+   |
+LL | w!('r#super);
+   |    ^^^^^^^^
+
+error: `Self` cannot be a raw lifetime
+  --> $DIR/raw-lt-invalid-raw-id.rs:15:4
+   |
+LL | w!('r#Self);
+   |    ^^^^^^^
+
+error: `crate` cannot be a raw lifetime
+  --> $DIR/raw-lt-invalid-raw-id.rs:17:4
+   |
+LL | w!('r#crate);
+   |    ^^^^^^^^
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
- Enforce that raw lifetimes must be valid raw identifiers #132363
- Update cdb annotations for some debuginfo tests with cdb `10.0.26100.2161` #133115

r? cuviper
