### PR TITLE
Fix docs for `<[T]>::as_array`.

### DIFF
--- a/library/core/src/slice/mod.rs
+++ b/library/core/src/slice/mod.rs
@@ -858,7 +858,7 @@ impl<T> [T] {
 
     /// Gets a reference to the underlying array.
     ///
-    /// If `N` is not exactly equal to slice's the length of `self`, then this method returns `None`.
+    /// If `N` is not exactly equal to the length of `self`, then this method returns `None`.
     #[unstable(feature = "slice_as_array", issue = "133508")]
     #[rustc_const_unstable(feature = "slice_as_array", issue = "133508")]
     #[inline]


### PR DESCRIPTION
Tracking issue: #133508

This PR fixes a small typographical error in the docs entry for `<[T]>::as_array`.