### PR TITLE
Do not print linker command in linker error by default

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1004,6 +1004,7 @@ fn link_natively(
                     exit_status: prog.status,
                     command: &cmd,
                     escaped_output,
+                    verbose: sess.opts.verbose,
                 };
                 sess.dcx().emit_err(err);
                 // If MSVC's `link.exe` was expected but the return code

--- a/src/tools/run-make-support/src/external_deps/rustc.rs
+++ b/src/tools/run-make-support/src/external_deps/rustc.rs
@@ -221,6 +221,11 @@ impl Rustc {
         self
     }
 
+    pub fn verbose(&mut self) -> &mut Self {
+        self.cmd.arg("--verbose");
+        self
+    }
+
     /// Specify json messages printed by the compiler
     pub fn json(&mut self, items: &str) -> &mut Self {
         self.cmd.arg(format!("--json={items}"));

--- a/tests/run-make/linkage-attr-framework/rmake.rs
+++ b/tests/run-make/linkage-attr-framework/rmake.rs
@@ -2,7 +2,7 @@
 
 //@ only-apple
 
-use run_make_support::{Rustc, run, rustc};
+use run_make_support::{Rustc, diff, run, rustc};
 
 fn compile(cfg: &str) -> Rustc {
     let mut rustc = rustc();
@@ -16,11 +16,15 @@ fn main() {
         run("main");
     }
 
-    let errs = compile("omit").run_fail();
+    let errs = compile("omit").verbose().run_fail();
     // The linker's exact error output changes between Xcode versions, depends on
     // linker invocation details, and the linker sometimes outputs more warnings.
     errs.assert_stderr_contains_regex(r"error: linking with `.*` failed");
     errs.assert_stderr_contains_regex(r"(Undefined symbols|ld: symbol[^\s]* not found)");
     errs.assert_stderr_contains_regex(r".?_CFRunLoopGetTypeID.?, referenced from:");
     errs.assert_stderr_contains("clang: error: linker command failed with exit code 1");
+    // Ensure we don't show the full linker command by default.
+    let errs = compile("omit").run_fail().assert_stderr_contains(
+        "to see the full command that was run, rerun with `--verbose` flag",
+    );
 }


### PR DESCRIPTION
Only print the entire linker command that failed if `--verbose` is set.

CC #110763. Fix #109979.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
