### PR TITLE
Miscellaneous fixes for nix-dev-shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,12 +88,12 @@ package.json
 tests/rustdoc-gui/src/**.lock
 
 ## direnv
-.envrc
-.direnv/
+/.envrc
+/.direnv/
 
 ## nix
-flake.nix
+/flake.nix
 flake.lock
-default.nix
+/default.nix
 
 # Before adding new lines, see the comment at the top.

--- a/src/tools/nix-dev-shell/envrc-flake
+++ b/src/tools/nix-dev-shell/envrc-flake
@@ -1,7 +1,7 @@
 # If you want to use this as an .envrc file to create a shell with necessery components 
 # to develop rustc, use the following command in the root of the rusr checkout:
 #	
-# ln -s ./src/tools/nix-dev-shell/envrc-flake ./.envrc && nix flake update --flake ./src/tools/nix-dev-shell && echo .envrc >> .git/info/exclude
+# ln -s ./src/tools/nix-dev-shell/envrc-flake ./.envrc && nix flake update --flake ./src/tools/nix-dev-shell
 
 if nix flake show path:./src/tools/nix-dev-shell &> /dev/null; then
   use flake path:./src/tools/nix-dev-shell

--- a/src/tools/nix-dev-shell/envrc-shell
+++ b/src/tools/nix-dev-shell/envrc-shell
@@ -1,7 +1,7 @@
 # If you want to use this as an .envrc file to create a shell with necessery components 
 # to develop rustc, use the following command in the root of the rusr checkout:
 #	
-# ln -s ./src/tools/nix-dev-shell/envrc-shell ./.envrc && echo .envrc >> .git/info/exclude
+# ln -s ./src/tools/nix-dev-shell/envrc-shell ./.envrc
 
 use nix ./src/tools/nix-dev-shell/shell.nix
   

--- a/src/tools/nix-dev-shell/flake.nix
+++ b/src/tools/nix-dev-shell/flake.nix
@@ -24,9 +24,8 @@
           # Avoid creating text files for ICEs.
           RUSTC_ICE = "0";
           # Provide `libstdc++.so.6` for the self-contained lld.
-          LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [
-            stdenv.cc.cc.lib
-          ]}";
+          # Provide `libz.so.1`.
+          LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [stdenv.cc.cc.lib zlib]}";
         };
       }
     );

--- a/src/tools/nix-dev-shell/shell.nix
+++ b/src/tools/nix-dev-shell/shell.nix
@@ -13,7 +13,6 @@ pkgs.mkShell {
   # Avoid creating text files for ICEs.
   RUSTC_ICE = "0";
   # Provide `libstdc++.so.6` for the self-contained lld.
-  LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [
-    stdenv.cc.cc.lib
-  ]}";
+  # Provide `libz.so.1`
+  LD_LIBRARY_PATH = "${with pkgs; lib.makeLibraryPath [stdenv.cc.cc.lib zlib]}";
 }


### PR DESCRIPTION
this makes it so files in `src/nix-dev-shell` are *not* ignored, as they
should not be. note that `flake.lock` is still ignored globally.<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

r? @Noratrieb

See individual commits for more info.

cc #131176 (it added gitignore entries I'm changing).