### PR TITLE
Add language tests for aggregate types

### DIFF
--- a/tests/ui/layout/aggregate-lang/struct-align.rs
+++ b/tests/ui/layout/aggregate-lang/struct-align.rs
@@ -1,0 +1,31 @@
+//@ run-pass
+//@ reference: layout.aggregate.struct-size-align
+//@ edition: 2018
+
+#[repr(align(64))]
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub struct Overaligned(u8);
+
+#[allow(dead_code)]
+struct ReprRustStruct {
+    x: i32,
+    y: [u32; 4],
+    z: f32,
+    a: u128,
+    b: Overaligned,
+}
+
+#[cfg_attr(test, test)]
+fn test_alignment_contains_all_fields() {
+    assert!(core::mem::align_of::<ReprRustStruct>() >= core::mem::align_of::<i32>());
+    assert!(core::mem::align_of::<ReprRustStruct>() >= core::mem::align_of::<[u32; 4]>());
+    assert!(core::mem::align_of::<ReprRustStruct>() >= core::mem::align_of::<f32>());
+    assert!(core::mem::align_of::<ReprRustStruct>() >= core::mem::align_of::<u128>());
+    assert!(core::mem::align_of::<ReprRustStruct>() >= core::mem::align_of::<Overaligned>());
+}
+
+#[cfg(not(test))]
+fn main() {
+    test_alignment_contains_all_fields();
+}

--- a/tests/ui/layout/aggregate-lang/struct-align.rs
+++ b/tests/ui/layout/aggregate-lang/struct-align.rs
@@ -16,7 +16,6 @@ struct ReprRustStruct {
     b: Overaligned,
 }
 
-#[cfg_attr(test, test)]
 fn test_alignment_contains_all_fields() {
     assert!(core::mem::align_of::<ReprRustStruct>() >= core::mem::align_of::<i32>());
     assert!(core::mem::align_of::<ReprRustStruct>() >= core::mem::align_of::<[u32; 4]>());
@@ -25,7 +24,6 @@ fn test_alignment_contains_all_fields() {
     assert!(core::mem::align_of::<ReprRustStruct>() >= core::mem::align_of::<Overaligned>());
 }
 
-#[cfg(not(test))]
 fn main() {
     test_alignment_contains_all_fields();
 }

--- a/tests/ui/layout/aggregate-lang/struct-offsets.rs
+++ b/tests/ui/layout/aggregate-lang/struct-offsets.rs
@@ -1,0 +1,93 @@
+//@ run-pass
+//@ reference: layout.aggregate.struct-offsets
+//@ edition: 2018
+
+#[repr(align(64))]
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub struct Overaligned(u8);
+
+#[allow(dead_code)]
+struct ReprRustStruct {
+    x: i32,
+    y: [u32; 4],
+    z: f32,
+    a: u128,
+    b: Overaligned,
+}
+
+macro_rules! span_of {
+    ($ty:ty , $field:tt) => {{
+        let __field = unsafe { ::core::mem::zeroed::<$ty>() };
+
+        (
+            core::mem::offset_of!($ty, $field),
+            core::mem::offset_of!($ty, $field) + core::mem::size_of_val(&__field.$field),
+        )
+    }};
+}
+
+fn test_fields_make_sense(a: &(usize, usize)) {
+    assert!(a.0 <= a.1);
+}
+
+// order is `begin, end`
+fn test_non_overlapping(a: &(usize, usize), b: &(usize, usize)) {
+    assert!((a.1 <= b.0) || (b.1 <= a.0));
+}
+
+#[cfg_attr(test, test)]
+fn test_fields_non_overlapping() {
+    let fields = [
+        span_of!(ReprRustStruct, x),
+        span_of!(ReprRustStruct, y),
+        span_of!(ReprRustStruct, z),
+        span_of!(ReprRustStruct, a),
+        span_of!(ReprRustStruct, b),
+    ];
+
+    test_fields_make_sense(&fields[0]);
+    test_fields_make_sense(&fields[1]);
+    test_fields_make_sense(&fields[2]);
+    test_fields_make_sense(&fields[3]);
+    test_fields_make_sense(&fields[4]);
+
+    test_non_overlapping(&fields[0], &fields[1]);
+    test_non_overlapping(&fields[0], &fields[2]);
+    test_non_overlapping(&fields[0], &fields[3]);
+    test_non_overlapping(&fields[0], &fields[4]);
+    test_non_overlapping(&fields[1], &fields[2]);
+    test_non_overlapping(&fields[2], &fields[3]);
+    test_non_overlapping(&fields[2], &fields[4]);
+    test_non_overlapping(&fields[3], &fields[4]);
+}
+
+#[cfg_attr(test, test)]
+fn test_fields_aligned() {
+    assert_eq!(
+        (core::mem::offset_of!(ReprRustStruct, x) % (core::mem::align_of::<i32>())),
+        0
+    );
+    assert_eq!(
+        (core::mem::offset_of!(ReprRustStruct, y) % (core::mem::align_of::<[u32; 4]>())),
+        0
+    );
+    assert_eq!(
+        (core::mem::offset_of!(ReprRustStruct, z) % (core::mem::align_of::<f32>())),
+        0
+    );
+    assert_eq!(
+        (core::mem::offset_of!(ReprRustStruct, a) % (core::mem::align_of::<u128>())),
+        0
+    );
+    assert_eq!(
+        (core::mem::offset_of!(ReprRustStruct, b) % (core::mem::align_of::<Overaligned>())),
+        0
+    );
+}
+
+#[cfg(not(test))]
+fn main() {
+    test_fields_non_overlapping();
+    test_fields_aligned();
+}

--- a/tests/ui/layout/aggregate-lang/struct-offsets.rs
+++ b/tests/ui/layout/aggregate-lang/struct-offsets.rs
@@ -36,7 +36,6 @@ fn test_non_overlapping(a: &(usize, usize), b: &(usize, usize)) {
     assert!((a.1 <= b.0) || (b.1 <= a.0));
 }
 
-#[cfg_attr(test, test)]
 fn test_fields_non_overlapping() {
     let fields = [
         span_of!(ReprRustStruct, x),
@@ -62,31 +61,17 @@ fn test_fields_non_overlapping() {
     test_non_overlapping(&fields[3], &fields[4]);
 }
 
-#[cfg_attr(test, test)]
 fn test_fields_aligned() {
-    assert_eq!(
-        (core::mem::offset_of!(ReprRustStruct, x) % (core::mem::align_of::<i32>())),
-        0
-    );
-    assert_eq!(
-        (core::mem::offset_of!(ReprRustStruct, y) % (core::mem::align_of::<[u32; 4]>())),
-        0
-    );
-    assert_eq!(
-        (core::mem::offset_of!(ReprRustStruct, z) % (core::mem::align_of::<f32>())),
-        0
-    );
-    assert_eq!(
-        (core::mem::offset_of!(ReprRustStruct, a) % (core::mem::align_of::<u128>())),
-        0
-    );
+    assert_eq!((core::mem::offset_of!(ReprRustStruct, x) % (core::mem::align_of::<i32>())), 0);
+    assert_eq!((core::mem::offset_of!(ReprRustStruct, y) % (core::mem::align_of::<[u32; 4]>())), 0);
+    assert_eq!((core::mem::offset_of!(ReprRustStruct, z) % (core::mem::align_of::<f32>())), 0);
+    assert_eq!((core::mem::offset_of!(ReprRustStruct, a) % (core::mem::align_of::<u128>())), 0);
     assert_eq!(
         (core::mem::offset_of!(ReprRustStruct, b) % (core::mem::align_of::<Overaligned>())),
         0
     );
 }
 
-#[cfg(not(test))]
 fn main() {
     test_fields_non_overlapping();
     test_fields_aligned();

--- a/tests/ui/layout/aggregate-lang/struct-size.rs
+++ b/tests/ui/layout/aggregate-lang/struct-size.rs
@@ -1,0 +1,57 @@
+//@ run-pass
+//@ reference: layout.aggregate.struct-size-align
+//@ edition: 2018
+
+#[allow(dead_code)]
+struct ReprRustStruct {
+    x: i32,
+    y: [u32; 4],
+    z: f32,
+    a: u128,
+}
+
+#[cfg_attr(test, test)]
+fn test_size_contains_all_types() {
+    assert!(
+        core::mem::size_of::<ReprRustStruct>()
+            >= (core::mem::size_of::<i32>()
+                + core::mem::size_of::<[u32; 4]>()
+                + core::mem::size_of::<f32>()
+                + core::mem::size_of::<u128>())
+    );
+}
+
+#[cfg_attr(test, test)]
+fn test_size_contains_all_fields() {
+    assert!(
+        (core::mem::offset_of!(ReprRustStruct, x) + core::mem::size_of::<i32>())
+            <= core::mem::size_of::<ReprRustStruct>()
+    );
+    assert!(
+        (core::mem::offset_of!(ReprRustStruct, y) + core::mem::size_of::<[u32; 4]>())
+            <= core::mem::size_of::<ReprRustStruct>()
+    );
+    assert!(
+        (core::mem::offset_of!(ReprRustStruct, z) + core::mem::size_of::<f32>())
+            <= core::mem::size_of::<ReprRustStruct>()
+    );
+    assert!(
+        (core::mem::offset_of!(ReprRustStruct, a) + core::mem::size_of::<u128>())
+            <= core::mem::size_of::<ReprRustStruct>()
+    );
+}
+
+#[cfg_attr(test, test)]
+fn test_size_modulo_align() {
+    assert_eq!(
+        core::mem::size_of::<ReprRustStruct>() % core::mem::align_of::<ReprRustStruct>(),
+        0
+    );
+}
+
+#[cfg(not(test))]
+fn main() {
+    test_size_contains_all_fields();
+    test_size_contains_all_types();
+    test_size_modulo_align();
+}

--- a/tests/ui/layout/aggregate-lang/struct-size.rs
+++ b/tests/ui/layout/aggregate-lang/struct-size.rs
@@ -10,7 +10,6 @@ struct ReprRustStruct {
     a: u128,
 }
 
-#[cfg_attr(test, test)]
 fn test_size_contains_all_types() {
     assert!(
         core::mem::size_of::<ReprRustStruct>()
@@ -21,7 +20,6 @@ fn test_size_contains_all_types() {
     );
 }
 
-#[cfg_attr(test, test)]
 fn test_size_contains_all_fields() {
     assert!(
         (core::mem::offset_of!(ReprRustStruct, x) + core::mem::size_of::<i32>())
@@ -41,15 +39,10 @@ fn test_size_contains_all_fields() {
     );
 }
 
-#[cfg_attr(test, test)]
 fn test_size_modulo_align() {
-    assert_eq!(
-        core::mem::size_of::<ReprRustStruct>() % core::mem::align_of::<ReprRustStruct>(),
-        0
-    );
+    assert_eq!(core::mem::size_of::<ReprRustStruct>() % core::mem::align_of::<ReprRustStruct>(), 0);
 }
 
-#[cfg(not(test))]
 fn main() {
     test_size_contains_all_fields();
     test_size_contains_all_types();

--- a/tests/ui/layout/aggregate-lang/union-align.rs
+++ b/tests/ui/layout/aggregate-lang/union-align.rs
@@ -16,7 +16,6 @@ union ReprRustUnion {
     b: Overaligned,
 }
 
-#[cfg_attr(test, test)]
 fn test_alignment_contains_all_fields() {
     assert!(core::mem::align_of::<ReprRustUnion>() >= core::mem::align_of::<i32>());
     assert!(core::mem::align_of::<ReprRustUnion>() >= core::mem::align_of::<[u32; 4]>());
@@ -25,7 +24,6 @@ fn test_alignment_contains_all_fields() {
     assert!(core::mem::align_of::<ReprRustUnion>() >= core::mem::align_of::<Overaligned>());
 }
 
-#[cfg(not(test))]
 fn main() {
     test_alignment_contains_all_fields();
 }

--- a/tests/ui/layout/aggregate-lang/union-align.rs
+++ b/tests/ui/layout/aggregate-lang/union-align.rs
@@ -1,0 +1,31 @@
+//@ run-pass
+//@ reference: layout.aggregate.struct-size-align
+//@ edition: 2018
+
+#[repr(align(64))]
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub struct Overaligned(u8);
+
+#[allow(dead_code)]
+union ReprRustUnion {
+    x: i32,
+    y: [u32; 4],
+    z: f32,
+    a: u128,
+    b: Overaligned,
+}
+
+#[cfg_attr(test, test)]
+fn test_alignment_contains_all_fields() {
+    assert!(core::mem::align_of::<ReprRustUnion>() >= core::mem::align_of::<i32>());
+    assert!(core::mem::align_of::<ReprRustUnion>() >= core::mem::align_of::<[u32; 4]>());
+    assert!(core::mem::align_of::<ReprRustUnion>() >= core::mem::align_of::<f32>());
+    assert!(core::mem::align_of::<ReprRustUnion>() >= core::mem::align_of::<u128>());
+    assert!(core::mem::align_of::<ReprRustUnion>() >= core::mem::align_of::<Overaligned>());
+}
+
+#[cfg(not(test))]
+fn main() {
+    test_alignment_contains_all_fields();
+}

--- a/tests/ui/layout/aggregate-lang/union-offsets.rs
+++ b/tests/ui/layout/aggregate-lang/union-offsets.rs
@@ -16,31 +16,17 @@ union ReprRustUnion {
     b: Overaligned,
 }
 
-#[cfg_attr(test, test)]
 fn test_fields_aligned() {
-    assert_eq!(
-        (core::mem::offset_of!(ReprRustUnion, x) % (core::mem::align_of::<i32>())),
-        0
-    );
-    assert_eq!(
-        (core::mem::offset_of!(ReprRustUnion, y) % (core::mem::align_of::<[u32; 4]>())),
-        0
-    );
-    assert_eq!(
-        (core::mem::offset_of!(ReprRustUnion, z) % (core::mem::align_of::<f32>())),
-        0
-    );
-    assert_eq!(
-        (core::mem::offset_of!(ReprRustUnion, a) % (core::mem::align_of::<u128>())),
-        0
-    );
+    assert_eq!((core::mem::offset_of!(ReprRustUnion, x) % (core::mem::align_of::<i32>())), 0);
+    assert_eq!((core::mem::offset_of!(ReprRustUnion, y) % (core::mem::align_of::<[u32; 4]>())), 0);
+    assert_eq!((core::mem::offset_of!(ReprRustUnion, z) % (core::mem::align_of::<f32>())), 0);
+    assert_eq!((core::mem::offset_of!(ReprRustUnion, a) % (core::mem::align_of::<u128>())), 0);
     assert_eq!(
         (core::mem::offset_of!(ReprRustUnion, b) % (core::mem::align_of::<Overaligned>())),
         0
     );
 }
 
-#[cfg(not(test))]
 fn main() {
     test_fields_aligned();
 }

--- a/tests/ui/layout/aggregate-lang/union-offsets.rs
+++ b/tests/ui/layout/aggregate-lang/union-offsets.rs
@@ -1,0 +1,46 @@
+//@ run-pass
+//@ reference: layout.aggregate.struct-offsets
+//@ edition: 2018
+
+#[repr(align(64))]
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub struct Overaligned(u8);
+
+#[allow(dead_code)]
+union ReprRustUnion {
+    x: i32,
+    y: [u32; 4],
+    z: f32,
+    a: u128,
+    b: Overaligned,
+}
+
+#[cfg_attr(test, test)]
+fn test_fields_aligned() {
+    assert_eq!(
+        (core::mem::offset_of!(ReprRustUnion, x) % (core::mem::align_of::<i32>())),
+        0
+    );
+    assert_eq!(
+        (core::mem::offset_of!(ReprRustUnion, y) % (core::mem::align_of::<[u32; 4]>())),
+        0
+    );
+    assert_eq!(
+        (core::mem::offset_of!(ReprRustUnion, z) % (core::mem::align_of::<f32>())),
+        0
+    );
+    assert_eq!(
+        (core::mem::offset_of!(ReprRustUnion, a) % (core::mem::align_of::<u128>())),
+        0
+    );
+    assert_eq!(
+        (core::mem::offset_of!(ReprRustUnion, b) % (core::mem::align_of::<Overaligned>())),
+        0
+    );
+}
+
+#[cfg(not(test))]
+fn main() {
+    test_fields_aligned();
+}

--- a/tests/ui/layout/aggregate-lang/union-size.rs
+++ b/tests/ui/layout/aggregate-lang/union-size.rs
@@ -1,0 +1,54 @@
+//@ run-pass
+//@ reference: layout.aggregate.struct-size-align
+//@ edition: 2018
+
+#[allow(dead_code)]
+union ReprRustUnion {
+    x: i32,
+    y: [u32; 4],
+    z: f32,
+    a: u128,
+}
+
+#[cfg_attr(test, test)]
+fn test_size_contains_each_type() {
+    assert!(core::mem::size_of::<i32>() <= core::mem::size_of::<ReprRustUnion>());
+    assert!(core::mem::size_of::<[u32; 4]>() <= core::mem::size_of::<ReprRustUnion>());
+    assert!(core::mem::size_of::<f32>() <= core::mem::size_of::<ReprRustUnion>());
+    assert!(core::mem::size_of::<u128>() <= core::mem::size_of::<ReprRustUnion>());
+}
+
+#[cfg_attr(test, test)]
+fn test_size_contains_all_fields() {
+    assert!(
+        (core::mem::offset_of!(ReprRustUnion, x) + core::mem::size_of::<i32>())
+            <= core::mem::size_of::<ReprRustUnion>()
+    );
+    assert!(
+        (core::mem::offset_of!(ReprRustUnion, y) + core::mem::size_of::<[u32; 4]>())
+            <= core::mem::size_of::<ReprRustUnion>()
+    );
+    assert!(
+        (core::mem::offset_of!(ReprRustUnion, z) + core::mem::size_of::<f32>())
+            <= core::mem::size_of::<ReprRustUnion>()
+    );
+    assert!(
+        (core::mem::offset_of!(ReprRustUnion, a) + core::mem::size_of::<u128>())
+            <= core::mem::size_of::<ReprRustUnion>()
+    );
+}
+
+#[cfg_attr(test, test)]
+fn test_size_modulo_align() {
+    assert_eq!(
+        core::mem::size_of::<ReprRustUnion>() % core::mem::align_of::<ReprRustUnion>(),
+        0
+    );
+}
+
+#[cfg(not(test))]
+fn main() {
+    test_size_contains_each_type();
+    test_size_contains_all_fields();
+    test_size_modulo_align();
+}

--- a/tests/ui/layout/aggregate-lang/union-size.rs
+++ b/tests/ui/layout/aggregate-lang/union-size.rs
@@ -10,7 +10,6 @@ union ReprRustUnion {
     a: u128,
 }
 
-#[cfg_attr(test, test)]
 fn test_size_contains_each_type() {
     assert!(core::mem::size_of::<i32>() <= core::mem::size_of::<ReprRustUnion>());
     assert!(core::mem::size_of::<[u32; 4]>() <= core::mem::size_of::<ReprRustUnion>());
@@ -18,7 +17,6 @@ fn test_size_contains_each_type() {
     assert!(core::mem::size_of::<u128>() <= core::mem::size_of::<ReprRustUnion>());
 }
 
-#[cfg_attr(test, test)]
 fn test_size_contains_all_fields() {
     assert!(
         (core::mem::offset_of!(ReprRustUnion, x) + core::mem::size_of::<i32>())
@@ -38,15 +36,10 @@ fn test_size_contains_all_fields() {
     );
 }
 
-#[cfg_attr(test, test)]
 fn test_size_modulo_align() {
-    assert_eq!(
-        core::mem::size_of::<ReprRustUnion>() % core::mem::align_of::<ReprRustUnion>(),
-        0
-    );
+    assert_eq!(core::mem::size_of::<ReprRustUnion>() % core::mem::align_of::<ReprRustUnion>(), 0);
 }
 
-#[cfg(not(test))]
 fn main() {
     test_size_contains_each_type();
     test_size_contains_all_fields();


### PR DESCRIPTION
This adds some tests for struct and union types, ensuring that they satisfy the rules for all structs and unions - namely that fields of structs do not overlap, fields are well-aligned, and the size of the entire.

The reference annotations used are from https://github.com/rust-lang/reference/pull/1654, though the rules tested here were FCPed in <https://github.com/rust-lang/reference/pull/1152>.