### PR TITLE
Fix: typo in E0751 error explanation

### DIFF
--- a/compiler/rustc_error_codes/src/error_codes/E0751.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0751.md
@@ -9,4 +9,4 @@ impl !MyTrait for i32 { } // error!
 ```
 
 Negative implementations are a promise that the trait will never be implemented
-for the given types. Therefore, both cannot exists at the same time.
+for the given types. Therefore, both cannot exist at the same time.


### PR DESCRIPTION
Corrected a grammatical error in the explanation for E0751. Changed "exists" to "exist" to improve clarity and ensure proper grammar in the error message.

<!-- homu-ignore:start -->
<!--
This PR fixes a typo in the error message for E0751 by correcting the grammar from "exists" to "exist".
There is no related tracking issue for this small typo correction, so no issue link is necessary.
-->
<!-- homu-ignore:end -->
