### PR TITLE
Define acronym for thread local storage

### DIFF
--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -12,7 +12,7 @@ use crate::cell::{Cell, RefCell};
 use crate::error::Error;
 use crate::fmt;
 
-/// A thread local storage key which owns its contents.
+/// A thread local storage (TLS) key which owns its contents.
 ///
 /// This key uses the fastest possible implementation available to it for the
 /// target platform. It is instantiated with the [`thread_local!`] macro and the


### PR DESCRIPTION
There are multiple references in this module's documentation to the acronym "TLS" (meaning "thread local storage"), without defining it. This is confusing for the reader.

I propose that this acronym be defined during the first use of the term.