### PR TITLE
Check let source before suggesting annotation

### DIFF
--- a/compiler/rustc_hir_typeck/src/fallback.rs
+++ b/compiler/rustc_hir_typeck/src/fallback.rs
@@ -705,7 +705,8 @@ impl<'tcx> Visitor<'tcx> for AnnotateUnitFallbackVisitor<'_, 'tcx> {
 
     fn visit_local(&mut self, local: &'tcx hir::LetStmt<'tcx>) -> Self::Result {
         // For a local, try suggest annotating the type if it's missing.
-        if let None = local.ty
+        if let hir::LocalSource::Normal = local.source
+            && let None = local.ty
             && let Some(ty) = self.fcx.typeck_results.borrow().node_type_opt(local.hir_id)
             && let Some(vid) = self.fcx.root_vid(ty)
             && self.reachable_vids.contains(&vid)

--- a/tests/ui/never_type/lint-breaking-2024-assign-underscore.fixed
+++ b/tests/ui/never_type/lint-breaking-2024-assign-underscore.fixed
@@ -1,0 +1,17 @@
+//@ run-rustfix
+
+#![allow(unused)]
+#![deny(dependency_on_unit_never_type_fallback)]
+
+fn foo<T: Default>() -> Result<T, ()> {
+    Err(())
+}
+
+fn test() -> Result<(), ()> {
+    //~^ ERROR this function depends on never type fallback being `()`
+    //~| WARN this was previously accepted by the compiler but is being phased out
+    _ = foo::<()>()?;
+    Ok(())
+}
+
+fn main() {}

--- a/tests/ui/never_type/lint-breaking-2024-assign-underscore.rs
+++ b/tests/ui/never_type/lint-breaking-2024-assign-underscore.rs
@@ -1,0 +1,17 @@
+//@ run-rustfix
+
+#![allow(unused)]
+#![deny(dependency_on_unit_never_type_fallback)]
+
+fn foo<T: Default>() -> Result<T, ()> {
+    Err(())
+}
+
+fn test() -> Result<(), ()> {
+    //~^ ERROR this function depends on never type fallback being `()`
+    //~| WARN this was previously accepted by the compiler but is being phased out
+    _ = foo()?;
+    Ok(())
+}
+
+fn main() {}

--- a/tests/ui/never_type/lint-breaking-2024-assign-underscore.stderr
+++ b/tests/ui/never_type/lint-breaking-2024-assign-underscore.stderr
@@ -1,0 +1,26 @@
+error: this function depends on never type fallback being `()`
+  --> $DIR/lint-breaking-2024-assign-underscore.rs:10:1
+   |
+LL | fn test() -> Result<(), ()> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
+   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = help: specify the types explicitly
+note: in edition 2024, the requirement `!: Default` will fail
+  --> $DIR/lint-breaking-2024-assign-underscore.rs:13:9
+   |
+LL |     _ = foo()?;
+   |         ^^^^^
+note: the lint level is defined here
+  --> $DIR/lint-breaking-2024-assign-underscore.rs:4:9
+   |
+LL | #![deny(dependency_on_unit_never_type_fallback)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+help: use `()` annotations to avoid fallback changes
+   |
+LL |     _ = foo::<()>()?;
+   |            ++++++
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Make sure we don't annotate nonsense type annotations on locals that come from desugarings.

fixes #133688