### PR TITLE
Misc: better instructions for envrc, ignore `/build` instead of `build/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,8 +46,7 @@ no_llvm_build
 /inst/
 /llvm/
 /mingw-build/
-build/
-!/compiler/rustc_mir_build/src/build/
+/build
 /build-rust-analyzer/
 /dist/
 /unicode-downloads

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -231,7 +231,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             if range.start <= range.end { BinOp::BitAnd } else { BinOp::BitOr };
 
                         let mut comparer = |range: u128, bin_op: BinOp| -> Place<'tcx> {
-                            // We can use `ty::TypingEnv::fully_monomorphized()`` here
+                            // We can use `ty::TypingEnv::fully_monomorphized()` here
                             // as we only need it to compute the layout of a primitive.
                             let range_val = Const::from_bits(
                                 this.tcx,

--- a/src/tools/nix-dev-shell/envrc-flake
+++ b/src/tools/nix-dev-shell/envrc-flake
@@ -1,7 +1,7 @@
 # If you want to use this as an .envrc file to create a shell with necessery components 
 # to develop rustc, use the following command in the root of the rusr checkout:
 #	
-# ln -s ./src/tools/nix-dev-shell/envrc-flake ./.envrc && echo .envrc >> .git/info/exclude
+# ln -s ./src/tools/nix-dev-shell/envrc-flake ./.envrc && nix flake update --flake ./src/tools/nix-dev-shell && echo .envrc >> .git/info/exclude
 
 if nix flake show path:./src/tools/nix-dev-shell &> /dev/null; then
   use flake path:./src/tools/nix-dev-shell


### PR DESCRIPTION
See commits for more information.

r? @jieyouxu