### PR TITLE
Forbid `unsafe_op_in_unsafe_fn` for Hurd

### DIFF
--- a/library/std/src/os/hurd/mod.rs
+++ b/library/std/src/os/hurd/mod.rs
@@ -1,6 +1,7 @@
 //! Hurd-specific definitions
 
 #![stable(feature = "raw_ext", since = "1.1.0")]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 pub mod fs;
 pub mod raw;


### PR DESCRIPTION
Tracking issue https://github.com/rust-lang/rust/issues/127747