### PR TITLE
[AIX] keep profile-rt symbol alive

### DIFF
--- a/compiler/rustc_codegen_ssa/src/back/linker.rs
+++ b/compiler/rustc_codegen_ssa/src/back/linker.rs
@@ -1694,6 +1694,8 @@ impl<'a> Linker for AixLinker<'a> {
 
     fn pgo_gen(&mut self) {
         self.link_arg("-bdbg:namedsects:ss");
+        self.link_arg("-u");
+        self.link_arg("__llvm_profile_runtime");
     }
 
     fn control_flow_guard(&mut self) {}


### PR DESCRIPTION
Clang passes `-u __llvm_profile_runtime` on AIX. https://reviews.llvm.org/D136192
We want to preserve the symbol in the case there are no instrumented object files.



