### PR TITLE
Don't use `AsyncFnOnce::CallOnceFuture` bounds for signature deduction

### DIFF
--- a/tests/ui/async-await/async-closures/call-once-deduction.rs
+++ b/tests/ui/async-await/async-closures/call-once-deduction.rs
@@ -1,0 +1,14 @@
+//@ edition: 2021
+//@ check-pass
+
+#![feature(async_closure, async_fn_traits, unboxed_closures)]
+
+fn bar<F, O>(_: F)
+where
+    F: AsyncFnOnce<(), CallOnceFuture = O>,
+{
+}
+
+fn main() {
+    bar(async move || {});
+}


### PR DESCRIPTION
We shouldn't be using `AsyncFnOnce::CallOnceFuture` projection bounds to deduce anything about the return type of an async closure, **only** `AsyncFnOnce::Output`. This was accidental b/c all we were looking at was the def id of the trait, rather than the projection. This PR fixes that.

This doesn't affect stable code, since `CallOnceFuture` bounds cannot be written on stable.

Fixes #134015