### PR TITLE
Allow injecting a profiler runtime into `#![no_core]` crates

### DIFF
--- a/compiler/rustc_metadata/messages.ftl
+++ b/compiler/rustc_metadata/messages.ftl
@@ -233,9 +233,6 @@ metadata_prev_alloc_error_handler =
 metadata_prev_global_alloc =
     previous global allocator defined here
 
-metadata_profiler_builtins_needs_core =
-    `profiler_builtins` crate (required by compiler options) is not compatible with crate attribute `#![no_core]`
-
 metadata_raw_dylib_no_nul =
     link name must not contain NUL characters if link kind is `raw-dylib`
 

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -800,9 +800,9 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
     }
 
     fn inject_profiler_runtime(&mut self, krate: &ast::Crate) {
-        if self.sess.opts.unstable_opts.no_profiler_runtime
-            || !(self.sess.instrument_coverage() || self.sess.opts.cg.profile_generate.enabled())
-        {
+        let needs_profiler_runtime =
+            self.sess.instrument_coverage() || self.sess.opts.cg.profile_generate.enabled();
+        if !needs_profiler_runtime || self.sess.opts.unstable_opts.no_profiler_runtime {
             return;
         }
 

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -799,7 +799,7 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
         self.inject_dependency_if(cnum, "a panic runtime", &|data| data.needs_panic_runtime());
     }
 
-    fn inject_profiler_runtime(&mut self, krate: &ast::Crate) {
+    fn inject_profiler_runtime(&mut self) {
         let needs_profiler_runtime =
             self.sess.instrument_coverage() || self.sess.opts.cg.profile_generate.enabled();
         if !needs_profiler_runtime || self.sess.opts.unstable_opts.no_profiler_runtime {
@@ -809,10 +809,6 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
         info!("loading profiler");
 
         let name = Symbol::intern(&self.sess.opts.unstable_opts.profiler_runtime);
-        if name == sym::profiler_builtins && attr::contains_name(&krate.attrs, sym::no_core) {
-            self.dcx().emit_err(errors::ProfilerBuiltinsNeedsCore);
-        }
-
         let Some(cnum) = self.resolve_crate(name, DUMMY_SP, CrateDepKind::Implicit) else {
             return;
         };
@@ -1046,7 +1042,7 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
 
     pub fn postprocess(&mut self, krate: &ast::Crate) {
         self.inject_forced_externs();
-        self.inject_profiler_runtime(krate);
+        self.inject_profiler_runtime();
         self.inject_allocator_crate(krate);
         self.inject_panic_runtime(krate);
 

--- a/compiler/rustc_metadata/src/errors.rs
+++ b/compiler/rustc_metadata/src/errors.rs
@@ -340,10 +340,6 @@ pub struct NoPanicStrategy {
 }
 
 #[derive(Diagnostic)]
-#[diag(metadata_profiler_builtins_needs_core)]
-pub struct ProfilerBuiltinsNeedsCore;
-
-#[derive(Diagnostic)]
 #[diag(metadata_not_profiler_runtime)]
 pub struct NotProfilerRuntime {
     pub crate_name: Symbol,

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -235,8 +235,6 @@ name = "profiler_builtins"
 version = "0.0.0"
 dependencies = [
  "cc",
- "compiler_builtins",
- "core",
 ]
 
 [[package]]

--- a/library/profiler_builtins/Cargo.toml
+++ b/library/profiler_builtins/Cargo.toml
@@ -9,8 +9,6 @@ bench = false
 doc = false
 
 [dependencies]
-core = { path = "../core" }
-compiler_builtins = { version = "0.1.0", features = ['rustc-dep-of-std'] }
 
 [build-dependencies]
 # FIXME: Pinned due to build error when bumped (#132556)

--- a/library/profiler_builtins/src/lib.rs
+++ b/library/profiler_builtins/src/lib.rs
@@ -1,11 +1,12 @@
 // tidy-alphabetical-start
 #![allow(internal_features)]
+#![feature(no_core)]
 #![feature(profiler_runtime)]
 #![feature(staged_api)]
 // tidy-alphabetical-end
 
 // Other attributes:
-#![no_std]
+#![no_core]
 #![profiler_runtime]
 #![unstable(
     feature = "profiler_runtime_lib",

--- a/library/profiler_builtins/src/lib.rs
+++ b/library/profiler_builtins/src/lib.rs
@@ -1,6 +1,5 @@
 // tidy-alphabetical-start
 #![allow(internal_features)]
-#![allow(unused_features)]
 #![feature(profiler_runtime)]
 #![feature(staged_api)]
 // tidy-alphabetical-end

--- a/library/profiler_builtins/src/lib.rs
+++ b/library/profiler_builtins/src/lib.rs
@@ -1,11 +1,15 @@
-#![no_std]
+// tidy-alphabetical-start
+#![allow(internal_features)]
+#![allow(unused_features)]
 #![feature(profiler_runtime)]
+#![feature(staged_api)]
+// tidy-alphabetical-end
+
+// Other attributes:
+#![no_std]
 #![profiler_runtime]
 #![unstable(
     feature = "profiler_runtime_lib",
     reason = "internal implementation detail of rustc right now",
     issue = "none"
 )]
-#![allow(unused_features)]
-#![allow(internal_features)]
-#![feature(staged_api)]

--- a/tests/coverage/no-core.cov-map
+++ b/tests/coverage/no-core.cov-map
@@ -1,0 +1,9 @@
+Function name: no_core::main
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 0c, 01, 00, 0d]
+Number of files: 1
+- file 0 => global file 1
+Number of expressions: 0
+Number of file 0 mappings: 1
+- Code(Counter(0)) at (prev + 12, 1) to (start + 0, 13)
+Highest counter ID seen: c0
+

--- a/tests/coverage/no-core.coverage
+++ b/tests/coverage/no-core.coverage
@@ -1,0 +1,13 @@
+   LL|       |#![feature(no_core)]
+   LL|       |#![no_core]
+   LL|       |//@ edition: 2021
+   LL|       |
+   LL|       |// Test that coverage instrumentation works for `#![no_core]` crates.
+   LL|       |
+   LL|       |// For this test, we pull in std anyway, to avoid having to set up our own
+   LL|       |// no-core or no-std environment. What's important is that the compiler allows
+   LL|       |// coverage for a crate with the `#![no_core]` annotation.
+   LL|       |extern crate std;
+   LL|       |
+   LL|      1|fn main() {}
+

--- a/tests/coverage/no-core.rs
+++ b/tests/coverage/no-core.rs
@@ -1,0 +1,12 @@
+#![feature(no_core)]
+#![no_core]
+//@ edition: 2021
+
+// Test that coverage instrumentation works for `#![no_core]` crates.
+
+// For this test, we pull in std anyway, to avoid having to set up our own
+// no-core or no-std environment. What's important is that the compiler allows
+// coverage for a crate with the `#![no_core]` annotation.
+extern crate std;
+
+fn main() {}


### PR DESCRIPTION
An alternative to #133300, allowing `-Cinstrument-coverage` to be used with `-Zbuild-std`.

The incompatibility between `profiler_builtins` and `#![no_core]` crates appears to have been caused by profiler_builtins depending on core, and therefore conflicting with core (or minicore).

But that's a false dependency, because the profiler doesn't contain any actual Rust code. So we can just mark the profiler itself as `#![no_core]`, and remove the incompatibility error.

---

For context, the error was originally added by #79958.