### PR TITLE
Implement From<MutexGuard<'a, T>> for &'a Mutex<T>

### DIFF
--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -500,6 +500,12 @@ impl<T: ?Sized + Default> Default for Mutex<T> {
     }
 }
 
+impl<'a, T> From<MutexGuard<'a, T>> for &'a Mutex<T>{
+    fn from(value: MutexGuard<'a, T>) -> Self{
+        value.lock
+    }
+}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized + fmt::Debug> fmt::Debug for Mutex<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
## Current Problem

Consider the following common pattern:

```rust
fn execute(items: impl Iterator<Item = Example>){
    let mutex: Mutex<usize> =  Mutex::new(0);
    let mut guard = mutex.lock().unwrap();
    for item in items {
        guard = item.execute_locked(&mutex, guard);
    }
}

struct Example;

impl Example {
    fn execute_locked<'a, T>(&self, mutex: &'a Mutex<T>, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T> {
        drop(guard);
        //do something unlocked...
        mutex.lock().unwrap()
    }
}
```

Current patterns for working with mutex locks require passing both the mutex and its guard between methods, which leads to verbose code. This proposal aims to simplify and optimize mutex handling by allowing direct conversion from a `MutexGuard` to a reference to its original `Mutex`. The MutexGuard already contains an immutable reference to the Mutex. Moreover, since the MutexGuard is consumed when delivering the immutable reference to the Mutex, this feature does not incentivize the occurrence of deadlocks.

## Proposed Solution

Implement `From` trait to allow direct conversion from `MutexGuard` to `&Mutex`:

```rust
impl<'a, T> From<MutexGuard<'a, T>> for &'a Mutex<T> {
    fn from(value: MutexGuard<'a, T>) -> Self {
        // Implementation leveraging internal lock field
    }
}
```

After implementation, the code would simplify to:

```rust
fn execute(items: impl Iterator<Item = Example>){
    let mutex: Mutex<usize> =  Mutex::new(0);
    let mut guard = mutex.lock().unwrap();
    for item in items {
        guard = item.execute_locked(guard);
    }
}

struct Example;

impl Example {
    fn execute_locked<'a, T>(&self, guard: MutexGuard<'a, T>) -> MutexGuard<'a, T> {
        drop(guard);
        // Access original mutex via From trait if needed
        let mutex: &Mutex<T> = guard.into();
        
        //do something unlocked...
        mutex.lock().unwrap()
    }
}
```

## Benefits

1. Reduced method signature complexity
2. Less boilerplate code
3. More intuitive mutex handling
4. Maintains existing safety guarantees