### PR TITLE
Use length prefix in default `Hasher::write_str`

### DIFF
--- a/library/core/src/hash/mod.rs
+++ b/library/core/src/hash/mod.rs
@@ -549,8 +549,8 @@ pub trait Hasher {
     #[inline]
     #[unstable(feature = "hasher_prefixfree_extras", issue = "96762")]
     fn write_str(&mut self, s: &str) {
+        self.write_length_prefix(s.len());
         self.write(s.as_bytes());
-        self.write_u8(0xff);
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/134134)*
<!-- homu-ignore:end -->

Using a 0xFF trailer is only correct for bytewise hashes. A generic `Hasher` is not necessarily bytewise, so use a length prefix in the default implementation instead.

Context: https://rust-lang.zulipchat.com/#narrow/channel/219381-t-libs/topic/collision-free.20non-bytewise.20hashers.20on.20stable

r? saethlin