### PR TITLE
Bail in effects in old solver if self ty is ty var

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/effects.rs
+++ b/compiler/rustc_trait_selection/src/traits/effects.rs
@@ -27,6 +27,11 @@ pub fn evaluate_host_effect_obligation<'tcx>(
         );
     }
 
+    // Force ambiguity for infer self ty.
+    if obligation.predicate.self_ty().is_ty_var() {
+        return Err(EvaluationFailure::Ambiguous);
+    }
+
     match evaluate_host_effect_from_bounds(selcx, obligation) {
         Ok(result) => return Ok(result),
         Err(EvaluationFailure::Ambiguous) => return Err(EvaluationFailure::Ambiguous),

--- a/tests/ui/traits/const-traits/effects/dont-prefer-param-env-for-infer-self-ty.rs
+++ b/tests/ui/traits/const-traits/effects/dont-prefer-param-env-for-infer-self-ty.rs
@@ -1,0 +1,16 @@
+//@ check-pass
+
+#![feature(const_trait_impl)]
+
+#[const_trait]
+trait Foo {}
+
+impl<T> const Foo for (T,) where T: ~const Foo {}
+
+const fn needs_const_foo(_: impl ~const Foo + Copy) {}
+
+const fn test<T: ~const Foo + Copy>(t: T) {
+    needs_const_foo((t,));
+}
+
+fn main() {}


### PR DESCRIPTION
Otherwise when we try to check something like `?t: ~const Trait` we'll immediately stick it to the first param-env candidate, lol.

r? lcnr