### PR TITLE
Use correct `hir_id` for array const arg infers

### DIFF
--- a/compiler/rustc_ast_lowering/src/lib.rs
+++ b/compiler/rustc_ast_lowering/src/lib.rs
@@ -2013,7 +2013,8 @@ impl<'a, 'hir> LoweringContext<'a, 'hir> {
             ExprKind::Underscore => {
                 if self.tcx.features().generic_arg_infer() {
                     let ct_kind = hir::ConstArgKind::Infer(self.lower_span(c.value.span));
-                    self.arena.alloc(hir::ConstArg { hir_id: self.next_id(), kind: ct_kind })
+                    self.arena
+                        .alloc(hir::ConstArg { hir_id: self.lower_node_id(c.id), kind: ct_kind })
                 } else {
                     feature_err(
                         &self.tcx.sess,

--- a/tests/ui/const-generics/generic_arg_infer/array-repeat-expr-lib.rs
+++ b/tests/ui/const-generics/generic_arg_infer/array-repeat-expr-lib.rs
@@ -1,0 +1,12 @@
+//@ check-pass
+
+#![feature(generic_arg_infer)]
+#![crate_type = "lib"]
+
+// Test that encoding the hallucinated `DefId` for the `_` const argument doesn't
+// ICE (see #133468). This requires this to be a library crate.
+
+pub fn foo() {
+    let s: [u8; 10];
+    s = [0; _];
+}


### PR DESCRIPTION
Fixes #133771

`self.next_id()` results in the `DefId` for the const argument, created from the hack introduced by #133468, having no `HirId` associated with it. This then results in an ICE in metadata encoding. Fixing this then results in *another* ICE where `encode_defs` was not skipping encoding `type_of` and other queries for `DefId`s when they correspond to a `ConstArgKind::Infer` node.

This only reproduces with a library crate as metadata is not encoded for binaries, and apparently we had 0 tests for `generic_arg_infer` for array lengths in a library crate so this was not caught :<

cc #133589 @voidc 

r? @compiler-errors @lcnr 