### PR TITLE
Refactor dyn-compatibility error and suggestions

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0038.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0038.md
@@ -264,15 +264,15 @@ trait Foo {
 ### Trait contains associated constants
 
 Just like static functions, associated constants aren't stored on the method
-table. If the trait or any subtrait contain an associated constant, they cannot
-be made into an object.
+table. If the trait or any subtrait contain an associated constant, they are not
+dyn compatible.
 
 ```compile_fail,E0038
 trait Foo {
     const X: i32;
 }
 
-impl Foo {}
+impl dyn Foo {}
 ```
 
 A simple workaround is to use a helper method instead:

--- a/compiler/rustc_feature/src/removed.rs
+++ b/compiler/rustc_feature/src/removed.rs
@@ -163,7 +163,7 @@ declare_features! (
     /// then removed. But there was no utility storing it separately, so now
     /// it's in this list.
     (removed, no_stack_check, "1.0.0", None, None),
-    /// Allows making `dyn Trait` well-formed even if `Trait` is not dyn-compatible (object safe).
+    /// Allows making `dyn Trait` well-formed even if `Trait` is not dyn compatible (object safe).
     /// Renamed to `dyn_compatible_for_dispatch`.
     (removed, object_safe_for_dispatch, "1.83.0", Some(43561),
      Some("renamed to `dyn_compatible_for_dispatch`")),

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -272,7 +272,7 @@ declare_features! (
     (unstable, doc_notable_trait, "1.52.0", Some(45040)),
     /// Allows using the `may_dangle` attribute (RFC 1327).
     (unstable, dropck_eyepatch, "1.10.0", Some(34761)),
-    /// Allows making `dyn Trait` well-formed even if `Trait` is not dyn-compatible[^1].
+    /// Allows making `dyn Trait` well-formed even if `Trait` is not dyn compatible[^1].
     /// In that case, `dyn Trait: Trait` does not hold. Moreover, coercions and
     /// casts in safe Rust to `dyn Trait` for such a `Trait` is also forbidden.
     ///

--- a/compiler/rustc_hir_analysis/src/coherence/mod.rs
+++ b/compiler/rustc_hir_analysis/src/coherence/mod.rs
@@ -185,7 +185,7 @@ fn check_object_overlap<'tcx>(
     // check for overlap with the automatic `impl Trait for dyn Trait`
     if let ty::Dynamic(data, ..) = trait_ref.self_ty().kind() {
         // This is something like `impl Trait1 for Trait2`. Illegal if
-        // Trait1 is a supertrait of Trait2 or Trait2 is not dyn-compatible.
+        // Trait1 is a supertrait of Trait2 or Trait2 is not dyn compatible.
 
         let component_def_ids = data.iter().flat_map(|predicate| {
             match predicate.skip_binder() {

--- a/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
+++ b/compiler/rustc_trait_selection/src/traits/dyn_compatibility.rs
@@ -53,7 +53,6 @@ fn dyn_compatibility_violations(
 ) -> &'_ [DynCompatibilityViolation] {
     debug_assert!(tcx.generics_of(trait_def_id).has_self);
     debug!("dyn_compatibility_violations: {:?}", trait_def_id);
-
     tcx.arena.alloc_from_iter(
         elaborate::supertrait_def_ids(tcx, trait_def_id)
             .flat_map(|def_id| dyn_compatibility_violations_for_trait(tcx, def_id)),

--- a/tests/rustdoc-ui/invalid_const_in_lifetime_position.rs
+++ b/tests/rustdoc-ui/invalid_const_in_lifetime_position.rs
@@ -8,4 +8,4 @@ fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
 //~| ERROR associated type takes 0 generic arguments but 1 generic argument
 //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
 //~| ERROR associated type takes 0 generic arguments but 1 generic argument
-//~| ERROR trait `X` cannot be made into an object
+//~| ERROR trait `X` is not dyn compatible

--- a/tests/rustdoc-ui/invalid_const_in_lifetime_position.stderr
+++ b/tests/rustdoc-ui/invalid_const_in_lifetime_position.stderr
@@ -92,17 +92,18 @@ LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/invalid_const_in_lifetime_position.rs:4:20
    |
 LL | fn f<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                    ^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |                    ^^^^^^^^^^^^^^^^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/invalid_const_in_lifetime_position.rs:2:10
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     type Y<'a>;
    |          ^ ...because it contains the generic associated type `Y`
    = help: consider moving `Y` to another trait

--- a/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.rs
+++ b/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.rs
@@ -5,8 +5,8 @@ use std::ops::Index;
 pub fn next<'a, T>(s: &'a mut dyn SVec<Item = T, Output = T>) {
     //~^ expected 1 lifetime argument
     //~| expected 1 generic argument
-    //~| the trait `SVec` cannot be made into an object
-    //~| `SVec` cannot be made into an object
+    //~| the trait `SVec` is not dyn compatible
+    //~| `SVec` is not dyn compatible
     //~| missing generics for associated type `SVec::Item`
     //~| missing generics for associated type `SVec::Item`
     let _ = s;

--- a/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.stderr
+++ b/tests/rustdoc-ui/issues/ice-generic-type-alias-105742.stderr
@@ -294,19 +294,20 @@ help: add missing generic argument
 LL |     Output = <Self as SVec>::Item> as SVec>::Item<T>,
    |                                                  +++
 
-error[E0038]: the trait `SVec` cannot be made into an object
+error[E0038]: the trait `SVec` is not dyn compatible
   --> $DIR/ice-generic-type-alias-105742.rs:5:35
    |
 LL | pub fn next<'a, T>(s: &'a mut dyn SVec<Item = T, Output = T>) {
-   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ `SVec` cannot be made into an object
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^ `SVec` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/ice-generic-type-alias-105742.rs:15:17
    |
 LL |    pub trait SVec: Index<
    |  ____________----__^
    | |            |
-   | |            this trait cannot be made into an object...
+   | |            this trait is not dyn compatible...
 LL | |      <Self as SVec>::Item,
 ...  |
 LL | |/     Output = <Index<<Self as SVec>::Item,

--- a/tests/ui/associated-consts/associated-const-in-trait.rs
+++ b/tests/ui/associated-consts/associated-const-in-trait.rs
@@ -5,9 +5,9 @@ trait Trait {
 }
 
 impl dyn Trait {
-    //~^ ERROR the trait `Trait` cannot be made into an object [E0038]
+    //~^ ERROR the trait `Trait` is not dyn compatible [E0038]
     const fn n() -> usize { Self::N }
-    //~^ ERROR the trait `Trait` cannot be made into an object [E0038]
+    //~^ ERROR the trait `Trait` is not dyn compatible [E0038]
 }
 
 fn main() {}

--- a/tests/ui/associated-consts/associated-const-in-trait.stderr
+++ b/tests/ui/associated-consts/associated-const-in-trait.stderr
@@ -1,29 +1,31 @@
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/associated-const-in-trait.rs:7:6
    |
 LL | impl dyn Trait {
-   |      ^^^^^^^^^ `Trait` cannot be made into an object
+   |      ^^^^^^^^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/associated-const-in-trait.rs:4:11
    |
 LL | trait Trait {
-   |       ----- this trait cannot be made into an object...
+   |       ----- this trait is not dyn compatible...
 LL |     const N: usize;
    |           ^ ...because it contains this associated `const`
    = help: consider moving `N` to another trait
 
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/associated-const-in-trait.rs:9:29
    |
 LL |     const fn n() -> usize { Self::N }
-   |                             ^^^^ `Trait` cannot be made into an object
+   |                             ^^^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/associated-const-in-trait.rs:4:11
    |
 LL | trait Trait {
-   |       ----- this trait cannot be made into an object...
+   |       ----- this trait is not dyn compatible...
 LL |     const N: usize;
    |           ^ ...because it contains this associated `const`
    = help: consider moving `N` to another trait

--- a/tests/ui/associated-item/issue-48027.rs
+++ b/tests/ui/associated-item/issue-48027.rs
@@ -3,6 +3,6 @@ trait Bar {
     fn return_n(&self) -> [u8; Bar::X]; //~ ERROR: E0790
 }
 
-impl dyn Bar {} //~ ERROR: the trait `Bar` cannot be made into an object
+impl dyn Bar {} //~ ERROR: the trait `Bar` is not dyn compatible
 
 fn main() {}

--- a/tests/ui/associated-item/issue-48027.stderr
+++ b/tests/ui/associated-item/issue-48027.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/issue-48027.rs:6:6
    |
 LL | impl dyn Bar {}
-   |      ^^^^^^^ `Bar` cannot be made into an object
+   |      ^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-48027.rs:2:11
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     const X: usize;
    |           ^ ...because it contains this associated `const`
    = help: consider moving `X` to another trait

--- a/tests/ui/async-await/async-fn/dyn-pos.rs
+++ b/tests/ui/async-await/async-fn/dyn-pos.rs
@@ -1,6 +1,6 @@
 //@ edition:2018
 
 fn foo(x: &dyn AsyncFn()) {}
-//~^ ERROR the trait `AsyncFnMut` cannot be made into an object
+//~^ ERROR the trait `AsyncFnMut` is not dyn compatible
 
 fn main() {}

--- a/tests/ui/async-await/async-fn/dyn-pos.stderr
+++ b/tests/ui/async-await/async-fn/dyn-pos.stderr
@@ -1,17 +1,14 @@
-error[E0038]: the trait `AsyncFnMut` cannot be made into an object
+error[E0038]: the trait `AsyncFnMut` is not dyn compatible
   --> $DIR/dyn-pos.rs:3:16
    |
 LL | fn foo(x: &dyn AsyncFn()) {}
-   |                ^^^^^^^^^ `AsyncFnMut` cannot be made into an object
+   |                ^^^^^^^^^ `AsyncFnMut` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/ops/async_function.rs:LL:COL
    |
-   = note: the trait cannot be made into an object because it contains the generic associated type `CallRefFuture`
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `AsyncFnMut` for this new enum and using it instead:
-             &F
-             &mut F
-             std::boxed::Box<F, A>
+   = note: the trait is not dyn compatible because it contains the generic associated type `CallRefFuture`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/async-await/in-trait/dyn-compatibility.rs
+++ b/tests/ui/async-await/in-trait/dyn-compatibility.rs
@@ -7,5 +7,5 @@ trait Foo {
 
 fn main() {
     let x: &dyn Foo = todo!();
-    //~^ ERROR the trait `Foo` cannot be made into an object
+    //~^ ERROR the trait `Foo` is not dyn compatible
 }

--- a/tests/ui/async-await/in-trait/dyn-compatibility.stderr
+++ b/tests/ui/async-await/in-trait/dyn-compatibility.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/dyn-compatibility.rs:9:12
    |
 LL |     let x: &dyn Foo = todo!();
-   |            ^^^^^^^^ `Foo` cannot be made into an object
+   |            ^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-compatibility.rs:5:14
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     async fn foo(&self);
    |              ^^^ ...because method `foo` is `async`
    = help: consider moving `foo` to another trait

--- a/tests/ui/async-await/inference_var_self_argument.rs
+++ b/tests/ui/async-await/inference_var_self_argument.rs
@@ -3,7 +3,7 @@
 
 trait Foo {
     async fn foo(self: &dyn Foo) {
-        //~^ ERROR: `Foo` cannot be made into an object
+        //~^ ERROR: `Foo` is not dyn compatible
         //~| ERROR invalid `self` parameter type: `&dyn Foo`
         todo!()
     }

--- a/tests/ui/async-await/inference_var_self_argument.stderr
+++ b/tests/ui/async-await/inference_var_self_argument.stderr
@@ -7,17 +7,18 @@ LL |     async fn foo(self: &dyn Foo) {
    = note: type of `self` must be `Self` or a type that dereferences to it
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/inference_var_self_argument.rs:5:5
    |
 LL |     async fn foo(self: &dyn Foo) {
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/inference_var_self_argument.rs:5:14
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     async fn foo(self: &dyn Foo) {
    |              ^^^ ...because method `foo` is `async`
    = help: consider moving `foo` to another trait

--- a/tests/ui/coherence/coherence-impl-trait-for-trait-dyn-compatible.stderr
+++ b/tests/ui/coherence/coherence-impl-trait-for-trait-dyn-compatible.stderr
@@ -1,16 +1,17 @@
-error[E0038]: the trait `DynIncompatible` cannot be made into an object
+error[E0038]: the trait `DynIncompatible` is not dyn compatible
   --> $DIR/coherence-impl-trait-for-trait-dyn-compatible.rs:7:26
    |
 LL | impl DynIncompatible for dyn DynIncompatible { }
-   |                          ^^^^^^^^^^^^^^^^^^^ `DynIncompatible` cannot be made into an object
+   |                          ^^^^^^^^^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/coherence-impl-trait-for-trait-dyn-compatible.rs:6:45
    |
 LL | trait DynIncompatible { fn eq(&self, other: Self); }
    |       ---------------                       ^^^^ ...because method `eq` references the `Self` type in this parameter
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
    = help: consider moving `eq` to another trait
 
 error[E0046]: not all trait items implemented, missing: `eq`

--- a/tests/ui/const-generics/adt_const_params/const_param_ty_dyn_compatibility.stderr
+++ b/tests/ui/const-generics/adt_const_params/const_param_ty_dyn_compatibility.stderr
@@ -1,28 +1,30 @@
-error[E0038]: the trait `ConstParamTy_` cannot be made into an object
+error[E0038]: the trait `ConstParamTy_` is not dyn compatible
   --> $DIR/const_param_ty_dyn_compatibility.rs:6:16
    |
 LL | fn foo(a: &dyn ConstParamTy_) {}
-   |                ^^^^^^^^^^^^^ `ConstParamTy_` cannot be made into an object
+   |                ^^^^^^^^^^^^^ `ConstParamTy_` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
-   = note: the trait cannot be made into an object because it uses `Self` as a type parameter
+   = note: the trait is not dyn compatible because it uses `Self` as a type parameter
 help: consider using an opaque type instead
    |
 LL | fn foo(a: &impl ConstParamTy_) {}
    |            ~~~~
 
-error[E0038]: the trait `UnsizedConstParamTy` cannot be made into an object
+error[E0038]: the trait `UnsizedConstParamTy` is not dyn compatible
   --> $DIR/const_param_ty_dyn_compatibility.rs:9:16
    |
 LL | fn bar(a: &dyn UnsizedConstParamTy) {}
-   |                ^^^^^^^^^^^^^^^^^^^ `UnsizedConstParamTy` cannot be made into an object
+   |                ^^^^^^^^^^^^^^^^^^^ `UnsizedConstParamTy` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
-   = note: the trait cannot be made into an object because it uses `Self` as a type parameter
+   = note: the trait is not dyn compatible because it uses `Self` as a type parameter
 help: consider using an opaque type instead
    |
 LL | fn bar(a: &impl UnsizedConstParamTy) {}

--- a/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-ret.rs
+++ b/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-ret.rs
@@ -14,8 +14,8 @@ impl Foo for () {
     }
 }
 
-fn use_dyn(v: &dyn Foo) { //~ERROR the trait `Foo` cannot be made into an object
-    v.test(); //~ERROR the trait `Foo` cannot be made into an object
+fn use_dyn(v: &dyn Foo) { //~ERROR the trait `Foo` is not dyn compatible
+    v.test(); //~ERROR the trait `Foo` is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-ret.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-ret.stderr
@@ -1,38 +1,40 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/dyn-compatibility-err-ret.rs:17:16
    |
 LL | fn use_dyn(v: &dyn Foo) {
-   |                ^^^^^^^ `Foo` cannot be made into an object
+   |                ^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-compatibility-err-ret.rs:8:8
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn test(&self) -> [u8; bar::<Self>()];
    |        ^^^^           ^^^^^^^^^^^^^^^^^^^ ...because method `test` references the `Self` type in its return type
    |        |
    |        ...because method `test` references the `Self` type in its `where` clause
    = help: consider moving `test` to another trait
-   = help: only type `()` implements the trait, consider using it directly instead
+   = help: only type `()` implements `Foo`; consider using it directly instead.
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/dyn-compatibility-err-ret.rs:18:5
    |
 LL |     v.test();
-   |     ^^^^^^^^ `Foo` cannot be made into an object
+   |     ^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-compatibility-err-ret.rs:8:8
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn test(&self) -> [u8; bar::<Self>()];
    |        ^^^^           ^^^^^^^^^^^^^^^^^^^ ...because method `test` references the `Self` type in its return type
    |        |
    |        ...because method `test` references the `Self` type in its `where` clause
    = help: consider moving `test` to another trait
-   = help: only type `()` implements the trait, consider using it directly instead
+   = help: only type `()` implements `Foo`; consider using it directly instead.
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-where-bounds.rs
+++ b/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-where-bounds.rs
@@ -13,9 +13,9 @@ impl Foo for () {
 }
 
 fn use_dyn(v: &dyn Foo) {
-    //~^ ERROR the trait `Foo` cannot be made into an object
+    //~^ ERROR the trait `Foo` is not dyn compatible
     v.test();
-    //~^ ERROR the trait `Foo` cannot be made into an object
+    //~^ ERROR the trait `Foo` is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-where-bounds.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/dyn-compatibility-err-where-bounds.stderr
@@ -1,34 +1,36 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/dyn-compatibility-err-where-bounds.rs:15:16
    |
 LL | fn use_dyn(v: &dyn Foo) {
-   |                ^^^^^^^ `Foo` cannot be made into an object
+   |                ^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-compatibility-err-where-bounds.rs:8:8
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn test(&self) where [u8; bar::<Self>()]: Sized;
    |        ^^^^ ...because method `test` references the `Self` type in its `where` clause
    = help: consider moving `test` to another trait
-   = help: only type `()` implements the trait, consider using it directly instead
+   = help: only type `()` implements `Foo`; consider using it directly instead.
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/dyn-compatibility-err-where-bounds.rs:17:5
    |
 LL |     v.test();
-   |     ^^^^^^^^ `Foo` cannot be made into an object
+   |     ^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-compatibility-err-where-bounds.rs:8:8
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn test(&self) where [u8; bar::<Self>()]: Sized;
    |        ^^^^ ...because method `test` references the `Self` type in its `where` clause
    = help: consider moving `test` to another trait
-   = help: only type `()` implements the trait, consider using it directly instead
+   = help: only type `()` implements `Foo`; consider using it directly instead.
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.rs
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.rs
@@ -13,7 +13,7 @@ const _: () = {
     //~| ERROR associated type takes 0 generic arguments but 1 generic argument
     //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
     //~| ERROR associated type takes 0 generic arguments but 1 generic argument
-    //~| ERROR `X` cannot be made into an object
+    //~| ERROR `X` is not dyn compatible
 };
 
 fn main() {}

--- a/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/issue-102768.stderr
@@ -92,17 +92,18 @@ LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/issue-102768.rs:9:24
    |
 LL |     fn f2<'a>(arg: Box<dyn X<Y<1> = &'a ()>>) {}
-   |                        ^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |                        ^^^^^^^^^^^^^^^^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-102768.rs:5:10
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     type Y<'a>;
    |          ^ ...because it contains the generic associated type `Y`
    = help: consider moving `Y` to another trait

--- a/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.rs
+++ b/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.rs
@@ -2,6 +2,6 @@
 
 fn main() {
     let _: &Copy + 'static; //~ ERROR expected a path
-    //~^ ERROR cannot be made into an object
+    //~^ ERROR is not dyn compatible
     let _: &'static Copy + 'static; //~ ERROR expected a path
 }

--- a/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
+++ b/tests/ui/did_you_mean/trait-object-reference-without-parens-suggestion.stderr
@@ -20,14 +20,15 @@ help: try adding parentheses
 LL |     let _: &'static (Copy + 'static);
    |                     +              +
 
-error[E0038]: the trait `Copy` cannot be made into an object
+error[E0038]: the trait `Copy` is not dyn compatible
   --> $DIR/trait-object-reference-without-parens-suggestion.rs:4:12
    |
 LL |     let _: &Copy + 'static;
-   |            ^^^^^ `Copy` cannot be made into an object
+   |            ^^^^^ `Copy` is not dyn compatible
    |
-   = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: the trait is not dyn compatible because it requires `Self: Sized`
+   = note: for a trait to be dyn compatible it needs to allow building a vtable
+           for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/dyn-compatibility/almost-supertrait-associated-type.rs
+++ b/tests/ui/dyn-compatibility/almost-supertrait-associated-type.rs
@@ -5,8 +5,8 @@ use std::marker::PhantomData;
 
 fn transmute<T, U>(t: T) -> U {
     (&PhantomData::<T> as &dyn Foo<T, U>).transmute(t)
-    //~^ ERROR the trait `Foo` cannot be made into an object
-    //~| ERROR the trait `Foo` cannot be made into an object
+    //~^ ERROR the trait `Foo` is not dyn compatible
+    //~| ERROR the trait `Foo` is not dyn compatible
 }
 
 struct ActuallySuper;
@@ -19,7 +19,7 @@ trait Dyn {
     type Out;
 }
 impl<T, U> Dyn for dyn Foo<T, U> + '_ {
-//~^ ERROR the trait `Foo` cannot be made into an object
+//~^ ERROR the trait `Foo` is not dyn compatible
     type Out = U;
 }
 impl<S: Dyn<Out = U> + ?Sized, U> Super<NotActuallySuper> for S {

--- a/tests/ui/dyn-compatibility/almost-supertrait-associated-type.stderr
+++ b/tests/ui/dyn-compatibility/almost-supertrait-associated-type.stderr
@@ -1,53 +1,53 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/almost-supertrait-associated-type.rs:21:20
    |
 LL | impl<T, U> Dyn for dyn Foo<T, U> + '_ {
-   |                    ^^^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |                    ^^^^^^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/almost-supertrait-associated-type.rs:33:34
    |
 LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T>
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 ...
 LL |     fn transmute(&self, t: T) -> <Self as Super<NotActuallySuper>>::Assoc;
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...because method `transmute` references the `Self` type in its return type
    = help: consider moving `transmute` to another trait
-   = help: only type `std::marker::PhantomData<T>` implements the trait, consider using it directly instead
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/almost-supertrait-associated-type.rs:7:27
    |
 LL |     (&PhantomData::<T> as &dyn Foo<T, U>).transmute(t)
-   |                           ^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |                           ^^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/almost-supertrait-associated-type.rs:33:34
    |
 LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T>
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 ...
 LL |     fn transmute(&self, t: T) -> <Self as Super<NotActuallySuper>>::Assoc;
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...because method `transmute` references the `Self` type in its return type
    = help: consider moving `transmute` to another trait
-   = help: only type `std::marker::PhantomData<T>` implements the trait, consider using it directly instead
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/almost-supertrait-associated-type.rs:7:6
    |
 LL |     (&PhantomData::<T> as &dyn Foo<T, U>).transmute(t)
-   |      ^^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |      ^^^^^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/almost-supertrait-associated-type.rs:33:34
    |
 LL | trait Foo<T, U>: Super<ActuallySuper, Assoc = T>
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 ...
 LL |     fn transmute(&self, t: T) -> <Self as Super<NotActuallySuper>>::Assoc;
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...because method `transmute` references the `Self` type in its return type
    = help: consider moving `transmute` to another trait
-   = help: only type `std::marker::PhantomData<T>` implements the trait, consider using it directly instead
    = note: required for the cast from `&PhantomData<T>` to `&dyn Foo<T, U>`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/dyn-compatibility/associated-consts.curr.stderr
+++ b/tests/ui/dyn-compatibility/associated-consts.curr.stderr
@@ -1,29 +1,31 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/associated-consts.rs:12:31
    |
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   |                               ^^^^^^^ `Bar` cannot be made into an object
+   |                               ^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/associated-consts.rs:9:11
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     const X: usize;
    |           ^ ...because it contains this associated `const`
    = help: consider moving `X` to another trait
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/associated-consts.rs:14:5
    |
 LL |     t
-   |     ^ `Bar` cannot be made into an object
+   |     ^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/associated-consts.rs:9:11
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     const X: usize;
    |           ^ ...because it contains this associated `const`
    = help: consider moving `X` to another trait

--- a/tests/ui/dyn-compatibility/associated-consts.dyn_compatible_for_dispatch.stderr
+++ b/tests/ui/dyn-compatibility/associated-consts.dyn_compatible_for_dispatch.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/associated-consts.rs:14:5
    |
 LL |     t
-   |     ^ `Bar` cannot be made into an object
+   |     ^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/associated-consts.rs:9:11
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     const X: usize;
    |           ^ ...because it contains this associated `const`
    = help: consider moving `X` to another trait

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.old.stderr
@@ -26,14 +26,15 @@ help: if this is a dyn-compatible trait, use `dyn`
 LL | fn id<F>(f: dyn Copy) -> usize {
    |             +++
 
-error[E0038]: the trait `Copy` cannot be made into an object
+error[E0038]: the trait `Copy` is not dyn compatible
   --> $DIR/avoid-ice-on-warning-2.rs:4:13
    |
 LL | fn id<F>(f: Copy) -> usize {
-   |             ^^^^ `Copy` cannot be made into an object
+   |             ^^^^ `Copy` is not dyn compatible
    |
-   = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: the trait is not dyn compatible because it requires `Self: Sized`
+   = note: for a trait to be dyn compatible it needs to allow building a vtable
+           for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
 error[E0618]: expected function, found `(dyn Copy + 'static)`
   --> $DIR/avoid-ice-on-warning-2.rs:12:5

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.rs
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-2.rs
@@ -3,7 +3,7 @@
 //@[new] edition:2021
 fn id<F>(f: Copy) -> usize {
 //[new]~^ ERROR expected a type, found a trait
-//[old]~^^ ERROR the trait `Copy` cannot be made into an object
+//[old]~^^ ERROR the trait `Copy` is not dyn compatible
 //[old]~| ERROR the size for values of type `(dyn Copy + 'static)`
 //[old]~| WARN trait objects without an explicit `dyn` are deprecated
 //[old]~| WARN this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-3.old.stderr
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-3.old.stderr
@@ -65,19 +65,20 @@ help: if this is a dyn-compatible trait, use `dyn`
 LL | trait B { fn f(a: dyn A) -> A; }
    |                   +++
 
-error[E0038]: the trait `A` cannot be made into an object
+error[E0038]: the trait `A` is not dyn compatible
   --> $DIR/avoid-ice-on-warning-3.rs:4:19
    |
 LL | trait B { fn f(a: A) -> A; }
-   |                   ^ `A` cannot be made into an object
+   |                   ^ `A` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/avoid-ice-on-warning-3.rs:14:14
    |
 LL | trait A { fn g(b: B) -> B; }
    |       -      ^ ...because associated function `g` has no `self` parameter
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 help: consider turning `g` into a method by giving it a `&self` argument
    |
 LL | trait A { fn g(&self, b: B) -> B; }
@@ -101,19 +102,20 @@ help: if this is a dyn-compatible trait, use `dyn`
 LL | trait A { fn g(b: dyn B) -> B; }
    |                   +++
 
-error[E0038]: the trait `B` cannot be made into an object
+error[E0038]: the trait `B` is not dyn compatible
   --> $DIR/avoid-ice-on-warning-3.rs:14:19
    |
 LL | trait A { fn g(b: B) -> B; }
-   |                   ^ `B` cannot be made into an object
+   |                   ^ `B` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/avoid-ice-on-warning-3.rs:4:14
    |
 LL | trait B { fn f(a: A) -> A; }
    |       -      ^ ...because associated function `f` has no `self` parameter
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 help: consider turning `f` into a method by giving it a `&self` argument
    |
 LL | trait B { fn f(&self, a: A) -> A; }

--- a/tests/ui/dyn-compatibility/avoid-ice-on-warning-3.rs
+++ b/tests/ui/dyn-compatibility/avoid-ice-on-warning-3.rs
@@ -4,7 +4,7 @@
 trait B { fn f(a: A) -> A; }
 //[new]~^ ERROR expected a type, found a trait
 //[new]~| ERROR expected a type, found a trait
-//[old]~^^^ ERROR the trait `A` cannot be made into an object
+//[old]~^^^ ERROR the trait `A` is not dyn compatible
 //[old]~| WARN trait objects without an explicit `dyn` are deprecated
 //[old]~| WARN trait objects without an explicit `dyn` are deprecated
 //[old]~| WARN trait objects without an explicit `dyn` are deprecated
@@ -14,7 +14,7 @@ trait B { fn f(a: A) -> A; }
 trait A { fn g(b: B) -> B; }
 //[new]~^ ERROR expected a type, found a trait
 //[new]~| ERROR expected a type, found a trait
-//[old]~^^^ ERROR the trait `B` cannot be made into an object
+//[old]~^^^ ERROR the trait `B` is not dyn compatible
 //[old]~| WARN trait objects without an explicit `dyn` are deprecated
 //[old]~| WARN trait objects without an explicit `dyn` are deprecated
 //[old]~| WARN trait objects without an explicit `dyn` are deprecated

--- a/tests/ui/dyn-compatibility/bare-trait-dont-suggest-dyn.new.fixed
+++ b/tests/ui/dyn-compatibility/bare-trait-dont-suggest-dyn.new.fixed
@@ -5,7 +5,7 @@
 #![deny(bare_trait_objects)]
 fn ord_prefer_dot(s: String) -> impl Ord {
     //[new]~^ ERROR expected a type, found a trait
-    //[old]~^^ ERROR the trait `Ord` cannot be made into an object
+    //[old]~^^ ERROR the trait `Ord` is not dyn compatible
     //[old]~| ERROR trait objects without an explicit `dyn` are deprecated
     //[old]~| WARNING this is accepted in the current edition (Rust 2015)
     (s.starts_with("."), s)

--- a/tests/ui/dyn-compatibility/bare-trait-dont-suggest-dyn.old.stderr
+++ b/tests/ui/dyn-compatibility/bare-trait-dont-suggest-dyn.old.stderr
@@ -16,19 +16,20 @@ help: if this is a dyn-compatible trait, use `dyn`
 LL | fn ord_prefer_dot(s: String) -> dyn Ord {
    |                                 +++
 
-error[E0038]: the trait `Ord` cannot be made into an object
+error[E0038]: the trait `Ord` is not dyn compatible
   --> $DIR/bare-trait-dont-suggest-dyn.rs:6:33
    |
 LL | fn ord_prefer_dot(s: String) -> Ord {
-   |                                 ^^^ `Ord` cannot be made into an object
+   |                                 ^^^ `Ord` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
-   = note: the trait cannot be made into an object because it uses `Self` as a type parameter
+   = note: the trait is not dyn compatible because it uses `Self` as a type parameter
   ::: $SRC_DIR/core/src/cmp.rs:LL:COL
    |
-   = note: the trait cannot be made into an object because it uses `Self` as a type parameter
+   = note: the trait is not dyn compatible because it uses `Self` as a type parameter
 help: consider using an opaque type instead
    |
 LL | fn ord_prefer_dot(s: String) -> impl Ord {

--- a/tests/ui/dyn-compatibility/bare-trait-dont-suggest-dyn.rs
+++ b/tests/ui/dyn-compatibility/bare-trait-dont-suggest-dyn.rs
@@ -5,7 +5,7 @@
 #![deny(bare_trait_objects)]
 fn ord_prefer_dot(s: String) -> Ord {
     //[new]~^ ERROR expected a type, found a trait
-    //[old]~^^ ERROR the trait `Ord` cannot be made into an object
+    //[old]~^^ ERROR the trait `Ord` is not dyn compatible
     //[old]~| ERROR trait objects without an explicit `dyn` are deprecated
     //[old]~| WARNING this is accepted in the current edition (Rust 2015)
     (s.starts_with("."), s)

--- a/tests/ui/dyn-compatibility/bounds.rs
+++ b/tests/ui/dyn-compatibility/bounds.rs
@@ -5,7 +5,7 @@ trait X {
 }
 
 fn f() -> Box<dyn X<U = u32>> {
-    //~^ ERROR the trait `X` cannot be made into an object
+    //~^ ERROR the trait `X` is not dyn compatible
     loop {}
 }
 

--- a/tests/ui/dyn-compatibility/bounds.stderr
+++ b/tests/ui/dyn-compatibility/bounds.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/bounds.rs:7:15
    |
 LL | fn f() -> Box<dyn X<U = u32>> {
-   |               ^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |               ^^^^^^^^^^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/bounds.rs:4:13
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     type U: PartialEq<Self>;
    |             ^^^^^^^^^^^^^^^ ...because it uses `Self` as a type parameter
 

--- a/tests/ui/dyn-compatibility/gat-incompatible-supertrait.rs
+++ b/tests/ui/dyn-compatibility/gat-incompatible-supertrait.rs
@@ -1,0 +1,18 @@
+// Test that the dyn-compatibility diagnostics for GATs refer first to the
+// user-named trait, not the GAT-containing supertrait.
+//
+// NOTE: this test is currently broken, and first reports:
+// "the trait `Super` is not dyn compatible"
+//
+//@ edition:2018
+
+trait Super {
+    type Assoc<'a>;
+}
+
+trait Child: Super {}
+
+fn take_dyn(_: &dyn Child) {}
+//~^ ERROR the trait `Super` is not dyn compatible
+
+fn main() {}

--- a/tests/ui/dyn-compatibility/gat-incompatible-supertrait.stderr
+++ b/tests/ui/dyn-compatibility/gat-incompatible-supertrait.stderr
@@ -1,0 +1,19 @@
+error[E0038]: the trait `Super` is not dyn compatible
+  --> $DIR/gat-incompatible-supertrait.rs:15:21
+   |
+LL | fn take_dyn(_: &dyn Child) {}
+   |                     ^^^^^ `Super` is not dyn compatible
+   |
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+  --> $DIR/gat-incompatible-supertrait.rs:10:10
+   |
+LL | trait Super {
+   |       ----- this trait is not dyn compatible...
+LL |     type Assoc<'a>;
+   |          ^^^^^ ...because it contains the generic associated type `Assoc`
+   = help: consider moving `Assoc` to another trait
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0038`.

--- a/tests/ui/dyn-compatibility/generics.curr.stderr
+++ b/tests/ui/dyn-compatibility/generics.curr.stderr
@@ -1,75 +1,80 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/generics.rs:18:31
    |
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   |                               ^^^^^^^ `Bar` cannot be made into an object
+   |                               ^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/generics.rs:10:8
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar<T>(&self, t: T);
    |        ^^^ ...because method `bar` has generic type parameters
    = help: consider moving `bar` to another trait
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/generics.rs:25:40
    |
 LL | fn make_bar_explicit<T:Bar>(t: &T) -> &dyn Bar {
-   |                                        ^^^^^^^ `Bar` cannot be made into an object
+   |                                        ^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/generics.rs:10:8
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar<T>(&self, t: T);
    |        ^^^ ...because method `bar` has generic type parameters
    = help: consider moving `bar` to another trait
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/generics.rs:20:5
    |
 LL |     t
-   |     ^ `Bar` cannot be made into an object
+   |     ^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/generics.rs:10:8
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar<T>(&self, t: T);
    |        ^^^ ...because method `bar` has generic type parameters
    = help: consider moving `bar` to another trait
    = note: required for the cast from `&T` to `&dyn Bar`
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/generics.rs:27:10
    |
 LL |     t as &dyn Bar
-   |          ^^^^^^^^ `Bar` cannot be made into an object
+   |          ^^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/generics.rs:10:8
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar<T>(&self, t: T);
    |        ^^^ ...because method `bar` has generic type parameters
    = help: consider moving `bar` to another trait
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/generics.rs:27:5
    |
 LL |     t as &dyn Bar
-   |     ^ `Bar` cannot be made into an object
+   |     ^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/generics.rs:10:8
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar<T>(&self, t: T);
    |        ^^^ ...because method `bar` has generic type parameters
    = help: consider moving `bar` to another trait

--- a/tests/ui/dyn-compatibility/generics.dyn_compatible_for_dispatch.stderr
+++ b/tests/ui/dyn-compatibility/generics.dyn_compatible_for_dispatch.stderr
@@ -1,30 +1,32 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/generics.rs:20:5
    |
 LL |     t
-   |     ^ `Bar` cannot be made into an object
+   |     ^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/generics.rs:10:8
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar<T>(&self, t: T);
    |        ^^^ ...because method `bar` has generic type parameters
    = help: consider moving `bar` to another trait
    = note: required for the cast from `&T` to `&dyn Bar`
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/generics.rs:27:5
    |
 LL |     t as &dyn Bar
-   |     ^ `Bar` cannot be made into an object
+   |     ^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/generics.rs:10:8
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar<T>(&self, t: T);
    |        ^^^ ...because method `bar` has generic type parameters
    = help: consider moving `bar` to another trait

--- a/tests/ui/dyn-compatibility/mention-correct-dyn-incompatible-trait.stderr
+++ b/tests/ui/dyn-compatibility/mention-correct-dyn-incompatible-trait.stderr
@@ -1,36 +1,38 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/mention-correct-dyn-incompatible-trait.rs:19:15
    |
 LL |     let test: &mut dyn Bar = &mut thing;
-   |               ^^^^^^^^^^^^ `Bar` cannot be made into an object
+   |               ^^^^^^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/mention-correct-dyn-incompatible-trait.rs:4:8
    |
 LL |     fn foo<T>(&self, val: T);
    |        ^^^ ...because method `foo` has generic type parameters
 ...
 LL | trait Bar: Foo { }
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
    = help: consider moving `foo` to another trait
-   = help: only type `Thing` implements the trait, consider using it directly instead
+   = help: only type `Thing` implements `Bar`; consider using it directly instead.
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/mention-correct-dyn-incompatible-trait.rs:19:30
    |
 LL |     let test: &mut dyn Bar = &mut thing;
-   |                              ^^^^^^^^^^ `Bar` cannot be made into an object
+   |                              ^^^^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/mention-correct-dyn-incompatible-trait.rs:4:8
    |
 LL |     fn foo<T>(&self, val: T);
    |        ^^^ ...because method `foo` has generic type parameters
 ...
 LL | trait Bar: Foo { }
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
    = help: consider moving `foo` to another trait
-   = help: only type `Thing` implements the trait, consider using it directly instead
+   = help: only type `Thing` implements `Bar`; consider using it directly instead.
    = note: required for the cast from `&mut Thing` to `&mut dyn Bar`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/dyn-compatibility/mentions-Self-in-super-predicates.rs
+++ b/tests/ui/dyn-compatibility/mentions-Self-in-super-predicates.rs
@@ -36,9 +36,9 @@ impl <'x> Expr for SExpr<'x> {
 
 fn main() {
     let a: Box<dyn Expr> = Box::new(SExpr::new());
-    //~^ ERROR: `Expr` cannot be made into an object
+    //~^ ERROR: `Expr` is not dyn compatible
     let b: Box<dyn Expr> = Box::new(SExpr::new());
-    //~^ ERROR: `Expr` cannot be made into an object
+    //~^ ERROR: `Expr` is not dyn compatible
 
     // assert_eq!(a , b);
 }

--- a/tests/ui/dyn-compatibility/mentions-Self-in-super-predicates.stderr
+++ b/tests/ui/dyn-compatibility/mentions-Self-in-super-predicates.stderr
@@ -1,47 +1,47 @@
-error[E0038]: the trait `Expr` cannot be made into an object
+error[E0038]: the trait `Expr` is not dyn compatible
   --> $DIR/mentions-Self-in-super-predicates.rs:12:27
    |
 LL |     elements: Vec<Box<dyn Expr + 'x>>,
-   |                           ^^^^ `Expr` cannot be made into an object
+   |                           ^^^^ `Expr` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/mentions-Self-in-super-predicates.rs:5:21
    |
 LL | trait Expr: Debug + PartialEq {
    |       ----          ^^^^^^^^^ ...because it uses `Self` as a type parameter
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `SExpr<'x>` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
 
-error[E0038]: the trait `Expr` cannot be made into an object
+error[E0038]: the trait `Expr` is not dyn compatible
   --> $DIR/mentions-Self-in-super-predicates.rs:38:20
    |
 LL |     let a: Box<dyn Expr> = Box::new(SExpr::new());
-   |                    ^^^^ `Expr` cannot be made into an object
+   |                    ^^^^ `Expr` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/mentions-Self-in-super-predicates.rs:5:21
    |
 LL | trait Expr: Debug + PartialEq {
    |       ----          ^^^^^^^^^ ...because it uses `Self` as a type parameter
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `SExpr<'x>` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
 
-error[E0038]: the trait `Expr` cannot be made into an object
+error[E0038]: the trait `Expr` is not dyn compatible
   --> $DIR/mentions-Self-in-super-predicates.rs:40:20
    |
 LL |     let b: Box<dyn Expr> = Box::new(SExpr::new());
-   |                    ^^^^ `Expr` cannot be made into an object
+   |                    ^^^^ `Expr` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/mentions-Self-in-super-predicates.rs:5:21
    |
 LL | trait Expr: Debug + PartialEq {
    |       ----          ^^^^^^^^^ ...because it uses `Self` as a type parameter
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `SExpr<'x>` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/dyn-compatibility/mentions-Self.curr.stderr
+++ b/tests/ui/dyn-compatibility/mentions-Self.curr.stderr
@@ -1,60 +1,64 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/mentions-Self.rs:22:31
    |
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   |                               ^^^^^^^ `Bar` cannot be made into an object
+   |                               ^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/mentions-Self.rs:11:22
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar(&self, x: &Self);
    |                      ^^^^^ ...because method `bar` references the `Self` type in this parameter
    = help: consider moving `bar` to another trait
 
-error[E0038]: the trait `Baz` cannot be made into an object
+error[E0038]: the trait `Baz` is not dyn compatible
   --> $DIR/mentions-Self.rs:28:31
    |
 LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
-   |                               ^^^^^^^ `Baz` cannot be made into an object
+   |                               ^^^^^^^ `Baz` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/mentions-Self.rs:15:22
    |
 LL | trait Baz {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn baz(&self) -> Self;
    |                      ^^^^ ...because method `baz` references the `Self` type in its return type
    = help: consider moving `baz` to another trait
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/mentions-Self.rs:24:5
    |
 LL |     t
-   |     ^ `Bar` cannot be made into an object
+   |     ^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/mentions-Self.rs:11:22
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar(&self, x: &Self);
    |                      ^^^^^ ...because method `bar` references the `Self` type in this parameter
    = help: consider moving `bar` to another trait
    = note: required for the cast from `&T` to `&dyn Bar`
 
-error[E0038]: the trait `Baz` cannot be made into an object
+error[E0038]: the trait `Baz` is not dyn compatible
   --> $DIR/mentions-Self.rs:30:5
    |
 LL |     t
-   |     ^ `Baz` cannot be made into an object
+   |     ^ `Baz` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/mentions-Self.rs:15:22
    |
 LL | trait Baz {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn baz(&self) -> Self;
    |                      ^^^^ ...because method `baz` references the `Self` type in its return type
    = help: consider moving `baz` to another trait

--- a/tests/ui/dyn-compatibility/mentions-Self.dyn_compatible_for_dispatch.stderr
+++ b/tests/ui/dyn-compatibility/mentions-Self.dyn_compatible_for_dispatch.stderr
@@ -1,30 +1,32 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/mentions-Self.rs:24:5
    |
 LL |     t
-   |     ^ `Bar` cannot be made into an object
+   |     ^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/mentions-Self.rs:11:22
    |
 LL | trait Bar {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar(&self, x: &Self);
    |                      ^^^^^ ...because method `bar` references the `Self` type in this parameter
    = help: consider moving `bar` to another trait
    = note: required for the cast from `&T` to `&dyn Bar`
 
-error[E0038]: the trait `Baz` cannot be made into an object
+error[E0038]: the trait `Baz` is not dyn compatible
   --> $DIR/mentions-Self.rs:30:5
    |
 LL |     t
-   |     ^ `Baz` cannot be made into an object
+   |     ^ `Baz` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/mentions-Self.rs:15:22
    |
 LL | trait Baz {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn baz(&self) -> Self;
    |                      ^^^^ ...because method `baz` references the `Self` type in its return type
    = help: consider moving `baz` to another trait

--- a/tests/ui/dyn-compatibility/missing-assoc-type.rs
+++ b/tests/ui/dyn-compatibility/missing-assoc-type.rs
@@ -2,6 +2,6 @@ trait Foo {
     type Bar<T>;
 }
 
-fn bar(x: &dyn Foo) {} //~ ERROR the trait `Foo` cannot be made into an object
+fn bar(x: &dyn Foo) {} //~ ERROR the trait `Foo` is not dyn compatible
 
 fn main() {}

--- a/tests/ui/dyn-compatibility/missing-assoc-type.stderr
+++ b/tests/ui/dyn-compatibility/missing-assoc-type.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/missing-assoc-type.rs:5:16
    |
 LL | fn bar(x: &dyn Foo) {}
-   |                ^^^ `Foo` cannot be made into an object
+   |                ^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/missing-assoc-type.rs:2:10
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     type Bar<T>;
    |          ^^^ ...because it contains the generic associated type `Bar`
    = help: consider moving `Bar` to another trait

--- a/tests/ui/dyn-compatibility/no-static.curr.stderr
+++ b/tests/ui/dyn-compatibility/no-static.curr.stderr
@@ -1,17 +1,18 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/no-static.rs:12:22
    |
 LL | fn diverges() -> Box<dyn Foo> {
-   |                      ^^^^^^^ `Foo` cannot be made into an object
+   |                      ^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/no-static.rs:9:8
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn foo() {}
    |        ^^^ ...because associated function `foo` has no `self` parameter
-   = help: only type `Bar` implements the trait, consider using it directly instead
+   = help: only type `Bar` implements `Foo`; consider using it directly instead.
 help: consider turning `foo` into a method by giving it a `&self` argument
    |
 LL |     fn foo(&self) {}
@@ -21,20 +22,21 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() where Self: Sized {}
    |              +++++++++++++++++
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/no-static.rs:22:12
    |
 LL |     let b: Box<dyn Foo> = Box::new(Bar);
-   |            ^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |            ^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/no-static.rs:9:8
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn foo() {}
    |        ^^^ ...because associated function `foo` has no `self` parameter
-   = help: only type `Bar` implements the trait, consider using it directly instead
+   = help: only type `Bar` implements `Foo`; consider using it directly instead.
 help: consider turning `foo` into a method by giving it a `&self` argument
    |
 LL |     fn foo(&self) {}
@@ -44,20 +46,21 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() where Self: Sized {}
    |              +++++++++++++++++
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/no-static.rs:22:27
    |
 LL |     let b: Box<dyn Foo> = Box::new(Bar);
-   |                           ^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |                           ^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/no-static.rs:9:8
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn foo() {}
    |        ^^^ ...because associated function `foo` has no `self` parameter
-   = help: only type `Bar` implements the trait, consider using it directly instead
+   = help: only type `Bar` implements `Foo`; consider using it directly instead.
    = note: required for the cast from `Box<Bar>` to `Box<dyn Foo>`
 help: consider turning `foo` into a method by giving it a `&self` argument
    |

--- a/tests/ui/dyn-compatibility/no-static.dyn_compatible_for_dispatch.stderr
+++ b/tests/ui/dyn-compatibility/no-static.dyn_compatible_for_dispatch.stderr
@@ -1,17 +1,18 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/no-static.rs:22:27
    |
 LL |     let b: Box<dyn Foo> = Box::new(Bar);
-   |                           ^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |                           ^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/no-static.rs:9:8
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn foo() {}
    |        ^^^ ...because associated function `foo` has no `self` parameter
-   = help: only type `Bar` implements the trait, consider using it directly instead
+   = help: only type `Bar` implements `Foo`; consider using it directly instead.
    = note: required for the cast from `Box<Bar>` to `Box<dyn Foo>`
 help: consider turning `foo` into a method by giving it a `&self` argument
    |

--- a/tests/ui/dyn-compatibility/sized-2.curr.stderr
+++ b/tests/ui/dyn-compatibility/sized-2.curr.stderr
@@ -1,28 +1,30 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/sized-2.rs:14:31
    |
 LL | fn make_bar<T:Bar>(t: &T) -> &dyn Bar {
-   |                               ^^^^^^^ `Bar` cannot be made into an object
+   |                               ^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/sized-2.rs:9:18
    |
 LL | trait Bar
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     where Self : Sized
    |                  ^^^^^ ...because it requires `Self: Sized`
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/sized-2.rs:16:5
    |
 LL |     t
-   |     ^ `Bar` cannot be made into an object
+   |     ^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/sized-2.rs:9:18
    |
 LL | trait Bar
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     where Self : Sized
    |                  ^^^^^ ...because it requires `Self: Sized`
    = note: required for the cast from `&T` to `&dyn Bar`

--- a/tests/ui/dyn-compatibility/sized-2.dyn_compatible_for_dispatch.stderr
+++ b/tests/ui/dyn-compatibility/sized-2.dyn_compatible_for_dispatch.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/sized-2.rs:16:5
    |
 LL |     t
-   |     ^ `Bar` cannot be made into an object
+   |     ^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/sized-2.rs:9:18
    |
 LL | trait Bar
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     where Self : Sized
    |                  ^^^^^ ...because it requires `Self: Sized`
    = note: required for the cast from `&T` to `&dyn Bar`

--- a/tests/ui/dyn-compatibility/sized.curr.stderr
+++ b/tests/ui/dyn-compatibility/sized.curr.stderr
@@ -1,30 +1,32 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/sized.rs:12:32
    |
 LL | fn make_bar<T: Bar>(t: &T) -> &dyn Bar {
-   |                                ^^^^^^^ `Bar` cannot be made into an object
+   |                                ^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/sized.rs:8:12
    |
 LL | trait Bar: Sized {
    |       ---  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/sized.rs:14:5
    |
 LL |     t
-   |     ^ `Bar` cannot be made into an object
+   |     ^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/sized.rs:8:12
    |
 LL | trait Bar: Sized {
    |       ---  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
    = note: required for the cast from `&T` to `&dyn Bar`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/dyn-compatibility/sized.dyn_compatible_for_dispatch.stderr
+++ b/tests/ui/dyn-compatibility/sized.dyn_compatible_for_dispatch.stderr
@@ -1,16 +1,17 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/sized.rs:14:5
    |
 LL |     t
-   |     ^ `Bar` cannot be made into an object
+   |     ^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/sized.rs:8:12
    |
 LL | trait Bar: Sized {
    |       ---  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
    = note: required for the cast from `&T` to `&dyn Bar`
 
 error: aborting due to 1 previous error

--- a/tests/ui/dyn-compatibility/supertrait-mentions-GAT.rs
+++ b/tests/ui/dyn-compatibility/supertrait-mentions-GAT.rs
@@ -9,7 +9,7 @@ trait GatTrait {
 trait SuperTrait<T>: for<'a> GatTrait<Gat<'a> = T> {
     fn c(&self) -> dyn SuperTrait<T>;
     //~^ ERROR associated item referring to unboxed trait object for its own trait
-    //~| ERROR the trait `SuperTrait` cannot be made into an object
+    //~| ERROR the trait `SuperTrait` is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/dyn-compatibility/supertrait-mentions-GAT.stderr
+++ b/tests/ui/dyn-compatibility/supertrait-mentions-GAT.stderr
@@ -20,20 +20,21 @@ help: you might have meant to use `Self` to refer to the implementing type
 LL |     fn c(&self) -> Self;
    |                    ~~~~
 
-error[E0038]: the trait `SuperTrait` cannot be made into an object
+error[E0038]: the trait `SuperTrait` is not dyn compatible
   --> $DIR/supertrait-mentions-GAT.rs:10:20
    |
 LL |     fn c(&self) -> dyn SuperTrait<T>;
-   |                    ^^^^^^^^^^^^^^^^^ `SuperTrait` cannot be made into an object
+   |                    ^^^^^^^^^^^^^^^^^ `SuperTrait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/supertrait-mentions-GAT.rs:4:10
    |
 LL |     type Gat<'a>
    |          ^^^ ...because it contains the generic associated type `Gat`
 ...
 LL | trait SuperTrait<T>: for<'a> GatTrait<Gat<'a> = T> {
-   |       ---------- this trait cannot be made into an object...
+   |       ---------- this trait is not dyn compatible...
    = help: consider moving `Gat` to another trait
 
 error: aborting due to 3 previous errors

--- a/tests/ui/dyn-compatibility/supertrait-mentions-Self.stderr
+++ b/tests/ui/dyn-compatibility/supertrait-mentions-Self.stderr
@@ -18,19 +18,20 @@ help: consider relaxing the implicit `Sized` restriction
 LL | trait Bar<T: ?Sized> {
    |            ++++++++
 
-error[E0038]: the trait `Baz` cannot be made into an object
+error[E0038]: the trait `Baz` is not dyn compatible
   --> $DIR/supertrait-mentions-Self.rs:16:35
    |
 LL | fn make_baz<T:Baz>(t: &T) -> &dyn Baz {
-   |                                   ^^^ `Baz` cannot be made into an object
+   |                                   ^^^ `Baz` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/supertrait-mentions-Self.rs:8:13
    |
 LL | trait Baz : Bar<Self> {
    |       ---   ^^^^^^^^^ ...because it uses `Self` as a type parameter
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 help: consider using an opaque type instead
    |
 LL | fn make_baz<T:Baz>(t: &T) -> &impl Baz {

--- a/tests/ui/dyn-compatibility/taint-const-eval.curr.stderr
+++ b/tests/ui/dyn-compatibility/taint-const-eval.curr.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `Qux` cannot be made into an object
+error[E0038]: the trait `Qux` is not dyn compatible
   --> $DIR/taint-const-eval.rs:11:15
    |
 LL | static FOO: &(dyn Qux + Sync) = "desc";
-   |               ^^^^^^^^^^^^^^ `Qux` cannot be made into an object
+   |               ^^^^^^^^^^^^^^ `Qux` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/taint-const-eval.rs:8:8
    |
 LL | trait Qux {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar();
    |        ^^^ ...because associated function `bar` has no `self` parameter
 help: consider turning `bar` into a method by giving it a `&self` argument
@@ -20,17 +21,18 @@ help: alternatively, consider constraining `bar` so it does not apply to trait o
 LL |     fn bar() where Self: Sized;
    |              +++++++++++++++++
 
-error[E0038]: the trait `Qux` cannot be made into an object
+error[E0038]: the trait `Qux` is not dyn compatible
   --> $DIR/taint-const-eval.rs:11:33
    |
 LL | static FOO: &(dyn Qux + Sync) = "desc";
-   |                                 ^^^^^^ `Qux` cannot be made into an object
+   |                                 ^^^^^^ `Qux` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/taint-const-eval.rs:8:8
    |
 LL | trait Qux {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar();
    |        ^^^ ...because associated function `bar` has no `self` parameter
    = note: required for the cast from `&'static str` to `&'static (dyn Qux + Sync + 'static)`
@@ -43,17 +45,18 @@ help: alternatively, consider constraining `bar` so it does not apply to trait o
 LL |     fn bar() where Self: Sized;
    |              +++++++++++++++++
 
-error[E0038]: the trait `Qux` cannot be made into an object
+error[E0038]: the trait `Qux` is not dyn compatible
   --> $DIR/taint-const-eval.rs:11:15
    |
 LL | static FOO: &(dyn Qux + Sync) = "desc";
-   |               ^^^^^^^^^^^^^^ `Qux` cannot be made into an object
+   |               ^^^^^^^^^^^^^^ `Qux` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/taint-const-eval.rs:8:8
    |
 LL | trait Qux {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar();
    |        ^^^ ...because associated function `bar` has no `self` parameter
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`

--- a/tests/ui/dyn-compatibility/taint-const-eval.dyn_compatible_for_dispatch.stderr
+++ b/tests/ui/dyn-compatibility/taint-const-eval.dyn_compatible_for_dispatch.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `Qux` cannot be made into an object
+error[E0038]: the trait `Qux` is not dyn compatible
   --> $DIR/taint-const-eval.rs:11:33
    |
 LL | static FOO: &(dyn Qux + Sync) = "desc";
-   |                                 ^^^^^^ `Qux` cannot be made into an object
+   |                                 ^^^^^^ `Qux` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/taint-const-eval.rs:8:8
    |
 LL | trait Qux {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar();
    |        ^^^ ...because associated function `bar` has no `self` parameter
    = note: required for the cast from `&'static str` to `&'static (dyn Qux + Sync + 'static)`

--- a/tests/ui/dyn-compatibility/taint-const-eval.rs
+++ b/tests/ui/dyn-compatibility/taint-const-eval.rs
@@ -9,8 +9,8 @@ trait Qux {
 }
 
 static FOO: &(dyn Qux + Sync) = "desc";
-//~^ the trait `Qux` cannot be made into an object
-//[curr]~| the trait `Qux` cannot be made into an object
-//[curr]~| the trait `Qux` cannot be made into an object
+//~^ the trait `Qux` is not dyn compatible
+//[curr]~| the trait `Qux` is not dyn compatible
+//[curr]~| the trait `Qux` is not dyn compatible
 
 fn main() {}

--- a/tests/ui/dyn-compatibility/undispatchable-receiver-and-wc-references-Self.rs
+++ b/tests/ui/dyn-compatibility/undispatchable-receiver-and-wc-references-Self.rs
@@ -17,13 +17,13 @@ pub trait Fetcher: Send + Sync {
 }
 
 fn fetcher() -> Box<dyn Fetcher> {
-    //~^ ERROR the trait `Fetcher` cannot be made into an object
+    //~^ ERROR the trait `Fetcher` is not dyn compatible
     todo!()
 }
 
 pub fn foo() {
     let fetcher = fetcher();
-    //~^ ERROR the trait `Fetcher` cannot be made into an object
+    //~^ ERROR the trait `Fetcher` is not dyn compatible
     let _ = fetcher.get();
-    //~^ ERROR the trait `Fetcher` cannot be made into an object
+    //~^ ERROR the trait `Fetcher` is not dyn compatible
 }

--- a/tests/ui/dyn-compatibility/undispatchable-receiver-and-wc-references-Self.stderr
+++ b/tests/ui/dyn-compatibility/undispatchable-receiver-and-wc-references-Self.stderr
@@ -1,51 +1,54 @@
-error[E0038]: the trait `Fetcher` cannot be made into an object
+error[E0038]: the trait `Fetcher` is not dyn compatible
   --> $DIR/undispatchable-receiver-and-wc-references-Self.rs:19:21
    |
 LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
    |                      ------------- help: consider changing method `get`'s `self` parameter to be `&self`: `&Self`
 ...
 LL | fn fetcher() -> Box<dyn Fetcher> {
-   |                     ^^^^^^^^^^^ `Fetcher` cannot be made into an object
+   |                     ^^^^^^^^^^^ `Fetcher` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/undispatchable-receiver-and-wc-references-Self.rs:11:22
    |
 LL | pub trait Fetcher: Send + Sync {
-   |           ------- this trait cannot be made into an object...
+   |           ------- this trait is not dyn compatible...
 LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
    |                      ^^^^^^^^^^^^^ ...because method `get`'s `self` parameter cannot be dispatched on
 
-error[E0038]: the trait `Fetcher` cannot be made into an object
+error[E0038]: the trait `Fetcher` is not dyn compatible
   --> $DIR/undispatchable-receiver-and-wc-references-Self.rs:25:19
    |
 LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
    |                      ------------- help: consider changing method `get`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     let fetcher = fetcher();
-   |                   ^^^^^^^^^ `Fetcher` cannot be made into an object
+   |                   ^^^^^^^^^ `Fetcher` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/undispatchable-receiver-and-wc-references-Self.rs:11:22
    |
 LL | pub trait Fetcher: Send + Sync {
-   |           ------- this trait cannot be made into an object...
+   |           ------- this trait is not dyn compatible...
 LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
    |                      ^^^^^^^^^^^^^ ...because method `get`'s `self` parameter cannot be dispatched on
 
-error[E0038]: the trait `Fetcher` cannot be made into an object
+error[E0038]: the trait `Fetcher` is not dyn compatible
   --> $DIR/undispatchable-receiver-and-wc-references-Self.rs:27:13
    |
 LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
    |                      ------------- help: consider changing method `get`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     let _ = fetcher.get();
-   |             ^^^^^^^^^^^^^ `Fetcher` cannot be made into an object
+   |             ^^^^^^^^^^^^^ `Fetcher` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/undispatchable-receiver-and-wc-references-Self.rs:11:22
    |
 LL | pub trait Fetcher: Send + Sync {
-   |           ------- this trait cannot be made into an object...
+   |           ------- this trait is not dyn compatible...
 LL |     fn get<'a>(self: &'a Box<Self>) -> Pin<Box<dyn Future<Output = Vec<u8>> + 'a>>
    |                      ^^^^^^^^^^^^^ ...because method `get`'s `self` parameter cannot be dispatched on
 

--- a/tests/ui/error-codes/E0038.stderr
+++ b/tests/ui/error-codes/E0038.stderr
@@ -1,29 +1,31 @@
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/E0038.rs:5:20
    |
 LL | fn call_foo(x: Box<dyn Trait>) {
-   |                    ^^^^^^^^^ `Trait` cannot be made into an object
+   |                    ^^^^^^^^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/E0038.rs:2:22
    |
 LL | trait Trait {
-   |       ----- this trait cannot be made into an object...
+   |       ----- this trait is not dyn compatible...
 LL |     fn foo(&self) -> Self;
    |                      ^^^^ ...because method `foo` references the `Self` type in its return type
    = help: consider moving `foo` to another trait
 
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/E0038.rs:7:13
    |
 LL |     let y = x.foo();
-   |             ^^^^^^^ `Trait` cannot be made into an object
+   |             ^^^^^^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/E0038.rs:2:22
    |
 LL | trait Trait {
-   |       ----- this trait cannot be made into an object...
+   |       ----- this trait is not dyn compatible...
 LL |     fn foo(&self) -> Self;
    |                      ^^^^ ...because method `foo` references the `Self` type in its return type
    = help: consider moving `foo` to another trait

--- a/tests/ui/feature-gates/feature-gate-async-fn-in-dyn-trait.rs
+++ b/tests/ui/feature-gates/feature-gate-async-fn-in-dyn-trait.rs
@@ -5,10 +5,10 @@ trait Foo {
 }
 
 async fn takes_dyn_trait(x: &dyn Foo) {
-    //~^ ERROR the trait `Foo` cannot be made into an object
+    //~^ ERROR the trait `Foo` is not dyn compatible
     x.bar().await;
-    //~^ ERROR the trait `Foo` cannot be made into an object
-    //~| ERROR the trait `Foo` cannot be made into an object
+    //~^ ERROR the trait `Foo` is not dyn compatible
+    //~| ERROR the trait `Foo` is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/feature-gates/feature-gate-async-fn-in-dyn-trait.stderr
+++ b/tests/ui/feature-gates/feature-gate-async-fn-in-dyn-trait.stderr
@@ -1,44 +1,47 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/feature-gate-async-fn-in-dyn-trait.rs:7:30
    |
 LL | async fn takes_dyn_trait(x: &dyn Foo) {
-   |                              ^^^^^^^ `Foo` cannot be made into an object
+   |                              ^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-async-fn-in-dyn-trait.rs:4:14
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     async fn bar(&self);
    |              ^^^ ...because method `bar` is `async`
    = help: consider moving `bar` to another trait
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/feature-gate-async-fn-in-dyn-trait.rs:9:7
    |
 LL |     x.bar().await;
-   |       ^^^ `Foo` cannot be made into an object
+   |       ^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-async-fn-in-dyn-trait.rs:4:14
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     async fn bar(&self);
    |              ^^^ ...because method `bar` is `async`
    = help: consider moving `bar` to another trait
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/feature-gate-async-fn-in-dyn-trait.rs:9:5
    |
 LL |     x.bar().await;
-   |     ^^^^^^^ `Foo` cannot be made into an object
+   |     ^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-async-fn-in-dyn-trait.rs:4:14
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     async fn bar(&self);
    |              ^^^ ...because method `bar` is `async`
    = help: consider moving `bar` to another trait

--- a/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.rs
+++ b/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.rs
@@ -30,6 +30,6 @@ impl Trait for i32 {
 
 fn main() {
     Ptr(Box::new(4)) as Ptr<dyn Trait>;
-    //~^ ERROR the trait `Trait` cannot be made into an object
-    //~^^ ERROR the trait `Trait` cannot be made into an object
+    //~^ ERROR the trait `Trait` is not dyn compatible
+    //~^^ ERROR the trait `Trait` is not dyn compatible
 }

--- a/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.stderr
+++ b/tests/ui/feature-gates/feature-gate-dispatch-from-dyn-missing-impl.stderr
@@ -1,38 +1,40 @@
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:32:25
    |
 LL |     fn ptr(self: Ptr<Self>);
    |                  --------- help: consider changing method `ptr`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     Ptr(Box::new(4)) as Ptr<dyn Trait>;
-   |                         ^^^^^^^^^^^^^^ `Trait` cannot be made into an object
+   |                         ^^^^^^^^^^^^^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:25:18
    |
 LL | trait Trait {
-   |       ----- this trait cannot be made into an object...
+   |       ----- this trait is not dyn compatible...
 LL |     fn ptr(self: Ptr<Self>);
    |                  ^^^^^^^^^ ...because method `ptr`'s `self` parameter cannot be dispatched on
-   = help: only type `i32` implements the trait, consider using it directly instead
+   = help: only type `i32` implements `Trait`; consider using it directly instead.
 
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:32:5
    |
 LL |     fn ptr(self: Ptr<Self>);
    |                  --------- help: consider changing method `ptr`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     Ptr(Box::new(4)) as Ptr<dyn Trait>;
-   |     ^^^^^^^^^^^^^^^^ `Trait` cannot be made into an object
+   |     ^^^^^^^^^^^^^^^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-dispatch-from-dyn-missing-impl.rs:25:18
    |
 LL | trait Trait {
-   |       ----- this trait cannot be made into an object...
+   |       ----- this trait is not dyn compatible...
 LL |     fn ptr(self: Ptr<Self>);
    |                  ^^^^^^^^^ ...because method `ptr`'s `self` parameter cannot be dispatched on
-   = help: only type `i32` implements the trait, consider using it directly instead
+   = help: only type `i32` implements `Trait`; consider using it directly instead.
    = note: required for the cast from `Ptr<{integer}>` to `Ptr<dyn Trait>`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/feature-gates/feature-gate-dyn_compatible_for_dispatch.stderr
+++ b/tests/ui/feature-gates/feature-gate-dyn_compatible_for_dispatch.stderr
@@ -1,28 +1,30 @@
-error[E0038]: the trait `DynIncompatible1` cannot be made into an object
+error[E0038]: the trait `DynIncompatible1` is not dyn compatible
   --> $DIR/feature-gate-dyn_compatible_for_dispatch.rs:18:40
    |
 LL | fn takes_dyn_incompatible_ref<T>(obj: &dyn DynIncompatible1) {
-   |                                        ^^^^^^^^^^^^^^^^^^^^ `DynIncompatible1` cannot be made into an object
+   |                                        ^^^^^^^^^^^^^^^^^^^^ `DynIncompatible1` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-dyn_compatible_for_dispatch.rs:4:25
    |
 LL | trait DynIncompatible1: Sized {}
    |       ----------------  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 
-error[E0038]: the trait `DynIncompatible2` cannot be made into an object
+error[E0038]: the trait `DynIncompatible2` is not dyn compatible
   --> $DIR/feature-gate-dyn_compatible_for_dispatch.rs:22:46
    |
 LL | fn return_dyn_incompatible_ref() -> &'static dyn DynIncompatible2 {
-   |                                              ^^^^^^^^^^^^^^^^^^^^ `DynIncompatible2` cannot be made into an object
+   |                                              ^^^^^^^^^^^^^^^^^^^^ `DynIncompatible2` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-dyn_compatible_for_dispatch.rs:7:8
    |
 LL | trait DynIncompatible2 {
-   |       ---------------- this trait cannot be made into an object...
+   |       ---------------- this trait is not dyn compatible...
 LL |     fn static_fn() {}
    |        ^^^^^^^^^ ...because associated function `static_fn` has no `self` parameter
 help: consider turning `static_fn` into a method by giving it a `&self` argument
@@ -34,49 +36,52 @@ help: alternatively, consider constraining `static_fn` so it does not apply to t
 LL |     fn static_fn() where Self: Sized {}
    |                    +++++++++++++++++
 
-error[E0038]: the trait `DynIncompatible3` cannot be made into an object
+error[E0038]: the trait `DynIncompatible3` is not dyn compatible
   --> $DIR/feature-gate-dyn_compatible_for_dispatch.rs:27:40
    |
 LL | fn takes_dyn_incompatible_box(obj: Box<dyn DynIncompatible3>) {
-   |                                        ^^^^^^^^^^^^^^^^^^^^ `DynIncompatible3` cannot be made into an object
+   |                                        ^^^^^^^^^^^^^^^^^^^^ `DynIncompatible3` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-dyn_compatible_for_dispatch.rs:11:8
    |
 LL | trait DynIncompatible3 {
-   |       ---------------- this trait cannot be made into an object...
+   |       ---------------- this trait is not dyn compatible...
 LL |     fn foo<T>(&self);
    |        ^^^ ...because method `foo` has generic type parameters
    = help: consider moving `foo` to another trait
 
-error[E0038]: the trait `DynIncompatible4` cannot be made into an object
+error[E0038]: the trait `DynIncompatible4` is not dyn compatible
   --> $DIR/feature-gate-dyn_compatible_for_dispatch.rs:31:48
    |
 LL | fn return_dyn_incompatible_rc() -> std::rc::Rc<dyn DynIncompatible4> {
-   |                                                ^^^^^^^^^^^^^^^^^^^^ `DynIncompatible4` cannot be made into an object
+   |                                                ^^^^^^^^^^^^^^^^^^^^ `DynIncompatible4` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-dyn_compatible_for_dispatch.rs:15:22
    |
 LL | trait DynIncompatible4 {
-   |       ---------------- this trait cannot be made into an object...
+   |       ---------------- this trait is not dyn compatible...
 LL |     fn foo(&self, s: &Self);
    |                      ^^^^^ ...because method `foo` references the `Self` type in this parameter
    = help: consider moving `foo` to another trait
 
-error[E0038]: the trait `DynIncompatible1` cannot be made into an object
+error[E0038]: the trait `DynIncompatible1` is not dyn compatible
   --> $DIR/feature-gate-dyn_compatible_for_dispatch.rs:38:16
    |
 LL | impl Trait for dyn DynIncompatible1 {}
-   |                ^^^^^^^^^^^^^^^^^^^^ `DynIncompatible1` cannot be made into an object
+   |                ^^^^^^^^^^^^^^^^^^^^ `DynIncompatible1` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/feature-gate-dyn_compatible_for_dispatch.rs:4:25
    |
 LL | trait DynIncompatible1: Sized {}
    |       ----------------  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.rs
+++ b/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.rs
@@ -8,5 +8,5 @@ fn main() {
     //~| ERROR: binding for associated type `Y` references lifetime
     //~| ERROR: binding for associated type `Y` references lifetime
     //~| ERROR: binding for associated type `Y` references lifetime
-    //~| ERROR: the trait `X` cannot be made into an object
+    //~| ERROR: the trait `X` is not dyn compatible
 }

--- a/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.stderr
+++ b/tests/ui/generic-associated-types/gat-in-trait-path-undeclared-lifetime.stderr
@@ -36,17 +36,18 @@ LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:6:19
    |
 LL |   fn _f(arg : Box<dyn for<'a> X<Y<'x> = &'a [u32]>>) {}
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-in-trait-path-undeclared-lifetime.rs:2:8
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |   type Y<'x>;
    |        ^ ...because it contains the generic associated type `Y`
    = help: consider moving `Y` to another trait

--- a/tests/ui/generic-associated-types/gat-in-trait-path.base.stderr
+++ b/tests/ui/generic-associated-types/gat-in-trait-path.base.stderr
@@ -1,56 +1,50 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/gat-in-trait-path.rs:26:17
    |
 LL | fn f(_arg : Box<dyn for<'a> Foo<A<'a> = &'a ()>>) {}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-in-trait-path.rs:10:10
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     type A<'a> where Self: 'a;
    |          ^ ...because it contains the generic associated type `A`
    = help: consider moving `A` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `Foo` for this new enum and using it instead:
-             Fooy
-             Fooer<T>
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/gat-in-trait-path.rs:32:5
    |
 LL |   f(Box::new(foo));
-   |     ^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |     ^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-in-trait-path.rs:10:10
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     type A<'a> where Self: 'a;
    |          ^ ...because it contains the generic associated type `A`
    = help: consider moving `A` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `Foo` for this new enum and using it instead:
-             Fooy
-             Fooer<T>
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/gat-in-trait-path.rs:32:5
    |
 LL |   f(Box::new(foo));
-   |     ^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |     ^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-in-trait-path.rs:10:10
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     type A<'a> where Self: 'a;
    |          ^ ...because it contains the generic associated type `A`
    = help: consider moving `A` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `Foo` for this new enum and using it instead:
-             Fooy
-             Fooer<T>
    = note: required for the cast from `Box<Fooer<{integer}>>` to `Box<(dyn Foo<A<'a> = &'a ()> + 'static)>`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/generic-associated-types/gat-in-trait-path.rs
+++ b/tests/ui/generic-associated-types/gat-in-trait-path.rs
@@ -20,12 +20,11 @@ impl<T> Foo for Fooer<T> {
 }
 
 fn f(_arg : Box<dyn for<'a> Foo<A<'a> = &'a ()>>) {}
-//~^ the trait `Foo` cannot be made into an object
-
+//~^ the trait `Foo` is not dyn compatible
 
 fn main() {
   let foo = Fooer(5);
   f(Box::new(foo));
-  //~^ the trait `Foo` cannot be made into an object
-  //~| the trait `Foo` cannot be made into an object
+  //~^ the trait `Foo` is not dyn compatible
+  //~| the trait `Foo` is not dyn compatible
 }

--- a/tests/ui/generic-associated-types/gat-in-trait-path.stderr
+++ b/tests/ui/generic-associated-types/gat-in-trait-path.stderr
@@ -1,56 +1,50 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/gat-in-trait-path.rs:22:17
    |
 LL | fn f(_arg : Box<dyn for<'a> Foo<A<'a> = &'a ()>>) {}
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-in-trait-path.rs:6:10
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     type A<'a> where Self: 'a;
    |          ^ ...because it contains the generic associated type `A`
    = help: consider moving `A` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `Foo` for this new enum and using it instead:
-             Fooy
-             Fooer<T>
 
-error[E0038]: the trait `Foo` cannot be made into an object
-  --> $DIR/gat-in-trait-path.rs:28:5
+error[E0038]: the trait `Foo` is not dyn compatible
+  --> $DIR/gat-in-trait-path.rs:27:5
    |
 LL |   f(Box::new(foo));
-   |     ^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |     ^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-in-trait-path.rs:6:10
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     type A<'a> where Self: 'a;
    |          ^ ...because it contains the generic associated type `A`
    = help: consider moving `A` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `Foo` for this new enum and using it instead:
-             Fooy
-             Fooer<T>
 
-error[E0038]: the trait `Foo` cannot be made into an object
-  --> $DIR/gat-in-trait-path.rs:28:5
+error[E0038]: the trait `Foo` is not dyn compatible
+  --> $DIR/gat-in-trait-path.rs:27:5
    |
 LL |   f(Box::new(foo));
-   |     ^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |     ^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-in-trait-path.rs:6:10
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     type A<'a> where Self: 'a;
    |          ^ ...because it contains the generic associated type `A`
    = help: consider moving `A` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `Foo` for this new enum and using it instead:
-             Fooy
-             Fooer<T>
    = note: required for the cast from `Box<Fooer<{integer}>>` to `Box<(dyn Foo<A<'a> = &'a ()> + 'static)>`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.rs
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.rs
@@ -12,7 +12,7 @@ fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
   //~| ERROR associated type takes 0 generic arguments but 1 generic argument
   //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
   //~| ERROR at least one trait is required
-  //~| ERROR: the trait `X` cannot be made into an object
+  //~| ERROR: the trait `X` is not dyn compatible
 
 
 fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
@@ -20,6 +20,6 @@ fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
   //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
   //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
   //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
-  //~| ERROR: the trait `X` cannot be made into an object
+  //~| ERROR: the trait `X` is not dyn compatible
 
 fn main() {}

--- a/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
+++ b/tests/ui/generic-associated-types/gat-trait-path-parenthesised-args.stderr
@@ -123,17 +123,18 @@ error[E0224]: at least one trait is required for an object type
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
    |                             ^^
 
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/gat-trait-path-parenthesised-args.rs:5:21
    |
 LL | fn foo<'a>(arg: Box<dyn X<Y('a) = &'a ()>>) {}
-   |                     ^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |                     ^^^^^^^^^^^^^^^^^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |   type Y<'a>;
    |        ^ ...because it contains the generic associated type `Y`
    = help: consider moving `Y` to another trait
@@ -188,17 +189,18 @@ help: add missing lifetime argument
 LL | fn bar<'a>(arg: Box<dyn X<Y('_) = ()>>) {}
    |                             ++
 
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/gat-trait-path-parenthesised-args.rs:18:21
    |
 LL | fn bar<'a>(arg: Box<dyn X<Y() = ()>>) {}
-   |                     ^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |                     ^^^^^^^^^^^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/gat-trait-path-parenthesised-args.rs:2:8
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |   type Y<'a>;
    |        ^ ...because it contains the generic associated type `Y`
    = help: consider moving `Y` to another trait

--- a/tests/ui/generic-associated-types/issue-67510-pass.base.stderr
+++ b/tests/ui/generic-associated-types/issue-67510-pass.base.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/issue-67510-pass.rs:12:23
    |
 LL | fn _func1<'a>(_x: Box<dyn X<Y<'a>=&'a ()>>) {}
-   |                       ^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |                       ^^^^^^^^^^^^^^^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-67510-pass.rs:9:10
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     type Y<'a>;
    |          ^ ...because it contains the generic associated type `Y`
    = help: consider moving `Y` to another trait

--- a/tests/ui/generic-associated-types/issue-67510-pass.rs
+++ b/tests/ui/generic-associated-types/issue-67510-pass.rs
@@ -5,6 +5,6 @@ trait X {
 }
 
 fn _func1<'a>(_x: Box<dyn X<Y<'a>=&'a ()>>) {}
-//~^ ERROR the trait `X` cannot be made into an object
+//~^ ERROR the trait `X` is not dyn compatible
 
 fn main() {}

--- a/tests/ui/generic-associated-types/issue-67510-pass.stderr
+++ b/tests/ui/generic-associated-types/issue-67510-pass.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/issue-67510-pass.rs:7:23
    |
 LL | fn _func1<'a>(_x: Box<dyn X<Y<'a>=&'a ()>>) {}
-   |                       ^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |                       ^^^^^^^^^^^^^^^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-67510-pass.rs:4:10
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     type Y<'a>;
    |          ^ ...because it contains the generic associated type `Y`
    = help: consider moving `Y` to another trait

--- a/tests/ui/generic-associated-types/issue-67510.rs
+++ b/tests/ui/generic-associated-types/issue-67510.rs
@@ -5,6 +5,6 @@ trait X {
 fn f(x: Box<dyn X<Y<'a> = &'a ()>>) {}
 //~^ ERROR: use of undeclared lifetime name `'a`
 //~| ERROR: use of undeclared lifetime name `'a`
-//~| ERROR: the trait `X` cannot be made into an object [E0038]
+//~| ERROR: the trait `X` is not dyn compatible [E0038]
 
 fn main() {}

--- a/tests/ui/generic-associated-types/issue-67510.stderr
+++ b/tests/ui/generic-associated-types/issue-67510.stderr
@@ -29,17 +29,18 @@ help: consider introducing lifetime `'a` here
 LL | fn f<'a>(x: Box<dyn X<Y<'a> = &'a ()>>) {}
    |     ++++
 
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/issue-67510.rs:5:13
    |
 LL | fn f(x: Box<dyn X<Y<'a> = &'a ()>>) {}
-   |             ^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |             ^^^^^^^^^^^^^^^^^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-67510.rs:2:10
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     type Y<'a>;
    |          ^ ...because it contains the generic associated type `Y`
    = help: consider moving `Y` to another trait

--- a/tests/ui/generic-associated-types/issue-71176.rs
+++ b/tests/ui/generic-associated-types/issue-71176.rs
@@ -11,13 +11,13 @@ struct Holder<B> {
   //~^ ERROR: missing generics for associated type
   //~| ERROR: missing generics for associated type
   //~| ERROR: missing generics for associated type
-  //~| ERROR: the trait `Provider` cannot be made into an object
+  //~| ERROR: the trait `Provider` is not dyn compatible
 }
 
 fn main() {
     Holder {
         inner: Box::new(()),
-        //~^ ERROR: the trait `Provider` cannot be made into an object
-        //~| ERROR: the trait `Provider` cannot be made into an object
+        //~^ ERROR: the trait `Provider` is not dyn compatible
+        //~| ERROR: the trait `Provider` is not dyn compatible
     };
 }

--- a/tests/ui/generic-associated-types/issue-71176.stderr
+++ b/tests/ui/generic-associated-types/issue-71176.stderr
@@ -48,53 +48,56 @@ help: add missing lifetime argument
 LL |   inner: Box<dyn Provider<A<'a> = B>>,
    |                            ++++
 
-error[E0038]: the trait `Provider` cannot be made into an object
+error[E0038]: the trait `Provider` is not dyn compatible
   --> $DIR/issue-71176.rs:10:14
    |
 LL |   inner: Box<dyn Provider<A = B>>,
-   |              ^^^^^^^^^^^^^^^^^^^ `Provider` cannot be made into an object
+   |              ^^^^^^^^^^^^^^^^^^^ `Provider` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-71176.rs:2:10
    |
 LL | trait Provider {
-   |       -------- this trait cannot be made into an object...
+   |       -------- this trait is not dyn compatible...
 LL |     type A<'a>;
    |          ^ ...because it contains the generic associated type `A`
    = help: consider moving `A` to another trait
-   = help: only type `()` implements the trait, consider using it directly instead
+   = help: only type `()` implements `Provider`; consider using it directly instead.
 
-error[E0038]: the trait `Provider` cannot be made into an object
+error[E0038]: the trait `Provider` is not dyn compatible
   --> $DIR/issue-71176.rs:19:16
    |
 LL |         inner: Box::new(()),
-   |                ^^^^^^^^^^^^ `Provider` cannot be made into an object
+   |                ^^^^^^^^^^^^ `Provider` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-71176.rs:2:10
    |
 LL | trait Provider {
-   |       -------- this trait cannot be made into an object...
+   |       -------- this trait is not dyn compatible...
 LL |     type A<'a>;
    |          ^ ...because it contains the generic associated type `A`
    = help: consider moving `A` to another trait
-   = help: only type `()` implements the trait, consider using it directly instead
+   = help: only type `()` implements `Provider`; consider using it directly instead.
 
-error[E0038]: the trait `Provider` cannot be made into an object
+error[E0038]: the trait `Provider` is not dyn compatible
   --> $DIR/issue-71176.rs:19:16
    |
 LL |         inner: Box::new(()),
-   |                ^^^^^^^^^^^^ `Provider` cannot be made into an object
+   |                ^^^^^^^^^^^^ `Provider` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-71176.rs:2:10
    |
 LL | trait Provider {
-   |       -------- this trait cannot be made into an object...
+   |       -------- this trait is not dyn compatible...
 LL |     type A<'a>;
    |          ^ ...because it contains the generic associated type `A`
    = help: consider moving `A` to another trait
-   = help: only type `()` implements the trait, consider using it directly instead
+   = help: only type `()` implements `Provider`; consider using it directly instead.
    = note: required for the cast from `Box<()>` to `Box<(dyn Provider<A<'_> = _> + 'static), {type error}>`
 
 error: aborting due to 6 previous errors

--- a/tests/ui/generic-associated-types/issue-76535.base.stderr
+++ b/tests/ui/generic-associated-types/issue-76535.base.stderr
@@ -14,39 +14,41 @@ help: add missing lifetime argument
 LL |     let sub: Box<dyn SuperTrait<SubType<'a> = SubStruct>> = Box::new(SuperStruct::new(0));
    |                                        ++++
 
-error[E0038]: the trait `SuperTrait` cannot be made into an object
+error[E0038]: the trait `SuperTrait` is not dyn compatible
   --> $DIR/issue-76535.rs:39:14
    |
 LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` cannot be made into an object
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-76535.rs:9:10
    |
 LL | pub trait SuperTrait {
-   |           ---------- this trait cannot be made into an object...
+   |           ---------- this trait is not dyn compatible...
 LL |     type SubType<'a>: SubTrait where Self: 'a;
    |          ^^^^^^^ ...because it contains the generic associated type `SubType`
    = help: consider moving `SubType` to another trait
-   = help: only type `SuperStruct` is seen to implement the trait in this crate, consider using it directly instead
-   = note: `SuperTrait` can be implemented in other crates; if you want to support your users passing their own types here, you can't refer to a specific type
+   = help: only type `SuperStruct` implements `SuperTrait` within this crate. Consider using it directly instead.
+   = note: `SuperTrait` may be implemented in other crates; if you want to support your users passing their own types here, you can't refer to a specific type
 
-error[E0038]: the trait `SuperTrait` cannot be made into an object
+error[E0038]: the trait `SuperTrait` is not dyn compatible
   --> $DIR/issue-76535.rs:39:57
    |
 LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
-   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` cannot be made into an object
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-76535.rs:9:10
    |
 LL | pub trait SuperTrait {
-   |           ---------- this trait cannot be made into an object...
+   |           ---------- this trait is not dyn compatible...
 LL |     type SubType<'a>: SubTrait where Self: 'a;
    |          ^^^^^^^ ...because it contains the generic associated type `SubType`
    = help: consider moving `SubType` to another trait
-   = help: only type `SuperStruct` is seen to implement the trait in this crate, consider using it directly instead
-   = note: `SuperTrait` can be implemented in other crates; if you want to support your users passing their own types here, you can't refer to a specific type
+   = help: only type `SuperStruct` implements `SuperTrait` within this crate. Consider using it directly instead.
+   = note: `SuperTrait` may be implemented in other crates; if you want to support your users passing their own types here, you can't refer to a specific type
    = note: required for the cast from `Box<SuperStruct>` to `Box<dyn SuperTrait<SubType<'_> = SubStruct<'_>>>`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/generic-associated-types/issue-76535.stderr
+++ b/tests/ui/generic-associated-types/issue-76535.stderr
@@ -14,39 +14,41 @@ help: add missing lifetime argument
 LL |     let sub: Box<dyn SuperTrait<SubType<'a> = SubStruct>> = Box::new(SuperStruct::new(0));
    |                                        ++++
 
-error[E0038]: the trait `SuperTrait` cannot be made into an object
+error[E0038]: the trait `SuperTrait` is not dyn compatible
   --> $DIR/issue-76535.rs:34:14
    |
 LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
-   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` cannot be made into an object
+   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-76535.rs:4:10
    |
 LL | pub trait SuperTrait {
-   |           ---------- this trait cannot be made into an object...
+   |           ---------- this trait is not dyn compatible...
 LL |     type SubType<'a>: SubTrait where Self: 'a;
    |          ^^^^^^^ ...because it contains the generic associated type `SubType`
    = help: consider moving `SubType` to another trait
-   = help: only type `SuperStruct` is seen to implement the trait in this crate, consider using it directly instead
-   = note: `SuperTrait` can be implemented in other crates; if you want to support your users passing their own types here, you can't refer to a specific type
+   = help: only type `SuperStruct` implements `SuperTrait` within this crate; consider using it directly instead.
+   = note: `SuperTrait` may be implemented in other crates; if you want to support your users passing their own types here, you can't refer to a specific type
 
-error[E0038]: the trait `SuperTrait` cannot be made into an object
+error[E0038]: the trait `SuperTrait` is not dyn compatible
   --> $DIR/issue-76535.rs:34:57
    |
 LL |     let sub: Box<dyn SuperTrait<SubType = SubStruct>> = Box::new(SuperStruct::new(0));
-   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` cannot be made into an object
+   |                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `SuperTrait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-76535.rs:4:10
    |
 LL | pub trait SuperTrait {
-   |           ---------- this trait cannot be made into an object...
+   |           ---------- this trait is not dyn compatible...
 LL |     type SubType<'a>: SubTrait where Self: 'a;
    |          ^^^^^^^ ...because it contains the generic associated type `SubType`
    = help: consider moving `SubType` to another trait
-   = help: only type `SuperStruct` is seen to implement the trait in this crate, consider using it directly instead
-   = note: `SuperTrait` can be implemented in other crates; if you want to support your users passing their own types here, you can't refer to a specific type
+   = help: only type `SuperStruct` implements `SuperTrait` within this crate; consider using it directly instead.
+   = note: `SuperTrait` may be implemented in other crates; if you want to support your users passing their own types here, you can't refer to a specific type
    = note: required for the cast from `Box<SuperStruct>` to `Box<dyn SuperTrait<SubType<'_> = SubStruct<'_>>>`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/generic-associated-types/issue-78671.base.stderr
+++ b/tests/ui/generic-associated-types/issue-78671.base.stderr
@@ -14,17 +14,18 @@ help: add missing generic argument
 LL |     Box::new(Family) as &dyn CollectionFamily<Member<T>=usize>
    |                                                     +++
 
-error[E0038]: the trait `CollectionFamily` cannot be made into an object
+error[E0038]: the trait `CollectionFamily` is not dyn compatible
   --> $DIR/issue-78671.rs:10:25
    |
 LL |     Box::new(Family) as &dyn CollectionFamily<Member=usize>
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CollectionFamily` cannot be made into an object
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CollectionFamily` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-78671.rs:7:10
    |
 LL | trait CollectionFamily {
-   |       ---------------- this trait cannot be made into an object...
+   |       ---------------- this trait is not dyn compatible...
 LL |     type Member<T>;
    |          ^^^^^^ ...because it contains the generic associated type `Member`
    = help: consider moving `Member` to another trait

--- a/tests/ui/generic-associated-types/issue-78671.rs
+++ b/tests/ui/generic-associated-types/issue-78671.rs
@@ -4,7 +4,7 @@ trait CollectionFamily {
 fn floatify() {
     Box::new(Family) as &dyn CollectionFamily<Member=usize>
     //~^ ERROR: missing generics for associated type
-    //~| ERROR: the trait `CollectionFamily` cannot be made into an object
+    //~| ERROR: the trait `CollectionFamily` is not dyn compatible
 }
 
 struct Family;

--- a/tests/ui/generic-associated-types/issue-78671.stderr
+++ b/tests/ui/generic-associated-types/issue-78671.stderr
@@ -14,17 +14,18 @@ help: add missing generic argument
 LL |     Box::new(Family) as &dyn CollectionFamily<Member<T>=usize>
    |                                                     +++
 
-error[E0038]: the trait `CollectionFamily` cannot be made into an object
+error[E0038]: the trait `CollectionFamily` is not dyn compatible
   --> $DIR/issue-78671.rs:5:25
    |
 LL |     Box::new(Family) as &dyn CollectionFamily<Member=usize>
-   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CollectionFamily` cannot be made into an object
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `CollectionFamily` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-78671.rs:2:10
    |
 LL | trait CollectionFamily {
-   |       ---------------- this trait cannot be made into an object...
+   |       ---------------- this trait is not dyn compatible...
 LL |     type Member<T>;
    |          ^^^^^^ ...because it contains the generic associated type `Member`
    = help: consider moving `Member` to another trait

--- a/tests/ui/generic-associated-types/issue-79422.base.stderr
+++ b/tests/ui/generic-associated-types/issue-79422.base.stderr
@@ -14,41 +14,37 @@ help: add missing lifetime argument
 LL |         as Box<dyn MapLike<u8, u8, VRefCont<'a> = dyn RefCont<'_, u8>>>;
    |                                            ++++
 
-error[E0038]: the trait `MapLike` cannot be made into an object
+error[E0038]: the trait `MapLike` is not dyn compatible
   --> $DIR/issue-79422.rs:47:12
    |
 LL |         as Box<dyn MapLike<u8, u8, VRefCont = dyn RefCont<'_, u8>>>;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` cannot be made into an object
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-79422.rs:23:10
    |
 LL | trait MapLike<K, V> {
-   |       ------- this trait cannot be made into an object...
+   |       ------- this trait is not dyn compatible...
 LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
    |          ^^^^^^^^ ...because it contains the generic associated type `VRefCont`
    = help: consider moving `VRefCont` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `MapLike` for this new enum and using it instead:
-             std::collections::BTreeMap<K, V>
-             Source
 
-error[E0038]: the trait `MapLike` cannot be made into an object
+error[E0038]: the trait `MapLike` is not dyn compatible
   --> $DIR/issue-79422.rs:44:13
    |
 LL |     let m = Box::new(std::collections::BTreeMap::<u8, u8>::new())
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` cannot be made into an object
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-79422.rs:23:10
    |
 LL | trait MapLike<K, V> {
-   |       ------- this trait cannot be made into an object...
+   |       ------- this trait is not dyn compatible...
 LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
    |          ^^^^^^^^ ...because it contains the generic associated type `VRefCont`
    = help: consider moving `VRefCont` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `MapLike` for this new enum and using it instead:
-             std::collections::BTreeMap<K, V>
-             Source
    = note: required for the cast from `Box<BTreeMap<u8, u8>>` to `Box<dyn MapLike<u8, u8, VRefCont<'_> = (dyn RefCont<'_, u8> + 'static)>>`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/generic-associated-types/issue-79422.stderr
+++ b/tests/ui/generic-associated-types/issue-79422.stderr
@@ -14,41 +14,37 @@ help: add missing lifetime argument
 LL |         as Box<dyn MapLike<u8, u8, VRefCont<'a> = dyn RefCont<'_, u8>>>;
    |                                            ++++
 
-error[E0038]: the trait `MapLike` cannot be made into an object
+error[E0038]: the trait `MapLike` is not dyn compatible
   --> $DIR/issue-79422.rs:41:12
    |
 LL |         as Box<dyn MapLike<u8, u8, VRefCont = dyn RefCont<'_, u8>>>;
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` cannot be made into an object
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-79422.rs:18:10
    |
 LL | trait MapLike<K, V> {
-   |       ------- this trait cannot be made into an object...
+   |       ------- this trait is not dyn compatible...
 LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
    |          ^^^^^^^^ ...because it contains the generic associated type `VRefCont`
    = help: consider moving `VRefCont` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `MapLike` for this new enum and using it instead:
-             std::collections::BTreeMap<K, V>
-             Source
 
-error[E0038]: the trait `MapLike` cannot be made into an object
+error[E0038]: the trait `MapLike` is not dyn compatible
   --> $DIR/issue-79422.rs:39:13
    |
 LL |     let m = Box::new(std::collections::BTreeMap::<u8, u8>::new())
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` cannot be made into an object
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `MapLike` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-79422.rs:18:10
    |
 LL | trait MapLike<K, V> {
-   |       ------- this trait cannot be made into an object...
+   |       ------- this trait is not dyn compatible...
 LL |     type VRefCont<'a>: RefCont<'a, V> where Self: 'a;
    |          ^^^^^^^^ ...because it contains the generic associated type `VRefCont`
    = help: consider moving `VRefCont` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `MapLike` for this new enum and using it instead:
-             std::collections::BTreeMap<K, V>
-             Source
    = note: required for the cast from `Box<BTreeMap<u8, u8>>` to `Box<dyn MapLike<u8, u8, VRefCont<'_> = (dyn RefCont<'_, u8> + 'static)>>`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/generic-associated-types/missing_lifetime_args.rs
+++ b/tests/ui/generic-associated-types/missing_lifetime_args.rs
@@ -12,7 +12,7 @@ fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
 //~^ ERROR missing generics for associated type
 //~| ERROR missing generics for associated type
 //~| ERROR missing generics for associated type
-//~| ERROR the trait `X` cannot be made into an object
+//~| ERROR the trait `X` is not dyn compatible
 
 fn bar<'a, 'b, 'c>(_arg: Foo<'a, 'b>) {}
 //~^ ERROR struct takes 3 lifetime arguments but 2 lifetime

--- a/tests/ui/generic-associated-types/missing_lifetime_args.stderr
+++ b/tests/ui/generic-associated-types/missing_lifetime_args.stderr
@@ -48,17 +48,18 @@ help: add missing lifetime arguments
 LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y<'_, '_> = (&'c u32, &'d u32)>>) {}
    |                                 ++++++++
 
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/missing_lifetime_args.rs:11:26
    |
 LL | fn foo<'c, 'd>(_arg: Box<dyn X<Y = (&'c u32, &'d u32)>>) {}
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/missing_lifetime_args.rs:2:10
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     type Y<'a, 'b>;
    |          ^ ...because it contains the generic associated type `Y`
    = help: consider moving `Y` to another trait

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.rs
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.rs
@@ -10,7 +10,7 @@ const _: () = {
       //~| ERROR associated type takes 0 generic arguments but 1 generic argument
       //~| ERROR associated type takes 1 lifetime argument but 0 lifetime arguments
       //~| ERROR associated type takes 0 generic arguments but 1 generic argument
-      //~| ERROR the trait `X` cannot be made into an object
+      //~| ERROR the trait `X` is not dyn compatible
 };
 
 fn main() {}

--- a/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
+++ b/tests/ui/generic-associated-types/parse/trait-path-type-error-once-implemented.stderr
@@ -92,17 +92,18 @@ LL |     type Y<'a>;
    |          ^
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/trait-path-type-error-once-implemented.rs:6:23
    |
 LL |   fn f2<'a>(arg : Box<dyn X<Y<1> = &'a ()>>) {}
-   |                       ^^^^^^^^^^^^^^^^^^^^ `X` cannot be made into an object
+   |                       ^^^^^^^^^^^^^^^^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/trait-path-type-error-once-implemented.rs:2:10
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     type Y<'a>;
    |          ^ ...because it contains the generic associated type `Y`
    = help: consider moving `Y` to another trait

--- a/tests/ui/generic-associated-types/trait-objects.base.stderr
+++ b/tests/ui/generic-associated-types/trait-objects.base.stderr
@@ -1,44 +1,47 @@
-error[E0038]: the trait `StreamingIterator` cannot be made into an object
+error[E0038]: the trait `StreamingIterator` is not dyn compatible
   --> $DIR/trait-objects.rs:13:21
    |
 LL | fn min_size(x: &mut dyn for<'a> StreamingIterator<Item<'a> = &'a i32>) -> usize {
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `StreamingIterator` cannot be made into an object
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `StreamingIterator` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/trait-objects.rs:7:10
    |
 LL | trait StreamingIterator {
-   |       ----------------- this trait cannot be made into an object...
+   |       ----------------- this trait is not dyn compatible...
 LL |     type Item<'a> where Self: 'a;
    |          ^^^^ ...because it contains the generic associated type `Item`
    = help: consider moving `Item` to another trait
 
-error[E0038]: the trait `StreamingIterator` cannot be made into an object
+error[E0038]: the trait `StreamingIterator` is not dyn compatible
   --> $DIR/trait-objects.rs:15:7
    |
 LL |     x.size_hint().0
-   |       ^^^^^^^^^ `StreamingIterator` cannot be made into an object
+   |       ^^^^^^^^^ `StreamingIterator` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/trait-objects.rs:7:10
    |
 LL | trait StreamingIterator {
-   |       ----------------- this trait cannot be made into an object...
+   |       ----------------- this trait is not dyn compatible...
 LL |     type Item<'a> where Self: 'a;
    |          ^^^^ ...because it contains the generic associated type `Item`
    = help: consider moving `Item` to another trait
 
-error[E0038]: the trait `StreamingIterator` cannot be made into an object
+error[E0038]: the trait `StreamingIterator` is not dyn compatible
   --> $DIR/trait-objects.rs:15:5
    |
 LL |     x.size_hint().0
-   |     ^^^^^^^^^^^^^ `StreamingIterator` cannot be made into an object
+   |     ^^^^^^^^^^^^^ `StreamingIterator` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/trait-objects.rs:7:10
    |
 LL | trait StreamingIterator {
-   |       ----------------- this trait cannot be made into an object...
+   |       ----------------- this trait is not dyn compatible...
 LL |     type Item<'a> where Self: 'a;
    |          ^^^^ ...because it contains the generic associated type `Item`
    = help: consider moving `Item` to another trait

--- a/tests/ui/generic-associated-types/trait-objects.rs
+++ b/tests/ui/generic-associated-types/trait-objects.rs
@@ -6,10 +6,10 @@ trait StreamingIterator {
 }
 
 fn min_size(x: &mut dyn for<'a> StreamingIterator<Item<'a> = &'a i32>) -> usize {
-    //~^ the trait `StreamingIterator` cannot be made into an object
+    //~^ the trait `StreamingIterator` is not dyn compatible
     x.size_hint().0
-    //~^ the trait `StreamingIterator` cannot be made into an object
-    //~| the trait `StreamingIterator` cannot be made into an object
+    //~^ the trait `StreamingIterator` is not dyn compatible
+    //~| the trait `StreamingIterator` is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/generic-associated-types/trait-objects.stderr
+++ b/tests/ui/generic-associated-types/trait-objects.stderr
@@ -1,44 +1,47 @@
-error[E0038]: the trait `StreamingIterator` cannot be made into an object
+error[E0038]: the trait `StreamingIterator` is not dyn compatible
   --> $DIR/trait-objects.rs:8:21
    |
 LL | fn min_size(x: &mut dyn for<'a> StreamingIterator<Item<'a> = &'a i32>) -> usize {
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `StreamingIterator` cannot be made into an object
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `StreamingIterator` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/trait-objects.rs:2:10
    |
 LL | trait StreamingIterator {
-   |       ----------------- this trait cannot be made into an object...
+   |       ----------------- this trait is not dyn compatible...
 LL |     type Item<'a> where Self: 'a;
    |          ^^^^ ...because it contains the generic associated type `Item`
    = help: consider moving `Item` to another trait
 
-error[E0038]: the trait `StreamingIterator` cannot be made into an object
+error[E0038]: the trait `StreamingIterator` is not dyn compatible
   --> $DIR/trait-objects.rs:10:7
    |
 LL |     x.size_hint().0
-   |       ^^^^^^^^^ `StreamingIterator` cannot be made into an object
+   |       ^^^^^^^^^ `StreamingIterator` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/trait-objects.rs:2:10
    |
 LL | trait StreamingIterator {
-   |       ----------------- this trait cannot be made into an object...
+   |       ----------------- this trait is not dyn compatible...
 LL |     type Item<'a> where Self: 'a;
    |          ^^^^ ...because it contains the generic associated type `Item`
    = help: consider moving `Item` to another trait
 
-error[E0038]: the trait `StreamingIterator` cannot be made into an object
+error[E0038]: the trait `StreamingIterator` is not dyn compatible
   --> $DIR/trait-objects.rs:10:5
    |
 LL |     x.size_hint().0
-   |     ^^^^^^^^^^^^^ `StreamingIterator` cannot be made into an object
+   |     ^^^^^^^^^^^^^ `StreamingIterator` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/trait-objects.rs:2:10
    |
 LL | trait StreamingIterator {
-   |       ----------------- this trait cannot be made into an object...
+   |       ----------------- this trait is not dyn compatible...
 LL |     type Item<'a> where Self: 'a;
    |          ^^^^ ...because it contains the generic associated type `Item`
    = help: consider moving `Item` to another trait

--- a/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.rs
+++ b/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.rs
@@ -12,8 +12,8 @@ fn needs_bar(_: *mut Type2) {}
 
 fn main() {
     let x: &dyn Foo = &();
-    //~^ ERROR the trait `Foo` cannot be made into an object
-    //~| ERROR the trait `Foo` cannot be made into an object
+    //~^ ERROR the trait `Foo` is not dyn compatible
+    //~| ERROR the trait `Foo` is not dyn compatible
 
     needs_bar(x);
     //~^ ERROR mismatched types

--- a/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/span-bug-issue-121597.stderr
@@ -1,31 +1,33 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/span-bug-issue-121597.rs:14:23
    |
 LL |     let x: &dyn Foo = &();
-   |                       ^^^ `Foo` cannot be made into an object
+   |                       ^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/span-bug-issue-121597.rs:4:12
    |
 LL | trait Foo: for<T> Bar<T> {}
    |       ---  ^^^^^^^^^^^^^ ...because where clause cannot reference non-lifetime `for<...>` variables
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
    = note: required for the cast from `&()` to `&dyn Foo`
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/span-bug-issue-121597.rs:14:12
    |
 LL |     let x: &dyn Foo = &();
-   |            ^^^^^^^^ `Foo` cannot be made into an object
+   |            ^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/span-bug-issue-121597.rs:4:12
    |
 LL | trait Foo: for<T> Bar<T> {}
    |       ---  ^^^^^^^^^^^^^ ...because where clause cannot reference non-lifetime `for<...>` variables
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 
 error[E0308]: mismatched types
   --> $DIR/span-bug-issue-121597.rs:18:15

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.rs
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.rs
@@ -19,7 +19,7 @@ impl DynIncompatible for B {
     }
 }
 
-fn car() -> dyn DynIncompatible { //~ ERROR the trait `DynIncompatible` cannot be made into an object
+fn car() -> dyn DynIncompatible { //~ ERROR the trait `DynIncompatible` is not dyn compatible
 //~^ ERROR return type cannot have an unboxed trait object
     if true {
         return A;
@@ -27,11 +27,11 @@ fn car() -> dyn DynIncompatible { //~ ERROR the trait `DynIncompatible` cannot b
     B
 }
 
-fn cat() -> Box<dyn DynIncompatible> { //~ ERROR the trait `DynIncompatible` cannot be made into an
+fn cat() -> Box<dyn DynIncompatible> { //~ ERROR the trait `DynIncompatible` is not dyn compatible
     if true {
-        return Box::new(A); //~ ERROR cannot be made into an object
+        return Box::new(A); //~ ERROR is not dyn compatible
     }
-    Box::new(B) //~ ERROR cannot be made into an object
+    Box::new(B) //~ ERROR is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
+++ b/tests/ui/impl-trait/dyn-incompatible-trait-in-return-position-dyn-trait.stderr
@@ -1,19 +1,22 @@
-error[E0038]: the trait `DynIncompatible` cannot be made into an object
+error[E0038]: the trait `DynIncompatible` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:22:13
    |
 LL | fn car() -> dyn DynIncompatible {
-   |             ^^^^^^^^^^^^^^^^^^^ `DynIncompatible` cannot be made into an object
+   |             ^^^^^^^^^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:4:8
    |
 LL | trait DynIncompatible {
-   |       --------------- this trait cannot be made into an object...
+   |       --------------- this trait is not dyn compatible...
 LL |     fn foo() -> Self;
    |        ^^^ ...because associated function `foo` has no `self` parameter
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `DynIncompatible` for this new enum and using it instead:
+   = help: the following types implement `DynIncompatible`:
              A
              B
+           consider defining an enum where each variant holds one of these types,
+           implementing `DynIncompatible` for this new enum and using it instead
 help: consider turning `foo` into a method by giving it a `&self` argument
    |
 LL |     fn foo(&self) -> Self;
@@ -23,22 +26,25 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
-error[E0038]: the trait `DynIncompatible` cannot be made into an object
+error[E0038]: the trait `DynIncompatible` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:30:17
    |
 LL | fn cat() -> Box<dyn DynIncompatible> {
-   |                 ^^^^^^^^^^^^^^^^^^^ `DynIncompatible` cannot be made into an object
+   |                 ^^^^^^^^^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:4:8
    |
 LL | trait DynIncompatible {
-   |       --------------- this trait cannot be made into an object...
+   |       --------------- this trait is not dyn compatible...
 LL |     fn foo() -> Self;
    |        ^^^ ...because associated function `foo` has no `self` parameter
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `DynIncompatible` for this new enum and using it instead:
+   = help: the following types implement `DynIncompatible`:
              A
              B
+           consider defining an enum where each variant holds one of these types,
+           implementing `DynIncompatible` for this new enum and using it instead
 help: consider turning `foo` into a method by giving it a `&self` argument
    |
 LL |     fn foo(&self) -> Self;
@@ -65,22 +71,25 @@ LL |     }
 LL ~     Box::new(B)
    |
 
-error[E0038]: the trait `DynIncompatible` cannot be made into an object
+error[E0038]: the trait `DynIncompatible` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:32:16
    |
 LL |         return Box::new(A);
-   |                ^^^^^^^^^^^ `DynIncompatible` cannot be made into an object
+   |                ^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:4:8
    |
 LL | trait DynIncompatible {
-   |       --------------- this trait cannot be made into an object...
+   |       --------------- this trait is not dyn compatible...
 LL |     fn foo() -> Self;
    |        ^^^ ...because associated function `foo` has no `self` parameter
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `DynIncompatible` for this new enum and using it instead:
+   = help: the following types implement `DynIncompatible`:
              A
              B
+           consider defining an enum where each variant holds one of these types,
+           implementing `DynIncompatible` for this new enum and using it instead
    = note: required for the cast from `Box<A>` to `Box<(dyn DynIncompatible + 'static)>`
 help: consider turning `foo` into a method by giving it a `&self` argument
    |
@@ -91,22 +100,25 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() -> Self where Self: Sized;
    |                      +++++++++++++++++
 
-error[E0038]: the trait `DynIncompatible` cannot be made into an object
+error[E0038]: the trait `DynIncompatible` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:34:5
    |
 LL |     Box::new(B)
-   |     ^^^^^^^^^^^ `DynIncompatible` cannot be made into an object
+   |     ^^^^^^^^^^^ `DynIncompatible` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-incompatible-trait-in-return-position-dyn-trait.rs:4:8
    |
 LL | trait DynIncompatible {
-   |       --------------- this trait cannot be made into an object...
+   |       --------------- this trait is not dyn compatible...
 LL |     fn foo() -> Self;
    |        ^^^ ...because associated function `foo` has no `self` parameter
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `DynIncompatible` for this new enum and using it instead:
+   = help: the following types implement `DynIncompatible`:
              A
              B
+           consider defining an enum where each variant holds one of these types,
+           implementing `DynIncompatible` for this new enum and using it instead
    = note: required for the cast from `Box<B>` to `Box<(dyn DynIncompatible + 'static)>`
 help: consider turning `foo` into a method by giving it a `&self` argument
    |

--- a/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-dyn-compatibility-check.rs
+++ b/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-dyn-compatibility-check.rs
@@ -14,13 +14,13 @@ impl MyTrait for Outer {
 }
 
 impl dyn MyTrait {
-    //~^ ERROR the trait `MyTrait` cannot be made into an object
+    //~^ ERROR the trait `MyTrait` is not dyn compatible
     fn other(&self) -> impl Marker {
-        //~^ ERROR the trait `MyTrait` cannot be made into an object
+        //~^ ERROR the trait `MyTrait` is not dyn compatible
         MyTrait::foo(&self)
         //~^ ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied
         //~| ERROR the trait bound `&dyn MyTrait: MyTrait` is not satisfied
-        //~| ERROR the trait `MyTrait` cannot be made into an object
+        //~| ERROR the trait `MyTrait` is not dyn compatible
     }
 }
 

--- a/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-dyn-compatibility-check.stderr
+++ b/tests/ui/impl-trait/in-trait/cycle-effective-visibilities-during-dyn-compatibility-check.stderr
@@ -8,21 +8,22 @@ LL |         MyTrait::foo(&self)
    |
    = help: the trait `MyTrait` is implemented for `Outer`
 
-error[E0038]: the trait `MyTrait` cannot be made into an object
+error[E0038]: the trait `MyTrait` is not dyn compatible
   --> $DIR/cycle-effective-visibilities-during-dyn-compatibility-check.rs:20:9
    |
 LL |         MyTrait::foo(&self)
-   |         ^^^^^^^^^^^^ `MyTrait` cannot be made into an object
+   |         ^^^^^^^^^^^^ `MyTrait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/cycle-effective-visibilities-during-dyn-compatibility-check.rs:5:22
    |
 LL | trait MyTrait {
-   |       ------- this trait cannot be made into an object...
+   |       ------- this trait is not dyn compatible...
 LL |     fn foo(&self) -> impl Marker;
    |                      ^^^^^^^^^^^ ...because method `foo` references an `impl Trait` type in its return type
    = help: consider moving `foo` to another trait
-   = help: only type `Outer` implements the trait, consider using it directly instead
+   = help: only type `Outer` implements `MyTrait`; consider using it directly instead.
 
 error[E0277]: the trait bound `&dyn MyTrait: MyTrait` is not satisfied
   --> $DIR/cycle-effective-visibilities-during-dyn-compatibility-check.rs:20:9
@@ -32,37 +33,39 @@ LL |         MyTrait::foo(&self)
    |
    = help: the trait `MyTrait` is implemented for `Outer`
 
-error[E0038]: the trait `MyTrait` cannot be made into an object
+error[E0038]: the trait `MyTrait` is not dyn compatible
   --> $DIR/cycle-effective-visibilities-during-dyn-compatibility-check.rs:16:6
    |
 LL | impl dyn MyTrait {
-   |      ^^^^^^^^^^^ `MyTrait` cannot be made into an object
+   |      ^^^^^^^^^^^ `MyTrait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/cycle-effective-visibilities-during-dyn-compatibility-check.rs:5:22
    |
 LL | trait MyTrait {
-   |       ------- this trait cannot be made into an object...
+   |       ------- this trait is not dyn compatible...
 LL |     fn foo(&self) -> impl Marker;
    |                      ^^^^^^^^^^^ ...because method `foo` references an `impl Trait` type in its return type
    = help: consider moving `foo` to another trait
-   = help: only type `Outer` implements the trait, consider using it directly instead
+   = help: only type `Outer` implements `MyTrait`; consider using it directly instead.
 
-error[E0038]: the trait `MyTrait` cannot be made into an object
+error[E0038]: the trait `MyTrait` is not dyn compatible
   --> $DIR/cycle-effective-visibilities-during-dyn-compatibility-check.rs:18:15
    |
 LL |     fn other(&self) -> impl Marker {
-   |               ^^^^ `MyTrait` cannot be made into an object
+   |               ^^^^ `MyTrait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/cycle-effective-visibilities-during-dyn-compatibility-check.rs:5:22
    |
 LL | trait MyTrait {
-   |       ------- this trait cannot be made into an object...
+   |       ------- this trait is not dyn compatible...
 LL |     fn foo(&self) -> impl Marker;
    |                      ^^^^^^^^^^^ ...because method `foo` references an `impl Trait` type in its return type
    = help: consider moving `foo` to another trait
-   = help: only type `Outer` implements the trait, consider using it directly instead
+   = help: only type `Outer` implements `MyTrait`; consider using it directly instead.
 
 error: aborting due to 5 previous errors
 

--- a/tests/ui/impl-trait/in-trait/dyn-compatibility.rs
+++ b/tests/ui/impl-trait/in-trait/dyn-compatibility.rs
@@ -12,9 +12,9 @@ impl Foo for u32 {
 
 fn main() {
     let i = Box::new(42_u32) as Box<dyn Foo>;
-    //~^ ERROR the trait `Foo` cannot be made into an object
-    //~| ERROR the trait `Foo` cannot be made into an object
+    //~^ ERROR the trait `Foo` is not dyn compatible
+    //~| ERROR the trait `Foo` is not dyn compatible
     let s = i.baz();
-    //~^ ERROR the trait `Foo` cannot be made into an object
-    //~| ERROR the trait `Foo` cannot be made into an object
+    //~^ ERROR the trait `Foo` is not dyn compatible
+    //~| ERROR the trait `Foo` is not dyn compatible
 }

--- a/tests/ui/impl-trait/in-trait/dyn-compatibility.stderr
+++ b/tests/ui/impl-trait/in-trait/dyn-compatibility.stderr
@@ -1,66 +1,70 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/dyn-compatibility.rs:14:33
    |
 LL |     let i = Box::new(42_u32) as Box<dyn Foo>;
-   |                                 ^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |                                 ^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-compatibility.rs:4:22
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn baz(&self) -> impl Debug;
    |                      ^^^^^^^^^^ ...because method `baz` references an `impl Trait` type in its return type
    = help: consider moving `baz` to another trait
-   = help: only type `u32` implements the trait, consider using it directly instead
+   = help: only type `u32` implements `Foo`; consider using it directly instead.
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/dyn-compatibility.rs:17:15
    |
 LL |     let s = i.baz();
-   |               ^^^ `Foo` cannot be made into an object
+   |               ^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-compatibility.rs:4:22
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn baz(&self) -> impl Debug;
    |                      ^^^^^^^^^^ ...because method `baz` references an `impl Trait` type in its return type
    = help: consider moving `baz` to another trait
-   = help: only type `u32` implements the trait, consider using it directly instead
+   = help: only type `u32` implements `Foo`; consider using it directly instead.
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/dyn-compatibility.rs:17:13
    |
 LL |     let s = i.baz();
-   |             ^^^^^^^ `Foo` cannot be made into an object
+   |             ^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-compatibility.rs:4:22
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn baz(&self) -> impl Debug;
    |                      ^^^^^^^^^^ ...because method `baz` references an `impl Trait` type in its return type
    = help: consider moving `baz` to another trait
-   = help: only type `u32` implements the trait, consider using it directly instead
+   = help: only type `u32` implements `Foo`; consider using it directly instead.
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/dyn-compatibility.rs:14:13
    |
 LL |     let i = Box::new(42_u32) as Box<dyn Foo>;
-   |             ^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |             ^^^^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-compatibility.rs:4:22
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn baz(&self) -> impl Debug;
    |                      ^^^^^^^^^^ ...because method `baz` references an `impl Trait` type in its return type
    = help: consider moving `baz` to another trait
-   = help: only type `u32` implements the trait, consider using it directly instead
+   = help: only type `u32` implements `Foo`; consider using it directly instead.
    = note: required for the cast from `Box<u32>` to `Box<dyn Foo>`
 
 error: aborting due to 4 previous errors

--- a/tests/ui/impl-trait/in-trait/foreign-dyn-error.rs
+++ b/tests/ui/impl-trait/in-trait/foreign-dyn-error.rs
@@ -4,5 +4,5 @@ extern crate rpitit;
 
 fn main() {
     let _: &dyn rpitit::Foo = todo!();
-    //~^ ERROR the trait `Foo` cannot be made into an object
+    //~^ ERROR the trait `Foo` is not dyn compatible
 }

--- a/tests/ui/impl-trait/in-trait/foreign-dyn-error.stderr
+++ b/tests/ui/impl-trait/in-trait/foreign-dyn-error.stderr
@@ -1,15 +1,16 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/foreign-dyn-error.rs:6:12
    |
 LL |     let _: &dyn rpitit::Foo = todo!();
-   |            ^^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |            ^^^^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/auxiliary/rpitit.rs:4:21
    |
 LL |     fn bar(self) -> impl Deref<Target = impl Sized>;
-   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait cannot be made into an object because method `bar` references an `impl Trait` type in its return type
-   = help: only type `rpitit::Foreign` implements the trait, consider using it directly instead
+   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait is not dyn compatible because method `bar` references an `impl Trait` type in its return type
+   = help: only type `rpitit::Foreign` implements `Foo`; consider using it directly instead.
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-18959.stderr
+++ b/tests/ui/issues/issue-18959.stderr
@@ -1,77 +1,82 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/issue-18959.rs:11:12
    |
 LL | fn foo(b: &dyn Bar) {
-   |            ^^^^^^^ `Bar` cannot be made into an object
+   |            ^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-18959.rs:1:20
    |
 LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
    |                    ^^^ ...because method `foo` has generic type parameters
 LL | pub trait Bar: Foo { }
-   |           --- this trait cannot be made into an object...
+   |           --- this trait is not dyn compatible...
    = help: consider moving `foo` to another trait
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/issue-18959.rs:13:5
    |
 LL |     b.foo(&0)
-   |     ^^^^^^^^^ `Bar` cannot be made into an object
+   |     ^^^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-18959.rs:1:20
    |
 LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
    |                    ^^^ ...because method `foo` has generic type parameters
 LL | pub trait Bar: Foo { }
-   |           --- this trait cannot be made into an object...
+   |           --- this trait is not dyn compatible...
    = help: consider moving `foo` to another trait
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/issue-18959.rs:19:15
    |
 LL |     let test: &dyn Bar = &mut thing;
-   |               ^^^^^^^^ `Bar` cannot be made into an object
+   |               ^^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-18959.rs:1:20
    |
 LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
    |                    ^^^ ...because method `foo` has generic type parameters
 LL | pub trait Bar: Foo { }
-   |           --- this trait cannot be made into an object...
+   |           --- this trait is not dyn compatible...
    = help: consider moving `foo` to another trait
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/issue-18959.rs:19:26
    |
 LL |     let test: &dyn Bar = &mut thing;
-   |                          ^^^^^^^^^^ `Bar` cannot be made into an object
+   |                          ^^^^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-18959.rs:1:20
    |
 LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
    |                    ^^^ ...because method `foo` has generic type parameters
 LL | pub trait Bar: Foo { }
-   |           --- this trait cannot be made into an object...
+   |           --- this trait is not dyn compatible...
    = help: consider moving `foo` to another trait
    = note: required for the cast from `&mut Thing` to `&dyn Bar`
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/issue-18959.rs:22:9
    |
 LL |     foo(test);
-   |         ^^^^ `Bar` cannot be made into an object
+   |         ^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-18959.rs:1:20
    |
 LL | pub trait Foo { fn foo<T>(&self, ext_thing: &T); }
    |                    ^^^ ...because method `foo` has generic type parameters
 LL | pub trait Bar: Foo { }
-   |           --- this trait cannot be made into an object...
+   |           --- this trait is not dyn compatible...
    = help: consider moving `foo` to another trait
 
 error: aborting due to 5 previous errors

--- a/tests/ui/issues/issue-19380.stderr
+++ b/tests/ui/issues/issue-19380.stderr
@@ -1,17 +1,18 @@
-error[E0038]: the trait `Qiz` cannot be made into an object
+error[E0038]: the trait `Qiz` is not dyn compatible
   --> $DIR/issue-19380.rs:11:29
    |
 LL |   foos: &'static [&'static (dyn Qiz + 'static)]
-   |                             ^^^^^^^^^^^^^^^^^ `Qiz` cannot be made into an object
+   |                             ^^^^^^^^^^^^^^^^^ `Qiz` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-19380.rs:2:6
    |
 LL | trait Qiz {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |   fn qiz();
    |      ^^^ ...because associated function `qiz` has no `self` parameter
-   = help: only type `Foo` implements the trait, consider using it directly instead
+   = help: only type `Foo` implements `Qiz`; consider using it directly instead.
 help: consider turning `qiz` into a method by giving it a `&self` argument
    |
 LL |   fn qiz(&self);
@@ -21,20 +22,21 @@ help: alternatively, consider constraining `qiz` so it does not apply to trait o
 LL |   fn qiz() where Self: Sized;
    |            +++++++++++++++++
 
-error[E0038]: the trait `Qiz` cannot be made into an object
+error[E0038]: the trait `Qiz` is not dyn compatible
   --> $DIR/issue-19380.rs:16:33
    |
 LL | const BAR : Bar = Bar { foos: &[&FOO]};
-   |                                 ^^^^ `Qiz` cannot be made into an object
+   |                                 ^^^^ `Qiz` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-19380.rs:2:6
    |
 LL | trait Qiz {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |   fn qiz();
    |      ^^^ ...because associated function `qiz` has no `self` parameter
-   = help: only type `Foo` implements the trait, consider using it directly instead
+   = help: only type `Foo` implements `Qiz`; consider using it directly instead.
    = note: required for the cast from `&Foo` to `&'static (dyn Qiz + 'static)`
 help: consider turning `qiz` into a method by giving it a `&self` argument
    |
@@ -45,20 +47,21 @@ help: alternatively, consider constraining `qiz` so it does not apply to trait o
 LL |   fn qiz() where Self: Sized;
    |            +++++++++++++++++
 
-error[E0038]: the trait `Qiz` cannot be made into an object
+error[E0038]: the trait `Qiz` is not dyn compatible
   --> $DIR/issue-19380.rs:16:31
    |
 LL | const BAR : Bar = Bar { foos: &[&FOO]};
-   |                               ^^^^^^^ `Qiz` cannot be made into an object
+   |                               ^^^^^^^ `Qiz` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-19380.rs:2:6
    |
 LL | trait Qiz {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |   fn qiz();
    |      ^^^ ...because associated function `qiz` has no `self` parameter
-   = help: only type `Foo` implements the trait, consider using it directly instead
+   = help: only type `Foo` implements `Qiz`; consider using it directly instead.
 help: consider turning `qiz` into a method by giving it a `&self` argument
    |
 LL |   fn qiz(&self);

--- a/tests/ui/issues/issue-26056.stderr
+++ b/tests/ui/issues/issue-26056.stderr
@@ -1,16 +1,17 @@
-error[E0038]: the trait `Map` cannot be made into an object
+error[E0038]: the trait `Map` is not dyn compatible
   --> $DIR/issue-26056.rs:20:17
    |
 LL |         as &dyn Map<Key=u32,MapValue=u32>;
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ `Map` cannot be made into an object
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^ `Map` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-26056.rs:9:12
    |
 LL | trait Map: MapLookup<<Self as Map>::Key> {
    |       ---  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...because it uses `Self` as a type parameter
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/issues/issue-50781.rs
+++ b/tests/ui/issues/issue-50781.rs
@@ -9,11 +9,11 @@ impl X for () {
 }
 
 impl Trait for dyn X {}
-//~^ ERROR the trait `X` cannot be made into an object
+//~^ ERROR the trait `X` is not dyn compatible
 
 pub fn main() {
     // Check that this does not segfault.
     <dyn X as X>::foo(&());
-    //~^ ERROR the trait `X` cannot be made into an object
-    //~| ERROR the trait `X` cannot be made into an object
+    //~^ ERROR the trait `X` is not dyn compatible
+    //~| ERROR the trait `X` is not dyn compatible
 }

--- a/tests/ui/issues/issue-50781.stderr
+++ b/tests/ui/issues/issue-50781.stderr
@@ -1,51 +1,54 @@
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/issue-50781.rs:11:16
    |
 LL | impl Trait for dyn X {}
-   |                ^^^^^ `X` cannot be made into an object
+   |                ^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-50781.rs:4:8
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     fn foo(&self) where Self: Trait;
    |        ^^^ ...because method `foo` references the `Self` type in its `where` clause
    = help: consider moving `foo` to another trait
-   = help: only type `()` implements the trait, consider using it directly instead
+   = help: only type `()` implements `X`; consider using it directly instead.
 
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/issue-50781.rs:16:23
    |
 LL |     <dyn X as X>::foo(&());
-   |                       ^^^ `X` cannot be made into an object
+   |                       ^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-50781.rs:4:8
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     fn foo(&self) where Self: Trait;
    |        ^^^ ...because method `foo` references the `Self` type in its `where` clause
    = help: consider moving `foo` to another trait
-   = help: only type `()` implements the trait, consider using it directly instead
+   = help: only type `()` implements `X`; consider using it directly instead.
    = note: required for the cast from `&()` to `&dyn X`
 
-error[E0038]: the trait `X` cannot be made into an object
+error[E0038]: the trait `X` is not dyn compatible
   --> $DIR/issue-50781.rs:16:6
    |
 LL |     <dyn X as X>::foo(&());
-   |      ^^^^^ `X` cannot be made into an object
+   |      ^^^^^ `X` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-50781.rs:4:8
    |
 LL | trait X {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     fn foo(&self) where Self: Trait;
    |        ^^^ ...because method `foo` references the `Self` type in its `where` clause
    = help: consider moving `foo` to another trait
-   = help: only type `()` implements the trait, consider using it directly instead
+   = help: only type `()` implements `X`; consider using it directly instead.
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/kindck/kindck-inherited-copy-bound.curr.stderr
+++ b/tests/ui/kindck/kindck-inherited-copy-bound.curr.stderr
@@ -19,33 +19,35 @@ note: required by a bound in `take_param`
 LL | fn take_param<T:Foo>(foo: &T) { }
    |                 ^^^ required by this bound in `take_param`
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/kindck-inherited-copy-bound.rs:28:19
    |
 LL |     let z = &x as &dyn Foo;
-   |                   ^^^^^^^^ `Foo` cannot be made into an object
+   |                   ^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/kindck-inherited-copy-bound.rs:10:13
    |
 LL | trait Foo : Copy {
    |       ---   ^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/kindck-inherited-copy-bound.rs:28:13
    |
 LL |     let z = &x as &dyn Foo;
-   |             ^^ `Foo` cannot be made into an object
+   |             ^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/kindck-inherited-copy-bound.rs:10:13
    |
 LL | trait Foo : Copy {
    |       ---   ^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
    = note: required for the cast from `&Box<{integer}>` to `&dyn Foo`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/kindck/kindck-inherited-copy-bound.dyn_compatible_for_dispatch.stderr
+++ b/tests/ui/kindck/kindck-inherited-copy-bound.dyn_compatible_for_dispatch.stderr
@@ -19,19 +19,20 @@ note: required by a bound in `take_param`
 LL | fn take_param<T:Foo>(foo: &T) { }
    |                 ^^^ required by this bound in `take_param`
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/kindck-inherited-copy-bound.rs:28:13
    |
 LL |     let z = &x as &dyn Foo;
-   |             ^^ `Foo` cannot be made into an object
+   |             ^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/kindck-inherited-copy-bound.rs:10:13
    |
 LL | trait Foo : Copy {
    |       ---   ^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
    = note: required for the cast from `&Box<i32>` to `&dyn Foo`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/resolve/issue-3907-2.stderr
+++ b/tests/ui/resolve/issue-3907-2.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `issue_3907::Foo` cannot be made into an object
+error[E0038]: the trait `issue_3907::Foo` is not dyn compatible
   --> $DIR/issue-3907-2.rs:11:12
    |
 LL | fn bar(_x: Foo) {}
-   |            ^^^ `issue_3907::Foo` cannot be made into an object
+   |            ^^^ `issue_3907::Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/auxiliary/issue-3907.rs:2:8
    |
 LL |     fn bar();
-   |        ^^^ the trait cannot be made into an object because associated function `bar` has no `self` parameter
+   |        ^^^ the trait is not dyn compatible because associated function `bar` has no `self` parameter
 
 error[E0277]: the size for values of type `(dyn issue_3907::Foo + 'static)` cannot be known at compilation time
   --> $DIR/issue-3907-2.rs:11:12

--- a/tests/ui/self/arbitrary-self-types-dyn-incompatible.curr.stderr
+++ b/tests/ui/self/arbitrary-self-types-dyn-incompatible.curr.stderr
@@ -1,38 +1,40 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/arbitrary-self-types-dyn-incompatible.rs:33:32
    |
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |                  --------- help: consider changing method `foo`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
-   |                                ^^^^^^^^^^^ `Foo` cannot be made into an object
+   |                                ^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/arbitrary-self-types-dyn-incompatible.rs:8:18
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |                  ^^^^^^^^^ ...because method `foo`'s `self` parameter cannot be dispatched on
-   = help: only type `usize` implements the trait, consider using it directly instead
+   = help: only type `usize` implements `Foo`; consider using it directly instead.
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/arbitrary-self-types-dyn-incompatible.rs:33:13
    |
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |                  --------- help: consider changing method `foo`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
-   |             ^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |             ^^^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/arbitrary-self-types-dyn-incompatible.rs:8:18
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |                  ^^^^^^^^^ ...because method `foo`'s `self` parameter cannot be dispatched on
-   = help: only type `usize` implements the trait, consider using it directly instead
+   = help: only type `usize` implements `Foo`; consider using it directly instead.
    = note: required for the cast from `Rc<usize>` to `Rc<dyn Foo>`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/self/arbitrary-self-types-dyn-incompatible.dyn_compatible_for_dispatch.stderr
+++ b/tests/ui/self/arbitrary-self-types-dyn-incompatible.dyn_compatible_for_dispatch.stderr
@@ -1,20 +1,21 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/arbitrary-self-types-dyn-incompatible.rs:33:13
    |
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |                  --------- help: consider changing method `foo`'s `self` parameter to be `&self`: `&Self`
 ...
 LL |     let x = Rc::new(5usize) as Rc<dyn Foo>;
-   |             ^^^^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |             ^^^^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/arbitrary-self-types-dyn-incompatible.rs:8:18
    |
 LL | trait Foo {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn foo(self: &Rc<Self>) -> usize;
    |                  ^^^^^^^^^ ...because method `foo`'s `self` parameter cannot be dispatched on
-   = help: only type `usize` implements the trait, consider using it directly instead
+   = help: only type `usize` implements `Foo`; consider using it directly instead.
    = note: required for the cast from `Rc<usize>` to `Rc<dyn Foo>`
 
 error: aborting due to 1 previous error

--- a/tests/ui/statics/unsizing-wfcheck-issue-127299.rs
+++ b/tests/ui/statics/unsizing-wfcheck-issue-127299.rs
@@ -6,12 +6,12 @@ trait Qux {
 
 pub struct Lint {
     pub desc: &'static dyn Qux,
-    //~^ ERROR cannot be made into an object
+    //~^ ERROR is not dyn compatible
 }
 
 static FOO: &Lint = &Lint { desc: "desc" };
 //~^ ERROR cannot be shared between threads safely
-//~| ERROR cannot be made into an object
-//~| ERROR cannot be made into an object
+//~| ERROR is not dyn compatible
+//~| ERROR is not dyn compatible
 
 fn main() {}

--- a/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
+++ b/tests/ui/statics/unsizing-wfcheck-issue-127299.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `Qux` cannot be made into an object
+error[E0038]: the trait `Qux` is not dyn compatible
   --> $DIR/unsizing-wfcheck-issue-127299.rs:8:24
    |
 LL |     pub desc: &'static dyn Qux,
-   |                        ^^^^^^^ `Qux` cannot be made into an object
+   |                        ^^^^^^^ `Qux` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/unsizing-wfcheck-issue-127299.rs:4:8
    |
 LL | trait Qux {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar() -> i32;
    |        ^^^ ...because associated function `bar` has no `self` parameter
 help: consider turning `bar` into a method by giving it a `&self` argument
@@ -36,17 +37,18 @@ LL | pub struct Lint {
    = note: required because it appears within the type `&'static Lint`
    = note: shared static variables must have a type that implements `Sync`
 
-error[E0038]: the trait `Qux` cannot be made into an object
+error[E0038]: the trait `Qux` is not dyn compatible
   --> $DIR/unsizing-wfcheck-issue-127299.rs:12:35
    |
 LL | static FOO: &Lint = &Lint { desc: "desc" };
-   |                                   ^^^^^^ `Qux` cannot be made into an object
+   |                                   ^^^^^^ `Qux` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/unsizing-wfcheck-issue-127299.rs:4:8
    |
 LL | trait Qux {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar() -> i32;
    |        ^^^ ...because associated function `bar` has no `self` parameter
    = note: required for the cast from `&'static str` to `&'static (dyn Qux + 'static)`
@@ -59,17 +61,18 @@ help: alternatively, consider constraining `bar` so it does not apply to trait o
 LL |     fn bar() -> i32 where Self: Sized;
    |                     +++++++++++++++++
 
-error[E0038]: the trait `Qux` cannot be made into an object
+error[E0038]: the trait `Qux` is not dyn compatible
   --> $DIR/unsizing-wfcheck-issue-127299.rs:12:35
    |
 LL | static FOO: &Lint = &Lint { desc: "desc" };
-   |                                   ^^^^^^ `Qux` cannot be made into an object
+   |                                   ^^^^^^ `Qux` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/unsizing-wfcheck-issue-127299.rs:4:8
    |
 LL | trait Qux {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn bar() -> i32;
    |        ^^^ ...because associated function `bar` has no `self` parameter
 help: consider turning `bar` into a method by giving it a `&self` argument

--- a/tests/ui/suggestions/dyn-incompatible-trait-references-self.rs
+++ b/tests/ui/suggestions/dyn-incompatible-trait-references-self.rs
@@ -6,10 +6,10 @@ trait Trait {
     //~| ERROR the size for values of type `Self` cannot be known
 }
 
-fn bar(x: &dyn Trait) {} //~ ERROR the trait `Trait` cannot be made into an object
+fn bar(x: &dyn Trait) {} //~ ERROR the trait `Trait` is not dyn compatible
 
 trait Other: Sized {}
 
-fn foo(x: &dyn Other) {} //~ ERROR the trait `Other` cannot be made into an object
+fn foo(x: &dyn Other) {} //~ ERROR the trait `Other` is not dyn compatible
 
 fn main() {}

--- a/tests/ui/suggestions/dyn-incompatible-trait-references-self.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-references-self.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-references-self.rs:9:12
    |
 LL | fn bar(x: &dyn Trait) {}
-   |            ^^^^^^^^^ `Trait` cannot be made into an object
+   |            ^^^^^^^^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-incompatible-trait-references-self.rs:2:22
    |
 LL | trait Trait {
-   |       ----- this trait cannot be made into an object...
+   |       ----- this trait is not dyn compatible...
 LL |     fn baz(&self, _: Self) {}
    |                      ^^^^ ...because method `baz` references the `Self` type in this parameter
 LL |
@@ -17,19 +18,20 @@ LL |     fn bat(&self) -> Self {}
    = help: consider moving `baz` to another trait
    = help: consider moving `bat` to another trait
 
-error[E0038]: the trait `Other` cannot be made into an object
+error[E0038]: the trait `Other` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-references-self.rs:13:12
    |
 LL | fn foo(x: &dyn Other) {}
-   |            ^^^^^^^^^ `Other` cannot be made into an object
+   |            ^^^^^^^^^ `Other` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-incompatible-trait-references-self.rs:11:14
    |
 LL | trait Other: Sized {}
    |       -----  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 
 error[E0277]: the size for values of type `Self` cannot be known at compilation time
   --> $DIR/dyn-incompatible-trait-references-self.rs:2:22

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-self-2021.rs
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-self-2021.rs
@@ -3,12 +3,12 @@
 trait A: Sized {
     fn f(a: dyn A) -> dyn A;
     //~^ ERROR associated item referring to unboxed trait object for its own trait
-    //~| ERROR the trait `A` cannot be made into an object
+    //~| ERROR the trait `A` is not dyn compatible
 }
 trait B {
     fn f(a: dyn B) -> dyn B;
     //~^ ERROR associated item referring to unboxed trait object for its own trait
-    //~| ERROR the trait `B` cannot be made into an object
+    //~| ERROR the trait `B` is not dyn compatible
 }
 trait C {
     fn f(&self, a: dyn C) -> dyn C;

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-self-2021.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-self-2021.stderr
@@ -11,19 +11,20 @@ help: you might have meant to use `Self` to refer to the implementing type
 LL |     fn f(a: Self) -> Self;
    |             ~~~~     ~~~~
 
-error[E0038]: the trait `A` cannot be made into an object
+error[E0038]: the trait `A` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-should-use-self-2021.rs:4:13
    |
 LL |     fn f(a: dyn A) -> dyn A;
-   |             ^^^^^ `A` cannot be made into an object
+   |             ^^^^^ `A` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-incompatible-trait-should-use-self-2021.rs:3:10
    |
 LL | trait A: Sized {
    |       -  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 
 error: associated item referring to unboxed trait object for its own trait
   --> $DIR/dyn-incompatible-trait-should-use-self-2021.rs:9:13
@@ -38,17 +39,18 @@ help: you might have meant to use `Self` to refer to the implementing type
 LL |     fn f(a: Self) -> Self;
    |             ~~~~     ~~~~
 
-error[E0038]: the trait `B` cannot be made into an object
+error[E0038]: the trait `B` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-should-use-self-2021.rs:9:13
    |
 LL |     fn f(a: dyn B) -> dyn B;
-   |             ^^^^^ `B` cannot be made into an object
+   |             ^^^^^ `B` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-incompatible-trait-should-use-self-2021.rs:9:8
    |
 LL | trait B {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     fn f(a: dyn B) -> dyn B;
    |        ^ ...because associated function `f` has no `self` parameter
 help: consider turning `f` into a method by giving it a `&self` argument

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-self.rs
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-self.rs
@@ -2,12 +2,12 @@
 trait A: Sized {
     fn f(a: A) -> A;
     //~^ ERROR associated item referring to unboxed trait object for its own trait
-    //~| ERROR the trait `A` cannot be made into an object
+    //~| ERROR the trait `A` is not dyn compatible
 }
 trait B {
     fn f(a: B) -> B;
     //~^ ERROR associated item referring to unboxed trait object for its own trait
-    //~| ERROR the trait `B` cannot be made into an object
+    //~| ERROR the trait `B` is not dyn compatible
 }
 trait C {
     fn f(&self, a: C) -> C;

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-self.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-self.stderr
@@ -11,19 +11,20 @@ help: you might have meant to use `Self` to refer to the implementing type
 LL |     fn f(a: Self) -> Self;
    |             ~~~~     ~~~~
 
-error[E0038]: the trait `A` cannot be made into an object
+error[E0038]: the trait `A` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-should-use-self.rs:3:13
    |
 LL |     fn f(a: A) -> A;
-   |             ^ `A` cannot be made into an object
+   |             ^ `A` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-incompatible-trait-should-use-self.rs:2:10
    |
 LL | trait A: Sized {
    |       -  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 
 error: associated item referring to unboxed trait object for its own trait
   --> $DIR/dyn-incompatible-trait-should-use-self.rs:8:13
@@ -38,17 +39,18 @@ help: you might have meant to use `Self` to refer to the implementing type
 LL |     fn f(a: Self) -> Self;
    |             ~~~~     ~~~~
 
-error[E0038]: the trait `B` cannot be made into an object
+error[E0038]: the trait `B` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-should-use-self.rs:8:13
    |
 LL |     fn f(a: B) -> B;
-   |             ^ `B` cannot be made into an object
+   |             ^ `B` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-incompatible-trait-should-use-self.rs:8:8
    |
 LL | trait B {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     fn f(a: B) -> B;
    |        ^ ...because associated function `f` has no `self` parameter
 help: consider turning `f` into a method by giving it a `&self` argument

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.fixed
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.fixed
@@ -6,7 +6,7 @@ trait Trait {
     fn bar(self: &Self) {} //~ ERROR invalid `self` parameter type
 }
 
-fn bar(x: &dyn Trait) {} //~ ERROR the trait `Trait` cannot be made into an object
+fn bar(x: &dyn Trait) {} //~ ERROR the trait `Trait` is not dyn compatible
 
 trait Other {}
 

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.rs
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.rs
@@ -6,7 +6,7 @@ trait Trait {
     fn bar(self: ()) {} //~ ERROR invalid `self` parameter type
 }
 
-fn bar(x: &dyn Trait) {} //~ ERROR the trait `Trait` cannot be made into an object
+fn bar(x: &dyn Trait) {} //~ ERROR the trait `Trait` is not dyn compatible
 
 trait Other {}
 

--- a/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.stderr
+++ b/tests/ui/suggestions/dyn-incompatible-trait-should-use-where-sized.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/dyn-incompatible-trait-should-use-where-sized.rs:9:12
    |
 LL | fn bar(x: &dyn Trait) {}
-   |            ^^^^^^^^^ `Trait` cannot be made into an object
+   |            ^^^^^^^^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/dyn-incompatible-trait-should-use-where-sized.rs:5:8
    |
 LL | trait Trait {
-   |       ----- this trait cannot be made into an object...
+   |       ----- this trait is not dyn compatible...
 LL |     fn foo() where Self: Other, { }
    |        ^^^ ...because associated function `foo` has no `self` parameter
 LL |     fn bar(self: ()) {}

--- a/tests/ui/suggestions/issue-116434-2015.rs
+++ b/tests/ui/suggestions/issue-116434-2015.rs
@@ -7,7 +7,7 @@ trait Foo {
     //~| WARNING trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
     //~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     //~| HELP if this is a dyn-compatible trait, use `dyn`
-    //~| ERROR the trait `Clone` cannot be made into an object [E0038]
+    //~| ERROR the trait `Clone` is not dyn compatible [E0038]
     //~| HELP there is an associated type with the same name
 }
 
@@ -22,7 +22,7 @@ trait DbInterface {
     //~| WARNING trait objects without an explicit `dyn` are deprecated [bare_trait_objects]
     //~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
     //~| HELP if this is a dyn-compatible trait, use `dyn`
-    //~| ERROR the trait `DbHandle` cannot be made into an object [E0038]
+    //~| ERROR the trait `DbHandle` is not dyn compatible [E0038]
     //~| HELP there is an associated type with the same name
 }
 

--- a/tests/ui/suggestions/issue-116434-2015.stderr
+++ b/tests/ui/suggestions/issue-116434-2015.stderr
@@ -39,14 +39,15 @@ help: if this is a dyn-compatible trait, use `dyn`
 LL |     fn foo() -> dyn Clone;
    |                 +++
 
-error[E0038]: the trait `Clone` cannot be made into an object
+error[E0038]: the trait `Clone` is not dyn compatible
   --> $DIR/issue-116434-2015.rs:3:17
    |
 LL |     fn foo() -> Clone;
-   |                 ^^^^^ `Clone` cannot be made into an object
+   |                 ^^^^^ `Clone` is not dyn compatible
    |
-   = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: the trait is not dyn compatible because it requires `Self: Sized`
+   = note: for a trait to be dyn compatible it needs to allow building a vtable
+           for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 help: there is an associated type with the same name
    |
 LL |     fn foo() -> Self::Clone;
@@ -66,19 +67,20 @@ help: if this is a dyn-compatible trait, use `dyn`
 LL |     fn handle() -> dyn DbHandle;
    |                    +++
 
-error[E0038]: the trait `DbHandle` cannot be made into an object
+error[E0038]: the trait `DbHandle` is not dyn compatible
   --> $DIR/issue-116434-2015.rs:18:20
    |
 LL |     fn handle() -> DbHandle;
-   |                    ^^^^^^^^ `DbHandle` cannot be made into an object
+   |                    ^^^^^^^^ `DbHandle` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-116434-2015.rs:14:17
    |
 LL | trait DbHandle: Sized {}
    |       --------  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 help: there is an associated type with the same name
    |
 LL |     fn handle() -> Self::DbHandle;

--- a/tests/ui/suggestions/issue-98500.rs
+++ b/tests/ui/suggestions/issue-98500.rs
@@ -9,6 +9,6 @@ pub trait B where
 }
 
 struct S(Box<dyn B>);
-//~^ ERROR the trait `B` cannot be made into an object
+//~^ ERROR the trait `B` is not dyn compatible
 
 fn main() {}

--- a/tests/ui/suggestions/issue-98500.stderr
+++ b/tests/ui/suggestions/issue-98500.stderr
@@ -1,10 +1,11 @@
-error[E0038]: the trait `B` cannot be made into an object
+error[E0038]: the trait `B` is not dyn compatible
   --> $DIR/issue-98500.rs:11:14
    |
 LL | struct S(Box<dyn B>);
-   |              ^^^^^ `B` cannot be made into an object
+   |              ^^^^^ `B` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/auxiliary/dyn-incompatible.rs:4:8
    |
 LL |     fn f();
@@ -15,7 +16,7 @@ LL |     fn f2(self: &Arc<Self>);
   ::: $DIR/issue-98500.rs:5:11
    |
 LL | pub trait B where
-   |           - this trait cannot be made into an object...
+   |           - this trait is not dyn compatible...
    = help: consider moving `f` to another trait
    = help: consider moving `f2` to another trait
 

--- a/tests/ui/traits/alias/generic-default-in-dyn.rs
+++ b/tests/ui/traits/alias/generic-default-in-dyn.rs
@@ -2,9 +2,9 @@ trait SendEqAlias<T> = PartialEq;
 //~^ ERROR trait aliases are experimental
 
 struct Foo<T>(dyn SendEqAlias<T>);
-//~^ ERROR the trait alias `SendEqAlias` cannot be made into an object
+//~^ ERROR the trait alias `SendEqAlias` is not dyn compatible
 
 struct Bar<T>(dyn SendEqAlias<T>, T);
-//~^ ERROR the trait alias `SendEqAlias` cannot be made into an object
+//~^ ERROR the trait alias `SendEqAlias` is not dyn compatible
 
 fn main() {}

--- a/tests/ui/traits/alias/generic-default-in-dyn.stderr
+++ b/tests/ui/traits/alias/generic-default-in-dyn.stderr
@@ -8,33 +8,35 @@ LL | trait SendEqAlias<T> = PartialEq;
    = help: add `#![feature(trait_alias)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error[E0038]: the trait alias `SendEqAlias` cannot be made into an object
+error[E0038]: the trait alias `SendEqAlias` is not dyn compatible
   --> $DIR/generic-default-in-dyn.rs:4:19
    |
 LL | struct Foo<T>(dyn SendEqAlias<T>);
-   |                   ^^^^^^^^^^^^^^ `SendEqAlias` cannot be made into an object
+   |                   ^^^^^^^^^^^^^^ `SendEqAlias` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/generic-default-in-dyn.rs:1:24
    |
 LL | trait SendEqAlias<T> = PartialEq;
    |       -----------      ^^^^^^^^^ ...because it uses `Self` as a type parameter
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 
-error[E0038]: the trait alias `SendEqAlias` cannot be made into an object
+error[E0038]: the trait alias `SendEqAlias` is not dyn compatible
   --> $DIR/generic-default-in-dyn.rs:7:19
    |
 LL | struct Bar<T>(dyn SendEqAlias<T>, T);
-   |                   ^^^^^^^^^^^^^^ `SendEqAlias` cannot be made into an object
+   |                   ^^^^^^^^^^^^^^ `SendEqAlias` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/generic-default-in-dyn.rs:1:24
    |
 LL | trait SendEqAlias<T> = PartialEq;
    |       -----------      ^^^^^^^^^ ...because it uses `Self` as a type parameter
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/traits/alias/object-fail.rs
+++ b/tests/ui/traits/alias/object-fail.rs
@@ -5,7 +5,7 @@ trait IteratorAlias = Iterator;
 
 fn main() {
     let _: &dyn EqAlias = &123;
-    //~^ ERROR the trait alias `EqAlias` cannot be made into an object [E0038]
+    //~^ ERROR the trait alias `EqAlias` is not dyn compatible [E0038]
     let _: &dyn IteratorAlias = &vec![123].into_iter();
     //~^ ERROR must be specified
 }

--- a/tests/ui/traits/alias/object-fail.stderr
+++ b/tests/ui/traits/alias/object-fail.stderr
@@ -1,10 +1,11 @@
-error[E0038]: the trait alias `EqAlias` cannot be made into an object
+error[E0038]: the trait alias `EqAlias` is not dyn compatible
   --> $DIR/object-fail.rs:7:17
    |
 LL |     let _: &dyn EqAlias = &123;
-   |                 ^^^^^^^ `EqAlias` cannot be made into an object
+   |                 ^^^^^^^ `EqAlias` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    |
    = note: ...because it uses `Self` as a type parameter
@@ -12,7 +13,7 @@ note: for a trait to be "dyn-compatible" it needs to allow building a vtable to 
   ::: $DIR/object-fail.rs:3:7
    |
 LL | trait EqAlias = Eq;
-   |       ------- this trait cannot be made into an object...
+   |       ------- this trait is not dyn compatible...
 
 error[E0191]: the value of the associated type `Item` in `Iterator` must be specified
   --> $DIR/object-fail.rs:9:17

--- a/tests/ui/traits/alias/self-in-const-generics.rs
+++ b/tests/ui/traits/alias/self-in-const-generics.rs
@@ -7,6 +7,6 @@ trait Bar<const N: usize> {}
 trait BB = Bar<{ 2 + 1 }>;
 
 fn foo(x: &dyn BB) {}
-//~^ ERROR the trait alias `BB` cannot be made into an object [E0038]
+//~^ ERROR the trait alias `BB` is not dyn compatible [E0038]
 
 fn main() {}

--- a/tests/ui/traits/alias/self-in-const-generics.stderr
+++ b/tests/ui/traits/alias/self-in-const-generics.stderr
@@ -1,16 +1,17 @@
-error[E0038]: the trait alias `BB` cannot be made into an object
+error[E0038]: the trait alias `BB` is not dyn compatible
   --> $DIR/self-in-const-generics.rs:9:16
    |
 LL | fn foo(x: &dyn BB) {}
-   |                ^^ `BB` cannot be made into an object
+   |                ^^ `BB` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/self-in-const-generics.rs:7:12
    |
 LL | trait BB = Bar<{ 2 + 1 }>;
    |       --   ^^^^^^^^^^^^^^ ...because it uses `Self` as a type parameter
    |       |
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 help: consider using an opaque type instead
    |
 LL | fn foo(x: &impl BB) {}

--- a/tests/ui/traits/alias/self-in-generics.rs
+++ b/tests/ui/traits/alias/self-in-generics.rs
@@ -6,6 +6,6 @@
 pub trait SelfInput = Fn(&mut Self);
 
 pub fn f(_f: &dyn SelfInput) {}
-//~^ ERROR the trait alias `SelfInput` cannot be made into an object [E0038]
+//~^ ERROR the trait alias `SelfInput` is not dyn compatible [E0038]
 
 fn main() {}

--- a/tests/ui/traits/alias/self-in-generics.stderr
+++ b/tests/ui/traits/alias/self-in-generics.stderr
@@ -1,10 +1,11 @@
-error[E0038]: the trait alias `SelfInput` cannot be made into an object
+error[E0038]: the trait alias `SelfInput` is not dyn compatible
   --> $DIR/self-in-generics.rs:8:19
    |
 LL | pub fn f(_f: &dyn SelfInput) {}
-   |                   ^^^^^^^^^ `SelfInput` cannot be made into an object
+   |                   ^^^^^^^^^ `SelfInput` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/self-in-generics.rs:6:23
    |
 LL | pub trait SelfInput = Fn(&mut Self);
@@ -12,7 +13,7 @@ LL | pub trait SelfInput = Fn(&mut Self);
    |           |           |
    |           |           ...because it uses `Self` as a type parameter
    |           |           ...because it uses `Self` as a type parameter
-   |           this trait cannot be made into an object...
+   |           this trait is not dyn compatible...
 help: consider using an opaque type instead
    |
 LL | pub fn f(_f: &impl SelfInput) {}

--- a/tests/ui/traits/issue-20692.rs
+++ b/tests/ui/traits/issue-20692.rs
@@ -2,10 +2,10 @@ trait Array: Sized + Copy {}
 
 fn f<T: Array>(x: &T) {
     let _ = x
-    //~^ ERROR `Array` cannot be made into an object
+    //~^ ERROR `Array` is not dyn compatible
     as
     &dyn Array;
-    //~^ ERROR `Array` cannot be made into an object
+    //~^ ERROR `Array` is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/traits/issue-20692.stderr
+++ b/tests/ui/traits/issue-20692.stderr
@@ -1,32 +1,34 @@
-error[E0038]: the trait `Array` cannot be made into an object
+error[E0038]: the trait `Array` is not dyn compatible
   --> $DIR/issue-20692.rs:7:5
    |
 LL |     &dyn Array;
-   |     ^^^^^^^^^^ `Array` cannot be made into an object
+   |     ^^^^^^^^^^ `Array` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-20692.rs:1:14
    |
 LL | trait Array: Sized + Copy {}
    |       -----  ^^^^^   ^^^^ ...because it requires `Self: Sized`
    |       |      |
    |       |      ...because it requires `Self: Sized`
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
 
-error[E0038]: the trait `Array` cannot be made into an object
+error[E0038]: the trait `Array` is not dyn compatible
   --> $DIR/issue-20692.rs:4:13
    |
 LL |     let _ = x
-   |             ^ `Array` cannot be made into an object
+   |             ^ `Array` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-20692.rs:1:14
    |
 LL | trait Array: Sized + Copy {}
    |       -----  ^^^^^   ^^^^ ...because it requires `Self: Sized`
    |       |      |
    |       |      ...because it requires `Self: Sized`
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
    = note: required for the cast from `&T` to `&dyn Array`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/traits/issue-28576.rs
+++ b/tests/ui/traits/issue-28576.rs
@@ -6,7 +6,7 @@ pub trait Bar: Foo<Assoc=()> {
     //~^ ERROR: the size for values of type `Self` cannot be known
     //~| ERROR: the size for values of type `Self` cannot be known
     fn new(&self, b: &
-           dyn Bar //~ ERROR the trait `Bar` cannot be made into an object
+           dyn Bar //~ ERROR the trait `Bar` is not dyn compatible
               <Assoc=()>
     );
 }

--- a/tests/ui/traits/issue-28576.stderr
+++ b/tests/ui/traits/issue-28576.stderr
@@ -18,15 +18,16 @@ help: consider relaxing the implicit `Sized` restriction
 LL | pub trait Foo<RHS: ?Sized=Self> {
    |                  ++++++++
 
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/issue-28576.rs:9:16
    |
 LL |              dyn Bar
    |  ________________^
 LL | |               <Assoc=()>
-   | |________________________^ `Bar` cannot be made into an object
+   | |________________________^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-28576.rs:5:16
    |
 LL | pub trait Bar: Foo<Assoc=()> {
@@ -34,7 +35,7 @@ LL | pub trait Bar: Foo<Assoc=()> {
    |           |    |   |
    |           |    |   ...because it uses `Self` as a type parameter
    |           |    ...because it uses `Self` as a type parameter
-   |           this trait cannot be made into an object...
+   |           this trait is not dyn compatible...
 help: consider using an opaque type instead
    |
 LL |            impl Bar

--- a/tests/ui/traits/issue-38404.rs
+++ b/tests/ui/traits/issue-38404.rs
@@ -1,8 +1,8 @@
 trait A<T>: std::ops::Add<Self> + Sized {}
 trait B<T>: A<T> {}
 trait C<T>: A<dyn B<T, Output = usize>> {}
-//~^ ERROR the trait `B` cannot be made into an object
-//~| ERROR the trait `B` cannot be made into an object
-//~| ERROR the trait `B` cannot be made into an object
+//~^ ERROR the trait `B` is not dyn compatible
+//~| ERROR the trait `B` is not dyn compatible
+//~| ERROR the trait `B` is not dyn compatible
 
 fn main() {}

--- a/tests/ui/traits/issue-38404.stderr
+++ b/tests/ui/traits/issue-38404.stderr
@@ -1,45 +1,48 @@
-error[E0038]: the trait `B` cannot be made into an object
+error[E0038]: the trait `B` is not dyn compatible
   --> $DIR/issue-38404.rs:3:19
    |
 LL | trait C<T>: A<dyn B<T, Output = usize>> {}
-   |                   ^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
+   |                   ^^^^^^^^^^^^^^^^^^^^ `B` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38404.rs:1:13
    |
 LL | trait A<T>: std::ops::Add<Self> + Sized {}
    |             ^^^^^^^^^^^^^^^^^^^ ...because it uses `Self` as a type parameter
 LL | trait B<T>: A<T> {}
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 
-error[E0038]: the trait `B` cannot be made into an object
+error[E0038]: the trait `B` is not dyn compatible
   --> $DIR/issue-38404.rs:3:19
    |
 LL | trait C<T>: A<dyn B<T, Output = usize>> {}
-   |                   ^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
+   |                   ^^^^^^^^^^^^^^^^^^^^ `B` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38404.rs:1:13
    |
 LL | trait A<T>: std::ops::Add<Self> + Sized {}
    |             ^^^^^^^^^^^^^^^^^^^ ...because it uses `Self` as a type parameter
 LL | trait B<T>: A<T> {}
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error[E0038]: the trait `B` cannot be made into an object
+error[E0038]: the trait `B` is not dyn compatible
   --> $DIR/issue-38404.rs:3:19
    |
 LL | trait C<T>: A<dyn B<T, Output = usize>> {}
-   |                   ^^^^^^^^^^^^^^^^^^^^ `B` cannot be made into an object
+   |                   ^^^^^^^^^^^^^^^^^^^^ `B` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38404.rs:1:13
    |
 LL | trait A<T>: std::ops::Add<Self> + Sized {}
    |             ^^^^^^^^^^^^^^^^^^^ ...because it uses `Self` as a type parameter
 LL | trait B<T>: A<T> {}
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/traits/issue-38604.rs
+++ b/tests/ui/traits/issue-38604.rs
@@ -11,6 +11,6 @@ impl Foo for () {
 }
 
 fn main() {
-    let _f: Box<dyn Foo> = //~ ERROR `Foo` cannot be made into an object
-        Box::new(()); //~ ERROR `Foo` cannot be made into an object
+    let _f: Box<dyn Foo> = //~ ERROR `Foo` is not dyn compatible
+        Box::new(()); //~ ERROR `Foo` is not dyn compatible
 }

--- a/tests/ui/traits/issue-38604.stderr
+++ b/tests/ui/traits/issue-38604.stderr
@@ -1,32 +1,34 @@
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/issue-38604.rs:14:13
    |
 LL |     let _f: Box<dyn Foo> =
-   |             ^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |             ^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38604.rs:2:22
    |
 LL | trait Foo where u32: Q<Self> {
    |       ---            ^^^^^^^ ...because it uses `Self` as a type parameter
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `()` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
+   = help: only type `()` implements `Foo`; consider using it directly instead.
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/issue-38604.rs:15:9
    |
 LL |         Box::new(());
-   |         ^^^^^^^^^^^^ `Foo` cannot be made into an object
+   |         ^^^^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-38604.rs:2:22
    |
 LL | trait Foo where u32: Q<Self> {
    |       ---            ^^^^^^^ ...because it uses `Self` as a type parameter
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `()` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
+   = help: only type `()` implements `Foo`; consider using it directly instead.
    = note: required for the cast from `Box<()>` to `Box<dyn Foo>`
 
 error: aborting due to 2 previous errors

--- a/tests/ui/traits/issue-72410.rs
+++ b/tests/ui/traits/issue-72410.rs
@@ -12,7 +12,7 @@ pub trait Foo {
 pub trait Bar {
     fn map()
     where for<'a> &'a mut [dyn Bar]: ;
-    //~^ ERROR: the trait `Bar` cannot be made into an object
+    //~^ ERROR: the trait `Bar` is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/traits/issue-72410.stderr
+++ b/tests/ui/traits/issue-72410.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `Bar` cannot be made into an object
+error[E0038]: the trait `Bar` is not dyn compatible
   --> $DIR/issue-72410.rs:14:19
    |
 LL |     where for<'a> &'a mut [dyn Bar]: ;
-   |                   ^^^^^^^^^^^^^^^^^ `Bar` cannot be made into an object
+   |                   ^^^^^^^^^^^^^^^^^ `Bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-72410.rs:13:8
    |
 LL | pub trait Bar {
-   |           --- this trait cannot be made into an object...
+   |           --- this trait is not dyn compatible...
 LL |     fn map()
    |        ^^^ ...because associated function `map` has no `self` parameter
 help: consider turning `map` into a method by giving it a `&self` argument

--- a/tests/ui/traits/item-privacy.rs
+++ b/tests/ui/traits/item-privacy.rs
@@ -99,8 +99,8 @@ fn check_assoc_const() {
     S::C; // OK
     // A, B, C are resolved as inherent items, their traits don't need to be in scope
     <dyn C>::A; //~ ERROR associated constant `A` is private
-                //~^ ERROR the trait `assoc_const::C` cannot be made into an object
-    <dyn C>::B; // ERROR the trait `assoc_const::C` cannot be made into an object
+                //~^ ERROR the trait `assoc_const::C` is not dyn compatible
+    <dyn C>::B; // ERROR the trait `assoc_const::C` is not dyn compatible
     C::C; // OK
 }
 

--- a/tests/ui/traits/item-privacy.stderr
+++ b/tests/ui/traits/item-privacy.stderr
@@ -136,13 +136,14 @@ LL |         const A: u8 = 0;
 LL |     <dyn C>::A;
    |              ^ private associated constant
 
-error[E0038]: the trait `assoc_const::C` cannot be made into an object
+error[E0038]: the trait `assoc_const::C` is not dyn compatible
   --> $DIR/item-privacy.rs:101:6
    |
 LL |     <dyn C>::A;
-   |      ^^^^^ `assoc_const::C` cannot be made into an object
+   |      ^^^^^ `assoc_const::C` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/item-privacy.rs:25:15
    |
 LL |         const A: u8 = 0;
@@ -152,13 +153,13 @@ LL |         const B: u8 = 0;
    |               ^ ...because it contains this associated `const`
 ...
 LL |     pub trait C: A + B {
-   |               - this trait cannot be made into an object...
+   |               - this trait is not dyn compatible...
 LL |         const C: u8 = 0;
    |               ^ ...because it contains this associated `const`
    = help: consider moving `C` to another trait
    = help: consider moving `A` to another trait
    = help: consider moving `B` to another trait
-   = help: only type `S` implements the trait, consider using it directly instead
+   = help: only type `S` implements `assoc_const::C`; consider using it directly instead.
 
 error[E0223]: ambiguous associated type
   --> $DIR/item-privacy.rs:115:12

--- a/tests/ui/traits/missing-for-type-in-impl.e2015.stderr
+++ b/tests/ui/traits/missing-for-type-in-impl.e2015.stderr
@@ -34,17 +34,18 @@ help: you might have intended to implement this trait for a given type
 LL | impl Foo<i64> for /* Type */ {
    |               ++++++++++++++
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/missing-for-type-in-impl.rs:8:6
    |
 LL | impl Foo<i64> {
-   |      ^^^^^^^^ `Foo` cannot be made into an object
+   |      ^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/missing-for-type-in-impl.rs:4:8
    |
 LL | trait Foo<T> {
-   |       --- this trait cannot be made into an object...
+   |       --- this trait is not dyn compatible...
 LL |     fn id(me: T) -> T;
    |        ^^ ...because associated function `id` has no `self` parameter
 help: consider turning `id` into a method by giving it a `&self` argument

--- a/tests/ui/traits/missing-for-type-in-impl.rs
+++ b/tests/ui/traits/missing-for-type-in-impl.rs
@@ -11,7 +11,7 @@ impl Foo<i64> {
 //[e2015]~| WARNING trait objects without an explicit `dyn` are deprecated
 //[e2015]~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
 //[e2015]~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2021!
-//[e2015]~| ERROR the trait `Foo` cannot be made into an object
+//[e2015]~| ERROR the trait `Foo` is not dyn compatible
     fn id(me: i64) -> i64 {me}
 }
 

--- a/tests/ui/traits/non_lifetime_binders/supertrait-dyn-compatibility.rs
+++ b/tests/ui/traits/non_lifetime_binders/supertrait-dyn-compatibility.rs
@@ -17,8 +17,8 @@ impl<T: ?Sized> Bar<T> for () {}
 
 fn main() {
     let x: &dyn Foo = &();
-    //~^ ERROR the trait `Foo` cannot be made into an object
-    //~| ERROR the trait `Foo` cannot be made into an object
+    //~^ ERROR the trait `Foo` is not dyn compatible
+    //~| ERROR the trait `Foo` is not dyn compatible
     needs_bar(x);
-    //~^ ERROR the trait `Foo` cannot be made into an object
+    //~^ ERROR the trait `Foo` is not dyn compatible
 }

--- a/tests/ui/traits/non_lifetime_binders/supertrait-dyn-compatibility.stderr
+++ b/tests/ui/traits/non_lifetime_binders/supertrait-dyn-compatibility.stderr
@@ -7,51 +7,54 @@ LL | #![feature(non_lifetime_binders)]
    = note: see issue #108185 <https://github.com/rust-lang/rust/issues/108185> for more information
    = note: `#[warn(incomplete_features)]` on by default
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/supertrait-dyn-compatibility.rs:19:23
    |
 LL |     let x: &dyn Foo = &();
-   |                       ^^^ `Foo` cannot be made into an object
+   |                       ^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/supertrait-dyn-compatibility.rs:4:12
    |
 LL | trait Foo: for<T> Bar<T> {}
    |       ---  ^^^^^^^^^^^^^ ...because where clause cannot reference non-lifetime `for<...>` variables
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `()` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
+   = help: only type `()` implements `Foo`; consider using it directly instead.
    = note: required for the cast from `&()` to `&dyn Foo`
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/supertrait-dyn-compatibility.rs:19:12
    |
 LL |     let x: &dyn Foo = &();
-   |            ^^^^^^^^ `Foo` cannot be made into an object
+   |            ^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/supertrait-dyn-compatibility.rs:4:12
    |
 LL | trait Foo: for<T> Bar<T> {}
    |       ---  ^^^^^^^^^^^^^ ...because where clause cannot reference non-lifetime `for<...>` variables
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `()` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
+   = help: only type `()` implements `Foo`; consider using it directly instead.
 
-error[E0038]: the trait `Foo` cannot be made into an object
+error[E0038]: the trait `Foo` is not dyn compatible
   --> $DIR/supertrait-dyn-compatibility.rs:22:5
    |
 LL |     needs_bar(x);
-   |     ^^^^^^^^^ `Foo` cannot be made into an object
+   |     ^^^^^^^^^ `Foo` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/supertrait-dyn-compatibility.rs:4:12
    |
 LL | trait Foo: for<T> Bar<T> {}
    |       ---  ^^^^^^^^^^^^^ ...because where clause cannot reference non-lifetime `for<...>` variables
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `()` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
+   = help: only type `()` implements `Foo`; consider using it directly instead.
 
 error: aborting due to 3 previous errors; 1 warning emitted
 

--- a/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.rs
+++ b/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.rs
@@ -8,8 +8,8 @@ trait Try {
 
 fn w<'a, T: 'a, F: Fn(&'a T)>() {
     let b: &dyn FromResidual = &();
-    //~^ ERROR: the trait `FromResidual` cannot be made into an object
-    //~| ERROR: the trait `FromResidual` cannot be made into an object
+    //~^ ERROR: the trait `FromResidual` is not dyn compatible
+    //~| ERROR: the trait `FromResidual` is not dyn compatible
 }
 
 fn main() {}

--- a/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.stderr
+++ b/tests/ui/traits/object/canonicalize-fresh-infer-vars-issue-103626.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `FromResidual` cannot be made into an object
+error[E0038]: the trait `FromResidual` is not dyn compatible
   --> $DIR/canonicalize-fresh-infer-vars-issue-103626.rs:10:32
    |
 LL |     let b: &dyn FromResidual = &();
-   |                                ^^^ `FromResidual` cannot be made into an object
+   |                                ^^^ `FromResidual` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/canonicalize-fresh-infer-vars-issue-103626.rs:2:8
    |
 LL | trait FromResidual<R = <Self as Try>::Residual> {
-   |       ------------ this trait cannot be made into an object...
+   |       ------------ this trait is not dyn compatible...
 LL |     fn from_residual(residual: R) -> Self;
    |        ^^^^^^^^^^^^^ ...because associated function `from_residual` has no `self` parameter
    = note: required for the cast from `&()` to `&dyn FromResidual<{type error}>`
@@ -21,17 +22,18 @@ help: alternatively, consider constraining `from_residual` so it does not apply 
 LL |     fn from_residual(residual: R) -> Self where Self: Sized;
    |                                           +++++++++++++++++
 
-error[E0038]: the trait `FromResidual` cannot be made into an object
+error[E0038]: the trait `FromResidual` is not dyn compatible
   --> $DIR/canonicalize-fresh-infer-vars-issue-103626.rs:10:12
    |
 LL |     let b: &dyn FromResidual = &();
-   |            ^^^^^^^^^^^^^^^^^ `FromResidual` cannot be made into an object
+   |            ^^^^^^^^^^^^^^^^^ `FromResidual` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/canonicalize-fresh-infer-vars-issue-103626.rs:2:8
    |
 LL | trait FromResidual<R = <Self as Try>::Residual> {
-   |       ------------ this trait cannot be made into an object...
+   |       ------------ this trait is not dyn compatible...
 LL |     fn from_residual(residual: R) -> Self;
    |        ^^^^^^^^^^^^^ ...because associated function `from_residual` has no `self` parameter
 help: consider turning `from_residual` into a method by giving it a `&self` argument

--- a/tests/ui/traits/object/macro-matcher.rs
+++ b/tests/ui/traits/object/macro-matcher.rs
@@ -6,7 +6,7 @@ macro_rules! m {
 
 fn main() {
     m!(dyn Copy + Send + 'static);
-    //~^ ERROR the trait `Copy` cannot be made into an object
+    //~^ ERROR the trait `Copy` is not dyn compatible
     m!(dyn 'static + Send);
     m!(dyn 'static +); //~ ERROR at least one trait is required for an object type
 }

--- a/tests/ui/traits/object/macro-matcher.stderr
+++ b/tests/ui/traits/object/macro-matcher.stderr
@@ -4,14 +4,15 @@ error[E0224]: at least one trait is required for an object type
 LL |     m!(dyn 'static +);
    |        ^^^^^^^^^^^^^
 
-error[E0038]: the trait `Copy` cannot be made into an object
+error[E0038]: the trait `Copy` is not dyn compatible
   --> $DIR/macro-matcher.rs:8:8
    |
 LL |     m!(dyn Copy + Send + 'static);
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ `Copy` cannot be made into an object
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^ `Copy` is not dyn compatible
    |
-   = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: the trait is not dyn compatible because it requires `Self: Sized`
+   = note: for a trait to be dyn compatible it needs to allow building a vtable
+           for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/object/safety.stderr
+++ b/tests/ui/traits/object/safety.stderr
@@ -1,17 +1,18 @@
-error[E0038]: the trait `Tr` cannot be made into an object
+error[E0038]: the trait `Tr` is not dyn compatible
   --> $DIR/safety.rs:15:22
    |
 LL |     let _: &dyn Tr = &St;
-   |                      ^^^ `Tr` cannot be made into an object
+   |                      ^^^ `Tr` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/safety.rs:4:8
    |
 LL | trait Tr {
-   |       -- this trait cannot be made into an object...
+   |       -- this trait is not dyn compatible...
 LL |     fn foo();
    |        ^^^ ...because associated function `foo` has no `self` parameter
-   = help: only type `St` implements the trait, consider using it directly instead
+   = help: only type `St` implements `Tr`; consider using it directly instead.
    = note: required for the cast from `&St` to `&dyn Tr`
 help: consider turning `foo` into a method by giving it a `&self` argument
    |
@@ -22,20 +23,21 @@ help: alternatively, consider constraining `foo` so it does not apply to trait o
 LL |     fn foo() where Self: Sized;
    |              +++++++++++++++++
 
-error[E0038]: the trait `Tr` cannot be made into an object
+error[E0038]: the trait `Tr` is not dyn compatible
   --> $DIR/safety.rs:15:12
    |
 LL |     let _: &dyn Tr = &St;
-   |            ^^^^^^^ `Tr` cannot be made into an object
+   |            ^^^^^^^ `Tr` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/safety.rs:4:8
    |
 LL | trait Tr {
-   |       -- this trait cannot be made into an object...
+   |       -- this trait is not dyn compatible...
 LL |     fn foo();
    |        ^^^ ...because associated function `foo` has no `self` parameter
-   = help: only type `St` implements the trait, consider using it directly instead
+   = help: only type `St` implements `Tr`; consider using it directly instead.
 help: consider turning `foo` into a method by giving it a `&self` argument
    |
 LL |     fn foo(&self);

--- a/tests/ui/traits/test-2.stderr
+++ b/tests/ui/traits/test-2.stderr
@@ -26,65 +26,74 @@ note: method defined here, with 1 generic parameter: `X`
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |                                       ^^^^ -
 
-error[E0038]: the trait `bar` cannot be made into an object
+error[E0038]: the trait `bar` is not dyn compatible
   --> $DIR/test-2.rs:13:22
    |
 LL |     (Box::new(10) as Box<dyn bar>).dup();
-   |                      ^^^^^^^^^^^^ `bar` cannot be made into an object
+   |                      ^^^^^^^^^^^^ `bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/test-2.rs:4:30
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |       ---                    ^^^^     ^^^^ ...because method `blah` has generic type parameters
    |       |                      |
    |       |                      ...because method `dup` references the `Self` type in its return type
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
    = help: consider moving `dup` to another trait
    = help: consider moving `blah` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `bar` for this new enum and using it instead:
+   = help: the following types implement `bar`:
              i32
              u32
+           consider defining an enum where each variant holds one of these types,
+           implementing `bar` for this new enum and using it instead
 
-error[E0038]: the trait `bar` cannot be made into an object
+error[E0038]: the trait `bar` is not dyn compatible
   --> $DIR/test-2.rs:13:5
    |
 LL |     (Box::new(10) as Box<dyn bar>).dup();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `bar` cannot be made into an object
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/test-2.rs:4:30
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |       ---                    ^^^^     ^^^^ ...because method `blah` has generic type parameters
    |       |                      |
    |       |                      ...because method `dup` references the `Self` type in its return type
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
    = help: consider moving `dup` to another trait
    = help: consider moving `blah` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `bar` for this new enum and using it instead:
+   = help: the following types implement `bar`:
              i32
              u32
+           consider defining an enum where each variant holds one of these types,
+           implementing `bar` for this new enum and using it instead
 
-error[E0038]: the trait `bar` cannot be made into an object
+error[E0038]: the trait `bar` is not dyn compatible
   --> $DIR/test-2.rs:13:6
    |
 LL |     (Box::new(10) as Box<dyn bar>).dup();
-   |      ^^^^^^^^^^^^ `bar` cannot be made into an object
+   |      ^^^^^^^^^^^^ `bar` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/test-2.rs:4:30
    |
 LL | trait bar { fn dup(&self) -> Self; fn blah<X>(&self); }
    |       ---                    ^^^^     ^^^^ ...because method `blah` has generic type parameters
    |       |                      |
    |       |                      ...because method `dup` references the `Self` type in its return type
-   |       this trait cannot be made into an object...
+   |       this trait is not dyn compatible...
    = help: consider moving `dup` to another trait
    = help: consider moving `blah` to another trait
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `bar` for this new enum and using it instead:
+   = help: the following types implement `bar`:
              i32
              u32
+           consider defining an enum where each variant holds one of these types,
+           implementing `bar` for this new enum and using it instead
    = note: required for the cast from `Box<{integer}>` to `Box<dyn bar>`
 
 error: aborting due to 5 previous errors

--- a/tests/ui/type/type-parameter-defaults-referencing-Self-ppaux.stderr
+++ b/tests/ui/type/type-parameter-defaults-referencing-Self-ppaux.stderr
@@ -10,21 +10,20 @@ help: consider using a box or reference as appropriate
 LL |     let y = x as dyn MyAdd<i32>;
    |             ^
 
-error[E0038]: the trait `MyAdd` cannot be made into an object
+error[E0038]: the trait `MyAdd` is not dyn compatible
   --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:14:18
    |
 LL |     let y = x as dyn MyAdd<i32>;
-   |                  ^^^^^^^^^^^^^^ `MyAdd` cannot be made into an object
+   |                  ^^^^^^^^^^^^^^ `MyAdd` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/type-parameter-defaults-referencing-Self-ppaux.rs:6:55
    |
 LL | trait MyAdd<Rhs=Self> { fn add(&self, other: &Rhs) -> Self; }
-   |       -----                                           ^^^^ ...because method `add` references the `Self` type in its return type
-   |       |
-   |       this trait cannot be made into an object...
+   |       ----- this trait is not dyn compatible...       ^^^^ ...because method `add` references the `Self` type in its return type
    = help: consider moving `add` to another trait
-   = help: only type `i32` implements the trait, consider using it directly instead
+   = help: only type `i32` implements `MyAdd`; consider using it directly instead.
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/wf/issue-87495.rs
+++ b/tests/ui/wf/issue-87495.rs
@@ -2,7 +2,7 @@
 
 trait T {
     const CONST: (bool, dyn T);
-    //~^ ERROR: the trait `T` cannot be made into an object [E0038]
+    //~^ ERROR: the trait `T` is not dyn compatible [E0038]
 }
 
 fn main() {}

--- a/tests/ui/wf/issue-87495.stderr
+++ b/tests/ui/wf/issue-87495.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `T` cannot be made into an object
+error[E0038]: the trait `T` is not dyn compatible
   --> $DIR/issue-87495.rs:4:25
    |
 LL |     const CONST: (bool, dyn T);
-   |                         ^^^^^ `T` cannot be made into an object
+   |                         ^^^^^ `T` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/issue-87495.rs:4:11
    |
 LL | trait T {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     const CONST: (bool, dyn T);
    |           ^^^^^ ...because it contains this associated `const`
    = help: consider moving `CONST` to another trait

--- a/tests/ui/wf/wf-convert-dyn-incompat-trait-obj-box.stderr
+++ b/tests/ui/wf/wf-convert-dyn-incompat-trait-obj-box.stderr
@@ -1,49 +1,52 @@
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/wf-convert-dyn-incompat-trait-obj-box.rs:16:33
    |
 LL |     let t_box: Box<dyn Trait> = Box::new(S);
-   |                                 ^^^^^^^^^^^ `Trait` cannot be made into an object
+   |                                 ^^^^^^^^^^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-convert-dyn-incompat-trait-obj-box.rs:6:14
    |
 LL | trait Trait: Sized {}
    |       -----  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `S` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
+   = help: only type `S` implements `Trait`; consider using it directly instead.
    = note: required for the cast from `Box<S>` to `Box<dyn Trait>`
 
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/wf-convert-dyn-incompat-trait-obj-box.rs:17:15
    |
 LL |     takes_box(Box::new(S));
-   |               ^^^^^^^^^^^ `Trait` cannot be made into an object
+   |               ^^^^^^^^^^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-convert-dyn-incompat-trait-obj-box.rs:6:14
    |
 LL | trait Trait: Sized {}
    |       -----  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `S` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
+   = help: only type `S` implements `Trait`; consider using it directly instead.
    = note: required for the cast from `Box<S>` to `Box<(dyn Trait + 'static)>`
 
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/wf-convert-dyn-incompat-trait-obj-box.rs:15:5
    |
 LL |     Box::new(S) as Box<dyn Trait>;
-   |     ^^^^^^^^^^^ `Trait` cannot be made into an object
+   |     ^^^^^^^^^^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-convert-dyn-incompat-trait-obj-box.rs:6:14
    |
 LL | trait Trait: Sized {}
    |       -----  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `S` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
+   = help: only type `S` implements `Trait`; consider using it directly instead.
    = note: required for the cast from `Box<S>` to `Box<dyn Trait>`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/wf/wf-convert-dyn-incompat-trait-obj.stderr
+++ b/tests/ui/wf/wf-convert-dyn-incompat-trait-obj.stderr
@@ -1,49 +1,52 @@
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/wf-convert-dyn-incompat-trait-obj.rs:16:25
    |
 LL |     let t: &dyn Trait = &S;
-   |                         ^^ `Trait` cannot be made into an object
+   |                         ^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-convert-dyn-incompat-trait-obj.rs:6:14
    |
 LL | trait Trait: Sized {}
    |       -----  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `S` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
+   = help: only type `S` implements `Trait`; consider using it directly instead.
    = note: required for the cast from `&S` to `&dyn Trait`
 
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/wf-convert-dyn-incompat-trait-obj.rs:17:17
    |
 LL |     takes_trait(&S);
-   |                 ^^ `Trait` cannot be made into an object
+   |                 ^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-convert-dyn-incompat-trait-obj.rs:6:14
    |
 LL | trait Trait: Sized {}
    |       -----  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `S` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
+   = help: only type `S` implements `Trait`; consider using it directly instead.
    = note: required for the cast from `&S` to `&dyn Trait`
 
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/wf-convert-dyn-incompat-trait-obj.rs:15:5
    |
 LL |     &S as &dyn Trait;
-   |     ^^ `Trait` cannot be made into an object
+   |     ^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-convert-dyn-incompat-trait-obj.rs:6:14
    |
 LL | trait Trait: Sized {}
    |       -----  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
-   = help: only type `S` implements the trait, consider using it directly instead
+   |       this trait is not dyn compatible...
+   = help: only type `S` implements `Trait`; consider using it directly instead.
    = note: required for the cast from `&S` to `&dyn Trait`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/wf/wf-dyn-incompat-trait-obj-match.stderr
+++ b/tests/ui/wf/wf-dyn-incompat-trait-obj-match.stderr
@@ -12,40 +12,46 @@ LL | |     }
    = note: expected reference `&S`
               found reference `&R`
 
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/wf-dyn-incompat-trait-obj-match.rs:26:21
    |
 LL |         Some(()) => &S,
-   |                     ^^ `Trait` cannot be made into an object
+   |                     ^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-dyn-incompat-trait-obj-match.rs:6:14
    |
 LL | trait Trait: Sized {}
    |       -----  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `Trait` for this new enum and using it instead:
+   |       this trait is not dyn compatible...
+   = help: the following types implement `Trait`:
              S
              R
+           consider defining an enum where each variant holds one of these types,
+           implementing `Trait` for this new enum and using it instead
    = note: required for the cast from `&S` to `&dyn Trait`
 
-error[E0038]: the trait `Trait` cannot be made into an object
+error[E0038]: the trait `Trait` is not dyn compatible
   --> $DIR/wf-dyn-incompat-trait-obj-match.rs:27:17
    |
 LL |         None => &R,
-   |                 ^^ `Trait` cannot be made into an object
+   |                 ^^ `Trait` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-dyn-incompat-trait-obj-match.rs:6:14
    |
 LL | trait Trait: Sized {}
    |       -----  ^^^^^ ...because it requires `Self: Sized`
    |       |
-   |       this trait cannot be made into an object...
-   = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `Trait` for this new enum and using it instead:
+   |       this trait is not dyn compatible...
+   = help: the following types implement `Trait`:
              S
              R
+           consider defining an enum where each variant holds one of these types,
+           implementing `Trait` for this new enum and using it instead
    = note: required for the cast from `&R` to `&dyn Trait`
 
 error: aborting due to 3 previous errors

--- a/tests/ui/wf/wf-dyn-incompatible.stderr
+++ b/tests/ui/wf/wf-dyn-incompatible.stderr
@@ -1,14 +1,15 @@
-error[E0038]: the trait `A` cannot be made into an object
+error[E0038]: the trait `A` is not dyn compatible
   --> $DIR/wf-dyn-incompatible.rs:9:13
    |
 LL |     let _x: &dyn A;
-   |             ^^^^^^ `A` cannot be made into an object
+   |             ^^^^^^ `A` is not dyn compatible
    |
-note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+note: for a trait to be dyn compatible it needs to allow building a vtable
+      for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> $DIR/wf-dyn-incompatible.rs:5:23
    |
 LL | trait A {
-   |       - this trait cannot be made into an object...
+   |       - this trait is not dyn compatible...
 LL |     fn foo(&self, _x: &Self);
    |                       ^^^^^ ...because method `foo` references the `Self` type in this parameter
    = help: consider moving `foo` to another trait

--- a/tests/ui/wf/wf-fn-where-clause.stderr
+++ b/tests/ui/wf/wf-fn-where-clause.stderr
@@ -14,14 +14,15 @@ help: consider further restricting type parameter `U` with trait `Copy`
 LL | fn foo<T,U>() where T: ExtraCopy<U>, U: std::marker::Copy
    |                                    ++++++++++++++++++++++
 
-error[E0038]: the trait `Copy` cannot be made into an object
+error[E0038]: the trait `Copy` is not dyn compatible
   --> $DIR/wf-fn-where-clause.rs:12:16
    |
 LL | fn bar() where Vec<dyn Copy>:, {}
-   |                ^^^^^^^^^^^^^ `Copy` cannot be made into an object
+   |                ^^^^^^^^^^^^^ `Copy` is not dyn compatible
    |
-   = note: the trait cannot be made into an object because it requires `Self: Sized`
-   = note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
+   = note: the trait is not dyn compatible because it requires `Self: Sized`
+   = note: for a trait to be dyn compatible it needs to allow building a vtable
+           for more information, visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
 
 error[E0277]: the size for values of type `(dyn Copy + 'static)` cannot be known at compilation time
   --> $DIR/wf-fn-where-clause.rs:12:16


### PR DESCRIPTION
This CL makes a number of small changes to dyn compatibility errors:
- "object safety" has been renamed to "dyn-compatibility" throughout
- "Convert to enum" suggestions are no longer generated when there exists a type-generic impl of the trait or an impl for `dyn OtherTrait`
- Several error messages are reorganized for user readability

Additionally, the dyn compatibility error creation code has been split out into functions.

cc #132713
cc #133267

r? @compiler-errors 