### PR TITLE
Avoid `opaque type not constrained` errors in the presence of other errors

### DIFF
--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -1,6 +1,5 @@
 use rustc_hir::def::CtorOf;
 use rustc_index::Idx;
-use tracing::trace;
 
 use crate::rmeta::*;
 
@@ -530,8 +529,6 @@ where
 {
     /// Given the metadata, extract out the value at a particular index (if any).
     pub(super) fn get<'a, 'tcx, M: Metadata<'a, 'tcx>>(&self, metadata: M, i: I) -> T::Value<'tcx> {
-        trace!("LazyTable::lookup: index={:?} len={:?}", i, self.len);
-
         // Access past the end of the table returns a Default
         if i.index() >= self.len {
             return Default::default();

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.next.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.next.stderr
@@ -1,5 +1,5 @@
 error[E0284]: type annotations needed: cannot satisfy `Foo == _`
-  --> $DIR/norm-before-method-resolution-opaque-type.rs:16:19
+  --> $DIR/norm-before-method-resolution-opaque-type.rs:15:19
    |
 LL | fn weird_bound<X>(x: &<X as Trait<'static>>::Out<Foo>) -> X
    |                   ^ cannot satisfy `Foo == _`

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.old.stderr
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.old.stderr
@@ -1,5 +1,5 @@
 error: item does not constrain `Foo::{opaque#0}`, but has it in its signature
-  --> $DIR/norm-before-method-resolution-opaque-type.rs:16:4
+  --> $DIR/norm-before-method-resolution-opaque-type.rs:15:4
    |
 LL | fn weird_bound<X>(x: &<X as Trait<'static>>::Out<Foo>) -> X
    |    ^^^^^^^^^^^
@@ -11,16 +11,8 @@ note: this opaque type is in the signature
 LL | type Foo = impl Sized;
    |            ^^^^^^^^^^
 
-error: unconstrained opaque type
-  --> $DIR/norm-before-method-resolution-opaque-type.rs:13:12
-   |
-LL | type Foo = impl Sized;
-   |            ^^^^^^^^^^
-   |
-   = note: `Foo` must be used in combination with a concrete type within the same module
-
 error[E0507]: cannot move out of `*x` which is behind a shared reference
-  --> $DIR/norm-before-method-resolution-opaque-type.rs:23:13
+  --> $DIR/norm-before-method-resolution-opaque-type.rs:22:13
    |
 LL |     let x = *x;
    |             ^^ move occurs because `*x` has type `<X as Trait<'_>>::Out<Foo>`, which does not implement the `Copy` trait
@@ -31,6 +23,6 @@ LL -     let x = *x;
 LL +     let x = x;
    |
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0507`.

--- a/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.rs
+++ b/tests/ui/higher-ranked/trait-bounds/normalize-under-binder/norm-before-method-resolution-opaque-type.rs
@@ -11,7 +11,6 @@ impl<'a, T> Trait<'a> for T {
 }
 
 type Foo = impl Sized;
-//[old]~^ ERROR: unconstrained opaque type
 
 fn weird_bound<X>(x: &<X as Trait<'static>>::Out<Foo>) -> X
 //[old]~^ ERROR: item does not constrain

--- a/tests/ui/impl-trait/issues/issue-86800.rs
+++ b/tests/ui/impl-trait/issues/issue-86800.rs
@@ -23,7 +23,6 @@ struct Context {
 type TransactionResult<O> = Result<O, ()>;
 
 type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResult<O>>;
-//~^ ERROR unconstrained opaque type
 
 fn execute_transaction_fut<'f, F, O>(
     //~^ ERROR: item does not constrain

--- a/tests/ui/impl-trait/issues/issue-86800.stderr
+++ b/tests/ui/impl-trait/issues/issue-86800.stderr
@@ -1,5 +1,5 @@
 error: item does not constrain `TransactionFuture::{opaque#0}`, but has it in its signature
-  --> $DIR/issue-86800.rs:28:4
+  --> $DIR/issue-86800.rs:27:4
    |
 LL | fn execute_transaction_fut<'f, F, O>(
    |    ^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL | type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResu
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: item does not constrain `TransactionFuture::{opaque#0}`, but has it in its signature
-  --> $DIR/issue-86800.rs:40:14
+  --> $DIR/issue-86800.rs:39:14
    |
 LL |     async fn do_transaction<O>(
    |              ^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL | type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResu
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: item does not constrain `TransactionFuture::{opaque#0}`, but has it in its signature
-  --> $DIR/issue-86800.rs:44:5
+  --> $DIR/issue-86800.rs:43:5
    |
 LL | /     {
 LL | |
@@ -43,16 +43,8 @@ note: this opaque type is in the signature
 LL | type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResult<O>>;
    |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unconstrained opaque type
-  --> $DIR/issue-86800.rs:25:34
-   |
-LL | type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResult<O>>;
-   |                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `TransactionFuture` must be used in combination with a concrete type within the same module
-
 error[E0792]: expected generic lifetime parameter, found `'_`
-  --> $DIR/issue-86800.rs:35:5
+  --> $DIR/issue-86800.rs:34:5
    |
 LL | type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResult<O>>;
    |                        --- this generic parameter must be used with a generic lifetime parameter
@@ -61,7 +53,7 @@ LL |     f
    |     ^
 
 error[E0792]: expected generic lifetime parameter, found `'_`
-  --> $DIR/issue-86800.rs:44:5
+  --> $DIR/issue-86800.rs:43:5
    |
 LL |   type TransactionFuture<'__, O> = impl '__ + Future<Output = TransactionResult<O>>;
    |                          --- this generic parameter must be used with a generic lifetime parameter
@@ -75,6 +67,6 @@ LL | |         f(&mut transaction).await
 LL | |     }
    | |_____^
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.rs
+++ b/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.rs
@@ -2,7 +2,6 @@
 
 mod a {
     type Foo = impl PartialEq<(Foo, i32)>;
-    //~^ ERROR: unconstrained opaque type
 
     struct Bar;
 

--- a/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
+++ b/tests/ui/impl-trait/recursive-type-alias-impl-trait-declaration-too-subtle.stderr
@@ -1,5 +1,5 @@
 error[E0053]: method `eq` has an incompatible type for trait
-  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:10:30
+  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:9:30
    |
 LL |     type Foo = impl PartialEq<(Foo, i32)>;
    |                -------------------------- the found opaque type
@@ -15,7 +15,7 @@ LL |         fn eq(&self, _other: &(a::Bar, i32)) -> bool {
    |                              ~~~~~~~~~~~~~~
 
 error: item does not constrain `a::Foo::{opaque#0}`, but has it in its signature
-  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:10:12
+  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:9:12
    |
 LL |         fn eq(&self, _other: &(Foo, i32)) -> bool {
    |            ^^
@@ -27,16 +27,8 @@ note: this opaque type is in the signature
 LL |     type Foo = impl PartialEq<(Foo, i32)>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unconstrained opaque type
-  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:4:16
-   |
-LL |     type Foo = impl PartialEq<(Foo, i32)>;
-   |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `Foo` must be used in combination with a concrete type within the same module
-
 error[E0053]: method `eq` has an incompatible type for trait
-  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:25:30
+  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:24:30
    |
 LL |     type Foo = impl PartialEq<(Foo, i32)>;
    |                -------------------------- the expected opaque type
@@ -47,7 +39,7 @@ LL |         fn eq(&self, _other: &(Bar, i32)) -> bool {
    = note: expected signature `fn(&b::Bar, &(b::Foo, _)) -> _`
               found signature `fn(&b::Bar, &(b::Bar, _)) -> _`
 note: this item must have the opaque type in its signature in order to be able to register hidden types
-  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:25:12
+  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:24:12
    |
 LL |         fn eq(&self, _other: &(Bar, i32)) -> bool {
    |            ^^
@@ -57,13 +49,13 @@ LL |         fn eq(&self, _other: &(b::Foo, i32)) -> bool {
    |                              ~~~~~~~~~~~~~~
 
 error: unconstrained opaque type
-  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:19:16
+  --> $DIR/recursive-type-alias-impl-trait-declaration-too-subtle.rs:18:16
    |
 LL |     type Foo = impl PartialEq<(Foo, i32)>;
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `Foo` must be used in combination with a concrete type within the same module
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0053`.

--- a/tests/ui/impl-trait/two_tait_defining_each_other2.current.stderr
+++ b/tests/ui/impl-trait/two_tait_defining_each_other2.current.stderr
@@ -11,14 +11,6 @@ note: this opaque type is in the signature
 LL | type A = impl Foo;
    |          ^^^^^^^^
 
-error: unconstrained opaque type
-  --> $DIR/two_tait_defining_each_other2.rs:6:10
-   |
-LL | type A = impl Foo;
-   |          ^^^^^^^^
-   |
-   = note: `A` must be used in combination with a concrete type within the same module
-
 error: opaque type's hidden type cannot be another opaque type from the same scope
   --> $DIR/two_tait_defining_each_other2.rs:14:5
    |
@@ -36,5 +28,5 @@ note: opaque type being used as hidden type
 LL | type A = impl Foo;
    |          ^^^^^^^^
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 

--- a/tests/ui/impl-trait/two_tait_defining_each_other2.rs
+++ b/tests/ui/impl-trait/two_tait_defining_each_other2.rs
@@ -3,7 +3,7 @@
 //@[next] compile-flags: -Znext-solver
 #![feature(type_alias_impl_trait)]
 
-type A = impl Foo; //[current]~ ERROR unconstrained opaque type
+type A = impl Foo;
 type B = impl Foo;
 
 trait Foo {}

--- a/tests/ui/self/arbitrary-self-opaque.rs
+++ b/tests/ui/self/arbitrary-self-opaque.rs
@@ -2,7 +2,6 @@
 struct Foo;
 
 type Bar = impl Sized;
-//~^ ERROR unconstrained opaque type
 
 impl Foo {
     fn foo(self: Bar) {}

--- a/tests/ui/self/arbitrary-self-opaque.stderr
+++ b/tests/ui/self/arbitrary-self-opaque.stderr
@@ -1,5 +1,5 @@
 error[E0307]: invalid `self` parameter type: `Bar`
-  --> $DIR/arbitrary-self-opaque.rs:8:18
+  --> $DIR/arbitrary-self-opaque.rs:7:18
    |
 LL |     fn foo(self: Bar) {}
    |                  ^^^
@@ -8,7 +8,7 @@ LL |     fn foo(self: Bar) {}
    = help: consider changing to `self`, `&self`, `&mut self`, `self: Box<Self>`, `self: Rc<Self>`, `self: Arc<Self>`, or `self: Pin<P>` (where P is one of the previous types except `Self`)
 
 error: item does not constrain `Bar::{opaque#0}`, but has it in its signature
-  --> $DIR/arbitrary-self-opaque.rs:8:8
+  --> $DIR/arbitrary-self-opaque.rs:7:8
    |
 LL |     fn foo(self: Bar) {}
    |        ^^^
@@ -20,14 +20,6 @@ note: this opaque type is in the signature
 LL | type Bar = impl Sized;
    |            ^^^^^^^^^^
 
-error: unconstrained opaque type
-  --> $DIR/arbitrary-self-opaque.rs:4:12
-   |
-LL | type Bar = impl Sized;
-   |            ^^^^^^^^^^
-   |
-   = note: `Bar` must be used in combination with a concrete type within the same module
-
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0307`.

--- a/tests/ui/type-alias-impl-trait/bad-tait-no-substs.rs
+++ b/tests/ui/type-alias-impl-trait/bad-tait-no-substs.rs
@@ -3,7 +3,6 @@
 #![feature(type_alias_impl_trait)]
 trait Trait<T> {}
 type Alias<'a, U> = impl Trait<U>;
-//~^ ERROR unconstrained opaque type
 
 pub enum UninhabitedVariants {
     Tuple(Alias),

--- a/tests/ui/type-alias-impl-trait/bad-tait-no-substs.stderr
+++ b/tests/ui/type-alias-impl-trait/bad-tait-no-substs.stderr
@@ -1,5 +1,5 @@
 error[E0106]: missing lifetime specifier
-  --> $DIR/bad-tait-no-substs.rs:9:11
+  --> $DIR/bad-tait-no-substs.rs:8:11
    |
 LL |     Tuple(Alias),
    |           ^^^^^ expected named lifetime parameter
@@ -11,7 +11,7 @@ LL ~     Tuple(Alias<'a>),
    |
 
 error[E0107]: missing generics for type alias `Alias`
-  --> $DIR/bad-tait-no-substs.rs:9:11
+  --> $DIR/bad-tait-no-substs.rs:8:11
    |
 LL |     Tuple(Alias),
    |           ^^^^^ expected 1 generic argument
@@ -27,7 +27,7 @@ LL |     Tuple(Alias<U>),
    |                +++
 
 error[E0792]: non-defining opaque type use in defining scope
-  --> $DIR/bad-tait-no-substs.rs:9:11
+  --> $DIR/bad-tait-no-substs.rs:8:11
    |
 LL |     Tuple(Alias),
    |           ^^^^^ argument `'_` is not a generic parameter
@@ -39,7 +39,7 @@ LL | type Alias<'a, U> = impl Trait<U>;
    |                     ^^^^^^^^^^^^^
 
 error: item does not constrain `Alias::{opaque#0}`, but has it in its signature
-  --> $DIR/bad-tait-no-substs.rs:15:4
+  --> $DIR/bad-tait-no-substs.rs:14:4
    |
 LL | fn uwu(x: UninhabitedVariants) {
    |    ^^^
@@ -51,22 +51,14 @@ note: this opaque type is in the signature
 LL | type Alias<'a, U> = impl Trait<U>;
    |                     ^^^^^^^^^^^^^
 
-error: unconstrained opaque type
-  --> $DIR/bad-tait-no-substs.rs:5:21
-   |
-LL | type Alias<'a, U> = impl Trait<U>;
-   |                     ^^^^^^^^^^^^^
-   |
-   = note: `Alias` must be used in combination with a concrete type within the same module
-
 error[E0004]: non-exhaustive patterns: `UninhabitedVariants::Tuple(_)` not covered
-  --> $DIR/bad-tait-no-substs.rs:17:11
+  --> $DIR/bad-tait-no-substs.rs:16:11
    |
 LL |     match x {}
    |           ^ pattern `UninhabitedVariants::Tuple(_)` not covered
    |
 note: `UninhabitedVariants` defined here
-  --> $DIR/bad-tait-no-substs.rs:8:10
+  --> $DIR/bad-tait-no-substs.rs:7:10
    |
 LL | pub enum UninhabitedVariants {
    |          ^^^^^^^^^^^^^^^^^^^
@@ -80,7 +72,7 @@ LL +         UninhabitedVariants::Tuple(_) => todo!(),
 LL +     }
    |
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 Some errors have detailed explanations: E0004, E0106, E0107, E0792.
 For more information about an error, try `rustc --explain E0004`.

--- a/tests/ui/type-alias-impl-trait/const_generic_type.infer.stderr
+++ b/tests/ui/type-alias-impl-trait/const_generic_type.infer.stderr
@@ -1,5 +1,5 @@
 error: `Bar` is forbidden as the type of a const generic parameter
-  --> $DIR/const_generic_type.rs:8:24
+  --> $DIR/const_generic_type.rs:7:24
    |
 LL | async fn test<const N: crate::Bar>() {
    |                        ^^^^^^^^^^

--- a/tests/ui/type-alias-impl-trait/const_generic_type.no_infer.stderr
+++ b/tests/ui/type-alias-impl-trait/const_generic_type.no_infer.stderr
@@ -1,5 +1,5 @@
 error: `Bar` is forbidden as the type of a const generic parameter
-  --> $DIR/const_generic_type.rs:8:24
+  --> $DIR/const_generic_type.rs:7:24
    |
 LL | async fn test<const N: crate::Bar>() {
    |                        ^^^^^^^^^^
@@ -7,7 +7,7 @@ LL | async fn test<const N: crate::Bar>() {
    = note: the only supported types are integers, `bool`, and `char`
 
 error: item does not constrain `Bar::{opaque#0}`, but has it in its signature
-  --> $DIR/const_generic_type.rs:8:10
+  --> $DIR/const_generic_type.rs:7:10
    |
 LL | async fn test<const N: crate::Bar>() {
    |          ^^^^
@@ -20,7 +20,7 @@ LL | type Bar = impl std::fmt::Display;
    |            ^^^^^^^^^^^^^^^^^^^^^^
 
 error: item does not constrain `Bar::{opaque#0}`, but has it in its signature
-  --> $DIR/const_generic_type.rs:8:38
+  --> $DIR/const_generic_type.rs:7:38
    |
 LL |   async fn test<const N: crate::Bar>() {
    |  ______________________________________^
@@ -39,13 +39,5 @@ note: this opaque type is in the signature
 LL | type Bar = impl std::fmt::Display;
    |            ^^^^^^^^^^^^^^^^^^^^^^
 
-error: unconstrained opaque type
-  --> $DIR/const_generic_type.rs:5:12
-   |
-LL | type Bar = impl std::fmt::Display;
-   |            ^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `Bar` must be used in combination with a concrete type within the same module
-
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/type-alias-impl-trait/const_generic_type.rs
+++ b/tests/ui/type-alias-impl-trait/const_generic_type.rs
@@ -3,7 +3,6 @@
 
 #![feature(type_alias_impl_trait)]
 type Bar = impl std::fmt::Display;
-//[no_infer]~^ ERROR: unconstrained opaque type
 
 async fn test<const N: crate::Bar>() {
     //~^ ERROR: `Bar` is forbidden as the type of a const generic parameter

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden4.rs
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden4.rs
@@ -8,7 +8,6 @@
 use std::future::Future;
 
 type FutNothing<'a> = impl 'a + Future<Output = ()>;
-//~^ ERROR: unconstrained opaque type
 
 async fn operation(_: &mut ()) -> () {
     //~^ ERROR: concrete type differs from previous

--- a/tests/ui/type-alias-impl-trait/hkl_forbidden4.stderr
+++ b/tests/ui/type-alias-impl-trait/hkl_forbidden4.stderr
@@ -1,5 +1,5 @@
 error: item does not constrain `FutNothing::{opaque#0}`, but has it in its signature
-  --> $DIR/hkl_forbidden4.rs:19:10
+  --> $DIR/hkl_forbidden4.rs:18:10
    |
 LL | async fn call<F>(_f: F)
    |          ^^^^
@@ -12,7 +12,7 @@ LL | type FutNothing<'a> = impl 'a + Future<Output = ()>;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: item does not constrain `FutNothing::{opaque#0}`, but has it in its signature
-  --> $DIR/hkl_forbidden4.rs:23:1
+  --> $DIR/hkl_forbidden4.rs:22:1
    |
 LL | / {
 LL | |
@@ -27,16 +27,8 @@ note: this opaque type is in the signature
 LL | type FutNothing<'a> = impl 'a + Future<Output = ()>;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: unconstrained opaque type
-  --> $DIR/hkl_forbidden4.rs:10:23
-   |
-LL | type FutNothing<'a> = impl 'a + Future<Output = ()>;
-   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: `FutNothing` must be used in combination with a concrete type within the same module
-
 error[E0792]: expected generic lifetime parameter, found `'any`
-  --> $DIR/hkl_forbidden4.rs:15:5
+  --> $DIR/hkl_forbidden4.rs:14:5
    |
 LL | async fn operation(_: &mut ()) -> () {
    |                       - this generic parameter must be used with a generic lifetime parameter
@@ -45,19 +37,19 @@ LL |     call(operation).await
    |     ^^^^^^^^^^^^^^^
 
 error: concrete type differs from previous defining opaque type use
-  --> $DIR/hkl_forbidden4.rs:13:1
+  --> $DIR/hkl_forbidden4.rs:12:1
    |
 LL | async fn operation(_: &mut ()) -> () {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `FutNothing<'_>`, got `{async fn body of operation()}`
    |
 note: previous use here
-  --> $DIR/hkl_forbidden4.rs:15:5
+  --> $DIR/hkl_forbidden4.rs:14:5
    |
 LL |     call(operation).await
    |     ^^^^^^^^^^^^^^^
 
 error[E0792]: expected generic lifetime parameter, found `'any`
-  --> $DIR/hkl_forbidden4.rs:23:1
+  --> $DIR/hkl_forbidden4.rs:22:1
    |
 LL |   type FutNothing<'a> = impl 'a + Future<Output = ()>;
    |                   -- this generic parameter must be used with a generic lifetime parameter
@@ -68,6 +60,6 @@ LL | |
 LL | | }
    | |_^
 
-error: aborting due to 6 previous errors
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0792`.

--- a/tests/ui/type-alias-impl-trait/nested-tait-inference3.rs
+++ b/tests/ui/type-alias-impl-trait/nested-tait-inference3.rs
@@ -4,7 +4,6 @@
 use std::fmt::Debug;
 
 type FooX = impl Debug;
-//~^ ERROR unconstrained opaque type
 
 trait Foo<A> {}
 

--- a/tests/ui/type-alias-impl-trait/nested-tait-inference3.stderr
+++ b/tests/ui/type-alias-impl-trait/nested-tait-inference3.stderr
@@ -1,5 +1,5 @@
 error: item does not constrain `FooX::{opaque#0}`, but has it in its signature
-  --> $DIR/nested-tait-inference3.rs:13:4
+  --> $DIR/nested-tait-inference3.rs:12:4
    |
 LL | fn foo() -> impl Foo<FooX> {
    |    ^^^
@@ -11,13 +11,5 @@ note: this opaque type is in the signature
 LL | type FooX = impl Debug;
    |             ^^^^^^^^^^
 
-error: unconstrained opaque type
-  --> $DIR/nested-tait-inference3.rs:6:13
-   |
-LL | type FooX = impl Debug;
-   |             ^^^^^^^^^^
-   |
-   = note: `FooX` must be used in combination with a concrete type within the same module
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 

--- a/tests/ui/type-alias-impl-trait/no_inferrable_concrete_type.rs
+++ b/tests/ui/type-alias-impl-trait/no_inferrable_concrete_type.rs
@@ -5,7 +5,6 @@
 
 mod foo {
     pub type Foo = impl Copy;
-    //~^ ERROR unconstrained opaque type
 
     // make compiler happy about using 'Foo'
     pub fn bar(x: Foo) -> Foo {

--- a/tests/ui/type-alias-impl-trait/no_inferrable_concrete_type.stderr
+++ b/tests/ui/type-alias-impl-trait/no_inferrable_concrete_type.stderr
@@ -1,5 +1,5 @@
 error: item does not constrain `Foo::{opaque#0}`, but has it in its signature
-  --> $DIR/no_inferrable_concrete_type.rs:11:12
+  --> $DIR/no_inferrable_concrete_type.rs:10:12
    |
 LL |     pub fn bar(x: Foo) -> Foo {
    |            ^^^
@@ -11,13 +11,5 @@ note: this opaque type is in the signature
 LL |     pub type Foo = impl Copy;
    |                    ^^^^^^^^^
 
-error: unconstrained opaque type
-  --> $DIR/no_inferrable_concrete_type.rs:7:20
-   |
-LL |     pub type Foo = impl Copy;
-   |                    ^^^^^^^^^
-   |
-   = note: `Foo` must be used in combination with a concrete type within the same module
-
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error
 


### PR DESCRIPTION
pulled out of https://github.com/rust-lang/rust/pull/128440

These errors carry no new information if the opaque type was actually used in a constraining (but erroneous) way somewhere.