### PR TITLE
[discussion][donotmerge]: Copy Python implementation for `float::div_euclid`

### DIFF
--- a/library/std/src/f128.rs
+++ b/library/std/src/f128.rs
@@ -255,8 +255,12 @@ impl f128 {
     /// let b = 4.0;
     /// assert_eq!(a.div_euclid(b), 1.0); // 7.0 > 4.0 * 1.0
     /// assert_eq!((-a).div_euclid(b), -2.0); // -7.0 >= 4.0 * -2.0
-    /// assert_eq!(a.div_euclid(-b), -1.0); // 7.0 >= -4.0 * -1.0
-    /// assert_eq!((-a).div_euclid(-b), 2.0); // -7.0 >= -4.0 * 2.0
+    /// assert_eq!(a.div_euclid(-b), -2.0); // 7.0 >= -4.0 * -1.0
+    /// assert_eq!((-a).div_euclid(-b), 1.0); // -7.0 >= -4.0 * 2.0
+    /// assert_eq!(11f128.div_euclid(1.1), 9.0);
+    /// assert_eq!((-11f128).div_euclid(1.1), -10.0);
+    /// assert_eq!(0.5f128.div_euclid(1.1), 0.0);
+    /// assert_eq!((-0.5f128).div_euclid(1.1), -1.0);
     /// # }
     /// ```
     #[inline]
@@ -264,10 +268,27 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn div_euclid(self, rhs: f128) -> f128 {
-        let q = (self / rhs).trunc();
-        if self % rhs < 0.0 {
-            return if rhs > 0.0 { q - 1.0 } else { q + 1.0 };
+        // Copied from Python implementation: <https://github.com/python/cpython/blob/3.13/Objects/floatobject.c#L662>
+        // NOTE: Should we use `fmod` instead?
+        let rem = self % rhs;
+        let mut div = (self - rem) / rhs;
+        if rem != 0.0 {
+            /* ensure the remainder has the same sign as the denominator */
+            if (rhs < 0.0) != (rem < 0.0) {
+                div -= 1.0;
+            }
         }
+        /* snap quotient to nearest integral value */
+        let q = if div != 0.0 {
+            let mut q = div.floor();
+            if div - q > 0.5 {
+                q += 1.0;
+            }
+            q
+        } else {
+            /* div is zero - get the same sign as the true quotient */
+            Self::copysign(0.0, self / rhs)
+        };
         q
     }
 

--- a/library/std/src/f16.rs
+++ b/library/std/src/f16.rs
@@ -255,8 +255,12 @@ impl f16 {
     /// let b = 4.0;
     /// assert_eq!(a.div_euclid(b), 1.0); // 7.0 > 4.0 * 1.0
     /// assert_eq!((-a).div_euclid(b), -2.0); // -7.0 >= 4.0 * -2.0
-    /// assert_eq!(a.div_euclid(-b), -1.0); // 7.0 >= -4.0 * -1.0
-    /// assert_eq!((-a).div_euclid(-b), 2.0); // -7.0 >= -4.0 * 2.0
+    /// assert_eq!(a.div_euclid(-b), -2.0); // 7.0 >= -4.0 * -1.0
+    /// assert_eq!((-a).div_euclid(-b), 1.0); // -7.0 >= -4.0 * 2.0
+    /// assert_eq!(11f16.div_euclid(1.1), 9.0);
+    /// assert_eq!((-11f16).div_euclid(1.1), -10.0);
+    /// assert_eq!(0.5f16.div_euclid(1.1), 0.0);
+    /// assert_eq!(-0.5f16.div_euclid(1.1), -1.0);
     /// # }
     /// ```
     #[inline]
@@ -264,10 +268,27 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn div_euclid(self, rhs: f16) -> f16 {
-        let q = (self / rhs).trunc();
-        if self % rhs < 0.0 {
-            return if rhs > 0.0 { q - 1.0 } else { q + 1.0 };
+        // Copied from Python implementation: <https://github.com/python/cpython/blob/3.13/Objects/floatobject.c#L662>
+        // NOTE: Should we use `fmod` instead?
+        let rem = self % rhs;
+        let mut div = (self - rem) / rhs;
+        if rem != 0.0 {
+            /* ensure the remainder has the same sign as the denominator */
+            if (rhs < 0.0) != (rem < 0.0) {
+                div -= 1.0;
+            }
         }
+        /* snap quotient to nearest integral value */
+        let q = if div != 0.0 {
+            let mut q = div.floor();
+            if div - q > 0.5 {
+                q += 1.0;
+            }
+            q
+        } else {
+            /* div is zero - get the same sign as the true quotient */
+            Self::copysign(0.0, self / rhs)
+        };
         q
     }
 

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -236,18 +236,39 @@ impl f64 {
     /// let b = 4.0;
     /// assert_eq!(a.div_euclid(b), 1.0); // 7.0 > 4.0 * 1.0
     /// assert_eq!((-a).div_euclid(b), -2.0); // -7.0 >= 4.0 * -2.0
-    /// assert_eq!(a.div_euclid(-b), -1.0); // 7.0 >= -4.0 * -1.0
-    /// assert_eq!((-a).div_euclid(-b), 2.0); // -7.0 >= -4.0 * 2.0
+    /// assert_eq!(a.div_euclid(-b), -2.0); // 7.0 >= -4.0 * -1.0
+    /// assert_eq!((-a).div_euclid(-b), 1.0); // -7.0 >= -4.0 * 2.0
+    /// assert_eq!(11f64.div_euclid(1.1), 9.0);
+    /// assert_eq!((-11f64).div_euclid(1.1), -10.0);
+    /// assert_eq!(0.5f64.div_euclid(1.1), 0.0);
+    /// assert_eq!((-0.5f64).div_euclid(1.1), -1.0);
     /// ```
     #[rustc_allow_incoherent_impl]
     #[must_use = "method returns a new number and does not mutate the original value"]
     #[inline]
     #[stable(feature = "euclidean_division", since = "1.38.0")]
     pub fn div_euclid(self, rhs: f64) -> f64 {
-        let q = (self / rhs).trunc();
-        if self % rhs < 0.0 {
-            return if rhs > 0.0 { q - 1.0 } else { q + 1.0 };
+        // Copied from Python implementation: <https://github.com/python/cpython/blob/3.13/Objects/floatobject.c#L662>
+        // NOTE: Should we use `fmod` instead?
+        let rem = self % rhs;
+        let mut div = (self - rem) / rhs;
+        if rem != 0.0 {
+            /* ensure the remainder has the same sign as the denominator */
+            if (rhs < 0.0) != (rem < 0.0) {
+                div -= 1.0;
+            }
         }
+        /* snap quotient to nearest integral value */
+        let q = if div != 0.0 {
+            let mut q = div.floor();
+            if div - q > 0.5 {
+                q += 1.0;
+            }
+            q
+        } else {
+            /* div is zero - get the same sign as the true quotient */
+            Self::copysign(0.0, self / rhs)
+        };
         q
     }
 


### PR DESCRIPTION
cuviper [pointed out a lisensing][1] issue about copying Python code, which as I understand is PSF owned (GPL compatible).
**This PR cannot be merged as is**. I let this PR open in the meantime for more discussions.

---

This is a breaking change trying to fix <https://internals.rust-lang.org/t/bug-rounding-error-that-break-the-ensurance-of-f32-div-euclid/21917>.

In summary, Rust `float::div_euclid` and Python `divmod` disagrees with each others:
|  | Python | Rust | This PR |
|--------|--------|--------|--------|
| div_eulid(11.0, 1.1) | 9.0 | 10.0 | 9.0 |
| div_eulid(-11.0, 1.1) | -10.0 | -9.0 | -10.0 |
| div_eulid(11.0, -1.1) | -10.0 | -10.0 | -10.0 |
| div_eulid(-11.0, -1.1) | 9.0 | 11.0 | 9.0 |
| div_eulid(0.5, 1.1) | 0.0 | 0.0 | 0.0 |
| div_eulid(-0.5, 1.1) | -1.0 | -1.0 | -1.0 |
| div_eulid(0.5, -1.1) | -1.0 | 0.0 | -1.0 |
| div_eulid(-0.5, -1.1) | 0.0 | 1.0 | 0.0 |

Personally I think the Python's behavior is more correct. Because given real numbers `a` and `b`,
` q` is euclidean division of `a` and `b`, and `r` is the eulidean remainder of them.
`q*b + r` should be equal to `a`.
Take the first example, 11.0 and 1.1. Currectly with Rust `10.0*1.1 + 1.0999998 > 11.0 + 1 > 11.0`.

FIXME: The Python link uses "fmod " to get more exact remander. But this PR only uses raw `%` operator. 
Is this a problem in practice?

Reference:

* <https://github.com/python/cpython/blob/3.13/Objects/floatobject.c#L662>.
* https://github.com/rust-lang/rust/issues/107904

r? @ghost

[1]: https://github.com/rust-lang/rust/pull/133485#issuecomment-2499880064
