### PR TITLE
[cfg_match] Adjust syntax

### DIFF
--- a/compiler/rustc_data_structures/src/flock.rs
+++ b/compiler/rustc_data_structures/src/flock.rs
@@ -4,6 +4,7 @@
 //! green/native threading. This is just a bare-bones enough solution for
 //! librustdoc, it is not production quality at all.
 
+#[cfg(bootstrap)]
 cfg_match! {
     cfg(target_os = "linux") => {
         mod linux;
@@ -18,6 +19,30 @@ cfg_match! {
         use unix as imp;
     }
     cfg(windows) => {
+        mod windows;
+        use self::windows as imp;
+    }
+    _ => {
+        mod unsupported;
+        use unsupported as imp;
+    }
+}
+
+#[cfg(not(bootstrap))]
+cfg_match! {
+    target_os = "linux" => {
+        mod linux;
+        use linux as imp;
+    }
+    target_os = "redox" => {
+        mod linux;
+        use linux as imp;
+    }
+    unix => {
+        mod unix;
+        use unix as imp;
+    }
+    windows => {
         mod windows;
         use self::windows as imp;
     }

--- a/compiler/rustc_data_structures/src/profiling.rs
+++ b/compiler/rustc_data_structures/src/profiling.rs
@@ -860,6 +860,7 @@ fn get_thread_id() -> u32 {
 }
 
 // Memory reporting
+#[cfg(bootstrap)]
 cfg_match! {
     cfg(windows) => {
         pub fn get_resident_set_size() -> Option<usize> {
@@ -905,6 +906,68 @@ cfg_match! {
         }
     }
     cfg(unix) => {
+        pub fn get_resident_set_size() -> Option<usize> {
+            let field = 1;
+            let contents = fs::read("/proc/self/statm").ok()?;
+            let contents = String::from_utf8(contents).ok()?;
+            let s = contents.split_whitespace().nth(field)?;
+            let npages = s.parse::<usize>().ok()?;
+            Some(npages * 4096)
+        }
+    }
+    _ => {
+        pub fn get_resident_set_size() -> Option<usize> {
+            None
+        }
+    }
+}
+
+#[cfg(not(bootstrap))]
+cfg_match! {
+    windows => {
+        pub fn get_resident_set_size() -> Option<usize> {
+            use std::mem;
+
+            use windows::{
+                Win32::System::ProcessStatus::{K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS},
+                Win32::System::Threading::GetCurrentProcess,
+            };
+
+            let mut pmc = PROCESS_MEMORY_COUNTERS::default();
+            let pmc_size = mem::size_of_val(&pmc);
+            unsafe {
+                K32GetProcessMemoryInfo(
+                    GetCurrentProcess(),
+                    &mut pmc,
+                    pmc_size as u32,
+                )
+            }
+            .ok()
+            .ok()?;
+
+            Some(pmc.WorkingSetSize)
+        }
+    }
+    target_os = "macos" => {
+        pub fn get_resident_set_size() -> Option<usize> {
+            use libc::{c_int, c_void, getpid, proc_pidinfo, proc_taskinfo, PROC_PIDTASKINFO};
+            use std::mem;
+            const PROC_TASKINFO_SIZE: c_int = mem::size_of::<proc_taskinfo>() as c_int;
+
+            unsafe {
+                let mut info: proc_taskinfo = mem::zeroed();
+                let info_ptr = &mut info as *mut proc_taskinfo as *mut c_void;
+                let pid = getpid() as c_int;
+                let ret = proc_pidinfo(pid, PROC_PIDTASKINFO, 0, info_ptr, PROC_TASKINFO_SIZE);
+                if ret == PROC_TASKINFO_SIZE {
+                    Some(info.pti_resident_size as usize)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+    unix => {
         pub fn get_resident_set_size() -> Option<usize> {
             let field = 1;
             let contents = fs::read("/proc/self/statm").ok()?;

--- a/compiler/rustc_span/src/analyze_source_file.rs
+++ b/compiler/rustc_span/src/analyze_source_file.rs
@@ -29,6 +29,7 @@ pub(crate) fn analyze_source_file(src: &str) -> (Vec<RelativeBytePos>, Vec<Multi
     (lines, multi_byte_chars)
 }
 
+#[cfg(bootstrap)]
 cfg_match! {
     cfg(any(target_arch = "x86", target_arch = "x86_64")) => {
         fn analyze_source_file_dispatch(
@@ -185,6 +186,165 @@ cfg_match! {
         }
     }
 }
+
+#[cfg(not(bootstrap))]
+cfg_match! {
+    any(target_arch = "x86", target_arch = "x86_64") => {
+        fn analyze_source_file_dispatch(
+            src: &str,
+            lines: &mut Vec<RelativeBytePos>,
+            multi_byte_chars: &mut Vec<MultiByteChar>,
+        ) {
+            if is_x86_feature_detected!("sse2") {
+                unsafe {
+                    analyze_source_file_sse2(src, lines, multi_byte_chars);
+                }
+            } else {
+                analyze_source_file_generic(
+                    src,
+                    src.len(),
+                    RelativeBytePos::from_u32(0),
+                    lines,
+                    multi_byte_chars,
+                );
+            }
+        }
+
+        /// Checks 16 byte chunks of text at a time. If the chunk contains
+        /// something other than printable ASCII characters and newlines, the
+        /// function falls back to the generic implementation. Otherwise it uses
+        /// SSE2 intrinsics to quickly find all newlines.
+        #[target_feature(enable = "sse2")]
+        unsafe fn analyze_source_file_sse2(
+            src: &str,
+            lines: &mut Vec<RelativeBytePos>,
+            multi_byte_chars: &mut Vec<MultiByteChar>,
+        ) {
+            #[cfg(target_arch = "x86")]
+            use std::arch::x86::*;
+            #[cfg(target_arch = "x86_64")]
+            use std::arch::x86_64::*;
+
+            const CHUNK_SIZE: usize = 16;
+
+            let src_bytes = src.as_bytes();
+
+            let chunk_count = src.len() / CHUNK_SIZE;
+
+            // This variable keeps track of where we should start decoding a
+            // chunk. If a multi-byte character spans across chunk boundaries,
+            // we need to skip that part in the next chunk because we already
+            // handled it.
+            let mut intra_chunk_offset = 0;
+
+            for chunk_index in 0..chunk_count {
+                let ptr = src_bytes.as_ptr() as *const __m128i;
+                // We don't know if the pointer is aligned to 16 bytes, so we
+                // use `loadu`, which supports unaligned loading.
+                let chunk = unsafe { _mm_loadu_si128(ptr.add(chunk_index)) };
+
+                // For character in the chunk, see if its byte value is < 0, which
+                // indicates that it's part of a UTF-8 char.
+                let multibyte_test = unsafe { _mm_cmplt_epi8(chunk, _mm_set1_epi8(0)) };
+                // Create a bit mask from the comparison results.
+                let multibyte_mask = unsafe { _mm_movemask_epi8(multibyte_test) };
+
+                // If the bit mask is all zero, we only have ASCII chars here:
+                if multibyte_mask == 0 {
+                    assert!(intra_chunk_offset == 0);
+
+                    // Check if there are any control characters in the chunk. All
+                    // control characters that we can encounter at this point have a
+                    // byte value less than 32 or ...
+                    let control_char_test0 = unsafe { _mm_cmplt_epi8(chunk, _mm_set1_epi8(32)) };
+                    let control_char_mask0 = unsafe { _mm_movemask_epi8(control_char_test0) };
+
+                    // ... it's the ASCII 'DEL' character with a value of 127.
+                    let control_char_test1 = unsafe { _mm_cmpeq_epi8(chunk, _mm_set1_epi8(127)) };
+                    let control_char_mask1 = unsafe { _mm_movemask_epi8(control_char_test1) };
+
+                    let control_char_mask = control_char_mask0 | control_char_mask1;
+
+                    if control_char_mask != 0 {
+                        // Check for newlines in the chunk
+                        let newlines_test = unsafe { _mm_cmpeq_epi8(chunk, _mm_set1_epi8(b'\n' as i8)) };
+                        let newlines_mask = unsafe { _mm_movemask_epi8(newlines_test) };
+
+                        if control_char_mask == newlines_mask {
+                            // All control characters are newlines, record them
+                            let mut newlines_mask = 0xFFFF0000 | newlines_mask as u32;
+                            let output_offset = RelativeBytePos::from_usize(chunk_index * CHUNK_SIZE + 1);
+
+                            loop {
+                                let index = newlines_mask.trailing_zeros();
+
+                                if index >= CHUNK_SIZE as u32 {
+                                    // We have arrived at the end of the chunk.
+                                    break;
+                                }
+
+                                lines.push(RelativeBytePos(index) + output_offset);
+
+                                // Clear the bit, so we can find the next one.
+                                newlines_mask &= (!1) << index;
+                            }
+
+                            // We are done for this chunk. All control characters were
+                            // newlines and we took care of those.
+                            continue;
+                        } else {
+                            // Some of the control characters are not newlines,
+                            // fall through to the slow path below.
+                        }
+                    } else {
+                        // No control characters, nothing to record for this chunk
+                        continue;
+                    }
+                }
+
+                // The slow path.
+                // There are control chars in here, fallback to generic decoding.
+                let scan_start = chunk_index * CHUNK_SIZE + intra_chunk_offset;
+                intra_chunk_offset = analyze_source_file_generic(
+                    &src[scan_start..],
+                    CHUNK_SIZE - intra_chunk_offset,
+                    RelativeBytePos::from_usize(scan_start),
+                    lines,
+                    multi_byte_chars,
+                );
+            }
+
+            // There might still be a tail left to analyze
+            let tail_start = chunk_count * CHUNK_SIZE + intra_chunk_offset;
+            if tail_start < src.len() {
+                analyze_source_file_generic(
+                    &src[tail_start..],
+                    src.len() - tail_start,
+                    RelativeBytePos::from_usize(tail_start),
+                    lines,
+                    multi_byte_chars,
+                );
+            }
+        }
+    }
+    _ => {
+        // The target (or compiler version) does not support SSE2 ...
+        fn analyze_source_file_dispatch(
+            src: &str,
+            lines: &mut Vec<RelativeBytePos>,
+            multi_byte_chars: &mut Vec<MultiByteChar>,
+        ) {
+            analyze_source_file_generic(
+                src,
+                src.len(),
+                RelativeBytePos::from_u32(0),
+                lines,
+                multi_byte_chars,
+            );
+        }
+    }
+}
+
 // `scan_len` determines the number of bytes in `src` to scan. Note that the
 // function can read past `scan_len` if a multi-byte character start within the
 // range but extends past it. The overflow is returned by the function.

--- a/library/core/tests/lib.rs
+++ b/library/core/tests/lib.rs
@@ -149,7 +149,10 @@ mod intrinsics;
 mod io;
 mod iter;
 mod lazy;
+#[cfg(not(bootstrap))]
 mod macros;
+#[cfg(bootstrap)]
+mod macros_bootstrap;
 mod manually_drop;
 mod mem;
 mod net;

--- a/library/core/tests/macros_bootstrap.rs
+++ b/library/core/tests/macros_bootstrap.rs
@@ -10,7 +10,7 @@ struct Struct;
 
 impl Trait for Struct {
     cfg_match! {
-        feature = "blah" => {
+        cfg(feature = "blah") => {
             fn blah(&self) {
                 unimplemented!();
             }
@@ -47,21 +47,21 @@ fn matches_leading_pipe() {
 #[test]
 fn cfg_match_basic() {
     cfg_match! {
-        target_pointer_width = "64" => { fn f0_() -> bool { true }}
+        cfg(target_pointer_width = "64") => { fn f0_() -> bool { true }}
     }
 
     cfg_match! {
-        unix => { fn f1_() -> bool { true } }
-        any(target_os = "macos", target_os = "linux") => { fn f1_() -> bool { false }}
+        cfg(unix) => { fn f1_() -> bool { true }}
+        cfg(any(target_os = "macos", target_os = "linux")) => { fn f1_() -> bool { false }}
     }
 
     cfg_match! {
-        target_pointer_width = "32" => { fn f2_() -> bool { false } }
-        target_pointer_width = "64" => { fn f2_() -> bool { true } }
+        cfg(target_pointer_width = "32") => { fn f2_() -> bool { false }}
+        cfg(target_pointer_width = "64") => { fn f2_() -> bool { true }}
     }
 
     cfg_match! {
-        target_pointer_width = "16" => { fn f3_() -> i32 { 1 } }
+        cfg(target_pointer_width = "16") => { fn f3_() -> i32 { 1 }}
         _ => { fn f3_() -> i32 { 2 }}
     }
 
@@ -83,7 +83,7 @@ fn cfg_match_basic() {
 #[test]
 fn cfg_match_debug_assertions() {
     cfg_match! {
-        debug_assertions => {
+        cfg(debug_assertions) => {
             assert!(cfg!(debug_assertions));
             assert_eq!(4, 2+2);
         }
@@ -98,13 +98,13 @@ fn cfg_match_debug_assertions() {
 #[test]
 fn cfg_match_no_duplication_on_64() {
     cfg_match! {
-        windows => {
+        cfg(windows) => {
             fn foo() {}
         }
-        unix => {
+        cfg(unix) => {
             fn foo() {}
         }
-        target_pointer_width = "64" => {
+        cfg(target_pointer_width = "64") => {
             fn foo() {}
         }
     }
@@ -114,7 +114,7 @@ fn cfg_match_no_duplication_on_64() {
 #[test]
 fn cfg_match_options() {
     cfg_match! {
-        test => {
+        cfg(test) => {
             use core::option::Option as Option2;
             fn works1() -> Option2<u32> { Some(1) }
         }
@@ -122,26 +122,26 @@ fn cfg_match_options() {
     }
 
     cfg_match! {
-        feature = "foo" => { fn works2() -> bool { false } }
-        test => { fn works2() -> bool { true } }
+        cfg(feature = "foo") => { fn works2() -> bool { false } }
+        cfg(test) => { fn works2() -> bool { true } }
         _ => { fn works2() -> bool { false } }
     }
 
     cfg_match! {
-        feature = "foo" => { fn works3() -> bool { false } }
+        cfg(feature = "foo") => { fn works3() -> bool { false } }
         _ => { fn works3() -> bool { true } }
     }
 
     cfg_match! {
-        test => {
+        cfg(test) => {
             use core::option::Option as Option3;
             fn works4() -> Option3<u32> { Some(1) }
         }
     }
 
     cfg_match! {
-        feature = "foo" => { fn works5() -> bool { false } }
-        test => { fn works5() -> bool { true } }
+        cfg(feature = "foo") => { fn works5() -> bool { false } }
+        cfg(test) => { fn works5() -> bool { true } }
     }
 
     assert!(works1().is_some());
@@ -154,7 +154,7 @@ fn cfg_match_options() {
 #[test]
 fn cfg_match_two_functions() {
     cfg_match! {
-        target_pointer_width = "64" => {
+        cfg(target_pointer_width = "64") => {
             fn foo1() {}
             fn bar1() {}
         }
@@ -178,29 +178,16 @@ fn cfg_match_two_functions() {
 
 fn _accepts_expressions() -> i32 {
     cfg_match! {
-        unix => { 1 }
+        cfg(unix) => { 1 }
         _ => { 2 }
     }
 }
 
-// The current implementation expands to a macro call, which allows the use of expression
-// statements.
 fn _allows_stmt_expr_attributes() {
     let one = 1;
     let two = 2;
     cfg_match! {
-        unix => { one * two; }
+        cfg(unix) => { one * two; }
         _ => { one + two; }
     }
-}
-
-fn _expression() {
-    let _ = cfg_match!({
-        windows => {
-            " XP"
-        }
-        _ => {
-            ""
-        }
-    });
 }


### PR DESCRIPTION
A year has passed since the creation of #115585 and the feature, as expected, is not moving forward. Let's change that.

This PR proposes changing the arm's syntax from  `cfg(SOME_CONDITION) => { ... }` to `SOME_CODITION => {}`.

```rust
match_cfg! {
   unix => {
        fn foo() { /* unix specific functionality */ }
    }
    target_pointer_width = "32" => {
        fn foo() { /* non-unix, 32-bit functionality */ }
    }
    _ => {
        fn foo() { /* fallback implementation */ }
    }
}
```

Why? Because after several manual migrations in https://github.com/rust-lang/rust/pull/116342 it became clear,  at least for me, that `cfg` prefixes are unnecessary, verbose and redundant.

Again, everything is just a proposal to move things forward. If the shown syntax isn't ideal, feel free to close this PR or suggest other alternatives.