### PR TITLE
const-eval: detect more pointers as definitely not-null

### DIFF
--- a/tests/ui/consts/const-ptr-is-null.rs
+++ b/tests/ui/consts/const-ptr-is-null.rs
@@ -12,7 +12,13 @@ const MAYBE_NULL: () = {
     let ptr = &x as *const i32;
     // This one is still unambiguous...
     assert!(!ptr.is_null());
-    // but once we shift outside the allocation, we might become null.
+    // and in fact, any offset not visible by 4 (the alignment) cannot be null,
+    // even if it goes out-of-bounds...
+    assert!(!ptr.wrapping_byte_add(13).is_null());
+    assert!(!ptr.wrapping_byte_add(18).is_null());
+    assert!(!ptr.wrapping_byte_sub(1).is_null());
+    // ... but once we shift outside the allocation, with an offset divisible by 4,
+    // we might become null.
     assert!(!ptr.wrapping_sub(512).is_null()); //~inside `MAYBE_NULL`
 };
 

--- a/tests/ui/consts/const-ptr-is-null.stderr
+++ b/tests/ui/consts/const-ptr-is-null.stderr
@@ -8,7 +8,7 @@ note: inside `std::ptr::const_ptr::<impl *const T>::is_null::compiletime`
 note: inside `std::ptr::const_ptr::<impl *const i32>::is_null`
   --> $SRC_DIR/core/src/ptr/const_ptr.rs:LL:COL
 note: inside `MAYBE_NULL`
-  --> $DIR/const-ptr-is-null.rs:16:14
+  --> $DIR/const-ptr-is-null.rs:22:14
    |
 LL |     assert!(!ptr.wrapping_sub(512).is_null());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This fixes https://github.com/rust-lang/rust/issues/133523 by making the `scalar_may_be_null` check smarter: for instance, an odd offset in any 2-aligned allocation can never be null, even if it is out-of-bounds.

More generally, if an allocation with unknown base address B is aligned to alignment N, and a pointer is at offset X inside that allocation, then we know that `(B + X) mod N = B mod N + X mod N = X mod N`. Since `0 mod N` is definitely 0, if we learn that `X mod N` is *not* 0 we can deduce that `B + X` is not 0.

This is immediately visible on stable, via `ptr.is_null()` (and, more subtly, by not raising a UB error when such a pointer is used somewhere that a non-null pointer is required). Therefore nominating for @rust-lang/lang.