### PR TITLE
Bump `ruzstd` to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4711,9 +4711,9 @@ checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ruzstd"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c3938e133aac070997ddc684d4b393777d293ba170f2988c8fd5ea2ad4ce21"
+checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
 dependencies = [
  "twox-hash",
 ]


### PR DESCRIPTION
This upgrades `ruzstd` to a version not affected by [RUSTSEC-2024-0400](https://rustsec.org/advisories/RUSTSEC-2024-0400.html)

