### PR TITLE
Impl From<Peekable> for Iterator

### DIFF
--- a/library/core/src/iter/adapters/peekable.rs
+++ b/library/core/src/iter/adapters/peekable.rs
@@ -8,7 +8,7 @@ use crate::ops::{ControlFlow, Try};
 /// This `struct` is created by the [`peekable`] method on [`Iterator`]. See its
 /// documentation for more.
 /// 
-/// `Peakable` has a implementation: `impl<I: Interator> From<Peekable<I>> for I`, use `I::from()` can get back to [`Iterator`].
+/// `Peakable` has an implementation: `impl<I: Interator> From<Peekable<I>> for I`, use `I::from()` can get back to [`Iterator`].
 /// ```rust
 /// struct Counter {
 ///     v: usize,
@@ -27,7 +27,7 @@ use crate::ops::{ControlFlow, Try};
 /// let counter = Counter { v: 0 };
 /// let mut peekable = counter.peekable();
 /// assert_eq!(peekable.peek(), Some(&0));
-/// let counter: Counter = Counter::from(peekable);
+/// let counter = Counter::from(peekable);
 /// assert_eq!(counter.next(), Some(0));
 /// ```
 ///
@@ -49,7 +49,7 @@ impl<I: Iterator> Peekable<I> {
     }
 }
 
-impl<I: Interator> From<Peekable<I>> for I {
+impl<I: Iterator> From<Peekable<I>> for I {
     fn from(p: Peekable<I>) -> Self {
         p.iter
     }

--- a/library/core/src/iter/adapters/peekable.rs
+++ b/library/core/src/iter/adapters/peekable.rs
@@ -7,6 +7,29 @@ use crate::ops::{ControlFlow, Try};
 ///
 /// This `struct` is created by the [`peekable`] method on [`Iterator`]. See its
 /// documentation for more.
+/// 
+/// `Peakable` has a implementation: `impl<I: Interator> From<Peekable<I>> for I`, use `I::from()` can get back to [`Iterator`].
+/// ```rust
+/// struct Counter {
+///     v: usize,
+/// }
+///
+/// impl Iterator for Counter {
+///     type Item = usize;
+///
+///     fn next(&mut self) -> Option<Self::Item> {
+///         let v = self.v;
+///         self.v += 1;
+///         Some(v)
+///     }
+/// }
+///
+/// let counter = Counter { v: 0 };
+/// let mut peekable = counter.peekable();
+/// assert_eq!(peekable.peek(), Some(&0));
+/// let counter: Counter = Counter::from(peekable);
+/// assert_eq!(counter.next(), Some(0));
+/// ```
 ///
 /// [`peekable`]: Iterator::peekable
 /// [`Iterator`]: trait.Iterator.html
@@ -23,6 +46,12 @@ pub struct Peekable<I: Iterator> {
 impl<I: Iterator> Peekable<I> {
     pub(in crate::iter) fn new(iter: I) -> Peekable<I> {
         Peekable { iter, peeked: None }
+    }
+}
+
+impl<I: Interator> From<Peekable<I>> for I {
+    fn from(p: Peekable<I>) -> Self {
+        p.iter
     }
 }
 


### PR DESCRIPTION
Currently, we have no way to get back to origin Iterator after call `peekable()`,
this PR impl `From<Peekable<I>>` trait for Iterator.