### PR TITLE
Do not call `extern_crate` on current trait on crate mismatch errors

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1731,6 +1731,10 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             span.push_span_label(self.tcx.def_span(trait_def_id), "this is the required trait");
             for (sp, label) in [trait_def_id, other_trait_def_id]
                 .iter()
+                // The current crate-version might depend on another version of the same crate
+                // (Think "semver-trick"). Do not call `extern_crate` in that case for the local
+                // crate as that doesn't make sense and ICEs (#133563).
+                .filter(|def_id| !def_id.is_local())
                 .filter_map(|def_id| self.tcx.extern_crate(def_id.krate))
                 .map(|data| {
                     let dependency = if data.dependency_of == LOCAL_CRATE {

--- a/src/tools/run-make-support/src/external_deps/rustc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustc.rs
@@ -227,6 +227,12 @@ impl Rustc {
         self
     }
 
+    /// Normalize the line number in the stderr output
+    pub fn ui_testing(&mut self) -> &mut Self {
+        self.cmd.arg(format!("-Zui-testing"));
+        self
+    }
+
     /// Specify the target triple, or a path to a custom target json spec file.
     pub fn target<S: AsRef<str>>(&mut self, target: S) -> &mut Self {
         let target = target.as_ref();

--- a/tests/run-make/crate-loading-crate-depends-on-itself/foo-current.rs
+++ b/tests/run-make/crate-loading-crate-depends-on-itself/foo-current.rs
@@ -1,0 +1,14 @@
+#![crate_type = "lib"]
+#![crate_name = "foo"]
+
+extern crate foo;
+
+pub struct Struct;
+pub trait Trait {}
+impl Trait for Struct {}
+
+fn check_trait<T: Trait>() {}
+
+fn ice() {
+    check_trait::<foo::Struct>();
+}

--- a/tests/run-make/crate-loading-crate-depends-on-itself/foo-prev.rs
+++ b/tests/run-make/crate-loading-crate-depends-on-itself/foo-prev.rs
@@ -1,0 +1,6 @@
+#![crate_type = "lib"]
+#![crate_name = "foo"]
+
+pub struct Struct;
+pub trait Trait {}
+impl Trait for Struct {}

--- a/tests/run-make/crate-loading-crate-depends-on-itself/foo.stderr
+++ b/tests/run-make/crate-loading-crate-depends-on-itself/foo.stderr
@@ -1,0 +1,34 @@
+error[E0277]: the trait bound `foo::Struct: Trait` is not satisfied
+  --> foo-current.rs:13:19
+   |
+13 |     check_trait::<foo::Struct>();
+   |                   ^^^^^^^^^^^ the trait `Trait` is not implemented for `foo::Struct`
+   |
+note: there are multiple different versions of crate `foo` in the dependency graph
+  --> foo-current.rs:7:1
+   |
+4  | extern crate foo;
+   | ----------------- one version of crate `foo` is used here, as a direct dependency of the current crate
+5  |
+6  | pub struct Struct;
+   | ----------------- this type implements the required trait
+7  | pub trait Trait {}
+   | ^^^^^^^^^^^^^^^ this is the required trait
+   |
+  ::: foo-prev.rs:X:Y
+   |
+4  | pub struct Struct;
+   | ----------------- this type doesn't implement the required trait
+5  | pub trait Trait {}
+   | --------------- this is the found trait
+   = note: two types coming from two different versions of the same crate are different types even if they look the same
+   = help: you can use `cargo tree` to explore your dependency tree
+note: required by a bound in `check_trait`
+  --> foo-current.rs:10:19
+   |
+10 | fn check_trait<T: Trait>() {}
+   |                   ^^^^^ required by this bound in `check_trait`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/run-make/crate-loading-crate-depends-on-itself/rmake.rs
+++ b/tests/run-make/crate-loading-crate-depends-on-itself/rmake.rs
@@ -7,26 +7,25 @@
 // and traits of the different versions are mixed, we produce diagnostic output and not an ICE.
 // #133563
 
-use run_make_support::{rust_lib_name, rustc};
+use run_make_support::{diff, rust_lib_name, rustc};
 
 fn main() {
     rustc().input("foo-prev.rs").run();
 
-    rustc()
+    let out = rustc()
         .extra_filename("current")
         .metadata("current")
         .input("foo-current.rs")
         .extern_("foo", rust_lib_name("foo"))
         .run_fail()
-        .assert_stderr_contains(r#"
-note: there are multiple different versions of crate `foo` in the dependency graph
-  --> foo-current.rs:7:1
-   |
-4  | extern crate foo;
-   | ----------------- one version of crate `foo` is used here, as a direct dependency of the current crate
-5  |
-6  | pub struct Struct;
-   | ----------------- this type implements the required trait
-7  | pub trait Trait {}
-   | ^^^^^^^^^^^^^^^ this is the required trait"#);
+        .stderr_utf8();
+
+    // We don't remap the path of the `foo-prev` crate, so we remap it here.
+    let mut lines: Vec<_> = out.lines().collect();
+    for line in &mut lines {
+        if line.starts_with("  ::: ") {
+            *line = "  ::: foo-prev.rs:X:Y";
+        }
+    }
+    diff().expected_file("foo.stderr").actual_text("(rustc)", &lines.join("\n")).run();
 }

--- a/tests/run-make/crate-loading-crate-depends-on-itself/rmake.rs
+++ b/tests/run-make/crate-loading-crate-depends-on-itself/rmake.rs
@@ -1,0 +1,32 @@
+//@ only-linux
+//@ ignore-wasm32
+//@ ignore-wasm64
+// ignore-tidy-linelength
+
+// Verify that if the current crate depends on a different version of the same crate, *and* types
+// and traits of the different versions are mixed, we produce diagnostic output and not an ICE.
+// #133563
+
+use run_make_support::{rust_lib_name, rustc};
+
+fn main() {
+    rustc().input("foo-prev.rs").run();
+
+    rustc()
+        .extra_filename("current")
+        .metadata("current")
+        .input("foo-current.rs")
+        .extern_("foo", rust_lib_name("foo"))
+        .run_fail()
+        .assert_stderr_contains(r#"
+note: there are multiple different versions of crate `foo` in the dependency graph
+  --> foo-current.rs:7:1
+   |
+4  | extern crate foo;
+   | ----------------- one version of crate `foo` is used here, as a direct dependency of the current crate
+5  |
+6  | pub struct Struct;
+   | ----------------- this type implements the required trait
+7  | pub trait Trait {}
+   | ^^^^^^^^^^^^^^^ this is the required trait"#);
+}

--- a/tests/run-make/crate-loading/multiple-dep-versions.stderr
+++ b/tests/run-make/crate-loading/multiple-dep-versions.stderr
@@ -1,0 +1,127 @@
+error[E0277]: the trait bound `dep_2_reexport::Type: Trait` is not satisfied
+  --> replaced
+   |
+LL |     do_something(Type);
+   |     ------------ ^^^^ the trait `Trait` is not implemented for `dep_2_reexport::Type`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: there are multiple different versions of crate `dependency` in the dependency graph
+  --> replaced
+   |
+LL | pub struct Type(pub i32);
+   | --------------- this type implements the required trait
+LL | pub trait Trait {
+   | ^^^^^^^^^^^^^^^ this is the required trait
+   |
+  ::: replaced
+   |
+LL | extern crate dep_2_reexport;
+   | ---------------------------- one version of crate `dependency` is used here, as a dependency of crate `foo`
+LL | extern crate dependency;
+   | ------------------------ one version of crate `dependency` is used here, as a direct dependency of the current crate
+   |
+  ::: replaced
+   |
+LL | pub struct Type;
+   | --------------- this type doesn't implement the required trait
+LL | pub trait Trait {
+   | --------------- this is the found trait
+   = note: two types coming from two different versions of the same crate are different types even if they look the same
+   = help: you can use `cargo tree` to explore your dependency tree
+note: required by a bound in `do_something`
+  --> replaced
+   |
+LL | pub fn do_something<X: Trait>(_: X) {}
+   |                        ^^^^^ required by this bound in `do_something`
+
+error[E0599]: no method named `foo` found for struct `dep_2_reexport::Type` in the current scope
+  --> replaced
+   |
+LL |     Type.foo();
+   |          ^^^ method not found in `Type`
+   |
+note: there are multiple different versions of crate `dependency` in the dependency graph
+  --> replaced
+   |
+LL | pub trait Trait {
+   | ^^^^^^^^^^^^^^^ this is the trait that is needed
+LL |     fn foo(&self);
+   |     -------------- the method is available for `dep_2_reexport::Type` here
+   |
+  ::: replaced
+   |
+LL | use dependency::{Trait, do_something};
+   |                  ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`
+   |
+  ::: replaced
+   |
+LL | pub trait Trait {
+   | --------------- this is the trait that was imported
+
+error[E0599]: no function or associated item named `bar` found for struct `dep_2_reexport::Type` in the current scope
+  --> replaced
+   |
+LL |     Type::bar();
+   |           ^^^ function or associated item not found in `Type`
+   |
+note: there are multiple different versions of crate `dependency` in the dependency graph
+  --> replaced
+   |
+LL | pub trait Trait {
+   | ^^^^^^^^^^^^^^^ this is the trait that is needed
+LL |     fn foo(&self);
+LL |     fn bar();
+   |     --------- the associated function is available for `dep_2_reexport::Type` here
+   |
+  ::: replaced
+   |
+LL | use dependency::{Trait, do_something};
+   |                  ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`
+   |
+  ::: replaced
+   |
+LL | pub trait Trait {
+   | --------------- this is the trait that was imported
+
+error[E0277]: the trait bound `OtherType: Trait` is not satisfied
+  --> replaced
+   |
+LL |     do_something(OtherType);
+   |     ------------ ^^^^^^^^^ the trait `Trait` is not implemented for `OtherType`
+   |     |
+   |     required by a bound introduced by this call
+   |
+note: there are multiple different versions of crate `dependency` in the dependency graph
+  --> replaced
+   |
+LL | pub trait Trait {
+   | ^^^^^^^^^^^^^^^ this is the required trait
+   |
+  ::: replaced
+   |
+LL | extern crate dep_2_reexport;
+   | ---------------------------- one version of crate `dependency` is used here, as a dependency of crate `foo`
+LL | extern crate dependency;
+   | ------------------------ one version of crate `dependency` is used here, as a direct dependency of the current crate
+   |
+  ::: replaced
+   |
+LL | pub struct OtherType;
+   | -------------------- this type doesn't implement the required trait
+   |
+  ::: replaced
+   |
+LL | pub trait Trait {
+   | --------------- this is the found trait
+   = help: you can use `cargo tree` to explore your dependency tree
+note: required by a bound in `do_something`
+  --> replaced
+   |
+LL | pub fn do_something<X: Trait>(_: X) {}
+   |                        ^^^^^ required by this bound in `do_something`
+
+error: aborting due to 4 previous errors
+
+Some errors have detailed explanations: E0277, E0599.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/run-make/crate-loading/rmake.rs
+++ b/tests/run-make/crate-loading/rmake.rs
@@ -3,7 +3,7 @@
 //@ ignore-wasm64
 // ignore-tidy-linelength
 
-use run_make_support::{rust_lib_name, rustc};
+use run_make_support::{diff, rust_lib_name, rustc};
 
 fn main() {
     rustc().input("multiple-dep-versions-1.rs").run();
@@ -13,83 +13,26 @@ fn main() {
         .extern_("dependency", rust_lib_name("dependency2"))
         .run();
 
-    rustc()
+    let out = rustc()
         .input("multiple-dep-versions.rs")
         .extern_("dependency", rust_lib_name("dependency"))
         .extern_("dep_2_reexport", rust_lib_name("foo"))
+        .ui_testing()
         .run_fail()
-        .assert_stderr_contains(r#"error[E0277]: the trait bound `dep_2_reexport::Type: Trait` is not satisfied
-  --> multiple-dep-versions.rs:7:18
-   |
-7  |     do_something(Type);
-   |     ------------ ^^^^ the trait `Trait` is not implemented for `dep_2_reexport::Type`
-   |     |
-   |     required by a bound introduced by this call
-   |
-note: there are multiple different versions of crate `dependency` in the dependency graph"#)
-        .assert_stderr_contains(r#"
-3  | pub struct Type(pub i32);
-   | --------------- this type implements the required trait
-4  | pub trait Trait {
-   | ^^^^^^^^^^^^^^^ this is the required trait
-"#)
-        .assert_stderr_contains(r#"
-1  | extern crate dep_2_reexport;
-   | ---------------------------- one version of crate `dependency` is used here, as a dependency of crate `foo`
-2  | extern crate dependency;
-   | ------------------------ one version of crate `dependency` is used here, as a direct dependency of the current crate"#)
-        .assert_stderr_contains(r#"
-3  | pub struct Type;
-   | --------------- this type doesn't implement the required trait
-4  | pub trait Trait {
-   | --------------- this is the found trait
-   = note: two types coming from two different versions of the same crate are different types even if they look the same
-   = help: you can use `cargo tree` to explore your dependency tree"#)
-        .assert_stderr_contains(r#"note: required by a bound in `do_something`"#)
-        .assert_stderr_contains(r#"
-12 | pub fn do_something<X: Trait>(_: X) {}
-   |                        ^^^^^ required by this bound in `do_something`"#)
-        .assert_stderr_contains(r#"error[E0599]: no method named `foo` found for struct `dep_2_reexport::Type` in the current scope
- --> multiple-dep-versions.rs:8:10
-  |
-8 |     Type.foo();
-  |          ^^^ method not found in `Type`
-  |
-note: there are multiple different versions of crate `dependency` in the dependency graph"#)
-        .assert_stderr_contains(r#"
-4 | pub trait Trait {
-  | ^^^^^^^^^^^^^^^ this is the trait that is needed
-5 |     fn foo(&self);
-  |     -------------- the method is available for `dep_2_reexport::Type` here
-  |
- ::: multiple-dep-versions.rs:4:18
-  |
-4 | use dependency::{Trait, do_something};
-  |                  ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`"#)
-        .assert_stderr_contains(r#"
-4 | pub trait Trait {
-  | --------------- this is the trait that was imported"#)
-        .assert_stderr_contains(r#"
-error[E0599]: no function or associated item named `bar` found for struct `dep_2_reexport::Type` in the current scope
- --> multiple-dep-versions.rs:9:11
-  |
-9 |     Type::bar();
-  |           ^^^ function or associated item not found in `Type`
-  |
-note: there are multiple different versions of crate `dependency` in the dependency graph"#)
-        .assert_stderr_contains(r#"
-4 | pub trait Trait {
-  | ^^^^^^^^^^^^^^^ this is the trait that is needed
-5 |     fn foo(&self);
-6 |     fn bar();
-  |     --------- the associated function is available for `dep_2_reexport::Type` here
-  |
- ::: multiple-dep-versions.rs:4:18
-  |
-4 | use dependency::{Trait, do_something};
-  |                  ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`"#)
-        .assert_stderr_contains(
-          r#"
-6  | pub struct OtherType;
-   | -------------------- this type doesn't implement the required trait"#);
+        .stderr_utf8();
+
+    // We don't remap all the paths, so we remap it here.
+    let mut lines: Vec<_> = out.lines().collect();
+    for line in &mut lines {
+        if line.starts_with("  --> ") {
+            *line = "  --> replaced";
+        }
+        if line.starts_with("  ::: ") {
+            *line = "  ::: replaced";
+        }
+    }
+    diff()
+        .expected_file("multiple-dep-versions.stderr")
+        .actual_text("(rustc)", &lines.join("\n"))
+        .run();
 }


### PR DESCRIPTION
When we encounter an error caused by traits/types of different versions of the same crate, filter out the current crate when collecting spans to add to the context so we don't call `extern_crate` on the `DefId` of the current crate, which is meaningless and ICEs.

Produced output with this filter:

```
error[E0277]: the trait bound `foo::Struct: Trait` is not satisfied
  --> y.rs:13:19
   |
13 |     check_trait::<foo::Struct>();
   |                   ^^^^^^^^^^^ the trait `Trait` is not implemented for `foo::Struct`
   |
note: there are multiple different versions of crate `foo` in the dependency graph
  --> y.rs:7:1
   |
4  | extern crate foo;
   | ----------------- one version of crate `foo` is used here, as a direct dependency of the current crate
5  |
6  | pub struct Struct;
   | ----------------- this type implements the required trait
7  | pub trait Trait {}
   | ^^^^^^^^^^^^^^^ this is the required trait
   |
  ::: x.rs:4:1
   |
4  | pub struct Struct;
   | ----------------- this type doesn't implement the required trait
5  | pub trait Trait {}
   | --------------- this is the found trait
   = note: two types coming from two different versions of the same crate are different types even if they look the same
   = help: you can use `cargo tree` to explore your dependency tree
note: required by a bound in `check_trait`
  --> y.rs:10:19
   |
10 | fn check_trait<T: Trait>() {}
   |                   ^^^^^ required by this bound in `check_trait`
```

Fix #133563.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
