### PR TITLE
[experiment] Try reverting the MSVC workarounds

### DIFF
--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
@@ -71,10 +71,7 @@ case $HOST_TARGET in
 esac
 # Also smoke-test `x.py miri`. This doesn't run any actual tests (that would take too long),
 # but it ensures that the crates build properly when tested with Miri.
-
-#FIXME: Re-enable this for msvc once CI issues are fixed
-if [ "$HOST_TARGET" != "x86_64-pc-windows-msvc" ]
-  python3 "$X_PY" miri --stage 2 library/core --test-args notest
-  python3 "$X_PY" miri --stage 2 library/alloc --test-args notest
-  python3 "$X_PY" miri --stage 2 library/std --test-args notest
-fi
+#FIXME: Re-enable this once CI issues are fixed
+#python3 "$X_PY" miri --stage 2 library/core --test-args notest
+#python3 "$X_PY" miri --stage 2 library/alloc --test-args notest
+#python3 "$X_PY" miri --stage 2 library/std --test-args notest

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
@@ -58,11 +58,8 @@ case $HOST_TARGET in
     # Strangely, Linux targets do not work here. cargo always says
     # "error: cannot produce cdylib for ... as the target ... does not support these crate types".
     # Only run "pass" tests, which is quite a bit faster.
-    #FIXME: Re-enable this once CI issues are fixed
-    # See <https://github.com/rust-lang/rust/issues/127883>
-    # For now, these tests are moved to `x86_64-msvc-ext2` in `src/ci/github-actions/jobs.yml`.
-    #python3 "$X_PY" test --stage 2 src/tools/miri --target aarch64-apple-darwin --test-args pass
-    #python3 "$X_PY" test --stage 2 src/tools/miri --target i686-pc-windows-gnu --test-args pass
+    python3 "$X_PY" test --stage 2 src/tools/miri --target aarch64-apple-darwin --test-args pass
+    python3 "$X_PY" test --stage 2 src/tools/miri --target i686-pc-windows-gnu --test-args pass
     ;;
   *)
     echo "FATAL: unexpected host $HOST_TARGET"
@@ -71,7 +68,6 @@ case $HOST_TARGET in
 esac
 # Also smoke-test `x.py miri`. This doesn't run any actual tests (that would take too long),
 # but it ensures that the crates build properly when tested with Miri.
-#FIXME: Re-enable this once CI issues are fixed
-#python3 "$X_PY" miri --stage 2 library/core --test-args notest
-#python3 "$X_PY" miri --stage 2 library/alloc --test-args notest
-#python3 "$X_PY" miri --stage 2 library/std --test-args notest
+python3 "$X_PY" miri --stage 2 library/core --test-args notest
+python3 "$X_PY" miri --stage 2 library/alloc --test-args notest
+python3 "$X_PY" miri --stage 2 library/std --test-args notest

--- a/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
+++ b/src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh
@@ -73,7 +73,7 @@ esac
 # but it ensures that the crates build properly when tested with Miri.
 
 #FIXME: Re-enable this for msvc once CI issues are fixed
-if [ "$HOST_TARGET" != "x86_64-pc-windows-msvc" ]; then
+if [ "$HOST_TARGET" != "x86_64-pc-windows-msvc" ]
   python3 "$X_PY" miri --stage 2 library/core --test-args notest
   python3 "$X_PY" miri --stage 2 library/alloc --test-args notest
   python3 "$X_PY" miri --stage 2 library/std --test-args notest

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -31,10 +31,6 @@ runners:
     os: macos-14
     <<: *base-job
 
-  - &job-windows
-    os: windows-2022
-    <<: *base-job
-
   - &job-windows-8c
     os: windows-2022-8core-32gb
     <<: *base-job
@@ -452,7 +448,7 @@ auto:
         python x.py miri --stage 2 library/alloc --test-args notest &&
         python x.py miri --stage 2 library/std --test-args notest
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld
-    <<: *job-windows
+    <<: *job-windows-8c
 
   # 32/64-bit MinGW builds.
   #

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -447,6 +447,8 @@ auto:
         python x.py miri --stage 2 library/core --test-args notest &&
         python x.py miri --stage 2 library/alloc --test-args notest &&
         python x.py miri --stage 2 library/std --test-args notest
+
+      HOST_TARGET: x86_64-pc-windows-msvc
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld
     <<: *job-windows-8c
 

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -432,12 +432,13 @@ auto:
       SCRIPT: make ci-msvc
     <<: *job-windows-8c
 
-  # x86_64-msvc-ext is split into multiple jobs to run tests in parallel.
-  - image: x86_64-msvc-ext1
+  - image: x86_64-msvc-ext
     env:
-      SCRIPT: python x.py --stage 2 test src/tools/cargotest src/tools/cargo
-      RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld
-    <<: *job-windows
+      SCRIPT: python x.py --stage 2 test src/tools/cargotest src/tools/cargo && src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh x.py /tmp/toolstate/toolstates.json windows
+      HOST_TARGET: x86_64-pc-windows-msvc
+      RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld --save-toolstates=/tmp/toolstate/toolstates.json
+      DEPLOY_TOOLSTATES_JSON: toolstates-windows.json
+    <<: *job-windows-8c
 
   # Temporary builder to workaround CI issues
   # See <https://github.com/rust-lang/rust/issues/127883>
@@ -451,15 +452,6 @@ auto:
         python x.py miri --stage 2 library/alloc --test-args notest &&
         python x.py miri --stage 2 library/std --test-args notest
       RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld
-    <<: *job-windows
-
-  # Run `checktools.sh` and upload the toolstate file.
-  - image: x86_64-msvc-ext3
-    env:
-      SCRIPT: src/ci/docker/host-x86_64/x86_64-gnu-tools/checktools.sh x.py /tmp/toolstate/toolstates.json windows
-      HOST_TARGET: x86_64-pc-windows-msvc
-      RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld --save-toolstates=/tmp/toolstate/toolstates.json
-      DEPLOY_TOOLSTATES_JSON: toolstates-windows.json
     <<: *job-windows
 
   # 32/64-bit MinGW builds.

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -436,22 +436,6 @@ auto:
       DEPLOY_TOOLSTATES_JSON: toolstates-windows.json
     <<: *job-windows-8c
 
-  # Temporary builder to workaround CI issues
-  # See <https://github.com/rust-lang/rust/issues/127883>
-  #FIXME: Remove this, and re-enable the same tests in `checktools.sh`, once CI issues are fixed.
-  - image: x86_64-msvc-ext2
-    env:
-      SCRIPT: >
-        python x.py test --stage 2 src/tools/miri --target aarch64-apple-darwin --test-args pass &&
-        python x.py test --stage 2 src/tools/miri --target i686-pc-windows-gnu --test-args pass &&
-        python x.py miri --stage 2 library/core --test-args notest &&
-        python x.py miri --stage 2 library/alloc --test-args notest &&
-        python x.py miri --stage 2 library/std --test-args notest
-
-      HOST_TARGET: x86_64-pc-windows-msvc
-      RUST_CONFIGURE_ARGS: --build=x86_64-pc-windows-msvc --enable-lld
-    <<: *job-windows-8c
-
   # 32/64-bit MinGW builds.
   #
   # We are using MinGW with POSIX threads since LLVM requires

--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -31,6 +31,10 @@ runners:
     os: macos-14
     <<: *base-job
 
+  - &job-windows
+    os: windows-2022
+    <<: *base-job
+
   - &job-windows-8c
     os: windows-2022-8core-32gb
     <<: *base-job


### PR DESCRIPTION
Get a fresh set of runs with the following workarounds reverted:

- https://github.com/rust-lang/rust/pull/130151
- https://github.com/rust-lang/rust/pull/130072
- https://github.com/rust-lang/rust/pull/133248

try-job: x86_64-msvc
try-job: x86_64-msvc-ext

<!-- homu-ignore:start -->
r? @ghost
<!-- homu-ignore:end -->