### PR TITLE
[AIX] create shim for lgammaf_r

### DIFF
--- a/library/std/src/sys/cmath.rs
+++ b/library/std/src/sys/cmath.rs
@@ -70,7 +70,7 @@ pub unsafe fn lgammaf_r(n: f32, s: &mut i32) -> f32 {
 cfg_if::cfg_if! {
 if #[cfg(all(target_os = "windows", target_env = "msvc", target_arch = "x86"))] {
     #[inline]
-   pub unsafe fn acosf(n: f32) -> f32 {
+    pub unsafe fn acosf(n: f32) -> f32 {
         f64::acos(n as f64) as f32
     }
 


### PR DESCRIPTION
On AIX, we don't have 32bit floating point for re-entrant `lgammaf_r` but we do have the 64bit floating point re-entrant `lgamma_r` so we can use the 64bit version instead and truncate back to a 32bit float.

This solves the linker missing symbol for `.lgammaf_r` when testing and using these parts of the `std`.