### PR TITLE
Fix `--nocapture` for run-make tests

### DIFF
--- a/src/tools/compiletest/src/runtest.rs
+++ b/src/tools/compiletest/src/runtest.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fs::{self, File, create_dir_all};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::prelude::*;
@@ -1836,7 +1836,20 @@ impl<'test> TestCx<'test> {
             return;
         }
 
-        let proc_name = Path::new(proc_name).file_name().unwrap().to_string_lossy();
+        let path = Path::new(proc_name);
+        let proc_name = if path.file_stem().is_some_and(|p| p == "rmake") {
+            OsString::from_iter(
+                path.parent()
+                    .unwrap()
+                    .file_name()
+                    .into_iter()
+                    .chain(Some(OsStr::new("/")))
+                    .chain(path.file_name()),
+            )
+        } else {
+            path.file_name().unwrap().into()
+        };
+        let proc_name = proc_name.to_string_lossy();
         println!("------{proc_name} stdout------------------------------");
         println!("{}", out);
         println!("------{proc_name} stderr------------------------------");

--- a/src/tools/run-make-support/src/assertion_helpers.rs
+++ b/src/tools/run-make-support/src/assertion_helpers.rs
@@ -5,16 +5,31 @@ use std::path::Path;
 
 use crate::{fs, regex};
 
+fn print<'a, 'e, A: AsRef<str>, E: AsRef<str>>(
+    assertion_kind: &str,
+    haystack: &'a A,
+    needle: &'e E,
+) -> (&'a str, &'e str) {
+    let haystack = haystack.as_ref();
+    let needle = needle.as_ref();
+    eprintln!("{assertion_kind}:");
+    eprintln!("=== HAYSTACK ===");
+    eprintln!("{}", haystack);
+    eprintln!("=== NEEDLE ===");
+    eprintln!("{}", needle);
+    (haystack, needle)
+}
+
 /// Assert that `actual` is equal to `expected`.
 #[track_caller]
 pub fn assert_equals<A: AsRef<str>, E: AsRef<str>>(actual: A, expected: E) {
     let actual = actual.as_ref();
     let expected = expected.as_ref();
+    eprintln!("=== ACTUAL TEXT ===");
+    eprintln!("{}", actual);
+    eprintln!("=== EXPECTED ===");
+    eprintln!("{}", expected);
     if actual != expected {
-        eprintln!("=== ACTUAL TEXT ===");
-        eprintln!("{}", actual);
-        eprintln!("=== EXPECTED ===");
-        eprintln!("{}", expected);
         panic!("expected text was not found in actual text");
     }
 }
@@ -22,13 +37,8 @@ pub fn assert_equals<A: AsRef<str>, E: AsRef<str>>(actual: A, expected: E) {
 /// Assert that `haystack` contains `needle`.
 #[track_caller]
 pub fn assert_contains<H: AsRef<str>, N: AsRef<str>>(haystack: H, needle: N) {
-    let haystack = haystack.as_ref();
-    let needle = needle.as_ref();
+    let (haystack, needle) = print("assert_contains", &haystack, &needle);
     if !haystack.contains(needle) {
-        eprintln!("=== HAYSTACK ===");
-        eprintln!("{}", haystack);
-        eprintln!("=== NEEDLE ===");
-        eprintln!("{}", needle);
         panic!("needle was not found in haystack");
     }
 }
@@ -36,13 +46,8 @@ pub fn assert_contains<H: AsRef<str>, N: AsRef<str>>(haystack: H, needle: N) {
 /// Assert that `haystack` does not contain `needle`.
 #[track_caller]
 pub fn assert_not_contains<H: AsRef<str>, N: AsRef<str>>(haystack: H, needle: N) {
-    let haystack = haystack.as_ref();
-    let needle = needle.as_ref();
+    let (haystack, needle) = print("assert_not_contains", &haystack, &needle);
     if haystack.contains(needle) {
-        eprintln!("=== HAYSTACK ===");
-        eprintln!("{}", haystack);
-        eprintln!("=== NEEDLE ===");
-        eprintln!("{}", needle);
         panic!("needle was unexpectedly found in haystack");
     }
 }
@@ -50,14 +55,9 @@ pub fn assert_not_contains<H: AsRef<str>, N: AsRef<str>>(haystack: H, needle: N)
 /// Assert that `haystack` contains the regex pattern `needle`.
 #[track_caller]
 pub fn assert_contains_regex<H: AsRef<str>, N: AsRef<str>>(haystack: H, needle: N) {
-    let haystack = haystack.as_ref();
-    let needle = needle.as_ref();
+    let (haystack, needle) = print("assert_contains_regex", &haystack, &needle);
     let re = regex::Regex::new(needle).unwrap();
     if !re.is_match(haystack) {
-        eprintln!("=== HAYSTACK ===");
-        eprintln!("{}", haystack);
-        eprintln!("=== NEEDLE ===");
-        eprintln!("{}", needle);
         panic!("needle was not found in haystack");
     }
 }
@@ -65,14 +65,9 @@ pub fn assert_contains_regex<H: AsRef<str>, N: AsRef<str>>(haystack: H, needle: 
 /// Assert that `haystack` does not contain the regex pattern `needle`.
 #[track_caller]
 pub fn assert_not_contains_regex<H: AsRef<str>, N: AsRef<str>>(haystack: H, needle: N) {
-    let haystack = haystack.as_ref();
-    let needle = needle.as_ref();
+    let (haystack, needle) = print("assert_not_contains_regex", &haystack, &needle);
     let re = regex::Regex::new(needle).unwrap();
     if re.is_match(haystack) {
-        eprintln!("=== HAYSTACK ===");
-        eprintln!("{}", haystack);
-        eprintln!("=== NEEDLE ===");
-        eprintln!("{}", needle);
         panic!("needle was unexpectedly found in haystack");
     }
 }
@@ -80,13 +75,8 @@ pub fn assert_not_contains_regex<H: AsRef<str>, N: AsRef<str>>(haystack: H, need
 /// Assert that `haystack` contains `needle` a `count` number of times.
 #[track_caller]
 pub fn assert_count_is<H: AsRef<str>, N: AsRef<str>>(count: usize, haystack: H, needle: N) {
-    let haystack = haystack.as_ref();
-    let needle = needle.as_ref();
+    let (haystack, needle) = print("assert_count_is", &haystack, &needle);
     if count != haystack.matches(needle).count() {
-        eprintln!("=== HAYSTACK ===");
-        eprintln!("{}", haystack);
-        eprintln!("=== NEEDLE ===");
-        eprintln!("{}", needle);
         panic!("needle did not appear {count} times in haystack");
     }
 }


### PR DESCRIPTION
This was confusing because there are three layers of output hiding.
1. libtest shoves all output into a buffer and does not print it unless the test fails or `--nocapture` is passed.
2. compiletest chooses whether to print the output from any given process.
3. run-make-support chooses what output to print.

This modifies 2 and 3.

- compiletest: Don't require both `--verbose` and `--nocapture` to show the output of run-make tests.
- compiletest: Print the output from `rmake` processes if they succeed. Previously this was only printed on failure.
- compiletest: Distinguish rustc and rmake stderr by printing the command name (e.g. "--stderr--" to "--rustc stderr--").
- run-make-support: Unconditionally print the needle/haystack being searched. Previously this was only printed on failure.

Before:
```
$ x t tests/run-make/linker-warning --force-rerun -- --nocapture
running 1 tests
.

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 377 filtered out; finished in 281.64ms
$ x t tests/run-make/linker-warning --force-rerun -v -- --nocapture 2>&1 | wc -l
1004
$ x t tests/run-make/linker-warning --force-rerun -v -- --nocapture | tail -n40
running 1 tests

------stdout------------------------------

------stderr------------------------------
warning: unused import: `std::path::Path`
 --> /home/jyn/src/rust2/tests/run-make/linker-warning/rmake.rs:1:5
  |
1 | use std::path::Path;
  |     ^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `run_make_support::rfs::remove_file`
 --> /home/jyn/src/rust2/tests/run-make/linker-warning/rmake.rs:3:5
  |
3 | use run_make_support::rfs::remove_file;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: 2 warnings emitted

------------------------------------------
test [run-make] tests/run-make/linker-warning ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 377 filtered out; finished in 285.89ms
```

After:

```
Testing stage1 compiletest suite=run-make mode=run-make (x86_64-unknown-linux-gnu)

running 1 tests
------rmake stdout------------------------------

------rmake stderr------------------------------
assert_contains_regex:
=== HAYSTACK ===
error: linking with `./fake-linker` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/home/jyn/src/rust2/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/bin:...:/bin" VSLANG="1033" "./fake-linker" "-m64" "/tmp/rustcYqdAZT/symbols.o" "main.main.d17f5fbe6225cf88-cgu.0.rcgu.o" "main.2uoctswmurc6ir5rvoay0p9ke.rcgu.o" "-Wl,--as-needed" "-Wl,-Bstatic" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-B/home/jyn/src/rust2/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "-fuse-ld=lld" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/home/jyn/src/rust2/build/x86_64-unknown-linux-gnu/test/run-make/linker-warning/rmake_out" "-L" "/home/jyn/src/rust2/build/x86_64-unknown-linux-gnu/stage1/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "main" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs" "run_make_error"
  = note: error: baz

error: aborting due to 1 previous error

=== NEEDLE ===
fake-linker.*run_make_error
assert_not_contains_regex:
=== HAYSTACK ===

=== NEEDLE ===
fake-linker.*run_make_error

------------------------------------------
.

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 377 filtered out; finished in 314.81ms
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->


r? @jieyouxu 