### PR TITLE
Stop git from merging generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,10 @@
 *.cpp rust
 *.h rust
 *.rs rust diff=rust
-*.fixed linguist-language=Rust
-*.mir linguist-language=Rust
+*.fixed linguist-language=Rust -merge
+*.mir linguist-language=Rust -merge
+*.stderr -merge
+*.stdout -merge
 src/etc/installer/gfx/* binary
 src/vendor/** -text
 Cargo.lock linguist-generated=false


### PR DESCRIPTION
See the relevant documentation for details: https://git-scm.com/docs/gitattributes#Documentation/gitattributes.txt-Unset-1-1-1

This will cause `.stderr`, `.stdout`, `.mir`, and `.fixed` files to stop generating conflict markers and instead just pick the version from your branch, not the one you're rebasing over. Git will still raise a conflict and thus stop a rebase at that commit, but it avoids having to deal with conflict markers in files where we just bless them away anyway.