### PR TITLE
`impl Default for EarlyDiagCtxt`

### DIFF
--- a/compiler/rustc_session/src/session.rs
+++ b/compiler/rustc_session/src/session.rs
@@ -1358,6 +1358,12 @@ pub struct EarlyDiagCtxt {
     dcx: DiagCtxt,
 }
 
+impl Default for EarlyDiagCtxt {
+    fn default() -> Self {
+        Self::new(ErrorOutputType::default())
+    }
+}
+
 impl EarlyDiagCtxt {
     pub fn new(output: ErrorOutputType) -> Self {
         let emitter = mk_emitter(output);


### PR DESCRIPTION
for small rustc_driver programs, most of their imports will currently be related to diagnostics. this change simplifies their code so it's more clear what in the driver is modified from the default.

this is especially important for external drivers which are out of tree and not updated in response to breaking changes. for these drivers, each import is a liability for future code, since it can be broken when refactors happen.

here is an example driver which is simplified by these changes:
```diff
diff --git a/src/main.rs b/src/main.rs
index f81aa3e..11e5f18 100644
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,8 @@
 #![feature(rustc_private)]
 extern crate rustc_driver;
 extern crate rustc_interface;
-extern crate rustc_errors;
-extern crate rustc_session;

 use rustc_driver::Callbacks;
-use rustc_errors::{emitter::HumanReadableErrorType, ColorConfig};
 use rustc_interface::interface;
-use rustc_session::config::ErrorOutputType;
-use rustc_session::EarlyDiagCtxt;

 struct DisableSafetyChecks;

@@ -26,11 +18,7 @@ fn main() {
         "https://github.com/jyn514/jyn514.github.io/issues/new",
         |_| (),
     );
-    let handler = EarlyDiagCtxt::new(ErrorOutputType::HumanReadable(
-        HumanReadableErrorType::Default,
-        ColorConfig::Auto,
-    ));
-    rustc_driver::init_rustc_env_logger(&handler);
+    rustc_driver::init_rustc_env_logger(&Default::default());
     std::process::exit(rustc_driver::catch_with_exit_code(move || {
         let args: Vec<String> = std::env::args().collect();
         rustc_driver::RunCompiler::new(&args, &mut DisableSafetyChecks).run()
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
