### PR TITLE
Bump unsupported `ubuntu` CI images to 24.04 LTS

### DIFF
--- a/src/ci/docker/host-x86_64/arm-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/arm-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 COPY scripts/android-base-apt-get.sh /scripts/
@@ -11,7 +11,8 @@ RUN . /scripts/android-ndk.sh && \
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-  libgl1-mesa-glx \
+  libgl1 \
+  libglx-mesa0 \
   libpulse0 \
   libstdc++6:i386 \
   openjdk-8-jre-headless \

--- a/src/ci/docker/host-x86_64/dist-android/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-android/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04
+FROM ubuntu:24.04
 
 COPY scripts/android-base-apt-get.sh /scripts/
 RUN sh /scripts/android-base-apt-get.sh

--- a/src/ci/docker/host-x86_64/dist-ohos/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-ohos/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/src/ci/docker/scripts/android-base-apt-get.sh
+++ b/src/ci/docker/scripts/android-base-apt-get.sh
@@ -10,7 +10,7 @@ apt-get install -y --no-install-recommends \
   g++ \
   git \
   libssl-dev \
-  libncurses5 \
+  libncurses-dev \
   make \
   ninja-build \
   pkg-config \


### PR DESCRIPTION
Closes #133531.

try-job: arm-android
try-job: dist-android
try-job: dist-ohos