### PR TITLE
refactor: replace format! with concat! for string literals

### DIFF
--- a/compiler/rustc_codegen_cranelift/scripts/cargo-clif.rs
+++ b/compiler/rustc_codegen_cranelift/scripts/cargo-clif.rs
@@ -13,8 +13,8 @@ fn main() {
     }
 
     let mut rustflags = vec!["-Cpanic=abort".to_owned(), "-Zpanic-abort-tests".to_owned()];
-    if let Some(name) = option_env!("BUILTIN_BACKEND") {
-        rustflags.push(format!("-Zcodegen-backend={name}"));
+    if let Some(_) = option_env!("BUILTIN_BACKEND") {
+        rustflags.push(concat!("-Zcodegen-backend=", env!("BUILTIN_BACKEND")).to_owned());
     } else {
         let dylib = sysroot.join(if cfg!(windows) { "bin" } else { "lib" }).join(
             env::consts::DLL_PREFIX.to_string()

--- a/compiler/rustc_codegen_cranelift/scripts/rustc-clif.rs
+++ b/compiler/rustc_codegen_cranelift/scripts/rustc-clif.rs
@@ -19,8 +19,8 @@ fn main() {
     let mut args = vec![];
     args.push(OsString::from("-Cpanic=abort"));
     args.push(OsString::from("-Zpanic-abort-tests"));
-    if let Some(name) = option_env!("BUILTIN_BACKEND") {
-        args.push(OsString::from(format!("-Zcodegen-backend={name}")))
+    if let Some(_) = option_env!("BUILTIN_BACKEND") {
+        args.push(OsString::from(concat!("-Zcodegen-backend=", env!("BUILTIN_BACKEND"))))
     } else {
         let mut codegen_backend_arg = OsString::from("-Zcodegen-backend=");
         codegen_backend_arg.push(cg_clif_dylib_path);

--- a/compiler/rustc_codegen_cranelift/scripts/rustdoc-clif.rs
+++ b/compiler/rustc_codegen_cranelift/scripts/rustdoc-clif.rs
@@ -19,8 +19,8 @@ fn main() {
     let mut args = vec![];
     args.push(OsString::from("-Cpanic=abort"));
     args.push(OsString::from("-Zpanic-abort-tests"));
-    if let Some(name) = option_env!("BUILTIN_BACKEND") {
-        args.push(OsString::from(format!("-Zcodegen-backend={name}")))
+    if let Some(_) = option_env!("BUILTIN_BACKEND") {
+        args.push(OsString::from(concat!("-Zcodegen-backend="), env!("BUILTIN_BACKEND")))
     } else {
         let mut codegen_backend_arg = OsString::from("-Zcodegen-backend=");
         codegen_backend_arg.push(cg_clif_dylib_path);

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -418,8 +418,10 @@ pub(crate) unsafe fn create_module<'ll>(
     // On the wasm targets it will get hooked up to the "producer" sections
     // `processed-by` information.
     #[allow(clippy::option_env_unwrap)]
-    let rustc_producer =
-        format!("rustc version {}", option_env!("CFG_VERSION").expect("CFG_VERSION"));
+    let rustc_producer = option_env!("CFG_VERSION")
+        .map(|_| concat!("rustc version ", env!("CFG_VERSION")))
+        .expect("CFG_VERSION");
+
     let name_metadata = unsafe {
         llvm::LLVMMDStringInContext2(
             llcx,

--- a/compiler/rustc_codegen_ssa/src/back/link.rs
+++ b/compiler/rustc_codegen_ssa/src/back/link.rs
@@ -1367,8 +1367,9 @@ fn link_sanitizer_runtime(
         }
     }
 
-    let channel =
-        option_env!("CFG_RELEASE_CHANNEL").map(|channel| format!("-{channel}")).unwrap_or_default();
+    let channel = option_env!("CFG_RELEASE_CHANNEL")
+        .map(|_| concat!("-", env!("CFG_RELEASE_CHANNEL")))
+        .unwrap_or_default();
 
     if sess.target.is_like_osx {
         // On Apple platforms, the sanitizer is always built as a dylib, and

--- a/src/librustdoc/html/render/mod.rs
+++ b/src/librustdoc/html/render/mod.rs
@@ -78,7 +78,7 @@ use crate::html::markdown::{
 use crate::html::static_files::SCRAPE_EXAMPLES_HELP_MD;
 use crate::html::{highlight, sources};
 use crate::scrape_examples::{CallData, CallLocation};
-use crate::{DOC_RUST_LANG_ORG_CHANNEL, try_none};
+use crate::try_none;
 
 pub(crate) fn ensure_trailing_slash(v: &str) -> impl fmt::Display + '_ {
     crate::html::format::display_fn(move |f| {
@@ -477,10 +477,12 @@ impl AllTypes {
 
 fn scrape_examples_help(shared: &SharedContext<'_>) -> String {
     let mut content = SCRAPE_EXAMPLES_HELP_MD.to_owned();
-    content.push_str(&format!(
+    content.push_str(concat!(
         "## More information\n\n\
       If you want more information about this feature, please read the [corresponding chapter in \
-      the Rustdoc book]({DOC_RUST_LANG_ORG_CHANNEL}/rustdoc/scraped-examples.html)."
+      the Rustdoc book](",
+        env!("DOC_RUST_LANG_ORG_CHANNEL"),
+        "/rustdoc/scraped-examples.html)."
     ));
 
     let mut ids = IdMap::default();

--- a/src/tools/clippy/lintcheck/src/main.rs
+++ b/src/tools/clippy/lintcheck/src/main.rs
@@ -88,15 +88,13 @@ impl Crate {
             );
         }
 
-        let cargo_home = env!("CARGO_HOME");
-
         // `src/lib.rs` -> `target/lintcheck/sources/crate-1.2.3/src/lib.rs`
         let remap_relative = format!("={}", self.path.display());
         // Fallback for other sources, `~/.cargo/...` -> `$CARGO_HOME/...`
-        let remap_cargo_home = format!("{cargo_home}=$CARGO_HOME");
+        let remap_cargo_home = concat!(env!("CARGO_HOME"), "=$CARGO_HOME");
         // `~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/crate-2.3.4/src/lib.rs`
         //     -> `crate-2.3.4/src/lib.rs`
-        let remap_crates_io = format!("{cargo_home}/registry/src/index.crates.io-6f17d22bba15001f/=");
+        let remap_crates_io = concat!(env!("CARGO_HOME"), "/registry/src/index.crates.io-6f17d22bba15001f/=");
 
         let mut clippy_args = vec![
             "--remap-path-prefix",

--- a/src/tools/miri/cargo-miri/src/phases.rs
+++ b/src/tools/miri/cargo-miri/src/phases.rs
@@ -49,7 +49,7 @@ fn show_help() {
 
 fn show_version() {
     print!("miri {}", env!("CARGO_PKG_VERSION"));
-    let version = format!("{} {}", env!("GIT_HASH"), env!("COMMIT_DATE"));
+    let version = concat!(env!("GIT_HASH"), " ", env!("COMMIT_DATE"));
     if version.len() > 1 {
         // If there is actually something here, print it.
         print!(" ({version})");

--- a/src/tools/rustfmt/src/config/mod.rs
+++ b/src/tools/rustfmt/src/config/mod.rs
@@ -713,7 +713,7 @@ mod test {
 
     #[test]
     fn test_dump_default_config() {
-        let default_config = format!(
+        let default_config = concat!(
             r#"max_width = 100
 hard_tabs = false
 tab_spaces = 4
@@ -784,7 +784,9 @@ use_field_init_shorthand = false
 force_explicit_abi = true
 condense_wildcard_suffixes = false
 color = "Auto"
-required_version = "{}"
+required_version = ""#,
+            env!("CARGO_PKG_VERSION"),
+            r#""
 unstable_features = false
 disable_all_formatting = false
 skip_children = false
@@ -795,7 +797,6 @@ ignore = []
 emit_mode = "Files"
 make_backup = false
 "#,
-            env!("CARGO_PKG_VERSION")
         );
         let toml = Config::default().all_options().to_toml().unwrap();
         assert_eq!(&toml, &default_config);
@@ -803,7 +804,7 @@ make_backup = false
 
     #[test]
     fn test_dump_style_edition_2024_config() {
-        let edition_2024_config = format!(
+        let edition_2024_config = concat!(
             r#"max_width = 100
 hard_tabs = false
 tab_spaces = 4
@@ -874,7 +875,9 @@ use_field_init_shorthand = false
 force_explicit_abi = true
 condense_wildcard_suffixes = false
 color = "Auto"
-required_version = "{}"
+required_version = ""#,
+            env!("CARGO_PKG_VERSION"),
+            r#""
 unstable_features = false
 disable_all_formatting = false
 skip_children = false
@@ -885,7 +888,6 @@ ignore = []
 emit_mode = "Files"
 make_backup = false
 "#,
-            env!("CARGO_PKG_VERSION")
         );
         let toml = Config::default_with_style_edition(StyleEdition::Edition2024)
             .all_options()


### PR DESCRIPTION
Although `format!` macro is very powerful, it introduces overhead of memory allocation on the heap compared to `&str`. Therefore, when `format!` macro is unnecessary, `concat!` is a better choice in terms of performance.