### PR TITLE
Add a new test ui/incoherent-inherent-impls/no-other-unrelated-errors to check E0116 does not cause unrelated errors

### DIFF
--- a/tests/ui/incoherent-inherent-impls/no-other-unrelated-errors.rs
+++ b/tests/ui/incoherent-inherent-impls/no-other-unrelated-errors.rs
@@ -1,0 +1,8 @@
+// E0116 caused other unrelated errors, so check no unrelated errors are emmitted.
+
+fn main() {
+    let x = "hello";
+    x.split(" ");
+}
+
+impl Vec<usize> {} //~ ERROR E0116

--- a/tests/ui/incoherent-inherent-impls/no-other-unrelated-errors.stderr
+++ b/tests/ui/incoherent-inherent-impls/no-other-unrelated-errors.stderr
@@ -1,0 +1,11 @@
+error[E0116]: cannot define inherent `impl` for a type outside of the crate where the type is defined
+  --> $DIR/no-other-unrelated-errors.rs:8:1
+   |
+LL | impl Vec<usize> {}
+   | ^^^^^^^^^^^^^^^ impl for type defined outside of crate
+   |
+   = note: define and implement a trait or new type instead
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0116`.


### PR DESCRIPTION
rustc xxx (we do not know) to 1.82.0 emits unrelated errors when E0116 is present (see #125814).

We do not know what caused and fixed it, but add a test to confirm rustc does not cause the same error in the future.