### PR TITLE
Default `rust.new-symbol-mangling` to `true` universally

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -757,11 +757,9 @@
 
 # Enable symbol-mangling-version v0. This can be helpful when profiling rustc,
 # as generics will be preserved in symbols (rather than erased into opaque T).
-# When no setting is given, the new scheme will be used when compiling the
-# compiler and its tools and the legacy scheme will be used when compiling the
-# standard library.
-# If an explicit setting is given, it will be used for all parts of the codebase.
-#new-symbol-mangling = true|false (see comment)
+# When no setting is given, the new scheme will be used when compiling all parts
+# of the codebase.
+#new-symbol-mangling = true (see comment)
 
 # Select LTO mode that will be used for compiling rustc. By default, thin local LTO
 # (LTO within a single crate) is used (like for any Rust crate). You can also select

--- a/src/bootstrap/src/core/builder/cargo.rs
+++ b/src/bootstrap/src/core/builder/cargo.rs
@@ -549,21 +549,7 @@ impl Builder<'_> {
             rustflags.arg(sysroot_str);
         }
 
-        let use_new_symbol_mangling = match self.config.rust_new_symbol_mangling {
-            Some(setting) => {
-                // If an explicit setting is given, use that
-                setting
-            }
-            None => {
-                if mode == Mode::Std {
-                    // The standard library defaults to the legacy scheme
-                    false
-                } else {
-                    // The compiler and tools default to the new scheme
-                    true
-                }
-            }
-        };
+        let use_new_symbol_mangling = self.config.rust_new_symbol_mangling.unwrap_or(true);
 
         // By default, windows-rs depends on a native library that doesn't get copied into the
         // sysroot. Passing this cfg enables raw-dylib support instead, which makes the native

--- a/src/bootstrap/src/utils/change_tracker.rs
+++ b/src/bootstrap/src/utils/change_tracker.rs
@@ -310,4 +310,9 @@ pub const CONFIG_CHANGE_HISTORY: &[ChangeInfo] = &[
         severity: ChangeSeverity::Warning,
         summary: "Revert `rust.download-rustc` global default to `false` and only use `rust.download-rustc = \"if-unchanged\"` default for library and tools profile. As alt CI rustc is built without debug assertions, `rust.debug-assertions = true` will now inhibit downloading CI rustc.",
     },
+    ChangeInfo {
+        change_id: 133998,
+        severity: ChangeSeverity::Warning,
+        summary: "`rust.new-symbol-mangling` now defaults to `true` universally when unset, including when build library.",
+    },
 ];


### PR DESCRIPTION
**FIXME: this needs to preserve mixed behavior for dist profile because v0 is not stable cc #60705 grrr**

Instead of using legacy scheme for library but new scheme for compiler when the option is not set.

r? @ghost
