### PR TITLE
bootstrap: use fs-err to improve error messages

### DIFF
--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +48,7 @@ dependencies = [
  "clap_complete",
  "cmake",
  "fd-lock",
+ "fs-err",
  "home",
  "ignore",
  "junction",
@@ -250,6 +257,15 @@ dependencies = [
  "libc",
  "libredox",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb60e7409f34ef959985bc9d9c5ee8f5db24ee46ed9775850548021710f807f"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -44,6 +44,7 @@ build_helper = { path = "../build_helper" }
 clap = { version = "4.4", default-features = false, features = ["std", "usage", "help", "derive", "error-context"] }
 clap_complete = "4.4"
 fd-lock = "4.0"
+fs-err = "3.0"
 home = "0.5"
 ignore = "0.4"
 libc = "0.2"

--- a/src/bootstrap/src/core/build_steps/format.rs
+++ b/src/bootstrap/src/core/build_steps/format.rs
@@ -82,7 +82,7 @@ fn update_rustfmt_version(build: &Builder<'_>) {
     let Some((version, stamp_file)) = get_rustfmt_version(build) else {
         return;
     };
-    t!(std::fs::write(stamp_file, version))
+    t!(fs_err::write(stamp_file, version))
 }
 
 /// Returns the Rust files modified between the `merge-base` of HEAD and
@@ -144,7 +144,7 @@ pub fn format(build: &Builder<'_>, check: bool, all: bool, paths: &[PathBuf]) {
         eprintln!("fmt error: This may happen in distributed tarballs.");
         return;
     }
-    let rustfmt_config = t!(std::fs::read_to_string(&rustfmt_config));
+    let rustfmt_config = t!(fs_err::read_to_string(&rustfmt_config));
     let rustfmt_config: RustfmtConfig = t!(toml::from_str(&rustfmt_config));
     let mut override_builder = ignore::overrides::OverrideBuilder::new(&build.src);
     for ignore in rustfmt_config.ignore {

--- a/src/bootstrap/src/core/build_steps/gcc.rs
+++ b/src/bootstrap/src/core/build_steps/gcc.rs
@@ -8,9 +8,10 @@
 //! GCC and compiler-rt are essentially just wired up to everything else to
 //! ensure that they're always in place if needed.
 
-use std::fs;
 use std::path::PathBuf;
 use std::sync::OnceLock;
+
+use fs_err;
 
 use crate::core::builder::{Builder, RunConfig, ShouldRun, Step};
 use crate::core::config::TargetSelection;
@@ -106,7 +107,7 @@ impl Step for Gcc {
         let _guard = builder.msg_unstaged(Kind::Build, "GCC", target);
         t!(stamp.remove());
         let _time = helpers::timeit(builder);
-        t!(fs::create_dir_all(&out_dir));
+        t!(fs_err::create_dir_all(&out_dir));
 
         if builder.config.dry_run() {
             return true;

--- a/src/bootstrap/src/core/build_steps/run.rs
+++ b/src/bootstrap/src/core/build_steps/run.rs
@@ -255,7 +255,7 @@ macro_rules! generate_completions {
     ( $( ( $shell:ident, $filename:expr ) ),* ) => {
         $(
             if let Some(comp) = get_completion($shell, &$filename) {
-                std::fs::write(&$filename, comp).expect(&format!("writing {} completion", stringify!($shell)));
+                fs_err::write(&$filename, comp).expect(&format!("writing {} completion", stringify!($shell)));
             }
         )*
     };

--- a/src/bootstrap/src/core/build_steps/synthetic_targets.rs
+++ b/src/bootstrap/src/core/build_steps/synthetic_targets.rs
@@ -49,10 +49,10 @@ fn create_synthetic_target(
 
     let name = format!("{base}-synthetic-{suffix}");
     let path = builder.out.join("synthetic-target-specs").join(format!("{name}.json"));
-    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs_err::create_dir_all(path.parent().unwrap()).unwrap();
 
     if builder.config.dry_run() {
-        std::fs::write(&path, b"dry run\n").unwrap();
+        fs_err::write(&path, b"dry run\n").unwrap();
         return TargetSelection::create_synthetic(&name, path.to_str().unwrap());
     }
 
@@ -73,6 +73,6 @@ fn create_synthetic_target(
 
     customize(spec_map);
 
-    std::fs::write(&path, serde_json::to_vec_pretty(&spec).unwrap()).unwrap();
+    fs_err::write(&path, serde_json::to_vec_pretty(&spec).unwrap()).unwrap();
     TargetSelection::create_synthetic(&name, path.to_str().unwrap())
 }

--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -6,7 +6,7 @@
 use std::collections::HashSet;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
-use std::{env, fs, iter};
+use std::{env, iter};
 
 use clap_complete::shells;
 
@@ -243,7 +243,7 @@ impl Step for Cargotest {
         // is currently to minimize the length of path on Windows where we otherwise
         // quickly run into path name limit constraints.
         let out_dir = builder.out.join("ct");
-        t!(fs::create_dir_all(&out_dir));
+        t!(fs_err::create_dir_all(&out_dir));
 
         let _time = helpers::timeit(builder);
         let mut cmd = builder.tool_cmd(Tool::CargoTest);
@@ -415,7 +415,7 @@ impl Step for Rustfmt {
         );
 
         let dir = testdir(builder, compiler.host);
-        t!(fs::create_dir_all(&dir));
+        t!(fs_err::create_dir_all(&dir));
         cargo.env("RUSTFMT_TEST_DIR", dir);
 
         cargo.add_rustc_lib_path(builder);
@@ -2445,7 +2445,7 @@ impl Step for ErrorIndex {
         let compiler = self.compiler;
 
         let dir = testdir(builder, compiler.host);
-        t!(fs::create_dir_all(&dir));
+        t!(fs_err::create_dir_all(&dir));
         let output = dir.join("error-index.md");
 
         let mut tool = tool::ErrorIndex::command(builder);
@@ -2464,7 +2464,7 @@ impl Step for ErrorIndex {
 }
 
 fn markdown_test(builder: &Builder<'_>, compiler: Compiler, markdown: &Path) -> bool {
-    if let Ok(contents) = fs::read_to_string(markdown) {
+    if let Ok(contents) = fs_err::read_to_string(markdown) {
         if !contents.contains("```") {
             return true;
         }
@@ -3039,8 +3039,8 @@ impl Step for Distcheck {
     fn run(self, builder: &Builder<'_>) {
         builder.info("Distcheck");
         let dir = builder.tempdir().join("distcheck");
-        let _ = fs::remove_dir_all(&dir);
-        t!(fs::create_dir_all(&dir));
+        let _ = fs_err::remove_dir_all(&dir);
+        t!(fs_err::create_dir_all(&dir));
 
         // Guarantee that these are built before we begin running.
         builder.ensure(dist::PlainSourceTarball);
@@ -3065,8 +3065,8 @@ impl Step for Distcheck {
         // Now make sure that rust-src has all of libstd's dependencies
         builder.info("Distcheck rust-src");
         let dir = builder.tempdir().join("distcheck-src");
-        let _ = fs::remove_dir_all(&dir);
-        t!(fs::create_dir_all(&dir));
+        let _ = fs_err::remove_dir_all(&dir);
+        t!(fs_err::create_dir_all(&dir));
 
         command("tar")
             .arg("-xf")
@@ -3270,8 +3270,8 @@ impl Step for RustInstaller {
 
         let mut cmd = command(builder.src.join("src/tools/rust-installer/test.sh"));
         let tmpdir = testdir(builder, compiler.host).join("rust-installer");
-        let _ = std::fs::remove_dir_all(&tmpdir);
-        let _ = std::fs::create_dir_all(&tmpdir);
+        let _ = fs_err::remove_dir_all(&tmpdir);
+        let _ = fs_err::create_dir_all(&tmpdir);
         cmd.current_dir(&tmpdir);
         cmd.env("CARGO_TARGET_DIR", tmpdir.join("cargo-target"));
         cmd.env("CARGO", &builder.initial_cargo);
@@ -3326,7 +3326,7 @@ impl Step for TestHelpers {
         }
 
         let _guard = builder.msg_unstaged(Kind::Build, "test helpers", target);
-        t!(fs::create_dir_all(&dst));
+        t!(fs_err::create_dir_all(&dst));
         let mut cfg = cc::Build::new();
 
         // We may have found various cross-compilers a little differently due to our

--- a/src/bootstrap/src/core/build_steps/tool.rs
+++ b/src/bootstrap/src/core/build_steps/tool.rs
@@ -1,5 +1,5 @@
+use std::env;
 use std::path::PathBuf;
-use std::{env, fs};
 
 use crate::core::build_steps::compile;
 use crate::core::build_steps::toolstate::ToolState;
@@ -582,9 +582,9 @@ impl Step for Rustdoc {
         let bin_rustdoc = || {
             let sysroot = builder.sysroot(target_compiler);
             let bindir = sysroot.join("bin");
-            t!(fs::create_dir_all(&bindir));
+            t!(fs_err::create_dir_all(&bindir));
             let bin_rustdoc = bindir.join(exe("rustdoc", target_compiler.host));
-            let _ = fs::remove_file(&bin_rustdoc);
+            let _ = fs_err::remove_file(&bin_rustdoc);
             bin_rustdoc
         };
 
@@ -835,7 +835,7 @@ impl Step for RustAnalyzerProcMacroSrv {
         // Copy `rust-analyzer-proc-macro-srv` to `<sysroot>/libexec/`
         // so that r-a can use it.
         let libexec_path = builder.sysroot(self.compiler).join("libexec");
-        t!(fs::create_dir_all(&libexec_path));
+        t!(fs_err::create_dir_all(&libexec_path));
         builder.copy_link(&path, &libexec_path.join("rust-analyzer-proc-macro-srv"));
 
         Some(path)
@@ -907,7 +907,7 @@ impl Step for LlvmBitcodeLinker {
             let bindir_self_contained = builder
                 .sysroot(self.compiler)
                 .join(format!("lib/rustlib/{}/bin/self-contained", self.target.triple));
-            t!(fs::create_dir_all(&bindir_self_contained));
+            t!(fs_err::create_dir_all(&bindir_self_contained));
             let bin_destination = bindir_self_contained.join(exe(bin_name, self.compiler.host));
             builder.copy_link(&tool_out, &bin_destination);
             bin_destination
@@ -948,7 +948,7 @@ impl Step for LibcxxVersionTool {
         // Therefore, we want to avoid recompiling this file unnecessarily.
         if !executable.exists() {
             if !out_dir.exists() {
-                t!(fs::create_dir_all(&out_dir));
+                t!(fs_err::create_dir_all(&out_dir));
             }
 
             let compiler = builder.cxx(self.target).unwrap();
@@ -1045,7 +1045,7 @@ macro_rules! tool_extended {
 
                 if (false $(|| !$add_bins_to_sysroot.is_empty())?) && $sel.compiler.stage > 0 {
                     let bindir = $builder.sysroot($sel.compiler).join("bin");
-                    t!(fs::create_dir_all(&bindir));
+                    t!(fs_err::create_dir_all(&bindir));
 
                     #[allow(unused_variables)]
                     let tools_out = $builder

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -892,7 +892,7 @@ impl Builder<'_> {
                 env_var.push("=/rust/deps");
             } else {
                 let registry_src = t!(home::cargo_home()).join("registry").join("src");
-                for entry in t!(std::fs::read_dir(registry_src)) {
+                for entry in t!(fs_err::read_dir(registry_src)) {
                     if !env_var.is_empty() {
                         env_var.push("\t");
                     }

--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -3,13 +3,13 @@ mod cargo;
 use std::any::{Any, type_name};
 use std::cell::{Cell, RefCell};
 use std::collections::BTreeSet;
+use std::env;
 use std::fmt::{Debug, Write};
 use std::hash::Hash;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
-use std::{env, fs};
 
 use clap::ValueEnum;
 
@@ -1196,8 +1196,8 @@ impl<'a> Builder<'a> {
                     builder.verbose(|| {
                         println!("Removing sysroot {} to avoid caching bugs", sysroot.display())
                     });
-                    let _ = fs::remove_dir_all(&sysroot);
-                    t!(fs::create_dir_all(&sysroot));
+                    let _ = fs_err::remove_dir_all(&sysroot);
+                    t!(fs_err::create_dir_all(&sysroot));
                 }
 
                 if self.compiler.stage == 0 {
@@ -1302,7 +1302,7 @@ impl<'a> Builder<'a> {
 
     /// Gets the paths to all of the compiler's codegen backends.
     fn codegen_backends(&self, compiler: Compiler) -> impl Iterator<Item = PathBuf> {
-        fs::read_dir(self.sysroot_codegen_backends(compiler))
+        fs_err::read_dir(self.sysroot_codegen_backends(compiler))
             .into_iter()
             .flatten()
             .filter_map(Result::ok)

--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -39,7 +39,7 @@ fn configure_with_args(cmd: &[String], host: &[&str], target: &[&str]) -> Config
     let dir = Path::new(env!("OUT_DIR"))
         .join("tmp-rustbuild-tests")
         .join(&thread::current().name().unwrap_or("unknown").replace(":", "-"));
-    t!(fs::create_dir_all(&dir));
+    t!(fs_err::create_dir_all(&dir));
     config.out = dir;
     config.build = TargetSelection::from_user(TEST_TRIPLE_1);
     config.hosts = host.iter().map(|s| TargetSelection::from_user(s)).collect();
@@ -137,7 +137,7 @@ fn check_missing_paths_for_x_test_tests() {
     let (_, tests_remap_paths) =
         PATH_REMAP.iter().find(|(target_path, _)| *target_path == "tests").unwrap();
 
-    let tests_dir = fs::read_dir(build.src.join("tests")).unwrap();
+    let tests_dir = fs_err::read_dir(build.src.join("tests")).unwrap();
     for dir in tests_dir {
         let path = dir.unwrap().path();
 
@@ -217,7 +217,7 @@ fn ci_rustc_if_unchanged_logic() {
     let builder = Builder::new(&build);
 
     if config.out.exists() {
-        fs::remove_dir_all(&config.out).unwrap();
+        fs_err::remove_dir_all(&config.out).unwrap();
     }
 
     builder.run_step_descriptions(&Builder::get_step_descriptions(config.cmd.kind()), &[]);

--- a/src/bootstrap/src/core/config/flags.rs
+++ b/src/bootstrap/src/core/config/flags.rs
@@ -627,7 +627,7 @@ pub fn get_completion<G: clap_complete::Generator>(shell: G, path: &Path) -> Opt
     let current = if !path.exists() {
         String::new()
     } else {
-        std::fs::read_to_string(path).unwrap_or_else(|_| {
+        fs_err::read_to_string(path).unwrap_or_else(|_| {
             eprintln!("couldn't read {}", path.display());
             crate::exit!(1)
         })

--- a/src/bootstrap/src/core/config/tests.rs
+++ b/src/bootstrap/src/core/config/tests.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeSet;
 use std::env;
-use std::fs::{File, remove_file};
 use std::io::Write;
 use std::path::Path;
 
 use clap::CommandFactory;
+use fs_err::{File, remove_file};
 use serde::Deserialize;
 
 use super::flags::Flags;
@@ -227,7 +227,7 @@ fn profile_user_dist() {
                 "profile = \"user\"".to_owned()
             } else {
                 assert!(file.ends_with("config.dist.toml"));
-                std::fs::read_to_string(file).unwrap()
+                fs_err::read_to_string(file).unwrap()
             };
 
         toml::from_str(&contents).and_then(|table: toml::Value| TomlConfig::deserialize(table))

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -10,9 +10,9 @@ use fs_err::{self, File};
 use xz2::bufread::XzDecoder;
 
 use crate::core::config::BUILDER_CONFIG_FILENAME;
-use crate::utils::exec::{command, BootstrapCommand};
+use crate::utils::exec::{BootstrapCommand, command};
 use crate::utils::helpers::{check_run, exe, hex_encode, move_file, program_out_of_date};
-use crate::{t, Config};
+use crate::{Config, t};
 
 static SHOULD_FIX_BINS_AND_DYLIBS: OnceLock<bool> = OnceLock::new();
 

--- a/src/bootstrap/src/core/sanity.rs
+++ b/src/bootstrap/src/core/sanity.rs
@@ -9,9 +9,9 @@
 //! practice that's likely not true!
 
 use std::collections::{HashMap, HashSet};
+use std::env;
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
-use std::{env, fs};
 
 use crate::Build;
 #[cfg(not(feature = "bootstrap-self-test"))]
@@ -336,7 +336,7 @@ than building it.
             }
             match build.musl_libdir(*target) {
                 Some(libdir) => {
-                    if fs::metadata(libdir.join("libc.a")).is_err() {
+                    if fs_err::metadata(libdir.join("libc.a")).is_err() {
                         panic!("couldn't find libc.a in musl libdir: {}", libdir.display());
                     }
                 }

--- a/src/bootstrap/src/utils/channel.rs
+++ b/src/bootstrap/src/utils/channel.rs
@@ -5,8 +5,9 @@
 //! `package_vers`, and otherwise indicating to the compiler what it should
 //! print out as part of its version information.
 
-use std::fs;
 use std::path::Path;
+
+use fs_err;
 
 use super::helpers;
 use crate::Build;
@@ -128,7 +129,7 @@ impl GitInfo {
 /// Read the commit information from the `git-commit-info` file given the
 /// project root.
 pub fn read_commit_info_file(root: &Path) -> Option<Info> {
-    if let Ok(contents) = fs::read_to_string(root.join("git-commit-info")) {
+    if let Ok(contents) = fs_err::read_to_string(root.join("git-commit-info")) {
         let mut lines = contents.lines();
         let sha = lines.next();
         let short_sha = lines.next();
@@ -151,10 +152,10 @@ pub fn read_commit_info_file(root: &Path) -> Option<Info> {
 /// root.
 pub fn write_commit_info_file(root: &Path, info: &Info) {
     let commit_info = format!("{}\n{}\n{}\n", info.sha, info.short_sha, info.commit_date);
-    t!(fs::write(root.join("git-commit-info"), commit_info));
+    t!(fs_err::write(root.join("git-commit-info"), commit_info));
 }
 
 /// Write the commit hash to the `git-commit-hash` file given the project root.
 pub fn write_commit_hash_file(root: &Path, sha: &str) {
-    t!(fs::write(root.join("git-commit-hash"), sha));
+    t!(fs_err::write(root.join("git-commit-hash"), sha));
 }

--- a/src/bootstrap/src/utils/helpers/tests.rs
+++ b/src/bootstrap/src/utils/helpers/tests.rs
@@ -1,6 +1,8 @@
-use std::fs::{self, File, remove_file};
+use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
+
+use fs_err::{self, File, remove_file};
 
 use crate::utils::helpers::{
     check_cfg_arg, extract_beta_rev, hex_encode, make, program_out_of_date, set_file_times,
@@ -80,18 +82,18 @@ fn test_symlink_dir() {
     let tempdir = config.tempdir().join(".tmp-dir");
     let link_path = config.tempdir().join(".tmp-link");
 
-    fs::create_dir_all(&tempdir).unwrap();
+    fs_err::create_dir_all(&tempdir).unwrap();
     symlink_dir(&config, &tempdir, &link_path).unwrap();
 
-    let link_source = fs::read_link(&link_path).unwrap();
+    let link_source = fs_err::read_link(&link_path).unwrap();
     assert_eq!(link_source, tempdir);
 
-    fs::remove_dir(tempdir).unwrap();
+    fs_err::remove_dir(tempdir).unwrap();
 
     #[cfg(windows)]
-    fs::remove_dir(link_path).unwrap();
+    fs_err::remove_dir(link_path).unwrap();
     #[cfg(not(windows))]
-    fs::remove_file(link_path).unwrap();
+    fs_err::remove_file(link_path).unwrap();
 }
 
 #[test]
@@ -111,7 +113,7 @@ fn test_set_file_times_sanity_check() {
     let target_time = fs::FileTimes::new().set_accessed(unix_epoch).set_modified(unix_epoch);
     set_file_times(&tempfile, target_time).unwrap();
 
-    let found_metadata = fs::metadata(tempfile).unwrap();
+    let found_metadata = fs_err::metadata(tempfile).unwrap();
     assert_eq!(found_metadata.accessed().unwrap(), unix_epoch);
     assert_eq!(found_metadata.modified().unwrap(), unix_epoch)
 }

--- a/src/bootstrap/src/utils/metrics.rs
+++ b/src/bootstrap/src/utils/metrics.rs
@@ -5,7 +5,6 @@
 //! away whenever the `build.metrics` config option is not set to `true`.
 
 use std::cell::RefCell;
-use std::fs::File;
 use std::io::BufWriter;
 use std::time::{Duration, Instant, SystemTime};
 
@@ -13,6 +12,7 @@ use build_helper::metrics::{
     JsonInvocation, JsonInvocationSystemStats, JsonNode, JsonRoot, JsonStepSystemStats, Test,
     TestOutcome, TestSuite, TestSuiteMetadata,
 };
+use fs_err::File;
 use sysinfo::{CpuRefreshKind, RefreshKind, System};
 
 use crate::Build;
@@ -176,7 +176,7 @@ impl BuildMetrics {
 
         // Some of our CI builds consist of multiple independent CI invocations. Ensure all the
         // previous invocations are still present in the resulting file.
-        let mut invocations = match std::fs::read(&dest) {
+        let mut invocations = match fs_err::read(&dest) {
             Ok(contents) => {
                 // We first parse just the format_version field to have the check succeed even if
                 // the rest of the contents are not valid anymore.
@@ -210,7 +210,7 @@ impl BuildMetrics {
 
         let json = JsonRoot { format_version: CURRENT_FORMAT_VERSION, system_stats, invocations };
 
-        t!(std::fs::create_dir_all(dest.parent().unwrap()));
+        t!(fs_err::create_dir_all(dest.parent().unwrap()));
         let mut file = BufWriter::new(t!(File::create(&dest)));
         t!(serde_json::to_writer(&mut file, &json));
     }

--- a/src/bootstrap/src/utils/shared_helpers.rs
+++ b/src/bootstrap/src/utils/shared_helpers.rs
@@ -8,10 +8,11 @@
 
 use std::env;
 use std::ffi::OsString;
-use std::fs::OpenOptions;
 use std::io::Write;
 use std::process::Command;
 use std::str::FromStr;
+
+use fs_err::OpenOptions;
 
 #[cfg(test)]
 mod tests;

--- a/src/bootstrap/src/utils/tarball.rs
+++ b/src/bootstrap/src/utils/tarball.rs
@@ -135,7 +135,7 @@ impl<'a> Tarball<'a> {
         if let Some(target) = &target {
             temp_dir = temp_dir.join(target);
         }
-        let _ = std::fs::remove_dir_all(&temp_dir);
+        let _ = fs_err::remove_dir_all(&temp_dir);
 
         let image_dir = temp_dir.join("image");
         let overlay_dir = temp_dir.join("overlay");
@@ -181,7 +181,7 @@ impl<'a> Tarball<'a> {
     }
 
     pub(crate) fn image_dir(&self) -> &Path {
-        t!(std::fs::create_dir_all(&self.image_dir));
+        t!(fs_err::create_dir_all(&self.image_dir));
         &self.image_dir
     }
 
@@ -194,7 +194,7 @@ impl<'a> Tarball<'a> {
             self.image_dir.join(destdir.as_ref())
         };
 
-        t!(std::fs::create_dir_all(&destdir));
+        t!(fs_err::create_dir_all(&destdir));
         self.builder.install(src.as_ref(), &destdir, perms);
     }
 
@@ -205,7 +205,7 @@ impl<'a> Tarball<'a> {
         new_name: &str,
     ) {
         let destdir = self.image_dir.join(destdir.as_ref());
-        t!(std::fs::create_dir_all(&destdir));
+        t!(fs_err::create_dir_all(&destdir));
         self.builder.copy_link(src.as_ref(), &destdir.join(new_name));
     }
 
@@ -218,7 +218,7 @@ impl<'a> Tarball<'a> {
     pub(crate) fn add_dir(&self, src: impl AsRef<Path>, dest: impl AsRef<Path>) {
         let dest = self.image_dir.join(dest.as_ref());
 
-        t!(std::fs::create_dir_all(&dest));
+        t!(fs_err::create_dir_all(&dest));
         self.builder.cp_link_r(src.as_ref(), &dest);
     }
 
@@ -282,7 +282,7 @@ impl<'a> Tarball<'a> {
 
         self.run(|this, cmd| {
             let distdir = distdir(this.builder);
-            t!(std::fs::create_dir_all(&distdir));
+            t!(fs_err::create_dir_all(&distdir));
             cmd.arg("tarball")
                 .arg("--input")
                 .arg(&dest)
@@ -312,7 +312,7 @@ impl<'a> Tarball<'a> {
     }
 
     fn run(self, build_cli: impl FnOnce(&Tarball<'a>, &mut BootstrapCommand)) -> GeneratedTarball {
-        t!(std::fs::create_dir_all(&self.overlay_dir));
+        t!(fs_err::create_dir_all(&self.overlay_dir));
         self.builder.create(&self.overlay_dir.join("version"), &self.overlay.version(self.builder));
         if let Some(info) = self.builder.rust_info().info() {
             channel::write_commit_hash_file(&self.overlay_dir, &info.sha);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->

I was trying to run bootstrap locally and some error messages were not easy to debug. I changed the code to use [fs_err](https://docs.rs/fs-err/latest/fs_err/) whenever possible.

For example, with this change, the error:
```
thread 'main' panicked at src/core/download.rs:606:13:
fs::write(rustc_stamp, stamp_key) failed with No such file or directory (os error 2)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
becomes
```
thread 'main' panicked at src/core/download.rs:606:13:
fs_err::write(rustc_stamp, stamp_key) failed with failed to create file `/path/to/rust/src/bootstrap/build/aarch64-apple-darwin/stage0/.rustc-stamp`: No such file or directory (os error 2)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

which also shows the file name.

I'm not sure if you like this change. If not, feel free to close this PR!

Concerns:
- fs_err might introduce some performance penalty
- I haven't reviewed all the code. There might be some errors that needs to be changed after introducing fs_err.
- There might be some code who relies on the old error messages

If you like the idea of adding fs_err, I can work on the concerns that worry you 👍

<!-- homu-ignore:end -->
