### PR TITLE
rustdoc: Rename `set_back_info` to `restore_module_data`.

### DIFF
--- a/src/librustdoc/html/render/context.rs
+++ b/src/librustdoc/html/render/context.rs
@@ -601,7 +601,7 @@ impl<'tcx> FormatRenderer<'tcx> for Context<'tcx> {
         self.info
     }
 
-    fn set_back_info(&mut self, info: Self::ModuleData) {
+    fn restore_module_data(&mut self, info: Self::ModuleData) {
         self.info = info;
     }
 

--- a/src/librustdoc/json/mod.rs
+++ b/src/librustdoc/json/mod.rs
@@ -163,11 +163,10 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
     }
 
     fn save_module_data(&mut self) -> Self::ModuleData {
-        unreachable!("RUN_ON_MODULE = false should never call save_module_data")
+        unreachable!("RUN_ON_MODULE = false, should never call save_module_data")
     }
-
-    fn set_back_info(&mut self, _info: Self::ModuleData) {
-        unreachable!("RUN_ON_MODULE = false should never call set_back_info")
+    fn restore_module_data(&mut self, _info: Self::ModuleData) {
+        unreachable!("RUN_ON_MODULE = false, should never call set_back_info")
     }
 
     /// Inserts an item into the index. This should be used rather than directly calling insert on
@@ -248,7 +247,7 @@ impl<'tcx> FormatRenderer<'tcx> for JsonRenderer<'tcx> {
     }
 
     fn mod_item_in(&mut self, _item: &clean::Item) -> Result<(), Error> {
-        unreachable!("RUN_ON_MODULE = false should never call mod_item_in")
+        unreachable!("RUN_ON_MODULE = false, should never call mod_item_in")
     }
 
     fn after_krate(&mut self) -> Result<(), Error> {


### PR DESCRIPTION
Follow-up to #133345, r? @GuillaumeGomez 

Most of the references to `info` got removed as it was clear that `module_data` makes more sense here. Makes it clearer that `save_module_data` and `restore_module_data` are a pair.