### PR TITLE
clarify simd_relaxed_fma non-determinism

### DIFF
--- a/library/core/src/intrinsics/simd.rs
+++ b/library/core/src/intrinsics/simd.rs
@@ -619,7 +619,8 @@ extern "rust-intrinsic" {
     /// set has support for a fused operation, and that the fused operation is more efficient
     /// than the equivalent, separate pair of mul and add instructions. It is unspecified
     /// whether or not a fused operation is selected, and that may depend on optimization
-    /// level and context, for example.
+    /// level and context, for example. It may even be the case that some SIMD lanes get fused
+    /// and others do not.
     ///
     /// `T` must be a vector of floats.
     #[cfg(not(bootstrap))]


### PR DESCRIPTION
This is the safer spec in the sense that it is more likely to be satisfied by the backend -- and if people are okay with a non-deterministic result, I assume they don't care whether it's the same choice across all lanes or not?

Cc @calebzulawski @workingjubilee 