### PR TITLE
fix confusing diagnostic for reserved `##`

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -733,6 +733,9 @@ lint_renamed_lint = lint `{$name}` has been renamed to `{$replace}`
 
 lint_requested_level = requested on the command line with `{$level} {$lint_name}`
 
+lint_reserved_multihash = reserved token in Rust 2024
+    .suggestion = insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
+
 lint_reserved_prefix = prefix `{$prefix}` is unknown
     .label = unknown prefix
     .suggestion = insert whitespace here to avoid this being parsed as a prefix in Rust 2021

--- a/compiler/rustc_lint/src/context/diagnostics.rs
+++ b/compiler/rustc_lint/src/context/diagnostics.rs
@@ -176,8 +176,12 @@ pub(super) fn decorate_lint(sess: &Session, diagnostic: BuiltinLintDiag, diag: &
             lints::RawPrefix { label: label_span, suggestion: label_span.shrink_to_hi() }
                 .decorate_lint(diag);
         }
-        BuiltinLintDiag::ReservedString(suggestion) => {
-            lints::ReservedString { suggestion }.decorate_lint(diag);
+        BuiltinLintDiag::ReservedString { is_string, suggestion } => {
+            if is_string {
+                lints::ReservedString { suggestion }.decorate_lint(diag);
+            } else {
+                lints::ReservedMultihash { suggestion }.decorate_lint(diag);
+            }
         }
         BuiltinLintDiag::UnusedBuiltinAttribute { attr_name, macro_name, invoc_span } => {
             lints::UnusedBuiltinAttribute { invoc_span, attr_name, macro_name }.decorate_lint(diag);

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3059,3 +3059,10 @@ pub(crate) struct ReservedString {
     #[suggestion(code = " ", applicability = "machine-applicable")]
     pub suggestion: Span,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(lint_reserved_multihash)]
+pub(crate) struct ReservedMultihash {
+    #[suggestion(code = " ", applicability = "machine-applicable")]
+    pub suggestion: Span,
+}

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -663,8 +663,11 @@ pub enum BuiltinLintDiag {
     ReservedPrefix(Span, String),
     /// `'r#` in edition < 2021.
     RawPrefix(Span),
-    /// `##` or `#"` is edition < 2024.
-    ReservedString(Span),
+    /// `##` or `#"` in edition < 2024.
+    ReservedString {
+        is_string: bool,
+        suggestion: Span,
+    },
     TrailingMacro(bool, Ident),
     BreakWithLabelAndLoop(Span),
     UnicodeTextFlow(Span, String),

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -716,6 +716,10 @@ parse_require_colon_after_labeled_expression = labeled expression must be follow
     .label = the label
     .suggestion = add `:` after the label
 
+parse_reserved_multihash = reserved multi-hash token is forbidden
+    .note = sequences of two or more # are reserved for future use since Rust 2024
+    .suggestion_whitespace = consider inserting whitespace here
+
 parse_reserved_string = invalid string literal
     .note = unprefixed guarded string literals are reserved for future use since Rust 2024
     .suggestion_whitespace = consider inserting whitespace here

--- a/compiler/rustc_parse/src/errors.rs
+++ b/compiler/rustc_parse/src/errors.rs
@@ -2152,6 +2152,15 @@ pub(crate) enum UnknownPrefixSugg {
 }
 
 #[derive(Diagnostic)]
+#[diag(parse_reserved_multihash)]
+#[note]
+pub(crate) struct ReservedMultihash {
+    #[primary_span]
+    pub span: Span,
+    #[subdiagnostic]
+    pub sugg: Option<GuardedStringSugg>,
+}
+#[derive(Diagnostic)]
 #[diag(parse_reserved_string)]
 #[note]
 pub(crate) struct ReservedString {

--- a/tests/ui/rust-2024/reserved-guarded-strings-lexing.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings-lexing.rs
@@ -26,24 +26,24 @@ macro_rules! demo7 {
 
 fn main() {
     demo3!(## "foo");
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo4!(### "foo");
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo4!(## "foo"#);
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo7!(### "foo"###);
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
 
     demo5!(###"foo"#);
@@ -56,14 +56,14 @@ fn main() {
     demo5!(#"foo"###);
     //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo4!("foo"###);
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
 
     // Non-ascii identifiers

--- a/tests/ui/rust-2024/reserved-guarded-strings-lexing.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-lexing.stderr
@@ -28,7 +28,7 @@ error: identifiers cannot contain emoji: `🙃`
 LL |     demo3!(🙃#"");
    |            ^^
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:28:12
    |
 LL |     demo3!(## "foo");
@@ -41,12 +41,12 @@ note: the lint level is defined here
    |
 LL | #![warn(rust_2024_guarded_string_incompatible_syntax)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo3!(# # "foo");
    |             +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:31:12
    |
 LL |     demo4!(### "foo");
@@ -54,12 +54,12 @@ LL |     demo4!(### "foo");
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# ## "foo");
    |             +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:31:13
    |
 LL |     demo4!(### "foo");
@@ -67,12 +67,12 @@ LL |     demo4!(### "foo");
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(## # "foo");
    |              +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:36:12
    |
 LL |     demo4!(## "foo"#);
@@ -80,12 +80,12 @@ LL |     demo4!(## "foo"#);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# # "foo"#);
    |             +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:39:12
    |
 LL |     demo7!(### "foo"###);
@@ -93,12 +93,12 @@ LL |     demo7!(### "foo"###);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(# ## "foo"###);
    |             +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:39:13
    |
 LL |     demo7!(### "foo"###);
@@ -106,12 +106,12 @@ LL |     demo7!(### "foo"###);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(## # "foo"###);
    |              +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:39:21
    |
 LL |     demo7!(### "foo"###);
@@ -119,12 +119,12 @@ LL |     demo7!(### "foo"###);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(### "foo"# ##);
    |                      +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:39:22
    |
 LL |     demo7!(### "foo"###);
@@ -132,7 +132,7 @@ LL |     demo7!(### "foo"###);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(### "foo"## #);
    |                       +
@@ -189,7 +189,7 @@ help: insert whitespace here to avoid this being parsed as a guarded string in R
 LL |     demo5!(# "foo"###);
    |             +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:56:18
    |
 LL |     demo5!(#"foo"###);
@@ -197,12 +197,12 @@ LL |     demo5!(#"foo"###);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo5!(#"foo"# ##);
    |                   +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:56:19
    |
 LL |     demo5!(#"foo"###);
@@ -210,12 +210,12 @@ LL |     demo5!(#"foo"###);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo5!(#"foo"## #);
    |                    +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:63:17
    |
 LL |     demo4!("foo"###);
@@ -223,12 +223,12 @@ LL |     demo4!("foo"###);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"# ##);
    |                  +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:63:18
    |
 LL |     demo4!("foo"###);
@@ -236,7 +236,7 @@ LL |     demo4!("foo"###);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"## #);
    |                   +

--- a/tests/ui/rust-2024/reserved-guarded-strings-migration.fixed
+++ b/tests/ui/rust-2024/reserved-guarded-strings-migration.fixed
@@ -38,28 +38,28 @@ fn main() {
     demo2!("foo"#);
 
     demo3!(# # "foo");
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo4!(# # # "foo");
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo4!(# # "foo"#);
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo6!(# # # "foo"# #);
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
 
     demo4!("foo"# # #);
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
 
     demo2!(# "");
@@ -94,6 +94,6 @@ fn main() {
     //~| WARNING hard error in Rust 2024
     //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
 }

--- a/tests/ui/rust-2024/reserved-guarded-strings-migration.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings-migration.rs
@@ -38,28 +38,28 @@ fn main() {
     demo2!("foo"#);
 
     demo3!(## "foo");
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo4!(### "foo");
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo4!(## "foo"#);
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo6!(### "foo"##);
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
 
     demo4!("foo"###);
-    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
 
     demo2!(#"");
@@ -94,6 +94,6 @@ fn main() {
     //~| WARNING hard error in Rust 2024
     //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
 }

--- a/tests/ui/rust-2024/reserved-guarded-strings-migration.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-migration.stderr
@@ -1,4 +1,4 @@
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:40:12
    |
 LL |     demo3!(## "foo");
@@ -11,12 +11,12 @@ note: the lint level is defined here
    |
 LL | #![warn(rust_2024_guarded_string_incompatible_syntax)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo3!(# # "foo");
    |             +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:43:12
    |
 LL |     demo4!(### "foo");
@@ -24,12 +24,12 @@ LL |     demo4!(### "foo");
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# ## "foo");
    |             +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:43:13
    |
 LL |     demo4!(### "foo");
@@ -37,12 +37,12 @@ LL |     demo4!(### "foo");
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(## # "foo");
    |              +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:48:12
    |
 LL |     demo4!(## "foo"#);
@@ -50,12 +50,12 @@ LL |     demo4!(## "foo"#);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# # "foo"#);
    |             +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:51:12
    |
 LL |     demo6!(### "foo"##);
@@ -63,12 +63,12 @@ LL |     demo6!(### "foo"##);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo6!(# ## "foo"##);
    |             +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:51:13
    |
 LL |     demo6!(### "foo"##);
@@ -76,12 +76,12 @@ LL |     demo6!(### "foo"##);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo6!(## # "foo"##);
    |              +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:51:21
    |
 LL |     demo6!(### "foo"##);
@@ -89,12 +89,12 @@ LL |     demo6!(### "foo"##);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo6!(### "foo"# #);
    |                      +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:59:17
    |
 LL |     demo4!("foo"###);
@@ -102,12 +102,12 @@ LL |     demo4!("foo"###);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"# ##);
    |                  +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:59:18
    |
 LL |     demo4!("foo"###);
@@ -115,7 +115,7 @@ LL |     demo4!("foo"###);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"## #);
    |                   +
@@ -276,7 +276,7 @@ help: insert whitespace here to avoid this being parsed as a guarded string in R
 LL |     demo5!(## "foo"##);
    |              +
 
-warning: will be parsed as a guarded string in Rust 2024
+warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:92:19
    |
 LL |     demo5!(##"foo"##);
@@ -284,7 +284,7 @@ LL |     demo5!(##"foo"##);
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo5!(##"foo"# #);
    |                    +

--- a/tests/ui/rust-2024/reserved-guarded-strings.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings.rs
@@ -46,13 +46,13 @@ fn main() {
     //~^ ERROR prefix `blah` is unknown
     //~| ERROR invalid string literal
 
-    demo2!(## "foo"); //~ ERROR invalid string literal
-    demo3!("foo"###); //~ ERROR invalid string literal
-    demo3!(### "foo"); //~ ERROR invalid string literal
-    demo3!(## "foo"#); //~ ERROR invalid string literal
+    demo2!(## "foo"); //~ reserved multi-hash token is forbidden
+    demo3!("foo"###); //~ reserved multi-hash token is forbidden
+    demo3!(### "foo"); //~ reserved multi-hash token is forbidden
+    demo3!(## "foo"#); //~ reserved multi-hash token is forbidden
     demo5!(### "foo"###);
-    //~^ ERROR invalid string literal
-    //~| ERROR invalid string literal
+    //~^ reserved multi-hash token is forbidden
+    //~| reserved multi-hash token is forbidden
 
     demo1!(#""); //~ ERROR invalid string literal
     demo1!(#""#); //~ ERROR invalid string literal
@@ -65,7 +65,7 @@ fn main() {
     demo1!(###"foo"###); //~ ERROR invalid string literal
     demo2!(#"foo"###);
     //~^ ERROR invalid string literal
-    //~| ERROR invalid string literal
+    //~| ERROR reserved multi-hash token is forbidden
 
     // More than 255 hashes
     demon!(####################################################################################################################################################################################################################################################################"foo");

--- a/tests/ui/rust-2024/reserved-guarded-strings.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings.stderr
@@ -34,73 +34,73 @@ help: consider inserting whitespace here
 LL |     demo2!(blah# "xx"#);
    |                 +
 
-error: invalid string literal
+error: reserved multi-hash token is forbidden
   --> $DIR/reserved-guarded-strings.rs:49:12
    |
 LL |     demo2!(## "foo");
    |            ^^
    |
-   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+   = note: sequences of two or more # are reserved for future use since Rust 2024
 help: consider inserting whitespace here
    |
 LL |     demo2!(# # "foo");
    |             +
 
-error: invalid string literal
+error: reserved multi-hash token is forbidden
   --> $DIR/reserved-guarded-strings.rs:50:17
    |
 LL |     demo3!("foo"###);
    |                 ^^
    |
-   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+   = note: sequences of two or more # are reserved for future use since Rust 2024
 help: consider inserting whitespace here
    |
 LL |     demo3!("foo"# ##);
    |                  +
 
-error: invalid string literal
+error: reserved multi-hash token is forbidden
   --> $DIR/reserved-guarded-strings.rs:51:12
    |
 LL |     demo3!(### "foo");
    |            ^^
    |
-   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+   = note: sequences of two or more # are reserved for future use since Rust 2024
 help: consider inserting whitespace here
    |
 LL |     demo3!(# ## "foo");
    |             +
 
-error: invalid string literal
+error: reserved multi-hash token is forbidden
   --> $DIR/reserved-guarded-strings.rs:52:12
    |
 LL |     demo3!(## "foo"#);
    |            ^^
    |
-   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+   = note: sequences of two or more # are reserved for future use since Rust 2024
 help: consider inserting whitespace here
    |
 LL |     demo3!(# # "foo"#);
    |             +
 
-error: invalid string literal
+error: reserved multi-hash token is forbidden
   --> $DIR/reserved-guarded-strings.rs:53:12
    |
 LL |     demo5!(### "foo"###);
    |            ^^
    |
-   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+   = note: sequences of two or more # are reserved for future use since Rust 2024
 help: consider inserting whitespace here
    |
 LL |     demo5!(# ## "foo"###);
    |             +
 
-error: invalid string literal
+error: reserved multi-hash token is forbidden
   --> $DIR/reserved-guarded-strings.rs:53:21
    |
 LL |     demo5!(### "foo"###);
    |                     ^^
    |
-   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+   = note: sequences of two or more # are reserved for future use since Rust 2024
 help: consider inserting whitespace here
    |
 LL |     demo5!(### "foo"# ##);
@@ -226,13 +226,13 @@ help: consider inserting whitespace here
 LL |     demo2!(# "foo"###);
    |             +
 
-error: invalid string literal
+error: reserved multi-hash token is forbidden
   --> $DIR/reserved-guarded-strings.rs:66:19
    |
 LL |     demo2!(#"foo"###);
    |                   ^^
    |
-   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+   = note: sequences of two or more # are reserved for future use since Rust 2024
 help: consider inserting whitespace here
    |
 LL |     demo2!(#"foo"## #);


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Closes #131615
