### PR TITLE
add flag to dump unstable feature status information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,6 +3596,7 @@ dependencies = [
  "rustc_target",
  "rustc_trait_selection",
  "rustc_ty_utils",
+ "serde",
  "serde_json",
  "shlex",
  "time",
@@ -4012,6 +4013,7 @@ dependencies = [
  "rustc_span",
  "rustc_target",
  "rustc_type_ir",
+ "serde",
  "tempfile",
  "tracing",
 ]

--- a/compiler/rustc_driver_impl/Cargo.toml
+++ b/compiler/rustc_driver_impl/Cargo.toml
@@ -47,6 +47,7 @@ rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
 rustc_trait_selection = { path = "../rustc_trait_selection" }
 rustc_ty_utils = { path = "../rustc_ty_utils" }
+serde = { version = "1.0.125", features = [ "derive" ] }
 serde_json = "1.0.59"
 shlex = "1.0"
 time = { version = "0.3.36", default-features = false, features = ["alloc", "formatting", "macros"] }

--- a/compiler/rustc_feature/src/lib.rs
+++ b/compiler/rustc_feature/src/lib.rs
@@ -132,6 +132,62 @@ pub fn find_feature_issue(feature: Symbol, issue: GateIssue) -> Option<NonZero<u
     }
 }
 
+#[derive(serde::Serialize)]
+enum LangFeature {
+    Unstable {
+        status: &'static str,
+        symbol: String,
+        since: &'static str,
+        issue: Option<NonZero<u32>>,
+    },
+    Accepted {
+        symbol: String,
+        since: &'static str,
+        issue: Option<NonZero<u32>>,
+    },
+    Removed {
+        symbol: String,
+        since: &'static str,
+        issue: Option<NonZero<u32>>,
+        reason: Option<&'static str>,
+    },
+}
+
+#[derive(serde::Serialize)]
+pub struct LangFeaturesStatus {
+    lang_features: Vec<LangFeature>,
+}
+
+/// Extract the status of all lang features as a json serializable struct
+pub fn lang_features_status() -> LangFeaturesStatus {
+    let unstable_lang_features =
+        UNSTABLE_LANG_FEATURES.iter().map(|feature| LangFeature::Unstable {
+            status: Features::feature_status(feature.name),
+            symbol: feature.name.to_string(),
+            since: feature.since,
+            issue: feature.issue,
+        });
+
+    let accepted_lang_features =
+        ACCEPTED_LANG_FEATURES.iter().map(|feature| LangFeature::Accepted {
+            symbol: feature.name.to_string(),
+            since: feature.since,
+            issue: feature.issue,
+        });
+
+    let removed_lang_features = REMOVED_LANG_FEATURES.iter().map(|removed| LangFeature::Removed {
+        symbol: removed.feature.name.to_string(),
+        since: removed.feature.since,
+        issue: removed.feature.issue,
+        reason: removed.reason,
+    });
+
+    let lang_features =
+        unstable_lang_features.chain(accepted_lang_features).chain(removed_lang_features).collect();
+
+    LangFeaturesStatus { lang_features }
+}
+
 pub use accepted::ACCEPTED_LANG_FEATURES;
 pub use builtin_attrs::{
     AttributeDuplicates, AttributeGate, AttributeSafety, AttributeTemplate, AttributeType,

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -99,6 +99,18 @@ impl Features {
     }
 }
 
+macro_rules! status_to_str {
+    (unstable) => {
+        "default"
+    };
+    (incomplete) => {
+        "incomplete"
+    };
+    (internal) => {
+        "internal"
+    };
+}
+
 macro_rules! declare_features {
     ($(
         $(#[doc = $doc:tt])* ($status:ident, $feature:ident, $ver:expr, $issue:expr),
@@ -156,6 +168,15 @@ macro_rules! declare_features {
                         let name = feature.as_str();
                         name == "core_intrinsics" || name.ends_with("_internal") || name.ends_with("_internals")
                     }
+                    _ => panic!("`{}` was not listed in `declare_features`", feature),
+                }
+            }
+
+            pub fn feature_status(feature: Symbol) -> &'static str {
+                match feature {
+                    $(
+                    sym::$feature => status_to_str!($status),
+                    )*
                     _ => panic!("`{}` was not listed in `declare_features`", feature),
                 }
             }

--- a/compiler/rustc_metadata/Cargo.toml
+++ b/compiler/rustc_metadata/Cargo.toml
@@ -28,6 +28,7 @@ rustc_session = { path = "../rustc_session" }
 rustc_span = { path = "../rustc_span" }
 rustc_target = { path = "../rustc_target" }
 rustc_type_ir = { path = "../rustc_type_ir" }
+serde = { version = "1.0.125", features = [ "derive" ] }
 tempfile = "3.2"
 tracing = "0.1"
 # tidy-alphabetical-end

--- a/compiler/rustc_metadata/src/lib.rs
+++ b/compiler/rustc_metadata/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(coroutines)]
 #![feature(decl_macro)]
 #![feature(error_iter)]
+#![feature(error_reporter)]
 #![feature(extract_if)]
 #![feature(file_buffered)]
 #![feature(if_let_guard)]
@@ -35,6 +36,7 @@ pub mod locator;
 
 pub use creader::{DylibError, load_symbol_from_dylib};
 pub use fs::{METADATA_FILENAME, emit_wrapper_file};
+pub use locator::lib_features_status;
 pub use native_libs::{
     find_native_static_library, try_find_native_dynamic_library, try_find_native_static_library,
     walk_native_lib_search_dirs,

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -935,6 +935,14 @@ impl MetadataBlob {
 
         Ok(())
     }
+
+    pub(crate) fn dump_crate_features_json(&self) -> Vec<(String, FeatureStability)> {
+        let root = self.get_root();
+        root.lib_features
+            .decode(self)
+            .map(|(symbol, status)| (symbol.to_string(), status))
+            .collect()
+    }
 }
 
 impl CrateRoot {

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1730,6 +1730,8 @@ options! {
     dump_dep_graph: bool = (false, parse_bool, [UNTRACKED],
         "dump the dependency graph to $RUST_DEP_GRAPH (default: /tmp/dep_graph.gv) \
         (default: no)"),
+    dump_features_status: bool = (false, parse_bool, [UNTRACKED],
+        "dump the status of rust language and library features as json"),
     dump_mir: Option<String> = (None, parse_opt_string, [UNTRACKED],
         "dump MIR state to file.
         `val` is used to select which passes and functions to dump. For example:


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
This pr is part of https://github.com/rust-lang/rust/issues/129485

It adds the ability to dump feature status for lang, std, and core as json

r? @estebank