### PR TITLE
Lint against manual `impl Default` that could have been `derive`d

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -32,7 +32,7 @@ use rustc_macros::{Decodable, Encodable, HashStable_Generic};
 pub use rustc_span::AttrId;
 use rustc_span::source_map::{Spanned, respan};
 use rustc_span::symbol::{Ident, Symbol, kw, sym};
-use rustc_span::{DUMMY_SP, ErrorGuaranteed, Span};
+use rustc_span::{ErrorGuaranteed, Span};
 use thin_vec::{ThinVec, thin_vec};
 
 pub use crate::format::*;
@@ -388,22 +388,15 @@ impl GenericParam {
 
 /// Represents lifetime, type and const parameters attached to a declaration of
 /// a function, enum, trait, etc.
-#[derive(Clone, Encodable, Decodable, Debug)]
+#[derive(Clone, Encodable, Decodable, Debug, Default)]
 pub struct Generics {
     pub params: ThinVec<GenericParam>,
     pub where_clause: WhereClause,
     pub span: Span,
 }
 
-impl Default for Generics {
-    /// Creates an instance of `Generics`.
-    fn default() -> Generics {
-        Generics { params: ThinVec::new(), where_clause: Default::default(), span: DUMMY_SP }
-    }
-}
-
 /// A where-clause in a definition.
-#[derive(Clone, Encodable, Decodable, Debug)]
+#[derive(Clone, Encodable, Decodable, Debug, Default)]
 pub struct WhereClause {
     /// `true` if we ate a `where` token.
     ///
@@ -417,12 +410,6 @@ pub struct WhereClause {
 impl WhereClause {
     pub fn is_empty(&self) -> bool {
         !self.has_where_token && self.predicates.is_empty()
-    }
-}
-
-impl Default for WhereClause {
-    fn default() -> WhereClause {
-        WhereClause { has_where_token: false, predicates: ThinVec::new(), span: DUMMY_SP }
     }
 }
 

--- a/compiler/rustc_ast_pretty/src/pprust/state/fixup.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/fixup.rs
@@ -1,7 +1,9 @@
 use rustc_ast::Expr;
 use rustc_ast::util::{classify, parser};
 
-#[derive(Copy, Clone, Debug)]
+// The default amount of fixing is minimal fixing. Fixups should be turned on
+// in a targeted fashion where needed.
+#[derive(Copy, Clone, Debug, Default)]
 pub(crate) struct FixupContext {
     /// Print expression such that it can be parsed back as a statement
     /// consisting of the original expression.
@@ -91,20 +93,6 @@ pub(crate) struct FixupContext {
     /// }
     /// ```
     parenthesize_exterior_struct_lit: bool,
-}
-
-/// The default amount of fixing is minimal fixing. Fixups should be turned on
-/// in a targeted fashion where needed.
-impl Default for FixupContext {
-    fn default() -> Self {
-        FixupContext {
-            stmt: false,
-            leftmost_subexpression_in_stmt: false,
-            match_arm: false,
-            leftmost_subexpression_in_match_arm: false,
-            parenthesize_exterior_struct_lit: false,
-        }
-    }
 }
 
 impl FixupContext {

--- a/compiler/rustc_error_codes/src/error_codes/E0665.md
+++ b/compiler/rustc_error_codes/src/error_codes/E0665.md
@@ -16,18 +16,30 @@ The `Default` cannot be derived on an enum for the simple reason that the
 compiler doesn't know which value to pick by default whereas it can for a
 struct as long as all its fields implement the `Default` trait as well.
 
-If you still want to implement `Default` on your enum, you'll have to do it "by
-hand":
+For the case where the desired default variant has no data, you can annotate
+it with `#[default]` to derive it:
+
+```
+#[derive(Default)]
+enum Food {
+    #[default]
+    Sweet,
+    Salty,
+}
+```
+
+In the case where the default variant does have data, you will have to
+implement `Default` on your enum "by hand":
 
 ```
 enum Food {
-    Sweet,
+    Sweet(i32),
     Salty,
 }
 
 impl Default for Food {
     fn default() -> Food {
-        Food::Sweet
+        Food::Sweet(1)
     }
 }
 ```

--- a/compiler/rustc_lint/src/default_could_be_derived.rs
+++ b/compiler/rustc_lint/src/default_could_be_derived.rs
@@ -1,0 +1,122 @@
+use rustc_errors::Applicability;
+use rustc_hir as hir;
+use rustc_hir::def::{CtorKind, CtorOf, DefKind, Res};
+use rustc_session::{declare_lint, declare_lint_pass};
+use rustc_span::symbol::{kw, sym};
+
+use crate::{LateContext, LateLintPass};
+
+declare_lint! {
+    /// The `default_could_be_derived` lint checks for manual `impl` blocks
+    /// of the `Default` trait that could have been derived.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,compile_fail
+    /// enum Foo {
+    ///     Bar,
+    /// }
+    ///
+    /// #[deny(default_could_be_derived)]
+    /// impl Default for Foo {
+    ///     fn default() -> Foo {
+    ///         Foo::Bar
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    pub DEFAULT_COULD_BE_DERIVED,
+    Warn,
+    "detect `Default` impl that could be derived"
+}
+
+declare_lint_pass!(DefaultCouldBeDerived => [DEFAULT_COULD_BE_DERIVED]);
+
+impl<'tcx> LateLintPass<'tcx> for DefaultCouldBeDerived {
+    fn check_item(&mut self, cx: &LateContext<'tcx>, item: &'tcx hir::Item<'tcx>) {
+        let hir::ItemKind::Impl(data) = item.kind else { return };
+        let Some(trait_ref) = data.of_trait else { return };
+        let Res::Def(DefKind::Trait, def_id) = trait_ref.path.res else { return };
+        if Some(def_id) != cx.tcx.get_diagnostic_item(sym::Default) {
+            return;
+        }
+        if cx.tcx.has_attr(def_id, sym::automatically_derived) {
+            return;
+        }
+        let hir_self_ty = data.self_ty;
+        let hir::TyKind::Path(hir::QPath::Resolved(_, path)) = hir_self_ty.kind else { return };
+        let Res::Def(_, type_def_id) = path.res else { return };
+        let generics = cx.tcx.generics_of(type_def_id);
+        if !generics.own_params.is_empty() {
+            return;
+        }
+        // We have a manual `impl Default for Ty {}` item, where `Ty` has no type parameters.
+
+        let hir = cx.tcx.hir();
+        for assoc in data.items {
+            let hir::AssocItemKind::Fn { has_self: false } = assoc.kind else { continue };
+            if assoc.ident.name != kw::Default {
+                continue;
+            }
+            let assoc = hir.impl_item(assoc.id);
+            let hir::ImplItemKind::Fn(_ty, body) = assoc.kind else { continue };
+            let body = hir.body(body);
+            let hir::ExprKind::Block(hir::Block { stmts: [], expr: Some(expr), .. }, None) =
+                body.value.kind
+            else {
+                continue;
+            };
+
+            match expr.kind {
+                hir::ExprKind::Path(hir::QPath::Resolved(_, path))
+                    if let Res::Def(DefKind::Ctor(CtorOf::Variant, CtorKind::Const), def_id) =
+                        path.res =>
+                {
+                    // We have a unit variant as the default of an enum in a manual impl.
+                    //
+                    // enum Foo {
+                    //     Bar,
+                    // }
+                    //
+                    // impl Default for Foo {
+                    //     fn default() -> Foo {
+                    //         Foo::Bar
+                    //     }
+                    // }
+                    //
+                    // We suggest
+                    //
+                    // #[derive(Default)] enum Foo {
+                    //     #[default] Bar,
+                    // }
+                    cx.tcx.node_span_lint(
+                        DEFAULT_COULD_BE_DERIVED,
+                        item.hir_id(),
+                        item.span,
+                        |diag| {
+                            diag.primary_message("`impl Default` that could be derived");
+                            diag.multipart_suggestion_verbose(
+                                "you don't need to manually `impl Default`, you can derive it",
+                                vec![
+                                    (
+                                        cx.tcx.def_span(type_def_id).shrink_to_lo(),
+                                        "#[derive(Default)] ".to_string(),
+                                    ),
+                                    (
+                                        cx.tcx.def_span(def_id).shrink_to_lo(),
+                                        "#[default] ".to_string(),
+                                    ),
+                                    (item.span, String::new()),
+                                ],
+                                Applicability::MachineApplicable,
+                            );
+                        },
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/compiler/rustc_lint/src/default_could_be_derived.rs
+++ b/compiler/rustc_lint/src/default_could_be_derived.rs
@@ -54,7 +54,7 @@ declare_lint! {
     /// so the derive for `Default` for a struct is trivial, and for an enum
     /// variant with no fields, which can be annotated with `#[default]`.
     pub DEFAULT_COULD_BE_DERIVED,
-    Warn,
+    Deny,
     "detect `Default` impl that could be derived"
 }
 

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -41,6 +41,7 @@ mod async_fn_in_trait;
 pub mod builtin;
 mod context;
 mod dangling;
+mod default_could_be_derived;
 mod deref_into_dyn_supertrait;
 mod drop_forget_useless;
 mod early;
@@ -85,6 +86,7 @@ use async_closures::AsyncClosureUsage;
 use async_fn_in_trait::AsyncFnInTrait;
 use builtin::*;
 use dangling::*;
+use default_could_be_derived::DefaultCouldBeDerived;
 use deref_into_dyn_supertrait::*;
 use drop_forget_useless::*;
 use enum_intrinsics_non_enums::EnumIntrinsicsNonEnums;
@@ -189,6 +191,7 @@ late_lint_methods!(
         BuiltinCombinedModuleLateLintPass,
         [
             ForLoopsOverFallibles: ForLoopsOverFallibles,
+            DefaultCouldBeDerived: DefaultCouldBeDerived,
             DerefIntoDynSupertrait: DerefIntoDynSupertrait,
             DropForgetUseless: DropForgetUseless,
             ImproperCTypesDeclarations: ImproperCTypesDeclarations,

--- a/compiler/rustc_lint/src/unused.rs
+++ b/compiler/rustc_lint/src/unused.rs
@@ -1024,17 +1024,12 @@ declare_lint! {
     "`if`, `match`, `while` and `return` do not need parentheses"
 }
 
+#[derive(Default)]
 pub(crate) struct UnusedParens {
     with_self_ty_parens: bool,
     /// `1 as (i32) < 2` parses to ExprKind::Lt
     /// `1 as i32 < 2` parses to i32::<2[missing angle bracket]
     parens_in_cast_in_lt: Vec<ast::NodeId>,
-}
-
-impl Default for UnusedParens {
-    fn default() -> Self {
-        Self { with_self_ty_parens: false, parens_in_cast_in_lt: Vec::new() }
-    }
 }
 
 impl_lint_pass!(UnusedParens => [UNUSED_PARENS]);

--- a/compiler/rustc_metadata/src/rmeta/decoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder.rs
@@ -1174,6 +1174,12 @@ impl<'a> CrateMetadataRef<'a> {
         self.root.tables.default_fields.get(self, id).map(|d| d.decode(self))
     }
 
+    /// For a given `impl Default for Ty`, return the "equivalence" for it, namely the `DefId` of
+    /// a path or function with no arguments that get's called from `<Ty as Default>::default()`.
+    fn get_default_impl_equivalent(self, id: DefIndex) -> Option<DefId> {
+        self.root.tables.default_impl_equivalent.get(self, id).map(|d| d.decode(self))
+    }
+
     fn get_trait_item_def_id(self, id: DefIndex) -> Option<DefId> {
         self.root.tables.trait_item_def_id.get(self, id).map(|d| d.decode_from_cdata(self))
     }

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -423,6 +423,8 @@ provide! { tcx, def_id, other, cdata,
         syms
     }
 
+    get_default_impl_equivalent => { cdata.get_default_impl_equivalent(def_id.index) }
+
     crate_extern_paths => { cdata.source().paths().cloned().collect() }
     expn_that_defined => { cdata.get_expn_that_defined(def_id.index, tcx.sess) }
     is_doc_hidden => { cdata.get_attr_flags(def_id.index).contains(AttrFlags::IS_DOC_HIDDEN) }

--- a/compiler/rustc_metadata/src/rmeta/encoder.rs
+++ b/compiler/rustc_metadata/src/rmeta/encoder.rs
@@ -1568,6 +1568,10 @@ impl<'a, 'tcx> EncodeContext<'a, 'tcx> {
                 let table = tcx.associated_types_for_impl_traits_in_associated_fn(def_id);
                 record_defaulted_array!(self.tables.associated_types_for_impl_traits_in_associated_fn[def_id] <- table);
             }
+
+            if let Some(path_def_id) = tcx.get_default_equivalent(def_kind, local_id) {
+                record!(self.tables.default_impl_equivalent[def_id] <- path_def_id);
+            }
         }
 
         for (def_id, impls) in &tcx.crate_inherent_impls(()).0.inherent_impls {

--- a/compiler/rustc_metadata/src/rmeta/mod.rs
+++ b/compiler/rustc_metadata/src/rmeta/mod.rs
@@ -451,6 +451,7 @@ define_tables! {
     trait_item_def_id: Table<DefIndex, RawDefId>,
     expn_that_defined: Table<DefIndex, LazyValue<ExpnId>>,
     default_fields: Table<DefIndex, LazyValue<DefId>>,
+    default_impl_equivalent: Table<DefIndex, LazyValue<DefId>>,
     params_in_repr: Table<DefIndex, LazyValue<BitSet<u32>>>,
     repr_options: Table<DefIndex, LazyValue<ReprOptions>>,
     // `def_keys` and `def_path_hashes` represent a lazy version of a

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1806,6 +1806,12 @@ rustc_queries! {
         desc { "looking up lifetime defaults for generic parameter `{}`", tcx.def_path_str(def_id) }
         separate_provide_extern
     }
+
+    query get_default_impl_equivalent(def_id: DefId) -> Option<DefId> {
+        desc { |tcx| "looking up the unit variant or fn call with no arguments equivalence for the `Default::default()` of `{}`", tcx.def_path_str(def_id) }
+        separate_provide_extern
+    }
+
     query late_bound_vars_map(owner_id: hir::OwnerId)
         -> &'tcx SortedMap<ItemLocalId, Vec<ty::BoundVariableKind>> {
         desc { |tcx| "looking up late bound vars inside `{}`", tcx.def_path_str(owner_id) }

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -162,9 +162,10 @@ pub struct CoverageOptions {
 }
 
 /// Controls whether branch coverage or MC/DC coverage is enabled.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
 pub enum CoverageLevel {
     /// Instrument for coverage at the MIR block level.
+    #[default]
     Block,
     /// Also instrument branch points (includes block coverage).
     Branch,
@@ -187,12 +188,6 @@ pub enum CoverageLevel {
     /// Instrument for MC/DC. Mostly a superset of condition coverage, but might
     /// differ in some corner cases.
     Mcdc,
-}
-
-impl Default for CoverageLevel {
-    fn default() -> Self {
-        Self::Block
-    }
 }
 
 /// Settings for `-Z instrument-xray` flag.

--- a/library/core/src/ascii/ascii_char.rs
+++ b/library/core/src/ascii/ascii_char.rs
@@ -54,12 +54,13 @@ use crate::{assert_unsafe_precondition, fmt};
 /// [chart]: https://www.unicode.org/charts/PDF/U0000.pdf
 /// [NIST FIPS 1-2]: https://nvlpubs.nist.gov/nistpubs/Legacy/FIPS/fipspub1-2-1977.pdf
 /// [NamesList]: https://www.unicode.org/Public/15.0.0/ucd/NamesList.txt
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
 #[unstable(feature = "ascii_char", issue = "110998")]
 #[repr(u8)]
 pub enum AsciiChar {
     /// U+0000 (The default variant)
     #[unstable(feature = "ascii_char_variants", issue = "110998")]
+    #[default]
     Null = 0,
     /// U+0001
     #[unstable(feature = "ascii_char_variants", issue = "110998")]

--- a/library/core/src/default.rs
+++ b/library/core/src/default.rs
@@ -77,6 +77,7 @@
 /// your type that should be the default:
 ///
 /// ```
+/// # #![cfg_attr(not(bootstrap), allow(default_could_be_derived))]
 /// # #![allow(dead_code)]
 /// enum Kind {
 ///     A,
@@ -121,6 +122,7 @@ pub trait Default: Sized {
     /// Making your own:
     ///
     /// ```
+    /// # #![cfg_attr(not(bootstrap), allow(default_could_be_derived))]
     /// # #[allow(dead_code)]
     /// enum Kind {
     ///     A,

--- a/library/core/src/default.rs
+++ b/library/core/src/default.rs
@@ -2,8 +2,6 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
-use crate::ascii::Char as AsciiChar;
-
 /// A trait for giving a type a useful default value.
 ///
 /// Sometimes, you want to fall back to some kind of default value, and
@@ -163,7 +161,6 @@ macro_rules! default_impl {
 default_impl! { (), (), "Returns the default value of `()`" }
 default_impl! { bool, false, "Returns the default value of `false`" }
 default_impl! { char, '\x00', "Returns the default value of `\\x00`" }
-default_impl! { AsciiChar, AsciiChar::Null, "Returns the default value of `Null`" }
 
 default_impl! { usize, 0, "Returns the default value of `0`" }
 default_impl! { u8, 0, "Returns the default value of `0`" }

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -564,7 +564,7 @@ use crate::{cmp, convert, hint, mem, slice};
 
 /// The `Option` type. See [the module level documentation](self) for more.
 #[doc(search_unbox)]
-#[derive(Copy, Eq, Debug, Hash)]
+#[derive(Copy, Eq, Debug, Hash, Default)]
 #[rustc_diagnostic_item = "Option"]
 #[lang = "Option"]
 #[stable(feature = "rust1", since = "1.0.0")]
@@ -573,6 +573,7 @@ pub enum Option<T> {
     /// No value.
     #[lang = "None"]
     #[stable(feature = "rust1", since = "1.0.0")]
+    #[default]
     None,
     /// Some value of type `T`.
     #[lang = "Some"]
@@ -2041,22 +2042,6 @@ where
             (Some(to), Some(from)) => to.clone_from(from),
             (to, from) => *to = from.clone(),
         }
-    }
-}
-
-#[stable(feature = "rust1", since = "1.0.0")]
-impl<T> Default for Option<T> {
-    /// Returns [`None`][Option::None].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// let opt: Option<u32> = Option::default();
-    /// assert!(opt.is_none());
-    /// ```
-    #[inline]
-    fn default() -> Option<T> {
-        None
     }
 }
 

--- a/library/core/tests/hash/mod.rs
+++ b/library/core/tests/hash/mod.rs
@@ -4,14 +4,9 @@ use std::hash::{BuildHasher, Hash, Hasher};
 use std::ptr;
 use std::rc::Rc;
 
+#[derive(Default)]
 struct MyHasher {
     hash: u64,
-}
-
-impl Default for MyHasher {
-    fn default() -> MyHasher {
-        MyHasher { hash: 0 }
-    }
 }
 
 impl Hasher for MyHasher {
@@ -107,6 +102,8 @@ fn test_writer_hasher() {
 struct Custom {
     hash: u64,
 }
+
+#[derive(Default)]
 struct CustomHasher {
     output: u64,
 }
@@ -120,12 +117,6 @@ impl Hasher for CustomHasher {
     }
     fn write_u64(&mut self, data: u64) {
         self.output = data;
-    }
-}
-
-impl Default for CustomHasher {
-    fn default() -> CustomHasher {
-        CustomHasher { output: 0 }
     }
 }
 

--- a/library/proc_macro/src/bridge/fxhash.rs
+++ b/library/proc_macro/src/bridge/fxhash.rs
@@ -22,6 +22,7 @@ pub type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
 /// out-performs an FNV-based hash within rustc itself -- the collision rate is
 /// similar or slightly worse than FNV, but the speed of the hash function
 /// itself is much higher because it works on up to 8 bytes at a time.
+#[derive(Default)]
 pub struct FxHasher {
     hash: usize,
 }
@@ -30,13 +31,6 @@ pub struct FxHasher {
 const K: usize = 0x9e3779b9;
 #[cfg(target_pointer_width = "64")]
 const K: usize = 0x517cc1b727220a95;
-
-impl Default for FxHasher {
-    #[inline]
-    fn default() -> FxHasher {
-        FxHasher { hash: 0 }
-    }
-}
 
 impl FxHasher {
     #[inline]

--- a/library/std/src/panicking.rs
+++ b/library/std/src/panicking.rs
@@ -81,7 +81,9 @@ extern "C" fn __rust_foreign_exception() -> ! {
     rtabort!("Rust cannot catch foreign exceptions");
 }
 
+#[derive(Default)]
 enum Hook {
+    #[default]
     Default,
     Custom(Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send>),
 }
@@ -93,13 +95,6 @@ impl Hook {
             Hook::Default => Box::new(default_hook),
             Hook::Custom(hook) => hook,
         }
-    }
-}
-
-impl Default for Hook {
-    #[inline]
-    fn default() -> Hook {
-        Hook::Default
     }
 }
 

--- a/library/std/src/sys_common/process.rs
+++ b/library/std/src/sys_common/process.rs
@@ -8,17 +8,11 @@ use crate::sys::process::{EnvKey, ExitStatus, Process, StdioPipes};
 use crate::{env, fmt, io};
 
 // Stores a set of changes to an environment
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct CommandEnv {
     clear: bool,
     saw_path: bool,
     vars: BTreeMap<EnvKey, Option<OsString>>,
-}
-
-impl Default for CommandEnv {
-    fn default() -> Self {
-        CommandEnv { clear: false, saw_path: false, vars: Default::default() }
-    }
 }
 
 impl fmt::Debug for CommandEnv {

--- a/src/tools/clippy/tests/ui/derivable_impls.fixed
+++ b/src/tools/clippy/tests/ui/derivable_impls.fixed
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, default_could_be_derived)]
 
 use std::collections::HashMap;
 

--- a/src/tools/clippy/tests/ui/derivable_impls.rs
+++ b/src/tools/clippy/tests/ui/derivable_impls.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code, default_could_be_derived)]
 
 use std::collections::HashMap;
 

--- a/src/tools/clippy/tests/ui/new_without_default.fixed
+++ b/src/tools/clippy/tests/ui/new_without_default.fixed
@@ -38,7 +38,7 @@ impl Bar {
     }
 }
 
-pub struct Ok;
+#[derive(Default)] pub struct Ok;
 
 impl Ok {
     pub fn new() -> Self {
@@ -46,11 +46,6 @@ impl Ok {
     }
 }
 
-impl Default for Ok {
-    fn default() -> Self {
-        Ok
-    }
-}
 
 pub struct Params;
 

--- a/src/tools/clippy/tests/ui/new_without_default.stderr
+++ b/src/tools/clippy/tests/ui/new_without_default.stderr
@@ -177,8 +177,7 @@ LL | |     }
 LL | | }
    | |_^
    |
-   = note: `-D default-could-be-derived` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(default_could_be_derived)]`
+   = note: `#[deny(default_could_be_derived)]` on by default
 help: you don't need to manually `impl Default`, you can derive it
    |
 LL ~ #[derive(Default)] pub struct Ok;

--- a/src/tools/clippy/tests/ui/new_without_default.stderr
+++ b/src/tools/clippy/tests/ui/new_without_default.stderr
@@ -166,5 +166,23 @@ LL +     }
 LL + }
    |
 
-error: aborting due to 9 previous errors
+error: `impl Default` that could be derived
+  --> tests/ui/new_without_default.rs:37:1
+   |
+LL | / impl Default for Ok {
+LL | |     fn default() -> Self {
+LL | |         Ok
+   | |         -- this type has no fields, so it's trivially derivable
+LL | |     }
+LL | | }
+   | |_^
+   |
+   = note: `-D default-could-be-derived` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(default_could_be_derived)]`
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL ~ #[derive(Default)] pub struct Ok;
+   |
+
+error: aborting due to 10 previous errors
 

--- a/src/tools/clippy/tests/ui/or_fun_call.fixed
+++ b/src/tools/clippy/tests/ui/or_fun_call.fixed
@@ -21,18 +21,14 @@ fn or_fun_call() {
         }
     }
 
-    struct FakeDefault;
+    #[derive(Default)] struct FakeDefault;
     impl FakeDefault {
         fn default() -> Self {
             FakeDefault
         }
     }
 
-    impl Default for FakeDefault {
-        fn default() -> Self {
-            FakeDefault
-        }
-    }
+    
 
     enum Enum {
         A(i32),
@@ -268,18 +264,14 @@ mod lazy {
             }
         }
 
-        struct FakeDefault;
+        #[derive(Default)] struct FakeDefault;
         impl FakeDefault {
             fn default() -> Self {
                 FakeDefault
             }
         }
 
-        impl Default for FakeDefault {
-            fn default() -> Self {
-                FakeDefault
-            }
-        }
+        
 
         let with_new = Some(vec![1]);
         with_new.unwrap_or_default();

--- a/src/tools/clippy/tests/ui/or_fun_call.stderr
+++ b/src/tools/clippy/tests/ui/or_fun_call.stderr
@@ -255,8 +255,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-   = note: `-D default-could-be-derived` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(default_could_be_derived)]`
+   = note: `#[deny(default_could_be_derived)]` on by default
 help: you don't need to manually `impl Default`, you can derive it
    |
 LL ~     #[derive(Default)] struct FakeDefault;

--- a/src/tools/clippy/tests/ui/or_fun_call.stderr
+++ b/src/tools/clippy/tests/ui/or_fun_call.stderr
@@ -244,5 +244,47 @@ error: function call inside of `unwrap_or`
 LL |     let _ = opt_foo.unwrap_or(Foo { val: String::default() });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `unwrap_or_else(|| Foo { val: String::default() })`
 
-error: aborting due to 38 previous errors
+error: `impl Default` that could be derived
+  --> tests/ui/or_fun_call.rs:31:5
+   |
+LL | /     impl Default for FakeDefault {
+LL | |         fn default() -> Self {
+LL | |             FakeDefault
+   | |             ----------- this type has no fields, so it's trivially derivable
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+   = note: `-D default-could-be-derived` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(default_could_be_derived)]`
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL ~     #[derive(Default)] struct FakeDefault;
+LL |     impl FakeDefault {
+...
+LL |
+LL ~     
+   |
+
+error: `impl Default` that could be derived
+  --> tests/ui/or_fun_call.rs:278:9
+   |
+LL | /         impl Default for FakeDefault {
+LL | |             fn default() -> Self {
+LL | |                 FakeDefault
+   | |                 ----------- this type has no fields, so it's trivially derivable
+LL | |             }
+LL | |         }
+   | |_________^
+   |
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL ~         #[derive(Default)] struct FakeDefault;
+LL |         impl FakeDefault {
+...
+LL |
+LL ~         
+   |
+
+error: aborting due to 40 previous errors
 

--- a/src/tools/clippy/tests/ui/unwrap_or_else_default.fixed
+++ b/src/tools/clippy/tests/ui/unwrap_or_else_default.fixed
@@ -17,7 +17,7 @@ fn unwrap_or_else_default() {
         }
     }
 
-    struct HasDefaultAndDuplicate;
+    #[derive(Default)] struct HasDefaultAndDuplicate;
 
     impl HasDefaultAndDuplicate {
         fn default() -> Self {
@@ -25,11 +25,7 @@ fn unwrap_or_else_default() {
         }
     }
 
-    impl Default for HasDefaultAndDuplicate {
-        fn default() -> Self {
-            HasDefaultAndDuplicate
-        }
-    }
+    
 
     enum Enum {
         A(),

--- a/src/tools/clippy/tests/ui/unwrap_or_else_default.stderr
+++ b/src/tools/clippy/tests/ui/unwrap_or_else_default.stderr
@@ -108,8 +108,7 @@ LL | |         }
 LL | |     }
    | |_____^
    |
-   = note: `-D default-could-be-derived` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(default_could_be_derived)]`
+   = note: `#[deny(default_could_be_derived)]` on by default
 help: you don't need to manually `impl Default`, you can derive it
    |
 LL ~     #[derive(Default)] struct HasDefaultAndDuplicate;

--- a/src/tools/clippy/tests/ui/unwrap_or_else_default.stderr
+++ b/src/tools/clippy/tests/ui/unwrap_or_else_default.stderr
@@ -97,5 +97,27 @@ error: use of `or_insert_with` to construct default value
 LL |     let _ = inner_map.entry(0).or_insert_with(Default::default);
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
 
-error: aborting due to 16 previous errors
+error: `impl Default` that could be derived
+  --> tests/ui/unwrap_or_else_default.rs:28:5
+   |
+LL | /     impl Default for HasDefaultAndDuplicate {
+LL | |         fn default() -> Self {
+LL | |             HasDefaultAndDuplicate
+   | |             ---------------------- this type has no fields, so it's trivially derivable
+LL | |         }
+LL | |     }
+   | |_____^
+   |
+   = note: `-D default-could-be-derived` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(default_could_be_derived)]`
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL ~     #[derive(Default)] struct HasDefaultAndDuplicate;
+LL |
+...
+LL |
+LL ~     
+   |
+
+error: aborting due to 17 previous errors
 

--- a/src/tools/rustfmt/src/config/options.rs
+++ b/src/tools/rustfmt/src/config/options.rs
@@ -155,9 +155,11 @@ pub enum ReportTactic {
 
 /// What Rustfmt should emit. Mostly corresponds to the `--emit` command line
 /// option.
+#[derive(Default)]
 #[config_type]
 pub enum EmitMode {
     /// Emits to files.
+    #[default]
     Files,
     /// Writes the output to stdout.
     Stdout,
@@ -310,12 +312,6 @@ impl ::std::str::FromStr for WidthHeuristics {
     }
 }
 
-impl Default for EmitMode {
-    fn default() -> EmitMode {
-        EmitMode::Files
-    }
-}
-
 /// A set of directories, files and modules that rustfmt should ignore.
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct IgnoreList {
@@ -425,10 +421,12 @@ pub trait CliOptions {
 }
 
 /// The edition of the syntax and semantics of code (RFC 2052).
+#[derive(Default)]
 #[config_type]
 pub enum Edition {
     #[value = "2015"]
     #[doc_hint = "2015"]
+    #[default]
     /// Edition 2015.
     Edition2015,
     #[value = "2018"]
@@ -443,12 +441,6 @@ pub enum Edition {
     #[doc_hint = "2024"]
     /// Edition 2024.
     Edition2024,
-}
-
-impl Default for Edition {
-    fn default() -> Edition {
-        Edition::Edition2015
-    }
 }
 
 impl From<Edition> for rustc_span::edition::Edition {

--- a/tests/ui/lint/lint-unconditional-recursion.rs
+++ b/tests/ui/lint/lint-unconditional-recursion.rs
@@ -182,7 +182,7 @@ pub struct Point {
     pub y: f32,
 }
 
-impl Default for Point { //~ WARN
+impl Default for Point {
     fn default() -> Self { //~ ERROR function cannot return without recursing
         Point {
             x: Default::default(),

--- a/tests/ui/lint/lint-unconditional-recursion.rs
+++ b/tests/ui/lint/lint-unconditional-recursion.rs
@@ -182,7 +182,7 @@ pub struct Point {
     pub y: f32,
 }
 
-impl Default for Point {
+impl Default for Point { //~ WARN
     fn default() -> Self { //~ ERROR function cannot return without recursing
         Point {
             x: Default::default(),

--- a/tests/ui/lint/lint-unconditional-recursion.stderr
+++ b/tests/ui/lint/lint-unconditional-recursion.stderr
@@ -197,23 +197,5 @@ LL |             ..Default::default()
    |
    = help: a `loop` may express intention better if this is on purpose
 
-warning: `impl Default` that could be derived
-  --> $DIR/lint-unconditional-recursion.rs:185:1
-   |
-LL | / impl Default for Point {
-LL | |     fn default() -> Self {
-LL | |         Point {
-LL | |             x: Default::default(),
-...  |
-LL | |     }
-LL | | }
-   | |_^
-   |
-   = note: `#[warn(default_could_be_derived)]` on by default
-help: you don't need to manually `impl Default`, you can derive it
-   |
-LL ~ #[derive(Default)] pub struct Point {
-   |
-
-error: aborting due to 18 previous errors; 1 warning emitted
+error: aborting due to 18 previous errors
 

--- a/tests/ui/lint/lint-unconditional-recursion.stderr
+++ b/tests/ui/lint/lint-unconditional-recursion.stderr
@@ -197,5 +197,23 @@ LL |             ..Default::default()
    |
    = help: a `loop` may express intention better if this is on purpose
 
-error: aborting due to 18 previous errors
+warning: `impl Default` that could be derived
+  --> $DIR/lint-unconditional-recursion.rs:185:1
+   |
+LL | / impl Default for Point {
+LL | |     fn default() -> Self {
+LL | |         Point {
+LL | |             x: Default::default(),
+...  |
+LL | |     }
+LL | | }
+   | |_^
+   |
+   = note: `#[warn(default_could_be_derived)]` on by default
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL ~ #[derive(Default)] pub struct Point {
+   |
+
+error: aborting due to 18 previous errors; 1 warning emitted
 

--- a/tests/ui/structs/manual-default-impl-could-be-derived.fixed
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.fixed
@@ -2,6 +2,7 @@
 //@ run-rustfix
 #![allow(dead_code)]
 #![deny(default_could_be_derived)]
+#![feature(default_field_values)]
 
 // #[derive(Debug)]
 // struct A;
@@ -40,15 +41,22 @@
 
 
 // Detection of unit variant ctors that could have been marked `#[default]`.
-#[derive(Default)] enum F {
+#[derive(Default)] enum F<T> {
     #[default] Unit,
-    Tuple(i32),
+    Tuple(T),
 }
 
 
 // Comparison of `impl` *fields* with their `Default::default()` bodies.
 #[derive(Default)] struct G {
-    f: F,
+    f: F<i32>,
+}
+
+
+// Always lint against manual `Default` impl if all fields are defaulted.
+#[derive(PartialEq, Debug)]
+#[derive(Default)] struct H {
+    x: i32 = 101,
 }
 
 
@@ -58,6 +66,7 @@ fn main() {
 //    let _ = C::default();
     let _ = D::default();
     let _ = E::default();
-    let _ = F::default();
+    let _ = F::<i32>::default();
     let _ = G::default();
+    assert_eq!(H::default(), H { .. });
 }

--- a/tests/ui/structs/manual-default-impl-could-be-derived.fixed
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.fixed
@@ -59,6 +59,32 @@
 }
 
 
+// Account for fn calls that are not assoc fns, still check that they match between what the user
+// wrote and the Default impl.
+#[derive(Default)] struct J {
+    x: K,
+}
+
+
+struct K;
+
+impl Default for K { // *could* be derived, but it isn't lintable because of the `foo()` call
+    fn default() -> Self {
+        foo()
+    }
+}
+
+fn foo() -> K {
+    K
+}
+
+// Verify that cross-crate tracking of "equivalences" keeps working.
+#[derive(PartialEq, Debug)]
+#[derive(Default)] struct L {
+    x: Vec<i32>,
+}
+
+
 fn main() {
     let _ = A::default();
     let _ = B::default();
@@ -68,4 +94,8 @@ fn main() {
     let _ = F::<i32>::default();
     let _ = G::default();
     assert_eq!(H::default(), H { .. });
+    let _ = I::default();
+    let _ = J::default();
+    let _ = K::default();
+    let _ = L::default();
 }

--- a/tests/ui/structs/manual-default-impl-could-be-derived.fixed
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.fixed
@@ -47,17 +47,10 @@
 
 
 // Comparison of `impl` *fields* with their `Default::default()` bodies.
-// struct G {
-//     f: F,
-// }
+#[derive(Default)] struct G {
+    f: F,
+}
 
-// impl Default for G {
-//     fn default() -> Self {
-//         G {
-//             f: F::Unit,
-//         }
-//     }
-// }
 
 fn main() {
 //    let _ = A::default();
@@ -66,5 +59,5 @@ fn main() {
     let _ = D::default();
     let _ = E::default();
     let _ = F::default();
-//    let _ = G::default();
+    let _ = G::default();
 }

--- a/tests/ui/structs/manual-default-impl-could-be-derived.fixed
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.fixed
@@ -25,36 +25,46 @@
 // }
 // 
 
+// Explicit check against numeric literals and `Default::default()` calls.
 #[derive(Default)] struct D {
     x: Option<i32>,
     y: i32,
 }
 
-// 
-// #[derive(Debug)]
-// struct E {
-//     x: Option<i32>,
-// }
-// 
-// impl Default for E {
-//     fn default() -> Self {
-//         E {
-//             x: None,
-//         }
-//     }
-// }
 
+// Explicit check against `None` literal, in the same way that we check against numeric literals.
+#[derive(Debug)]
+#[derive(Default)] struct E {
+    x: Option<i32>,
+}
+
+
+// Detection of unit variant ctors that could have been marked `#[default]`.
 #[derive(Default)] enum F {
     #[default] Unit,
     Tuple(i32),
 }
 
 
+// Comparison of `impl` *fields* with their `Default::default()` bodies.
+// struct G {
+//     f: F,
+// }
+
+// impl Default for G {
+//     fn default() -> Self {
+//         G {
+//             f: F::Unit,
+//         }
+//     }
+// }
+
 fn main() {
 //    let _ = A::default();
 //    let _ = B::default();
 //    let _ = C::default();
-//    let _ = D::default();
-//    let _ = E::default();
+    let _ = D::default();
+    let _ = E::default();
     let _ = F::default();
+//    let _ = G::default();
 }

--- a/tests/ui/structs/manual-default-impl-could-be-derived.fixed
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.fixed
@@ -1,7 +1,7 @@
 // Warn when we encounter a manual `Default` impl that could be derived.
 //@ run-rustfix
 #![allow(dead_code)]
-#![deny(default_could_be_derived)]
+#![deny(default_could_be_derived, manual_default_for_type_with_default_fields)]
 #![feature(default_field_values)]
 
 #[derive(Debug)]

--- a/tests/ui/structs/manual-default-impl-could-be-derived.fixed
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.fixed
@@ -24,18 +24,12 @@
 //     fn default() -> Self { C(None) }
 // }
 // 
-// #[derive(Debug)]
-// struct D {
-//     x: Option<i32>,
-// }
-// 
-// impl Default for D {
-//     fn default() -> Self {
-//         D {
-//             x: Default::default(),
-//         }
-//     }
-// }
+
+#[derive(Default)] struct D {
+    x: Option<i32>,
+    y: i32,
+}
+
 // 
 // #[derive(Debug)]
 // struct E {

--- a/tests/ui/structs/manual-default-impl-could-be-derived.fixed
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.fixed
@@ -79,11 +79,26 @@ fn foo() -> K {
 }
 
 // Verify that cross-crate tracking of "equivalences" keeps working.
-#[derive(PartialEq, Debug)]
 #[derive(Default)] struct L {
     x: Vec<i32>,
 }
 
+
+// Account for `const`s
+#[derive(Default)] struct M {
+    x: N,
+}
+
+
+struct N;
+
+impl Default for N { // ok
+    fn default() -> Self {
+        N_CONST
+    }
+}
+
+const N_CONST: N = N;
 
 fn main() {
     let _ = A::default();
@@ -98,4 +113,6 @@ fn main() {
     let _ = J::default();
     let _ = K::default();
     let _ = L::default();
+    let _ = M::default();
+    let _ = N::default();
 }

--- a/tests/ui/structs/manual-default-impl-could-be-derived.fixed
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.fixed
@@ -1,0 +1,66 @@
+// Warn when we encounter a manual `Default` impl that could be derived.
+//@ run-rustfix
+#![allow(dead_code)]
+#![deny(default_could_be_derived)]
+
+// #[derive(Debug)]
+// struct A;
+// 
+// impl Default for A {
+//     fn default() -> Self { A }
+// }
+// 
+// #[derive(Debug)]
+// struct B(Option<i32>);
+// 
+// impl Default for B {
+//     fn default() -> Self { B(Default::default()) }
+// }
+// 
+// #[derive(Debug)]
+// struct C(Option<i32>);
+// 
+// impl Default for C {
+//     fn default() -> Self { C(None) }
+// }
+// 
+// #[derive(Debug)]
+// struct D {
+//     x: Option<i32>,
+// }
+// 
+// impl Default for D {
+//     fn default() -> Self {
+//         D {
+//             x: Default::default(),
+//         }
+//     }
+// }
+// 
+// #[derive(Debug)]
+// struct E {
+//     x: Option<i32>,
+// }
+// 
+// impl Default for E {
+//     fn default() -> Self {
+//         E {
+//             x: None,
+//         }
+//     }
+// }
+
+#[derive(Default)] enum F {
+    #[default] Unit,
+    Tuple(i32),
+}
+
+
+fn main() {
+//    let _ = A::default();
+//    let _ = B::default();
+//    let _ = C::default();
+//    let _ = D::default();
+//    let _ = E::default();
+    let _ = F::default();
+}

--- a/tests/ui/structs/manual-default-impl-could-be-derived.fixed
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.fixed
@@ -11,20 +11,14 @@
 //     fn default() -> Self { A }
 // }
 // 
-// #[derive(Debug)]
-// struct B(Option<i32>);
-// 
-// impl Default for B {
-//     fn default() -> Self { B(Default::default()) }
-// }
-// 
-// #[derive(Debug)]
-// struct C(Option<i32>);
-// 
-// impl Default for C {
-//     fn default() -> Self { C(None) }
-// }
-// 
+#[derive(Debug)]
+#[derive(Default)] struct B(Option<i32>);
+
+
+#[derive(Debug)]
+#[derive(Default)] struct C(Option<i32>);
+
+
 
 // Explicit check against numeric literals and `Default::default()` calls.
 #[derive(Default)] struct D {

--- a/tests/ui/structs/manual-default-impl-could-be-derived.fixed
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.fixed
@@ -60,6 +60,14 @@
 }
 
 
+// Always lint against manual `Default` impl if all fields are defaulted.
+#[derive(PartialEq, Debug)]
+#[derive(Default)] struct I {
+    x: i32 = 101,
+    y: Option<i32>,
+}
+
+
 fn main() {
 //    let _ = A::default();
 //    let _ = B::default();

--- a/tests/ui/structs/manual-default-impl-could-be-derived.fixed
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.fixed
@@ -4,13 +4,10 @@
 #![deny(default_could_be_derived)]
 #![feature(default_field_values)]
 
-// #[derive(Debug)]
-// struct A;
-// 
-// impl Default for A {
-//     fn default() -> Self { A }
-// }
-// 
+#[derive(Debug)]
+#[derive(Default)] struct A;
+
+
 #[derive(Debug)]
 #[derive(Default)] struct B(Option<i32>);
 
@@ -63,9 +60,9 @@
 
 
 fn main() {
-//    let _ = A::default();
-//    let _ = B::default();
-//    let _ = C::default();
+    let _ = A::default();
+    let _ = B::default();
+    let _ = C::default();
     let _ = D::default();
     let _ = E::default();
     let _ = F::<i32>::default();

--- a/tests/ui/structs/manual-default-impl-could-be-derived.rs
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.rs
@@ -2,6 +2,7 @@
 //@ run-rustfix
 #![allow(dead_code)]
 #![deny(default_could_be_derived)]
+#![feature(default_field_values)]
 
 // #[derive(Debug)]
 // struct A;
@@ -79,6 +80,20 @@ impl Default for G { //~ ERROR
     }
 }
 
+// Always lint against manual `Default` impl if all fields are defaulted.
+#[derive(PartialEq, Debug)]
+struct H {
+    x: i32 = 101,
+}
+
+impl Default for H { //~ ERROR
+    fn default() -> Self {
+        H {
+            x: 1,
+        }
+    }
+}
+
 fn main() {
 //    let _ = A::default();
 //    let _ = B::default();
@@ -87,4 +102,5 @@ fn main() {
     let _ = E::default();
     let _ = F::<i32>::default();
     let _ = G::default();
+    assert_eq!(H::default(), H { .. });
 }

--- a/tests/ui/structs/manual-default-impl-could-be-derived.rs
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.rs
@@ -11,20 +11,20 @@
 //     fn default() -> Self { A }
 // }
 // 
-// #[derive(Debug)]
-// struct B(Option<i32>);
-// 
-// impl Default for B {
-//     fn default() -> Self { B(Default::default()) }
-// }
-// 
-// #[derive(Debug)]
-// struct C(Option<i32>);
-// 
-// impl Default for C {
-//     fn default() -> Self { C(None) }
-// }
-// 
+#[derive(Debug)]
+struct B(Option<i32>);
+
+impl Default for B { //~ ERROR
+    fn default() -> Self { B(Default::default()) }
+}
+
+#[derive(Debug)]
+struct C(Option<i32>);
+
+impl Default for C { //~ ERROR
+    fn default() -> Self { C(None) }
+}
+
 
 // Explicit check against numeric literals and `Default::default()` calls.
 struct D {
@@ -112,8 +112,8 @@ impl Default for I { //~ ERROR
 
 fn main() {
 //    let _ = A::default();
-//    let _ = B::default();
-//    let _ = C::default();
+    let _ = B::default();
+    let _ = C::default();
     let _ = D::default();
     let _ = E::default();
     let _ = F::<i32>::default();

--- a/tests/ui/structs/manual-default-impl-could-be-derived.rs
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.rs
@@ -25,6 +25,7 @@
 // }
 // 
 
+// Explicit check against numeric literals and `Default::default()` calls.
 struct D {
     x: Option<i32>,
     y: i32,
@@ -38,20 +39,22 @@ impl Default for D { //~ ERROR
         }
     }
 }
-// 
-// #[derive(Debug)]
-// struct E {
-//     x: Option<i32>,
-// }
-// 
-// impl Default for E {
-//     fn default() -> Self {
-//         E {
-//             x: None,
-//         }
-//     }
-// }
 
+// Explicit check against `None` literal, in the same way that we check against numeric literals.
+#[derive(Debug)]
+struct E {
+    x: Option<i32>,
+}
+
+impl Default for E { //~ ERROR
+    fn default() -> Self {
+        E {
+            x: None,
+        }
+    }
+}
+
+// Detection of unit variant ctors that could have been marked `#[default]`.
 enum F {
     Unit,
     Tuple(i32),
@@ -63,11 +66,25 @@ impl Default for F { //~ ERROR
     }
 }
 
+// Comparison of `impl` *fields* with their `Default::default()` bodies.
+// struct G {
+//     f: F,
+// }
+
+// impl Default for G {
+//     fn default() -> Self {
+//         G {
+//             f: F::Unit,
+//         }
+//     }
+// }
+
 fn main() {
 //    let _ = A::default();
 //    let _ = B::default();
 //    let _ = C::default();
-//    let _ = D::default();
-//    let _ = E::default();
+    let _ = D::default();
+    let _ = E::default();
     let _ = F::default();
+//    let _ = G::default();
 }

--- a/tests/ui/structs/manual-default-impl-could-be-derived.rs
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.rs
@@ -1,27 +1,27 @@
 // Warn when we encounter a manual `Default` impl that could be derived.
 //@ run-rustfix
 #![allow(dead_code)]
-#![deny(default_could_be_derived)]
+#![deny(default_could_be_derived, manual_default_for_type_with_default_fields)]
 #![feature(default_field_values)]
 
 #[derive(Debug)]
 struct A;
 
-impl Default for A { //~ ERROR
+impl Default for A { //~ ERROR default_could_be_derived
     fn default() -> Self { A }
 }
 
 #[derive(Debug)]
 struct B(Option<i32>);
 
-impl Default for B { //~ ERROR
+impl Default for B { //~ ERROR default_could_be_derived
     fn default() -> Self { B(Default::default()) }
 }
 
 #[derive(Debug)]
 struct C(Option<i32>);
 
-impl Default for C { //~ ERROR
+impl Default for C { //~ ERROR default_could_be_derived
     fn default() -> Self { C(None) }
 }
 
@@ -32,7 +32,7 @@ struct D {
     y: i32,
 }
 
-impl Default for D { //~ ERROR
+impl Default for D { //~ ERROR default_could_be_derived
     fn default() -> Self {
         D {
             x: Default::default(),
@@ -47,7 +47,7 @@ struct E {
     x: Option<i32>,
 }
 
-impl Default for E { //~ ERROR
+impl Default for E { //~ ERROR default_could_be_derived
     fn default() -> Self {
         E {
             x: None,
@@ -61,7 +61,7 @@ enum F<T> {
     Tuple(T),
 }
 
-impl<T> Default for F<T> { //~ ERROR
+impl<T> Default for F<T> { //~ ERROR default_could_be_derived
     fn default() -> Self {
         F::Unit
     }
@@ -72,7 +72,7 @@ struct G {
     f: F<i32>,
 }
 
-impl Default for G { //~ ERROR
+impl Default for G { //~ ERROR default_could_be_derived
     fn default() -> Self {
         G {
             f: F::Unit,
@@ -86,7 +86,7 @@ struct H {
     x: i32 = 101,
 }
 
-impl Default for H { //~ ERROR
+impl Default for H { //~ ERROR [manual_default_for_type_with_default_fields]
     fn default() -> Self {
         H {
             x: 1,
@@ -101,7 +101,7 @@ struct I {
     y: Option<i32>,
 }
 
-impl Default for I { //~ ERROR
+impl Default for I {  //~ ERROR [manual_default_for_type_with_default_fields]
     fn default() -> Self {
         I {
             x: 1,
@@ -116,7 +116,7 @@ struct J {
     x: K,
 }
 
-impl Default for J { //~ ERROR
+impl Default for J { //~ ERROR default_could_be_derived
     fn default() -> Self {
         J {
             x: foo(), // fn call that isn't an assoc fn
@@ -141,7 +141,7 @@ struct L {
     x: Vec<i32>,
 }
 
-impl Default for L { //~ ERROR
+impl Default for L { //~ ERROR default_could_be_derived
     fn default() -> Self {
         L {
             x: Vec::new(), // `<Vec as Default>::default()` just calls `Vec::new()`
@@ -154,7 +154,7 @@ struct M {
     x: N,
 }
 
-impl Default for M { //~ ERROR
+impl Default for M { //~ ERROR default_could_be_derived
     fn default() -> Self {
         M {
             x: N_CONST,

--- a/tests/ui/structs/manual-default-impl-could-be-derived.rs
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.rs
@@ -55,12 +55,12 @@ impl Default for E { //~ ERROR
 }
 
 // Detection of unit variant ctors that could have been marked `#[default]`.
-enum F {
+enum F<T> {
     Unit,
-    Tuple(i32),
+    Tuple(T),
 }
 
-impl Default for F { //~ ERROR
+impl<T> Default for F<T> { //~ ERROR
     fn default() -> Self {
         F::Unit
     }
@@ -68,7 +68,7 @@ impl Default for F { //~ ERROR
 
 // Comparison of `impl` *fields* with their `Default::default()` bodies.
 struct G {
-    f: F,
+    f: F<i32>,
 }
 
 impl Default for G { //~ ERROR
@@ -85,6 +85,6 @@ fn main() {
 //    let _ = C::default();
     let _ = D::default();
     let _ = E::default();
-    let _ = F::default();
+    let _ = F::<i32>::default();
     let _ = G::default();
 }

--- a/tests/ui/structs/manual-default-impl-could-be-derived.rs
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.rs
@@ -67,17 +67,17 @@ impl Default for F { //~ ERROR
 }
 
 // Comparison of `impl` *fields* with their `Default::default()` bodies.
-// struct G {
-//     f: F,
-// }
+struct G {
+    f: F,
+}
 
-// impl Default for G {
-//     fn default() -> Self {
-//         G {
-//             f: F::Unit,
-//         }
-//     }
-// }
+impl Default for G { //~ ERROR
+    fn default() -> Self {
+        G {
+            f: F::Unit,
+        }
+    }
+}
 
 fn main() {
 //    let _ = A::default();
@@ -86,5 +86,5 @@ fn main() {
     let _ = D::default();
     let _ = E::default();
     let _ = F::default();
-//    let _ = G::default();
+    let _ = G::default();
 }

--- a/tests/ui/structs/manual-default-impl-could-be-derived.rs
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.rs
@@ -137,7 +137,6 @@ fn foo() -> K {
 }
 
 // Verify that cross-crate tracking of "equivalences" keeps working.
-#[derive(PartialEq, Debug)]
 struct L {
     x: Vec<i32>,
 }
@@ -149,6 +148,29 @@ impl Default for L { //~ ERROR
         }
     }
 }
+
+// Account for `const`s
+struct M {
+    x: N,
+}
+
+impl Default for M { //~ ERROR
+    fn default() -> Self {
+        M {
+            x: N_CONST,
+        }
+    }
+}
+
+struct N;
+
+impl Default for N { // ok
+    fn default() -> Self {
+        N_CONST
+    }
+}
+
+const N_CONST: N = N;
 
 fn main() {
     let _ = A::default();
@@ -163,4 +185,6 @@ fn main() {
     let _ = J::default();
     let _ = K::default();
     let _ = L::default();
+    let _ = M::default();
+    let _ = N::default();
 }

--- a/tests/ui/structs/manual-default-impl-could-be-derived.rs
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.rs
@@ -4,13 +4,13 @@
 #![deny(default_could_be_derived)]
 #![feature(default_field_values)]
 
-// #[derive(Debug)]
-// struct A;
-// 
-// impl Default for A {
-//     fn default() -> Self { A }
-// }
-// 
+#[derive(Debug)]
+struct A;
+
+impl Default for A { //~ ERROR
+    fn default() -> Self { A }
+}
+
 #[derive(Debug)]
 struct B(Option<i32>);
 
@@ -111,7 +111,7 @@ impl Default for I { //~ ERROR
 }
 
 fn main() {
-//    let _ = A::default();
+    let _ = A::default();
     let _ = B::default();
     let _ = C::default();
     let _ = D::default();

--- a/tests/ui/structs/manual-default-impl-could-be-derived.rs
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.rs
@@ -1,0 +1,71 @@
+// Warn when we encounter a manual `Default` impl that could be derived.
+//@ run-rustfix
+#![allow(dead_code)]
+#![deny(default_could_be_derived)]
+
+// #[derive(Debug)]
+// struct A;
+// 
+// impl Default for A {
+//     fn default() -> Self { A }
+// }
+// 
+// #[derive(Debug)]
+// struct B(Option<i32>);
+// 
+// impl Default for B {
+//     fn default() -> Self { B(Default::default()) }
+// }
+// 
+// #[derive(Debug)]
+// struct C(Option<i32>);
+// 
+// impl Default for C {
+//     fn default() -> Self { C(None) }
+// }
+// 
+// #[derive(Debug)]
+// struct D {
+//     x: Option<i32>,
+// }
+// 
+// impl Default for D {
+//     fn default() -> Self {
+//         D {
+//             x: Default::default(),
+//         }
+//     }
+// }
+// 
+// #[derive(Debug)]
+// struct E {
+//     x: Option<i32>,
+// }
+// 
+// impl Default for E {
+//     fn default() -> Self {
+//         E {
+//             x: None,
+//         }
+//     }
+// }
+
+enum F {
+    Unit,
+    Tuple(i32),
+}
+
+impl Default for F { //~ ERROR
+    fn default() -> Self {
+        F::Unit
+    }
+}
+
+fn main() {
+//    let _ = A::default();
+//    let _ = B::default();
+//    let _ = C::default();
+//    let _ = D::default();
+//    let _ = E::default();
+    let _ = F::default();
+}

--- a/tests/ui/structs/manual-default-impl-could-be-derived.rs
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.rs
@@ -94,6 +94,22 @@ impl Default for H { //~ ERROR
     }
 }
 
+// Always lint against manual `Default` impl if all fields are defaulted.
+#[derive(PartialEq, Debug)]
+struct I {
+    x: i32 = 101,
+    y: Option<i32>,
+}
+
+impl Default for I { //~ ERROR
+    fn default() -> Self {
+        I {
+            x: 1,
+            y: None,
+        }
+    }
+}
+
 fn main() {
 //    let _ = A::default();
 //    let _ = B::default();

--- a/tests/ui/structs/manual-default-impl-could-be-derived.rs
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.rs
@@ -24,18 +24,20 @@
 //     fn default() -> Self { C(None) }
 // }
 // 
-// #[derive(Debug)]
-// struct D {
-//     x: Option<i32>,
-// }
-// 
-// impl Default for D {
-//     fn default() -> Self {
-//         D {
-//             x: Default::default(),
-//         }
-//     }
-// }
+
+struct D {
+    x: Option<i32>,
+    y: i32,
+}
+
+impl Default for D { //~ ERROR
+    fn default() -> Self {
+        D {
+            x: Default::default(),
+            y: 0,
+        }
+    }
+}
 // 
 // #[derive(Debug)]
 // struct E {

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -1,9 +1,11 @@
 error: `impl Default` that could be derived
-  --> $DIR/manual-default-impl-could-be-derived.rs:58:1
+  --> $DIR/manual-default-impl-could-be-derived.rs:33:1
    |
-LL | / impl Default for F {
+LL | / impl Default for D {
 LL | |     fn default() -> Self {
-LL | |         F::Unit
+LL | |         D {
+LL | |             x: Default::default(),
+...  |
 LL | |     }
 LL | | }
    | |_^
@@ -15,9 +17,24 @@ LL | #![deny(default_could_be_derived)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 help: you don't need to manually `impl Default`, you can derive it
    |
+LL ~ #[derive(Default)] struct D {
+   |
+
+error: `impl Default` that could be derived
+  --> $DIR/manual-default-impl-could-be-derived.rs:60:1
+   |
+LL | / impl Default for F {
+LL | |     fn default() -> Self {
+LL | |         F::Unit
+LL | |     }
+LL | | }
+   | |_^
+   |
+help: you don't need to manually `impl Default`, you can derive it
+   |
 LL ~ #[derive(Default)] enum F {
 LL ~     #[default] Unit,
    |
 
-error: aborting due to 1 previous error
+error: aborting due to 2 previous errors
 

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -3,6 +3,7 @@ error: `impl Default` that could be derived
    |
 LL | / impl Default for A {
 LL | |     fn default() -> Self { A }
+   | |                            - this type has no fields, so it's trivially derivable
 LL | | }
    | |_^
    |
@@ -22,6 +23,7 @@ error: `impl Default` that could be derived
    |
 LL | / impl Default for B {
 LL | |     fn default() -> Self { B(Default::default()) }
+   | |                              ------------------ this is the same value the expansion of `#[derive(Default)]` would use
 LL | | }
    | |_^
    |
@@ -36,6 +38,7 @@ error: `impl Default` that could be derived
    |
 LL | / impl Default for C {
 LL | |     fn default() -> Self { C(None) }
+   | |                              ---- this is the same value the expansion of `#[derive(Default)]` would use
 LL | | }
    | |_^
    |
@@ -52,7 +55,10 @@ LL | / impl Default for D {
 LL | |     fn default() -> Self {
 LL | |         D {
 LL | |             x: Default::default(),
-...  |
+   | |                ------------------
+LL | |             y: 0,
+   | |                - these are the same values the expansion of `#[derive(Default)]` would use
+LL | |         }
 LL | |     }
 LL | | }
    | |_^
@@ -69,6 +75,7 @@ LL | / impl Default for E {
 LL | |     fn default() -> Self {
 LL | |         E {
 LL | |             x: None,
+   | |                ---- this is the same value the expansion of `#[derive(Default)]` would use
 LL | |         }
 LL | |     }
 LL | | }
@@ -85,6 +92,7 @@ error: `impl Default` that could be derived
 LL | / impl<T> Default for F<T> {
 LL | |     fn default() -> Self {
 LL | |         F::Unit
+   | |         ------- this enum variant has no fields, so it's trivially derivable
 LL | |     }
 LL | | }
    | |_^
@@ -102,6 +110,7 @@ LL | / impl Default for G {
 LL | |     fn default() -> Self {
 LL | |         G {
 LL | |             f: F::Unit,
+   | |                ------- this is the same value the expansion of `#[derive(Default)]` would use
 LL | |         }
 LL | |     }
 LL | | }
@@ -165,6 +174,7 @@ LL | / impl Default for J {
 LL | |     fn default() -> Self {
 LL | |         J {
 LL | |             x: foo(), // fn call that isn't an assoc fn
+   | |                ----- this is the same value the expansion of `#[derive(Default)]` would use
 LL | |         }
 LL | |     }
 LL | | }
@@ -182,6 +192,7 @@ LL | / impl Default for L {
 LL | |     fn default() -> Self {
 LL | |         L {
 LL | |             x: Vec::new(), // `<Vec as Default>::default()` just calls `Vec::new()`
+   | |                ---------- this is the same value the expansion of `#[derive(Default)]` would use
 LL | |         }
 LL | |     }
 LL | | }
@@ -199,6 +210,7 @@ LL | / impl Default for M {
 LL | |     fn default() -> Self {
 LL | |         M {
 LL | |             x: N_CONST,
+   | |                ------- this is the same value the expansion of `#[derive(Default)]` would use
 LL | |         }
 LL | |     }
 LL | | }

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -76,7 +76,7 @@ error: `impl Default` that could be derived
 LL |   struct H {
    |   -------- all the fields in this struct have default values
 LL |       x: i32 = 101,
-   |                ---
+   |                --- default value
 ...
 LL | / impl Default for H {
 LL | |     fn default() -> Self {
@@ -92,5 +92,29 @@ help: to avoid divergence in behavior between `Struct { .. }` and `<Struct as De
 LL ~ #[derive(Default)] struct H {
    |
 
-error: aborting due to 5 previous errors
+error: `impl Default` that could be derived
+  --> $DIR/manual-default-impl-could-be-derived.rs:104:1
+   |
+LL |   struct I {
+   |   -------- all the fields in this struct have default values or a type that impls `Default`
+LL |       x: i32 = 101,
+   |                --- default value
+LL |       y: Option<i32>,
+   |          ----------- implements `Default`
+...
+LL | / impl Default for I {
+LL | |     fn default() -> Self {
+LL | |         I {
+LL | |             x: 1,
+...  |
+LL | |     }
+LL | | }
+   | |_^
+   |
+help: to avoid divergence in behavior between `Struct { .. }` and `<Struct as Default>::default()`, derive the `Default`
+   |
+LL ~ #[derive(Default)] struct I {
+   |
+
+error: aborting due to 6 previous errors
 

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -158,5 +158,39 @@ help: to avoid divergence in behavior between `Struct { .. }` and `<Struct as De
 LL ~ #[derive(Default)] struct I {
    |
 
-error: aborting due to 9 previous errors
+error: `impl Default` that could be derived
+  --> $DIR/manual-default-impl-could-be-derived.rs:119:1
+   |
+LL | / impl Default for J {
+LL | |     fn default() -> Self {
+LL | |         J {
+LL | |             x: foo(), // fn call that isn't an assoc fn
+LL | |         }
+LL | |     }
+LL | | }
+   | |_^
+   |
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL ~ #[derive(Default)] struct J {
+   |
+
+error: `impl Default` that could be derived
+  --> $DIR/manual-default-impl-could-be-derived.rs:145:1
+   |
+LL | / impl Default for L {
+LL | |     fn default() -> Self {
+LL | |         L {
+LL | |             x: Vec::new(), // `<Vec as Default>::default()` just calls `Vec::new()`
+LL | |         }
+LL | |     }
+LL | | }
+   | |_^
+   |
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL ~ #[derive(Default)] struct L {
+   |
+
+error: aborting due to 11 previous errors
 

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -1,0 +1,23 @@
+error: `impl Default` that could be derived
+  --> $DIR/manual-default-impl-could-be-derived.rs:58:1
+   |
+LL | / impl Default for F {
+LL | |     fn default() -> Self {
+LL | |         F::Unit
+LL | |     }
+LL | | }
+   | |_^
+   |
+note: the lint level is defined here
+  --> $DIR/manual-default-impl-could-be-derived.rs:4:9
+   |
+LL | #![deny(default_could_be_derived)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL ~ #[derive(Default)] enum F {
+LL ~     #[default] Unit,
+   |
+
+error: aborting due to 1 previous error
+

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -176,7 +176,7 @@ LL ~ #[derive(Default)] struct J {
    |
 
 error: `impl Default` that could be derived
-  --> $DIR/manual-default-impl-could-be-derived.rs:145:1
+  --> $DIR/manual-default-impl-could-be-derived.rs:144:1
    |
 LL | / impl Default for L {
 LL | |     fn default() -> Self {
@@ -192,5 +192,22 @@ help: you don't need to manually `impl Default`, you can derive it
 LL ~ #[derive(Default)] struct L {
    |
 
-error: aborting due to 11 previous errors
+error: `impl Default` that could be derived
+  --> $DIR/manual-default-impl-could-be-derived.rs:157:1
+   |
+LL | / impl Default for M {
+LL | |     fn default() -> Self {
+LL | |         M {
+LL | |             x: N_CONST,
+LL | |         }
+LL | |     }
+LL | | }
+   | |_^
+   |
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL ~ #[derive(Default)] struct M {
+   |
+
+error: aborting due to 12 previous errors
 

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -53,5 +53,22 @@ LL ~ #[derive(Default)] enum F {
 LL ~     #[default] Unit,
    |
 
-error: aborting due to 3 previous errors
+error: `impl Default` that could be derived
+  --> $DIR/manual-default-impl-could-be-derived.rs:74:1
+   |
+LL | / impl Default for G {
+LL | |     fn default() -> Self {
+LL | |         G {
+LL | |             f: F::Unit,
+LL | |         }
+LL | |     }
+LL | | }
+   | |_^
+   |
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL ~ #[derive(Default)] struct G {
+   |
+
+error: aborting due to 4 previous errors
 

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -1,5 +1,5 @@
 error: `impl Default` that could be derived
-  --> $DIR/manual-default-impl-could-be-derived.rs:34:1
+  --> $DIR/manual-default-impl-could-be-derived.rs:35:1
    |
 LL | / impl Default for D {
 LL | |     fn default() -> Self {
@@ -21,7 +21,7 @@ LL ~ #[derive(Default)] struct D {
    |
 
 error: `impl Default` that could be derived
-  --> $DIR/manual-default-impl-could-be-derived.rs:49:1
+  --> $DIR/manual-default-impl-could-be-derived.rs:50:1
    |
 LL | / impl Default for E {
 LL | |     fn default() -> Self {
@@ -38,7 +38,7 @@ LL ~ #[derive(Default)] struct E {
    |
 
 error: `impl Default` that could be derived
-  --> $DIR/manual-default-impl-could-be-derived.rs:63:1
+  --> $DIR/manual-default-impl-could-be-derived.rs:64:1
    |
 LL | / impl<T> Default for F<T> {
 LL | |     fn default() -> Self {
@@ -54,7 +54,7 @@ LL ~     #[default] Unit,
    |
 
 error: `impl Default` that could be derived
-  --> $DIR/manual-default-impl-could-be-derived.rs:74:1
+  --> $DIR/manual-default-impl-could-be-derived.rs:75:1
    |
 LL | / impl Default for G {
 LL | |     fn default() -> Self {
@@ -70,5 +70,27 @@ help: you don't need to manually `impl Default`, you can derive it
 LL ~ #[derive(Default)] struct G {
    |
 
-error: aborting due to 4 previous errors
+error: `impl Default` that could be derived
+  --> $DIR/manual-default-impl-could-be-derived.rs:89:1
+   |
+LL |   struct H {
+   |   -------- all the fields in this struct have default values
+LL |       x: i32 = 101,
+   |                ---
+...
+LL | / impl Default for H {
+LL | |     fn default() -> Self {
+LL | |         H {
+LL | |             x: 1,
+LL | |         }
+LL | |     }
+LL | | }
+   | |_^
+   |
+help: to avoid divergence in behavior between `Struct { .. }` and `<Struct as Default>::default()`, derive the `Default`
+   |
+LL ~ #[derive(Default)] struct H {
+   |
+
+error: aborting due to 5 previous errors
 

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -10,7 +10,7 @@ LL | | }
 note: the lint level is defined here
   --> $DIR/manual-default-impl-could-be-derived.rs:4:9
    |
-LL | #![deny(default_could_be_derived)]
+LL | #![deny(default_could_be_derived, manual_default_for_type_with_default_fields)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
 help: you don't need to manually `impl Default`, you can derive it
    |
@@ -121,7 +121,7 @@ help: you don't need to manually `impl Default`, you can derive it
 LL ~ #[derive(Default)] struct G {
    |
 
-error: `impl Default` that could be derived
+error: manual `Default` impl for type with default field values
   --> $DIR/manual-default-impl-could-be-derived.rs:89:1
    |
 LL |   struct H {
@@ -138,12 +138,17 @@ LL | |     }
 LL | | }
    | |_^
    |
+note: the lint level is defined here
+  --> $DIR/manual-default-impl-could-be-derived.rs:4:35
+   |
+LL | #![deny(default_could_be_derived, manual_default_for_type_with_default_fields)]
+   |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 help: to avoid divergence in behavior between `Struct { .. }` and `<Struct as Default>::default()`, derive the `Default`
    |
 LL ~ #[derive(Default)] struct H {
    |
 
-error: `impl Default` that could be derived
+error: manual `Default` impl for type with default field values
   --> $DIR/manual-default-impl-could-be-derived.rs:104:1
    |
 LL |   struct I {

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -58,8 +58,7 @@ LL | |             x: Default::default(),
    | |                ------------------
 LL | |             y: 0,
    | |                - these are the same values the expansion of `#[derive(Default)]` would use
-LL | |         }
-LL | |     }
+...  |
 LL | | }
    | |_^
    |
@@ -76,8 +75,7 @@ LL | |     fn default() -> Self {
 LL | |         E {
 LL | |             x: None,
    | |                ---- this is the same value the expansion of `#[derive(Default)]` would use
-LL | |         }
-LL | |     }
+...  |
 LL | | }
    | |_^
    |
@@ -111,8 +109,7 @@ LL | |     fn default() -> Self {
 LL | |         G {
 LL | |             f: F::Unit,
    | |                ------- this is the same value the expansion of `#[derive(Default)]` would use
-LL | |         }
-LL | |     }
+...  |
 LL | | }
    | |_^
    |
@@ -133,8 +130,7 @@ LL | / impl Default for H {
 LL | |     fn default() -> Self {
 LL | |         H {
 LL | |             x: 1,
-LL | |         }
-LL | |     }
+...  |
 LL | | }
    | |_^
    |
@@ -163,7 +159,6 @@ LL | |     fn default() -> Self {
 LL | |         I {
 LL | |             x: 1,
 ...  |
-LL | |     }
 LL | | }
    | |_^
    |
@@ -180,8 +175,7 @@ LL | |     fn default() -> Self {
 LL | |         J {
 LL | |             x: foo(), // fn call that isn't an assoc fn
    | |                ----- this is the same value the expansion of `#[derive(Default)]` would use
-LL | |         }
-LL | |     }
+...  |
 LL | | }
    | |_^
    |
@@ -198,8 +192,7 @@ LL | |     fn default() -> Self {
 LL | |         L {
 LL | |             x: Vec::new(), // `<Vec as Default>::default()` just calls `Vec::new()`
    | |                ---------- this is the same value the expansion of `#[derive(Default)]` would use
-LL | |         }
-LL | |     }
+...  |
 LL | | }
    | |_^
    |
@@ -216,8 +209,7 @@ LL | |     fn default() -> Self {
 LL | |         M {
 LL | |             x: N_CONST,
    | |                ------- this is the same value the expansion of `#[derive(Default)]` would use
-LL | |         }
-LL | |     }
+...  |
 LL | | }
    | |_^
    |

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -1,5 +1,5 @@
 error: `impl Default` that could be derived
-  --> $DIR/manual-default-impl-could-be-derived.rs:33:1
+  --> $DIR/manual-default-impl-could-be-derived.rs:34:1
    |
 LL | / impl Default for D {
 LL | |     fn default() -> Self {
@@ -21,7 +21,24 @@ LL ~ #[derive(Default)] struct D {
    |
 
 error: `impl Default` that could be derived
-  --> $DIR/manual-default-impl-could-be-derived.rs:60:1
+  --> $DIR/manual-default-impl-could-be-derived.rs:49:1
+   |
+LL | / impl Default for E {
+LL | |     fn default() -> Self {
+LL | |         E {
+LL | |             x: None,
+LL | |         }
+LL | |     }
+LL | | }
+   | |_^
+   |
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL ~ #[derive(Default)] struct E {
+   |
+
+error: `impl Default` that could be derived
+  --> $DIR/manual-default-impl-could-be-derived.rs:63:1
    |
 LL | / impl Default for F {
 LL | |     fn default() -> Self {
@@ -36,5 +53,5 @@ LL ~ #[derive(Default)] enum F {
 LL ~     #[default] Unit,
    |
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -1,4 +1,37 @@
 error: `impl Default` that could be derived
+  --> $DIR/manual-default-impl-could-be-derived.rs:17:1
+   |
+LL | / impl Default for B {
+LL | |     fn default() -> Self { B(Default::default()) }
+LL | | }
+   | |_^
+   |
+note: the lint level is defined here
+  --> $DIR/manual-default-impl-could-be-derived.rs:4:9
+   |
+LL | #![deny(default_could_be_derived)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL - struct B(Option<i32>);
+LL + #[derive(Default)] struct B(Option<i32>);
+   |
+
+error: `impl Default` that could be derived
+  --> $DIR/manual-default-impl-could-be-derived.rs:24:1
+   |
+LL | / impl Default for C {
+LL | |     fn default() -> Self { C(None) }
+LL | | }
+   | |_^
+   |
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL - struct C(Option<i32>);
+LL + #[derive(Default)] struct C(Option<i32>);
+   |
+
+error: `impl Default` that could be derived
   --> $DIR/manual-default-impl-could-be-derived.rs:35:1
    |
 LL | / impl Default for D {
@@ -10,11 +43,6 @@ LL | |     }
 LL | | }
    | |_^
    |
-note: the lint level is defined here
-  --> $DIR/manual-default-impl-could-be-derived.rs:4:9
-   |
-LL | #![deny(default_could_be_derived)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^
 help: you don't need to manually `impl Default`, you can derive it
    |
 LL ~ #[derive(Default)] struct D {
@@ -116,5 +144,5 @@ help: to avoid divergence in behavior between `Struct { .. }` and `<Struct as De
 LL ~ #[derive(Default)] struct I {
    |
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -1,8 +1,8 @@
 error: `impl Default` that could be derived
-  --> $DIR/manual-default-impl-could-be-derived.rs:17:1
+  --> $DIR/manual-default-impl-could-be-derived.rs:10:1
    |
-LL | / impl Default for B {
-LL | |     fn default() -> Self { B(Default::default()) }
+LL | / impl Default for A {
+LL | |     fn default() -> Self { A }
 LL | | }
    | |_^
    |
@@ -11,6 +11,20 @@ note: the lint level is defined here
    |
 LL | #![deny(default_could_be_derived)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^
+help: you don't need to manually `impl Default`, you can derive it
+   |
+LL - struct A;
+LL + #[derive(Default)] struct A;
+   |
+
+error: `impl Default` that could be derived
+  --> $DIR/manual-default-impl-could-be-derived.rs:17:1
+   |
+LL | / impl Default for B {
+LL | |     fn default() -> Self { B(Default::default()) }
+LL | | }
+   | |_^
+   |
 help: you don't need to manually `impl Default`, you can derive it
    |
 LL - struct B(Option<i32>);
@@ -144,5 +158,5 @@ help: to avoid divergence in behavior between `Struct { .. }` and `<Struct as De
 LL ~ #[derive(Default)] struct I {
    |
 
-error: aborting due to 8 previous errors
+error: aborting due to 9 previous errors
 

--- a/tests/ui/structs/manual-default-impl-could-be-derived.stderr
+++ b/tests/ui/structs/manual-default-impl-could-be-derived.stderr
@@ -40,7 +40,7 @@ LL ~ #[derive(Default)] struct E {
 error: `impl Default` that could be derived
   --> $DIR/manual-default-impl-could-be-derived.rs:63:1
    |
-LL | / impl Default for F {
+LL | / impl<T> Default for F<T> {
 LL | |     fn default() -> Self {
 LL | |         F::Unit
 LL | |     }
@@ -49,7 +49,7 @@ LL | | }
    |
 help: you don't need to manually `impl Default`, you can derive it
    |
-LL ~ #[derive(Default)] enum F {
+LL ~ #[derive(Default)] enum F<T> {
 LL ~     #[default] Unit,
    |
 


### PR DESCRIPTION
```
error: `impl Default` that could be derived
  --> $DIR/manual-default-impl-could-be-derived.rs:74:1
   |
LL | / impl Default for G {
LL | |     fn default() -> Self {
LL | |         G {
LL | |             f: F::Unit,
LL | |         }
LL | |     }
LL | | }
   | |_^
   |
help: you don't need to manually `impl Default`, you can derive it
   |
LL ~ #[derive(Default)] struct G {
   |
```

As part of #132162/https://github.com/rust-lang/rfcs/pull/3681 we want to lint when default fields values could preclude the need of a manual `impl Default`, but there are already cases where these manual impls could be derived. This PR introduces a new `default_could_be_derived` lint that makes a best effort check of the body of the `Default::default()` implementation to see if all the fields of a single expression in that body are either known to be `Default` already (like an explicit call to `Default::default()`, a `0` literal, or `Option::None` path) or are identified to be equivalent to the field's type's `Default` value (by opportunistically looking at the `Default::default()` body for that field's type).