### PR TITLE
Support `vec![const { ... }; n]` syntax

### DIFF
--- a/library/alloc/src/macros.rs
+++ b/library/alloc/src/macros.rs
@@ -43,6 +43,10 @@ macro_rules! vec {
     () => (
         $crate::vec::Vec::new()
     );
+    (const $elem:block; $n:expr) => (
+        // SAFETY: The `const` keyword asserts the value being the result of a const expression.
+        unsafe { $crate::vec::from_const_elem(const $elem, $n) }
+    );
     ($elem:expr; $n:expr) => (
         $crate::vec::from_elem($elem, $n)
     );

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -3205,11 +3205,13 @@ pub unsafe fn from_const_elem<T>(elem: T, n: usize) -> Vec<T> {
 unsafe fn from_const_elem_in<T, A: Allocator>(elem: T, n: usize, alloc: A) -> Vec<T, A> {
     /// # Safety
     ///
-    /// `value` must points to a valid `T` value that is the result of some const expression.
+    /// `value` must point to a valid `T` value that is the result of some const expression.
     unsafe fn fill_const_value<T>(buffer: &mut [MaybeUninit<T>], value: *const T) {
         for target in buffer {
-            // SAFETY: If `value` is the result of some const expression, we can make as many
-            // copies as needed.
+            // SAFETY: The current compiler implementation guarantees that if `value` points to a
+            // value that is the result of some const expression, we can make as many copies as
+            // needed safely by duplicating its byte representation. Code outside of the standard
+            // library should not rely on this fact.
             unsafe { target.write(ptr::read(value)) };
         }
     }

--- a/library/alloc/tests/lib.rs
+++ b/library/alloc/tests/lib.rs
@@ -36,6 +36,7 @@
 #![cfg_attr(not(bootstrap), feature(strict_provenance_lints))]
 #![feature(drain_keep_rest)]
 #![feature(local_waker)]
+#![feature(vec_of_const_expr)]
 #![feature(vec_pop_if)]
 #![feature(unique_rc_arc)]
 #![feature(macro_metavar_expr_concat)]

--- a/library/alloc/tests/vec.rs
+++ b/library/alloc/tests/vec.rs
@@ -2312,6 +2312,28 @@ fn test_vec_macro_repeat() {
 }
 
 #[test]
+fn test_vec_macro_repeat_const() {
+    #[derive(Eq, PartialEq, Debug)]
+    struct Item {
+        x: u64,
+        y: u32, // Paddings are added to test the uninitialized bytes case.
+    }
+
+    impl Clone for Item {
+        fn clone(&self) -> Self {
+            panic!("no clone should be called");
+        }
+    }
+
+    const ITEM: Item = Item { x: 2, y: 3 };
+
+    assert_eq!(vec![const { ITEM }; 0], vec![ITEM; 0]);
+    assert_eq!(vec![const { ITEM }; 1], vec![ITEM]);
+    assert_eq!(vec![const { ITEM }; 2], vec![ITEM, ITEM]);
+    assert_eq!(vec![const { ITEM }; 3], vec![ITEM, ITEM, ITEM]);
+}
+
+#[test]
 fn test_vec_swap() {
     let mut a: Vec<isize> = vec![0, 1, 2, 3, 4, 5, 6];
     a.swap(2, 4);


### PR DESCRIPTION
ACP: https://github.com/rust-lang/libs-team/issues/484.