### PR TITLE
[CORE] added unreachable unwrap function to `Option`

### DIFF
--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1840,6 +1840,34 @@ impl<T> Option<T> {
             _ => None,
         }
     }
+
+    /// Returns the contained [`Some`] value (consumes the `self` value).
+    /// 
+    /// # Panics
+    ///
+    /// This function throws an unreachable if the self value equals [`None`]
+    ///
+    /// # Examples
+    /// ```
+    /// let x = Some("air");
+    /// assert_eq!(x.unreachable(), "air");
+    /// ```
+    ///
+    /// ```should_panic
+    /// let x: Option<&str> = None;
+    /// assert_eq!(x.unreachable(), "air"); // fails
+    /// ```
+    #[inline(always)]
+    #[track_caller]
+    #[stable(feature = "rust1", since = "1.0.0")]
+    #[cfg_attr(not(test), rustc_diagnostic_item = "option_unreachable")]
+    #[rustc_allow_const_fn_unstable(const_precise_live_drops)]
+    #[rustc_const_stable(feature = "const_option", since = "1.83.0")]
+    pub const fn unreachable(self) -> T {
+        let Some(value) = self else { unreachable!() };
+
+        value
+    }
 }
 
 impl<T, U> Option<(T, U)> {

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -1842,7 +1842,7 @@ impl<T> Option<T> {
     }
 
     /// Returns the contained [`Some`] value (consumes the `self` value).
-    /// 
+    ///
     /// # Panics
     ///
     /// This function throws an unreachable if the self value equals [`None`]


### PR DESCRIPTION
Hi,
In this PR i added a function to `Option` which throws an unreachable exception, if the internal value is None.

## Would this have use cases?

Yes, I want a feature like that for a very long time.
It would make development of some of my codegen libs easier.

Best wishes,
Toni
