### PR TITLE
On Neutrino QNX, reduce the need to set archiver via environment variables

### DIFF
--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -44,6 +44,16 @@ fn cc2ar(cc: &Path, target: TargetSelection) -> Option<PathBuf> {
         Some(PathBuf::from("ar"))
     } else if target.contains("vxworks") {
         Some(PathBuf::from("wr-ar"))
+    } else if target.contains("-nto-") {
+        if target.starts_with("i586") {
+            Some(PathBuf::from("ntox86-ar"))
+        } else if target.starts_with("aarch64") {
+            Some(PathBuf::from("ntoaarch64-ar"))
+        } else if target.starts_with("x86_64") {
+            Some(PathBuf::from("ntox86_64-ar"))
+        } else {
+            panic!("Unknown architecture, cannot determine archiver for Neutrino QNX");
+        }
     } else if target.contains("android") || target.contains("-wasi") {
         Some(cc.parent().unwrap().join(PathBuf::from("llvm-ar")))
     } else {


### PR DESCRIPTION
This adds support for automatically selecting the correct `ar` tool when compiling for Neutrino QNX.
Once https://github.com/rust-lang/cc-rs/pull/1319 is merged and a new cc version is integrated, all environment variables of the [Neutrino documentation](https://github.com/rust-lang/rust/blob/stable/src/doc/rustc/src/platform-support/nto-qnx.md) can be removed.

CC: @jonathanpallant @japaric @gh-tr @AkhilTThomas