### PR TITLE
Move `Const::{from_anon_const,try_from_lit}` to hir_ty_lowering

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/dump.rs
+++ b/compiler/rustc_hir_analysis/src/collect/dump.rs
@@ -1,6 +1,6 @@
 use rustc_hir::def_id::{CRATE_DEF_ID, LocalDefId};
 use rustc_hir::intravisit;
-use rustc_middle::hir::nested_filter::OnlyBodies;
+use rustc_middle::hir::nested_filter;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::sym;
 
@@ -42,7 +42,8 @@ pub(crate) fn predicates_and_item_bounds(tcx: TyCtxt<'_>) {
 }
 
 pub(crate) fn def_parents(tcx: TyCtxt<'_>) {
-    for did in tcx.hir().body_owners() {
+    for iid in tcx.hir().items() {
+        let did = iid.owner_id.def_id;
         if tcx.has_attr(did, sym::rustc_dump_def_parents) {
             struct AnonConstFinder<'tcx> {
                 tcx: TyCtxt<'tcx>,
@@ -50,7 +51,7 @@ pub(crate) fn def_parents(tcx: TyCtxt<'_>) {
             }
 
             impl<'tcx> intravisit::Visitor<'tcx> for AnonConstFinder<'tcx> {
-                type NestedFilter = OnlyBodies;
+                type NestedFilter = nested_filter::All;
 
                 fn nested_visit_map(&mut self) -> Self::Map {
                     self.tcx.hir()
@@ -62,11 +63,11 @@ pub(crate) fn def_parents(tcx: TyCtxt<'_>) {
                 }
             }
 
-            // Look for any anon consts inside of this body owner as there is no way to apply
+            // Look for any anon consts inside of this item as there is no way to apply
             // the `rustc_dump_def_parents` attribute to the anon const so it would not be possible
             // to see what its def parent is.
             let mut anon_ct_finder = AnonConstFinder { tcx, anon_consts: vec![] };
-            intravisit::walk_expr(&mut anon_ct_finder, tcx.hir().body_owned_by(did).value);
+            intravisit::walk_item(&mut anon_ct_finder, tcx.hir().item(iid));
 
             for did in [did].into_iter().chain(anon_ct_finder.anon_consts) {
                 let span = tcx.def_span(did);

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/bounds.rs
@@ -703,7 +703,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
 ///
 /// It might actually be possible that we can already support early-bound generic params
 /// in such types if we just lifted some more checks in other places, too, for example
-/// inside [`ty::Const::from_anon_const`]. However, even if that were the case, we should
+/// inside `HirTyLowerer::lower_anon_const`. However, even if that were the case, we should
 /// probably gate this behind another feature flag.
 ///
 /// [^1]: <https://github.com/rust-lang/project-const-generics/issues/28>.

--- a/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
+++ b/compiler/rustc_hir_analysis/src/hir_ty_lowering/mod.rs
@@ -2089,7 +2089,7 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
                 qpath.span(),
                 format!("Const::lower_const_arg: invalid qpath {qpath:?}"),
             ),
-            hir::ConstArgKind::Anon(anon) => Const::from_anon_const(tcx, anon.def_id),
+            hir::ConstArgKind::Anon(anon) => self.lower_anon_const(anon.def_id),
             hir::ConstArgKind::Infer(span) => self.ct_infer(None, span),
         }
     }
@@ -2175,6 +2175,92 @@ impl<'tcx> dyn HirTyLowerer<'tcx> + '_ {
             | Res::NonMacroAttr(_)
             | Res::Err => Const::new_error_with_message(tcx, span, "invalid Res for const path"),
         }
+    }
+
+    /// Literals and const generic parameters are eagerly converted to a constant, everything else
+    /// becomes `Unevaluated`.
+    #[instrument(skip(self), level = "debug")]
+    fn lower_anon_const(&self, def: LocalDefId) -> Const<'tcx> {
+        let tcx = self.tcx();
+
+        let body_id = match tcx.hir_node_by_def_id(def) {
+            hir::Node::AnonConst(ac) => ac.body,
+            node => span_bug!(
+                tcx.def_span(def.to_def_id()),
+                "from_anon_const can only process anonymous constants, not {node:?}"
+            ),
+        };
+
+        let expr = &tcx.hir().body(body_id).value;
+        debug!(?expr);
+
+        let ty = tcx.type_of(def).no_bound_vars().expect("const parameter types cannot be generic");
+
+        match self.try_lower_anon_const_lit(ty, expr) {
+            Some(v) => v,
+            None => ty::Const::new_unevaluated(tcx, ty::UnevaluatedConst {
+                def: def.to_def_id(),
+                args: ty::GenericArgs::identity_for_item(tcx, def.to_def_id()),
+            }),
+        }
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    fn try_lower_anon_const_lit(
+        &self,
+        ty: Ty<'tcx>,
+        expr: &'tcx hir::Expr<'tcx>,
+    ) -> Option<Const<'tcx>> {
+        let tcx = self.tcx();
+
+        // Unwrap a block, so that e.g. `{ P }` is recognised as a parameter. Const arguments
+        // currently have to be wrapped in curly brackets, so it's necessary to special-case.
+        let expr = match &expr.kind {
+            hir::ExprKind::Block(block, _) if block.stmts.is_empty() && block.expr.is_some() => {
+                block.expr.as_ref().unwrap()
+            }
+            _ => expr,
+        };
+
+        if let hir::ExprKind::Path(hir::QPath::Resolved(
+            _,
+            &hir::Path { res: Res::Def(DefKind::ConstParam, _), .. },
+        )) = expr.kind
+        {
+            span_bug!(
+                expr.span,
+                "try_lower_anon_const_lit: received const param which shouldn't be possible"
+            );
+        };
+
+        let lit_input = match expr.kind {
+            hir::ExprKind::Lit(lit) => Some(LitToConstInput { lit: &lit.node, ty, neg: false }),
+            hir::ExprKind::Unary(hir::UnOp::Neg, expr) => match expr.kind {
+                hir::ExprKind::Lit(lit) => Some(LitToConstInput { lit: &lit.node, ty, neg: true }),
+                _ => None,
+            },
+            _ => None,
+        };
+
+        if let Some(lit_input) = lit_input {
+            // If an error occurred, ignore that it's a literal and leave reporting the error up to
+            // mir.
+            match tcx.at(expr.span).lit_to_const(lit_input) {
+                Ok(c) => return Some(c),
+                Err(_) if lit_input.ty.has_aliases() => {
+                    // allow the `ty` to be an alias type, though we cannot handle it here
+                    return None;
+                }
+                Err(e) => {
+                    tcx.dcx().span_delayed_bug(
+                        expr.span,
+                        format!("try_lower_anon_const_lit: couldn't lit_to_const {e:?}"),
+                    );
+                }
+            }
+        }
+
+        None
     }
 
     fn lower_delegation_ty(&self, idx: hir::InferDelegationKind) -> Ty<'tcx> {

--- a/tests/crashes/121429.rs
+++ b/tests/crashes/121429.rs
@@ -1,13 +1,10 @@
 //@ known-bug: #121429
+
 #![feature(generic_const_exprs)]
 
-pub trait True {}
-
-impl<const N: usize = { const { 3 } }> PartialEq<FixedI8<FRAC_RHS>> for FixedI8<FRAC_LHS> where
-    If<{}>: True
-{
-}
-#![feature(generic_const_exprs)]
+struct FixedI8<const X: usize>;
+const FRAC_LHS: usize = 0;
+const FRAC_RHS: usize = 1;
 
 pub trait True {}
 

--- a/tests/ui/attributes/dump_def_parents.rs
+++ b/tests/ui/attributes/dump_def_parents.rs
@@ -3,16 +3,17 @@
 
 fn bar() {
     fn foo() {
+        #[rustc_dump_def_parents]
         fn baz() {
-            #[rustc_dump_def_parents]
+            //~^ ERROR: rustc_dump_def_parents: DefId
             || {
-                //~^ ERROR: rustc_dump_def_parents: DefId
                 qux::<
                     {
                         //~^ ERROR: rustc_dump_def_parents: DefId
                         fn inhibits_dump() {
                             qux::<
                                 {
+                                    //~^ ERROR: rustc_dump_def_parents: DefId
                                     "hi";
                                     1
                                 },

--- a/tests/ui/attributes/dump_def_parents.stderr
+++ b/tests/ui/attributes/dump_def_parents.stderr
@@ -1,14 +1,9 @@
 error: rustc_dump_def_parents: DefId(..)
-  --> $DIR/dump_def_parents.rs:8:13
-   |
-LL |             || {
-   |             ^^
-   |
-note: DefId(..)
-  --> $DIR/dump_def_parents.rs:6:9
+  --> $DIR/dump_def_parents.rs:7:9
    |
 LL |         fn baz() {
    |         ^^^^^^^^
+   |
 note: DefId(..)
   --> $DIR/dump_def_parents.rs:5:5
    |
@@ -44,12 +39,12 @@ LL | |                     },
    | |_____________________^
    |
 note: DefId(..)
-  --> $DIR/dump_def_parents.rs:8:13
+  --> $DIR/dump_def_parents.rs:9:13
    |
 LL |             || {
    |             ^^
 note: DefId(..)
-  --> $DIR/dump_def_parents.rs:6:9
+  --> $DIR/dump_def_parents.rs:7:9
    |
 LL |         fn baz() {
    |         ^^^^^^^^
@@ -76,7 +71,65 @@ LL | | fn main() {}
    | |____________^
 
 error: rustc_dump_def_parents: DefId(..)
-  --> $DIR/dump_def_parents.rs:22:31
+  --> $DIR/dump_def_parents.rs:15:33
+   |
+LL | / ...                   {
+LL | | ...
+LL | | ...                       "hi";
+LL | | ...                       1
+LL | | ...                   },
+   | |_______________________^
+   |
+note: DefId(..)
+  --> $DIR/dump_def_parents.rs:13:25
+   |
+LL |                         fn inhibits_dump() {
+   |                         ^^^^^^^^^^^^^^^^^^
+note: DefId(..)
+  --> $DIR/dump_def_parents.rs:11:21
+   |
+LL | /                     {
+LL | |
+LL | |                         fn inhibits_dump() {
+LL | |                             qux::<
+...  |
+LL | |                         1
+LL | |                     },
+   | |_____________________^
+note: DefId(..)
+  --> $DIR/dump_def_parents.rs:9:13
+   |
+LL |             || {
+   |             ^^
+note: DefId(..)
+  --> $DIR/dump_def_parents.rs:7:9
+   |
+LL |         fn baz() {
+   |         ^^^^^^^^
+note: DefId(..)
+  --> $DIR/dump_def_parents.rs:5:5
+   |
+LL |     fn foo() {
+   |     ^^^^^^^^
+note: DefId(..)
+  --> $DIR/dump_def_parents.rs:4:1
+   |
+LL | fn bar() {
+   | ^^^^^^^^
+note: DefId(..)
+  --> $DIR/dump_def_parents.rs:2:1
+   |
+LL | / #![feature(rustc_attrs)]
+LL | |
+LL | | fn bar() {
+LL | |     fn foo() {
+...  |
+LL | |
+LL | | fn main() {}
+   | |____________^
+
+error: rustc_dump_def_parents: DefId(..)
+  --> $DIR/dump_def_parents.rs:23:31
    |
 LL |                         qux::<{ 1 + 1 }>();
    |                               ^^^^^^^^^
@@ -93,12 +146,12 @@ LL | |                         1
 LL | |                     },
    | |_____________________^
 note: DefId(..)
-  --> $DIR/dump_def_parents.rs:8:13
+  --> $DIR/dump_def_parents.rs:9:13
    |
 LL |             || {
    |             ^^
 note: DefId(..)
-  --> $DIR/dump_def_parents.rs:6:9
+  --> $DIR/dump_def_parents.rs:7:9
    |
 LL |         fn baz() {
    |         ^^^^^^^^
@@ -124,5 +177,5 @@ LL | |
 LL | | fn main() {}
    | |____________^
 
-error: aborting due to 3 previous errors
+error: aborting due to 4 previous errors
 

--- a/tests/ui/const-generics/issues/cg-in-dyn-issue-128176.rs
+++ b/tests/ui/const-generics/issues/cg-in-dyn-issue-128176.rs
@@ -1,7 +1,11 @@
-//@ known-bug: rust-lang/rust#128176
+//@ check-pass
+
+// Regression test for #128176.
 
 #![feature(generic_const_exprs)]
 #![feature(dyn_compatible_for_dispatch)]
+#![allow(incomplete_features)]
+
 trait X {
     type Y<const N: i16>;
 }

--- a/tests/ui/const-generics/issues/issue-83765.stderr
+++ b/tests/ui/const-generics/issues/issue-83765.stderr
@@ -10,11 +10,11 @@ note: ...which requires computing candidate for `<LazyUpdim<'_, T, <T as TensorD
 LL | trait TensorDimension {
    | ^^^^^^^^^^^^^^^^^^^^^
    = note: ...which again requires resolving instance `<LazyUpdim<'_, T, <T as TensorDimension>::DIM, DIM> as TensorDimension>::DIM`, completing the cycle
-note: cycle used when computing candidate for `<LazyUpdim<'_, T, { T::DIM }, DIM> as TensorDimension>`
-  --> $DIR/issue-83765.rs:4:1
+note: cycle used when checking assoc item `<impl at $DIR/issue-83765.rs:50:1: 50:94>::size` is compatible with trait definition
+  --> $DIR/issue-83765.rs:51:5
    |
-LL | trait TensorDimension {
-   | ^^^^^^^^^^^^^^^^^^^^^
+LL |     fn size(&self) -> [usize; DIM] {
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: see https://rustc-dev-guide.rust-lang.org/overview.html#queries and https://rustc-dev-guide.rust-lang.org/query.html for more information
 
 error[E0391]: cycle detected when resolving instance `<LazyUpdim<'_, T, <T as TensorDimension>::DIM, DIM> as TensorDimension>::DIM`


### PR DESCRIPTION
Fixes #128176.
This accomplishes one of the followup items from #131081.

These operations are much more about lowering the HIR than about
`Const`s themselves. They fit better in hir_ty_lowering with
`lower_const_arg` (formerly `Const::from_const_arg`) and the rest.

To accomplish this, `const_evaluatable_predicates_of` had to be changed
to not use `from_anon_const` anymore. Instead of visiting the HIR and
lowering anon consts on the fly, it now visits the `rustc_middle::ty`
data structures instead and directly looks for `UnevaluatedConst`s. This
approach was proposed in:
https://github.com/rust-lang/rust/pull/131081#discussion_r1821189257

r? @BoxyUwU
