### PR TITLE
Recover some lost performence from #132732

### DIFF
--- a/compiler/rustc_lint/src/dangling.rs
+++ b/compiler/rustc_lint/src/dangling.rs
@@ -130,9 +130,9 @@ impl DanglingPointerSearcher<'_, '_> {
 
 fn lint_expr(cx: &LateContext<'_>, expr: &Expr<'_>) {
     if let ExprKind::MethodCall(method, receiver, _args, _span) = expr.kind
+        && is_temporary_rvalue(receiver)
         && let Some(fn_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id)
         && cx.tcx.has_attr(fn_id, sym::rustc_as_ptr)
-        && is_temporary_rvalue(receiver)
         && let ty = cx.typeck_results().expr_ty(receiver)
         && owns_allocation(cx.tcx, ty)
     {

--- a/compiler/rustc_lint/src/dangling.rs
+++ b/compiler/rustc_lint/src/dangling.rs
@@ -131,10 +131,10 @@ impl DanglingPointerSearcher<'_, '_> {
 fn lint_expr(cx: &LateContext<'_>, expr: &Expr<'_>) {
     if let ExprKind::MethodCall(method, receiver, _args, _span) = expr.kind
         && is_temporary_rvalue(receiver)
-        && let Some(fn_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id)
-        && cx.tcx.has_attr(fn_id, sym::rustc_as_ptr)
         && let ty = cx.typeck_results().expr_ty(receiver)
         && owns_allocation(cx.tcx, ty)
+        && let Some(fn_id) = cx.typeck_results().type_dependent_def_id(expr.hir_id)
+        && cx.tcx.has_attr(fn_id, sym::rustc_as_ptr)
     {
         // FIXME: use `emit_node_lint` when `#[primary_span]` is added.
         cx.tcx.emit_node_span_lint(


### PR DESCRIPTION
This PR reorders some conditions in the `dangling_pointers_from_temporaries` lint to avoid some potentially expensive query call, in particular those who could involve some metadata decoding from disk.

cc https://github.com/rust-lang/rust/pull/132732#issuecomment-2499990683
cc @Kobzol
