### PR TITLE
lib: constify bool::then_some

### DIFF
--- a/library/core/src/bool.rs
+++ b/library/core/src/bool.rs
@@ -29,8 +29,9 @@ impl bool {
     /// assert_eq!(a, 2);
     /// ```
     #[stable(feature = "bool_to_option", since = "1.62.0")]
+    #[rustc_const_stable(feature = "const_bool_to_option", since = "1.85.0")]
     #[inline]
-    pub fn then_some<T>(self, t: T) -> Option<T> {
+    pub const fn then_some<T>(self, t: T) -> Option<T> {
         if self { Some(t) } else { None }
     }
 


### PR DESCRIPTION
This is pretty straightforward and risk-free, so I took liberty marking it stable right away. I would also have loved to mark `bool::then` const, but that depends on `~const FnOnce()` which is currently unstable.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
