### PR TITLE
Added a doc test for std::path::strip_prefix

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2504,6 +2504,7 @@ impl Path {
     /// assert_eq!(path.strip_prefix("/test/haha/foo.txt/"), Ok(Path::new("")));
     ///
     /// assert!(path.strip_prefix("test").is_err());
+    /// assert!(path.strip_prefix("/te").is_err());
     /// assert!(path.strip_prefix("/haha").is_err());
     ///
     /// let prefix = PathBuf::from("/test/");


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

I was about 90% sure `Path::new("/test/haha/foo.txt").strip_prefix("/te")` would return an Err, but I couldn't find an example to confirm this behaviour.

This should be an easy merge :)