### PR TITLE
tests: Add regression test for self referential structs with cow as last field

### DIFF
--- a/tests/ui/traits/solver-cycles/107481-self-referential-struct-cow-as-last-field.rs
+++ b/tests/ui/traits/solver-cycles/107481-self-referential-struct-cow-as-last-field.rs
@@ -1,0 +1,19 @@
+// Regression test for #107481
+
+//@ check-pass
+
+use std::{borrow::Cow, collections::HashMap};
+
+#[derive(Clone)]
+struct Foo<'a>(Cow<'a, [Self]>);
+
+#[derive(Clone)]
+struct Bar<'a>(Cow<'a, HashMap<String, Self>>);
+
+#[derive(Clone)]
+struct Baz<'a>(Cow<'a, Vec<Self>>);
+
+#[derive(Clone)]
+struct Qux<'a>(Cow<'a, Box<Self>>);
+
+fn main() {}


### PR DESCRIPTION
Making compilation pass for this code was retroactively stabilized via FCP in 1.79. The code does not compile in 1.78.

See https://github.com/rust-lang/rust/issues/129541 for details.

Closes #107481
