### PR TITLE
Fix `{f16,f32,f64,f128}::div_euclid`

### DIFF
--- a/library/std/src/f128.rs
+++ b/library/std/src/f128.rs
@@ -309,8 +309,21 @@ impl f128 {
     #[unstable(feature = "f128", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn rem_euclid(self, rhs: f128) -> f128 {
-        let r = self % rhs;
-        if r < 0.0 { r + rhs.abs() } else { r }
+        if rhs.is_infinite() {
+            if self.is_infinite() || self.is_nan() {
+                return f128::NAN;
+            } else {
+                return self;
+            }
+        }
+        // FIXME(#133755): Though `self % rhs` is documented to be
+        // equivalent to this, it is not, and the distinction matters
+        // here.
+        let r = self - rhs * (self / rhs).trunc();
+        if r < 0.0 {
+            return if rhs > 0.0 { r + rhs } else { r - rhs };
+        }
+        r
     }
 
     /// Raises a number to an integer power.

--- a/library/std/src/f16.rs
+++ b/library/std/src/f16.rs
@@ -309,8 +309,21 @@ impl f16 {
     #[unstable(feature = "f16", issue = "116909")]
     #[must_use = "method returns a new number and does not mutate the original value"]
     pub fn rem_euclid(self, rhs: f16) -> f16 {
-        let r = self % rhs;
-        if r < 0.0 { r + rhs.abs() } else { r }
+        if rhs.is_infinite() {
+            if self.is_infinite() || self.is_nan() {
+                return f16::NAN;
+            } else {
+                return self;
+            }
+        }
+        // FIXME(#133755): Though `self % rhs` is documented to be
+        // equivalent to this, it is not, and the distinction matters
+        // here.
+        let r = self - rhs * (self / rhs).trunc();
+        if r < 0.0 {
+            return if rhs > 0.0 { r + rhs } else { r - rhs };
+        }
+        r
     }
 
     /// Raises a number to an integer power.

--- a/library/std/src/f32.rs
+++ b/library/std/src/f32.rs
@@ -285,8 +285,21 @@ impl f32 {
     #[inline]
     #[stable(feature = "euclidean_division", since = "1.38.0")]
     pub fn rem_euclid(self, rhs: f32) -> f32 {
-        let r = self % rhs;
-        if r < 0.0 { r + rhs.abs() } else { r }
+        if rhs.is_infinite() {
+            if self.is_infinite() || self.is_nan() {
+                return f32::NAN;
+            } else {
+                return self;
+            }
+        }
+        // FIXME(#133755): Though `self % rhs` is documented to be
+        // equivalent to this, it is not, and the distinction matters
+        // here.
+        let r = self - rhs * (self / rhs).trunc();
+        if r < 0.0 {
+            return if rhs > 0.0 { r + rhs } else { r - rhs };
+        }
+        r
     }
 
     /// Raises a number to an integer power.

--- a/library/std/src/f64.rs
+++ b/library/std/src/f64.rs
@@ -285,8 +285,21 @@ impl f64 {
     #[inline]
     #[stable(feature = "euclidean_division", since = "1.38.0")]
     pub fn rem_euclid(self, rhs: f64) -> f64 {
-        let r = self % rhs;
-        if r < 0.0 { r + rhs.abs() } else { r }
+        if rhs.is_infinite() {
+            if self.is_infinite() || self.is_nan() {
+                return f64::NAN;
+            } else {
+                return self;
+            }
+        }
+        // FIXME(#133755): Though `self % rhs` is documented to be
+        // equivalent to this, it is not, and the distinction matters
+        // here.
+        let r = self - rhs * (self / rhs).trunc();
+        if r < 0.0 {
+            return if rhs > 0.0 { r + rhs } else { r - rhs };
+        }
+        r
     }
 
     /// Raises a number to an integer power.


### PR DESCRIPTION
### DRAFT

We're still analyzing this.

cc #133485

See also:

- https://github.com/rust-lang/rust/issues/133758

"Division and Modulus for Computer Scientists",
Daan Leijen, 2001,
<https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/divmodnote-letter.pdf>

r? ghost