### PR TITLE
Validate self in host predicates correctly

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
+++ b/compiler/rustc_hir_analysis/src/collect/predicates_of.rs
@@ -711,12 +711,19 @@ pub(super) fn assert_only_contains_predicates_from<'tcx>(
                             `{filter:?}` implied bounds: {clause:?}"
                         );
                     }
+                    ty::ClauseKind::HostEffect(host_effect_predicate) => {
+                        assert_eq!(
+                            host_effect_predicate.self_ty(),
+                            ty,
+                            "expected `Self` predicate when computing \
+                            `{filter:?}` implied bounds: {clause:?}"
+                        );
+                    }
 
                     ty::ClauseKind::RegionOutlives(_)
                     | ty::ClauseKind::ConstArgHasType(_, _)
                     | ty::ClauseKind::WellFormed(_)
-                    | ty::ClauseKind::ConstEvaluatable(_)
-                    | ty::ClauseKind::HostEffect(..) => {
+                    | ty::ClauseKind::ConstEvaluatable(_) => {
                         bug!(
                             "unexpected non-`Self` predicate when computing \
                             `{filter:?}` implied bounds: {clause:?}"

--- a/tests/ui/traits/const-traits/dont-ice-on-const-pred-for-bounds.rs
+++ b/tests/ui/traits/const-traits/dont-ice-on-const-pred-for-bounds.rs
@@ -1,0 +1,22 @@
+// Regression test for <https://github.com/rust-lang/rust/issues/133526>.
+
+// Ensures we don't ICE when we encounter a `HostEffectPredicate` when computing
+// the "item super predicates" for `Assoc`.
+
+//@ compile-flags: -Znext-solver
+//@ check-pass
+
+#![feature(const_trait_impl)]
+
+#[const_trait]
+trait Trait {
+    type Assoc: const Trait;
+}
+
+const fn needs_trait<T: ~const Trait>() {}
+
+fn test<T: Trait>() {
+    const { needs_trait::<T::Assoc>() };
+}
+
+fn main() {}


### PR DESCRIPTION
`assert_only_contains_predicates_from` was added to make sure that we are computing predicates for the correct self type for a given `PredicateFilter`. That was not implemented correctly for `PredicateFilter::SelfOnly` when there are const predicates.

Fixes #133526