### PR TITLE
Structurally resolve before applying projection in borrowck

### DIFF
--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1064,7 +1064,9 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
         let tcx = self.infcx.tcx;
 
         for proj in &user_ty.projs {
-            if let ty::Alias(ty::Opaque, ..) = curr_projected_ty.ty.kind() {
+            if !self.infcx.next_trait_solver()
+                && let ty::Alias(ty::Opaque, ..) = curr_projected_ty.ty.kind()
+            {
                 // There is nothing that we can compare here if we go through an opaque type.
                 // We're always in its defining scope as we can otherwise not project through
                 // it, so we're constraining it anyways.
@@ -1075,7 +1077,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                 proj,
                 |this, field, ()| {
                     let ty = this.field_ty(tcx, field);
-                    self.normalize(ty, locations)
+                    self.structurally_resolve(ty, locations)
                 },
                 |_, _| unreachable!(),
             );

--- a/tests/ui/traits/next-solver/structurally-normalize-in-borrowck-field-projection.rs
+++ b/tests/ui/traits/next-solver/structurally-normalize-in-borrowck-field-projection.rs
@@ -1,0 +1,32 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+trait Interner: Sized {
+    type Value;
+}
+
+enum Kind<I: Interner> {
+    Value(I::Value),
+}
+
+struct Intern;
+
+impl Interner for Intern {
+    type Value = Wrap<u32>;
+}
+
+struct Wrap<T>(T);
+
+type KindAlias = Kind<Intern>;
+
+trait PrettyPrinter: Sized {
+    fn hello(c: KindAlias) {
+        match c {
+            KindAlias::Value(Wrap(v)) => {
+                println!("{v:?}");
+            }
+        }
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
As far as I can tell, all other `.normalize` calls in borrowck are noops and can remain that way. This is the only one that actually requires structurally resolving the type.

r? lcnr