### PR TITLE
crash tests: use individual mir opts instead of mir-opt-level where easily possible

### DIFF
--- a/tests/crashes/121363.rs
+++ b/tests/crashes/121363.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #121363
-//@ compile-flags: -Zmir-opt-level=5 --crate-type lib
+//@ compile-flags: -Zmir-enable-passes=+GVN --crate-type lib
 
 #![feature(trivial_bounds)]
 

--- a/tests/crashes/128094.rs
+++ b/tests/crashes/128094.rs
@@ -1,5 +1,5 @@
 //@ known-bug: rust-lang/rust#128094
-//@ compile-flags: -Zmir-opt-level=5 --edition=2018
+//@ compile-flags: -Zmir-enable-passes=+GVN --edition=2018
 
 pub enum Request {
     TestSome(T),

--- a/tests/crashes/129095.rs
+++ b/tests/crashes/129095.rs
@@ -1,5 +1,5 @@
 //@ known-bug: rust-lang/rust#129095
-//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir
+//@ compile-flags: -Zmir-enable-passes=+GVN -Zmir-enable-passes=+Inline -Zvalidate-mir
 
 pub fn function_with_bytes<const BYTES: &'static [u8; 4]>() -> &'static [u8] {
     BYTES

--- a/tests/crashes/129109.rs
+++ b/tests/crashes/129109.rs
@@ -1,5 +1,5 @@
 //@ known-bug: rust-lang/rust#129109
-//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir
+//@ compile-flags: -Zmir-enable-passes=+GVN -Zvalidate-mir
 
 extern "C" {
     pub static mut symbol: [i8];

--- a/tests/crashes/130970.rs
+++ b/tests/crashes/130970.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #130970
-//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir
+//@ compile-flags: -Zmir-enable-passes=+GVN -Zvalidate-mir
 
 fn main() {
     extern "C" {

--- a/tests/crashes/131347.rs
+++ b/tests/crashes/131347.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #131347
-//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir
+//@ compile-flags: -Zmir-enable-passes=+GVN -Zmir-enable-passes=+Inline -Zvalidate-mir
 
 struct S;
 static STUFF: [i8] = [0; S::N];

--- a/tests/crashes/131507.rs
+++ b/tests/crashes/131507.rs
@@ -1,5 +1,5 @@
 //@ known-bug: #131507
-//@ compile-flags: -Zmir-opt-level=5 -Zvalidate-mir
+//@ compile-flags: -Zmir-enable-passes=+GVN -Zmir-enable-passes=+Inline -Zvalidate-mir
 #![feature(non_lifetime_binders)]
 
 fn brick()


### PR DESCRIPTION
r? @saethlin 
