### PR TITLE
update link to "C++ Exceptions under the hood" blog

### DIFF
--- a/library/panic_unwind/src/gcc.rs
+++ b/library/panic_unwind/src/gcc.rs
@@ -5,7 +5,7 @@
 //! documents linked from it.
 //! These are also good reads:
 //!  * <https://itanium-cxx-abi.github.io/cxx-abi/abi-eh.html>
-//!  * <https://monoinfinito.wordpress.com/series/exception-handling-in-c/>
+//!  * <https://nicolasbrailo.github.io/blog/projects_texts/13exceptionsunderthehood.html>
 //!  * <https://www.airs.com/blog/index.php?s=exception+frames>
 //!
 //! ## A brief summary

--- a/library/std/src/sys/personality/gcc.rs
+++ b/library/std/src/sys/personality/gcc.rs
@@ -5,7 +5,7 @@
 //! documents linked from it.
 //! These are also good reads:
 //!  * <https://itanium-cxx-abi.github.io/cxx-abi/abi-eh.html>
-//!  * <https://monoinfinito.wordpress.com/series/exception-handling-in-c/>
+//!  * <https://nicolasbrailo.github.io/blog/projects_texts/13exceptionsunderthehood.html>
 //!  * <https://www.airs.com/blog/index.php?s=exception+frames>
 //!
 //! ## A brief summary


### PR DESCRIPTION
The link was introduced in 0ec321f7b541fcbfbf20286beb497e6d9d3352b2. For the old link, see https://web.archive.org/web/20170409223244/https://monoinfinito.wordpress.com/series/exception-handling-in-c/. The blog has migrated from WordPress to Blogger in 2021 and to GitHub pages in 2024.