### PR TITLE
Add `needs-target-has-atomic` directive

### DIFF
--- a/src/tools/compiletest/src/directive-list.rs
+++ b/src/tools/compiletest/src/directive-list.rs
@@ -154,6 +154,7 @@ const KNOWN_DIRECTIVE_NAMES: &[&str] = &[
     "needs-sanitizer-thread",
     "needs-std-debug-assertions",
     "needs-symlink",
+    "needs-target-has-atomic",
     "needs-threads",
     "needs-unwind",
     "needs-wasmtime",


### PR DESCRIPTION
Before this PR, the test writer has to specify platforms and architectures by hand for targets that have differing atomic width support. `#[cfg(target_has_atomic="...")]` is not quite the same because (1) you may have to specify additional matchers manually which has to be maintained individually, and (2) the `#[cfg]` blocks does not communicate to compiletest that a test would be ignored for a given target.

This PR implements a `//@ needs-target-has-atomic` directive which admits a comma-separated list of required atomic widths that the target must satisfy in order for the test to run.

```
//@ needs-target-has-atomic: 8, 16, ptr
```

See <https://github.com/rust-lang/rust/issues/87377>.

This PR supersedes #133095 and is co-authored by @kei519, because it was somewhat subtle, and it turned out easier to implement than to review.

rustc-dev-guide docs PR: https://github.com/rust-lang/rustc-dev-guide/pull/2154
