### PR TITLE
Normalize target-cpus.rs stdout test for LLVM changes

### DIFF
--- a/tests/ui/codegen/target-cpus.rs
+++ b/tests/ui/codegen/target-cpus.rs
@@ -1,3 +1,9 @@
 //@ needs-llvm-components: webassembly
 //@ compile-flags: --print=target-cpus --target=wasm32-unknown-unknown
 //@ check-pass
+
+// LLVM at HEAD has added support for the `lime1` CPU. Remove it from the
+// output so that the stdout with LLVM-at-HEAD matches the output of the LLVM
+// versions currently used by default.
+// FIXME(#133919): Once Rust upgrades to LLVM 20, remove this.
+//@ normalize-stdout-test: "(?m)^ *lime1\n" -> ""


### PR DESCRIPTION
LLVM has recently added support for the `lime1` CPU in https://github.com/llvm/llvm-project/commit/35cce408eef1a253df12c0023c993d78b180b1f3, so the `target-cpus.rs` test currently produces different output depending on the LLVM version.

This CL adds a normalization directive, to remove the new CPU from the output list.

Alternatives fixes I can think of:

* Add two revisions of the test (one per LLVM version)
* Ignore the test on one of the LLVM versions
  * I dislike this, because it's possible that the test won't get updated for the next LLVM version.

I don't think the exact list of target CPUs is relevant for this test, so it shouldn't be too bad if the normalization sticks around longer than necessary.

@rustbot label: +llvm-main

