### PR TITLE
Add more info on type/trait mismatches for different crate versions

### DIFF
--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -1745,9 +1745,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     };
                     (
                         data.span,
-                        format!(
-                            "one version of crate `{crate_name}` is used here, as a {dependency}"
-                        ),
+                        format!("one version of crate `{crate_name}` used here, as a {dependency}"),
                     )
                 })
             {

--- a/tests/incremental/circular-dependencies.rs
+++ b/tests/incremental/circular-dependencies.rs
@@ -6,10 +6,12 @@
 //@ [cfail2] compile-flags: --test --extern aux={{build-base}}/circular-dependencies/auxiliary/libcircular_dependencies_aux.rmeta -L dependency={{build-base}}/circular-dependencies
 
 pub struct Foo;
-//[cfail2]~^ NOTE `Foo` is defined in the current crate
-//[cfail2]~| NOTE `Foo` is defined in the current crate
-//[cfail2]~| NOTE `circular_dependencies::Foo` is defined in crate `circular_dependencies`
-//[cfail2]~| NOTE `circular_dependencies::Foo` is defined in crate `circular_dependencies`
+//[cfail2]~^ NOTE the crate `circular_dependencies` is compiled multiple times, possibly with different configurations
+//[cfail2]~| NOTE the crate `circular_dependencies` is compiled multiple times, possibly with different configurations
+//[cfail2]~| NOTE this is the expected type `Foo`
+//[cfail2]~| NOTE this is the expected type `circular_dependencies::Foo`
+//[cfail2]~| NOTE this is the found type `Foo`
+//[cfail2]~| NOTE this is the found type `circular_dependencies::Foo`
 
 pub fn consume_foo(_: Foo) {}
 //[cfail2]~^ NOTE function defined here
@@ -24,14 +26,12 @@ fn test() {
     //[cfail2]~^ ERROR mismatched types [E0308]
     //[cfail2]~| NOTE expected `circular_dependencies::Foo`, found `Foo`
     //[cfail2]~| NOTE arguments to this function are incorrect
-    //[cfail2]~| NOTE `Foo` and `circular_dependencies::Foo` have similar names, but are actually distinct types
-    //[cfail2]~| NOTE the crate `circular_dependencies` is compiled multiple times, possibly with different configurations
     //[cfail2]~| NOTE function defined here
+    //[cfail2]~| NOTE one version of crate `circular_dependencies` used here, as a dependency of crate `circular_dependencies_aux`
+    //[cfail2]~| NOTE one version of crate `circular_dependencies` used here, as a dependency of crate `circular_dependencies_aux`
 
     consume_foo(aux::produce_foo());
     //[cfail2]~^ ERROR mismatched types [E0308]
     //[cfail2]~| NOTE expected `Foo`, found `circular_dependencies::Foo`
     //[cfail2]~| NOTE arguments to this function are incorrect
-    //[cfail2]~| NOTE `circular_dependencies::Foo` and `Foo` have similar names, but are actually distinct types
-    //[cfail2]~| NOTE the crate `circular_dependencies` is compiled multiple times, possibly with different configurations
 }

--- a/tests/run-make/crate-loading-crate-depends-on-itself/foo.stderr
+++ b/tests/run-make/crate-loading-crate-depends-on-itself/foo.stderr
@@ -8,7 +8,7 @@ note: there are multiple different versions of crate `foo` in the dependency gra
   --> foo-current.rs:7:1
    |
 4  | extern crate foo;
-   | ----------------- one version of crate `foo` is used here, as a direct dependency of the current crate
+   | ----------------- one version of crate `foo` used here, as a direct dependency of the current crate
 5  |
 6  | pub struct Struct;
    | ----------------- this type implements the required trait

--- a/tests/run-make/crate-loading/multiple-dep-versions-1.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-1.rs
@@ -5,8 +5,11 @@ pub trait Trait {
     fn foo(&self);
     fn bar();
 }
+pub trait Trait2 {}
 impl Trait for Type {
     fn foo(&self) {}
     fn bar() {}
 }
 pub fn do_something<X: Trait>(_: X) {}
+pub fn do_something_type(_: Type) {}
+pub fn do_something_trait(_: Box<dyn Trait2>) {}

--- a/tests/run-make/crate-loading/multiple-dep-versions-2.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-2.rs
@@ -5,8 +5,12 @@ pub trait Trait {
     fn foo(&self);
     fn bar();
 }
+pub trait Trait2 {}
+impl Trait2 for Type {}
 impl Trait for Type {
     fn foo(&self) {}
     fn bar() {}
 }
 pub fn do_something<X: Trait>(_: X) {}
+pub fn do_something_type(_: Type) {}
+pub fn do_something_trait(_: Box<dyn Trait2>) {}

--- a/tests/run-make/crate-loading/multiple-dep-versions-3.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions-3.rs
@@ -2,7 +2,7 @@
 #![crate_type = "rlib"]
 
 extern crate dependency;
-pub use dependency::Type;
+pub use dependency::{Trait2, Type, do_something_trait, do_something_type};
 pub struct OtherType;
 impl dependency::Trait for OtherType {
     fn foo(&self) {}

--- a/tests/run-make/crate-loading/multiple-dep-versions.rs
+++ b/tests/run-make/crate-loading/multiple-dep-versions.rs
@@ -1,11 +1,13 @@
 extern crate dep_2_reexport;
 extern crate dependency;
-use dep_2_reexport::{OtherType, Type};
-use dependency::{Trait, do_something};
+use dep_2_reexport::{OtherType, Trait2, Type};
+use dependency::{Trait, do_something, do_something_trait, do_something_type};
 
 fn main() {
     do_something(Type);
     Type.foo();
     Type::bar();
     do_something(OtherType);
+    do_something_type(Type);
+    do_something_trait(Box::new(Type) as Box<dyn Trait2>);
 }

--- a/tests/run-make/crate-loading/multiple-dep-versions.stderr
+++ b/tests/run-make/crate-loading/multiple-dep-versions.stderr
@@ -17,9 +17,9 @@ LL | pub trait Trait {
   ::: replaced
    |
 LL | extern crate dep_2_reexport;
-   | ---------------------------- one version of crate `dependency` is used here, as a dependency of crate `foo`
+   | ---------------------------- one version of crate `dependency` used here, as a dependency of crate `foo`
 LL | extern crate dependency;
-   | ------------------------ one version of crate `dependency` is used here, as a direct dependency of the current crate
+   | ------------------------ one version of crate `dependency` used here, as a direct dependency of the current crate
    |
   ::: replaced
    |
@@ -51,7 +51,7 @@ LL |     fn foo(&self);
    |
   ::: replaced
    |
-LL | use dependency::{Trait, do_something};
+LL | use dependency::{Trait, do_something, do_something_trait, do_something_type};
    |                  ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`
    |
   ::: replaced
@@ -76,7 +76,7 @@ LL |     fn bar();
    |
   ::: replaced
    |
-LL | use dependency::{Trait, do_something};
+LL | use dependency::{Trait, do_something, do_something_trait, do_something_type};
    |                  ----- `Trait` imported here doesn't correspond to the right version of crate `dependency`
    |
   ::: replaced
@@ -101,9 +101,9 @@ LL | pub trait Trait {
   ::: replaced
    |
 LL | extern crate dep_2_reexport;
-   | ---------------------------- one version of crate `dependency` is used here, as a dependency of crate `foo`
+   | ---------------------------- one version of crate `dependency` used here, as a dependency of crate `foo`
 LL | extern crate dependency;
-   | ------------------------ one version of crate `dependency` is used here, as a direct dependency of the current crate
+   | ------------------------ one version of crate `dependency` used here, as a direct dependency of the current crate
    |
   ::: replaced
    |
@@ -121,7 +121,71 @@ note: required by a bound in `do_something`
 LL | pub fn do_something<X: Trait>(_: X) {}
    |                        ^^^^^ required by this bound in `do_something`
 
-error: aborting due to 4 previous errors
+error[E0308]: mismatched types
+  --> replaced
+   |
+LL |     do_something_type(Type);
+   |     ----------------- ^^^^ expected `dependency::Type`, found `dep_2_reexport::Type`
+   |     |
+   |     arguments to this function are incorrect
+   |
+note: two different versions of crate `dependency` are being used; two types coming from two different versions of the same crate are different types even if they look the same
+  --> replaced
+   |
+LL | pub struct Type(pub i32);
+   | ^^^^^^^^^^^^^^^ this is the expected type `dependency::Type`
+   |
+  ::: replaced
+   |
+LL | pub struct Type;
+   | ^^^^^^^^^^^^^^^ this is the found type `dep_2_reexport::Type`
+   |
+  ::: replaced
+   |
+LL | extern crate dep_2_reexport;
+   | ---------------------------- one version of crate `dependency` used here, as a dependency of crate `foo`
+LL | extern crate dependency;
+   | ------------------------ one version of crate `dependency` used here, as a direct dependency of the current crate
+   = help: you can use `cargo tree` to explore your dependency tree
+note: function defined here
+  --> replaced
+   |
+LL | pub fn do_something_type(_: Type) {}
+   |        ^^^^^^^^^^^^^^^^^
 
-Some errors have detailed explanations: E0277, E0599.
+error[E0308]: mismatched types
+  --> replaced
+   |
+LL |     do_something_trait(Box::new(Type) as Box<dyn Trait2>);
+   |     ------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected trait `dependency::Trait2`, found trait `dep_2_reexport::Trait2`
+   |     |
+   |     arguments to this function are incorrect
+   |
+note: two different versions of crate `dependency` are being used; two types coming from two different versions of the same crate are different types even if they look the same
+  --> replaced
+   |
+LL | pub trait Trait2 {}
+   | ^^^^^^^^^^^^^^^^ this is the expected trait `dependency::Trait2`
+   |
+  ::: replaced
+   |
+LL | pub trait Trait2 {}
+   | ^^^^^^^^^^^^^^^^ this is the found trait `dep_2_reexport::Trait2`
+   |
+  ::: replaced
+   |
+LL | extern crate dep_2_reexport;
+   | ---------------------------- one version of crate `dependency` used here, as a dependency of crate `foo`
+LL | extern crate dependency;
+   | ------------------------ one version of crate `dependency` used here, as a direct dependency of the current crate
+   = help: you can use `cargo tree` to explore your dependency tree
+note: function defined here
+  --> replaced
+   |
+LL | pub fn do_something_trait(_: Box<dyn Trait2>) {}
+   |        ^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 6 previous errors
+
+Some errors have detailed explanations: E0277, E0308, E0599.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/mismatched_types/similar_paths_primitive.rs
+++ b/tests/ui/mismatched_types/similar_paths_primitive.rs
@@ -1,14 +1,22 @@
 #![allow(non_camel_case_types)]
 
-struct bool;
-struct str;
+struct bool; //~ NOTE the other `bool` is defined in the current crate
+struct str; //~ NOTE the other `str` is defined in the current crate
 
-fn foo(_: bool) {}
-fn bar(_: &str) {}
+fn foo(_: bool) {} //~ NOTE function defined here
+fn bar(_: &str) {} //~ NOTE function defined here
 
 fn main() {
     foo(true);
     //~^ ERROR mismatched types [E0308]
+    //~| NOTE expected `bool`, found a different `bool`
+    //~| NOTE arguments to this function are incorrect
+    //~| NOTE `bool` and `bool` have similar names, but are actually distinct types
+    //~| NOTE one `bool` is a primitive defined by the language
     bar("hello");
     //~^ ERROR mismatched types [E0308]
+    //~| NOTE expected `str`, found a different `str`
+    //~| NOTE arguments to this function are incorrect
+    //~| NOTE `str` and `str` have similar names, but are actually distinct types
+    //~| NOTE one `str` is a primitive defined by the language
 }

--- a/tests/ui/mismatched_types/similar_paths_primitive.stderr
+++ b/tests/ui/mismatched_types/similar_paths_primitive.stderr
@@ -6,9 +6,9 @@ LL |     foo(true);
    |     |
    |     arguments to this function are incorrect
    |
-   = note: bool and `bool` have similar names, but are actually distinct types
-   = note: bool is a primitive defined by the language
-note: `bool` is defined in the current crate
+   = note: `bool` and `bool` have similar names, but are actually distinct types
+   = note: one `bool` is a primitive defined by the language
+note: the other `bool` is defined in the current crate
   --> $DIR/similar_paths_primitive.rs:3:1
    |
 LL | struct bool;
@@ -20,16 +20,16 @@ LL | fn foo(_: bool) {}
    |    ^^^ -------
 
 error[E0308]: mismatched types
-  --> $DIR/similar_paths_primitive.rs:12:9
+  --> $DIR/similar_paths_primitive.rs:16:9
    |
 LL |     bar("hello");
    |     --- ^^^^^^^ expected `str`, found a different `str`
    |     |
    |     arguments to this function are incorrect
    |
-   = note: str and `str` have similar names, but are actually distinct types
-   = note: str is a primitive defined by the language
-note: `str` is defined in the current crate
+   = note: `str` and `str` have similar names, but are actually distinct types
+   = note: one `str` is a primitive defined by the language
+note: the other `str` is defined in the current crate
   --> $DIR/similar_paths_primitive.rs:4:1
    |
 LL | struct str;

--- a/tests/ui/type/auxiliary/crate_a1.rs
+++ b/tests/ui/type/auxiliary/crate_a1.rs
@@ -1,6 +1,6 @@
 pub struct Foo;
 
-pub trait Bar{}
+pub trait Bar {}
 
 pub fn bar() -> Box<Bar> {
     unimplemented!()

--- a/tests/ui/type/auxiliary/crate_a2.rs
+++ b/tests/ui/type/auxiliary/crate_a2.rs
@@ -1,6 +1,6 @@
 pub struct Foo;
 
-pub trait Bar{}
+pub trait Bar {}
 
 pub fn bar() -> Box<Bar> {
     unimplemented!()

--- a/tests/ui/type/type-mismatch-same-crate-name.rs
+++ b/tests/ui/type/type-mismatch-same-crate-name.rs
@@ -3,25 +3,32 @@
 
 // This tests the extra note reported when a type error deals with
 // seemingly identical types.
-// The main use case of this error is when there are two crates
-// (generally different versions of the same crate) with the same name
-// causing a type mismatch. Here, we simulate that error using block-scoped
-// aliased `extern crate` declarations.
+// The main use case of this error is when there are two crates imported
+// with the same name, causing a type mismatch. Here, we simulate that error
+// using block-scoped aliased `extern crate` declarations.
+// This is *not* the same case as two different crate versions in the
+// dependency tree. That is tested in `tests/run-make/crate-loading/`.
 
 fn main() {
     let foo2 = {extern crate crate_a2 as a; a::Foo};
+        //~^ NOTE one type comes from crate `crate_a2` used here, which is renamed locally to `a`
+        //~| NOTE one trait comes from crate `crate_a2` used here, which is renamed locally to `a`
     let bar2 = {extern crate crate_a2 as a; a::bar()};
     {
         extern crate crate_a1 as a;
+        //~^ NOTE one type comes from crate `crate_a1` used here, which is renamed locally to `a`
+        //~| NOTE one trait comes from crate `crate_a1` used here, which is renamed locally to `a`
         a::try_foo(foo2);
         //~^ ERROR mismatched types
-        //~| perhaps two different versions of crate `crate_a1`
-        //~| expected `main::a::Foo`, found a different `main::a::Foo`
+        //~| NOTE expected `main::a::Foo`, found a different `main::a::Foo`
+        //~| NOTE arguments to this function are incorrect
+        //~| NOTE two types coming from two different crates are different types even if they look the same
+        //~| NOTE function defined here
         a::try_bar(bar2);
         //~^ ERROR mismatched types
-        //~| perhaps two different versions of crate `crate_a1`
-        //~| expected trait `main::a::Bar`
-        //~| expected struct `Box<(dyn main::a::Bar + 'static)>`
-        //~| found struct `Box<dyn main::a::Bar>`
+        //~| NOTE expected trait `main::a::Bar`, found a different trait `main::a::Bar`
+        //~| NOTE arguments to this function are incorrect
+        //~| NOTE two types coming from two different crates are different types even if they look the same
+        //~| NOTE function defined here
     }
 }

--- a/tests/ui/type/type-mismatch-same-crate-name.stderr
+++ b/tests/ui/type/type-mismatch-same-crate-name.stderr
@@ -1,23 +1,29 @@
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch-same-crate-name.rs:16:20
+  --> $DIR/type-mismatch-same-crate-name.rs:21:20
    |
 LL |         a::try_foo(foo2);
    |         ---------- ^^^^ expected `main::a::Foo`, found a different `main::a::Foo`
    |         |
    |         arguments to this function are incorrect
    |
-   = note: `main::a::Foo` and `main::a::Foo` have similar names, but are actually distinct types
-note: `main::a::Foo` is defined in crate `crate_a2`
+note: two types coming from two different crates are different types even if they look the same
   --> $DIR/auxiliary/crate_a2.rs:1:1
    |
 LL | pub struct Foo;
-   | ^^^^^^^^^^^^^^
-note: `main::a::Foo` is defined in crate `crate_a1`
-  --> $DIR/auxiliary/crate_a1.rs:1:1
+   | ^^^^^^^^^^^^^^ this is the found type `crate_a2::Foo`
+   |
+  ::: $DIR/auxiliary/crate_a1.rs:1:1
    |
 LL | pub struct Foo;
-   | ^^^^^^^^^^^^^^
-   = note: perhaps two different versions of crate `crate_a1` are being used?
+   | ^^^^^^^^^^^^^^ this is the expected type `crate_a1::Foo`
+   |
+  ::: $DIR/type-mismatch-same-crate-name.rs:13:17
+   |
+LL |     let foo2 = {extern crate crate_a2 as a; a::Foo};
+   |                 --------------------------- one type comes from crate `crate_a2` used here, which is renamed locally to `a`
+...
+LL |         extern crate crate_a1 as a;
+   |         --------------------------- one type comes from crate `crate_a1` used here, which is renamed locally to `a`
 note: function defined here
   --> $DIR/auxiliary/crate_a1.rs:10:8
    |
@@ -25,16 +31,31 @@ LL | pub fn try_foo(x: Foo){}
    |        ^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/type-mismatch-same-crate-name.rs:20:20
+  --> $DIR/type-mismatch-same-crate-name.rs:27:20
    |
 LL |         a::try_bar(bar2);
    |         ---------- ^^^^ expected trait `main::a::Bar`, found a different trait `main::a::Bar`
    |         |
    |         arguments to this function are incorrect
    |
-   = note: expected struct `Box<(dyn main::a::Bar + 'static)>`
-              found struct `Box<dyn main::a::Bar>`
-   = note: perhaps two different versions of crate `crate_a1` are being used?
+note: two types coming from two different crates are different types even if they look the same
+  --> $DIR/auxiliary/crate_a2.rs:3:1
+   |
+LL | pub trait Bar {}
+   | ^^^^^^^^^^^^^ this is the found trait `crate_a2::Bar`
+   |
+  ::: $DIR/auxiliary/crate_a1.rs:3:1
+   |
+LL | pub trait Bar {}
+   | ^^^^^^^^^^^^^ this is the expected trait `crate_a1::Bar`
+   |
+  ::: $DIR/type-mismatch-same-crate-name.rs:13:17
+   |
+LL |     let foo2 = {extern crate crate_a2 as a; a::Foo};
+   |                 --------------------------- one trait comes from crate `crate_a2` used here, which is renamed locally to `a`
+...
+LL |         extern crate crate_a1 as a;
+   |         --------------------------- one trait comes from crate `crate_a1` used here, which is renamed locally to `a`
 note: function defined here
   --> $DIR/auxiliary/crate_a1.rs:11:8
    |


### PR DESCRIPTION
When encountering a type or trait mismatch for two types coming from two different crates with the same name, detect if it is either mixing two types/traits from the same crate on different versions:

```
error[E0308]: mismatched types
  --> replaced
   |
LL |     do_something_type(Type);
   |     ----------------- ^^^^ expected `dependency::Type`, found `dep_2_reexport::Type`
   |     |
   |     arguments to this function are incorrect
   |
note: two different versions of crate `dependency` are being used; two types coming from two different versions of the same crate are different types even if they look the same
  --> replaced
   |
LL | pub struct Type(pub i32);
   | ^^^^^^^^^^^^^^^ this is the expected type `dependency::Type`
   |
  ::: replaced
   |
LL | pub struct Type;
   | ^^^^^^^^^^^^^^^ this is the found type `dep_2_reexport::Type`
   |
  ::: replaced
   |
LL | extern crate dep_2_reexport;
   | ---------------------------- one version of crate `dependency` is used here, as a dependency of crate `foo`
LL | extern crate dependency;
   | ------------------------ one version of crate `dependency` is used here, as a direct dependency of the current crate
   = help: you can use `cargo tree` to explore your dependency tree
note: function defined here
  --> replaced
   |
LL | pub fn do_something_type(_: Type) {}
   |        ^^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
  --> replaced
   |
LL |     do_something_trait(Box::new(Type) as Box<dyn Trait2>);
   |     ------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected trait `dependency::Trait2`, found trait `dep_2_reexport::Trait2`
   |     |
   |     arguments to this function are incorrect
   |
note: two different versions of crate `dependency` are being used; two types coming from two different versions of the same crate are different types even if they look the same
  --> replaced
   |
LL | pub trait Trait2 {}
   | ^^^^^^^^^^^^^^^^ this is the expected trait `dependency::Trait2`
   |
  ::: replaced
   |
LL | pub trait Trait2 {}
   | ^^^^^^^^^^^^^^^^ this is the found trait `dep_2_reexport::Trait2`
   |
  ::: replaced
   |
LL | extern crate dep_2_reexport;
   | ---------------------------- one version of crate `dependency` is used here, as a dependency of crate `foo`
LL | extern crate dependency;
   | ------------------------ one version of crate `dependency` is used here, as a direct dependency of the current crate
   = help: you can use `cargo tree` to explore your dependency tree
note: function defined here
  --> replaced
   |
LL | pub fn do_something_trait(_: Box<dyn Trait2>) {}
   |        ^^^^^^^^^^^^^^^^^^
```

or if it is different crates that were renamed to the same name:

```
error[E0308]: mismatched types
  --> $DIR/type-mismatch-same-crate-name.rs:21:20
   |
LL |         a::try_foo(foo2);
   |         ---------- ^^^^ expected `main::a::Foo`, found a different `main::a::Foo`
   |         |
   |         arguments to this function are incorrect
   |
note: two types coming from two different crates are different types even if they look the same
  --> $DIR/auxiliary/crate_a2.rs:1:1
   |
LL | pub struct Foo;
   | ^^^^^^^^^^^^^^ this is the found type `crate_a2::Foo`
   |
  ::: $DIR/auxiliary/crate_a1.rs:1:1
   |
LL | pub struct Foo;
   | ^^^^^^^^^^^^^^ this is the expected type `crate_a1::Foo`
   |
  ::: $DIR/type-mismatch-same-crate-name.rs:13:17
   |
LL |     let foo2 = {extern crate crate_a2 as a; a::Foo};
   |                 --------------------------- one type comes from crate `crate_a2` is used here, which is renamed locally to `a`
...
LL |         extern crate crate_a1 as a;
   |         --------------------------- one type comes from crate `crate_a1` is used here, which is renamed locally to `a`
note: function defined here
  --> $DIR/auxiliary/crate_a1.rs:10:8
   |
LL | pub fn try_foo(x: Foo){}
   |        ^^^^^^^

error[E0308]: mismatched types
  --> $DIR/type-mismatch-same-crate-name.rs:27:20
   |
LL |         a::try_bar(bar2);
   |         ---------- ^^^^ expected trait `main::a::Bar`, found a different trait `main::a::Bar`
   |         |
   |         arguments to this function are incorrect
   |
note: two types coming from two different crates are different types even if they look the same
  --> $DIR/auxiliary/crate_a2.rs:3:1
   |
LL | pub trait Bar {}
   | ^^^^^^^^^^^^^ this is the found trait `crate_a2::Bar`
   |
  ::: $DIR/auxiliary/crate_a1.rs:3:1
   |
LL | pub trait Bar {}
   | ^^^^^^^^^^^^^ this is the expected trait `crate_a1::Bar`
   |
  ::: $DIR/type-mismatch-same-crate-name.rs:13:17
   |
LL |     let foo2 = {extern crate crate_a2 as a; a::Foo};
   |                 --------------------------- one trait comes from crate `crate_a2` is used here, which is renamed locally to `a`
...
LL |         extern crate crate_a1 as a;
   |         --------------------------- one trait comes from crate `crate_a1` is used here, which is renamed locally to `a`
note: function defined here
  --> $DIR/auxiliary/crate_a1.rs:11:8
   |
LL | pub fn try_bar(x: Box<Bar>){}
   |        ^^^^^^^
```

This new output unifies the E0308 errors detail with the pre-existing E0277 errors, and better differentiates the "`extern crate` renamed" and "same crate, different versions" cases.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
