### PR TITLE
fix: Implement missing logics in `exported_private_dependencies` lint

### DIFF
--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -25,7 +25,7 @@ hashbrown = { version = "0.15", default-features = false, features = [
 ] }
 std_detect = { path = "../stdarch/crates/std_detect", default-features = false, features = [
     'rustc-dep-of-std',
-] }
+], public = true }
 
 # Dependencies of the `backtrace` crate
 rustc-demangle = { version = "0.1.24", features = ['rustc-dep-of-std'] }

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -25,7 +25,7 @@ hashbrown = { version = "0.15", default-features = false, features = [
 ] }
 std_detect = { path = "../stdarch/crates/std_detect", default-features = false, features = [
     'rustc-dep-of-std',
-], public = true }
+] }
 
 # Dependencies of the `backtrace` crate
 rustc-demangle = { version = "0.1.24", features = ['rustc-dep-of-std'] }

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
@@ -10,8 +10,8 @@
 #![allow(hidden_glob_reexports)]
 
 // This crate is a private dependency
+// FIXME: This should trigger.
 pub extern crate priv_dep;
-//~^ ERROR extern crate `priv_dep` from private dependency 'priv_dep' in public interface
 // This crate is a public dependency
 extern crate pub_dep;
 // This crate is a private dependency
@@ -91,17 +91,18 @@ pub struct AllowedPrivType {
     pub allowed: OtherType,
 }
 
+// FIXME: This should trigger.
 pub use priv_dep::m;
-//~^ ERROR `use` import `m` from private dependency 'priv_dep' in public interface
+// FIXME: This should trigger.
 pub use pm::fn_like;
-//~^ ERROR `use` import `fn_like` from private dependency 'pm' in public interface
+// FIXME: This should trigger.
 pub use pm::PmDerive;
-//~^ ERROR `use` import `PmDerive` from private dependency 'pm' in public interface
+// FIXME: This should trigger.
 pub use pm::pm_attr;
-//~^ ERROR `use` import `pm_attr` from private dependency 'pm' in public interface
+
+// FIXME: This should trigger.
 pub use priv_dep::E::V1;
-//~^ ERROR `use` import `V1` from private dependency 'priv_dep' in public interface
+// FIXME: This should trigger.
 pub use priv_dep::*;
-//~^ ERROR `use` import `priv_dep` from private dependency 'priv_dep' in public interface
 
 fn main() {}

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.rs
@@ -7,10 +7,11 @@
 // dependency or a private one.
 
 #![deny(exported_private_dependencies)]
+#![allow(hidden_glob_reexports)]
 
 // This crate is a private dependency
-// FIXME: This should trigger.
 pub extern crate priv_dep;
+//~^ ERROR extern crate `priv_dep` from private dependency 'priv_dep' in public interface
 // This crate is a public dependency
 extern crate pub_dep;
 // This crate is a private dependency
@@ -77,31 +78,30 @@ pub type Alias = OtherType;
 
 pub struct PublicWithPrivateImpl;
 
-// FIXME: This should trigger.
-// See https://github.com/rust-lang/rust/issues/71043
 impl OtherTrait for PublicWithPrivateImpl {}
+//~^ ERROR trait `OtherTrait` from private dependency 'priv_dep' in public interface
 
 pub trait PubTraitOnPrivate {}
 
-// FIXME: This should trigger.
-// See https://github.com/rust-lang/rust/issues/71043
 impl PubTraitOnPrivate for OtherType {}
+//~^ ERROR type `OtherType` from private dependency 'priv_dep' in public interface
 
 pub struct AllowedPrivType {
     #[allow(exported_private_dependencies)]
     pub allowed: OtherType,
 }
 
-// FIXME: This should trigger.
 pub use priv_dep::m;
-// FIXME: This should trigger.
+//~^ ERROR `use` import `m` from private dependency 'priv_dep' in public interface
 pub use pm::fn_like;
-// FIXME: This should trigger.
+//~^ ERROR `use` import `fn_like` from private dependency 'pm' in public interface
 pub use pm::PmDerive;
-// FIXME: This should trigger.
+//~^ ERROR `use` import `PmDerive` from private dependency 'pm' in public interface
 pub use pm::pm_attr;
-
-// FIXME: This should trigger.
+//~^ ERROR `use` import `pm_attr` from private dependency 'pm' in public interface
 pub use priv_dep::E::V1;
+//~^ ERROR `use` import `V1` from private dependency 'priv_dep' in public interface
+pub use priv_dep::*;
+//~^ ERROR `use` import `priv_dep` from private dependency 'priv_dep' in public interface
 
 fn main() {}

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
@@ -1,8 +1,8 @@
-error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:29:5
+error: extern crate `priv_dep` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:13:1
    |
-LL |     pub field: OtherType,
-   |     ^^^^^^^^^^^^^^^^^^^^
+LL | pub extern crate priv_dep;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/pub-priv1.rs:9:9
@@ -11,64 +11,118 @@ LL | #![deny(exported_private_dependencies)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:36:5
+  --> $DIR/pub-priv1.rs:30:5
+   |
+LL |     pub field: OtherType,
+   |     ^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:37:5
    |
 LL |     pub fn pub_fn_param(param: OtherType) {}
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:39:5
+  --> $DIR/pub-priv1.rs:40:5
    |
 LL |     pub fn pub_fn_return() -> OtherType { OtherType }
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:46:5
+  --> $DIR/pub-priv1.rs:47:5
    |
 LL |     type Foo: OtherTrait;
    |     ^^^^^^^^^^^^^^^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:50:1
+  --> $DIR/pub-priv1.rs:51:1
    |
 LL | pub trait WithSuperTrait: OtherTrait {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:59:5
+  --> $DIR/pub-priv1.rs:60:5
    |
 LL |     type X = OtherType;
    |     ^^^^^^
 
 error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:63:1
+  --> $DIR/pub-priv1.rs:64:1
    |
 LL | pub fn in_bounds<T: OtherTrait>(x: T) { unimplemented!() }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:66:1
+  --> $DIR/pub-priv1.rs:67:1
    |
 LL | pub fn private_in_generic() -> std::num::Saturating<OtherType> { unimplemented!() }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:69:1
+  --> $DIR/pub-priv1.rs:70:1
    |
 LL | pub static STATIC: OtherType = OtherType;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:72:1
+  --> $DIR/pub-priv1.rs:73:1
    |
 LL | pub const CONST: OtherType = OtherType;
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:75:1
+  --> $DIR/pub-priv1.rs:76:1
    |
 LL | pub type Alias = OtherType;
    | ^^^^^^^^^^^^^^
 
-error: aborting due to 11 previous errors
+error: trait `OtherTrait` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:81:1
+   |
+LL | impl OtherTrait for PublicWithPrivateImpl {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:86:1
+   |
+LL | impl PubTraitOnPrivate for OtherType {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `use` import `m` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:94:9
+   |
+LL | pub use priv_dep::m;
+   |         ^^^^^^^^^^^
+
+error: `use` import `fn_like` from private dependency 'pm' in public interface
+  --> $DIR/pub-priv1.rs:96:9
+   |
+LL | pub use pm::fn_like;
+   |         ^^^^^^^^^^^
+
+error: `use` import `PmDerive` from private dependency 'pm' in public interface
+  --> $DIR/pub-priv1.rs:98:9
+   |
+LL | pub use pm::PmDerive;
+   |         ^^^^^^^^^^^^
+
+error: `use` import `pm_attr` from private dependency 'pm' in public interface
+  --> $DIR/pub-priv1.rs:100:9
+   |
+LL | pub use pm::pm_attr;
+   |         ^^^^^^^^^^^
+
+error: `use` import `V1` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:102:9
+   |
+LL | pub use priv_dep::E::V1;
+   |         ^^^^^^^^^^^^^^^
+
+error: `use` import `priv_dep` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:104:9
+   |
+LL | pub use priv_dep::*;
+   |         ^^^^^^^^
+
+error: aborting due to 20 previous errors
 

--- a/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
+++ b/tests/ui/privacy/pub-priv-dep/pub-priv1.stderr
@@ -1,20 +1,14 @@
-error: extern crate `priv_dep` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:13:1
+error: type `OtherType` from private dependency 'priv_dep' in public interface
+  --> $DIR/pub-priv1.rs:30:5
    |
-LL | pub extern crate priv_dep;
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |     pub field: OtherType,
+   |     ^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/pub-priv1.rs:9:9
    |
 LL | #![deny(exported_private_dependencies)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: type `OtherType` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:30:5
-   |
-LL |     pub field: OtherType,
-   |     ^^^^^^^^^^^^^^^^^^^^
 
 error: type `OtherType` from private dependency 'priv_dep' in public interface
   --> $DIR/pub-priv1.rs:37:5
@@ -88,41 +82,5 @@ error: type `OtherType` from private dependency 'priv_dep' in public interface
 LL | impl PubTraitOnPrivate for OtherType {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: `use` import `m` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:94:9
-   |
-LL | pub use priv_dep::m;
-   |         ^^^^^^^^^^^
-
-error: `use` import `fn_like` from private dependency 'pm' in public interface
-  --> $DIR/pub-priv1.rs:96:9
-   |
-LL | pub use pm::fn_like;
-   |         ^^^^^^^^^^^
-
-error: `use` import `PmDerive` from private dependency 'pm' in public interface
-  --> $DIR/pub-priv1.rs:98:9
-   |
-LL | pub use pm::PmDerive;
-   |         ^^^^^^^^^^^^
-
-error: `use` import `pm_attr` from private dependency 'pm' in public interface
-  --> $DIR/pub-priv1.rs:100:9
-   |
-LL | pub use pm::pm_attr;
-   |         ^^^^^^^^^^^
-
-error: `use` import `V1` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:102:9
-   |
-LL | pub use priv_dep::E::V1;
-   |         ^^^^^^^^^^^^^^^
-
-error: `use` import `priv_dep` from private dependency 'priv_dep' in public interface
-  --> $DIR/pub-priv1.rs:104:9
-   |
-LL | pub use priv_dep::*;
-   |         ^^^^^^^^
-
-error: aborting due to 20 previous errors
+error: aborting due to 13 previous errors
 


### PR DESCRIPTION
Fixes some cases of #71043 