### PR TITLE
Small doc fixes in `rustc_codegen_ssa`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -71,11 +71,11 @@ pub trait CodegenBackend {
         need_metadata_module: bool,
     ) -> Box<dyn Any>;
 
-    /// This is called on the returned `Box<dyn Any>` from `codegen_backend`
+    /// This is called on the returned `Box<dyn Any>` from [`codegen_crate`](Self::codegen_crate)
     ///
     /// # Panics
     ///
-    /// Panics when the passed `Box<dyn Any>` was not returned by `codegen_backend`.
+    /// Panics when the passed `Box<dyn Any>` was not returned by [`codegen_crate`](Self::codegen_crate).
     fn join_codegen(
         &self,
         ongoing_codegen: Box<dyn Any>,

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -83,7 +83,7 @@ pub trait CodegenBackend {
         outputs: &OutputFilenames,
     ) -> (CodegenResults, FxIndexMap<WorkProductId, WorkProduct>);
 
-    /// This is called on the returned `CodegenResults` from `join_codegen`
+    /// This is called on the returned [`CodegenResults`] from [`join_codegen`](Self::join_codegen).
     fn link(
         &self,
         sess: &Session,


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

I'm trying to make a toy codegen backend for `rustc`, and I got confused for a few minutes about what `codegen_backend` was referring to in the `CodegenBackend::join_codegen` docs.

Experimentally, it looks like the result of `CodegenBackend::codegen_crate` is passed to `CodegenBackend::join_codegen`, so this updates the docs to refer to that. This time using intra-doc links to hopefully cause people to notice if that gets out of date again.

Also, added another intra-doc link nearby, on `CodegenBackend::link`, for the same reason.
