### PR TITLE
Add doc alias 'then_with' for `then` method on `bool`

### DIFF
--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -54,6 +54,7 @@ impl bool {
     /// // `then`.
     /// assert_eq!(a, 1);
     /// ```
+    #[doc(alias = "then_with")]
     #[stable(feature = "lazy_bool_to_option", since = "1.50.0")]
     #[cfg_attr(not(test), rustc_diagnostic_item = "bool_then")]
     #[inline]


### PR DESCRIPTION
I think its logical to search for this name since `Ordering::then_with` exists as well.
