### PR TITLE
adapt `Path::file_stem()` function for directories

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2591,6 +2591,7 @@ impl Path {
     ///
     /// * [`None`], if there is no file name;
     /// * The entire file name if there is no embedded `.`;
+    /// * The entire file name if the path is a directory;
     /// * The entire file name if the file name begins with `.` and has no other `.`s within;
     /// * Otherwise, the portion of the file name before the final `.`
     ///
@@ -2603,6 +2604,13 @@ impl Path {
     /// assert_eq!("foo.tar", Path::new("foo.tar.gz").file_stem().unwrap());
     /// ```
     ///
+    /// if the path is a directory, the function will always return the complete filename
+    /// ```no_run
+    /// use std::path::Path;
+    ///
+    /// assert_eq!("2024.11.23_directory", Path::new("2024.11.23_directory").file_stem().unwrap());
+    /// ```
+    ///
     /// # See Also
     /// This method is similar to [`Path::file_prefix`], which extracts the portion of the file name
     /// before the *first* `.`
@@ -2612,7 +2620,11 @@ impl Path {
     #[stable(feature = "rust1", since = "1.0.0")]
     #[must_use]
     pub fn file_stem(&self) -> Option<&OsStr> {
-        self.file_name().map(rsplit_file_at_dot).and_then(|(before, after)| before.or(after))
+        if self.is_dir() {
+            self.file_name()
+        } else {
+            self.file_name().map(rsplit_file_at_dot).and_then(|(before, after)| before.or(after))
+        }
     }
 
     /// Extracts the prefix of [`self.file_name`].


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This PR addresses #133399 .
This adaptation leads to `Path::file_steam()` no longer treating directories with dots in the name as files with extensions.
