### PR TITLE
Use `iter::repeat_n` to implement `Vec::extend_with`

### DIFF
--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -172,6 +172,12 @@ use self::spec_extend::SpecExtend;
 #[cfg(not(no_global_oom_handling))]
 mod spec_extend;
 
+#[cfg(not(no_global_oom_handling))]
+use self::spec_extend_with::SpecExtendWith;
+
+#[cfg(not(no_global_oom_handling))]
+mod spec_extend_with;
+
 /// A contiguous growable array type, written as `Vec<T>`, short for 'vector'.
 ///
 /// # Examples
@@ -3449,7 +3455,7 @@ impl<T: Clone, A: Allocator> Vec<T, A> {
     #[cfg(not(no_global_oom_handling))]
     #[inline]
     fn extend_with(&mut self, n: usize, value: T) {
-        self.extend_trusted(iter::repeat_n(value, n));
+        <Self as SpecExtendWith<T>>::spec_extend_with(self, n, value);
     }
 }
 

--- a/library/alloc/src/vec/spec_extend_with.rs
+++ b/library/alloc/src/vec/spec_extend_with.rs
@@ -1,0 +1,35 @@
+use core::clone::TrivialClone;
+use core::{iter, ptr};
+
+use super::Vec;
+use crate::alloc::Allocator;
+
+// Specialization trait used for Vec::extend_with
+pub(super) trait SpecExtendWith<T> {
+    fn spec_extend_with(&mut self, n: usize, value: T);
+}
+
+impl<T: Clone, A: Allocator> SpecExtendWith<T> for Vec<T, A> {
+    #[inline]
+    default fn spec_extend_with(&mut self, n: usize, value: T) {
+        self.extend_trusted(iter::repeat_n(value, n));
+    }
+}
+
+impl<T: TrivialClone, A: Allocator> SpecExtendWith<T> for Vec<T, A> {
+    fn spec_extend_with(&mut self, n: usize, value: T) {
+        let len = self.len();
+        self.reserve(n);
+        let unfilled = self.spare_capacity_mut().as_mut_ptr().cast_init();
+
+        for i in 0..n {
+            // SAFETY: `unfilled` is at least as long as `n` thanks
+            // to the `reserve` call. Because `T` is `TrivialClone`,
+            // this is equivalent to calling `T::clone` for every element.
+            unsafe { ptr::write(unfilled.add(i), ptr::read(&value)) };
+        }
+
+        // SAFETY: the elements have been initialized above.
+        unsafe { self.set_len(len + n) }
+    }
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/133662)*
<!-- homu-ignore:end -->

This replaces the `Vec::extend_with` manual implementation with `iter::repeat_n`, simplifying the code and fixing the issue identified in rust-lang/rust#120050.
