### PR TITLE
mem::transmute warns if transmuting to a type with interior mutability

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -142,6 +142,10 @@ lint_builtin_special_module_name_used_lib = found module declaration for lib.rs
 lint_builtin_special_module_name_used_main = found module declaration for main.rs
     .note = a binary crate cannot be used as library
 
+lint_builtin_transmute_to_interior_mutability =
+    transmuting from a type without interior mutability to a type with interior mutability is undefined behaviour if you modify the content
+    .help = `{$output_ty}` has interior mutability
+
 lint_builtin_trivial_bounds = {$predicate_kind_name} bound {$predicate} does not depend on any type or lifetime parameters
 
 lint_builtin_type_alias_bounds_enable_feat_help = add `#![feature(lazy_type_alias)]` to the crate attributes to enable the desired semantics

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -229,6 +229,13 @@ pub(crate) struct BuiltinConstNoMangle {
 pub(crate) struct BuiltinMutablesTransmutes;
 
 #[derive(LintDiagnostic)]
+#[diag(lint_builtin_transmute_to_interior_mutability)]
+#[help]
+pub(crate) struct BuiltinTransmuteInteriorMutability<'tcx> {
+    pub output_ty: Ty<'tcx>,
+}
+
+#[derive(LintDiagnostic)]
 #[diag(lint_builtin_unstable_features)]
 pub(crate) struct BuiltinUnstableFeatures;
 

--- a/compiler/rustc_lint/src/passes.rs
+++ b/compiler/rustc_lint/src/passes.rs
@@ -57,7 +57,6 @@ macro_rules! late_lint_methods {
 //
 // FIXME: eliminate the duplication with `Visitor`. But this also
 // contains a few lint-specific methods with no equivalent in `Visitor`.
-
 macro_rules! declare_late_lint_pass {
     ([], [$($(#[$attr:meta])* fn $name:ident($($param:ident: $arg:ty),*);)*]) => (
         pub trait LateLintPass<'tcx>: LintPass {

--- a/tests/ui/consts/const-eval/issue-55541.rs
+++ b/tests/ui/consts/const-eval/issue-55541.rs
@@ -3,6 +3,7 @@
 // Test that we can handle newtypes wrapping extern types
 
 #![feature(extern_types)]
+#![allow(transmute_to_interior_mutability)]
 
 use std::marker::PhantomData;
 

--- a/tests/ui/consts/const-eval/issue-55541.stderr
+++ b/tests/ui/consts/const-eval/issue-55541.stderr
@@ -1,0 +1,27 @@
+warning: unknown lint: `transmute_to_interior_mutability`
+  --> $DIR/issue-55541.rs:6:10
+   |
+LL | #![allow(transmute_to_interior_mutability)]
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(unknown_lints)]` on by default
+
+warning: transmuting from a type without interior mutability to a type with interior mutability is undefined behaviour if you modify the content
+  --> $DIR/issue-55541.rs:19:3
+   |
+LL |   std::mem::transmute(&MAGIC_FFI_STATIC)
+   |   ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `Wrapper` has interior mutability
+   = note: `#[warn(transmute_to_interior_mutability)]` on by default
+
+warning: transmuting from a type without interior mutability to a type with interior mutability is undefined behaviour if you modify the content
+  --> $DIR/issue-55541.rs:25:3
+   |
+LL |   std::mem::transmute(&MAGIC_FFI_STATIC)
+   |   ^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `Wrapper2` has interior mutability
+
+warning: 3 warnings emitted
+

--- a/tests/ui/transmute/interior-mutability-issue-111229.rs
+++ b/tests/ui/transmute/interior-mutability-issue-111229.rs
@@ -1,0 +1,16 @@
+//@ run-pass
+// https://github.com/rust-lang/rust/issues/111229
+
+pub struct Foo(std::cell::UnsafeCell<usize>);
+pub struct Bar([u8; 0]);
+
+pub fn foo(f: &Bar) {
+    unsafe {
+        let f = std::mem::transmute::<&Bar, &Foo>(f);
+        //~^ WARNING transmuting from a type without interior mutability to a type with interior mutability
+        //~| HELP `Foo` has interior mutability
+        *(f.0.get()) += 1;
+    }
+}
+
+fn main() {}

--- a/tests/ui/transmute/interior-mutability-issue-111229.stderr
+++ b/tests/ui/transmute/interior-mutability-issue-111229.stderr
@@ -1,0 +1,11 @@
+warning: transmuting from a type without interior mutability to a type with interior mutability is undefined behaviour if you modify the content
+  --> $DIR/interior-mutability-issue-111229.rs:9:17
+   |
+LL |         let f = std::mem::transmute::<&Bar, &Foo>(f);
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `Foo` has interior mutability
+   = note: `#[warn(transmute_to_interior_mutability)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/transmute/transmute-interior-mutability.rs
+++ b/tests/ui/transmute/transmute-interior-mutability.rs
@@ -1,0 +1,19 @@
+#![allow(unused)]
+use std::{cell::UnsafeCell, mem, sync::atomic::AtomicI32};
+
+fn main() {
+    unsafe {
+        mem::transmute::<&i32, &UnsafeCell<i32>>(&42);
+        //~^ WARNING transmuting from a type without interior mutability to a type with interior mutability
+        //~| HELP `UnsafeCell<i32>` has interior mutability
+        // It's an error to transmute to a type containing unsafe cell
+        mem::transmute::<&i32, &AtomicI32>(&42);
+        //~^ WARNING transmuting from a type without interior mutability to a type with interior mutability
+        //~| HELP `AtomicI32` has interior mutability
+        // mutable_transmutes triggers before
+
+        // This one is here because & -> &mut is worse, to assert that this one triggers.
+        mem::transmute::<&i32, &mut UnsafeCell<i32>>(&42);
+        //~^ ERROR transmuting &T to &mut T is undefined behavior, even if the reference is unused, consider instead using an UnsafeCell
+    };
+}

--- a/tests/ui/transmute/transmute-interior-mutability.stderr
+++ b/tests/ui/transmute/transmute-interior-mutability.stderr
@@ -1,0 +1,27 @@
+warning: transmuting from a type without interior mutability to a type with interior mutability is undefined behaviour if you modify the content
+  --> $DIR/transmute-interior-mutability.rs:6:9
+   |
+LL |         mem::transmute::<&i32, &UnsafeCell<i32>>(&42);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `UnsafeCell<i32>` has interior mutability
+   = note: `#[warn(transmute_to_interior_mutability)]` on by default
+
+warning: transmuting from a type without interior mutability to a type with interior mutability is undefined behaviour if you modify the content
+  --> $DIR/transmute-interior-mutability.rs:10:9
+   |
+LL |         mem::transmute::<&i32, &AtomicI32>(&42);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: `AtomicI32` has interior mutability
+
+error: transmuting &T to &mut T is undefined behavior, even if the reference is unused, consider instead using an UnsafeCell
+  --> $DIR/transmute-interior-mutability.rs:16:9
+   |
+LL |         mem::transmute::<&i32, &mut UnsafeCell<i32>>(&42);
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(mutable_transmutes)]` on by default
+
+error: aborting due to 1 previous error; 2 warnings emitted
+


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
closes #111229 

Now `mem::transmute` warns when transmuting from `&T` -> `&UnsafeCell<T>` (or things that contain it).
In reality it warns when transmuting `&impl Freeze` -> `&impl !Freeze` so it might also warn against things like extern types and so on.

- I've created a new lint: `transmute_to_interior_mutability` (please check this as I'm not sure if I've done it properly)
- I've refactored how the `mutable_transmutes` lint works
- I've reused the same function as `mutable_transmutes` so that we can reuse most of the work.
- notice that in `tests/ui/consts/const-eval/issue-55541.rs` I've silenced the error... Should we do something about interior mutability and extern types?
- This leaves the door open for more checks in `mem::transmute`

Please review the lint text carefully as I don't know how factual that is.
Also, should we do this with raw pointers too? and if so, which cases are worth covering?