### PR TITLE
Stabilize `std::io::ErrorKind::InvalidFilename`

### DIFF
--- a/library/std/src/io/error.rs
+++ b/library/std/src/io/error.rs
@@ -373,8 +373,8 @@ pub enum ErrorKind {
     TooManyLinks,
     /// A filename was invalid.
     ///
-    /// This error can also cause if it exceeded the filename length limit.
-    #[unstable(feature = "io_error_more", issue = "86442")]
+    /// This error can also occur if a length limit for a name was exceeded.
+    #[stable(feature = "io_error_invalid_filename", since = "CURRENT_RUSTC_VERSION")]
     InvalidFilename,
     /// Program argument list too long.
     ///


### PR DESCRIPTION
FCP complete: https://github.com/rust-lang/rust/issues/130192#issuecomment-2674989358

Tracking issues: #86442 & #130192

This PR:
- Stabilizes `InvalidFilename` without changing its name to `InvalidFileName`.
- Fixes the doc comment (https://github.com/rust-lang/rust/issues/130192#issuecomment-2429534640)
- Does not separate "the name is too long" case into a separate `ErrorKind`. That case is currently documented to be covered by `InvalidFilename` in the doc. I'm not sure if it would be possible to change this later or if that would be an unacceptable breaking change.
- Does not map more raw OS errors to this `ErrorKind` (as suggested in https://github.com/rust-lang/rust/issues/86442#issuecomment-1441709738). This can presumably be addressed later.