### PR TITLE
borrowck diagnostics: make `add_move_error_suggestions` use the HIR rather than `SourceMap`

### DIFF
--- a/tests/ui/issues/issue-12567.stderr
+++ b/tests/ui/issues/issue-12567.stderr
@@ -11,14 +11,16 @@ LL |         (&[hd1, ..], &[hd2, ..])
    |                        --- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |         (&[], &[ref hd, ..]) | (&[hd, ..], &[])
-   |                 +++
-help: consider borrowing the pattern binding
+LL -         (&[], &[hd, ..]) | (&[hd, ..], &[])
+LL +         (&[], [hd, ..]) | (&[hd, ..], &[])
    |
-LL |         (&[hd1, ..], &[ref hd2, ..])
-   |                        +++
+help: consider removing the borrow
+   |
+LL -         (&[hd1, ..], &[hd2, ..])
+LL +         (&[hd1, ..], [hd2, ..])
+   |
 
 error[E0508]: cannot move out of type `[T]`, a non-copy slice
   --> $DIR/issue-12567.rs:2:11
@@ -33,14 +35,16 @@ LL |         (&[hd1, ..], &[hd2, ..])
    |            --- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |         (&[], &[ref hd, ..]) | (&[hd, ..], &[])
-   |                 +++
-help: consider borrowing the pattern binding
+LL -         (&[], &[hd, ..]) | (&[hd, ..], &[])
+LL +         (&[], [hd, ..]) | (&[hd, ..], &[])
    |
-LL |         (&[ref hd1, ..], &[hd2, ..])
-   |            +++
+help: consider removing the borrow
+   |
+LL -         (&[hd1, ..], &[hd2, ..])
+LL +         ([hd1, ..], &[hd2, ..])
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail2.stderr
+++ b/tests/ui/match/ref_pat_eat_one_layer_2024/ref_pat_eat_one_layer_2024_fail2.stderr
@@ -7,10 +7,11 @@ LL |     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
    |                       data moved here
    |                       move occurs because `x` has type `&mut u32`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |     if let Some(&Some(ref x)) = Some(&Some(&mut 0)) {
-   |                       +++
+LL -     if let Some(&Some(x)) = Some(&Some(&mut 0)) {
+LL +     if let Some(Some(x)) = Some(&Some(&mut 0)) {
+   |
 
 error[E0596]: cannot borrow data in a `&` reference as mutable
   --> $DIR/ref_pat_eat_one_layer_2024_fail2.rs:11:10

--- a/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.fixed
+++ b/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.fixed
@@ -1,0 +1,10 @@
+//@ run-rustfix
+//! diagnostic test for #132806: make sure the suggestion to bind by-reference in patterns doesn't
+//! erroneously remove the wrong `&`
+
+use std::collections::HashMap;
+
+fn main() {
+    let _ = HashMap::<String, i32>::new().iter().filter(|&(_k, &_v)| { true });
+    //~^ ERROR cannot move out of a shared reference
+}

--- a/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.rs
+++ b/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.rs
@@ -1,0 +1,10 @@
+//@ run-rustfix
+//! diagnostic test for #132806: make sure the suggestion to bind by-reference in patterns doesn't
+//! erroneously remove the wrong `&`
+
+use std::collections::HashMap;
+
+fn main() {
+    let _ = HashMap::<String, i32>::new().iter().filter(|&(&_k, &_v)| { true });
+    //~^ ERROR cannot move out of a shared reference
+}

--- a/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.stderr
+++ b/tests/ui/moves/do-not-suggest-removing-wrong-ref-pattern-issue-132806.stderr
@@ -1,0 +1,18 @@
+error[E0507]: cannot move out of a shared reference
+  --> $DIR/do-not-suggest-removing-wrong-ref-pattern-issue-132806.rs:8:58
+   |
+LL |     let _ = HashMap::<String, i32>::new().iter().filter(|&(&_k, &_v)| { true });
+   |                                                          ^^^--^^^^^^
+   |                                                             |
+   |                                                             data moved here
+   |                                                             move occurs because `_k` has type `String`, which does not implement the `Copy` trait
+   |
+help: consider removing the borrow
+   |
+LL -     let _ = HashMap::<String, i32>::new().iter().filter(|&(&_k, &_v)| { true });
+LL +     let _ = HashMap::<String, i32>::new().iter().filter(|&(_k, &_v)| { true });
+   |
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0507`.

--- a/tests/ui/nll/move-errors.stderr
+++ b/tests/ui/nll/move-errors.stderr
@@ -209,10 +209,11 @@ LL |         (D(s), &t) => (),
    |                 data moved here
    |                 move occurs because `t` has type `String`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |         (D(s), &ref t) => (),
-   |                 +++
+LL -         (D(s), &t) => (),
+LL +         (D(s), t) => (),
+   |
 
 error[E0509]: cannot move out of type `F`, which implements the `Drop` trait
   --> $DIR/move-errors.rs:102:11

--- a/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.stderr
+++ b/tests/ui/pattern/deref-patterns/cant_move_out_of_pattern.stderr
@@ -9,6 +9,11 @@ LL |         deref!(x) => x,
    |                |
    |                data moved here
    |                move occurs because `x` has type `Struct`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         deref!(ref x) => x,
+   |                +++
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/cant_move_out_of_pattern.rs:17:11
@@ -21,6 +26,11 @@ LL |         deref!(x) => x,
    |                |
    |                data moved here
    |                move occurs because `x` has type `Struct`, which does not implement the `Copy` trait
+   |
+help: consider borrowing the pattern binding
+   |
+LL |         deref!(ref x) => x,
+   |                +++
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/suggestions/dont-suggest-ref/simple.rs
+++ b/tests/ui/suggestions/dont-suggest-ref/simple.rs
@@ -219,42 +219,42 @@ pub fn main() {
 
     let (&X(_t),) = (&x.clone(),);
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the borrow
     if let (&Either::One(_t),) = (&e.clone(),) { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the borrow
     while let (&Either::One(_t),) = (&e.clone(),) { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the borrow
     match (&e.clone(),) {
         //~^ ERROR cannot move
         (&Either::One(_t),)
-        //~^ HELP consider borrowing the pattern binding
+        //~^ HELP consider removing the borrow
         | (&Either::Two(_t),) => (),
     }
     fn f3((&X(_t),): (&X,)) { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the borrow
 
     let (&mut X(_t),) = (&mut xm.clone(),);
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the mutable borrow
     if let (&mut Either::One(_t),) = (&mut em.clone(),) { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the mutable borrow
     while let (&mut Either::One(_t),) = (&mut em.clone(),) { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the mutable borrow
     match (&mut em.clone(),) {
         //~^ ERROR cannot move
         (&mut Either::One(_t),) => (),
-        //~^ HELP consider borrowing the pattern binding
+        //~^ HELP consider removing the mutable borrow
         (&mut Either::Two(_t),) => (),
-        //~^ HELP consider borrowing the pattern binding
+        //~^ HELP consider removing the mutable borrow
     }
     fn f4((&mut X(_t),): (&mut X,)) { }
     //~^ ERROR cannot move
-    //~| HELP consider borrowing the pattern binding
+    //~| HELP consider removing the mutable borrow
 
     // move from &Either/&X value
 

--- a/tests/ui/suggestions/dont-suggest-ref/simple.stderr
+++ b/tests/ui/suggestions/dont-suggest-ref/simple.stderr
@@ -578,10 +578,11 @@ LL |     let (&X(_t),) = (&x.clone(),);
    |             data moved here
    |             move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |     let (&X(ref _t),) = (&x.clone(),);
-   |             +++
+LL -     let (&X(_t),) = (&x.clone(),);
+LL +     let (X(_t),) = (&x.clone(),);
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/simple.rs:223:34
@@ -592,10 +593,11 @@ LL |     if let (&Either::One(_t),) = (&e.clone(),) { }
    |                          data moved here
    |                          move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |     if let (&Either::One(ref _t),) = (&e.clone(),) { }
-   |                          +++
+LL -     if let (&Either::One(_t),) = (&e.clone(),) { }
+LL +     if let (Either::One(_t),) = (&e.clone(),) { }
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/simple.rs:226:37
@@ -606,10 +608,11 @@ LL |     while let (&Either::One(_t),) = (&e.clone(),) { }
    |                             data moved here
    |                             move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |     while let (&Either::One(ref _t),) = (&e.clone(),) { }
-   |                             +++
+LL -     while let (&Either::One(_t),) = (&e.clone(),) { }
+LL +     while let (Either::One(_t),) = (&e.clone(),) { }
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/simple.rs:229:11
@@ -623,10 +626,11 @@ LL |         (&Either::One(_t),)
    |                       data moved here
    |                       move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |         (&Either::One(ref _t),)
-   |                       +++
+LL -         (&Either::One(_t),)
+LL +         (Either::One(_t),)
+   |
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/simple.rs:239:25
@@ -637,10 +641,11 @@ LL |     let (&mut X(_t),) = (&mut xm.clone(),);
    |                 data moved here
    |                 move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the mutable borrow
    |
-LL |     let (&mut X(ref _t),) = (&mut xm.clone(),);
-   |                 +++
+LL -     let (&mut X(_t),) = (&mut xm.clone(),);
+LL +     let (X(_t),) = (&mut xm.clone(),);
+   |
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/simple.rs:242:38
@@ -651,10 +656,11 @@ LL |     if let (&mut Either::One(_t),) = (&mut em.clone(),) { }
    |                              data moved here
    |                              move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the mutable borrow
    |
-LL |     if let (&mut Either::One(ref _t),) = (&mut em.clone(),) { }
-   |                              +++
+LL -     if let (&mut Either::One(_t),) = (&mut em.clone(),) { }
+LL +     if let (Either::One(_t),) = (&mut em.clone(),) { }
+   |
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/simple.rs:245:41
@@ -665,10 +671,11 @@ LL |     while let (&mut Either::One(_t),) = (&mut em.clone(),) { }
    |                                 data moved here
    |                                 move occurs because `_t` has type `X`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the mutable borrow
    |
-LL |     while let (&mut Either::One(ref _t),) = (&mut em.clone(),) { }
-   |                                 +++
+LL -     while let (&mut Either::One(_t),) = (&mut em.clone(),) { }
+LL +     while let (Either::One(_t),) = (&mut em.clone(),) { }
+   |
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/simple.rs:248:11
@@ -683,14 +690,16 @@ LL |         (&mut Either::Two(_t),) => (),
    |                           -- ...and here
    |
    = note: move occurs because these variables have types that don't implement the `Copy` trait
-help: consider borrowing the pattern binding
+help: consider removing the mutable borrow
    |
-LL |         (&mut Either::One(ref _t),) => (),
-   |                           +++
-help: consider borrowing the pattern binding
+LL -         (&mut Either::One(_t),) => (),
+LL +         (Either::One(_t),) => (),
    |
-LL |         (&mut Either::Two(ref _t),) => (),
-   |                           +++
+help: consider removing the mutable borrow
+   |
+LL -         (&mut Either::Two(_t),) => (),
+LL +         (Either::Two(_t),) => (),
+   |
 
 error[E0507]: cannot move out of a shared reference
   --> $DIR/simple.rs:261:18
@@ -947,10 +956,11 @@ LL |     fn f3((&X(_t),): (&X,)) { }
    |               data moved here
    |               move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |     fn f3((&X(ref _t),): (&X,)) { }
-   |               +++
+LL -     fn f3((&X(_t),): (&X,)) { }
+LL +     fn f3((X(_t),): (&X,)) { }
+   |
 
 error[E0507]: cannot move out of a mutable reference
   --> $DIR/simple.rs:255:11
@@ -961,10 +971,11 @@ LL |     fn f4((&mut X(_t),): (&mut X,)) { }
    |                   data moved here
    |                   move occurs because `_t` has type `Y`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the mutable borrow
    |
-LL |     fn f4((&mut X(ref _t),): (&mut X,)) { }
-   |                   +++
+LL -     fn f4((&mut X(_t),): (&mut X,)) { }
+LL +     fn f4((X(_t),): (&mut X,)) { }
+   |
 
 error[E0507]: cannot move out of `a.a` as enum variant `Some` which is behind a shared reference
   --> $DIR/simple.rs:331:20

--- a/tests/ui/suggestions/option-content-move-from-tuple-match.stderr
+++ b/tests/ui/suggestions/option-content-move-from-tuple-match.stderr
@@ -10,10 +10,11 @@ LL |         (None, &c) => &c.unwrap(),
    |                 data moved here
    |                 move occurs because `c` has type `Option<String>`, which does not implement the `Copy` trait
    |
-help: consider borrowing the pattern binding
+help: consider removing the borrow
    |
-LL |         (None, &ref c) => &c.unwrap(),
-   |                 +++
+LL -         (None, &c) => &c.unwrap(),
+LL +         (None, c) => &c.unwrap(),
+   |
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
This PR aims to fix #132806 by rewriting `add_move_error_suggestions`[^1]. Previously, it manually scanned the source text to find a leading `&`, which isn't always going to produce a correct result (see: that issue). Admittedly, the HIR visitor in this PR introduces a lot of boilerplate, but hopefully the logic at its core isn't too complicated (I go over it in the comments). I also tried a simpler version that didn't use a HIR visitor and suggested adding `ref` always, but the `&ref x` suggestions really didn't look good. As a bonus for the added complexity though, it's now able to produce nice `&`-removing suggestions in more cases.

I tried to do this such that it avoids edition-dependent checks and its suggestions can be applied together with those from the match ergonomics 2024 migration lint. I haven't added tests for that since the details of match ergonomics 2024 are still being sorted out, but I can try if desired once that's finalized.

[^1]: In brief, it fires on patterns where users try to bind by-value in such a way that moves out of a reference to a non-Copy type (including slice references with non-copy elements). The suggestions are to change the binding's mode to be by-reference, either by removing[^2] an enclosing `&`/`&mut` or adding `ref` to the binding.

[^2]: Incidentally, I find the terminology of "consider removing the borrow" a bit confusing for a suggestion to remove a `&` pattern in order to make bindings borrow rather than move. I'm not sure what a good, concise way to explain that would be though, and that should go in a separate PR anyway.