### PR TITLE
fix: hurd build, stat64.st_fsid was renamed to st_dev

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 dependencies = [
  "rustc-std-workspace-core",
 ]

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -34,7 +34,7 @@ miniz_oxide = { version = "0.7.0", optional = true, default-features = false }
 addr2line = { version = "0.22.0", optional = true, default-features = false }
 
 [target.'cfg(not(all(windows, target_env = "msvc")))'.dependencies]
-libc = { version = "0.2.162", default-features = false, features = [
+libc = { version = "0.2.167", default-features = false, features = [
     'rustc-dep-of-std',
 ], public = true }
 

--- a/library/std/src/os/hurd/fs.rs
+++ b/library/std/src/os/hurd/fs.rs
@@ -298,7 +298,7 @@ pub trait MetadataExt {
 #[stable(feature = "metadata_ext", since = "1.1.0")]
 impl MetadataExt for Metadata {
     fn st_dev(&self) -> u64 {
-        self.as_inner().as_inner().st_fsid as u64
+        self.as_inner().as_inner().st_dev as u64
     }
     fn st_ino(&self) -> u64 {
         self.as_inner().as_inner().st_ino as u64

--- a/library/std/src/sys/pal/unix/os.rs
+++ b/library/std/src/sys/pal/unix/os.rs
@@ -428,11 +428,13 @@ pub fn current_exe() -> io::Result<PathBuf> {
 pub fn current_exe() -> io::Result<PathBuf> {
     unsafe {
         let mut sz: u32 = 0;
+        #[expect(deprecated)]
         libc::_NSGetExecutablePath(ptr::null_mut(), &mut sz);
         if sz == 0 {
             return Err(io::Error::last_os_error());
         }
         let mut v: Vec<u8> = Vec::with_capacity(sz as usize);
+        #[expect(deprecated)]
         let err = libc::_NSGetExecutablePath(v.as_mut_ptr() as *mut i8, &mut sz);
         if err != 0 {
             return Err(io::Error::last_os_error());


### PR DESCRIPTION
On hurd, `stat64.st_fsid` was renamed to `st_dev` in https://github.com/rust-lang/libc/pull/3785, so if you have a new libc with this patch included, and you build std from source, you get this error:

```sh
error[E0609]: no field `st_fsid` on type `&stat64`
   --> /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/os/hurd/fs.rs:301:36
    |
301 |         self.as_inner().as_inner().st_fsid as u64
    |                                    ^^^^^^^ unknown field
    |
help: a field with a similar name exists
    |
301 |         self.as_inner().as_inner().st_uid as u64
    |                                    ~~~~~~
```

Full CI log: https://github.com/nix-rust/nix/actions/runs/12033180710/job/33546728266?pr=2544
