### PR TITLE
extend group-forbid-always-trumps-cli test

### DIFF
--- a/tests/ui/lint/forbid-always-trumps-cli.allow-first-group.stderr
+++ b/tests/ui/lint/forbid-always-trumps-cli.allow-first-group.stderr
@@ -1,5 +1,5 @@
 error: unused variable: `x`
-  --> $DIR/group-forbid-always-trumps-cli.rs:4:9
+  --> $DIR/forbid-always-trumps-cli.rs:15:9
    |
 LL |     let x = 1;
    |         ^ help: if this is intentional, prefix it with an underscore: `_x`

--- a/tests/ui/lint/forbid-always-trumps-cli.allow-first-lint.stderr
+++ b/tests/ui/lint/forbid-always-trumps-cli.allow-first-lint.stderr
@@ -1,0 +1,10 @@
+error: unused variable: `x`
+  --> $DIR/forbid-always-trumps-cli.rs:15:9
+   |
+LL |     let x = 1;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: requested on the command line with `-F unused-variables`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/forbid-always-trumps-cli.allow-first-mix1.stderr
+++ b/tests/ui/lint/forbid-always-trumps-cli.allow-first-mix1.stderr
@@ -1,0 +1,10 @@
+error: unused variable: `x`
+  --> $DIR/forbid-always-trumps-cli.rs:15:9
+   |
+LL |     let x = 1;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: `-F unused-variables` implied by `-F unused`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/forbid-always-trumps-cli.allow-first-mix2.stderr
+++ b/tests/ui/lint/forbid-always-trumps-cli.allow-first-mix2.stderr
@@ -1,0 +1,10 @@
+error: unused variable: `x`
+  --> $DIR/forbid-always-trumps-cli.rs:15:9
+   |
+LL |     let x = 1;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: requested on the command line with `-F unused-variables`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/forbid-always-trumps-cli.forbid-first-group.stderr
+++ b/tests/ui/lint/forbid-always-trumps-cli.forbid-first-group.stderr
@@ -1,0 +1,10 @@
+error: unused variable: `x`
+  --> $DIR/forbid-always-trumps-cli.rs:15:9
+   |
+LL |     let x = 1;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: `-F unused-variables` implied by `-F unused`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/forbid-always-trumps-cli.forbid-first-lint.stderr
+++ b/tests/ui/lint/forbid-always-trumps-cli.forbid-first-lint.stderr
@@ -1,0 +1,10 @@
+error: unused variable: `x`
+  --> $DIR/forbid-always-trumps-cli.rs:15:9
+   |
+LL |     let x = 1;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: requested on the command line with `-F unused-variables`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/forbid-always-trumps-cli.forbid-first-mix1.stderr
+++ b/tests/ui/lint/forbid-always-trumps-cli.forbid-first-mix1.stderr
@@ -1,0 +1,10 @@
+error: unused variable: `x`
+  --> $DIR/forbid-always-trumps-cli.rs:15:9
+   |
+LL |     let x = 1;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: `-F unused-variables` implied by `-F unused`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/forbid-always-trumps-cli.forbid-first-mix2.stderr
+++ b/tests/ui/lint/forbid-always-trumps-cli.forbid-first-mix2.stderr
@@ -1,0 +1,10 @@
+error: unused variable: `x`
+  --> $DIR/forbid-always-trumps-cli.rs:15:9
+   |
+LL |     let x = 1;
+   |         ^ help: if this is intentional, prefix it with an underscore: `_x`
+   |
+   = note: requested on the command line with `-F unused-variables`
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/lint/forbid-always-trumps-cli.rs
+++ b/tests/ui/lint/forbid-always-trumps-cli.rs
@@ -1,0 +1,17 @@
+//! Ensure that "forbid" always trumps" allow" in CLI arguments, no matter the order
+//! and no matter whether it is used with a lint group vs an individual lint.
+// ignore-tidy-linelength
+//@ revisions: forbid-first-group allow-first-group forbid-first-lint allow-first-lint forbid-first-mix1 allow-first-mix1 forbid-first-mix2 allow-first-mix2
+//@[forbid-first-group] compile-flags: -F unused -A unused
+//@[allow-first-group] compile-flags: -A unused -F unused
+//@[forbid-first-lint] compile-flags: -F unused_variables -A unused_variables
+//@[allow-first-lint] compile-flags: -A unused_variables -F unused_variables
+//@[forbid-first-mix1] compile-flags: -F unused -A unused_variables
+//@[allow-first-mix1] compile-flags: -A unused_variables -F unused
+//@[forbid-first-mix2] compile-flags: -F unused_variables -A unused
+//@[allow-first-mix2] compile-flags: -A unused -F unused_variables
+
+fn main() {
+    let x = 1;
+    //~^ ERROR unused variable: `x`
+}

--- a/tests/ui/lint/group-forbid-always-trumps-cli.rs
+++ b/tests/ui/lint/group-forbid-always-trumps-cli.rs
@@ -1,6 +1,0 @@
-//@ compile-flags: -F unused -A unused
-
-fn main() {
-    let x = 1;
-    //~^ ERROR unused variable: `x`
-}


### PR DESCRIPTION
Test it not just for a lint group, but also an individual lint, or when mixing the lint and the group. And test both orders in which the flags could be passed.