### PR TITLE
Rename `-Zparse-only`

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -425,7 +425,9 @@ fn run_compiler(
                 return early_exit();
             }
 
-            if sess.opts.unstable_opts.parse_only || sess.opts.unstable_opts.show_span.is_some() {
+            if sess.opts.unstable_opts.parse_crate_root_only
+                || sess.opts.unstable_opts.show_span.is_some()
+            {
                 return early_exit();
             }
 

--- a/compiler/rustc_interface/src/tests.rs
+++ b/compiler/rustc_interface/src/tests.rs
@@ -712,7 +712,7 @@ fn test_unstable_options_tracking_hash() {
     untracked!(no_analysis, true);
     untracked!(no_leak_check, true);
     untracked!(no_parallel_backend, true);
-    untracked!(parse_only, true);
+    untracked!(parse_crate_root_only, true);
     // `pre_link_arg` is omitted because it just forwards to `pre_link_args`.
     untracked!(pre_link_args, vec![String::from("abc"), String::from("def")]);
     untracked!(print_codegen_stats, true);

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -1208,7 +1208,7 @@ impl Options {
 
     /// Returns `true` if there will be an output file generated.
     pub fn will_create_output_file(&self) -> bool {
-        !self.unstable_opts.parse_only && // The file is just being parsed
+        !self.unstable_opts.parse_crate_root_only && // The file is just being parsed
             self.unstable_opts.ls.is_empty() // The file is just being queried
     }
 
@@ -1864,7 +1864,7 @@ fn parse_output_types(
     matches: &getopts::Matches,
 ) -> OutputTypes {
     let mut output_types = BTreeMap::new();
-    if !unstable_opts.parse_only {
+    if !unstable_opts.parse_crate_root_only {
         for list in matches.opt_strs("emit") {
             for output_type in list.split(',') {
                 let (shorthand, path) = split_out_file_name(output_type);

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -2037,7 +2037,7 @@ written to standard error output)"),
     shell_argfiles: bool = (false, parse_bool, [UNTRACKED],
         "allow argument files to be specified with POSIX \"shell-style\" argument quoting"),
     show_span: Option<String> = (None, parse_opt_string, [TRACKED],
-        "show spans for compiler debugging (expr|pat|ty)"),
+        "show spans in the crate root file, for compiler debugging (expr|pat|ty)"),
     simulate_remapped_rust_src_base: Option<PathBuf> = (None, parse_opt_pathbuf, [TRACKED],
         "simulate the effect of remap-debuginfo = true at bootstrapping by remapping path \
         to rust's source base directory. only meant for testing purposes"),

--- a/compiler/rustc_session/src/options.rs
+++ b/compiler/rustc_session/src/options.rs
@@ -1937,8 +1937,9 @@ options! {
         "support compiling tests with panic=abort (default: no)"),
     panic_in_drop: PanicStrategy = (PanicStrategy::Unwind, parse_panic_strategy, [TRACKED],
         "panic strategy for panics in drops"),
-    parse_only: bool = (false, parse_bool, [UNTRACKED],
-        "parse only; do not compile, assemble, or link (default: no)"),
+    parse_crate_root_only: bool = (false, parse_bool, [UNTRACKED],
+        "parse the crate root file only; do not parse other files, compile, assemble, or link \
+        (default: no)"),
     patchable_function_entry: PatchableFunctionEntry = (PatchableFunctionEntry::default(), parse_patchable_function_entry, [TRACKED],
         "nop padding at function entry"),
     plt: Option<bool> = (None, parse_opt_bool, [TRACKED],

--- a/tests/ui/generic-associated-types/parse/in-trait-impl.rs
+++ b/tests/ui/generic-associated-types/parse/in-trait-impl.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-//@ compile-flags: -Z parse-only
+//@ compile-flags: -Z parse-crate-root-only
 
 impl<T> Baz for T where T: Foo {
     type Quux<'a> = <T as Foo>::Bar<'a, 'static>;

--- a/tests/ui/generic-associated-types/parse/in-trait.rs
+++ b/tests/ui/generic-associated-types/parse/in-trait.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-//@ compile-flags: -Z parse-only
+//@ compile-flags: -Z parse-crate-root-only
 
 use std::ops::Deref;
 use std::fmt::Debug;

--- a/tests/ui/impl-trait/impl-trait-plus-priority.rs
+++ b/tests/ui/impl-trait/impl-trait-plus-priority.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z parse-only
+//@ compile-flags: -Z parse-crate-root-only
 
 fn f() -> impl A + {} // OK
 fn f() -> impl A + B {} // OK

--- a/tests/ui/parser/assoc/assoc-oddities-1.rs
+++ b/tests/ui/parser/assoc/assoc-oddities-1.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z parse-only
+//@ compile-flags: -Z parse-crate-root-only
 
 fn main() {
     // following lines below parse and must not fail

--- a/tests/ui/parser/assoc/assoc-oddities-2.rs
+++ b/tests/ui/parser/assoc/assoc-oddities-2.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z parse-only
+//@ compile-flags: -Z parse-crate-root-only
 
 fn main() {
     // see assoc-oddities-1 for explanation

--- a/tests/ui/parser/bounds-type.rs
+++ b/tests/ui/parser/bounds-type.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z parse-only
+//@ compile-flags: -Z parse-crate-root-only
 //@ edition: 2021
 
 struct S<

--- a/tests/ui/parser/impl-qpath.rs
+++ b/tests/ui/parser/impl-qpath.rs
@@ -1,5 +1,5 @@
 //@ check-pass
-//@ compile-flags: -Z parse-only
+//@ compile-flags: -Z parse-crate-root-only
 
 impl <*const u8>::AssocTy {} // OK
 impl <Type as Trait>::AssocTy {} // OK

--- a/tests/ui/parser/issues/issue-17904.rs
+++ b/tests/ui/parser/issues/issue-17904.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Zparse-only
+//@ compile-flags: -Zparse-crate-root-only
 
 struct Baz<U> where U: Eq(U); //This is parsed as the new Fn* style parenthesis syntax.
 struct Baz<U> where U: Eq(U) -> R; // Notice this parses as well.

--- a/tests/ui/traits/const-traits/syntax.rs
+++ b/tests/ui/traits/const-traits/syntax.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z parse-only
+//@ compile-flags: -Z parse-crate-root-only
 //@ check-pass
 
 #![feature(const_trait_bound_opt_out)]

--- a/tests/ui/traits/const-traits/tilde-const-syntax.rs
+++ b/tests/ui/traits/const-traits/tilde-const-syntax.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z parse-only
+//@ compile-flags: -Z parse-crate-root-only
 //@ check-pass
 
 #![feature(const_trait_impl)]

--- a/tests/ui/traits/const-traits/tilde-twice.rs
+++ b/tests/ui/traits/const-traits/tilde-twice.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: -Z parse-only
+//@ compile-flags: -Z parse-crate-root-only
 
 #![feature(const_trait_impl)]
 


### PR DESCRIPTION
It's a misleading name.

r? @estebank 