### PR TITLE
tests: Add regression test for recursive enum with Cow and Clone

### DIFF
--- a/tests/ui/traits/solver-cycles/100347-recursive-enum-cow-slice.rs
+++ b/tests/ui/traits/solver-cycles/100347-recursive-enum-cow-slice.rs
@@ -1,0 +1,11 @@
+//@ check-pass
+
+use std::borrow::Cow;
+
+#[derive(Clone)]
+enum Test<'a> {
+    Int(u8),
+    Array(Cow<'a, [Test<'a>]>),
+}
+
+fn main() {}


### PR DESCRIPTION
I could not find any existing test. `git grep "(Cow<'[^>]\+\["` gave no hits before this tests.

Closes #100347
