### PR TITLE
disallow `repr()` on invalid items

### DIFF
--- a/tests/crashes/132391.rs
+++ b/tests/crashes/132391.rs
@@ -1,8 +1,0 @@
-//@ known-bug: #123291
-
-trait MyTrait {
-    #[repr(align)]
-    fn myfun();
-}
-
-pub fn main() {}

--- a/tests/ui/feature-gates/feature-gate-fn_align.rs
+++ b/tests/ui/feature-gates/feature-gate-fn_align.rs
@@ -2,3 +2,8 @@
 
 #[repr(align(16))] //~ ERROR `repr(align)` attributes on functions are unstable
 fn requires_alignment() {}
+
+trait MyTrait {
+    #[repr(align)] //~ ERROR `repr(align)` attributes on functions are unstable
+    fn myfun();
+}

--- a/tests/ui/feature-gates/feature-gate-fn_align.stderr
+++ b/tests/ui/feature-gates/feature-gate-fn_align.stderr
@@ -8,6 +8,16 @@ LL | #[repr(align(16))]
    = help: add `#![feature(fn_align)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 1 previous error
+error[E0658]: `repr(align)` attributes on functions are unstable
+  --> $DIR/feature-gate-fn_align.rs:7:12
+   |
+LL |     #[repr(align)]
+   |            ^^^^^
+   |
+   = note: see issue #82232 <https://github.com/rust-lang/rust/issues/82232> for more information
+   = help: add `#![feature(fn_align)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/repr/attr-usage-repr.rs
+++ b/tests/ui/repr/attr-usage-repr.rs
@@ -16,18 +16,39 @@ struct SSimd([f64; 2]);
 struct SInt(f64, f64);
 
 #[repr(C)]
-enum EExtern { A, B }
+enum EExtern {
+    A,
+    B,
+}
 
 #[repr(align(8))]
-enum EAlign { A, B }
+enum EAlign {
+    A,
+    B,
+}
 
 #[repr(packed)] //~ ERROR: attribute should be applied to a struct
-enum EPacked { A, B }
+enum EPacked {
+    A,
+    B,
+}
 
 #[repr(simd)] //~ ERROR: attribute should be applied to a struct
-enum ESimd { A, B }
+enum ESimd {
+    A,
+    B,
+}
 
 #[repr(i8)]
-enum EInt { A, B }
+enum EInt {
+    A,
+    B,
+}
+
+#[repr()] //~ attribute should be applied to a struct, enum, function, associated function, or union [E0517]
+type SirThisIsAType = i32;
+
+#[repr()]
+struct EmptyReprArgumentList(i32);
 
 fn main() {}

--- a/tests/ui/repr/attr-usage-repr.stderr
+++ b/tests/ui/repr/attr-usage-repr.stderr
@@ -15,21 +15,35 @@ LL | struct SInt(f64, f64);
    | ---------------------- not an enum
 
 error[E0517]: attribute should be applied to a struct or union
-  --> $DIR/attr-usage-repr.rs:24:8
+  --> $DIR/attr-usage-repr.rs:30:8
    |
-LL | #[repr(packed)]
-   |        ^^^^^^
-LL | enum EPacked { A, B }
-   | --------------------- not a struct or union
+LL |   #[repr(packed)]
+   |          ^^^^^^
+LL | / enum EPacked {
+LL | |     A,
+LL | |     B,
+LL | | }
+   | |_- not a struct or union
 
 error[E0517]: attribute should be applied to a struct
-  --> $DIR/attr-usage-repr.rs:27:8
+  --> $DIR/attr-usage-repr.rs:36:8
    |
-LL | #[repr(simd)]
-   |        ^^^^
-LL | enum ESimd { A, B }
-   | ------------------- not a struct
+LL |   #[repr(simd)]
+   |          ^^^^
+LL | / enum ESimd {
+LL | |     A,
+LL | |     B,
+LL | | }
+   | |_- not a struct
 
-error: aborting due to 4 previous errors
+error[E0517]: attribute should be applied to a struct, enum, function, associated function, or union
+  --> $DIR/attr-usage-repr.rs:48:1
+   |
+LL | #[repr()]
+   | ^^^^^^^^^
+LL | type SirThisIsAType = i32;
+   | -------------------------- not a struct, enum, function, associated function, or union
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0517`.


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust/issues/129606
fixes https://github.com/rust-lang/rust/issues/132391

Disallows `repr()` (so a repr with no arguments) on items where that won't ever make sense.

Also this generates an error when `repr` is used on a trait method and the `fn_align` feature is not enabled. Looks like that was missed here:

https://github.com/rust-lang/rust/pull/110313/files

Which first accepts the align attribute on trait methods.

r? @compiler-errors 

cc @jdonszelmann who claimed https://github.com/rust-lang/rust/issues/132391 and generally has been working on attributes
