### PR TITLE
Rollup of 6 pull requests

### DIFF
--- a/compiler/rustc_codegen_ssa/src/mir/place.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/place.rs
@@ -1,5 +1,6 @@
 use rustc_abi::Primitive::{Int, Pointer};
-use rustc_abi::{Align, FieldsShape, Size, TagEncoding, VariantIdx, Variants};
+use rustc_abi::{Align, BackendRepr, FieldsShape, Size, TagEncoding, VariantIdx, Variants};
+use rustc_middle::mir::interpret::Scalar;
 use rustc_middle::mir::tcx::PlaceTy;
 use rustc_middle::ty::layout::{HasTyCtxt, LayoutOf, TyAndLayout};
 use rustc_middle::ty::{self, Ty};
@@ -385,15 +386,22 @@ impl<'a, 'tcx, V: CodegenObject> PlaceRef<'tcx, V> {
                 if variant_index != untagged_variant {
                     let niche = self.project_field(bx, tag_field);
                     let niche_llty = bx.cx().immediate_backend_type(niche.layout);
+                    let BackendRepr::Scalar(scalar) = niche.layout.backend_repr else {
+                        bug!("expected a scalar placeref for the niche");
+                    };
+                    // We are supposed to compute `niche_value.wrapping_add(niche_start)` wrapping
+                    // around the `niche`'s type.
+                    // The easiest way to do that is to do wrapping arithmetic on `u128` and then
+                    // masking off any extra bits that occur because we did the arithmetic with too many bits.
                     let niche_value = variant_index.as_u32() - niche_variants.start().as_u32();
                     let niche_value = (niche_value as u128).wrapping_add(niche_start);
-                    // FIXME(eddyb): check the actual primitive type here.
-                    let niche_llval = if niche_value == 0 {
-                        // HACK(eddyb): using `c_null` as it works on all types.
-                        bx.cx().const_null(niche_llty)
-                    } else {
-                        bx.cx().const_uint_big(niche_llty, niche_value)
-                    };
+                    let niche_value = niche_value & niche.layout.size.unsigned_int_max();
+
+                    let niche_llval = bx.cx().scalar_to_backend(
+                        Scalar::from_uint(niche_value, niche.layout.size),
+                        scalar,
+                        niche_llty,
+                    );
                     OperandValue::Immediate(niche_llval).store(bx, niche);
                 }
             }

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos.rs
@@ -9,7 +9,7 @@ pub(crate) fn target() -> Target {
             description: Some("ARM64 Apple visionOS".into()),
             tier: Some(3),
             host_tools: Some(false),
-            std: Some(false),
+            std: Some(true),
         },
         pointer_width: 64,
         data_layout: "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos_sim.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_visionos_sim.rs
@@ -9,7 +9,7 @@ pub(crate) fn target() -> Target {
             description: Some("ARM64 Apple visionOS simulator".into()),
             tier: Some(3),
             host_tools: Some(false),
-            std: Some(false),
+            std: Some(true),
         },
         pointer_width: 64,
         data_layout: "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"

--- a/library/Cargo.lock
+++ b/library/Cargo.lock
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "compiler_builtins",

--- a/src/bootstrap/src/core/build_steps/clean.rs
+++ b/src/bootstrap/src/core/build_steps/clean.rs
@@ -203,10 +203,8 @@ fn rm_rf(path: &Path) {
 
             do_op(path, "remove dir", |p| match fs::remove_dir(p) {
                 // Check for dir not empty on Windows
-                // FIXME: Once `ErrorKind::DirectoryNotEmpty` is stabilized,
-                // match on `e.kind()` instead.
                 #[cfg(windows)]
-                Err(e) if e.raw_os_error() == Some(145) => Ok(()),
+                Err(e) if e.kind() == ErrorKind::DirectoryNotEmpty => Ok(()),
                 r => r,
             });
         }

--- a/tests/run-make/thumb-none-qemu/rmake.rs
+++ b/tests/run-make/thumb-none-qemu/rmake.rs
@@ -27,7 +27,6 @@ fn main() {
     std::env::set_current_dir(CRATE).unwrap();
 
     let target_dir = path("target");
-    let manifest_path = path("Cargo.toml");
 
     // Debug
     cargo()

--- a/tests/ui/enum-discriminant/ptr_niche.rs
+++ b/tests/ui/enum-discriminant/ptr_niche.rs
@@ -1,0 +1,38 @@
+//@ run-pass
+//! Check that we can codegen setting and getting discriminants, including non-null niches,
+//! for enums with a pointer-like ABI. This used to crash llvm.
+
+#![feature(rustc_attrs)]
+use std::{ptr, mem};
+
+
+#[rustc_layout_scalar_valid_range_start(1)]
+#[rustc_layout_scalar_valid_range_end(100)]
+#[derive(Copy, Clone)]
+struct PointerWithRange(#[allow(dead_code)] *const u8);
+
+
+fn main() {
+    let val = unsafe { PointerWithRange(ptr::without_provenance(90)) };
+
+    let ptr = Some(val);
+    assert!(ptr.is_some());
+    let raw = unsafe { mem::transmute::<_, usize>(ptr) };
+    assert_eq!(raw, 90);
+
+    let ptr = Some(Some(val));
+    assert!(ptr.is_some());
+    assert!(ptr.unwrap().is_some());
+    let raw = unsafe { mem::transmute::<_, usize>(ptr) };
+    assert_eq!(raw, 90);
+
+    let ptr: Option<PointerWithRange> = None;
+    assert!(ptr.is_none());
+    let raw = unsafe { mem::transmute::<_, usize>(ptr) };
+    assert!(!(1..=100).contains(&raw));
+
+    let ptr: Option<Option<PointerWithRange>> = None;
+    assert!(ptr.is_none());
+    let raw = unsafe { mem::transmute::<_, usize>(ptr) };
+    assert!(!(1..=100).contains(&raw));
+}

--- a/tests/ui/structs-enums/type-sizes.rs
+++ b/tests/ui/structs-enums/type-sizes.rs
@@ -5,6 +5,7 @@
 #![allow(dead_code)]
 #![feature(never_type)]
 #![feature(pointer_is_aligned_to)]
+#![feature(rustc_attrs)]
 
 use std::mem::size_of;
 use std::num::NonZero;
@@ -237,6 +238,10 @@ struct VecDummy {
     len: usize,
 }
 
+#[rustc_layout_scalar_valid_range_start(1)]
+#[rustc_layout_scalar_valid_range_end(100)]
+struct PointerWithRange(#[allow(dead_code)] *const u8);
+
 pub fn main() {
     assert_eq!(size_of::<u8>(), 1 as usize);
     assert_eq!(size_of::<u32>(), 4 as usize);
@@ -354,4 +359,6 @@ pub fn main() {
     assert!(ptr::from_ref(&v.a).addr() > ptr::from_ref(&v.b).addr());
 
 
+    assert_eq!(size_of::<Option<PointerWithRange>>(), size_of::<PointerWithRange>());
+    assert_eq!(size_of::<Option<Option<PointerWithRange>>>(), size_of::<PointerWithRange>());
 }


### PR DESCRIPTION
Successful merges:

 - #131698 (use stores of the correct size to set discriminants)
 - #133571 (Mark visionOS as supporting `std`)
 - #133655 (Eliminate print_expr_maybe_paren function from pretty printers)
 - #133667 (Remove unused code)
 - #133670 (bump hashbrown version)
 - #133673 (replace hard coded error id with `ErrorKind::DirectoryNotEmpty`)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=131698,133571,133655,133667,133670,133673)
<!-- homu-ignore:end -->