### PR TITLE
Add targeted suggestion for incompatible `{un,}safe` keywords when parsing fn-frontmatter-like fragments

### DIFF
--- a/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-block-1.rs
+++ b/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-block-1.rs
@@ -1,0 +1,31 @@
+//! Check that we don't try to suggest reordering incompatible keywords `safe` and `unsafe` when
+//! parsing things that looks like fn frontmatter/extern blocks.
+//!
+//! # Context
+//!
+//! Previously, there was some recovery logic related to misplaced keywords (e.g. `safe` and
+//! `unsafe`) when we tried to parse fn frontmatter (this is what happens when trying to parse
+//! something malformed like `unsafe safe extern {}` or `safe unsafe extern {}`). Unfortunately, the
+//! recovery logic only really handled duplicate keywords or misplaced keywords. This meant that
+//! incompatible keywords like {`unsafe`, `safe`} when used together produces some funny suggestion
+//! e.g.
+//!
+//! ```text
+//! help: `unsafe` must come before `safe`: `unsafe safe`
+//! ```
+//!
+//! and then if you applied that suggestion, another suggestion in the recovery logic will tell you
+//! to flip it back, ad infinitum.
+//!
+//! # References
+//!
+//! See <https://github.com/rust-lang/rust/issues/133586>.
+//!
+//! See `incompatible-safe-unsafe-keywords-extern-block-2.rs` for the `safe unsafe extern {}`
+//! version.
+#![crate_type = "lib"]
+
+safe unsafe extern {}
+//~^ ERROR expected one of `extern` or `fn`, found keyword `unsafe`
+//~| NOTE expected one of `extern` or `fn`
+//~| HELP `safe` and `unsafe` are incompatible, use only one of the keywords

--- a/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-block-1.stderr
+++ b/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-block-1.stderr
@@ -1,0 +1,14 @@
+error: expected one of `extern` or `fn`, found keyword `unsafe`
+  --> $DIR/incompatible-safe-unsafe-keywords-extern-block-1.rs:28:6
+   |
+LL | safe unsafe extern {}
+   |      ^^^^^^ expected one of `extern` or `fn`
+   |
+help: `safe` and `unsafe` are incompatible, use only one of the keywords
+  --> $DIR/incompatible-safe-unsafe-keywords-extern-block-1.rs:28:1
+   |
+LL | safe unsafe extern {}
+   | ^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-block-2.rs
+++ b/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-block-2.rs
@@ -1,0 +1,15 @@
+//! Check that we don't try to suggest reordering incompatible keywords `safe` and `unsafe` when
+//! parsing things that looks like fn frontmatter/extern blocks.
+//!
+//! # References
+//!
+//! See <https://github.com/rust-lang/rust/issues/133586>.
+//!
+//! See `incompatible-safe-unsafe-keywords-extern-block-1.rs` for the `unsafe safqe extern {}`
+//! version.
+#![crate_type = "lib"]
+
+unsafe safe extern {}
+//~^ ERROR expected one of `extern` or `fn`, found `safe`
+//~| NOTE expected one of `extern` or `fn`
+//~| HELP `unsafe` and `safe` are incompatible, use only one of the keywords

--- a/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-block-2.stderr
+++ b/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-block-2.stderr
@@ -1,0 +1,14 @@
+error: expected one of `extern` or `fn`, found `safe`
+  --> $DIR/incompatible-safe-unsafe-keywords-extern-block-2.rs:12:8
+   |
+LL | unsafe safe extern {}
+   |        ^^^^ expected one of `extern` or `fn`
+   |
+help: `unsafe` and `safe` are incompatible, use only one of the keywords
+  --> $DIR/incompatible-safe-unsafe-keywords-extern-block-2.rs:12:1
+   |
+LL | unsafe safe extern {}
+   | ^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-fn-in-extern-block.rs
+++ b/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-fn-in-extern-block.rs
@@ -1,0 +1,11 @@
+//! Check that we emit a targeted suggestion for an extern fn that uses incompatible `safe` and
+//! `unsafe` keywords.
+#![crate_type = "lib"]
+
+unsafe extern {
+//~^ NOTE while parsing this item list starting here
+    pub safe unsafe extern fn foo() {}
+    //~^ ERROR expected one of `extern` or `fn`, found keyword `unsafe`
+    //~| NOTE expected one of `extern` or `fn`
+    //~| `safe` and `unsafe` are incompatible, use only one of the keywords
+} //~ NOTE the item list ends here

--- a/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-fn-in-extern-block.stderr
+++ b/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-fn-in-extern-block.stderr
@@ -1,0 +1,20 @@
+error: expected one of `extern` or `fn`, found keyword `unsafe`
+  --> $DIR/incompatible-safe-unsafe-keywords-extern-fn-in-extern-block.rs:7:14
+   |
+LL | unsafe extern {
+   |               - while parsing this item list starting here
+LL |
+LL |     pub safe unsafe extern fn foo() {}
+   |              ^^^^^^ expected one of `extern` or `fn`
+...
+LL | }
+   | - the item list ends here
+   |
+help: `safe` and `unsafe` are incompatible, use only one of the keywords
+  --> $DIR/incompatible-safe-unsafe-keywords-extern-fn-in-extern-block.rs:7:9
+   |
+LL |     pub safe unsafe extern fn foo() {}
+   |         ^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-fn.rs
+++ b/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-fn.rs
@@ -1,0 +1,8 @@
+//! Check that we emit a targeted suggestion for an extern fn that uses incompatible `safe` and
+//! `unsafe` keywords.
+#![crate_type = "lib"]
+
+pub safe unsafe extern fn foo() {}
+//~^ ERROR expected one of `extern` or `fn`, found keyword `unsafe`
+//~| NOTE expected one of `extern` or `fn`
+//~| `safe` and `unsafe` are incompatible, use only one of the keywords

--- a/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-fn.stderr
+++ b/tests/ui/parser/incompatible-safe-unsafe-keywords-extern-fn.stderr
@@ -1,0 +1,14 @@
+error: expected one of `extern` or `fn`, found keyword `unsafe`
+  --> $DIR/incompatible-safe-unsafe-keywords-extern-fn.rs:5:10
+   |
+LL | pub safe unsafe extern fn foo() {}
+   |          ^^^^^^ expected one of `extern` or `fn`
+   |
+help: `safe` and `unsafe` are incompatible, use only one of the keywords
+  --> $DIR/incompatible-safe-unsafe-keywords-extern-fn.rs:5:5
+   |
+LL | pub safe unsafe extern fn foo() {}
+   |     ^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #133586[^1], where previously we had two suggestions for `unsafe safe extern {}` and `safe unsafe extern {}` to shuffle the order of `unsafe` and `safe` ad infinitum.

This PR introduces a special case for incompatible keywords (currently only limited to `unsafe` and `safe`) when parsing fn-frontmatter-like fragments, and produces a specialized help message for that case to use only one of them. In cases where incompatible keywords are used, no automated fix is offered because user intention is unclear.

After this PR, the diagnostics will look like:

```
error: expected one of `extern` or `fn`, found keyword `unsafe`
  --> $DIR/incompatible-safe-unsafe-keywords-extern-block-1.rs:28:6
   |
LL | safe unsafe extern {}
   |      ^^^^^^ expected one of `extern` or `fn`
   |
help: `safe` and `unsafe` are incompatible, use only one of the keywords
  --> $DIR/incompatible-safe-unsafe-keywords-extern-block-1.rs:28:1
   |
LL | safe unsafe extern {}
   | ^^^^^^^^^^^

error: aborting due to 1 previous error
```

Note that this is still not *super* precise. Extern blocks cannot have `safe` keyword, so in theory one can provide a machine-applicable suggestion to remove the safe keyword on extern block, at the cost of even more complexity that I don't think pulls the extra weight[^2].

[^1]: it's not perfect, but I hope it's at least less confusing
[^2]: it's complicated when the prefixes to the block/fn shaped fragments can include a bunch of other keywords like `const` or `async` or whatever, then you can also have optional ABI-strings thrown into the mix.