### PR TITLE
Make CoercePointee errors translatable

### DIFF
--- a/compiler/rustc_builtin_macros/messages.ftl
+++ b/compiler/rustc_builtin_macros/messages.ftl
@@ -94,6 +94,21 @@ builtin_macros_cfg_accessible_indeterminate = cannot determine whether the path 
 builtin_macros_cfg_accessible_literal_path = `cfg_accessible` path cannot be a literal
 builtin_macros_cfg_accessible_multiple_paths = multiple `cfg_accessible` paths are specified
 builtin_macros_cfg_accessible_unspecified_path = `cfg_accessible` path is not specified
+
+builtin_macros_coerce_pointee_requires_maybe_sized = `derive(CoercePointee)` requires `{$name}` to be marked `?Sized`
+
+builtin_macros_coerce_pointee_requires_one_field = `CoercePointee` can only be derived on `struct`s with at least one field
+
+builtin_macros_coerce_pointee_requires_one_generic = `CoercePointee` can only be derived on `struct`s that are generic over at least one type
+
+builtin_macros_coerce_pointee_requires_one_pointee = exactly one generic type parameter must be marked as `#[pointee]` to derive `CoercePointee` traits
+
+builtin_macros_coerce_pointee_requires_transparent = `CoercePointee` can only be derived on `struct`s with `#[repr(transparent)]`
+
+builtin_macros_coerce_pointee_too_many_pointees = only one type parameter can be marked as `#[pointee]` when deriving `CoercePointee` traits
+    .label = here another type parameter is marked as `#[pointee]`
+
+
 builtin_macros_concat_bytes_array = cannot concatenate doubly nested array
     .note = byte strings are treated as arrays of bytes
     .help = try flattening the array

--- a/tests/ui/deriving/deriving-coerce-pointee-neg.rs
+++ b/tests/ui/deriving/deriving-coerce-pointee-neg.rs
@@ -29,7 +29,7 @@ struct NoFieldUnit<'a, #[pointee] T: ?Sized>();
 struct NoGeneric<'a>(&'a u8);
 
 #[derive(CoercePointee)]
-//~^ ERROR: exactly one generic type parameter must be marked as #[pointee] to derive CoercePointee traits
+//~^ ERROR: exactly one generic type parameter must be marked as `#[pointee]` to derive `CoercePointee` traits
 #[repr(transparent)]
 struct AmbiguousPointee<'a, T1: ?Sized, T2: ?Sized> {
     a: (&'a T1, &'a T2),
@@ -38,7 +38,7 @@ struct AmbiguousPointee<'a, T1: ?Sized, T2: ?Sized> {
 #[derive(CoercePointee)]
 #[repr(transparent)]
 struct TooManyPointees<'a, #[pointee] A: ?Sized, #[pointee] B: ?Sized>((&'a A, &'a B));
-//~^ ERROR: only one type parameter can be marked as `#[pointee]` when deriving CoercePointee traits
+//~^ ERROR: only one type parameter can be marked as `#[pointee]` when deriving `CoercePointee` traits
 
 #[derive(CoercePointee)]
 //~^ ERROR: `CoercePointee` can only be derived on `struct`s with `#[repr(transparent)]`
@@ -49,7 +49,7 @@ struct NotTransparent<'a, #[pointee] T: ?Sized> {
 #[derive(CoercePointee)]
 #[repr(transparent)]
 struct NoMaybeSized<'a, #[pointee] T> {
-    //~^ ERROR: `derive(CoercePointee)` requires T to be marked `?Sized`
+    //~^ ERROR: `derive(CoercePointee)` requires `T` to be marked `?Sized`
     ptr: &'a T,
 }
 

--- a/tests/ui/deriving/deriving-coerce-pointee-neg.stderr
+++ b/tests/ui/deriving/deriving-coerce-pointee-neg.stderr
@@ -30,7 +30,7 @@ LL | #[derive(CoercePointee)]
    |
    = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: exactly one generic type parameter must be marked as #[pointee] to derive CoercePointee traits
+error: exactly one generic type parameter must be marked as `#[pointee]` to derive `CoercePointee` traits
   --> $DIR/deriving-coerce-pointee-neg.rs:31:10
    |
 LL | #[derive(CoercePointee)]
@@ -38,11 +38,11 @@ LL | #[derive(CoercePointee)]
    |
    = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: only one type parameter can be marked as `#[pointee]` when deriving CoercePointee traits
+error: only one type parameter can be marked as `#[pointee]` when deriving `CoercePointee` traits
   --> $DIR/deriving-coerce-pointee-neg.rs:40:39
    |
 LL | struct TooManyPointees<'a, #[pointee] A: ?Sized, #[pointee] B: ?Sized>((&'a A, &'a B));
-   |                                       ^                     ^
+   |                                       ^                     - here another type parameter is marked as `#[pointee]`
 
 error: `CoercePointee` can only be derived on `struct`s with `#[repr(transparent)]`
   --> $DIR/deriving-coerce-pointee-neg.rs:43:10
@@ -52,7 +52,7 @@ LL | #[derive(CoercePointee)]
    |
    = note: this error originates in the derive macro `CoercePointee` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: `derive(CoercePointee)` requires T to be marked `?Sized`
+error: `derive(CoercePointee)` requires `T` to be marked `?Sized`
   --> $DIR/deriving-coerce-pointee-neg.rs:51:36
    |
 LL | struct NoMaybeSized<'a, #[pointee] T> {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

Tracked by #123430 

Just in case that a translatable error message would become a blocker to stabilization, this PR switches over to fluent error messages, which also slightly improve the wordings and use more accurate span information.

cc @Darksonn @traviscross 