### PR TITLE
Only error raw lifetime followed by `\'` in edition 2021+

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -707,17 +707,7 @@ impl Cursor<'_> {
             self.bump();
             self.bump();
             self.eat_while(is_id_continue);
-            match self.first() {
-                '\'' => {
-                    // Check if after skipping literal contents we've met a closing
-                    // single quote (which means that user attempted to create a
-                    // string with single quotes).
-                    self.bump();
-                    let kind = Char { terminated: true };
-                    return Literal { kind, suffix_start: self.pos_within_token() };
-                }
-                _ => return RawLifetime,
-            }
+            return RawLifetime;
         }
 
         // Either a lifetime or a character literal with

--- a/tests/ui/lifetimes/raw/immediately-followed-by-lt.e2021.stderr
+++ b/tests/ui/lifetimes/raw/immediately-followed-by-lt.e2021.stderr
@@ -1,5 +1,5 @@
 error: character literal may only contain one codepoint
-  --> $DIR/immediately-followed-by-lt.rs:11:4
+  --> $DIR/immediately-followed-by-lt.rs:15:4
    |
 LL | w!('r#long'id);
    |    ^^^^^^^^

--- a/tests/ui/lifetimes/raw/immediately-followed-by-lt.rs
+++ b/tests/ui/lifetimes/raw/immediately-followed-by-lt.rs
@@ -1,4 +1,8 @@
-//@ edition: 2021
+//@ revisions: e2015 e2021
+
+//@[e2021] edition: 2021
+//@[e2015] edition: 2015
+//@[e2015] check-pass
 
 // Make sure we reject the case where a raw lifetime is immediately followed by another
 // lifetime. This reserves a modest amount of space for changing lexing to, for example,
@@ -9,6 +13,6 @@ macro_rules! w {
 }
 
 w!('r#long'id);
-//~^ ERROR character literal may only contain one codepoint
+//[e2021]~^ ERROR character literal may only contain one codepoint
 
 fn main() {}


### PR DESCRIPTION
Fixes #133479
cc #132341

I think this fixes a purely theoretical regression since it only affects edition 2015 (who is using that?) and only in the very rare case of a raw lifetime followed immediately by a lifetime like `'r#a'r`.