### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -43,7 +43,7 @@ Libraries
 - [Document that `catch_unwind` can deal with foreign exceptions without UB, although the exact behavior is unspecified.](https://github.com/rust-lang/rust/pull/128321)
 - [Implement `Default` for `HashMap`/`HashSet` iterators that don't already have it.](https://github.com/rust-lang/rust/pull/128711)
 - [Bump Unicode to version 16.0.0.](https://github.com/rust-lang/rust/pull/130183)
-- [Change documentation of `ptr::add`/`sub` to not claim equivalence with `offset`.](https://github.com/rust-lang/rust/pull/130229).
+- [Change documentation of `ptr::add`/`sub` to not claim equivalence with `offset`.](https://github.com/rust-lang/rust/pull/130229)
 
 
 <a id="1.83.0-Stabilized-APIs"></a>

--- a/library/alloc/src/collections/binary_heap/mod.rs
+++ b/library/alloc/src/collections/binary_heap/mod.rs
@@ -452,7 +452,7 @@ impl<T: Ord> BinaryHeap<T> {
     ///
     /// The binary heap will be able to hold at least `capacity` elements without
     /// reallocating. This method is allowed to allocate for more elements than
-    /// `capacity`. If `capacity` is 0, the binary heap will not allocate.
+    /// `capacity`. If `capacity` is zero, the binary heap will not allocate.
     ///
     /// # Examples
     ///
@@ -496,7 +496,7 @@ impl<T: Ord, A: Allocator> BinaryHeap<T, A> {
     ///
     /// The binary heap will be able to hold at least `capacity` elements without
     /// reallocating. This method is allowed to allocate for more elements than
-    /// `capacity`. If `capacity` is 0, the binary heap will not allocate.
+    /// `capacity`. If `capacity` is zero, the binary heap will not allocate.
     ///
     /// # Examples
     ///

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -427,7 +427,7 @@ impl<T> Vec<T> {
     ///
     /// The vector will be able to hold at least `capacity` elements without
     /// reallocating. This method is allowed to allocate for more elements than
-    /// `capacity`. If `capacity` is 0, the vector will not allocate.
+    /// `capacity`. If `capacity` is zero, the vector will not allocate.
     ///
     /// It is important to note that although the returned vector has the
     /// minimum *capacity* specified, the vector will have a zero *length*. For
@@ -487,7 +487,7 @@ impl<T> Vec<T> {
     ///
     /// The vector will be able to hold at least `capacity` elements without
     /// reallocating. This method is allowed to allocate for more elements than
-    /// `capacity`. If `capacity` is 0, the vector will not allocate.
+    /// `capacity`. If `capacity` is zero, the vector will not allocate.
     ///
     /// # Errors
     ///
@@ -745,7 +745,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// The vector will be able to hold at least `capacity` elements without
     /// reallocating. This method is allowed to allocate for more elements than
-    /// `capacity`. If `capacity` is 0, the vector will not allocate.
+    /// `capacity`. If `capacity` is zero, the vector will not allocate.
     ///
     /// It is important to note that although the returned vector has the
     /// minimum *capacity* specified, the vector will have a zero *length*. For
@@ -808,7 +808,7 @@ impl<T, A: Allocator> Vec<T, A> {
     ///
     /// The vector will be able to hold at least `capacity` elements without
     /// reallocating. This method is allowed to allocate for more elements than
-    /// `capacity`. If `capacity` is 0, the vector will not allocate.
+    /// `capacity`. If `capacity` is zero, the vector will not allocate.
     ///
     /// # Errors
     ///

--- a/library/core/src/iter/traits/iterator.rs
+++ b/library/core/src/iter/traits/iterator.rs
@@ -1553,7 +1553,7 @@ pub trait Iterator {
     ///
     /// # Panics
     ///
-    /// Panics if `N` is 0. This check will most probably get changed to a
+    /// Panics if `N` is zero. This check will most probably get changed to a
     /// compile time error before this method gets stabilized.
     ///
     /// ```should_panic
@@ -3454,7 +3454,7 @@ pub trait Iterator {
     ///
     /// # Panics
     ///
-    /// Panics if `N` is 0.
+    /// Panics if `N` is zero.
     ///
     /// # Examples
     ///

--- a/library/core/src/num/int_macros.rs
+++ b/library/core/src/num/int_macros.rs
@@ -1828,7 +1828,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -1986,7 +1986,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2014,7 +2014,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2042,7 +2042,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2069,7 +2069,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2526,7 +2526,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2557,7 +2557,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2588,7 +2588,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2619,7 +2619,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2887,7 +2887,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0 or if `self` is `Self::MIN`
+        /// This function will panic if `rhs` is zero or if `self` is `Self::MIN`
         /// and `rhs` is -1. This behavior is not affected by the `overflow-checks` flag.
         ///
         /// # Examples
@@ -2926,7 +2926,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0 or if `self` is `Self::MIN` and
+        /// This function will panic if `rhs` is zero or if `self` is `Self::MIN` and
         /// `rhs` is -1. This behavior is not affected by the `overflow-checks` flag.
         ///
         /// # Examples
@@ -2975,7 +2975,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0 or if `self` is `Self::MIN`
+        /// This function will panic if `rhs` is zero or if `self` is `Self::MIN`
         /// and `rhs` is -1. This behavior is not affected by the `overflow-checks` flag.
         ///
         /// # Examples
@@ -3019,7 +3019,7 @@ macro_rules! int_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0 or if `self` is `Self::MIN`
+        /// This function will panic if `rhs` is zero or if `self` is `Self::MIN`
         /// and `rhs` is -1. This behavior is not affected by the `overflow-checks` flag.
         ///
         /// # Examples

--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -1877,7 +1877,7 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2034,7 +2034,7 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2063,7 +2063,7 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2091,7 +2091,7 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2121,7 +2121,7 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2545,7 +2545,7 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2576,7 +2576,7 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2604,7 +2604,7 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2635,7 +2635,7 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2872,7 +2872,7 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///
@@ -2900,7 +2900,7 @@ macro_rules! uint_impl {
         ///
         /// # Panics
         ///
-        /// This function will panic if `rhs` is 0.
+        /// This function will panic if `rhs` is zero.
         ///
         /// # Examples
         ///

--- a/library/core/src/pin.rs
+++ b/library/core/src/pin.rs
@@ -373,9 +373,9 @@
 //! exactly what we did with our `AddrTracker` example above. Without doing this, you *must not*
 //! rely on pinning-related guarantees to apply to your type!
 //!
-//! If need to truly pin a value of a foreign or built-in type that implements [`Unpin`], you'll
-//! need to create your own wrapper type around the [`Unpin`] type you want to pin and then
-//! opts-out of [`Unpin`] using [`PhantomPinned`].
+//! If you really need to pin a value of a foreign or built-in type that implements [`Unpin`],
+//! you'll need to create your own wrapper type around the [`Unpin`] type you want to pin and then
+//! opt-out of [`Unpin`] using [`PhantomPinned`].
 //!
 //! Exposing access to the inner field which you want to remain pinned must then be carefully
 //! considered as well! Remember, exposing a method that gives access to a

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -1039,7 +1039,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `size` is 0.
+    /// Panics if `size` is zero.
     ///
     /// # Examples
     ///
@@ -1095,7 +1095,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `chunk_size` is 0.
+    /// Panics if `chunk_size` is zero.
     ///
     /// # Examples
     ///
@@ -1130,7 +1130,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `chunk_size` is 0.
+    /// Panics if `chunk_size` is zero.
     ///
     /// # Examples
     ///
@@ -1172,7 +1172,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `chunk_size` is 0.
+    /// Panics if `chunk_size` is zero.
     ///
     /// # Examples
     ///
@@ -1211,7 +1211,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `chunk_size` is 0.
+    /// Panics if `chunk_size` is zero.
     ///
     /// # Examples
     ///
@@ -1288,7 +1288,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `N` is 0. This check will most probably get changed to a compile time
+    /// Panics if `N` is zero. This check will most probably get changed to a compile time
     /// error before this method gets stabilized.
     ///
     /// # Examples
@@ -1334,7 +1334,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `N` is 0. This check will most probably get changed to a compile time
+    /// Panics if `N` is zero. This check will most probably get changed to a compile time
     /// error before this method gets stabilized.
     ///
     /// # Examples
@@ -1372,7 +1372,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `N` is 0. This check will most probably get changed to a compile time
+    /// Panics if `N` is zero. This check will most probably get changed to a compile time
     /// error before this method gets stabilized.
     ///
     /// # Examples
@@ -1448,7 +1448,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `N` is 0. This check will most probably get changed to a compile time
+    /// Panics if `N` is zero. This check will most probably get changed to a compile time
     /// error before this method gets stabilized.
     ///
     /// # Examples
@@ -1489,7 +1489,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `N` is 0. This check will most probably get changed to a compile time
+    /// Panics if `N` is zero. This check will most probably get changed to a compile time
     /// error before this method gets stabilized.
     ///
     /// # Examples
@@ -1533,7 +1533,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `N` is 0. This check will most probably get changed to a compile time
+    /// Panics if `N` is zero. This check will most probably get changed to a compile time
     /// error before this method gets stabilized.
     ///
     /// # Examples
@@ -1568,7 +1568,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `N` is 0. This check will most probably get changed to a compile time
+    /// Panics if `N` is zero. This check will most probably get changed to a compile time
     /// error before this method gets stabilized.
     ///
     /// # Examples
@@ -1604,7 +1604,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `chunk_size` is 0.
+    /// Panics if `chunk_size` is zero.
     ///
     /// # Examples
     ///
@@ -1639,7 +1639,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `chunk_size` is 0.
+    /// Panics if `chunk_size` is zero.
     ///
     /// # Examples
     ///
@@ -1682,7 +1682,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `chunk_size` is 0.
+    /// Panics if `chunk_size` is zero.
     ///
     /// # Examples
     ///
@@ -1722,7 +1722,7 @@ impl<T> [T] {
     ///
     /// # Panics
     ///
-    /// Panics if `chunk_size` is 0.
+    /// Panics if `chunk_size` is zero.
     ///
     /// # Examples
     ///

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -235,7 +235,7 @@ impl<K, V> HashMap<K, V, RandomState> {
     ///
     /// The hash map will be able to hold at least `capacity` elements without
     /// reallocating. This method is allowed to allocate for more elements than
-    /// `capacity`. If `capacity` is 0, the hash map will not allocate.
+    /// `capacity`. If `capacity` is zero, the hash map will not allocate.
     ///
     /// # Examples
     ///
@@ -287,7 +287,7 @@ impl<K, V, S> HashMap<K, V, S> {
     ///
     /// The hash map will be able to hold at least `capacity` elements without
     /// reallocating. This method is allowed to allocate for more elements than
-    /// `capacity`. If `capacity` is 0, the hash map will not allocate.
+    /// `capacity`. If `capacity` is zero, the hash map will not allocate.
     ///
     /// Warning: `hasher` is normally randomly generated, and
     /// is designed to allow HashMaps to be resistant to attacks that

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -130,7 +130,7 @@ impl<T> HashSet<T, RandomState> {
     ///
     /// The hash set will be able to hold at least `capacity` elements without
     /// reallocating. This method is allowed to allocate for more elements than
-    /// `capacity`. If `capacity` is 0, the hash set will not allocate.
+    /// `capacity`. If `capacity` is zero, the hash set will not allocate.
     ///
     /// # Examples
     ///
@@ -379,7 +379,7 @@ impl<T, S> HashSet<T, S> {
     ///
     /// The hash set will be able to hold at least `capacity` elements without
     /// reallocating. This method is allowed to allocate for more elements than
-    /// `capacity`. If `capacity` is 0, the hash set will not allocate.
+    /// `capacity`. If `capacity` is zero, the hash set will not allocate.
     ///
     /// Warning: `hasher` is normally randomly generated, and
     /// is designed to allow `HashSet`s to be resistant to attacks that

--- a/src/doc/rustc/src/platform-support/armeb-unknown-linux-gnueabi.md
+++ b/src/doc/rustc/src/platform-support/armeb-unknown-linux-gnueabi.md
@@ -16,7 +16,7 @@ BE8 architecture is the default big-endian architecture for Arm since [Armv6](ht
 The target is cross-compiled. This target supports `std` in the normal way (indeed only nominal changes are required from the standard Arm configuration).
 
 ## Target definition
-The target definition can be seen [here](https://github.com/rust-lang/rust/tree/master/compiler/rustc_target/src/spec/armeb_unknown_linux_gnueabi.rs). In particular, it should be noted that the `features` specify that this target is built for the Armv8 core. Though this can likely be modified as required.
+The target definition can be seen [here](https://github.com/rust-lang/rust/blob/master/compiler/rustc_target/src/spec/targets/armeb_unknown_linux_gnueabi.rs). In particular, it should be noted that the `features` specify that this target is built for the Armv8 core. Though this can likely be modified as required.
 
 ## Building the target
 Because it is Tier 3, rust does not yet ship pre-compiled artifacts for this target.

--- a/src/doc/rustc/src/platform-support/s390x-unknown-linux-gnu.md
+++ b/src/doc/rustc/src/platform-support/s390x-unknown-linux-gnu.md
@@ -64,6 +64,22 @@ There are no special requirements for testing and running the target.
 For testing cross builds on the host, please refer to the "Cross-compilation
 toolchains and C code" section below.
 
+If you want to do native testing but do not have your own s390x
+machine, there are several options how to get access to one:
+
+* The [IBM LinuxONE Community Cloud][cloud-community] provides a
+  self-service portal where you can create s390x virtual machine
+  instances.  These are intended for temporary use (limited to 120 days).
+
+* The [IBM LinuxONE Open Source Cloud][cloud-opensource] provides
+  permanent access to s390x machines.  This requires approval by IBM,
+  which will normally be granted if you're planning to use the machine
+  to work on an open-source project that is relevant to the IBM Z
+  ecosystem - the Rust compiler would certainly qualify.
+
+[cloud-community]: https://linuxone.cloud.marist.edu/
+[cloud-opensource]: https://community.ibm.com/zsystems/form/l1cc-oss-vm-request/
+
 ## Cross-compilation toolchains and C code
 
 Rust code built using the target is compatible with C code compiled with

--- a/tests/rustdoc-ui/doctest/doctest-output-include-fail.rs
+++ b/tests/rustdoc-ui/doctest/doctest-output-include-fail.rs
@@ -1,5 +1,5 @@
 //@ edition:2024
-//@ compile-flags:--test --test-args=--test-threads=1 -Z unstable-options
+//@ compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ failure-status: 101

--- a/tests/rustdoc-ui/doctest/doctest-output.rs
+++ b/tests/rustdoc-ui/doctest/doctest-output.rs
@@ -4,7 +4,7 @@
 //@[edition2015]compile-flags:--test --test-args=--test-threads=1
 //@[edition2024]edition:2015
 //@[edition2024]aux-build:extern_macros.rs
-//@[edition2024]compile-flags:--test --test-args=--test-threads=1 -Z unstable-options
+//@[edition2024]compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 //@ check-pass

--- a/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
+++ b/tests/rustdoc-ui/doctest/relative-path-include-bytes-132203.rs
@@ -6,7 +6,7 @@
 //@[edition2015]compile-flags:--test --test-args=--test-threads=1
 //@[edition2024]edition:2024
 //@[edition2024]check-pass
-//@[edition2024]compile-flags:--test --test-args=--test-threads=1 -Z unstable-options
+//@[edition2024]compile-flags:--test --test-args=--test-threads=1
 //@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
 //@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
 

--- a/tests/ui/coroutine/async-gen-deduce-yield.rs
+++ b/tests/ui/coroutine/async-gen-deduce-yield.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2024 -Zunstable-options
+//@ compile-flags: --edition 2024
 //@ check-pass
 
 #![feature(async_iterator, gen_blocks)]

--- a/tests/ui/coroutine/async-gen-yield-ty-is-unit.rs
+++ b/tests/ui/coroutine/async-gen-yield-ty-is-unit.rs
@@ -1,4 +1,4 @@
-//@ compile-flags: --edition 2024 -Zunstable-options
+//@ compile-flags: --edition 2024
 //@ check-pass
 
 #![feature(async_iterator, gen_blocks, noop_waker)]

--- a/tests/ui/drop/drop_order.rs
+++ b/tests/ui/drop/drop_order.rs
@@ -2,7 +2,6 @@
 //@ compile-flags: -Z validate-mir
 //@ revisions: edition2021 edition2024
 //@ [edition2021] edition: 2021
-//@ [edition2024] compile-flags: -Z unstable-options
 //@ [edition2024] edition: 2024
 
 #![feature(let_chains)]

--- a/tests/ui/drop/lint-if-let-rescope-gated.edition2021.stderr
+++ b/tests/ui/drop/lint-if-let-rescope-gated.edition2021.stderr
@@ -1,5 +1,5 @@
 error: `if let` assigns a shorter lifetime since Edition 2024
-  --> $DIR/lint-if-let-rescope-gated.rs:27:8
+  --> $DIR/lint-if-let-rescope-gated.rs:26:8
    |
 LL |     if let Some(_value) = Droppy.get() {
    |        ^^^^^^^^^^^^^^^^^^^------^^^^^^
@@ -9,12 +9,12 @@ LL |     if let Some(_value) = Droppy.get() {
    = warning: this changes meaning in Rust 2024
    = note: for more information, see issue #124085 <https://github.com/rust-lang/rust/issues/124085>
 help: the value is now dropped here in Edition 2024
-  --> $DIR/lint-if-let-rescope-gated.rs:31:5
+  --> $DIR/lint-if-let-rescope-gated.rs:30:5
    |
 LL |     } else {
    |     ^
 note: the lint level is defined here
-  --> $DIR/lint-if-let-rescope-gated.rs:11:9
+  --> $DIR/lint-if-let-rescope-gated.rs:10:9
    |
 LL | #![deny(if_let_rescope)]
    |         ^^^^^^^^^^^^^^

--- a/tests/ui/drop/lint-if-let-rescope-gated.rs
+++ b/tests/ui/drop/lint-if-let-rescope-gated.rs
@@ -5,7 +5,6 @@
 //@ revisions: edition2021 edition2024
 //@ [edition2021] edition: 2021
 //@ [edition2024] edition: 2024
-//@ [edition2024] compile-flags: -Zunstable-options
 //@ [edition2024] check-pass
 
 #![deny(if_let_rescope)]

--- a/tests/ui/drop/tail-expr-drop-order-negative.edition2024.stderr
+++ b/tests/ui/drop/tail-expr-drop-order-negative.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0716]: temporary value dropped while borrowed
-  --> $DIR/tail-expr-drop-order-negative.rs:9:15
+  --> $DIR/tail-expr-drop-order-negative.rs:8:15
    |
 LL |     x.replace(std::cell::RefCell::new(123).borrow()).is_some()
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                   - temporary value is freed at the end of this statement

--- a/tests/ui/drop/tail-expr-drop-order-negative.rs
+++ b/tests/ui/drop/tail-expr-drop-order-negative.rs
@@ -1,5 +1,4 @@
 //@ revisions: edition2021 edition2024
-//@ [edition2024] compile-flags: -Zunstable-options
 //@ [edition2024] edition: 2024
 //@ [edition2021] check-pass
 

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.fixed
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.fixed
@@ -2,7 +2,6 @@
 //
 //@[e2021] edition: 2021
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //
 //@[e2021] run-pass
 //@[e2021] run-rustfix

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
@@ -1,5 +1,5 @@
 warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:17:1
+  --> $DIR/never-type-fallback-breaking.rs:16:1
    |
 LL | fn m() {
    | ^^^^^^
@@ -8,7 +8,7 @@ LL | fn m() {
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/never-type-fallback-breaking.rs:21:17
+  --> $DIR/never-type-fallback-breaking.rs:20:17
    |
 LL |         true => Default::default(),
    |                 ^^^^^^^^^^^^^^^^^^
@@ -19,7 +19,7 @@ LL |     let x: () = match true {
    |          ++++
 
 warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:29:1
+  --> $DIR/never-type-fallback-breaking.rs:28:1
    |
 LL | fn q() -> Option<()> {
    | ^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL | fn q() -> Option<()> {
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
-  --> $DIR/never-type-fallback-breaking.rs:36:5
+  --> $DIR/never-type-fallback-breaking.rs:35:5
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL |     deserialize::<()>()?;
    |                ++++++
 
 warning: this function depends on never type fallback being `()`
-  --> $DIR/never-type-fallback-breaking.rs:46:1
+  --> $DIR/never-type-fallback-breaking.rs:45:1
    |
 LL | fn meow() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -47,7 +47,7 @@ LL | fn meow() -> Result<(), ()> {
    = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `(): From<!>` will fail
-  --> $DIR/never-type-fallback-breaking.rs:49:5
+  --> $DIR/never-type-fallback-breaking.rs:48:5
    |
 LL |     help(1)?;
    |     ^^^^^^^

--- a/tests/ui/editions/never-type-fallback-breaking.e2024.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2024.stderr
@@ -1,5 +1,5 @@
 error[E0277]: the trait bound `!: Default` is not satisfied
-  --> $DIR/never-type-fallback-breaking.rs:21:17
+  --> $DIR/never-type-fallback-breaking.rs:20:17
    |
 LL |         true => Default::default(),
    |                 ^^^^^^^^^^^^^^^^^^ the trait `Default` is not implemented for `!`
@@ -8,7 +8,7 @@ LL |         true => Default::default(),
    = help: did you intend to use the type `()` here instead?
 
 error[E0277]: the trait bound `!: Default` is not satisfied
-  --> $DIR/never-type-fallback-breaking.rs:36:5
+  --> $DIR/never-type-fallback-breaking.rs:35:5
    |
 LL |     deserialize()?;
    |     ^^^^^^^^^^^^^ the trait `Default` is not implemented for `!`
@@ -16,13 +16,13 @@ LL |     deserialize()?;
    = note: this error might have been caused by changes to Rust's type-inference algorithm (see issue #48950 <https://github.com/rust-lang/rust/issues/48950> for more information)
    = help: did you intend to use the type `()` here instead?
 note: required by a bound in `deserialize`
-  --> $DIR/never-type-fallback-breaking.rs:32:23
+  --> $DIR/never-type-fallback-breaking.rs:31:23
    |
 LL |     fn deserialize<T: Default>() -> Option<T> {
    |                       ^^^^^^^ required by this bound in `deserialize`
 
 error[E0277]: the trait bound `(): From<!>` is not satisfied
-  --> $DIR/never-type-fallback-breaking.rs:49:5
+  --> $DIR/never-type-fallback-breaking.rs:48:5
    |
 LL |     help(1)?;
    |     ^^^^^^^ the trait `From<!>` is not implemented for `()`
@@ -39,7 +39,7 @@ LL |     help(1)?;
            and 4 others
    = note: required for `!` to implement `Into<()>`
 note: required by a bound in `help`
-  --> $DIR/never-type-fallback-breaking.rs:43:20
+  --> $DIR/never-type-fallback-breaking.rs:42:20
    |
 LL | fn help<'a: 'a, T: Into<()>, U>(_: U) -> Result<T, ()> {
    |                    ^^^^^^^^ required by this bound in `help`

--- a/tests/ui/editions/never-type-fallback-breaking.rs
+++ b/tests/ui/editions/never-type-fallback-breaking.rs
@@ -2,7 +2,6 @@
 //
 //@[e2021] edition: 2021
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //
 //@[e2021] run-pass
 //@[e2021] run-rustfix

--- a/tests/ui/editions/never-type-fallback.rs
+++ b/tests/ui/editions/never-type-fallback.rs
@@ -2,7 +2,6 @@
 //
 //@[e2021] edition: 2021
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //
 //@ run-pass
 //@ check-run-results

--- a/tests/ui/hello.rs
+++ b/tests/ui/hello.rs
@@ -5,8 +5,6 @@
 //@[e2021] edition:2021
 //@[e2024] edition:2024
 
-//@[e2024] compile-flags: -Zunstable-options
-
 fn main() {
     println!("hello");
 }

--- a/tests/ui/impl-trait/variance.e2024.stderr
+++ b/tests/ui/impl-trait/variance.e2024.stderr
@@ -1,23 +1,23 @@
 error: ['a: *, 'a: o]
-  --> $DIR/variance.rs:14:36
+  --> $DIR/variance.rs:13:36
    |
 LL | fn not_captured_early<'a: 'a>() -> impl Sized {}
    |                                    ^^^^^^^^^^
 
 error: ['a: *, 'a: o]
-  --> $DIR/variance.rs:19:32
+  --> $DIR/variance.rs:18:32
    |
 LL | fn captured_early<'a: 'a>() -> impl Sized + Captures<'a> {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: ['a: o]
-  --> $DIR/variance.rs:21:40
+  --> $DIR/variance.rs:20:40
    |
 LL | fn not_captured_late<'a>(_: &'a ()) -> impl Sized {}
    |                                        ^^^^^^^^^^
 
 error: ['a: o]
-  --> $DIR/variance.rs:26:36
+  --> $DIR/variance.rs:25:36
    |
 LL | fn captured_late<'a>(_: &'a ()) -> impl Sized + Captures<'a> {}
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-trait/variance.new.stderr
+++ b/tests/ui/impl-trait/variance.new.stderr
@@ -1,23 +1,23 @@
 error: ['a: *, 'a: o]
-  --> $DIR/variance.rs:14:36
+  --> $DIR/variance.rs:13:36
    |
 LL | fn not_captured_early<'a: 'a>() -> impl Sized {}
    |                                    ^^^^^^^^^^
 
 error: ['a: *, 'a: o]
-  --> $DIR/variance.rs:19:32
+  --> $DIR/variance.rs:18:32
    |
 LL | fn captured_early<'a: 'a>() -> impl Sized + Captures<'a> {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: ['a: o]
-  --> $DIR/variance.rs:21:40
+  --> $DIR/variance.rs:20:40
    |
 LL | fn not_captured_late<'a>(_: &'a ()) -> impl Sized {}
    |                                        ^^^^^^^^^^
 
 error: ['a: o]
-  --> $DIR/variance.rs:26:36
+  --> $DIR/variance.rs:25:36
    |
 LL | fn captured_late<'a>(_: &'a ()) -> impl Sized + Captures<'a> {}
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-trait/variance.old.stderr
+++ b/tests/ui/impl-trait/variance.old.stderr
@@ -1,23 +1,23 @@
 error: ['a: *]
-  --> $DIR/variance.rs:14:36
+  --> $DIR/variance.rs:13:36
    |
 LL | fn not_captured_early<'a: 'a>() -> impl Sized {}
    |                                    ^^^^^^^^^^
 
 error: ['a: *, 'a: o]
-  --> $DIR/variance.rs:19:32
+  --> $DIR/variance.rs:18:32
    |
 LL | fn captured_early<'a: 'a>() -> impl Sized + Captures<'a> {}
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: []
-  --> $DIR/variance.rs:21:40
+  --> $DIR/variance.rs:20:40
    |
 LL | fn not_captured_late<'a>(_: &'a ()) -> impl Sized {}
    |                                        ^^^^^^^^^^
 
 error: ['a: o]
-  --> $DIR/variance.rs:26:36
+  --> $DIR/variance.rs:25:36
    |
 LL | fn captured_late<'a>(_: &'a ()) -> impl Sized + Captures<'a> {}
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/impl-trait/variance.rs
+++ b/tests/ui/impl-trait/variance.rs
@@ -1,6 +1,5 @@
 //@ revisions: old new e2024
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Z unstable-options
 
 #![cfg_attr(new, feature(lifetime_capture_rules_2024))]
 

--- a/tests/ui/lifetimes/raw/gen-lt.e2024.stderr
+++ b/tests/ui/lifetimes/raw/gen-lt.e2024.stderr
@@ -1,5 +1,5 @@
 error: lifetimes cannot use keyword names
-  --> $DIR/gen-lt.rs:11:11
+  --> $DIR/gen-lt.rs:10:11
    |
 LL | fn gen_lt<'gen>() {}
    |           ^^^^

--- a/tests/ui/lifetimes/raw/gen-lt.rs
+++ b/tests/ui/lifetimes/raw/gen-lt.rs
@@ -2,7 +2,6 @@
 
 //@[e2021] edition:2021
 //@[e2024] edition:2024
-//@[e2024] compile-flags: -Zunstable-options
 
 //@[e2021] check-pass
 

--- a/tests/ui/lifetimes/refcell-in-tail-expr.edition2021.stderr
+++ b/tests/ui/lifetimes/refcell-in-tail-expr.edition2021.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `cell` does not live long enough
-  --> $DIR/refcell-in-tail-expr.rs:10:27
+  --> $DIR/refcell-in-tail-expr.rs:9:27
    |
 LL |     let cell = std::cell::RefCell::new(0u8);
    |         ---- binding `cell` declared here

--- a/tests/ui/lifetimes/refcell-in-tail-expr.rs
+++ b/tests/ui/lifetimes/refcell-in-tail-expr.rs
@@ -1,7 +1,6 @@
 //@ revisions: edition2021 edition2024
 //@ [edition2021] edition: 2021
 //@ [edition2024] edition: 2024
-//@ [edition2024] compile-flags: -Zunstable-options
 //@ [edition2024] check-pass
 
 fn main() {

--- a/tests/ui/lifetimes/shorter-tail-expr-lifetime.edition2021.stderr
+++ b/tests/ui/lifetimes/shorter-tail-expr-lifetime.edition2021.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `c` does not live long enough
-  --> $DIR/shorter-tail-expr-lifetime.rs:8:5
+  --> $DIR/shorter-tail-expr-lifetime.rs:7:5
    |
 LL |     let c = std::cell::RefCell::new("..");
    |         - binding `c` declared here

--- a/tests/ui/lifetimes/shorter-tail-expr-lifetime.rs
+++ b/tests/ui/lifetimes/shorter-tail-expr-lifetime.rs
@@ -1,5 +1,4 @@
 //@ revisions: edition2021 edition2024
-//@ [edition2024] compile-flags: -Zunstable-options
 //@ [edition2024] edition: 2024
 //@ [edition2024] run-pass
 

--- a/tests/ui/lifetimes/tail-expr-lock-poisoning.rs
+++ b/tests/ui/lifetimes/tail-expr-lock-poisoning.rs
@@ -1,6 +1,5 @@
 //@ revisions: edition2021 edition2024
 //@ ignore-wasm no panic or subprocess support
-//@ [edition2024] compile-flags: -Zunstable-options
 //@ [edition2024] edition: 2024
 //@ run-pass
 //@ needs-unwind

--- a/tests/ui/lifetimes/temporary-lifetime-extension.rs
+++ b/tests/ui/lifetimes/temporary-lifetime-extension.rs
@@ -15,7 +15,6 @@
 //@ revisions: edition2021 edition2024
 //@ [edition2021] edition: 2021
 //@ [edition2024] edition: 2024
-//@ [edition2024] compile-flags: -Z unstable-options
 
 fn temp() -> (String, i32) {
     (String::from("Hello"), 1)

--- a/tests/ui/lint/static-mut-refs.e2021.stderr
+++ b/tests/ui/lint/static-mut-refs.e2021.stderr
@@ -1,5 +1,5 @@
 warning: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:39:18
+  --> $DIR/static-mut-refs.rs:38:18
    |
 LL |         let _y = &X;
    |                  ^^ shared reference to mutable static
@@ -13,7 +13,7 @@ LL |         let _y = &raw const X;
    |                  ~~~~~~~~~~
 
 warning: creating a mutable reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:43:18
+  --> $DIR/static-mut-refs.rs:42:18
    |
 LL |         let _y = &mut X;
    |                  ^^^^^^ mutable reference to mutable static
@@ -26,7 +26,7 @@ LL |         let _y = &raw mut X;
    |                  ~~~~~~~~
 
 warning: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:51:22
+  --> $DIR/static-mut-refs.rs:50:22
    |
 LL |         let ref _a = X;
    |                      ^ shared reference to mutable static
@@ -35,7 +35,7 @@ LL |         let ref _a = X;
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:55:25
+  --> $DIR/static-mut-refs.rs:54:25
    |
 LL |         let (_b, _c) = (&X, &Y);
    |                         ^^ shared reference to mutable static
@@ -48,7 +48,7 @@ LL |         let (_b, _c) = (&raw const X, &Y);
    |                         ~~~~~~~~~~
 
 warning: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:55:29
+  --> $DIR/static-mut-refs.rs:54:29
    |
 LL |         let (_b, _c) = (&X, &Y);
    |                             ^^ shared reference to mutable static
@@ -61,7 +61,7 @@ LL |         let (_b, _c) = (&X, &raw const Y);
    |                             ~~~~~~~~~~
 
 warning: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:61:13
+  --> $DIR/static-mut-refs.rs:60:13
    |
 LL |         foo(&X);
    |             ^^ shared reference to mutable static
@@ -74,7 +74,7 @@ LL |         foo(&raw const X);
    |             ~~~~~~~~~~
 
 warning: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:67:17
+  --> $DIR/static-mut-refs.rs:66:17
    |
 LL |         let _ = Z.len();
    |                 ^^^^^^^ shared reference to mutable static
@@ -83,7 +83,7 @@ LL |         let _ = Z.len();
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:73:33
+  --> $DIR/static-mut-refs.rs:72:33
    |
 LL |         let _ = format!("{:?}", Z);
    |                                 ^ shared reference to mutable static
@@ -92,7 +92,7 @@ LL |         let _ = format!("{:?}", Z);
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:77:18
+  --> $DIR/static-mut-refs.rs:76:18
    |
 LL |         let _v = &A.value;
    |                  ^^^^^^^^ shared reference to mutable static
@@ -105,7 +105,7 @@ LL |         let _v = &raw const A.value;
    |                  ~~~~~~~~~~
 
 warning: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:81:18
+  --> $DIR/static-mut-refs.rs:80:18
    |
 LL |         let _s = &A.s.value;
    |                  ^^^^^^^^^^ shared reference to mutable static
@@ -118,7 +118,7 @@ LL |         let _s = &raw const A.s.value;
    |                  ~~~~~~~~~~
 
 warning: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:85:22
+  --> $DIR/static-mut-refs.rs:84:22
    |
 LL |         let ref _v = A.value;
    |                      ^^^^^^^ shared reference to mutable static
@@ -127,7 +127,7 @@ LL |         let ref _v = A.value;
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 warning: creating a mutable reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:15:14
+  --> $DIR/static-mut-refs.rs:14:14
    |
 LL |         &mut ($x.0)
    |              ^^^^^^ mutable reference to mutable static

--- a/tests/ui/lint/static-mut-refs.e2024.stderr
+++ b/tests/ui/lint/static-mut-refs.e2024.stderr
@@ -1,5 +1,5 @@
 error: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:39:18
+  --> $DIR/static-mut-refs.rs:38:18
    |
 LL |         let _y = &X;
    |                  ^^ shared reference to mutable static
@@ -13,7 +13,7 @@ LL |         let _y = &raw const X;
    |                  ~~~~~~~~~~
 
 error: creating a mutable reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:43:18
+  --> $DIR/static-mut-refs.rs:42:18
    |
 LL |         let _y = &mut X;
    |                  ^^^^^^ mutable reference to mutable static
@@ -26,7 +26,7 @@ LL |         let _y = &raw mut X;
    |                  ~~~~~~~~
 
 error: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:51:22
+  --> $DIR/static-mut-refs.rs:50:22
    |
 LL |         let ref _a = X;
    |                      ^ shared reference to mutable static
@@ -35,7 +35,7 @@ LL |         let ref _a = X;
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 error: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:55:25
+  --> $DIR/static-mut-refs.rs:54:25
    |
 LL |         let (_b, _c) = (&X, &Y);
    |                         ^^ shared reference to mutable static
@@ -48,7 +48,7 @@ LL |         let (_b, _c) = (&raw const X, &Y);
    |                         ~~~~~~~~~~
 
 error: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:55:29
+  --> $DIR/static-mut-refs.rs:54:29
    |
 LL |         let (_b, _c) = (&X, &Y);
    |                             ^^ shared reference to mutable static
@@ -61,7 +61,7 @@ LL |         let (_b, _c) = (&X, &raw const Y);
    |                             ~~~~~~~~~~
 
 error: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:61:13
+  --> $DIR/static-mut-refs.rs:60:13
    |
 LL |         foo(&X);
    |             ^^ shared reference to mutable static
@@ -74,7 +74,7 @@ LL |         foo(&raw const X);
    |             ~~~~~~~~~~
 
 error: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:67:17
+  --> $DIR/static-mut-refs.rs:66:17
    |
 LL |         let _ = Z.len();
    |                 ^^^^^^^ shared reference to mutable static
@@ -83,7 +83,7 @@ LL |         let _ = Z.len();
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 error: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:73:33
+  --> $DIR/static-mut-refs.rs:72:33
    |
 LL |         let _ = format!("{:?}", Z);
    |                                 ^ shared reference to mutable static
@@ -92,7 +92,7 @@ LL |         let _ = format!("{:?}", Z);
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 error: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:77:18
+  --> $DIR/static-mut-refs.rs:76:18
    |
 LL |         let _v = &A.value;
    |                  ^^^^^^^^ shared reference to mutable static
@@ -105,7 +105,7 @@ LL |         let _v = &raw const A.value;
    |                  ~~~~~~~~~~
 
 error: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:81:18
+  --> $DIR/static-mut-refs.rs:80:18
    |
 LL |         let _s = &A.s.value;
    |                  ^^^^^^^^^^ shared reference to mutable static
@@ -118,7 +118,7 @@ LL |         let _s = &raw const A.s.value;
    |                  ~~~~~~~~~~
 
 error: creating a shared reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:85:22
+  --> $DIR/static-mut-refs.rs:84:22
    |
 LL |         let ref _v = A.value;
    |                      ^^^^^^^ shared reference to mutable static
@@ -127,7 +127,7 @@ LL |         let ref _v = A.value;
    = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives
 
 error: creating a mutable reference to mutable static is discouraged
-  --> $DIR/static-mut-refs.rs:15:14
+  --> $DIR/static-mut-refs.rs:14:14
    |
 LL |         &mut ($x.0)
    |              ^^^^^^ mutable reference to mutable static

--- a/tests/ui/lint/static-mut-refs.rs
+++ b/tests/ui/lint/static-mut-refs.rs
@@ -6,7 +6,6 @@
 //@ [e2021] run-pass
 
 //@ [e2024] edition:2024
-//@ [e2024] compile-flags: -Zunstable-options
 
 static mut FOO: (u32, u32) = (1, 2);
 

--- a/tests/ui/macros/macro-missing-fragment.e2015.stderr
+++ b/tests/ui/macros/macro-missing-fragment.e2015.stderr
@@ -1,11 +1,11 @@
 error: missing fragment specifier
-  --> $DIR/macro-missing-fragment.rs:9:20
+  --> $DIR/macro-missing-fragment.rs:8:20
    |
 LL |     ( $( any_token $field_rust_type )* ) => {};
    |                    ^^^^^^^^^^^^^^^^
 
 warning: missing fragment specifier
-  --> $DIR/macro-missing-fragment.rs:9:20
+  --> $DIR/macro-missing-fragment.rs:8:20
    |
 LL |     ( $( any_token $field_rust_type )* ) => {};
    |                    ^^^^^^^^^^^^^^^^
@@ -13,13 +13,13 @@ LL |     ( $( any_token $field_rust_type )* ) => {};
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #40107 <https://github.com/rust-lang/rust/issues/40107>
 note: the lint level is defined here
-  --> $DIR/macro-missing-fragment.rs:6:9
+  --> $DIR/macro-missing-fragment.rs:5:9
    |
 LL | #![warn(missing_fragment_specifier)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: missing fragment specifier
-  --> $DIR/macro-missing-fragment.rs:19:7
+  --> $DIR/macro-missing-fragment.rs:18:7
    |
 LL |     ( $name ) => {};
    |       ^^^^^
@@ -28,7 +28,7 @@ LL |     ( $name ) => {};
    = note: for more information, see issue #40107 <https://github.com/rust-lang/rust/issues/40107>
 
 warning: missing fragment specifier
-  --> $DIR/macro-missing-fragment.rs:26:7
+  --> $DIR/macro-missing-fragment.rs:25:7
    |
 LL |     ( $name ) => {};
    |       ^^^^^
@@ -40,7 +40,7 @@ error: aborting due to 1 previous error; 3 warnings emitted
 
 Future incompatibility report: Future breakage diagnostic:
 warning: missing fragment specifier
-  --> $DIR/macro-missing-fragment.rs:9:20
+  --> $DIR/macro-missing-fragment.rs:8:20
    |
 LL |     ( $( any_token $field_rust_type )* ) => {};
    |                    ^^^^^^^^^^^^^^^^
@@ -48,14 +48,14 @@ LL |     ( $( any_token $field_rust_type )* ) => {};
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #40107 <https://github.com/rust-lang/rust/issues/40107>
 note: the lint level is defined here
-  --> $DIR/macro-missing-fragment.rs:6:9
+  --> $DIR/macro-missing-fragment.rs:5:9
    |
 LL | #![warn(missing_fragment_specifier)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
 warning: missing fragment specifier
-  --> $DIR/macro-missing-fragment.rs:19:7
+  --> $DIR/macro-missing-fragment.rs:18:7
    |
 LL |     ( $name ) => {};
    |       ^^^^^
@@ -63,14 +63,14 @@ LL |     ( $name ) => {};
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #40107 <https://github.com/rust-lang/rust/issues/40107>
 note: the lint level is defined here
-  --> $DIR/macro-missing-fragment.rs:6:9
+  --> $DIR/macro-missing-fragment.rs:5:9
    |
 LL | #![warn(missing_fragment_specifier)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Future breakage diagnostic:
 warning: missing fragment specifier
-  --> $DIR/macro-missing-fragment.rs:26:7
+  --> $DIR/macro-missing-fragment.rs:25:7
    |
 LL |     ( $name ) => {};
    |       ^^^^^
@@ -78,7 +78,7 @@ LL |     ( $name ) => {};
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #40107 <https://github.com/rust-lang/rust/issues/40107>
 note: the lint level is defined here
-  --> $DIR/macro-missing-fragment.rs:6:9
+  --> $DIR/macro-missing-fragment.rs:5:9
    |
 LL | #![warn(missing_fragment_specifier)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/macros/macro-missing-fragment.e2024.stderr
+++ b/tests/ui/macros/macro-missing-fragment.e2024.stderr
@@ -1,5 +1,5 @@
 error: missing fragment specifier
-  --> $DIR/macro-missing-fragment.rs:9:20
+  --> $DIR/macro-missing-fragment.rs:8:20
    |
 LL |     ( $( any_token $field_rust_type )* ) => {};
    |                    ^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL |     ( $( any_token $field_rust_type:spec )* ) => {};
    |                                    +++++
 
 error: missing fragment specifier
-  --> $DIR/macro-missing-fragment.rs:19:7
+  --> $DIR/macro-missing-fragment.rs:18:7
    |
 LL |     ( $name ) => {};
    |       ^^^^^
@@ -25,7 +25,7 @@ LL |     ( $name:spec ) => {};
    |            +++++
 
 error: missing fragment specifier
-  --> $DIR/macro-missing-fragment.rs:26:7
+  --> $DIR/macro-missing-fragment.rs:25:7
    |
 LL |     ( $name ) => {};
    |       ^^^^^
@@ -38,7 +38,7 @@ LL |     ( $name:spec ) => {};
    |            +++++
 
 error: missing fragment specifier
-  --> $DIR/macro-missing-fragment.rs:9:20
+  --> $DIR/macro-missing-fragment.rs:8:20
    |
 LL |     ( $( any_token $field_rust_type )* ) => {};
    |                    ^^^^^^^^^^^^^^^^

--- a/tests/ui/macros/macro-missing-fragment.rs
+++ b/tests/ui/macros/macro-missing-fragment.rs
@@ -1,7 +1,6 @@
 //@ revisions: e2015 e2024
 //@[e2015] edition:2015
 //@[e2024] edition:2024
-//@[e2024] compile-flags: -Zunstable-options
 
 #![warn(missing_fragment_specifier)]
 

--- a/tests/ui/mir/mir_let_chains_drop_order.rs
+++ b/tests/ui/mir/mir_let_chains_drop_order.rs
@@ -2,7 +2,6 @@
 //@ needs-unwind
 //@ revisions: edition2021 edition2024
 //@ [edition2021] edition: 2021
-//@ [edition2024] compile-flags: -Z unstable-options
 //@ [edition2024] edition: 2024
 
 // See `mir_drop_order.rs` for more information

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
@@ -1,5 +1,5 @@
 warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:13:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:12:18
    |
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ LL |         unsafe { mem::zeroed::<()>() }
    |                             ++++++
 
 warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:30:13
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:29:13
    |
 LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL |             core::mem::transmute::<_, ()>(Zst)
    |                                 +++++++++
 
 warning: never type fallback affects this union access
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:47:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:46:18
    |
 LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL |         unsafe { Union { a: () }.b }
    = help: specify the type explicitly
 
 warning: never type fallback affects this raw pointer dereference
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:58:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:57:18
    |
 LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast::<()>() }
    |                                          ++++++
 
 warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:79:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:78:18
    |
 LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ LL |         unsafe { internally_create::<()>(x) }
    |                                   ++++++
 
 warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:97:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:96:18
    |
 LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
@@ -80,7 +80,7 @@ LL |         let zeroed = mem::zeroed::<()>;
    |                                 ++++++
 
 warning: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:92:22
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:91:22
    |
 LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
@@ -94,7 +94,7 @@ LL |         let zeroed = mem::zeroed::<()>;
    |                                 ++++++
 
 warning: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:115:17
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:114:17
    |
 LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
@@ -108,7 +108,7 @@ LL |         let f = internally_create::<()>;
    |                                  ++++++
 
 warning: never type fallback affects this call to an `unsafe` method
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:140:13
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:139:13
    |
 LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -118,7 +118,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    = help: specify the type explicitly
 
 warning: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:158:19
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:157:19
    |
 LL |             match send_message::<_ /* ?0 */>() {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
@@ -1,5 +1,5 @@
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:13:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:12:18
    |
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
@@ -14,7 +14,7 @@ LL |         unsafe { mem::zeroed::<()>() }
    |                             ++++++
 
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:30:13
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:29:13
    |
 LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL |             core::mem::transmute::<_, ()>(Zst)
    |                                 +++++++++
 
 error: never type fallback affects this union access
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:47:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:46:18
    |
 LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL |         unsafe { Union { a: () }.b }
    = help: specify the type explicitly
 
 error: never type fallback affects this raw pointer dereference
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:58:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:57:18
    |
 LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast::<()>() }
    |                                          ++++++
 
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:79:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:78:18
    |
 LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +66,7 @@ LL |         unsafe { internally_create::<()>(x) }
    |                                   ++++++
 
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:97:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:96:18
    |
 LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
@@ -80,7 +80,7 @@ LL |         let zeroed = mem::zeroed::<()>;
    |                                 ++++++
 
 error: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:92:22
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:91:22
    |
 LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
@@ -94,7 +94,7 @@ LL |         let zeroed = mem::zeroed::<()>;
    |                                 ++++++
 
 error: never type fallback affects this `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:115:17
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:114:17
    |
 LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
@@ -108,7 +108,7 @@ LL |         let f = internally_create::<()>;
    |                                  ++++++
 
 error: never type fallback affects this call to an `unsafe` method
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:140:13
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:139:13
    |
 LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -118,7 +118,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    = help: specify the type explicitly
 
 error: never type fallback affects this call to an `unsafe` function
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:158:19
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:157:19
    |
 LL |             match send_message::<_ /* ?0 */>() {
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,7 +136,7 @@ LL |             match send_message::<() /* ?0 */>() {
    |                                  ~~
 
 warning: the type `!` does not permit zero-initialization
-  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:13:18
+  --> $DIR/lint-never-type-fallback-flowing-into-unsafe.rs:12:18
    |
 LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^ this code causes undefined behavior when executed

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.rs
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.rs
@@ -2,7 +2,6 @@
 //@[e2015] check-pass
 //@[e2024] check-fail
 //@[e2024] edition:2024
-//@[e2024] compile-flags: -Zunstable-options
 
 use std::{marker, mem, ptr};
 

--- a/tests/ui/nll/issue-54556-niconii.edition2021.stderr
+++ b/tests/ui/nll/issue-54556-niconii.edition2021.stderr
@@ -1,5 +1,5 @@
 error[E0597]: `counter` does not live long enough
-  --> $DIR/issue-54556-niconii.rs:28:20
+  --> $DIR/issue-54556-niconii.rs:27:20
    |
 LL |     let counter = Mutex;
    |         ------- binding `counter` declared here

--- a/tests/ui/nll/issue-54556-niconii.rs
+++ b/tests/ui/nll/issue-54556-niconii.rs
@@ -9,7 +9,6 @@
 //@ revisions: edition2021 edition2024
 //@ [edition2021] edition: 2021
 //@ [edition2024] edition: 2024
-//@ [edition2024] compile-flags: -Z unstable-options
 //@ [edition2024] check-pass
 
 struct Mutex;

--- a/tests/ui/proc-macro/macro_rules_edition_from_pm.rs
+++ b/tests/ui/proc-macro/macro_rules_edition_from_pm.rs
@@ -6,7 +6,6 @@
 //@ revisions: edition2021 edition2024
 //@[edition2021] edition:2021
 //@[edition2024] edition:2024
-//@[edition2024] compile-flags: -Zunstable-options
 //@ check-pass
 
 // This checks how the expr fragment specifier works.

--- a/tests/ui/rfcs/rfc-2627-raw-dylib/invalid-dlltool.rs
+++ b/tests/ui/rfcs/rfc-2627-raw-dylib/invalid-dlltool.rs
@@ -1,7 +1,7 @@
 // Tests that failing to run dlltool will raise an error.
 
 //@ needs-dlltool
-//@ compile-flags: --crate-type lib --emit link -Cdlltool=does_not_exit.exe
+//@ compile-flags: --crate-type lib --emit link -Cdlltool=does_not_exist.exe
 #[link(name = "foo", kind = "raw-dylib")]
 extern "C" {
     fn f(x: i32);

--- a/tests/ui/rust-2024/prelude-migration/future-poll-already-future.rs
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-already-future.rs
@@ -1,7 +1,6 @@
 //@ revisions: e2021 e2024
 //@[e2021] edition: 2021
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //@ check-pass
 
 #![deny(rust_2024_prelude_collisions)]

--- a/tests/ui/rust-2024/prelude-migration/future-poll-async-block.e2021.fixed
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-async-block.e2021.fixed
@@ -2,7 +2,6 @@
 //@[e2021] edition: 2021
 //@[e2021] run-rustfix
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //@[e2024] check-pass
 
 #![deny(rust_2024_prelude_collisions)]

--- a/tests/ui/rust-2024/prelude-migration/future-poll-async-block.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-async-block.e2021.stderr
@@ -1,5 +1,5 @@
 error: trait method `poll` will become ambiguous in Rust 2024
-  --> $DIR/future-poll-async-block.rs:14:5
+  --> $DIR/future-poll-async-block.rs:13:5
    |
 LL |     core::pin::pin!(async {}).poll(&mut context());
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::poll(&core::pin::pin!(async {}), &mut context())`
@@ -7,7 +7,7 @@ LL |     core::pin::pin!(async {}).poll(&mut context());
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
-  --> $DIR/future-poll-async-block.rs:8:9
+  --> $DIR/future-poll-async-block.rs:7:9
    |
 LL | #![deny(rust_2024_prelude_collisions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rust-2024/prelude-migration/future-poll-async-block.rs
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-async-block.rs
@@ -2,7 +2,6 @@
 //@[e2021] edition: 2021
 //@[e2021] run-rustfix
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //@[e2024] check-pass
 
 #![deny(rust_2024_prelude_collisions)]

--- a/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.e2021.fixed
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.e2021.fixed
@@ -2,7 +2,6 @@
 //@[e2021] edition: 2021
 //@[e2021] run-rustfix
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //@[e2024] check-pass
 
 #![deny(rust_2024_prelude_collisions)]

--- a/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.e2021.stderr
@@ -1,5 +1,5 @@
 error: trait method `poll` will become ambiguous in Rust 2024
-  --> $DIR/future-poll-not-future-pinned.rs:18:5
+  --> $DIR/future-poll-not-future-pinned.rs:17:5
    |
 LL |     core::pin::pin!(()).poll();
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::poll(&core::pin::pin!(()))`
@@ -7,7 +7,7 @@ LL |     core::pin::pin!(()).poll();
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
-  --> $DIR/future-poll-not-future-pinned.rs:8:9
+  --> $DIR/future-poll-not-future-pinned.rs:7:9
    |
 LL | #![deny(rust_2024_prelude_collisions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.rs
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-not-future-pinned.rs
@@ -2,7 +2,6 @@
 //@[e2021] edition: 2021
 //@[e2021] run-rustfix
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //@[e2024] check-pass
 
 #![deny(rust_2024_prelude_collisions)]

--- a/tests/ui/rust-2024/prelude-migration/future-poll-not-future.rs
+++ b/tests/ui/rust-2024/prelude-migration/future-poll-not-future.rs
@@ -1,7 +1,6 @@
 //@ revisions: e2021 e2024
 //@[e2021] edition: 2021
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //@ check-pass
 
 #![deny(rust_2024_prelude_collisions)]

--- a/tests/ui/rust-2024/prelude-migration/into-future-adt.e2021.fixed
+++ b/tests/ui/rust-2024/prelude-migration/into-future-adt.e2021.fixed
@@ -2,7 +2,6 @@
 //@[e2021] edition: 2021
 //@[e2021] run-rustfix
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //@[e2024] check-pass
 
 #![deny(rust_2024_prelude_collisions)]

--- a/tests/ui/rust-2024/prelude-migration/into-future-adt.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/into-future-adt.e2021.stderr
@@ -1,5 +1,5 @@
 error: trait method `into_future` will become ambiguous in Rust 2024
-  --> $DIR/into-future-adt.rs:26:5
+  --> $DIR/into-future-adt.rs:25:5
    |
 LL |     Cat.into_future();
    |     ^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::into_future(&Cat)`
@@ -7,7 +7,7 @@ LL |     Cat.into_future();
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
-  --> $DIR/into-future-adt.rs:8:9
+  --> $DIR/into-future-adt.rs:7:9
    |
 LL | #![deny(rust_2024_prelude_collisions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rust-2024/prelude-migration/into-future-adt.rs
+++ b/tests/ui/rust-2024/prelude-migration/into-future-adt.rs
@@ -2,7 +2,6 @@
 //@[e2021] edition: 2021
 //@[e2021] run-rustfix
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //@[e2024] check-pass
 
 #![deny(rust_2024_prelude_collisions)]

--- a/tests/ui/rust-2024/prelude-migration/into-future-already-into-future.rs
+++ b/tests/ui/rust-2024/prelude-migration/into-future-already-into-future.rs
@@ -1,7 +1,6 @@
 //@ revisions: e2021 e2024
 //@[e2021] edition: 2021
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //@ check-pass
 
 #![deny(rust_2024_prelude_collisions)]

--- a/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.e2021.fixed
+++ b/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.e2021.fixed
@@ -2,7 +2,6 @@
 //@[e2021] edition: 2021
 //@[e2021] run-rustfix
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //@[e2024] check-pass
 
 #![deny(rust_2024_prelude_collisions)]

--- a/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.e2021.stderr
+++ b/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.e2021.stderr
@@ -1,5 +1,5 @@
 error: trait method `into_future` will become ambiguous in Rust 2024
-  --> $DIR/into-future-not-into-future.rs:20:5
+  --> $DIR/into-future-not-into-future.rs:19:5
    |
 LL |     Cat.into_future();
    |     ^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `Meow::into_future(&Cat)`
@@ -7,7 +7,7 @@ LL |     Cat.into_future();
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/prelude.html>
 note: the lint level is defined here
-  --> $DIR/into-future-not-into-future.rs:8:9
+  --> $DIR/into-future-not-into-future.rs:7:9
    |
 LL | #![deny(rust_2024_prelude_collisions)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.rs
+++ b/tests/ui/rust-2024/prelude-migration/into-future-not-into-future.rs
@@ -2,7 +2,6 @@
 //@[e2021] edition: 2021
 //@[e2021] run-rustfix
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 //@[e2024] check-pass
 
 #![deny(rust_2024_prelude_collisions)]

--- a/tests/ui/rust-2024/unsafe-attributes/unsafe-attribute-marked.rs
+++ b/tests/ui/rust-2024/unsafe-attributes/unsafe-attribute-marked.rs
@@ -1,7 +1,6 @@
 //@ revisions: edition2021 edition2024
 //@[edition2021] edition:2021
 //@[edition2024] edition:2024
-//@[edition2024] compile-flags: -Zunstable-options
 //@ check-pass
 
 

--- a/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-from-pm.rs
+++ b/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-from-pm.rs
@@ -5,7 +5,6 @@
 //@ check-pass
 //@[edition2021] edition:2021
 //@[edition2024] edition:2024
-//@[edition2024] compile-flags: -Zunstable-options
 //@ aux-crate: unsafe_attributes_pm=unsafe-attributes-pm.rs
 
 unsafe_attributes_pm::missing_unsafe!();

--- a/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes.edition2024.stderr
+++ b/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes.edition2024.stderr
@@ -1,5 +1,5 @@
 error: unsafe attribute used without unsafe
-  --> $DIR/unsafe-attributes.rs:8:3
+  --> $DIR/unsafe-attributes.rs:7:3
    |
 LL | #[no_mangle]
    |   ^^^^^^^^^ usage of unsafe attribute

--- a/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes.rs
+++ b/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes.rs
@@ -2,7 +2,6 @@
 //@[edition2021] edition:2021
 //@[edition2021] check-pass
 //@[edition2024] edition:2024
-//@[edition2024] compile-flags: -Zunstable-options
 
 
 #[no_mangle] //[edition2024]~ ERROR: unsafe attribute used without unsafe

--- a/tests/ui/rust-2024/unsafe-before_exec.e2024.stderr
+++ b/tests/ui/rust-2024/unsafe-before_exec.e2024.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to unsafe function `before_exec` is unsafe and requires unsafe block
-  --> $DIR/unsafe-before_exec.rs:14:5
+  --> $DIR/unsafe-before_exec.rs:13:5
    |
 LL |     cmd.before_exec(|| Ok(()));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function

--- a/tests/ui/rust-2024/unsafe-before_exec.rs
+++ b/tests/ui/rust-2024/unsafe-before_exec.rs
@@ -3,7 +3,6 @@
 //@[e2021] edition: 2021
 //@[e2021] check-pass
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 
 use std::process::Command;
 use std::os::unix::process::CommandExt;

--- a/tests/ui/rust-2024/unsafe-env.e2021.stderr
+++ b/tests/ui/rust-2024/unsafe-env.e2021.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe block
-  --> $DIR/unsafe-env.rs:15:9
+  --> $DIR/unsafe-env.rs:14:9
    |
 LL |         unsafe_fn();
    |         ^^^^^^^^^^^ call to unsafe function
@@ -7,18 +7,18 @@ LL |         unsafe_fn();
    = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
-  --> $DIR/unsafe-env.rs:9:1
+  --> $DIR/unsafe-env.rs:8:1
    |
 LL | unsafe fn unsafe_fn() {
    | ^^^^^^^^^^^^^^^^^^^^^
 note: the lint level is defined here
-  --> $DIR/unsafe-env.rs:8:8
+  --> $DIR/unsafe-env.rs:7:8
    |
 LL | #[deny(unsafe_op_in_unsafe_fn)]
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-env.rs:33:5
+  --> $DIR/unsafe-env.rs:32:5
    |
 LL |     unsafe_fn();
    |     ^^^^^^^^^^^ call to unsafe function
@@ -26,13 +26,13 @@ LL |     unsafe_fn();
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error: unnecessary `unsafe` block
-  --> $DIR/unsafe-env.rs:36:5
+  --> $DIR/unsafe-env.rs:35:5
    |
 LL |     unsafe {
    |     ^^^^^^ unnecessary `unsafe` block
    |
 note: the lint level is defined here
-  --> $DIR/unsafe-env.rs:21:8
+  --> $DIR/unsafe-env.rs:20:8
    |
 LL | #[deny(unused_unsafe)]
    |        ^^^^^^^^^^^^^

--- a/tests/ui/rust-2024/unsafe-env.e2024.stderr
+++ b/tests/ui/rust-2024/unsafe-env.e2024.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to unsafe function `std::env::set_var` is unsafe and requires unsafe block
-  --> $DIR/unsafe-env.rs:10:5
+  --> $DIR/unsafe-env.rs:9:5
    |
 LL |     env::set_var("FOO", "BAR");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
@@ -7,18 +7,18 @@ LL |     env::set_var("FOO", "BAR");
    = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
-  --> $DIR/unsafe-env.rs:9:1
+  --> $DIR/unsafe-env.rs:8:1
    |
 LL | unsafe fn unsafe_fn() {
    | ^^^^^^^^^^^^^^^^^^^^^
 note: the lint level is defined here
-  --> $DIR/unsafe-env.rs:8:8
+  --> $DIR/unsafe-env.rs:7:8
    |
 LL | #[deny(unsafe_op_in_unsafe_fn)]
    |        ^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0133]: call to unsafe function `std::env::remove_var` is unsafe and requires unsafe block
-  --> $DIR/unsafe-env.rs:12:5
+  --> $DIR/unsafe-env.rs:11:5
    |
 LL |     env::remove_var("FOO");
    |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
@@ -27,7 +27,7 @@ LL |     env::remove_var("FOO");
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe block
-  --> $DIR/unsafe-env.rs:15:9
+  --> $DIR/unsafe-env.rs:14:9
    |
 LL |         unsafe_fn();
    |         ^^^^^^^^^^^ call to unsafe function
@@ -36,7 +36,7 @@ LL |         unsafe_fn();
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `set_var` is unsafe and requires unsafe block
-  --> $DIR/unsafe-env.rs:23:5
+  --> $DIR/unsafe-env.rs:22:5
    |
 LL |     env::set_var("FOO", "BAR");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
@@ -44,7 +44,7 @@ LL |     env::set_var("FOO", "BAR");
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `remove_var` is unsafe and requires unsafe block
-  --> $DIR/unsafe-env.rs:25:5
+  --> $DIR/unsafe-env.rs:24:5
    |
 LL |     env::remove_var("FOO");
    |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
@@ -52,7 +52,7 @@ LL |     env::remove_var("FOO");
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe block
-  --> $DIR/unsafe-env.rs:33:5
+  --> $DIR/unsafe-env.rs:32:5
    |
 LL |     unsafe_fn();
    |     ^^^^^^^^^^^ call to unsafe function
@@ -60,13 +60,13 @@ LL |     unsafe_fn();
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error: unnecessary `unsafe` block
-  --> $DIR/unsafe-env.rs:36:5
+  --> $DIR/unsafe-env.rs:35:5
    |
 LL |     unsafe {
    |     ^^^^^^ unnecessary `unsafe` block
    |
 note: the lint level is defined here
-  --> $DIR/unsafe-env.rs:21:8
+  --> $DIR/unsafe-env.rs:20:8
    |
 LL | #[deny(unused_unsafe)]
    |        ^^^^^^^^^^^^^

--- a/tests/ui/rust-2024/unsafe-env.rs
+++ b/tests/ui/rust-2024/unsafe-env.rs
@@ -1,7 +1,6 @@
 //@ revisions: e2021 e2024
 //@[e2021] edition: 2021
 //@[e2024] edition: 2024
-//@[e2024] compile-flags: -Zunstable-options
 
 use std::env;
 

--- a/tests/ui/rust-2024/unsafe-extern-blocks/extern-items-unsafe.edition2021.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/extern-items-unsafe.edition2021.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to unsafe function `test1` is unsafe and requires unsafe function or block
-  --> $DIR/extern-items-unsafe.rs:12:5
+  --> $DIR/extern-items-unsafe.rs:11:5
    |
 LL |     test1(TEST1);
    |     ^^^^^^^^^^^^ call to unsafe function
@@ -7,7 +7,7 @@ LL |     test1(TEST1);
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/extern-items-unsafe.rs:12:11
+  --> $DIR/extern-items-unsafe.rs:11:11
    |
 LL |     test1(TEST1);
    |           ^^^^^ use of extern static

--- a/tests/ui/rust-2024/unsafe-extern-blocks/extern-items-unsafe.edition2024.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/extern-items-unsafe.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to unsafe function `test1` is unsafe and requires unsafe block
-  --> $DIR/extern-items-unsafe.rs:12:5
+  --> $DIR/extern-items-unsafe.rs:11:5
    |
 LL |     test1(TEST1);
    |     ^^^^^^^^^^^^ call to unsafe function
@@ -7,7 +7,7 @@ LL |     test1(TEST1);
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: use of extern static is unsafe and requires unsafe block
-  --> $DIR/extern-items-unsafe.rs:12:11
+  --> $DIR/extern-items-unsafe.rs:11:11
    |
 LL |     test1(TEST1);
    |           ^^^^^ use of extern static

--- a/tests/ui/rust-2024/unsafe-extern-blocks/extern-items-unsafe.rs
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/extern-items-unsafe.rs
@@ -1,7 +1,6 @@
 //@ revisions: edition2021 edition2024
 //@[edition2021] edition:2021
 //@[edition2024] edition:2024
-//@[edition2024] compile-flags: -Zunstable-options
 
 unsafe extern "C" {
     static TEST1: i32;

--- a/tests/ui/rust-2024/unsafe-extern-blocks/extern-items.edition2024.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/extern-items.edition2024.stderr
@@ -1,5 +1,5 @@
 error: extern blocks must be unsafe
-  --> $DIR/extern-items.rs:7:1
+  --> $DIR/extern-items.rs:6:1
    |
 LL | / extern "C" {
 LL | |

--- a/tests/ui/rust-2024/unsafe-extern-blocks/extern-items.rs
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/extern-items.rs
@@ -2,7 +2,6 @@
 //@[edition2021] edition:2021
 //@[edition2021] check-pass
 //@[edition2024] edition:2024
-//@[edition2024] compile-flags: -Zunstable-options
 
 extern "C" {
     //[edition2024]~^ ERROR extern blocks must be unsafe

--- a/tests/ui/rust-2024/unsafe-extern-blocks/safe-items.rs
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/safe-items.rs
@@ -1,7 +1,6 @@
 //@ revisions: edition2021 edition2024
 //@[edition2021] edition:2021
 //@[edition2024] edition:2024
-//@[edition2024] compile-flags: -Zunstable-options
 //@ check-pass
 
 unsafe extern "C" {

--- a/tests/ui/rust-2024/unsafe-extern-blocks/safe-unsafe-on-unadorned-extern-block.edition2021.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/safe-unsafe-on-unadorned-extern-block.edition2021.stderr
@@ -1,5 +1,5 @@
 error: items in `extern` blocks without an `unsafe` qualifier cannot have safety qualifiers
-  --> $DIR/safe-unsafe-on-unadorned-extern-block.rs:8:5
+  --> $DIR/safe-unsafe-on-unadorned-extern-block.rs:7:5
    |
 LL |     safe static TEST1: i32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL | unsafe extern "C" {
    | ++++++
 
 error: items in `extern` blocks without an `unsafe` qualifier cannot have safety qualifiers
-  --> $DIR/safe-unsafe-on-unadorned-extern-block.rs:10:5
+  --> $DIR/safe-unsafe-on-unadorned-extern-block.rs:9:5
    |
 LL |     safe fn test1(i: i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rust-2024/unsafe-extern-blocks/safe-unsafe-on-unadorned-extern-block.edition2024.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/safe-unsafe-on-unadorned-extern-block.edition2024.stderr
@@ -1,5 +1,5 @@
 error: extern blocks must be unsafe
-  --> $DIR/safe-unsafe-on-unadorned-extern-block.rs:6:1
+  --> $DIR/safe-unsafe-on-unadorned-extern-block.rs:5:1
    |
 LL | / extern "C" {
 LL | |
@@ -11,7 +11,7 @@ LL | | }
    | |_^
 
 error: items in `extern` blocks without an `unsafe` qualifier cannot have safety qualifiers
-  --> $DIR/safe-unsafe-on-unadorned-extern-block.rs:8:5
+  --> $DIR/safe-unsafe-on-unadorned-extern-block.rs:7:5
    |
 LL |     safe static TEST1: i32;
    |     ^^^^^^^^^^^^^^^^^^^^^^^
@@ -22,7 +22,7 @@ LL | unsafe extern "C" {
    | ++++++
 
 error: items in `extern` blocks without an `unsafe` qualifier cannot have safety qualifiers
-  --> $DIR/safe-unsafe-on-unadorned-extern-block.rs:10:5
+  --> $DIR/safe-unsafe-on-unadorned-extern-block.rs:9:5
    |
 LL |     safe fn test1(i: i32);
    |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/rust-2024/unsafe-extern-blocks/safe-unsafe-on-unadorned-extern-block.rs
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/safe-unsafe-on-unadorned-extern-block.rs
@@ -1,7 +1,6 @@
 //@ revisions: edition2021 edition2024
 //@[edition2021] edition:2021
 //@[edition2024] edition:2024
-//@[edition2024] compile-flags: -Zunstable-options
 
 extern "C" {
     //[edition2024]~^ ERROR extern blocks must be unsafe

--- a/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-items.edition2021.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-items.edition2021.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to unsafe function `test1` is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-items.rs:18:5
+  --> $DIR/unsafe-items.rs:17:5
    |
 LL |     test1(TEST1);
    |     ^^^^^^^^^^^^ call to unsafe function
@@ -7,7 +7,7 @@ LL |     test1(TEST1);
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: use of extern static is unsafe and requires unsafe function or block
-  --> $DIR/unsafe-items.rs:18:11
+  --> $DIR/unsafe-items.rs:17:11
    |
 LL |     test1(TEST1);
    |           ^^^^^ use of extern static

--- a/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-items.edition2024.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-items.edition2024.stderr
@@ -1,5 +1,5 @@
 error[E0133]: call to unsafe function `test1` is unsafe and requires unsafe block
-  --> $DIR/unsafe-items.rs:18:5
+  --> $DIR/unsafe-items.rs:17:5
    |
 LL |     test1(TEST1);
    |     ^^^^^^^^^^^^ call to unsafe function
@@ -7,7 +7,7 @@ LL |     test1(TEST1);
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: use of extern static is unsafe and requires unsafe block
-  --> $DIR/unsafe-items.rs:18:11
+  --> $DIR/unsafe-items.rs:17:11
    |
 LL |     test1(TEST1);
    |           ^^^^^ use of extern static

--- a/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-items.rs
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-items.rs
@@ -1,7 +1,6 @@
 //@ revisions: edition2021 edition2024
 //@[edition2021] edition:2021
 //@[edition2024] edition:2024
-//@[edition2024] compile-flags: -Zunstable-options
 
 unsafe extern "C" {
     unsafe static TEST1: i32;


### PR DESCRIPTION
Successful merges:

 - #133466 (Fix typos in pin.rs)
 - #133530 (Use consistent wording in docs, use is zero instead of is 0)
 - #133565 (chore: fix 404 status URL)
 - #133575 (Fix typo in RELEASES.md)
 - #133577 (Document s390x machine access via community cloud)
 - #133583 (Fix type (exit → exist))
 - #133584 (Update more 2024 tests to remove -Zunstable-options)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=133466,133530,133565,133575,133577,133583,133584)
<!-- homu-ignore:end -->