### PR TITLE
fix ICE on type error in promoted

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/error.rs
+++ b/compiler/rustc_const_eval/src/const_eval/error.rs
@@ -170,7 +170,7 @@ where
             let reported = if allowed_in_infallible {
                 ReportedErrorInfo::allowed_in_infallible(g)
             } else {
-                ReportedErrorInfo::from(g)
+                ReportedErrorInfo::const_eval_error(g)
             };
             ErrorHandled::Reported(reported, span)
         }

--- a/compiler/rustc_const_eval/src/const_eval/machine.rs
+++ b/compiler/rustc_const_eval/src/const_eval/machine.rs
@@ -8,6 +8,7 @@ use rustc_data_structures::fx::{FxHashMap, FxIndexMap, IndexEntry};
 use rustc_hir::def_id::{DefId, LocalDefId};
 use rustc_hir::{self as hir, CRATE_HIR_ID, LangItem};
 use rustc_middle::mir::AssertMessage;
+use rustc_middle::mir::interpret::ReportedErrorInfo;
 use rustc_middle::query::TyCtxtAt;
 use rustc_middle::ty::layout::{HasTypingEnv, TyAndLayout};
 use rustc_middle::ty::{self, Ty, TyCtxt};
@@ -563,7 +564,7 @@ impl<'tcx> interpret::Machine<'tcx> for CompileTimeMachine<'tcx> {
                         .tcx
                         .dcx()
                         .span_delayed_bug(span, "The deny lint should have already errored");
-                    throw_inval!(AlreadyReported(guard.into()));
+                    throw_inval!(AlreadyReported(ReportedErrorInfo::allowed_in_infallible(guard)));
                 }
             } else if new_steps > start && new_steps.is_power_of_two() {
                 // Only report after a certain number of terminators have been evaluated and the

--- a/compiler/rustc_const_eval/src/const_eval/valtrees.rs
+++ b/compiler/rustc_const_eval/src/const_eval/valtrees.rs
@@ -1,6 +1,6 @@
 use rustc_abi::{BackendRepr, VariantIdx};
 use rustc_data_structures::stack::ensure_sufficient_stack;
-use rustc_middle::mir::interpret::{EvalToValTreeResult, GlobalId};
+use rustc_middle::mir::interpret::{EvalToValTreeResult, GlobalId, ReportedErrorInfo};
 use rustc_middle::ty::layout::{LayoutCx, LayoutOf, TyAndLayout};
 use rustc_middle::ty::{self, ScalarInt, Ty, TyCtxt};
 use rustc_middle::{bug, mir};
@@ -261,7 +261,7 @@ pub(crate) fn eval_to_valtree<'tcx>(
                 ValTreeCreationError::NodesOverflow => {
                     let handled =
                         tcx.dcx().emit_err(MaxNumNodesInConstErr { span, global_const_id });
-                    Err(handled.into())
+                    Err(ReportedErrorInfo::allowed_in_infallible(handled).into())
                 }
                 ValTreeCreationError::NonSupportedType(ty) => Ok(Err(ty)),
             }

--- a/compiler/rustc_const_eval/src/interpret/eval_context.rs
+++ b/compiler/rustc_const_eval/src/interpret/eval_context.rs
@@ -268,7 +268,7 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
         };
         // do not continue if typeck errors occurred (can only occur in local crate)
         if let Some(err) = body.tainted_by_errors {
-            throw_inval!(AlreadyReported(ReportedErrorInfo::from(err)));
+            throw_inval!(AlreadyReported(ReportedErrorInfo::non_const_eval_error(err)));
         }
         interp_ok(body)
     }
@@ -317,7 +317,9 @@ impl<'tcx, M: Machine<'tcx>> InterpCx<'tcx, M> {
             Ok(None) => throw_inval!(TooGeneric),
 
             // FIXME(eddyb) this could be a bit more specific than `AlreadyReported`.
-            Err(error_reported) => throw_inval!(AlreadyReported(error_reported.into())),
+            Err(error_guaranteed) => throw_inval!(AlreadyReported(
+                ReportedErrorInfo::non_const_eval_error(error_guaranteed)
+            )),
         }
     }
 

--- a/compiler/rustc_middle/src/mir/consts.rs
+++ b/compiler/rustc_middle/src/mir/consts.rs
@@ -8,6 +8,7 @@ use rustc_session::config::RemapPathScopeComponents;
 use rustc_span::{DUMMY_SP, Span};
 use rustc_type_ir::visit::TypeVisitableExt;
 
+use super::interpret::ReportedErrorInfo;
 use crate::mir::interpret::{AllocId, ConstAllocation, ErrorHandled, Scalar, alloc_range};
 use crate::mir::{Promoted, pretty_print_const_value};
 use crate::ty::print::{pretty_print_const, with_no_trimmed_paths};
@@ -331,7 +332,10 @@ impl<'tcx> Const<'tcx> {
                     ConstKind::Expr(_) => {
                         bug!("Normalization of `ty::ConstKind::Expr` is unimplemented")
                     }
-                    _ => Err(tcx.dcx().delayed_bug("Unevaluated `ty::Const` in MIR body").into()),
+                    _ => Err(ReportedErrorInfo::non_const_eval_error(
+                        tcx.dcx().delayed_bug("Unevaluated `ty::Const` in MIR body"),
+                    )
+                    .into()),
                 }
             }
             Const::Unevaluated(uneval, _) => {

--- a/compiler/rustc_middle/src/mir/interpret/queries.rs
+++ b/compiler/rustc_middle/src/mir/interpret/queries.rs
@@ -6,6 +6,7 @@ use tracing::{debug, instrument};
 
 use super::{
     ErrorHandled, EvalToAllocationRawResult, EvalToConstValueResult, EvalToValTreeResult, GlobalId,
+    ReportedErrorInfo,
 };
 use crate::mir;
 use crate::query::TyCtxtEnsure;
@@ -81,7 +82,9 @@ impl<'tcx> TyCtxt<'tcx> {
             // For errors during resolution, we deliberately do not point at the usage site of the constant,
             // since for these errors the place the constant is used shouldn't matter.
             Ok(None) => Err(ErrorHandled::TooGeneric(DUMMY_SP)),
-            Err(err) => Err(ErrorHandled::Reported(err.into(), DUMMY_SP)),
+            Err(err) => {
+                Err(ErrorHandled::Reported(ReportedErrorInfo::non_const_eval_error(err), DUMMY_SP))
+            }
         }
     }
 
@@ -138,7 +141,9 @@ impl<'tcx> TyCtxt<'tcx> {
             // For errors during resolution, we deliberately do not point at the usage site of the constant,
             // since for these errors the place the constant is used shouldn't matter.
             Ok(None) => Err(ErrorHandled::TooGeneric(DUMMY_SP)),
-            Err(err) => Err(ErrorHandled::Reported(err.into(), DUMMY_SP)),
+            Err(err) => {
+                Err(ErrorHandled::Reported(ReportedErrorInfo::non_const_eval_error(err), DUMMY_SP))
+            }
         }
     }
 

--- a/src/tools/clippy/clippy_lints/src/non_copy_const.rs
+++ b/src/tools/clippy/clippy_lints/src/non_copy_const.rs
@@ -11,7 +11,7 @@ use rustc_hir::{
     BodyId, Expr, ExprKind, HirId, Impl, ImplItem, ImplItemKind, Item, ItemKind, Node, TraitItem, TraitItemKind, UnOp,
 };
 use rustc_lint::{LateContext, LateLintPass, Lint};
-use rustc_middle::mir::interpret::{ErrorHandled, EvalToValTreeResult, GlobalId};
+use rustc_middle::mir::interpret::{ErrorHandled, EvalToValTreeResult, GlobalId, ReportedErrorInfo};
 use rustc_middle::ty::adjustment::Adjust;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 use rustc_session::impl_lint_pass;
@@ -302,7 +302,10 @@ impl<'tcx> NonCopyConst<'tcx> {
                 tcx.const_eval_global_id_for_typeck(typing_env, cid, span)
             },
             Ok(None) => Err(ErrorHandled::TooGeneric(span)),
-            Err(err) => Err(ErrorHandled::Reported(err.into(), span)),
+            Err(err) => Err(ErrorHandled::Reported(
+                ReportedErrorInfo::non_const_eval_error(err),
+                span,
+            )),
         }
     }
 }

--- a/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
+++ b/tests/ui/const-generics/generic_const_exprs/unevaluated-const-ice-119731.stderr
@@ -72,20 +72,6 @@ help: add `#![feature(adt_const_params)]` to the crate attributes to enable more
 LL + #![feature(adt_const_params)]
    |
 
-note: erroneous constant encountered
-  --> $DIR/unevaluated-const-ice-119731.rs:22:19
-   |
-LL |     impl v17<512, v0> {
-   |                   ^^
-
-note: erroneous constant encountered
-  --> $DIR/unevaluated-const-ice-119731.rs:22:19
-   |
-LL |     impl v17<512, v0> {
-   |                   ^^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
 error: maximum number of nodes exceeded in constant v20::v17::<v10, v2>::{constant#0}
   --> $DIR/unevaluated-const-ice-119731.rs:28:37
    |

--- a/tests/ui/consts/const-integer-bool-ops.stderr
+++ b/tests/ui/consts/const-integer-bool-ops.stderr
@@ -16,12 +16,6 @@ error[E0308]: mismatched types
 LL | const X: usize = 42 && 39;
    |                  ^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant encountered
-  --> $DIR/const-integer-bool-ops.rs:8:18
-   |
-LL | const ARR: [i32; X] = [99; 34];
-   |                  ^
-
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:10:19
    |
@@ -39,12 +33,6 @@ error[E0308]: mismatched types
    |
 LL | const X1: usize = 42 || 39;
    |                   ^^^^^^^^ expected `usize`, found `bool`
-
-note: erroneous constant encountered
-  --> $DIR/const-integer-bool-ops.rs:17:19
-   |
-LL | const ARR1: [i32; X1] = [99; 47];
-   |                   ^^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:19:19
@@ -64,12 +52,6 @@ error[E0308]: mismatched types
 LL | const X2: usize = -42 || -39;
    |                   ^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant encountered
-  --> $DIR/const-integer-bool-ops.rs:26:19
-   |
-LL | const ARR2: [i32; X2] = [99; 18446744073709551607];
-   |                   ^^
-
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:28:19
    |
@@ -88,23 +70,11 @@ error[E0308]: mismatched types
 LL | const X3: usize = -42 && -39;
    |                   ^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant encountered
-  --> $DIR/const-integer-bool-ops.rs:35:19
-   |
-LL | const ARR3: [i32; X3] = [99; 6];
-   |                   ^^
-
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:37:18
    |
 LL | const Y: usize = 42.0 == 42.0;
    |                  ^^^^^^^^^^^^ expected `usize`, found `bool`
-
-note: erroneous constant encountered
-  --> $DIR/const-integer-bool-ops.rs:40:19
-   |
-LL | const ARRR: [i32; Y] = [99; 1];
-   |                   ^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:42:19
@@ -112,23 +82,11 @@ error[E0308]: mismatched types
 LL | const Y1: usize = 42.0 >= 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant encountered
-  --> $DIR/const-integer-bool-ops.rs:45:20
-   |
-LL | const ARRR1: [i32; Y1] = [99; 1];
-   |                    ^^
-
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:47:19
    |
 LL | const Y2: usize = 42.0 <= 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
-
-note: erroneous constant encountered
-  --> $DIR/const-integer-bool-ops.rs:50:20
-   |
-LL | const ARRR2: [i32; Y2] = [99; 1];
-   |                    ^^
 
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:52:19
@@ -136,35 +94,17 @@ error[E0308]: mismatched types
 LL | const Y3: usize = 42.0 > 42.0;
    |                   ^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant encountered
-  --> $DIR/const-integer-bool-ops.rs:55:20
-   |
-LL | const ARRR3: [i32; Y3] = [99; 0];
-   |                    ^^
-
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:57:19
    |
 LL | const Y4: usize = 42.0 < 42.0;
    |                   ^^^^^^^^^^^ expected `usize`, found `bool`
 
-note: erroneous constant encountered
-  --> $DIR/const-integer-bool-ops.rs:60:20
-   |
-LL | const ARRR4: [i32; Y4] = [99; 0];
-   |                    ^^
-
 error[E0308]: mismatched types
   --> $DIR/const-integer-bool-ops.rs:62:19
    |
 LL | const Y5: usize = 42.0 != 42.0;
    |                   ^^^^^^^^^^^^ expected `usize`, found `bool`
-
-note: erroneous constant encountered
-  --> $DIR/const-integer-bool-ops.rs:65:20
-   |
-LL | const ARRR5: [i32; Y5] = [99; 0];
-   |                    ^^
 
 error: aborting due to 18 previous errors
 

--- a/tests/ui/consts/const-mut-refs/issue-76510.stderr
+++ b/tests/ui/consts/const-mut-refs/issue-76510.stderr
@@ -4,12 +4,6 @@ error[E0764]: mutable references are not allowed in the final value of constants
 LL | const S: &'static mut str = &mut " hello ";
    |                             ^^^^^^^^^^^^^^
 
-note: erroneous constant encountered
-  --> $DIR/issue-76510.rs:7:70
-   |
-LL |         let s = transmute::<(*const u8, usize), &ManuallyDrop<str>>((S.as_ptr(), 3));
-   |                                                                      ^
-
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0764`.

--- a/tests/ui/consts/const-tup-index-span.stderr
+++ b/tests/ui/consts/const-tup-index-span.stderr
@@ -11,12 +11,6 @@ help: use a trailing comma to create a tuple with one element
 LL | const TUP: (usize,) = (5usize << 64,);
    |                       +            ++
 
-note: erroneous constant encountered
-  --> $DIR/const-tup-index-span.rs:6:18
-   |
-LL | const ARR: [i32; TUP.0] = [];
-   |                  ^^^
-
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/consts/issue-54954.stderr
+++ b/tests/ui/consts/issue-54954.stderr
@@ -19,24 +19,6 @@ LL | |         core::mem::size_of::<T>()
 LL | |     }
    | |_____- `Tt::const_val` defined here
 
-note: erroneous constant encountered
-  --> $DIR/issue-54954.rs:11:15
-   |
-LL | fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
-   |               ^^^^^^^
-
-note: erroneous constant encountered
-  --> $DIR/issue-54954.rs:11:34
-   |
-LL | fn f(z: [f32; ARR_LEN]) -> [f32; ARR_LEN] {
-   |                                  ^^^^^^^
-
-note: erroneous constant encountered
-  --> $DIR/issue-54954.rs:16:22
-   |
-LL |     let _ = f([1f32; ARR_LEN]);
-   |                      ^^^^^^^
-
 error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0379, E0790.

--- a/tests/ui/consts/missing_assoc_const_type2.stderr
+++ b/tests/ui/consts/missing_assoc_const_type2.stderr
@@ -4,11 +4,5 @@ error: missing type for `const` item
 LL |     const FIRST:  = 10;
    |                 ^ help: provide a type for the associated constant: `u8`
 
-note: erroneous constant encountered
-  --> $DIR/missing_assoc_const_type2.rs:18:5
-   |
-LL |     TwoDigits::FIRST as usize
-   |     ^^^^^^^^^^^^^^^^
-
 error: aborting due to 1 previous error
 

--- a/tests/ui/consts/promoted-type-error-issue-133968.rs
+++ b/tests/ui/consts/promoted-type-error-issue-133968.rs
@@ -1,0 +1,7 @@
+struct B<T: ?Sized + Send + 'static> {
+    x: &'static T,
+}
+static STR: &'static [u8] = "a b"; //~ERROR: mismatched types
+static C: &B<[u8]> = &B { x: STR };
+
+fn main() {}

--- a/tests/ui/consts/promoted-type-error-issue-133968.stderr
+++ b/tests/ui/consts/promoted-type-error-issue-133968.stderr
@@ -1,0 +1,16 @@
+error[E0308]: mismatched types
+  --> $DIR/promoted-type-error-issue-133968.rs:4:29
+   |
+LL | static STR: &'static [u8] = "a b";
+   |                             ^^^^^ expected `&[u8]`, found `&str`
+   |
+   = note: expected reference `&'static [u8]`
+              found reference `&'static str`
+help: consider adding a leading `b`
+   |
+LL | static STR: &'static [u8] = b"a b";
+   |                             +
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.

--- a/tests/ui/enum-discriminant/issue-41394.stderr
+++ b/tests/ui/enum-discriminant/issue-41394.stderr
@@ -6,12 +6,6 @@ LL |     A = "" + 1
    |         |
    |         &str
 
-note: erroneous constant encountered
-  --> $DIR/issue-41394.rs:7:9
-   |
-LL |     A = Foo::A as isize
-   |         ^^^^^^^^^^^^^^^
-
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0369`.

--- a/tests/ui/layout/base-layout-is-sized-ice-123078.stderr
+++ b/tests/ui/layout/base-layout-is-sized-ice-123078.stderr
@@ -25,12 +25,6 @@ LL | const C: S = unsafe { std::mem::transmute(()) };
    = note: source type: `()` (0 bits)
    = note: target type: `S` (size can vary because of [u8])
 
-note: erroneous constant encountered
-  --> $DIR/base-layout-is-sized-ice-123078.rs:13:5
-   |
-LL |     C;
-   |     ^
-
 error: aborting due to 2 previous errors
 
 Some errors have detailed explanations: E0277, E0512.

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.default.stderr
@@ -29,20 +29,6 @@ LL |     const _: u32 = T::C;
    |
    = note: a `const` is a separate item from the item that contains it
 
-note: erroneous constant encountered
-  --> $DIR/generic-params-from-outer-item-in-const-item.rs:22:9
-   |
-LL |         I
-   |         ^
-
-note: erroneous constant encountered
-  --> $DIR/generic-params-from-outer-item-in-const-item.rs:22:9
-   |
-LL |         I
-   |         ^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
 error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0401`.

--- a/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
+++ b/tests/ui/resolve/generic-params-from-outer-item-in-const-item.generic_const_items.stderr
@@ -35,20 +35,6 @@ LL |     const _: u32 = T::C;
    |
    = note: a `const` is a separate item from the item that contains it
 
-note: erroneous constant encountered
-  --> $DIR/generic-params-from-outer-item-in-const-item.rs:22:9
-   |
-LL |         I
-   |         ^
-
-note: erroneous constant encountered
-  --> $DIR/generic-params-from-outer-item-in-const-item.rs:22:9
-   |
-LL |         I
-   |         ^
-   |
-   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
-
 error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0401`.

--- a/tests/ui/resolve/issue-50599.stderr
+++ b/tests/ui/resolve/issue-50599.stderr
@@ -20,12 +20,6 @@ LL -     const M: usize = (f64::from(N) * std::f64::LOG10_2) as usize;
 LL +     const M: usize = (f64::from(N) * LOG10_2) as usize;
    |
 
-note: erroneous constant encountered
-  --> $DIR/issue-50599.rs:4:29
-   |
-LL |     let mut digits = [0u32; M];
-   |                             ^
-
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0425`.

--- a/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.stderr
+++ b/tests/ui/rfcs/rfc-2497-if-let-chains/avoid-invalid-mir.stderr
@@ -6,11 +6,5 @@ LL |     !let y = 42;
    |
    = note: only supported directly in conditions of `if` and `while` expressions
 
-note: erroneous constant encountered
-  --> $DIR/avoid-invalid-mir.rs:11:13
-   |
-LL |     x: [(); N]
-   |             ^
-
 error: aborting due to 1 previous error
 

--- a/tests/ui/self/arbitrary-self-from-method-substs-ice.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs-ice.stderr
@@ -17,12 +17,6 @@ LL |     const fn get<R: Deref<Target = Self>>(self: R) -> u32 {
 LL |     }
    |     - value is dropped here
 
-note: erroneous constant encountered
-  --> $DIR/arbitrary-self-from-method-substs-ice.rs:24:5
-   |
-LL |     FOO;
-   |     ^^^
-
 error[E0801]: invalid generic `self` parameter type: `R`
   --> $DIR/arbitrary-self-from-method-substs-ice.rs:10:49
    |

--- a/tests/ui/type/type-dependent-def-issue-49241.stderr
+++ b/tests/ui/type/type-dependent-def-issue-49241.stderr
@@ -9,12 +9,6 @@ help: consider using `let` instead of `const`
 LL |     let l: usize = v.count();
    |     ~~~
 
-note: erroneous constant encountered
-  --> $DIR/type-dependent-def-issue-49241.rs:4:18
-   |
-LL |     let s: [u32; l] = v.into_iter().collect();
-   |                  ^
-
 error: aborting due to 1 previous error
 
 For more information about this error, try `rustc --explain E0435`.


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/133968

Ensure that when we turn a type error into a "this promoted failed to evaluate" error, we do record this as something that may happen even in "infallible" promoteds.