### PR TITLE
bootstrap: Forward cargo JSON output to stdout, not stderr

### DIFF
--- a/src/bootstrap/src/core/build_steps/compile.rs
+++ b/src/bootstrap/src/core/build_steps/compile.rs
@@ -2261,7 +2261,7 @@ pub fn stream_cargo(
             Ok(msg) => {
                 if builder.config.json_output {
                     // Forward JSON to stdout.
-                    eprintln!("{line}");
+                    println!("{line}");
                 }
                 cb(msg)
             }


### PR DESCRIPTION
This fixes the RA errors I've been seeing on proc-macros after the re-landing of #134040.

r? clubby789 