### PR TITLE
Remove rustc_const_stable attribute on const NOOP

### DIFF
--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -61,7 +61,6 @@ impl RawWaker {
     }
 
     #[stable(feature = "noop_waker", since = "CURRENT_RUSTC_VERSION")]
-    #[rustc_const_stable(feature = "noop_waker", since = "CURRENT_RUSTC_VERSION")]
     const NOOP: RawWaker = {
         const VTABLE: RawWakerVTable = RawWakerVTable::new(
             // Cloning just returns a new no-op raw waker


### PR DESCRIPTION
This was accidentally reintroduced while editing #133089.

r? dtolnay

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
