### PR TITLE
always create `DefId`s for anon consts

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1184,14 +1184,15 @@ pub struct Expr {
 }
 
 impl Expr {
-    /// Is this expr either `N`, or `{ N }`.
+    /// Could this expr be either `N`, or `{ N }`, where `N` is a const parameter.
     ///
     /// If this is not the case, name resolution does not resolve `N` when using
     /// `min_const_generics` as more complex expressions are not supported.
     ///
     /// Does not ensure that the path resolves to a const param, the caller should check this.
-    pub fn is_potential_trivial_const_arg(&self, strip_identity_block: bool) -> bool {
-        let this = if strip_identity_block { self.maybe_unwrap_block() } else { self };
+    /// This also does not consider macros, so it's only correct after macro-expansion.
+    pub fn is_potential_trivial_const_arg(&self) -> bool {
+        let this = self.maybe_unwrap_block();
 
         if let ExprKind::Path(None, path) = &this.kind
             && path.is_potential_trivial_const_arg()

--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -224,16 +224,13 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             // Wrap the expression in an AnonConst.
                             let parent_def_id = self.current_def_id_parent;
                             let node_id = self.next_node_id();
-                            // HACK(min_generic_const_args): see lower_anon_const
-                            if !expr.is_potential_trivial_const_arg(true) {
-                                self.create_def(
-                                    parent_def_id,
-                                    node_id,
-                                    kw::Empty,
-                                    DefKind::AnonConst,
-                                    *op_sp,
-                                );
-                            }
+                            self.create_def(
+                                parent_def_id,
+                                node_id,
+                                kw::Empty,
+                                DefKind::AnonConst,
+                                *op_sp,
+                            );
                             let anon_const = AnonConst { id: node_id, value: P(expr) };
                             hir::InlineAsmOperand::SymFn {
                                 anon_const: self.lower_anon_const_to_anon_const(&anon_const),

--- a/compiler/rustc_ast_lowering/src/asm.rs
+++ b/compiler/rustc_ast_lowering/src/asm.rs
@@ -222,7 +222,7 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
                             };
 
                             // Wrap the expression in an AnonConst.
-                            let parent_def_id = self.current_def_id_parent;
+                            let parent_def_id = self.current_hir_id_owner.def_id;
                             let node_id = self.next_node_id();
                             self.create_def(
                                 parent_def_id,

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -454,13 +454,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
             if legacy_args_idx.contains(&idx) {
                 let parent_def_id = self.current_def_id_parent;
                 let node_id = self.next_node_id();
-
-                // HACK(min_generic_const_args): see lower_anon_const
-                if !arg.is_potential_trivial_const_arg(true) {
-                    // Add a definition for the in-band const def.
-                    self.create_def(parent_def_id, node_id, kw::Empty, DefKind::AnonConst, f.span);
-                }
-
+                self.create_def(parent_def_id, node_id, kw::Empty, DefKind::AnonConst, f.span);
                 let mut visitor = WillCreateDefIdsVisitor {};
                 let const_value = if let ControlFlow::Break(span) = visitor.visit_expr(&arg) {
                     AstP(Expr {

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -109,9 +109,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                         hir::ConstBlock {
                             def_id,
                             hir_id: this.lower_node_id(c.id),
-                            body: this.with_def_id_parent(def_id, |this| {
-                                this.lower_const_body(c.value.span, Some(&c.value))
-                            }),
+                            body: this.lower_const_body(c.value.span, Some(&c.value)),
                         }
                     });
                     hir::ExprKind::ConstBlock(c)
@@ -452,7 +450,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let mut generic_args = ThinVec::new();
         for (idx, arg) in args.iter().cloned().enumerate() {
             if legacy_args_idx.contains(&idx) {
-                let parent_def_id = self.current_def_id_parent;
+                let parent_def_id = self.current_hir_id_owner.def_id;
                 let node_id = self.next_node_id();
                 self.create_def(parent_def_id, node_id, kw::Empty, DefKind::AnonConst, f.span);
                 let mut visitor = WillCreateDefIdsVisitor {};
@@ -753,19 +751,17 @@ impl<'hir> LoweringContext<'_, 'hir> {
             lifetime_elision_allowed: false,
         });
 
-        let body = self.with_def_id_parent(closure_def_id, move |this| {
-            this.lower_body(move |this| {
-                this.coroutine_kind = Some(coroutine_kind);
+        let body = self.lower_body(move |this| {
+            this.coroutine_kind = Some(coroutine_kind);
 
-                let old_ctx = this.task_context;
-                if task_context.is_some() {
-                    this.task_context = task_context;
-                }
-                let res = body(this);
-                this.task_context = old_ctx;
+            let old_ctx = this.task_context;
+            if task_context.is_some() {
+                this.task_context = task_context;
+            }
+            let res = body(this);
+            this.task_context = old_ctx;
 
-                (params, res)
-            })
+            (params, res)
         });
 
         // `static |<_task_context?>| -> <return_ty> { <body> }`:
@@ -1050,26 +1046,24 @@ impl<'hir> LoweringContext<'_, 'hir> {
         let (binder_clause, generic_params) = self.lower_closure_binder(binder);
 
         let (body_id, closure_kind) = self.with_new_scopes(fn_decl_span, move |this| {
-            this.with_def_id_parent(closure_def_id, move |this| {
-                let mut coroutine_kind = if this
-                    .attrs
-                    .get(&closure_hir_id.local_id)
-                    .is_some_and(|attrs| attrs.iter().any(|attr| attr.has_name(sym::coroutine)))
-                {
-                    Some(hir::CoroutineKind::Coroutine(Movability::Movable))
-                } else {
-                    None
-                };
-                let body_id = this.lower_fn_body(decl, |this| {
-                    this.coroutine_kind = coroutine_kind;
-                    let e = this.lower_expr_mut(body);
-                    coroutine_kind = this.coroutine_kind;
-                    e
-                });
-                let coroutine_option =
-                    this.closure_movability_for_fn(decl, fn_decl_span, coroutine_kind, movability);
-                (body_id, coroutine_option)
-            })
+            let mut coroutine_kind = if this
+                .attrs
+                .get(&closure_hir_id.local_id)
+                .is_some_and(|attrs| attrs.iter().any(|attr| attr.has_name(sym::coroutine)))
+            {
+                Some(hir::CoroutineKind::Coroutine(Movability::Movable))
+            } else {
+                None
+            };
+            let body_id = this.lower_fn_body(decl, |this| {
+                this.coroutine_kind = coroutine_kind;
+                let e = this.lower_expr_mut(body);
+                coroutine_kind = this.coroutine_kind;
+                e
+            });
+            let coroutine_option =
+                this.closure_movability_for_fn(decl, fn_decl_span, coroutine_kind, movability);
+            (body_id, coroutine_option)
         });
 
         let bound_generic_params = self.lower_lifetime_binder(closure_id, generic_params);
@@ -1159,28 +1153,26 @@ impl<'hir> LoweringContext<'_, 'hir> {
         );
 
         let body = self.with_new_scopes(fn_decl_span, |this| {
-            this.with_def_id_parent(closure_def_id, |this| {
-                let inner_decl =
-                    FnDecl { inputs: decl.inputs.clone(), output: FnRetTy::Default(fn_decl_span) };
+            let inner_decl =
+                FnDecl { inputs: decl.inputs.clone(), output: FnRetTy::Default(fn_decl_span) };
 
-                // Transform `async |x: u8| -> X { ... }` into
-                // `|x: u8| || -> X { ... }`.
-                let body_id = this.lower_body(|this| {
-                    let (parameters, expr) = this.lower_coroutine_body_with_moved_arguments(
-                        &inner_decl,
-                        |this| this.with_new_scopes(fn_decl_span, |this| this.lower_expr_mut(body)),
-                        fn_decl_span,
-                        body.span,
-                        coroutine_kind,
-                        hir::CoroutineSource::Closure,
-                    );
+            // Transform `async |x: u8| -> X { ... }` into
+            // `|x: u8| || -> X { ... }`.
+            let body_id = this.lower_body(|this| {
+                let (parameters, expr) = this.lower_coroutine_body_with_moved_arguments(
+                    &inner_decl,
+                    |this| this.with_new_scopes(fn_decl_span, |this| this.lower_expr_mut(body)),
+                    fn_decl_span,
+                    body.span,
+                    coroutine_kind,
+                    hir::CoroutineSource::Closure,
+                );
 
-                    this.maybe_forward_track_caller(body.span, closure_hir_id, expr.hir_id);
+                this.maybe_forward_track_caller(body.span, closure_hir_id, expr.hir_id);
 
-                    (parameters, expr)
-                });
-                body_id
-            })
+                (parameters, expr)
+            });
+            body_id
         });
 
         let bound_generic_params = self.lower_lifetime_binder(closure_id, generic_params);

--- a/compiler/rustc_hir/src/def.rs
+++ b/compiler/rustc_hir/src/def.rs
@@ -109,7 +109,16 @@ pub enum DefKind {
     Use,
     /// An `extern` block.
     ForeignMod,
-    /// Anonymous constant, e.g. the `1 + 2` in `[u8; 1 + 2]`
+    /// Anonymous constant, e.g. the `1 + 2` in `[u8; 1 + 2]`.
+    ///
+    /// Not all anon-consts are actually still relevant in the HIR. We lower
+    /// trivial const-arguments directly to `hir::ConstArgKind::Path`, at which
+    /// point the definition for the anon-const ends up unused and incomplete.
+    ///
+    /// We do not provide any a `Span` for the definition and pretty much all other
+    /// queries also ICE when using this `DefId`. Given that the `DefId` of such
+    /// constants should only be reachable by iterating all definitions of a
+    /// given crate, you should not have to worry about this.
     AnonConst,
     /// An inline constant, e.g. `const { 1 + 2 }`
     InlineConst,

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4521,7 +4521,7 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
         );
 
         self.resolve_anon_const_manual(
-            constant.value.is_potential_trivial_const_arg(true),
+            constant.value.is_potential_trivial_const_arg(),
             anon_const_kind,
             |this| this.resolve_expr(&constant.value, None),
         )
@@ -4685,7 +4685,7 @@ impl<'a, 'ast, 'ra: 'ast, 'tcx> LateResolutionVisitor<'a, 'ast, 'ra, 'tcx> {
                     // that is how they will be later lowered to HIR.
                     if const_args.contains(&idx) {
                         self.resolve_anon_const_manual(
-                            argument.is_potential_trivial_const_arg(true),
+                            argument.is_potential_trivial_const_arg(),
                             AnonConstKind::ConstArg(IsRepeatExpr::No),
                             |this| this.resolve_expr(argument, None),
                         );

--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -174,7 +174,6 @@ impl<'ra> ParentScope<'ra> {
 #[derive(Copy, Debug, Clone)]
 struct InvocationParent {
     parent_def: LocalDefId,
-    pending_anon_const_info: Option<PendingAnonConstInfo>,
     impl_trait_context: ImplTraitContext,
     in_attr: bool,
 }
@@ -182,21 +181,9 @@ struct InvocationParent {
 impl InvocationParent {
     const ROOT: Self = Self {
         parent_def: CRATE_DEF_ID,
-        pending_anon_const_info: None,
         impl_trait_context: ImplTraitContext::Existential,
         in_attr: false,
     };
-}
-
-#[derive(Copy, Debug, Clone)]
-struct PendingAnonConstInfo {
-    // A const arg is only a "trivial" const arg if it has at *most* one set of braces
-    // around the argument. We track whether we have stripped an outter brace so that
-    // if a macro expands to a braced expression *and* the macro was itself inside of
-    // some braces then we can consider it to be a non-trivial const argument.
-    block_was_stripped: bool,
-    id: NodeId,
-    span: Span,
 }
 
 #[derive(Copy, Debug, Clone)]

--- a/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-1.rs
+++ b/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-1.rs
@@ -85,6 +85,14 @@ macro_rules! braced_braced_expr {
     () => {{ braced_expr!() }};
 }
 
+macro_rules! closure {
+    () => { |()| () };
+}
+
+macro_rules! empty {
+    () => {};
+}
+
 #[rustfmt::skip]
 mod array_paren_call {
     // Arrays where the expanded result is a `Res::Err`
@@ -128,6 +136,14 @@ mod array_paren_call {
     fn array_33() -> [(); braced_expr!()] { loop {} }
     fn array_34() -> [(); { unbraced_expr!() }] { loop {} }
     fn array_35() -> [(); { braced_expr!() }] { loop {} }
+
+    // Arrays whose expanded form contains a nested definition
+    fn array_36() -> [(); closure!()] { loop {} }
+    fn array_37() -> [(); { closure!() }] { loop {} }
+
+    // Arrays whose macro expansion is empty
+    fn array_38() -> [(); empty!()] { loop {} }
+    fn array_39() -> [(); { empty!() }] { loop {} }
 }
 
 #[rustfmt::skip]
@@ -173,6 +189,14 @@ mod array_brace_call {
     fn array_33() -> [(); braced_expr!{}] { loop {} }
     fn array_34() -> [(); { unbraced_expr!{} }] { loop {} }
     fn array_35() -> [(); { braced_expr!{} }] { loop {} }
+
+    // Arrays whose expanded form contains a nested definition
+    fn array_36() -> [(); closure!{}] { loop {} }
+    fn array_37() -> [(); { closure!{} }] { loop {} }
+
+    // Arrays whose macro expansion is empty
+    fn array_38() -> [(); empty!{}] { loop {} }
+    fn array_39() -> [(); { empty!{} }] { loop {} }
 }
 
 #[rustfmt::skip]
@@ -218,6 +242,14 @@ mod array_square_call {
     fn array_33() -> [(); braced_expr![]] { loop {} }
     fn array_34() -> [(); { unbraced_expr![] }] { loop {} }
     fn array_35() -> [(); { braced_expr![] }] { loop {} }
+
+    // Arrays whose expanded form contains a nested definition
+    fn array_36() -> [(); closure![]] { loop {} }
+    fn array_37() -> [(); { closure![] }] { loop {} }
+
+    // Arrays whose macro expansion is empty
+    fn array_38() -> [(); empty![]] { loop {} }
+    fn array_39() -> [(); { empty![] }] { loop {} }
 }
 
 struct Foo<const N: usize>;
@@ -255,18 +287,26 @@ mod adt_paren_call {
     fn adt_23<const ident: usize>() -> Foo<{ braced_ident!() }> { loop {} }
 
     // An ADT where the expanded result is a complex expr
-    fn array_24() -> Foo<unbraced_unbraced_expr!()> { loop {} }
-    fn array_25() -> Foo<braced_unbraced_expr!()> { loop {} }
-    fn array_26() -> Foo<unbraced_braced_expr!()> { loop {} }
-    fn array_27() -> Foo<braced_braced_expr!()> { loop {} }
-    fn array_28() -> Foo<{ unbraced_unbraced_expr!() }> { loop {} }
-    fn array_29() -> Foo<{ braced_unbraced_expr!() }> { loop {} }
-    fn array_30() -> Foo<{ unbraced_braced_expr!() }> { loop {} }
-    fn array_31() -> Foo<{ braced_braced_expr!() }> { loop {} }
-    fn array_32() -> Foo<unbraced_expr!()> { loop {} }
-    fn array_33() -> Foo<braced_expr!()> { loop {} }
-    fn array_34() -> Foo<{ unbraced_expr!() }> { loop {} }
-    fn array_35() -> Foo<{ braced_expr!() }> { loop {} }
+    fn adt_24() -> Foo<unbraced_unbraced_expr!()> { loop {} }
+    fn adt_25() -> Foo<braced_unbraced_expr!()> { loop {} }
+    fn adt_26() -> Foo<unbraced_braced_expr!()> { loop {} }
+    fn adt_27() -> Foo<braced_braced_expr!()> { loop {} }
+    fn adt_28() -> Foo<{ unbraced_unbraced_expr!() }> { loop {} }
+    fn adt_29() -> Foo<{ braced_unbraced_expr!() }> { loop {} }
+    fn adt_30() -> Foo<{ unbraced_braced_expr!() }> { loop {} }
+    fn adt_31() -> Foo<{ braced_braced_expr!() }> { loop {} }
+    fn adt_32() -> Foo<unbraced_expr!()> { loop {} }
+    fn adt_33() -> Foo<braced_expr!()> { loop {} }
+    fn adt_34() -> Foo<{ unbraced_expr!() }> { loop {} }
+    fn adt_35() -> Foo<{ braced_expr!() }> { loop {} }
+
+    // An ADT whose expanded form contains a nested definition
+    fn adt_36() -> Foo<closure!()> { loop {} }
+    fn adt_37() -> Foo<{ closure!() }> { loop {} }
+
+    // An ADT whose macro expansion is empty
+    fn adt_38() -> Foo<empty!()> { loop {} }
+    fn adt_39() -> Foo<{ empty!() }> { loop {} }
 }
 
 #[rustfmt::skip]
@@ -302,18 +342,26 @@ mod adt_brace_call {
     fn adt_23<const ident: usize>() -> Foo<{ braced_ident!{} }> { loop {} }
 
     // An ADT where the expanded result is a complex expr
-    fn array_24() -> Foo<unbraced_unbraced_expr!{}> { loop {} }
-    fn array_25() -> Foo<braced_unbraced_expr!{}> { loop {} }
-    fn array_26() -> Foo<unbraced_braced_expr!{}> { loop {} }
-    fn array_27() -> Foo<braced_braced_expr!{}> { loop {} }
-    fn array_28() -> Foo<{ unbraced_unbraced_expr!{} }> { loop {} }
-    fn array_29() -> Foo<{ braced_unbraced_expr!{} }> { loop {} }
-    fn array_30() -> Foo<{ unbraced_braced_expr!{} }> { loop {} }
-    fn array_31() -> Foo<{ braced_braced_expr!{} }> { loop {} }
-    fn array_32() -> Foo<unbraced_expr!{}> { loop {} }
-    fn array_33() -> Foo<braced_expr!{}> { loop {} }
-    fn array_34() -> Foo<{ unbraced_expr!{} }> { loop {} }
-    fn array_35() -> Foo<{ braced_expr!{} }> { loop {} }
+    fn adt_24() -> Foo<unbraced_unbraced_expr!{}> { loop {} }
+    fn adt_25() -> Foo<braced_unbraced_expr!{}> { loop {} }
+    fn adt_26() -> Foo<unbraced_braced_expr!{}> { loop {} }
+    fn adt_27() -> Foo<braced_braced_expr!{}> { loop {} }
+    fn adt_28() -> Foo<{ unbraced_unbraced_expr!{} }> { loop {} }
+    fn adt_29() -> Foo<{ braced_unbraced_expr!{} }> { loop {} }
+    fn adt_30() -> Foo<{ unbraced_braced_expr!{} }> { loop {} }
+    fn adt_31() -> Foo<{ braced_braced_expr!{} }> { loop {} }
+    fn adt_32() -> Foo<unbraced_expr!{}> { loop {} }
+    fn adt_33() -> Foo<braced_expr!{}> { loop {} }
+    fn adt_34() -> Foo<{ unbraced_expr!{} }> { loop {} }
+    fn adt_35() -> Foo<{ braced_expr!{} }> { loop {} }
+
+    // An ADT whose expanded form contains a nested definition
+    fn adt_36() -> Foo<closure!{}> { loop {} }
+    fn adt_37() -> Foo<{ closure!{} }> { loop {} }
+
+    // An ADT whose macro expansion is empty
+    fn adt_38() -> Foo<empty!{}> { loop {} }
+    fn adt_39() -> Foo<{ empty!{} }> { loop {} }
 }
 
 #[rustfmt::skip]
@@ -349,18 +397,185 @@ mod adt_square_call {
     fn adt_23<const ident: usize>() -> Foo<{ braced_ident![] }> { loop {} }
 
     // An ADT where the expanded result is a complex expr
-    fn array_24() -> Foo<unbraced_unbraced_expr![]> { loop {} }
-    fn array_25() -> Foo<braced_unbraced_expr![]> { loop {} }
-    fn array_26() -> Foo<unbraced_braced_expr![]> { loop {} }
-    fn array_27() -> Foo<braced_braced_expr![]> { loop {} }
-    fn array_28() -> Foo<{ unbraced_unbraced_expr![] }> { loop {} }
-    fn array_29() -> Foo<{ braced_unbraced_expr![] }> { loop {} }
-    fn array_30() -> Foo<{ unbraced_braced_expr![] }> { loop {} }
-    fn array_31() -> Foo<{ braced_braced_expr![] }> { loop {} }
-    fn array_32() -> Foo<unbraced_expr![]> { loop {} }
-    fn array_33() -> Foo<braced_expr![]> { loop {} }
-    fn array_34() -> Foo<{ unbraced_expr![] }> { loop {} }
-    fn array_35() -> Foo<{ braced_expr![] }> { loop {} }
+    fn adt_24() -> Foo<unbraced_unbraced_expr![]> { loop {} }
+    fn adt_25() -> Foo<braced_unbraced_expr![]> { loop {} }
+    fn adt_26() -> Foo<unbraced_braced_expr![]> { loop {} }
+    fn adt_27() -> Foo<braced_braced_expr![]> { loop {} }
+    fn adt_28() -> Foo<{ unbraced_unbraced_expr![] }> { loop {} }
+    fn adt_29() -> Foo<{ braced_unbraced_expr![] }> { loop {} }
+    fn adt_30() -> Foo<{ unbraced_braced_expr![] }> { loop {} }
+    fn adt_31() -> Foo<{ braced_braced_expr![] }> { loop {} }
+    fn adt_32() -> Foo<unbraced_expr![]> { loop {} }
+    fn adt_33() -> Foo<braced_expr![]> { loop {} }
+    fn adt_34() -> Foo<{ unbraced_expr![] }> { loop {} }
+    fn adt_35() -> Foo<{ braced_expr![] }> { loop {} }
+
+    // An ADT whose expanded form contains a nested definition
+    fn adt_36() -> Foo<closure![]> { loop {} }
+    fn adt_37() -> Foo<{ closure![] }> { loop {} }
+
+    // An ADT whose macro expansion is empty
+    fn adt_38() -> Foo<empty![]> { loop {} }
+    fn adt_39() -> Foo<{ empty![] }> { loop {} }
+}
+
+#[rustfmt::skip]
+mod repeat_paren_call {
+    // A repeat expr where the expanded result is a `Res::Err`
+    fn repeat_0() { [(); unbraced_unbraced_ident!()]; }
+    fn repeat_1() { [(); braced_unbraced_ident!()]; }
+    fn repeat_2() { [(); unbraced_braced_ident!()]; }
+    fn repeat_3() { [(); braced_braced_ident!()]; }
+    fn repeat_4() { [(); { unbraced_unbraced_ident!() }]; }
+    fn repeat_5() { [(); { braced_unbraced_ident!() }]; }
+    fn repeat_6() { [(); { unbraced_braced_ident!() }]; }
+    fn repeat_7() { [(); { braced_braced_ident!() }]; }
+    fn repeat_8() { [(); unbraced_ident!()]; }
+    fn repeat_9() { [(); braced_ident!()]; }
+    fn repeat_10() { [(); { unbraced_ident!() }]; }
+    fn repeat_11() { [(); { braced_ident!() }]; }
+
+    // A repeat expr where the expanded result is a `Res::ConstParam`
+    fn repeat_12<const ident: usize>() { [(); unbraced_unbraced_ident!()]; }
+    fn repeat_13<const ident: usize>() { [(); braced_unbraced_ident!()]; }
+    fn repeat_14<const ident: usize>() { [(); unbraced_braced_ident!()]; }
+    fn repeat_15<const ident: usize>() { [(); braced_braced_ident!()]; }
+    fn repeat_16<const ident: usize>() { [(); { unbraced_unbraced_ident!() }]; }
+    fn repeat_17<const ident: usize>() { [(); { braced_unbraced_ident!() }]; }
+    fn repeat_18<const ident: usize>() { [(); { unbraced_braced_ident!() }]; }
+    fn repeat_19<const ident: usize>() { [(); { braced_braced_ident!() }]; }
+    fn repeat_20<const ident: usize>() { [(); unbraced_ident!()]; }
+    fn repeat_21<const ident: usize>() { [(); braced_ident!()]; }
+    fn repeat_22<const ident: usize>() { [(); { unbraced_ident!() }]; }
+    fn repeat_23<const ident: usize>() { [(); { braced_ident!() }]; }
+
+    // A repeat expr where the expanded result is a complex expr
+    fn repeat_24() { [(); unbraced_unbraced_expr!()]; }
+    fn repeat_25() { [(); braced_unbraced_expr!()]; }
+    fn repeat_26() { [(); unbraced_braced_expr!()]; }
+    fn repeat_27() { [(); braced_braced_expr!()]; }
+    fn repeat_28() { [(); { unbraced_unbraced_expr!() }]; }
+    fn repeat_29() { [(); { braced_unbraced_expr!() }]; }
+    fn repeat_30() { [(); { unbraced_braced_expr!() }]; }
+    fn repeat_31() { [(); { braced_braced_expr!() }]; }
+    fn repeat_32() { [(); unbraced_expr!()]; }
+    fn repeat_33() { [(); braced_expr!()]; }
+    fn repeat_34() { [(); { unbraced_expr!() }]; }
+    fn repeat_35() { [(); { braced_expr!() }]; }
+
+    // A repeat expr whose expanded form contains a nested definition
+    fn repeat_36() { [(); closure!()] }
+    fn repeat_37() { [(); { closure!() }] }
+
+    // A repeat expr whose macro expansion is empty
+    fn repeat_38() { [(); empty!()] }
+    fn repeat_39() { [(); { empty!() }] }
+}
+
+#[rustfmt::skip]
+mod repeat_brace_call {
+    // A repeat expr where the expanded result is a `Res::Err`
+    fn repeat_0() { [(); unbraced_unbraced_ident!{}]; }
+    fn repeat_1() { [(); braced_unbraced_ident!{}]; }
+    fn repeat_2() { [(); unbraced_braced_ident!{}]; }
+    fn repeat_3() { [(); braced_braced_ident!{}]; }
+    fn repeat_4() { [(); { unbraced_unbraced_ident!{} }]; }
+    fn repeat_5() { [(); { braced_unbraced_ident!{} }]; }
+    fn repeat_6() { [(); { unbraced_braced_ident!{} }]; }
+    fn repeat_7() { [(); { braced_braced_ident!{} }]; }
+    fn repeat_8() { [(); unbraced_ident!{}]; }
+    fn repeat_9() { [(); braced_ident!{}]; }
+    fn repeat_10() { [(); { unbraced_ident!{} }]; }
+    fn repeat_11() { [(); { braced_ident!{} }]; }
+
+    // A repeat expr where the expanded result is a `Res::ConstParam`
+    fn repeat_12<const ident: usize>() { [(); unbraced_unbraced_ident!{}]; }
+    fn repeat_13<const ident: usize>() { [(); braced_unbraced_ident!{}]; }
+    fn repeat_14<const ident: usize>() { [(); unbraced_braced_ident!{}]; }
+    fn repeat_15<const ident: usize>() { [(); braced_braced_ident!{}]; }
+    fn repeat_16<const ident: usize>() { [(); { unbraced_unbraced_ident!{} }]; }
+    fn repeat_17<const ident: usize>() { [(); { braced_unbraced_ident!{} }]; }
+    fn repeat_18<const ident: usize>() { [(); { unbraced_braced_ident!{} }]; }
+    fn repeat_19<const ident: usize>() { [(); { braced_braced_ident!{} }]; }
+    fn repeat_20<const ident: usize>() { [(); unbraced_ident!{}]; }
+    fn repeat_21<const ident: usize>() { [(); braced_ident!{}]; }
+    fn repeat_22<const ident: usize>() { [(); { unbraced_ident!{} }]; }
+    fn repeat_23<const ident: usize>() { [(); { braced_ident!{} }]; }
+
+    // A repeat expr where the expanded result is a complex expr
+    fn repeat_24() { [(); unbraced_unbraced_expr!{}]; }
+    fn repeat_25() { [(); braced_unbraced_expr!{}]; }
+    fn repeat_26() { [(); unbraced_braced_expr!{}]; }
+    fn repeat_27() { [(); braced_braced_expr!{}]; }
+    fn repeat_28() { [(); { unbraced_unbraced_expr!{} }]; }
+    fn repeat_29() { [(); { braced_unbraced_expr!{} }]; }
+    fn repeat_30() { [(); { unbraced_braced_expr!{} }]; }
+    fn repeat_31() { [(); { braced_braced_expr!{} }]; }
+    fn repeat_32() { [(); unbraced_expr!{}]; }
+    fn repeat_33() { [(); braced_expr!{}]; }
+    fn repeat_34() { [(); { unbraced_expr!{} }]; }
+    fn repeat_35() { [(); { braced_expr!{} }]; }
+
+    // A repeat expr whose expanded form contains a nested definition
+    fn repeat_36() { [(); closure!{}] }
+    fn repeat_37() { [(); { closure!{} }] }
+
+    // A repeat expr whose macro expansion is empty
+    fn repeat_38() { [(); empty!{}] }
+    fn repeat_39() { [(); { empty!{} }] }
+}
+
+#[rustfmt::skip]
+mod repeat_square_call {
+    // A repeat expr where the expanded result is a `Res::Err`
+    fn repeat_0() { [(); unbraced_unbraced_ident![]]; }
+    fn repeat_1() { [(); braced_unbraced_ident![]]; }
+    fn repeat_2() { [(); unbraced_braced_ident![]]; }
+    fn repeat_3() { [(); braced_braced_ident![]]; }
+    fn repeat_4() { [(); { unbraced_unbraced_ident![] }]; }
+    fn repeat_5() { [(); { braced_unbraced_ident![] }]; }
+    fn repeat_6() { [(); { unbraced_braced_ident![] }]; }
+    fn repeat_7() { [(); { braced_braced_ident![] }]; }
+    fn repeat_8() { [(); unbraced_ident![]]; }
+    fn repeat_9() { [(); braced_ident![]]; }
+    fn repeat_10() { [(); { unbraced_ident![] }]; }
+    fn repeat_11() { [(); { braced_ident![] }]; }
+
+    // A repeat expr where the expanded result is a `Res::ConstParam`
+    fn repeat_12<const ident: usize>() { [(); unbraced_unbraced_ident![]]; }
+    fn repeat_13<const ident: usize>() { [(); braced_unbraced_ident![]]; }
+    fn repeat_14<const ident: usize>() { [(); unbraced_braced_ident![]]; }
+    fn repeat_15<const ident: usize>() { [(); braced_braced_ident![]]; }
+    fn repeat_16<const ident: usize>() { [(); { unbraced_unbraced_ident![] }]; }
+    fn repeat_17<const ident: usize>() { [(); { braced_unbraced_ident![] }]; }
+    fn repeat_18<const ident: usize>() { [(); { unbraced_braced_ident![] }]; }
+    fn repeat_19<const ident: usize>() { [(); { braced_braced_ident![] }]; }
+    fn repeat_20<const ident: usize>() { [(); unbraced_ident![]]; }
+    fn repeat_21<const ident: usize>() { [(); braced_ident![]]; }
+    fn repeat_22<const ident: usize>() { [(); { unbraced_ident![] }]; }
+    fn repeat_23<const ident: usize>() { [(); { braced_ident![] }]; }
+
+    // A repeat expr where the expanded result is a complex expr
+    fn repeat_24() { [(); unbraced_unbraced_expr![]]; }
+    fn repeat_25() { [(); braced_unbraced_expr![]]; }
+    fn repeat_26() { [(); unbraced_braced_expr![]]; }
+    fn repeat_27() { [(); braced_braced_expr![]]; }
+    fn repeat_28() { [(); { unbraced_unbraced_expr![] }]; }
+    fn repeat_29() { [(); { braced_unbraced_expr![] }]; }
+    fn repeat_30() { [(); { unbraced_braced_expr![] }]; }
+    fn repeat_31() { [(); { braced_braced_expr![] }]; }
+    fn repeat_32() { [(); unbraced_expr![]]; }
+    fn repeat_33() { [(); braced_expr![]]; }
+    fn repeat_34() { [(); { unbraced_expr![] }]; }
+    fn repeat_35() { [(); { braced_expr![] }]; }
+
+    // A repeat expr whose expanded form contains a nested definition
+    fn repeat_36() { [(); closure![]] }
+    fn repeat_37() { [(); { closure![] }] }
+
+    // A repeat expr whose macro expansion is empty
+    fn repeat_38() { [(); empty![]] }
+    fn repeat_39() { [(); { empty![] }] }
 }
 
 fn main() {}

--- a/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-3-pass.rs
+++ b/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-3-pass.rs
@@ -1,0 +1,46 @@
+// Additional checks for macro expansion in const args
+
+//@ check-pass
+
+macro_rules! closure {
+    () => { |()| () };
+}
+
+macro_rules! indir_semi {
+    ($nested:ident) => { $nested!(); };
+}
+
+macro_rules! indir {
+    ($nested:ident) => { $nested!() };
+}
+
+macro_rules! empty {
+    () => {};
+}
+
+macro_rules! arg {
+    () => { N };
+}
+
+struct Adt<const N: usize>;
+
+fn array1() -> [(); { closure!(); 0 }] { loop {} }
+fn array2() -> [(); { indir!(closure); 0}] { loop {} }
+fn array3() -> [(); { indir_semi!{ closure } 0 }] { loop {} }
+fn array4<const N: usize>() -> [(); { indir!{ empty } arg!{} }] { loop {} }
+fn array5<const N: usize>() -> [(); { empty!{} arg!() }] { loop {} }
+fn array6<const N: usize>() -> [(); { empty!{} N }] { loop {} }
+fn array7<const N: usize>() -> [(); { arg!{} empty!{} }] { loop {} }
+fn array8<const N: usize>() -> [(); { empty!{} arg!{} empty!{} }] { loop {} }
+
+fn adt1() -> Adt<{ closure!(); 0 }> { loop {} }
+fn adt2() -> Adt<{ indir!(closure); 0}> { loop {} }
+fn adt3() -> Adt<{ indir_semi!{ closure } 0 }> { loop {} }
+fn adt4<const N: usize>() -> Adt<{ indir!{ empty } arg!{} }> { loop {} }
+fn adt5<const N: usize>() -> Adt<{ empty!{} arg!() }> { loop {} }
+fn adt6<const N: usize>() -> Adt<{ empty!{} N }> { loop {} }
+fn adt7<const N: usize>() -> Adt<{ arg!{} empty!{} }> { loop {} }
+fn adt8<const N: usize>() -> Adt<{ empty!{} arg!{} empty!{} }> { loop {} }
+
+
+fn main() {}

--- a/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-4.rs
+++ b/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-4.rs
@@ -1,0 +1,18 @@
+macro_rules! empty {
+    () => {};
+}
+
+macro_rules! arg {
+    () => {
+        N
+        //~^ ERROR generic parameters may not be used in const operations
+        //~| ERROR generic parameters may not be used in const operations
+    };
+}
+
+struct Foo<const N: usize>;
+fn foo<const N: usize>() -> Foo<{ arg!{} arg!{} }> { loop {} }
+fn bar<const N: usize>() -> [(); { empty!{}; N }] { loop {} }
+//~^ ERROR generic parameters may not be used in const operations
+
+fn main() {}

--- a/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-4.stderr
+++ b/tests/ui/const-generics/early/const_arg_trivial_macro_expansion-4.stderr
@@ -1,0 +1,37 @@
+error: generic parameters may not be used in const operations
+  --> $DIR/const_arg_trivial_macro_expansion-4.rs:7:9
+   |
+LL |         N
+   |         ^ cannot perform const operation using `N`
+...
+LL | fn foo<const N: usize>() -> Foo<{ arg!{} arg!{} }> { loop {} }
+   |                                   ------ in this macro invocation
+   |
+   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = note: this error originates in the macro `arg` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: generic parameters may not be used in const operations
+  --> $DIR/const_arg_trivial_macro_expansion-4.rs:7:9
+   |
+LL |         N
+   |         ^ cannot perform const operation using `N`
+...
+LL | fn foo<const N: usize>() -> Foo<{ arg!{} arg!{} }> { loop {} }
+   |                                          ------ in this macro invocation
+   |
+   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+   = note: this error originates in the macro `arg` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: generic parameters may not be used in const operations
+  --> $DIR/const_arg_trivial_macro_expansion-4.rs:15:46
+   |
+LL | fn bar<const N: usize>() -> [(); { empty!{}; N }] { loop {} }
+   |                                              ^ cannot perform const operation using `N`
+   |
+   = help: const parameters may only be used as standalone arguments, i.e. `N`
+   = help: add `#![feature(generic_const_exprs)]` to allow generic const expressions
+
+error: aborting due to 3 previous errors
+

--- a/tests/ui/consts/issue-36163.stderr
+++ b/tests/ui/consts/issue-36163.stderr
@@ -1,10 +1,10 @@
-error[E0391]: cycle detected when simplifying constant for the type system `Foo::{constant#0}`
+error[E0391]: cycle detected when simplifying constant for the type system `Foo::B::{constant#0}`
   --> $DIR/issue-36163.rs:4:9
    |
 LL |     B = A,
    |         ^
    |
-note: ...which requires const-evaluating + checking `Foo::{constant#0}`...
+note: ...which requires const-evaluating + checking `Foo::B::{constant#0}`...
   --> $DIR/issue-36163.rs:4:9
    |
 LL |     B = A,
@@ -19,7 +19,7 @@ note: ...which requires const-evaluating + checking `A`...
    |
 LL | const A: isize = Foo::B as isize;
    |                  ^^^^^^^^^^^^^^^
-   = note: ...which again requires simplifying constant for the type system `Foo::{constant#0}`, completing the cycle
+   = note: ...which again requires simplifying constant for the type system `Foo::B::{constant#0}`, completing the cycle
 note: cycle used when checking that `Foo` is well-formed
   --> $DIR/issue-36163.rs:3:1
    |


### PR DESCRIPTION
but don't use them anywhere, we intentionally don't encode them in the crate metadata.

best reviewed by disabling whitespace.

This pretty much reimplements #133285 while adding the tests of #133455. Fixes #133064

r? @BoxyUwU @compiler-errors 