### PR TITLE
bootstrap: allow skipping steps with start of path

### DIFF
--- a/src/bootstrap/src/core/builder/mod.rs
+++ b/src/bootstrap/src/core/builder/mod.rs
@@ -258,11 +258,11 @@ impl PathSet {
 
     // internal use only
     fn check(p: &TaskPath, needle: &Path, module: Kind) -> bool {
-        if let Some(p_kind) = &p.kind {
-            p.path.ends_with(needle) && *p_kind == module
-        } else {
-            p.path.ends_with(needle)
-        }
+        let check_path = || {
+            // This order is important for retro-compatibility, as `starts_with` was introduced later.
+            p.path.ends_with(needle) || p.path.starts_with(needle)
+        };
+        if let Some(p_kind) = &p.kind { check_path() && *p_kind == module } else { check_path() }
     }
 
     /// Return all `TaskPath`s in `Self` that contain any of the `needles`, removing the


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->


## Current status
Right now the way to skip steps in bootstrap is by doing `--skip=<something>` or `--exclude=<something>`, where `<something>` must be the end of the path of the step you want to exclude.

E.g. if I want to skip the step `src/etc/test-float-parse` you can pass one of these:
- `--skip=test-float-parse`
- `--skip=etc/test-float-parse`
- `--skip=src/etc/test-float-parse`.

## Change of this PR
I added the ability to skip steps that *starts* with a certain path.
E.g. now you can do `--skip=src` or `--skip=src/etc/` to skip all subdirectories.

## How to test

Run `cargo run -- test --stage 2 --dry-run --exclude=tests/` and verify the log lines starting with "Skipping" 👍
You might also add `--verbose` for additional logs.

## Retro-compatibility

Maintaining the precedence of `ends_with` should maintain retro-compatibility, as existing "skips" match first.

> [!WARNING]  
> A breaking change in an invocation might happen if both:
> 1. there was a  `--skip <something>` that didn't match anything initially (that's an error in the script)
> 2. this `<something>` matches the beginning of a path
> 
> Imo this is VERY rare so I'm not concerned about breakages in existing scripts.

## Why I need this

In CI, I would like to split tests across multiple jobs, and having this feature allows things like `--skip tests/` ✨
The alternative is specifying `--skip tests/ui --skip tests/rustdoc ...` and so on for every subdirectory 😵


<!-- homu-ignore:end -->
