### PR TITLE
Don't suggest restricting bound with unstable traits on stable and mention it's unstable on nightly

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/conflict_errors.rs
@@ -1450,6 +1450,7 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                         ty::Param(param_ty) => Ok((
                             generics.type_param(param_ty, tcx),
                             predicate.trait_ref.print_trait_sugared().to_string(),
+                            Some(predicate.trait_ref.def_id),
                         )),
                         _ => Err(()),
                     }
@@ -1463,9 +1464,9 @@ impl<'infcx, 'tcx> MirBorrowckCtxt<'_, 'infcx, 'tcx> {
                 tcx,
                 hir_generics,
                 err,
-                predicates
-                    .iter()
-                    .map(|(param, constraint)| (param.name.as_str(), &**constraint, None)),
+                predicates.iter().map(|(param, constraint, def_id)| {
+                    (param.name.as_str(), &**constraint, *def_id)
+                }),
                 None,
             );
         }

--- a/compiler/rustc_const_eval/src/check_consts/ops.rs
+++ b/compiler/rustc_const_eval/src/check_consts/ops.rs
@@ -140,7 +140,7 @@ impl<'tcx> NonConstOp<'tcx> for FnCallNonConst<'tcx> {
                             err,
                             param_ty.name.as_str(),
                             &constraint,
-                            None,
+                            Some(trait_ref.def_id),
                             None,
                         );
                     }

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/errors.rs
@@ -279,7 +279,13 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                     } else {
                         let mut err = self.dcx().create_err(err);
                         if suggest_constraining_type_param(
-                            tcx, generics, &mut err, &qself_str, &trait_ref, None, None,
+                            tcx,
+                            generics,
+                            &mut err,
+                            &qself_str,
+                            &trait_ref,
+                            Some(best_trait),
+                            None,
                         ) && !identically_named
                         {
                             // We suggested constraining a type parameter, but the associated item on it

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -345,6 +345,7 @@ pub fn suggest_constraining_type_params<'a>(
         let mut constraint = constraints.iter().map(|&(c, _, _)| c).collect::<Vec<_>>();
         constraint.sort();
         constraint.dedup();
+        let all_known = constraints.iter().all(|&(_, def_id, _)| def_id.is_some());
         let all_stable = constraints.iter().all(|&(_, _, stable)| stable.is_empty());
         let all_unstable = constraints.iter().all(|&(_, _, stable)| !stable.is_empty());
         let post = if all_stable || all_unstable {
@@ -360,7 +361,8 @@ pub fn suggest_constraining_type_params<'a>(
             trait_names.dedup();
             let n = trait_names.len();
             let stable = if all_stable { "" } else { "unstable " };
-            format!("{stable}trait{} {}", pluralize!(n), match &trait_names[..] {
+            let trait_ = if all_known { "trait" } else { "" };
+            format!("{stable}{trait_}{} {}", pluralize!(n), match &trait_names[..] {
                 [t] => t.to_string(),
                 [ts @ .., last] => format!("{} and {last}", ts.join(", ")),
                 [] => return false,
@@ -370,7 +372,7 @@ pub fn suggest_constraining_type_params<'a>(
             let mut trait_names = constraints
                 .iter()
                 .map(|&(c, def_id, stable)| match def_id {
-                    None => format!("{stable}trait `{c}`"),
+                    None => format!("`{c}`"),
                     Some(def_id) => format!("{stable}trait `{}`", tcx.item_name(def_id)),
                 })
                 .collect::<Vec<_>>();

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -488,7 +488,7 @@ pub fn suggest_constraining_type_params<'a>(
         .into_iter()
         .filter(|(span, _, _, _)| !span.in_derive_expansion())
         .collect::<Vec<_>>();
-
+    let suggested = !suggestions.is_empty();
     if suggestions.len() == 1 {
         let (span, constraint, suggestion, msg) = suggestions.pop().unwrap();
         let post = format!(
@@ -524,7 +524,7 @@ pub fn suggest_constraining_type_params<'a>(
         );
     }
 
-    true
+    suggested
 }
 
 /// Collect al types that have an implicit `'static` obligation that we could suggest `'_` for.

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -531,6 +531,12 @@ pub fn suggest_constraining_type_params<'a>(
             SuggestChangingConstraintsMessage::RestrictBoundFurther => {
                 format!("consider further restricting this bound with {post}")
             }
+            SuggestChangingConstraintsMessage::RestrictTypeFurther { ty }
+            | SuggestChangingConstraintsMessage::RestrictType { ty }
+                if ty.starts_with("impl ") =>
+            {
+                format!("consider restricting opaque type `{ty}` with {post}")
+            }
             SuggestChangingConstraintsMessage::RestrictType { ty } => {
                 format!("consider restricting type parameter `{ty}` with {post}")
             }

--- a/compiler/rustc_middle/src/ty/diagnostics.rs
+++ b/compiler/rustc_middle/src/ty/diagnostics.rs
@@ -361,10 +361,10 @@ pub fn suggest_constraining_type_params<'a>(
             trait_names.dedup();
             let n = trait_names.len();
             let stable = if all_stable { "" } else { "unstable " };
-            let trait_ = if all_known { "trait" } else { "" };
-            format!("{stable}{trait_}{} {}", pluralize!(n), match &trait_names[..] {
-                [t] => t.to_string(),
-                [ts @ .., last] => format!("{} and {last}", ts.join(", ")),
+            let trait_ = if all_known { format!("trait{}", pluralize!(n)) } else { String::new() };
+            format!("{stable}{trait_}{}", match &trait_names[..] {
+                [t] => format!(" {t}"),
+                [ts @ .., last] => format!(" {} and {last}", ts.join(", ")),
                 [] => return false,
             },)
         } else {
@@ -531,7 +531,7 @@ pub fn suggest_constraining_type_params<'a>(
         let (span, post, suggestion, msg) = suggestions.pop().unwrap();
         let msg = match msg {
             SuggestChangingConstraintsMessage::RestrictBoundFurther => {
-                format!("consider further restricting this bound with {post}")
+                format!("consider further restricting this bound")
             }
             SuggestChangingConstraintsMessage::RestrictTypeFurther { ty }
             | SuggestChangingConstraintsMessage::RestrictType { ty }

--- a/tests/run-make/missing-unstable-trait-bound/missing-bound.rs
+++ b/tests/run-make/missing-unstable-trait-bound/missing-bound.rs
@@ -1,0 +1,4 @@
+pub fn baz<T>(t: std::ops::Range<T>) {
+    for _ in t {}
+}
+fn main() {}

--- a/tests/run-make/missing-unstable-trait-bound/missing-bound.stderr
+++ b/tests/run-make/missing-unstable-trait-bound/missing-bound.stderr
@@ -1,0 +1,12 @@
+error[E0277]: the trait bound `T: Step` is not satisfied
+ --> missing-bound.rs:2:14
+  |
+2 |     for _ in t {}
+  |              ^ the trait `Step` is not implemented for `T`
+  |
+  = note: required for `std::ops::Range<T>` to implement `Iterator`
+  = note: required for `std::ops::Range<T>` to implement `IntoIterator`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/run-make/missing-unstable-trait-bound/rmake.rs
+++ b/tests/run-make/missing-unstable-trait-bound/rmake.rs
@@ -6,10 +6,10 @@
 // Ensure that on stable we don't suggest restricting with an unsafe trait and we continue
 // mentioning the rest of the obligation chain.
 
-use run_make_support::{rust_lib_name, rustc};
+use run_make_support::{diff, rust_lib_name, rustc};
 
 fn main() {
-    rustc()
+    let out = rustc()
         .env("RUSTC_BOOTSTRAP", "-1")
         .input("missing-bound.rs")
         .run_fail()
@@ -18,5 +18,7 @@ fn main() {
             r#"
   = note: required for `std::ops::Range<T>` to implement `Iterator`
   = note: required for `std::ops::Range<T>` to implement `IntoIterator`"#,
-        );
+        )
+        .stderr_utf8();
+    diff().expected_file("missing-bound.stderr").actual_text("(stable rustc)", &out).run()
 }

--- a/tests/run-make/missing-unstable-trait-bound/rmake.rs
+++ b/tests/run-make/missing-unstable-trait-bound/rmake.rs
@@ -1,0 +1,22 @@
+//@ only-linux
+//@ ignore-wasm32
+//@ ignore-wasm64
+// ignore-tidy-linelength
+
+// Ensure that on stable we don't suggest restricting with an unsafe trait and we continue
+// mentioning the rest of the obligation chain.
+
+use run_make_support::{rust_lib_name, rustc};
+
+fn main() {
+    rustc()
+        .env("RUSTC_BOOTSTRAP", "-1")
+        .input("missing-bound.rs")
+        .run_fail()
+        .assert_stderr_not_contains("help: consider restricting type parameter `T`")
+        .assert_stderr_contains(
+            r#"
+  = note: required for `std::ops::Range<T>` to implement `Iterator`
+  = note: required for `std::ops::Range<T>` to implement `IntoIterator`"#,
+        );
+}

--- a/tests/rustdoc-ui/issues/issue-96287.stderr
+++ b/tests/rustdoc-ui/issues/issue-96287.stderr
@@ -4,7 +4,7 @@ error[E0220]: associated type `Assoc` not found for `V`
 LL | pub type Foo<V> = impl Trait<V::Assoc>;
    |                                 ^^^^^ there is an associated type `Assoc` in the trait `TraitWithAssoc`
    |
-help: consider restricting type parameter `V`
+help: consider restricting type parameter `V` with trait `TraitWithAssoc`
    |
 LL | pub type Foo<V: TraitWithAssoc> = impl Trait<V::Assoc>;
    |               ++++++++++++++++
@@ -16,7 +16,7 @@ LL | pub type Foo<V> = impl Trait<V::Assoc>;
    |                                 ^^^^^ there is an associated type `Assoc` in the trait `TraitWithAssoc`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider restricting type parameter `V`
+help: consider restricting type parameter `V` with trait `TraitWithAssoc`
    |
 LL | pub type Foo<V: TraitWithAssoc> = impl Trait<V::Assoc>;
    |               ++++++++++++++++

--- a/tests/rustdoc-ui/synthetic-auto-trait-impls/projections-in-super-trait-bound-unsatisfied.stderr
+++ b/tests/rustdoc-ui/synthetic-auto-trait-impls/projections-in-super-trait-bound-unsatisfied.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `C: Bar<5>` is not satisfied
 LL | pub struct Structure<C: Tec> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar<5>` is not implemented for `C`
    |
-help: consider further restricting this bound with trait `Bar<5>`
+help: consider further restricting this bound with trait `Bar`
    |
 LL | pub struct Structure<C: Tec + Bar<5>> {
    |                             ++++++++
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `C: Bar<5>` is not satisfied
 LL |     _field: C::BarType,
    |             ^^^^^^^^^^ the trait `Bar<5>` is not implemented for `C`
    |
-help: consider further restricting this bound with trait `Bar<5>`
+help: consider further restricting this bound with trait `Bar`
    |
 LL | pub struct Structure<C: Tec + Bar<5>> {
    |                             ++++++++

--- a/tests/rustdoc-ui/synthetic-auto-trait-impls/projections-in-super-trait-bound-unsatisfied.stderr
+++ b/tests/rustdoc-ui/synthetic-auto-trait-impls/projections-in-super-trait-bound-unsatisfied.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `C: Bar<5>` is not satisfied
 LL | pub struct Structure<C: Tec> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar<5>` is not implemented for `C`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Bar<5>`
    |
 LL | pub struct Structure<C: Tec + Bar<5>> {
    |                             ++++++++
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `C: Bar<5>` is not satisfied
 LL |     _field: C::BarType,
    |             ^^^^^^^^^^ the trait `Bar<5>` is not implemented for `C`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Bar<5>`
    |
 LL | pub struct Structure<C: Tec + Bar<5>> {
    |                             ++++++++

--- a/tests/rustdoc-ui/synthetic-auto-trait-impls/projections-in-super-trait-bound-unsatisfied.stderr
+++ b/tests/rustdoc-ui/synthetic-auto-trait-impls/projections-in-super-trait-bound-unsatisfied.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `C: Bar<5>` is not satisfied
 LL | pub struct Structure<C: Tec> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Bar<5>` is not implemented for `C`
    |
-help: consider further restricting this bound with trait `Bar`
+help: consider further restricting type parameter `C` with trait `Bar`
    |
 LL | pub struct Structure<C: Tec + Bar<5>> {
    |                             ++++++++
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `C: Bar<5>` is not satisfied
 LL |     _field: C::BarType,
    |             ^^^^^^^^^^ the trait `Bar<5>` is not implemented for `C`
    |
-help: consider further restricting this bound with trait `Bar`
+help: consider further restricting type parameter `C` with trait `Bar`
    |
 LL | pub struct Structure<C: Tec + Bar<5>> {
    |                             ++++++++

--- a/tests/ui/associated-types/associated-types-no-suitable-bound.stderr
+++ b/tests/ui/associated-types/associated-types-no-suitable-bound.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `T: Get` is not satisfied
 LL |     fn uhoh<T>(foo: <T as Get>::Value) {}
    |                     ^^^^^^^^^^^^^^^^^ the trait `Get` is not implemented for `T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Get`
    |
 LL |     fn uhoh<T: Get>(foo: <T as Get>::Value) {}
    |              +++++
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `T: Get` is not satisfied
 LL |     fn uhoh<T>(foo: <T as Get>::Value) {}
    |                                        ^^ the trait `Get` is not implemented for `T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Get`
    |
 LL |     fn uhoh<T: Get>(foo: <T as Get>::Value) {}
    |              +++++

--- a/tests/ui/associated-types/defaults-suitability.current.stderr
+++ b/tests/ui/associated-types/defaults-suitability.current.stderr
@@ -47,7 +47,7 @@ note: required by a bound in `Foo::Bar`
    |
 LL |     type Bar: Clone = Vec<T>;
    |               ^^^^^ required by this bound in `Foo::Bar`
-help: consider restricting type parameter `T` with trait `std::clone::Clone`
+help: consider restricting type parameter `T` with trait `Clone`
    |
 LL | trait Foo<T: std::clone::Clone> {
    |            +++++++++++++++++++
@@ -132,7 +132,7 @@ LL |     Self::Baz: Clone,
 ...
 LL |     type Baz = T;
    |          --- required by a bound in this associated type
-help: consider further restricting type parameter `T` with trait `std::clone::Clone`
+help: consider further restricting type parameter `T` with trait `Clone`
    |
 LL |     Self::Baz: Clone, T: std::clone::Clone
    |                     ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/ui/associated-types/defaults-suitability.current.stderr
+++ b/tests/ui/associated-types/defaults-suitability.current.stderr
@@ -47,7 +47,7 @@ note: required by a bound in `Foo::Bar`
    |
 LL |     type Bar: Clone = Vec<T>;
    |               ^^^^^ required by this bound in `Foo::Bar`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::clone::Clone`
    |
 LL | trait Foo<T: std::clone::Clone> {
    |            +++++++++++++++++++
@@ -132,7 +132,7 @@ LL |     Self::Baz: Clone,
 ...
 LL |     type Baz = T;
    |          --- required by a bound in this associated type
-help: consider further restricting type parameter `T`
+help: consider further restricting type parameter `T` with trait `std::clone::Clone`
    |
 LL |     Self::Baz: Clone, T: std::clone::Clone
    |                     ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/ui/associated-types/defaults-suitability.next.stderr
+++ b/tests/ui/associated-types/defaults-suitability.next.stderr
@@ -47,7 +47,7 @@ note: required by a bound in `Foo::Bar`
    |
 LL |     type Bar: Clone = Vec<T>;
    |               ^^^^^ required by this bound in `Foo::Bar`
-help: consider restricting type parameter `T` with trait `std::clone::Clone`
+help: consider restricting type parameter `T` with trait `Clone`
    |
 LL | trait Foo<T: std::clone::Clone> {
    |            +++++++++++++++++++
@@ -132,7 +132,7 @@ LL |     Self::Baz: Clone,
 ...
 LL |     type Baz = T;
    |          --- required by a bound in this associated type
-help: consider further restricting type parameter `T` with trait `std::clone::Clone`
+help: consider further restricting type parameter `T` with trait `Clone`
    |
 LL |     Self::Baz: Clone, T: std::clone::Clone
    |                     ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/ui/associated-types/defaults-suitability.next.stderr
+++ b/tests/ui/associated-types/defaults-suitability.next.stderr
@@ -47,7 +47,7 @@ note: required by a bound in `Foo::Bar`
    |
 LL |     type Bar: Clone = Vec<T>;
    |               ^^^^^ required by this bound in `Foo::Bar`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::clone::Clone`
    |
 LL | trait Foo<T: std::clone::Clone> {
    |            +++++++++++++++++++
@@ -132,7 +132,7 @@ LL |     Self::Baz: Clone,
 ...
 LL |     type Baz = T;
    |          --- required by a bound in this associated type
-help: consider further restricting type parameter `T`
+help: consider further restricting type parameter `T` with trait `std::clone::Clone`
    |
 LL |     Self::Baz: Clone, T: std::clone::Clone
    |                     ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/ui/associated-types/hr-associated-type-bound-param-6.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-6.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `for<'b> T: X<'b, T>` is not satisfied
 LL | impl<S, T> X<'_, T> for (S,) {
    |            ^^^^^^^^ the trait `for<'b> X<'b, T>` is not implemented for `T`
    |
-help: consider restricting type parameter `T` with trait `for<'b> X<'b, T>`
+help: consider restricting type parameter `T` with trait `X`
    |
 LL | impl<S, T: for<'b> X<'b, T>> X<'_, T> for (S,) {
    |          ++++++++++++++++++

--- a/tests/ui/associated-types/hr-associated-type-bound-param-6.stderr
+++ b/tests/ui/associated-types/hr-associated-type-bound-param-6.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `for<'b> T: X<'b, T>` is not satisfied
 LL | impl<S, T> X<'_, T> for (S,) {
    |            ^^^^^^^^ the trait `for<'b> X<'b, T>` is not implemented for `T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `for<'b> X<'b, T>`
    |
 LL | impl<S, T: for<'b> X<'b, T>> X<'_, T> for (S,) {
    |          ++++++++++++++++++

--- a/tests/ui/associated-types/hr-associated-type-projection-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-projection-1.stderr
@@ -16,7 +16,7 @@ LL | trait UnsafeCopy<'a, T: Copy>
 LL | where
 LL |     for<'b> <Self as UnsafeCopy<'b, T>>::Item: std::ops::Deref<Target = T>,
    |                                                                ^^^^^^^^^^ required by this bound in `UnsafeCopy`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `<Target = T>`
    |
 LL | impl<T: Copy + std::ops::Deref<Target = T>> UnsafeCopy<'_, T> for T {
    |                               ++++++++++++

--- a/tests/ui/associated-types/hr-associated-type-projection-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-projection-1.stderr
@@ -16,7 +16,7 @@ LL | trait UnsafeCopy<'a, T: Copy>
 LL | where
 LL |     for<'b> <Self as UnsafeCopy<'b, T>>::Item: std::ops::Deref<Target = T>,
    |                                                                ^^^^^^^^^^ required by this bound in `UnsafeCopy`
-help: consider further restricting this bound with trait `<Target = T>`
+help: consider further restricting this bound with  `<Target = T>`
    |
 LL | impl<T: Copy + std::ops::Deref<Target = T>> UnsafeCopy<'_, T> for T {
    |                               ++++++++++++

--- a/tests/ui/associated-types/hr-associated-type-projection-1.stderr
+++ b/tests/ui/associated-types/hr-associated-type-projection-1.stderr
@@ -16,7 +16,7 @@ LL | trait UnsafeCopy<'a, T: Copy>
 LL | where
 LL |     for<'b> <Self as UnsafeCopy<'b, T>>::Item: std::ops::Deref<Target = T>,
    |                                                                ^^^^^^^^^^ required by this bound in `UnsafeCopy`
-help: consider further restricting this bound with  `<Target = T>`
+help: consider further restricting this bound
    |
 LL | impl<T: Copy + std::ops::Deref<Target = T>> UnsafeCopy<'_, T> for T {
    |                               ++++++++++++

--- a/tests/ui/associated-types/issue-27675-unchecked-bounds.stderr
+++ b/tests/ui/associated-types/issue-27675-unchecked-bounds.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `copy`
    |
 LL | fn copy<U: Setup + ?Sized>(from: &U::From) -> U::From {
    |            ^^^^^ required by this bound in `copy`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | pub fn copy_any<T: std::marker::Copy>(t: &T) -> T {
    |                  +++++++++++++++++++

--- a/tests/ui/associated-types/issue-27675-unchecked-bounds.stderr
+++ b/tests/ui/associated-types/issue-27675-unchecked-bounds.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `copy`
    |
 LL | fn copy<U: Setup + ?Sized>(from: &U::From) -> U::From {
    |            ^^^^^ required by this bound in `copy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | pub fn copy_any<T: std::marker::Copy>(t: &T) -> T {
    |                  +++++++++++++++++++

--- a/tests/ui/associated-types/issue-43784-associated-type.stderr
+++ b/tests/ui/associated-types/issue-43784-associated-type.stderr
@@ -14,7 +14,7 @@ note: required by a bound in `Complete::Assoc`
    |
 LL |     type Assoc: Partial<Self>;
    |                 ^^^^^^^^^^^^^ required by this bound in `Complete::Assoc`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | impl<T: std::marker::Copy> Complete for T {
    |       +++++++++++++++++++

--- a/tests/ui/associated-types/issue-43784-associated-type.stderr
+++ b/tests/ui/associated-types/issue-43784-associated-type.stderr
@@ -14,7 +14,7 @@ note: required by a bound in `Complete::Assoc`
    |
 LL |     type Assoc: Partial<Self>;
    |                 ^^^^^^^^^^^^^ required by this bound in `Complete::Assoc`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | impl<T: std::marker::Copy> Complete for T {
    |       +++++++++++++++++++

--- a/tests/ui/associated-types/issue-59324.stderr
+++ b/tests/ui/associated-types/issue-59324.stderr
@@ -7,7 +7,7 @@ LL | |
 LL | |     Service<AssocType = <Bug as Foo>::OnlyFoo>
    | |______________________________________________^ the trait `Foo` is not implemented for `Bug`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Foo`
    |
 LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++
@@ -24,7 +24,7 @@ LL | |
 LL | | }
    | |_^ the trait `Foo` is not implemented for `Bug`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Foo`
    |
 LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++
@@ -38,7 +38,7 @@ LL | |         &self,
 LL | |     ) -> Self::AssocType;
    | |_________________________^ the trait `Foo` is not implemented for `Bug`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Foo`
    |
 LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++
@@ -61,7 +61,7 @@ error[E0277]: the trait bound `Bug: Foo` is not satisfied
 LL |     ) -> Self::AssocType;
    |          ^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `Bug`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Foo`
    |
 LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++

--- a/tests/ui/associated-types/issue-59324.stderr
+++ b/tests/ui/associated-types/issue-59324.stderr
@@ -7,7 +7,7 @@ LL | |
 LL | |     Service<AssocType = <Bug as Foo>::OnlyFoo>
    | |______________________________________________^ the trait `Foo` is not implemented for `Bug`
    |
-help: consider further restricting this bound with trait `Foo`
+help: consider further restricting type parameter `Bug` with trait `Foo`
    |
 LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++
@@ -24,7 +24,7 @@ LL | |
 LL | | }
    | |_^ the trait `Foo` is not implemented for `Bug`
    |
-help: consider further restricting this bound with trait `Foo`
+help: consider further restricting type parameter `Bug` with trait `Foo`
    |
 LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++
@@ -38,7 +38,7 @@ LL | |         &self,
 LL | |     ) -> Self::AssocType;
    | |_________________________^ the trait `Foo` is not implemented for `Bug`
    |
-help: consider further restricting this bound with trait `Foo`
+help: consider further restricting type parameter `Bug` with trait `Foo`
    |
 LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++
@@ -61,7 +61,7 @@ error[E0277]: the trait bound `Bug: Foo` is not satisfied
 LL |     ) -> Self::AssocType;
    |          ^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `Bug`
    |
-help: consider further restricting this bound with trait `Foo`
+help: consider further restricting type parameter `Bug` with trait `Foo`
    |
 LL | pub trait ThriftService<Bug: NotFoo + Foo>:
    |                                     +++++

--- a/tests/ui/async-await/issue-70818.stderr
+++ b/tests/ui/async-await/issue-70818.stderr
@@ -9,7 +9,7 @@ note: captured value is not `Send`
    |
 LL |     async { (ty, ty1) }
    |                  ^^^ has type `U` which is not `Send`
-help: consider restricting type parameter `U`
+help: consider restricting type parameter `U` with trait `std::marker::Send`
    |
 LL | fn foo<T: Send, U: std::marker::Send>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                  +++++++++++++++++++

--- a/tests/ui/async-await/issue-70818.stderr
+++ b/tests/ui/async-await/issue-70818.stderr
@@ -9,7 +9,7 @@ note: captured value is not `Send`
    |
 LL |     async { (ty, ty1) }
    |                  ^^^ has type `U` which is not `Send`
-help: consider restricting type parameter `U` with trait `std::marker::Send`
+help: consider restricting type parameter `U` with trait `Send`
    |
 LL | fn foo<T: Send, U: std::marker::Send>(ty: T, ty1: U) -> impl Future<Output = (T, U)> + Send {
    |                  +++++++++++++++++++

--- a/tests/ui/async-await/issue-86507.stderr
+++ b/tests/ui/async-await/issue-86507.stderr
@@ -14,7 +14,7 @@ note: captured value is not `Send` because `&` references cannot be sent unless 
 LL |                     let x = x;
    |                             ^ has type `&T` which is not `Send`, because `T` is not `Sync`
    = note: required for the cast from `Pin<Box<{async block@$DIR/issue-86507.rs:18:17: 18:27}>>` to `Pin<Box<(dyn Future<Output = ()> + Send + 'async_trait)>>`
-help: consider further restricting this bound with trait `Sync`
+help: consider further restricting type parameter `T` with trait `Sync`
    |
 LL |     fn bar<'me, 'async_trait, T: Send + std::marker::Sync>(x: &'me T)
    |                                       +++++++++++++++++++

--- a/tests/ui/async-await/issue-86507.stderr
+++ b/tests/ui/async-await/issue-86507.stderr
@@ -14,7 +14,7 @@ note: captured value is not `Send` because `&` references cannot be sent unless 
 LL |                     let x = x;
    |                             ^ has type `&T` which is not `Send`, because `T` is not `Sync`
    = note: required for the cast from `Pin<Box<{async block@$DIR/issue-86507.rs:18:17: 18:27}>>` to `Pin<Box<(dyn Future<Output = ()> + Send + 'async_trait)>>`
-help: consider further restricting this bound with trait `std::marker::Sync`
+help: consider further restricting this bound with trait `Sync`
    |
 LL |     fn bar<'me, 'async_trait, T: Send + std::marker::Sync>(x: &'me T)
    |                                       +++++++++++++++++++

--- a/tests/ui/async-await/issue-86507.stderr
+++ b/tests/ui/async-await/issue-86507.stderr
@@ -14,7 +14,7 @@ note: captured value is not `Send` because `&` references cannot be sent unless 
 LL |                     let x = x;
    |                             ^ has type `&T` which is not `Send`, because `T` is not `Sync`
    = note: required for the cast from `Pin<Box<{async block@$DIR/issue-86507.rs:18:17: 18:27}>>` to `Pin<Box<(dyn Future<Output = ()> + Send + 'async_trait)>>`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Sync`
    |
 LL |     fn bar<'me, 'async_trait, T: Send + std::marker::Sync>(x: &'me T)
    |                                       +++++++++++++++++++

--- a/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
+++ b/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
@@ -30,7 +30,7 @@ LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
    |         ^                            - you could clone this value
    |         |
    |         consider constraining this type parameter with `Clone`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn copy<T: Magic + Copy>(x: T) -> (T, T) { (x, x) }
    |                  ++++++

--- a/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
+++ b/tests/ui/auto-traits/typeck-auto-trait-no-supertraits-2.stderr
@@ -30,7 +30,7 @@ LL | fn copy<T: Magic>(x: T) -> (T, T) { (x, x) }
    |         ^                            - you could clone this value
    |         |
    |         consider constraining this type parameter with `Clone`
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL | fn copy<T: Magic + Copy>(x: T) -> (T, T) { (x, x) }
    |                  ++++++

--- a/tests/ui/binop/binop-consume-args.stderr
+++ b/tests/ui/binop/binop-consume-args.stderr
@@ -17,7 +17,7 @@ LL |     lhs + rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn add<A: Add<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -40,7 +40,7 @@ LL | fn add<A: Add<B, Output=()>, B>(lhs: A, rhs: B) {
    |                              ^ consider constraining this type parameter with `Clone`
 LL |     lhs + rhs;
    |           --- you could clone this value
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Copy`
    |
 LL | fn add<A: Add<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
    |                               ++++++
@@ -64,7 +64,7 @@ LL |     lhs - rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn sub<A: Sub<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -87,7 +87,7 @@ LL | fn sub<A: Sub<B, Output=()>, B>(lhs: A, rhs: B) {
    |                              ^ consider constraining this type parameter with `Clone`
 LL |     lhs - rhs;
    |           --- you could clone this value
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Copy`
    |
 LL | fn sub<A: Sub<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
    |                               ++++++
@@ -111,7 +111,7 @@ LL |     lhs * rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn mul<A: Mul<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -134,7 +134,7 @@ LL | fn mul<A: Mul<B, Output=()>, B>(lhs: A, rhs: B) {
    |                              ^ consider constraining this type parameter with `Clone`
 LL |     lhs * rhs;
    |           --- you could clone this value
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Copy`
    |
 LL | fn mul<A: Mul<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
    |                               ++++++
@@ -158,7 +158,7 @@ LL |     lhs / rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn div<A: Div<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -181,7 +181,7 @@ LL | fn div<A: Div<B, Output=()>, B>(lhs: A, rhs: B) {
    |                              ^ consider constraining this type parameter with `Clone`
 LL |     lhs / rhs;
    |           --- you could clone this value
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Copy`
    |
 LL | fn div<A: Div<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
    |                               ++++++
@@ -205,7 +205,7 @@ LL |     lhs % rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn rem<A: Rem<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -228,7 +228,7 @@ LL | fn rem<A: Rem<B, Output=()>, B>(lhs: A, rhs: B) {
    |                              ^ consider constraining this type parameter with `Clone`
 LL |     lhs % rhs;
    |           --- you could clone this value
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Copy`
    |
 LL | fn rem<A: Rem<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
    |                               ++++++
@@ -252,7 +252,7 @@ LL |     lhs & rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn bitand<A: BitAnd<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                                   ++++++
@@ -275,7 +275,7 @@ LL | fn bitand<A: BitAnd<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                    ^ consider constraining this type parameter with `Clone`
 LL |     lhs & rhs;
    |           --- you could clone this value
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Copy`
    |
 LL | fn bitand<A: BitAnd<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
    |                                     ++++++
@@ -299,7 +299,7 @@ LL |     lhs | rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn bitor<A: BitOr<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                                 ++++++
@@ -322,7 +322,7 @@ LL | fn bitor<A: BitOr<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                  ^ consider constraining this type parameter with `Clone`
 LL |     lhs | rhs;
    |           --- you could clone this value
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Copy`
    |
 LL | fn bitor<A: BitOr<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
    |                                   ++++++
@@ -346,7 +346,7 @@ LL |     lhs ^ rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn bitxor<A: BitXor<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                                   ++++++
@@ -369,7 +369,7 @@ LL | fn bitxor<A: BitXor<B, Output=()>, B>(lhs: A, rhs: B) {
    |                                    ^ consider constraining this type parameter with `Clone`
 LL |     lhs ^ rhs;
    |           --- you could clone this value
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Copy`
    |
 LL | fn bitxor<A: BitXor<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
    |                                     ++++++
@@ -393,7 +393,7 @@ LL |     lhs << rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn shl<A: Shl<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -416,7 +416,7 @@ LL | fn shl<A: Shl<B, Output=()>, B>(lhs: A, rhs: B) {
    |                              ^ consider constraining this type parameter with `Clone`
 LL |     lhs << rhs;
    |            --- you could clone this value
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Copy`
    |
 LL | fn shl<A: Shl<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
    |                               ++++++
@@ -440,7 +440,7 @@ LL |     lhs >> rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn shr<A: Shr<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -463,7 +463,7 @@ LL | fn shr<A: Shr<B, Output=()>, B>(lhs: A, rhs: B) {
    |                              ^ consider constraining this type parameter with `Clone`
 LL |     lhs >> rhs;
    |            --- you could clone this value
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Copy`
    |
 LL | fn shr<A: Shr<B, Output=()>, B: Copy>(lhs: A, rhs: B) {
    |                               ++++++

--- a/tests/ui/binop/binop-consume-args.stderr
+++ b/tests/ui/binop/binop-consume-args.stderr
@@ -17,7 +17,7 @@ LL |     lhs + rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `A` with trait `Copy`
    |
 LL | fn add<A: Add<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -64,7 +64,7 @@ LL |     lhs - rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `A` with trait `Copy`
    |
 LL | fn sub<A: Sub<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -111,7 +111,7 @@ LL |     lhs * rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `A` with trait `Copy`
    |
 LL | fn mul<A: Mul<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -158,7 +158,7 @@ LL |     lhs / rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `A` with trait `Copy`
    |
 LL | fn div<A: Div<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -205,7 +205,7 @@ LL |     lhs % rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `A` with trait `Copy`
    |
 LL | fn rem<A: Rem<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -252,7 +252,7 @@ LL |     lhs & rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `A` with trait `Copy`
    |
 LL | fn bitand<A: BitAnd<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                                   ++++++
@@ -299,7 +299,7 @@ LL |     lhs | rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `A` with trait `Copy`
    |
 LL | fn bitor<A: BitOr<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                                 ++++++
@@ -346,7 +346,7 @@ LL |     lhs ^ rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `A` with trait `Copy`
    |
 LL | fn bitxor<A: BitXor<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                                   ++++++
@@ -393,7 +393,7 @@ LL |     lhs << rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `A` with trait `Copy`
    |
 LL | fn shl<A: Shl<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++
@@ -440,7 +440,7 @@ LL |     lhs >> rhs;
    |     --- you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/bit.rs:LL:COL
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `A` with trait `Copy`
    |
 LL | fn shr<A: Shr<B, Output=()> + Copy, B>(lhs: A, rhs: B) {
    |                             ++++++

--- a/tests/ui/binop/binop-move-semantics.stderr
+++ b/tests/ui/binop/binop-move-semantics.stderr
@@ -20,7 +20,7 @@ LL |     x
    |     - you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn double_move<T: Add<Output=()> + Copy>(x: T) {
    |                                  ++++++
@@ -40,7 +40,7 @@ help: consider cloning the value if the performance cost is acceptable
    |
 LL |     x.clone()
    |      ++++++++
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn move_then_borrow<T: Add<Output=()> + Clone + Copy>(x: T) {
    |                                               ++++++

--- a/tests/ui/binop/binop-move-semantics.stderr
+++ b/tests/ui/binop/binop-move-semantics.stderr
@@ -20,7 +20,7 @@ LL |     x
    |     - you could clone this value
 note: calling this operator moves the left-hand side
   --> $SRC_DIR/core/src/ops/arith.rs:LL:COL
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL | fn double_move<T: Add<Output=()> + Copy>(x: T) {
    |                                  ++++++
@@ -40,7 +40,7 @@ help: consider cloning the value if the performance cost is acceptable
    |
 LL |     x.clone()
    |      ++++++++
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL | fn move_then_borrow<T: Add<Output=()> + Clone + Copy>(x: T) {
    |                                               ++++++

--- a/tests/ui/binop/issue-93927.stderr
+++ b/tests/ui/binop/issue-93927.stderr
@@ -6,7 +6,7 @@ LL |     val == val
    |     |
    |     MyType<T>
    |
-help: consider further restricting this bound with trait `std::cmp::Eq`
+help: consider further restricting this bound with trait `Eq`
    |
 LL | fn cond<T: PartialEq + std::cmp::Eq>(val: MyType<T>) -> bool {
    |                      ++++++++++++++

--- a/tests/ui/binop/issue-93927.stderr
+++ b/tests/ui/binop/issue-93927.stderr
@@ -6,7 +6,7 @@ LL |     val == val
    |     |
    |     MyType<T>
    |
-help: consider further restricting this bound with trait `Eq`
+help: consider further restricting type parameter `T` with trait `Eq`
    |
 LL | fn cond<T: PartialEq + std::cmp::Eq>(val: MyType<T>) -> bool {
    |                      ++++++++++++++

--- a/tests/ui/binop/issue-93927.stderr
+++ b/tests/ui/binop/issue-93927.stderr
@@ -6,7 +6,7 @@ LL |     val == val
    |     |
    |     MyType<T>
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::cmp::Eq`
    |
 LL | fn cond<T: PartialEq + std::cmp::Eq>(val: MyType<T>) -> bool {
    |                      ++++++++++++++

--- a/tests/ui/borrowck/clone-on-ref.stderr
+++ b/tests/ui/borrowck/clone-on-ref.stderr
@@ -12,7 +12,7 @@ LL |
 LL |     drop(cloned_items);
    |          ------------ immutable borrow later used here
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Clone`
    |
 LL | fn foo<T: Default + Clone>(list: &mut Vec<T>) {
    |                   +++++++
@@ -39,7 +39,7 @@ LL | fn bar<T: std::fmt::Display>(x: T) {
    |        ^ consider constraining this type parameter with `Clone`
 LL |     let a = &x;
    |              - you could clone this value
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Clone`
    |
 LL | fn bar<T: std::fmt::Display + Clone>(x: T) {
    |                             +++++++

--- a/tests/ui/borrowck/clone-on-ref.stderr
+++ b/tests/ui/borrowck/clone-on-ref.stderr
@@ -12,7 +12,7 @@ LL |
 LL |     drop(cloned_items);
    |          ------------ immutable borrow later used here
    |
-help: consider further restricting this bound with trait `Clone`
+help: consider further restricting type parameter `T` with trait `Clone`
    |
 LL | fn foo<T: Default + Clone>(list: &mut Vec<T>) {
    |                   +++++++
@@ -39,7 +39,7 @@ LL | fn bar<T: std::fmt::Display>(x: T) {
    |        ^ consider constraining this type parameter with `Clone`
 LL |     let a = &x;
    |              - you could clone this value
-help: consider further restricting this bound with trait `Clone`
+help: consider further restricting type parameter `T` with trait `Clone`
    |
 LL | fn bar<T: std::fmt::Display + Clone>(x: T) {
    |                             +++++++

--- a/tests/ui/borrowck/move-error-suggest-clone-panic-issue-127915.stderr
+++ b/tests/ui/borrowck/move-error-suggest-clone-panic-issue-127915.stderr
@@ -15,7 +15,7 @@ LL | fn test<T, U>(a: i64, b: i64, c: i64, d: i64, e: i64, f: T, g: U) -> i64 {
 ...
 LL |             6, a as f64, b, b as f64, f, c as f64, d, d as f64, e, e as f64, f, g,
    |                                       - you could clone this value
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | fn test<T: Copy, U>(a: i64, b: i64, c: i64, d: i64, e: i64, f: T, g: U) -> i64 {
    |          ++++++

--- a/tests/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Foo`
    |
 LL | trait Foo : Send+Sync { }
    |             ^^^^ required by this bound in `Foo`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Send`
    |
 LL | impl <T: Sync+'static + std::marker::Send> Foo for (T,) { }
    |                       +++++++++++++++++++
@@ -27,7 +27,7 @@ note: required by a bound in `Foo`
    |
 LL | trait Foo : Send+Sync { }
    |                  ^^^^ required by this bound in `Foo`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Sync`
    |
 LL | impl <T: Send + std::marker::Sync> Foo for (T,T) { }
    |               +++++++++++++++++++

--- a/tests/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Foo`
    |
 LL | trait Foo : Send+Sync { }
    |             ^^^^ required by this bound in `Foo`
-help: consider further restricting this bound with trait `Send`
+help: consider further restricting type parameter `T` with trait `Send`
    |
 LL | impl <T: Sync+'static + std::marker::Send> Foo for (T,) { }
    |                       +++++++++++++++++++
@@ -27,7 +27,7 @@ note: required by a bound in `Foo`
    |
 LL | trait Foo : Send+Sync { }
    |                  ^^^^ required by this bound in `Foo`
-help: consider further restricting this bound with trait `Sync`
+help: consider further restricting type parameter `T` with trait `Sync`
    |
 LL | impl <T: Send + std::marker::Sync> Foo for (T,T) { }
    |               +++++++++++++++++++

--- a/tests/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-double-superkind.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Foo`
    |
 LL | trait Foo : Send+Sync { }
    |             ^^^^ required by this bound in `Foo`
-help: consider further restricting this bound with trait `std::marker::Send`
+help: consider further restricting this bound with trait `Send`
    |
 LL | impl <T: Sync+'static + std::marker::Send> Foo for (T,) { }
    |                       +++++++++++++++++++
@@ -27,7 +27,7 @@ note: required by a bound in `Foo`
    |
 LL | trait Foo : Send+Sync { }
    |                  ^^^^ required by this bound in `Foo`
-help: consider further restricting this bound with trait `std::marker::Sync`
+help: consider further restricting this bound with trait `Sync`
    |
 LL | impl <T: Send + std::marker::Sync> Foo for (T,T) { }
    |               +++++++++++++++++++

--- a/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -14,7 +14,7 @@ note: required by a bound in `RequiresRequiresShareAndSend`
    |
 LL | pub trait RequiresRequiresShareAndSend : RequiresShare + Send { }
    |                                                          ^^^^ required by this bound in `RequiresRequiresShareAndSend`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Send`
    |
 LL | impl <T:Sync+'static + std::marker::Send> RequiresRequiresShareAndSend for X<T> { }
    |                      +++++++++++++++++++

--- a/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -14,7 +14,7 @@ note: required by a bound in `RequiresRequiresShareAndSend`
    |
 LL | pub trait RequiresRequiresShareAndSend : RequiresShare + Send { }
    |                                                          ^^^^ required by this bound in `RequiresRequiresShareAndSend`
-help: consider further restricting this bound with trait `Send`
+help: consider further restricting type parameter `T` with trait `Send`
    |
 LL | impl <T:Sync+'static + std::marker::Send> RequiresRequiresShareAndSend for X<T> { }
    |                      +++++++++++++++++++

--- a/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-in-metadata.stderr
@@ -14,7 +14,7 @@ note: required by a bound in `RequiresRequiresShareAndSend`
    |
 LL | pub trait RequiresRequiresShareAndSend : RequiresShare + Send { }
    |                                                          ^^^^ required by this bound in `RequiresRequiresShareAndSend`
-help: consider further restricting this bound with trait `std::marker::Send`
+help: consider further restricting this bound with trait `Send`
    |
 LL | impl <T:Sync+'static + std::marker::Send> RequiresRequiresShareAndSend for X<T> { }
    |                      +++++++++++++++++++

--- a/tests/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Foo`
    |
 LL | trait Foo : Send { }
    |             ^^^^ required by this bound in `Foo`
-help: consider further restricting this bound with trait `std::marker::Send`
+help: consider further restricting this bound with trait `Send`
    |
 LL | impl <T: Sync+'static + std::marker::Send> Foo for T { }
    |                       +++++++++++++++++++

--- a/tests/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Foo`
    |
 LL | trait Foo : Send { }
    |             ^^^^ required by this bound in `Foo`
-help: consider further restricting this bound with trait `Send`
+help: consider further restricting type parameter `T` with trait `Send`
    |
 LL | impl <T: Sync+'static + std::marker::Send> Foo for T { }
    |                       +++++++++++++++++++

--- a/tests/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
+++ b/tests/ui/builtin-superkinds/builtin-superkinds-typaram-not-send.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Foo`
    |
 LL | trait Foo : Send { }
    |             ^^^^ required by this bound in `Foo`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Send`
    |
 LL | impl <T: Sync+'static + std::marker::Send> Foo for T { }
    |                       +++++++++++++++++++

--- a/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `X`
    |
 LL | struct X<F> where F: FnOnce() + 'static + Send {
    |                                           ^^^^ required by this bound in `X`
-help: consider further restricting this bound with trait `Send`
+help: consider further restricting type parameter `F` with trait `Send`
    |
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {
    |                                                       +++++++++++++++++++
@@ -25,7 +25,7 @@ note: required by a bound in `X`
    |
 LL | struct X<F> where F: FnOnce() + 'static + Send {
    |                                           ^^^^ required by this bound in `X`
-help: consider further restricting this bound with trait `Send`
+help: consider further restricting type parameter `F` with trait `Send`
    |
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {
    |                                                       +++++++++++++++++++

--- a/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `X`
    |
 LL | struct X<F> where F: FnOnce() + 'static + Send {
    |                                           ^^^^ required by this bound in `X`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Send`
    |
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {
    |                                                       +++++++++++++++++++
@@ -25,7 +25,7 @@ note: required by a bound in `X`
    |
 LL | struct X<F> where F: FnOnce() + 'static + Send {
    |                                           ^^^^ required by this bound in `X`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Send`
    |
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {
    |                                                       +++++++++++++++++++

--- a/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
+++ b/tests/ui/closures/closure-bounds-cant-promote-superkind-in-struct.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `X`
    |
 LL | struct X<F> where F: FnOnce() + 'static + Send {
    |                                           ^^^^ required by this bound in `X`
-help: consider further restricting this bound with trait `std::marker::Send`
+help: consider further restricting this bound with trait `Send`
    |
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {
    |                                                       +++++++++++++++++++
@@ -25,7 +25,7 @@ note: required by a bound in `X`
    |
 LL | struct X<F> where F: FnOnce() + 'static + Send {
    |                                           ^^^^ required by this bound in `X`
-help: consider further restricting this bound with trait `std::marker::Send`
+help: consider further restricting this bound with trait `Send`
    |
 LL | fn foo<F>(blk: F) -> X<F> where F: FnOnce() + 'static + std::marker::Send {
    |                                                       +++++++++++++++++++

--- a/tests/ui/closures/closure-bounds-subtype.stderr
+++ b/tests/ui/closures/closure-bounds-subtype.stderr
@@ -15,7 +15,7 @@ help: use parentheses to call this type parameter
    |
 LL |     take_const_owned(f());
    |                       ++
-help: consider further restricting this bound with trait `Sync`
+help: consider further restricting type parameter `F` with trait `Sync`
    |
 LL | fn give_owned<F>(f: F) where F: FnOnce() + Send + std::marker::Sync {
    |                                                 +++++++++++++++++++

--- a/tests/ui/closures/closure-bounds-subtype.stderr
+++ b/tests/ui/closures/closure-bounds-subtype.stderr
@@ -15,7 +15,7 @@ help: use parentheses to call this type parameter
    |
 LL |     take_const_owned(f());
    |                       ++
-help: consider further restricting this bound with trait `std::marker::Sync`
+help: consider further restricting this bound with trait `Sync`
    |
 LL | fn give_owned<F>(f: F) where F: FnOnce() + Send + std::marker::Sync {
    |                                                 +++++++++++++++++++

--- a/tests/ui/closures/closure-bounds-subtype.stderr
+++ b/tests/ui/closures/closure-bounds-subtype.stderr
@@ -15,7 +15,7 @@ help: use parentheses to call this type parameter
    |
 LL |     take_const_owned(f());
    |                       ++
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Sync`
    |
 LL | fn give_owned<F>(f: F) where F: FnOnce() + Send + std::marker::Sync {
    |                                                 +++++++++++++++++++

--- a/tests/ui/closures/issue-67123.stderr
+++ b/tests/ui/closures/issue-67123.stderr
@@ -7,7 +7,7 @@ LL |     || { t; t; };
    |          value moved here
    |
    = note: move occurs because `t` has type `T`, which does not implement the `Copy` trait
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | fn foo<T: Copy>(t: T) {
    |         ++++++

--- a/tests/ui/coherence/fuzzing/best-obligation-ICE.stderr
+++ b/tests/ui/coherence/fuzzing/best-obligation-ICE.stderr
@@ -41,7 +41,7 @@ note: required by a bound in `W`
    |
 LL | struct W<T: Trait>(*mut T);
    |             ^^^^^ required by this bound in `W`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL | impl<T: Trait> Trait for W<W<W<T>>> {}
    |       +++++++

--- a/tests/ui/const-generics/issues/issue-61336-2.stderr
+++ b/tests/ui/const-generics/issues/issue-61336-2.stderr
@@ -7,7 +7,7 @@ LL |     [x; { N }]
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
    = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
    |       +++++++++++++++++++

--- a/tests/ui/const-generics/issues/issue-61336-2.stderr
+++ b/tests/ui/const-generics/issues/issue-61336-2.stderr
@@ -7,7 +7,7 @@ LL |     [x; { N }]
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
    = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
    |       +++++++++++++++++++

--- a/tests/ui/const-generics/issues/issue-61336.stderr
+++ b/tests/ui/const-generics/issues/issue-61336.stderr
@@ -7,7 +7,7 @@ LL |     [x; N]
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
    = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
    |       +++++++++++++++++++

--- a/tests/ui/const-generics/issues/issue-61336.stderr
+++ b/tests/ui/const-generics/issues/issue-61336.stderr
@@ -7,7 +7,7 @@ LL |     [x; N]
    = note: the `Copy` trait is required because this value will be copied for each element of the array
    = help: consider using `core::array::from_fn` to initialize the array
    = help: see https://doc.rust-lang.org/stable/std/array/fn.from_fn.html for more information
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | fn g<T: std::marker::Copy, const N: usize>(x: T) -> [T; N] {
    |       +++++++++++++++++++

--- a/tests/ui/consts/ct-var-in-collect_all_mismatches.stderr
+++ b/tests/ui/consts/ct-var-in-collect_all_mismatches.stderr
@@ -12,7 +12,7 @@ LL |     fn unsatisfied(self)
 LL |     where
 LL |         T: Bar<N>,
    |            ^^^^^^ required by this bound in `Foo::<T, N>::unsatisfied`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Bar<N>`
    |
 LL | impl<T: Bar<N>, const N: usize> Foo<T, N> {
    |       ++++++++

--- a/tests/ui/consts/ct-var-in-collect_all_mismatches.stderr
+++ b/tests/ui/consts/ct-var-in-collect_all_mismatches.stderr
@@ -12,7 +12,7 @@ LL |     fn unsatisfied(self)
 LL |     where
 LL |         T: Bar<N>,
    |            ^^^^^^ required by this bound in `Foo::<T, N>::unsatisfied`
-help: consider restricting type parameter `T` with trait `Bar<N>`
+help: consider restricting type parameter `T` with trait `Bar`
    |
 LL | impl<T: Bar<N>, const N: usize> Foo<T, N> {
    |       ++++++++

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -212,10 +212,6 @@ LL |     f()
    |     ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const Fn()`
-   |
-LL |     T: ~const Fn<()> + ~const Destruct + ~const Fn(),
-   |                                        +++++++++++++
 
 error[E0015]: cannot call non-const closure in constant functions
   --> $DIR/fn_trait_refs.rs:23:5
@@ -224,10 +220,6 @@ LL |     f()
    |     ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const FnMut()`
-   |
-LL |     T: ~const FnMut<()> + ~const Destruct + ~const FnMut(),
-   |                                           ++++++++++++++++
 
 error[E0015]: cannot call non-const closure in constant functions
   --> $DIR/fn_trait_refs.rs:30:5
@@ -236,10 +228,6 @@ LL |     f()
    |     ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const FnOnce()`
-   |
-LL |     T: ~const FnOnce<()> + ~const FnOnce(),
-   |                          +++++++++++++++++
 
 error: aborting due to 25 previous errors
 

--- a/tests/ui/consts/fn_trait_refs.stderr
+++ b/tests/ui/consts/fn_trait_refs.stderr
@@ -212,7 +212,7 @@ LL |     f()
    |     ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const Fn()`
    |
 LL |     T: ~const Fn<()> + ~const Destruct + ~const Fn(),
    |                                        +++++++++++++
@@ -224,7 +224,7 @@ LL |     f()
    |     ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const FnMut()`
    |
 LL |     T: ~const FnMut<()> + ~const Destruct + ~const FnMut(),
    |                                           ++++++++++++++++
@@ -236,7 +236,7 @@ LL |     f()
    |     ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const FnOnce()`
    |
 LL |     T: ~const FnOnce<()> + ~const FnOnce(),
    |                          +++++++++++++++++

--- a/tests/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/tests/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -19,10 +19,6 @@ LL |             Opt::None => f(),
    |                          ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const FnOnce()`
-   |
-LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T + ~const FnOnce()>(self, f: F) -> T {
-   |                                                     +++++++++++++++++
 
 error[E0493]: destructor of `F` cannot be evaluated at compile-time
   --> $DIR/unstable-const-fn-in-libcore.rs:19:60

--- a/tests/ui/consts/unstable-const-fn-in-libcore.stderr
+++ b/tests/ui/consts/unstable-const-fn-in-libcore.stderr
@@ -19,7 +19,7 @@ LL |             Opt::None => f(),
    |                          ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const FnOnce()`
    |
 LL |     const fn unwrap_or_else<F: ~const FnOnce() -> T + ~const FnOnce()>(self, f: F) -> T {
    |                                                     +++++++++++++++++

--- a/tests/ui/dropck/explicit-drop-bounds.bad1.stderr
+++ b/tests/ui/dropck/explicit-drop-bounds.bad1.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `DropMe`
    |
 LL | struct DropMe<T: Copy>(T);
    |                  ^^^^ required by this bound in `DropMe`
-help: consider further restricting type parameter `T` with trait `std::marker::Copy`
+help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL |     [T; 1]: Copy, T: std::marker::Copy // But `[T; 1]: Copy` does not imply `T: Copy`
    |                 ~~~~~~~~~~~~~~~~~~~~~~
@@ -25,7 +25,7 @@ note: required by a bound in `DropMe`
    |
 LL | struct DropMe<T: Copy>(T);
    |                  ^^^^ required by this bound in `DropMe`
-help: consider further restricting type parameter `T` with trait `std::marker::Copy`
+help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL |     [T; 1]: Copy, T: std::marker::Copy // But `[T; 1]: Copy` does not imply `T: Copy`
    |                 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/ui/dropck/explicit-drop-bounds.bad1.stderr
+++ b/tests/ui/dropck/explicit-drop-bounds.bad1.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `DropMe`
    |
 LL | struct DropMe<T: Copy>(T);
    |                  ^^^^ required by this bound in `DropMe`
-help: consider further restricting type parameter `T`
+help: consider further restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL |     [T; 1]: Copy, T: std::marker::Copy // But `[T; 1]: Copy` does not imply `T: Copy`
    |                 ~~~~~~~~~~~~~~~~~~~~~~
@@ -25,7 +25,7 @@ note: required by a bound in `DropMe`
    |
 LL | struct DropMe<T: Copy>(T);
    |                  ^^^^ required by this bound in `DropMe`
-help: consider further restricting type parameter `T`
+help: consider further restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL |     [T; 1]: Copy, T: std::marker::Copy // But `[T; 1]: Copy` does not imply `T: Copy`
    |                 ~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/ui/dropck/explicit-drop-bounds.bad2.stderr
+++ b/tests/ui/dropck/explicit-drop-bounds.bad2.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `DropMe`
    |
 LL | struct DropMe<T: Copy>(T);
    |                  ^^^^ required by this bound in `DropMe`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | impl<T: std::marker::Copy> Drop for DropMe<T>
    |       +++++++++++++++++++
@@ -25,7 +25,7 @@ note: required by a bound in `DropMe`
    |
 LL | struct DropMe<T: Copy>(T);
    |                  ^^^^ required by this bound in `DropMe`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | impl<T: std::marker::Copy> Drop for DropMe<T>
    |       +++++++++++++++++++

--- a/tests/ui/dropck/explicit-drop-bounds.bad2.stderr
+++ b/tests/ui/dropck/explicit-drop-bounds.bad2.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `DropMe`
    |
 LL | struct DropMe<T: Copy>(T);
    |                  ^^^^ required by this bound in `DropMe`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | impl<T: std::marker::Copy> Drop for DropMe<T>
    |       +++++++++++++++++++
@@ -25,7 +25,7 @@ note: required by a bound in `DropMe`
    |
 LL | struct DropMe<T: Copy>(T);
    |                  ^^^^ required by this bound in `DropMe`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | impl<T: std::marker::Copy> Drop for DropMe<T>
    |       +++++++++++++++++++

--- a/tests/ui/error-codes/E0229.stderr
+++ b/tests/ui/error-codes/E0229.stderr
@@ -42,7 +42,7 @@ error[E0277]: the trait bound `I: Foo` is not satisfied
 LL | fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
    |               ^^^^^^^^^^^^^^^^^^^^^^ the trait `Foo` is not implemented for `I`
    |
-help: consider restricting type parameter `I`
+help: consider restricting type parameter `I` with trait `Foo`
    |
 LL | fn baz<I: Foo>(x: &<I as Foo<A = Bar>>::A) {}
    |         +++++
@@ -53,7 +53,7 @@ error[E0277]: the trait bound `I: Foo` is not satisfied
 LL | fn baz<I>(x: &<I as Foo<A = Bar>>::A) {}
    |                                       ^^ the trait `Foo` is not implemented for `I`
    |
-help: consider restricting type parameter `I`
+help: consider restricting type parameter `I` with trait `Foo`
    |
 LL | fn baz<I: Foo>(x: &<I as Foo<A = Bar>>::A) {}
    |         +++++

--- a/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
+++ b/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
@@ -25,7 +25,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -73,7 +73,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `std::iter::Iterator`
    |
 LL | fn example<Q: std::iter::Iterator>(q: Q) {
    |             +++++++++++++++++++++
@@ -100,7 +100,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `std::iter::Iterator`
    |
 LL | fn example<Q: std::iter::Iterator>(q: Q) {
    |             +++++++++++++++++++++
@@ -125,7 +125,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -150,7 +150,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -175,7 +175,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -200,7 +200,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -225,7 +225,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -248,7 +248,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -273,7 +273,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -296,7 +296,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -319,7 +319,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -342,7 +342,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -367,7 +367,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -392,7 +392,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++

--- a/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
+++ b/tests/ui/errors/trait-bound-error-spans/blame-trait-error.stderr
@@ -73,7 +73,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q` with trait `std::iter::Iterator`
+help: consider restricting type parameter `Q` with trait `Iterator`
    |
 LL | fn example<Q: std::iter::Iterator>(q: Q) {
    |             +++++++++++++++++++++
@@ -100,7 +100,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q` with trait `std::iter::Iterator`
+help: consider restricting type parameter `Q` with trait `Iterator`
    |
 LL | fn example<Q: std::iter::Iterator>(q: Q) {
    |             +++++++++++++++++++++

--- a/tests/ui/errors/traits/blame-trait-error-spans-on-exprs.stderr
+++ b/tests/ui/errors/traits/blame-trait-error-spans-on-exprs.stderr
@@ -23,7 +23,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -53,7 +53,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -85,7 +85,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -117,7 +117,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -147,7 +147,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -172,7 +172,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T2`
    |
 LL | fn example<Q: T2>(q: Q) {
    |             ++++
@@ -204,7 +204,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -236,7 +236,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -261,7 +261,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T1`
    |
 LL | fn example<Q: T1>(q: Q) {
    |             ++++
@@ -286,7 +286,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T1`
    |
 LL | fn example<Q: T1>(q: Q) {
    |             ++++
@@ -318,7 +318,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++
@@ -343,7 +343,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T1`
    |
 LL | fn example<Q: T1>(q: Q) {
    |             ++++
@@ -370,7 +370,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T1`
    |
 LL | fn example<Q: T1>(q: Q) {
    |             ++++
@@ -402,7 +402,7 @@ note: required by a bound in `want`
    |
 LL | fn want<V: T1>(_x: V) {}
    |            ^^ required by this bound in `want`
-help: consider restricting type parameter `Q`
+help: consider restricting type parameter `Q` with trait `T3`
    |
 LL | fn example<Q: T3>(q: Q) {
    |             ++++

--- a/tests/ui/generic-associated-types/generic-associated-types-where.stderr
+++ b/tests/ui/generic-associated-types/generic-associated-types-where.stderr
@@ -5,7 +5,7 @@ LL |     type Assoc2<T> = Vec<T>;
    |                      ^^^^^^ `T` cannot be formatted with the default formatter
    |
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::fmt::Display`
    |
 LL |     type Assoc2<T: std::fmt::Display> = Vec<T>;
    |                  +++++++++++++++++++

--- a/tests/ui/generic-associated-types/generic-associated-types-where.stderr
+++ b/tests/ui/generic-associated-types/generic-associated-types-where.stderr
@@ -5,7 +5,7 @@ LL |     type Assoc2<T> = Vec<T>;
    |                      ^^^^^^ `T` cannot be formatted with the default formatter
    |
    = note: in format strings you may be able to use `{:?}` (or {:#?} for pretty-print) instead
-help: consider restricting type parameter `T` with trait `std::fmt::Display`
+help: consider restricting type parameter `T` with trait `Display`
    |
 LL |     type Assoc2<T: std::fmt::Display> = Vec<T>;
    |                  +++++++++++++++++++

--- a/tests/ui/generic-associated-types/impl_bounds.stderr
+++ b/tests/ui/generic-associated-types/impl_bounds.stderr
@@ -41,7 +41,7 @@ LL | trait Foo {
 LL |     type C where Self: Clone;
    |          ^ this trait's associated type doesn't have the requirement `Fooy<T>: Copy`
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | impl<T: std::marker::Copy> Foo for Fooy<T> {
    |       +++++++++++++++++++
@@ -66,7 +66,7 @@ LL | trait Foo {
 LL |     fn d() where Self: Clone;
    |        ^ this trait's method doesn't have the requirement `Fooy<T>: Copy`
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | impl<T: std::marker::Copy> Foo for Fooy<T> {
    |       +++++++++++++++++++

--- a/tests/ui/generic-associated-types/impl_bounds.stderr
+++ b/tests/ui/generic-associated-types/impl_bounds.stderr
@@ -41,7 +41,7 @@ LL | trait Foo {
 LL |     type C where Self: Clone;
    |          ^ this trait's associated type doesn't have the requirement `Fooy<T>: Copy`
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | impl<T: std::marker::Copy> Foo for Fooy<T> {
    |       +++++++++++++++++++
@@ -66,7 +66,7 @@ LL | trait Foo {
 LL |     fn d() where Self: Clone;
    |        ^ this trait's method doesn't have the requirement `Fooy<T>: Copy`
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | impl<T: std::marker::Copy> Foo for Fooy<T> {
    |       +++++++++++++++++++

--- a/tests/ui/generic-associated-types/issue-68641-check-gat-bounds.stderr
+++ b/tests/ui/generic-associated-types/issue-68641-check-gat-bounds.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `UnsafeCopy::Item`
    |
 LL |     type Item<'a>: Copy;
    |                    ^^^^ required by this bound in `UnsafeCopy::Item`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | impl<T: std::marker::Copy> UnsafeCopy for T {
    |       +++++++++++++++++++

--- a/tests/ui/generic-associated-types/issue-68641-check-gat-bounds.stderr
+++ b/tests/ui/generic-associated-types/issue-68641-check-gat-bounds.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `UnsafeCopy::Item`
    |
 LL |     type Item<'a>: Copy;
    |                    ^^^^ required by this bound in `UnsafeCopy::Item`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | impl<T: std::marker::Copy> UnsafeCopy for T {
    |       +++++++++++++++++++

--- a/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
+++ b/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Fun::F`
    |
 LL |     type F<'a>: Fn() -> u32;
    |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Fn()`
    |
 LL | impl<T: Fn()> Fun for T {
    |       ++++++

--- a/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
+++ b/tests/ui/generic-associated-types/issue-68642-broken-llvm-ir.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Fun::F`
    |
 LL |     type F<'a>: Fn() -> u32;
    |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
-help: consider restricting type parameter `T` with trait `Fn()`
+help: consider restricting type parameter `T` with trait `Fn`
    |
 LL | impl<T: Fn()> Fun for T {
    |       ++++++

--- a/tests/ui/generic-associated-types/issue-68643-broken-mir.stderr
+++ b/tests/ui/generic-associated-types/issue-68643-broken-mir.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Fun::F`
    |
 LL |     type F<'a>: Fn() -> u32;
    |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Fn()`
    |
 LL | impl<T: Fn()> Fun for T {
    |       ++++++

--- a/tests/ui/generic-associated-types/issue-68643-broken-mir.stderr
+++ b/tests/ui/generic-associated-types/issue-68643-broken-mir.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Fun::F`
    |
 LL |     type F<'a>: Fn() -> u32;
    |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
-help: consider restricting type parameter `T` with trait `Fn()`
+help: consider restricting type parameter `T` with trait `Fn`
    |
 LL | impl<T: Fn()> Fun for T {
    |       ++++++

--- a/tests/ui/generic-associated-types/issue-68644-codegen-selection.stderr
+++ b/tests/ui/generic-associated-types/issue-68644-codegen-selection.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Fun::F`
    |
 LL |     type F<'a>: Fn() -> u32;
    |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Fn()`
    |
 LL | impl<T: Fn()> Fun for T {
    |       ++++++

--- a/tests/ui/generic-associated-types/issue-68644-codegen-selection.stderr
+++ b/tests/ui/generic-associated-types/issue-68644-codegen-selection.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Fun::F`
    |
 LL |     type F<'a>: Fn() -> u32;
    |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
-help: consider restricting type parameter `T` with trait `Fn()`
+help: consider restricting type parameter `T` with trait `Fn`
    |
 LL | impl<T: Fn()> Fun for T {
    |       ++++++

--- a/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
+++ b/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Fun::F`
    |
 LL |     type F<'a>: Fn() -> u32;
    |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Fn()`
    |
 LL | impl<T: Fn()> Fun for T {
    |       ++++++

--- a/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
+++ b/tests/ui/generic-associated-types/issue-68645-codegen-fulfillment.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Fun::F`
    |
 LL |     type F<'a>: Fn() -> u32;
    |                 ^^^^^^^^^^^ required by this bound in `Fun::F`
-help: consider restricting type parameter `T` with trait `Fn()`
+help: consider restricting type parameter `T` with trait `Fn`
    |
 LL | impl<T: Fn()> Fun for T {
    |       ++++++

--- a/tests/ui/generic-associated-types/issue-68656-unsized-values.stderr
+++ b/tests/ui/generic-associated-types/issue-68656-unsized-values.stderr
@@ -13,7 +13,7 @@ note: required by a bound in `UnsafeCopy::Item`
    |
 LL |     type Item<'a>: std::ops::Deref<Target = T>;
    |                                    ^^^^^^^^^^ required by this bound in `UnsafeCopy::Item`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `<Target = T>`
    |
 LL | impl<T: Copy + std::ops::Deref<Target = T>> UnsafeCopy<T> for T {
    |                               ++++++++++++

--- a/tests/ui/generic-associated-types/issue-68656-unsized-values.stderr
+++ b/tests/ui/generic-associated-types/issue-68656-unsized-values.stderr
@@ -13,7 +13,7 @@ note: required by a bound in `UnsafeCopy::Item`
    |
 LL |     type Item<'a>: std::ops::Deref<Target = T>;
    |                                    ^^^^^^^^^^ required by this bound in `UnsafeCopy::Item`
-help: consider further restricting this bound with trait `<Target = T>`
+help: consider further restricting this bound with  `<Target = T>`
    |
 LL | impl<T: Copy + std::ops::Deref<Target = T>> UnsafeCopy<T> for T {
    |                               ++++++++++++

--- a/tests/ui/generic-associated-types/issue-68656-unsized-values.stderr
+++ b/tests/ui/generic-associated-types/issue-68656-unsized-values.stderr
@@ -13,7 +13,7 @@ note: required by a bound in `UnsafeCopy::Item`
    |
 LL |     type Item<'a>: std::ops::Deref<Target = T>;
    |                                    ^^^^^^^^^^ required by this bound in `UnsafeCopy::Item`
-help: consider further restricting this bound with  `<Target = T>`
+help: consider further restricting this bound
    |
 LL | impl<T: Copy + std::ops::Deref<Target = T>> UnsafeCopy<T> for T {
    |                               ++++++++++++

--- a/tests/ui/generic-associated-types/issue-74824.current.stderr
+++ b/tests/ui/generic-associated-types/issue-74824.current.stderr
@@ -23,7 +23,7 @@ note: required by a bound in `UnsafeCopy::Copy`
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::clone::Clone`
    |
 LL |     type Copy<T: std::clone::Clone>: Copy = Box<T>;
    |                +++++++++++++++++++

--- a/tests/ui/generic-associated-types/issue-74824.current.stderr
+++ b/tests/ui/generic-associated-types/issue-74824.current.stderr
@@ -23,7 +23,7 @@ note: required by a bound in `UnsafeCopy::Copy`
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
-help: consider restricting type parameter `T` with trait `std::clone::Clone`
+help: consider restricting type parameter `T` with trait `Clone`
    |
 LL |     type Copy<T: std::clone::Clone>: Copy = Box<T>;
    |                +++++++++++++++++++

--- a/tests/ui/generic-associated-types/issue-74824.next.stderr
+++ b/tests/ui/generic-associated-types/issue-74824.next.stderr
@@ -23,7 +23,7 @@ note: required by a bound in `UnsafeCopy::Copy`
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::clone::Clone`
    |
 LL |     type Copy<T: std::clone::Clone>: Copy = Box<T>;
    |                +++++++++++++++++++

--- a/tests/ui/generic-associated-types/issue-74824.next.stderr
+++ b/tests/ui/generic-associated-types/issue-74824.next.stderr
@@ -23,7 +23,7 @@ note: required by a bound in `UnsafeCopy::Copy`
    |
 LL |     type Copy<T>: Copy = Box<T>;
    |                   ^^^^ required by this bound in `UnsafeCopy::Copy`
-help: consider restricting type parameter `T` with trait `std::clone::Clone`
+help: consider restricting type parameter `T` with trait `Clone`
    |
 LL |     type Copy<T: std::clone::Clone>: Copy = Box<T>;
    |                +++++++++++++++++++

--- a/tests/ui/generic-associated-types/missing-bounds.stderr
+++ b/tests/ui/generic-associated-types/missing-bounds.stderr
@@ -71,7 +71,7 @@ LL |         Self(self.0 + rhs.0)
    |              |
    |              B
    |
-help: consider restricting type parameter `B` with trait `std::ops::Add<Output = B>`
+help: consider restricting type parameter `B` with trait `Add`
    |
 LL | impl<B: std::ops::Add<Output = B>> Add for D<B> {
    |       +++++++++++++++++++++++++++

--- a/tests/ui/generic-associated-types/missing-bounds.stderr
+++ b/tests/ui/generic-associated-types/missing-bounds.stderr
@@ -35,7 +35,7 @@ note: tuple struct defined here
    |
 LL | struct A<B>(B);
    |        ^
-help: consider further restricting this bound with trait `<Output = B>`
+help: consider further restricting this bound with  `<Output = B>`
    |
 LL | impl<B> Add for A<B> where B: Add<Output = B> {
    |                                  ++++++++++++
@@ -58,7 +58,7 @@ note: tuple struct defined here
    |
 LL | struct C<B>(B);
    |        ^
-help: consider further restricting this bound with trait `<Output = B>`
+help: consider further restricting this bound with  `<Output = B>`
    |
 LL | impl<B: Add<Output = B>> Add for C<B> {
    |            ++++++++++++
@@ -94,7 +94,7 @@ note: tuple struct defined here
    |
 LL | struct E<B>(B);
    |        ^
-help: consider further restricting this bound with trait `<Output = B>`
+help: consider further restricting this bound with  `<Output = B>`
    |
 LL | impl<B: Add<Output = B>> Add for E<B> where <B as Add>::Output = B {
    |            ++++++++++++

--- a/tests/ui/generic-associated-types/missing-bounds.stderr
+++ b/tests/ui/generic-associated-types/missing-bounds.stderr
@@ -35,7 +35,7 @@ note: tuple struct defined here
    |
 LL | struct A<B>(B);
    |        ^
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `<Output = B>`
    |
 LL | impl<B> Add for A<B> where B: Add<Output = B> {
    |                                  ++++++++++++
@@ -58,7 +58,7 @@ note: tuple struct defined here
    |
 LL | struct C<B>(B);
    |        ^
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `<Output = B>`
    |
 LL | impl<B: Add<Output = B>> Add for C<B> {
    |            ++++++++++++
@@ -71,7 +71,7 @@ LL |         Self(self.0 + rhs.0)
    |              |
    |              B
    |
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `std::ops::Add<Output = B>`
    |
 LL | impl<B: std::ops::Add<Output = B>> Add for D<B> {
    |       +++++++++++++++++++++++++++
@@ -94,7 +94,7 @@ note: tuple struct defined here
    |
 LL | struct E<B>(B);
    |        ^
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `<Output = B>`
    |
 LL | impl<B: Add<Output = B>> Add for E<B> where <B as Add>::Output = B {
    |            ++++++++++++

--- a/tests/ui/generic-associated-types/missing-bounds.stderr
+++ b/tests/ui/generic-associated-types/missing-bounds.stderr
@@ -35,7 +35,7 @@ note: tuple struct defined here
    |
 LL | struct A<B>(B);
    |        ^
-help: consider further restricting this bound with  `<Output = B>`
+help: consider further restricting this bound
    |
 LL | impl<B> Add for A<B> where B: Add<Output = B> {
    |                                  ++++++++++++
@@ -58,7 +58,7 @@ note: tuple struct defined here
    |
 LL | struct C<B>(B);
    |        ^
-help: consider further restricting this bound with  `<Output = B>`
+help: consider further restricting this bound
    |
 LL | impl<B: Add<Output = B>> Add for C<B> {
    |            ++++++++++++
@@ -94,7 +94,7 @@ note: tuple struct defined here
    |
 LL | struct E<B>(B);
    |        ^
-help: consider further restricting this bound with  `<Output = B>`
+help: consider further restricting this bound
    |
 LL | impl<B: Add<Output = B>> Add for E<B> where <B as Add>::Output = B {
    |            ++++++++++++

--- a/tests/ui/higher-ranked/structually-relate-aliases.stderr
+++ b/tests/ui/higher-ranked/structually-relate-aliases.stderr
@@ -5,7 +5,7 @@ error[E0277]: the trait bound `for<'a> T: ToUnit<'a>` is not satisfied
 LL | impl<T> Overlap<for<'a> fn(&'a (), Assoc<'a, T>)> for T {}
    |                                    ^^^^^^^^^^^^ the trait `for<'a> ToUnit<'a>` is not implemented for `T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `for<'a> ToUnit<'a>`
    |
 LL | impl<T: for<'a> ToUnit<'a>> Overlap<for<'a> fn(&'a (), Assoc<'a, T>)> for T {}
    |       ++++++++++++++++++++

--- a/tests/ui/higher-ranked/structually-relate-aliases.stderr
+++ b/tests/ui/higher-ranked/structually-relate-aliases.stderr
@@ -5,7 +5,7 @@ error[E0277]: the trait bound `for<'a> T: ToUnit<'a>` is not satisfied
 LL | impl<T> Overlap<for<'a> fn(&'a (), Assoc<'a, T>)> for T {}
    |                                    ^^^^^^^^^^^^ the trait `for<'a> ToUnit<'a>` is not implemented for `T`
    |
-help: consider restricting type parameter `T` with trait `for<'a> ToUnit<'a>`
+help: consider restricting type parameter `T` with trait `ToUnit`
    |
 LL | impl<T: for<'a> ToUnit<'a>> Overlap<for<'a> fn(&'a (), Assoc<'a, T>)> for T {}
    |       ++++++++++++++++++++

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -13,7 +13,7 @@ LL | fn want_bar_for_any_ccx<B>(b: &B)
    |    -------------------- required by a bound in this function
 LL |     where B : for<'ccx> Bar<'ccx>
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_bar_for_any_ccx`
-help: consider further restricting this bound with trait `Bar`
+help: consider further restricting type parameter `B` with trait `Bar`
    |
 LL |     where B : Qux + for<'ccx> Bar<'ccx>
    |                   +++++++++++++++++++++

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -13,7 +13,7 @@ LL | fn want_bar_for_any_ccx<B>(b: &B)
    |    -------------------- required by a bound in this function
 LL |     where B : for<'ccx> Bar<'ccx>
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_bar_for_any_ccx`
-help: consider further restricting this bound with trait `for<'ccx> Bar<'ccx>`
+help: consider further restricting this bound with trait `Bar`
    |
 LL |     where B : Qux + for<'ccx> Bar<'ccx>
    |                   +++++++++++++++++++++

--- a/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits-transitive.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/hrtb-higher-ranker-supertraits-transitive.stderr
@@ -13,7 +13,7 @@ LL | fn want_bar_for_any_ccx<B>(b: &B)
    |    -------------------- required by a bound in this function
 LL |     where B : for<'ccx> Bar<'ccx>
    |               ^^^^^^^^^^^^^^^^^^^ required by this bound in `want_bar_for_any_ccx`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `for<'ccx> Bar<'ccx>`
    |
 LL |     where B : Qux + for<'ccx> Bar<'ccx>
    |                   +++++++++++++++++++++

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-85455.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-85455.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `for<'a> T: SomeTrait<'a>` is not satisfied
 LL |     callee::<fn(&()) -> <T as SomeTrait<'_>>::Associated>();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> SomeTrait<'a>` is not implemented for `T`
    |
-help: consider restricting type parameter `T` with trait `for<'a> SomeTrait<'a>`
+help: consider restricting type parameter `T` with trait `SomeTrait`
    |
 LL | fn give_me_ice<T: for<'a> SomeTrait<'a>>() {
    |                 +++++++++++++++++++++++
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `for<'a> T: SomeTrait<'a>` is not satisfied
 LL |     callee::<fn(&()) -> <T as SomeTrait<'_>>::Associated>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> SomeTrait<'a>` is not implemented for `T`
    |
-help: consider restricting type parameter `T` with trait `for<'a> SomeTrait<'a>`
+help: consider restricting type parameter `T` with trait `SomeTrait`
    |
 LL | fn give_me_ice<T: for<'a> SomeTrait<'a>>() {
    |                 +++++++++++++++++++++++

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-85455.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/issue-85455.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `for<'a> T: SomeTrait<'a>` is not satisfied
 LL |     callee::<fn(&()) -> <T as SomeTrait<'_>>::Associated>();
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> SomeTrait<'a>` is not implemented for `T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `for<'a> SomeTrait<'a>`
    |
 LL | fn give_me_ice<T: for<'a> SomeTrait<'a>>() {
    |                 +++++++++++++++++++++++
@@ -15,7 +15,7 @@ error[E0277]: the trait bound `for<'a> T: SomeTrait<'a>` is not satisfied
 LL |     callee::<fn(&()) -> <T as SomeTrait<'_>>::Associated>();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> SomeTrait<'a>` is not implemented for `T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `for<'a> SomeTrait<'a>`
    |
 LL | fn give_me_ice<T: for<'a> SomeTrait<'a>>() {
    |                 +++++++++++++++++++++++

--- a/tests/ui/impl-trait/in-trait/false-positive-predicate-entailment-error.current.stderr
+++ b/tests/ui/impl-trait/in-trait/false-positive-predicate-entailment-error.current.stderr
@@ -17,7 +17,7 @@ LL | impl<A, F: MyFn<A>> Callback<A> for F {
    |            -------  ^^^^^^^^^^^     ^
    |            |
    |            unsatisfied trait bound introduced here
-help: consider further restricting this bound with trait `MyFn`
+help: consider further restricting type parameter `F` with trait `MyFn`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
@@ -43,7 +43,7 @@ LL |     fn autobatch<F>(self) -> impl Trait
 ...
 LL |         F: Callback<Self::CallbackArg>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `<Sender as ChannelSender>::autobatch`
-help: consider further restricting this bound with trait `MyFn`
+help: consider further restricting type parameter `F` with trait `MyFn`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
@@ -68,7 +68,7 @@ LL | impl<A, F: MyFn<A>> Callback<A> for F {
    |            |
    |            unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider further restricting this bound with trait `MyFn`
+help: consider further restricting type parameter `F` with trait `MyFn`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
@@ -121,7 +121,7 @@ LL | impl<A, F: MyFn<A>> Callback<A> for F {
    |            |
    |            unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider further restricting this bound with trait `MyFn`
+help: consider further restricting type parameter `F` with trait `MyFn`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
@@ -137,7 +137,7 @@ note: required by a bound in `Callback`
    |
 LL | trait Callback<A>: MyFn<A, Output = Self::Ret> {
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Callback`
-help: consider further restricting this bound with trait `MyFn`
+help: consider further restricting type parameter `F` with trait `MyFn`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++

--- a/tests/ui/impl-trait/in-trait/false-positive-predicate-entailment-error.current.stderr
+++ b/tests/ui/impl-trait/in-trait/false-positive-predicate-entailment-error.current.stderr
@@ -17,7 +17,7 @@ LL | impl<A, F: MyFn<A>> Callback<A> for F {
    |            -------  ^^^^^^^^^^^     ^
    |            |
    |            unsatisfied trait bound introduced here
-help: consider further restricting this bound with trait `MyFn<i32>`
+help: consider further restricting this bound with trait `MyFn`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
@@ -43,7 +43,7 @@ LL |     fn autobatch<F>(self) -> impl Trait
 ...
 LL |         F: Callback<Self::CallbackArg>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `<Sender as ChannelSender>::autobatch`
-help: consider further restricting this bound with trait `MyFn<i32>`
+help: consider further restricting this bound with trait `MyFn`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
@@ -68,7 +68,7 @@ LL | impl<A, F: MyFn<A>> Callback<A> for F {
    |            |
    |            unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider further restricting this bound with trait `MyFn<i32>`
+help: consider further restricting this bound with trait `MyFn`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
@@ -121,7 +121,7 @@ LL | impl<A, F: MyFn<A>> Callback<A> for F {
    |            |
    |            unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider further restricting this bound with trait `MyFn<i32>`
+help: consider further restricting this bound with trait `MyFn`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
@@ -137,7 +137,7 @@ note: required by a bound in `Callback`
    |
 LL | trait Callback<A>: MyFn<A, Output = Self::Ret> {
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Callback`
-help: consider further restricting this bound with trait `MyFn<i32>`
+help: consider further restricting this bound with trait `MyFn`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++

--- a/tests/ui/impl-trait/in-trait/false-positive-predicate-entailment-error.current.stderr
+++ b/tests/ui/impl-trait/in-trait/false-positive-predicate-entailment-error.current.stderr
@@ -17,7 +17,7 @@ LL | impl<A, F: MyFn<A>> Callback<A> for F {
    |            -------  ^^^^^^^^^^^     ^
    |            |
    |            unsatisfied trait bound introduced here
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `MyFn<i32>`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
@@ -43,7 +43,7 @@ LL |     fn autobatch<F>(self) -> impl Trait
 ...
 LL |         F: Callback<Self::CallbackArg>,
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `<Sender as ChannelSender>::autobatch`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `MyFn<i32>`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
@@ -68,7 +68,7 @@ LL | impl<A, F: MyFn<A>> Callback<A> for F {
    |            |
    |            unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `MyFn<i32>`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
@@ -121,7 +121,7 @@ LL | impl<A, F: MyFn<A>> Callback<A> for F {
    |            |
    |            unsatisfied trait bound introduced here
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `MyFn<i32>`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++
@@ -137,7 +137,7 @@ note: required by a bound in `Callback`
    |
 LL | trait Callback<A>: MyFn<A, Output = Self::Ret> {
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Callback`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `MyFn<i32>`
    |
 LL |         F: Callback<Self::CallbackArg> + MyFn<i32>,
    |                                        +++++++++++

--- a/tests/ui/impl-trait/issue-55872-1.stderr
+++ b/tests/ui/impl-trait/issue-55872-1.stderr
@@ -17,7 +17,7 @@ LL |         (S::default(), T::default())
    |         ---------------------------- return type was inferred to be `(S, T)` here
    |
    = note: required because it appears within the type `(S, T)`
-help: consider further restricting this bound with trait `std::marker::Copy`
+help: consider further restricting this bound with trait `Copy`
    |
 LL | impl<S: Default + std::marker::Copy> Bar for S {
    |                 +++++++++++++++++++
@@ -32,7 +32,7 @@ LL |         (S::default(), T::default())
    |         ---------------------------- return type was inferred to be `(S, T)` here
    |
    = note: required because it appears within the type `(S, T)`
-help: consider further restricting this bound with trait `std::marker::Copy`
+help: consider further restricting this bound with trait `Copy`
    |
 LL |     fn foo<T: Default + std::marker::Copy>() -> Self::E {
    |                       +++++++++++++++++++

--- a/tests/ui/impl-trait/issue-55872-1.stderr
+++ b/tests/ui/impl-trait/issue-55872-1.stderr
@@ -17,7 +17,7 @@ LL |         (S::default(), T::default())
    |         ---------------------------- return type was inferred to be `(S, T)` here
    |
    = note: required because it appears within the type `(S, T)`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Copy`
    |
 LL | impl<S: Default + std::marker::Copy> Bar for S {
    |                 +++++++++++++++++++
@@ -32,7 +32,7 @@ LL |         (S::default(), T::default())
    |         ---------------------------- return type was inferred to be `(S, T)` here
    |
    = note: required because it appears within the type `(S, T)`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Copy`
    |
 LL |     fn foo<T: Default + std::marker::Copy>() -> Self::E {
    |                       +++++++++++++++++++

--- a/tests/ui/impl-trait/issue-55872-1.stderr
+++ b/tests/ui/impl-trait/issue-55872-1.stderr
@@ -17,7 +17,7 @@ LL |         (S::default(), T::default())
    |         ---------------------------- return type was inferred to be `(S, T)` here
    |
    = note: required because it appears within the type `(S, T)`
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `S` with trait `Copy`
    |
 LL | impl<S: Default + std::marker::Copy> Bar for S {
    |                 +++++++++++++++++++
@@ -32,7 +32,7 @@ LL |         (S::default(), T::default())
    |         ---------------------------- return type was inferred to be `(S, T)` here
    |
    = note: required because it appears within the type `(S, T)`
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL |     fn foo<T: Default + std::marker::Copy>() -> Self::E {
    |                       +++++++++++++++++++

--- a/tests/ui/impl-trait/normalize-tait-in-const.stderr
+++ b/tests/ui/impl-trait/normalize-tait-in-const.stderr
@@ -33,7 +33,7 @@ LL |     fun(filter_positive());
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const Fn(&foo::Alias<'_>)`
    |
 LL | const fn with_positive<F: for<'a> ~const Fn(&'a Alias<'a>) + ~const Destruct + ~const Fn(&foo::Alias<'_>)>(fun: F) {
    |                                                                              ++++++++++++++++++++++++++++

--- a/tests/ui/impl-trait/normalize-tait-in-const.stderr
+++ b/tests/ui/impl-trait/normalize-tait-in-const.stderr
@@ -33,10 +33,6 @@ LL |     fun(filter_positive());
    |     ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const Fn(&foo::Alias<'_>)`
-   |
-LL | const fn with_positive<F: for<'a> ~const Fn(&'a Alias<'a>) + ~const Destruct + ~const Fn(&foo::Alias<'_>)>(fun: F) {
-   |                                                                              ++++++++++++++++++++++++++++
 
 error: aborting due to 4 previous errors
 

--- a/tests/ui/issues/issue-6738.stderr
+++ b/tests/ui/issues/issue-6738.stderr
@@ -6,7 +6,7 @@ LL |         self.x += v.x;
    |         |
    |         cannot use `+=` on type `T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::ops::AddAssign`
    |
 LL | impl<T: std::ops::AddAssign> Foo<T> {
    |       +++++++++++++++++++++

--- a/tests/ui/issues/issue-6738.stderr
+++ b/tests/ui/issues/issue-6738.stderr
@@ -6,7 +6,7 @@ LL |         self.x += v.x;
    |         |
    |         cannot use `+=` on type `T`
    |
-help: consider restricting type parameter `T` with trait `std::ops::AddAssign`
+help: consider restricting type parameter `T` with trait `AddAssign`
    |
 LL | impl<T: std::ops::AddAssign> Foo<T> {
    |       +++++++++++++++++++++

--- a/tests/ui/kindck/kindck-impl-type-params.stderr
+++ b/tests/ui/kindck/kindck-impl-type-params.stderr
@@ -12,7 +12,7 @@ LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |         |
    |         unsatisfied trait bound introduced here
    = note: required for the cast from `&S<T>` to `&dyn Gettable<T>`
-help: consider restricting type parameter `T` with trait `std::marker::Send`
+help: consider restricting type parameter `T` with trait `Send`
    |
 LL | fn f<T: std::marker::Send>(val: T) {
    |       +++++++++++++++++++
@@ -31,7 +31,7 @@ LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |                |
    |                unsatisfied trait bound introduced here
    = note: required for the cast from `&S<T>` to `&dyn Gettable<T>`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | fn f<T: std::marker::Copy>(val: T) {
    |       +++++++++++++++++++
@@ -50,7 +50,7 @@ LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |         |
    |         unsatisfied trait bound introduced here
    = note: required for the cast from `&S<T>` to `&dyn Gettable<T>`
-help: consider restricting type parameter `T` with trait `std::marker::Send`
+help: consider restricting type parameter `T` with trait `Send`
    |
 LL | fn g<T: std::marker::Send>(val: T) {
    |       +++++++++++++++++++
@@ -69,7 +69,7 @@ LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |                |
    |                unsatisfied trait bound introduced here
    = note: required for the cast from `&S<T>` to `&dyn Gettable<T>`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | fn g<T: std::marker::Copy>(val: T) {
    |       +++++++++++++++++++

--- a/tests/ui/kindck/kindck-impl-type-params.stderr
+++ b/tests/ui/kindck/kindck-impl-type-params.stderr
@@ -12,7 +12,7 @@ LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |         |
    |         unsatisfied trait bound introduced here
    = note: required for the cast from `&S<T>` to `&dyn Gettable<T>`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Send`
    |
 LL | fn f<T: std::marker::Send>(val: T) {
    |       +++++++++++++++++++
@@ -31,7 +31,7 @@ LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |                |
    |                unsatisfied trait bound introduced here
    = note: required for the cast from `&S<T>` to `&dyn Gettable<T>`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | fn f<T: std::marker::Copy>(val: T) {
    |       +++++++++++++++++++
@@ -50,7 +50,7 @@ LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |         |
    |         unsatisfied trait bound introduced here
    = note: required for the cast from `&S<T>` to `&dyn Gettable<T>`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Send`
    |
 LL | fn g<T: std::marker::Send>(val: T) {
    |       +++++++++++++++++++
@@ -69,7 +69,7 @@ LL | impl<T: Send + Copy + 'static> Gettable<T> for S<T> {}
    |                |
    |                unsatisfied trait bound introduced here
    = note: required for the cast from `&S<T>` to `&dyn Gettable<T>`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | fn g<T: std::marker::Copy>(val: T) {
    |       +++++++++++++++++++

--- a/tests/ui/layout/rust-call-abi-not-a-tuple-ice-81974.stderr
+++ b/tests/ui/layout/rust-call-abi-not-a-tuple-ice-81974.stderr
@@ -6,7 +6,7 @@ LL | impl<A, B> FnOnce<A> for CachedFun<A, B>
    |
 note: required by a bound in `FnOnce`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting this bound but it is an `unstable` trait
+help: consider further restricting this bound with unstable trait `std::marker::Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -19,7 +19,7 @@ LL | impl<A, B> FnMut<A> for CachedFun<A, B>
    |
 note: required by a bound in `FnMut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting this bound but it is an `unstable` trait
+help: consider further restricting this bound with unstable trait `std::marker::Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -30,7 +30,7 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
 LL |     extern "rust-call" fn call_once(mut self, a: A) -> Self::Output {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `A`
    |
-help: consider further restricting this bound but it is an `unstable` trait
+help: consider further restricting this bound with unstable trait `std::marker::Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -41,7 +41,7 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
 LL |     extern "rust-call" fn call_mut(&mut self, a: A) -> Self::Output {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `A`
    |
-help: consider further restricting this bound but it is an `unstable` trait
+help: consider further restricting this bound with unstable trait `std::marker::Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -56,7 +56,7 @@ LL |         self.call_mut(a)
    |
 note: required by a bound in `call_mut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting this bound but it is an `unstable` trait
+help: consider further restricting this bound with unstable trait `std::marker::Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++

--- a/tests/ui/layout/rust-call-abi-not-a-tuple-ice-81974.stderr
+++ b/tests/ui/layout/rust-call-abi-not-a-tuple-ice-81974.stderr
@@ -6,7 +6,7 @@ LL | impl<A, B> FnOnce<A> for CachedFun<A, B>
    |
 note: required by a bound in `FnOnce`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting this bound with unstable trait `std::marker::Tuple`
+help: consider further restricting this bound with unstable trait `Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -19,7 +19,7 @@ LL | impl<A, B> FnMut<A> for CachedFun<A, B>
    |
 note: required by a bound in `FnMut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting this bound with unstable trait `std::marker::Tuple`
+help: consider further restricting this bound with unstable trait `Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -30,7 +30,7 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
 LL |     extern "rust-call" fn call_once(mut self, a: A) -> Self::Output {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `A`
    |
-help: consider further restricting this bound with unstable trait `std::marker::Tuple`
+help: consider further restricting this bound with unstable trait `Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -41,7 +41,7 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
 LL |     extern "rust-call" fn call_mut(&mut self, a: A) -> Self::Output {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `A`
    |
-help: consider further restricting this bound with unstable trait `std::marker::Tuple`
+help: consider further restricting this bound with unstable trait `Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -56,7 +56,7 @@ LL |         self.call_mut(a)
    |
 note: required by a bound in `call_mut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting this bound with unstable trait `std::marker::Tuple`
+help: consider further restricting this bound with unstable trait `Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++

--- a/tests/ui/layout/rust-call-abi-not-a-tuple-ice-81974.stderr
+++ b/tests/ui/layout/rust-call-abi-not-a-tuple-ice-81974.stderr
@@ -6,7 +6,7 @@ LL | impl<A, B> FnOnce<A> for CachedFun<A, B>
    |
 note: required by a bound in `FnOnce`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound but it is an `unstable` trait
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -19,7 +19,7 @@ LL | impl<A, B> FnMut<A> for CachedFun<A, B>
    |
 note: required by a bound in `FnMut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound but it is an `unstable` trait
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -30,7 +30,7 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
 LL |     extern "rust-call" fn call_once(mut self, a: A) -> Self::Output {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `A`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound but it is an `unstable` trait
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -41,7 +41,7 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
 LL |     extern "rust-call" fn call_mut(&mut self, a: A) -> Self::Output {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `A`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound but it is an `unstable` trait
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -56,7 +56,7 @@ LL |         self.call_mut(a)
    |
 note: required by a bound in `call_mut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound but it is an `unstable` trait
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++

--- a/tests/ui/layout/rust-call-abi-not-a-tuple-ice-81974.stderr
+++ b/tests/ui/layout/rust-call-abi-not-a-tuple-ice-81974.stderr
@@ -6,7 +6,7 @@ LL | impl<A, B> FnOnce<A> for CachedFun<A, B>
    |
 note: required by a bound in `FnOnce`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting this bound with unstable trait `Tuple`
+help: consider further restricting type parameter `A` with unstable trait `Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -19,7 +19,7 @@ LL | impl<A, B> FnMut<A> for CachedFun<A, B>
    |
 note: required by a bound in `FnMut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting this bound with unstable trait `Tuple`
+help: consider further restricting type parameter `A` with unstable trait `Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -30,7 +30,7 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
 LL |     extern "rust-call" fn call_once(mut self, a: A) -> Self::Output {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `A`
    |
-help: consider further restricting this bound with unstable trait `Tuple`
+help: consider further restricting type parameter `A` with unstable trait `Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -41,7 +41,7 @@ error[E0277]: functions with the "rust-call" ABI must take a single non-self tup
 LL |     extern "rust-call" fn call_mut(&mut self, a: A) -> Self::Output {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Tuple` is not implemented for `A`
    |
-help: consider further restricting this bound with unstable trait `Tuple`
+help: consider further restricting type parameter `A` with unstable trait `Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++
@@ -56,7 +56,7 @@ LL |         self.call_mut(a)
    |
 note: required by a bound in `call_mut`
   --> $SRC_DIR/core/src/ops/function.rs:LL:COL
-help: consider further restricting this bound with unstable trait `Tuple`
+help: consider further restricting type parameter `A` with unstable trait `Tuple`
    |
 LL |     A: Eq + Hash + Clone + std::marker::Tuple,
    |                          ++++++++++++++++++++

--- a/tests/ui/lazy-type-alias/unsatisfied-bounds-type-alias-body.stderr
+++ b/tests/ui/lazy-type-alias/unsatisfied-bounds-type-alias-body.stderr
@@ -4,7 +4,7 @@ error[E0277]: cannot multiply `T` by `T`
 LL | type Alias<T> = <T as std::ops::Mul>::Output;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `T * T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::ops::Mul`
    |
 LL | type Alias<T: std::ops::Mul> = <T as std::ops::Mul>::Output;
    |             +++++++++++++++

--- a/tests/ui/lazy-type-alias/unsatisfied-bounds-type-alias-body.stderr
+++ b/tests/ui/lazy-type-alias/unsatisfied-bounds-type-alias-body.stderr
@@ -4,7 +4,7 @@ error[E0277]: cannot multiply `T` by `T`
 LL | type Alias<T> = <T as std::ops::Mul>::Output;
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no implementation for `T * T`
    |
-help: consider restricting type parameter `T` with trait `std::ops::Mul`
+help: consider restricting type parameter `T` with trait `Mul`
    |
 LL | type Alias<T: std::ops::Mul> = <T as std::ops::Mul>::Output;
    |             +++++++++++++++

--- a/tests/ui/methods/filter-relevant-fn-bounds.stderr
+++ b/tests/ui/methods/filter-relevant-fn-bounds.stderr
@@ -8,7 +8,7 @@ LL | |     where
 LL | |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
    | |___________________________________________________^ the trait `for<'a> Output<'a>` is not implemented for `F`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `for<'a> Output<'a>`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
    |                                                    ++++++++++++++++++++
@@ -19,7 +19,7 @@ error[E0277]: the trait bound `for<'a> F: Output<'a>` is not satisfied
 LL |     fn do_something_wrapper<O, F>(self, _: F)
    |        ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Output<'a>` is not implemented for `F`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `for<'a> Output<'a>`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
    |                                                    ++++++++++++++++++++
@@ -30,7 +30,7 @@ error[E0277]: the trait bound `F: Output<'_>` is not satisfied
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Output<'_>` is not implemented for `F`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Output<'_>`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + Output<'_>,
    |                                                    ++++++++++++
@@ -41,7 +41,7 @@ error[E0277]: the trait bound `F: Output<'_>` is not satisfied
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Output<'_>` is not implemented for `F`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Output<'_>`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + Output<'_>,
    |                                                    ++++++++++++

--- a/tests/ui/methods/filter-relevant-fn-bounds.stderr
+++ b/tests/ui/methods/filter-relevant-fn-bounds.stderr
@@ -8,7 +8,7 @@ LL | |     where
 LL | |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
    | |___________________________________________________^ the trait `for<'a> Output<'a>` is not implemented for `F`
    |
-help: consider further restricting this bound with trait `for<'a> Output<'a>`
+help: consider further restricting this bound with trait `Output`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
    |                                                    ++++++++++++++++++++
@@ -19,7 +19,7 @@ error[E0277]: the trait bound `for<'a> F: Output<'a>` is not satisfied
 LL |     fn do_something_wrapper<O, F>(self, _: F)
    |        ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Output<'a>` is not implemented for `F`
    |
-help: consider further restricting this bound with trait `for<'a> Output<'a>`
+help: consider further restricting this bound with trait `Output`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
    |                                                    ++++++++++++++++++++
@@ -30,7 +30,7 @@ error[E0277]: the trait bound `F: Output<'_>` is not satisfied
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Output<'_>` is not implemented for `F`
    |
-help: consider further restricting this bound with trait `Output<'_>`
+help: consider further restricting this bound with trait `Output`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + Output<'_>,
    |                                                    ++++++++++++
@@ -41,7 +41,7 @@ error[E0277]: the trait bound `F: Output<'_>` is not satisfied
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Output<'_>` is not implemented for `F`
    |
-help: consider further restricting this bound with trait `Output<'_>`
+help: consider further restricting this bound with trait `Output`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + Output<'_>,
    |                                                    ++++++++++++

--- a/tests/ui/methods/filter-relevant-fn-bounds.stderr
+++ b/tests/ui/methods/filter-relevant-fn-bounds.stderr
@@ -8,7 +8,7 @@ LL | |     where
 LL | |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
    | |___________________________________________________^ the trait `for<'a> Output<'a>` is not implemented for `F`
    |
-help: consider further restricting this bound with trait `Output`
+help: consider further restricting type parameter `F` with trait `Output`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
    |                                                    ++++++++++++++++++++
@@ -19,7 +19,7 @@ error[E0277]: the trait bound `for<'a> F: Output<'a>` is not satisfied
 LL |     fn do_something_wrapper<O, F>(self, _: F)
    |        ^^^^^^^^^^^^^^^^^^^^ the trait `for<'a> Output<'a>` is not implemented for `F`
    |
-help: consider further restricting this bound with trait `Output`
+help: consider further restricting type parameter `F` with trait `Output`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + for<'a> Output<'a>,
    |                                                    ++++++++++++++++++++
@@ -30,7 +30,7 @@ error[E0277]: the trait bound `F: Output<'_>` is not satisfied
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Output<'_>` is not implemented for `F`
    |
-help: consider further restricting this bound with trait `Output`
+help: consider further restricting type parameter `F` with trait `Output`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + Output<'_>,
    |                                                    ++++++++++++
@@ -41,7 +41,7 @@ error[E0277]: the trait bound `F: Output<'_>` is not satisfied
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type),
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Output<'_>` is not implemented for `F`
    |
-help: consider further restricting this bound with trait `Output`
+help: consider further restricting type parameter `F` with trait `Output`
    |
 LL |         F: for<'a> FnOnce(<F as Output<'a>>::Type) + Output<'_>,
    |                                                    ++++++++++++

--- a/tests/ui/mir/validate/validate-unsize-cast.stderr
+++ b/tests/ui/mir/validate/validate-unsize-cast.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `CastTo`
    |
 LL | pub trait CastTo<U: ?Sized>: Unsize<U> {}
    |                              ^^^^^^^^^ required by this bound in `CastTo`
-help: consider further restricting this bound
+help: consider further restricting this bound but it is an `unstable` trait
    |
 LL | impl<T: ?Sized + std::marker::Unsize<U>, U: ?Sized> CastTo<U> for T {}
    |                ++++++++++++++++++++++++

--- a/tests/ui/mir/validate/validate-unsize-cast.stderr
+++ b/tests/ui/mir/validate/validate-unsize-cast.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `CastTo`
    |
 LL | pub trait CastTo<U: ?Sized>: Unsize<U> {}
    |                              ^^^^^^^^^ required by this bound in `CastTo`
-help: consider further restricting this bound but it is an `unstable` trait
+help: consider further restricting this bound with unstable trait `std::marker::Unsize<U>`
    |
 LL | impl<T: ?Sized + std::marker::Unsize<U>, U: ?Sized> CastTo<U> for T {}
    |                ++++++++++++++++++++++++

--- a/tests/ui/mir/validate/validate-unsize-cast.stderr
+++ b/tests/ui/mir/validate/validate-unsize-cast.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `CastTo`
    |
 LL | pub trait CastTo<U: ?Sized>: Unsize<U> {}
    |                              ^^^^^^^^^ required by this bound in `CastTo`
-help: consider further restricting this bound with unstable trait `std::marker::Unsize<U>`
+help: consider further restricting this bound with unstable trait `Unsize`
    |
 LL | impl<T: ?Sized + std::marker::Unsize<U>, U: ?Sized> CastTo<U> for T {}
    |                ++++++++++++++++++++++++

--- a/tests/ui/mir/validate/validate-unsize-cast.stderr
+++ b/tests/ui/mir/validate/validate-unsize-cast.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `CastTo`
    |
 LL | pub trait CastTo<U: ?Sized>: Unsize<U> {}
    |                              ^^^^^^^^^ required by this bound in `CastTo`
-help: consider further restricting this bound with unstable trait `Unsize`
+help: consider further restricting type parameter `T` with unstable trait `Unsize`
    |
 LL | impl<T: ?Sized + std::marker::Unsize<U>, U: ?Sized> CastTo<U> for T {}
    |                ++++++++++++++++++++++++

--- a/tests/ui/missing-trait-bounds/missing-trait-bound-for-op.stderr
+++ b/tests/ui/missing-trait-bounds/missing-trait-bound-for-op.stderr
@@ -6,7 +6,7 @@ LL |     let _ = s == t;
    |             |
    |             &[T]
    |
-help: consider restricting type parameter `T` with trait `std::cmp::PartialEq`
+help: consider restricting type parameter `T` with trait `PartialEq`
    |
 LL | pub fn foo<T: std::cmp::PartialEq>(s: &[T], t: &[T]) {
    |             +++++++++++++++++++++

--- a/tests/ui/missing-trait-bounds/missing-trait-bound-for-op.stderr
+++ b/tests/ui/missing-trait-bounds/missing-trait-bound-for-op.stderr
@@ -6,7 +6,7 @@ LL |     let _ = s == t;
    |             |
    |             &[T]
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::cmp::PartialEq`
    |
 LL | pub fn foo<T: std::cmp::PartialEq>(s: &[T], t: &[T]) {
    |             +++++++++++++++++++++

--- a/tests/ui/moves/issue-34721.stderr
+++ b/tests/ui/moves/issue-34721.stderr
@@ -18,7 +18,7 @@ note: `Foo::zero` takes ownership of the receiver `self`, which moves `x`
    |
 LL |     fn zero(self) -> Self;
    |             ^^^^
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL |     pub fn baz<T: Foo + Copy>(x: T) -> T {
    |                       ++++++

--- a/tests/ui/moves/issue-34721.stderr
+++ b/tests/ui/moves/issue-34721.stderr
@@ -18,7 +18,7 @@ note: `Foo::zero` takes ownership of the receiver `self`, which moves `x`
    |
 LL |     fn zero(self) -> Self;
    |             ^^^^
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL |     pub fn baz<T: Foo + Copy>(x: T) -> T {
    |                       ++++++

--- a/tests/ui/moves/use_of_moved_value_copy_suggestions.fixed
+++ b/tests/ui/moves/use_of_moved_value_copy_suggestions.fixed
@@ -48,7 +48,7 @@ fn duplicate_custom_1<T: Copy + Trait>(t: S<T>) -> (S<T>, S<T>) where {
 fn duplicate_custom_2<T>(t: S<T>) -> (S<T>, S<T>)
 where
     T: A + Copy + Trait,
-    //~^ HELP consider further restricting this bound
+    //~^ HELP consider further restricting
 {
     (t, t) //~ use of moved value: `t`
 }
@@ -56,14 +56,14 @@ where
 fn duplicate_custom_3<T>(t: S<T>) -> (S<T>, S<T>)
 where
     T: A + Copy + Trait,
-    //~^ HELP consider further restricting this bound
+    //~^ HELP consider further restricting
     T: B,
 {
     (t, t) //~ use of moved value: `t`
 }
 
 fn duplicate_custom_4<T: A + Copy + Trait>(t: S<T>) -> (S<T>, S<T>)
-//~^ HELP consider further restricting this bound
+//~^ HELP consider further restricting
 where
     T: B,
 {

--- a/tests/ui/moves/use_of_moved_value_copy_suggestions.rs
+++ b/tests/ui/moves/use_of_moved_value_copy_suggestions.rs
@@ -48,7 +48,7 @@ fn duplicate_custom_1<T>(t: S<T>) -> (S<T>, S<T>) where {
 fn duplicate_custom_2<T>(t: S<T>) -> (S<T>, S<T>)
 where
     T: A,
-    //~^ HELP consider further restricting this bound
+    //~^ HELP consider further restricting
 {
     (t, t) //~ use of moved value: `t`
 }
@@ -56,14 +56,14 @@ where
 fn duplicate_custom_3<T>(t: S<T>) -> (S<T>, S<T>)
 where
     T: A,
-    //~^ HELP consider further restricting this bound
+    //~^ HELP consider further restricting
     T: B,
 {
     (t, t) //~ use of moved value: `t`
 }
 
 fn duplicate_custom_4<T: A>(t: S<T>) -> (S<T>, S<T>)
-//~^ HELP consider further restricting this bound
+//~^ HELP consider further restricting
 where
     T: B,
 {

--- a/tests/ui/moves/use_of_moved_value_copy_suggestions.stderr
+++ b/tests/ui/moves/use_of_moved_value_copy_suggestions.stderr
@@ -81,7 +81,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider restricting type parameter `T` with traits `Copy + Trait`
+help: consider restricting type parameter `T` with traits `Copy` and `Trait`
    |
 LL | fn duplicate_custom<T: Copy + Trait>(t: S<T>) -> (S<T>, S<T>) {
    |                      ++++++++++++++
@@ -97,7 +97,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider restricting type parameter `T` with traits `Copy + Trait`
+help: consider restricting type parameter `T` with traits `Copy` and `Trait`
    |
 LL | fn duplicate_custom_1<T: Copy + Trait>(t: S<T>) -> (S<T>, S<T>) where {
    |                        ++++++++++++++
@@ -113,7 +113,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider further restricting this bound with traits `Copy + Trait`
+help: consider further restricting this bound with traits `Copy` and `Trait`
    |
 LL |     T: A + Copy + Trait,
    |          ++++++++++++++
@@ -129,7 +129,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider further restricting this bound with traits `Copy + Trait`
+help: consider further restricting this bound with traits `Copy` and `Trait`
    |
 LL |     T: A + Copy + Trait,
    |          ++++++++++++++
@@ -145,7 +145,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider further restricting this bound with traits `Copy + Trait`
+help: consider further restricting this bound with traits `Copy` and `Trait`
    |
 LL | fn duplicate_custom_4<T: A + Copy + Trait>(t: S<T>) -> (S<T>, S<T>)
    |                            ++++++++++++++

--- a/tests/ui/moves/use_of_moved_value_copy_suggestions.stderr
+++ b/tests/ui/moves/use_of_moved_value_copy_suggestions.stderr
@@ -17,7 +17,7 @@ LL | fn duplicate_t<T>(t: T) -> (T, T) {
 ...
 LL |     (t, t)
    |      - you could clone this value
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | fn duplicate_t<T: Copy>(t: T) -> (T, T) {
    |                 ++++++
@@ -33,7 +33,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | fn duplicate_opt<T: Copy>(t: Option<T>) -> (Option<T>, Option<T>) {
    |                   ++++++
@@ -49,7 +49,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | fn duplicate_tup1<T: Copy>(t: (T,)) -> ((T,), (T,)) {
    |                    ++++++
@@ -81,7 +81,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with traits `Copy + Trait`
    |
 LL | fn duplicate_custom<T: Copy + Trait>(t: S<T>) -> (S<T>, S<T>) {
    |                      ++++++++++++++
@@ -97,7 +97,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with traits `Copy + Trait`
    |
 LL | fn duplicate_custom_1<T: Copy + Trait>(t: S<T>) -> (S<T>, S<T>) where {
    |                        ++++++++++++++
@@ -113,7 +113,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with traits `Copy + Trait`
    |
 LL |     T: A + Copy + Trait,
    |          ++++++++++++++
@@ -129,7 +129,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with traits `Copy + Trait`
    |
 LL |     T: A + Copy + Trait,
    |          ++++++++++++++
@@ -145,7 +145,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with traits `Copy + Trait`
    |
 LL | fn duplicate_custom_4<T: A + Copy + Trait>(t: S<T>) -> (S<T>, S<T>)
    |                            ++++++++++++++
@@ -169,7 +169,7 @@ LL | fn existing_colon<T:>(t: T) {
 ...
 LL |     [t, t];
    |      - you could clone this value
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | fn existing_colon<T: Copy>(t: T) {
    |                      ++++
@@ -193,7 +193,7 @@ LL | fn existing_colon_in_where<T>(t: T)
 ...
 LL |     [t, t];
    |      - you could clone this value
-help: consider further restricting type parameter `T`
+help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL |     T:, T: Copy
    |       ~~~~~~~~~

--- a/tests/ui/moves/use_of_moved_value_copy_suggestions.stderr
+++ b/tests/ui/moves/use_of_moved_value_copy_suggestions.stderr
@@ -113,7 +113,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider further restricting this bound with traits `Copy` and `Trait`
+help: consider further restricting type parameter `T` with traits `Copy` and `Trait`
    |
 LL |     T: A + Copy + Trait,
    |          ++++++++++++++
@@ -129,7 +129,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider further restricting this bound with traits `Copy` and `Trait`
+help: consider further restricting type parameter `T` with traits `Copy` and `Trait`
    |
 LL |     T: A + Copy + Trait,
    |          ++++++++++++++
@@ -145,7 +145,7 @@ LL |     (t, t)
    |      |
    |      value moved here
    |
-help: consider further restricting this bound with traits `Copy` and `Trait`
+help: consider further restricting type parameter `T` with traits `Copy` and `Trait`
    |
 LL | fn duplicate_custom_4<T: A + Copy + Trait>(t: S<T>) -> (S<T>, S<T>)
    |                            ++++++++++++++

--- a/tests/ui/phantom-auto-trait.stderr
+++ b/tests/ui/phantom-auto-trait.stderr
@@ -23,7 +23,7 @@ note: required by a bound in `is_zen`
    |
 LL | fn is_zen<T: Zen>(_: T) {}
    |              ^^^ required by this bound in `is_zen`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Sync`
    |
 LL | fn not_sync<T: std::marker::Sync>(x: Guard<T>) {
    |              +++++++++++++++++++
@@ -58,7 +58,7 @@ note: required by a bound in `is_zen`
    |
 LL | fn is_zen<T: Zen>(_: T) {}
    |              ^^^ required by this bound in `is_zen`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Sync`
    |
 LL | fn nested_not_sync<T: std::marker::Sync>(x: Nested<Guard<T>>) {
    |                     +++++++++++++++++++

--- a/tests/ui/phantom-auto-trait.stderr
+++ b/tests/ui/phantom-auto-trait.stderr
@@ -23,7 +23,7 @@ note: required by a bound in `is_zen`
    |
 LL | fn is_zen<T: Zen>(_: T) {}
    |              ^^^ required by this bound in `is_zen`
-help: consider restricting type parameter `T` with trait `std::marker::Sync`
+help: consider restricting type parameter `T` with trait `Sync`
    |
 LL | fn not_sync<T: std::marker::Sync>(x: Guard<T>) {
    |              +++++++++++++++++++
@@ -58,7 +58,7 @@ note: required by a bound in `is_zen`
    |
 LL | fn is_zen<T: Zen>(_: T) {}
    |              ^^^ required by this bound in `is_zen`
-help: consider restricting type parameter `T` with trait `std::marker::Sync`
+help: consider restricting type parameter `T` with trait `Sync`
    |
 LL | fn nested_not_sync<T: std::marker::Sync>(x: Nested<Guard<T>>) {
    |                     +++++++++++++++++++

--- a/tests/ui/regions/regions-implied-bounds-projection-gap-hr-1.stderr
+++ b/tests/ui/regions/regions-implied-bounds-projection-gap-hr-1.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
 LL | fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'z> Trait2<'y, 'z>` is not implemented for `T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `for<'z> Trait2<'y, 'z>`
    |
 LL | fn callee<'x, 'y, T: for<'z> Trait2<'y, 'z>>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
    |                    ++++++++++++++++++++++++
@@ -17,7 +17,7 @@ LL | |
 LL | | }
    | |_^ the trait `for<'z> Trait2<'y, 'z>` is not implemented for `T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `for<'z> Trait2<'y, 'z>`
    |
 LL | fn callee<'x, 'y, T: for<'z> Trait2<'y, 'z>>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
    |                    ++++++++++++++++++++++++

--- a/tests/ui/regions/regions-implied-bounds-projection-gap-hr-1.stderr
+++ b/tests/ui/regions/regions-implied-bounds-projection-gap-hr-1.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `for<'z> T: Trait2<'y, 'z>` is not satisfied
 LL | fn callee<'x, 'y, T>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
    |                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `for<'z> Trait2<'y, 'z>` is not implemented for `T`
    |
-help: consider restricting type parameter `T` with trait `for<'z> Trait2<'y, 'z>`
+help: consider restricting type parameter `T` with trait `Trait2`
    |
 LL | fn callee<'x, 'y, T: for<'z> Trait2<'y, 'z>>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
    |                    ++++++++++++++++++++++++
@@ -17,7 +17,7 @@ LL | |
 LL | | }
    | |_^ the trait `for<'z> Trait2<'y, 'z>` is not implemented for `T`
    |
-help: consider restricting type parameter `T` with trait `for<'z> Trait2<'y, 'z>`
+help: consider restricting type parameter `T` with trait `Trait2`
    |
 LL | fn callee<'x, 'y, T: for<'z> Trait2<'y, 'z>>(t: &'x dyn for<'z> Trait1< <T as Trait2<'y, 'z>>::Foo >)
    |                    ++++++++++++++++++++++++

--- a/tests/ui/resolve/issue-55673.stderr
+++ b/tests/ui/resolve/issue-55673.stderr
@@ -15,7 +15,7 @@ error[E0220]: associated type `Baa` not found for `T`
 LL |     T::Baa: std::fmt::Debug,
    |        ^^^ there is a similarly named associated type `Bar` in the trait `Foo`
    |
-help: consider further restricting type parameter `T`
+help: consider further restricting type parameter `T` with trait `Foo`
    |
 LL |     T::Baa: std::fmt::Debug, T: Foo
    |                            ~~~~~~~~

--- a/tests/ui/specialization/default-generic-associated-type-bound.stderr
+++ b/tests/ui/specialization/default-generic-associated-type-bound.stderr
@@ -20,7 +20,7 @@ note: required by a bound in `X::U`
    |
 LL |     type U<'a>: PartialEq<&'a Self> where Self: 'a;
    |                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `X::U`
-help: consider further restricting this bound with trait `PartialEq`
+help: consider further restricting type parameter `T` with trait `PartialEq`
    |
 LL | impl<T: 'static + std::cmp::PartialEq> X for T {
    |                 +++++++++++++++++++++

--- a/tests/ui/specialization/default-generic-associated-type-bound.stderr
+++ b/tests/ui/specialization/default-generic-associated-type-bound.stderr
@@ -20,7 +20,7 @@ note: required by a bound in `X::U`
    |
 LL |     type U<'a>: PartialEq<&'a Self> where Self: 'a;
    |                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `X::U`
-help: consider further restricting this bound with trait `std::cmp::PartialEq`
+help: consider further restricting this bound with trait `PartialEq`
    |
 LL | impl<T: 'static + std::cmp::PartialEq> X for T {
    |                 +++++++++++++++++++++

--- a/tests/ui/specialization/default-generic-associated-type-bound.stderr
+++ b/tests/ui/specialization/default-generic-associated-type-bound.stderr
@@ -20,7 +20,7 @@ note: required by a bound in `X::U`
    |
 LL |     type U<'a>: PartialEq<&'a Self> where Self: 'a;
    |                 ^^^^^^^^^^^^^^^^^^^ required by this bound in `X::U`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::cmp::PartialEq`
    |
 LL | impl<T: 'static + std::cmp::PartialEq> X for T {
    |                 +++++++++++++++++++++

--- a/tests/ui/specialization/defaultimpl/specialization-wfcheck.stderr
+++ b/tests/ui/specialization/defaultimpl/specialization-wfcheck.stderr
@@ -19,7 +19,7 @@ note: required by a bound in `Foo`
    |
 LL | trait Foo<'a, T: Eq + 'a> { }
    |                  ^^ required by this bound in `Foo`
-help: consider restricting type parameter `U`
+help: consider restricting type parameter `U` with trait `std::cmp::Eq`
    |
 LL | default impl<U: std::cmp::Eq> Foo<'static, U> for () {}
    |               ++++++++++++++

--- a/tests/ui/specialization/defaultimpl/specialization-wfcheck.stderr
+++ b/tests/ui/specialization/defaultimpl/specialization-wfcheck.stderr
@@ -19,7 +19,7 @@ note: required by a bound in `Foo`
    |
 LL | trait Foo<'a, T: Eq + 'a> { }
    |                  ^^ required by this bound in `Foo`
-help: consider restricting type parameter `U` with trait `std::cmp::Eq`
+help: consider restricting type parameter `U` with trait `Eq`
    |
 LL | default impl<U: std::cmp::Eq> Foo<'static, U> for () {}
    |               ++++++++++++++

--- a/tests/ui/specialization/issue-33017.stderr
+++ b/tests/ui/specialization/issue-33017.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `UncheckedCopy::Output`
    |
 LL |     type Output: From<Self> + Copy + Into<Self>;
    |                               ^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | impl<T: std::marker::Copy> UncheckedCopy for T {
    |       +++++++++++++++++++

--- a/tests/ui/specialization/issue-33017.stderr
+++ b/tests/ui/specialization/issue-33017.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `UncheckedCopy::Output`
    |
 LL |     type Output: From<Self> + Copy + Into<Self>;
    |                               ^^^^ required by this bound in `UncheckedCopy::Output`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | impl<T: std::marker::Copy> UncheckedCopy for T {
    |       +++++++++++++++++++

--- a/tests/ui/specialization/min_specialization/issue-79224.stderr
+++ b/tests/ui/specialization/min_specialization/issue-79224.stderr
@@ -5,7 +5,7 @@ LL | impl<B: ?Sized> Display for Cow<'_, B> {
    |                             ^^^^^^^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
-help: consider further restricting this bound with trait `Clone`
+help: consider further restricting type parameter `B` with trait `Clone`
    |
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
@@ -17,7 +17,7 @@ LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
-help: consider further restricting this bound with trait `Clone`
+help: consider further restricting type parameter `B` with trait `Clone`
    |
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
@@ -29,7 +29,7 @@ LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
    |             ^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
-help: consider further restricting this bound with trait `Clone`
+help: consider further restricting type parameter `B` with trait `Clone`
    |
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
@@ -47,7 +47,7 @@ LL | |     }
    | |_____^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
-help: consider further restricting this bound with trait `Clone`
+help: consider further restricting type parameter `B` with trait `Clone`
    |
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++

--- a/tests/ui/specialization/min_specialization/issue-79224.stderr
+++ b/tests/ui/specialization/min_specialization/issue-79224.stderr
@@ -5,7 +5,7 @@ LL | impl<B: ?Sized> Display for Cow<'_, B> {
    |                             ^^^^^^^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
-help: consider further restricting this bound with trait `std::clone::Clone`
+help: consider further restricting this bound with trait `Clone`
    |
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
@@ -17,7 +17,7 @@ LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
-help: consider further restricting this bound with trait `std::clone::Clone`
+help: consider further restricting this bound with trait `Clone`
    |
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
@@ -29,7 +29,7 @@ LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
    |             ^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
-help: consider further restricting this bound with trait `std::clone::Clone`
+help: consider further restricting this bound with trait `Clone`
    |
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
@@ -47,7 +47,7 @@ LL | |     }
    | |_____^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
-help: consider further restricting this bound with trait `std::clone::Clone`
+help: consider further restricting this bound with trait `Clone`
    |
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++

--- a/tests/ui/specialization/min_specialization/issue-79224.stderr
+++ b/tests/ui/specialization/min_specialization/issue-79224.stderr
@@ -5,7 +5,7 @@ LL | impl<B: ?Sized> Display for Cow<'_, B> {
    |                             ^^^^^^^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::clone::Clone`
    |
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
@@ -17,7 +17,7 @@ LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::clone::Clone`
    |
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
@@ -29,7 +29,7 @@ LL |     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
    |             ^^^^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::clone::Clone`
    |
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++
@@ -47,7 +47,7 @@ LL | |     }
    | |_____^ the trait `Clone` is not implemented for `B`
    |
    = note: required for `B` to implement `ToOwned`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::clone::Clone`
    |
 LL | impl<B: ?Sized + std::clone::Clone> Display for Cow<'_, B> {
    |                +++++++++++++++++++

--- a/tests/ui/suggestions/assoc-const-as-fn.stderr
+++ b/tests/ui/suggestions/assoc-const-as-fn.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `T: GlUniformScalar` is not satisfied
 LL |     <T as GlUniformScalar>::FACTORY(1, value);
    |      ^ the trait `GlUniformScalar` is not implemented for `T`
    |
-help: consider further restricting this bound with trait `GlUniformScalar`
+help: consider further restricting type parameter `T` with trait `GlUniformScalar`
    |
 LL | pub fn foo<T: UniformScalar + GlUniformScalar>(value: T) {
    |                             +++++++++++++++++

--- a/tests/ui/suggestions/assoc-const-as-fn.stderr
+++ b/tests/ui/suggestions/assoc-const-as-fn.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `T: GlUniformScalar` is not satisfied
 LL |     <T as GlUniformScalar>::FACTORY(1, value);
    |      ^ the trait `GlUniformScalar` is not implemented for `T`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `GlUniformScalar`
    |
 LL | pub fn foo<T: UniformScalar + GlUniformScalar>(value: T) {
    |                             +++++++++++++++++

--- a/tests/ui/suggestions/bound-suggestions.stderr
+++ b/tests/ui/suggestions/bound-suggestions.stderr
@@ -5,7 +5,7 @@ LL |     println!("{:?}", t);
    |                      ^ `impl Sized` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::fmt::Debug`
    |
 LL | fn test_impl(t: impl Sized + std::fmt::Debug) {
    |                            +++++++++++++++++
@@ -17,7 +17,7 @@ LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::fmt::Debug`
    |
 LL | fn test_no_bounds<T: std::fmt::Debug>(t: T) {
    |                    +++++++++++++++++
@@ -29,7 +29,7 @@ LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::fmt::Debug`
    |
 LL | fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
    |                            +++++++++++++++++
@@ -41,7 +41,7 @@ LL |     println!("{:?} {:?}", x, y);
    |                              ^ `Y` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting type parameter `Y`
+help: consider further restricting type parameter `Y` with trait `std::fmt::Debug`
    |
 LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
    |                                                                   ~~~~~~~~~~~~~~~~~~~~
@@ -53,7 +53,7 @@ LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::fmt::Debug`
    |
 LL | fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
    |                                                 +++++++++++++++++
@@ -65,7 +65,7 @@ LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::fmt::Debug`
    |
 LL | fn test_many_bounds_where<X>(x: X) where X: Sized + std::fmt::Debug, X: Sized {
    |                                                   +++++++++++++++++

--- a/tests/ui/suggestions/bound-suggestions.stderr
+++ b/tests/ui/suggestions/bound-suggestions.stderr
@@ -5,7 +5,7 @@ LL |     println!("{:?}", t);
    |                      ^ `impl Sized` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `std::fmt::Debug`
+help: consider further restricting this bound with trait `Debug`
    |
 LL | fn test_impl(t: impl Sized + std::fmt::Debug) {
    |                            +++++++++++++++++
@@ -17,7 +17,7 @@ LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T` with trait `std::fmt::Debug`
+help: consider restricting type parameter `T` with trait `Debug`
    |
 LL | fn test_no_bounds<T: std::fmt::Debug>(t: T) {
    |                    +++++++++++++++++
@@ -29,7 +29,7 @@ LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `std::fmt::Debug`
+help: consider further restricting this bound with trait `Debug`
    |
 LL | fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
    |                            +++++++++++++++++
@@ -41,7 +41,7 @@ LL |     println!("{:?} {:?}", x, y);
    |                              ^ `Y` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting type parameter `Y` with trait `std::fmt::Debug`
+help: consider further restricting type parameter `Y` with trait `Debug`
    |
 LL | fn test_no_bounds_where<X, Y>(x: X, y: Y) where X: std::fmt::Debug, Y: std::fmt::Debug {
    |                                                                   ~~~~~~~~~~~~~~~~~~~~
@@ -53,7 +53,7 @@ LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `std::fmt::Debug`
+help: consider further restricting this bound with trait `Debug`
    |
 LL | fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
    |                                                 +++++++++++++++++
@@ -65,7 +65,7 @@ LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `std::fmt::Debug`
+help: consider further restricting this bound with trait `Debug`
    |
 LL | fn test_many_bounds_where<X>(x: X) where X: Sized + std::fmt::Debug, X: Sized {
    |                                                   +++++++++++++++++

--- a/tests/ui/suggestions/bound-suggestions.stderr
+++ b/tests/ui/suggestions/bound-suggestions.stderr
@@ -5,7 +5,7 @@ LL |     println!("{:?}", t);
    |                      ^ `impl Sized` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting type parameter `impl Sized` with trait `Debug`
+help: consider restricting opaque type `impl Sized` with trait `Debug`
    |
 LL | fn test_impl(t: impl Sized + std::fmt::Debug) {
    |                            +++++++++++++++++

--- a/tests/ui/suggestions/bound-suggestions.stderr
+++ b/tests/ui/suggestions/bound-suggestions.stderr
@@ -5,7 +5,7 @@ LL |     println!("{:?}", t);
    |                      ^ `impl Sized` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `Debug`
+help: consider further restricting type parameter `impl Sized` with trait `Debug`
    |
 LL | fn test_impl(t: impl Sized + std::fmt::Debug) {
    |                            +++++++++++++++++
@@ -29,7 +29,7 @@ LL |     println!("{:?}", t);
    |                      ^ `T` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `Debug`
+help: consider further restricting type parameter `T` with trait `Debug`
    |
 LL | fn test_one_bound<T: Sized + std::fmt::Debug>(t: T) {
    |                            +++++++++++++++++
@@ -53,7 +53,7 @@ LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `Debug`
+help: consider further restricting type parameter `X` with trait `Debug`
    |
 LL | fn test_one_bound_where<X>(x: X) where X: Sized + std::fmt::Debug {
    |                                                 +++++++++++++++++
@@ -65,7 +65,7 @@ LL |     println!("{:?}", x);
    |                      ^ `X` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `Debug`
+help: consider further restricting type parameter `X` with trait `Debug`
    |
 LL | fn test_many_bounds_where<X>(x: X) where X: Sized + std::fmt::Debug, X: Sized {
    |                                                   +++++++++++++++++

--- a/tests/ui/suggestions/clone-bounds-121524.rs
+++ b/tests/ui/suggestions/clone-bounds-121524.rs
@@ -6,7 +6,7 @@ trait DoesAThing {}
 impl DoesAThing for ThingThatDoesAThing {}
 
 fn clones_impl_ref_inline(thing: &impl DoesAThing) {
-    //~^ HELP consider further restricting type parameter `impl DoesAThing` with trait `Clone`
+    //~^ HELP consider restricting opaque type `impl DoesAThing` with trait `Clone`
     drops_impl_owned(thing.clone()); //~ ERROR E0277
     //~^ NOTE copies the reference
     //~| NOTE the trait `DoesAThing` is not implemented for `&impl DoesAThing`

--- a/tests/ui/suggestions/clone-bounds-121524.rs
+++ b/tests/ui/suggestions/clone-bounds-121524.rs
@@ -6,7 +6,7 @@ trait DoesAThing {}
 impl DoesAThing for ThingThatDoesAThing {}
 
 fn clones_impl_ref_inline(thing: &impl DoesAThing) {
-    //~^ HELP consider further restricting this bound
+    //~^ HELP consider further restricting type parameter `impl DoesAThing` with trait `Clone`
     drops_impl_owned(thing.clone()); //~ ERROR E0277
     //~^ NOTE copies the reference
     //~| NOTE the trait `DoesAThing` is not implemented for `&impl DoesAThing`

--- a/tests/ui/suggestions/clone-bounds-121524.stderr
+++ b/tests/ui/suggestions/clone-bounds-121524.stderr
@@ -9,7 +9,7 @@ note: this `clone()` copies the reference, which does not do anything, because `
    |
 LL |     drops_impl_owned(thing.clone());
    |                            ^^^^^
-help: consider further restricting this bound with trait `Clone`
+help: consider further restricting type parameter `impl DoesAThing` with trait `Clone`
    |
 LL | fn clones_impl_ref_inline(thing: &impl DoesAThing + Clone) {
    |                                                   +++++++

--- a/tests/ui/suggestions/clone-bounds-121524.stderr
+++ b/tests/ui/suggestions/clone-bounds-121524.stderr
@@ -9,7 +9,7 @@ note: this `clone()` copies the reference, which does not do anything, because `
    |
 LL |     drops_impl_owned(thing.clone());
    |                            ^^^^^
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Clone`
    |
 LL | fn clones_impl_ref_inline(thing: &impl DoesAThing + Clone) {
    |                                                   +++++++

--- a/tests/ui/suggestions/clone-bounds-121524.stderr
+++ b/tests/ui/suggestions/clone-bounds-121524.stderr
@@ -9,7 +9,7 @@ note: this `clone()` copies the reference, which does not do anything, because `
    |
 LL |     drops_impl_owned(thing.clone());
    |                            ^^^^^
-help: consider further restricting type parameter `impl DoesAThing` with trait `Clone`
+help: consider restricting opaque type `impl DoesAThing` with trait `Clone`
    |
 LL | fn clones_impl_ref_inline(thing: &impl DoesAThing + Clone) {
    |                                                   +++++++

--- a/tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.stderr
+++ b/tests/ui/suggestions/clone-on-unconstrained-borrowed-type-param.stderr
@@ -15,7 +15,7 @@ note: `T` does not implement `Clone`, so `&T` was cloned instead
    |
 LL |     t.clone()
    |     ^
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Clone`
    |
 LL | fn wat<T: Clone>(t: &T) -> T {
    |         +++++++

--- a/tests/ui/suggestions/derive-clone-for-eq.stderr
+++ b/tests/ui/suggestions/derive-clone-for-eq.stderr
@@ -14,7 +14,7 @@ LL | impl<T: Clone, U> PartialEq<U> for Struct<T>
 note: required by a bound in `Eq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T` with trait `std::clone::Clone`
+help: consider restricting type parameter `T` with trait `Clone`
    |
 LL | pub struct Struct<T: std::clone::Clone>(T);
    |                    +++++++++++++++++++

--- a/tests/ui/suggestions/derive-clone-for-eq.stderr
+++ b/tests/ui/suggestions/derive-clone-for-eq.stderr
@@ -14,7 +14,7 @@ LL | impl<T: Clone, U> PartialEq<U> for Struct<T>
 note: required by a bound in `Eq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::clone::Clone`
    |
 LL | pub struct Struct<T: std::clone::Clone>(T);
    |                    +++++++++++++++++++

--- a/tests/ui/suggestions/derive-macro-missing-bounds.stderr
+++ b/tests/ui/suggestions/derive-macro-missing-bounds.stderr
@@ -38,7 +38,7 @@ LL |     impl<T: Debug + Trait> Debug for Inner<T> {
    = note: required for `&c::Inner<T>` to implement `Debug`
    = note: required for the cast from `&&c::Inner<T>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `c::Trait`
    |
 LL |     struct Outer<T: c::Trait>(Inner<T>);
    |                   ++++++++++
@@ -60,7 +60,7 @@ LL |     impl<T> Debug for Inner<T> where T: Debug, T: Trait {
    = note: required for `&d::Inner<T>` to implement `Debug`
    = note: required for the cast from `&&d::Inner<T>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `d::Trait`
    |
 LL |     struct Outer<T: d::Trait>(Inner<T>);
    |                   ++++++++++
@@ -82,7 +82,7 @@ LL |     impl<T> Debug for Inner<T> where T: Debug + Trait {
    = note: required for `&e::Inner<T>` to implement `Debug`
    = note: required for the cast from `&&e::Inner<T>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `e::Trait`
    |
 LL |     struct Outer<T: e::Trait>(Inner<T>);
    |                   ++++++++++
@@ -104,7 +104,7 @@ LL |     impl<T: Debug> Debug for Inner<T> where T: Trait {
    = note: required for `&f::Inner<T>` to implement `Debug`
    = note: required for the cast from `&&f::Inner<T>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `f::Trait`
    |
 LL |     struct Outer<T: f::Trait>(Inner<T>);
    |                   ++++++++++

--- a/tests/ui/suggestions/derive-macro-missing-bounds.stderr
+++ b/tests/ui/suggestions/derive-macro-missing-bounds.stderr
@@ -38,7 +38,7 @@ LL |     impl<T: Debug + Trait> Debug for Inner<T> {
    = note: required for `&c::Inner<T>` to implement `Debug`
    = note: required for the cast from `&&c::Inner<T>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T` with trait `c::Trait`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL |     struct Outer<T: c::Trait>(Inner<T>);
    |                   ++++++++++
@@ -60,7 +60,7 @@ LL |     impl<T> Debug for Inner<T> where T: Debug, T: Trait {
    = note: required for `&d::Inner<T>` to implement `Debug`
    = note: required for the cast from `&&d::Inner<T>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T` with trait `d::Trait`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL |     struct Outer<T: d::Trait>(Inner<T>);
    |                   ++++++++++
@@ -82,7 +82,7 @@ LL |     impl<T> Debug for Inner<T> where T: Debug + Trait {
    = note: required for `&e::Inner<T>` to implement `Debug`
    = note: required for the cast from `&&e::Inner<T>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T` with trait `e::Trait`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL |     struct Outer<T: e::Trait>(Inner<T>);
    |                   ++++++++++
@@ -104,7 +104,7 @@ LL |     impl<T: Debug> Debug for Inner<T> where T: Trait {
    = note: required for `&f::Inner<T>` to implement `Debug`
    = note: required for the cast from `&&f::Inner<T>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T` with trait `f::Trait`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL |     struct Outer<T: f::Trait>(Inner<T>);
    |                   ++++++++++

--- a/tests/ui/suggestions/issue-106443-sugg-clone-for-bound.stderr
+++ b/tests/ui/suggestions/issue-106443-sugg-clone-for-bound.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `&T: X` is not satisfied
 LL |     foo(s);
    |         ^ the trait `X` is not implemented for `&T`
    |
-help: consider further restricting this bound with trait `Clone`
+help: consider further restricting type parameter `T` with trait `Clone`
    |
 LL | fn bar<T: X + Clone>(s: &T) {
    |             +++++++

--- a/tests/ui/suggestions/issue-106443-sugg-clone-for-bound.stderr
+++ b/tests/ui/suggestions/issue-106443-sugg-clone-for-bound.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `&T: X` is not satisfied
 LL |     foo(s);
    |         ^ the trait `X` is not implemented for `&T`
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Clone`
    |
 LL | fn bar<T: X + Clone>(s: &T) {
    |             +++++++

--- a/tests/ui/suggestions/issue-97677.stderr
+++ b/tests/ui/suggestions/issue-97677.stderr
@@ -6,7 +6,7 @@ LL |     n + 10
    |     |
    |     N
    |
-help: consider restricting type parameter `N`
+help: consider restricting type parameter `N` with trait `std::ops::Add<i32, Output = N>`
    |
 LL | fn add_ten<N: std::ops::Add<i32, Output = N>>(n: N) -> N {
    |             ++++++++++++++++++++++++++++++++

--- a/tests/ui/suggestions/issue-97677.stderr
+++ b/tests/ui/suggestions/issue-97677.stderr
@@ -6,7 +6,7 @@ LL |     n + 10
    |     |
    |     N
    |
-help: consider restricting type parameter `N` with trait `std::ops::Add<i32, Output = N>`
+help: consider restricting type parameter `N` with trait `Add`
    |
 LL | fn add_ten<N: std::ops::Add<i32, Output = N>>(n: N) -> N {
    |             ++++++++++++++++++++++++++++++++

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Vector2`
    |
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
-help: consider further restricting this bound with trait `std::marker::Copy`
+help: consider further restricting this bound with trait `Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++
@@ -32,7 +32,7 @@ LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
    = note: required for the cast from `&Vector2<K>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `std::marker::Copy`
+help: consider further restricting this bound with trait `Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++
@@ -52,7 +52,7 @@ note: required by a bound in `Vector2`
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `std::marker::Copy`
+help: consider further restricting this bound with trait `Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++
@@ -74,7 +74,7 @@ LL | #[derive(Debug, Copy, Clone)]
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `std::marker::Copy`
+help: consider further restricting this bound with trait `Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Vector2`
    |
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++
@@ -32,7 +32,7 @@ LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
    = note: required for the cast from `&Vector2<K>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++
@@ -52,7 +52,7 @@ note: required by a bound in `Vector2`
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++
@@ -74,7 +74,7 @@ LL | #[derive(Debug, Copy, Clone)]
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-2.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Vector2`
    |
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++
@@ -32,7 +32,7 @@ LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
    = note: required for the cast from `&Vector2<K>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++
@@ -52,7 +52,7 @@ note: required by a bound in `Vector2`
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++
@@ -74,7 +74,7 @@ LL | #[derive(Debug, Copy, Clone)]
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Copy`
    |
 LL | pub struct AABB<K: Debug + std::marker::Copy> {
    |                          +++++++++++++++++++

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
@@ -13,7 +13,7 @@ note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
 LL |     pub loc: Vector2<K>,
    |              ^^^^^^^^^^
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Debug`
    |
 LL | pub struct AABB<K: Copy + Debug>{
    |                         +++++++
@@ -29,7 +29,7 @@ note: required by a bound in `Vector2`
    |
 LL | pub struct Vector2<T: Debug + Copy + Clone>{
    |                       ^^^^^ required by this bound in `Vector2`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::fmt::Debug`
    |
 LL | pub struct AABB<K: Copy + std::fmt::Debug>{
    |                         +++++++++++++++++
@@ -44,7 +44,7 @@ LL |     pub loc: Vector2<K>,
    |     ^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::fmt::Debug`
    |
 LL | pub struct AABB<K: Copy + std::fmt::Debug>{
    |                         +++++++++++++++++
@@ -59,7 +59,7 @@ LL |     pub size: Vector2<K>
    |     ^^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::fmt::Debug`
    |
 LL | pub struct AABB<K: Copy + std::fmt::Debug>{
    |                         +++++++++++++++++

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
@@ -29,7 +29,7 @@ note: required by a bound in `Vector2`
    |
 LL | pub struct Vector2<T: Debug + Copy + Clone>{
    |                       ^^^^^ required by this bound in `Vector2`
-help: consider further restricting this bound with trait `std::fmt::Debug`
+help: consider further restricting this bound with trait `Debug`
    |
 LL | pub struct AABB<K: Copy + std::fmt::Debug>{
    |                         +++++++++++++++++
@@ -44,7 +44,7 @@ LL |     pub loc: Vector2<K>,
    |     ^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `std::fmt::Debug`
+help: consider further restricting this bound with trait `Debug`
    |
 LL | pub struct AABB<K: Copy + std::fmt::Debug>{
    |                         +++++++++++++++++
@@ -59,7 +59,7 @@ LL |     pub size: Vector2<K>
    |     ^^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `std::fmt::Debug`
+help: consider further restricting this bound with trait `Debug`
    |
 LL | pub struct AABB<K: Copy + std::fmt::Debug>{
    |                         +++++++++++++++++

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl-3.stderr
@@ -13,7 +13,7 @@ note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
 LL |     pub loc: Vector2<K>,
    |              ^^^^^^^^^^
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `Debug`
+help: consider further restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: Copy + Debug>{
    |                         +++++++
@@ -29,7 +29,7 @@ note: required by a bound in `Vector2`
    |
 LL | pub struct Vector2<T: Debug + Copy + Clone>{
    |                       ^^^^^ required by this bound in `Vector2`
-help: consider further restricting this bound with trait `Debug`
+help: consider further restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: Copy + std::fmt::Debug>{
    |                         +++++++++++++++++
@@ -44,7 +44,7 @@ LL |     pub loc: Vector2<K>,
    |     ^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `Debug`
+help: consider further restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: Copy + std::fmt::Debug>{
    |                         +++++++++++++++++
@@ -59,7 +59,7 @@ LL |     pub size: Vector2<K>
    |     ^^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider further restricting this bound with trait `Debug`
+help: consider further restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: Copy + std::fmt::Debug>{
    |                         +++++++++++++++++

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
@@ -29,7 +29,7 @@ note: required by a bound in `Vector2`
    |
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                       ^^^^^ required by this bound in `Vector2`
-help: consider restricting type parameter `K` with trait `std::fmt::Debug`
+help: consider restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: std::fmt::Debug> {
    |                  +++++++++++++++++
@@ -45,7 +45,7 @@ note: required by a bound in `Vector2`
    |
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
-help: consider restricting type parameter `K` with trait `std::marker::Copy`
+help: consider restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: std::marker::Copy> {
    |                  +++++++++++++++++++
@@ -68,7 +68,7 @@ LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
    = note: required for the cast from `&Vector2<K>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `K` with trait `std::marker::Copy`
+help: consider restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: std::marker::Copy> {
    |                  +++++++++++++++++++
@@ -83,7 +83,7 @@ LL |     pub loc: Vector2<K>,
    |     ^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `K` with trait `std::fmt::Debug`
+help: consider restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: std::fmt::Debug> {
    |                  +++++++++++++++++
@@ -103,7 +103,7 @@ note: required by a bound in `Vector2`
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `K` with trait `std::marker::Copy`
+help: consider restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: std::marker::Copy> {
    |                  +++++++++++++++++++
@@ -118,7 +118,7 @@ LL |     pub size: Vector2<K>,
    |     ^^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `K` with trait `std::fmt::Debug`
+help: consider restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: std::fmt::Debug> {
    |                  +++++++++++++++++
@@ -140,7 +140,7 @@ LL | #[derive(Debug, Copy, Clone)]
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `K` with trait `std::marker::Copy`
+help: consider restricting type parameter `K` with trait `Copy`
    |
 LL | pub struct AABB<K: std::marker::Copy> {
    |                  +++++++++++++++++++

--- a/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
+++ b/tests/ui/suggestions/missing-bound-in-derive-copy-impl.stderr
@@ -13,7 +13,7 @@ note: the `Copy` impl for `Vector2<K>` requires that `K: Debug`
 LL |     pub loc: Vector2<K>,
    |              ^^^^^^^^^^
    = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `K`
+help: consider restricting type parameter `K` with trait `Debug`
    |
 LL | pub struct AABB<K: Debug> {
    |                  +++++++
@@ -29,7 +29,7 @@ note: required by a bound in `Vector2`
    |
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                       ^^^^^ required by this bound in `Vector2`
-help: consider restricting type parameter `K`
+help: consider restricting type parameter `K` with trait `std::fmt::Debug`
    |
 LL | pub struct AABB<K: std::fmt::Debug> {
    |                  +++++++++++++++++
@@ -45,7 +45,7 @@ note: required by a bound in `Vector2`
    |
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
-help: consider restricting type parameter `K`
+help: consider restricting type parameter `K` with trait `std::marker::Copy`
    |
 LL | pub struct AABB<K: std::marker::Copy> {
    |                  +++++++++++++++++++
@@ -68,7 +68,7 @@ LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
    = note: required for the cast from `&Vector2<K>` to `&dyn Debug`
    = note: this error originates in the derive macro `Debug` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `K`
+help: consider restricting type parameter `K` with trait `std::marker::Copy`
    |
 LL | pub struct AABB<K: std::marker::Copy> {
    |                  +++++++++++++++++++
@@ -83,7 +83,7 @@ LL |     pub loc: Vector2<K>,
    |     ^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `K`
+help: consider restricting type parameter `K` with trait `std::fmt::Debug`
    |
 LL | pub struct AABB<K: std::fmt::Debug> {
    |                  +++++++++++++++++
@@ -103,7 +103,7 @@ note: required by a bound in `Vector2`
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ^^^^ required by this bound in `Vector2`
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `K`
+help: consider restricting type parameter `K` with trait `std::marker::Copy`
    |
 LL | pub struct AABB<K: std::marker::Copy> {
    |                  +++++++++++++++++++
@@ -118,7 +118,7 @@ LL |     pub size: Vector2<K>,
    |     ^^^^^^^^^^^^^^^^^^^^ `K` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `K`
+help: consider restricting type parameter `K` with trait `std::fmt::Debug`
    |
 LL | pub struct AABB<K: std::fmt::Debug> {
    |                  +++++++++++++++++
@@ -140,7 +140,7 @@ LL | #[derive(Debug, Copy, Clone)]
 LL | pub struct Vector2<T: Debug + Copy + Clone> {
    |                               ---- unsatisfied trait bound introduced in this `derive` macro
    = note: this error originates in the derive macro `Clone` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `K`
+help: consider restricting type parameter `K` with trait `std::marker::Copy`
    |
 LL | pub struct AABB<K: std::marker::Copy> {
    |                  +++++++++++++++++++

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
@@ -12,7 +12,7 @@ note: the `Copy` impl for `OnlyCopyIfDisplay<S>` requires that `S: std::fmt::Dis
    |
 LL | struct Wrapper<T>(T);
    |                   ^
-help: consider restricting type parameter `S` with trait `std::fmt::Display`
+help: consider restricting type parameter `S` with trait `Display`
    |
 LL | impl<S: std::fmt::Display> Copy for Wrapper<OnlyCopyIfDisplay<S>> {}
    |       +++++++++++++++++++

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl-2.stderr
@@ -12,7 +12,7 @@ note: the `Copy` impl for `OnlyCopyIfDisplay<S>` requires that `S: std::fmt::Dis
    |
 LL | struct Wrapper<T>(T);
    |                   ^
-help: consider restricting type parameter `S`
+help: consider restricting type parameter `S` with trait `std::fmt::Display`
    |
 LL | impl<S: std::fmt::Display> Copy for Wrapper<OnlyCopyIfDisplay<S>> {}
    |       +++++++++++++++++++

--- a/tests/ui/suggestions/missing-bound-in-manual-copy-impl.stderr
+++ b/tests/ui/suggestions/missing-bound-in-manual-copy-impl.stderr
@@ -7,7 +7,7 @@ LL |
 LL | impl<S> Copy for Wrapper<S> {}
    |                  ^^^^^^^^^^
    |
-help: consider restricting type parameter `S`
+help: consider restricting type parameter `S` with trait `Copy`
    |
 LL | impl<S: Copy> Copy for Wrapper<S> {}
    |       ++++++

--- a/tests/ui/suggestions/restrict-existing-type-bounds.stderr
+++ b/tests/ui/suggestions/restrict-existing-type-bounds.stderr
@@ -20,7 +20,7 @@ LL |         Ok(self)
    |            this argument influences the type of `Ok`
 note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-help: consider further restricting this bound with trait `<Output = T>`
+help: consider further restricting this bound with  `<Output = T>`
    |
 LL | impl<T: TryAdd<Output = T>> TryAdd for Option<T> {
    |               ++++++++++++
@@ -47,7 +47,7 @@ LL |         Ok(self)
    |            this argument influences the type of `Ok`
 note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-help: consider further restricting this bound with trait `, Output = T`
+help: consider further restricting this bound with  `, Output = T`
    |
 LL | impl<T: TryAdd<Error = X, Output = T>> TryAdd for Other<T> {
    |                         ++++++++++++

--- a/tests/ui/suggestions/restrict-existing-type-bounds.stderr
+++ b/tests/ui/suggestions/restrict-existing-type-bounds.stderr
@@ -20,7 +20,7 @@ LL |         Ok(self)
    |            this argument influences the type of `Ok`
 note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `<Output = T>`
    |
 LL | impl<T: TryAdd<Output = T>> TryAdd for Option<T> {
    |               ++++++++++++
@@ -47,7 +47,7 @@ LL |         Ok(self)
    |            this argument influences the type of `Ok`
 note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `, Output = T`
    |
 LL | impl<T: TryAdd<Error = X, Output = T>> TryAdd for Other<T> {
    |                         ++++++++++++

--- a/tests/ui/suggestions/restrict-existing-type-bounds.stderr
+++ b/tests/ui/suggestions/restrict-existing-type-bounds.stderr
@@ -20,7 +20,7 @@ LL |         Ok(self)
    |            this argument influences the type of `Ok`
 note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-help: consider further restricting this bound with  `<Output = T>`
+help: consider further restricting this bound
    |
 LL | impl<T: TryAdd<Output = T>> TryAdd for Option<T> {
    |               ++++++++++++
@@ -47,7 +47,7 @@ LL |         Ok(self)
    |            this argument influences the type of `Ok`
 note: tuple variant defined here
   --> $SRC_DIR/core/src/result.rs:LL:COL
-help: consider further restricting this bound with  `, Output = T`
+help: consider further restricting this bound
    |
 LL | impl<T: TryAdd<Error = X, Output = T>> TryAdd for Other<T> {
    |                         ++++++++++++

--- a/tests/ui/suggestions/restrict-type-argument.stderr
+++ b/tests/ui/suggestions/restrict-type-argument.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Send`
    |
 LL | fn use_impl_sync(val: impl Sync + std::marker::Send) {
    |                                 +++++++++++++++++++
@@ -29,7 +29,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Send`
    |
 LL | fn use_where<S>(val: S) where S: Sync + std::marker::Send {
    |                                       +++++++++++++++++++
@@ -47,7 +47,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Send`
    |
 LL | fn use_bound<S: Sync + std::marker::Send>(val: S) {
    |                      +++++++++++++++++++
@@ -65,7 +65,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Send`
    |
 LL |     Sync + std::marker::Send
    |          +++++++++++++++++++
@@ -83,7 +83,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Send`
    |
 LL | fn use_bound_and_where<S: Sync + std::marker::Send>(val: S) where S: std::fmt::Debug {
    |                                +++++++++++++++++++
@@ -101,7 +101,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider restricting type parameter `S`
+help: consider restricting type parameter `S` with trait `std::marker::Send`
    |
 LL | fn use_unbound<S: std::marker::Send>(val: S) {
    |                 +++++++++++++++++++

--- a/tests/ui/suggestions/restrict-type-argument.stderr
+++ b/tests/ui/suggestions/restrict-type-argument.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound with trait `Send`
+help: consider further restricting type parameter `impl Sync` with trait `Send`
    |
 LL | fn use_impl_sync(val: impl Sync + std::marker::Send) {
    |                                 +++++++++++++++++++
@@ -29,7 +29,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound with trait `Send`
+help: consider further restricting type parameter `S` with trait `Send`
    |
 LL | fn use_where<S>(val: S) where S: Sync + std::marker::Send {
    |                                       +++++++++++++++++++
@@ -47,7 +47,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound with trait `Send`
+help: consider further restricting type parameter `S` with trait `Send`
    |
 LL | fn use_bound<S: Sync + std::marker::Send>(val: S) {
    |                      +++++++++++++++++++
@@ -65,7 +65,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound with trait `Send`
+help: consider further restricting type parameter `S` with trait `Send`
    |
 LL |     Sync + std::marker::Send
    |          +++++++++++++++++++
@@ -83,7 +83,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound with trait `Send`
+help: consider further restricting type parameter `S` with trait `Send`
    |
 LL | fn use_bound_and_where<S: Sync + std::marker::Send>(val: S) where S: std::fmt::Debug {
    |                                +++++++++++++++++++

--- a/tests/ui/suggestions/restrict-type-argument.stderr
+++ b/tests/ui/suggestions/restrict-type-argument.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound with trait `std::marker::Send`
+help: consider further restricting this bound with trait `Send`
    |
 LL | fn use_impl_sync(val: impl Sync + std::marker::Send) {
    |                                 +++++++++++++++++++
@@ -29,7 +29,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound with trait `std::marker::Send`
+help: consider further restricting this bound with trait `Send`
    |
 LL | fn use_where<S>(val: S) where S: Sync + std::marker::Send {
    |                                       +++++++++++++++++++
@@ -47,7 +47,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound with trait `std::marker::Send`
+help: consider further restricting this bound with trait `Send`
    |
 LL | fn use_bound<S: Sync + std::marker::Send>(val: S) {
    |                      +++++++++++++++++++
@@ -65,7 +65,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound with trait `std::marker::Send`
+help: consider further restricting this bound with trait `Send`
    |
 LL |     Sync + std::marker::Send
    |          +++++++++++++++++++
@@ -83,7 +83,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting this bound with trait `std::marker::Send`
+help: consider further restricting this bound with trait `Send`
    |
 LL | fn use_bound_and_where<S: Sync + std::marker::Send>(val: S) where S: std::fmt::Debug {
    |                                +++++++++++++++++++
@@ -101,7 +101,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider restricting type parameter `S` with trait `std::marker::Send`
+help: consider restricting type parameter `S` with trait `Send`
    |
 LL | fn use_unbound<S: std::marker::Send>(val: S) {
    |                 +++++++++++++++++++

--- a/tests/ui/suggestions/restrict-type-argument.stderr
+++ b/tests/ui/suggestions/restrict-type-argument.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T: Send>(val: T) {}
    |               ^^^^ required by this bound in `is_send`
-help: consider further restricting type parameter `impl Sync` with trait `Send`
+help: consider restricting opaque type `impl Sync` with trait `Send`
    |
 LL | fn use_impl_sync(val: impl Sync + std::marker::Send) {
    |                                 +++++++++++++++++++

--- a/tests/ui/suggestions/trait-impl-bound-suggestions.stderr
+++ b/tests/ui/suggestions/trait-impl-bound-suggestions.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ConstrainedStruct`
    |
 LL | struct ConstrainedStruct<X: Copy> {
    |                             ^^^^ required by this bound in `ConstrainedStruct`
-help: consider further restricting type parameter `X` with trait `std::marker::Copy`
+help: consider further restricting type parameter `X` with trait `Copy`
    |
 LL | trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::marker::Copy {
    |                                                               ++++++++++++++++++++++
@@ -25,7 +25,7 @@ note: required by a bound in `ConstrainedStruct`
    |
 LL | struct ConstrainedStruct<X: Copy> {
    |                             ^^^^ required by this bound in `ConstrainedStruct`
-help: consider further restricting type parameter `X` with trait `std::marker::Copy`
+help: consider further restricting type parameter `X` with trait `Copy`
    |
 LL | trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized, X: std::marker::Copy {
    |                                                                             ++++++++++++++++++++++
@@ -41,7 +41,7 @@ note: required by a bound in `ConstrainedStruct`
    |
 LL | struct ConstrainedStruct<X: Copy> {
    |                             ^^^^ required by this bound in `ConstrainedStruct`
-help: consider further restricting type parameter `X` with trait `std::marker::Copy`
+help: consider further restricting type parameter `X` with trait `Copy`
    |
 LL | trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::marker::Copy {
    |                                                               ++++++++++++++++++++++
@@ -57,7 +57,7 @@ note: required by a bound in `ConstrainedStruct`
    |
 LL | struct ConstrainedStruct<X: Copy> {
    |                             ^^^^ required by this bound in `ConstrainedStruct`
-help: consider further restricting type parameter `X` with trait `std::marker::Copy`
+help: consider further restricting type parameter `X` with trait `Copy`
    |
 LL | trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized, X: std::marker::Copy {
    |                                                                             ++++++++++++++++++++++

--- a/tests/ui/suggestions/trait-impl-bound-suggestions.stderr
+++ b/tests/ui/suggestions/trait-impl-bound-suggestions.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ConstrainedStruct`
    |
 LL | struct ConstrainedStruct<X: Copy> {
    |                             ^^^^ required by this bound in `ConstrainedStruct`
-help: consider further restricting type parameter `X`
+help: consider further restricting type parameter `X` with trait `std::marker::Copy`
    |
 LL | trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::marker::Copy {
    |                                                               ++++++++++++++++++++++
@@ -25,7 +25,7 @@ note: required by a bound in `ConstrainedStruct`
    |
 LL | struct ConstrainedStruct<X: Copy> {
    |                             ^^^^ required by this bound in `ConstrainedStruct`
-help: consider further restricting type parameter `X`
+help: consider further restricting type parameter `X` with trait `std::marker::Copy`
    |
 LL | trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized, X: std::marker::Copy {
    |                                                                             ++++++++++++++++++++++
@@ -41,7 +41,7 @@ note: required by a bound in `ConstrainedStruct`
    |
 LL | struct ConstrainedStruct<X: Copy> {
    |                             ^^^^ required by this bound in `ConstrainedStruct`
-help: consider further restricting type parameter `X`
+help: consider further restricting type parameter `X` with trait `std::marker::Copy`
    |
 LL | trait InsufficientlyConstrainedGeneric<X=()> where Self: Sized, X: std::marker::Copy {
    |                                                               ++++++++++++++++++++++
@@ -57,7 +57,7 @@ note: required by a bound in `ConstrainedStruct`
    |
 LL | struct ConstrainedStruct<X: Copy> {
    |                             ^^^^ required by this bound in `ConstrainedStruct`
-help: consider further restricting type parameter `X`
+help: consider further restricting type parameter `X` with trait `std::marker::Copy`
    |
 LL | trait InsufficientlyConstrainedGenericWithEmptyWhere<X=()> where Self: Sized, X: std::marker::Copy {
    |                                                                             ++++++++++++++++++++++

--- a/tests/ui/trait-bounds/restrict-assoc-type-of-generic-bound.stderr
+++ b/tests/ui/trait-bounds/restrict-assoc-type-of-generic-bound.stderr
@@ -11,7 +11,7 @@ LL |     return a.bar();
    = note: expected type parameter `B`
              found associated type `<A as MyTrait>::T`
    = note: the caller chooses a type for `B` which can be different from `<A as MyTrait>::T`
-help: consider further restricting this bound with trait `<T = B>`
+help: consider further restricting this bound with  `<T = B>`
    |
 LL | pub fn foo<A: MyTrait<T = B>, B>(a: A) -> B {
    |                      +++++++

--- a/tests/ui/trait-bounds/restrict-assoc-type-of-generic-bound.stderr
+++ b/tests/ui/trait-bounds/restrict-assoc-type-of-generic-bound.stderr
@@ -11,7 +11,7 @@ LL |     return a.bar();
    = note: expected type parameter `B`
              found associated type `<A as MyTrait>::T`
    = note: the caller chooses a type for `B` which can be different from `<A as MyTrait>::T`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `<T = B>`
    |
 LL | pub fn foo<A: MyTrait<T = B>, B>(a: A) -> B {
    |                      +++++++

--- a/tests/ui/trait-bounds/restrict-assoc-type-of-generic-bound.stderr
+++ b/tests/ui/trait-bounds/restrict-assoc-type-of-generic-bound.stderr
@@ -11,7 +11,7 @@ LL |     return a.bar();
    = note: expected type parameter `B`
              found associated type `<A as MyTrait>::T`
    = note: the caller chooses a type for `B` which can be different from `<A as MyTrait>::T`
-help: consider further restricting this bound with  `<T = B>`
+help: consider further restricting this bound
    |
 LL | pub fn foo<A: MyTrait<T = B>, B>(a: A) -> B {
    |                      +++++++

--- a/tests/ui/trait-bounds/unstable-trait-suggestion.rs
+++ b/tests/ui/trait-bounds/unstable-trait-suggestion.rs
@@ -9,7 +9,11 @@ pub trait Unstable {}
 fn foo<T: Unstable>(_: T) {}
 
 #[stable(feature = "unit_test", since = "1.0.0")]
-pub fn demo<T>(t: T) { //~ HELP consider restricting type parameter `T` with unstable trait `Unstable`
+pub fn bar<T>(t: T) { //~ HELP consider restricting type parameter `T` with unstable trait `Unstable`
     foo(t) //~ ERROR E0277
+}
+#[stable(feature = "unit_test", since = "1.0.0")]
+pub fn baz<T>(t: std::ops::Range<T>) { //~ HELP consider restricting type parameter `T` with unstable trait
+    for _ in t {} //~ ERROR E0277
 }
 fn main() {}

--- a/tests/ui/trait-bounds/unstable-trait-suggestion.rs
+++ b/tests/ui/trait-bounds/unstable-trait-suggestion.rs
@@ -9,7 +9,7 @@ pub trait Unstable {}
 fn foo<T: Unstable>(_: T) {}
 
 #[stable(feature = "unit_test", since = "1.0.0")]
-pub fn demo<T>(t: T) { //~ HELP consider restricting type parameter `T` but it is an `unstable` trait
+pub fn demo<T>(t: T) { //~ HELP consider restricting type parameter `T` with unstable trait `Unstable`
     foo(t) //~ ERROR E0277
 }
 fn main() {}

--- a/tests/ui/trait-bounds/unstable-trait-suggestion.rs
+++ b/tests/ui/trait-bounds/unstable-trait-suggestion.rs
@@ -1,0 +1,15 @@
+#![feature(staged_api)]
+#![allow(internal_features)]
+#![stable(feature = "unit_test", since = "1.0.0")]
+
+#[unstable(feature = "step_trait", issue = "42168")]
+pub trait Unstable {}
+
+#[stable(feature = "unit_test", since = "1.0.0")]
+fn foo<T: Unstable>(_: T) {}
+
+#[stable(feature = "unit_test", since = "1.0.0")]
+pub fn demo<T>(t: T) { //~ HELP consider restricting type parameter `T` but it is an `unstable` trait
+    foo(t) //~ ERROR E0277
+}
+fn main() {}

--- a/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
+++ b/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
@@ -1,0 +1,21 @@
+error[E0277]: the trait bound `T: Unstable` is not satisfied
+  --> $DIR/unstable-trait-suggestion.rs:13:9
+   |
+LL |     foo(t)
+   |     --- ^ the trait `Unstable` is not implemented for `T`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: required by a bound in `foo`
+  --> $DIR/unstable-trait-suggestion.rs:9:11
+   |
+LL | fn foo<T: Unstable>(_: T) {}
+   |           ^^^^^^^^ required by this bound in `foo`
+help: consider restricting type parameter `T` but it is an `unstable` trait
+   |
+LL | pub fn demo<T: Unstable>(t: T) {
+   |              ++++++++++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
+++ b/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `foo`
    |
 LL | fn foo<T: Unstable>(_: T) {}
    |           ^^^^^^^^ required by this bound in `foo`
-help: consider restricting type parameter `T` but it is an `unstable` trait
+help: consider restricting type parameter `T` with unstable trait `Unstable`
    |
 LL | pub fn demo<T: Unstable>(t: T) {
    |              ++++++++++

--- a/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
+++ b/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
@@ -13,9 +13,22 @@ LL | fn foo<T: Unstable>(_: T) {}
    |           ^^^^^^^^ required by this bound in `foo`
 help: consider restricting type parameter `T` with unstable trait `Unstable`
    |
-LL | pub fn demo<T: Unstable>(t: T) {
-   |              ++++++++++
+LL | pub fn bar<T: Unstable>(t: T) {
+   |             ++++++++++
 
-error: aborting due to 1 previous error
+error[E0277]: the trait bound `T: Step` is not satisfied
+  --> $DIR/unstable-trait-suggestion.rs:17:14
+   |
+LL |     for _ in t {}
+   |              ^ the trait `Step` is not implemented for `T`
+   |
+   = note: required for `std::ops::Range<T>` to implement `Iterator`
+   = note: required for `std::ops::Range<T>` to implement `IntoIterator`
+help: consider restricting type parameter `T` with unstable trait `std::iter::Step`
+   |
+LL | pub fn baz<T: std::iter::Step>(t: std::ops::Range<T>) {
+   |             +++++++++++++++++
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
+++ b/tests/ui/trait-bounds/unstable-trait-suggestion.stderr
@@ -24,7 +24,7 @@ LL |     for _ in t {}
    |
    = note: required for `std::ops::Range<T>` to implement `Iterator`
    = note: required for `std::ops::Range<T>` to implement `IntoIterator`
-help: consider restricting type parameter `T` with unstable trait `std::iter::Step`
+help: consider restricting type parameter `T` with unstable trait `Step`
    |
 LL | pub fn baz<T: std::iter::Step>(t: std::ops::Range<T>) {
    |             +++++++++++++++++

--- a/tests/ui/traits/alias/wf.stderr
+++ b/tests/ui/traits/alias/wf.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `A`
    |
 LL | trait A<T: Foo> {}
    |            ^^^ required by this bound in `A`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Foo`
    |
 LL | trait B<T: Foo> = A<T>;
    |          +++++

--- a/tests/ui/traits/bad-method-typaram-kind.stderr
+++ b/tests/ui/traits/bad-method-typaram-kind.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `Bar::bar`
    |
 LL |     fn bar<T:Send>(&self);
    |              ^^^^ required by this bound in `Bar::bar`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Send`
    |
 LL | fn foo<T:'static + std::marker::Send>() {
    |                  +++++++++++++++++++

--- a/tests/ui/traits/bad-method-typaram-kind.stderr
+++ b/tests/ui/traits/bad-method-typaram-kind.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `Bar::bar`
    |
 LL |     fn bar<T:Send>(&self);
    |              ^^^^ required by this bound in `Bar::bar`
-help: consider further restricting this bound with trait `std::marker::Send`
+help: consider further restricting this bound with trait `Send`
    |
 LL | fn foo<T:'static + std::marker::Send>() {
    |                  +++++++++++++++++++

--- a/tests/ui/traits/bad-method-typaram-kind.stderr
+++ b/tests/ui/traits/bad-method-typaram-kind.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `Bar::bar`
    |
 LL |     fn bar<T:Send>(&self);
    |              ^^^^ required by this bound in `Bar::bar`
-help: consider further restricting this bound with trait `Send`
+help: consider further restricting type parameter `T` with trait `Send`
    |
 LL | fn foo<T:'static + std::marker::Send>() {
    |                  +++++++++++++++++++

--- a/tests/ui/traits/bound/on-structs-and-enums.stderr
+++ b/tests/ui/traits/bound/on-structs-and-enums.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Foo`
    |
 LL | struct Foo<T:Trait> {
    |              ^^^^^ required by this bound in `Foo`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL | impl<T: Trait> Foo<T> {
    |       +++++++
@@ -59,7 +59,7 @@ note: required by a bound in `Foo`
    |
 LL | struct Foo<T:Trait> {
    |              ^^^^^ required by this bound in `Foo`
-help: consider restricting type parameter `U`
+help: consider restricting type parameter `U` with trait `Trait`
    |
 LL | struct Badness<U: Trait> {
    |                 +++++++
@@ -75,7 +75,7 @@ note: required by a bound in `Bar`
    |
 LL | enum Bar<T:Trait> {
    |            ^^^^^ required by this bound in `Bar`
-help: consider restricting type parameter `V`
+help: consider restricting type parameter `V` with trait `Trait`
    |
 LL | enum MoreBadness<V: Trait> {
    |                   +++++++

--- a/tests/ui/traits/const-traits/call-generic-method-chain.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-chain.stderr
@@ -42,10 +42,6 @@ LL |     *t == *t
    |     ^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const std::cmp::PartialEq`
-   |
-LL | const fn equals_self<T: ~const PartialEq + ~const std::cmp::PartialEq>(t: &T) -> bool {
-   |                                          ++++++++++++++++++++++++++++
 
 error[E0015]: cannot call non-const fn `<S as PartialEq>::eq` in constant functions
   --> $DIR/call-generic-method-chain.rs:16:15

--- a/tests/ui/traits/const-traits/call-generic-method-chain.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-chain.stderr
@@ -42,7 +42,7 @@ LL |     *t == *t
    |     ^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const std::cmp::PartialEq`
    |
 LL | const fn equals_self<T: ~const PartialEq + ~const std::cmp::PartialEq>(t: &T) -> bool {
    |                                          ++++++++++++++++++++++++++++

--- a/tests/ui/traits/const-traits/call-generic-method-dup-bound.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-dup-bound.stderr
@@ -42,7 +42,7 @@ LL |     *t == *t
    |     ^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const std::cmp::PartialEq`
    |
 LL | const fn equals_self<T: PartialEq + ~const PartialEq + ~const std::cmp::PartialEq>(t: &T) -> bool {
    |                                                      ++++++++++++++++++++++++++++
@@ -62,7 +62,7 @@ LL |     *t == *t
    |     ^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const std::cmp::PartialEq`
    |
 LL | const fn equals_self2<T: A + ~const PartialEq + ~const std::cmp::PartialEq>(t: &T) -> bool {
    |                                               ++++++++++++++++++++++++++++

--- a/tests/ui/traits/const-traits/call-generic-method-dup-bound.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-dup-bound.stderr
@@ -42,10 +42,6 @@ LL |     *t == *t
    |     ^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const std::cmp::PartialEq`
-   |
-LL | const fn equals_self<T: PartialEq + ~const PartialEq + ~const std::cmp::PartialEq>(t: &T) -> bool {
-   |                                                      ++++++++++++++++++++++++++++
 
 error[E0015]: cannot call non-const fn `<S as PartialEq>::eq` in constant functions
   --> $DIR/call-generic-method-dup-bound.rs:14:15
@@ -62,10 +58,6 @@ LL |     *t == *t
    |     ^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const std::cmp::PartialEq`
-   |
-LL | const fn equals_self2<T: A + ~const PartialEq + ~const std::cmp::PartialEq>(t: &T) -> bool {
-   |                                               ++++++++++++++++++++++++++++
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/traits/const-traits/call-generic-method-fail.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-fail.stderr
@@ -5,7 +5,7 @@ LL |     *t == *t
    |     ^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const std::cmp::PartialEq`
    |
 LL | pub const fn equals_self<T: PartialEq + ~const std::cmp::PartialEq>(t: &T) -> bool {
    |                                       ++++++++++++++++++++++++++++

--- a/tests/ui/traits/const-traits/call-generic-method-fail.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-fail.stderr
@@ -5,10 +5,6 @@ LL |     *t == *t
    |     ^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const std::cmp::PartialEq`
-   |
-LL | pub const fn equals_self<T: PartialEq + ~const std::cmp::PartialEq>(t: &T) -> bool {
-   |                                       ++++++++++++++++++++++++++++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/traits/const-traits/call-generic-method-pass.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-pass.stderr
@@ -28,10 +28,6 @@ LL |     *t == *t
    |     ^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const std::cmp::PartialEq`
-   |
-LL | const fn equals_self<T: ~const PartialEq + ~const std::cmp::PartialEq>(t: &T) -> bool {
-   |                                          ++++++++++++++++++++++++++++
 
 error[E0015]: cannot call non-const fn `<S as PartialEq>::eq` in constant functions
   --> $DIR/call-generic-method-pass.rs:16:15

--- a/tests/ui/traits/const-traits/call-generic-method-pass.stderr
+++ b/tests/ui/traits/const-traits/call-generic-method-pass.stderr
@@ -28,7 +28,7 @@ LL |     *t == *t
    |     ^^^^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const std::cmp::PartialEq`
    |
 LL | const fn equals_self<T: ~const PartialEq + ~const std::cmp::PartialEq>(t: &T) -> bool {
    |                                          ++++++++++++++++++++++++++++

--- a/tests/ui/traits/const-traits/const-closure-trait-method-fail.stderr
+++ b/tests/ui/traits/const-traits/const-closure-trait-method-fail.stderr
@@ -19,7 +19,7 @@ LL |     x(())
    |     ^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const FnOnce(())`
    |
 LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32 + ~const FnOnce(())>(x: T) -> i32 {
    |                                                         +++++++++++++++++++

--- a/tests/ui/traits/const-traits/const-closure-trait-method-fail.stderr
+++ b/tests/ui/traits/const-traits/const-closure-trait-method-fail.stderr
@@ -19,10 +19,6 @@ LL |     x(())
    |     ^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const FnOnce(())`
-   |
-LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32 + ~const FnOnce(())>(x: T) -> i32 {
-   |                                                         +++++++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/traits/const-traits/const-closure-trait-method.stderr
+++ b/tests/ui/traits/const-traits/const-closure-trait-method.stderr
@@ -19,7 +19,7 @@ LL |     x(())
    |     ^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const FnOnce(())`
    |
 LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32 + ~const FnOnce(())>(x: T) -> i32 {
    |                                                         +++++++++++++++++++

--- a/tests/ui/traits/const-traits/const-closure-trait-method.stderr
+++ b/tests/ui/traits/const-traits/const-closure-trait-method.stderr
@@ -19,10 +19,6 @@ LL |     x(())
    |     ^^^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const FnOnce(())`
-   |
-LL | const fn need_const_closure<T: ~const FnOnce(()) -> i32 + ~const FnOnce(())>(x: T) -> i32 {
-   |                                                         +++++++++++++++++++
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/traits/const-traits/const-closures.stderr
+++ b/tests/ui/traits/const-traits/const-closures.stderr
@@ -61,10 +61,6 @@ LL |     f() + f()
    |     ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const Fn()`
-   |
-LL | const fn answer<F: ~const Fn() -> u8 + ~const Fn()>(f: &F) -> u8 {
-   |                                      +++++++++++++
 
 error[E0015]: cannot call non-const closure in constant functions
   --> $DIR/const-closures.rs:24:11
@@ -73,10 +69,6 @@ LL |     f() + f()
    |           ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const Fn()`
-   |
-LL | const fn answer<F: ~const Fn() -> u8 + ~const Fn()>(f: &F) -> u8 {
-   |                                      +++++++++++++
 
 error[E0015]: cannot call non-const closure in constant functions
   --> $DIR/const-closures.rs:12:5
@@ -85,10 +77,6 @@ LL |     f() * 7
    |     ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound with trait `~const Fn()`
-   |
-LL |         F: ~const FnOnce() -> u8 + ~const Fn(),
-   |                                  +++++++++++++
 
 error: aborting due to 11 previous errors
 

--- a/tests/ui/traits/const-traits/const-closures.stderr
+++ b/tests/ui/traits/const-traits/const-closures.stderr
@@ -61,7 +61,7 @@ LL |     f() + f()
    |     ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const Fn()`
    |
 LL | const fn answer<F: ~const Fn() -> u8 + ~const Fn()>(f: &F) -> u8 {
    |                                      +++++++++++++
@@ -73,7 +73,7 @@ LL |     f() + f()
    |           ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const Fn()`
    |
 LL | const fn answer<F: ~const Fn() -> u8 + ~const Fn()>(f: &F) -> u8 {
    |                                      +++++++++++++
@@ -85,7 +85,7 @@ LL |     f() * 7
    |     ^^^
    |
    = note: calls in constant functions are limited to constant functions, tuple structs and tuple variants
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `~const Fn()`
    |
 LL |         F: ~const FnOnce() -> u8 + ~const Fn(),
    |                                  +++++++++++++

--- a/tests/ui/traits/const-traits/trait-where-clause.stderr
+++ b/tests/ui/traits/const-traits/trait-where-clause.stderr
@@ -33,7 +33,7 @@ note: required by a bound in `Foo::b`
    |
 LL |     fn b() where Self: ~const Bar;
    |                        ^^^^^^^^^^ required by this bound in `Foo::b`
-help: consider further restricting this bound with trait `Bar`
+help: consider further restricting type parameter `T` with trait `Bar`
    |
 LL | fn test1<T: Foo + Bar>() {
    |                 +++++
@@ -49,7 +49,7 @@ note: required by a bound in `Foo::c`
    |
 LL |     fn c<T: ~const Bar>();
    |             ^^^^^^^^^^ required by this bound in `Foo::c`
-help: consider further restricting this bound with trait `Bar`
+help: consider further restricting type parameter `T` with trait `Bar`
    |
 LL | fn test1<T: Foo + Bar>() {
    |                 +++++

--- a/tests/ui/traits/const-traits/trait-where-clause.stderr
+++ b/tests/ui/traits/const-traits/trait-where-clause.stderr
@@ -33,7 +33,7 @@ note: required by a bound in `Foo::b`
    |
 LL |     fn b() where Self: ~const Bar;
    |                        ^^^^^^^^^^ required by this bound in `Foo::b`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Bar`
    |
 LL | fn test1<T: Foo + Bar>() {
    |                 +++++
@@ -49,7 +49,7 @@ note: required by a bound in `Foo::c`
    |
 LL |     fn c<T: ~const Bar>();
    |             ^^^^^^^^^^ required by this bound in `Foo::c`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Bar`
    |
 LL | fn test1<T: Foo + Bar>() {
    |                 +++++

--- a/tests/ui/traits/copy-impl-cannot-normalize.stderr
+++ b/tests/ui/traits/copy-impl-cannot-normalize.stderr
@@ -14,7 +14,7 @@ LL |     T: TraitFoo,
    |        -------- unsatisfied trait bound introduced here
 note: required by a bound in `Copy`
   --> $SRC_DIR/core/src/marker.rs:LL:COL
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `TraitFoo`
    |
 LL | impl<T: TraitFoo> Copy for Foo<T> {}
    |       ++++++++++

--- a/tests/ui/traits/copy-is-not-modulo-regions.not_static.stderr
+++ b/tests/ui/traits/copy-is-not-modulo-regions.not_static.stderr
@@ -12,7 +12,7 @@ note: the `Copy` impl for `Foo<'any>` requires that `'any: 'static`
    |
 LL | struct Bar<'lt>(Foo<'lt>);
    |                 ^^^^^^^^
-help: consider restricting type parameter `'any`
+help: consider restricting type parameter `'any` with trait `'static`
    |
 LL | impl<'any: 'static> Copy for Bar<'any> {}
    |          +++++++++

--- a/tests/ui/traits/copy-is-not-modulo-regions.not_static.stderr
+++ b/tests/ui/traits/copy-is-not-modulo-regions.not_static.stderr
@@ -12,7 +12,7 @@ note: the `Copy` impl for `Foo<'any>` requires that `'any: 'static`
    |
 LL | struct Bar<'lt>(Foo<'lt>);
    |                 ^^^^^^^^
-help: consider restricting type parameter `'any` with trait `'static`
+help: consider restricting type parameter `'any` with  `'static`
    |
 LL | impl<'any: 'static> Copy for Bar<'any> {}
    |          +++++++++

--- a/tests/ui/traits/inductive-overflow/two-traits.stderr
+++ b/tests/ui/traits/inductive-overflow/two-traits.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Magic::X`
    |
 LL |     type X: Trait;
    |             ^^^^^ required by this bound in `Magic::X`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::marker::Sync`
    |
 LL | impl<T: Magic + std::marker::Sync> Magic for T {
    |               +++++++++++++++++++

--- a/tests/ui/traits/inductive-overflow/two-traits.stderr
+++ b/tests/ui/traits/inductive-overflow/two-traits.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Magic::X`
    |
 LL |     type X: Trait;
    |             ^^^^^ required by this bound in `Magic::X`
-help: consider further restricting this bound with trait `Sync`
+help: consider further restricting type parameter `T` with trait `Sync`
    |
 LL | impl<T: Magic + std::marker::Sync> Magic for T {
    |               +++++++++++++++++++

--- a/tests/ui/traits/inductive-overflow/two-traits.stderr
+++ b/tests/ui/traits/inductive-overflow/two-traits.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Magic::X`
    |
 LL |     type X: Trait;
    |             ^^^^^ required by this bound in `Magic::X`
-help: consider further restricting this bound with trait `std::marker::Sync`
+help: consider further restricting this bound with trait `Sync`
    |
 LL | impl<T: Magic + std::marker::Sync> Magic for T {
    |               +++++++++++++++++++

--- a/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
+++ b/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
@@ -18,7 +18,7 @@ LL |     c.same_as(22)
    |       |
    |       required by a bound introduced by this call
    |
-help: consider further restricting this bound with trait `CompareTo`
+help: consider further restricting type parameter `C` with trait `CompareTo`
    |
 LL | fn with_trait<C:CompareToInts + CompareTo<i32>>(c: &C) -> bool {
    |                               ++++++++++++++++
@@ -41,7 +41,7 @@ LL |     CompareTo::same_as(c, 22)
    |     |
    |     required by a bound introduced by this call
    |
-help: consider further restricting this bound with trait `CompareTo`
+help: consider further restricting type parameter `C` with trait `CompareTo`
    |
 LL | fn with_ufcs2<C:CompareToInts + CompareTo<i32>>(c: &C) -> bool {
    |                               ++++++++++++++++

--- a/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
+++ b/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
@@ -18,7 +18,7 @@ LL |     c.same_as(22)
    |       |
    |       required by a bound introduced by this call
    |
-help: consider further restricting this bound with trait `CompareTo<i32>`
+help: consider further restricting this bound with trait `CompareTo`
    |
 LL | fn with_trait<C:CompareToInts + CompareTo<i32>>(c: &C) -> bool {
    |                               ++++++++++++++++
@@ -41,7 +41,7 @@ LL |     CompareTo::same_as(c, 22)
    |     |
    |     required by a bound introduced by this call
    |
-help: consider further restricting this bound with trait `CompareTo<i32>`
+help: consider further restricting this bound with trait `CompareTo`
    |
 LL | fn with_ufcs2<C:CompareToInts + CompareTo<i32>>(c: &C) -> bool {
    |                               ++++++++++++++++

--- a/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
+++ b/tests/ui/traits/inheritance/repeated-supertrait-ambig.stderr
@@ -18,7 +18,7 @@ LL |     c.same_as(22)
    |       |
    |       required by a bound introduced by this call
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `CompareTo<i32>`
    |
 LL | fn with_trait<C:CompareToInts + CompareTo<i32>>(c: &C) -> bool {
    |                               ++++++++++++++++
@@ -41,7 +41,7 @@ LL |     CompareTo::same_as(c, 22)
    |     |
    |     required by a bound introduced by this call
    |
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `CompareTo<i32>`
    |
 LL | fn with_ufcs2<C:CompareToInts + CompareTo<i32>>(c: &C) -> bool {
    |                               ++++++++++++++++

--- a/tests/ui/traits/issue-21837.stderr
+++ b/tests/ui/traits/issue-21837.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `Foo`
    |
 LL | pub struct Foo<T: Bound>(T);
    |                   ^^^^^ required by this bound in `Foo`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Bound`
    |
 LL | impl<T: Bound> Trait2 for Foo<T> {}
    |       +++++++

--- a/tests/ui/traits/issue-43784-supertrait.stderr
+++ b/tests/ui/traits/issue-43784-supertrait.stderr
@@ -14,7 +14,7 @@ note: required by a bound in `Complete`
    |
 LL | pub trait Complete: Partial {
    |                     ^^^^^^^ required by this bound in `Complete`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | impl<T: std::marker::Copy> Complete for T {}
    |       +++++++++++++++++++

--- a/tests/ui/traits/issue-43784-supertrait.stderr
+++ b/tests/ui/traits/issue-43784-supertrait.stderr
@@ -14,7 +14,7 @@ note: required by a bound in `Complete`
    |
 LL | pub trait Complete: Partial {
    |                     ^^^^^^^ required by this bound in `Complete`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | impl<T: std::marker::Copy> Complete for T {}
    |       +++++++++++++++++++

--- a/tests/ui/traits/next-solver/diagnostics/projection-trait-ref.stderr
+++ b/tests/ui/traits/next-solver/diagnostics/projection-trait-ref.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `T: Trait` is not satisfied
 LL |     let x: <T as Trait>::Assoc = ();
    |            ^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL | fn test_poly<T: Trait>() {
    |               +++++++

--- a/tests/ui/traits/next-solver/dyn-incompatibility.stderr
+++ b/tests/ui/traits/next-solver/dyn-incompatibility.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `copy`
    |
 LL | fn copy<U: Setup + ?Sized>(from: &U::From) -> U::From {
    |            ^^^^^ required by this bound in `copy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | pub fn copy_any<T: std::marker::Copy>(t: &T) -> T {
    |                  +++++++++++++++++++
@@ -38,7 +38,7 @@ LL |     copy::<dyn Setup<From=T>>(t)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `dyn Setup<From = T>`, the trait `Copy` is not implemented for `T`
    |
    = note: required because it appears within the type `dyn Setup<From = T>`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | pub fn copy_any<T: std::marker::Copy>(t: &T) -> T {
    |                  +++++++++++++++++++

--- a/tests/ui/traits/next-solver/dyn-incompatibility.stderr
+++ b/tests/ui/traits/next-solver/dyn-incompatibility.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `copy`
    |
 LL | fn copy<U: Setup + ?Sized>(from: &U::From) -> U::From {
    |            ^^^^^ required by this bound in `copy`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | pub fn copy_any<T: std::marker::Copy>(t: &T) -> T {
    |                  +++++++++++++++++++
@@ -38,7 +38,7 @@ LL |     copy::<dyn Setup<From=T>>(t)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `dyn Setup<From = T>`, the trait `Copy` is not implemented for `T`
    |
    = note: required because it appears within the type `dyn Setup<From = T>`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | pub fn copy_any<T: std::marker::Copy>(t: &T) -> T {
    |                  +++++++++++++++++++

--- a/tests/ui/traits/next-solver/global-cache-and-parallel-frontend.stderr
+++ b/tests/ui/traits/next-solver/global-cache-and-parallel-frontend.stderr
@@ -14,7 +14,7 @@ LL | impl<T: Clone, U> PartialEq<U> for Struct<T>
 note: required by a bound in `Eq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T` with trait `std::clone::Clone`
+help: consider restricting type parameter `T` with trait `Clone`
    |
 LL | pub struct Struct<T: std::clone::Clone>(T);
    |                    +++++++++++++++++++

--- a/tests/ui/traits/next-solver/global-cache-and-parallel-frontend.stderr
+++ b/tests/ui/traits/next-solver/global-cache-and-parallel-frontend.stderr
@@ -14,7 +14,7 @@ LL | impl<T: Clone, U> PartialEq<U> for Struct<T>
 note: required by a bound in `Eq`
   --> $SRC_DIR/core/src/cmp.rs:LL:COL
    = note: this error originates in the derive macro `Eq` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::clone::Clone`
    |
 LL | pub struct Struct<T: std::clone::Clone>(T);
    |                    +++++++++++++++++++

--- a/tests/ui/traits/next-solver/issue-118950-root-region.stderr
+++ b/tests/ui/traits/next-solver/issue-118950-root-region.stderr
@@ -32,7 +32,7 @@ error[E0277]: the trait bound `T: Overlap<for<'a> fn(Assoc<'a, T>)>` is not sati
 LL | impl<T> Overlap<for<'a> fn(Assoc<'a, T>)> for T where Missing: Overlap<T> {}
    |                                               ^ the trait `Overlap<for<'a> fn(Assoc<'a, T>)>` is not implemented for `T`
    |
-help: consider further restricting type parameter `T`
+help: consider further restricting type parameter `T` with trait `Overlap<for<'a> fn(Assoc<'a, T>)>`
    |
 LL | impl<T> Overlap<for<'a> fn(Assoc<'a, T>)> for T where Missing: Overlap<T>, T: Overlap<for<'a> fn(Assoc<'a, T>)> {}
    |                                                                          ++++++++++++++++++++++++++++++++++++++

--- a/tests/ui/traits/next-solver/issue-118950-root-region.stderr
+++ b/tests/ui/traits/next-solver/issue-118950-root-region.stderr
@@ -32,7 +32,7 @@ error[E0277]: the trait bound `T: Overlap<for<'a> fn(Assoc<'a, T>)>` is not sati
 LL | impl<T> Overlap<for<'a> fn(Assoc<'a, T>)> for T where Missing: Overlap<T> {}
    |                                               ^ the trait `Overlap<for<'a> fn(Assoc<'a, T>)>` is not implemented for `T`
    |
-help: consider further restricting type parameter `T` with trait `Overlap<for<'a> fn(Assoc<'a, T>)>`
+help: consider further restricting type parameter `T` with trait `Overlap`
    |
 LL | impl<T> Overlap<for<'a> fn(Assoc<'a, T>)> for T where Missing: Overlap<T>, T: Overlap<for<'a> fn(Assoc<'a, T>)> {}
    |                                                                          ++++++++++++++++++++++++++++++++++++++

--- a/tests/ui/tuple/builtin-fail.stderr
+++ b/tests/ui/tuple/builtin-fail.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `assert_is_tuple`
    |
 LL | fn assert_is_tuple<T: std::marker::Tuple + ?Sized>() {}
    |                       ^^^^^^^^^^^^^^^^^^ required by this bound in `assert_is_tuple`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` but it is an `unstable` trait
    |
 LL | fn from_param_env<T: std::marker::Tuple>() {
    |                    ++++++++++++++++++++

--- a/tests/ui/tuple/builtin-fail.stderr
+++ b/tests/ui/tuple/builtin-fail.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `assert_is_tuple`
    |
 LL | fn assert_is_tuple<T: std::marker::Tuple + ?Sized>() {}
    |                       ^^^^^^^^^^^^^^^^^^ required by this bound in `assert_is_tuple`
-help: consider restricting type parameter `T` with unstable trait `std::marker::Tuple`
+help: consider restricting type parameter `T` with unstable trait `Tuple`
    |
 LL | fn from_param_env<T: std::marker::Tuple>() {
    |                    ++++++++++++++++++++

--- a/tests/ui/tuple/builtin-fail.stderr
+++ b/tests/ui/tuple/builtin-fail.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `assert_is_tuple`
    |
 LL | fn assert_is_tuple<T: std::marker::Tuple + ?Sized>() {}
    |                       ^^^^^^^^^^^^^^^^^^ required by this bound in `assert_is_tuple`
-help: consider restricting type parameter `T` but it is an `unstable` trait
+help: consider restricting type parameter `T` with unstable trait `std::marker::Tuple`
    |
 LL | fn from_param_env<T: std::marker::Tuple>() {
    |                    ++++++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/bounds-are-checked-2.stderr
+++ b/tests/ui/type-alias-impl-trait/bounds-are-checked-2.stderr
@@ -14,7 +14,7 @@ note: this definition site has more where clauses than the opaque type
    |
 LL |     fn f<T: Clone>(t: T) -> X<T> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::clone::Clone`
    |
 LL |     pub type X<T: std::clone::Clone> = impl Clone;
    |                 +++++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/bounds-are-checked-2.stderr
+++ b/tests/ui/type-alias-impl-trait/bounds-are-checked-2.stderr
@@ -14,7 +14,7 @@ note: this definition site has more where clauses than the opaque type
    |
 LL |     fn f<T: Clone>(t: T) -> X<T> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider restricting type parameter `T` with trait `std::clone::Clone`
+help: consider restricting type parameter `T` with trait `Clone`
    |
 LL |     pub type X<T: std::clone::Clone> = impl Clone;
    |                 +++++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/bounds-are-checked3.stderr
+++ b/tests/ui/type-alias-impl-trait/bounds-are-checked3.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Struct`
    |
 LL | struct Struct<V: Display>(Option<V>);
    |                  ^^^^^^^ required by this bound in `Struct`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `std::fmt::Display`
    |
 LL | type Foo<T: Debug + std::fmt::Display> = (impl Debug, Struct<T>);
    |                   +++++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/bounds-are-checked3.stderr
+++ b/tests/ui/type-alias-impl-trait/bounds-are-checked3.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Struct`
    |
 LL | struct Struct<V: Display>(Option<V>);
    |                  ^^^^^^^ required by this bound in `Struct`
-help: consider further restricting this bound with trait `Display`
+help: consider further restricting type parameter `T` with trait `Display`
    |
 LL | type Foo<T: Debug + std::fmt::Display> = (impl Debug, Struct<T>);
    |                   +++++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/bounds-are-checked3.stderr
+++ b/tests/ui/type-alias-impl-trait/bounds-are-checked3.stderr
@@ -10,7 +10,7 @@ note: required by a bound in `Struct`
    |
 LL | struct Struct<V: Display>(Option<V>);
    |                  ^^^^^^^ required by this bound in `Struct`
-help: consider further restricting this bound with trait `std::fmt::Display`
+help: consider further restricting this bound with trait `Display`
    |
 LL | type Foo<T: Debug + std::fmt::Display> = (impl Debug, Struct<T>);
    |                   +++++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/future.stderr
+++ b/tests/ui/type-alias-impl-trait/future.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `foo`
    |
 LL | fn foo<B: Bar>(bar: B) -> FooFuture<B> {
    |           ^^^ required by this bound in `foo`
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Bar`
    |
 LL | type FooFuture<B: Bar> = impl Future<Output = ()>;
    |                 +++++

--- a/tests/ui/type-alias-impl-trait/generic_duplicate_param_use2.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_duplicate_param_use2.stderr
@@ -14,7 +14,7 @@ note: this definition site has more where clauses than the opaque type
    |
 LL | fn two<T: Debug, U>(t: T, _: U) -> Two<T, U> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider restricting type parameter `T` with trait `std::fmt::Debug`
+help: consider restricting type parameter `T` with trait `Debug`
    |
 LL | type Two<T: std::fmt::Debug, U> = impl Debug;
    |           +++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/generic_duplicate_param_use2.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_duplicate_param_use2.stderr
@@ -14,7 +14,7 @@ note: this definition site has more where clauses than the opaque type
    |
 LL | fn two<T: Debug, U>(t: T, _: U) -> Two<T, U> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::fmt::Debug`
    |
 LL | type Two<T: std::fmt::Debug, U> = impl Debug;
    |           +++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/generic_duplicate_param_use4.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_duplicate_param_use4.stderr
@@ -14,7 +14,7 @@ note: this definition site has more where clauses than the opaque type
    |
 LL | fn three<T, U: Debug>(_: T, u: U) -> Two<T, U> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider restricting type parameter `U`
+help: consider restricting type parameter `U` with trait `std::fmt::Debug`
    |
 LL | type Two<T, U: std::fmt::Debug> = impl Debug;
    |              +++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/generic_duplicate_param_use4.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_duplicate_param_use4.stderr
@@ -14,7 +14,7 @@ note: this definition site has more where clauses than the opaque type
    |
 LL | fn three<T, U: Debug>(_: T, u: U) -> Two<T, U> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider restricting type parameter `U` with trait `std::fmt::Debug`
+help: consider restricting type parameter `U` with trait `Debug`
    |
 LL | type Two<T, U: std::fmt::Debug> = impl Debug;
    |              +++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/generic_underconstrained.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_underconstrained.stderr
@@ -9,7 +9,7 @@ note: required by a bound on the type alias `Underconstrained`
    |
 LL | type Underconstrained<T: Trait> = impl Send;
    |                          ^^^^^ required by this bound
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL | fn underconstrain<T: Trait>(_: T) -> Underconstrained<T> {
    |                    +++++++
@@ -30,7 +30,7 @@ note: required by a bound on the type alias `Underconstrained`
    |
 LL | type Underconstrained<T: Trait> = impl Send;
    |                          ^^^^^ required by this bound
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL | fn underconstrain<T: Trait>(_: T) -> Underconstrained<T> {
    |                    +++++++

--- a/tests/ui/type-alias-impl-trait/generic_underconstrained2.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_underconstrained2.stderr
@@ -9,7 +9,7 @@ note: required by a bound on the type alias `Underconstrained`
    |
 LL | type Underconstrained<T: std::fmt::Debug> = impl Send;
    |                          ^^^^^^^^^^^^^^^ required by this bound
-help: consider restricting type parameter `U` with trait `std::fmt::Debug`
+help: consider restricting type parameter `U` with trait `Debug`
    |
 LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
    |                      +++++++++++++++++
@@ -25,7 +25,7 @@ note: required by a bound on the type alias `Underconstrained2`
    |
 LL | type Underconstrained2<T: std::fmt::Debug> = impl Send;
    |                           ^^^^^^^^^^^^^^^ required by this bound
-help: consider restricting type parameter `V` with trait `std::fmt::Debug`
+help: consider restricting type parameter `V` with trait `Debug`
    |
 LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained2<V> {
    |                          +++++++++++++++++
@@ -46,7 +46,7 @@ note: required by a bound on the type alias `Underconstrained`
    |
 LL | type Underconstrained<T: std::fmt::Debug> = impl Send;
    |                          ^^^^^^^^^^^^^^^ required by this bound
-help: consider restricting type parameter `U` with trait `std::fmt::Debug`
+help: consider restricting type parameter `U` with trait `Debug`
    |
 LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
    |                      +++++++++++++++++
@@ -67,7 +67,7 @@ note: required by a bound on the type alias `Underconstrained2`
    |
 LL | type Underconstrained2<T: std::fmt::Debug> = impl Send;
    |                           ^^^^^^^^^^^^^^^ required by this bound
-help: consider restricting type parameter `V` with trait `std::fmt::Debug`
+help: consider restricting type parameter `V` with trait `Debug`
    |
 LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained2<V> {
    |                          +++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/generic_underconstrained2.stderr
+++ b/tests/ui/type-alias-impl-trait/generic_underconstrained2.stderr
@@ -9,7 +9,7 @@ note: required by a bound on the type alias `Underconstrained`
    |
 LL | type Underconstrained<T: std::fmt::Debug> = impl Send;
    |                          ^^^^^^^^^^^^^^^ required by this bound
-help: consider restricting type parameter `U`
+help: consider restricting type parameter `U` with trait `std::fmt::Debug`
    |
 LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
    |                      +++++++++++++++++
@@ -25,7 +25,7 @@ note: required by a bound on the type alias `Underconstrained2`
    |
 LL | type Underconstrained2<T: std::fmt::Debug> = impl Send;
    |                           ^^^^^^^^^^^^^^^ required by this bound
-help: consider restricting type parameter `V`
+help: consider restricting type parameter `V` with trait `std::fmt::Debug`
    |
 LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained2<V> {
    |                          +++++++++++++++++
@@ -46,7 +46,7 @@ note: required by a bound on the type alias `Underconstrained`
    |
 LL | type Underconstrained<T: std::fmt::Debug> = impl Send;
    |                          ^^^^^^^^^^^^^^^ required by this bound
-help: consider restricting type parameter `U`
+help: consider restricting type parameter `U` with trait `std::fmt::Debug`
    |
 LL | fn underconstrained<U: std::fmt::Debug>(_: U) -> Underconstrained<U> {
    |                      +++++++++++++++++
@@ -67,7 +67,7 @@ note: required by a bound on the type alias `Underconstrained2`
    |
 LL | type Underconstrained2<T: std::fmt::Debug> = impl Send;
    |                           ^^^^^^^^^^^^^^^ required by this bound
-help: consider restricting type parameter `V`
+help: consider restricting type parameter `V` with trait `std::fmt::Debug`
    |
 LL | fn underconstrained2<U, V: std::fmt::Debug>(_: U, _: V) -> Underconstrained2<V> {
    |                          +++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/issue-52843.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-52843.stderr
@@ -14,7 +14,7 @@ note: this definition site has more where clauses than the opaque type
    |
 LL | fn foo<T: Default>(t: T) -> Foo<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::default::Default`
    |
 LL | type Foo<T: std::default::Default> = impl Default;
    |           +++++++++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/issue-52843.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-52843.stderr
@@ -14,7 +14,7 @@ note: this definition site has more where clauses than the opaque type
    |
 LL | fn foo<T: Default>(t: T) -> Foo<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider restricting type parameter `T` with trait `std::default::Default`
+help: consider restricting type parameter `T` with trait `Default`
    |
 LL | type Foo<T: std::default::Default> = impl Default;
    |           +++++++++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/issue-53092.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-53092.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `make_bug`
    |
 LL |     fn make_bug<T, U: From<T>>() -> Bug<T, U> {
    |                       ^^^^^^^ required by this bound in `make_bug`
-help: consider restricting type parameter `U` with trait `std::convert::From<T>`
+help: consider restricting type parameter `U` with trait `From`
    |
 LL |     pub type Bug<T, U: std::convert::From<T>> = impl Fn(T) -> U + Copy;
    |                      +++++++++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/issue-53092.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-53092.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `make_bug`
    |
 LL |     fn make_bug<T, U: From<T>>() -> Bug<T, U> {
    |                       ^^^^^^^ required by this bound in `make_bug`
-help: consider restricting type parameter `U`
+help: consider restricting type parameter `U` with trait `std::convert::From<T>`
    |
 LL |     pub type Bug<T, U: std::convert::From<T>> = impl Fn(T) -> U + Copy;
    |                      +++++++++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/issue-89686.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-89686.stderr
@@ -4,7 +4,7 @@ error[E0277]: the trait bound `T: Trait` is not satisfied
 LL |         async move { self.f().await }
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Trait` is not implemented for `T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL | type G<'a, T: Trait> = impl Future<Output = ()>;
    |             +++++++

--- a/tests/ui/type-alias-impl-trait/issue-90400-1.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-90400-1.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `<MyFoo as Foo>::foo`
    |
 LL |     fn foo<B: Bar>(&self, bar: B) -> Self::FooFn<B> {
    |               ^^^ required by this bound in `<MyFoo as Foo>::foo`
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Bar`
    |
 LL |     type FooFn<B: Bar> = impl FnOnce();
    |                 +++++

--- a/tests/ui/type-alias-impl-trait/issue-90400-2.stderr
+++ b/tests/ui/type-alias-impl-trait/issue-90400-2.stderr
@@ -21,7 +21,7 @@ note: this definition site has more where clauses than the opaque type
    |
 LL |     fn foo<B: Bar>(&self, bar: B) -> Self::FooFn<B> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Bar`
    |
 LL |     type FooFn<B: Bar> = impl Baz;
    |                 +++++

--- a/tests/ui/type-alias-impl-trait/not_well_formed.stderr
+++ b/tests/ui/type-alias-impl-trait/not_well_formed.stderr
@@ -4,7 +4,7 @@ error[E0220]: associated type `Assoc` not found for `V`
 LL | type Foo<V> = impl Trait<V::Assoc>;
    |                             ^^^^^ there is an associated type `Assoc` in the trait `TraitWithAssoc`
    |
-help: consider restricting type parameter `V`
+help: consider restricting type parameter `V` with trait `TraitWithAssoc`
    |
 LL | type Foo<V: TraitWithAssoc> = impl Trait<V::Assoc>;
    |           ++++++++++++++++
@@ -16,7 +16,7 @@ LL | type Foo<V> = impl Trait<V::Assoc>;
    |                             ^^^^^ there is an associated type `Assoc` in the trait `TraitWithAssoc`
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-help: consider restricting type parameter `V`
+help: consider restricting type parameter `V` with trait `TraitWithAssoc`
    |
 LL | type Foo<V: TraitWithAssoc> = impl Trait<V::Assoc>;
    |           ++++++++++++++++

--- a/tests/ui/type-alias-impl-trait/underconstrained_generic.stderr
+++ b/tests/ui/type-alias-impl-trait/underconstrained_generic.stderr
@@ -21,7 +21,7 @@ note: this definition site has more where clauses than the opaque type
    |
 LL | fn _defining_use<T: Trait>() -> Converter<T> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL | type Converter<T: Trait> = impl ProofForConversion<T>;
    |                 +++++++

--- a/tests/ui/type-alias-impl-trait/wf-check-fn-def.stderr
+++ b/tests/ui/type-alias-impl-trait/wf-check-fn-def.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `mop`
    |
 LL |     fn mop<B: Bar>(bar: B) { bar.bar() }
    |               ^^^ required by this bound in `mop`
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Bar`
    |
 LL | type FooFn<B: Bar> = impl FnOnce(B);
    |             +++++

--- a/tests/ui/type-alias-impl-trait/wf_check_closures.stderr
+++ b/tests/ui/type-alias-impl-trait/wf_check_closures.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `foo`
    |
 LL | fn foo<B: Bar>(bar: B) -> FooFn<B> {
    |           ^^^ required by this bound in `foo`
-help: consider restricting type parameter `B`
+help: consider restricting type parameter `B` with trait `Bar`
    |
 LL | type FooFn<B: Bar> = impl FnOnce();
    |             +++++

--- a/tests/ui/type-alias/unresolved-assoc-ty-suggest-trait.lazy.stderr
+++ b/tests/ui/type-alias/unresolved-assoc-ty-suggest-trait.lazy.stderr
@@ -4,7 +4,7 @@ error[E0220]: associated type `Assoc` not found for `T`
 LL | type AssocOf<T> = T::Assoc;
    |                      ^^^^^ there is an associated type `Assoc` in the trait `Trait`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL | type AssocOf<T: Trait> = T::Assoc;
    |               +++++++
@@ -15,7 +15,7 @@ error[E0220]: associated type `Assok` not found for `T`
 LL | type AssokOf<T> = T::Assok;
    |                      ^^^^^ there is a similarly named associated type `Assoc` in the trait `Trait`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Trait`
    |
 LL | type AssokOf<T: Trait> = T::Assok;
    |               +++++++
@@ -30,7 +30,7 @@ error[E0220]: associated type `Proj` not found for `T`
 LL | type ProjOf<T> = T::Proj;
    |                     ^^^^ there is an associated type `Proj` in the trait `Parametrized`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `Parametrized</* 'a, T, N */>`
    |
 LL | type ProjOf<T: Parametrized</* 'a, T, N */>> = T::Proj;
    |              ++++++++++++++++++++++++++++++

--- a/tests/ui/type-alias/unresolved-assoc-ty-suggest-trait.lazy.stderr
+++ b/tests/ui/type-alias/unresolved-assoc-ty-suggest-trait.lazy.stderr
@@ -30,7 +30,7 @@ error[E0220]: associated type `Proj` not found for `T`
 LL | type ProjOf<T> = T::Proj;
    |                     ^^^^ there is an associated type `Proj` in the trait `Parametrized`
    |
-help: consider restricting type parameter `T` with trait `Parametrized</* 'a, T, N */>`
+help: consider restricting type parameter `T` with trait `Parametrized`
    |
 LL | type ProjOf<T: Parametrized</* 'a, T, N */>> = T::Proj;
    |              ++++++++++++++++++++++++++++++

--- a/tests/ui/type/type-check-defaults.stderr
+++ b/tests/ui/type/type-check-defaults.stderr
@@ -53,7 +53,7 @@ note: required by a bound in `Super`
    |
 LL | trait Super<T: Copy> { }
    |                ^^^^ required by this bound in `Super`
-help: consider further restricting type parameter `T`
+help: consider further restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | trait Base<T = String>: Super<T> where T: std::marker::Copy { }
    |                                  ++++++++++++++++++++++++++

--- a/tests/ui/type/type-check-defaults.stderr
+++ b/tests/ui/type/type-check-defaults.stderr
@@ -53,7 +53,7 @@ note: required by a bound in `Super`
    |
 LL | trait Super<T: Copy> { }
    |                ^^^^ required by this bound in `Super`
-help: consider further restricting type parameter `T` with trait `std::marker::Copy`
+help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL | trait Base<T = String>: Super<T> where T: std::marker::Copy { }
    |                                  ++++++++++++++++++++++++++

--- a/tests/ui/type/type-check/missing_trait_impl.stderr
+++ b/tests/ui/type/type-check/missing_trait_impl.stderr
@@ -6,7 +6,7 @@ LL |     let z = x + y;
    |             |
    |             T
    |
-help: consider restricting type parameter `T` with trait `std::ops::Add`
+help: consider restricting type parameter `T` with trait `Add`
    |
 LL | fn foo<T: std::ops::Add>(x: T, y: T) {
    |         +++++++++++++++
@@ -19,7 +19,7 @@ LL |     x += x;
    |     |
    |     cannot use `+=` on type `T`
    |
-help: consider restricting type parameter `T` with trait `std::ops::AddAssign`
+help: consider restricting type parameter `T` with trait `AddAssign`
    |
 LL | fn bar<T: std::ops::AddAssign>(x: T) {
    |         +++++++++++++++++++++
@@ -30,7 +30,7 @@ error[E0600]: cannot apply unary operator `-` to type `T`
 LL |     let y = -x;
    |             ^^ cannot apply unary operator `-`
    |
-help: consider restricting type parameter `T` with trait `std::ops::Neg`
+help: consider restricting type parameter `T` with trait `Neg`
    |
 LL | fn baz<T: std::ops::Neg>(x: T) {
    |         +++++++++++++++
@@ -41,7 +41,7 @@ error[E0600]: cannot apply unary operator `!` to type `T`
 LL |     let y = !x;
    |             ^^ cannot apply unary operator `!`
    |
-help: consider restricting type parameter `T` with trait `std::ops::Not`
+help: consider restricting type parameter `T` with trait `Not`
    |
 LL | fn baz<T: std::ops::Not>(x: T) {
    |         +++++++++++++++

--- a/tests/ui/type/type-check/missing_trait_impl.stderr
+++ b/tests/ui/type/type-check/missing_trait_impl.stderr
@@ -6,7 +6,7 @@ LL |     let z = x + y;
    |             |
    |             T
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::ops::Add`
    |
 LL | fn foo<T: std::ops::Add>(x: T, y: T) {
    |         +++++++++++++++
@@ -19,7 +19,7 @@ LL |     x += x;
    |     |
    |     cannot use `+=` on type `T`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::ops::AddAssign`
    |
 LL | fn bar<T: std::ops::AddAssign>(x: T) {
    |         +++++++++++++++++++++
@@ -30,7 +30,7 @@ error[E0600]: cannot apply unary operator `-` to type `T`
 LL |     let y = -x;
    |             ^^ cannot apply unary operator `-`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::ops::Neg`
    |
 LL | fn baz<T: std::ops::Neg>(x: T) {
    |         +++++++++++++++
@@ -41,7 +41,7 @@ error[E0600]: cannot apply unary operator `!` to type `T`
 LL |     let y = !x;
    |             ^^ cannot apply unary operator `!`
    |
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::ops::Not`
    |
 LL | fn baz<T: std::ops::Not>(x: T) {
    |         +++++++++++++++

--- a/tests/ui/typeck/bad-index-due-to-nested.stderr
+++ b/tests/ui/typeck/bad-index-due-to-nested.stderr
@@ -12,7 +12,7 @@ LL | impl<K, V> Index<&K> for HashMap<K, V>
 LL | where
 LL |     K: Hash,
    |        ---- unsatisfied trait bound introduced here
-help: consider restricting type parameter `K`
+help: consider restricting type parameter `K` with trait `std::hash::Hash`
    |
 LL | fn index<'a, K: std::hash::Hash, V>(map: &'a HashMap<K, V>, k: K) -> &'a V {
    |               +++++++++++++++++
@@ -31,7 +31,7 @@ LL | impl<K, V> Index<&K> for HashMap<K, V>
 ...
 LL |     V: Copy,
    |        ---- unsatisfied trait bound introduced here
-help: consider restricting type parameter `V`
+help: consider restricting type parameter `V` with trait `std::marker::Copy`
    |
 LL | fn index<'a, K, V: std::marker::Copy>(map: &'a HashMap<K, V>, k: K) -> &'a V {
    |                  +++++++++++++++++++

--- a/tests/ui/typeck/bad-index-due-to-nested.stderr
+++ b/tests/ui/typeck/bad-index-due-to-nested.stderr
@@ -12,7 +12,7 @@ LL | impl<K, V> Index<&K> for HashMap<K, V>
 LL | where
 LL |     K: Hash,
    |        ---- unsatisfied trait bound introduced here
-help: consider restricting type parameter `K` with trait `std::hash::Hash`
+help: consider restricting type parameter `K` with trait `Hash`
    |
 LL | fn index<'a, K: std::hash::Hash, V>(map: &'a HashMap<K, V>, k: K) -> &'a V {
    |               +++++++++++++++++
@@ -31,7 +31,7 @@ LL | impl<K, V> Index<&K> for HashMap<K, V>
 ...
 LL |     V: Copy,
    |        ---- unsatisfied trait bound introduced here
-help: consider restricting type parameter `V` with trait `std::marker::Copy`
+help: consider restricting type parameter `V` with trait `Copy`
    |
 LL | fn index<'a, K, V: std::marker::Copy>(map: &'a HashMap<K, V>, k: K) -> &'a V {
    |                  +++++++++++++++++++

--- a/tests/ui/typeck/issue-90164.stderr
+++ b/tests/ui/typeck/issue-90164.stderr
@@ -13,7 +13,7 @@ note: required by a bound in `copy`
    |
 LL | fn copy<R: Unpin, W>(_: R, _: W) {}
    |            ^^^^^ required by this bound in `copy`
-help: consider restricting type parameter `T` with trait `std::marker::Unpin`
+help: consider restricting type parameter `T` with trait `Unpin`
    |
 LL | fn f<T: std::marker::Unpin>(r: T) {
    |       ++++++++++++++++++++

--- a/tests/ui/typeck/issue-90164.stderr
+++ b/tests/ui/typeck/issue-90164.stderr
@@ -13,7 +13,7 @@ note: required by a bound in `copy`
    |
 LL | fn copy<R: Unpin, W>(_: R, _: W) {}
    |            ^^^^^ required by this bound in `copy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Unpin`
    |
 LL | fn f<T: std::marker::Unpin>(r: T) {
    |       ++++++++++++++++++++

--- a/tests/ui/typeck/typeck-default-trait-impl-send-param.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-send-param.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T:Send>() {
    |              ^^^^ required by this bound in `is_send`
-help: consider restricting type parameter `T` with trait `std::marker::Send`
+help: consider restricting type parameter `T` with trait `Send`
    |
 LL | fn foo<T: std::marker::Send>() {
    |         +++++++++++++++++++

--- a/tests/ui/typeck/typeck-default-trait-impl-send-param.stderr
+++ b/tests/ui/typeck/typeck-default-trait-impl-send-param.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `is_send`
    |
 LL | fn is_send<T:Send>() {
    |              ^^^^ required by this bound in `is_send`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Send`
    |
 LL | fn foo<T: std::marker::Send>() {
    |         +++++++++++++++++++

--- a/tests/ui/union/issue-81199.stderr
+++ b/tests/ui/union/issue-81199.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `PtrComponents`
    |
 LL | struct PtrComponents<T: Pointee + ?Sized> {
    |                         ^^^^^^^ required by this bound in `PtrComponents`
-help: consider further restricting this bound with trait `Pointee`
+help: consider further restricting type parameter `T` with trait `Pointee`
    |
 LL | union PtrRepr<T: ?Sized + Pointee> {
    |                         +++++++++

--- a/tests/ui/union/issue-81199.stderr
+++ b/tests/ui/union/issue-81199.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `PtrComponents`
    |
 LL | struct PtrComponents<T: Pointee + ?Sized> {
    |                         ^^^^^^^ required by this bound in `PtrComponents`
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Pointee`
    |
 LL | union PtrRepr<T: ?Sized + Pointee> {
    |                         +++++++++

--- a/tests/ui/unop/unop-move-semantics.stderr
+++ b/tests/ui/unop/unop-move-semantics.stderr
@@ -15,7 +15,7 @@ help: consider cloning the value if the performance cost is acceptable
    |
 LL |     !x.clone();
    |       ++++++++
-help: consider further restricting this bound with trait `Copy`
+help: consider further restricting type parameter `T` with trait `Copy`
    |
 LL | fn move_then_borrow<T: Not<Output=T> + Clone + Copy>(x: T) {
    |                                              ++++++

--- a/tests/ui/unop/unop-move-semantics.stderr
+++ b/tests/ui/unop/unop-move-semantics.stderr
@@ -15,7 +15,7 @@ help: consider cloning the value if the performance cost is acceptable
    |
 LL |     !x.clone();
    |       ++++++++
-help: consider further restricting this bound
+help: consider further restricting this bound with trait `Copy`
    |
 LL | fn move_then_borrow<T: Not<Output=T> + Clone + Copy>(x: T) {
    |                                              ++++++

--- a/tests/ui/wf/issue-96810.stderr
+++ b/tests/ui/wf/issue-96810.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `S`
    |
 LL | struct S<T: Tr>(T::Assoc);
    |             ^^ required by this bound in `S`
-help: consider restricting type parameter `K`
+help: consider restricting type parameter `K` with trait `Tr`
    |
 LL | struct Hoge<K: Tr> {
    |              ++++

--- a/tests/ui/wf/wf-enum-bound.stderr
+++ b/tests/ui/wf/wf-enum-bound.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider further restricting type parameter `U` with trait `std::marker::Copy`
+help: consider further restricting type parameter `U` with trait `Copy`
    |
 LL |     where T: ExtraCopy<U>, U: std::marker::Copy
    |                          ++++++++++++++++++++++

--- a/tests/ui/wf/wf-enum-bound.stderr
+++ b/tests/ui/wf/wf-enum-bound.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider further restricting type parameter `U`
+help: consider further restricting type parameter `U` with trait `std::marker::Copy`
    |
 LL |     where T: ExtraCopy<U>, U: std::marker::Copy
    |                          ++++++++++++++++++++++

--- a/tests/ui/wf/wf-enum-fields-struct-variant.stderr
+++ b/tests/ui/wf/wf-enum-fields-struct-variant.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `IsCopy`
    |
 LL | struct IsCopy<T:Copy> {
    |                 ^^^^ required by this bound in `IsCopy`
-help: consider restricting type parameter `A`
+help: consider restricting type parameter `A` with trait `std::marker::Copy`
    |
 LL | enum AnotherEnum<A: std::marker::Copy> {
    |                   +++++++++++++++++++

--- a/tests/ui/wf/wf-enum-fields-struct-variant.stderr
+++ b/tests/ui/wf/wf-enum-fields-struct-variant.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `IsCopy`
    |
 LL | struct IsCopy<T:Copy> {
    |                 ^^^^ required by this bound in `IsCopy`
-help: consider restricting type parameter `A` with trait `std::marker::Copy`
+help: consider restricting type parameter `A` with trait `Copy`
    |
 LL | enum AnotherEnum<A: std::marker::Copy> {
    |                   +++++++++++++++++++

--- a/tests/ui/wf/wf-enum-fields.stderr
+++ b/tests/ui/wf/wf-enum-fields.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `IsCopy`
    |
 LL | struct IsCopy<T:Copy> {
    |                 ^^^^ required by this bound in `IsCopy`
-help: consider restricting type parameter `A` with trait `std::marker::Copy`
+help: consider restricting type parameter `A` with trait `Copy`
    |
 LL | enum SomeEnum<A: std::marker::Copy> {
    |                +++++++++++++++++++

--- a/tests/ui/wf/wf-enum-fields.stderr
+++ b/tests/ui/wf/wf-enum-fields.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `IsCopy`
    |
 LL | struct IsCopy<T:Copy> {
    |                 ^^^^ required by this bound in `IsCopy`
-help: consider restricting type parameter `A`
+help: consider restricting type parameter `A` with trait `std::marker::Copy`
    |
 LL | enum SomeEnum<A: std::marker::Copy> {
    |                +++++++++++++++++++

--- a/tests/ui/wf/wf-fn-where-clause.stderr
+++ b/tests/ui/wf/wf-fn-where-clause.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider further restricting type parameter `U` with trait `std::marker::Copy`
+help: consider further restricting type parameter `U` with trait `Copy`
    |
 LL | fn foo<T,U>() where T: ExtraCopy<U>, U: std::marker::Copy
    |                                    ++++++++++++++++++++++

--- a/tests/ui/wf/wf-fn-where-clause.stderr
+++ b/tests/ui/wf/wf-fn-where-clause.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider further restricting type parameter `U`
+help: consider further restricting type parameter `U` with trait `std::marker::Copy`
    |
 LL | fn foo<T,U>() where T: ExtraCopy<U>, U: std::marker::Copy
    |                                    ++++++++++++++++++++++

--- a/tests/ui/wf/wf-impl-associated-type-trait.stderr
+++ b/tests/ui/wf/wf-impl-associated-type-trait.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MySet`
    |
 LL | pub struct MySet<T:MyHash> {
    |                    ^^^^^^ required by this bound in `MySet`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `MyHash`
    |
 LL | impl<T: MyHash> Foo for T {
    |       ++++++++

--- a/tests/ui/wf/wf-in-fn-arg.stderr
+++ b/tests/ui/wf/wf-in-fn-arg.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MustBeCopy`
    |
 LL | struct MustBeCopy<T:Copy> {
    |                     ^^^^ required by this bound in `MustBeCopy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | fn bar<T: std::marker::Copy>(_: &MustBeCopy<T>)
    |         +++++++++++++++++++

--- a/tests/ui/wf/wf-in-fn-arg.stderr
+++ b/tests/ui/wf/wf-in-fn-arg.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MustBeCopy`
    |
 LL | struct MustBeCopy<T:Copy> {
    |                     ^^^^ required by this bound in `MustBeCopy`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | fn bar<T: std::marker::Copy>(_: &MustBeCopy<T>)
    |         +++++++++++++++++++

--- a/tests/ui/wf/wf-in-fn-ret.stderr
+++ b/tests/ui/wf/wf-in-fn-ret.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MustBeCopy`
    |
 LL | struct MustBeCopy<T: Copy> {
    |                      ^^^^ required by this bound in `MustBeCopy`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | fn bar<T: std::marker::Copy>() -> MustBeCopy<T>
    |         +++++++++++++++++++

--- a/tests/ui/wf/wf-in-fn-ret.stderr
+++ b/tests/ui/wf/wf-in-fn-ret.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MustBeCopy`
    |
 LL | struct MustBeCopy<T: Copy> {
    |                      ^^^^ required by this bound in `MustBeCopy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | fn bar<T: std::marker::Copy>() -> MustBeCopy<T>
    |         +++++++++++++++++++

--- a/tests/ui/wf/wf-in-fn-type-arg.stderr
+++ b/tests/ui/wf/wf-in-fn-type-arg.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MustBeCopy`
    |
 LL | struct MustBeCopy<T:Copy> {
    |                     ^^^^ required by this bound in `MustBeCopy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | struct Bar<T: std::marker::Copy> {
    |             +++++++++++++++++++

--- a/tests/ui/wf/wf-in-fn-type-arg.stderr
+++ b/tests/ui/wf/wf-in-fn-type-arg.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MustBeCopy`
    |
 LL | struct MustBeCopy<T:Copy> {
    |                     ^^^^ required by this bound in `MustBeCopy`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | struct Bar<T: std::marker::Copy> {
    |             +++++++++++++++++++

--- a/tests/ui/wf/wf-in-fn-type-ret.stderr
+++ b/tests/ui/wf/wf-in-fn-type-ret.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MustBeCopy`
    |
 LL | struct MustBeCopy<T:Copy> {
    |                     ^^^^ required by this bound in `MustBeCopy`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | struct Foo<T: std::marker::Copy> {
    |             +++++++++++++++++++

--- a/tests/ui/wf/wf-in-fn-type-ret.stderr
+++ b/tests/ui/wf/wf-in-fn-type-ret.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MustBeCopy`
    |
 LL | struct MustBeCopy<T:Copy> {
    |                     ^^^^ required by this bound in `MustBeCopy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | struct Foo<T: std::marker::Copy> {
    |             +++++++++++++++++++

--- a/tests/ui/wf/wf-in-fn-where-clause.stderr
+++ b/tests/ui/wf/wf-in-fn-where-clause.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MustBeCopy`
    |
 LL | trait MustBeCopy<T:Copy> {
    |                    ^^^^ required by this bound in `MustBeCopy`
-help: consider further restricting type parameter `U`
+help: consider further restricting type parameter `U` with trait `std::marker::Copy`
    |
 LL |     where T: MustBeCopy<U>, U: std::marker::Copy
    |                           ++++++++++++++++++++++

--- a/tests/ui/wf/wf-in-fn-where-clause.stderr
+++ b/tests/ui/wf/wf-in-fn-where-clause.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MustBeCopy`
    |
 LL | trait MustBeCopy<T:Copy> {
    |                    ^^^^ required by this bound in `MustBeCopy`
-help: consider further restricting type parameter `U` with trait `std::marker::Copy`
+help: consider further restricting type parameter `U` with trait `Copy`
    |
 LL |     where T: MustBeCopy<U>, U: std::marker::Copy
    |                           ++++++++++++++++++++++

--- a/tests/ui/wf/wf-in-obj-type-trait.stderr
+++ b/tests/ui/wf/wf-in-obj-type-trait.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MustBeCopy`
    |
 LL | struct MustBeCopy<T:Copy> {
    |                     ^^^^ required by this bound in `MustBeCopy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | struct Bar<T: std::marker::Copy> {
    |             +++++++++++++++++++

--- a/tests/ui/wf/wf-in-obj-type-trait.stderr
+++ b/tests/ui/wf/wf-in-obj-type-trait.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `MustBeCopy`
    |
 LL | struct MustBeCopy<T:Copy> {
    |                     ^^^^ required by this bound in `MustBeCopy`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | struct Bar<T: std::marker::Copy> {
    |             +++++++++++++++++++

--- a/tests/ui/wf/wf-inherent-impl-method-where-clause.stderr
+++ b/tests/ui/wf/wf-inherent-impl-method-where-clause.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider restricting type parameter `U` with trait `std::marker::Copy`
+help: consider restricting type parameter `U` with trait `Copy`
    |
 LL | impl<T,U: std::marker::Copy> Foo<T,U> {
    |         +++++++++++++++++++

--- a/tests/ui/wf/wf-inherent-impl-method-where-clause.stderr
+++ b/tests/ui/wf/wf-inherent-impl-method-where-clause.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider restricting type parameter `U`
+help: consider restricting type parameter `U` with trait `std::marker::Copy`
    |
 LL | impl<T,U: std::marker::Copy> Foo<T,U> {
    |         +++++++++++++++++++

--- a/tests/ui/wf/wf-inherent-impl-where-clause.stderr
+++ b/tests/ui/wf/wf-inherent-impl-where-clause.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider further restricting type parameter `U` with trait `std::marker::Copy`
+help: consider further restricting type parameter `U` with trait `Copy`
    |
 LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>, U: std::marker::Copy
    |                                         ++++++++++++++++++++++

--- a/tests/ui/wf/wf-inherent-impl-where-clause.stderr
+++ b/tests/ui/wf/wf-inherent-impl-where-clause.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider further restricting type parameter `U`
+help: consider further restricting type parameter `U` with trait `std::marker::Copy`
    |
 LL | impl<T,U> Foo<T,U> where T: ExtraCopy<U>, U: std::marker::Copy
    |                                         ++++++++++++++++++++++

--- a/tests/ui/wf/wf-struct-bound.stderr
+++ b/tests/ui/wf/wf-struct-bound.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider further restricting type parameter `U` with trait `std::marker::Copy`
+help: consider further restricting type parameter `U` with trait `Copy`
    |
 LL |     where T: ExtraCopy<U>, U: std::marker::Copy
    |                          ++++++++++++++++++++++

--- a/tests/ui/wf/wf-struct-bound.stderr
+++ b/tests/ui/wf/wf-struct-bound.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider further restricting type parameter `U`
+help: consider further restricting type parameter `U` with trait `std::marker::Copy`
    |
 LL |     where T: ExtraCopy<U>, U: std::marker::Copy
    |                          ++++++++++++++++++++++

--- a/tests/ui/wf/wf-struct-field.stderr
+++ b/tests/ui/wf/wf-struct-field.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `IsCopy`
    |
 LL | struct IsCopy<T:Copy> {
    |                 ^^^^ required by this bound in `IsCopy`
-help: consider restricting type parameter `A`
+help: consider restricting type parameter `A` with trait `std::marker::Copy`
    |
 LL | struct SomeStruct<A: std::marker::Copy> {
    |                    +++++++++++++++++++

--- a/tests/ui/wf/wf-struct-field.stderr
+++ b/tests/ui/wf/wf-struct-field.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `IsCopy`
    |
 LL | struct IsCopy<T:Copy> {
    |                 ^^^^ required by this bound in `IsCopy`
-help: consider restricting type parameter `A` with trait `std::marker::Copy`
+help: consider restricting type parameter `A` with trait `Copy`
    |
 LL | struct SomeStruct<A: std::marker::Copy> {
    |                    +++++++++++++++++++

--- a/tests/ui/wf/wf-trait-associated-type-bound.stderr
+++ b/tests/ui/wf/wf-trait-associated-type-bound.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | trait SomeTrait<T: std::marker::Copy> {
    |                  +++++++++++++++++++

--- a/tests/ui/wf/wf-trait-associated-type-bound.stderr
+++ b/tests/ui/wf/wf-trait-associated-type-bound.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | trait SomeTrait<T: std::marker::Copy> {
    |                  +++++++++++++++++++

--- a/tests/ui/wf/wf-trait-bound.stderr
+++ b/tests/ui/wf/wf-trait-bound.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider further restricting type parameter `U` with trait `std::marker::Copy`
+help: consider further restricting type parameter `U` with trait `Copy`
    |
 LL |     where T: ExtraCopy<U>, U: std::marker::Copy
    |                          ++++++++++++++++++++++

--- a/tests/ui/wf/wf-trait-bound.stderr
+++ b/tests/ui/wf/wf-trait-bound.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider further restricting type parameter `U`
+help: consider further restricting type parameter `U` with trait `std::marker::Copy`
    |
 LL |     where T: ExtraCopy<U>, U: std::marker::Copy
    |                          ++++++++++++++++++++++

--- a/tests/ui/wf/wf-trait-superbound.stderr
+++ b/tests/ui/wf/wf-trait-superbound.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | trait SomeTrait<T: std::marker::Copy>: ExtraCopy<T> {
    |                  +++++++++++++++++++

--- a/tests/ui/wf/wf-trait-superbound.stderr
+++ b/tests/ui/wf/wf-trait-superbound.stderr
@@ -9,7 +9,7 @@ note: required by a bound in `ExtraCopy`
    |
 LL | trait ExtraCopy<T:Copy> { }
    |                   ^^^^ required by this bound in `ExtraCopy`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | trait SomeTrait<T: std::marker::Copy>: ExtraCopy<T> {
    |                  +++++++++++++++++++

--- a/tests/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
+++ b/tests/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `require_copy`
    |
 LL | fn require_copy<T: Copy>(x: T) {}
    |                    ^^^^ required by this bound in `require_copy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | impl<T: std::marker::Copy> Foo<T> {
    |       +++++++++++++++++++

--- a/tests/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
+++ b/tests/ui/where-clauses/where-clause-constraints-are-local-for-inherent-impl.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `require_copy`
    |
 LL | fn require_copy<T: Copy>(x: T) {}
    |                    ^^^^ required by this bound in `require_copy`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | impl<T: std::marker::Copy> Foo<T> {
    |       +++++++++++++++++++

--- a/tests/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
+++ b/tests/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `require_copy`
    |
 LL | fn require_copy<T: Copy>(x: T) {}
    |                    ^^^^ required by this bound in `require_copy`
-help: consider restricting type parameter `T`
+help: consider restricting type parameter `T` with trait `std::marker::Copy`
    |
 LL | impl<T: std::marker::Copy> Foo<T> for Bar<T> {
    |       +++++++++++++++++++

--- a/tests/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
+++ b/tests/ui/where-clauses/where-clause-constraints-are-local-for-trait-impl.stderr
@@ -11,7 +11,7 @@ note: required by a bound in `require_copy`
    |
 LL | fn require_copy<T: Copy>(x: T) {}
    |                    ^^^^ required by this bound in `require_copy`
-help: consider restricting type parameter `T` with trait `std::marker::Copy`
+help: consider restricting type parameter `T` with trait `Copy`
    |
 LL | impl<T: std::marker::Copy> Foo<T> for Bar<T> {
    |       +++++++++++++++++++


### PR DESCRIPTION
On nightly, we mention the trait is unstable

```
error[E0277]: the trait bound `T: Unstable` is not satisfied
  --> $DIR/unstable-trait-suggestion.rs:13:9
   |
LL |     foo(t)
   |     --- ^ the trait `Unstable` is not implemented for `T`
   |     |
   |     required by a bound introduced by this call
   |
note: required by a bound in `foo`
  --> $DIR/unstable-trait-suggestion.rs:9:11
   |
LL | fn foo<T: Unstable>(_: T) {}
   |           ^^^^^^^^ required by this bound in `foo`
help: consider restricting type parameter `T` but it is an `unstable` trait
   |
LL | pub fn demo<T: Unstable>(t: T) {
   |              ++++++++++
```

On stable, we don't suggest the trait at all

```
error[E0277]: the trait bound `T: Unstable` is not satisfied
  --> $DIR/unstable-trait-suggestion.rs:13:9
   |
LL |     foo(t)
   |     --- ^ the trait `Unstable` is not implemented for `T`
   |     |
   |     required by a bound introduced by this call
   |
note: required by a bound in `foo`
  --> $DIR/unstable-trait-suggestion.rs:9:11
   |
LL | fn foo<T: Unstable>(_: T) {}
   |           ^^^^^^^^ required by this bound in `foo`
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->


Fix #133511.