### PR TITLE
Move some functions out of const_swap feature gate

### DIFF
--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -1009,6 +1009,7 @@ pub const fn slice_from_raw_parts_mut<T>(data: *mut T, len: usize) -> *mut [T] {
 #[stable(feature = "rust1", since = "1.0.0")]
 #[rustc_const_unstable(feature = "const_swap", issue = "83163")]
 #[rustc_diagnostic_item = "ptr_swap"]
+#[rustc_const_stable_indirect]
 pub const unsafe fn swap<T>(x: *mut T, y: *mut T) {
     // Give ourselves some scratch space to work with.
     // We do not have to worry about drops: `MaybeUninit` does nothing when dropped.
@@ -1069,7 +1070,7 @@ pub const unsafe fn swap<T>(x: *mut T, y: *mut T) {
 /// ```
 #[inline]
 #[stable(feature = "swap_nonoverlapping", since = "1.27.0")]
-#[rustc_const_unstable(feature = "const_swap", issue = "83163")]
+#[rustc_const_unstable(feature = "const_swap_nonoverlapping", issue = "133668")]
 #[rustc_diagnostic_item = "ptr_swap_nonoverlapping"]
 pub const unsafe fn swap_nonoverlapping<T>(x: *mut T, y: *mut T, count: usize) {
     #[allow(unused)]
@@ -1129,7 +1130,6 @@ pub const unsafe fn swap_nonoverlapping<T>(x: *mut T, y: *mut T, count: usize) {
 /// LLVM can vectorize this (at least it can for the power-of-two-sized types
 /// `swap_nonoverlapping` tries to use) so no need to manually SIMD it.
 #[inline]
-#[rustc_const_unstable(feature = "const_swap", issue = "83163")]
 const unsafe fn swap_nonoverlapping_simple_untyped<T>(x: *mut T, y: *mut T, count: usize) {
     let x = x.cast::<MaybeUninit<T>>();
     let y = y.cast::<MaybeUninit<T>>();

--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -959,7 +959,7 @@ impl<T> [T] {
     /// [`swap`]: slice::swap
     /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
     #[unstable(feature = "slice_swap_unchecked", issue = "88539")]
-    #[rustc_const_unstable(feature = "const_swap", issue = "83163")]
+    #[rustc_const_unstable(feature = "slice_swap_unchecked", issue = "88539")]
     pub const unsafe fn swap_unchecked(&mut self, a: usize, b: usize) {
         assert_unsafe_precondition!(
             check_library_ub,

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -18,6 +18,7 @@
 #![feature(const_eval_select)]
 #![feature(const_heap)]
 #![feature(const_nonnull_new)]
+#![feature(const_swap)]
 #![feature(const_trait_impl)]
 #![feature(core_intrinsics)]
 #![feature(core_io_borrowed_buf)]

--- a/library/core/tests/ptr.rs
+++ b/library/core/tests/ptr.rs
@@ -898,6 +898,25 @@ fn test_const_copy() {
 }
 
 #[test]
+fn test_const_swap() {
+    const {
+        let mut ptr1 = &1;
+        let mut ptr2 = &666;
+
+        // Swap ptr1 and ptr2, bytewise. `swap` does not take a count
+        // so the best we can do is use an array.
+        type T = [u8; mem::size_of::<&i32>()];
+        unsafe {
+            ptr::swap(ptr::from_mut(&mut ptr1).cast::<T>(), ptr::from_mut(&mut ptr2).cast::<T>());
+        }
+
+        // Make sure they still work.
+        assert!(*ptr1 == 666);
+        assert!(*ptr2 == 1);
+    };
+}
+
+#[test]
 fn test_null_array_as_slice() {
     let arr: *mut [u8; 4] = null_mut();
     let ptr: *mut [u8] = arr.as_mut_slice();

--- a/tests/ui/consts/missing_span_in_backtrace.rs
+++ b/tests/ui/consts/missing_span_in_backtrace.rs
@@ -1,7 +1,7 @@
 //@ compile-flags: -Z ui-testing=no
 
 
-#![feature(const_swap)]
+#![feature(const_swap_nonoverlapping)]
 use std::{
     mem::{self, MaybeUninit},
     ptr,


### PR DESCRIPTION
- `swap_unchecked` is still unstable as a regular fn, so that feature gate can also cover its constness.
- `swap_nonoverlapping` isn't ready to be stabilized yet, so make it a different feature gate.

Part of https://github.com/rust-lang/rust/issues/83163, https://github.com/rust-lang/rust/issues/88539, https://github.com/rust-lang/rust/issues/133668