### PR TITLE
bump hashbrown version

### DIFF
--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "compiler_builtins",


### PR DESCRIPTION
This pulls in https://github.com/rust-lang/hashbrown/pull/586, in preparation for https://github.com/rust-lang/rust/issues/102575.

Cc @Amanieu 