### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -1,5 +1,6 @@
 use rustc_abi::Primitive::{Int, Pointer};
-use rustc_abi::{Align, FieldsShape, Size, TagEncoding, VariantIdx, Variants};
+use rustc_abi::{Align, BackendRepr, FieldsShape, Size, TagEncoding, VariantIdx, Variants};
+use rustc_middle::mir::interpret::Scalar;
 use rustc_middle::mir::tcx::PlaceTy;
 use rustc_middle::ty::layout::{HasTyCtxt, LayoutOf, TyAndLayout};
 use rustc_middle::ty::{self, Ty};
@@ -385,15 +386,22 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
                 if variant_index != untagged_variant {
                     let niche = self.project_field(bx, tag_field);
                     let niche_llty = bx.cx().immediate_backend_type(niche.layout);
+                    let BackendRepr::Scalar(scalar) = niche.layout.backend_repr else {
+                        bug!("expected a scalar placeref for the niche");
+                    };
+                    // We are supposed to compute `niche_value.wrapping_add(niche_start)` wrapping
+                    // around the `niche`'s type.
+                    // The easiest way to do that is to do wrapping arithmetic on `u128` and then
+                    // masking off any extra bits that occur because we did the arithmetic with too many bits.
                     let niche_value = variant_index.as_u32() - niche_variants.start().as_u32();
                     let niche_value = (niche_value as u128).wrapping_add(niche_start);
-                    // FIXME(eddyb): check the actual primitive type here.
-                    let niche_llval = if niche_value == 0 {
-                        // HACK(eddyb): using `c_null` as it works on all types.
-                        bx.cx().const_null(niche_llty)
-                    } else {
-                        bx.cx().const_uint_big(niche_llty, niche_value)
-                    };
+                    let niche_value = niche_value & niche.layout.size.unsigned_int_max();
+
+                    let niche_llval = bx.cx().scalar_to_backend(
+                        Scalar::from_uint(niche_value, niche.layout.size),
+                        scalar,
+                        niche_llty,
+                    );
                     OperandValue::Immediate(niche_llval).store(bx, niche);
                 }
             }

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos.rs
@@ -9,7 +9,7 @@ pub(crate) fn target() -> Target {
             description: Some("ARM64 Apple visionOS".into()),
             tier: Some(3),
             host_tools: Some(false),
-            std: Some(false),
+            std: Some(true),
         },
         pointer_width: 64,
         data_layout: "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos_sim.rs
@@ -9,7 +9,7 @@ pub(crate) fn target() -> Target {
             description: Some("ARM64 Apple visionOS simulator".into()),
             tier: Some(3),
             host_tools: Some(false),
-            std: Some(false),
+            std: Some(true),
         },
         pointer_width: 64,
         data_layout: "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "compiler_builtins",

--- a/library/core/src/num/f128.rs
+++ b/library/core/src/num/f128.rs
@@ -819,7 +819,6 @@ impl f128 {
     ///
     /// ```
     /// #![feature(f128)]
-    /// #![feature(num_midpoint)]
     /// # // Using aarch64 because `reliable_f128_math` is needed
     /// # #[cfg(all(target_arch = "aarch64", target_os = "linux"))] {
     ///
@@ -829,8 +828,7 @@ impl f128 {
     /// ```
     #[inline]
     #[unstable(feature = "f128", issue = "116909")]
-    // #[unstable(feature = "num_midpoint", issue = "110840")]
-    pub fn midpoint(self, other: f128) -> f128 {
+    pub const fn midpoint(self, other: f128) -> f128 {
         const LO: f128 = f128::MIN_POSITIVE * 2.;
         const HI: f128 = f128::MAX / 2.;
 

--- a/library/core/src/num/f16.rs
+++ b/library/core/src/num/f16.rs
@@ -805,7 +805,6 @@ impl f16 {
     ///
     /// ```
     /// #![feature(f16)]
-    /// #![feature(num_midpoint)]
     /// # #[cfg(target_arch = "aarch64")] { // FIXME(f16_F128): rust-lang/rust#123885
     ///
     /// assert_eq!(1f16.midpoint(4.0), 2.5);
@@ -814,8 +813,7 @@ impl f16 {
     /// ```
     #[inline]
     #[unstable(feature = "f16", issue = "116909")]
-    // #[unstable(feature = "num_midpoint", issue = "110840")]
-    pub fn midpoint(self, other: f16) -> f16 {
+    pub const fn midpoint(self, other: f16) -> f16 {
         const LO: f16 = f16::MIN_POSITIVE * 2.;
         const HI: f16 = f16::MAX / 2.;
 

--- a/library/core/src/num/f32.rs
+++ b/library/core/src/num/f32.rs
@@ -992,27 +992,27 @@ impl f32 {
     /// # Examples
     ///
     /// ```
-    /// #![feature(num_midpoint)]
     /// assert_eq!(1f32.midpoint(4.0), 2.5);
     /// assert_eq!((-5.5f32).midpoint(8.0), 1.25);
     /// ```
     #[inline]
-    #[unstable(feature = "num_midpoint", issue = "110840")]
-    pub fn midpoint(self, other: f32) -> f32 {
+    #[stable(feature = "num_midpoint", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "num_midpoint", since = "CURRENT_RUSTC_VERSION")]
+    pub const fn midpoint(self, other: f32) -> f32 {
         cfg_if! {
+            // Allow faster implementation that have known good 64-bit float
+            // implementations. Falling back to the branchy code on targets that don't
+            // have 64-bit hardware floats or buggy implementations.
+            // https://github.com/rust-lang/rust/pull/121062#issuecomment-2123408114
             if #[cfg(any(
                     target_arch = "x86_64",
                     target_arch = "aarch64",
-                    all(any(target_arch="riscv32", target_arch= "riscv64"), target_feature="d"),
-                    all(target_arch = "arm", target_feature="vfp2"),
+                    all(any(target_arch = "riscv32", target_arch = "riscv64"), target_feature = "d"),
+                    all(target_arch = "arm", target_feature = "vfp2"),
                     target_arch = "wasm32",
                     target_arch = "wasm64",
                 ))] {
-                // whitelist the faster implementation to targets that have known good 64-bit float
-                // implementations. Falling back to the branchy code on targets that don't have
-                // 64-bit hardware floats or buggy implementations.
-                // see: https://github.com/rust-lang/rust/pull/121062#issuecomment-2123408114
-                ((f64::from(self) + f64::from(other)) / 2.0) as f32
+                ((self as f64 + other as f64) / 2.0) as f32
             } else {
                 const LO: f32 = f32::MIN_POSITIVE * 2.;
                 const HI: f32 = f32::MAX / 2.;

--- a/library/core/src/num/f64.rs
+++ b/library/core/src/num/f64.rs
@@ -1010,13 +1010,13 @@ impl f64 {
     /// # Examples
     ///
     /// ```
-    /// #![feature(num_midpoint)]
     /// assert_eq!(1f64.midpoint(4.0), 2.5);
     /// assert_eq!((-5.5f64).midpoint(8.0), 1.25);
     /// ```
     #[inline]
-    #[unstable(feature = "num_midpoint", issue = "110840")]
-    pub fn midpoint(self, other: f64) -> f64 {
+    #[stable(feature = "num_midpoint", since = "CURRENT_RUSTC_VERSION")]
+    #[rustc_const_stable(feature = "num_midpoint", since = "CURRENT_RUSTC_VERSION")]
+    pub const fn midpoint(self, other: f64) -> f64 {
         const LO: f64 = f64::MIN_POSITIVE * 2.;
         const HI: f64 = f64::MAX / 2.;
 

--- a/library/core/src/num/mod.rs
+++ b/library/core/src/num/mod.rs
@@ -102,18 +102,18 @@ macro_rules! midpoint_impl {
     ($SelfT:ty, unsigned) => {
         /// Calculates the middle point of `self` and `rhs`.
         ///
-        /// `midpoint(a, b)` is `(a + b) >> 1` as if it were performed in a
-        /// sufficiently-large signed integral type. This implies that the result is
-        /// always rounded towards negative infinity and that no overflow will ever occur.
+        /// `midpoint(a, b)` is `(a + b) / 2` as if it were performed in a
+        /// sufficiently-large unsigned integral type. This implies that the result is
+        /// always rounded towards zero and that no overflow will ever occur.
         ///
         /// # Examples
         ///
         /// ```
-        /// #![feature(num_midpoint)]
         #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".midpoint(4), 2);")]
         #[doc = concat!("assert_eq!(1", stringify!($SelfT), ".midpoint(4), 2);")]
         /// ```
-        #[unstable(feature = "num_midpoint", issue = "110840")]
+        #[stable(feature = "num_midpoint", since = "CURRENT_RUSTC_VERSION")]
+        #[rustc_const_stable(feature = "num_midpoint", since = "CURRENT_RUSTC_VERSION")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
@@ -133,14 +133,14 @@ macro_rules! midpoint_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(num_midpoint)]
+        /// #![feature(num_midpoint_signed)]
         #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".midpoint(4), 2);")]
         #[doc = concat!("assert_eq!((-1", stringify!($SelfT), ").midpoint(2), 0);")]
         #[doc = concat!("assert_eq!((-7", stringify!($SelfT), ").midpoint(0), -3);")]
         #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".midpoint(-7), -3);")]
         #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".midpoint(7), 3);")]
         /// ```
-        #[unstable(feature = "num_midpoint", issue = "110840")]
+        #[unstable(feature = "num_midpoint_signed", issue = "110840")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
@@ -156,18 +156,18 @@ macro_rules! midpoint_impl {
     ($SelfT:ty, $WideT:ty, unsigned) => {
         /// Calculates the middle point of `self` and `rhs`.
         ///
-        /// `midpoint(a, b)` is `(a + b) >> 1` as if it were performed in a
-        /// sufficiently-large signed integral type. This implies that the result is
-        /// always rounded towards negative infinity and that no overflow will ever occur.
+        /// `midpoint(a, b)` is `(a + b) / 2` as if it were performed in a
+        /// sufficiently-large unsigned integral type. This implies that the result is
+        /// always rounded towards zero and that no overflow will ever occur.
         ///
         /// # Examples
         ///
         /// ```
-        /// #![feature(num_midpoint)]
         #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".midpoint(4), 2);")]
         #[doc = concat!("assert_eq!(1", stringify!($SelfT), ".midpoint(4), 2);")]
         /// ```
-        #[unstable(feature = "num_midpoint", issue = "110840")]
+        #[stable(feature = "num_midpoint", since = "CURRENT_RUSTC_VERSION")]
+        #[rustc_const_stable(feature = "num_midpoint", since = "CURRENT_RUSTC_VERSION")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]
@@ -185,14 +185,14 @@ macro_rules! midpoint_impl {
         /// # Examples
         ///
         /// ```
-        /// #![feature(num_midpoint)]
+        /// #![feature(num_midpoint_signed)]
         #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".midpoint(4), 2);")]
         #[doc = concat!("assert_eq!((-1", stringify!($SelfT), ").midpoint(2), 0);")]
         #[doc = concat!("assert_eq!((-7", stringify!($SelfT), ").midpoint(0), -3);")]
         #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".midpoint(-7), -3);")]
         #[doc = concat!("assert_eq!(0", stringify!($SelfT), ".midpoint(7), 3);")]
         /// ```
-        #[unstable(feature = "num_midpoint", issue = "110840")]
+        #[unstable(feature = "num_midpoint_signed", issue = "110840")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/src/num/nonzero.rs
+++ b/library/core/src/num/nonzero.rs
@@ -1458,8 +1458,6 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         /// # Examples
         ///
         /// ```
-        /// #![feature(num_midpoint)]
-        ///
         /// # use std::num::NonZero;
         /// #
         /// # fn main() { test().unwrap(); }
@@ -1473,7 +1471,8 @@ macro_rules! nonzero_integer_signedness_dependent_methods {
         /// # Some(())
         /// # }
         /// ```
-        #[unstable(feature = "num_midpoint", issue = "110840")]
+        #[stable(feature = "num_midpoint", since = "CURRENT_RUSTC_VERSION")]
+        #[rustc_const_stable(feature = "num_midpoint", since = "CURRENT_RUSTC_VERSION")]
         #[must_use = "this returns the result of the operation, \
                       without modifying the original"]
         #[inline]

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -71,7 +71,7 @@
 #![feature(min_specialization)]
 #![feature(never_type)]
 #![feature(noop_waker)]
-#![feature(num_midpoint)]
+#![feature(num_midpoint_signed)]
 #![feature(numfmt)]
 #![feature(pattern)]
 #![feature(pointer_is_aligned_to)]

--- a/src/bootstrap/src/core/build_steps/clean.rs
+++ b/src/bootstrap/src/core/build_steps/clean.rs
@@ -203,10 +203,8 @@ fn rm_rf(path: &Path) {
 
             do_op(path, "remove dir", |p| match fs::remove_dir(p) {
                 // Check for dir not empty on Windows
-                // FIXME: Once `ErrorKind::DirectoryNotEmpty` is stabilized,
-                // match on `e.kind()` instead.
                 #[cfg(windows)]
-                Err(e) if e.raw_os_error() == Some(145) => Ok(()),
+                Err(e) if e.kind() == ErrorKind::DirectoryNotEmpty => Ok(()),
                 r => r,
             });
         }

--- a/tests/run-make/thumb-none-qemu/rmake.rs
+++ b/tests/run-make/thumb-none-qemu/rmake.rs
@@ -27,7 +27,6 @@ fn main() {
     std::env::set_current_dir(CRATE).unwrap();
 
     let target_dir = path("target");
-    let manifest_path = path("Cargo.toml");
 
     // Debug
     cargo()

--- a/tests/ui/enum-discriminant/ptr_niche.rs
+++ b/tests/ui/enum-discriminant/ptr_niche.rs
@@ -1,0 +1,38 @@
+//@ run-pass
+//! Check that we can codegen setting and getting discriminants, including non-null niches,
+//! for enums with a pointer-like ABI. This used to crash llvm.
+
+#![feature(rustc_attrs)]
+use std::{ptr, mem};
+
+
+#[rustc_layout_scalar_valid_range_start(1)]
+#[rustc_layout_scalar_valid_range_end(100)]
+#[derive(Copy, Clone)]
+struct PointerWithRange(#[allow(dead_code)] *const u8);
+
+
+fn main() {
+    let val = unsafe { PointerWithRange(ptr::without_provenance(90)) };
+
+    let ptr = Some(val);
+    assert!(ptr.is_some());
+    let raw = unsafe { mem::transmute::<_, usize>(ptr) };
+    assert_eq!(raw, 90);
+
+    let ptr = Some(Some(val));
+    assert!(ptr.is_some());
+    assert!(ptr.unwrap().is_some());
+    let raw = unsafe { mem::transmute::<_, usize>(ptr) };
+    assert_eq!(raw, 90);
+
+    let ptr: Option<PointerWithRange> = None;
+    assert!(ptr.is_none());
+    let raw = unsafe { mem::transmute::<_, usize>(ptr) };
+    assert!(!(1..=100).contains(&raw));
+
+    let ptr: Option<Option<PointerWithRange>> = None;
+    assert!(ptr.is_none());
+    let raw = unsafe { mem::transmute::<_, usize>(ptr) };
+    assert!(!(1..=100).contains(&raw));
+}

--- a/tests/ui/structs-enums/type-sizes.rs
+++ b/tests/ui/structs-enums/type-sizes.rs
@@ -5,6 +5,7 @@
 #![allow(dead_code)]
 #![feature(never_type)]
 #![feature(pointer_is_aligned_to)]
+#![feature(rustc_attrs)]
 
 use std::mem::size_of;
 use std::num::NonZero;
@@ -237,6 +238,10 @@ struct VecDummy {
     len: usize,
 }
 
+#[rustc_layout_scalar_valid_range_start(1)]
+#[rustc_layout_scalar_valid_range_end(100)]
+struct PointerWithRange(#[allow(dead_code)] *const u8);
+
 pub fn main() {
     assert_eq!(size_of::<u8>(), 1 as usize);
     assert_eq!(size_of::<u32>(), 4 as usize);
@@ -354,4 +359,6 @@ pub fn main() {
     assert!(ptr::from_ref(&v.a).addr() > ptr::from_ref(&v.b).addr());
 
 
+    assert_eq!(size_of::<Option<PointerWithRange>>(), size_of::<PointerWithRange>());
+    assert_eq!(size_of::<Option<Option<PointerWithRange>>>(), size_of::<PointerWithRange>());
 }


### PR DESCRIPTION
Successful merges:

 - #131698 (use stores of the correct size to set discriminants)
 - #131784 (Stabilize unsigned and float variants of `num_midpoint` feature)
 - #133571 (Mark visionOS as supporting `std`)
 - #133655 (Eliminate print_expr_maybe_paren function from pretty printers)
 - #133667 (Remove unused code)
 - #133670 (bump hashbrown version)
 - #133673 (replace hard coded error id with `ErrorKind::DirectoryNotEmpty`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131698,131784,133571,133655,133667,133670,133673)
<!-- homu-ignore:end -->