### PR TITLE
Fix keyword_idents_2024 missing lifetimes in various positions

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1913,6 +1913,9 @@ impl EarlyLintPass for KeywordIdents {
             self.check_ident_token(cx, UnderMacro(false), *ident, "");
         }
     }
+    fn check_lifetime(&mut self, cx: &EarlyContext<'_>, lt: &ast::Lifetime) {
+        self.check_ident_token(cx, UnderMacro(false), lt.ident.without_first_quote(), "'");
+    }
 }
 
 declare_lint_pass!(ExplicitOutlivesRequirements => [EXPLICIT_OUTLIVES_REQUIREMENTS]);

--- a/compiler/rustc_lint/src/early.rs
+++ b/compiler/rustc_lint/src/early.rs
@@ -245,6 +245,7 @@ impl<'a, T: EarlyLintPass> ast_visit::Visitor<'a> for EarlyContextAndPass<'a, T>
 
     fn visit_lifetime(&mut self, lt: &'a ast::Lifetime, _: ast_visit::LifetimeCtxt) {
         self.check_id(lt.id);
+        lint_callback!(self, check_lifetime, lt);
     }
 
     fn visit_path(&mut self, p: &'a ast::Path, id: ast::NodeId) {

--- a/compiler/rustc_lint/src/passes.rs
+++ b/compiler/rustc_lint/src/passes.rs
@@ -137,6 +137,7 @@ macro_rules! early_lint_methods {
         $macro!($args, [
             fn check_param(a: &rustc_ast::Param);
             fn check_ident(a: &rustc_span::symbol::Ident);
+            fn check_lifetime(a: &rustc_ast::Lifetime);
             fn check_crate(a: &rustc_ast::Crate);
             fn check_crate_post(a: &rustc_ast::Crate);
             fn check_item(a: &rustc_ast::Item);

--- a/tests/ui/rust-2024/gen-kw.e2015.stderr
+++ b/tests/ui/rust-2024/gen-kw.e2015.stderr
@@ -34,11 +34,29 @@ LL |     () => { mod test { fn gen() {} } }
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:9
    |
-LL | fn test<'gen>() {}
+LL | fn test<'gen>(_: &'gen i32) {}
    |         ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
-error: aborting due to 4 previous errors
+error: `gen` is a keyword in the 2024 edition
+  --> $DIR/gen-kw.rs:30:10
+   |
+LL | struct S<'gen>(&'gen i32);
+   |          ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: `gen` is a keyword in the 2024 edition
+  --> $DIR/gen-kw.rs:36:6
+   |
+LL | impl<'gen> Tr for S<'gen> {}
+   |      ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/rust-2024/gen-kw.e2015.stderr
+++ b/tests/ui/rust-2024/gen-kw.e2015.stderr
@@ -41,7 +41,16 @@ LL | fn test<'gen>(_: &'gen i32) {}
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `gen` is a keyword in the 2024 edition
-  --> $DIR/gen-kw.rs:30:10
+  --> $DIR/gen-kw.rs:25:19
+   |
+LL | fn test<'gen>(_: &'gen i32) {}
+   |                   ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: `gen` is a keyword in the 2024 edition
+  --> $DIR/gen-kw.rs:33:10
    |
 LL | struct S<'gen>(&'gen i32);
    |          ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
@@ -50,7 +59,16 @@ LL | struct S<'gen>(&'gen i32);
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `gen` is a keyword in the 2024 edition
-  --> $DIR/gen-kw.rs:36:6
+  --> $DIR/gen-kw.rs:33:17
+   |
+LL | struct S<'gen>(&'gen i32);
+   |                 ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: `gen` is a keyword in the 2024 edition
+  --> $DIR/gen-kw.rs:42:6
    |
 LL | impl<'gen> Tr for S<'gen> {}
    |      ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
@@ -58,5 +76,14 @@ LL | impl<'gen> Tr for S<'gen> {}
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
-error: aborting due to 6 previous errors
+error: `gen` is a keyword in the 2024 edition
+  --> $DIR/gen-kw.rs:42:21
+   |
+LL | impl<'gen> Tr for S<'gen> {}
+   |                     ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
+   |
+   = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/rust-2024/gen-kw.e2018.stderr
+++ b/tests/ui/rust-2024/gen-kw.e2018.stderr
@@ -34,11 +34,29 @@ LL |     () => { mod test { fn gen() {} } }
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:9
    |
-LL | fn test<'gen>() {}
+LL | fn test<'gen>(_: &'gen i32) {}
    |         ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
-error: aborting due to 4 previous errors
+error: `gen` is a keyword in the 2024 edition
+  --> $DIR/gen-kw.rs:30:10
+   |
+LL | struct S<'gen>(&'gen i32);
+   |          ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
+   |
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: `gen` is a keyword in the 2024 edition
+  --> $DIR/gen-kw.rs:36:6
+   |
+LL | impl<'gen> Tr for S<'gen> {}
+   |      ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
+   |
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/rust-2024/gen-kw.e2018.stderr
+++ b/tests/ui/rust-2024/gen-kw.e2018.stderr
@@ -41,7 +41,16 @@ LL | fn test<'gen>(_: &'gen i32) {}
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `gen` is a keyword in the 2024 edition
-  --> $DIR/gen-kw.rs:30:10
+  --> $DIR/gen-kw.rs:25:19
+   |
+LL | fn test<'gen>(_: &'gen i32) {}
+   |                   ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
+   |
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: `gen` is a keyword in the 2024 edition
+  --> $DIR/gen-kw.rs:33:10
    |
 LL | struct S<'gen>(&'gen i32);
    |          ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
@@ -50,7 +59,16 @@ LL | struct S<'gen>(&'gen i32);
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
 error: `gen` is a keyword in the 2024 edition
-  --> $DIR/gen-kw.rs:36:6
+  --> $DIR/gen-kw.rs:33:17
+   |
+LL | struct S<'gen>(&'gen i32);
+   |                 ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
+   |
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: `gen` is a keyword in the 2024 edition
+  --> $DIR/gen-kw.rs:42:6
    |
 LL | impl<'gen> Tr for S<'gen> {}
    |      ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
@@ -58,5 +76,14 @@ LL | impl<'gen> Tr for S<'gen> {}
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
    = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
 
-error: aborting due to 6 previous errors
+error: `gen` is a keyword in the 2024 edition
+  --> $DIR/gen-kw.rs:42:21
+   |
+LL | impl<'gen> Tr for S<'gen> {}
+   |                     ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
+   |
+   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
+   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+
+error: aborting due to 9 previous errors
 

--- a/tests/ui/rust-2024/gen-kw.rs
+++ b/tests/ui/rust-2024/gen-kw.rs
@@ -22,7 +22,18 @@ macro_rules! t {
     //[e2018]~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
 }
 
-fn test<'gen>() {}
+fn test<'gen>(_: &'gen i32) {}
+//~^ ERROR `gen` is a keyword in the 2024 edition
+//[e2015]~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+//[e2018]~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
+
+struct S<'gen>(&'gen i32);
+//~^ ERROR `gen` is a keyword in the 2024 edition
+//[e2015]~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+//[e2018]~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
+
+trait Tr {}
+impl<'gen> Tr for S<'gen> {}
 //~^ ERROR `gen` is a keyword in the 2024 edition
 //[e2015]~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
 //[e2018]~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!

--- a/tests/ui/rust-2024/gen-kw.rs
+++ b/tests/ui/rust-2024/gen-kw.rs
@@ -24,18 +24,27 @@ macro_rules! t {
 
 fn test<'gen>(_: &'gen i32) {}
 //~^ ERROR `gen` is a keyword in the 2024 edition
+//~| ERROR `gen` is a keyword in the 2024 edition
 //[e2015]~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+//[e2015]~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+//[e2018]~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
 //[e2018]~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
 
 struct S<'gen>(&'gen i32);
 //~^ ERROR `gen` is a keyword in the 2024 edition
+//~| ERROR `gen` is a keyword in the 2024 edition
 //[e2015]~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+//[e2015]~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+//[e2018]~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
 //[e2018]~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
 
 trait Tr {}
 impl<'gen> Tr for S<'gen> {}
 //~^ ERROR `gen` is a keyword in the 2024 edition
+//~| ERROR `gen` is a keyword in the 2024 edition
 //[e2015]~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+//[e2015]~| WARNING this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
+//[e2018]~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
 //[e2018]~| WARNING this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
 
 t!();


### PR DESCRIPTION
This fixes the `keyword_idents_2024` lint which was missing `'gen` in various positions (it was generally only catching macros and generic arguments). Lifetimes are only treated as an "ident" for the purpose of `visit_ident` in generic arguments. In other positions, it needs to go through `visit_lifetime`.

Fixes #133839
