### PR TITLE
Configure renovatebot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  // Let Renovatebot keep an opened issue that tracks our dependencies
+  "dependencyDashboard": true,
+  // Disable "normal" package updates
+  "enabledManagers": [],
+  // Update lockfiles once per week
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 5am on Tuesday"
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds a basic Renovatebot configuration. We would mostly like to use the bot for updating lockfiles. First, I want to try out if the built-in lockFileMaintenance will work for that. I'm a bit skeptical, because it is not very configurable, but it's worth a try. I set the schedule for Tuesday, so that we can test what happens tomorrow.

I also enabled the dependency dashboard, as I think it could be useful for us, to see a global state of our dependencies.

r? @MarcoIeni