### PR TITLE
[DO NOT MERGE] `-Znext-solver=globally` experiments 

### DIFF
--- a/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
+++ b/compiler/rustc_next_trait_solver/src/solve/eval_ctxt/mod.rs
@@ -338,18 +338,6 @@ fn maybe_evaluate_root_goal_with_higher_recursion_limit<D, I>(
         Ok(goal_evaluation) => goal_evaluation.goal.predicate,
     };
 
-    // Some goals no longer overflow after the stalled infers are resolved.
-    // Thus we don't have to rerun eagerly here.
-    let has_stalled_infers = match predicate.kind().skip_binder() {
-        ty::PredicateKind::Clause(ty::ClauseKind::Projection(projection)) => {
-            projection.projection_term.has_non_region_infer()
-        }
-        _ => predicate.has_non_region_infer(),
-    };
-    if has_stalled_infers {
-        return;
-    }
-
     let rerun_result = delegate.commit_if_ok(|| {
         let rerun_result =
             EvalCtxt::enter_root(delegate, delegate.cx().recursion_limit() * 2, span, |ecx| {
@@ -397,19 +385,6 @@ fn maybe_evaluate_root_goal_for_proof_tree_with_higher_recursion_limit<D, I>(
         Ok(_) => {}
     }
 
-    // Some goals no longer overflow after the stalled infers are resolved.
-    // Thus we don't have to rerun eagerly here.
-    let predicate: I::Predicate = goal_evaluation.uncanonicalized_goal.predicate;
-    let has_stalled_infers = match predicate.kind().skip_binder() {
-        ty::PredicateKind::Clause(ty::ClauseKind::Projection(projection)) => {
-            projection.projection_term.has_non_region_infer()
-        }
-        _ => predicate.has_non_region_infer(),
-    };
-    if has_stalled_infers {
-        return;
-    }
-
     let rerun_result = delegate.commit_if_ok(|| {
         let (new_result, new_goal_evaluation) = evaluate_root_goal_for_proof_tree(
             delegate,
@@ -426,6 +401,7 @@ fn maybe_evaluate_root_goal_for_proof_tree_with_higher_recursion_limit<D, I>(
         }
     });
     if let Ok(rerun_result) = rerun_result {
+        let predicate: I::Predicate = goal_evaluation.uncanonicalized_goal.predicate;
         delegate.cx().emit_next_solver_overflow_fcw(predicate, span);
         *initial_result = rerun_result;
     }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1009,7 +1009,7 @@ pub struct NextSolverConfig {
     pub coherence: bool = true,
     /// Whether the new trait solver should be enabled everywhere.
     /// This is only `true` if `coherence` is also enabled.
-    pub globally: bool = false,
+    pub globally: bool = true,
 }
 
 #[derive(Clone)]

--- a/tests/ui/traits/next-solver/overflow-discards-constraints.rs
+++ b/tests/ui/traits/next-solver/overflow-discards-constraints.rs
@@ -1,0 +1,75 @@
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+// Previously we didn't rerun the goal with doubled recursion limit if the goal contained ty vars.
+// This is to avoid futile evaluation. However, sometimes the type inference progress relies on
+// successful trait solving response. If we don't evaluate with higher recursion limit, the type
+// inference would fail eventually.
+//
+// See the `recursion_depth_exceeding_limit` FCW for why we need the doubled recursion limit.
+
+// Setting it to 12 would make it compile.
+#![recursion_limit = "6"]
+
+trait Trait<T> {}
+
+struct W1<T>(T);
+struct W2<T>(T);
+struct W3<T>(T);
+struct W4<T>(T);
+struct W5<T>(T);
+struct W6<T>(T);
+struct W7<T>(T);
+
+
+impl<T> Trait<T> for ()
+    where
+    W1<T>: Trait<T>,
+{}
+
+impl<T> Trait<T> for W1<T>
+where
+    W2<T>: Trait<T>,
+{}
+
+impl<T> Trait<T> for W2<T>
+where
+    W3<T>: Trait<T>,
+{}
+
+impl<T> Trait<T> for W3<T>
+where
+    W4<T>: Trait<T>,
+{}
+
+impl<T> Trait<T> for W4<T>
+where
+    W5<T>: Trait<T>,
+{}
+
+impl<T> Trait<T> for W5<T>
+where
+    W6<T>: Trait<T>,
+{}
+
+impl<T> Trait<T> for W6<T>
+where
+    W7<T>: Trait<T>,
+{}
+
+impl Trait<i32> for W7<i32> {}
+
+fn foo<T>()
+    where
+        (): Trait<T>,
+{
+}
+
+fn main() {
+    foo(); // register a `(): Trait<?t>` obligation
+    //~^ WARN: overflow evaluating the requirement `(): Trait<_>` [recursion_depth_exceeding_limit]
+    //~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+    //~| WARN: overflow evaluating the requirement `(): Trait<i32>` [recursion_depth_exceeding_limit]
+    //~| WARN: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+
+}

--- a/tests/ui/traits/next-solver/overflow-discards-constraints.stderr
+++ b/tests/ui/traits/next-solver/overflow-discards-constraints.stderr
@@ -1,0 +1,27 @@
+warning: overflow evaluating the requirement `(): Trait<_>`
+  --> $DIR/overflow-discards-constraints.rs:69:5
+   |
+LL |     foo(); // register a `(): Trait<?t>` obligation
+   |     ^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "12"]` attribute to your crate (`overflow_discards_constraints`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+   = note: `#[warn(recursion_depth_exceeding_limit)]` (part of `#[warn(future_incompatible)]`) on by default
+
+warning: overflow evaluating the requirement `(): Trait<i32>`
+  --> $DIR/overflow-discards-constraints.rs:69:5
+   |
+LL |     foo(); // register a `(): Trait<?t>` obligation
+   |     ^^^^^
+   |
+   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "12"]` attribute to your crate (`overflow_discards_constraints`)
+   = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
+   = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
+
+warning: 2 warnings emitted
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/133502)*
<!-- homu-ignore:end -->

A revival of rust-lang/rust#124812. See
- https://github.com/rust-lang/rust/issues/107374
- https://github.com/rust-lang/trait-system-refactor-initiative/issues/211

Current status:

~~`./x.py b --stage 2` passes :tada:~~

`try` builds succeed 🎉 🎉 🎉 

[first perf run](https://github.com/rust-lang/rust/pull/133502#issuecomment-2516183651) :ghost: [second perf run](https://github.com/rust-lang/rust/pull/133502#issuecomment-3309925395) :ghost: [third perf run](https://github.com/rust-lang/rust/pull/133502#issuecomment-3379055825) :ghost: [fourth perf run](https://github.com/rust-lang/rust/pull/133502#issuecomment-4917157007) :ghost:

### crater

This does not detect hangs or memory issues. We are triaging the regressions in https://rust-lang.zulipchat.com/#narrow/channel/364551-t-types.2Ftrait-system-refactor/topic/crater.20triage.20.3A3/with/572783267 and welcome your help there.

| date | #crates | #regressions |
| ---- | ------- | ------------ |
| 2025.04.11 | 100 | 2 |
| 2025.04.11 | 1000 | 27 |
| 2025.04.17 | 10000 | 456 |
| 2025.04.18 | 10000 | 437 |
| 2025.04.24 | 10000 | 164 |
| 2025.04.26 | 10000 | 108 |
| 2025.04.28 | 10000 | 91 |
| 2025.05.01 | 10000 | 145 woops |
| 2025.05.03 | 624228[^1] |  1585[^3] |
| 2025.05.05 | 8964[^2] | 931[^3] |
| 2025.05.06 | 4401[^2] | 726[^3] |
| [2025.05.07](https://github.com/rust-lang/rust/pull/133502#issuecomment-2861521770) | 2704[^2] | 668[^3] |
| [2025.05.09](https://github.com/rust-lang/rust/pull/133502#issuecomment-2867177940) | 2345[^2] | 664[^3] |
| [2025.09.20](https://github.com/rust-lang/rust/pull/133502#issuecomment-3314984977) | 701952[^1] | 4739 + 7039 spurious |
| [2025.10.02](https://github.com/rust-lang/rust/pull/133502#issuecomment-3358623722) | 11712[^2] | 2568 + 2014 spurious |
| [2025.10.04](https://github.com/rust-lang/rust/pull/133502#issuecomment-3367902058) | 4582[^2] | 1173 + 1147 spurious[^3] |
| [2025.12.30](https://github.com/rust-lang/rust/pull/133502#issuecomment-3698783160) | 761102[^1] | 1424 + 8938 spurious [^3]  |
| [2026.01.01](https://github.com/rust-lang/rust/pull/133502#issuecomment-3703330257) | 5745[^2] | 1371 + 3227 spurious [^3] | 
| [2026.01.06](https://github.com/rust-lang/rust/pull/133502#issuecomment-3722792788) | 4171[^2] | 1361 + 2623 spurious [^3] |
| [2026.07.17](https://github.com/rust-lang/rust/pull/133502#issuecomment-4996294776) | 1014957[^1] | 6502 + 11187 spurious [^3] |
| [2026.07.20](https://github.com/rust-lang/rust/pull/133502#issuecomment-5017938238) | 17458[^2] | 991 + 3331 spurious [^3] |
| [2026.07.23](https://github.com/rust-lang/rust/pull/133502#issuecomment-5055102242) | 4322[^2] | 959 + 1680 spurious [^3] |
| [2026.07.31](https://github.com/rust-lang/rust/pull/133502#issuecomment-5137382959) | 1049848[^1] | 1254 +  13493 spurious |
| [2026.08.03](https://github.com/rust-lang/rust/pull/133502#issuecomment-5163000232) | 14035[^2] | 679 + 2245 spurious |
| [2026.08.05](https://github.com/rust-lang/rust/pull/133502#issuecomment-5193289315) | 2915[^2] | 457 + 997 spurious |

[^1]: a complete crater run
[^2]: only testing crates which may have regressed from the above run
[^3]: with doubled `recursion_limit` when evaluating goals

### in-flight changes

none :3

r? @ghost