### PR TITLE
change guarded string reserved tokens to `#"`, `##"`, `###`

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -415,8 +415,16 @@ impl Cursor<'_> {
             }
 
             // Guarded string literal prefix: `#"` or `##`
-            '#' if matches!(self.first(), '"' | '#') => {
+            '#' if matches!(
+                (self.first(), self.second()),
+                //  #"         ##"          ###
+                ('"', _) | ('#', '"') | ('#', '#')
+            ) =>
+            {
                 self.bump();
+                if self.first() != '"' {
+                    self.bump();
+                }
                 TokenKind::GuardedStrPrefix
             }
 
@@ -804,8 +812,6 @@ impl Cursor<'_> {
     /// guarded string is not found. It is the caller's
     /// responsibility to do so.
     pub fn guarded_double_quoted_string(&mut self) -> Option<GuardedStr> {
-        debug_assert!(self.prev() != '#');
-
         let mut n_start_hashes: u32 = 0;
         while self.first() == '#' {
             n_start_hashes += 1;

--- a/compiler/rustc_parse/messages.ftl
+++ b/compiler/rustc_parse/messages.ftl
@@ -720,7 +720,7 @@ parse_require_colon_after_labeled_expression = labeled expression must be follow
     .suggestion = add `:` after the label
 
 parse_reserved_multihash = reserved multi-hash token is forbidden
-    .note = sequences of two or more # are reserved for future use since Rust 2024
+    .note = sequences of three or more # are reserved for future use since Rust 2024
     .suggestion_whitespace = consider inserting whitespace here
 
 parse_reserved_string = invalid string literal

--- a/compiler/rustc_parse/src/lexer/mod.rs
+++ b/compiler/rustc_parse/src/lexer/mod.rs
@@ -851,8 +851,8 @@ impl<'psess, 'src> Lexer<'psess, 'src> {
                 (true, span, unterminated)
             }
             None => {
-                // We should only get here in the `##+` case.
-                debug_assert_eq!(self.str_from_to(start, start + BytePos(2)), "##");
+                // We should only get here in the `###+` case.
+                debug_assert_eq!(self.str_from_to(start, start + BytePos(3)), "###");
 
                 (false, span, None)
             }

--- a/tests/ui/rust-2024/reserved-guarded-strings-lexing.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings-lexing.rs
@@ -6,37 +6,47 @@
 macro_rules! demo2 {
     ( $a:tt $b:tt ) => { println!("two tokens") };
 }
-
 macro_rules! demo3 {
     ( $a:tt $b:tt $c:tt ) => { println!("three tokens") };
 }
-
 macro_rules! demo4 {
     ( $a:tt $b:tt $c:tt $d:tt ) => { println!("four tokens") };
 }
-
 macro_rules! demo5 {
     ( $a:tt $b:tt $c:tt $d:tt $e:tt ) => { println!("five tokens") };
 }
-
+macro_rules! demo6 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt ) => { println!("six tokens") };
+}
 macro_rules! demo7 {
     ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt ) => { println!("seven tokens") };
+}
+macro_rules! demo9 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt $i:tt ) => { println!("nine tokens") };
 }
 
 
 fn main() {
     demo3!(## "foo");
+    demo4!(## "foo"#);
+
+    demo4!(### "foo");
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    demo4!(### "foo");
+    demo5!(#### "foo");
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    demo4!(## "foo"#);
+    demo5!(### "foo"#);
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo7!(### "foo"###);
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo9!(#### "foo"####);
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
@@ -58,9 +68,17 @@ fn main() {
     //~| WARNING hard error in Rust 2024
     //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
+    demo4!("foo"###);
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo6!(#"foo"####);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
     //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    demo4!("foo"###);
+    //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo5!("foo"####);
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]

--- a/tests/ui/rust-2024/reserved-guarded-strings-lexing.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-lexing.stderr
@@ -1,5 +1,5 @@
 error: prefix `Ñ` is unknown
-  --> $DIR/reserved-guarded-strings-lexing.rs:70:12
+  --> $DIR/reserved-guarded-strings-lexing.rs:88:12
    |
 LL |     demo2!(Ñ"foo");
    |            ^ unknown prefix
@@ -11,7 +11,7 @@ LL |     demo2!(Ñ "foo");
    |             +
 
 error: prefix `Ñ` is unknown
-  --> $DIR/reserved-guarded-strings-lexing.rs:72:12
+  --> $DIR/reserved-guarded-strings-lexing.rs:90:12
    |
 LL |     demo4!(Ñ#""#);
    |            ^ unknown prefix
@@ -23,16 +23,16 @@ LL |     demo4!(Ñ #""#);
    |             +
 
 error: identifiers cannot contain emoji: `🙃`
-  --> $DIR/reserved-guarded-strings-lexing.rs:76:12
+  --> $DIR/reserved-guarded-strings-lexing.rs:94:12
    |
 LL |     demo3!(🙃#"");
    |            ^^
 
 warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:28:12
+  --> $DIR/reserved-guarded-strings-lexing.rs:33:12
    |
-LL |     demo3!(## "foo");
-   |            ^^
+LL |     demo4!(### "foo");
+   |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
@@ -43,53 +43,53 @@ LL | #![warn(rust_2024_guarded_string_incompatible_syntax)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
-LL |     demo3!(# # "foo");
-   |             +
-
-warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:31:12
-   |
-LL |     demo4!(### "foo");
-   |            ^^
-   |
-   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
-   |
 LL |     demo4!(# ## "foo");
    |             +
 
 warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:31:13
-   |
-LL |     demo4!(### "foo");
-   |             ^^
-   |
-   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
-   |
-LL |     demo4!(## # "foo");
-   |              +
-
-warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-lexing.rs:36:12
    |
-LL |     demo4!(## "foo"#);
-   |            ^^
+LL |     demo5!(#### "foo");
+   |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
-LL |     demo4!(# # "foo"#);
+LL |     demo5!(# ### "foo");
    |             +
 
 warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:39:12
+  --> $DIR/reserved-guarded-strings-lexing.rs:36:13
+   |
+LL |     demo5!(#### "foo");
+   |             ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
+   |
+LL |     demo5!(## ## "foo");
+   |              +
+
+warning: reserved token in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:41:12
+   |
+LL |     demo5!(### "foo"#);
+   |            ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
+   |
+LL |     demo5!(# ## "foo"#);
+   |             +
+
+warning: reserved token in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:44:12
    |
 LL |     demo7!(### "foo"###);
-   |            ^^
+   |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
@@ -99,23 +99,10 @@ LL |     demo7!(# ## "foo"###);
    |             +
 
 warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:39:13
+  --> $DIR/reserved-guarded-strings-lexing.rs:44:21
    |
 LL |     demo7!(### "foo"###);
-   |             ^^
-   |
-   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
-   |
-LL |     demo7!(## # "foo"###);
-   |              +
-
-warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:39:21
-   |
-LL |     demo7!(### "foo"###);
-   |                     ^^
+   |                     ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
@@ -125,20 +112,59 @@ LL |     demo7!(### "foo"# ##);
    |                      +
 
 warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:39:22
+  --> $DIR/reserved-guarded-strings-lexing.rs:49:12
    |
-LL |     demo7!(### "foo"###);
-   |                      ^^
+LL |     demo9!(#### "foo"####);
+   |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
-LL |     demo7!(### "foo"## #);
+LL |     demo9!(# ### "foo"####);
+   |             +
+
+warning: reserved token in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:49:13
+   |
+LL |     demo9!(#### "foo"####);
+   |             ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
+   |
+LL |     demo9!(## ## "foo"####);
+   |              +
+
+warning: reserved token in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:49:22
+   |
+LL |     demo9!(#### "foo"####);
+   |                      ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
+   |
+LL |     demo9!(#### "foo"# ###);
    |                       +
 
+warning: reserved token in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:49:23
+   |
+LL |     demo9!(#### "foo"####);
+   |                       ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
+   |
+LL |     demo9!(#### "foo"## ##);
+   |                        +
+
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:49:12
+  --> $DIR/reserved-guarded-strings-lexing.rs:59:12
    |
 LL |     demo5!(###"foo"#);
    |            ^^^^^^^^^
@@ -151,7 +177,7 @@ LL |     demo5!(# ##"foo"#);
    |             +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:49:13
+  --> $DIR/reserved-guarded-strings-lexing.rs:59:13
    |
 LL |     demo5!(###"foo"#);
    |             ^^^^^^^^
@@ -164,7 +190,7 @@ LL |     demo5!(## #"foo"#);
    |              +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:49:14
+  --> $DIR/reserved-guarded-strings-lexing.rs:59:14
    |
 LL |     demo5!(###"foo"#);
    |              ^^^^^^^
@@ -177,7 +203,7 @@ LL |     demo5!(### "foo"#);
    |               +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:56:12
+  --> $DIR/reserved-guarded-strings-lexing.rs:66:12
    |
 LL |     demo5!(#"foo"###);
    |            ^^^^^^^
@@ -190,10 +216,10 @@ LL |     demo5!(# "foo"###);
    |             +
 
 warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:56:18
+  --> $DIR/reserved-guarded-strings-lexing.rs:66:18
    |
 LL |     demo5!(#"foo"###);
-   |                  ^^
+   |                  ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
@@ -203,23 +229,10 @@ LL |     demo5!(#"foo"# ##);
    |                   +
 
 warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:56:19
-   |
-LL |     demo5!(#"foo"###);
-   |                   ^^
-   |
-   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
-help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
-   |
-LL |     demo5!(#"foo"## #);
-   |                    +
-
-warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:63:17
+  --> $DIR/reserved-guarded-strings-lexing.rs:71:17
    |
 LL |     demo4!("foo"###);
-   |                 ^^
+   |                 ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
@@ -228,21 +241,73 @@ help: insert whitespace here to avoid this being parsed as a forbidden token in 
 LL |     demo4!("foo"# ##);
    |                  +
 
-warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:63:18
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:74:12
    |
-LL |     demo4!("foo"###);
-   |                  ^^
+LL |     demo6!(#"foo"####);
+   |            ^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo6!(# "foo"####);
+   |             +
+
+warning: reserved token in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:74:18
+   |
+LL |     demo6!(#"foo"####);
+   |                  ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
-LL |     demo4!("foo"## #);
+LL |     demo6!(#"foo"# ###);
+   |                   +
+
+warning: reserved token in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:74:19
+   |
+LL |     demo6!(#"foo"####);
+   |                   ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
+   |
+LL |     demo6!(#"foo"## ##);
+   |                    +
+
+warning: reserved token in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:81:17
+   |
+LL |     demo5!("foo"####);
+   |                 ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
+   |
+LL |     demo5!("foo"# ###);
+   |                  +
+
+warning: reserved token in Rust 2024
+  --> $DIR/reserved-guarded-strings-lexing.rs:81:18
+   |
+LL |     demo5!("foo"####);
+   |                  ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
+   |
+LL |     demo5!("foo"## ##);
    |                   +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:72:13
+  --> $DIR/reserved-guarded-strings-lexing.rs:90:13
    |
 LL |     demo4!(Ñ#""#);
    |             ^^^^
@@ -255,7 +320,7 @@ LL |     demo4!(Ñ# ""#);
    |              +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-lexing.rs:76:13
+  --> $DIR/reserved-guarded-strings-lexing.rs:94:13
    |
 LL |     demo3!(🙃#"");
    |              ^^^
@@ -267,5 +332,5 @@ help: insert whitespace here to avoid this being parsed as a guarded string in R
 LL |     demo3!(🙃# "");
    |               +
 
-error: aborting due to 3 previous errors; 18 warnings emitted
+error: aborting due to 3 previous errors; 23 warnings emitted
 

--- a/tests/ui/rust-2024/reserved-guarded-strings-migration.fixed
+++ b/tests/ui/rust-2024/reserved-guarded-strings-migration.fixed
@@ -7,25 +7,23 @@
 macro_rules! demo1 {
     ( $a:tt ) => { println!("one tokens") };
 }
-
 macro_rules! demo2 {
     ( $a:tt $b:tt ) => { println!("two tokens") };
 }
-
 macro_rules! demo3 {
     ( $a:tt $b:tt $c:tt ) => { println!("three tokens") };
 }
-
 macro_rules! demo4 {
     ( $a:tt $b:tt $c:tt $d:tt ) => { println!("four tokens") };
 }
-
 macro_rules! demo5 {
     ( $a:tt $b:tt $c:tt $d:tt $e:tt ) => { println!("five tokens") };
 }
-
 macro_rules! demo6 {
     ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt ) => { println!("six tokens") };
+}
+macro_rules! demo8 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt ) => { println!("eight tokens") };
 }
 
 
@@ -36,19 +34,24 @@ fn main() {
     demo2!(# "foo");
     demo3!(# "foo"#);
     demo2!("foo"#);
+    demo3!(## "foo");
+    demo4!(## "foo"#);
 
-    demo3!(# # "foo");
+    demo4!(# ## "foo");
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    demo4!(# # # "foo");
+    demo5!(# # ## "foo");
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    demo4!(# # "foo"#);
+    demo5!(# ## "foo"#);
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    demo6!(# # # "foo"# #);
+    demo6!(# ## "foo"##);
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo8!(# # ## "foo"# ##);
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
@@ -56,7 +59,10 @@ fn main() {
     //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
 
-    demo4!("foo"# # #);
+    demo4!("foo"# ##);
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo5!("foo"# # ##);
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
@@ -89,7 +95,12 @@ fn main() {
     //~| WARNING hard error in Rust 2024
     //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    demo5!(# # "foo"# #);
+    demo5!(# # "foo"##);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo6!(# # "foo"# ##);
     //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]

--- a/tests/ui/rust-2024/reserved-guarded-strings-migration.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings-migration.rs
@@ -7,25 +7,23 @@
 macro_rules! demo1 {
     ( $a:tt ) => { println!("one tokens") };
 }
-
 macro_rules! demo2 {
     ( $a:tt $b:tt ) => { println!("two tokens") };
 }
-
 macro_rules! demo3 {
     ( $a:tt $b:tt $c:tt ) => { println!("three tokens") };
 }
-
 macro_rules! demo4 {
     ( $a:tt $b:tt $c:tt $d:tt ) => { println!("four tokens") };
 }
-
 macro_rules! demo5 {
     ( $a:tt $b:tt $c:tt $d:tt $e:tt ) => { println!("five tokens") };
 }
-
 macro_rules! demo6 {
     ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt ) => { println!("six tokens") };
+}
+macro_rules! demo8 {
+    ( $a:tt $b:tt $c:tt $d:tt $e:tt $f:tt $g:tt $h:tt ) => { println!("eight tokens") };
 }
 
 
@@ -36,19 +34,24 @@ fn main() {
     demo2!(# "foo");
     demo3!(# "foo"#);
     demo2!("foo"#);
-
     demo3!(## "foo");
+    demo4!(## "foo"#);
+
+    demo4!(### "foo");
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    demo4!(### "foo");
+    demo5!(#### "foo");
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
-    demo4!(## "foo"#);
+    demo5!(### "foo"#);
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo6!(### "foo"##);
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo8!(#### "foo"###);
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
@@ -57,6 +60,9 @@ fn main() {
     //~| WARNING hard error in Rust 2024
 
     demo4!("foo"###);
+    //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo5!("foo"####);
     //~^ WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     //~| WARNING reserved token in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
@@ -90,6 +96,11 @@ fn main() {
     //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     demo5!(##"foo"##);
+    //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
+    //~| WARNING hard error in Rust 2024
+    demo6!(##"foo"###);
     //~^ WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]
     //~| WARNING hard error in Rust 2024
     //~| WARNING parsed as a guarded string in Rust 2024 [rust_2024_guarded_string_incompatible_syntax]

--- a/tests/ui/rust-2024/reserved-guarded-strings-migration.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-migration.stderr
@@ -1,8 +1,8 @@
 warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:40:12
    |
-LL |     demo3!(## "foo");
-   |            ^^
+LL |     demo4!(### "foo");
+   |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
@@ -13,53 +13,53 @@ LL | #![warn(rust_2024_guarded_string_incompatible_syntax)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
-LL |     demo3!(# # "foo");
+LL |     demo4!(# ## "foo");
    |             +
 
 warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:43:12
    |
-LL |     demo4!(### "foo");
-   |            ^^
+LL |     demo5!(#### "foo");
+   |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
-LL |     demo4!(# ## "foo");
+LL |     demo5!(# ### "foo");
    |             +
 
 warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:43:13
    |
-LL |     demo4!(### "foo");
-   |             ^^
+LL |     demo5!(#### "foo");
+   |             ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
-LL |     demo4!(## # "foo");
+LL |     demo5!(## ## "foo");
    |              +
 
 warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:48:12
    |
-LL |     demo4!(## "foo"#);
-   |            ^^
+LL |     demo5!(### "foo"#);
+   |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
-LL |     demo4!(# # "foo"#);
+LL |     demo5!(# ## "foo"#);
    |             +
 
 warning: reserved token in Rust 2024
   --> $DIR/reserved-guarded-strings-migration.rs:51:12
    |
 LL |     demo6!(### "foo"##);
-   |            ^^
+   |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
@@ -69,36 +69,49 @@ LL |     demo6!(# ## "foo"##);
    |             +
 
 warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:51:13
+  --> $DIR/reserved-guarded-strings-migration.rs:54:12
    |
-LL |     demo6!(### "foo"##);
-   |             ^^
+LL |     demo8!(#### "foo"###);
+   |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
-LL |     demo6!(## # "foo"##);
+LL |     demo8!(# ### "foo"###);
+   |             +
+
+warning: reserved token in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:54:13
+   |
+LL |     demo8!(#### "foo"###);
+   |             ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
+   |
+LL |     demo8!(## ## "foo"###);
    |              +
 
 warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:51:21
+  --> $DIR/reserved-guarded-strings-migration.rs:54:22
    |
-LL |     demo6!(### "foo"##);
-   |                     ^^
+LL |     demo8!(#### "foo"###);
+   |                      ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
-LL |     demo6!(### "foo"# #);
-   |                      +
+LL |     demo8!(#### "foo"# ##);
+   |                       +
 
 warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:59:17
+  --> $DIR/reserved-guarded-strings-migration.rs:62:17
    |
 LL |     demo4!("foo"###);
-   |                 ^^
+   |                 ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
@@ -108,20 +121,33 @@ LL |     demo4!("foo"# ##);
    |                  +
 
 warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:59:18
+  --> $DIR/reserved-guarded-strings-migration.rs:65:17
    |
-LL |     demo4!("foo"###);
-   |                  ^^
+LL |     demo5!("foo"####);
+   |                 ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
-LL |     demo4!("foo"## #);
+LL |     demo5!("foo"# ###);
+   |                  +
+
+warning: reserved token in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:65:18
+   |
+LL |     demo5!("foo"####);
+   |                  ^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
+   |
+LL |     demo5!("foo"## ##);
    |                   +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:65:12
+  --> $DIR/reserved-guarded-strings-migration.rs:71:12
    |
 LL |     demo2!(#"");
    |            ^^^
@@ -134,7 +160,7 @@ LL |     demo2!(# "");
    |             +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:68:12
+  --> $DIR/reserved-guarded-strings-migration.rs:74:12
    |
 LL |     demo3!(#""#);
    |            ^^^^
@@ -147,7 +173,7 @@ LL |     demo3!(# ""#);
    |             +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:71:12
+  --> $DIR/reserved-guarded-strings-migration.rs:77:12
    |
 LL |     demo3!(##"");
    |            ^^^^
@@ -160,7 +186,7 @@ LL |     demo3!(# #"");
    |             +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:71:13
+  --> $DIR/reserved-guarded-strings-migration.rs:77:13
    |
 LL |     demo3!(##"");
    |             ^^^
@@ -173,7 +199,7 @@ LL |     demo3!(## "");
    |              +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:76:12
+  --> $DIR/reserved-guarded-strings-migration.rs:82:12
    |
 LL |     demo2!(#"foo");
    |            ^^^^^^
@@ -186,7 +212,7 @@ LL |     demo2!(# "foo");
    |             +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:79:12
+  --> $DIR/reserved-guarded-strings-migration.rs:85:12
    |
 LL |     demo3!(##"foo");
    |            ^^^^^^^
@@ -199,7 +225,7 @@ LL |     demo3!(# #"foo");
    |             +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:79:13
+  --> $DIR/reserved-guarded-strings-migration.rs:85:13
    |
 LL |     demo3!(##"foo");
    |             ^^^^^^
@@ -212,7 +238,7 @@ LL |     demo3!(## "foo");
    |              +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:84:12
+  --> $DIR/reserved-guarded-strings-migration.rs:90:12
    |
 LL |     demo3!(#"foo"#);
    |            ^^^^^^^
@@ -225,7 +251,7 @@ LL |     demo3!(# "foo"#);
    |             +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:87:12
+  --> $DIR/reserved-guarded-strings-migration.rs:93:12
    |
 LL |     demo4!(##"foo"#);
    |            ^^^^^^^^
@@ -238,7 +264,7 @@ LL |     demo4!(# #"foo"#);
    |             +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:87:13
+  --> $DIR/reserved-guarded-strings-migration.rs:93:13
    |
 LL |     demo4!(##"foo"#);
    |             ^^^^^^^
@@ -251,7 +277,7 @@ LL |     demo4!(## "foo"#);
    |              +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:92:12
+  --> $DIR/reserved-guarded-strings-migration.rs:98:12
    |
 LL |     demo5!(##"foo"##);
    |            ^^^^^^^^^
@@ -264,7 +290,7 @@ LL |     demo5!(# #"foo"##);
    |             +
 
 warning: will be parsed as a guarded string in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:92:13
+  --> $DIR/reserved-guarded-strings-migration.rs:98:13
    |
 LL |     demo5!(##"foo"##);
    |             ^^^^^^^
@@ -276,18 +302,44 @@ help: insert whitespace here to avoid this being parsed as a guarded string in R
 LL |     demo5!(## "foo"##);
    |              +
 
-warning: reserved token in Rust 2024
-  --> $DIR/reserved-guarded-strings-migration.rs:92:19
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:103:12
    |
-LL |     demo5!(##"foo"##);
-   |                   ^^
+LL |     demo6!(##"foo"###);
+   |            ^^^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo6!(# #"foo"###);
+   |             +
+
+warning: will be parsed as a guarded string in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:103:13
+   |
+LL |     demo6!(##"foo"###);
+   |             ^^^^^^^
+   |
+   = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
+   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
+   |
+LL |     demo6!(## "foo"###);
+   |              +
+
+warning: reserved token in Rust 2024
+  --> $DIR/reserved-guarded-strings-migration.rs:103:19
+   |
+LL |     demo6!(##"foo"###);
+   |                   ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
    = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
-LL |     demo5!(##"foo"# #);
+LL |     demo6!(##"foo"# ##);
    |                    +
 
-warning: 22 warnings emitted
+warning: 26 warnings emitted
 

--- a/tests/ui/rust-2024/reserved-guarded-strings.rs
+++ b/tests/ui/rust-2024/reserved-guarded-strings.rs
@@ -40,17 +40,24 @@ fn main() {
     demo2!(# "foo");
     demo3!(# "foo"#);
     demo2!("foo"#);
+    demo3!(## "foo");
+    demo4!(## "foo"#);
+    demo5!(## "foo"##);
 
     demo2!(blah"xx"); //~ ERROR prefix `blah` is unknown
     demo2!(blah#"xx"#);
     //~^ ERROR prefix `blah` is unknown
     //~| ERROR invalid string literal
 
-    demo2!(## "foo"); //~ reserved multi-hash token is forbidden
-    demo3!("foo"###); //~ reserved multi-hash token is forbidden
-    demo3!(### "foo"); //~ reserved multi-hash token is forbidden
-    demo3!(## "foo"#); //~ reserved multi-hash token is forbidden
-    demo5!(### "foo"###);
+    demo2!("foo"###); //~ reserved multi-hash token is forbidden
+    demo2!(### "foo"); //~ reserved multi-hash token is forbidden
+    demo3!("foo"####); //~ reserved multi-hash token is forbidden
+    demo3!(#### "foo"); //~ reserved multi-hash token is forbidden
+    demo3!(### "foo"#); //~ reserved multi-hash token is forbidden
+    demo3!(### "foo"###);
+    //~^ reserved multi-hash token is forbidden
+    //~| reserved multi-hash token is forbidden
+    demo5!(#### "foo"####);
     //~^ reserved multi-hash token is forbidden
     //~| reserved multi-hash token is forbidden
 
@@ -63,7 +70,8 @@ fn main() {
     demo1!(###"foo"#); //~ ERROR invalid string literal
     demo1!(###"foo"##); //~ ERROR invalid string literal
     demo1!(###"foo"###); //~ ERROR invalid string literal
-    demo2!(#"foo"###);
+    demo3!(#"foo"###); //~ ERROR invalid string literal
+    demo2!(#"foo"####);
     //~^ ERROR invalid string literal
     //~| ERROR reserved multi-hash token is forbidden
 

--- a/tests/ui/rust-2024/reserved-guarded-strings.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings.stderr
@@ -1,5 +1,5 @@
 error: prefix `blah` is unknown
-  --> $DIR/reserved-guarded-strings.rs:44:12
+  --> $DIR/reserved-guarded-strings.rs:47:12
    |
 LL |     demo2!(blah"xx");
    |            ^^^^ unknown prefix
@@ -11,7 +11,7 @@ LL |     demo2!(blah "xx");
    |                +
 
 error: prefix `blah` is unknown
-  --> $DIR/reserved-guarded-strings.rs:45:12
+  --> $DIR/reserved-guarded-strings.rs:48:12
    |
 LL |     demo2!(blah#"xx"#);
    |            ^^^^ unknown prefix
@@ -23,7 +23,7 @@ LL |     demo2!(blah #"xx"#);
    |                +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:45:16
+  --> $DIR/reserved-guarded-strings.rs:48:16
    |
 LL |     demo2!(blah#"xx"#);
    |                ^^^^^^
@@ -35,79 +35,115 @@ LL |     demo2!(blah# "xx"#);
    |                 +
 
 error: reserved multi-hash token is forbidden
-  --> $DIR/reserved-guarded-strings.rs:49:12
+  --> $DIR/reserved-guarded-strings.rs:52:17
    |
-LL |     demo2!(## "foo");
-   |            ^^
+LL |     demo2!("foo"###);
+   |                 ^^^
    |
-   = note: sequences of two or more # are reserved for future use since Rust 2024
+   = note: sequences of three or more # are reserved for future use since Rust 2024
 help: consider inserting whitespace here
    |
-LL |     demo2!(# # "foo");
-   |             +
-
-error: reserved multi-hash token is forbidden
-  --> $DIR/reserved-guarded-strings.rs:50:17
-   |
-LL |     demo3!("foo"###);
-   |                 ^^
-   |
-   = note: sequences of two or more # are reserved for future use since Rust 2024
-help: consider inserting whitespace here
-   |
-LL |     demo3!("foo"# ##);
+LL |     demo2!("foo"# ##);
    |                  +
-
-error: reserved multi-hash token is forbidden
-  --> $DIR/reserved-guarded-strings.rs:51:12
-   |
-LL |     demo3!(### "foo");
-   |            ^^
-   |
-   = note: sequences of two or more # are reserved for future use since Rust 2024
-help: consider inserting whitespace here
-   |
-LL |     demo3!(# ## "foo");
-   |             +
-
-error: reserved multi-hash token is forbidden
-  --> $DIR/reserved-guarded-strings.rs:52:12
-   |
-LL |     demo3!(## "foo"#);
-   |            ^^
-   |
-   = note: sequences of two or more # are reserved for future use since Rust 2024
-help: consider inserting whitespace here
-   |
-LL |     demo3!(# # "foo"#);
-   |             +
 
 error: reserved multi-hash token is forbidden
   --> $DIR/reserved-guarded-strings.rs:53:12
    |
-LL |     demo5!(### "foo"###);
-   |            ^^
+LL |     demo2!(### "foo");
+   |            ^^^
    |
-   = note: sequences of two or more # are reserved for future use since Rust 2024
+   = note: sequences of three or more # are reserved for future use since Rust 2024
 help: consider inserting whitespace here
    |
-LL |     demo5!(# ## "foo"###);
+LL |     demo2!(# ## "foo");
    |             +
 
 error: reserved multi-hash token is forbidden
-  --> $DIR/reserved-guarded-strings.rs:53:21
+  --> $DIR/reserved-guarded-strings.rs:54:17
    |
-LL |     demo5!(### "foo"###);
-   |                     ^^
+LL |     demo3!("foo"####);
+   |                 ^^^
    |
-   = note: sequences of two or more # are reserved for future use since Rust 2024
+   = note: sequences of three or more # are reserved for future use since Rust 2024
 help: consider inserting whitespace here
    |
-LL |     demo5!(### "foo"# ##);
+LL |     demo3!("foo"# ###);
+   |                  +
+
+error: reserved multi-hash token is forbidden
+  --> $DIR/reserved-guarded-strings.rs:55:12
+   |
+LL |     demo3!(#### "foo");
+   |            ^^^
+   |
+   = note: sequences of three or more # are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo3!(# ### "foo");
+   |             +
+
+error: reserved multi-hash token is forbidden
+  --> $DIR/reserved-guarded-strings.rs:56:12
+   |
+LL |     demo3!(### "foo"#);
+   |            ^^^
+   |
+   = note: sequences of three or more # are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo3!(# ## "foo"#);
+   |             +
+
+error: reserved multi-hash token is forbidden
+  --> $DIR/reserved-guarded-strings.rs:57:12
+   |
+LL |     demo3!(### "foo"###);
+   |            ^^^
+   |
+   = note: sequences of three or more # are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo3!(# ## "foo"###);
+   |             +
+
+error: reserved multi-hash token is forbidden
+  --> $DIR/reserved-guarded-strings.rs:57:21
+   |
+LL |     demo3!(### "foo"###);
+   |                     ^^^
+   |
+   = note: sequences of three or more # are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo3!(### "foo"# ##);
    |                      +
 
+error: reserved multi-hash token is forbidden
+  --> $DIR/reserved-guarded-strings.rs:60:12
+   |
+LL |     demo5!(#### "foo"####);
+   |            ^^^
+   |
+   = note: sequences of three or more # are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo5!(# ### "foo"####);
+   |             +
+
+error: reserved multi-hash token is forbidden
+  --> $DIR/reserved-guarded-strings.rs:60:22
+   |
+LL |     demo5!(#### "foo"####);
+   |                      ^^^
+   |
+   = note: sequences of three or more # are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo5!(#### "foo"# ###);
+   |                       +
+
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:57:12
+  --> $DIR/reserved-guarded-strings.rs:64:12
    |
 LL |     demo1!(#"");
    |            ^^^
@@ -119,7 +155,7 @@ LL |     demo1!(# "");
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:58:12
+  --> $DIR/reserved-guarded-strings.rs:65:12
    |
 LL |     demo1!(#""#);
    |            ^^^^
@@ -131,7 +167,7 @@ LL |     demo1!(# ""#);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:59:12
+  --> $DIR/reserved-guarded-strings.rs:66:12
    |
 LL |     demo1!(####"");
    |            ^^^^^^
@@ -143,7 +179,7 @@ LL |     demo1!(# ###"");
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:60:12
+  --> $DIR/reserved-guarded-strings.rs:67:12
    |
 LL |     demo1!(#"foo");
    |            ^^^^^^
@@ -155,7 +191,7 @@ LL |     demo1!(# "foo");
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:61:12
+  --> $DIR/reserved-guarded-strings.rs:68:12
    |
 LL |     demo1!(###"foo");
    |            ^^^^^^^^
@@ -167,7 +203,7 @@ LL |     demo1!(# ##"foo");
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:62:12
+  --> $DIR/reserved-guarded-strings.rs:69:12
    |
 LL |     demo1!(#"foo"#);
    |            ^^^^^^^
@@ -179,7 +215,7 @@ LL |     demo1!(# "foo"#);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:63:12
+  --> $DIR/reserved-guarded-strings.rs:70:12
    |
 LL |     demo1!(###"foo"#);
    |            ^^^^^^^^^
@@ -191,7 +227,7 @@ LL |     demo1!(# ##"foo"#);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:64:12
+  --> $DIR/reserved-guarded-strings.rs:71:12
    |
 LL |     demo1!(###"foo"##);
    |            ^^^^^^^^^^
@@ -203,7 +239,7 @@ LL |     demo1!(# ##"foo"##);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:65:12
+  --> $DIR/reserved-guarded-strings.rs:72:12
    |
 LL |     demo1!(###"foo"###);
    |            ^^^^^^^^^^^
@@ -215,31 +251,43 @@ LL |     demo1!(# ##"foo"###);
    |             +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:66:12
+  --> $DIR/reserved-guarded-strings.rs:73:12
    |
-LL |     demo2!(#"foo"###);
+LL |     demo3!(#"foo"###);
    |            ^^^^^^^
    |
    = note: unprefixed guarded string literals are reserved for future use since Rust 2024
 help: consider inserting whitespace here
    |
-LL |     demo2!(# "foo"###);
+LL |     demo3!(# "foo"###);
+   |             +
+
+error: invalid string literal
+  --> $DIR/reserved-guarded-strings.rs:74:12
+   |
+LL |     demo2!(#"foo"####);
+   |            ^^^^^^^
+   |
+   = note: unprefixed guarded string literals are reserved for future use since Rust 2024
+help: consider inserting whitespace here
+   |
+LL |     demo2!(# "foo"####);
    |             +
 
 error: reserved multi-hash token is forbidden
-  --> $DIR/reserved-guarded-strings.rs:66:19
+  --> $DIR/reserved-guarded-strings.rs:74:19
    |
-LL |     demo2!(#"foo"###);
-   |                   ^^
+LL |     demo2!(#"foo"####);
+   |                   ^^^
    |
-   = note: sequences of two or more # are reserved for future use since Rust 2024
+   = note: sequences of three or more # are reserved for future use since Rust 2024
 help: consider inserting whitespace here
    |
-LL |     demo2!(#"foo"## #);
+LL |     demo2!(#"foo"## ##);
    |                    +
 
 error: invalid string literal
-  --> $DIR/reserved-guarded-strings.rs:71:12
+  --> $DIR/reserved-guarded-strings.rs:79:12
    |
 LL | ...n!(####################################################################################################################################################################################################################################################################"foo...
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -250,5 +298,5 @@ help: consider inserting whitespace here
 LL |     demon!(# ###################################################################################################################################################################################################################################################################"foo");
    |             +
 
-error: aborting due to 21 previous errors
+error: aborting due to 25 previous errors
 


### PR DESCRIPTION
reserving `##` broke the peg proc macro

fixes #133887

cc @ehuss @traviscross 

Tracking:

- https://github.com/rust-lang/rust/issues/123735