### PR TITLE
Make `#[used]` work when linking with `ld64`

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -2063,8 +2063,8 @@ fn add_post_link_args(cmd: &mut dyn Linker, sess: &Session, flavor: LinkerFlavor
 /// linker, and since they never participate in the linking, using `KEEP` in the linker scripts
 /// can't keep them either. This causes #47384.
 ///
-/// To keep them around, we could use `--whole-archive` and equivalents to force rlib to
-/// participate in linking like object files, but this proves to be expensive (#93791). Therefore
+/// To keep them around, we could use `--whole-archive`, `-force_load` and equivalents to force rlib
+/// to participate in linking like object files, but this proves to be expensive (#93791). Therefore
 /// we instead just introduce an undefined reference to them. This could be done by `-u` command
 /// line option to the linker or `EXTERN(...)` in linker scripts, however they does not only
 /// introduce an undefined reference, but also make them the GC roots, preventing `--gc-sections`
@@ -2106,8 +2106,20 @@ fn add_linked_symbol_object(
         file.set_mangling(object::write::Mangling::None);
     }
 
+    // ld64 requires a relocation to load undefined symbols, see below.
+    // Not strictly needed if linking with lld, but might as well do it there too.
+    let ld64_section_helper = if file.format() == object::BinaryFormat::MachO {
+        Some(file.add_section(
+            file.segment_name(object::write::StandardSegment::Data).to_vec(),
+            "__data".into(),
+            object::SectionKind::Data,
+        ))
+    } else {
+        None
+    };
+
     for (sym, kind) in symbols.iter() {
-        file.add_symbol(object::write::Symbol {
+        let symbol = file.add_symbol(object::write::Symbol {
             name: sym.clone().into(),
             value: 0,
             size: 0,
@@ -2121,6 +2133,47 @@ fn add_linked_symbol_object(
             section: object::write::SymbolSection::Undefined,
             flags: object::SymbolFlags::None,
         });
+
+        // The linker shipped with Apple's Xcode, ld64, works a bit differently from other linkers.
+        //
+        // Code-wise, the relevant parts of ld64 are roughly:
+        // 1. Find the `ArchiveLoadMode` based on commandline options, default to `parseObjects`.
+        //    https://github.com/apple-oss-distributions/ld64/blob/ld64-954.16/src/ld/Options.cpp#L924-L932
+        //    https://github.com/apple-oss-distributions/ld64/blob/ld64-954.16/src/ld/Options.h#L55
+        //
+        // 2. Read the archive table of contents (__.SYMDEF file).
+        //    https://github.com/apple-oss-distributions/ld64/blob/ld64-954.16/src/ld/parsers/archive_file.cpp#L294-L325
+        //
+        // 3. Begin linking by loading "atoms" from input files.
+        //    https://github.com/apple-oss-distributions/ld64/blob/ld64-954.16/doc/design/linker.html
+        //    https://github.com/apple-oss-distributions/ld64/blob/ld64-954.16/src/ld/InputFiles.cpp#L1349
+        //
+        //   a. Directly specified object files (`.o`) are parsed immediately.
+        //      https://github.com/apple-oss-distributions/ld64/blob/ld64-954.16/src/ld/parsers/macho_relocatable_file.cpp#L4611-L4627
+        //
+        //     - Undefined symbols are not atoms (`n_value > 0` denotes a common symbol).
+        //       https://github.com/apple-oss-distributions/ld64/blob/ld64-954.16/src/ld/parsers/macho_relocatable_file.cpp#L2455-L2468
+        //       https://maskray.me/blog/2022-02-06-all-about-common-symbols
+        //
+        //     - Relocations/fixups are atoms.
+        //       https://github.com/apple-oss-distributions/ld64/blob/ce6341ae966b3451aa54eeb049f2be865afbd578/src/ld/parsers/macho_relocatable_file.cpp#L2088-L2114
+        //
+        //   b. Archives are not parsed yet.
+        //      https://github.com/apple-oss-distributions/ld64/blob/ld64-954.16/src/ld/parsers/archive_file.cpp#L467-L577
+        //
+        // 4. When a symbol is needed by an atom, parse the object file that contains the symbol.
+        //    https://github.com/apple-oss-distributions/ld64/blob/ld64-954.16/src/ld/InputFiles.cpp#L1417-L1491
+        //    https://github.com/apple-oss-distributions/ld64/blob/ld64-954.16/src/ld/parsers/archive_file.cpp#L579-L597
+        //
+        // All of the steps above are fairly similar to other linkers, except that **it completely
+        // ignores undefined symbols**.
+        //
+        // So to make this trick work on ld64, we need to do something else to load the relevant
+        // object files. We do this by inserting a relocation (fixup) for each symbol.
+        if let Some(section) = ld64_section_helper {
+            apple::add_data_and_relocation(&mut file, section, symbol, &sess.target, *kind)
+                .expect("failed adding relocation");
+        }
     }
 
     let path = tmpdir.join("symbols.o");

--- a/tests/run-make/include-all-symbols-linking/lib.rs
+++ b/tests/run-make/include-all-symbols-linking/lib.rs
@@ -1,5 +1,6 @@
 mod foo {
-    #[link_section = ".rodata.STATIC"]
+    #[cfg_attr(target_os = "linux", link_section = ".rodata.STATIC")]
+    #[cfg_attr(target_vendor = "apple", link_section = "__DATA,STATIC")]
     #[used]
     static STATIC: [u32; 10] = [1; 10];
 }

--- a/tests/run-make/include-all-symbols-linking/rmake.rs
+++ b/tests/run-make/include-all-symbols-linking/rmake.rs
@@ -7,15 +7,20 @@
 // See https://github.com/rust-lang/rust/pull/95604
 // See https://github.com/rust-lang/rust/issues/47384
 
-//@ only-linux
-// Reason: differences in object file formats on OSX and Windows
-// causes errors in the llvm_objdump step
+//@ ignore-wasm differences in object file formats causes errors in the llvm_objdump step.
+//@ ignore-windows differences in object file formats causes errors in the llvm_objdump step.
 
-use run_make_support::{dynamic_lib_name, llvm_objdump, llvm_readobj, rustc};
+use run_make_support::{dynamic_lib_name, llvm_objdump, llvm_readobj, rustc, target};
 
 fn main() {
     rustc().crate_type("lib").input("lib.rs").run();
-    rustc().crate_type("cdylib").link_args("-Tlinker.ld").input("main.rs").run();
+    let mut main = rustc();
+    main.crate_type("cdylib");
+    if target().contains("linux") {
+        main.link_args("-Tlinker.ld");
+    }
+    main.input("main.rs").run();
+
     // Ensure `#[used]` and `KEEP`-ed section is there
     llvm_objdump()
         .arg("--full-contents")

--- a/tests/ui/attributes/auxiliary/used_pre_main_constructor.rs
+++ b/tests/ui/attributes/auxiliary/used_pre_main_constructor.rs
@@ -1,0 +1,32 @@
+//! Add a constructor that runs pre-main, similar to what the `ctor` crate does.
+//!
+//! #[ctor]
+//! fn constructor() {
+//!     println!("constructor");
+//! }
+
+//@ no-prefer-dynamic explicitly test with crates that are built as an archive
+#![crate_type = "rlib"]
+
+#[cfg_attr(
+    any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly",
+        target_os = "illumos",
+        target_os = "haiku"
+    ),
+    link_section = ".init_array"
+)]
+#[cfg_attr(target_vendor = "apple", link_section = "__DATA,__mod_init_func,mod_init_funcs")]
+#[cfg_attr(target_os = "windows", link_section = ".CRT$XCU")]
+#[used]
+static CONSTRUCTOR: extern "C" fn() = constructor;
+
+#[cfg_attr(any(target_os = "linux", target_os = "android"), link_section = ".text.startup")]
+extern "C" fn constructor() {
+    println!("constructor");
+}

--- a/tests/ui/attributes/used_with_archive.rs
+++ b/tests/ui/attributes/used_with_archive.rs
@@ -1,0 +1,16 @@
+//! Ensure that `#[used]` in archives are correctly registered.
+//!
+//! Regression test for https://github.com/rust-lang/rust/issues/133491.
+
+//@ run-pass
+//@ check-run-results
+//@ aux-build: used_pre_main_constructor.rs
+
+//@ ignore-wasm ctor doesn't work on WASM
+
+// Make sure `rustc` links the archive, but intentionally do not import/use any items.
+extern crate used_pre_main_constructor as _;
+
+fn main() {
+    println!("main");
+}

--- a/tests/ui/attributes/used_with_archive.run.stdout
+++ b/tests/ui/attributes/used_with_archive.run.stdout
@@ -1,0 +1,2 @@
+constructor
+main


### PR DESCRIPTION
To make `#[used]` work in static libraries, we use the `symbols.o` trick introduced in https://github.com/rust-lang/rust/pull/95604.

However, the linker shipped with Xcode, ld64, works a bit differently from other linkers; in particular, [it completely ignores undefined symbols by themselves](https://github.com/apple-oss-distributions/ld64/blob/ld64-954.16/src/ld/parsers/macho_relocatable_file.cpp#L2455-L2468), and only consider them if they have relocations (something something atoms something fixups, I don't know the details).

So to make the `symbols.o` file work on ld64, we need to actually insert a relocation. That's kinda cumbersome to do though, since the relocation must be valid, and hence must point to a valid piece of machine code, and is hence very architecture-specific.

Fixes https://github.com/rust-lang/rust/issues/133491, see that for investigation.

---

Another option would be to pass `-u _foo` to the final linker invocation. This has the problem that `-u` causes the linker to not be able to dead-strip the symbol, which is undesirable. (If we did this, we would possibly also want to do it by putting the arguments in a file by itself, and passing that file via `@`, e.g. `@undefined_symbols.txt`, similar to https://github.com/rust-lang/rust/issues/52699, though that [is only supported since Xcode 12](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes#Linking), and I'm not sure we wanna bump that).

Various other options that are probably all undesirable as they affect link time performance:
- Pass `-all_load` to the linker.
- Pass `-ObjC` to the linker (the Objective-C support in the linker has different code paths that load more of the binary), and instrument the binaries that contain `#[used]` symbols.
- Pass `-force_load` to libraries that contain `#[used]` symbols.

Failed attempt: Embed `-u _foo` in the object file with `LC_LINKER_OPTION`, akin to https://github.com/rust-lang/rust/issues/121293. Doesn't work, both because `ld64` doesn't read that from archive members unless it already has a reason to load the member (which is what this PR is trying to make it do), and because `ld64` only support the `-l`, `-needed-l`, `-framework` and `-needed_framework` flags in there.

---

TODO:
- [x] Support all Apple architectures.
- [x] Ensure that this works regardless of the actual type of the symbol.
- [x] Write up more docs.
- [x] Wire up a few proper tests.

@rustbot label O-apple
