### PR TITLE
handle paren in macro expand for let-init-else expr

### DIFF
--- a/tests/ui/lint/unused-parens-for-macro-call-with-brace.fixed
+++ b/tests/ui/lint/unused-parens-for-macro-call-with-brace.fixed
@@ -1,0 +1,28 @@
+//@ run-rustfix
+
+#![deny(unused_parens)]
+
+fn main() {
+    macro_rules! x {
+        () => { None::<i32> };
+    }
+
+    let Some(_) = (x!{}) else { return }; // no error
+    let Some(_) = (x!{}) else { return };
+    //~^ ERROR: unnecessary parentheses around assigned value
+
+    let Some(_) = (x!{}) else { return };
+    //~^ ERROR: unnecessary parentheses around pattern
+
+    let _ = x!{};
+    let _ = x!{};
+    //~^ ERROR: unnecessary parentheses around assigned value
+
+    if let Some(_) = x!{} {};
+    if let Some(_) = x!{} {};
+    //~^ ERROR: unnecessary parentheses around `let` scrutinee expression
+
+    while let Some(_) = x!{} {};
+    while let Some(_) = x!{} {};
+    //~^ ERROR: unnecessary parentheses around `let` scrutinee expression
+}

--- a/tests/ui/lint/unused-parens-for-macro-call-with-brace.rs
+++ b/tests/ui/lint/unused-parens-for-macro-call-with-brace.rs
@@ -1,0 +1,28 @@
+//@ run-rustfix
+
+#![deny(unused_parens)]
+
+fn main() {
+    macro_rules! x {
+        () => { None::<i32> };
+    }
+
+    let Some(_) = (x!{}) else { return }; // no error
+    let Some(_) = ((x!{})) else { return };
+    //~^ ERROR: unnecessary parentheses around assigned value
+
+    let Some((_)) = (x!{}) else { return };
+    //~^ ERROR: unnecessary parentheses around pattern
+
+    let _ = x!{};
+    let _ = (x!{});
+    //~^ ERROR: unnecessary parentheses around assigned value
+
+    if let Some(_) = x!{} {};
+    if let Some(_) = (x!{}) {};
+    //~^ ERROR: unnecessary parentheses around `let` scrutinee expression
+
+    while let Some(_) = x!{} {};
+    while let Some(_) = (x!{}) {};
+    //~^ ERROR: unnecessary parentheses around `let` scrutinee expression
+}

--- a/tests/ui/lint/unused-parens-for-macro-call-with-brace.stderr
+++ b/tests/ui/lint/unused-parens-for-macro-call-with-brace.stderr
@@ -1,0 +1,67 @@
+error: unnecessary parentheses around assigned value
+  --> $DIR/unused-parens-for-macro-call-with-brace.rs:11:19
+   |
+LL |     let Some(_) = ((x!{})) else { return };
+   |                   ^      ^
+   |
+note: the lint level is defined here
+  --> $DIR/unused-parens-for-macro-call-with-brace.rs:3:9
+   |
+LL | #![deny(unused_parens)]
+   |         ^^^^^^^^^^^^^
+help: remove these parentheses
+   |
+LL -     let Some(_) = ((x!{})) else { return };
+LL +     let Some(_) = (x!{}) else { return };
+   |
+
+error: unnecessary parentheses around pattern
+  --> $DIR/unused-parens-for-macro-call-with-brace.rs:14:14
+   |
+LL |     let Some((_)) = (x!{}) else { return };
+   |              ^ ^
+   |
+help: remove these parentheses
+   |
+LL -     let Some((_)) = (x!{}) else { return };
+LL +     let Some(_) = (x!{}) else { return };
+   |
+
+error: unnecessary parentheses around assigned value
+  --> $DIR/unused-parens-for-macro-call-with-brace.rs:18:13
+   |
+LL |     let _ = (x!{});
+   |             ^    ^
+   |
+help: remove these parentheses
+   |
+LL -     let _ = (x!{});
+LL +     let _ = x!{};
+   |
+
+error: unnecessary parentheses around `let` scrutinee expression
+  --> $DIR/unused-parens-for-macro-call-with-brace.rs:22:22
+   |
+LL |     if let Some(_) = (x!{}) {};
+   |                      ^    ^
+   |
+help: remove these parentheses
+   |
+LL -     if let Some(_) = (x!{}) {};
+LL +     if let Some(_) = x!{} {};
+   |
+
+error: unnecessary parentheses around `let` scrutinee expression
+  --> $DIR/unused-parens-for-macro-call-with-brace.rs:26:25
+   |
+LL |     while let Some(_) = (x!{}) {};
+   |                         ^    ^
+   |
+help: remove these parentheses
+   |
+LL -     while let Some(_) = (x!{}) {};
+LL +     while let Some(_) = x!{} {};
+   |
+
+error: aborting due to 5 previous errors
+


### PR DESCRIPTION
Fixes #131655 

This PR modifies the codegen logic of the macro expansion within `let-init-else` expression:
- Before: The expression `let xxx = (mac! {}) else {}` expands to `let xxx = (expanded_ast) else {}`.
- After: The same expression expands to `let xxx = expanded_ast else {}`.

An alternative solution to this issue could involve handling the source code directly when encountering unused parentheses in `let-init-else` expressions. However, this approach might be more cumbersome due to the absence of the necessary data structure.

r? @petrochenkov 