### PR TITLE
[stable(not yet) backport] Revert r-a completions breakage

### DIFF
--- a/src/tools/rust-analyzer/crates/ide-completion/src/config.rs
+++ b/src/tools/rust-analyzer/crates/ide-completion/src/config.rs
@@ -7,7 +7,7 @@
 use hir::ImportPathConfig;
 use ide_db::{imports::insert_use::InsertUseConfig, SnippetCap};
 
-use crate::{snippet::Snippet, CompletionFieldsToResolve};
+use crate::snippet::Snippet;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CompletionConfig {
@@ -27,7 +27,6 @@ pub struct CompletionConfig {
     pub prefer_absolute: bool,
     pub snippets: Vec<Snippet>,
     pub limit: Option<usize>,
-    pub fields_to_resolve: CompletionFieldsToResolve,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/tools/rust-analyzer/crates/ide-completion/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/ide-completion/src/lib.rs
@@ -43,8 +43,11 @@ pub struct CompletionFieldsToResolve {
     pub resolve_tags: bool,
     pub resolve_detail: bool,
     pub resolve_documentation: bool,
+    pub resolve_sort_text: bool,
     pub resolve_filter_text: bool,
     pub resolve_text_edit: bool,
+    // FIXME: those are always resolved
+    // pub resolve_additional_text_edits: bool,
     pub resolve_command: bool,
 }
 
@@ -55,6 +58,7 @@ impl CompletionFieldsToResolve {
             resolve_tags: false,
             resolve_detail: false,
             resolve_documentation: false,
+            resolve_sort_text: false,
             resolve_filter_text: false,
             resolve_text_edit: false,
             resolve_command: false,

--- a/src/tools/rust-analyzer/crates/ide-completion/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/ide-completion/src/lib.rs
@@ -37,35 +37,6 @@ pub use crate::{
     snippet::{Snippet, SnippetScope},
 };
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct CompletionFieldsToResolve {
-    pub resolve_label_details: bool,
-    pub resolve_tags: bool,
-    pub resolve_detail: bool,
-    pub resolve_documentation: bool,
-    pub resolve_sort_text: bool,
-    pub resolve_filter_text: bool,
-    pub resolve_text_edit: bool,
-    // FIXME: those are always resolved
-    // pub resolve_additional_text_edits: bool,
-    pub resolve_command: bool,
-}
-
-impl CompletionFieldsToResolve {
-    pub const fn empty() -> Self {
-        Self {
-            resolve_label_details: false,
-            resolve_tags: false,
-            resolve_detail: false,
-            resolve_documentation: false,
-            resolve_sort_text: false,
-            resolve_filter_text: false,
-            resolve_text_edit: false,
-            resolve_command: false,
-        }
-    }
-}
-
 //FIXME: split the following feature into fine-grained features.
 
 // Feature: Magic Completions

--- a/src/tools/rust-analyzer/crates/ide-completion/src/tests.rs
+++ b/src/tools/rust-analyzer/crates/ide-completion/src/tests.rs
@@ -37,8 +37,8 @@ use test_fixture::ChangeFixture;
 use test_utils::assert_eq_text;
 
 use crate::{
-    resolve_completion_edits, CallableSnippets, CompletionConfig, CompletionFieldsToResolve,
-    CompletionItem, CompletionItemKind,
+    resolve_completion_edits, CallableSnippets, CompletionConfig, CompletionItem,
+    CompletionItemKind,
 };
 
 /// Lots of basic item definitions
@@ -84,7 +84,6 @@ pub(crate) const TEST_CONFIG: CompletionConfig = CompletionConfig {
     prefer_absolute: false,
     snippets: Vec::new(),
     limit: None,
-    fields_to_resolve: CompletionFieldsToResolve::empty(),
 };
 
 pub(crate) fn completion_list(ra_fixture: &str) -> String {

--- a/src/tools/rust-analyzer/crates/ide/src/lib.rs
+++ b/src/tools/rust-analyzer/crates/ide/src/lib.rs
@@ -119,8 +119,8 @@ pub use ide_assists::{
     Assist, AssistConfig, AssistId, AssistKind, AssistResolveStrategy, SingleResolve,
 };
 pub use ide_completion::{
-    CallableSnippets, CompletionConfig, CompletionFieldsToResolve, CompletionItem,
-    CompletionItemKind, CompletionRelevance, Snippet, SnippetScope,
+    CallableSnippets, CompletionConfig, CompletionItem, CompletionItemKind, CompletionRelevance,
+    Snippet, SnippetScope,
 };
 pub use ide_db::{
     base_db::{Cancelled, CrateGraph, CrateId, FileChange, SourceRoot, SourceRootId},

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/config.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/config.rs
@@ -1423,6 +1423,7 @@ impl Config {
                 resolve_tags: client_capability_fields.contains("tags"),
                 resolve_detail: client_capability_fields.contains("detail"),
                 resolve_documentation: client_capability_fields.contains("documentation"),
+                resolve_sort_text: client_capability_fields.contains("sortText"),
                 resolve_filter_text: client_capability_fields.contains("filterText"),
                 resolve_text_edit: client_capability_fields.contains("textEdit"),
                 resolve_command: client_capability_fields.contains("command"),

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/config.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/config.rs
@@ -12,10 +12,10 @@ use std::{
 use cfg::{CfgAtom, CfgDiff};
 use hir::Symbol;
 use ide::{
-    AssistConfig, CallableSnippets, CompletionConfig, CompletionFieldsToResolve, DiagnosticsConfig,
-    ExprFillDefaultMode, GenericParameterHints, HighlightConfig, HighlightRelatedConfig,
-    HoverConfig, HoverDocFormat, InlayFieldsToResolve, InlayHintsConfig, JoinLinesConfig,
-    MemoryLayoutHoverConfig, MemoryLayoutHoverRenderKind, Snippet, SnippetScope, SourceRootId,
+    AssistConfig, CallableSnippets, CompletionConfig, DiagnosticsConfig, ExprFillDefaultMode,
+    GenericParameterHints, HighlightConfig, HighlightRelatedConfig, HoverConfig, HoverDocFormat,
+    InlayFieldsToResolve, InlayHintsConfig, JoinLinesConfig, MemoryLayoutHoverConfig,
+    MemoryLayoutHoverRenderKind, Snippet, SnippetScope, SourceRootId,
 };
 use ide_db::{
     imports::insert_use::{ImportGranularity, InsertUseConfig, PrefixKind},
@@ -1393,7 +1393,6 @@ impl Config {
     }
 
     pub fn completion(&self, source_root: Option<SourceRootId>) -> CompletionConfig {
-        let client_capability_fields = self.completion_resolve_support_properties();
         CompletionConfig {
             enable_postfix_completions: self.completion_postfix_enable(source_root).to_owned(),
             enable_imports_on_the_fly: self.completion_autoimport_enable(source_root).to_owned()
@@ -1418,16 +1417,6 @@ impl Config {
             limit: self.completion_limit(source_root).to_owned(),
             enable_term_search: self.completion_termSearch_enable(source_root).to_owned(),
             term_search_fuel: self.completion_termSearch_fuel(source_root).to_owned() as u64,
-            fields_to_resolve: CompletionFieldsToResolve {
-                resolve_label_details: client_capability_fields.contains("labelDetails"),
-                resolve_tags: client_capability_fields.contains("tags"),
-                resolve_detail: client_capability_fields.contains("detail"),
-                resolve_documentation: client_capability_fields.contains("documentation"),
-                resolve_sort_text: client_capability_fields.contains("sortText"),
-                resolve_filter_text: client_capability_fields.contains("filterText"),
-                resolve_text_edit: client_capability_fields.contains("textEdit"),
-                resolve_command: client_capability_fields.contains("command"),
-            },
         }
     }
 

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/handlers/request.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/handlers/request.rs
@@ -1061,7 +1061,7 @@ pub(crate) fn handle_completion_resolve(
 
     let position = FilePosition { file_id, offset };
     let Some(unresolved_completions) = snap.analysis.completions(
-        &forced_resolve_completions_config,
+        &&forced_resolve_completions_config,
         position,
         resolve_data.trigger_character,
     )?

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/handlers/request.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/handlers/request.rs
@@ -1019,11 +1019,9 @@ pub(crate) fn handle_completion(
 
     let items = to_proto::completion_items(
         &snap.config,
-        &completion_config.fields_to_resolve,
         &line_index,
         snap.file_version(position.file_id),
         text_document_position,
-        completion_trigger_character,
         items,
     );
 

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/handlers/request.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/handlers/request.rs
@@ -1068,7 +1068,7 @@ pub(crate) fn handle_completion_resolve(
     else {
         return Ok(original_completion);
     };
-    let mut resolved_completions = to_proto::completion_items(
+    let resolved_completions = to_proto::completion_items(
         &snap.config,
         &forced_resolve_completions_config.fields_to_resolve,
         &line_index,
@@ -1077,13 +1077,15 @@ pub(crate) fn handle_completion_resolve(
         resolve_data.trigger_character,
         resolved_completions,
     );
-
-    let mut resolved_completion =
-        if resolved_completions.get(resolve_data.completion_item_index).is_some() {
-            resolved_completions.swap_remove(resolve_data.completion_item_index)
-        } else {
-            return Ok(original_completion);
-        };
+    let Some(mut resolved_completion) = resolved_completions.into_iter().find(|completion| {
+        completion.label == original_completion.label
+            && completion.kind == original_completion.kind
+            && completion.deprecated == original_completion.deprecated
+            && completion.preselect == original_completion.preselect
+            && completion.sort_text == original_completion.sort_text
+    }) else {
+        return Ok(original_completion);
+    };
 
     if !resolve_data.imports.is_empty() {
         let additional_edits = snap

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/handlers/request.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/handlers/request.rs
@@ -1060,7 +1060,7 @@ pub(crate) fn handle_completion_resolve(
     forced_resolve_completions_config.fields_to_resolve = CompletionFieldsToResolve::empty();
 
     let position = FilePosition { file_id, offset };
-    let Some(resolved_completions) = snap.analysis.completions(
+    let Some(unresolved_completions) = snap.analysis.completions(
         &forced_resolve_completions_config,
         position,
         resolve_data.trigger_character,
@@ -1075,7 +1075,7 @@ pub(crate) fn handle_completion_resolve(
         snap.file_version(position.file_id),
         resolve_data.position,
         resolve_data.trigger_character,
-        resolved_completions,
+        unresolved_completions,
     );
     let Some(mut resolved_completion) = resolved_completions.into_iter().find(|completion| {
         completion.label == original_completion.label

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/handlers/request.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/handlers/request.rs
@@ -10,9 +10,9 @@ use std::{
 use anyhow::Context;
 
 use ide::{
-    AnnotationConfig, AssistKind, AssistResolveStrategy, Cancellable, CompletionFieldsToResolve,
-    FilePosition, FileRange, HoverAction, HoverGotoTypeData, InlayFieldsToResolve, Query,
-    RangeInfo, ReferenceCategory, Runnable, RunnableKind, SingleResolve, SourceChange, TextEdit,
+    AnnotationConfig, AssistKind, AssistResolveStrategy, Cancellable, FilePosition, FileRange,
+    HoverAction, HoverGotoTypeData, InlayFieldsToResolve, Query, RangeInfo, ReferenceCategory,
+    Runnable, RunnableKind, SingleResolve, SourceChange, TextEdit,
 };
 use ide_db::SymbolKind;
 use itertools::Itertools;
@@ -1056,43 +1056,12 @@ pub(crate) fn handle_completion_resolve(
     };
     let source_root = snap.analysis.source_root_id(file_id)?;
 
-    let mut forced_resolve_completions_config = snap.config.completion(Some(source_root));
-    forced_resolve_completions_config.fields_to_resolve = CompletionFieldsToResolve::empty();
-
-    let position = FilePosition { file_id, offset };
-    let Some(unresolved_completions) = snap.analysis.completions(
-        &&forced_resolve_completions_config,
-        position,
-        resolve_data.trigger_character,
-    )?
-    else {
-        return Ok(original_completion);
-    };
-    let resolved_completions = to_proto::completion_items(
-        &snap.config,
-        &forced_resolve_completions_config.fields_to_resolve,
-        &line_index,
-        snap.file_version(position.file_id),
-        resolve_data.position,
-        resolve_data.trigger_character,
-        unresolved_completions,
-    );
-    let Some(mut resolved_completion) = resolved_completions.into_iter().find(|completion| {
-        completion.label == original_completion.label
-            && completion.kind == original_completion.kind
-            && completion.deprecated == original_completion.deprecated
-            && completion.preselect == original_completion.preselect
-            && completion.sort_text == original_completion.sort_text
-    }) else {
-        return Ok(original_completion);
-    };
-
     if !resolve_data.imports.is_empty() {
         let additional_edits = snap
             .analysis
             .resolve_completion_edits(
-                &forced_resolve_completions_config,
-                position,
+                &snap.config.completion(Some(source_root)),
+                FilePosition { file_id, offset },
                 resolve_data
                     .imports
                     .into_iter()
@@ -1102,7 +1071,7 @@ pub(crate) fn handle_completion_resolve(
             .flat_map(|edit| edit.into_iter().map(|indel| to_proto::text_edit(&line_index, indel)))
             .collect::<Vec<_>>();
 
-        if !all_edits_are_disjoint(&resolved_completion, &additional_edits) {
+        if !all_edits_are_disjoint(&original_completion, &additional_edits) {
             return Err(LspError::new(
                 ErrorCode::InternalError as i32,
                 "Import edit overlaps with the original completion edits, this is not LSP-compliant"
@@ -1111,15 +1080,15 @@ pub(crate) fn handle_completion_resolve(
             .into());
         }
 
-        if let Some(original_additional_edits) = resolved_completion.additional_text_edits.as_mut()
+        if let Some(original_additional_edits) = original_completion.additional_text_edits.as_mut()
         {
             original_additional_edits.extend(additional_edits)
         } else {
-            resolved_completion.additional_text_edits = Some(additional_edits);
+            original_completion.additional_text_edits = Some(additional_edits);
         }
     }
 
-    Ok(resolved_completion)
+    Ok(original_completion)
 }
 
 pub(crate) fn handle_folding_range(

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/integrated_benchmarks.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/integrated_benchmarks.rs
@@ -12,8 +12,7 @@
 
 use hir::ChangeWithProcMacros;
 use ide::{
-    AnalysisHost, CallableSnippets, CompletionConfig, CompletionFieldsToResolve, DiagnosticsConfig,
-    FilePosition, TextSize,
+    AnalysisHost, CallableSnippets, CompletionConfig, DiagnosticsConfig, FilePosition, TextSize,
 };
 use ide_db::{
     imports::insert_use::{ImportGranularity, InsertUseConfig},
@@ -173,7 +172,6 @@ fn integrated_completion_benchmark() {
             snippets: Vec::new(),
             limit: None,
             add_semicolon_to_unit: true,
-            fields_to_resolve: CompletionFieldsToResolve::empty(),
         };
         let position =
             FilePosition { file_id, offset: TextSize::try_from(completion_offset).unwrap() };
@@ -221,7 +219,6 @@ fn integrated_completion_benchmark() {
             snippets: Vec::new(),
             limit: None,
             add_semicolon_to_unit: true,
-            fields_to_resolve: CompletionFieldsToResolve::empty(),
         };
         let position =
             FilePosition { file_id, offset: TextSize::try_from(completion_offset).unwrap() };
@@ -267,7 +264,6 @@ fn integrated_completion_benchmark() {
             snippets: Vec::new(),
             limit: None,
             add_semicolon_to_unit: true,
-            fields_to_resolve: CompletionFieldsToResolve::empty(),
         };
         let position =
             FilePosition { file_id, offset: TextSize::try_from(completion_offset).unwrap() };

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/capabilities.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/capabilities.rs
@@ -448,7 +448,7 @@ impl ClientCapabilities {
             .unwrap_or_default()
     }
 
-    pub fn inlay_hint_resolve_support_properties(&self) -> FxHashSet<&str> {
+    pub fn inlay_hint_resolve_support_properties(&self) -> FxHashSet<String> {
         self.0
             .text_document
             .as_ref()
@@ -457,11 +457,11 @@ impl ClientCapabilities {
             .map(|inlay_resolve| inlay_resolve.properties.iter())
             .into_iter()
             .flatten()
-            .map(|s| s.as_str())
+            .cloned()
             .collect()
     }
 
-    pub fn completion_resolve_support_properties(&self) -> FxHashSet<&str> {
+    pub fn completion_resolve_support_properties(&self) -> FxHashSet<String> {
         self.0
             .text_document
             .as_ref()
@@ -471,7 +471,7 @@ impl ClientCapabilities {
             .map(|resolve_support| resolve_support.properties.iter())
             .into_iter()
             .flatten()
-            .map(|s| s.as_str())
+            .cloned()
             .collect()
     }
 

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/capabilities.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/capabilities.rs
@@ -458,21 +458,7 @@ impl ClientCapabilities {
             .into_iter()
             .flatten()
             .cloned()
-            .collect()
-    }
-
-    pub fn completion_resolve_support_properties(&self) -> FxHashSet<String> {
-        self.0
-            .text_document
-            .as_ref()
-            .and_then(|text| text.completion.as_ref())
-            .and_then(|completion_caps| completion_caps.completion_item.as_ref())
-            .and_then(|completion_item_caps| completion_item_caps.resolve_support.as_ref())
-            .map(|resolve_support| resolve_support.properties.iter())
-            .into_iter()
-            .flatten()
-            .cloned()
-            .collect()
+            .collect::<FxHashSet<_>>()
     }
 
     pub fn hover_markdown_support(&self) -> bool {

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/ext.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/ext.rs
@@ -825,7 +825,7 @@ pub struct CompletionResolveData {
     pub position: lsp_types::TextDocumentPositionParams,
     pub imports: Vec<CompletionImport>,
     pub version: Option<i32>,
-    pub trigger_character: Option<char>,
+    pub completion_trigger_character: Option<char>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/ext.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/ext.rs
@@ -825,7 +825,6 @@ pub struct CompletionResolveData {
     pub position: lsp_types::TextDocumentPositionParams,
     pub imports: Vec<CompletionImport>,
     pub version: Option<i32>,
-    pub completion_trigger_character: Option<char>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/ext.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/ext.rs
@@ -826,7 +826,6 @@ pub struct CompletionResolveData {
     pub imports: Vec<CompletionImport>,
     pub version: Option<i32>,
     pub trigger_character: Option<char>,
-    pub completion_item_index: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -396,7 +396,7 @@ fn completion_item(
             position: tdpp.clone(),
             imports,
             version,
-            trigger_character: completion_trigger_character,
+            completion_trigger_character,
         };
         lsp_item.data = Some(to_value(data).unwrap());
     }

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -286,12 +286,12 @@ fn completion_item(
         Some(item.lookup().to_owned())
     };
 
+    // LSP does not allow arbitrary edits in completion, so we have to do a
+    // non-trivial mapping here.
     let text_edit = if fields_to_resolve.resolve_text_edit {
         something_to_resolve = true;
         None
     } else {
-        // LSP does not allow arbitrary edits in completion, so we have to do a
-        // non-trivial mapping here.
         let mut text_edit = None;
         let source_range = item.source_range;
         for indel in item.text_edit {
@@ -327,9 +327,9 @@ fn completion_item(
     let command = if item.trigger_call_info && config.client_commands().trigger_parameter_hints {
         if fields_to_resolve.resolve_command {
             something_to_resolve = true;
-            None
-        } else {
             Some(command::trigger_parameter_hints())
+        } else {
+            None
         }
     } else {
         None

--- a/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/to_proto.rs
+++ b/src/tools/rust-analyzer/crates/rust-analyzer/src/lsp/to_proto.rs
@@ -391,36 +391,18 @@ fn completion_item(
         } else {
             Vec::new()
         };
-    let (ref_resolve_data, resolve_data) = if something_to_resolve || !imports.is_empty() {
-        let mut item_index = acc.len();
-        let ref_resolve_data = if ref_match.is_some() {
-            let ref_resolve_data = lsp_ext::CompletionResolveData {
-                position: tdpp.clone(),
-                imports: Vec::new(),
-                version,
-                trigger_character: completion_trigger_character,
-                completion_item_index: item_index,
-            };
-            item_index += 1;
-            Some(to_value(ref_resolve_data).unwrap())
-        } else {
-            None
-        };
-        let resolve_data = lsp_ext::CompletionResolveData {
+    if something_to_resolve || !imports.is_empty() {
+        let data = lsp_ext::CompletionResolveData {
             position: tdpp.clone(),
             imports,
             version,
             trigger_character: completion_trigger_character,
-            completion_item_index: item_index,
         };
-        (ref_resolve_data, Some(to_value(resolve_data).unwrap()))
-    } else {
-        (None, None)
-    };
+        lsp_item.data = Some(to_value(data).unwrap());
+    }
 
     if let Some((label, indel, relevance)) = ref_match {
-        let mut lsp_item_with_ref =
-            lsp_types::CompletionItem { label, data: ref_resolve_data, ..lsp_item.clone() };
+        let mut lsp_item_with_ref = lsp_types::CompletionItem { label, ..lsp_item.clone() };
         lsp_item_with_ref
             .additional_text_edits
             .get_or_insert_with(Default::default)
@@ -429,7 +411,6 @@ fn completion_item(
         acc.push(lsp_item_with_ref);
     };
 
-    lsp_item.data = resolve_data;
     acc.push(lsp_item);
 
     fn set_score(

--- a/src/tools/rust-analyzer/docs/dev/lsp-extensions.md
+++ b/src/tools/rust-analyzer/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: 90cf7718d54fe3c2
+lsp/ext.rs hash: 6292ee8d88d4c9ec
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:

--- a/src/tools/rust-analyzer/docs/dev/lsp-extensions.md
+++ b/src/tools/rust-analyzer/docs/dev/lsp-extensions.md
@@ -1,5 +1,5 @@
 <!---
-lsp/ext.rs hash: 96f88b7a5d0080c6
+lsp/ext.rs hash: 90cf7718d54fe3c2
 
 If you need to change the above hash to make the test pass, please check if you
 need to adjust this doc as well and ping this issue:


### PR DESCRIPTION
This PR revers recent completion-related changes in r-a, which caused nvim and helix to malfunction.
Changes reverted:
1. https://github.com/rust-lang/rust-analyzer/pull/18167
2. https://github.com/rust-lang/rust-analyzer/pull/18247
3. https://github.com/rust-lang/rust-analyzer/pull/18503

See https://github.com/rust-lang/rust-analyzer/pull/18503#issuecomment-2498920382 for more context

cc @BoxyUwU 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
