### PR TITLE
Mark visionOS as supporting `std`

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos.rs
@@ -9,7 +9,7 @@ pub(crate) fn target() -> Target {
             description: Some("ARM64 Apple visionOS".into()),
             tier: Some(3),
             host_tools: Some(false),
-            std: Some(false),
+            std: Some(true),
         },
         pointer_width: 64,
         data_layout: "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos_sim.rs
@@ -9,7 +9,7 @@ pub(crate) fn target() -> Target {
             description: Some("ARM64 Apple visionOS simulator".into()),
             tier: Some(3),
             host_tools: Some(false),
-            std: Some(false),
+            std: Some(true),
         },
         pointer_width: 64,
         data_layout: "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"


### PR DESCRIPTION
Cargo's -Zbuild-std has recently started checking this field, which causes it to fail to compile even though we have full support for the standard library on these targets.

[Example of failed build](https://github.com/rust-random/getrandom/actions/runs/12069033154/job/33655430622).

Affected targets: `aarch64-apple-visionos` and `aarch64-apple-visionos-sim`.

r? Noratrieb (because you've worked with `rustc` target metadata IIRC)
@rustbot label O-visionos