### PR TITLE
Correct the LLVM target of `aarch64-unknown-uefi`

### DIFF
--- a/compiler/rustc_target/src/spec/targets/aarch64_unknown_uefi.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_unknown_uefi.rs
@@ -11,7 +11,7 @@ pub(crate) fn target() -> Target {
     base.features = "+v8a".into();
 
     Target {
-        llvm_target: "aarch64-unknown-windows".into(),
+        llvm_target: "aarch64-unknown-uefi".into(),
         metadata: crate::spec::TargetMetadata {
             description: Some("ARM64 UEFI".into()),
             tier: Some(2),


### PR DESCRIPTION
As noticed in https://github.com/rust-lang/rust/pull/132975#issuecomment-2533330141, the LLVM target string  for aarch64 UEFI is not correct. Fix it here.