### PR TITLE
Add diagnostic item for `std::ops::ControlFlow`

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -182,6 +182,7 @@ symbols! {
         ConstParamTy_,
         Context,
         Continue,
+        ControlFlow,
         Copy,
         Cow,
         Debug,

--- a/library/core/src/ops/control_flow.rs
+++ b/library/core/src/ops/control_flow.rs
@@ -79,6 +79,7 @@ use crate::{convert, ops};
 /// [`Break`]: ControlFlow::Break
 /// [`Continue`]: ControlFlow::Continue
 #[stable(feature = "control_flow_enum_type", since = "1.55.0")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "ControlFlow")]
 // ControlFlow should not implement PartialOrd or Ord, per RFC 3058:
 // https://rust-lang.github.io/rfcs/3058-try-trait-v2.html#traits-for-controlflow
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
This will be used in Clippy to detect useless conversions done through `ControlFlow::map_break()` and `ControlFlow::map_continue()`.

