### PR TITLE
check local cache even if global is usable

### DIFF
--- a/compiler/rustc_trait_selection/src/traits/select/mod.rs
+++ b/compiler/rustc_trait_selection/src/traits/select/mod.rs
@@ -1537,14 +1537,19 @@ impl<'cx, 'tcx> SelectionContext<'cx, 'tcx> {
 
         if self.can_use_global_caches(param_env, cache_fresh_trait_pred) {
             if let Some(res) = tcx.selection_cache.get(&(infcx.typing_env(param_env), pred), tcx) {
-                Some(res)
-            } else {
-                debug_assert_eq!(infcx.selection_cache.get(&(param_env, pred), tcx), None);
-                None
+                return Some(res);
+            } else if cfg!(debug_assertions) {
+                match infcx.selection_cache.get(&(param_env, pred), tcx) {
+                    None | Some(Err(Overflow(OverflowError::Canonical))) => {}
+                    res => bug!("unexpected local cache result: {res:?}"),
+                }
             }
-        } else {
-            infcx.selection_cache.get(&(param_env, pred), tcx)
         }
+
+        // Subtle: we need to check the local cache even if we're able to use the
+        // global cache as we don't cache overflow in the global cache but need to
+        // cache it as otherwise rustdoc hangs when compiling diesel.
+        infcx.selection_cache.get(&(param_env, pred), tcx)
     }
 
     /// Determines whether can we safely cache the result


### PR DESCRIPTION
we store overflow errors locally, even if we can otherwise use the global cache for this goal. should fix #133616, didn't test it locally yet as diesel tends to hit an unrelated debug assertion in rustdoc.

r? types