### PR TITLE
[AIX] change AIX default codemodel=large

### DIFF
--- a/compiler/rustc_target/src/spec/base/aix.rs
+++ b/compiler/rustc_target/src/spec/base/aix.rs
@@ -4,7 +4,7 @@ use crate::spec::{Cc, CodeModel, LinkOutputKind, LinkerFlavor, TargetOptions, cr
 pub(crate) fn opts() -> TargetOptions {
     TargetOptions {
         abi: "vec-extabi".into(),
-        code_model: Some(CodeModel::Small),
+        code_model: Some(CodeModel::Large),
         cpu: "pwr7".into(),
         os: "aix".into(),
         vendor: "ibm".into(),


### PR DESCRIPTION
On AIX, for most libraries, we run out of Table of Contents (TOC) offsets very quickly due to the default 16-bit offset limit. We want the large code model should be used as the default to provide more TOC entries so the end user does not have to specify `-Ccode-model=large` for all their packages. This is even more of an issue with ThinLTO as the ThinLTO globals can very quickly use all available TOC entry. 

In addition, on AIX, code with different code-model across different compilation units will not cause undefined behavior, so this is safe to do.

