### PR TITLE
Stabilize the 2024 edition

### DIFF
--- a/compiler/rustc_span/src/edition.rs
+++ b/compiler/rustc_span/src/edition.rs
@@ -33,7 +33,7 @@ pub const EDITION_NAME_LIST: &str = "2015|2018|2021|2024";
 
 pub const DEFAULT_EDITION: Edition = Edition::Edition2015;
 
-pub const LATEST_STABLE_EDITION: Edition = Edition::Edition2021;
+pub const LATEST_STABLE_EDITION: Edition = Edition::Edition2024;
 
 impl fmt::Display for Edition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -62,7 +62,7 @@ impl Edition {
             Edition::Edition2015 => true,
             Edition::Edition2018 => true,
             Edition::Edition2021 => true,
-            Edition::Edition2024 => false,
+            Edition::Edition2024 => true,
         }
     }
 

--- a/src/doc/rustc/src/command-line-arguments.md
+++ b/src/doc/rustc/src/command-line-arguments.md
@@ -179,7 +179,7 @@ This informs `rustc` of the name of your crate.
 <a id="option-edition"></a>
 ## `--edition`: specify the edition to use
 
-This flag takes a value of `2015`, `2018` or `2021`. The default is `2015`. More
+This flag takes a value of `2015`, `2018`,`2021`, or `2024`. The default is `2015`. More
 information about editions may be found in the [edition guide].
 
 [edition guide]: ../edition-guide/introduction.html

--- a/src/doc/rustdoc/src/write-documentation/documentation-tests.md
+++ b/src/doc/rustdoc/src/write-documentation/documentation-tests.md
@@ -360,7 +360,7 @@ are added.
 # fn foo() {}
 ```
 
-`edition2015`, `edition2018` and `edition2021` tell `rustdoc`
+`edition2015`, `edition2018`, `edition2021`, and `edition2024` tell `rustdoc`
 that the code sample should be compiled using the respective edition of Rust.
 
 ```rust

--- a/tests/crashes/124751.rs
+++ b/tests/crashes/124751.rs
@@ -1,5 +1,5 @@
 //@ known-bug: rust-lang/rust#124751
-//@ compile-flags: -Zunstable-options --edition=2024
+//@ edition: 2024
 
 #![feature(gen_blocks)]
 

--- a/tests/run-make/rustc-help/help-v.stdout
+++ b/tests/run-make/rustc-help/help-v.stdout
@@ -25,7 +25,7 @@ Options:
         --edition 2015|2018|2021|2024
                         Specify which edition of the compiler to use when
                         compiling code. The default is 2015 and the latest
-                        stable edition is 2021.
+                        stable edition is 2024.
         --emit [asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info|mir]
                         Comma separated list of types of output for the
                         compiler to emit

--- a/tests/run-make/rustc-help/help.stdout
+++ b/tests/run-make/rustc-help/help.stdout
@@ -25,7 +25,7 @@ Options:
         --edition 2015|2018|2021|2024
                         Specify which edition of the compiler to use when
                         compiling code. The default is 2015 and the latest
-                        stable edition is 2021.
+                        stable edition is 2024.
         --emit [asm|llvm-bc|llvm-ir|obj|metadata|link|dep-info|mir]
                         Comma separated list of types of output for the
                         compiler to emit

--- a/tests/rustdoc-ui/2024-doctests-checks.rs
+++ b/tests/rustdoc-ui/2024-doctests-checks.rs
@@ -1,5 +1,6 @@
 //@ check-pass
-//@ compile-flags: --test --test-args=--test-threads=1 -Zunstable-options --edition 2024
+//@ edition: 2024
+//@ compile-flags: --test --test-args=--test-threads=1
 //@ normalize-stdout-test: "tests/rustdoc-ui" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ normalize-stdout-test: ".rs:\d+:\d+" -> ".rs:$$LINE:$$COL"

--- a/tests/rustdoc-ui/2024-doctests-checks.stdout
+++ b/tests/rustdoc-ui/2024-doctests-checks.stdout
@@ -1,12 +1,12 @@
 
 running 1 test
-test $DIR/2024-doctests-checks.rs - Foo (line 7) ... ok
+test $DIR/2024-doctests-checks.rs - Foo (line 8) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
 
 running 1 test
-test $DIR/2024-doctests-checks.rs - Foo (line 14) ... ok
+test $DIR/2024-doctests-checks.rs - Foo (line 15) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/2024-doctests-crate-attribute.rs
+++ b/tests/rustdoc-ui/2024-doctests-crate-attribute.rs
@@ -1,5 +1,6 @@
 //@ check-pass
-//@ compile-flags: --test --test-args=--test-threads=1 -Zunstable-options --edition 2024
+//@ edition: 2024
+//@ compile-flags: --test --test-args=--test-threads=1
 //@ normalize-stdout-test: "tests/rustdoc-ui" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ normalize-stdout-test: ".rs:\d+:\d+" -> ".rs:$$LINE:$$COL"

--- a/tests/rustdoc-ui/2024-doctests-crate-attribute.stdout
+++ b/tests/rustdoc-ui/2024-doctests-crate-attribute.stdout
@@ -1,12 +1,12 @@
 
 running 1 test
-test $DIR/2024-doctests-crate-attribute.rs - Foo (line 19) ... ok
+test $DIR/2024-doctests-crate-attribute.rs - Foo (line 20) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
 
 running 1 test
-test $DIR/2024-doctests-crate-attribute.rs - Foo (line 10) ... ok
+test $DIR/2024-doctests-crate-attribute.rs - Foo (line 11) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/auxiliary/extern_macros_2024.rs
+++ b/tests/rustdoc-ui/doctest/auxiliary/extern_macros_2024.rs
@@ -1,5 +1,4 @@
 //@ edition:2024
-//@ compile-flags:-Z unstable-options
 #![crate_name="extern_macros"]
 #[macro_export]
 macro_rules! attrs_on_struct {

--- a/tests/rustdoc-ui/doctest/dead-code-2024.rs
+++ b/tests/rustdoc-ui/doctest/dead-code-2024.rs
@@ -1,6 +1,7 @@
 // This test ensures that the 2024 edition merged doctest will not use `#[allow(unused)]`.
 
-//@ compile-flags:--test -Zunstable-options --edition 2024
+//@ edition: 2024
+//@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101

--- a/tests/rustdoc-ui/doctest/dead-code-2024.stdout
+++ b/tests/rustdoc-ui/doctest/dead-code-2024.stdout
@@ -1,18 +1,18 @@
 
 running 1 test
-test $DIR/dead-code-2024.rs - f (line 12) - compile ... FAILED
+test $DIR/dead-code-2024.rs - f (line 13) - compile ... FAILED
 
 failures:
 
----- $DIR/dead-code-2024.rs - f (line 12) stdout ----
+---- $DIR/dead-code-2024.rs - f (line 13) stdout ----
 error: trait `T` is never used
-  --> $DIR/dead-code-2024.rs:13:7
+  --> $DIR/dead-code-2024.rs:14:7
    |
 LL | trait T { fn f(); }
    |       ^
    |
 note: the lint level is defined here
-  --> $DIR/dead-code-2024.rs:11:9
+  --> $DIR/dead-code-2024.rs:12:9
    |
 LL | #![deny(warnings)]
    |         ^^^^^^^^
@@ -23,7 +23,7 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/dead-code-2024.rs - f (line 12)
+    $DIR/dead-code-2024.rs - f (line 13)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/failed-doctest-should-panic.rs
+++ b/tests/rustdoc-ui/doctest/failed-doctest-should-panic.rs
@@ -1,7 +1,8 @@
 // FIXME: if/when the output of the test harness can be tested on its own, this test should be
 // adapted to use that, and that normalize line can go away
 
-//@ compile-flags:--test -Z unstable-options --edition 2024
+//@ edition: 2024
+//@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101

--- a/tests/rustdoc-ui/doctest/failed-doctest-should-panic.stdout
+++ b/tests/rustdoc-ui/doctest/failed-doctest-should-panic.stdout
@@ -1,14 +1,14 @@
 
 running 1 test
-test $DIR/failed-doctest-should-panic.rs - Foo (line 9) - should panic ... FAILED
+test $DIR/failed-doctest-should-panic.rs - Foo (line 10) - should panic ... FAILED
 
 failures:
 
----- $DIR/failed-doctest-should-panic.rs - Foo (line 9) stdout ----
+---- $DIR/failed-doctest-should-panic.rs - Foo (line 10) stdout ----
 note: test did not panic as expected
 
 failures:
-    $DIR/failed-doctest-should-panic.rs - Foo (line 9)
+    $DIR/failed-doctest-should-panic.rs - Foo (line 10)
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/merged-ignore-no_run.rs
+++ b/tests/rustdoc-ui/doctest/merged-ignore-no_run.rs
@@ -1,4 +1,5 @@
-//@ compile-flags:--test --test-args=--test-threads=1 -Zunstable-options --edition 2024
+//@ edition: 2024
+//@ compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ check-pass

--- a/tests/rustdoc-ui/doctest/merged-ignore-no_run.stdout
+++ b/tests/rustdoc-ui/doctest/merged-ignore-no_run.stdout
@@ -1,7 +1,7 @@
 
 running 2 tests
-test $DIR/merged-ignore-no_run.rs - ignored (line 6) ... ignored
-test $DIR/merged-ignore-no_run.rs - no_run (line 11) - compile ... ok
+test $DIR/merged-ignore-no_run.rs - ignored (line 7) ... ignored
+test $DIR/merged-ignore-no_run.rs - no_run (line 12) - compile ... ok
 
 test result: ok. 1 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/rustdoc-ui/doctest/standalone-warning-2024.rs
+++ b/tests/rustdoc-ui/doctest/standalone-warning-2024.rs
@@ -1,6 +1,7 @@
 // This test checks that it will output warnings for usage of `standalone` or `standalone_crate`.
 
-//@ compile-flags:--test -Zunstable-options --edition 2024
+//@ edition: 2024
+//@ compile-flags:--test
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ normalize-stdout-test: ".rs:\d+:\d+" -> ".rs:$$LINE:$$COL"

--- a/tests/rustdoc-ui/doctest/standalone-warning-2024.stderr
+++ b/tests/rustdoc-ui/doctest/standalone-warning-2024.stderr
@@ -1,34 +1,34 @@
 error: unknown attribute `standalone`
-  --> $DIR/standalone-warning-2024.rs:10:1
+  --> $DIR/standalone-warning-2024.rs:11:1
    |
-10 | / //! ```standalone
-11 | | //! bla
-12 | | //! ```
-13 | | //!
-14 | | //! ```standalone-crate
-15 | | //! bla
-16 | | //! ```
+11 | / //! ```standalone
+12 | | //! bla
+13 | | //! ```
+14 | | //!
+15 | | //! ```standalone-crate
+16 | | //! bla
+17 | | //! ```
    | |_______^
    |
    = help: use `standalone_crate` to compile this code block separately
    = help: this code block may be skipped during testing, because unknown attributes are treated as markers for code samples written in other programming languages, unless it is also explicitly marked as `rust`
 note: the lint level is defined here
-  --> $DIR/standalone-warning-2024.rs:8:9
+  --> $DIR/standalone-warning-2024.rs:9:9
    |
-8  | #![deny(warnings)]
+9  | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(rustdoc::invalid_codeblock_attributes)]` implied by `#[deny(warnings)]`
 
 error: unknown attribute `standalone-crate`
-  --> $DIR/standalone-warning-2024.rs:10:1
+  --> $DIR/standalone-warning-2024.rs:11:1
    |
-10 | / //! ```standalone
-11 | | //! bla
-12 | | //! ```
-13 | | //!
-14 | | //! ```standalone-crate
-15 | | //! bla
-16 | | //! ```
+11 | / //! ```standalone
+12 | | //! bla
+13 | | //! ```
+14 | | //!
+15 | | //! ```standalone-crate
+16 | | //! bla
+17 | | //! ```
    | |_______^
    |
    = help: use `standalone_crate` to compile this code block separately

--- a/tests/rustdoc-ui/doctest/wrong-ast-2024.rs
+++ b/tests/rustdoc-ui/doctest/wrong-ast-2024.rs
@@ -1,4 +1,5 @@
-//@ compile-flags:--test --test-args=--test-threads=1 -Zunstable-options --edition 2024
+//@ edition: 2024
+//@ compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ normalize-stdout-test: ".rs:\d+:\d+" -> ".rs:$$LINE:$$COL"

--- a/tests/rustdoc-ui/doctest/wrong-ast-2024.stdout
+++ b/tests/rustdoc-ui/doctest/wrong-ast-2024.stdout
@@ -1,17 +1,17 @@
 
 running 1 test
-test $DIR/wrong-ast-2024.rs - three (line 17) - should panic ... ok
+test $DIR/wrong-ast-2024.rs - three (line 18) - should panic ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
 
 running 2 tests
-test $DIR/wrong-ast-2024.rs - one (line 7) ... FAILED
-test $DIR/wrong-ast-2024.rs - two (line 12) ... FAILED
+test $DIR/wrong-ast-2024.rs - one (line 8) ... FAILED
+test $DIR/wrong-ast-2024.rs - two (line 13) ... FAILED
 
 failures:
 
----- $DIR/wrong-ast-2024.rs - one (line 7) stdout ----
+---- $DIR/wrong-ast-2024.rs - one (line 8) stdout ----
 error[E0758]: unterminated block comment
   --> $DIR/wrong-ast-2024.rs:$LINE:$COL
    |
@@ -22,7 +22,7 @@ error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0758`.
 Couldn't compile the test.
----- $DIR/wrong-ast-2024.rs - two (line 12) stdout ----
+---- $DIR/wrong-ast-2024.rs - two (line 13) stdout ----
 error: unexpected closing delimiter: `}`
   --> $DIR/wrong-ast-2024.rs:$LINE:$COL
    |
@@ -34,8 +34,8 @@ error: aborting due to 1 previous error
 Couldn't compile the test.
 
 failures:
-    $DIR/wrong-ast-2024.rs - one (line 7)
-    $DIR/wrong-ast-2024.rs - two (line 12)
+    $DIR/wrong-ast-2024.rs - one (line 8)
+    $DIR/wrong-ast-2024.rs - two (line 13)
 
 test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 

--- a/tests/ui/async-await/async-fn/edition-2015.stderr
+++ b/tests/ui/async-await/async-fn/edition-2015.stderr
@@ -4,7 +4,7 @@ error: `async` trait bounds are only allowed in Rust 2018 or later
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    |                ^^^^^
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: `async` trait bounds are only allowed in Rust 2018 or later
@@ -13,7 +13,7 @@ error: `async` trait bounds are only allowed in Rust 2018 or later
 LL | fn foo(x: impl async Fn()) -> impl async Fn() { x }
    |                                    ^^^^^
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0658]: async closures are unstable

--- a/tests/ui/async-await/edition-deny-async-fns-2015.stderr
+++ b/tests/ui/async-await/edition-deny-async-fns-2015.stderr
@@ -4,7 +4,7 @@ error[E0670]: `async fn` is not permitted in Rust 2015
 LL | async fn foo() {}
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
@@ -13,7 +13,7 @@ error[E0670]: `async fn` is not permitted in Rust 2015
 LL | fn baz() { async fn foo() {} }
    |            ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
@@ -22,7 +22,7 @@ error[E0670]: `async fn` is not permitted in Rust 2015
 LL | async fn async_baz() {
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
@@ -31,7 +31,7 @@ error[E0670]: `async fn` is not permitted in Rust 2015
 LL |     async fn bar() {}
    |     ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
@@ -40,7 +40,7 @@ error[E0670]: `async fn` is not permitted in Rust 2015
 LL |     async fn foo() {}
    |     ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
@@ -49,7 +49,7 @@ error[E0670]: `async fn` is not permitted in Rust 2015
 LL |     async fn foo() {}
    |     ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
@@ -58,7 +58,7 @@ error[E0670]: `async fn` is not permitted in Rust 2015
 LL |         async fn bar() {}
    |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
@@ -67,7 +67,7 @@ error[E0670]: `async fn` is not permitted in Rust 2015
 LL |         async fn foo() {}
    |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0670]: `async fn` is not permitted in Rust 2015
@@ -76,7 +76,7 @@ error[E0670]: `async fn` is not permitted in Rust 2015
 LL |             async fn bar() {}
    |             ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: aborting due to 9 previous errors

--- a/tests/ui/async-await/for-await-passthrough.rs
+++ b/tests/ui/async-await/for-await-passthrough.rs
@@ -1,6 +1,5 @@
 //@ run-pass
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 #![feature(async_iterator, async_iter_from_iter, async_for_loop, noop_waker,
            gen_blocks)]
 

--- a/tests/ui/async-await/suggest-switching-edition-on-await-cargo.rs
+++ b/tests/ui/async-await/suggest-switching-edition-on-await-cargo.rs
@@ -12,7 +12,7 @@ fn await_on_struct_missing() {
     //~^ ERROR no field `await` on type
     //~| NOTE unknown field
     //~| NOTE to `.await` a `Future`, switch to Rust 2018
-    //~| HELP set `edition = "2021"` in `Cargo.toml`
+    //~| HELP set `edition = "2024"` in `Cargo.toml`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 }
 
@@ -26,7 +26,7 @@ fn await_on_struct_similar() {
     //~| NOTE unknown field
     //~| HELP a field with a similar name exists
     //~| NOTE to `.await` a `Future`, switch to Rust 2018
-    //~| HELP set `edition = "2021"` in `Cargo.toml`
+    //~| HELP set `edition = "2024"` in `Cargo.toml`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 }
 
@@ -35,7 +35,7 @@ fn await_on_63533(x: Pin<&mut dyn Future<Output = ()>>) {
     //~^ ERROR no field `await` on type
     //~| NOTE unknown field
     //~| NOTE to `.await` a `Future`, switch to Rust 2018
-    //~| HELP set `edition = "2021"` in `Cargo.toml`
+    //~| HELP set `edition = "2024"` in `Cargo.toml`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 }
 
@@ -44,6 +44,6 @@ fn await_on_apit(x: impl Future<Output = ()>) {
     //~^ ERROR no field `await` on type
     //~| NOTE unknown field
     //~| NOTE to `.await` a `Future`, switch to Rust 2018
-    //~| HELP set `edition = "2021"` in `Cargo.toml`
+    //~| HELP set `edition = "2024"` in `Cargo.toml`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 }

--- a/tests/ui/async-await/suggest-switching-edition-on-await-cargo.stderr
+++ b/tests/ui/async-await/suggest-switching-edition-on-await-cargo.stderr
@@ -5,7 +5,7 @@ LL |     x.await;
    |       ^^^^^ unknown field
    |
    = note: to `.await` a `Future`, switch to Rust 2018 or later
-   = help: set `edition = "2021"` in `Cargo.toml`
+   = help: set `edition = "2024"` in `Cargo.toml`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0609]: no field `await` on type `await_on_struct_similar::S`
@@ -15,7 +15,7 @@ LL |     x.await;
    |       ^^^^^ unknown field
    |
    = note: to `.await` a `Future`, switch to Rust 2018 or later
-   = help: set `edition = "2021"` in `Cargo.toml`
+   = help: set `edition = "2024"` in `Cargo.toml`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 help: a field with a similar name exists
    |
@@ -29,7 +29,7 @@ LL |     x.await;
    |       ^^^^^ unknown field
    |
    = note: to `.await` a `Future`, switch to Rust 2018 or later
-   = help: set `edition = "2021"` in `Cargo.toml`
+   = help: set `edition = "2024"` in `Cargo.toml`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0609]: no field `await` on type `impl Future<Output = ()>`
@@ -39,7 +39,7 @@ LL |     x.await;
    |       ^^^^^ unknown field
    |
    = note: to `.await` a `Future`, switch to Rust 2018 or later
-   = help: set `edition = "2021"` in `Cargo.toml`
+   = help: set `edition = "2024"` in `Cargo.toml`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: aborting due to 4 previous errors

--- a/tests/ui/async-await/suggest-switching-edition-on-await.rs
+++ b/tests/ui/async-await/suggest-switching-edition-on-await.rs
@@ -10,7 +10,7 @@ fn await_on_struct_missing() {
     //~^ ERROR no field `await` on type
     //~| NOTE unknown field
     //~| NOTE to `.await` a `Future`, switch to Rust 2018
-    //~| HELP pass `--edition 2021` to `rustc`
+    //~| HELP pass `--edition 2024` to `rustc`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 }
 
@@ -24,7 +24,7 @@ fn await_on_struct_similar() {
     //~| NOTE unknown field
     //~| HELP a field with a similar name exists
     //~| NOTE to `.await` a `Future`, switch to Rust 2018
-    //~| HELP pass `--edition 2021` to `rustc`
+    //~| HELP pass `--edition 2024` to `rustc`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 }
 
@@ -33,7 +33,7 @@ fn await_on_63533(x: Pin<&mut dyn Future<Output = ()>>) {
     //~^ ERROR no field `await` on type
     //~| NOTE unknown field
     //~| NOTE to `.await` a `Future`, switch to Rust 2018
-    //~| HELP pass `--edition 2021` to `rustc`
+    //~| HELP pass `--edition 2024` to `rustc`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 }
 
@@ -42,6 +42,6 @@ fn await_on_apit(x: impl Future<Output = ()>) {
     //~^ ERROR no field `await` on type
     //~| NOTE unknown field
     //~| NOTE to `.await` a `Future`, switch to Rust 2018
-    //~| HELP pass `--edition 2021` to `rustc`
+    //~| HELP pass `--edition 2024` to `rustc`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 }

--- a/tests/ui/async-await/suggest-switching-edition-on-await.stderr
+++ b/tests/ui/async-await/suggest-switching-edition-on-await.stderr
@@ -5,7 +5,7 @@ LL |     x.await;
    |       ^^^^^ unknown field
    |
    = note: to `.await` a `Future`, switch to Rust 2018 or later
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0609]: no field `await` on type `await_on_struct_similar::S`
@@ -15,7 +15,7 @@ LL |     x.await;
    |       ^^^^^ unknown field
    |
    = note: to `.await` a `Future`, switch to Rust 2018 or later
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 help: a field with a similar name exists
    |
@@ -29,7 +29,7 @@ LL |     x.await;
    |       ^^^^^ unknown field
    |
    = note: to `.await` a `Future`, switch to Rust 2018 or later
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0609]: no field `await` on type `impl Future<Output = ()>`
@@ -39,7 +39,7 @@ LL |     x.await;
    |       ^^^^^ unknown field
    |
    = note: to `.await` a `Future`, switch to Rust 2018 or later
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: aborting due to 4 previous errors

--- a/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.rs
+++ b/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 
 #[unsafe(cfg(any()))] //~ ERROR: is not an unsafe attribute
 fn a() {}

--- a/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.stderr
+++ b/tests/ui/attributes/unsafe/extraneous-unsafe-attributes.stderr
@@ -1,5 +1,5 @@
 error: `cfg` is not an unsafe attribute
-  --> $DIR/extraneous-unsafe-attributes.rs:4:3
+  --> $DIR/extraneous-unsafe-attributes.rs:3:3
    |
 LL | #[unsafe(cfg(any()))]
    |   ^^^^^^ this is not an unsafe attribute
@@ -7,7 +7,7 @@ LL | #[unsafe(cfg(any()))]
    = note: extraneous unsafe is not allowed in attributes
 
 error: `cfg_attr` is not an unsafe attribute
-  --> $DIR/extraneous-unsafe-attributes.rs:7:3
+  --> $DIR/extraneous-unsafe-attributes.rs:6:3
    |
 LL | #[unsafe(cfg_attr(any(), allow(dead_code)))]
    |   ^^^^^^ this is not an unsafe attribute
@@ -15,7 +15,7 @@ LL | #[unsafe(cfg_attr(any(), allow(dead_code)))]
    = note: extraneous unsafe is not allowed in attributes
 
 error: `test` is not an unsafe attribute
-  --> $DIR/extraneous-unsafe-attributes.rs:10:3
+  --> $DIR/extraneous-unsafe-attributes.rs:9:3
    |
 LL | #[unsafe(test)]
    |   ^^^^^^ this is not an unsafe attribute
@@ -23,7 +23,7 @@ LL | #[unsafe(test)]
    = note: extraneous unsafe is not allowed in attributes
 
 error: expected identifier, found keyword `unsafe`
-  --> $DIR/extraneous-unsafe-attributes.rs:31:19
+  --> $DIR/extraneous-unsafe-attributes.rs:30:19
    |
 LL |     let _a = cfg!(unsafe(foo));
    |                   ^^^^^^ expected identifier, found keyword
@@ -34,13 +34,13 @@ LL |     let _a = cfg!(r#unsafe(foo));
    |                   ++
 
 error[E0537]: invalid predicate `r#unsafe`
-  --> $DIR/extraneous-unsafe-attributes.rs:31:19
+  --> $DIR/extraneous-unsafe-attributes.rs:30:19
    |
 LL |     let _a = cfg!(unsafe(foo));
    |                   ^^^^^^^^^^^
 
 error: `ignore` is not an unsafe attribute
-  --> $DIR/extraneous-unsafe-attributes.rs:13:3
+  --> $DIR/extraneous-unsafe-attributes.rs:12:3
    |
 LL | #[unsafe(ignore = "test")]
    |   ^^^^^^ this is not an unsafe attribute
@@ -48,7 +48,7 @@ LL | #[unsafe(ignore = "test")]
    = note: extraneous unsafe is not allowed in attributes
 
 error: `should_panic` is not an unsafe attribute
-  --> $DIR/extraneous-unsafe-attributes.rs:16:3
+  --> $DIR/extraneous-unsafe-attributes.rs:15:3
    |
 LL | #[unsafe(should_panic(expected = "test"))]
    |   ^^^^^^ this is not an unsafe attribute
@@ -56,7 +56,7 @@ LL | #[unsafe(should_panic(expected = "test"))]
    = note: extraneous unsafe is not allowed in attributes
 
 error: `macro_use` is not an unsafe attribute
-  --> $DIR/extraneous-unsafe-attributes.rs:19:3
+  --> $DIR/extraneous-unsafe-attributes.rs:18:3
    |
 LL | #[unsafe(macro_use)]
    |   ^^^^^^ this is not an unsafe attribute
@@ -64,7 +64,7 @@ LL | #[unsafe(macro_use)]
    = note: extraneous unsafe is not allowed in attributes
 
 error: `macro_export` is not an unsafe attribute
-  --> $DIR/extraneous-unsafe-attributes.rs:21:7
+  --> $DIR/extraneous-unsafe-attributes.rs:20:7
    |
 LL |     #[unsafe(macro_export)]
    |       ^^^^^^ this is not an unsafe attribute
@@ -72,7 +72,7 @@ LL |     #[unsafe(macro_export)]
    = note: extraneous unsafe is not allowed in attributes
 
 error: `used` is not an unsafe attribute
-  --> $DIR/extraneous-unsafe-attributes.rs:27:3
+  --> $DIR/extraneous-unsafe-attributes.rs:26:3
    |
 LL | #[unsafe(used)]
    |   ^^^^^^ this is not an unsafe attribute

--- a/tests/ui/coroutine/async_gen_fn.none.stderr
+++ b/tests/ui/coroutine/async_gen_fn.none.stderr
@@ -4,7 +4,7 @@ error[E0670]: `async fn` is not permitted in Rust 2015
 LL | async gen fn foo() {}
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: expected one of `extern`, `fn`, `safe`, or `unsafe`, found `gen`

--- a/tests/ui/coroutine/async_gen_fn.rs
+++ b/tests/ui/coroutine/async_gen_fn.rs
@@ -1,5 +1,5 @@
 //@ revisions: e2024 none
-//@[e2024] compile-flags: --edition 2024 -Zunstable-options
+//@[e2024] edition: 2024
 
 async gen fn foo() {}
 //[none]~^ ERROR: `async fn` is not permitted in Rust 2015

--- a/tests/ui/coroutine/async_gen_fn_iter.rs
+++ b/tests/ui/coroutine/async_gen_fn_iter.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 //@ run-pass
 
 #![feature(gen_blocks, async_iterator)]

--- a/tests/ui/coroutine/break-inside-coroutine-issue-124495.rs
+++ b/tests/ui/coroutine/break-inside-coroutine-issue-124495.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Z unstable-options
 
 #![feature(gen_blocks)]
 #![feature(async_closure)]

--- a/tests/ui/coroutine/break-inside-coroutine-issue-124495.stderr
+++ b/tests/ui/coroutine/break-inside-coroutine-issue-124495.stderr
@@ -1,5 +1,5 @@
 error[E0267]: `break` inside `async` function
-  --> $DIR/break-inside-coroutine-issue-124495.rs:8:5
+  --> $DIR/break-inside-coroutine-issue-124495.rs:7:5
    |
 LL | async fn async_fn() {
    | ------------------- enclosing `async` function
@@ -7,7 +7,7 @@ LL |     break;
    |     ^^^^^ cannot `break` inside `async` function
 
 error[E0267]: `break` inside `gen` function
-  --> $DIR/break-inside-coroutine-issue-124495.rs:12:5
+  --> $DIR/break-inside-coroutine-issue-124495.rs:11:5
    |
 LL | gen fn gen_fn() {
    | --------------- enclosing `gen` function
@@ -15,7 +15,7 @@ LL |     break;
    |     ^^^^^ cannot `break` inside `gen` function
 
 error[E0267]: `break` inside `async gen` function
-  --> $DIR/break-inside-coroutine-issue-124495.rs:16:5
+  --> $DIR/break-inside-coroutine-issue-124495.rs:15:5
    |
 LL | async gen fn async_gen_fn() {
    | --------------------------- enclosing `async gen` function
@@ -23,7 +23,7 @@ LL |     break;
    |     ^^^^^ cannot `break` inside `async gen` function
 
 error[E0267]: `break` inside `async` block
-  --> $DIR/break-inside-coroutine-issue-124495.rs:20:21
+  --> $DIR/break-inside-coroutine-issue-124495.rs:19:21
    |
 LL |     let _ = async { break; };
    |             -----   ^^^^^ cannot `break` inside `async` block
@@ -31,7 +31,7 @@ LL |     let _ = async { break; };
    |             enclosing `async` block
 
 error[E0267]: `break` inside `async` closure
-  --> $DIR/break-inside-coroutine-issue-124495.rs:22:24
+  --> $DIR/break-inside-coroutine-issue-124495.rs:21:24
    |
 LL |     let _ = async || { break; };
    |             --------   ^^^^^ cannot `break` inside `async` closure
@@ -39,7 +39,7 @@ LL |     let _ = async || { break; };
    |             enclosing `async` closure
 
 error[E0267]: `break` inside `gen` block
-  --> $DIR/break-inside-coroutine-issue-124495.rs:24:19
+  --> $DIR/break-inside-coroutine-issue-124495.rs:23:19
    |
 LL |     let _ = gen { break; };
    |             ---   ^^^^^ cannot `break` inside `gen` block
@@ -47,7 +47,7 @@ LL |     let _ = gen { break; };
    |             enclosing `gen` block
 
 error[E0267]: `break` inside `async gen` block
-  --> $DIR/break-inside-coroutine-issue-124495.rs:26:25
+  --> $DIR/break-inside-coroutine-issue-124495.rs:25:25
    |
 LL |     let _ = async gen { break; };
    |             ---------   ^^^^^ cannot `break` inside `async gen` block

--- a/tests/ui/coroutine/const_gen_fn.rs
+++ b/tests/ui/coroutine/const_gen_fn.rs
@@ -1,5 +1,4 @@
 //@ edition:2024
-//@ compile-flags: -Zunstable-options
 
 #![feature(gen_blocks)]
 

--- a/tests/ui/coroutine/const_gen_fn.stderr
+++ b/tests/ui/coroutine/const_gen_fn.stderr
@@ -1,5 +1,5 @@
 error: functions cannot be both `const` and `gen`
-  --> $DIR/const_gen_fn.rs:6:1
+  --> $DIR/const_gen_fn.rs:5:1
    |
 LL | const gen fn a() {}
    | ^^^^^-^^^----------
@@ -8,7 +8,7 @@ LL | const gen fn a() {}
    | `const` because of this
 
 error: functions cannot be both `const` and `async gen`
-  --> $DIR/const_gen_fn.rs:9:1
+  --> $DIR/const_gen_fn.rs:8:1
    |
 LL | const async gen fn b() {}
    | ^^^^^-^^^^^^^^^----------

--- a/tests/ui/coroutine/gen_block.rs
+++ b/tests/ui/coroutine/gen_block.rs
@@ -1,5 +1,5 @@
 //@ revisions: e2024 none
-//@[e2024] compile-flags: --edition 2024 -Zunstable-options
+//@[e2024] edition: 2024
 #![cfg_attr(e2024, feature(gen_blocks))]
 #![feature(stmt_expr_attributes)]
 

--- a/tests/ui/coroutine/gen_block_is_coro.rs
+++ b/tests/ui/coroutine/gen_block_is_coro.rs
@@ -1,4 +1,5 @@
-//@compile-flags: --edition 2024 -Zunstable-options --diagnostic-width=300
+//@ edition: 2024
+//@ compile-flags: --diagnostic-width=300
 #![feature(coroutines, coroutine_trait, gen_blocks)]
 
 use std::ops::Coroutine;

--- a/tests/ui/coroutine/gen_block_is_coro.stderr
+++ b/tests/ui/coroutine/gen_block_is_coro.stderr
@@ -1,26 +1,26 @@
-error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:7:5: 7:8}: Coroutine` is not satisfied
-  --> $DIR/gen_block_is_coro.rs:6:13
+error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:8:5: 8:8}: Coroutine` is not satisfied
+  --> $DIR/gen_block_is_coro.rs:7:13
    |
 LL | fn foo() -> impl Coroutine<Yield = u32, Return = ()> {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:7:5: 7:8}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:8:5: 8:8}`
 LL |     gen { yield 42 }
-   |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_coro.rs:7:5: 7:8}` here
+   |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_coro.rs:8:5: 8:8}` here
 
-error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:11:5: 11:8}: Coroutine` is not satisfied
-  --> $DIR/gen_block_is_coro.rs:10:13
+error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:12:5: 12:8}: Coroutine` is not satisfied
+  --> $DIR/gen_block_is_coro.rs:11:13
    |
 LL | fn bar() -> impl Coroutine<Yield = i64, Return = ()> {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:11:5: 11:8}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:12:5: 12:8}`
 LL |     gen { yield 42 }
-   |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_coro.rs:11:5: 11:8}` here
+   |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_coro.rs:12:5: 12:8}` here
 
-error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:15:5: 15:8}: Coroutine` is not satisfied
-  --> $DIR/gen_block_is_coro.rs:14:13
+error[E0277]: the trait bound `{gen block@$DIR/gen_block_is_coro.rs:16:5: 16:8}: Coroutine` is not satisfied
+  --> $DIR/gen_block_is_coro.rs:15:13
    |
 LL | fn baz() -> impl Coroutine<Yield = i32, Return = ()> {
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:15:5: 15:8}`
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Coroutine` is not implemented for `{gen block@$DIR/gen_block_is_coro.rs:16:5: 16:8}`
 LL |     gen { yield 42 }
-   |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_coro.rs:15:5: 15:8}` here
+   |     ---------------- return type was inferred to be `{gen block@$DIR/gen_block_is_coro.rs:16:5: 16:8}` here
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/coroutine/gen_block_is_fused_iter.rs
+++ b/tests/ui/coroutine/gen_block_is_fused_iter.rs
@@ -1,5 +1,5 @@
 //@ revisions: next old
-//@compile-flags: --edition 2024 -Zunstable-options
+//@ edition: 2024
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 #![feature(gen_blocks)]

--- a/tests/ui/coroutine/gen_block_is_iter.rs
+++ b/tests/ui/coroutine/gen_block_is_iter.rs
@@ -1,5 +1,5 @@
 //@ revisions: next old
-//@compile-flags: --edition 2024 -Zunstable-options
+//@ edition: 2024
 //@[next] compile-flags: -Znext-solver
 //@ check-pass
 #![feature(gen_blocks)]

--- a/tests/ui/coroutine/gen_block_is_no_future.rs
+++ b/tests/ui/coroutine/gen_block_is_no_future.rs
@@ -1,4 +1,4 @@
-//@compile-flags: --edition 2024 -Zunstable-options
+//@ edition: 2024
 #![feature(gen_blocks)]
 
 fn foo() -> impl std::future::Future { //~ ERROR is not a future

--- a/tests/ui/coroutine/gen_block_iterate.rs
+++ b/tests/ui/coroutine/gen_block_iterate.rs
@@ -1,5 +1,5 @@
 //@ revisions: next old
-//@compile-flags: --edition 2024 -Zunstable-options
+//@ edition: 2024
 //@[next] compile-flags: -Znext-solver
 //@ run-pass
 #![feature(gen_blocks)]

--- a/tests/ui/coroutine/gen_block_move.fixed
+++ b/tests/ui/coroutine/gen_block_move.fixed
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2024 -Zunstable-options
+//@ edition: 2024
 //@ run-rustfix
 #![feature(gen_blocks)]
 

--- a/tests/ui/coroutine/gen_block_move.rs
+++ b/tests/ui/coroutine/gen_block_move.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2024 -Zunstable-options
+//@ edition: 2024
 //@ run-rustfix
 #![feature(gen_blocks)]
 

--- a/tests/ui/coroutine/gen_block_panic.rs
+++ b/tests/ui/coroutine/gen_block_panic.rs
@@ -1,4 +1,4 @@
-//@compile-flags: --edition 2024 -Zunstable-options
+//@ edition: 2024
 //@ run-pass
 //@ needs-unwind
 #![feature(gen_blocks)]

--- a/tests/ui/coroutine/gen_fn.rs
+++ b/tests/ui/coroutine/gen_fn.rs
@@ -1,5 +1,5 @@
 //@ revisions: e2024 none
-//@[e2024] compile-flags: --edition 2024 -Zunstable-options
+//@[e2024] edition: 2024
 
 gen fn foo() {}
 //[none]~^ ERROR: expected one of `#`, `async`, `const`, `default`, `extern`, `fn`, `pub`, `safe`, `unsafe`, or `use`, found `gen`

--- a/tests/ui/coroutine/gen_fn_iter.rs
+++ b/tests/ui/coroutine/gen_fn_iter.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 //@ run-pass
 #![feature(gen_blocks)]
 

--- a/tests/ui/coroutine/gen_fn_lifetime_capture.rs
+++ b/tests/ui/coroutine/gen_fn_lifetime_capture.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 //@ check-pass
 #![feature(gen_blocks)]
 

--- a/tests/ui/coroutine/other-attribute-on-gen.rs
+++ b/tests/ui/coroutine/other-attribute-on-gen.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 //@ run-pass
 #![feature(gen_blocks)]
 #![feature(optimize_attribute)]

--- a/tests/ui/coroutine/return-types-diverge.rs
+++ b/tests/ui/coroutine/return-types-diverge.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2024 -Zunstable-options
+//@ edition: 2024
 //@ check-pass
 
 #![feature(gen_blocks)]

--- a/tests/ui/coroutine/return-types.rs
+++ b/tests/ui/coroutine/return-types.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2024 -Zunstable-options
+//@ edition: 2024
 
 #![feature(gen_blocks)]
 

--- a/tests/ui/coroutine/self_referential_gen_block.rs
+++ b/tests/ui/coroutine/self_referential_gen_block.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2024 -Zunstable-options
+//@ edition: 2024
 #![feature(gen_blocks)]
 //! This test checks that we don't allow self-referential generators
 

--- a/tests/ui/drop/auxiliary/edition-2024-macros.rs
+++ b/tests/ui/drop/auxiliary/edition-2024-macros.rs
@@ -1,5 +1,4 @@
 //@ edition:2024
-//@ compile-flags: -Zunstable-options
 
 #[macro_export]
 macro_rules! edition_2024_block {

--- a/tests/ui/drop/drop_order_if_let_rescope.rs
+++ b/tests/ui/drop/drop_order_if_let_rescope.rs
@@ -1,6 +1,6 @@
 //@ run-pass
 //@ edition:2024
-//@ compile-flags: -Z validate-mir -Zunstable-options
+//@ compile-flags: -Z validate-mir
 
 #![feature(let_chains)]
 

--- a/tests/ui/drop/if-let-rescope-borrowck-suggestions.rs
+++ b/tests/ui/drop/if-let-rescope-borrowck-suggestions.rs
@@ -1,5 +1,5 @@
 //@ edition: 2024
-//@ compile-flags: -Z validate-mir -Zunstable-options
+//@ compile-flags: -Z validate-mir
 
 #![deny(if_let_rescope)]
 

--- a/tests/ui/drop/lint-tail-expr-drop-order-gated.rs
+++ b/tests/ui/drop/lint-tail-expr-drop-order-gated.rs
@@ -3,7 +3,6 @@
 // Only `cargo fix --edition 2024` shall activate this lint.
 
 //@ check-pass
-//@ compile-flags: -Z unstable-options
 //@ edition: 2024
 
 #![deny(tail_expr_drop_order)]

--- a/tests/ui/drop/tail-expr-drop-order.rs
+++ b/tests/ui/drop/tail-expr-drop-order.rs
@@ -1,6 +1,6 @@
 //@ aux-build:edition-2021-macros.rs
 //@ aux-build:edition-2024-macros.rs
-//@ compile-flags: -Z validate-mir -Zunstable-options
+//@ compile-flags: -Z validate-mir
 //@ edition: 2024
 //@ run-pass
 

--- a/tests/ui/editions/async-block-2015.rs
+++ b/tests/ui/editions/async-block-2015.rs
@@ -1,7 +1,7 @@
 async fn foo() {
 //~^ ERROR `async fn` is not permitted in Rust 2015
 //~| NOTE to use `async fn`, switch to Rust 2018 or later
-//~| HELP pass `--edition 2021` to `rustc`
+//~| HELP pass `--edition 2024` to `rustc`
 //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 
     let x = async {};
@@ -11,7 +11,7 @@ async fn foo() {
         let x = 42;
         //~^ ERROR expected identifier, found keyword `let`
         //~| NOTE expected identifier, found keyword
-        //~| HELP pass `--edition 2021` to `rustc`
+        //~| HELP pass `--edition 2024` to `rustc`
         //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
         42
     };
@@ -19,7 +19,7 @@ async fn foo() {
         42
         //~^ ERROR expected identifier, found `42`
         //~| NOTE expected identifier
-        //~| HELP pass `--edition 2021` to `rustc`
+        //~| HELP pass `--edition 2024` to `rustc`
         //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
     };
     y.await;

--- a/tests/ui/editions/async-block-2015.stderr
+++ b/tests/ui/editions/async-block-2015.stderr
@@ -4,7 +4,7 @@ error[E0670]: `async fn` is not permitted in Rust 2015
 LL | async fn foo() {
    | ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: expected identifier, found keyword `let`
@@ -15,7 +15,7 @@ LL |     let y = async {
 LL |         let x = 42;
    |         ^^^ expected identifier, found keyword
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: expected identifier, found `42`
@@ -26,7 +26,7 @@ LL |     let z = async {
 LL |         42
    |         ^^ expected identifier
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0422]: cannot find struct, variant or union type `async` in this scope

--- a/tests/ui/editions/edition-cstr-2015-2018.rs
+++ b/tests/ui/editions/edition-cstr-2015-2018.rs
@@ -7,7 +7,7 @@ macro_rules! contain { () => { c"str" } }
     //~| NOTE expected one of 8 possible tokens
     //~| NOTE you may be trying to write a c-string literal
     //~| NOTE c-string literals require Rust 2021 or later
-    //~| HELP pass `--edition 2021` to `rustc`
+    //~| HELP pass `--edition 2024` to `rustc`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 
 fn check_macro_construct() {
@@ -29,7 +29,7 @@ fn check_basic() {
     //~| NOTE expected one of 8 possible tokens
     //~| NOTE you may be trying to write a c-string literal
     //~| NOTE c-string literals require Rust 2021 or later
-    //~| HELP pass `--edition 2021` to `rustc`
+    //~| HELP pass `--edition 2024` to `rustc`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 }
 
@@ -39,7 +39,7 @@ fn check_craw() {
     //~| NOTE expected one of 8 possible tokens
     //~| NOTE you may be trying to write a c-string literal
     //~| NOTE c-string literals require Rust 2021 or later
-    //~| HELP pass `--edition 2021` to `rustc`
+    //~| HELP pass `--edition 2024` to `rustc`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 }
 
@@ -49,7 +49,7 @@ fn check_craw_hash() {
     //~| NOTE expected one of 8 possible tokens
     //~| NOTE you may be trying to write a c-string literal
     //~| NOTE c-string literals require Rust 2021 or later
-    //~| HELP pass `--edition 2021` to `rustc`
+    //~| HELP pass `--edition 2024` to `rustc`
     //~| NOTE for more on editions, read https://doc.rust-lang.org/edition-guide
 }
 

--- a/tests/ui/editions/edition-cstr-2015-2018.stderr
+++ b/tests/ui/editions/edition-cstr-2015-2018.stderr
@@ -6,7 +6,7 @@ LL |     c"str";
    |
    = note: you may be trying to write a c-string literal
    = note: c-string literals require Rust 2021 or later
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"str"`
@@ -17,7 +17,7 @@ LL |     cr"str";
    |
    = note: you may be trying to write a c-string literal
    = note: c-string literals require Rust 2021 or later
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `#`
@@ -28,7 +28,7 @@ LL |     cr##"str"##;
    |
    = note: you may be trying to write a c-string literal
    = note: c-string literals require Rust 2021 or later
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `"str"`
@@ -59,7 +59,7 @@ LL |     contain!();
    |
    = note: you may be trying to write a c-string literal
    = note: c-string literals require Rust 2021 or later
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
    = note: this error originates in the macro `contain` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/feature-gates/feature-gate-coroutines.rs
+++ b/tests/ui/feature-gates/feature-gate-coroutines.rs
@@ -1,5 +1,5 @@
 //@ revisions: e2024 none
-//@[e2024] compile-flags: --edition 2024 -Zunstable-options
+//@[e2024] edition: 2024
 
 fn main() {
     yield true; //~ ERROR yield syntax is experimental

--- a/tests/ui/feature-gates/feature-gate-gen_blocks.rs
+++ b/tests/ui/feature-gates/feature-gate-gen_blocks.rs
@@ -1,5 +1,5 @@
 //@ revisions: e2024 none
-//@[e2024] compile-flags: --edition 2024 -Zunstable-options
+//@[e2024] edition: 2024
 
 fn test_gen() {
     gen {};

--- a/tests/ui/higher-ranked/builtin-closure-like-bounds.rs
+++ b/tests/ui/higher-ranked/builtin-closure-like-bounds.rs
@@ -1,5 +1,4 @@
 //@ edition:2024
-//@ compile-flags: -Zunstable-options
 //@ revisions: current next
 //@[next] compile-flags: -Znext-solver
 //@ check-pass

--- a/tests/ui/impl-trait/in-trait/late-bound-in-object-assocty.rs
+++ b/tests/ui/impl-trait/in-trait/late-bound-in-object-assocty.rs
@@ -1,5 +1,5 @@
 // Test for issue #132429
-//@compile-flags: -Zunstable-options --edition=2024
+//@ edition: 2024
 //@check-pass
 
 use std::future::Future;

--- a/tests/ui/impl-trait/issues/issue-79099.stderr
+++ b/tests/ui/impl-trait/issues/issue-79099.stderr
@@ -6,7 +6,7 @@ LL |         let f: impl core::future::Future<Output = u8> = async { 1 };
    |                                                         |
    |                                                         `async` blocks are only allowed in Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0562]: `impl Trait` is not allowed in the type of variable bindings

--- a/tests/ui/impl-trait/precise-capturing/auxiliary/foreign.rs
+++ b/tests/ui/impl-trait/precise-capturing/auxiliary/foreign.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 
 use std::fmt::Display;
 

--- a/tests/ui/impl-trait/precise-capturing/capturing-implicit.rs
+++ b/tests/ui/impl-trait/precise-capturing/capturing-implicit.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 
 #![feature(rustc_attrs)]
 #![feature(type_alias_impl_trait)]

--- a/tests/ui/impl-trait/precise-capturing/capturing-implicit.stderr
+++ b/tests/ui/impl-trait/precise-capturing/capturing-implicit.stderr
@@ -1,5 +1,5 @@
 error: `impl Trait` captures lifetime parameter, but it is not mentioned in `use<...>` precise captures list
-  --> $DIR/capturing-implicit.rs:8:11
+  --> $DIR/capturing-implicit.rs:7:11
    |
 LL | fn foo(x: &()) -> impl IntoIterator<Item = impl Sized> + use<> {
    |           ^       -------------------------------------------- lifetime captured due to being mentioned in the bounds of the `impl Trait`
@@ -7,13 +7,13 @@ LL | fn foo(x: &()) -> impl IntoIterator<Item = impl Sized> + use<> {
    |           this lifetime parameter is captured
 
 error: ['_: o]
-  --> $DIR/capturing-implicit.rs:8:19
+  --> $DIR/capturing-implicit.rs:7:19
    |
 LL | fn foo(x: &()) -> impl IntoIterator<Item = impl Sized> + use<> {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: ['_: o]
-  --> $DIR/capturing-implicit.rs:8:44
+  --> $DIR/capturing-implicit.rs:7:44
    |
 LL | fn foo(x: &()) -> impl IntoIterator<Item = impl Sized> + use<> {
    |                                            ^^^^^^^^^^

--- a/tests/ui/impl-trait/precise-capturing/external-macro.rs
+++ b/tests/ui/impl-trait/precise-capturing/external-macro.rs
@@ -5,7 +5,6 @@
 //@ aux-crate: no_use_pm=no-use-pm.rs
 //@ aux-crate: no_use_macro=no-use-macro.rs
 //@ edition: 2024
-//@ compile-flags:-Z unstable-options
 //@ check-pass
 
 no_use_pm::pm_rpit!{}

--- a/tests/ui/impl-trait/precise-capturing/foreign-2021.stderr
+++ b/tests/ui/impl-trait/precise-capturing/foreign-2021.stderr
@@ -16,7 +16,7 @@ note: this call may capture more lifetimes than intended, because Rust 2024 has 
 LL |     let h = foreign::hello(&x);
    |             ^^^^^^^^^^^^^^^^^^
 help: if you can modify this crate, add a precise capturing bound to avoid overcapturing: `+ use<>`
-  --> $DIR/auxiliary/foreign.rs:6:31
+  --> $DIR/auxiliary/foreign.rs:5:31
    |
 LL | pub fn hello(x: &Vec<i32>) -> impl Display { 0 }
    |                               ^^^^^^^^^^^^

--- a/tests/ui/impl-trait/precise-capturing/migration-note.rs
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 
 use std::fmt::Display;
 

--- a/tests/ui/impl-trait/precise-capturing/migration-note.stderr
+++ b/tests/ui/impl-trait/precise-capturing/migration-note.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `x` does not live long enough
-  --> $DIR/migration-note.rs:183:17
+  --> $DIR/migration-note.rs:182:17
    |
 LL |     let x = vec![0];
    |         - binding `x` declared here
@@ -14,7 +14,7 @@ LL | }
    | - `x` dropped here while still borrowed
 
 error[E0502]: cannot borrow `x` as mutable because it is also borrowed as immutable
-  --> $DIR/migration-note.rs:20:5
+  --> $DIR/migration-note.rs:19:5
    |
 LL |     let a = display_len(&x);
    |                         -- immutable borrow occurs here
@@ -26,7 +26,7 @@ LL |     println!("{a}");
    |               --- immutable borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:17:13
+  --> $DIR/migration-note.rs:16:13
    |
 LL |     let a = display_len(&x);
    |             ^^^^^^^^^^^^^^^
@@ -36,7 +36,7 @@ LL | fn display_len<T>(x: &Vec<T>) -> impl Display + use<T> {
    |                                               ++++++++
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/migration-note.rs:30:25
+  --> $DIR/migration-note.rs:29:25
    |
 LL |     let x = vec![1];
    |         - binding `x` declared here
@@ -51,7 +51,7 @@ LL | }
    | - `x` dropped here while still borrowed
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:30:13
+  --> $DIR/migration-note.rs:29:13
    |
 LL |     let a = display_len(&x);
    |             ^^^^^^^^^^^^^^^
@@ -61,7 +61,7 @@ LL | fn display_len<T>(x: &Vec<T>) -> impl Display + use<T> {
    |                                               ++++++++
 
 error[E0505]: cannot move out of `x` because it is borrowed
-  --> $DIR/migration-note.rs:49:8
+  --> $DIR/migration-note.rs:48:8
    |
 LL |     let x = vec![1];
    |         - binding `x` declared here
@@ -76,7 +76,7 @@ LL | }
    | - borrow might be used here, when `a` is dropped and runs the destructor for type `impl std::fmt::Display`
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:44:13
+  --> $DIR/migration-note.rs:43:13
    |
 LL |     let a = display_len(&x);
    |             ^^^^^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL |     let a = display_len(&x.clone());
    |                           ++++++++
 
 error[E0499]: cannot borrow `x` as mutable more than once at a time
-  --> $DIR/migration-note.rs:67:5
+  --> $DIR/migration-note.rs:66:5
    |
 LL |     let a = display_len_mut(&mut x);
    |                             ------ first mutable borrow occurs here
@@ -102,7 +102,7 @@ LL |     println!("{a}");
    |               --- first borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:64:13
+  --> $DIR/migration-note.rs:63:13
    |
 LL |     let a = display_len_mut(&mut x);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,7 +112,7 @@ LL | fn display_len_mut<T>(x: &mut Vec<T>) -> impl Display + use<T> {
    |                                                       ++++++++
 
 error[E0597]: `x` does not live long enough
-  --> $DIR/migration-note.rs:77:29
+  --> $DIR/migration-note.rs:76:29
    |
 LL |     let mut x = vec![1];
    |         ----- binding `x` declared here
@@ -127,7 +127,7 @@ LL | }
    | - `x` dropped here while still borrowed
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:77:13
+  --> $DIR/migration-note.rs:76:13
    |
 LL |     let a = display_len_mut(&mut x);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -137,7 +137,7 @@ LL | fn display_len_mut<T>(x: &mut Vec<T>) -> impl Display + use<T> {
    |                                                       ++++++++
 
 error[E0505]: cannot move out of `x` because it is borrowed
-  --> $DIR/migration-note.rs:96:8
+  --> $DIR/migration-note.rs:95:8
    |
 LL |     let mut x = vec![1];
    |         ----- binding `x` declared here
@@ -152,7 +152,7 @@ LL | }
    | - borrow might be used here, when `a` is dropped and runs the destructor for type `impl std::fmt::Display`
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:91:13
+  --> $DIR/migration-note.rs:90:13
    |
 LL |     let a = display_len_mut(&mut x);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -166,7 +166,7 @@ LL |     let a = display_len_mut(&mut x.clone());
    |                                   ++++++++
 
 error[E0506]: cannot assign to `s.f` because it is borrowed
-  --> $DIR/migration-note.rs:116:5
+  --> $DIR/migration-note.rs:115:5
    |
 LL |     let a = display_field(&s.f);
    |                           ---- `s.f` is borrowed here
@@ -178,7 +178,7 @@ LL |     println!("{a}");
    |               --- borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:113:13
+  --> $DIR/migration-note.rs:112:13
    |
 LL |     let a = display_field(&s.f);
    |             ^^^^^^^^^^^^^^^^^^^
@@ -188,7 +188,7 @@ LL | fn display_field<T: Copy + Display>(t: &T) -> impl Display + use<T> {
    |                                                            ++++++++
 
 error[E0506]: cannot assign to `s.f` because it is borrowed
-  --> $DIR/migration-note.rs:132:5
+  --> $DIR/migration-note.rs:131:5
    |
 LL |     let a = display_field(&mut s.f);
    |                           -------- `s.f` is borrowed here
@@ -200,7 +200,7 @@ LL |     println!("{a}");
    |               --- borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:129:13
+  --> $DIR/migration-note.rs:128:13
    |
 LL |     let a = display_field(&mut s.f);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -210,7 +210,7 @@ LL | fn display_field<T: Copy + Display>(t: &T) -> impl Display + use<T> {
    |                                                            ++++++++
 
 error[E0503]: cannot use `s.f` because it was mutably borrowed
-  --> $DIR/migration-note.rs:144:5
+  --> $DIR/migration-note.rs:143:5
    |
 LL |     let a = display_field(&mut s.f);
    |                           -------- `s.f` is borrowed here
@@ -222,7 +222,7 @@ LL |     println!("{a}");
    |               --- borrow later used here
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:141:13
+  --> $DIR/migration-note.rs:140:13
    |
 LL |     let a = display_field(&mut s.f);
    |             ^^^^^^^^^^^^^^^^^^^^^^^
@@ -232,7 +232,7 @@ LL | fn display_field<T: Copy + Display>(t: &T) -> impl Display + use<T> {
    |                                                            ++++++++
 
 error[E0597]: `z.f` does not live long enough
-  --> $DIR/migration-note.rs:160:25
+  --> $DIR/migration-note.rs:159:25
    |
 LL |         let z = Z { f: vec![1] };
    |             - binding `z` declared here
@@ -248,7 +248,7 @@ LL | }
    |
    = note: values in a scope are dropped in the opposite order they are defined
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:160:13
+  --> $DIR/migration-note.rs:159:13
    |
 LL |         x = display_len(&z.f);
    |             ^^^^^^^^^^^^^^^^^
@@ -258,7 +258,7 @@ LL | fn display_len<T>(x: &Vec<T>) -> impl Display + use<T> {
    |                                               ++++++++
 
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/migration-note.rs:171:40
+  --> $DIR/migration-note.rs:170:40
    |
 LL |     let x = { let x = display_len(&mut vec![0]); x };
    |                                        ^^^^^^^ - - borrow later used here
@@ -268,7 +268,7 @@ LL |     let x = { let x = display_len(&mut vec![0]); x };
    |
    = note: consider using a `let` binding to create a longer lived value
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:171:23
+  --> $DIR/migration-note.rs:170:23
    |
 LL |     let x = { let x = display_len(&mut vec![0]); x };
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -279,7 +279,7 @@ LL | fn display_len<T>(x: &Vec<T>) -> impl Display + use<T> {
    |                                               ++++++++
 
 error[E0505]: cannot move out of `x` because it is borrowed
-  --> $DIR/migration-note.rs:199:10
+  --> $DIR/migration-note.rs:198:10
    |
 LL |     let x = String::new();
    |         - binding `x` declared here
@@ -294,12 +294,12 @@ LL | }
    | - borrow might be used here, when `y` is dropped and runs the destructor for type `impl Sized`
    |
 note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
-  --> $DIR/migration-note.rs:196:13
+  --> $DIR/migration-note.rs:195:13
    |
 LL |     let y = capture_apit(&x);
    |             ^^^^^^^^^^^^^^^^
 note: you could use a `use<...>` bound to explicitly specify captures, but argument-position `impl Trait`s are not nameable
-  --> $DIR/migration-note.rs:190:21
+  --> $DIR/migration-note.rs:189:21
    |
 LL | fn capture_apit(x: &impl Sized) -> impl Sized {}
    |                     ^^^^^^^^^^

--- a/tests/ui/impl-trait/precise-capturing/redundant.rs
+++ b/tests/ui/impl-trait/precise-capturing/redundant.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zunstable-options --edition=2024
+//@ edition: 2024
 //@ check-pass
 
 #![feature(precise_capturing_in_traits)]

--- a/tests/ui/iterators/into-iter-on-boxed-slices-2024.rs
+++ b/tests/ui/iterators/into-iter-on-boxed-slices-2024.rs
@@ -1,6 +1,5 @@
 //@ check-pass
 //@ edition:2024
-//@ compile-flags: -Zunstable-options
 
 use std::ops::Deref;
 use std::rc::Rc;

--- a/tests/ui/lifetimes/tail-expr-in-nested-expr.rs
+++ b/tests/ui/lifetimes/tail-expr-in-nested-expr.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 
 fn main() {
     let _ = { String::new().as_str() }.len();

--- a/tests/ui/lifetimes/tail-expr-in-nested-expr.stderr
+++ b/tests/ui/lifetimes/tail-expr-in-nested-expr.stderr
@@ -1,5 +1,5 @@
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/tail-expr-in-nested-expr.rs:5:15
+  --> $DIR/tail-expr-in-nested-expr.rs:4:15
    |
 LL |     let _ = { String::new().as_str() }.len();
    |               ^^^^^^^^^^^^^---------

--- a/tests/ui/macros/expr_2021_implicit_in_2024.rs
+++ b/tests/ui/macros/expr_2021_implicit_in_2024.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition=2024 -Zunstable-options
+//@ edition: 2024
 //@ aux-build:expr_2021_implicit.rs
 
 //@ check-pass

--- a/tests/ui/macros/expr_2021_inline_const.rs
+++ b/tests/ui/macros/expr_2021_inline_const.rs
@@ -1,6 +1,6 @@
 //@ revisions: edi2021 edi2024
-//@[edi2024]compile-flags: --edition=2024 -Z unstable-options
-//@[edi2021]compile-flags: --edition=2021
+//@[edi2024] edition: 2024
+//@[edi2021] edition: 2021
 
 // This test ensures that the inline const match only on edition 2024
 macro_rules! m2021 {

--- a/tests/ui/macros/expr_2024_underscore_expr.rs
+++ b/tests/ui/macros/expr_2024_underscore_expr.rs
@@ -1,6 +1,6 @@
 //@ revisions: edi2021 edi2024
-//@[edi2024]compile-flags: --edition=2024 -Z unstable-options
-//@[edi2021]compile-flags: --edition=2021
+//@[edi2024] edition: 2024
+//@[edi2021] edition: 2021
 // This test ensures that the `_` tok is considered an
 // expression on edition 2024.
 macro_rules! m2021 {

--- a/tests/ui/macros/metavar_cross_edition_recursive_macros.rs
+++ b/tests/ui/macros/metavar_cross_edition_recursive_macros.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition=2024 -Z unstable-options
+//@ edition: 2024
 //@ aux-build: metavar_2018.rs
 //@ known-bug: #130484
 //@ run-pass

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/feature-gate-ref_pat_eat_one_layer_2024.rs
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/feature-gate-ref_pat_eat_one_layer_2024.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 // gate-test-ref_pat_eat_one_layer_2024_structural
 
 pub fn main() {

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/feature-gate-ref_pat_eat_one_layer_2024.stderr
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/feature-gate-ref_pat_eat_one_layer_2024.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:6:22
+  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:5:22
    |
 LL |     if let Some(Some(&x)) = &Some(&Some(0)) {
    |                      ^^     --------------- this expression has type `&Option<&Option<{integer}>>`
@@ -14,7 +14,7 @@ LL |     if let Some(Some(x)) = &Some(&Some(0)) {
    |                      ~
 
 error[E0308]: mismatched types
-  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:11:23
+  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:10:23
    |
 LL |         let _: &u32 = x;
    |                ----   ^ expected `&u32`, found integer
@@ -27,7 +27,7 @@ LL |         let _: &u32 = &x;
    |                       +
 
 error[E0308]: mismatched types
-  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:14:23
+  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:13:23
    |
 LL |     if let Some(Some(&&x)) = &Some(Some(&0)) {
    |                       ^^     --------------- this expression has type `&Option<Option<&{integer}>>`
@@ -43,7 +43,7 @@ LL +     if let Some(Some(&x)) = &Some(Some(&0)) {
    |
 
 error[E0308]: mismatched types
-  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:18:17
+  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:17:17
    |
 LL |     if let Some(&Some(x)) = &Some(Some(0)) {
    |                 ^^^^^^^^    -------------- this expression has type `&Option<Option<{integer}>>`
@@ -54,7 +54,7 @@ LL |     if let Some(&Some(x)) = &Some(Some(0)) {
            found reference `&_`
 
 error[E0308]: mismatched types
-  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:22:22
+  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:21:22
    |
 LL |     if let Some(Some(&mut x)) = &mut Some(&mut Some(0)) {
    |                      ^^^^^^     ----------------------- this expression has type `&mut Option<&mut Option<{integer}>>`
@@ -64,7 +64,7 @@ LL |     if let Some(Some(&mut x)) = &mut Some(&mut Some(0)) {
    = note:           expected type `{integer}`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:22:22
+  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:21:22
    |
 LL |     if let Some(Some(&mut x)) = &mut Some(&mut Some(0)) {
    |                      ^^^^^^
@@ -74,7 +74,7 @@ LL |     if let Some(Some(x)) = &mut Some(&mut Some(0)) {
    |                      ~
 
 error[E0308]: mismatched types
-  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:26:22
+  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:25:22
    |
 LL |     if let Some(Some(&x)) = &Some(&Some(0)) {
    |                      ^^     --------------- this expression has type `&Option<&Option<{integer}>>`
@@ -89,7 +89,7 @@ LL |     if let Some(Some(x)) = &Some(&Some(0)) {
    |                      ~
 
 error[E0308]: mismatched types
-  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:30:27
+  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:29:27
    |
 LL |     if let Some(&mut Some(&x)) = &Some(&mut Some(0)) {
    |                           ^^     ------------------- this expression has type `&Option<&mut Option<{integer}>>`
@@ -104,7 +104,7 @@ LL |     if let Some(&mut Some(x)) = &Some(&mut Some(0)) {
    |                           ~
 
 error[E0308]: mismatched types
-  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:34:23
+  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:33:23
    |
 LL |     if let Some(&Some(&mut x)) = &mut Some(&Some(0)) {
    |                       ^^^^^^     ------------------- this expression has type `&mut Option<&Option<{integer}>>`
@@ -114,7 +114,7 @@ LL |     if let Some(&Some(&mut x)) = &mut Some(&Some(0)) {
    = note:           expected type `{integer}`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:34:23
+  --> $DIR/feature-gate-ref_pat_eat_one_layer_2024.rs:33:23
    |
 LL |     if let Some(&Some(&mut x)) = &mut Some(&Some(0)) {
    |                       ^^^^^^

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024.rs
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024.rs
@@ -1,6 +1,5 @@
 //@ run-pass
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 //@ revisions: classic structural both
 #![allow(incomplete_features)]
 #![cfg_attr(any(classic, both), feature(ref_pat_eat_one_layer_2024))]

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail.both.stderr
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail.both.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:9:17
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:8:17
    |
 LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
    |                 ^^^^^^^^^^^^^    --------------- this expression has type `&Option<&Option<{integer}>>`
@@ -10,7 +10,7 @@ LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:12:23
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:11:23
    |
 LL |     if let Some(&Some(&mut _)) = &Some(&mut Some(0)) {
    |                       ^^^^^^     ------------------- this expression has type `&Option<&mut Option<{integer}>>`
@@ -21,7 +21,7 @@ LL |     if let Some(&Some(&mut _)) = &Some(&mut Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:16:27
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:15:27
    |
 LL |         let _: &mut u32 = x;
    |                --------   ^ types differ in mutability
@@ -32,7 +32,7 @@ LL |         let _: &mut u32 = x;
                       found reference `&{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:19:23
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:18:23
    |
 LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
    |                       ^^^^^^     ------------------- this expression has type `&mut Option<&Option<{integer}>>`
@@ -43,7 +43,7 @@ LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:22:29
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:21:29
    |
 LL |     if let Some(&Some(Some((&mut _)))) = &Some(Some(&mut Some(0))) {
    |                             ^^^^^^       ------------------------- this expression has type `&Option<Option<&mut Option<{integer}>>>`
@@ -54,7 +54,7 @@ LL |     if let Some(&Some(Some((&mut _)))) = &Some(Some(&mut Some(0))) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:25:17
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:24:17
    |
 LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
    |                 ^^^^^^^^^^^^    -------------- this expression has type `&Option<Option<{integer}>>`
@@ -65,7 +65,7 @@ LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:28:17
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:27:17
    |
 LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
    |                 ^^^^^^^^^^^^    -------------- this expression has type `&Option<Option<{integer}>>`
@@ -76,7 +76,7 @@ LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:32:9
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:31:9
    |
 LL |     let &mut _ = &&0;
    |         ^^^^^^   --- this expression has type `&&{integer}`
@@ -87,7 +87,7 @@ LL |     let &mut _ = &&0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:35:9
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:34:9
    |
 LL |     let &mut _ = &&&&&&&&&&&&&&&&&&&&&&&&&&&&0;
    |         ^^^^^^   ----------------------------- this expression has type `&&&&&&&&&&&&&&&&&&&&&&&&&&&&{integer}`
@@ -98,7 +98,7 @@ LL |     let &mut _ = &&&&&&&&&&&&&&&&&&&&&&&&&&&&0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:46:9
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:45:9
    |
 LL |     let &mut _ = &&mut 0;
    |         ^^^^^^   ------- this expression has type `&&mut {integer}`
@@ -109,7 +109,7 @@ LL |     let &mut _ = &&mut 0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:49:9
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:48:9
    |
 LL |     let &mut _ = &&&&&&&&&&&&&&&&&&&&&&&&&&&&mut 0;
    |         ^^^^^^   --------------------------------- this expression has type `&&&&&&&&&&&&&&&&&&&&&&&&&&&&mut {integer}`
@@ -120,7 +120,7 @@ LL |     let &mut _ = &&&&&&&&&&&&&&&&&&&&&&&&&&&&mut 0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:52:14
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:51:14
    |
 LL |     let &mut &mut &mut &mut _ = &mut &&&&mut &&&mut &mut 0;
    |              ^^^^^^^^^^^^^^^^   -------------------------- this expression has type `&mut &&&&mut &&&mut &mut {integer}`
@@ -131,7 +131,7 @@ LL |     let &mut &mut &mut &mut _ = &mut &&&&mut &&&mut &mut 0;
            found mutable reference `&mut _`
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:61:13
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:60:13
    |
 LL |     let Foo(mut a) = &Foo(0);
    |             ^^^^
@@ -141,7 +141,7 @@ LL |     let Foo(mut a) = &Foo(0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:65:13
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:64:13
    |
 LL |     let Foo(mut a) = &mut Foo(0);
    |             ^^^^
@@ -151,14 +151,14 @@ LL |     let Foo(mut a) = &mut Foo(0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0277]: the trait bound `&_: main::Ref` is not satisfied
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:83:14
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:82:14
    |
 LL |     let &_ = generic();
    |              ^^^^^^^^^ the trait `main::Ref` is not implemented for `&_`
    |
    = help: the trait `main::Ref` is implemented for `&'static mut [(); 0]`
 note: required by a bound in `generic`
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:69:19
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:68:19
    |
 LL |     fn generic<R: Ref>() -> R {
    |                   ^^^ required by this bound in `generic`

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail.classic.stderr
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail.classic.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:9:17
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:8:17
    |
 LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
    |                 ^^^^^
@@ -11,7 +11,7 @@ LL |     if let Some(&Some(&_)) = &Some(&Some(0)) {
    |                 ~
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:12:23
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:11:23
    |
 LL |     if let Some(&Some(&mut _)) = &Some(&mut Some(0)) {
    |                       ^^^^^
@@ -23,7 +23,7 @@ LL |     if let Some(&Some(&_)) = &Some(&mut Some(0)) {
    |                       ~
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:16:27
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:15:27
    |
 LL |         let _: &mut u32 = x;
    |                --------   ^ types differ in mutability
@@ -34,7 +34,7 @@ LL |         let _: &mut u32 = x;
                       found reference `&{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:19:23
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:18:23
    |
 LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
    |                       ^^^^^
@@ -46,7 +46,7 @@ LL |     if let Some(&Some(&_)) = &mut Some(&Some(0)) {
    |                       ~
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:22:29
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:21:29
    |
 LL |     if let Some(&Some(Some((&mut _)))) = &Some(Some(&mut Some(0))) {
    |                             ^^^^^
@@ -58,7 +58,7 @@ LL |     if let Some(&Some(Some((&_)))) = &Some(Some(&mut Some(0))) {
    |                             ~
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:25:17
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:24:17
    |
 LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
    |                 ^^^^^
@@ -70,7 +70,7 @@ LL |     if let Some(&Some(x)) = &Some(Some(0)) {
    |                 ~
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:28:17
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:27:17
    |
 LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
    |                 ^^^^^
@@ -82,7 +82,7 @@ LL |     if let Some(&Some(x)) = &Some(Some(0)) {
    |                 ~
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:32:9
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:31:9
    |
 LL |     let &mut _ = &&0;
    |         ^^^^^^   --- this expression has type `&&{integer}`
@@ -93,7 +93,7 @@ LL |     let &mut _ = &&0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:35:9
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:34:9
    |
 LL |     let &mut _ = &&&&&&&&&&&&&&&&&&&&&&&&&&&&0;
    |         ^^^^^^   ----------------------------- this expression has type `&&&&&&&&&&&&&&&&&&&&&&&&&&&&{integer}`
@@ -104,7 +104,7 @@ LL |     let &mut _ = &&&&&&&&&&&&&&&&&&&&&&&&&&&&0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:38:17
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:37:17
    |
 LL |     if let Some(&mut Some(&_)) = &Some(&mut Some(0)) {
    |                 ^^^^^
@@ -116,7 +116,7 @@ LL |     if let Some(&Some(&_)) = &Some(&mut Some(0)) {
    |                 ~
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:42:22
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:41:22
    |
 LL |     if let Some(Some(&mut x)) = &Some(Some(&mut 0)) {
    |                      ^^^^^
@@ -128,7 +128,7 @@ LL |     if let Some(Some(&x)) = &Some(Some(&mut 0)) {
    |                      ~
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:46:9
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:45:9
    |
 LL |     let &mut _ = &&mut 0;
    |         ^^^^^^   ------- this expression has type `&&mut {integer}`
@@ -139,7 +139,7 @@ LL |     let &mut _ = &&mut 0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:49:9
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:48:9
    |
 LL |     let &mut _ = &&&&&&&&&&&&&&&&&&&&&&&&&&&&mut 0;
    |         ^^^^^^   --------------------------------- this expression has type `&&&&&&&&&&&&&&&&&&&&&&&&&&&&mut {integer}`
@@ -150,7 +150,7 @@ LL |     let &mut _ = &&&&&&&&&&&&&&&&&&&&&&&&&&&&mut 0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:52:14
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:51:14
    |
 LL |     let &mut &mut &mut &mut _ = &mut &&&&mut &&&mut &mut 0;
    |              ^^^^^^^^^^^^^^^^   -------------------------- this expression has type `&mut &&&&mut &&&mut &mut {integer}`
@@ -161,7 +161,7 @@ LL |     let &mut &mut &mut &mut _ = &mut &&&&mut &&&mut &mut 0;
            found mutable reference `&mut _`
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:61:13
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:60:13
    |
 LL |     let Foo(mut a) = &Foo(0);
    |             ^^^^
@@ -171,7 +171,7 @@ LL |     let Foo(mut a) = &Foo(0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:65:13
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:64:13
    |
 LL |     let Foo(mut a) = &mut Foo(0);
    |             ^^^^
@@ -181,14 +181,14 @@ LL |     let Foo(mut a) = &mut Foo(0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0277]: the trait bound `&_: main::Ref` is not satisfied
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:83:14
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:82:14
    |
 LL |     let &_ = generic();
    |              ^^^^^^^^^ the trait `main::Ref` is not implemented for `&_`
    |
    = help: the trait `main::Ref` is implemented for `&'static mut [(); 0]`
 note: required by a bound in `generic`
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:69:19
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:68:19
    |
 LL |     fn generic<R: Ref>() -> R {
    |                   ^^^ required by this bound in `generic`

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail.rs
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 //@ revisions: classic structural both
 #![allow(incomplete_features)]
 #![cfg_attr(any(classic, both), feature(ref_pat_eat_one_layer_2024))]

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail.structural.stderr
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail.structural.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:9:17
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:8:17
    |
 LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
    |                 ^^^^^^^^^^^^^    --------------- this expression has type `&Option<&Option<{integer}>>`
@@ -10,7 +10,7 @@ LL |     if let Some(&mut Some(&_)) = &Some(&Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:12:23
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:11:23
    |
 LL |     if let Some(&Some(&mut _)) = &Some(&mut Some(0)) {
    |                       ^^^^^^     ------------------- this expression has type `&Option<&mut Option<{integer}>>`
@@ -21,7 +21,7 @@ LL |     if let Some(&Some(&mut _)) = &Some(&mut Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:16:27
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:15:27
    |
 LL |         let _: &mut u32 = x;
    |                --------   ^ types differ in mutability
@@ -32,7 +32,7 @@ LL |         let _: &mut u32 = x;
                       found reference `&{integer}`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:19:23
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:18:23
    |
 LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
    |                       ^^^^^^     ------------------- this expression has type `&mut Option<&Option<{integer}>>`
@@ -43,7 +43,7 @@ LL |     if let Some(&Some(&mut _)) = &mut Some(&Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:22:29
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:21:29
    |
 LL |     if let Some(&Some(Some((&mut _)))) = &Some(Some(&mut Some(0))) {
    |                             ^^^^^^       ------------------------- this expression has type `&Option<Option<&mut Option<{integer}>>>`
@@ -54,7 +54,7 @@ LL |     if let Some(&Some(Some((&mut _)))) = &Some(Some(&mut Some(0))) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:25:17
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:24:17
    |
 LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
    |                 ^^^^^^^^^^^^    -------------- this expression has type `&Option<Option<{integer}>>`
@@ -65,7 +65,7 @@ LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:28:17
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:27:17
    |
 LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
    |                 ^^^^^^^^^^^^    -------------- this expression has type `&Option<Option<{integer}>>`
@@ -76,7 +76,7 @@ LL |     if let Some(&mut Some(x)) = &Some(Some(0)) {
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:32:9
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:31:9
    |
 LL |     let &mut _ = &&0;
    |         ^^^^^^   --- this expression has type `&&{integer}`
@@ -87,7 +87,7 @@ LL |     let &mut _ = &&0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:35:9
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:34:9
    |
 LL |     let &mut _ = &&&&&&&&&&&&&&&&&&&&&&&&&&&&0;
    |         ^^^^^^   ----------------------------- this expression has type `&&&&&&&&&&&&&&&&&&&&&&&&&&&&{integer}`
@@ -98,7 +98,7 @@ LL |     let &mut _ = &&&&&&&&&&&&&&&&&&&&&&&&&&&&0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:46:9
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:45:9
    |
 LL |     let &mut _ = &&mut 0;
    |         ^^^^^^   ------- this expression has type `&&mut {integer}`
@@ -109,7 +109,7 @@ LL |     let &mut _ = &&mut 0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:49:9
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:48:9
    |
 LL |     let &mut _ = &&&&&&&&&&&&&&&&&&&&&&&&&&&&mut 0;
    |         ^^^^^^   --------------------------------- this expression has type `&&&&&&&&&&&&&&&&&&&&&&&&&&&&mut {integer}`
@@ -120,7 +120,7 @@ LL |     let &mut _ = &&&&&&&&&&&&&&&&&&&&&&&&&&&&mut 0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:52:14
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:51:14
    |
 LL |     let &mut &mut &mut &mut _ = &mut &&&&mut &&&mut &mut 0;
    |              ^^^^^^^^^^^^^^^^   -------------------------- this expression has type `&mut &&&&mut &&&mut &mut {integer}`
@@ -131,7 +131,7 @@ LL |     let &mut &mut &mut &mut _ = &mut &&&&mut &&&mut &mut 0;
            found mutable reference `&mut _`
 
 error[E0308]: mismatched types
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:55:17
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:54:17
    |
 LL |     if let Some(&mut _) = &mut Some(&0) {
    |                 ^^^^^^    ------------- this expression has type `&mut Option<&{integer}>`
@@ -142,7 +142,7 @@ LL |     if let Some(&mut _) = &mut Some(&0) {
            found mutable reference `&mut _`
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:61:13
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:60:13
    |
 LL |     let Foo(mut a) = &Foo(0);
    |             ^^^^
@@ -152,7 +152,7 @@ LL |     let Foo(mut a) = &Foo(0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: binding cannot be both mutable and by-reference
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:65:13
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:64:13
    |
 LL |     let Foo(mut a) = &mut Foo(0);
    |             ^^^^
@@ -162,14 +162,14 @@ LL |     let Foo(mut a) = &mut Foo(0);
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0277]: the trait bound `&_: main::Ref` is not satisfied
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:83:14
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:82:14
    |
 LL |     let &_ = generic();
    |              ^^^^^^^^^ the trait `main::Ref` is not implemented for `&_`
    |
    = help: the trait `main::Ref` is implemented for `&'static mut [(); 0]`
 note: required by a bound in `generic`
-  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:69:19
+  --> $DIR/ref_pat_eat_one_layer_2024_fail.rs:68:19
    |
 LL |     fn generic<R: Ref>() -> R {
    |                   ^^^ required by this bound in `generic`

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail2.rs
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail2.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 #![allow(incomplete_features)]
 #![feature(ref_pat_eat_one_layer_2024)]
 

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail2.stderr
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail2.stderr
@@ -1,5 +1,5 @@
 error[E0507]: cannot move out of a shared reference
-  --> $DIR/ref_pat_eat_one_layer_2024_fail2.rs:7:29
+  --> $DIR/ref_pat_eat_one_layer_2024_fail2.rs:6:29
    |
 LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       -     ^^^^^^^^^^^^^^^^^^^
@@ -13,7 +13,7 @@ LL |     if let Some(&Some(ref x)) = Some(&Some(&mut 0)) {
    |                       +++
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
-  --> $DIR/ref_pat_eat_one_layer_2024_fail2.rs:12:10
+  --> $DIR/ref_pat_eat_one_layer_2024_fail2.rs:11:10
    |
 LL |     let &ref mut x = &0;
    |          ^^^^^^^^^ cannot borrow as mutable

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_ref_mut_inside_and.fixed
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_ref_mut_inside_and.fixed
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 //@ run-rustfix
 #![allow(incomplete_features)]
 #![feature(ref_pat_eat_one_layer_2024)]

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_ref_mut_inside_and.rs
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_ref_mut_inside_and.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 //@ run-rustfix
 #![allow(incomplete_features)]
 #![feature(ref_pat_eat_one_layer_2024)]

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_ref_mut_inside_and.stderr
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_ref_mut_inside_and.stderr
@@ -1,5 +1,5 @@
 error[E0596]: cannot borrow as mutable inside an `&` pattern
-  --> $DIR/ref_pat_eat_one_layer_2024_ref_mut_inside_and.rs:8:31
+  --> $DIR/ref_pat_eat_one_layer_2024_ref_mut_inside_and.rs:7:31
    |
 LL |     if let Some(&Some(ref mut x)) = &mut Some(Some(0)) {
    |                 -             ^
@@ -7,7 +7,7 @@ LL |     if let Some(&Some(ref mut x)) = &mut Some(Some(0)) {
    |                 help: replace this `&` with `&mut`: `&mut`
 
 error[E0596]: cannot borrow as mutable inside an `&` pattern
-  --> $DIR/ref_pat_eat_one_layer_2024_ref_mut_inside_and.rs:13:31
+  --> $DIR/ref_pat_eat_one_layer_2024_ref_mut_inside_and.rs:12:31
    |
 LL |     if let &Some(Some(ref mut x)) = &mut Some(Some(0)) {
    |            -                  ^
@@ -15,7 +15,7 @@ LL |     if let &Some(Some(ref mut x)) = &mut Some(Some(0)) {
    |            help: replace this `&` with `&mut`: `&mut`
 
 error[E0596]: cannot borrow as mutable inside an `&` pattern
-  --> $DIR/ref_pat_eat_one_layer_2024_ref_mut_inside_and.rs:21:15
+  --> $DIR/ref_pat_eat_one_layer_2024_ref_mut_inside_and.rs:20:15
    |
 LL |     let &pat!(x) = &mut 0;
    |         -     ^
@@ -23,7 +23,7 @@ LL |     let &pat!(x) = &mut 0;
    |         help: replace this `&` with `&mut`: `&mut`
 
 error[E0596]: cannot borrow as mutable inside an `&` pattern
-  --> $DIR/ref_pat_eat_one_layer_2024_ref_mut_inside_and.rs:25:19
+  --> $DIR/ref_pat_eat_one_layer_2024_ref_mut_inside_and.rs:24:19
    |
 LL |     let &(ref mut a, ref mut b) = &mut (true, false);
    |         -         ^
@@ -31,7 +31,7 @@ LL |     let &(ref mut a, ref mut b) = &mut (true, false);
    |         help: replace this `&` with `&mut`: `&mut`
 
 error[E0596]: cannot borrow as mutable inside an `&` pattern
-  --> $DIR/ref_pat_eat_one_layer_2024_ref_mut_inside_and.rs:25:30
+  --> $DIR/ref_pat_eat_one_layer_2024_ref_mut_inside_and.rs:24:30
    |
 LL |     let &(ref mut a, ref mut b) = &mut (true, false);
    |         -                    ^

--- a/tests/ui/parser/help-set-edition-ice-122130.stderr
+++ b/tests/ui/parser/help-set-edition-ice-122130.stderr
@@ -6,7 +6,7 @@ LL |     s#[c"owned_box"]
    |
    = note: you may be trying to write a c-string literal
    = note: c-string literals require Rust 2021 or later
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error: expected item, found `"owned_box"`

--- a/tests/ui/pattern/mut_preserve_binding_mode_2024.rs
+++ b/tests/ui/pattern/mut_preserve_binding_mode_2024.rs
@@ -1,6 +1,5 @@
 //@ run-pass
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 #![feature(mut_ref, ref_pat_eat_one_layer_2024)]
 #![allow(incomplete_features, unused)]
 

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/auxiliary/migration_lint_macros.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/auxiliary/migration_lint_macros.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Z unstable-options
 
 // This contains a binding in edition 2024, so if matched with a reference binding mode it will end
 // up with a `mut ref mut` binding mode. We use this to test the migration lint on patterns with

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/min_match_ergonomics_fail.rs
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/min_match_ergonomics_fail.rs
@@ -1,6 +1,5 @@
 //@ check-fail
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 #![deny(rust_2024_incompatible_pat)]
 
 fn main() {}

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/min_match_ergonomics_fail.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/min_match_ergonomics_fail.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
-  --> $DIR/min_match_ergonomics_fail.rs:24:20
+  --> $DIR/min_match_ergonomics_fail.rs:23:20
    |
 LL | test_pat_on_type![(&x,): &(T,)];
    |                    ^^    ----- expected due to this
@@ -15,7 +15,7 @@ LL + test_pat_on_type![(x,): &(T,)];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/min_match_ergonomics_fail.rs:26:20
+  --> $DIR/min_match_ergonomics_fail.rs:25:20
    |
 LL | test_pat_on_type![(&x,): &(&mut T,)];
    |                    ^^    ---------- expected due to this
@@ -31,7 +31,7 @@ LL + test_pat_on_type![(x,): &(&mut T,)];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/min_match_ergonomics_fail.rs:27:20
+  --> $DIR/min_match_ergonomics_fail.rs:26:20
    |
 LL | test_pat_on_type![(&mut x,): &(&T,)];
    |                    ^^^^^^    ------ expected due to this
@@ -41,7 +41,7 @@ LL | test_pat_on_type![(&mut x,): &(&T,)];
    = note:      expected reference `&T`
            found mutable reference `&mut _`
 note: to declare a mutable binding use: `mut x`
-  --> $DIR/min_match_ergonomics_fail.rs:27:20
+  --> $DIR/min_match_ergonomics_fail.rs:26:20
    |
 LL | test_pat_on_type![(&mut x,): &(&T,)];
    |                    ^^^^^^
@@ -52,7 +52,7 @@ LL + test_pat_on_type![(x,): &(&T,)];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/min_match_ergonomics_fail.rs:29:20
+  --> $DIR/min_match_ergonomics_fail.rs:28:20
    |
 LL | test_pat_on_type![(&x,): &&mut &(T,)];
    |                    ^^    ----------- expected due to this
@@ -68,7 +68,7 @@ LL + test_pat_on_type![(x,): &&mut &(T,)];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/min_match_ergonomics_fail.rs:30:29
+  --> $DIR/min_match_ergonomics_fail.rs:29:29
    |
 LL | test_pat_on_type![Foo { f: (&x,) }: Foo];
    |                             ^^      --- expected due to this
@@ -84,7 +84,7 @@ LL + test_pat_on_type![Foo { f: (x,) }: Foo];
    |
 
 error[E0308]: mismatched types
-  --> $DIR/min_match_ergonomics_fail.rs:31:29
+  --> $DIR/min_match_ergonomics_fail.rs:30:29
    |
 LL | test_pat_on_type![Foo { f: (&x,) }: &mut Foo];
    |                             ^^      -------- expected due to this
@@ -100,7 +100,7 @@ LL + test_pat_on_type![Foo { f: (x,) }: &mut Foo];
    |
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
-  --> $DIR/min_match_ergonomics_fail.rs:25:19
+  --> $DIR/min_match_ergonomics_fail.rs:24:19
    |
 LL | test_pat_on_type![(&x,): &(&T,)];
    |                   -^^^^
@@ -108,7 +108,7 @@ LL | test_pat_on_type![(&x,): &(&T,)];
    |                   help: desugar the match ergonomics: `&`
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
-  --> $DIR/min_match_ergonomics_fail.rs:28:19
+  --> $DIR/min_match_ergonomics_fail.rs:27:19
    |
 LL | test_pat_on_type![(&mut x,): &(&mut T,)];
    |                   -^^^^^^^^
@@ -116,7 +116,7 @@ LL | test_pat_on_type![(&mut x,): &(&mut T,)];
    |                   help: desugar the match ergonomics: `&`
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
-  --> $DIR/min_match_ergonomics_fail.rs:32:19
+  --> $DIR/min_match_ergonomics_fail.rs:31:19
    |
 LL | test_pat_on_type![Foo { f: &(x,) }: &Foo];
    |                   -^^^^^^^^^^^^^^^
@@ -124,7 +124,7 @@ LL | test_pat_on_type![Foo { f: &(x,) }: &Foo];
    |                   help: desugar the match ergonomics: `&`
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
-  --> $DIR/min_match_ergonomics_fail.rs:33:19
+  --> $DIR/min_match_ergonomics_fail.rs:32:19
    |
 LL | test_pat_on_type![(mut x,): &(T,)];
    |                   -^^^^^^^
@@ -132,7 +132,7 @@ LL | test_pat_on_type![(mut x,): &(T,)];
    |                   help: desugar the match ergonomics: `&`
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
-  --> $DIR/min_match_ergonomics_fail.rs:34:19
+  --> $DIR/min_match_ergonomics_fail.rs:33:19
    |
 LL | test_pat_on_type![(ref x,): &(T,)];
    |                   -^^^^^^^
@@ -140,7 +140,7 @@ LL | test_pat_on_type![(ref x,): &(T,)];
    |                   help: desugar the match ergonomics: `&`
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
-  --> $DIR/min_match_ergonomics_fail.rs:35:19
+  --> $DIR/min_match_ergonomics_fail.rs:34:19
    |
 LL | test_pat_on_type![(ref mut x,): &mut (T,)];
    |                   -^^^^^^^^^^^
@@ -148,7 +148,7 @@ LL | test_pat_on_type![(ref mut x,): &mut (T,)];
    |                   help: desugar the match ergonomics: `&mut`
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
-  --> $DIR/min_match_ergonomics_fail.rs:44:9
+  --> $DIR/min_match_ergonomics_fail.rs:43:9
    |
 LL |         (&x,) => x,
    |         -^^^^

--- a/tests/ui/pattern/skipped-ref-pats-issue-125058.rs
+++ b/tests/ui/pattern/skipped-ref-pats-issue-125058.rs
@@ -1,6 +1,5 @@
 //@ run-pass
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 
 #![allow(incomplete_features)]
 #![feature(ref_pat_eat_one_layer_2024)]

--- a/tests/ui/pattern/skipped-ref-pats-issue-125058.stderr
+++ b/tests/ui/pattern/skipped-ref-pats-issue-125058.stderr
@@ -1,5 +1,5 @@
 warning: struct `Foo` is never constructed
-  --> $DIR/skipped-ref-pats-issue-125058.rs:8:8
+  --> $DIR/skipped-ref-pats-issue-125058.rs:7:8
    |
 LL | struct Foo;
    |        ^^^
@@ -7,7 +7,7 @@ LL | struct Foo;
    = note: `#[warn(dead_code)]` on by default
 
 warning: unused closure that must be used
-  --> $DIR/skipped-ref-pats-issue-125058.rs:12:5
+  --> $DIR/skipped-ref-pats-issue-125058.rs:11:5
    |
 LL | /     || {
 LL | |

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/temporary-early-drop.rs
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/temporary-early-drop.rs
@@ -1,5 +1,5 @@
 // issue-103476
-//@ compile-flags: -Zlint-mir -Zunstable-options
+//@ compile-flags: -Zlint-mir
 //@ edition: 2024
 //@ check-pass
 

--- a/tests/ui/rust-2024/auxiliary/reserved-guarded-strings-macro-2024.rs
+++ b/tests/ui/rust-2024/auxiliary/reserved-guarded-strings-macro-2024.rs
@@ -1,5 +1,4 @@
 //@ force-host
-//@ compile-flags: -Zunstable-options
 //@ edition:2024
 //@ no-prefer-dynamic
 

--- a/tests/ui/rust-2024/prelude2024.rs
+++ b/tests/ui/rust-2024/prelude2024.rs
@@ -1,5 +1,4 @@
 //@ check-pass
-//@ compile-flags: -Zunstable-options
 //@ edition:2024
 
 fn main() {

--- a/tests/ui/rust-2024/reserved-guarded-strings-via-macro.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings-via-macro.rs
@@ -1,5 +1,4 @@
 //@ run-pass
-//@ compile-flags: -Zunstable-options
 //@ edition:2024
 //@ aux-build:reserved-guarded-strings-macro-2021.rs
 

--- a/tests/ui/rust-2024/reserved-guarded-strings.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings.rs
@@ -1,4 +1,3 @@
-//@ compile-flags: -Zunstable-options
 //@ edition:2024
 // ignore-tidy-linelength
 

--- a/tests/ui/rust-2024/reserved-guarded-strings.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings.stderr
@@ -1,5 +1,5 @@
 error: prefix `blah` is unknown
-  --> $DIR/reserved-guarded-strings.rs:45:12
+  --> $DIR/reserved-guarded-strings.rs:44:12
    |
 LL |     demo2!(blah"xx");
    |            ^^^^ unknown prefix
@@ -11,7 +11,7 @@ LL |     demo2!(blah "xx");
    |                +
 
 error: prefix `blah` is unknown
-  --> $DIR/reserved-guarded-strings.rs:46:12
+  --> $DIR/reserved-guarded-strings.rs:45:12
    |
 LL |     demo2!(blah#"xx"#);
    |            ^^^^ unknown prefix
@@ -23,7 +23,7 @@ LL |     demo2!(blah #"xx"#);
    |                +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:46:16
+  --> $DIR/reserved-guarded-strings.rs:45:16
    |
 LL |     demo2!(blah#"xx"#);
    |                ^^^^^^
@@ -35,7 +35,7 @@ LL |     demo2!(blah# "xx"#);
    |                 +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:50:12
+  --> $DIR/reserved-guarded-strings.rs:49:12
    |
 LL |     demo2!(## "foo");
    |            ^^
@@ -47,7 +47,7 @@ LL |     demo2!(# # "foo");
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:51:17
+  --> $DIR/reserved-guarded-strings.rs:50:17
    |
 LL |     demo3!("foo"###);
    |                 ^^
@@ -59,7 +59,7 @@ LL |     demo3!("foo"# ##);
    |                  +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:52:12
+  --> $DIR/reserved-guarded-strings.rs:51:12
    |
 LL |     demo3!(### "foo");
    |            ^^
@@ -71,7 +71,7 @@ LL |     demo3!(# ## "foo");
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:53:12
+  --> $DIR/reserved-guarded-strings.rs:52:12
    |
 LL |     demo3!(## "foo"#);
    |            ^^
@@ -83,7 +83,7 @@ LL |     demo3!(# # "foo"#);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:54:12
+  --> $DIR/reserved-guarded-strings.rs:53:12
    |
 LL |     demo5!(### "foo"###);
    |            ^^
@@ -95,7 +95,7 @@ LL |     demo5!(# ## "foo"###);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:54:21
+  --> $DIR/reserved-guarded-strings.rs:53:21
    |
 LL |     demo5!(### "foo"###);
    |                     ^^
@@ -107,7 +107,7 @@ LL |     demo5!(### "foo"# ##);
    |                      +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:58:12
+  --> $DIR/reserved-guarded-strings.rs:57:12
    |
 LL |     demo1!(#"");
    |            ^^^
@@ -119,7 +119,7 @@ LL |     demo1!(# "");
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:59:12
+  --> $DIR/reserved-guarded-strings.rs:58:12
    |
 LL |     demo1!(#""#);
    |            ^^^^
@@ -131,7 +131,7 @@ LL |     demo1!(# ""#);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:60:12
+  --> $DIR/reserved-guarded-strings.rs:59:12
    |
 LL |     demo1!(####"");
    |            ^^^^^^
@@ -143,7 +143,7 @@ LL |     demo1!(# ###"");
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:61:12
+  --> $DIR/reserved-guarded-strings.rs:60:12
    |
 LL |     demo1!(#"foo");
    |            ^^^^^^
@@ -155,7 +155,7 @@ LL |     demo1!(# "foo");
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:62:12
+  --> $DIR/reserved-guarded-strings.rs:61:12
    |
 LL |     demo1!(###"foo");
    |            ^^^^^^^^
@@ -167,7 +167,7 @@ LL |     demo1!(# ##"foo");
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:63:12
+  --> $DIR/reserved-guarded-strings.rs:62:12
    |
 LL |     demo1!(#"foo"#);
    |            ^^^^^^^
@@ -179,7 +179,7 @@ LL |     demo1!(# "foo"#);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:64:12
+  --> $DIR/reserved-guarded-strings.rs:63:12
    |
 LL |     demo1!(###"foo"#);
    |            ^^^^^^^^^
@@ -191,7 +191,7 @@ LL |     demo1!(# ##"foo"#);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:65:12
+  --> $DIR/reserved-guarded-strings.rs:64:12
    |
 LL |     demo1!(###"foo"##);
    |            ^^^^^^^^^^
@@ -203,7 +203,7 @@ LL |     demo1!(# ##"foo"##);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:66:12
+  --> $DIR/reserved-guarded-strings.rs:65:12
    |
 LL |     demo1!(###"foo"###);
    |            ^^^^^^^^^^^
@@ -215,7 +215,7 @@ LL |     demo1!(# ##"foo"###);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:67:12
+  --> $DIR/reserved-guarded-strings.rs:66:12
    |
 LL |     demo2!(#"foo"###);
    |            ^^^^^^^
@@ -227,7 +227,7 @@ LL |     demo2!(# "foo"###);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:67:19
+  --> $DIR/reserved-guarded-strings.rs:66:19
    |
 LL |     demo2!(#"foo"###);
    |                   ^^
@@ -239,7 +239,7 @@ LL |     demo2!(#"foo"## #);
    |                    +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:72:12
+  --> $DIR/reserved-guarded-strings.rs:71:12
    |
 LL | ...n!(####################################################################################################################################################################################################################################################################"foo...
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/sanitizer/cfi/coroutine.rs
+++ b/tests/ui/sanitizer/cfi/coroutine.rs
@@ -11,7 +11,7 @@
 //@ [cfi] compile-flags: -Z sanitizer=cfi
 //@ [kcfi] compile-flags: -Z sanitizer=kcfi
 //@ [kcfi] compile-flags: -C panic=abort -Z panic-abort-tests -C prefer-dynamic=off
-//@ compile-flags: --test -Z unstable-options
+//@ compile-flags: --test
 //@ run-pass
 
 #![feature(coroutines, stmt_expr_attributes)]

--- a/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.stderr
+++ b/tests/ui/span/drop-location-span-error-rust-2021-incompatible-closure-captures-96258.stderr
@@ -4,7 +4,7 @@ error[E0670]: `async fn` is not permitted in Rust 2015
 LL |     pub(crate) async fn new(
    |                ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
-   = help: pass `--edition 2021` to `rustc`
+   = help: pass `--edition 2024` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
 
 error[E0412]: cannot find type `Duration` in this scope

--- a/tests/ui/unpretty/expanded-exhaustive.rs
+++ b/tests/ui/unpretty/expanded-exhaustive.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zunpretty=expanded -Zunstable-options
+//@ compile-flags: -Zunpretty=expanded
 //@ edition:2024
 //@ check-pass
 

--- a/tests/ui/unpretty/expanded-exhaustive.stdout
+++ b/tests/ui/unpretty/expanded-exhaustive.stdout
@@ -1,5 +1,5 @@
 #![feature(prelude_import)]
-//@ compile-flags: -Zunpretty=expanded -Zunstable-options
+//@ compile-flags: -Zunpretty=expanded
 //@ edition:2024
 //@ check-pass
 

--- a/tests/ui/unsafe/edition-2024-unsafe_op_in_unsafe_fn.rs
+++ b/tests/ui/unsafe/edition-2024-unsafe_op_in_unsafe_fn.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 //@ check-pass
 #![crate_type = "lib"]
 #![deny(unused_unsafe)]

--- a/tests/ui/unsafe/edition-2024-unsafe_op_in_unsafe_fn.stderr
+++ b/tests/ui/unsafe/edition-2024-unsafe_op_in_unsafe_fn.stderr
@@ -1,5 +1,5 @@
 warning[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
-  --> $DIR/edition-2024-unsafe_op_in_unsafe_fn.rs:10:5
+  --> $DIR/edition-2024-unsafe_op_in_unsafe_fn.rs:9:5
    |
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
@@ -7,7 +7,7 @@ LL |     unsf();
    = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
-  --> $DIR/edition-2024-unsafe_op_in_unsafe_fn.rs:9:1
+  --> $DIR/edition-2024-unsafe_op_in_unsafe_fn.rs:8:1
    |
 LL | unsafe fn foo() {
    | ^^^^^^^^^^^^^^^

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/edition_2024_default.rs
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/edition_2024_default.rs
@@ -1,5 +1,4 @@
 //@ edition: 2024
-//@ compile-flags: -Zunstable-options
 //@ check-pass
 
 // Tests that `unsafe_op_in_unsafe_fn` is warn-by-default in edition 2024 and that the

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/edition_2024_default.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/edition_2024_default.stderr
@@ -1,5 +1,5 @@
 warning[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
-  --> $DIR/edition_2024_default.rs:13:5
+  --> $DIR/edition_2024_default.rs:12:5
    |
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
@@ -7,7 +7,7 @@ LL |     unsf();
    = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
-  --> $DIR/edition_2024_default.rs:12:1
+  --> $DIR/edition_2024_default.rs:11:1
    |
 LL | unsafe fn foo() {
    | ^^^^^^^^^^^^^^^


### PR DESCRIPTION
This stabilizes the 2024 edition for Rust 1.85, scheduled to be released on February 20, 2025. 🎉 

cc tracking issue: https://github.com/rust-lang/rust/issues/117258

There is a fair amount of follow-up work after this that I am working on (various docs, cargo, rustfmt, etc.), and this is will unblock those other changes.
