### PR TITLE
triagebot: automatically add more rustdoc related labels

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -227,6 +227,16 @@ exclude_labels = [
     "T-*",
 ]
 
+trigger_labels = [
+    "A-rustdoc-json",
+    "A-rustdoc-type-layout",
+    "A-rustdoc-scrape-examples",
+    "A-link-to-definition",
+    "A-cross-crate-reexports",
+    "A-intra-doc-links",
+    "A-doc-alias",
+]
+
 [autolabel."A-rustdoc-json"]
 trigger_files = [
     "src/librustdoc/json/",
@@ -243,6 +253,33 @@ trigger_files = [
     "compiler/rustc_attr_parsing",
     "compiler/rustc_attr_data_structures",
     "compiler/rustc_attr_validation",
+]
+
+[autolabel."T-rustdoc-frontend"]
+trigger_labels = [
+    "A-rustdoc-search",
+    "A-rustdoc-ui",
+    "A-rustdoc-js",
+]
+
+trigger_files = [
+    "src/librustdoc/html/",
+    "tests/rustdoc/",
+    "tests/rustdoc-gui/",
+    "tests/rustdoc-js/",
+    "tests/rustdoc-js-std/",
+    # note: tests/rustdoc-ui tests the CLI, not the web frontend
+]
+
+[autolabel."A-rustdoc-search"]
+trigger_files = [
+    "src/librustdoc/html/static/js/search.js",
+    "tests/rustdoc-js",
+    "tests/rustdoc-js-std",
+]
+
+trigger_labels = [
+    "A-type-based-search",
 ]
 
 [autolabel."T-compiler"]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

[inspired by zulip discussion](https://rust-lang.zulipchat.com/#narrow/channel/242269-t-release.2Ftriage/topic/auto-adding.20team.20labels.20based.20on.20certain.20other.20labels)