### PR TITLE
Use `cfg_attr_trace` in AST with a placeholder attribute for accurate suggestion

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -953,7 +953,8 @@ lint_unused_doc_comment = unused doc comment
     .help = to document an item produced by a macro, the macro must produce the documentation as part of its expansion
 
 lint_unused_extern_crate = unused extern crate
-    .suggestion = remove it
+    .label = unused
+    .suggestion = remove the unused `extern crate`
 
 lint_unused_import_braces = braces around {$node} is unnecessary
 

--- a/compiler/rustc_lint/src/early/diagnostics.rs
+++ b/compiler/rustc_lint/src/early/diagnostics.rs
@@ -292,8 +292,8 @@ pub(super) fn decorate_lint(
         BuiltinLintDiag::ByteSliceInPackedStructWithDerive { ty } => {
             lints::ByteSliceInPackedStructWithDerive { ty }.decorate_lint(diag);
         }
-        BuiltinLintDiag::UnusedExternCrate { removal_span } => {
-            lints::UnusedExternCrate { removal_span }.decorate_lint(diag);
+        BuiltinLintDiag::UnusedExternCrate { span, removal_span } => {
+            lints::UnusedExternCrate { span, removal_span }.decorate_lint(diag);
         }
         BuiltinLintDiag::ExternCrateNotIdiomatic { vis_span, ident_span } => {
             let suggestion_span = vis_span.between(ident_span);

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -3051,7 +3051,9 @@ pub(crate) struct ByteSliceInPackedStructWithDerive {
 #[derive(LintDiagnostic)]
 #[diag(lint_unused_extern_crate)]
 pub(crate) struct UnusedExternCrate {
-    #[suggestion(code = "", applicability = "machine-applicable")]
+    #[label]
+    pub span: Span,
+    #[suggestion(code = "", applicability = "machine-applicable", style = "verbose")]
     pub removal_span: Span,
 }
 

--- a/compiler/rustc_lint_defs/src/lib.rs
+++ b/compiler/rustc_lint_defs/src/lib.rs
@@ -736,6 +736,7 @@ pub enum BuiltinLintDiag {
         ty: String,
     },
     UnusedExternCrate {
+        span: Span,
         removal_span: Span,
     },
     ExternCrateNotIdiomatic {

--- a/compiler/rustc_resolve/src/check_unused.rs
+++ b/compiler/rustc_resolve/src/check_unused.rs
@@ -154,6 +154,7 @@ impl<'a, 'ra, 'tcx> UnusedImportCheckVisitor<'a, 'ra, 'tcx> {
                         extern_crate.id,
                         span,
                         BuiltinLintDiag::UnusedExternCrate {
+                            span: extern_crate.span,
                             removal_span: extern_crate.span_with_attributes,
                         },
                     );

--- a/tests/ui/editions/edition-extern-crate-allowed.stderr
+++ b/tests/ui/editions/edition-extern-crate-allowed.stderr
@@ -2,7 +2,7 @@ warning: unused extern crate
   --> $DIR/edition-extern-crate-allowed.rs:7:1
    |
 LL | extern crate edition_extern_crate_allowed;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
    |
 note: the lint level is defined here
   --> $DIR/edition-extern-crate-allowed.rs:5:9
@@ -10,6 +10,10 @@ note: the lint level is defined here
 LL | #![warn(rust_2018_idioms)]
    |         ^^^^^^^^^^^^^^^^
    = note: `#[warn(unused_extern_crates)]` implied by `#[warn(rust_2018_idioms)]`
+help: remove the unused `extern crate`
+   |
+LL - extern crate edition_extern_crate_allowed;
+   |
 
 warning: 1 warning emitted
 

--- a/tests/ui/imports/extern-crate-used.stderr
+++ b/tests/ui/imports/extern-crate-used.stderr
@@ -2,13 +2,18 @@ error: unused extern crate
   --> $DIR/extern-crate-used.rs:18:1
    |
 LL | extern crate core;
-   | ^^^^^^^^^^^^^^^^^^ help: remove it
+   | ^^^^^^^^^^^^^^^^^^ unused
    |
 note: the lint level is defined here
   --> $DIR/extern-crate-used.rs:6:9
    |
 LL | #![deny(unused_extern_crates)]
    |         ^^^^^^^^^^^^^^^^^^^^
+help: remove the unused `extern crate`
+   |
+LL - extern crate core;
+LL +
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/lint/unnecessary-extern-crate.stderr
+++ b/tests/ui/lint/unnecessary-extern-crate.stderr
@@ -2,43 +2,72 @@ error: unused extern crate
   --> $DIR/unnecessary-extern-crate.rs:6:1
    |
 LL | extern crate core;
-   | ^^^^^^^^^^^^^^^^^^ help: remove it
+   | ^^^^^^^^^^^^^^^^^^ unused
    |
 note: the lint level is defined here
   --> $DIR/unnecessary-extern-crate.rs:3:9
    |
 LL | #![deny(unused_extern_crates)]
    |         ^^^^^^^^^^^^^^^^^^^^
+help: remove the unused `extern crate`
+   |
+LL - extern crate core;
+   |
 
 error: unused extern crate
   --> $DIR/unnecessary-extern-crate.rs:9:1
    |
 LL | extern crate core as x;
-   | ^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
+   | ^^^^^^^^^^^^^^^^^^^^^^^ unused
+   |
+help: remove the unused `extern crate`
+   |
+LL - extern crate core as x;
+   |
 
 error: unused extern crate
   --> $DIR/unnecessary-extern-crate.rs:31:5
    |
 LL |     extern crate core;
-   |     ^^^^^^^^^^^^^^^^^^ help: remove it
+   |     ^^^^^^^^^^^^^^^^^^ unused
+   |
+help: remove the unused `extern crate`
+   |
+LL -     extern crate core;
+   |
 
 error: unused extern crate
   --> $DIR/unnecessary-extern-crate.rs:35:5
    |
 LL |     extern crate core as x;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ unused
+   |
+help: remove the unused `extern crate`
+   |
+LL -     extern crate core as x;
+   |
 
 error: unused extern crate
   --> $DIR/unnecessary-extern-crate.rs:44:9
    |
 LL |         extern crate core;
-   |         ^^^^^^^^^^^^^^^^^^ help: remove it
+   |         ^^^^^^^^^^^^^^^^^^ unused
+   |
+help: remove the unused `extern crate`
+   |
+LL -         extern crate core;
+   |
 
 error: unused extern crate
   --> $DIR/unnecessary-extern-crate.rs:48:9
    |
 LL |         extern crate core as x;
-   |         ^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ unused
+   |
+help: remove the unused `extern crate`
+   |
+LL -         extern crate core as x;
+   |
 
 error: aborting due to 6 previous errors
 

--- a/tests/ui/lint/unused/lint-unused-extern-crate.stderr
+++ b/tests/ui/lint/unused/lint-unused-extern-crate.stderr
@@ -2,19 +2,30 @@ error: unused extern crate
   --> $DIR/lint-unused-extern-crate.rs:11:1
    |
 LL | extern crate lint_unused_extern_crate5;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
    |
 note: the lint level is defined here
   --> $DIR/lint-unused-extern-crate.rs:7:9
    |
 LL | #![deny(unused_extern_crates)]
    |         ^^^^^^^^^^^^^^^^^^^^
+help: remove the unused `extern crate`
+   |
+LL - extern crate lint_unused_extern_crate5;
+LL +
+   |
 
 error: unused extern crate
   --> $DIR/lint-unused-extern-crate.rs:29:5
    |
 LL |     extern crate lint_unused_extern_crate2;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
+   |
+help: remove the unused `extern crate`
+   |
+LL -     extern crate lint_unused_extern_crate2;
+LL +
+   |
 
 error: aborting due to 2 previous errors
 

--- a/tests/ui/proc-macro/no-macro-use-attr.stderr
+++ b/tests/ui/proc-macro/no-macro-use-attr.stderr
@@ -2,13 +2,17 @@ warning: unused extern crate
   --> $DIR/no-macro-use-attr.rs:6:1
    |
 LL | extern crate test_macros;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^ unused
    |
 note: the lint level is defined here
   --> $DIR/no-macro-use-attr.rs:4:9
    |
 LL | #![warn(unused_extern_crates)]
    |         ^^^^^^^^^^^^^^^^^^^^
+help: remove the unused `extern crate`
+   |
+LL - extern crate test_macros;
+   |
 
 warning: 1 warning emitted
 

--- a/tests/ui/rust-2018/extern-crate-idiomatic-in-2018.stderr
+++ b/tests/ui/rust-2018/extern-crate-idiomatic-in-2018.stderr
@@ -2,7 +2,7 @@ error: unused extern crate
   --> $DIR/extern-crate-idiomatic-in-2018.rs:12:1
    |
 LL | extern crate edition_lint_paths;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
    |
 note: the lint level is defined here
   --> $DIR/extern-crate-idiomatic-in-2018.rs:9:9
@@ -10,6 +10,10 @@ note: the lint level is defined here
 LL | #![deny(rust_2018_idioms)]
    |         ^^^^^^^^^^^^^^^^
    = note: `#[deny(unused_extern_crates)]` implied by `#[deny(rust_2018_idioms)]`
+help: remove the unused `extern crate`
+   |
+LL - extern crate edition_lint_paths;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.rs
+++ b/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.rs
@@ -8,7 +8,7 @@
 
 // The suggestion span should include the attribute.
 
-#[cfg(not(FALSE))] //~ HELP remove it
+#[cfg(not(FALSE))] //~ HELP remove
 extern crate edition_lint_paths;
 //~^ ERROR unused extern crate
 

--- a/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
+++ b/tests/ui/rust-2018/issue-54400-unused-extern-crate-attr-span.stderr
@@ -1,11 +1,8 @@
 error: unused extern crate
   --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:12:1
    |
-LL | / #[cfg(not(FALSE))]
-LL | | extern crate edition_lint_paths;
-   | | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^-
-   | |________________________________|
-   |                                  help: remove it
+LL | extern crate edition_lint_paths;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
    |
 note: the lint level is defined here
   --> $DIR/issue-54400-unused-extern-crate-attr-span.rs:6:9
@@ -13,6 +10,11 @@ note: the lint level is defined here
 LL | #![deny(rust_2018_idioms)]
    |         ^^^^^^^^^^^^^^^^
    = note: `#[deny(unused_extern_crates)]` implied by `#[deny(rust_2018_idioms)]`
+help: remove the unused `extern crate`
+   |
+LL - #[cfg(not(FALSE))]
+LL - extern crate edition_lint_paths;
+   |
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rust-2018/remove-extern-crate.stderr
+++ b/tests/ui/rust-2018/remove-extern-crate.stderr
@@ -2,7 +2,7 @@ warning: unused extern crate
   --> $DIR/remove-extern-crate.rs:11:1
    |
 LL | extern crate core;
-   | ^^^^^^^^^^^^^^^^^^ help: remove it
+   | ^^^^^^^^^^^^^^^^^^ unused
    |
 note: the lint level is defined here
   --> $DIR/remove-extern-crate.rs:7:9
@@ -10,6 +10,11 @@ note: the lint level is defined here
 LL | #![warn(rust_2018_idioms)]
    |         ^^^^^^^^^^^^^^^^
    = note: `#[warn(unused_extern_crates)]` implied by `#[warn(rust_2018_idioms)]`
+help: remove the unused `extern crate`
+   |
+LL - extern crate core;
+LL +
+   |
 
 warning: `extern crate` is not idiomatic in the new edition
   --> $DIR/remove-extern-crate.rs:35:5

--- a/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.fixed
+++ b/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.fixed
@@ -1,0 +1,15 @@
+//@ edition:2018
+//@ aux-build:../removing-extern-crate.rs
+//@ run-rustfix
+
+#![warn(rust_2018_idioms)]
+
+ //~ WARNING unused extern crate
+ //~ WARNING unused extern crate
+
+mod another {
+     //~ WARNING unused extern crate
+     //~ WARNING unused extern crate
+}
+
+fn main() {}

--- a/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.rs
+++ b/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.rs
@@ -1,0 +1,17 @@
+//@ edition:2018
+//@ aux-build:../removing-extern-crate.rs
+//@ run-rustfix
+
+#![warn(rust_2018_idioms)]
+
+#[cfg_attr(test, "macro_use")] //~ ERROR expected
+extern crate removing_extern_crate as foo; //~ WARNING unused extern crate
+extern crate core; //~ WARNING unused extern crate
+
+mod another {
+    #[cfg_attr(test)] //~ ERROR expected
+    extern crate removing_extern_crate as foo; //~ WARNING unused extern crate
+    extern crate core; //~ WARNING unused extern crate
+}
+
+fn main() {}

--- a/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.stderr
+++ b/tests/ui/rust-2018/removing-extern-crate-malformed-cfg.stderr
@@ -1,0 +1,76 @@
+error: expected identifier, found `"macro_use"`
+  --> $DIR/removing-extern-crate-malformed-cfg.rs:7:18
+   |
+LL | #[cfg_attr(test, "macro_use")]
+   |                  ^^^^^^^^^^^ expected identifier
+   |
+   = help: the valid syntax is `#[cfg_attr(condition, attribute, other_attribute, ...)]`
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+
+error: expected one of `(`, `,`, `::`, or `=`, found `<eof>`
+  --> $DIR/removing-extern-crate-malformed-cfg.rs:12:16
+   |
+LL |     #[cfg_attr(test)]
+   |                ^^^^ expected one of `(`, `,`, `::`, or `=`
+   |
+   = help: the valid syntax is `#[cfg_attr(condition, attribute, other_attribute, ...)]`
+   = note: for more information, visit <https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute>
+
+warning: unused extern crate
+  --> $DIR/removing-extern-crate-malformed-cfg.rs:8:1
+   |
+LL | extern crate removing_extern_crate as foo;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
+   |
+note: the lint level is defined here
+  --> $DIR/removing-extern-crate-malformed-cfg.rs:5:9
+   |
+LL | #![warn(rust_2018_idioms)]
+   |         ^^^^^^^^^^^^^^^^
+   = note: `#[warn(unused_extern_crates)]` implied by `#[warn(rust_2018_idioms)]`
+help: remove the unused `extern crate`
+   |
+LL - #[cfg_attr(test, "macro_use")]
+LL - extern crate removing_extern_crate as foo;
+LL +
+   |
+
+warning: unused extern crate
+  --> $DIR/removing-extern-crate-malformed-cfg.rs:9:1
+   |
+LL | extern crate core;
+   | ^^^^^^^^^^^^^^^^^^ unused
+   |
+help: remove the unused `extern crate`
+   |
+LL - extern crate core;
+LL +
+   |
+
+warning: unused extern crate
+  --> $DIR/removing-extern-crate-malformed-cfg.rs:13:5
+   |
+LL |     extern crate removing_extern_crate as foo;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
+   |
+help: remove the unused `extern crate`
+   |
+LL -     #[cfg_attr(test)]
+LL -     extern crate removing_extern_crate as foo;
+LL +
+   |
+
+warning: unused extern crate
+  --> $DIR/removing-extern-crate-malformed-cfg.rs:14:5
+   |
+LL |     extern crate core;
+   |     ^^^^^^^^^^^^^^^^^^ unused
+   |
+help: remove the unused `extern crate`
+   |
+LL -     extern crate core;
+LL +
+   |
+
+error: aborting due to 2 previous errors; 4 warnings emitted
+

--- a/tests/ui/rust-2018/removing-extern-crate.stderr
+++ b/tests/ui/rust-2018/removing-extern-crate.stderr
@@ -2,7 +2,7 @@ warning: unused extern crate
   --> $DIR/removing-extern-crate.rs:8:1
    |
 LL | extern crate dummy_crate as foo;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
    |
 note: the lint level is defined here
   --> $DIR/removing-extern-crate.rs:6:9
@@ -10,24 +10,47 @@ note: the lint level is defined here
 LL | #![warn(rust_2018_idioms)]
    |         ^^^^^^^^^^^^^^^^
    = note: `#[warn(unused_extern_crates)]` implied by `#[warn(rust_2018_idioms)]`
+help: remove the unused `extern crate`
+   |
+LL - extern crate dummy_crate as foo;
+LL +
+   |
 
 warning: unused extern crate
   --> $DIR/removing-extern-crate.rs:9:1
    |
 LL | extern crate core;
-   | ^^^^^^^^^^^^^^^^^^ help: remove it
+   | ^^^^^^^^^^^^^^^^^^ unused
+   |
+help: remove the unused `extern crate`
+   |
+LL - extern crate core;
+LL +
+   |
 
 warning: unused extern crate
   --> $DIR/removing-extern-crate.rs:12:5
    |
 LL |     extern crate dummy_crate as foo;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove it
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
+   |
+help: remove the unused `extern crate`
+   |
+LL -     extern crate dummy_crate as foo;
+LL +
+   |
 
 warning: unused extern crate
   --> $DIR/removing-extern-crate.rs:13:5
    |
 LL |     extern crate core;
-   |     ^^^^^^^^^^^^^^^^^^ help: remove it
+   |     ^^^^^^^^^^^^^^^^^^ unused
+   |
+help: remove the unused `extern crate`
+   |
+LL -     extern crate core;
+LL +
+   |
 
 warning: 4 warnings emitted
 


### PR DESCRIPTION
In rust-lang/rust#138515, we insert a placeholder attribute so that checks for attributes can still know about the placement of `cfg` attributes. When we suggest removing items with `cfg_attr`s (fix rust-lang/rust#56328) and make them verbose. We tweak the wording of the existing "unused `extern crate`" lint.

```
warning: unused `extern crate`
  --> $DIR/removing-extern-crate.rs:9:1
   |
LL | extern crate removing_extern_crate as foo;
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unused
   |
note: the lint level is defined here
  --> $DIR/removing-extern-crate.rs:6:9
   |
LL | #![warn(rust_2018_idioms)]
   |         ^^^^^^^^^^^^^^^^
   = note: `#[warn(unused_extern_crates)]` implied by `#[warn(rust_2018_idioms)]`
help: remove the unused `extern crate`
   |
LL - #[cfg_attr(test, macro_use)]
LL - extern crate removing_extern_crate as foo;
   |
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

r? @petrochenkov 

try-job: x86_64-gnu-aux