### PR TITLE
fix ICE when promoted has layout size overflow

### DIFF
--- a/tests/crashes/125476.rs
+++ b/tests/crashes/125476.rs
@@ -1,4 +1,0 @@
-//@ known-bug: rust-lang/rust#125476
-//@ only-x86_64
-pub struct Data([u8; usize::MAX >> 2]);
-const _: &'static [Data] = &[];

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
@@ -72,6 +72,20 @@ help: add `#![feature(adt_const_params)]` to the crate attributes to enable more
 LL + #![feature(adt_const_params)]
    |
 
+note: erroneous constant encountered
+  --> $DIR/unevaluated-const-ice-119731.rs:22:19
+   |
+LL |     impl v17<512, v0> {
+   |                   ^^
+
+note: erroneous constant encountered
+  --> $DIR/unevaluated-const-ice-119731.rs:22:19
+   |
+LL |     impl v17<512, v0> {
+   |                   ^^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#0}
   --> $DIR/unevaluated-const-ice-119731.rs:28:37
    |

--- a/tests/ui/consts/const-integer-bool-ops.stderr
+++ b/tests/ui/consts/const-integer-bool-ops.stderr
@@ -16,6 +16,12 @@ error[E0308]: mismatched types
 LL | const X: usize = 42 && 39;
    |                  ^^^^^^^^ expected `usize`, found `bool`
 
+note: erroneous constant encountered
+  --> $DIR/const-integer-bool-ops.rs:8:18
+   |
+LL | const ARR: [i32; X] = [99; 34];
+   |                  ^
+
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:10:19
    |
@@ -33,6 +39,12 @@ error[E0308]: mismatched types
    |
 LL | const X1: usize = 42 || 39;
    |                   ^^^^^^^^ expected `usize`, found `bool`
+
+note: erroneous constant encountered
+  --> $DIR/const-integer-bool-ops.rs:17:19
+   |
+LL | const ARR1: [i32; X1] = [99; 47];
+   |                   ^^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:19:19
@@ -52,6 +64,12 @@ error[E0308]: mismatched types
 LL | const X2: usize = -42 || -39;
    |                   ^^^^^^^^^^ expected `usize`, found `bool`
 
+note: erroneous constant encountered
+  --> $DIR/const-integer-bool-ops.rs:26:19
+   |
+LL | const ARR2: [i32; X2] = [99; 18446744073709551607];
+   |                   ^^
+
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:28:19
    |
@@ -70,11 +88,23 @@ error[E0308]: mismatched types
 LL | const X3: usize = -42 && -39;
    |                   ^^^^^^^^^^ expected `usize`, found `bool`
 
+note: erroneous constant encountered
+  --> $DIR/const-integer-bool-ops.rs:35:19
+   |
+LL | const ARR3: [i32; X3] = [99; 6];
+   |                   ^^
+
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:37:18
    |
 LL | const Y: usize = 42.0 == 42.0;
    |                  ^^^^^^^^^^^^ expected `usize`, found `bool`
+
+note: erroneous constant encountered
+  --> $DIR/const-integer-bool-ops.rs:40:19
+   |
+LL | const ARRR: [i32; Y] = [99; 1];
+   |                   ^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:42:19
@@ -82,11 +112,23 @@ error[E0308]: mismatched types
 LL | const Y1: usize = 42.0 >= 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
 
+note: erroneous constant encountered
+  --> $DIR/const-integer-bool-ops.rs:45:20
+   |
+LL | const ARRR1: [i32; Y1] = [99; 1];
+   |                    ^^
+
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:47:19
    |
 LL | const Y2: usize = 42.0 <= 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
+
+note: erroneous constant encountered
+  --> $DIR/const-integer-bool-ops.rs:50:20
+   |
+LL | const ARRR2: [i32; Y2] = [99; 1];
+   |                    ^^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:52:19
@@ -94,17 +136,35 @@ error[E0308]: mismatched types
 LL | const Y3: usize = 42.0 > 42.0;
    |                   ^^^^^^^^^^^ expected `usize`, found `bool`
 
+note: erroneous constant encountered
+  --> $DIR/const-integer-bool-ops.rs:55:20
+   |
+LL | const ARRR3: [i32; Y3] = [99; 0];
+   |                    ^^
+
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:57:19
    |
 LL | const Y4: usize = 42.0 < 42.0;
    |                   ^^^^^^^^^^^ expected `usize`, found `bool`
 
+note: erroneous constant encountered
+  --> $DIR/const-integer-bool-ops.rs:60:20
+   |
+LL | const ARRR4: [i32; Y4] = [99; 0];
+   |                    ^^
+
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:62:19
    |
 LL | const Y5: usize = 42.0 != 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
+
+note: erroneous constant encountered
+  --> $DIR/const-integer-bool-ops.rs:65:20
+   |
+LL | const ARRR5: [i32; Y5] = [99; 0];
+   |                    ^^
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/consts/const-mut-refs/issue-76510.stderr
+++ b/tests/ui/consts/const-mut-refs/issue-76510.stderr
@@ -4,6 +4,12 @@ error[E0764]: mutable references are not allowed in the final value of constants
 LL | const S: &'static mut str = &mut " hello ";
    |                             ^^^^^^^^^^^^^^
 
+note: erroneous constant encountered
+  --> $DIR/issue-76510.rs:7:70
+   |
+LL |         let s = transmute::<(*const u8, usize), &ManuallyDrop<str>>((S.as_ptr(), 3));
+   |                                                                      ^
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0764`.

--- a/tests/ui/consts/const-tup-index-span.stderr
+++ b/tests/ui/consts/const-tup-index-span.stderr
@@ -11,6 +11,12 @@ help: use a trailing comma to create a tuple with one element
 LL | const TUP: (usize,) = (5usize << 64,);
    |                       +            ++
 
+note: erroneous constant encountered
+  --> $DIR/const-tup-index-span.rs:6:18
+   |
+LL | const ARR: [i32; TUP.0] = [];
+   |                  ^^^
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/consts/issue-54954.stderr
+++ b/tests/ui/consts/issue-54954.stderr
@@ -19,6 +19,24 @@ LL | |         core::mem::size_of::<T>()
 LL | |     }
    | |_____- `Tt::const_val` defined here
 
+note: erroneous constant encountered
+  --> $DIR/issue-54954.rs:11:15
+   |
+LL | fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
+   |               ^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/issue-54954.rs:11:34
+   |
+LL | fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
+   |                                  ^^^^^^^
+
+note: erroneous constant encountered
+  --> $DIR/issue-54954.rs:16:22
+   |
+LL |     let _ = f([1f32; ARR_LEN]);
+   |                      ^^^^^^^
+
 error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0379, E0790.

--- a/tests/ui/consts/missing_assoc_const_type2.stderr
+++ b/tests/ui/consts/missing_assoc_const_type2.stderr
@@ -4,5 +4,11 @@ error: missing type for `const` item
 LL |     const FIRST:  = 10;
    |                 ^ help: provide a type for the associated constant: `u8`
 
+note: erroneous constant encountered
+  --> $DIR/missing_assoc_const_type2.rs:18:5
+   |
+LL |     TwoDigits::FIRST as usize
+   |     ^^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/promoted_running_out_of_memory_issue-130687.stderr
+++ b/tests/ui/consts/promoted_running_out_of_memory_issue-130687.stderr
@@ -4,12 +4,6 @@ error[E0080]: evaluation of constant value failed
 LL | const _: &'static Data = &Data([0; (1 << 47) - 1]);
    |                                ^^^^^^^^^^^^^^^^^^ tried to allocate more memory than available to compiler
 
-note: erroneous constant encountered
-  --> $DIR/promoted_running_out_of_memory_issue-130687.rs:8:26
-   |
-LL | const _: &'static Data = &Data([0; (1 << 47) - 1]);
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^
-
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/promoted_size_overflow.rs
+++ b/tests/ui/consts/promoted_size_overflow.rs
@@ -1,0 +1,7 @@
+//@ only-64bit
+pub struct Data([u8; usize::MAX >> 2]);
+const _: &'static [Data] = &[];
+//~^ERROR: evaluation of constant value failed
+//~| too big for the target architecture
+
+fn main() {}

--- a/tests/ui/consts/promoted_size_overflow.stderr
+++ b/tests/ui/consts/promoted_size_overflow.stderr
@@ -1,0 +1,9 @@
+error[E0080]: evaluation of constant value failed
+  --> $DIR/promoted_size_overflow.rs:3:29
+   |
+LL | const _: &'static [Data] = &[];
+   |                             ^^ values of the type `[u8; 4611686018427387903]` are too big for the target architecture
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/consts/uninhabited-const-issue-61744.rs
+++ b/tests/ui/consts/uninhabited-const-issue-61744.rs
@@ -5,15 +5,15 @@ pub const unsafe fn fake_type<T>() -> T {
 }
 
 pub const unsafe fn hint_unreachable() -> ! {
-    fake_type()
+    fake_type() //~ inside
 }
 
 trait Const {
-    const CONSTANT: i32 = unsafe { fake_type() };
+    const CONSTANT: i32 = unsafe { fake_type() }; //~ inside
 }
 
 impl<T> Const for T {}
 
 pub fn main() -> () {
-    dbg!(i32::CONSTANT); //~ constant
+    dbg!(i32::CONSTANT);
 }

--- a/tests/ui/consts/uninhabited-const-issue-61744.stderr
+++ b/tests/ui/consts/uninhabited-const-issue-61744.stderr
@@ -645,20 +645,6 @@ note: inside `<i32 as Const>::CONSTANT`
 LL |     const CONSTANT: i32 = unsafe { fake_type() };
    |                                    ^^^^^^^^^^^
 
-note: erroneous constant encountered
-  --> $DIR/uninhabited-const-issue-61744.rs:18:10
-   |
-LL |     dbg!(i32::CONSTANT);
-   |          ^^^^^^^^^^^^^
-
-note: erroneous constant encountered
-  --> $DIR/uninhabited-const-issue-61744.rs:18:10
-   |
-LL |     dbg!(i32::CONSTANT);
-   |          ^^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/enum-discriminant/issue-41394.stderr
+++ b/tests/ui/enum-discriminant/issue-41394.stderr
@@ -6,6 +6,12 @@ LL |     A = "" + 1
    |         |
    |         &str
 
+note: erroneous constant encountered
+  --> $DIR/issue-41394.rs:7:9
+   |
+LL |     A = Foo::A as isize
+   |         ^^^^^^^^^^^^^^^
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0369`.

--- a/tests/ui/explicit-tail-calls/ctfe-id-unlimited.return.stderr
+++ b/tests/ui/explicit-tail-calls/ctfe-id-unlimited.return.stderr
@@ -25,12 +25,6 @@ note: inside `ID_ED`
 LL | const ID_ED: u32 = rec_id(ORIGINAL);
    |                    ^^^^^^^^^^^^^^^^
 
-note: erroneous constant encountered
-  --> $DIR/ctfe-id-unlimited.rs:31:40
-   |
-LL | const ASSERT: () = assert!(ORIGINAL == ID_ED);
-   |                                        ^^^^^
-
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/layout/base-layout-is-sized-ice-123078.stderr
+++ b/tests/ui/layout/base-layout-is-sized-ice-123078.stderr
@@ -25,6 +25,12 @@ LL | const C: S = unsafe { std::mem::transmute(()) };
    = note: source type: `()` (0 bits)
    = note: target type: `S` (size can vary because of [u8])
 
+note: erroneous constant encountered
+  --> $DIR/base-layout-is-sized-ice-123078.rs:13:5
+   |
+LL |     C;
+   |     ^
+
 error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0277, E0512.

--- a/tests/ui/limits/issue-55878.stderr
+++ b/tests/ui/limits/issue-55878.stderr
@@ -11,23 +11,6 @@ note: inside `main`
 LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
    |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-note: erroneous constant encountered
-  --> $DIR/issue-55878.rs:7:26
-   |
-LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-note: erroneous constant encountered
-  --> $DIR/issue-55878.rs:7:26
-   |
-LL |     println!("Size: {}", std::mem::size_of::<[u8; u64::MAX as usize]>());
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-   = note: this note originates in the macro `$crate::format_args_nl` which comes from the expansion of the macro `println` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0080`.

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
@@ -29,6 +29,20 @@ LL |     const _: u32 = T::C;
    |
    = note: a `const` is a separate item from the item that contains it
 
+note: erroneous constant encountered
+  --> $DIR/generic-params-from-outer-item-in-const-item.rs:22:9
+   |
+LL |         I
+   |         ^
+
+note: erroneous constant encountered
+  --> $DIR/generic-params-from-outer-item-in-const-item.rs:22:9
+   |
+LL |         I
+   |         ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0401`.

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
@@ -35,6 +35,20 @@ LL |     const _: u32 = T::C;
    |
    = note: a `const` is a separate item from the item that contains it
 
+note: erroneous constant encountered
+  --> $DIR/generic-params-from-outer-item-in-const-item.rs:22:9
+   |
+LL |         I
+   |         ^
+
+note: erroneous constant encountered
+  --> $DIR/generic-params-from-outer-item-in-const-item.rs:22:9
+   |
+LL |         I
+   |         ^
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
 error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0401`.

--- a/tests/ui/resolve/issue-50599.stderr
+++ b/tests/ui/resolve/issue-50599.stderr
@@ -20,6 +20,12 @@ LL -     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize;
 LL +     const M: usize = (f64::from(N) * LOG10_2) as usize;
    |
 
+note: erroneous constant encountered
+  --> $DIR/issue-50599.rs:4:29
+   |
+LL |     let mut digits = [0u32; M];
+   |                             ^
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.stderr
@@ -6,5 +6,11 @@ LL |     !let y = 42;
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
+note: erroneous constant encountered
+  --> $DIR/avoid-invalid-mir.rs:11:13
+   |
+LL |     x: [(); N]
+   |             ^
+
 error: aborting due to 1 previous error
 

--- a/tests/ui/self/arbitrary-self-from-method-substs-ice.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs-ice.stderr
@@ -17,6 +17,12 @@ LL |     const fn get<R: Deref<Target = Self>>(self: R) -> u32 {
 LL |     }
    |     - value is dropped here
 
+note: erroneous constant encountered
+  --> $DIR/arbitrary-self-from-method-substs-ice.rs:24:5
+   |
+LL |     FOO;
+   |     ^^^
+
 error[E0801]: invalid generic `self` parameter type: `R`
   --> $DIR/arbitrary-self-from-method-substs-ice.rs:10:49
    |

--- a/tests/ui/type/type-dependent-def-issue-49241.stderr
+++ b/tests/ui/type/type-dependent-def-issue-49241.stderr
@@ -9,6 +9,12 @@ help: consider using `let` instead of `const`
 LL |     let l: usize = v.count();
    |     ~~~
 
+note: erroneous constant encountered
+  --> $DIR/type-dependent-def-issue-49241.rs:4:18
+   |
+LL |     let s: [u32; l] = v.into_iter().collect();
+   |                  ^
+
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0435`.


### PR DESCRIPTION
Turns out there is no reason to distinguish `tainted_by_errors` and `can_be_spurious` here, we can just track whether we allow this even in "infallible" constants.

Fixes https://github.com/rust-lang/rust/issues/125476