### PR TITLE
Make `adjust_fulfillment_errors` work with `HostEffectPredicate` and `const_conditions`

### DIFF
--- a/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
+++ b/compiler/rustc_hir_typeck/src/fn_ctxt/_impl.rs
@@ -185,7 +185,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         span: Span,
         method: MethodCallee<'tcx>,
     ) {
-        self.enforce_context_effects(span, method.def_id, method.args);
+        self.enforce_context_effects(Some(hir_id), span, method.def_id, method.args);
         self.write_resolution(hir_id, Ok((DefKind::AssocFn, method.def_id)));
         self.write_args(hir_id, method.args);
     }
@@ -263,6 +263,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 }
                 Adjust::Deref(Some(overloaded_deref)) => {
                     self.enforce_context_effects(
+                        None,
                         expr.span,
                         overloaded_deref.method_call(self.tcx),
                         self.tcx.mk_args(&[a.target.into()]),

--- a/compiler/rustc_hir_typeck/src/place_op.rs
+++ b/compiler/rustc_hir_typeck/src/place_op.rs
@@ -296,7 +296,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                             );
                         };
                         *deref = OverloadedDeref { mutbl, span: deref.span };
-                        self.enforce_context_effects(expr.span, method.def_id, method.args);
+                        self.enforce_context_effects(None, expr.span, method.def_id, method.args);
                         // If this is a union field, also throw an error for `DerefMut` of `ManuallyDrop` (see RFC 2514).
                         // This helps avoid accidental drops.
                         if inside_union

--- a/compiler/rustc_middle/src/traits/mod.rs
+++ b/compiler/rustc_middle/src/traits/mod.rs
@@ -204,6 +204,10 @@ pub enum ObligationCauseCode<'tcx> {
     /// list of the item.
     WhereClauseInExpr(DefId, Span, HirId, usize),
 
+    /// Like `WhereClauseinExpr`, but indexes into the `const_conditions`
+    /// rather than the `predicates_of`.
+    HostEffectInExpr(DefId, Span, HirId, usize),
+
     /// A type like `&'a T` is WF only if `T: 'a`.
     ReferenceOutlivesReferent(Ty<'tcx>),
 

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -2803,6 +2803,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             }
             ObligationCauseCode::WhereClause(item_def_id, span)
             | ObligationCauseCode::WhereClauseInExpr(item_def_id, span, ..)
+            | ObligationCauseCode::HostEffectInExpr(item_def_id, span, ..)
                 if !span.is_dummy() =>
             {
                 if let ObligationCauseCode::WhereClauseInExpr(_, _, hir_id, pos) = &cause_code {
@@ -2966,7 +2967,9 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     err.help(help);
                 }
             }
-            ObligationCauseCode::WhereClause(..) | ObligationCauseCode::WhereClauseInExpr(..) => {
+            ObligationCauseCode::WhereClause(..)
+            | ObligationCauseCode::WhereClauseInExpr(..)
+            | ObligationCauseCode::HostEffectInExpr(..) => {
                 // We hold the `DefId` of the item introducing the obligation, but displaying it
                 // doesn't add user usable information. It always point at an associated item.
             }

--- a/tests/ui/consts/const-block-const-bound.stderr
+++ b/tests/ui/consts/const-block-const-bound.stderr
@@ -1,8 +1,16 @@
 error[E0277]: the trait bound `UnconstDrop: const Destruct` is not satisfied
-  --> $DIR/const-block-const-bound.rs:18:9
+  --> $DIR/const-block-const-bound.rs:18:11
    |
 LL |         f(UnconstDrop);
-   |         ^^^^^^^^^^^^^^
+   |         - ^^^^^^^^^^^
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `f`
+  --> $DIR/const-block-const-bound.rs:8:15
+   |
+LL | const fn f<T: ~const Destruct>(x: T) {}
+   |               ^^^^^^ required by this bound in `f`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/constifconst-call-in-const-position.stderr
+++ b/tests/ui/consts/constifconst-call-in-const-position.stderr
@@ -2,13 +2,13 @@ error[E0277]: the trait bound `T: const Tr` is not satisfied
   --> $DIR/constifconst-call-in-const-position.rs:17:38
    |
 LL | const fn foo<T: ~const Tr>() -> [u8; T::a()] {
-   |                                      ^^^^^^
+   |                                      ^
 
 error[E0277]: the trait bound `T: const Tr` is not satisfied
   --> $DIR/constifconst-call-in-const-position.rs:18:9
    |
 LL |     [0; T::a()]
-   |         ^^^^^^
+   |         ^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -121,34 +121,89 @@ LL |     T: ~const FnMut<()> + ~const Destruct,
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `fn() -> i32 {one}: const Destruct` is not satisfied
-  --> $DIR/fn_trait_refs.rs:70:24
+  --> $DIR/fn_trait_refs.rs:70:32
    |
 LL |         let test_one = test_fn(one);
-   |                        ^^^^^^^^^^^^
+   |                        ------- ^^^
+   |                        |
+   |                        required by a bound introduced by this call
+   |
+note: required by a bound in `test_fn`
+  --> $DIR/fn_trait_refs.rs:35:24
+   |
+LL | const fn test_fn<T>(mut f: T) -> (T::Output, T::Output, T::Output)
+   |          ------- required by a bound in this function
+LL | where
+LL |     T: ~const Fn<()> + ~const Destruct,
+   |                        ^^^^^^ required by this bound in `test_fn`
 
 error[E0277]: the trait bound `fn() -> i32 {two}: const Destruct` is not satisfied
-  --> $DIR/fn_trait_refs.rs:73:24
+  --> $DIR/fn_trait_refs.rs:73:36
    |
 LL |         let test_two = test_fn_mut(two);
-   |                        ^^^^^^^^^^^^^^^^
+   |                        ----------- ^^^
+   |                        |
+   |                        required by a bound introduced by this call
+   |
+note: required by a bound in `test_fn_mut`
+  --> $DIR/fn_trait_refs.rs:49:27
+   |
+LL | const fn test_fn_mut<T>(mut f: T) -> (T::Output, T::Output)
+   |          ----------- required by a bound in this function
+LL | where
+LL |     T: ~const FnMut<()> + ~const Destruct,
+   |                           ^^^^^^ required by this bound in `test_fn_mut`
 
 error[E0277]: the trait bound `&T: ~const Destruct` is not satisfied
-  --> $DIR/fn_trait_refs.rs:39:9
+  --> $DIR/fn_trait_refs.rs:39:19
    |
 LL |         tester_fn(&f),
-   |         ^^^^^^^^^^^^^
+   |         --------- ^^
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `tester_fn`
+  --> $DIR/fn_trait_refs.rs:14:24
+   |
+LL | const fn tester_fn<T>(f: T) -> T::Output
+   |          --------- required by a bound in this function
+LL | where
+LL |     T: ~const Fn<()> + ~const Destruct,
+   |                        ^^^^^^ required by this bound in `tester_fn`
 
 error[E0277]: the trait bound `&T: ~const Destruct` is not satisfied
-  --> $DIR/fn_trait_refs.rs:41:9
+  --> $DIR/fn_trait_refs.rs:41:23
    |
 LL |         tester_fn_mut(&f),
-   |         ^^^^^^^^^^^^^^^^^
+   |         ------------- ^^
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `tester_fn_mut`
+  --> $DIR/fn_trait_refs.rs:21:27
+   |
+LL | const fn tester_fn_mut<T>(mut f: T) -> T::Output
+   |          ------------- required by a bound in this function
+LL | where
+LL |     T: ~const FnMut<()> + ~const Destruct,
+   |                           ^^^^^^ required by this bound in `tester_fn_mut`
 
 error[E0277]: the trait bound `&mut T: ~const Destruct` is not satisfied
-  --> $DIR/fn_trait_refs.rs:53:9
+  --> $DIR/fn_trait_refs.rs:53:23
    |
 LL |         tester_fn_mut(&mut f),
-   |         ^^^^^^^^^^^^^^^^^^^^^
+   |         ------------- ^^^^^^
+   |         |
+   |         required by a bound introduced by this call
+   |
+note: required by a bound in `tester_fn_mut`
+  --> $DIR/fn_trait_refs.rs:21:27
+   |
+LL | const fn tester_fn_mut<T>(mut f: T) -> T::Output
+   |          ------------- required by a bound in this function
+LL | where
+LL |     T: ~const FnMut<()> + ~const Destruct,
+   |                           ^^^^^^ required by this bound in `tester_fn_mut`
 
 error[E0015]: cannot call non-const closure in constant functions
   --> $DIR/fn_trait_refs.rs:16:5

--- a/tests/ui/impl-trait/normalize-tait-in-const.stderr
+++ b/tests/ui/impl-trait/normalize-tait-in-const.stderr
@@ -13,10 +13,18 @@ LL | const fn with_positive<F: for<'a> ~const Fn(&'a Alias<'a>) + ~const Destruc
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `for<'a, 'b> fn(&'a foo::Alias<'b>) {foo}: const Destruct` is not satisfied
-  --> $DIR/normalize-tait-in-const.rs:33:5
+  --> $DIR/normalize-tait-in-const.rs:33:19
    |
 LL |     with_positive(foo);
-   |     ^^^^^^^^^^^^^^^^^^
+   |     ------------- ^^^
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `with_positive`
+  --> $DIR/normalize-tait-in-const.rs:26:62
+   |
+LL | const fn with_positive<F: for<'a> ~const Fn(&'a Alias<'a>) + ~const Destruct>(fun: F) {
+   |                                                              ^^^^^^ required by this bound in `with_positive`
 
 error[E0015]: cannot call non-const closure in constant functions
   --> $DIR/normalize-tait-in-const.rs:27:5

--- a/tests/ui/traits/const-traits/assoc-type-const-bound-usage-fail-2.stderr
+++ b/tests/ui/traits/const-traits/assoc-type-const-bound-usage-fail-2.stderr
@@ -2,13 +2,13 @@ error[E0277]: the trait bound `<T as Trait>::Assoc<U>: ~const Trait` is not sati
   --> $DIR/assoc-type-const-bound-usage-fail-2.rs:23:5
    |
 LL |     T::Assoc::<U>::func();
-   |     ^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `<T as Trait>::Assoc<U>: ~const Trait` is not satisfied
   --> $DIR/assoc-type-const-bound-usage-fail-2.rs:25:5
    |
 LL |     <T as Trait>::Assoc::<U>::func();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/assoc-type-const-bound-usage-fail.stderr
+++ b/tests/ui/traits/const-traits/assoc-type-const-bound-usage-fail.stderr
@@ -2,13 +2,13 @@ error[E0277]: the trait bound `T: ~const Trait` is not satisfied
   --> $DIR/assoc-type-const-bound-usage-fail.rs:16:5
    |
 LL |     T::Assoc::func();
-   |     ^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^
 
 error[E0277]: the trait bound `T: ~const Trait` is not satisfied
   --> $DIR/assoc-type-const-bound-usage-fail.rs:18:5
    |
 LL |     <T as Trait>::Assoc::func();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/call-const-closure.stderr
+++ b/tests/ui/traits/const-traits/call-const-closure.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `(): ~const Bar` is not satisfied
-  --> $DIR/call-const-closure.rs:17:15
+  --> $DIR/call-const-closure.rs:17:18
    |
 LL |     (const || ().foo())();
-   |               ^^^^^^^^
+   |                  ^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/call-const-in-tilde-const.stderr
+++ b/tests/ui/traits/const-traits/call-const-in-tilde-const.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `T: const Foo` is not satisfied
   --> $DIR/call-const-in-tilde-const.rs:9:13
    |
 LL |     const { T::foo() }
-   |             ^^^^^^^^
+   |             ^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/call-const-trait-method-fail.stderr
+++ b/tests/ui/traits/const-traits/call-const-trait-method-fail.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `u32: ~const Plus` is not satisfied
   --> $DIR/call-const-trait-method-fail.rs:26:5
    |
 LL |     a.plus(b)
-   |     ^^^^^^^^^
+   |     ^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/call-generic-method-nonconst.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-nonconst.stderr
@@ -1,8 +1,16 @@
 error[E0277]: the trait bound `S: const Foo` is not satisfied
-  --> $DIR/call-generic-method-nonconst.rs:24:22
+  --> $DIR/call-generic-method-nonconst.rs:24:34
    |
 LL | pub const EQ: bool = equals_self(&S);
-   |                      ^^^^^^^^^^^^^^^
+   |                      ----------- ^^
+   |                      |
+   |                      required by a bound introduced by this call
+   |
+note: required by a bound in `equals_self`
+  --> $DIR/call-generic-method-nonconst.rs:17:25
+   |
+LL | const fn equals_self<T: ~const Foo>(t: &T) -> bool {
+   |                         ^^^^^^ required by this bound in `equals_self`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/const-default-method-bodies.stderr
+++ b/tests/ui/traits/const-traits/const-default-method-bodies.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `NonConstImpl: ~const ConstDefaultFn` is not satisfied
-  --> $DIR/const-default-method-bodies.rs:25:5
+  --> $DIR/const-default-method-bodies.rs:25:18
    |
 LL |     NonConstImpl.a();
-   |     ^^^^^^^^^^^^^^^^
+   |                  ^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/const-drop-bound.stderr
+++ b/tests/ui/traits/const-traits/const-drop-bound.stderr
@@ -1,8 +1,16 @@
 error[E0277]: the trait bound `Foo<E>: ~const Destruct` is not satisfied
-  --> $DIR/const-drop-bound.rs:23:5
+  --> $DIR/const-drop-bound.rs:23:9
    |
 LL |     foo(res)
-   |     ^^^^^^^^
+   |     --- ^^^
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `foo`
+  --> $DIR/const-drop-bound.rs:9:61
+   |
+LL | const fn foo<T, E>(res: Result<T, E>) -> Option<T> where E: ~const Destruct {
+   |                                                             ^^^^^^ required by this bound in `foo`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/const-drop-fail-2.precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail-2.precise.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `ConstDropImplWithBounds<NonTrivialDrop>: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail-2.rs:31:15
+  --> $DIR/const-drop-fail-2.rs:31:23
    |
-LL |   const _: () = check::<ConstDropImplWithBounds<NonTrivialDrop>>(
-   |  _______________^
-LL | |
-LL | |     ConstDropImplWithBounds(PhantomData)
-LL | | );
-   | |_^
+LL | const _: () = check::<ConstDropImplWithBounds<NonTrivialDrop>>(
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: required by a bound in `check`
+  --> $DIR/const-drop-fail-2.rs:21:19
+   |
+LL | const fn check<T: ~const Destruct>(_: T) {}
+   |                   ^^^^^^ required by this bound in `check`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/const-drop-fail-2.stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail-2.stock.stderr
@@ -1,12 +1,14 @@
 error[E0277]: the trait bound `ConstDropImplWithBounds<NonTrivialDrop>: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail-2.rs:31:15
+  --> $DIR/const-drop-fail-2.rs:31:23
    |
-LL |   const _: () = check::<ConstDropImplWithBounds<NonTrivialDrop>>(
-   |  _______________^
-LL | |
-LL | |     ConstDropImplWithBounds(PhantomData)
-LL | | );
-   | |_^
+LL | const _: () = check::<ConstDropImplWithBounds<NonTrivialDrop>>(
+   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: required by a bound in `check`
+  --> $DIR/const-drop-fail-2.rs:21:19
+   |
+LL | const fn check<T: ~const Destruct>(_: T) {}
+   |                   ^^^^^^ required by this bound in `check`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/const-drop-fail.precise.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.precise.stderr
@@ -1,31 +1,32 @@
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail.rs:27:23
+  --> $DIR/const-drop-fail.rs:32:5
    |
-LL |           const _: () = check($exp);
-   |                         ^^^^^^^^^^^
+LL |         const _: () = check($exp);
+   |                       ----- required by a bound introduced by this call
 ...
-LL | / check_all! {
-LL | |     NonTrivialDrop,
-LL | |     ConstImplWithDropGlue(NonTrivialDrop),
-LL | | }
-   | |_- in this macro invocation
+LL |     NonTrivialDrop,
+   |     ^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `check_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+note: required by a bound in `check`
+  --> $DIR/const-drop-fail.rs:23:19
+   |
+LL | const fn check<T: ~const Destruct>(_: T) {}
+   |                   ^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail.rs:27:23
+  --> $DIR/const-drop-fail.rs:34:5
    |
-LL |           const _: () = check($exp);
-   |                         ^^^^^^^^^^^
+LL |         const _: () = check($exp);
+   |                       ----- required by a bound introduced by this call
 ...
-LL | / check_all! {
-LL | |     NonTrivialDrop,
-LL | |     ConstImplWithDropGlue(NonTrivialDrop),
-LL | | }
-   | |_- in this macro invocation
+LL |     ConstImplWithDropGlue(NonTrivialDrop),
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the macro `check_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+note: required by a bound in `check`
+  --> $DIR/const-drop-fail.rs:23:19
+   |
+LL | const fn check<T: ~const Destruct>(_: T) {}
+   |                   ^^^^^^ required by this bound in `check`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/const-drop-fail.rs
+++ b/tests/ui/traits/const-traits/const-drop-fail.rs
@@ -25,14 +25,14 @@ const fn check<T: ~const Destruct>(_: T) {}
 macro_rules! check_all {
     ($($exp:expr),*$(,)?) => {$(
         const _: () = check($exp);
-        //~^ ERROR the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-        //~| ERROR the trait bound `NonTrivialDrop: const Destruct` is not satisfied
     )*};
 }
 
 check_all! {
     NonTrivialDrop,
+    //~^ ERROR the trait bound `NonTrivialDrop: const Destruct` is not satisfied
     ConstImplWithDropGlue(NonTrivialDrop),
+    //~^ ERROR the trait bound `NonTrivialDrop: const Destruct` is not satisfied
 }
 
 fn main() {}

--- a/tests/ui/traits/const-traits/const-drop-fail.stock.stderr
+++ b/tests/ui/traits/const-traits/const-drop-fail.stock.stderr
@@ -1,31 +1,32 @@
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail.rs:27:23
+  --> $DIR/const-drop-fail.rs:32:5
    |
-LL |           const _: () = check($exp);
-   |                         ^^^^^^^^^^^
+LL |         const _: () = check($exp);
+   |                       ----- required by a bound introduced by this call
 ...
-LL | / check_all! {
-LL | |     NonTrivialDrop,
-LL | |     ConstImplWithDropGlue(NonTrivialDrop),
-LL | | }
-   | |_- in this macro invocation
+LL |     NonTrivialDrop,
+   |     ^^^^^^^^^^^^^^
    |
-   = note: this error originates in the macro `check_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+note: required by a bound in `check`
+  --> $DIR/const-drop-fail.rs:23:19
+   |
+LL | const fn check<T: ~const Destruct>(_: T) {}
+   |                   ^^^^^^ required by this bound in `check`
 
 error[E0277]: the trait bound `NonTrivialDrop: const Destruct` is not satisfied
-  --> $DIR/const-drop-fail.rs:27:23
+  --> $DIR/const-drop-fail.rs:34:5
    |
-LL |           const _: () = check($exp);
-   |                         ^^^^^^^^^^^
+LL |         const _: () = check($exp);
+   |                       ----- required by a bound introduced by this call
 ...
-LL | / check_all! {
-LL | |     NonTrivialDrop,
-LL | |     ConstImplWithDropGlue(NonTrivialDrop),
-LL | | }
-   | |_- in this macro invocation
+LL |     ConstImplWithDropGlue(NonTrivialDrop),
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this error originates in the macro `check_all` (in Nightly builds, run with -Z macro-backtrace for more info)
+note: required by a bound in `check`
+  --> $DIR/const-drop-fail.rs:23:19
+   |
+LL | const fn check<T: ~const Destruct>(_: T) {}
+   |                   ^^^^^^ required by this bound in `check`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/const-opaque.no.stderr
+++ b/tests/ui/traits/const-traits/const-opaque.no.stderr
@@ -1,14 +1,22 @@
 error[E0277]: the trait bound `(): const Foo` is not satisfied
-  --> $DIR/const-opaque.rs:31:18
+  --> $DIR/const-opaque.rs:31:22
    |
 LL |     let opaque = bar(());
-   |                  ^^^^^^^
+   |                  --- ^^
+   |                  |
+   |                  required by a bound introduced by this call
+   |
+note: required by a bound in `bar`
+  --> $DIR/const-opaque.rs:26:17
+   |
+LL | const fn bar<T: ~const Foo>(t: T) -> impl ~const Foo {
+   |                 ^^^^^^ required by this bound in `bar`
 
 error[E0277]: the trait bound `(): const Foo` is not satisfied
-  --> $DIR/const-opaque.rs:33:5
+  --> $DIR/const-opaque.rs:33:12
    |
 LL |     opaque.method();
-   |     ^^^^^^^^^^^^^^^
+   |            ^^^^^^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/cross-crate.gatednc.stderr
+++ b/tests/ui/traits/const-traits/cross-crate.gatednc.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `cross_crate::NonConst: ~const cross_crate::MyTrait` is not satisfied
-  --> $DIR/cross-crate.rs:19:5
+  --> $DIR/cross-crate.rs:19:14
    |
 LL |     NonConst.func();
-   |     ^^^^^^^^^^^^^^^
+   |              ^^^^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/default-method-body-is-const-body-checking.stderr
+++ b/tests/ui/traits/const-traits/default-method-body-is-const-body-checking.stderr
@@ -1,8 +1,14 @@
 error[E0277]: the trait bound `(): ~const Tr` is not satisfied
-  --> $DIR/default-method-body-is-const-body-checking.rs:12:9
+  --> $DIR/default-method-body-is-const-body-checking.rs:12:15
    |
 LL |         foo::<()>();
-   |         ^^^^^^^^^^^
+   |               ^^
+   |
+note: required by a bound in `foo`
+  --> $DIR/default-method-body-is-const-body-checking.rs:7:28
+   |
+LL | const fn foo<T>() where T: ~const Tr {}
+   |                            ^^^^^^ required by this bound in `foo`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/default-method-body-is-const-same-trait-ck.stderr
+++ b/tests/ui/traits/const-traits/default-method-body-is-const-same-trait-ck.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `(): ~const Tr` is not satisfied
-  --> $DIR/default-method-body-is-const-same-trait-ck.rs:9:9
+  --> $DIR/default-method-body-is-const-same-trait-ck.rs:9:12
    |
 LL |         ().a()
-   |         ^^^^^^
+   |            ^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/effects/minicore-fn-fail.stderr
+++ b/tests/ui/traits/const-traits/effects/minicore-fn-fail.stderr
@@ -1,8 +1,16 @@
 error[E0277]: the trait bound `(): ~const Foo` is not satisfied
-  --> $DIR/minicore-fn-fail.rs:19:5
+  --> $DIR/minicore-fn-fail.rs:19:19
    |
 LL |     call_indirect(&foo::<()>);
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |     ------------- ^^^^^^^^^^
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `call_indirect`
+  --> $DIR/minicore-fn-fail.rs:11:27
+   |
+LL | const fn call_indirect<T: ~const Fn()>(t: &T) { t() }
+   |                           ^^^^^^ required by this bound in `call_indirect`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/effects/no-explicit-const-params.stderr
+++ b/tests/ui/traits/const-traits/effects/no-explicit-const-params.stderr
@@ -27,10 +27,10 @@ LL | trait Bar {
    |       ^^^
 
 error[E0277]: the trait bound `(): const Bar` is not satisfied
-  --> $DIR/no-explicit-const-params.rs:24:5
+  --> $DIR/no-explicit-const-params.rs:24:6
    |
 LL |     <() as Bar<false>>::bar();
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |      ^^
 
 error[E0107]: function takes 0 generic arguments but 1 generic argument was supplied
   --> $DIR/no-explicit-const-params.rs:15:5

--- a/tests/ui/traits/const-traits/specializing-constness-2.stderr
+++ b/tests/ui/traits/const-traits/specializing-constness-2.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: ~const A` is not satisfied
-  --> $DIR/specializing-constness-2.rs:27:5
+  --> $DIR/specializing-constness-2.rs:27:6
    |
 LL |     <T as A>::a();
-   |     ^^^^^^^^^^^^^
+   |      ^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/super-traits-fail-2.yn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.yn.stderr
@@ -11,10 +11,10 @@ LL | trait Bar: ~const Foo {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `T: ~const Foo` is not satisfied
-  --> $DIR/super-traits-fail-2.rs:20:5
+  --> $DIR/super-traits-fail-2.rs:20:7
    |
 LL |     x.a();
-   |     ^^^^^
+   |       ^
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/super-traits-fail-2.yy.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-2.yy.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `T: ~const Foo` is not satisfied
-  --> $DIR/super-traits-fail-2.rs:20:5
+  --> $DIR/super-traits-fail-2.rs:20:7
    |
 LL |     x.a();
-   |     ^^^^^
+   |       ^
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/super-traits-fail-3.yn.stderr
+++ b/tests/ui/traits/const-traits/super-traits-fail-3.yn.stderr
@@ -25,10 +25,10 @@ LL | const fn foo<T: ~const Bar>(x: &T) {
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0277]: the trait bound `T: ~const Foo` is not satisfied
-  --> $DIR/super-traits-fail-3.rs:24:5
+  --> $DIR/super-traits-fail-3.rs:24:7
    |
 LL |     x.a();
-   |     ^^^^^
+   |       ^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/traits/const-traits/tilde-const-and-const-params.stderr
+++ b/tests/ui/traits/const-traits/tilde-const-and-const-params.stderr
@@ -26,13 +26,13 @@ error[E0277]: the trait bound `A: const Add42` is not satisfied
   --> $DIR/tilde-const-and-const-params.rs:27:61
    |
 LL | fn bar<A: ~const Add42, const N: usize>(_: Foo<N>) -> Foo<{ A::add(N) }> {
-   |                                                             ^^^^^^^^^
+   |                                                             ^
 
 error[E0277]: the trait bound `A: const Add42` is not satisfied
   --> $DIR/tilde-const-and-const-params.rs:9:44
    |
 LL |     fn add<A: ~const Add42>(self) -> Foo<{ A::add(N) }> {
-   |                                            ^^^^^^^^^
+   |                                            ^
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/traits/const-traits/trait-where-clause-const.stderr
+++ b/tests/ui/traits/const-traits/trait-where-clause-const.stderr
@@ -2,13 +2,25 @@ error[E0277]: the trait bound `T: ~const Bar` is not satisfied
   --> $DIR/trait-where-clause-const.rs:21:5
    |
 LL |     T::b();
-   |     ^^^^^^
+   |     ^
+   |
+note: required by a bound in `Foo::b`
+  --> $DIR/trait-where-clause-const.rs:15:24
+   |
+LL |     fn b() where Self: ~const Bar;
+   |                        ^^^^^^ required by this bound in `Foo::b`
 
 error[E0277]: the trait bound `T: ~const Bar` is not satisfied
-  --> $DIR/trait-where-clause-const.rs:23:5
+  --> $DIR/trait-where-clause-const.rs:23:12
    |
 LL |     T::c::<T>();
-   |     ^^^^^^^^^^^
+   |            ^
+   |
+note: required by a bound in `Foo::c`
+  --> $DIR/trait-where-clause-const.rs:16:13
+   |
+LL |     fn c<T: ~const Bar>();
+   |             ^^^^^^ required by this bound in `Foo::c`
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
+++ b/tests/ui/traits/const-traits/unsatisfied-const-trait-bound.stderr
@@ -10,19 +10,19 @@ error[E0277]: the trait bound `T: const Trait` is not satisfied
   --> $DIR/unsatisfied-const-trait-bound.rs:29:37
    |
 LL | fn accept0<T: Trait>(_: Container<{ T::make() }>) {}
-   |                                     ^^^^^^^^^
+   |                                     ^
 
 error[E0277]: the trait bound `T: const Trait` is not satisfied
   --> $DIR/unsatisfied-const-trait-bound.rs:33:50
    |
 LL | const fn accept1<T: ~const Trait>(_: Container<{ T::make() }>) {}
-   |                                                  ^^^^^^^^^
+   |                                                  ^
 
 error[E0277]: the trait bound `Ty: const Trait` is not satisfied
-  --> $DIR/unsatisfied-const-trait-bound.rs:22:5
+  --> $DIR/unsatisfied-const-trait-bound.rs:22:15
    |
 LL |     require::<Ty>();
-   |     ^^^^^^^^^^^^^^^
+   |               ^^
    |
 note: required by a bound in `require`
   --> $DIR/unsatisfied-const-trait-bound.rs:8:15


### PR DESCRIPTION
Greatly improves the spans for reporting unsatisfied `~const` bounds :) 

r? project-const-traits or maybe @lcnr (if you want to deal with a diagnostics PR lmao)