### PR TITLE
Rudimentary heuristic to insert parentheses when needed for RPIT overcaptures lint

### DIFF
--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024.fixed
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024.fixed
@@ -42,4 +42,8 @@ async fn async_fn<'a>(x: &'a ()) -> impl Sized + use<> {}
 //~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
 //~| WARN this changes meaning in Rust 2024
 
+pub fn parens(x: &i32) -> &(impl Clone + use<>) { x }
+//~^ ERROR `impl Clone` will capture more lifetimes than possibly intended in edition 2024
+//~| WARN this changes meaning in Rust 2024
+
 fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024.rs
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024.rs
@@ -42,4 +42,8 @@ async fn async_fn<'a>(x: &'a ()) -> impl Sized {}
 //~^ ERROR `impl Sized` will capture more lifetimes than possibly intended in edition 2024
 //~| WARN this changes meaning in Rust 2024
 
+pub fn parens(x: &i32) -> &impl Clone { x }
+//~^ ERROR `impl Clone` will capture more lifetimes than possibly intended in edition 2024
+//~| WARN this changes meaning in Rust 2024
+
 fn main() {}

--- a/tests/ui/impl-trait/precise-capturing/overcaptures-2024.stderr
+++ b/tests/ui/impl-trait/precise-capturing/overcaptures-2024.stderr
@@ -146,5 +146,24 @@ help: use the precise capturing `use<...>` syntax to make the captures explicit
 LL | async fn async_fn<'a>(x: &'a ()) -> impl Sized + use<> {}
    |                                                +++++++
 
-error: aborting due to 7 previous errors
+error: `impl Clone` will capture more lifetimes than possibly intended in edition 2024
+  --> $DIR/overcaptures-2024.rs:45:28
+   |
+LL | pub fn parens(x: &i32) -> &impl Clone { x }
+   |                            ^^^^^^^^^^
+   |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rpit-lifetime-capture.html>
+note: specifically, this lifetime is in scope but not mentioned in the type's bounds
+  --> $DIR/overcaptures-2024.rs:45:18
+   |
+LL | pub fn parens(x: &i32) -> &impl Clone { x }
+   |                  ^
+   = note: all lifetimes in scope will be captured by `impl Trait`s in edition 2024
+help: use the precise capturing `use<...>` syntax to make the captures explicit
+   |
+LL | pub fn parens(x: &i32) -> &(impl Clone + use<>) { x }
+   |                            +           ++++++++
+
+error: aborting due to 8 previous errors
 


### PR DESCRIPTION
We don't have basically any preexisting machinery to detect when parentheses are needed for *types*. AFAICT, all of the diagnostics we have for opaques just... fail when they suggest `+ 'a` when that's ambiguous.

Fixes #132853