### PR TITLE
Clarify the Pin may not pin the data when the type is Unpin.

### DIFF
--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -1,4 +1,4 @@
-//! Types that pin data to a location in memory.
+//! A pointer wrapper that pins data to a location in memory, only when the target type requires it.
 //!
 //! It is sometimes useful to be able to rely upon a certain value not being able to *move*,
 //! in the sense that its address in memory cannot change. This is useful especially when there
@@ -931,7 +931,7 @@ use crate::{
 };
 use crate::{cmp, fmt};
 
-/// A pointer which pins its pointee in place.
+/// A pointer wrapper which pins its pointee in place, only when the target type requires it.
 ///
 /// [`Pin`] is a wrapper around some kind of pointer `Ptr` which makes that pointer "pin" its
 /// pointee value in place, thus preventing the value referenced by that pointer from being moved


### PR DESCRIPTION
Update the first sentence of the module documentation to make it clear that Pin only works when the type does not implement Unpin (which is not clear enough from its name and the first some paragraphs of the doc).

One common mistake when using Pin is forgetting to add `PhantomPinned` to the target type. The type name `Pin` seems to suggest that the type will be always pinned when it is wrapped by Pin but it's actually not so make it clear to avoid people spending multiple hours to debug their code due to its behavior when the type is Unpin.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
