### PR TITLE
Update the definition of `borrowing_sub`

### DIFF
--- a/library/core/src/num/uint_macros.rs
+++ b/library/core/src/num/uint_macros.rs
@@ -2445,7 +2445,7 @@ macro_rules! uint_impl {
             //   to generate optimal code for now, and LLVM doesn't have an equivalent intrinsic
             let (a, b) = self.overflowing_sub(rhs);
             let (c, d) = a.overflowing_sub(borrow as $SelfT);
-            (c, b || d)
+            (c, b | d)
         }
 
         /// Calculates `self` - `rhs` with a signed `rhs`

--- a/tests/assembly/x86_64-bigint-helpers.rs
+++ b/tests/assembly/x86_64-bigint-helpers.rs
@@ -6,8 +6,8 @@
 #![no_std]
 #![feature(bigint_helper_methods)]
 
-// This checks that the `carrying_add` implementation successfully chains, to catch
-// issues like <https://github.com/rust-lang/rust/issues/85532#issuecomment-2495119815>
+// This checks that the `carrying_add` and `borrowing_sub` implementation successfully chain,
+// to catch issues like <https://github.com/rust-lang/rust/issues/85532#issuecomment-2495119815>
 
 // This forces the ABI to avoid the windows-vs-linux ABI differences.
 
@@ -28,6 +28,27 @@ pub unsafe extern "sysv64" fn bigint_chain_carrying_add(
     // CHECK: mov qword ptr [rdi + 8*[[IND]] + 16], [[TEMP]]
     for i in 0..n {
         (*dest.add(i), carry) = u64::carrying_add(*src1.add(i), *src2.add(i), carry);
+    }
+    carry
+}
+
+// CHECK-LABEL: bigint_chain_borrowing_sub:
+#[no_mangle]
+pub unsafe extern "sysv64" fn bigint_chain_borrowing_sub(
+    dest: *mut u64,
+    src1: *const u64,
+    src2: *const u64,
+    n: usize,
+    mut carry: bool,
+) -> bool {
+    // CHECK: mov [[TEMP:r..]], qword ptr [rsi + 8*[[IND:r..]] + 8]
+    // CHECK: sbb [[TEMP]], qword ptr [rdx + 8*[[IND]] + 8]
+    // CHECK: mov qword ptr [rdi + 8*[[IND]] + 8], [[TEMP]]
+    // CHECK: mov [[TEMP]], qword ptr [rsi + 8*[[IND]] + 16]
+    // CHECK: sbb [[TEMP]], qword ptr [rdx + 8*[[IND]] + 16]
+    // CHECK: mov qword ptr [rdi + 8*[[IND]] + 16], [[TEMP]]
+    for i in 0..n {
+        (*dest.add(i), carry) = u64::borrowing_sub(*src1.add(i), *src2.add(i), carry);
     }
     carry
 }


### PR DESCRIPTION
Complementary PR to https://github.com/rust-lang/rust/pull/133674, which only updated `carrying_add`.
