### PR TITLE
Structurally resolve before matching on type of projection

### DIFF
--- a/compiler/rustc_hir_typeck/src/upvar.rs
+++ b/compiler/rustc_hir_typeck/src/upvar.rs
@@ -1802,7 +1802,8 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
         let mut is_mutbl = bm.1;
 
         for pointer_ty in place.deref_tys() {
-            match pointer_ty.kind() {
+            match self.structurally_resolve_type(self.tcx.hir().span(var_hir_id), pointer_ty).kind()
+            {
                 // We don't capture derefs of raw ptrs
                 ty::RawPtr(_, _) => unreachable!(),
 
@@ -1816,7 +1817,11 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
                 // Dereferencing a box doesn't change mutability
                 ty::Adt(def, ..) if def.is_box() => {}
 
-                unexpected_ty => bug!("deref of unexpected pointer type {:?}", unexpected_ty),
+                unexpected_ty => span_bug!(
+                    self.tcx.hir().span(var_hir_id),
+                    "deref of unexpected pointer type {:?}",
+                    unexpected_ty
+                ),
             }
         }
 

--- a/tests/ui/traits/next-solver/typeck/resolve-before-checking-builtin-ptr.rs
+++ b/tests/ui/traits/next-solver/typeck/resolve-before-checking-builtin-ptr.rs
@@ -1,0 +1,20 @@
+//@ check-pass
+//@ compile-flags: -Znext-solver
+
+trait Mirror {
+    type Assoc;
+}
+impl<T> Mirror for T {
+    type Assoc = T;
+}
+
+struct Place {
+    field: <&'static [u8] as Mirror>::Assoc,
+}
+
+fn main() {
+    let local = Place { field: &[] };
+    let z = || {
+        let y = &local.field[0];
+    };
+}


### PR DESCRIPTION
Another missing structural resolve in closure upvar analysis. I think it's better to place the normalization here rather than trying to guarantee that all types returned by the expr use visitor are structurally normalized, which I don't think we do now. Thoughts?

r? lcnr