### PR TITLE
skip `setup::Hook` on non-git sources

### DIFF
--- a/src/bootstrap/src/core/build_steps/setup.rs
+++ b/src/bootstrap/src/core/build_steps/setup.rs
@@ -452,24 +452,26 @@ pub struct Hook;
 impl Step for Hook {
     type Output = ();
     const DEFAULT: bool = true;
+
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
         run.alias("hook")
     }
+
     fn make_run(run: RunConfig<'_>) {
-        if run.builder.config.dry_run() {
-            return;
-        }
         if let [cmd] = &run.paths[..] {
             if cmd.assert_single_path().path.as_path().as_os_str() == "hook" {
                 run.builder.ensure(Hook);
             }
         }
     }
+
     fn run(self, builder: &Builder<'_>) -> Self::Output {
         let config = &builder.config;
-        if config.dry_run() {
+
+        if config.dry_run() || !config.rust_info.is_managed_git_subrepository() {
             return;
         }
+
         t!(install_git_hook_maybe(builder, config));
     }
 }


### PR DESCRIPTION
Running `setup::Hook` (with `x setup`) leads tarball sources to panic and this PR resolves that problem by skipping `Hook` step on non-git sources.