### PR TITLE
build `rustc` with 1 CGU on `aarch64-apple-darwin`

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -338,6 +338,7 @@ auto:
         --set rust.jemalloc
         --set llvm.ninja=false
         --set rust.lto=thin
+        --set rust.codegen-units=1
       RUSTC_RETRY_LINKER_ON_SEGFAULT: 1
       SELECT_XCODE: /Applications/Xcode_15.4.app
       USE_XCODE_CLANG: 1


### PR DESCRIPTION
Distribute `aarch64-apple-darwin` artifacts built with `rust.codegen-units=1`, like we already do on Linux/Windows/macOS Intel.

1. Performance results (only wall-time on mac as usual)
- I only did some `ripgrep` check builds (the revision from rustc-perf), because we had noticeable wins in wall-time there back then on linux. It's a ~2-4% (mostly 3%) improvement on local builds.

```console
Benchmark 1: cargo +caa81728c37f5ccfa9a0979574b9272a67f8a286 check -q
  Time (mean ± σ):      5.800 s ±  0.087 s    [User: 16.048 s, System: 2.294 s]
  Range (min … max):    5.725 s …  6.028 s    10 runs
 
Benchmark 2: cargo +41f40c97bbff6c8642f5510d0be283551b095b70 check -q
  Time (mean ± σ):      5.551 s ±  0.037 s    [User: 15.451 s, System: 2.252 s]
  Range (min … max):    5.477 s …  5.602 s    10 runs
 
Summary
  'cargo +41f40c97bbff6c8642f5510d0be283551b095b70 check -q' ran
    1.04 ± 0.02 times faster than 'cargo +caa81728c37f5ccfa9a0979574b9272a67f8a286 check -q'
```

```console
Benchmark 1: CARGO_INCREMENTAL=0 cargo +caa81728c37f5ccfa9a0979574b9272a67f8a286 check -q
  Time (mean ± σ):      5.743 s ±  0.030 s    [User: 16.005 s, System: 2.249 s]
  Range (min … max):    5.720 s …  5.792 s    5 runs
 
Benchmark 2: CARGO_INCREMENTAL=0 cargo +41f40c97bbff6c8642f5510d0be283551b095b70 check -q
  Time (mean ± σ):      5.469 s ±  0.055 s    [User: 15.244 s, System: 2.110 s]
  Range (min … max):    5.404 s …  5.524 s    5 runs
 
Summary
  'CARGO_INCREMENTAL=0 cargo +41f40c97bbff6c8642f5510d0be283551b095b70 check -q' ran
    1.05 ± 0.01 times faster than 'CARGO_INCREMENTAL=0 cargo +caa81728c37f5ccfa9a0979574b9272a67f8a286 check -q'
```


```console
Benchmark 1: CARGO_INCREMENTAL=0 cargo +caa81728c37f5ccfa9a0979574b9272a67f8a286 check -q -j1
  Time (mean ± σ):     15.092 s ±  0.049 s    [User: 11.969 s, System: 1.665 s]
  Range (min … max):   15.052 s … 15.165 s    5 runs
 
Benchmark 2: CARGO_INCREMENTAL=0 cargo +41f40c97bbff6c8642f5510d0be283551b095b70 check -q -j1
  Time (mean ± σ):     14.623 s ±  0.035 s    [User: 11.520 s, System: 1.619 s]
  Range (min … max):   14.593 s … 14.682 s    5 runs
 
Summary
  'CARGO_INCREMENTAL=0 cargo +41f40c97bbff6c8642f5510d0be283551b095b70 check -q -j1' ran
    1.03 ± 0.00 times faster than 'CARGO_INCREMENTAL=0 cargo +caa81728c37f5ccfa9a0979574b9272a67f8a286 check -q -j1'
``` 

2. Effects on code size on `aarch64-apple-darwin`: it's a 13.24% reduction on `librustc_driver.dylib`
- [before](https://ci-artifacts.rust-lang.org/rustc-builds/caa81728c37f5ccfa9a0979574b9272a67f8a286/rustc-nightly-aarch64-apple-darwin.tar.xz): 173452888 (57.3 MB compressed).
- [after](https://ci-artifacts.rust-lang.org/rustc-builds/41f40c97bbff6c8642f5510d0be283551b095b70/rustc-nightly-aarch64-apple-darwin.tar.xz): 150471368 (55.2 MB compressed, -3.7% here).

3. Effects on CI
- the [1st try build](https://github.com/rust-lang-ci/rust/actions/runs/12118946198/job/33784512526) took 1h31
- the [2nd try build](https://github.com/rust-lang-ci/rust/actions/runs/12121452825/job/33792429553) took 1h28
- I don't know how long the builder usually takes