### PR TITLE
rustdoc: remove eq for clean::Attributes

### DIFF
--- a/src/librustdoc/clean/types.rs
+++ b/src/librustdoc/clean/types.rs
@@ -1241,19 +1241,6 @@ impl Attributes {
     }
 }
 
-impl PartialEq for Attributes {
-    fn eq(&self, rhs: &Self) -> bool {
-        self.doc_strings == rhs.doc_strings
-            && self
-                .other_attrs
-                .iter()
-                .map(|attr| attr.id)
-                .eq(rhs.other_attrs.iter().map(|attr| attr.id))
-    }
-}
-
-impl Eq for Attributes {}
-
 #[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub(crate) enum GenericBound {
     TraitBound(PolyTrait, hir::TraitBoundModifiers),


### PR DESCRIPTION
This change removes the `PartialEq` and `Eq` implementations from `Attributes`. This implementation was not used, and whether the implementation is useful at all is questionable. I care about removing it, because I'm working #131229. While simplifying the representation of attributes, I intend to remove attr ids from attributes where possible. They're actually rarely useful. This piece of code uses them, but for no real reason, so I think simply removing the implementation makes most sense. Let me know if there are major objections to this.