### PR TITLE
Revert "Stop git from merging generated files"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,10 +4,8 @@
 *.cpp rust
 *.h rust
 *.rs rust diff=rust
-*.fixed linguist-language=Rust -merge
-*.mir linguist-language=Rust -merge
-*.stderr -merge
-*.stdout -merge
+*.fixed linguist-language=Rust
+*.mir linguist-language=Rust
 src/etc/installer/gfx/* binary
 src/vendor/** -text
 Cargo.lock linguist-generated=false


### PR DESCRIPTION
This reverts https://github.com/rust-lang/rust/pull/133851. "-merge" makes git not even do merges if they are entirely conflict-free, which is not the behavior we want. We sometimes have conflict-free merges in generated files and it's much better if git can handle them automatically.

r? @oli-obk 
Cc @jieyouxu @Urgau 

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
