### PR TITLE
Add a new lint that warns for pointers to stack memory

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -138,6 +138,8 @@ lint_builtin_overridden_symbol_name =
 lint_builtin_overridden_symbol_section =
     the program's behavior with overridden link sections on items is unpredictable and Rust cannot provide guarantees when you manually override them
 
+lint_builtin_returning_pointers_to_local_variables = returning a pointer to stack memory associated with a local variable
+
 lint_builtin_special_module_name_used_lib = found module declaration for lib.rs
     .note = lib.rs is the root of this crate's library target
     .help = to refer to it from other targets, use the library's name as the path

--- a/compiler/rustc_lint/src/lib.rs
+++ b/compiler/rustc_lint/src/lib.rs
@@ -243,6 +243,7 @@ late_lint_methods!(
             IfLetRescope: IfLetRescope::default(),
             StaticMutRefs: StaticMutRefs,
             UnqualifiedLocalImports: UnqualifiedLocalImports,
+            ReturningPointersToLocalVariables : ReturningPointersToLocalVariables,
         ]
     ]
 );

--- a/compiler/rustc_lint/src/lints.rs
+++ b/compiler/rustc_lint/src/lints.rs
@@ -529,6 +529,10 @@ pub(crate) enum BuiltinSpecialModuleNameUsed {
     Main,
 }
 
+#[derive(LintDiagnostic)]
+#[diag(lint_builtin_returning_pointers_to_local_variables)]
+pub(crate) struct BuiltinReturningPointersToLocalVariables;
+
 // deref_into_dyn_supertrait.rs
 #[derive(LintDiagnostic)]
 #[diag(lint_supertrait_as_deref_target)]

--- a/src/tools/miri/tests/fail/validity/dangling_ref3.rs
+++ b/src/tools/miri/tests/fail/validity/dangling_ref3.rs
@@ -1,5 +1,6 @@
 // Make sure we catch this even without Stacked Borrows
 //@compile-flags: -Zmiri-disable-stacked-borrows
+#![allow(returning_pointers_to_local_variables)]
 use std::mem;
 
 fn dangling() -> *const u8 {

--- a/tests/ui/lint/lint-returning-pointers-to-local-variables.rs
+++ b/tests/ui/lint/lint-returning-pointers-to-local-variables.rs
@@ -1,0 +1,52 @@
+//@ check-pass
+
+#![warn(returning_pointers_to_local_variables)]
+
+fn foo() -> *const u32 {
+    let empty = 42u32;
+    return &empty as *const _;
+    //~^ WARN returning a pointer to stack memory associated with a local variable
+}
+
+fn bar() -> *const u32 {
+    let empty = 42u32;
+    &empty as *const _
+    //~^ WARN returning a pointer to stack memory associated with a local variable
+}
+
+fn baz() -> *const u32 {
+    let empty = 42u32;
+    return &empty;
+    //~^ WARN returning a pointer to stack memory associated with a local variable
+}
+
+fn faa() -> *const u32 {
+    let empty = 42u32;
+    &empty
+    //~^ WARN returning a pointer to stack memory associated with a local variable
+}
+
+fn pointer_to_pointer() -> *const *mut u32 {
+    let mut empty = 42u32;
+    &(&mut empty as *mut u32) as *const _
+    //~^ WARN returning a pointer to stack memory associated with a local variable
+}
+
+fn dont_lint_unit() -> *const () {
+    let foo = ();
+    &foo as *const _
+}
+
+fn dont_lint_param(val: u32) -> *const u32 {
+    &val
+}
+
+struct Foo {}
+
+impl Foo {
+    fn dont_lint_self_param(&self) -> *const Foo {
+        self
+    }
+}
+
+fn main() {}

--- a/tests/ui/lint/lint-returning-pointers-to-local-variables.stderr
+++ b/tests/ui/lint/lint-returning-pointers-to-local-variables.stderr
@@ -1,0 +1,38 @@
+warning: returning a pointer to stack memory associated with a local variable
+  --> $DIR/lint-returning-pointers-to-local-variables.rs:7:13
+   |
+LL |     return &empty as *const _;
+   |             ^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/lint-returning-pointers-to-local-variables.rs:3:9
+   |
+LL | #![warn(returning_pointers_to_local_variables)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: returning a pointer to stack memory associated with a local variable
+  --> $DIR/lint-returning-pointers-to-local-variables.rs:13:6
+   |
+LL |     &empty as *const _
+   |      ^^^^^
+
+warning: returning a pointer to stack memory associated with a local variable
+  --> $DIR/lint-returning-pointers-to-local-variables.rs:19:13
+   |
+LL |     return &empty;
+   |             ^^^^^
+
+warning: returning a pointer to stack memory associated with a local variable
+  --> $DIR/lint-returning-pointers-to-local-variables.rs:25:6
+   |
+LL |     &empty
+   |      ^^^^^
+
+warning: returning a pointer to stack memory associated with a local variable
+  --> $DIR/lint-returning-pointers-to-local-variables.rs:31:12
+   |
+LL |     &(&mut empty as *mut u32) as *const _
+   |            ^^^^^
+
+warning: 5 warnings emitted
+


### PR DESCRIPTION
This adds a new lint with level `Warn` to check for code like:

```rust
fn foo() -> *const i32 {
  let x = 42;
  &x
}
```

and produce a warning like:
```text
error: returning a pointer to stack memory associated with a local variable
  --> <source>:12:5
   |
 LL|  &x
   |  ^^
```
This fixes #134215.

