### PR TITLE
the Item of a Windows iterator should be an explicitly sized array : …

### DIFF
--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -1347,10 +1347,10 @@ impl<T> Clone for Windows<'_, T> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<'a, T> Iterator for Windows<'a, T> {
-    type Item = &'a [T];
+    type Item = &'a [T;self.size.get()];
 
     #[inline]
-    fn next(&mut self) -> Option<&'a [T]> {
+    fn next(&mut self) -> Option<&'a [T;self.size.get()]> {
         if self.size.get() > self.v.len() {
             None
         } else {


### PR DESCRIPTION
…iter.rs

the Windows iterator normally returns an array of type [T], but this results in an error where the compiler can't determine the size of the array at compile time when you try to use the [T] in another function like: Vec_of_i32.windows(2).all(|x| x.do_something());
doesn't compile because x is of type: [i32] and the compiler doesn't know the size. x's type should be: [i32;2] and the compiler now knows x's size and the code now compiles correctly

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
