### PR TITLE
Add test to check unicode identifier version

### DIFF
--- a/compiler/rustc_lexer/src/lib.rs
+++ b/compiler/rustc_lexer/src/lib.rs
@@ -33,6 +33,7 @@ pub mod unescape;
 mod tests;
 
 use unicode_properties::UnicodeEmoji;
+pub use unicode_xid::UNICODE_VERSION as UNICODE_XID_VERSION;
 
 use self::LiteralKind::*;
 use self::TokenKind::*;

--- a/compiler/rustc_parse/src/lib.rs
+++ b/compiler/rustc_parse/src/lib.rs
@@ -24,6 +24,7 @@ use rustc_data_structures::sync::Lrc;
 use rustc_errors::{Diag, FatalError, PResult};
 use rustc_session::parse::ParseSess;
 use rustc_span::{FileName, SourceFile, Span};
+pub use unicode_normalization::UNICODE_VERSION as UNICODE_NORMALIZATION_VERSION;
 
 pub const MACRO_ARGUMENTS: Option<&str> = Some("macro arguments");
 

--- a/tests/ui-fulldeps/lexer/unicode-version.rs
+++ b/tests/ui-fulldeps/lexer/unicode-version.rs
@@ -1,0 +1,27 @@
+// This test is used to validate which version of Unicode is used for parsing
+// identifiers. If the Unicode version changes, it should also be updated in
+// the reference at
+// https://github.com/rust-lang/reference/blob/HEAD/src/identifiers.md.
+
+//@ run-pass
+//@ check-run-results
+//@ ignore-cross-compile
+//@ reference: ident.unicode
+//@ reference: ident.normalization
+
+#![feature(rustc_private)]
+
+extern crate rustc_driver;
+extern crate rustc_lexer;
+extern crate rustc_parse;
+
+fn main() {
+    println!("Checking if Unicode version changed.");
+    println!(
+        "If the Unicode version changes are intentional, \
+         it should also be updated in the reference at \
+         https://github.com/rust-lang/reference/blob/HEAD/src/identifiers.md."
+    );
+    println!("Unicode XID version is: {:?}", rustc_lexer::UNICODE_XID_VERSION);
+    println!("Unicode normalization version is: {:?}", rustc_parse::UNICODE_NORMALIZATION_VERSION);
+}

--- a/tests/ui-fulldeps/lexer/unicode-version.run.stdout
+++ b/tests/ui-fulldeps/lexer/unicode-version.run.stdout
@@ -1,0 +1,4 @@
+Checking if Unicode version changed.
+If the Unicode version changes are intentional, it should also be updated in the reference at https://github.com/rust-lang/reference/blob/HEAD/src/identifiers.md.
+Unicode XID version is: (16, 0, 0)
+Unicode normalization version is: (16, 0, 0)

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -991,6 +991,13 @@ cc = ["@Zalathar"]
 [mentions."src/tools/opt-dist"]
 cc = ["@kobzol"]
 
+[mentions."tests/ui-fulldeps/lexer/unicode-version.run.stdout"]
+message = """If the Unicode version changes are intentional,
+it should also be updated in the reference at
+https://github.com/rust-lang/reference/blob/HEAD/src/identifiers.md.
+"""
+cc = ["@ehuss"]
+
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"


### PR DESCRIPTION
This adds a test to verify which version of Unicode is used for identifiers. This is part of the language, documented at https://doc.rust-lang.org/nightly/reference/identifiers.html#r-ident.unicode. The version here often changes implicitly due to dependency updates pulling in new versions, and thus we often don't notice it has changed leaving the documentation out of date. The intent here is to have a canary to give us a notification when it changes so that we can update the documentation.
