### PR TITLE
rustdoc: do not call to_string, it's already impl Display

### DIFF
--- a/src/librustdoc/html/format.rs
+++ b/src/librustdoc/html/format.rs
@@ -1296,7 +1296,7 @@ impl clean::Impl {
                         self.print_type(inner_type, f, use_absolute, cx)?;
                         write!(f, ">")?;
                     } else {
-                        write!(f, "{}&lt;", anchor(ty.def_id(), last, cx).to_string())?;
+                        write!(f, "{}&lt;", anchor(ty.def_id(), last, cx))?;
                         self.print_type(inner_type, f, use_absolute, cx)?;
                         write!(f, "&gt;")?;
                     }


### PR DESCRIPTION
`anchor` returns impl Display, so no need to call to_string().