### PR TITLE
Only ignore windows-gnu in avr-jmp-offset

### DIFF
--- a/tests/run-make/avr-rjmp-offset/rmake.rs
+++ b/tests/run-make/avr-rjmp-offset/rmake.rs
@@ -13,7 +13,7 @@
 
 // FIXME(#133480): this has been randomly failing on `x86_64-mingw` due to linker hangs or
 // crashes... so I'm going to disable this test for windows for now.
-//@ ignore-windows
+//@ ignore-windows-gnu
 
 use run_make_support::{llvm_objdump, rustc};
 


### PR DESCRIPTION
The failure in 133480 occurs on mingw but there's currently no evidence it fails on msvc too.
