### PR TITLE
rustdoc-json: Include safety of `static`s

### DIFF
--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -30,7 +30,7 @@ pub type FxHashMap<K, V> = HashMap<K, V>; // re-export for use in src/librustdoc
 /// This integer is incremented with every breaking change to the API,
 /// and is returned along with the JSON blob as [`Crate::format_version`].
 /// Consuming code should assert that this value matches the format version(s) that it supports.
-pub const FORMAT_VERSION: u32 = 36;
+pub const FORMAT_VERSION: u32 = 37;
 
 /// The root of the emitted JSON blob.
 ///
@@ -1238,6 +1238,22 @@ pub struct Static {
     ///
     /// It's not guaranteed that it'll match the actual source code for the initial value.
     pub expr: String,
+
+    /// Is the static `unsafe`?
+    ///
+    /// This is only true if it's in an `extern` block, and not explicity marked
+    /// as `safe`.
+    ///
+    /// ```rust
+    /// unsafe extern {
+    ///     static A: i32;      // unsafe
+    ///     safe static B: i32; // safe
+    /// }
+    ///
+    /// static C: i32 = 0;     // safe
+    /// static mut D: i32 = 0; // safe
+    /// ```
+    pub is_unsafe: bool,
 }
 
 /// A primitive type declaration. Declarations of this kind can only come from the core library.

--- a/tests/rustdoc-json/statics/extern.rs
+++ b/tests/rustdoc-json/statics/extern.rs
@@ -1,0 +1,39 @@
+// ignore-tidy-linelength
+//@ edition: 2021
+
+extern "C" {
+    //@ is '$.index[*][?(@.name=="A")].inner.static.is_unsafe'  true
+    //@ is '$.index[*][?(@.name=="A")].inner.static.is_mutable' false
+    pub static A: i32;
+    //@ is '$.index[*][?(@.name=="B")].inner.static.is_unsafe'  true
+    //@ is '$.index[*][?(@.name=="B")].inner.static.is_mutable' true
+    pub static mut B: i32;
+
+    // items in unadorned `extern` blocks cannot have safety qualifiers
+}
+
+unsafe extern "C" {
+    //@ is '$.index[*][?(@.name=="C")].inner.static.is_unsafe'  true
+    //@ is '$.index[*][?(@.name=="C")].inner.static.is_mutable' false
+    pub static C: i32;
+    //@ is '$.index[*][?(@.name=="D")].inner.static.is_unsafe'  true
+    //@ is '$.index[*][?(@.name=="D")].inner.static.is_mutable' true
+    pub static mut D: i32;
+
+    //@ is '$.index[*][?(@.name=="E")].inner.static.is_unsafe'  false
+    //@ is '$.index[*][?(@.name=="E")].inner.static.is_mutable' false
+    pub safe static E: i32;
+    //@ is '$.index[*][?(@.name=="F")].inner.static.is_unsafe'  false
+    //@ is '$.index[*][?(@.name=="F")].inner.static.is_mutable' true
+    pub safe static mut F: i32;
+
+    //@ is '$.index[*][?(@.name=="G")].inner.static.is_unsafe'  true
+    //@ is '$.index[*][?(@.name=="G")].inner.static.is_mutable' false
+    pub unsafe static G: i32;
+    //@ is '$.index[*][?(@.name=="H")].inner.static.is_unsafe'  true
+    //@ is '$.index[*][?(@.name=="H")].inner.static.is_mutable' true
+    pub unsafe static mut H: i32;
+}
+
+//@ ismany '$.index[*][?(@.inner.static)].inner.static.expr' '""' '""' '""' '""' '""' '""' '""' '""'
+//@ ismany '$.index[*][?(@.inner.static)].inner.static.type.primitive' '"i32"' '"i32"' '"i32"' '"i32"' '"i32"' '"i32"' '"i32"' '"i32"'

--- a/tests/rustdoc-json/statics/statics.rs
+++ b/tests/rustdoc-json/statics/statics.rs
@@ -1,10 +1,12 @@
 //@ is '$.index[*][?(@.name=="A")].inner.static.type.primitive' '"i32"'
 //@ is '$.index[*][?(@.name=="A")].inner.static.is_mutable' false
 //@ is '$.index[*][?(@.name=="A")].inner.static.expr' '"5"'
+//@ is '$.index[*][?(@.name=="A")].inner.static.is_unsafe' false
 pub static A: i32 = 5;
 
 //@ is '$.index[*][?(@.name=="B")].inner.static.type.primitive' '"u32"'
 //@ is '$.index[*][?(@.name=="B")].inner.static.is_mutable' true
 // Expr value isn't gaurenteed, it'd be fine to change it.
 //@ is '$.index[*][?(@.name=="B")].inner.static.expr' '"_"'
+//@ is '$.index[*][?(@.name=="B")].inner.static.is_unsafe' false
 pub static mut B: u32 = 2 + 3;

--- a/tests/rustdoc-json/statics/statics.rs
+++ b/tests/rustdoc-json/statics/statics.rs
@@ -1,0 +1,10 @@
+//@ is '$.index[*][?(@.name=="A")].inner.static.type.primitive' '"i32"'
+//@ is '$.index[*][?(@.name=="A")].inner.static.is_mutable' false
+//@ is '$.index[*][?(@.name=="A")].inner.static.expr' '"5"'
+pub static A: i32 = 5;
+
+//@ is '$.index[*][?(@.name=="B")].inner.static.type.primitive' '"u32"'
+//@ is '$.index[*][?(@.name=="B")].inner.static.is_mutable' true
+// Expr value isn't gaurenteed, it'd be fine to change it.
+//@ is '$.index[*][?(@.name=="B")].inner.static.expr' '"_"'
+pub static mut B: u32 = 2 + 3;


### PR DESCRIPTION
`static`s in an `extern` block can have an associated safety annotation ["because there is nothing guaranteeing that the bit pattern at the static’s memory is valid for the type it is declared with"](https://doc.rust-lang.org/reference/items/external-blocks.html#statics). Rustdoc already knows this and displays in for HTML. This PR also includes it in JSON.

Inspired by https://github.com/obi1kenobi/cargo-semver-checks/issues/975 which needs this, but it's probably useful in other places.

r? @GuillaumeGomez. Possibly easier to review commit-by-commit.