### PR TITLE
[CRATER] Detect cases when user written object assoc bound differs from elaborated non-self-referential bound

### DIFF
--- a/tests/ui/associated-types/associated-types-overridden-binding-2.stderr
+++ b/tests/ui/associated-types/associated-types-overridden-binding-2.stderr
@@ -1,3 +1,9 @@
+error: expected u32, found i32
+  --> $DIR/associated-types-overridden-binding-2.rs:6:29
+   |
+LL |     let _: &dyn I32Iterator<Item = u32> = &vec![42].into_iter();
+   |                             ^^^^^^^^^^
+
 error[E0271]: expected `IntoIter<u32>` to be an iterator that yields `i32`, but it yields `u32`
   --> $DIR/associated-types-overridden-binding-2.rs:6:43
    |
@@ -6,6 +12,6 @@ LL |     let _: &dyn I32Iterator<Item = u32> = &vec![42].into_iter();
    |
    = note: required for the cast from `&std::vec::IntoIter<u32>` to `&dyn Iterator<Item = u32, Item = i32>`
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/associated-types/associated-types-overridden-binding.stderr
+++ b/tests/ui/associated-types/associated-types-overridden-binding.stderr
@@ -22,6 +22,12 @@ note: required by a bound in `I32Iterator`
 LL | trait I32Iterator = Iterator<Item = i32>;
    |                              ^^^^^^^^^^ required by this bound in `I32Iterator`
 
-error: aborting due to 2 previous errors
+error: expected u32, found i32
+  --> $DIR/associated-types-overridden-binding.rs:10:29
+   |
+LL |     let _: &dyn I32Iterator<Item = u32>;
+   |                             ^^^^^^^^^^
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0284`.

--- a/tests/ui/traits/object/pretty.stderr
+++ b/tests/ui/traits/object/pretty.stderr
@@ -1,3 +1,15 @@
+error: expected u16, found u8
+  --> $DIR/pretty.rs:28:34
+   |
+LL | fn dyn_fixed_multi(x: &dyn Fixed<Assoc = u16>) { x }
+   |                                  ^^^^^^^^^^^
+
+error: expected &'a u8, found for<'a> &'a u8
+  --> $DIR/pretty.rs:36:62
+   |
+LL | fn dyn_fixed_generic_multi(x: &dyn for<'a> FixedGeneric1<'a, Assoc2 = &u8>) { x }
+   |                                                              ^^^^^^^^^^^^
+
 warning: unnecessary associated type bound for dyn-incompatible associated type
   --> $DIR/pretty.rs:41:35
    |
@@ -161,6 +173,6 @@ LL | fn dyn_has_gat(x: &dyn HasGat<u8, Assoc<bool> = ()>) { x }
    = note: expected unit type `()`
               found reference `&dyn HasGat<u8, Assoc<bool> = ()>`
 
-error: aborting due to 14 previous errors; 1 warning emitted
+error: aborting due to 16 previous errors; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
an experiment relating to a potential fix for https://github.com/rust-lang/rust/issues/133361

r? @ghost