### PR TITLE
miri: implement `TlsFree`

### DIFF
--- a/src/tools/miri/src/shims/windows/foreign_items.rs
+++ b/src/tools/miri/src/shims/windows/foreign_items.rs
@@ -382,6 +382,14 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
                 // Return success (`1`).
                 this.write_int(1, dest)?;
             }
+            "TlsFree" => {
+                let [key] = this.check_shim(abi, ExternAbi::System { unwind: false }, link_name, args)?;
+                let key = u128::from(this.read_scalar(key)?.to_u32()?);
+                this.machine.tls.delete_tls_key(key)?;
+
+                // Return success (`1`).
+                this.write_int(1, dest)?;
+            }
 
             // Access to command-line arguments
             "GetCommandLineW" => {

--- a/src/tools/miri/tests/pass/tls/windows-tls.rs
+++ b/src/tools/miri/tests/pass/tls/windows-tls.rs
@@ -1,0 +1,18 @@
+//@only-target: windows # this directly tests windows-only functions
+
+use std::ffi::c_void;
+use std::ptr;
+
+extern "system" {
+    fn TlsAlloc() -> u32;
+    fn TlsSetValue(key: u32, val: *mut c_void) -> bool;
+    fn TlsGetValue(key: u32) -> *mut c_void;
+    fn TlsFree(key: u32) -> bool;
+}
+
+fn main() {
+    let key = unsafe { TlsAlloc() };
+    assert!(unsafe { TlsSetValue(key, ptr::without_provenance_mut(1)) });
+    assert_eq!(unsafe { TlsGetValue(key).addr() }, 1);
+    assert!(unsafe { TlsFree(key) });
+}


### PR DESCRIPTION
If the variable does not need a destructor, `std` uses racy initialization for creating TLS keys on Windows. With just the right timing, this can lead to `TlsFree` being called. Unfortunately, with #132654 this is hit quite often, so miri should definitely support `TlsFree` ([documentation](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-tlsfree)).

I'm filing this here instead of in the miri repo so that #132654 isn't blocked for so long.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
