### PR TITLE
Lint #[inline(always)] closure in #[target_feature] functions

### DIFF
--- a/compiler/rustc_codegen_ssa/messages.ftl
+++ b/compiler/rustc_codegen_ssa/messages.ftl
@@ -82,6 +82,11 @@ codegen_ssa_incorrect_cgu_reuse_type =
     *[other] {""}
     }`{$expected_reuse}`
 
+codegen_ssa_inline_always_closure_in_target_feature_function =
+  cannot use `#[inline(always)]` with `#[target_feature]`
+  .note = `#[target_feature]` will not be applied to this closure and may result in unpredictable code generation
+  .help = consider using `#[inline]` instead
+
 codegen_ssa_insufficient_vs_code_product = VS Code is a different product, and is not sufficient.
 
 codegen_ssa_invalid_link_ordinal_nargs = incorrect number of arguments to `#[link_ordinal]`

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -590,14 +590,13 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
             && !tcx.codegen_fn_attrs(owner_id).target_features.is_empty()
         {
             if codegen_fn_attrs.inline == InlineAttr::Always {
-                if let Some(inline_span) = inline_span {
-                    tcx.emit_node_span_lint(
-                        lint::builtin::INLINE_ALWAYS_CLOSURE_IN_TARGET_FEATURE_FUNCTION,
-                        rustc_hir::CRATE_HIR_ID,
-                        inline_span,
-                        errors::InlineAlwaysClosureInTargetFeatureFunction,
-                    );
-                }
+                // Do *not* inherit target features here, that could be unsound.
+                tcx.emit_node_span_lint(
+                    lint::builtin::INLINE_ALWAYS_CLOSURE_IN_TARGET_FEATURE_FUNCTION,
+                    rustc_hir::CRATE_HIR_ID,
+                    inline_span.unwrap_or(tcx.def_span(did)),
+                    errors::InlineAlwaysClosureInTargetFeatureFunction,
+                );
             } else {
                 codegen_fn_attrs
                     .target_features

--- a/compiler/rustc_codegen_ssa/src/errors.rs
+++ b/compiler/rustc_codegen_ssa/src/errors.rs
@@ -10,7 +10,7 @@ use rustc_errors::codes::*;
 use rustc_errors::{
     Diag, DiagArgValue, DiagCtxtHandle, Diagnostic, EmissionGuarantee, IntoDiagArg, Level,
 };
-use rustc_macros::{Diagnostic, Subdiagnostic};
+use rustc_macros::{Diagnostic, LintDiagnostic, Subdiagnostic};
 use rustc_middle::ty::Ty;
 use rustc_middle::ty::layout::LayoutError;
 use rustc_span::{Span, Symbol};
@@ -1092,6 +1092,12 @@ pub struct TargetFeatureDisableOrEnable<'a> {
     pub span: Option<Span>,
     pub missing_features: Option<MissingFeatures>,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(codegen_ssa_inline_always_closure_in_target_feature_function)]
+#[note]
+#[help]
+pub struct InlineAlwaysClosureInTargetFeatureFunction;
 
 #[derive(Subdiagnostic)]
 #[help(codegen_ssa_missing_features)]

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -52,6 +52,7 @@ declare_lint_pass! {
         ILL_FORMED_ATTRIBUTE_INPUT,
         INCOMPLETE_INCLUDE,
         INEFFECTIVE_UNSTABLE_TRAIT_IMPL,
+        INLINE_ALWAYS_CLOSURE_IN_TARGET_FEATURE_FUNCTION,
         INLINE_NO_SANITIZE,
         INVALID_DOC_ATTRIBUTES,
         INVALID_MACRO_EXPORT_ARGUMENTS,
@@ -5175,5 +5176,40 @@ declare_lint! {
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps,
         reference: "issue #116558 <https://github.com/rust-lang/rust/issues/116558>",
+    };
+}
+
+declare_lint! {
+    /// The `inline_always_closure_in_target_feature_function` lint detects using
+    /// the `#[inline(always)]` attribute on closures within functions marked with
+    /// the `#[target_feature(enable = "...")]` attribute.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,edition2021,compile_fail
+    /// #![deny(inline_always_closure_in_target_feature_function)]
+    ///
+    /// #[target_feature(enable = "avx")]
+    /// fn example() {
+    ///     let closure = #[inline(always)] || {};
+    /// }
+    ///
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// Rust previously did not apply a function's target features to closures
+    /// within it.
+    /// The `#[inline(always)]` attribute is incompatible with target features
+    /// due to the possibility of target feature mismatches.
+    /// The `#[inline]` attribute may be used instead.
+    pub INLINE_ALWAYS_CLOSURE_IN_TARGET_FEATURE_FUNCTION,
+    Warn,
+    "detect closures marked #[inline(always)] inside functions marked #[target_feature]",
+    @future_incompatible = FutureIncompatibleInfo {
+        reason: FutureIncompatibilityReason::FutureReleaseErrorDontReportInDeps,
+        reference: "issue #108655 <https://github.com/rust-lang/rust/issues/108655>",
     };
 }

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -5188,10 +5188,14 @@ declare_lint! {
     ///
     /// ```rust,edition2021,compile_fail
     /// #![deny(inline_always_closure_in_target_feature_function)]
+    /// #![feature(target_feature_11)]
     ///
     /// #[target_feature(enable = "avx")]
     /// fn example() {
-    ///     let closure = #[inline(always)] || {};
+    ///     let closure = {
+    ///         #[inline(always)] move || {}
+    ///     };
+    ///     closure()
     /// }
     ///
     /// ```

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/issue-108655-inline-always-closure.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/issue-108655-inline-always-closure.rs
@@ -5,11 +5,42 @@
 
 #![feature(target_feature_11)]
 
-#[target_feature(enable = "avx")]
-pub unsafe fn test() {
+pub fn okay() {
     ({
         #[inline(always)]
         move || {}
+    })();
+}
+
+#[target_feature(enable = "avx")]
+pub unsafe fn also_okay() {
+    ({
+        #[inline]
+        move || {}
+    })();
+}
+
+#[target_feature(enable = "avx")]
+pub unsafe fn warn() {
+    ({
+        #[inline(always)]
+        //~^ WARNING: cannot use `#[inline(always)]` with `#[target_feature]` [inline_always_closure_in_target_feature_function]
+        //~^^ WARNING: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+        move || {}
+    })();
+}
+
+#[target_feature(enable = "avx")]
+pub unsafe fn also_warn() {
+    ({
+        move || {
+            ({
+                #[inline(always)]
+                //~^ WARNING: cannot use `#[inline(always)]` with `#[target_feature]` [inline_always_closure_in_target_feature_function]
+                //~^^ WARNING: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+                move || {}
+            })();
+        }
     })();
 }
 

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/issue-108655-inline-always-closure.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/issue-108655-inline-always-closure.stderr
@@ -1,0 +1,25 @@
+warning: cannot use `#[inline(always)]` with `#[target_feature]`
+  --> $DIR/issue-108655-inline-always-closure.rs:26:9
+   |
+LL |         #[inline(always)]
+   |         ^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #108655 <https://github.com/rust-lang/rust/issues/108655>
+   = note: `#[target_feature]` will not be applied to this closure and may result in unpredictable code generation
+   = help: consider using `#[inline]` instead
+   = note: `#[warn(inline_always_closure_in_target_feature_function)]` on by default
+
+warning: cannot use `#[inline(always)]` with `#[target_feature]`
+  --> $DIR/issue-108655-inline-always-closure.rs:38:17
+   |
+LL |                 #[inline(always)]
+   |                 ^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #108655 <https://github.com/rust-lang/rust/issues/108655>
+   = note: `#[target_feature]` will not be applied to this closure and may result in unpredictable code generation
+   = help: consider using `#[inline]` instead
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
Make #108655 a future-incompatible lint as suggested in https://github.com/rust-lang/rust/issues/69098#issuecomment-2495554295

r? @RalfJung 

Some context:

In Rust today, closures don't inherit target features from their enclosing function.  This behavior might be surprising to users.  The `target_feature_11` feature changes this--otherwise, safe target feature 1.1 calls would still require `unsafe` within a closure.

Rust does not allow `#[inline(always)]` to be applied to `#[target_feature]` functions, so adding target features to closures causes errors in previously accepted code (#108655).  Unfortunately, we can't simply allow both attributes for two reasons.  First, it is possible for the closure to "escape" the function (e.g. an indirect call optimization) and attempt to inline into a function that doesn't have the target features, resulting in an ICE when inlining fails.  Additionally, there are soundness concerns when combining `#[inline(always)]` with `#[target_feature]`, see #116573.

This leaves us with a few options:
* Don't pass target features to closures.  This prevents target feature 1.1 from working in closures.  Inconsistent safety requirements inside and outside closures might be confusing.  This also potentially affects performance: e.g. std::arch intrinsics don't inline into closures.
* Pass target features to closures, but don't enable them at codegen when `#[inline(always)]` is present.  This is the current `target_feature_11` behavior.  This allows any existing code to still work, but it is potentially confusing for `#[inline]` to affect other codegen behavior.
* Merge this PR: add a future-incompatible warning, and reject `#[inline(always)]` on closures in `#[target_feature]` functions in a future version of rust.