### PR TITLE
Improve span handling in `parse_expr_bottom`.

### DIFF
--- a/compiler/rustc_parse/src/parser/diagnostics.rs
+++ b/compiler/rustc_parse/src/parser/diagnostics.rs
@@ -1990,7 +1990,6 @@ impl<'a> Parser<'a> {
     /// `await? <expr>`, `await(<expr>)`, and `await { <expr> }`.
     pub(super) fn recover_incorrect_await_syntax(
         &mut self,
-        lo: Span,
         await_sp: Span,
     ) -> PResult<'a, P<Expr>> {
         let (hi, expr, is_question) = if self.token == token::Not {
@@ -1999,8 +1998,8 @@ impl<'a> Parser<'a> {
         } else {
             self.recover_await_prefix(await_sp)?
         };
-        let (sp, guar) = self.error_on_incorrect_await(lo, hi, &expr, is_question);
-        let expr = self.mk_expr_err(lo.to(sp), guar);
+        let (sp, guar) = self.error_on_incorrect_await(await_sp, hi, &expr, is_question);
+        let expr = self.mk_expr_err(await_sp.to(sp), guar);
         self.maybe_recover_from_bad_qpath(expr)
     }
 

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1446,34 +1446,31 @@ impl<'a> Parser<'a> {
                     this.parse_expr_closure()
                 } else {
                     assert!(this.eat_keyword(kw::For));
-                    this.parse_expr_for(None, this.prev_token.span)
+                    this.parse_expr_for(None, lo)
                 }
             } else if this.eat_keyword(kw::While) {
-                this.parse_expr_while(None, this.prev_token.span)
+                this.parse_expr_while(None, lo)
             } else if let Some(label) = this.eat_label() {
                 this.parse_expr_labeled(label, true)
             } else if this.eat_keyword(kw::Loop) {
-                let sp = this.prev_token.span;
-                this.parse_expr_loop(None, this.prev_token.span).map_err(|mut err| {
-                    err.span_label(sp, "while parsing this `loop` expression");
+                this.parse_expr_loop(None, lo).map_err(|mut err| {
+                    err.span_label(lo, "while parsing this `loop` expression");
                     err
                 })
             } else if this.eat_keyword(kw::Match) {
-                let match_sp = this.prev_token.span;
                 this.parse_expr_match().map_err(|mut err| {
-                    err.span_label(match_sp, "while parsing this `match` expression");
+                    err.span_label(lo, "while parsing this `match` expression");
                     err
                 })
             } else if this.eat_keyword(kw::Unsafe) {
-                let sp = this.prev_token.span;
                 this.parse_expr_block(None, lo, BlockCheckMode::Unsafe(ast::UserProvided)).map_err(
                     |mut err| {
-                        err.span_label(sp, "while parsing this `unsafe` expression");
+                        err.span_label(lo, "while parsing this `unsafe` expression");
                         err
                     },
                 )
             } else if this.check_inline_const(0) {
-                this.parse_const_block(lo.to(this.token.span), false)
+                this.parse_const_block(lo, false)
             } else if this.may_recover() && this.is_do_catch_block() {
                 this.recover_do_catch()
             } else if this.is_try_block() {
@@ -1514,7 +1511,7 @@ impl<'a> Parser<'a> {
                         this.parse_expr_closure()
                     }
                 } else if this.eat_keyword_noexpect(kw::Await) {
-                    this.recover_incorrect_await_syntax(lo, this.prev_token.span)
+                    this.recover_incorrect_await_syntax(lo)
                 } else {
                     this.parse_expr_lit()
                 }


### PR DESCRIPTION
`parse_expr_bottom` stores `this.token.span` in `lo`, but then fails to use it in many places where it could. This commit fixes that, and likewise (to a smaller extent) in `parse_ty_common`.

r? @spastorino 