### PR TITLE
[do not merge] quantify liveness optimization gains

### DIFF
--- a/compiler/rustc_borrowck/src/constraints/graph.rs
+++ b/compiler/rustc_borrowck/src/constraints/graph.rs
@@ -18,7 +18,7 @@ pub(crate) struct ConstraintGraph<D: ConstraintGraphDirection> {
 
 pub(crate) type NormalConstraintGraph = ConstraintGraph<Normal>;
 
-pub(crate) type ReverseConstraintGraph = ConstraintGraph<Reverse>;
+// pub(crate) type ReverseConstraintGraph = ConstraintGraph<Reverse>;
 
 /// Marker trait that controls whether a `R1: R2` constraint
 /// represents an edge `R1 -> R2` or `R2 -> R1`.
@@ -49,26 +49,26 @@ impl ConstraintGraphDirection for Normal {
     }
 }
 
-/// In reverse mode, a `R1: R2` constraint results in an edge `R2 ->
-/// R1`. We use this for optimizing liveness computation, because then
-/// we wish to iterate from a region (e.g., R2) to all the regions
-/// that will outlive it (e.g., R1).
-#[derive(Copy, Clone, Debug)]
-pub(crate) struct Reverse;
+// /// In reverse mode, a `R1: R2` constraint results in an edge `R2 ->
+// /// R1`. We use this for optimizing liveness computation, because then
+// /// we wish to iterate from a region (e.g., R2) to all the regions
+// /// that will outlive it (e.g., R1).
+// #[derive(Copy, Clone, Debug)]
+// pub(crate) struct Reverse;
 
-impl ConstraintGraphDirection for Reverse {
-    fn start_region(c: &OutlivesConstraint<'_>) -> RegionVid {
-        c.sub
-    }
+// impl ConstraintGraphDirection for Reverse {
+//     fn start_region(c: &OutlivesConstraint<'_>) -> RegionVid {
+//         c.sub
+//     }
 
-    fn end_region(c: &OutlivesConstraint<'_>) -> RegionVid {
-        c.sup
-    }
+//     fn end_region(c: &OutlivesConstraint<'_>) -> RegionVid {
+//         c.sup
+//     }
 
-    fn is_normal() -> bool {
-        false
-    }
-}
+//     fn is_normal() -> bool {
+//         false
+//     }
+// }
 
 impl<D: ConstraintGraphDirection> ConstraintGraph<D> {
     /// Creates a "dependency graph" where each region constraint `R1:

--- a/compiler/rustc_borrowck/src/constraints/mod.rs
+++ b/compiler/rustc_borrowck/src/constraints/mod.rs
@@ -42,11 +42,11 @@ impl<'tcx> OutlivesConstraintSet<'tcx> {
         graph::ConstraintGraph::new(graph::Normal, self, num_region_vars)
     }
 
-    /// Like `graph`, but constraints a reverse graph where `R1: R2`
-    /// represents an edge `R2 -> R1`.
-    pub(crate) fn reverse_graph(&self, num_region_vars: usize) -> graph::ReverseConstraintGraph {
-        graph::ConstraintGraph::new(graph::Reverse, self, num_region_vars)
-    }
+    // /// Like `graph`, but constraints a reverse graph where `R1: R2`
+    // /// represents an edge `R2 -> R1`.
+    // pub(crate) fn reverse_graph(&self, num_region_vars: usize) -> graph::ReverseConstraintGraph {
+    //     graph::ConstraintGraph::new(graph::Reverse, self, num_region_vars)
+    // }
 
     pub(crate) fn outlives(
         &self,


### PR DESCRIPTION
This PR is an experiment to quantify the cost/gains of this NLL optimization: we don't compute liveness for locals whose type contains regions that flow into free regions, and are therefore conceptually live everywhere in the current model. This optimization works for location-insensitive analyses, but not for location-sensitive ones (polonius). What's that going to cost?

Some 80 or so tests also fail as different errors will be emitted for diagnostics that are tailored to the current constraints, e.g. more general "temporary value dropped while borrowed" at the return stmt instead of "cannot return value referencing temporary value".

r? ghost