### PR TITLE
Use constness query for const_trait, too

### DIFF
--- a/compiler/rustc_const_eval/src/const_eval/fn_queries.rs
+++ b/compiler/rustc_const_eval/src/const_eval/fn_queries.rs
@@ -5,7 +5,7 @@ use rustc_middle::query::Providers;
 use rustc_middle::ty::TyCtxt;
 use rustc_span::sym;
 
-pub fn is_parent_const_impl_raw(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
+fn is_parent_const_impl_raw(tcx: TyCtxt<'_>, def_id: LocalDefId) -> bool {
     let parent_id = tcx.local_parent(def_id);
     matches!(tcx.def_kind(parent_id), DefKind::Impl { .. })
         && tcx.constness(parent_id) == hir::Constness::Const

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1135,13 +1135,6 @@ fn trait_def(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::TraitDef {
         _ => span_bug!(item.span, "trait_def_of_item invoked on non-trait"),
     };
 
-    // Only regular traits can be const.
-    let constness = if !is_alias && tcx.has_attr(def_id, sym::const_trait) {
-        hir::Constness::Const
-    } else {
-        hir::Constness::NotConst
-    };
-
     let paren_sugar = tcx.has_attr(def_id, sym::rustc_paren_sugar);
     if paren_sugar && !tcx.features().unboxed_closures() {
         tcx.dcx().emit_err(errors::ParenSugarAttribute { span: item.span });
@@ -1299,7 +1292,6 @@ fn trait_def(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::TraitDef {
     ty::TraitDef {
         def_id: def_id.to_def_id(),
         safety,
-        constness,
         paren_sugar,
         has_auto_impl: is_auto,
         is_marker,

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1269,6 +1269,7 @@ fn should_encode_constness(def_kind: DefKind) -> bool {
         | DefKind::Closure
         | DefKind::Impl { of_trait: true }
         | DefKind::Variant
+        | DefKind::Trait
         | DefKind::Ctor(..) => true,
 
         DefKind::Struct
@@ -1287,7 +1288,6 @@ fn should_encode_constness(def_kind: DefKind) -> bool {
         | DefKind::InlineConst
         | DefKind::AssocTy
         | DefKind::TyParam
-        | DefKind::Trait
         | DefKind::TraitAlias
         | DefKind::Mod
         | DefKind::ForeignMod

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -2067,7 +2067,8 @@ impl<'tcx> TyCtxt<'tcx> {
 
     #[inline]
     pub fn is_const_trait(self, def_id: DefId) -> bool {
-        self.trait_def(def_id).constness == hir::Constness::Const
+        debug_assert_eq!(self.def_kind(def_id), DefKind::Trait);
+        self.constness(def_id) == hir::Constness::Const
     }
 
     #[inline]

--- a/compiler/rustc_middle/src/ty/trait_def.rs
+++ b/compiler/rustc_middle/src/ty/trait_def.rs
@@ -20,9 +20,6 @@ pub struct TraitDef {
 
     pub safety: hir::Safety,
 
-    /// Whether this trait has been annotated with `#[const_trait]`.
-    pub constness: hir::Constness,
-
     /// If `true`, then this trait had the `#[rustc_paren_sugar]`
     /// attribute, indicating that it should be used with `Foo()`
     /// sugar. This is a temporary thing -- eventually any trait will


### PR DESCRIPTION
We also use that query for impls, so it seems kinda nice to put everything into one location

cc @compiler-errors 