### PR TITLE
Update test expectations to accept LLVM 'initializes' attribute

### DIFF
--- a/tests/codegen/aarch64-softfloat.rs
+++ b/tests/codegen/aarch64-softfloat.rs
@@ -41,7 +41,7 @@ fn pass_f32_pair_Rust(x: (f32, f32)) -> (f32, f32) {
     x
 }
 
-// CHECK: void @pass_f64_pair_Rust(ptr {{[^,]*}}, ptr {{[^,]*}})
+// CHECK: void @pass_f64_pair_Rust(ptr {{.*}}%{{[^ ]+}}, ptr {{.*}}%{{[^ ]+}})
 #[no_mangle]
 fn pass_f64_pair_Rust(x: (f64, f64)) -> (f64, f64) {
     x


### PR DESCRIPTION
The test was checking for two `ptr` arguments by matching commas (or non-commas), however after
https://github.com/llvm/llvm-project/pull/117104 LLVM adds an `initializes((0, 16))` attribute, which includes a comma.

So instead, we make the test check for two LLVM values, i.e. something prefixed by %.

(See also https://crbug.com/380707238)