### PR TITLE
Add submodule for document translation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 	path = src/gcc
 	url = https://github.com/rust-lang/gcc.git
 	shallow = true
+[submodule "src/doc/translations"]
+	path = src/doc/translations
+	url = https://github.com/dalance/translations

--- a/src/bootstrap/src/core/build_steps/doc.rs
+++ b/src/bootstrap/src/core/build_steps/doc.rs
@@ -177,6 +177,8 @@ impl<P: Step> Step for RustbookSrc<P> {
                 .arg(&out)
                 .arg("--rust-root")
                 .arg(&builder.src)
+                .arg("-n")
+                .arg(&name)
                 .run(builder);
 
             for lang in &self.languages {
@@ -191,6 +193,10 @@ impl<P: Step> Step for RustbookSrc<P> {
                     .arg(&src)
                     .arg("-d")
                     .arg(&out)
+                    .arg("--rust-root")
+                    .arg(&builder.src)
+                    .arg("-n")
+                    .arg(&name)
                     .arg("-l")
                     .arg(lang)
                     .run(builder);

--- a/src/tools/rustbook/Cargo.lock
+++ b/src/tools/rustbook/Cargo.lock
@@ -1146,6 +1146,7 @@ dependencies = [
  "mdbook-spec",
  "mdbook-trpl-listing",
  "mdbook-trpl-note",
+ "toml 0.5.11",
 ]
 
 [[package]]

--- a/src/tools/rustbook/Cargo.toml
+++ b/src/tools/rustbook/Cargo.toml
@@ -13,6 +13,7 @@ mdbook-trpl-listing = { path = "../../doc/book/packages/mdbook-trpl-listing" }
 mdbook-trpl-note = { path = "../../doc/book/packages/mdbook-trpl-note" }
 mdbook-i18n-helpers = "0.3.3"
 mdbook-spec = { path = "../../doc/reference/mdbook-spec" }
+toml = "0.5.11"
 
 [dependencies.mdbook]
 version = "0.4.37"


### PR DESCRIPTION
This PR adds a submodule for document translation.

## Motivation
Now translation DBs are placed at the each document repositories (e.g. rust-by-example).
This causes to increse merging cost of translation update by document maintainers.
Instead of it, the merging cost can be reduced by splitting the translation DBs to another submodule.

I tried to gather feedback about this idea through Internal Forum and Zulip, and I create this PR because there was no feedback.

https://internals.rust-lang.org/t/pre-rfc-translation-sub-repository-for-rust-docs/21666

## Summary of this PR

This PR adds the following steps to bootstrap build of doc.

* Copy css/js for language picker to the theme directory, if there is a translation DB for the processed doc,.
* Set `po-dir` to specify the translation DB in the translation submodule.
* Build translated docs (this is already added)
* Cleanup the copied css/js files to keep the repository clean.

## TODO

This PR is incomplete yet.
If this is acceptable, I think the following items should be done before merging this PR.

- [ ] Move the submodule into rust-lang organization
- [ ] Write README.md of the translation submodule
- [ ] Follow other rules for submodule of rust-lang/rust
- [ ] Remove modified `index.hbs` from rust-by-example ( because it conflicts with this PR )
- [ ] Remove language entries directly written in `src/bootstrap/src/core/build_steps/doc.rs` and add a mechanism to refer the entries from the translation submodule
