### PR TITLE
rename `fn member_constraint`  to `fn add_member_constraint`

### DIFF
--- a/compiler/rustc_infer/src/infer/mod.rs
+++ b/compiler/rustc_infer/src/infer/mod.rs
@@ -689,7 +689,7 @@ impl<'tcx> InferCtxt<'tcx> {
     /// Require that the region `r` be equal to one of the regions in
     /// the set `regions`.
     #[instrument(skip(self), level = "debug")]
-    pub fn member_constraint(
+    pub fn add_member_constraint(
         &self,
         key: ty::OpaqueTypeKey<'tcx>,
         definition_span: Span,
@@ -697,7 +697,9 @@ impl<'tcx> InferCtxt<'tcx> {
         region: ty::Region<'tcx>,
         in_regions: Lrc<Vec<ty::Region<'tcx>>>,
     ) {
-        self.inner.borrow_mut().unwrap_region_constraints().member_constraint(
+        // We do not support adding member constraints while in snapshots.
+        assert!(!self.in_snapshot());
+        self.inner.borrow_mut().unwrap_region_constraints().add_member_constraint(
             key,
             definition_span,
             hidden_ty,

--- a/compiler/rustc_infer/src/infer/opaque_types/mod.rs
+++ b/compiler/rustc_infer/src/infer/opaque_types/mod.rs
@@ -364,7 +364,7 @@ impl<'tcx> InferCtxt<'tcx> {
         concrete_ty.visit_with(&mut ConstrainOpaqueTypeRegionVisitor {
             tcx: self.tcx,
             op: |r| {
-                self.member_constraint(
+                self.add_member_constraint(
                     opaque_type_key,
                     span,
                     concrete_ty,

--- a/compiler/rustc_infer/src/infer/region_constraints/mod.rs
+++ b/compiler/rustc_infer/src/infer/region_constraints/mod.rs
@@ -466,7 +466,7 @@ impl<'tcx> RegionConstraintCollector<'_, 'tcx> {
         }
     }
 
-    pub(super) fn member_constraint(
+    pub(super) fn add_member_constraint(
         &mut self,
         key: ty::OpaqueTypeKey<'tcx>,
         definition_span: Span,


### PR DESCRIPTION
also assert that we're not in a snapshot, closing #109654

r? types
