### PR TITLE
Change mutation of non-mutable locals from an error to a lint

### DIFF
--- a/compiler/rustc_borrowck/messages.ftl
+++ b/compiler/rustc_borrowck/messages.ftl
@@ -273,9 +273,6 @@ borrowck_var_does_not_need_mut =
     variable does not need to be mutable
     .suggestion = remove this `mut`
 
-borrowck_var_needs_mut = 
-    variable should be marked mutable
-
 borrowck_var_first_borrow_by_use_place_in_closure =
     first borrow occurs due to use of {$place} in closure
 

--- a/compiler/rustc_borrowck/messages.ftl
+++ b/compiler/rustc_borrowck/messages.ftl
@@ -273,6 +273,9 @@ borrowck_var_does_not_need_mut =
     variable does not need to be mutable
     .suggestion = remove this `mut`
 
+borrowck_var_needs_mut = 
+    variable should be marked mutable
+
 borrowck_var_first_borrow_by_use_place_in_closure =
     first borrow occurs due to use of {$place} in closure
 

--- a/compiler/rustc_borrowck/src/borrowck_errors.rs
+++ b/compiler/rustc_borrowck/src/borrowck_errors.rs
@@ -68,7 +68,9 @@ impl BorrowckDiag for BWarn {
     fn struct_span_diag<'a>(cx: DiagCtxtHandle<'a>, span: impl Into<MultiSpan>, msg: impl Into<DiagMessage>)
         -> Diag<'a, Self::Guarantee>
     {
-        cx.struct_span_warn(span, msg)
+        let mut ret = cx.struct_span_warn(span, msg);
+        ret.is_lint("mut_non_mut".into(), false); // note: just a placeholder so we can detect it later
+        ret
     }
 
     fn buffer_error<'infcx>(cx: &mut crate::MirBorrowckCtxt<'_, 'infcx, '_>, err: Diag<'infcx, Self::Guarantee>){
@@ -342,7 +344,9 @@ impl<'infcx, 'tcx> crate::MirBorrowckCtxt<'_, 'infcx, 'tcx> {
         is_arg: bool,
     ) -> Diag<'infcx, ()> {
         let msg = if is_arg { "to immutable argument" } else { "twice to immutable variable" };
-        struct_span_code_warn!(self.dcx(), span, E0384, "cannot assign {} {}", msg, desc)
+        let mut ret = struct_span_code_warn!(self.dcx(), span, E0384, "cannot assign {} {}", msg, desc);
+        ret.is_lint("mut_non_mut".into(), false); // note: just a placeholder so we can detect it later
+        ret
     }
 
     pub(crate) fn cannot_assign<T: BorrowckDiag>(&self, span: Span, desc: &str) -> Diag<'infcx, T::Guarantee> {

--- a/compiler/rustc_borrowck/src/borrowck_errors.rs
+++ b/compiler/rustc_borrowck/src/borrowck_errors.rs
@@ -56,6 +56,33 @@ impl BorrowckDiag for BError {
     }
 }
 
+pub(crate) struct BWarn;
+impl BorrowckDiag for BWarn {
+    type Guarantee = ();
+    fn take_existing<'infcx>(cx: &mut crate::MirBorrowckCtxt<'_, 'infcx, '_>, span: Span)
+        -> Option<(Diag<'infcx, Self::Guarantee>, usize)>
+    {
+        cx.get_buffered_mut_non_error(span)
+    }
+
+    fn struct_span_diag<'a>(cx: DiagCtxtHandle<'a>, span: impl Into<MultiSpan>, msg: impl Into<DiagMessage>)
+        -> Diag<'a, Self::Guarantee>
+    {
+        cx.struct_span_warn(span, msg)
+    }
+
+    fn buffer_error<'infcx>(cx: &mut crate::MirBorrowckCtxt<'_, 'infcx, '_>, err: Diag<'infcx, Self::Guarantee>){
+        cx.buffer_non_error(err);
+    }
+
+    fn buffer_mut_error<'infcx>(
+        cx: &mut crate::MirBorrowckCtxt<'_, 'infcx, '_>,
+        span: Span, diag: Diag<'infcx, Self::Guarantee>, count: usize)
+    {
+        cx.buffer_mut_non_error(span, diag, count);
+    }
+}
+
 #[macro_export]
 macro_rules! struct_span_code_diag {
     ($t:ty, $dcx:expr, $span:expr, $code:expr, $($message:tt)*) => ({

--- a/compiler/rustc_borrowck/src/diagnostics/mod.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mod.rs
@@ -1,7 +1,7 @@
 //! Borrow checker diagnostics.
 
 use rustc_abi::{FieldIdx, VariantIdx};
-use rustc_errors::{Applicability, Diag, MultiSpan};
+use rustc_errors::{Applicability, Diag, EmissionGuarantee, MultiSpan};
 use rustc_hir::def::{CtorKind, Namespace};
 use rustc_hir::{self as hir, CoroutineKind, LangItem};
 use rustc_index::IndexSlice;
@@ -626,9 +626,9 @@ impl UseSpans<'_> {
 
     /// Add a subdiagnostic to the use of the captured variable, if it exists.
     #[allow(rustc::diagnostic_outside_of_impl)]
-    pub(super) fn var_subdiag(
+    pub(super) fn var_subdiag<G: EmissionGuarantee>(
         self,
-        err: &mut Diag<'_>,
+        err: &mut Diag<'_, G>,
         kind: Option<rustc_middle::mir::BorrowKind>,
         f: impl FnOnce(hir::ClosureKind, Span) -> CaptureVarCause,
     ) {

--- a/compiler/rustc_borrowck/src/session_diagnostics.rs
+++ b/compiler/rustc_borrowck/src/session_diagnostics.rs
@@ -53,14 +53,6 @@ pub(crate) struct VarNeedNotMut {
     #[suggestion(style = "short", applicability = "machine-applicable", code = "")]
     pub span: Span,
 }
-
-#[derive(LintDiagnostic)]
-#[diag(borrowck_var_needs_mut)]
-pub(crate) struct VarNeedsMut {
-    //#[suggestion(style = "short", applicability = "machine-applicable", code = "mut")]
-    //pub span: Span,
-}
-
 #[derive(Diagnostic)]
 #[diag(borrowck_var_cannot_escape_closure)]
 #[note]

--- a/compiler/rustc_borrowck/src/session_diagnostics.rs
+++ b/compiler/rustc_borrowck/src/session_diagnostics.rs
@@ -53,6 +53,14 @@ pub(crate) struct VarNeedNotMut {
     #[suggestion(style = "short", applicability = "machine-applicable", code = "")]
     pub span: Span,
 }
+
+#[derive(LintDiagnostic)]
+#[diag(borrowck_var_needs_mut)]
+pub(crate) struct VarNeedsMut {
+    //#[suggestion(style = "short", applicability = "machine-applicable", code = "mut")]
+    //pub span: Span,
+}
+
 #[derive(Diagnostic)]
 #[diag(borrowck_var_cannot_escape_closure)]
 #[note]

--- a/compiler/rustc_errors/src/diagnostic.rs
+++ b/compiler/rustc_errors/src/diagnostic.rs
@@ -1397,3 +1397,10 @@ macro_rules! struct_span_code_err {
         $dcx.struct_span_err($span, format!($($message)*)).with_code($code)
     })
 }
+
+#[macro_export]
+macro_rules! struct_span_code_warn {
+    ($dcx:expr, $span:expr, $code:expr, $($message:tt)*) => ({
+        $dcx.struct_span_warn($span, format!($($message)*)).with_code($code)
+    })
+}

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1647,6 +1647,26 @@ declare_lint! {
 }
 
 declare_lint! {
+    /// The `mut_non_mut` lint warns when mutating a non-mut variable
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// let x = 5;
+    /// x = 6;
+    /// ```
+    ///
+    /// {{produces}}
+    ///
+    /// ### Explanation
+    ///
+    /// The `mut` keyword helps the reader to know that a variable may be mutated.
+    pub MUT_NON_MUT,
+    Warn,
+    "mutation of a variable which was not declared with `mut`"
+}
+
+declare_lint! {
     /// The `rust_2024_incompatible_pat` lint
     /// detects patterns whose meaning will change in the Rust 2024 edition.
     ///

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -68,6 +68,7 @@ declare_lint_pass! {
         MISSING_FRAGMENT_SPECIFIER,
         MISSING_UNSAFE_ON_EXTERN,
         MUST_NOT_SUSPEND,
+        MUT_NON_MUT,
         NAMED_ARGUMENTS_USED_POSITIONALLY,
         NEVER_TYPE_FALLBACK_FLOWING_INTO_UNSAFE,
         NON_CONTIGUOUS_RANGE_ENDPOINTS,
@@ -1647,7 +1648,7 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `mut_non_mut` lint warns when mutating a non-mut variable
+    /// The `mut_non_mut` lint warns when mutating a non-mut binding
     ///
     /// ### Example
     ///
@@ -1660,10 +1661,11 @@ declare_lint! {
     ///
     /// ### Explanation
     ///
-    /// The `mut` keyword helps the reader to know that a variable may be mutated.
+    /// The `mut` keyword helps the reader to know that a binding may be mutated.  Its
+    /// absence may indicate that the mutation was accidental.
     pub MUT_NON_MUT,
     Warn,
-    "mutation of a variable which was not declared with `mut`"
+    "mutation or mutable borrow of a binding which was not declared with `mut`"
 }
 
 declare_lint! {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/suggestions.rs
@@ -3707,10 +3707,10 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
         }
     }
 
-    pub fn suggest_derive(
+    pub fn suggest_derive<G: EmissionGuarantee>(
         &self,
         obligation: &PredicateObligation<'tcx>,
-        err: &mut Diag<'_>,
+        err: &mut Diag<'_, G>,
         trait_pred: ty::PolyTraitPredicate<'tcx>,
     ) {
         if trait_pred.polarity() == ty::PredicatePolarity::Negative {

--- a/tests/ui/asm/x86_64/type-check-2.rs
+++ b/tests/ui/asm/x86_64/type-check-2.rs
@@ -22,7 +22,7 @@ fn main() {
         // Outputs require mutable places
 
         let v: Vec<u64> = vec![0, 1, 2];
-        //~^ ERROR is not declared as mutable
+        //~^ WARNING is not declared as mutable
         asm!("{}", in(reg) v[0]);
         asm!("{}", out(reg) v[0]);
         asm!("{}", inout(reg) v[0]);

--- a/tests/ui/asm/x86_64/type-check-2.stderr
+++ b/tests/ui/asm/x86_64/type-check-2.stderr
@@ -81,7 +81,7 @@ help: consider assigning a value
 LL |         let mut y: u64 = 42;
    |                        ++++
 
-error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
   --> $DIR/type-check-2.rs:24:13
    |
 LL |         let v: Vec<u64> = vec![0, 1, 2];
@@ -92,12 +92,13 @@ LL |         asm!("{}", out(reg) v[0]);
 LL |         asm!("{}", inout(reg) v[0]);
    |                               - cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |         let mut v: Vec<u64> = vec![0, 1, 2];
    |             +++
 
-error: aborting due to 10 previous errors
+error: aborting due to 9 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0381, E0596.
 For more information about an error, try `rustc --explain E0381`.

--- a/tests/ui/asm/x86_64/type-check-5.rs
+++ b/tests/ui/asm/x86_64/type-check-5.rs
@@ -19,7 +19,7 @@ fn main() {
         // Outputs require mutable places
 
         let v: Vec<u64> = vec![0, 1, 2];
-        //~^ ERROR cannot borrow `v` as mutable, as it is not declared as mutable
+        //~^ WARNING cannot borrow `v` as mutable, as it is not declared as mutable
         asm!("{}", in(reg) v[0]);
         asm!("{}", out(reg) v[0]);
         asm!("{}", inout(reg) v[0]);

--- a/tests/ui/asm/x86_64/type-check-5.stderr
+++ b/tests/ui/asm/x86_64/type-check-5.stderr
@@ -24,7 +24,7 @@ help: consider assigning a value
 LL |         let mut y: u64 = 42;
    |                        ++++
 
-error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
   --> $DIR/type-check-5.rs:21:13
    |
 LL |         let v: Vec<u64> = vec![0, 1, 2];
@@ -35,12 +35,13 @@ LL |         asm!("{}", out(reg) v[0]);
 LL |         asm!("{}", inout(reg) v[0]);
    |                               - cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |         let mut v: Vec<u64> = vec![0, 1, 2];
    |             +++
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0381, E0596.
 For more information about an error, try `rustc --explain E0381`.

--- a/tests/ui/assign-imm-local-twice.rs
+++ b/tests/ui/assign-imm-local-twice.rs
@@ -1,11 +1,13 @@
+//@ check-pass
 fn test() {
     let v: isize;
     //~^ HELP consider making this binding mutable
     //~| SUGGESTION mut
     v = 1; //~ NOTE first assignment
     println!("v={}", v);
-    v = 2; //~ ERROR cannot assign twice to immutable variable
+    v = 2; //~ WARNING cannot assign twice to immutable variable
            //~| NOTE cannot assign twice to immutable
+           //~| NOTE on by default
     println!("v={}", v);
 }
 

--- a/tests/ui/assign-imm-local-twice.stderr
+++ b/tests/ui/assign-imm-local-twice.stderr
@@ -1,5 +1,5 @@
-error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/assign-imm-local-twice.rs:7:5
+warning[E0384]: cannot assign twice to immutable variable `v`
+  --> $DIR/assign-imm-local-twice.rs:8:5
    |
 LL |     v = 1;
    |     ----- first assignment to `v`
@@ -7,11 +7,12 @@ LL |     println!("v={}", v);
 LL |     v = 2;
    |     ^^^^^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     let mut v: isize;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/async-await/issue-61452.rs
+++ b/tests/ui/async-await/issue-61452.rs
@@ -1,13 +1,14 @@
+//@ check-pass
 //@ edition:2018
 
 pub async fn f(x: Option<usize>) {
     x.take();
-    //~^ ERROR cannot borrow `x` as mutable, as it is not declared as mutable [E0596]
+    //~^ WARNING cannot borrow `x` as mutable, as it is not declared as mutable [E0596]
 }
 
 pub async fn g(x: usize) {
     x += 1;
-    //~^ ERROR cannot assign twice to immutable variable `x` [E0384]
+    //~^ WARNING cannot assign twice to immutable variable `x` [E0384]
 }
 
 fn main() {}

--- a/tests/ui/async-await/issue-61452.stderr
+++ b/tests/ui/async-await/issue-61452.stderr
@@ -1,16 +1,17 @@
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/issue-61452.rs:4:5
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/issue-61452.rs:5:5
    |
 LL |     x.take();
    |     ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | pub async fn f(mut x: Option<usize>) {
    |                +++
 
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/issue-61452.rs:9:5
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/issue-61452.rs:10:5
    |
 LL | pub async fn g(x: usize) {
    |                - first assignment to `x`
@@ -22,7 +23,7 @@ help: consider making this binding mutable
 LL | pub async fn g(mut x: usize) {
    |                +++
 
-error: aborting due to 2 previous errors
+warning: 2 warnings emitted
 
 Some errors have detailed explanations: E0384, E0596.
 For more information about an error, try `rustc --explain E0384`.

--- a/tests/ui/async-await/issues/issue-61187.rs
+++ b/tests/ui/async-await/issues/issue-61187.rs
@@ -1,7 +1,8 @@
+//@ check-pass
 //@ edition:2018
 
 fn main() {}
 
 async fn response(data: Vec<u8>) {
-    data.reverse(); //~ ERROR E0596
+    data.reverse(); //~ WARNING E0596
 }

--- a/tests/ui/async-await/issues/issue-61187.stderr
+++ b/tests/ui/async-await/issues/issue-61187.stderr
@@ -1,14 +1,15 @@
-error[E0596]: cannot borrow `data` as mutable, as it is not declared as mutable
-  --> $DIR/issue-61187.rs:6:5
+warning[E0596]: cannot borrow `data` as mutable, as it is not declared as mutable
+  --> $DIR/issue-61187.rs:7:5
    |
 LL |     data.reverse();
    |     ^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | async fn response(mut data: Vec<u8>) {
    |                   +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/augmented-assignments.rs
+++ b/tests/ui/augmented-assignments.rs
@@ -21,8 +21,9 @@ fn main() {
     let y = Int(2);
     //~^ HELP consider changing this to be mutable
     //~| SUGGESTION mut
-    y   //~ ERROR cannot borrow `y` as mutable, as it is not declared as mutable
+    y   //~ WARNING cannot borrow `y` as mutable, as it is not declared as mutable
         //~| cannot borrow as mutable
+        //~| on by default
     +=
     Int(1);
 }

--- a/tests/ui/augmented-assignments.stderr
+++ b/tests/ui/augmented-assignments.stderr
@@ -9,18 +9,19 @@ LL |     x
 LL |     x;
    |     ^ move out of `x` occurs here
 
-error[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
   --> $DIR/augmented-assignments.rs:24:5
    |
 LL |     y
    |     ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut y = Int(2);
    |         +++
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error; 1 warning emitted
 
 Some errors have detailed explanations: E0505, E0596.
 For more information about an error, try `rustc --explain E0505`.

--- a/tests/ui/borrowck/borrow-raw-address-of-mutability.rs
+++ b/tests/ui/borrowck/borrow-raw-address-of-mutability.rs
@@ -1,12 +1,12 @@
 fn mutable_address_of() {
     let x = 0;
-    let y = &raw mut x;                 //~ ERROR cannot borrow
+    let y = &raw mut x;                 //~ WARNING cannot borrow
 }
 
 fn mutable_address_of_closure() {
     let x = 0;
     let mut f = || {
-        let y = &raw mut x;             //~ ERROR cannot borrow
+        let y = &raw mut x;             //~ WARNING cannot borrow
     };
     f();
 }
@@ -16,7 +16,7 @@ fn mutable_address_of_imm_closure() {
     let f = || {
         let y = &raw mut x;
     };
-    f();                                //~ ERROR cannot borrow
+    f();                                //~ WARNING cannot borrow
 }
 
 fn make_fn<F: Fn()>(f: F) -> F { f }

--- a/tests/ui/borrowck/borrow-raw-address-of-mutability.stderr
+++ b/tests/ui/borrowck/borrow-raw-address-of-mutability.stderr
@@ -1,15 +1,16 @@
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrow-raw-address-of-mutability.rs:3:13
    |
 LL |     let y = &raw mut x;
    |             ^^^^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x = 0;
    |         +++
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrow-raw-address-of-mutability.rs:9:17
    |
 LL |         let y = &raw mut x;
@@ -20,7 +21,7 @@ help: consider changing this to be mutable
 LL |     let mut x = 0;
    |         +++
 
-error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
   --> $DIR/borrow-raw-address-of-mutability.rs:19:5
    |
 LL |         let y = &raw mut x;
@@ -60,6 +61,6 @@ LL |     let f = make_fn(move || {
 LL |         let y = &raw mut x;
    |                 ^^^^^^^^^^ cannot borrow as mutable
 
-error: aborting due to 5 previous errors
+error: aborting due to 2 previous errors; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/borrowck-access-permissions.rs
+++ b/tests/ui/borrowck/borrowck-access-permissions.rs
@@ -7,7 +7,7 @@ fn main() {
 
     {
         // borrow of local
-        let _y1 = &mut x; //~ ERROR [E0596]
+        let _y1 = &mut x; //~ WARNING [E0596]
         let _y2 = &mut x_mut; // No error
     }
 
@@ -24,7 +24,7 @@ fn main() {
         let box_x = Box::new(1);
         let mut box_x_mut = Box::new(1);
 
-        let _y1 = &mut *box_x; //~ ERROR [E0596]
+        let _y1 = &mut *box_x; //~ WARNING [E0596]
         let _y2 = &mut *box_x_mut; // No error
     }
 

--- a/tests/ui/borrowck/borrowck-access-permissions.stderr
+++ b/tests/ui/borrowck/borrowck-access-permissions.stderr
@@ -1,9 +1,10 @@
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-access-permissions.rs:10:19
    |
 LL |         let _y1 = &mut x;
    |                   ^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x = 1;
@@ -15,7 +16,7 @@ error[E0596]: cannot borrow immutable static item `static_x` as mutable
 LL |         let _y1 = &mut static_x;
    |                   ^^^^^^^^^^^^^ cannot borrow as mutable
 
-error[E0596]: cannot borrow `*box_x` as mutable, as `box_x` is not declared as mutable
+warning[E0596]: cannot borrow `*box_x` as mutable, as `box_x` is not declared as mutable
   --> $DIR/borrowck-access-permissions.rs:27:19
    |
 LL |         let _y1 = &mut *box_x;
@@ -59,6 +60,6 @@ help: consider changing this to be a mutable reference
 LL |         let foo_ref = &mut foo;
    |                        +++
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/borrowck-argument.rs
+++ b/tests/ui/borrowck/borrowck-argument.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 #[derive(Copy, Clone)]
 struct S;
 
@@ -7,18 +8,18 @@ impl S {
 }
 
 fn func(arg: S) {
-    arg.mutate(); //~ ERROR: cannot borrow `arg` as mutable, as it is not declared as mutable
+    arg.mutate(); //~ WARNING: cannot borrow `arg` as mutable, as it is not declared as mutable
 }
 
 impl S {
     fn method(&self, arg: S) {
-        arg.mutate(); //~ ERROR: cannot borrow `arg` as mutable, as it is not declared as mutable
+        arg.mutate(); //~ WARNING: cannot borrow `arg` as mutable, as it is not declared as mutable
     }
 }
 
 trait T {
     fn default(&self, arg: S) {
-        arg.mutate(); //~ ERROR: cannot borrow `arg` as mutable, as it is not declared as mutable
+        arg.mutate(); //~ WARNING: cannot borrow `arg` as mutable, as it is not declared as mutable
     }
 }
 
@@ -30,5 +31,5 @@ fn main() {
     s.method(s);
     s.default(s);
     (|arg: S| { arg.mutate() })(s);
-    //~^ ERROR: cannot borrow `arg` as mutable, as it is not declared as mutable
+    //~^ WARNING: cannot borrow `arg` as mutable, as it is not declared as mutable
 }

--- a/tests/ui/borrowck/borrowck-argument.stderr
+++ b/tests/ui/borrowck/borrowck-argument.stderr
@@ -1,16 +1,17 @@
-error[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
-  --> $DIR/borrowck-argument.rs:10:5
+warning[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
+  --> $DIR/borrowck-argument.rs:11:5
    |
 LL |     arg.mutate();
    |     ^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn func(mut arg: S) {
    |         +++
 
-error[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
-  --> $DIR/borrowck-argument.rs:15:9
+warning[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
+  --> $DIR/borrowck-argument.rs:16:9
    |
 LL |         arg.mutate();
    |         ^^^ cannot borrow as mutable
@@ -20,8 +21,8 @@ help: consider changing this to be mutable
 LL |     fn method(&self, mut arg: S) {
    |                      +++
 
-error[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
-  --> $DIR/borrowck-argument.rs:21:9
+warning[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
+  --> $DIR/borrowck-argument.rs:22:9
    |
 LL |         arg.mutate();
    |         ^^^ cannot borrow as mutable
@@ -31,8 +32,8 @@ help: consider changing this to be mutable
 LL |     fn default(&self, mut arg: S) {
    |                       +++
 
-error[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
-  --> $DIR/borrowck-argument.rs:32:17
+warning[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
+  --> $DIR/borrowck-argument.rs:33:17
    |
 LL |     (|arg: S| { arg.mutate() })(s);
    |                 ^^^ cannot borrow as mutable
@@ -42,6 +43,6 @@ help: consider changing this to be mutable
 LL |     (|mut arg: S| { arg.mutate() })(s);
    |       +++
 
-error: aborting due to 4 previous errors
+warning: 4 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/borrowck-auto-mut-ref-to-immut-var.rs
+++ b/tests/ui/borrowck/borrowck-auto-mut-ref-to-immut-var.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 // Tests that auto-ref can't create mutable aliases to immutable memory.
 
 struct Foo {
@@ -12,5 +13,5 @@ impl Foo {
 
 fn main() {
     let x = Foo { x: 3 };
-    x.printme();    //~ ERROR cannot borrow
+    x.printme();    //~ WARNING cannot borrow
 }

--- a/tests/ui/borrowck/borrowck-auto-mut-ref-to-immut-var.stderr
+++ b/tests/ui/borrowck/borrowck-auto-mut-ref-to-immut-var.stderr
@@ -1,14 +1,15 @@
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/borrowck-auto-mut-ref-to-immut-var.rs:15:5
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/borrowck-auto-mut-ref-to-immut-var.rs:16:5
    |
 LL |     x.printme();
    |     ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x = Foo { x: 3 };
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/borrowck-borrow-from-owned-ptr.rs
+++ b/tests/ui/borrowck/borrowck-borrow-from-owned-ptr.rs
@@ -119,7 +119,7 @@ fn borrow_mut_and_imm() {
 
 fn borrow_mut_from_imm() {
     let foo = make_foo();
-    let bar1 = &mut foo.bar1; //~ ERROR cannot borrow
+    let bar1 = &mut foo.bar1; //~ WARNING cannot borrow
     *bar1;
 }
 

--- a/tests/ui/borrowck/borrowck-borrow-from-owned-ptr.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-from-owned-ptr.stderr
@@ -102,18 +102,19 @@ LL |     let _foo2 = &mut *foo;
 LL |     *bar1;
    |     ----- immutable borrow later used here
 
-error[E0596]: cannot borrow `foo.bar1` as mutable, as `foo` is not declared as mutable
+warning[E0596]: cannot borrow `foo.bar1` as mutable, as `foo` is not declared as mutable
   --> $DIR/borrowck-borrow-from-owned-ptr.rs:122:16
    |
 LL |     let bar1 = &mut foo.bar1;
    |                ^^^^^^^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut foo = make_foo();
    |         +++
 
-error: aborting due to 11 previous errors
+error: aborting due to 10 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0499, E0502, E0596.
 For more information about an error, try `rustc --explain E0499`.

--- a/tests/ui/borrowck/borrowck-borrow-from-stack-variable.rs
+++ b/tests/ui/borrowck/borrowck-borrow-from-stack-variable.rs
@@ -117,7 +117,7 @@ fn borrow_mut_and_imm() {
 
 fn borrow_mut_from_imm() {
     let foo = make_foo();
-    let bar1 = &mut foo.bar1; //~ ERROR cannot borrow
+    let bar1 = &mut foo.bar1; //~ WARNING cannot borrow
     *bar1;
 }
 

--- a/tests/ui/borrowck/borrowck-borrow-from-stack-variable.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-from-stack-variable.stderr
@@ -102,18 +102,19 @@ LL |     let _foo2 = &mut foo;
 LL |     *bar1;
    |     ----- immutable borrow later used here
 
-error[E0596]: cannot borrow `foo.bar1` as mutable, as `foo` is not declared as mutable
+warning[E0596]: cannot borrow `foo.bar1` as mutable, as `foo` is not declared as mutable
   --> $DIR/borrowck-borrow-from-stack-variable.rs:120:16
    |
 LL |     let bar1 = &mut foo.bar1;
    |                ^^^^^^^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut foo = make_foo();
    |         +++
 
-error: aborting due to 11 previous errors
+error: aborting due to 10 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0499, E0502, E0596.
 For more information about an error, try `rustc --explain E0499`.

--- a/tests/ui/borrowck/borrowck-borrow-immut-deref-of-box-as-mut.rs
+++ b/tests/ui/borrowck/borrowck-borrow-immut-deref-of-box-as-mut.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 struct A;
 
 impl A {
@@ -10,5 +11,5 @@ impl A {
 pub fn main() {
     let a: Box<_> = Box::new(A);
     a.foo();
-    //~^ ERROR cannot borrow `*a` as mutable, as `a` is not declared as mutable [E0596]
+    //~^ WARNING cannot borrow `*a` as mutable, as `a` is not declared as mutable [E0596]
 }

--- a/tests/ui/borrowck/borrowck-borrow-immut-deref-of-box-as-mut.stderr
+++ b/tests/ui/borrowck/borrowck-borrow-immut-deref-of-box-as-mut.stderr
@@ -1,14 +1,15 @@
-error[E0596]: cannot borrow `*a` as mutable, as `a` is not declared as mutable
-  --> $DIR/borrowck-borrow-immut-deref-of-box-as-mut.rs:12:5
+warning[E0596]: cannot borrow `*a` as mutable, as `a` is not declared as mutable
+  --> $DIR/borrowck-borrow-immut-deref-of-box-as-mut.rs:13:5
    |
 LL |     a.foo();
    |     ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut a: Box<_> = Box::new(A);
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/borrowck-closures-unique.rs
+++ b/tests/ui/borrowck/borrowck-closures-unique.rs
@@ -41,7 +41,7 @@ fn d(x: &mut isize) {
 
 fn e(x: &'static mut isize) {
     let c1 = |y: &'static mut isize| x = y;
-    //~^ ERROR cannot assign to `x`, as it is not declared as mutable
+    //~^ WARNING cannot assign to `x`, as it is not declared as mutable
     c1;
 }
 

--- a/tests/ui/borrowck/borrowck-closures-unique.stderr
+++ b/tests/ui/borrowck/borrowck-closures-unique.stderr
@@ -40,18 +40,19 @@ LL |     let c2 = || set(x);
 LL |     c1;
    |     -- first borrow later used here
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/borrowck-closures-unique.rs:43:38
    |
 LL |     let c1 = |y: &'static mut isize| x = y;
    |                                      ^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn e(mut x: &'static mut isize) {
    |      +++
 
-error: aborting due to 4 previous errors
+error: aborting due to 3 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0500, E0524, E0594.
 For more information about an error, try `rustc --explain E0500`.

--- a/tests/ui/borrowck/borrowck-match-binding-is-assignment.rs
+++ b/tests/ui/borrowck/borrowck-match-binding-is-assignment.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 // Test that immutable pattern bindings cannot be reassigned.
 
 enum E {
@@ -11,31 +12,31 @@ struct S {
 pub fn main() {
     match 1 {
         x => {
-            x += 1; //~ ERROR [E0384]
+            x += 1; //~ WARNING [E0384]
         }
     }
 
     match E::Foo(1) {
         E::Foo(x) => {
-            x += 1; //~ ERROR [E0384]
+            x += 1; //~ WARNING [E0384]
         }
     }
 
     match (S { bar: 1 }) {
         S { bar: x } => {
-            x += 1; //~ ERROR [E0384]
+            x += 1; //~ WARNING [E0384]
         }
     }
 
     match (1,) {
         (x,) => {
-            x += 1; //~ ERROR [E0384]
+            x += 1; //~ WARNING [E0384]
         }
     }
 
     match [1,2,3] {
         [x,_,_] => {
-            x += 1; //~ ERROR [E0384]
+            x += 1; //~ WARNING [E0384]
         }
     }
 }

--- a/tests/ui/borrowck/borrowck-match-binding-is-assignment.stderr
+++ b/tests/ui/borrowck/borrowck-match-binding-is-assignment.stderr
@@ -1,11 +1,12 @@
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-match-binding-is-assignment.rs:14:13
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/borrowck-match-binding-is-assignment.rs:15:13
    |
 LL |         x => {
    |         - first assignment to `x`
 LL |             x += 1;
    |             ^^^^^^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |         mut x => {
@@ -15,8 +16,8 @@ help: to modify the original value, take a borrow instead
 LL |         ref mut x => {
    |         +++++++
 
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-match-binding-is-assignment.rs:20:13
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/borrowck-match-binding-is-assignment.rs:21:13
    |
 LL |         E::Foo(x) => {
    |                - first assignment to `x`
@@ -32,8 +33,8 @@ help: to modify the original value, take a borrow instead
 LL |         E::Foo(ref mut x) => {
    |                +++++++
 
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-match-binding-is-assignment.rs:26:13
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/borrowck-match-binding-is-assignment.rs:27:13
    |
 LL |         S { bar: x } => {
    |                  - first assignment to `x`
@@ -49,8 +50,8 @@ help: to modify the original value, take a borrow instead
 LL |         S { bar: ref mut x } => {
    |                  +++++++
 
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-match-binding-is-assignment.rs:32:13
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/borrowck-match-binding-is-assignment.rs:33:13
    |
 LL |         (x,) => {
    |          - first assignment to `x`
@@ -66,8 +67,8 @@ help: to modify the original value, take a borrow instead
 LL |         (ref mut x,) => {
    |          +++++++
 
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/borrowck-match-binding-is-assignment.rs:38:13
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/borrowck-match-binding-is-assignment.rs:39:13
    |
 LL |         [x,_,_] => {
    |          - first assignment to `x`
@@ -83,6 +84,6 @@ help: to modify the original value, take a borrow instead
 LL |         [ref mut x,_,_] => {
    |          +++++++
 
-error: aborting due to 5 previous errors
+warning: 5 warnings emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/borrowck/borrowck-mut-addr-of-imm-var.rs
+++ b/tests/ui/borrowck/borrowck-mut-addr-of-imm-var.rs
@@ -1,6 +1,7 @@
+//@ check-pass
 fn main() {
     let x: isize = 3;
-    let y: &mut isize = &mut x; //~ ERROR cannot borrow
+    let y: &mut isize = &mut x; //~ WARNING cannot borrow
     *y = 5;
     println!("{}", *y);
 }

--- a/tests/ui/borrowck/borrowck-mut-addr-of-imm-var.stderr
+++ b/tests/ui/borrowck/borrowck-mut-addr-of-imm-var.stderr
@@ -1,14 +1,15 @@
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/borrowck-mut-addr-of-imm-var.rs:3:25
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/borrowck-mut-addr-of-imm-var.rs:4:25
    |
 LL |     let y: &mut isize = &mut x;
    |                         ^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x: isize = 3;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/borrowck-mut-slice-of-imm-vec.rs
+++ b/tests/ui/borrowck/borrowck-mut-slice-of-imm-vec.rs
@@ -1,8 +1,9 @@
+//@ check-pass
 fn write(v: &mut [isize]) {
     v[0] += 1;
 }
 
 fn main() {
     let v = vec![1, 2, 3];
-    write(&mut v); //~ ERROR cannot borrow
+    write(&mut v); //~ WARNING cannot borrow
 }

--- a/tests/ui/borrowck/borrowck-mut-slice-of-imm-vec.stderr
+++ b/tests/ui/borrowck/borrowck-mut-slice-of-imm-vec.stderr
@@ -1,14 +1,15 @@
-error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
-  --> $DIR/borrowck-mut-slice-of-imm-vec.rs:7:11
+warning[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
+  --> $DIR/borrowck-mut-slice-of-imm-vec.rs:8:11
    |
 LL |     write(&mut v);
    |           ^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut v = vec![1, 2, 3];
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/borrowck-overloaded-call.rs
+++ b/tests/ui/borrowck/borrowck-overloaded-call.rs
@@ -64,7 +64,7 @@ fn g() {
         x: 1,
         y: 2,
     };
-    s(3);   //~ ERROR cannot borrow `s` as mutable, as it is not declared as mutable
+    s(3);   //~ WARNING cannot borrow `s` as mutable, as it is not declared as mutable
 }
 
 fn h() {

--- a/tests/ui/borrowck/borrowck-overloaded-call.stderr
+++ b/tests/ui/borrowck/borrowck-overloaded-call.stderr
@@ -8,12 +8,13 @@ LL |     s(3);
 LL |     use_mut(sp);
    |             -- mutable borrow later used here
 
-error[E0596]: cannot borrow `s` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `s` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-overloaded-call.rs:67:5
    |
 LL |     s(3);
    |     ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut s = SFnMut {
@@ -39,7 +40,7 @@ LL | struct SFnOnce {
 LL |     s(" world".to_string());
    |     - you could clone this value
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0382, E0502, E0596.
 For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/borrowck/borrowck-ref-mut-of-imm.rs
+++ b/tests/ui/borrowck/borrowck-ref-mut-of-imm.rs
@@ -1,7 +1,8 @@
+//@ check-pass
 fn destructure(x: Option<isize>) -> isize {
     match x {
       None => 0,
-      Some(ref mut v) => *v //~ ERROR cannot borrow
+      Some(ref mut v) => *v //~ WARNING cannot borrow
     }
 }
 

--- a/tests/ui/borrowck/borrowck-ref-mut-of-imm.stderr
+++ b/tests/ui/borrowck/borrowck-ref-mut-of-imm.stderr
@@ -1,14 +1,15 @@
-error[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
-  --> $DIR/borrowck-ref-mut-of-imm.rs:4:12
+warning[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
+  --> $DIR/borrowck-ref-mut-of-imm.rs:5:12
    |
 LL |       Some(ref mut v) => *v
    |            ^^^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn destructure(mut x: Option<isize>) -> isize {
    |                +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/borrowck-unboxed-closures.rs
+++ b/tests/ui/borrowck/borrowck-unboxed-closures.rs
@@ -4,7 +4,7 @@ fn a<F:Fn(isize, isize) -> isize>(mut f: F) {
     use_mut(g);
 }
 fn b<F:FnMut(isize, isize) -> isize>(f: F) {
-    f(1, 2);    //~ ERROR cannot borrow `f` as mutable, as it is not declared as mutable
+    f(1, 2);    //~ WARNING cannot borrow `f` as mutable, as it is not declared as mutable
 }
 
 fn c<F:FnOnce(isize, isize) -> isize>(f: F) {

--- a/tests/ui/borrowck/borrowck-unboxed-closures.stderr
+++ b/tests/ui/borrowck/borrowck-unboxed-closures.stderr
@@ -8,12 +8,13 @@ LL |     f(1, 2);
 LL |     use_mut(g);
    |             - mutable borrow later used here
 
-error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-unboxed-closures.rs:7:5
    |
 LL |     f(1, 2);
    |     ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn b<F:FnMut(isize, isize) -> isize>(mut f: F) {
@@ -37,7 +38,7 @@ LL | fn c<F:FnOnce(isize, isize) -> isize>(f: F) {
 LL |     f(1, 2);
    |     ------- this value implements `FnOnce`, which causes it to be moved when called
 
-error: aborting due to 3 previous errors
+error: aborting due to 2 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0382, E0502, E0596.
 For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/borrowck/immut-function-arguments.rs
+++ b/tests/ui/borrowck/immut-function-arguments.rs
@@ -1,9 +1,10 @@
+//@ check-pass
 fn f(y: Box<isize>) {
-    *y = 5; //~ ERROR cannot assign
+    *y = 5; //~ WARNING cannot assign
 }
 
 fn g() {
-    let _frob = |q: Box<isize>| { *q = 2; }; //~ ERROR cannot assign
+    let _frob = |q: Box<isize>| { *q = 2; }; //~ WARNING cannot assign
 }
 
 fn main() {}

--- a/tests/ui/borrowck/immut-function-arguments.stderr
+++ b/tests/ui/borrowck/immut-function-arguments.stderr
@@ -1,16 +1,17 @@
-error[E0594]: cannot assign to `*y`, as `y` is not declared as mutable
-  --> $DIR/immut-function-arguments.rs:2:5
+warning[E0594]: cannot assign to `*y`, as `y` is not declared as mutable
+  --> $DIR/immut-function-arguments.rs:3:5
    |
 LL |     *y = 5;
    |     ^^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn f(mut y: Box<isize>) {
    |      +++
 
-error[E0594]: cannot assign to `*q`, as `q` is not declared as mutable
-  --> $DIR/immut-function-arguments.rs:6:35
+warning[E0594]: cannot assign to `*q`, as `q` is not declared as mutable
+  --> $DIR/immut-function-arguments.rs:7:35
    |
 LL |     let _frob = |q: Box<isize>| { *q = 2; };
    |                                   ^^^^^^ cannot assign
@@ -20,6 +21,6 @@ help: consider changing this to be mutable
 LL |     let _frob = |mut q: Box<isize>| { *q = 2; };
    |                  +++
 
-error: aborting due to 2 previous errors
+warning: 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0594`.

--- a/tests/ui/borrowck/immutable-arg.rs
+++ b/tests/ui/borrowck/immutable-arg.rs
@@ -1,6 +1,7 @@
+//@ check-pass
 fn foo(_x: u32) {
     _x = 4;
-    //~^ ERROR cannot assign to immutable argument `_x`
+    //~^ WARNING cannot assign to immutable argument `_x`
 }
 
 fn main() {}

--- a/tests/ui/borrowck/immutable-arg.stderr
+++ b/tests/ui/borrowck/immutable-arg.stderr
@@ -1,14 +1,15 @@
-error[E0384]: cannot assign to immutable argument `_x`
-  --> $DIR/immutable-arg.rs:2:5
+warning[E0384]: cannot assign to immutable argument `_x`
+  --> $DIR/immutable-arg.rs:3:5
    |
 LL |     _x = 4;
    |     ^^^^^^ cannot assign to immutable argument
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL | fn foo(mut _x: u32) {
    |        +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/borrowck/issue-111554.rs
+++ b/tests/ui/borrowck/issue-111554.rs
@@ -3,12 +3,12 @@ struct Foo {}
 impl Foo {
     pub fn foo(&mut self) {
         || bar(&mut self);
-        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable
+        //~^ WARNING cannot borrow `self` as mutable, as it is not declared as mutable
     }
 
     pub fn baz(&self) {
         || bar(&mut self);
-        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable
+        //~^ WARNING cannot borrow `self` as mutable, as it is not declared as mutable
         //~| ERROR cannot borrow data in a `&` reference as mutable
     }
 
@@ -19,7 +19,7 @@ impl Foo {
 
     pub fn quux(self) {
         || bar(&mut self);
-        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable
+        //~^ WARNING cannot borrow `self` as mutable, as it is not declared as mutable
     }
 }
 

--- a/tests/ui/borrowck/issue-111554.stderr
+++ b/tests/ui/borrowck/issue-111554.stderr
@@ -1,10 +1,12 @@
-error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-111554.rs:5:16
    |
 LL |         || bar(&mut self);
    |                ^^^^^^^^^ cannot borrow as mutable
+   |
+   = note: `#[warn(mut_non_mut)]` on by default
 
-error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-111554.rs:10:16
    |
 LL |         || bar(&mut self);
@@ -16,7 +18,7 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
 LL |         || bar(&mut self);
    |                ^^^^^^^^^ cannot borrow as mutable
 
-error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-111554.rs:21:16
    |
 LL |         || bar(&mut self);
@@ -27,6 +29,6 @@ help: consider changing this to be mutable
 LL |     pub fn quux(mut self) {
    |                 +++
 
-error: aborting due to 4 previous errors
+error: aborting due to 1 previous error; 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/issue-33819.rs
+++ b/tests/ui/borrowck/issue-33819.rs
@@ -1,8 +1,9 @@
+//@ check-pass
 fn main() {
     let mut op = Some(2);
     match op {
         Some(ref v) => { let a = &mut v; },
-        //~^ ERROR cannot borrow `v` as mutable, as it is not declared as mutable
+        //~^ WARNING cannot borrow `v` as mutable, as it is not declared as mutable
         //~| HELP try removing `&mut` here
         None => {},
     }

--- a/tests/ui/borrowck/issue-33819.stderr
+++ b/tests/ui/borrowck/issue-33819.stderr
@@ -1,15 +1,16 @@
-error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
-  --> $DIR/issue-33819.rs:4:34
+warning[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
+  --> $DIR/issue-33819.rs:5:34
    |
 LL |         Some(ref v) => { let a = &mut v; },
    |                                  ^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: try removing `&mut` here
    |
 LL -         Some(ref v) => { let a = &mut v; },
 LL +         Some(ref v) => { let a = v; },
    |
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/issue-45199.rs
+++ b/tests/ui/borrowck/issue-45199.rs
@@ -1,23 +1,25 @@
+//@ check-pass
 fn test_drop_replace() {
     let b: Box<isize>;
     //~^ HELP consider making this binding mutable
     //~| SUGGESTION mut
     b = Box::new(1);    //~ NOTE first assignment
-    b = Box::new(2);    //~ ERROR cannot assign twice to immutable variable `b`
+    b = Box::new(2);    //~ WARNING cannot assign twice to immutable variable `b`
                         //~| NOTE cannot assign twice to immutable
+                        //~| NOTE on by default
 }
 
 fn test_call() {
     let b = Box::new(1);    //~ NOTE first assignment
                             //~| HELP consider making this binding mutable
                             //~| SUGGESTION mut
-    b = Box::new(2);        //~ ERROR cannot assign twice to immutable variable `b`
+    b = Box::new(2);        //~ WARNING cannot assign twice to immutable variable `b`
                             //~| NOTE cannot assign twice to immutable
 }
 
 fn test_args(b: Box<i32>) {  //~ HELP consider making this binding mutable
                                 //~| SUGGESTION mut
-    b = Box::new(2);            //~ ERROR cannot assign to immutable argument `b`
+    b = Box::new(2);            //~ WARNING cannot assign to immutable argument `b`
                                 //~| NOTE cannot assign to immutable argument
 }
 

--- a/tests/ui/borrowck/issue-45199.stderr
+++ b/tests/ui/borrowck/issue-45199.stderr
@@ -1,18 +1,19 @@
-error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/issue-45199.rs:6:5
+warning[E0384]: cannot assign twice to immutable variable `b`
+  --> $DIR/issue-45199.rs:7:5
    |
 LL |     b = Box::new(1);
    |     - first assignment to `b`
 LL |     b = Box::new(2);
    |     ^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     let mut b: Box<isize>;
    |         +++
 
-error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/issue-45199.rs:14:5
+warning[E0384]: cannot assign twice to immutable variable `b`
+  --> $DIR/issue-45199.rs:16:5
    |
 LL |     let b = Box::new(1);
    |         - first assignment to `b`
@@ -25,8 +26,8 @@ help: consider making this binding mutable
 LL |     let mut b = Box::new(1);
    |         +++
 
-error[E0384]: cannot assign to immutable argument `b`
-  --> $DIR/issue-45199.rs:20:5
+warning[E0384]: cannot assign to immutable argument `b`
+  --> $DIR/issue-45199.rs:22:5
    |
 LL |     b = Box::new(2);
    |     ^ cannot assign to immutable argument
@@ -36,6 +37,6 @@ help: consider making this binding mutable
 LL | fn test_args(mut b: Box<i32>) {
    |              +++
 
-error: aborting due to 3 previous errors
+warning: 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/borrowck/issue-54499-field-mutation-of-moved-out.rs
+++ b/tests/ui/borrowck/issue-54499-field-mutation-of-moved-out.rs
@@ -12,9 +12,9 @@ fn main() {
         drop(t);
         t.0 = S(1);
         //~^ ERROR assign to part of moved value: `t` [E0382]
-        //~| ERROR cannot assign to `t.0`, as `t` is not declared as mutable [E0594]
+        //~| WARNING cannot assign to `t.0`, as `t` is not declared as mutable [E0594]
         t.1 = 2;
-        //~^ ERROR cannot assign to `t.1`, as `t` is not declared as mutable [E0594]
+        //~^ WARNING cannot assign to `t.1`, as `t` is not declared as mutable [E0594]
         println!("{:?} {:?}", t.0, t.1);
     }
 
@@ -23,9 +23,9 @@ fn main() {
         drop(u);
         u.0 = S(1);
         //~^ ERROR assign to part of moved value: `u` [E0382]
-        //~| ERROR cannot assign to `u.0`, as `u` is not declared as mutable [E0594]
+        //~| WARNING cannot assign to `u.0`, as `u` is not declared as mutable [E0594]
         u.1 = 2;
-        //~^ ERROR cannot assign to `u.1`, as `u` is not declared as mutable [E0594]
+        //~^ WARNING cannot assign to `u.1`, as `u` is not declared as mutable [E0594]
         println!("{:?} {:?}", u.0, u.1);
     }
 
@@ -34,9 +34,9 @@ fn main() {
         drop(v);
         v.x = S(1);
         //~^ ERROR assign to part of moved value: `v` [E0382]
-        //~| ERROR cannot assign to `v.x`, as `v` is not declared as mutable [E0594]
+        //~| WARNING cannot assign to `v.x`, as `v` is not declared as mutable [E0594]
         v.y = 2;
-        //~^ ERROR cannot assign to `v.y`, as `v` is not declared as mutable [E0594]
+        //~^ WARNING cannot assign to `v.y`, as `v` is not declared as mutable [E0594]
         println!("{:?} {:?}", v.x, v.y);
     }
 }

--- a/tests/ui/borrowck/issue-54499-field-mutation-of-moved-out.stderr
+++ b/tests/ui/borrowck/issue-54499-field-mutation-of-moved-out.stderr
@@ -1,9 +1,10 @@
-error[E0594]: cannot assign to `t.0`, as `t` is not declared as mutable
+warning[E0594]: cannot assign to `t.0`, as `t` is not declared as mutable
   --> $DIR/issue-54499-field-mutation-of-moved-out.rs:13:9
    |
 LL |         t.0 = S(1);
    |         ^^^^^^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |         let mut t: Tuple = (S(0), 0);
@@ -19,7 +20,7 @@ LL |         drop(t);
 LL |         t.0 = S(1);
    |         ^^^^^^^^^^ value partially assigned here after move
 
-error[E0594]: cannot assign to `t.1`, as `t` is not declared as mutable
+warning[E0594]: cannot assign to `t.1`, as `t` is not declared as mutable
   --> $DIR/issue-54499-field-mutation-of-moved-out.rs:16:9
    |
 LL |         t.1 = 2;
@@ -30,7 +31,7 @@ help: consider changing this to be mutable
 LL |         let mut t: Tuple = (S(0), 0);
    |             +++
 
-error[E0594]: cannot assign to `u.0`, as `u` is not declared as mutable
+warning[E0594]: cannot assign to `u.0`, as `u` is not declared as mutable
   --> $DIR/issue-54499-field-mutation-of-moved-out.rs:24:9
    |
 LL |         u.0 = S(1);
@@ -51,7 +52,7 @@ LL |         drop(u);
 LL |         u.0 = S(1);
    |         ^^^^^^^^^^ value partially assigned here after move
 
-error[E0594]: cannot assign to `u.1`, as `u` is not declared as mutable
+warning[E0594]: cannot assign to `u.1`, as `u` is not declared as mutable
   --> $DIR/issue-54499-field-mutation-of-moved-out.rs:27:9
    |
 LL |         u.1 = 2;
@@ -62,7 +63,7 @@ help: consider changing this to be mutable
 LL |         let mut u: Tpair = Tpair(S(0), 0);
    |             +++
 
-error[E0594]: cannot assign to `v.x`, as `v` is not declared as mutable
+warning[E0594]: cannot assign to `v.x`, as `v` is not declared as mutable
   --> $DIR/issue-54499-field-mutation-of-moved-out.rs:35:9
    |
 LL |         v.x = S(1);
@@ -83,7 +84,7 @@ LL |         drop(v);
 LL |         v.x = S(1);
    |         ^^^^^^^^^^ value partially assigned here after move
 
-error[E0594]: cannot assign to `v.y`, as `v` is not declared as mutable
+warning[E0594]: cannot assign to `v.y`, as `v` is not declared as mutable
   --> $DIR/issue-54499-field-mutation-of-moved-out.rs:38:9
    |
 LL |         v.y = 2;
@@ -94,7 +95,7 @@ help: consider changing this to be mutable
 LL |         let mut v: Spair = Spair { x: S(0), y: 0 };
    |             +++
 
-error: aborting due to 9 previous errors
+error: aborting due to 3 previous errors; 6 warnings emitted
 
 Some errors have detailed explanations: E0382, E0594.
 For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.rs
+++ b/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 // rust-lang/rust#55492: errors detected during MIR-borrowck's
 // analysis of a closure body may only be caught when AST-borrowck
 // looks at some parent.
@@ -7,9 +8,9 @@ mod borrowck_closures_unique {
     pub fn e(x: &'static mut isize) {
         static mut Y: isize = 3;
         let mut c1 = |y: &'static mut isize| x = y;
-        //~^ ERROR is not declared as mutable
+        //~^ WARNING is not declared as mutable
         unsafe {
-            c1(&mut Y);
+            c1(&mut Y); //~ WARNING mutable static
         }
     }
 }
@@ -19,11 +20,11 @@ mod borrowck_closures_unique_grandparent {
         static mut Z: isize = 3;
         let mut c1 = |z: &'static mut isize| {
             let mut c2 = |y: &'static mut isize| x = y;
-            //~^ ERROR is not declared as mutable
+            //~^ WARNING is not declared as mutable
             c2(z);
         };
         unsafe {
-            c1(&mut Z);
+            c1(&mut Z); //~ WARNING mutable static
         }
     }
 }
@@ -33,25 +34,25 @@ mod mutability_errors {
     pub fn capture_assign_whole(x: (i32,)) {
         || {
             x = (1,);
-            //~^ ERROR is not declared as mutable
+            //~^ WARNING is not declared as mutable
         };
     }
     pub fn capture_assign_part(x: (i32,)) {
         || {
             x.0 = 1;
-            //~^ ERROR is not declared as mutable
+            //~^ WARNING is not declared as mutable
         };
     }
     pub fn capture_reborrow_whole(x: (i32,)) {
         || {
             &mut x;
-            //~^ ERROR is not declared as mutable
+            //~^ WARNING is not declared as mutable
         };
     }
     pub fn capture_reborrow_part(x: (i32,)) {
         || {
             &mut x.0;
-            //~^ ERROR is not declared as mutable
+            //~^ WARNING is not declared as mutable
         };
     }
 }
@@ -59,7 +60,7 @@ mod mutability_errors {
 fn main() {
     static mut X: isize = 2;
     unsafe {
-        borrowck_closures_unique::e(&mut X);
+        borrowck_closures_unique::e(&mut X); //~ WARNING mutable static
     }
 
     mutability_errors::capture_assign_whole((1000,));

--- a/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.stderr
+++ b/tests/ui/borrowck/issue-55492-borrowck-migrate-scans-parents.stderr
@@ -1,16 +1,17 @@
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:9:46
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:10:46
    |
 LL |         let mut c1 = |y: &'static mut isize| x = y;
    |                                              ^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     pub fn e(mut x: &'static mut isize) {
    |              +++
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:21:50
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:22:50
    |
 LL |             let mut c2 = |y: &'static mut isize| x = y;
    |                                                  ^^^^^ cannot assign
@@ -20,8 +21,8 @@ help: consider changing this to be mutable
 LL |     pub fn ee(mut x: &'static mut isize) {
    |               +++
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:35:13
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:36:13
    |
 LL |             x = (1,);
    |             ^^^^^^^^ cannot assign
@@ -31,8 +32,8 @@ help: consider changing this to be mutable
 LL |     pub fn capture_assign_whole(mut x: (i32,)) {
    |                                 +++
 
-error[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:41:13
+warning[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:42:13
    |
 LL |             x.0 = 1;
    |             ^^^^^^^ cannot assign
@@ -42,8 +43,8 @@ help: consider changing this to be mutable
 LL |     pub fn capture_assign_part(mut x: (i32,)) {
    |                                +++
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:47:13
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:48:13
    |
 LL |             &mut x;
    |             ^^^^^^ cannot borrow as mutable
@@ -53,8 +54,8 @@ help: consider changing this to be mutable
 LL |     pub fn capture_reborrow_whole(mut x: (i32,)) {
    |                                   +++
 
-error[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
-  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:53:13
+warning[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:54:13
    |
 LL |             &mut x.0;
    |             ^^^^^^^^ cannot borrow as mutable
@@ -64,7 +65,47 @@ help: consider changing this to be mutable
 LL |     pub fn capture_reborrow_part(mut x: (i32,)) {
    |                                  +++
 
-error: aborting due to 6 previous errors
+warning: creating a mutable reference to mutable static is discouraged
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:63:37
+   |
+LL |         borrowck_closures_unique::e(&mut X);
+   |                                     ^^^^^^ mutable reference to mutable static
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
+   = note: `#[warn(static_mut_refs)]` on by default
+help: use `&raw mut` instead to create a raw pointer
+   |
+LL |         borrowck_closures_unique::e(&raw mut X);
+   |                                     ~~~~~~~~
+
+warning: creating a mutable reference to mutable static is discouraged
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:13:16
+   |
+LL |             c1(&mut Y);
+   |                ^^^^^^ mutable reference to mutable static
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
+help: use `&raw mut` instead to create a raw pointer
+   |
+LL |             c1(&raw mut Y);
+   |                ~~~~~~~~
+
+warning: creating a mutable reference to mutable static is discouraged
+  --> $DIR/issue-55492-borrowck-migrate-scans-parents.rs:27:16
+   |
+LL |             c1(&mut Z);
+   |                ^^^^^^ mutable reference to mutable static
+   |
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
+   = note: mutable references to mutable statics are dangerous; it's undefined behavior if any other pointer to the static is used or if any other reference is created for the static while the mutable reference lives
+help: use `&raw mut` instead to create a raw pointer
+   |
+LL |             c1(&raw mut Z);
+   |                ~~~~~~~~
+
+warning: 9 warnings emitted
 
 Some errors have detailed explanations: E0594, E0596.
 For more information about an error, try `rustc --explain E0594`.

--- a/tests/ui/borrowck/issue-93078.rs
+++ b/tests/ui/borrowck/issue-93078.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 trait Modify {
     fn modify(&mut self) ;
 }
@@ -8,7 +9,7 @@ impl<T> Modify for T  {
 
 trait Foo {
     fn mute(&mut self) {
-        self.modify(); //~ ERROR cannot borrow `self` as mutable
+        self.modify(); //~ WARNING cannot borrow `self` as mutable
     }
 }
 

--- a/tests/ui/borrowck/issue-93078.stderr
+++ b/tests/ui/borrowck/issue-93078.stderr
@@ -1,12 +1,13 @@
-error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
-  --> $DIR/issue-93078.rs:11:9
+warning[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+  --> $DIR/issue-93078.rs:12:9
    |
 LL |         self.modify();
    |         ^^^^ cannot borrow as mutable
    |
    = note: as `Self` may be unsized, this call attempts to take `&mut &mut self`
    = note: however, `&mut self` expands to `self: &mut Self`, therefore `self` cannot be borrowed mutably
+   = note: `#[warn(mut_non_mut)]` on by default
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/many-mutable-borrows.rs
+++ b/tests/ui/borrowck/many-mutable-borrows.rs
@@ -1,5 +1,6 @@
+//@ check-pass
 fn main() {
-    let v = Vec::new(); //~ ERROR cannot borrow `v` as mutable, as it is not declared as mutable
+    let v = Vec::new(); //~ WARNING cannot borrow `v` as mutable, as it is not declared as mutable
     v.push(0);
     v.push(0);
     v.push(0);

--- a/tests/ui/borrowck/many-mutable-borrows.stderr
+++ b/tests/ui/borrowck/many-mutable-borrows.stderr
@@ -1,5 +1,5 @@
-error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
-  --> $DIR/many-mutable-borrows.rs:2:9
+warning[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
+  --> $DIR/many-mutable-borrows.rs:3:9
    |
 LL |     let v = Vec::new();
    |         ^ not mutable
@@ -23,11 +23,12 @@ LL |     v.push(0);
    |     - cannot borrow as mutable
    |
    = note: ...and 5 other attempted mutable borrows
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut v = Vec::new();
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/mut-borrow-of-mut-ref.rs
+++ b/tests/ui/borrowck/mut-borrow-of-mut-ref.rs
@@ -1,10 +1,12 @@
+//@ check-pass
 // Suggest not mutably borrowing a mutable reference
 #![crate_type = "rlib"]
 
 pub fn f(b: &mut i32) {
-    //~^ ERROR cannot borrow
+    //~^ WARNING cannot borrow
     //~| NOTE not mutable
     //~| NOTE the binding is already a mutable borrow
+    //~| NOTE on by default
     h(&mut b);
     //~^ NOTE cannot borrow as mutable
     //~| HELP try removing `&mut` here
@@ -15,7 +17,7 @@ pub fn f(b: &mut i32) {
 
 pub fn g(b: &mut i32) { //~ NOTE the binding is already a mutable borrow
     h(&mut &mut b);
-    //~^ ERROR cannot borrow
+    //~^ WARNING cannot borrow
     //~| NOTE cannot borrow as mutable
     //~| HELP try removing `&mut` here
 }
@@ -31,6 +33,6 @@ impl Foo for &mut String {
 }
 
 pub fn baz(f: &mut String) { //~ HELP consider making the binding mutable
-    f.bar(); //~ ERROR cannot borrow `f` as mutable, as it is not declared as mutable
+    f.bar(); //~ WARNING cannot borrow `f` as mutable, as it is not declared as mutable
     //~^ NOTE cannot borrow as mutable
 }

--- a/tests/ui/borrowck/mut-borrow-of-mut-ref.stderr
+++ b/tests/ui/borrowck/mut-borrow-of-mut-ref.stderr
@@ -1,5 +1,5 @@
-error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
-  --> $DIR/mut-borrow-of-mut-ref.rs:4:10
+warning[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
+  --> $DIR/mut-borrow-of-mut-ref.rs:5:10
    |
 LL | pub fn f(b: &mut i32) {
    |          ^ not mutable
@@ -11,10 +11,11 @@ LL |     g(&mut &mut b);
    |            ------ cannot borrow as mutable
    |
 note: the binding is already a mutable borrow
-  --> $DIR/mut-borrow-of-mut-ref.rs:4:13
+  --> $DIR/mut-borrow-of-mut-ref.rs:5:13
    |
 LL | pub fn f(b: &mut i32) {
    |             ^^^^^^^^
+   = note: `#[warn(mut_non_mut)]` on by default
 help: try removing `&mut` here
    |
 LL -     h(&mut b);
@@ -26,14 +27,14 @@ LL -     g(&mut &mut b);
 LL +     g(&mut b);
    |
 
-error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
-  --> $DIR/mut-borrow-of-mut-ref.rs:17:12
+warning[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
+  --> $DIR/mut-borrow-of-mut-ref.rs:19:12
    |
 LL |     h(&mut &mut b);
    |            ^^^^^^ cannot borrow as mutable
    |
 note: the binding is already a mutable borrow
-  --> $DIR/mut-borrow-of-mut-ref.rs:16:13
+  --> $DIR/mut-borrow-of-mut-ref.rs:18:13
    |
 LL | pub fn g(b: &mut i32) {
    |             ^^^^^^^^
@@ -43,8 +44,8 @@ LL -     h(&mut &mut b);
 LL +     h(&mut b);
    |
 
-error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
-  --> $DIR/mut-borrow-of-mut-ref.rs:34:5
+warning[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
+  --> $DIR/mut-borrow-of-mut-ref.rs:36:5
    |
 LL |     f.bar();
    |     ^ cannot borrow as mutable
@@ -54,6 +55,6 @@ help: consider making the binding mutable
 LL | pub fn baz(mut f: &mut String) {
    |            +++
 
-error: aborting due to 3 previous errors
+warning: 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/borrowck/mutability-errors.rs
+++ b/tests/ui/borrowck/mutability-errors.rs
@@ -50,23 +50,23 @@ fn ref_closure(mut x: (i32,)) {
     });
 }
 
-fn imm_local(x: (i32,)) { //~ ERROR
+fn imm_local(x: (i32,)) { //~ WARNING
     &mut x;
     &mut x.0;
 }
 
 fn imm_capture(x: (i32,)) {
     || {
-        x = (1,); //~ ERROR
-        x.0 = 1; //~ ERROR
-        &mut x; //~ ERROR
-        &mut x.0; //~ ERROR
+        x = (1,); //~ WARNING
+        x.0 = 1; //~ WARNING
+        &mut x; //~ WARNING
+        &mut x.0; //~ WARNING
     };
     move || {
-        x = (1,); //~ ERROR
-        x.0 = 1; //~ ERROR
-        &mut x; //~ ERROR
-        &mut x.0; //~ ERROR
+        x = (1,); //~ WARNING
+        x.0 = 1; //~ WARNING
+        &mut x; //~ WARNING
+        &mut x.0; //~ WARNING
     };
 }
 

--- a/tests/ui/borrowck/mutability-errors.stderr
+++ b/tests/ui/borrowck/mutability-errors.stderr
@@ -244,7 +244,7 @@ LL |     fn_ref(move || {
 LL |         &mut x.0;
    |         ^^^^^^^^ cannot borrow as mutable
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/mutability-errors.rs:53:14
    |
 LL | fn imm_local(x: (i32,)) {
@@ -254,12 +254,13 @@ LL |     &mut x;
 LL |     &mut x.0;
    |     -------- cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn imm_local(mut x: (i32,)) {
    |              +++
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/mutability-errors.rs:60:9
    |
 LL |         x = (1,);
@@ -270,7 +271,7 @@ help: consider changing this to be mutable
 LL | fn imm_capture(mut x: (i32,)) {
    |                +++
 
-error[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
+warning[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
   --> $DIR/mutability-errors.rs:61:9
    |
 LL |         x.0 = 1;
@@ -281,7 +282,7 @@ help: consider changing this to be mutable
 LL | fn imm_capture(mut x: (i32,)) {
    |                +++
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/mutability-errors.rs:62:9
    |
 LL |         &mut x;
@@ -292,7 +293,7 @@ help: consider changing this to be mutable
 LL | fn imm_capture(mut x: (i32,)) {
    |                +++
 
-error[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
+warning[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
   --> $DIR/mutability-errors.rs:63:9
    |
 LL |         &mut x.0;
@@ -303,7 +304,7 @@ help: consider changing this to be mutable
 LL | fn imm_capture(mut x: (i32,)) {
    |                +++
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/mutability-errors.rs:66:9
    |
 LL |         x = (1,);
@@ -314,7 +315,7 @@ help: consider changing this to be mutable
 LL | fn imm_capture(mut x: (i32,)) {
    |                +++
 
-error[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
+warning[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
   --> $DIR/mutability-errors.rs:67:9
    |
 LL |         x.0 = 1;
@@ -325,7 +326,7 @@ help: consider changing this to be mutable
 LL | fn imm_capture(mut x: (i32,)) {
    |                +++
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/mutability-errors.rs:68:9
    |
 LL |         &mut x;
@@ -336,7 +337,7 @@ help: consider changing this to be mutable
 LL | fn imm_capture(mut x: (i32,)) {
    |                +++
 
-error[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
+warning[E0596]: cannot borrow `x.0` as mutable, as `x` is not declared as mutable
   --> $DIR/mutability-errors.rs:69:9
    |
 LL |         &mut x.0;
@@ -371,7 +372,7 @@ error[E0596]: cannot borrow `X.0` as mutable, as `X` is an immutable static item
 LL |     &mut X.0;
    |     ^^^^^^^^ cannot borrow as mutable
 
-error: aborting due to 37 previous errors
+error: aborting due to 28 previous errors; 9 warnings emitted
 
 Some errors have detailed explanations: E0594, E0596.
 For more information about an error, try `rustc --explain E0594`.

--- a/tests/ui/borrowck/reassignment_immutable_fields_overlapping.rs
+++ b/tests/ui/borrowck/reassignment_immutable_fields_overlapping.rs
@@ -10,7 +10,7 @@ union Foo {
 unsafe fn overlapping_fields() {
     let x: Foo;
     x.a = 1;  //~ ERROR
-    x.b = 22; //~ ERROR
+    x.b = 22; //~ WARNING
 }
 
 fn main() { }

--- a/tests/ui/borrowck/reassignment_immutable_fields_overlapping.stderr
+++ b/tests/ui/borrowck/reassignment_immutable_fields_overlapping.stderr
@@ -8,18 +8,19 @@ LL |     x.a = 1;
    |
    = help: partial initialization isn't supported, fully initialize the binding with a default value and mutate it, or use `std::mem::MaybeUninit`
 
-error[E0594]: cannot assign to `x.b`, as `x` is not declared as mutable
+warning[E0594]: cannot assign to `x.b`, as `x` is not declared as mutable
   --> $DIR/reassignment_immutable_fields_overlapping.rs:13:5
    |
 LL |     x.b = 22;
    |     ^^^^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x: Foo;
    |         +++
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error; 1 warning emitted
 
 Some errors have detailed explanations: E0381, E0594.
 For more information about an error, try `rustc --explain E0381`.

--- a/tests/ui/borrowck/reassignment_immutable_fields_twice.rs
+++ b/tests/ui/borrowck/reassignment_immutable_fields_twice.rs
@@ -4,12 +4,12 @@
 fn var_then_field() {
     let x: (u32, u32);
     x = (22, 44);
-    x.0 = 1; //~ ERROR
+    x.0 = 1; //~ WARNING
 }
 
 fn same_field_twice() {
     let x: (u32, u32);
-    x.0 = 1; //~ ERROR
+    x.0 = 1; //~ ERROR partially assigned
     x.0 = 22;
     x.1 = 44;
 }

--- a/tests/ui/borrowck/reassignment_immutable_fields_twice.stderr
+++ b/tests/ui/borrowck/reassignment_immutable_fields_twice.stderr
@@ -1,9 +1,10 @@
-error[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
+warning[E0594]: cannot assign to `x.0`, as `x` is not declared as mutable
   --> $DIR/reassignment_immutable_fields_twice.rs:7:5
    |
 LL |     x.0 = 1;
    |     ^^^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x: (u32, u32);
@@ -19,7 +20,7 @@ LL |     x.0 = 1;
    |
    = help: partial initialization isn't supported, fully initialize the binding with a default value and mutate it, or use `std::mem::MaybeUninit`
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error; 1 warning emitted
 
 Some errors have detailed explanations: E0381, E0594.
 For more information about an error, try `rustc --explain E0381`.

--- a/tests/ui/borrowck/suggest-ref-mut-issue-118596.rs
+++ b/tests/ui/borrowck/suggest-ref-mut-issue-118596.rs
@@ -1,11 +1,12 @@
+//@ check-pass
 fn main() {
     let y = Some(0);
     if let Some(x) = y {
-        x = 2; //~ ERROR cannot assign twice to immutable variable `x`
+        x = 2; //~ WARNING cannot assign twice to immutable variable `x`
     }
 
     let mut arr = [1, 2, 3];
     let [x, ref xs_hold @ ..] = arr;
-    x = 0; //~ ERROR cannot assign twice to immutable variable `x`
+    x = 0; //~ WARNING cannot assign twice to immutable variable `x`
     eprintln!("{:?}", arr);
 }

--- a/tests/ui/borrowck/suggest-ref-mut-issue-118596.stderr
+++ b/tests/ui/borrowck/suggest-ref-mut-issue-118596.stderr
@@ -1,11 +1,12 @@
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/suggest-ref-mut-issue-118596.rs:4:9
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/suggest-ref-mut-issue-118596.rs:5:9
    |
 LL |     if let Some(x) = y {
    |                 - first assignment to `x`
 LL |         x = 2;
    |         ^^^^^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     if let Some(mut x) = y {
@@ -15,8 +16,8 @@ help: to modify the original value, take a borrow instead
 LL |     if let Some(ref mut x) = y {
    |                 +++++++
 
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/suggest-ref-mut-issue-118596.rs:9:5
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/suggest-ref-mut-issue-118596.rs:10:5
    |
 LL |     let [x, ref xs_hold @ ..] = arr;
    |          - first assignment to `x`
@@ -32,6 +33,6 @@ help: to modify the original value, take a borrow instead
 LL |     let [ref mut x, ref xs_hold @ ..] = arr;
    |          +++++++
 
-error: aborting due to 2 previous errors
+warning: 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/borrowck/tainted-promoteds.rs
+++ b/tests/ui/borrowck/tainted-promoteds.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 // Regression test for issue #110856, where a borrowck error for a MIR tainted
 // all promoteds within. This in turn generated a spurious "erroneous constant
 // used" note when trying to evaluate a promoted.
@@ -5,7 +6,7 @@
 pub fn f() -> u32 {
     let a = 0;
     a = &0 * &1 * &2 * &3;
-    //~^ ERROR: cannot assign twice to immutable variable
+    //~^ WARNING: cannot assign twice to immutable variable
     a
 }
 

--- a/tests/ui/borrowck/tainted-promoteds.stderr
+++ b/tests/ui/borrowck/tainted-promoteds.stderr
@@ -1,16 +1,17 @@
-error[E0384]: cannot assign twice to immutable variable `a`
-  --> $DIR/tainted-promoteds.rs:7:5
+warning[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/tainted-promoteds.rs:8:5
    |
 LL |     let a = 0;
    |         - first assignment to `a`
 LL |     a = &0 * &1 * &2 * &3;
    |     ^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     let mut a = 0;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/cannot-mutate-captured-non-mut-var.rs
+++ b/tests/ui/cannot-mutate-captured-non-mut-var.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 #![feature(unboxed_closures, tuple_trait)]
 
 use std::io::Read;
@@ -7,9 +8,9 @@ fn to_fn_once<A:std::marker::Tuple,F:FnOnce<A>>(f: F) -> F { f }
 fn main() {
     let x = 1;
     to_fn_once(move|| { x = 2; });
-    //~^ ERROR: cannot assign to `x`, as it is not declared as mutable
+    //~^ WARNING: cannot assign to `x`, as it is not declared as mutable
 
     let s = std::io::stdin();
     to_fn_once(move|| { s.read_to_end(&mut Vec::new()); });
-    //~^ ERROR: cannot borrow `s` as mutable, as it is not declared as mutable
+    //~^ WARNING: cannot borrow `s` as mutable, as it is not declared as mutable
 }

--- a/tests/ui/cannot-mutate-captured-non-mut-var.stderr
+++ b/tests/ui/cannot-mutate-captured-non-mut-var.stderr
@@ -1,16 +1,17 @@
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/cannot-mutate-captured-non-mut-var.rs:9:25
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/cannot-mutate-captured-non-mut-var.rs:10:25
    |
 LL |     to_fn_once(move|| { x = 2; });
    |                         ^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x = 1;
    |         +++
 
-error[E0596]: cannot borrow `s` as mutable, as it is not declared as mutable
-  --> $DIR/cannot-mutate-captured-non-mut-var.rs:13:25
+warning[E0596]: cannot borrow `s` as mutable, as it is not declared as mutable
+  --> $DIR/cannot-mutate-captured-non-mut-var.rs:14:25
    |
 LL |     to_fn_once(move|| { s.read_to_end(&mut Vec::new()); });
    |                         ^ cannot borrow as mutable
@@ -20,7 +21,7 @@ help: consider changing this to be mutable
 LL |     let mut s = std::io::stdin();
    |         +++
 
-error: aborting due to 2 previous errors
+warning: 2 warnings emitted
 
 Some errors have detailed explanations: E0594, E0596.
 For more information about an error, try `rustc --explain E0594`.

--- a/tests/ui/closures/2229_closure_analysis/array_subslice.rs
+++ b/tests/ui/closures/2229_closure_analysis/array_subslice.rs
@@ -1,13 +1,14 @@
+//@ check-pass
 // regression test for #109298
 //@ edition: 2021
 
 pub fn subslice_array(x: [u8; 3]) {
     let f = || {
         let [_x @ ..] = x;
-        let [ref y, ref mut z @ ..] = x; //~ ERROR cannot borrow `x[..]` as mutable
+        let [ref y, ref mut z @ ..] = x; //~ WARNING cannot borrow `x[..]` as mutable
     };
 
-    f(); //~ ERROR cannot borrow `f` as mutable
+    f(); //~ WARNING cannot borrow `f` as mutable
 }
 
 fn main() {}

--- a/tests/ui/closures/2229_closure_analysis/array_subslice.stderr
+++ b/tests/ui/closures/2229_closure_analysis/array_subslice.stderr
@@ -1,16 +1,17 @@
-error[E0596]: cannot borrow `x[..]` as mutable, as `x` is not declared as mutable
-  --> $DIR/array_subslice.rs:7:21
+warning[E0596]: cannot borrow `x[..]` as mutable, as `x` is not declared as mutable
+  --> $DIR/array_subslice.rs:8:21
    |
 LL |         let [ref y, ref mut z @ ..] = x;
    |                     ^^^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | pub fn subslice_array(mut x: [u8; 3]) {
    |                       +++
 
-error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
-  --> $DIR/array_subslice.rs:10:5
+warning[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
+  --> $DIR/array_subslice.rs:11:5
    |
 LL |         let [ref y, ref mut z @ ..] = x;
    |                                       - calling `f` requires mutable binding due to mutable borrow of `x`
@@ -23,6 +24,6 @@ help: consider changing this to be mutable
 LL |     let mut f = || {
    |         +++
 
-error: aborting due to 2 previous errors
+warning: 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm.rs
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 //@ edition:2021
 
 // Ensure that diagnostics for mutability error (because the root variable
@@ -10,7 +11,7 @@ fn mut_error_struct() {
 
     let mut c = || {
         z.0.0.0 = 20;
-        //~^ ERROR: cannot assign to `z.0.0.0`, as it is not declared as mutable
+        //~^ WARNING: cannot assign to `z.0.0.0`, as it is not declared as mutable
     };
 
     c();
@@ -22,7 +23,7 @@ fn mut_error_box() {
 
     let mut c = || {
         bx.0 = 20;
-        //~^ ERROR: cannot assign to `*bx.0`, as it is not declared as mutable
+        //~^ WARNING: cannot assign to `*bx.0`, as it is not declared as mutable
     };
 
     c();

--- a/tests/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm.stderr
+++ b/tests/ui/closures/2229_closure_analysis/diagnostics/cant-mutate-imm.stderr
@@ -1,16 +1,17 @@
-error[E0594]: cannot assign to `z.0.0.0`, as it is not declared as mutable
-  --> $DIR/cant-mutate-imm.rs:12:9
+warning[E0594]: cannot assign to `z.0.0.0`, as it is not declared as mutable
+  --> $DIR/cant-mutate-imm.rs:13:9
    |
 LL |         z.0.0.0 = 20;
    |         ^^^^^^^^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut z = (y, 10);
    |         +++
 
-error[E0594]: cannot assign to `*bx.0`, as it is not declared as mutable
-  --> $DIR/cant-mutate-imm.rs:24:9
+warning[E0594]: cannot assign to `*bx.0`, as it is not declared as mutable
+  --> $DIR/cant-mutate-imm.rs:25:9
    |
 LL |         bx.0 = 20;
    |         ^^^^^^^^^ cannot assign
@@ -20,6 +21,6 @@ help: consider changing this to be mutable
 LL |     let mut bx = Box::new(x);
    |         +++
 
-error: aborting due to 2 previous errors
+warning: 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0594`.

--- a/tests/ui/closures/closure-immutable-outer-variable.fixed
+++ b/tests/ui/closures/closure-immutable-outer-variable.fixed
@@ -1,3 +1,4 @@
+//@ check-pass
 //@ run-rustfix
 
 // Point at the captured immutable outer variable
@@ -9,5 +10,5 @@ fn foo(mut f: Box<dyn FnMut()>) {
 fn main() {
     let mut y = true;
     foo(Box::new(move || y = !y) as Box<_>);
-    //~^ ERROR cannot assign to `y`, as it is not declared as mutable
+    //~^ WARNING cannot assign to `y`, as it is not declared as mutable
 }

--- a/tests/ui/closures/closure-immutable-outer-variable.rs
+++ b/tests/ui/closures/closure-immutable-outer-variable.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 //@ run-rustfix
 
 // Point at the captured immutable outer variable
@@ -9,5 +10,5 @@ fn foo(mut f: Box<dyn FnMut()>) {
 fn main() {
     let y = true;
     foo(Box::new(move || y = !y) as Box<_>);
-    //~^ ERROR cannot assign to `y`, as it is not declared as mutable
+    //~^ WARNING cannot assign to `y`, as it is not declared as mutable
 }

--- a/tests/ui/closures/closure-immutable-outer-variable.stderr
+++ b/tests/ui/closures/closure-immutable-outer-variable.stderr
@@ -1,14 +1,15 @@
-error[E0594]: cannot assign to `y`, as it is not declared as mutable
-  --> $DIR/closure-immutable-outer-variable.rs:11:26
+warning[E0594]: cannot assign to `y`, as it is not declared as mutable
+  --> $DIR/closure-immutable-outer-variable.rs:12:26
    |
 LL |     foo(Box::new(move || y = !y) as Box<_>);
    |                          ^^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut y = true;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0594`.

--- a/tests/ui/closures/issue-80313-mutable-borrow-in-closure.rs
+++ b/tests/ui/closures/issue-80313-mutable-borrow-in-closure.rs
@@ -1,7 +1,8 @@
+//@ check-pass
 fn main() {
     let mut my_var = false;
     let callback = || {
         &mut my_var;
     };
-    callback(); //~ ERROR E0596
+    callback(); //~ WARNING E0596
 }

--- a/tests/ui/closures/issue-80313-mutable-borrow-in-closure.stderr
+++ b/tests/ui/closures/issue-80313-mutable-borrow-in-closure.stderr
@@ -1,5 +1,5 @@
-error[E0596]: cannot borrow `callback` as mutable, as it is not declared as mutable
-  --> $DIR/issue-80313-mutable-borrow-in-closure.rs:6:5
+warning[E0596]: cannot borrow `callback` as mutable, as it is not declared as mutable
+  --> $DIR/issue-80313-mutable-borrow-in-closure.rs:7:5
    |
 LL |         &mut my_var;
    |              ------ calling `callback` requires mutable binding due to mutable borrow of `my_var`
@@ -7,11 +7,12 @@ LL |     };
 LL |     callback();
    |     ^^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut callback = || {
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/closures/issue-80313-mutable-borrow-in-move-closure.rs
+++ b/tests/ui/closures/issue-80313-mutable-borrow-in-move-closure.rs
@@ -1,7 +1,8 @@
+//@ check-pass
 fn main() {
     let mut my_var = false;
     let callback = move || {
         &mut my_var;
     };
-    callback(); //~ ERROR E0596
+    callback(); //~ WARNING E0596
 }

--- a/tests/ui/closures/issue-80313-mutable-borrow-in-move-closure.stderr
+++ b/tests/ui/closures/issue-80313-mutable-borrow-in-move-closure.stderr
@@ -1,5 +1,5 @@
-error[E0596]: cannot borrow `callback` as mutable, as it is not declared as mutable
-  --> $DIR/issue-80313-mutable-borrow-in-move-closure.rs:6:5
+warning[E0596]: cannot borrow `callback` as mutable, as it is not declared as mutable
+  --> $DIR/issue-80313-mutable-borrow-in-move-closure.rs:7:5
    |
 LL |         &mut my_var;
    |              ------ calling `callback` requires mutable binding due to possible mutation of `my_var`
@@ -7,11 +7,12 @@ LL |     };
 LL |     callback();
    |     ^^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut callback = move || {
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/closures/issue-80313-mutation-in-closure.rs
+++ b/tests/ui/closures/issue-80313-mutation-in-closure.rs
@@ -1,7 +1,8 @@
+//@ check-pass
 fn main() {
     let mut my_var = false;
     let callback = || {
         my_var = true;
     };
-    callback(); //~ ERROR E0596
+    callback(); //~ WARNING E0596
 }

--- a/tests/ui/closures/issue-80313-mutation-in-closure.stderr
+++ b/tests/ui/closures/issue-80313-mutation-in-closure.stderr
@@ -1,5 +1,5 @@
-error[E0596]: cannot borrow `callback` as mutable, as it is not declared as mutable
-  --> $DIR/issue-80313-mutation-in-closure.rs:6:5
+warning[E0596]: cannot borrow `callback` as mutable, as it is not declared as mutable
+  --> $DIR/issue-80313-mutation-in-closure.rs:7:5
    |
 LL |         my_var = true;
    |         ------ calling `callback` requires mutable binding due to mutable borrow of `my_var`
@@ -7,11 +7,12 @@ LL |     };
 LL |     callback();
    |     ^^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut callback = || {
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/closures/issue-80313-mutation-in-move-closure.rs
+++ b/tests/ui/closures/issue-80313-mutation-in-move-closure.rs
@@ -1,7 +1,8 @@
+//@ check-pass
 fn main() {
     let mut my_var = false;
     let callback = move || {
         my_var = true;
     };
-    callback(); //~ ERROR E0596
+    callback(); //~ WARNING E0596
 }

--- a/tests/ui/closures/issue-80313-mutation-in-move-closure.stderr
+++ b/tests/ui/closures/issue-80313-mutation-in-move-closure.stderr
@@ -1,5 +1,5 @@
-error[E0596]: cannot borrow `callback` as mutable, as it is not declared as mutable
-  --> $DIR/issue-80313-mutation-in-move-closure.rs:6:5
+warning[E0596]: cannot borrow `callback` as mutable, as it is not declared as mutable
+  --> $DIR/issue-80313-mutation-in-move-closure.rs:7:5
    |
 LL |         my_var = true;
    |         ------ calling `callback` requires mutable binding due to possible mutation of `my_var`
@@ -7,11 +7,12 @@ LL |     };
 LL |     callback();
    |     ^^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut callback = move || {
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/closures/issue-81700-mut-borrow.rs
+++ b/tests/ui/closures/issue-81700-mut-borrow.rs
@@ -1,5 +1,6 @@
+//@ check-pass
 fn foo(x: &mut u32) {
     let bar = || { foo(x); };
-    bar(); //~ ERROR cannot borrow
+    bar(); //~ WARNING cannot borrow
 }
 fn main() {}

--- a/tests/ui/closures/issue-81700-mut-borrow.stderr
+++ b/tests/ui/closures/issue-81700-mut-borrow.stderr
@@ -1,16 +1,17 @@
-error[E0596]: cannot borrow `bar` as mutable, as it is not declared as mutable
-  --> $DIR/issue-81700-mut-borrow.rs:3:5
+warning[E0596]: cannot borrow `bar` as mutable, as it is not declared as mutable
+  --> $DIR/issue-81700-mut-borrow.rs:4:5
    |
 LL |     let bar = || { foo(x); };
    |                        - calling `bar` requires mutable binding due to mutable borrow of `x`
 LL |     bar();
    |     ^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut bar = || { foo(x); };
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/closures/issue-82438-mut-without-upvar.rs
+++ b/tests/ui/closures/issue-82438-mut-without-upvar.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 use std::error::Error;
 struct A {
 }
@@ -19,10 +20,10 @@ impl A {
 
 
 fn main() {
-    let A = A::new();
+    let a = A::new();
     let participant_name = "A";
 
     let c = |a, b, c, d| {};
 
-    A.f(participant_name, &mut c); //~ ERROR cannot borrow
+    a.f(participant_name, &mut c); //~ WARNING cannot borrow
 }

--- a/tests/ui/closures/issue-82438-mut-without-upvar.stderr
+++ b/tests/ui/closures/issue-82438-mut-without-upvar.stderr
@@ -1,14 +1,15 @@
-error[E0596]: cannot borrow `c` as mutable, as it is not declared as mutable
-  --> $DIR/issue-82438-mut-without-upvar.rs:27:27
+warning[E0596]: cannot borrow `c` as mutable, as it is not declared as mutable
+  --> $DIR/issue-82438-mut-without-upvar.rs:28:27
    |
-LL |     A.f(participant_name, &mut c);
+LL |     a.f(participant_name, &mut c);
    |                           ^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut c = |a, b, c, d| {};
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/closures/issue-84044-drop-non-mut.rs
+++ b/tests/ui/closures/issue-84044-drop-non-mut.rs
@@ -1,6 +1,8 @@
+//@ check-pass
 // #84044: This used to ICE.
 
 fn main() {
     let f = || {};
-    drop(&mut f); //~ ERROR cannot borrow `f` as mutable, as it is not declared as mutable
+    drop(&mut f); //~ WARNING cannot borrow `f` as mutable, as it is not declared as mutable
+                  //~| WARNING does nothing
 }

--- a/tests/ui/closures/issue-84044-drop-non-mut.stderr
+++ b/tests/ui/closures/issue-84044-drop-non-mut.stderr
@@ -1,14 +1,30 @@
-error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
-  --> $DIR/issue-84044-drop-non-mut.rs:5:10
+warning[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
+  --> $DIR/issue-84044-drop-non-mut.rs:6:10
    |
 LL |     drop(&mut f);
    |          ^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut f = || {};
    |         +++
 
-error: aborting due to 1 previous error
+warning: calls to `std::mem::drop` with a reference instead of an owned value does nothing
+  --> $DIR/issue-84044-drop-non-mut.rs:6:5
+   |
+LL |     drop(&mut f);
+   |     ^^^^^------^
+   |          |
+   |          argument has type `&mut {closure@$DIR/issue-84044-drop-non-mut.rs:5:13: 5:15}`
+   |
+   = note: `#[warn(dropping_references)]` on by default
+help: use `let _ = ...` to ignore the expression or result
+   |
+LL -     drop(&mut f);
+LL +     let _ = &mut f;
+   |
+
+warning: 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/command-line-diagnostics.rs
+++ b/tests/ui/command-line-diagnostics.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 // This test checks the output format without the intermediate json representation
 //@ compile-flags: --error-format=human
 

--- a/tests/ui/command-line-diagnostics.stderr
+++ b/tests/ui/command-line-diagnostics.stderr
@@ -1,16 +1,17 @@
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/command-line-diagnostics.rs:6:5
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/command-line-diagnostics.rs:7:5
    |
 LL |     let x = 42;
    |         - first assignment to `x`
 LL |     x = 43;
    |     ^^^^^^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     let mut x = 42;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/did_you_mean/issue-31424.rs
+++ b/tests/ui/did_you_mean/issue-31424.rs
@@ -1,10 +1,11 @@
 //@ forbid-output: &mut mut self
+//@ check-pass
 
 struct Struct;
 
 impl Struct {
     fn foo(&mut self) {
-        (&mut self).bar(); //~ ERROR cannot borrow
+        (&mut self).bar(); //~ WARNING cannot borrow
         //~^ HELP try removing `&mut` here
     }
 
@@ -13,7 +14,8 @@ impl Struct {
     fn bar(self: &mut Self) {
         //~^ WARN function cannot return without recursing
         //~^^ HELP a `loop` may express intention better if this is on purpose
-        (&mut self).bar(); //~ ERROR cannot borrow
+
+        (&mut self).bar(); //~ WARNING cannot borrow
         //~^ HELP try removing `&mut` here
     }
 }

--- a/tests/ui/did_you_mean/issue-31424.stderr
+++ b/tests/ui/did_you_mean/issue-31424.stderr
@@ -1,22 +1,23 @@
-error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
-  --> $DIR/issue-31424.rs:7:9
+warning[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+  --> $DIR/issue-31424.rs:8:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^ cannot borrow as mutable
    |
 note: the binding is already a mutable borrow
-  --> $DIR/issue-31424.rs:6:12
+  --> $DIR/issue-31424.rs:7:12
    |
 LL |     fn foo(&mut self) {
    |            ^^^^^^^^^
 help: try removing `&mut` here
-  --> $DIR/issue-31424.rs:7:9
+  --> $DIR/issue-31424.rs:8:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^
+   = note: `#[warn(mut_non_mut)]` on by default
 
 warning: function cannot return without recursing
-  --> $DIR/issue-31424.rs:13:5
+  --> $DIR/issue-31424.rs:14:5
    |
 LL |     fn bar(self: &mut Self) {
    |     ^^^^^^^^^^^^^^^^^^^^^^^ cannot return without recursing
@@ -27,23 +28,23 @@ LL |         (&mut self).bar();
    = help: a `loop` may express intention better if this is on purpose
    = note: `#[warn(unconditional_recursion)]` on by default
 
-error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
-  --> $DIR/issue-31424.rs:16:9
+warning[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+  --> $DIR/issue-31424.rs:18:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^ cannot borrow as mutable
    |
 note: the binding is already a mutable borrow
-  --> $DIR/issue-31424.rs:13:18
+  --> $DIR/issue-31424.rs:14:18
    |
 LL |     fn bar(self: &mut Self) {
    |                  ^^^^^^^^^
 help: try removing `&mut` here
-  --> $DIR/issue-31424.rs:16:9
+  --> $DIR/issue-31424.rs:18:9
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^
 
-error: aborting due to 2 previous errors; 1 warning emitted
+warning: 3 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/did_you_mean/issue-34126.rs
+++ b/tests/ui/did_you_mean/issue-34126.rs
@@ -3,7 +3,7 @@ struct Z { }
 impl Z {
     fn run(&self, z: &mut Z) { }
     fn start(&mut self) {
-        self.run(&mut self); //~ ERROR cannot borrow
+        self.run(&mut self); //~ WARNING cannot borrow
         //~| ERROR cannot borrow
         //~| HELP try removing `&mut` here
     }

--- a/tests/ui/did_you_mean/issue-34126.stderr
+++ b/tests/ui/did_you_mean/issue-34126.stderr
@@ -1,4 +1,4 @@
-error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-34126.rs:6:18
    |
 LL |         self.run(&mut self);
@@ -9,6 +9,7 @@ note: the binding is already a mutable borrow
    |
 LL |     fn start(&mut self) {
    |              ^^^^^^^^^
+   = note: `#[warn(mut_non_mut)]` on by default
 help: try removing `&mut` here
    |
 LL -         self.run(&mut self);
@@ -24,7 +25,7 @@ LL |         self.run(&mut self);
    |         |    immutable borrow later used by call
    |         immutable borrow occurs here
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error; 1 warning emitted
 
 Some errors have detailed explanations: E0502, E0596.
 For more information about an error, try `rustc --explain E0502`.

--- a/tests/ui/did_you_mean/issue-34337.rs
+++ b/tests/ui/did_you_mean/issue-34337.rs
@@ -1,8 +1,9 @@
+//@ check-pass
 fn get(key: &mut String) { }
 
 fn main() {
     let mut v: Vec<String> = Vec::new();
     let ref mut key = v[0];
-    get(&mut key); //~ ERROR cannot borrow
+    get(&mut key); //~ WARNING cannot borrow
     //~| HELP try removing `&mut` here
 }

--- a/tests/ui/did_you_mean/issue-34337.stderr
+++ b/tests/ui/did_you_mean/issue-34337.stderr
@@ -1,15 +1,16 @@
-error[E0596]: cannot borrow `key` as mutable, as it is not declared as mutable
-  --> $DIR/issue-34337.rs:6:9
+warning[E0596]: cannot borrow `key` as mutable, as it is not declared as mutable
+  --> $DIR/issue-34337.rs:7:9
    |
 LL |     get(&mut key);
    |         ^^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: try removing `&mut` here
    |
 LL -     get(&mut key);
 LL +     get(key);
    |
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/did_you_mean/issue-35937.rs
+++ b/tests/ui/did_you_mean/issue-35937.rs
@@ -1,10 +1,11 @@
+//@ check-pass
 struct Foo {
     pub v: Vec<String>
 }
 
 fn main() {
     let f = Foo { v: Vec::new() };
-    f.v.push("cat".to_string()); //~ ERROR cannot borrow
+    f.v.push("cat".to_string()); //~ WARNING cannot borrow
 }
 
 
@@ -13,9 +14,9 @@ struct S {
 }
 fn foo() {
     let s = S { x: 42 };
-    s.x += 1; //~ ERROR cannot assign
+    s.x += 1; //~ WARNING cannot assign
 }
 
 fn bar(s: S) {
-    s.x += 1; //~ ERROR cannot assign
+    s.x += 1; //~ WARNING cannot assign
 }

--- a/tests/ui/did_you_mean/issue-35937.stderr
+++ b/tests/ui/did_you_mean/issue-35937.stderr
@@ -1,16 +1,17 @@
-error[E0596]: cannot borrow `f.v` as mutable, as `f` is not declared as mutable
-  --> $DIR/issue-35937.rs:7:5
+warning[E0596]: cannot borrow `f.v` as mutable, as `f` is not declared as mutable
+  --> $DIR/issue-35937.rs:8:5
    |
 LL |     f.v.push("cat".to_string());
    |     ^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut f = Foo { v: Vec::new() };
    |         +++
 
-error[E0594]: cannot assign to `s.x`, as `s` is not declared as mutable
-  --> $DIR/issue-35937.rs:16:5
+warning[E0594]: cannot assign to `s.x`, as `s` is not declared as mutable
+  --> $DIR/issue-35937.rs:17:5
    |
 LL |     s.x += 1;
    |     ^^^^^^^^ cannot assign
@@ -20,8 +21,8 @@ help: consider changing this to be mutable
 LL |     let mut s = S { x: 42 };
    |         +++
 
-error[E0594]: cannot assign to `s.x`, as `s` is not declared as mutable
-  --> $DIR/issue-35937.rs:20:5
+warning[E0594]: cannot assign to `s.x`, as `s` is not declared as mutable
+  --> $DIR/issue-35937.rs:21:5
    |
 LL |     s.x += 1;
    |     ^^^^^^^^ cannot assign
@@ -31,7 +32,7 @@ help: consider changing this to be mutable
 LL | fn bar(mut s: S) {
    |        +++
 
-error: aborting due to 3 previous errors
+warning: 3 warnings emitted
 
 Some errors have detailed explanations: E0594, E0596.
 For more information about an error, try `rustc --explain E0594`.

--- a/tests/ui/did_you_mean/issue-37139.rs
+++ b/tests/ui/did_you_mean/issue-37139.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 enum TestEnum {
     Item(i32),
 }
@@ -9,7 +10,7 @@ fn main() {
     let mut x = TestEnum::Item(10);
     match x {
         TestEnum::Item(ref mut x) => {
-            test(&mut x); //~ ERROR cannot borrow `x` as mutable, as it is not declared as mutable
+            test(&mut x); //~ WARNING cannot borrow `x` as mutable, as it is not declared as mutable
             //~| HELP try removing `&mut` here
         }
     }

--- a/tests/ui/did_you_mean/issue-37139.stderr
+++ b/tests/ui/did_you_mean/issue-37139.stderr
@@ -1,15 +1,16 @@
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/issue-37139.rs:12:18
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/issue-37139.rs:13:18
    |
 LL |             test(&mut x);
    |                  ^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: try removing `&mut` here
    |
 LL -             test(&mut x);
 LL +             test(x);
    |
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/did_you_mean/issue-39544.rs
+++ b/tests/ui/did_you_mean/issue-39544.rs
@@ -8,7 +8,7 @@ pub struct Z {
 
 fn main() {
     let z = Z { x: X::Y };
-    let _ = &mut z.x; //~ ERROR cannot borrow
+    let _ = &mut z.x; //~ WARNING cannot borrow
 }
 
 impl Z {
@@ -38,7 +38,7 @@ impl Z {
 }
 
 pub fn with_arg(z: Z, w: &Z) {
-    let _ = &mut z.x; //~ ERROR cannot borrow
+    let _ = &mut z.x; //~ WARNING cannot borrow
     let _ = &mut w.x; //~ ERROR cannot borrow
 }
 

--- a/tests/ui/did_you_mean/issue-39544.stderr
+++ b/tests/ui/did_you_mean/issue-39544.stderr
@@ -1,9 +1,10 @@
-error[E0596]: cannot borrow `z.x` as mutable, as `z` is not declared as mutable
+warning[E0596]: cannot borrow `z.x` as mutable, as `z` is not declared as mutable
   --> $DIR/issue-39544.rs:11:13
    |
 LL |     let _ = &mut z.x;
    |             ^^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut z = Z { x: X::Y };
@@ -97,7 +98,7 @@ help: consider changing this to be a mutable reference
 LL |     fn foo4(other: &mut Z) {
    |                     +++
 
-error[E0596]: cannot borrow `z.x` as mutable, as `z` is not declared as mutable
+warning[E0596]: cannot borrow `z.x` as mutable, as `z` is not declared as mutable
   --> $DIR/issue-39544.rs:41:13
    |
 LL |     let _ = &mut z.x;
@@ -125,7 +126,7 @@ error[E0594]: cannot assign to `*x.0`, which is behind a `&` reference
 LL |     *x.0 = 1;
    |     ^^^^^^^^ cannot assign
 
-error: aborting due to 12 previous errors
+error: aborting due to 10 previous errors; 2 warnings emitted
 
 Some errors have detailed explanations: E0594, E0596.
 For more information about an error, try `rustc --explain E0594`.

--- a/tests/ui/error-codes/E0596.rs
+++ b/tests/ui/error-codes/E0596.rs
@@ -1,4 +1,5 @@
+//@ check-pass
 fn main() {
     let x = 1;
-    let y = &mut x; //~ ERROR [E0596]
+    let y = &mut x; //~ WARNING [E0596]
 }

--- a/tests/ui/error-codes/E0596.stderr
+++ b/tests/ui/error-codes/E0596.stderr
@@ -1,14 +1,15 @@
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/E0596.rs:3:13
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/E0596.rs:4:13
    |
 LL |     let y = &mut x;
    |             ^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x = 1;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/fn/suggest-return-closure.rs
+++ b/tests/ui/fn/suggest-return-closure.rs
@@ -24,7 +24,8 @@ fn fn_mut() -> _ {
         //~^ ERROR: does not live long enough
         //~| NOTE: does not live long enough
         //~| NOTE: cannot borrow as mutable
-        //~| ERROR: not declared as mutable
+        //~| WARNING: not declared as mutable
+        //~| NOTE: on by default
     }
 } //~ NOTE: borrow later used here
 //~^ NOTE: dropped here

--- a/tests/ui/fn/suggest-return-closure.stderr
+++ b/tests/ui/fn/suggest-return-closure.stderr
@@ -21,7 +21,7 @@ LL | fn fn_mut() -> _ {
    = note: for more information on `Fn` traits and closure types, see https://doc.rust-lang.org/book/ch13-01-closures.html
 
 error[E0121]: the placeholder `_` is not allowed within types on item signatures for return types
-  --> $DIR/suggest-return-closure.rs:32:13
+  --> $DIR/suggest-return-closure.rs:33:13
    |
 LL | fn fun() -> _ {
    |             ^
@@ -31,12 +31,13 @@ LL | fn fun() -> _ {
    |
    = note: for more information on `Fn` traits and closure types, see https://doc.rust-lang.org/book/ch13-01-closures.html
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/suggest-return-closure.rs:23:9
    |
 LL |         x.push(c);
    |         ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x = String::new();
@@ -58,7 +59,7 @@ LL | }
    | |
    | `x` dropped here while still borrowed
 
-error: aborting due to 5 previous errors
+error: aborting due to 4 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0121, E0596, E0597.
 For more information about an error, try `rustc --explain E0121`.

--- a/tests/ui/issues/issue-28971.rs
+++ b/tests/ui/issues/issue-28971.rs
@@ -13,5 +13,5 @@ fn main(){
 
 fn foo<F>(f: F) where F: FnMut() {
     f();
-    //~^ ERROR: cannot borrow
+    //~^ WARNING: cannot borrow
 }

--- a/tests/ui/issues/issue-28971.stderr
+++ b/tests/ui/issues/issue-28971.stderr
@@ -12,18 +12,19 @@ help: there is a variant with a similar name
 LL |             Foo::Bar(..) => (),
    |                  ~~~
 
-error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
   --> $DIR/issue-28971.rs:15:5
    |
 LL |     f();
    |     ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn foo<F>(mut f: F) where F: FnMut() {
    |           +++
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error; 1 warning emitted
 
 Some errors have detailed explanations: E0596, E0599.
 For more information about an error, try `rustc --explain E0596`.

--- a/tests/ui/issues/issue-36400.rs
+++ b/tests/ui/issues/issue-36400.rs
@@ -1,6 +1,7 @@
+//@ check-pass
 fn f(x: &mut u32) {}
 
 fn main() {
     let x = Box::new(3);
-    f(&mut *x); //~ ERROR cannot borrow `*x` as mutable, as `x` is not declared as mutable
+    f(&mut *x); //~ WARNING cannot borrow `*x` as mutable, as `x` is not declared as mutable
 }

--- a/tests/ui/issues/issue-36400.stderr
+++ b/tests/ui/issues/issue-36400.stderr
@@ -1,14 +1,15 @@
-error[E0596]: cannot borrow `*x` as mutable, as `x` is not declared as mutable
-  --> $DIR/issue-36400.rs:5:7
+warning[E0596]: cannot borrow `*x` as mutable, as `x` is not declared as mutable
+  --> $DIR/issue-36400.rs:6:7
    |
 LL |     f(&mut *x);
    |       ^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x = Box::new(3);
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.rs
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.rs
@@ -3,7 +3,7 @@ struct Ref<'a, 'b> { a: &'a u32, b: &'b u32 }
 fn foo(mut x: Ref, y: &u32) {
     y = x.b;
     //~^ ERROR lifetime may not live long enough
-    //~| ERROR cannot assign to immutable argument
+    //~| WARNING cannot assign to immutable argument
 }
 
 fn main() { }

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-one-is-struct-2.stderr
@@ -13,17 +13,18 @@ help: consider introducing a named lifetime parameter
 LL | fn foo<'a>(mut x: Ref<'a, 'a>, y: &'a u32) {
    |       ++++           ++++++++      ++
 
-error[E0384]: cannot assign to immutable argument `y`
+warning[E0384]: cannot assign to immutable argument `y`
   --> $DIR/ex3-both-anon-regions-one-is-struct-2.rs:4:5
    |
 LL |     y = x.b;
    |     ^^^^^^^ cannot assign to immutable argument
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL | fn foo(mut x: Ref, mut y: &u32) {
    |                    +++
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.rs
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.rs
@@ -1,7 +1,7 @@
 fn foo(x:fn(&u8, &u8), y: Vec<&u8>, z: &u8) {
   y.push(z);
   //~^ ERROR lifetime may not live long enough
-  //~| ERROR cannot borrow
+  //~| WARNING cannot borrow
 }
 
 fn main() { }

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-fn-items.stderr
@@ -1,9 +1,10 @@
-error[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
   --> $DIR/ex3-both-anon-regions-using-fn-items.rs:2:3
    |
 LL |   y.push(z);
    |   ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn foo(x:fn(&u8, &u8), mut y: Vec<&u8>, z: &u8) {
@@ -24,6 +25,6 @@ help: consider introducing a named lifetime parameter
 LL | fn foo<'a>(x:fn(&u8, &u8), y: Vec<&'a u8>, z: &'a u8) {
    |       ++++                         ++          ++
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.rs
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.rs
@@ -1,7 +1,7 @@
 fn foo(x:Box<dyn Fn(&u8, &u8)> , y: Vec<&u8>, z: &u8) {
   y.push(z);
   //~^ ERROR lifetime may not live long enough
-  //~| ERROR cannot borrow
+  //~| WARNING cannot borrow
 }
 
 fn main() { }

--- a/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/ex3-both-anon-regions-using-trait-objects.stderr
@@ -1,9 +1,10 @@
-error[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `y` as mutable, as it is not declared as mutable
   --> $DIR/ex3-both-anon-regions-using-trait-objects.rs:2:3
    |
 LL |   y.push(z);
    |   ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn foo(x:Box<dyn Fn(&u8, &u8)> , mut y: Vec<&u8>, z: &u8) {
@@ -24,6 +25,6 @@ help: consider introducing a named lifetime parameter
 LL | fn foo<'a>(x:Box<dyn Fn(&u8, &u8)> , y: Vec<&'a u8>, z: &'a u8) {
    |       ++++                                   ++          ++
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/lifetimes/lifetime-errors/liveness-assign-imm-local-notes.rs
+++ b/tests/ui/lifetimes/lifetime-errors/liveness-assign-imm-local-notes.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 // Check notes are placed on an assignment that can actually precede the current assignment
 // Don't emit a first assignment for assignment in a loop.
 
@@ -7,7 +8,7 @@ fn test() {
         x = 1;
     } else {
         x = 2;
-        x = 3;      //~ ERROR [E0384]
+        x = 3;      //~ WARNING [E0384]
     }
 }
 
@@ -18,7 +19,7 @@ fn test_in_loop() {
             x = 1;
         } else {
             x = 2;
-            x = 3;      //~ ERROR [E0384]
+            x = 3;      //~ WARNING [E0384]
         }
     }
 }
@@ -27,9 +28,9 @@ fn test_using_loop() {
     let x;
     loop {
         if true {
-            x = 1;      //~ ERROR [E0384]
+            x = 1;      //~ WARNING [E0384]
         } else {
-            x = 2;      //~ ERROR [E0384]
+            x = 2;      //~ WARNING [E0384]
         }
     }
 }

--- a/tests/ui/lifetimes/lifetime-errors/liveness-assign-imm-local-notes.stderr
+++ b/tests/ui/lifetimes/lifetime-errors/liveness-assign-imm-local-notes.stderr
@@ -1,18 +1,19 @@
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/liveness-assign-imm-local-notes.rs:10:9
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/liveness-assign-imm-local-notes.rs:11:9
    |
 LL |         x = 2;
    |         ----- first assignment to `x`
 LL |         x = 3;
    |         ^^^^^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     let mut x;
    |         +++
 
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/liveness-assign-imm-local-notes.rs:21:13
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/liveness-assign-imm-local-notes.rs:22:13
    |
 LL |             x = 2;
    |             ----- first assignment to `x`
@@ -24,8 +25,8 @@ help: consider making this binding mutable
 LL |         let mut x;
    |             +++
 
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/liveness-assign-imm-local-notes.rs:30:13
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/liveness-assign-imm-local-notes.rs:31:13
    |
 LL |             x = 1;
    |             ^^^^^ cannot assign twice to immutable variable
@@ -35,8 +36,8 @@ help: consider making this binding mutable
 LL |     let mut x;
    |         +++
 
-error[E0384]: cannot assign twice to immutable variable `x`
-  --> $DIR/liveness-assign-imm-local-notes.rs:32:13
+warning[E0384]: cannot assign twice to immutable variable `x`
+  --> $DIR/liveness-assign-imm-local-notes.rs:33:13
    |
 LL |             x = 1;
    |             ----- first assignment to `x`
@@ -49,6 +50,6 @@ help: consider making this binding mutable
 LL |     let mut x;
    |         +++
 
-error: aborting due to 4 previous errors
+warning: 4 warnings emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.rs
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.rs
@@ -1,10 +1,12 @@
+//@ check-pass
 fn test() {
     let v: isize;
     //~^ HELP consider making this binding mutable
     //~| SUGGESTION mut
     loop {
-        v = 1; //~ ERROR cannot assign twice to immutable variable `v`
+        v = 1; //~ WARNING cannot assign twice to immutable variable `v`
                //~| NOTE cannot assign twice to immutable variable
+               //~| NOTE on by default
     }
 }
 

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.stderr
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-loop.stderr
@@ -1,14 +1,15 @@
-error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/liveness-assign-imm-local-in-loop.rs:6:9
+warning[E0384]: cannot assign twice to immutable variable `v`
+  --> $DIR/liveness-assign-imm-local-in-loop.rs:7:9
    |
 LL |         v = 1;
    |         ^^^^^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     let mut v: isize;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.rs
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.rs
@@ -1,10 +1,12 @@
+//@ check-pass
 fn test() {
     let v: isize;
     //~^ HELP consider making this binding mutable
     //~| SUGGESTION mut
     v = 2;  //~ NOTE first assignment
-    v += 1; //~ ERROR cannot assign twice to immutable variable `v`
+    v += 1; //~ WARNING cannot assign twice to immutable variable `v`
             //~| NOTE cannot assign twice to immutable
+            //~| NOTE on by default
     v.clone();
 }
 

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.stderr
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-in-op-eq.stderr
@@ -1,16 +1,17 @@
-error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/liveness-assign-imm-local-in-op-eq.rs:6:5
+warning[E0384]: cannot assign twice to immutable variable `v`
+  --> $DIR/liveness-assign-imm-local-in-op-eq.rs:7:5
    |
 LL |     v = 2;
    |     ----- first assignment to `v`
 LL |     v += 1;
    |     ^^^^^^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     let mut v: isize;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.rs
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.rs
@@ -1,10 +1,12 @@
+//@ check-pass
 fn test() {
     let b = Box::new(1); //~ NOTE first assignment
                          //~| HELP consider making this binding mutable
                          //~| SUGGESTION mut
     drop(b);
-    b = Box::new(2); //~ ERROR cannot assign twice to immutable variable `b`
+    b = Box::new(2); //~ WARNING cannot assign twice to immutable variable `b`
                      //~| NOTE cannot assign twice to immutable
+                     //~| NOTE on by default
     drop(b);
 }
 

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.stderr
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-drop.stderr
@@ -1,5 +1,5 @@
-error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/liveness-assign-imm-local-with-drop.rs:6:5
+warning[E0384]: cannot assign twice to immutable variable `b`
+  --> $DIR/liveness-assign-imm-local-with-drop.rs:7:5
    |
 LL |     let b = Box::new(1);
    |         - first assignment to `b`
@@ -7,11 +7,12 @@ LL |     let b = Box::new(1);
 LL |     b = Box::new(2);
    |     ^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     let mut b = Box::new(1);
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.rs
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.rs
@@ -1,10 +1,12 @@
+//@ check-pass
 fn test() {
     let v: isize = 1; //~ NOTE first assignment
                       //~| HELP consider making this binding mutable
                       //~| SUGGESTION mut
     v.clone();
-    v = 2; //~ ERROR cannot assign twice to immutable variable `v`
+    v = 2; //~ WARNING cannot assign twice to immutable variable `v`
            //~| NOTE cannot assign twice to immutable
+           //~| NOTE on by default
     v.clone();
 }
 

--- a/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.stderr
+++ b/tests/ui/liveness/liveness-assign/liveness-assign-imm-local-with-init.stderr
@@ -1,5 +1,5 @@
-error[E0384]: cannot assign twice to immutable variable `v`
-  --> $DIR/liveness-assign-imm-local-with-init.rs:6:5
+warning[E0384]: cannot assign twice to immutable variable `v`
+  --> $DIR/liveness-assign-imm-local-with-init.rs:7:5
    |
 LL |     let v: isize = 1;
    |         - first assignment to `v`
@@ -7,11 +7,12 @@ LL |     let v: isize = 1;
 LL |     v = 2;
    |     ^^^^^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     let mut v: isize = 1;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/macros/span-covering-argument-1.rs
+++ b/tests/ui/macros/span-covering-argument-1.rs
@@ -1,9 +1,10 @@
+//@ check-pass
 macro_rules! bad {
     ($s:ident whatever) => {
         {
             let $s = 0;
             *&mut $s = 0;
-            //~^ ERROR cannot borrow `foo` as mutable, as it is not declared as mutable [E0596]
+            //~^ WARNING cannot borrow `foo` as mutable, as it is not declared as mutable [E0596]
         }
     }
 }

--- a/tests/ui/macros/span-covering-argument-1.stderr
+++ b/tests/ui/macros/span-covering-argument-1.stderr
@@ -1,5 +1,5 @@
-error[E0596]: cannot borrow `foo` as mutable, as it is not declared as mutable
-  --> $DIR/span-covering-argument-1.rs:5:14
+warning[E0596]: cannot borrow `foo` as mutable, as it is not declared as mutable
+  --> $DIR/span-covering-argument-1.rs:6:14
    |
 LL |             *&mut $s = 0;
    |              ^^^^^^^ cannot borrow as mutable
@@ -7,12 +7,13 @@ LL |             *&mut $s = 0;
 LL |     bad!(foo whatever);
    |     ------------------ in this macro invocation
    |
-   = note: this error originates in the macro `bad` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: `#[warn(mut_non_mut)]` on by default
+   = note: this warning originates in the macro `bad` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider changing this to be mutable
    |
 LL |             let mut $s = 0;
    |                 +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/mut/mut-pattern-internal-mutability.rs
+++ b/tests/ui/mut/mut-pattern-internal-mutability.rs
@@ -2,7 +2,7 @@ fn main() {
     let foo = &mut 1;
 
     let &mut x = foo;
-    x += 1; //~ ERROR cannot assign twice to immutable variable `x`
+    x += 1; //~ WARNING cannot assign twice to immutable variable `x`
 
     // explicitly mut-ify internals
     let &mut mut x = foo;

--- a/tests/ui/mut/mut-pattern-internal-mutability.stderr
+++ b/tests/ui/mut/mut-pattern-internal-mutability.stderr
@@ -1,4 +1,4 @@
-error[E0384]: cannot assign twice to immutable variable `x`
+warning[E0384]: cannot assign twice to immutable variable `x`
   --> $DIR/mut-pattern-internal-mutability.rs:5:5
    |
 LL |     let &mut x = foo;
@@ -6,6 +6,7 @@ LL |     let &mut x = foo;
 LL |     x += 1;
    |     ^^^^^^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     let &mut mut x = foo;
@@ -25,7 +26,7 @@ LL |     *foo += 1;
 LL |     drop(x);
    |          - borrow later used here
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error; 1 warning emitted
 
 Some errors have detailed explanations: E0384, E0506.
 For more information about an error, try `rustc --explain E0384`.

--- a/tests/ui/mut/mut-suggestion.rs
+++ b/tests/ui/mut/mut-suggestion.rs
@@ -1,3 +1,5 @@
+//@ check-pass
+
 #[derive(Copy, Clone)]
 struct S;
 
@@ -10,7 +12,7 @@ fn func(arg: S) {
     //~^ HELP consider changing this to be mutable
     //~| SUGGESTION mut
     arg.mutate();
-    //~^ ERROR cannot borrow `arg` as mutable, as it is not declared as mutable
+    //~^ WARNING cannot borrow `arg` as mutable, as it is not declared as mutable
 }
 
 fn main() {
@@ -18,5 +20,5 @@ fn main() {
     //~^ HELP consider changing this to be mutable
     //~| SUGGESTION mut
     local.mutate();
-    //~^ ERROR cannot borrow `local` as mutable, as it is not declared as mutable
+    //~^ WARNING cannot borrow `local` as mutable, as it is not declared as mutable
 }

--- a/tests/ui/mut/mut-suggestion.stderr
+++ b/tests/ui/mut/mut-suggestion.stderr
@@ -1,16 +1,17 @@
-error[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
-  --> $DIR/mut-suggestion.rs:12:5
+warning[E0596]: cannot borrow `arg` as mutable, as it is not declared as mutable
+  --> $DIR/mut-suggestion.rs:14:5
    |
 LL |     arg.mutate();
    |     ^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn func(mut arg: S) {
    |         +++
 
-error[E0596]: cannot borrow `local` as mutable, as it is not declared as mutable
-  --> $DIR/mut-suggestion.rs:20:5
+warning[E0596]: cannot borrow `local` as mutable, as it is not declared as mutable
+  --> $DIR/mut-suggestion.rs:22:5
    |
 LL |     local.mutate();
    |     ^^^^^ cannot borrow as mutable
@@ -20,6 +21,6 @@ help: consider changing this to be mutable
 LL |     let mut local = S;
    |         +++
 
-error: aborting due to 2 previous errors
+warning: 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/mut/mutable-class-fields.rs
+++ b/tests/ui/mut/mutable-class-fields.rs
@@ -1,3 +1,5 @@
+//@ check-pass
+
 struct Cat {
   meows : usize,
   how_hungry : isize,
@@ -12,5 +14,5 @@ fn cat(in_x : usize, in_y : isize) -> Cat {
 
 fn main() {
   let nyan : Cat = cat(52, 99);
-  nyan.how_hungry = 0; //~ ERROR cannot assign
+  nyan.how_hungry = 0; //~ WARNING cannot assign
 }

--- a/tests/ui/mut/mutable-class-fields.stderr
+++ b/tests/ui/mut/mutable-class-fields.stderr
@@ -1,14 +1,15 @@
-error[E0594]: cannot assign to `nyan.how_hungry`, as `nyan` is not declared as mutable
-  --> $DIR/mutable-class-fields.rs:15:3
+warning[E0594]: cannot assign to `nyan.how_hungry`, as `nyan` is not declared as mutable
+  --> $DIR/mutable-class-fields.rs:17:3
    |
 LL |   nyan.how_hungry = 0;
    |   ^^^^^^^^^^^^^^^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |   let mut nyan : Cat = cat(52, 99);
    |       +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0594`.

--- a/tests/ui/nll/closure-captures.rs
+++ b/tests/ui/nll/closure-captures.rs
@@ -4,19 +4,19 @@
 
 fn one_closure(x: i32) {
     ||
-    x = 1; //~ ERROR
+    x = 1; //~ WARNING
     move ||
-    x = 1; //~ ERROR
+    x = 1; //~ WARNING
 }
 
 fn two_closures(x: i32) {
     || {
         ||
-        x = 1; //~ ERROR
+        x = 1; //~ WARNING
     };
     move || {
         ||
-        x = 1; //~ ERROR
+        x = 1; //~ WARNING
     };
 }
 
@@ -36,11 +36,11 @@ fn two_closures_ref_mut(mut x: i32) {
 fn two_closures_ref(x: i32) {
     fn_ref(|| {
         || //~ ERROR
-         x = 1;} //~ ERROR
+         x = 1;} //~ WARNING
     );
     fn_ref(move || {
         ||  //~ ERROR
-    x = 1;}); //~ ERROR
+    x = 1;}); //~ WARNING
 }
 
 fn two_closures_two_refs(x: &mut i32) {

--- a/tests/ui/nll/closure-captures.stderr
+++ b/tests/ui/nll/closure-captures.stderr
@@ -1,15 +1,16 @@
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/closure-captures.rs:7:5
    |
 LL |     x = 1;
    |     ^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn one_closure(mut x: i32) {
    |                +++
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/closure-captures.rs:9:5
    |
 LL |     x = 1;
@@ -20,7 +21,7 @@ help: consider changing this to be mutable
 LL | fn one_closure(mut x: i32) {
    |                +++
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/closure-captures.rs:15:9
    |
 LL |         x = 1;
@@ -31,7 +32,7 @@ help: consider changing this to be mutable
 LL | fn two_closures(mut x: i32) {
    |                 +++
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/closure-captures.rs:19:9
    |
 LL |         x = 1;
@@ -72,7 +73,7 @@ LL |         ||
 LL |     x = 1;});
    |     - mutable borrow occurs due to use of `x` in closure
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/closure-captures.rs:39:10
    |
 LL |          x = 1;}
@@ -98,7 +99,7 @@ LL |         ||
 LL |          x = 1;}
    |          - mutable borrow occurs due to use of `x` in closure
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
   --> $DIR/closure-captures.rs:43:5
    |
 LL |     x = 1;});
@@ -154,7 +155,7 @@ LL |         ||
 LL |         *x = 1;});
    |         -- mutable borrow occurs due to use of `x` in closure
 
-error: aborting due to 12 previous errors
+error: aborting due to 6 previous errors; 6 warnings emitted
 
 Some errors have detailed explanations: E0594, E0596.
 For more information about an error, try `rustc --explain E0594`.

--- a/tests/ui/nll/coroutine-upvar-mutability.rs
+++ b/tests/ui/nll/coroutine-upvar-mutability.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 // Check that coroutines respect the muatability of their upvars.
 
 #![feature(coroutines)]
@@ -8,7 +9,7 @@ fn mutate_upvar() {
     #[coroutine]
     move || {
         x = 1;
-        //~^ ERROR
+        //~^ WARNING
         yield;
     };
 }

--- a/tests/ui/nll/coroutine-upvar-mutability.stderr
+++ b/tests/ui/nll/coroutine-upvar-mutability.stderr
@@ -1,14 +1,15 @@
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/coroutine-upvar-mutability.rs:10:9
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/coroutine-upvar-mutability.rs:11:9
    |
 LL |         x = 1;
    |         ^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x = 0;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0594`.

--- a/tests/ui/nll/issue-46023.rs
+++ b/tests/ui/nll/issue-46023.rs
@@ -1,8 +1,9 @@
+//@ check-pass
 fn main() {
     let x = 0;
 
     (move || {
         x = 1;
-        //~^ ERROR cannot assign to `x`, as it is not declared as mutable [E0594]
+        //~^ WARNING cannot assign to `x`, as it is not declared as mutable [E0594]
     })()
 }

--- a/tests/ui/nll/issue-46023.stderr
+++ b/tests/ui/nll/issue-46023.stderr
@@ -1,14 +1,15 @@
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/issue-46023.rs:5:9
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/issue-46023.rs:6:9
    |
 LL |         x = 1;
    |         ^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x = 0;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0594`.

--- a/tests/ui/nll/issue-51191.rs
+++ b/tests/ui/nll/issue-51191.rs
@@ -5,13 +5,13 @@ impl Struct {
         //~^ WARN function cannot return without recursing
         //~^^ HELP a `loop` may express intention better if this is on purpose
         (&mut self).bar();
-        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
+        //~^ WARNING cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
         //~^^ HELP try removing `&mut` here
     }
 
     fn imm(self) { //~ HELP consider changing this to be mutable
         (&mut self).bar();
-        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
+        //~^ WARNING cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
     }
 
     fn mtbl(mut self) {
@@ -20,13 +20,13 @@ impl Struct {
 
     fn immref(&self) {
         (&mut self).bar();
-        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
+        //~^ WARNING cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
         //~^^ ERROR cannot borrow data in a `&` reference as mutable [E0596]
     }
 
     fn mtblref(&mut self) {
         (&mut self).bar();
-        //~^ ERROR cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
+        //~^ WARNING cannot borrow `self` as mutable, as it is not declared as mutable [E0596]
         //~^^ HELP try removing `&mut` here
     }
 }

--- a/tests/ui/nll/issue-51191.stderr
+++ b/tests/ui/nll/issue-51191.stderr
@@ -10,7 +10,7 @@ LL |         (&mut self).bar();
    = help: a `loop` may express intention better if this is on purpose
    = note: `#[warn(unconditional_recursion)]` on by default
 
-error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-51191.rs:7:9
    |
 LL |         (&mut self).bar();
@@ -26,8 +26,9 @@ help: try removing `&mut` here
    |
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^
+   = note: `#[warn(mut_non_mut)]` on by default
 
-error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-51191.rs:13:9
    |
 LL |         (&mut self).bar();
@@ -38,7 +39,7 @@ help: consider changing this to be mutable
 LL |     fn imm(mut self) {
    |            +++
 
-error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-51191.rs:22:9
    |
 LL |         (&mut self).bar();
@@ -50,7 +51,7 @@ error[E0596]: cannot borrow data in a `&` reference as mutable
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^ cannot borrow as mutable
 
-error[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `self` as mutable, as it is not declared as mutable
   --> $DIR/issue-51191.rs:28:9
    |
 LL |         (&mut self).bar();
@@ -67,6 +68,6 @@ help: try removing `&mut` here
 LL |         (&mut self).bar();
    |         ^^^^^^^^^^^
 
-error: aborting due to 5 previous errors; 1 warning emitted
+error: aborting due to 1 previous error; 5 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/pattern/bindings-after-at/nested-binding-modes-mut.rs
+++ b/tests/ui/pattern/bindings-after-at/nested-binding-modes-mut.rs
@@ -1,11 +1,12 @@
+//@ check-pass
 fn main() {
     let mut is_mut @ not_mut = 42;
     &mut is_mut;
     &mut not_mut;
-    //~^ ERROR cannot borrow
+    //~^ WARNING cannot borrow
 
     let not_mut @ mut is_mut = 42;
     &mut is_mut;
     &mut not_mut;
-    //~^ ERROR cannot borrow
+    //~^ WARNING cannot borrow
 }

--- a/tests/ui/pattern/bindings-after-at/nested-binding-modes-mut.stderr
+++ b/tests/ui/pattern/bindings-after-at/nested-binding-modes-mut.stderr
@@ -1,16 +1,17 @@
-error[E0596]: cannot borrow `not_mut` as mutable, as it is not declared as mutable
-  --> $DIR/nested-binding-modes-mut.rs:4:5
+warning[E0596]: cannot borrow `not_mut` as mutable, as it is not declared as mutable
+  --> $DIR/nested-binding-modes-mut.rs:5:5
    |
 LL |     &mut not_mut;
    |     ^^^^^^^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut is_mut @ mut not_mut = 42;
    |                      +++
 
-error[E0596]: cannot borrow `not_mut` as mutable, as it is not declared as mutable
-  --> $DIR/nested-binding-modes-mut.rs:9:5
+warning[E0596]: cannot borrow `not_mut` as mutable, as it is not declared as mutable
+  --> $DIR/nested-binding-modes-mut.rs:10:5
    |
 LL |     &mut not_mut;
    |     ^^^^^^^^^^^^ cannot borrow as mutable
@@ -20,6 +21,6 @@ help: consider changing this to be mutable
 LL |     let mut not_mut @ mut is_mut = 42;
    |         +++
 
-error: aborting due to 2 previous errors
+warning: 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.rs
+++ b/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.rs
@@ -10,7 +10,7 @@ fn main() {
     match Ok(0) {
         Ok(a @ b @ a)
         //~^ ERROR identifier `a` is bound more than once in the same pattern
-        | Err(a @ b @ a) //~ ERROR cannot assign twice to immutable variable `a`
+        | Err(a @ b @ a) //~ WARNING cannot assign twice to immutable variable `a`
         //~^ ERROR identifier `a` is bound more than once in the same pattern
         => {}
     }

--- a/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.stderr
+++ b/tests/ui/pattern/bindings-after-at/pat-at-same-name-both.stderr
@@ -66,7 +66,7 @@ LL |     let ref mut a @ ref mut a = ();
    |         |
    |         value is mutably borrowed by `a` here
 
-error[E0384]: cannot assign twice to immutable variable `a`
+warning[E0384]: cannot assign twice to immutable variable `a`
   --> $DIR/pat-at-same-name-both.rs:13:15
    |
 LL |         Ok(a @ b @ a)
@@ -75,6 +75,7 @@ LL |
 LL |         | Err(a @ b @ a)
    |               ^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |         Ok(a @ b @ mut a)
@@ -84,7 +85,7 @@ help: to modify the original value, take a borrow instead
 LL |         Ok(a @ b @ ref mut a)
    |                    +++++++
 
-error: aborting due to 12 previous errors
+error: aborting due to 11 previous errors; 1 warning emitted
 
 Some errors have detailed explanations: E0384, E0415, E0416.
 For more information about an error, try `rustc --explain E0384`.

--- a/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.rs
+++ b/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.rs
@@ -6,7 +6,7 @@ fn slice() {
     let mut arr = [U, U, U, U, U];
     let hold_all = &arr;
     let [ref _x0_hold, _x1, ref xs_hold @ ..] = arr; //~ ERROR cannot move out of `arr[..]`
-    _x1 = U; //~ ERROR cannot assign twice to immutable variable `_x1`
+    _x1 = U; //~ WARNING cannot assign twice to immutable variable `_x1`
     drop(hold_all);
     let [_x0, ..] = arr; //~ ERROR cannot move out of `arr[..]`
     drop(_x0_hold);
@@ -20,7 +20,7 @@ fn slice() {
 fn tuple() {
     let mut tup = (U, U, U, U);
     let (ref _x0, _x1, ref _x2, ..) = tup;
-    _x1 = U; //~ ERROR cannot assign twice to immutable variable
+    _x1 = U; //~ WARNING cannot assign twice to immutable variable
     let _x0_hold = &mut tup.0; //~ ERROR cannot borrow `tup.0` as mutable because it is also
     let (ref mut _x0_hold, ..) = tup; //~ ERROR cannot borrow `tup.0` as mutable because it is also
     *_x0 = U; //~ ERROR cannot assign to `*_x0`, which is behind a `&` reference

--- a/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
+++ b/tests/ui/pattern/move-ref-patterns/borrowck-move-ref-pattern.stderr
@@ -11,7 +11,7 @@ LL |     _x1 = U;
 LL |     drop(hold_all);
    |          -------- borrow later used here
 
-error[E0384]: cannot assign twice to immutable variable `_x1`
+warning[E0384]: cannot assign twice to immutable variable `_x1`
   --> $DIR/borrowck-move-ref-pattern.rs:9:5
    |
 LL |     let [ref _x0_hold, _x1, ref xs_hold @ ..] = arr;
@@ -19,6 +19,7 @@ LL |     let [ref _x0_hold, _x1, ref xs_hold @ ..] = arr;
 LL |     _x1 = U;
    |     ^^^^^^^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     let [ref _x0_hold, mut _x1, ref xs_hold @ ..] = arr;
@@ -75,7 +76,7 @@ LL |     let [_, _, ref mut _x2, _x3, mut _x4] = arr;
 LL |     drop(xs_hold);
    |          ------- borrow later used here
 
-error[E0384]: cannot assign twice to immutable variable `_x1`
+warning[E0384]: cannot assign twice to immutable variable `_x1`
   --> $DIR/borrowck-move-ref-pattern.rs:23:5
    |
 LL |     let (ref _x0, _x1, ref _x2, ..) = tup;
@@ -224,7 +225,7 @@ LL |
 LL |         let (ref mut _x0, _, _x2) = tup;
    |                                     --- use occurs due to use in closure
 
-error: aborting due to 18 previous errors
+error: aborting due to 16 previous errors; 2 warnings emitted
 
 Some errors have detailed explanations: E0382, E0384, E0499, E0502, E0505, E0594.
 For more information about an error, try `rustc --explain E0382`.

--- a/tests/ui/pattern/mut-ref-mut-2021.rs
+++ b/tests/ui/pattern/mut-ref-mut-2021.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 //@ edition: 2021
 #![allow(incomplete_features)]
 #![feature(mut_ref)]
@@ -6,49 +7,49 @@ struct Foo(u8);
 
 fn main() {
     let Foo(a) = Foo(0);
-    a = 42; //~ ERROR [E0384]
+    a = 42; //~ WARNING [E0384]
 
     let Foo(mut a) = Foo(0);
     a = 42;
 
     let Foo(ref a) = Foo(0);
-    a = &42; //~ ERROR [E0384]
+    a = &42; //~ WARNING [E0384]
 
     let Foo(mut ref a) = Foo(0);
     a = &42;
 
     let Foo(ref mut a) = Foo(0);
-    a = &mut 42; //~ ERROR [E0384]
+    a = &mut 42; //~ WARNING [E0384]
 
     let Foo(mut ref mut a) = Foo(0);
     a = &mut 42;
 
     let Foo(a) = &Foo(0);
-    a = &42; //~ ERROR [E0384]
+    a = &42; //~ WARNING [E0384]
 
     let Foo(mut a) = &Foo(0);
     a = 42;
 
     let Foo(ref a) = &Foo(0);
-    a = &42; //~ ERROR [E0384]
+    a = &42; //~ WARNING [E0384]
 
     let Foo(mut ref a) = &Foo(0);
     a = &42;
 
     let Foo(a) = &mut Foo(0);
-    a = &mut 42; //~ ERROR [E0384]
+    a = &mut 42; //~ WARNING [E0384]
 
     let Foo(mut a) = &mut Foo(0);
     a = 42;
 
     let Foo(ref a) = &mut Foo(0);
-    a = &42; //~ ERROR [E0384]
+    a = &42; //~ WARNING [E0384]
 
     let Foo(mut ref a) = &mut Foo(0);
     a = &42;
 
     let Foo(ref mut a) = &mut Foo(0);
-    a = &mut 42; //~ ERROR [E0384]
+    a = &mut 42; //~ WARNING [E0384]
 
     let Foo(mut ref mut a) = &mut Foo(0);
     a = &mut 42;

--- a/tests/ui/pattern/mut-ref-mut-2021.stderr
+++ b/tests/ui/pattern/mut-ref-mut-2021.stderr
@@ -1,11 +1,12 @@
-error[E0384]: cannot assign twice to immutable variable `a`
-  --> $DIR/mut-ref-mut-2021.rs:9:5
+warning[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/mut-ref-mut-2021.rs:10:5
    |
 LL |     let Foo(a) = Foo(0);
    |             - first assignment to `a`
 LL |     a = 42;
    |     ^^^^^^ cannot assign twice to immutable variable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider making this binding mutable
    |
 LL |     let Foo(mut a) = Foo(0);
@@ -15,62 +16,62 @@ help: to modify the original value, take a borrow instead
 LL |     let Foo(ref mut a) = Foo(0);
    |             +++++++
 
-error[E0384]: cannot assign twice to immutable variable `a`
-  --> $DIR/mut-ref-mut-2021.rs:15:5
+warning[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/mut-ref-mut-2021.rs:16:5
    |
 LL |     let Foo(ref a) = Foo(0);
    |             ----- first assignment to `a`
 LL |     a = &42;
    |     ^^^^^^^ cannot assign twice to immutable variable
 
-error[E0384]: cannot assign twice to immutable variable `a`
-  --> $DIR/mut-ref-mut-2021.rs:21:5
+warning[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/mut-ref-mut-2021.rs:22:5
    |
 LL |     let Foo(ref mut a) = Foo(0);
    |             --------- first assignment to `a`
 LL |     a = &mut 42;
    |     ^^^^^^^^^^^ cannot assign twice to immutable variable
 
-error[E0384]: cannot assign twice to immutable variable `a`
-  --> $DIR/mut-ref-mut-2021.rs:27:5
+warning[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/mut-ref-mut-2021.rs:28:5
    |
 LL |     let Foo(a) = &Foo(0);
    |             - first assignment to `a`
 LL |     a = &42;
    |     ^^^^^^^ cannot assign twice to immutable variable
 
-error[E0384]: cannot assign twice to immutable variable `a`
-  --> $DIR/mut-ref-mut-2021.rs:33:5
+warning[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/mut-ref-mut-2021.rs:34:5
    |
 LL |     let Foo(ref a) = &Foo(0);
    |             ----- first assignment to `a`
 LL |     a = &42;
    |     ^^^^^^^ cannot assign twice to immutable variable
 
-error[E0384]: cannot assign twice to immutable variable `a`
-  --> $DIR/mut-ref-mut-2021.rs:39:5
+warning[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/mut-ref-mut-2021.rs:40:5
    |
 LL |     let Foo(a) = &mut Foo(0);
    |             - first assignment to `a`
 LL |     a = &mut 42;
    |     ^^^^^^^^^^^ cannot assign twice to immutable variable
 
-error[E0384]: cannot assign twice to immutable variable `a`
-  --> $DIR/mut-ref-mut-2021.rs:45:5
+warning[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/mut-ref-mut-2021.rs:46:5
    |
 LL |     let Foo(ref a) = &mut Foo(0);
    |             ----- first assignment to `a`
 LL |     a = &42;
    |     ^^^^^^^ cannot assign twice to immutable variable
 
-error[E0384]: cannot assign twice to immutable variable `a`
-  --> $DIR/mut-ref-mut-2021.rs:51:5
+warning[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/mut-ref-mut-2021.rs:52:5
    |
 LL |     let Foo(ref mut a) = &mut Foo(0);
    |             --------- first assignment to `a`
 LL |     a = &mut 42;
    |     ^^^^^^^^^^^ cannot assign twice to immutable variable
 
-error: aborting due to 8 previous errors
+warning: 8 warnings emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.fixed
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.fixed
@@ -1,3 +1,4 @@
+//@ check-pass
 //@ run-rustfix
 #![allow(dead_code)]
 
@@ -5,6 +6,6 @@ fn main() {
     fn x(a: &char) {
         let &(mut b) = a;
         b.make_ascii_uppercase();
-//~^ cannot borrow `b` as mutable, as it is not declared as mutable
+//~^ WARNING cannot borrow `b` as mutable, as it is not declared as mutable
     }
 }

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.rs
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 //@ run-rustfix
 #![allow(dead_code)]
 
@@ -5,6 +6,6 @@ fn main() {
     fn x(a: &char) {
         let &b = a;
         b.make_ascii_uppercase();
-//~^ cannot borrow `b` as mutable, as it is not declared as mutable
+//~^ WARNING cannot borrow `b` as mutable, as it is not declared as mutable
     }
 }

--- a/tests/ui/pattern/patkind-ref-binding-issue-114896.stderr
+++ b/tests/ui/pattern/patkind-ref-binding-issue-114896.stderr
@@ -1,14 +1,15 @@
-error[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
-  --> $DIR/patkind-ref-binding-issue-114896.rs:7:9
+warning[E0596]: cannot borrow `b` as mutable, as it is not declared as mutable
+  --> $DIR/patkind-ref-binding-issue-114896.rs:8:9
    |
 LL |         b.make_ascii_uppercase();
    |         ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |         let &(mut b) = a;
    |             ~~~~~  +
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/pattern/patkind-ref-binding-issue-122415.fixed
+++ b/tests/ui/pattern/patkind-ref-binding-issue-122415.fixed
@@ -1,3 +1,4 @@
+//@ check-pass
 //@ run-rustfix
 #![allow(dead_code)]
 
@@ -5,7 +6,7 @@ fn mutate(_y: &mut i32) {}
 
 fn foo(&(mut x): &i32) {
     mutate(&mut x);
-    //~^ ERROR cannot borrow `x` as mutable
+    //~^ WARNING cannot borrow `x` as mutable
 }
 
 fn main() {}

--- a/tests/ui/pattern/patkind-ref-binding-issue-122415.rs
+++ b/tests/ui/pattern/patkind-ref-binding-issue-122415.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 //@ run-rustfix
 #![allow(dead_code)]
 
@@ -5,7 +6,7 @@ fn mutate(_y: &mut i32) {}
 
 fn foo(&x: &i32) {
     mutate(&mut x);
-    //~^ ERROR cannot borrow `x` as mutable
+    //~^ WARNING cannot borrow `x` as mutable
 }
 
 fn main() {}

--- a/tests/ui/pattern/patkind-ref-binding-issue-122415.stderr
+++ b/tests/ui/pattern/patkind-ref-binding-issue-122415.stderr
@@ -1,14 +1,15 @@
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/patkind-ref-binding-issue-122415.rs:7:12
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/patkind-ref-binding-issue-122415.rs:8:12
    |
 LL |     mutate(&mut x);
    |            ^^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn foo(&(mut x): &i32) {
    |        ~~~~~  +
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/reassign-ref-mut.rs
+++ b/tests/ui/reassign-ref-mut.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 // Tests how we behave when the user attempts to mutate an immutable
 // binding that was introduced by either `ref` or `ref mut`
 // patterns.
@@ -10,7 +11,7 @@ fn main() {
     let (mut one_two, mut three_four) = ((1, 2), (3, 4));
     let &mut (ref a, ref mut b) = &mut one_two;
     a = &three_four.0;
-    //~^ ERROR cannot assign twice to immutable variable `a` [E0384]
+    //~^ WARNING cannot assign twice to immutable variable `a` [E0384]
     b = &mut three_four.1;
-    //~^ ERROR cannot assign twice to immutable variable `b` [E0384]
+    //~^ WARNING cannot assign twice to immutable variable `b` [E0384]
 }

--- a/tests/ui/reassign-ref-mut.stderr
+++ b/tests/ui/reassign-ref-mut.stderr
@@ -1,13 +1,15 @@
-error[E0384]: cannot assign twice to immutable variable `a`
-  --> $DIR/reassign-ref-mut.rs:12:5
+warning[E0384]: cannot assign twice to immutable variable `a`
+  --> $DIR/reassign-ref-mut.rs:13:5
    |
 LL |     let &mut (ref a, ref mut b) = &mut one_two;
    |               ----- first assignment to `a`
 LL |     a = &three_four.0;
    |     ^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
+   |
+   = note: `#[warn(mut_non_mut)]` on by default
 
-error[E0384]: cannot assign twice to immutable variable `b`
-  --> $DIR/reassign-ref-mut.rs:14:5
+warning[E0384]: cannot assign twice to immutable variable `b`
+  --> $DIR/reassign-ref-mut.rs:15:5
    |
 LL |     let &mut (ref a, ref mut b) = &mut one_two;
    |                      --------- first assignment to `b`
@@ -15,6 +17,6 @@ LL |     let &mut (ref a, ref mut b) = &mut one_two;
 LL |     b = &mut three_four.1;
    |     ^^^^^^^^^^^^^^^^^^^^^ cannot assign twice to immutable variable
 
-error: aborting due to 2 previous errors
+warning: 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0384`.

--- a/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.rs
+++ b/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.rs
@@ -50,7 +50,7 @@ fn deref_imm_field(x: Own<Point>) {
 }
 
 fn deref_mut_field1(x: Own<Point>) {
-    let __isize = &mut x.y; //~ ERROR cannot borrow
+    let __isize = &mut x.y; //~ WARNING cannot borrow
 }
 
 fn deref_mut_field2(mut x: Own<Point>) {
@@ -85,7 +85,7 @@ fn deref_extend_mut_field4<'a>(x: &'a mut Own<Point>) {
 }
 
 fn assign_field1<'a>(x: Own<Point>) {
-    x.y = 3; //~ ERROR cannot borrow
+    x.y = 3; //~ WARNING cannot borrow
 }
 
 fn assign_field2<'a>(x: &'a Own<Point>) {
@@ -106,7 +106,7 @@ fn deref_imm_method(x: Own<Point>) {
 }
 
 fn deref_mut_method1(x: Own<Point>) {
-    x.set(0, 0); //~ ERROR cannot borrow
+    x.set(0, 0); //~ WARNING cannot borrow
 }
 
 fn deref_mut_method2(mut x: Own<Point>) {
@@ -126,7 +126,7 @@ fn deref_extend_mut_method2(x: &mut Own<Point>) -> &mut isize {
 }
 
 fn assign_method1<'a>(x: Own<Point>) {
-    *x.y_mut() = 3; //~ ERROR cannot borrow
+    *x.y_mut() = 3; //~ WARNING cannot borrow
 }
 
 fn assign_method2<'a>(x: &'a Own<Point>) {

--- a/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-auto-deref-mut.stderr
@@ -1,9 +1,10 @@
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:53:24
    |
 LL |     let __isize = &mut x.y;
    |                        ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn deref_mut_field1(mut x: Own<Point>) {
@@ -30,7 +31,7 @@ LL |     let _y = &mut x.y;
 LL |     use_mut(_x);
    |             -- first borrow later used here
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:88:5
    |
 LL |     x.y = 3;
@@ -62,7 +63,7 @@ LL |     x.y = 3;
 LL |     use_mut(_p);
    |             -- first borrow later used here
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:109:5
    |
 LL |     x.set(0, 0);
@@ -84,7 +85,7 @@ help: consider changing this to be a mutable reference
 LL | fn deref_extend_mut_method1(x: &mut Own<Point>) -> &mut isize {
    |                                 +++
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-borrow-overloaded-auto-deref-mut.rs:129:6
    |
 LL |     *x.y_mut() = 3;
@@ -106,7 +107,7 @@ help: consider changing this to be a mutable reference
 LL | fn assign_method2<'a>(x: &'a mut Own<Point>) {
    |                              +++
 
-error: aborting due to 10 previous errors
+error: aborting due to 6 previous errors; 4 warnings emitted
 
 Some errors have detailed explanations: E0499, E0596.
 For more information about an error, try `rustc --explain E0499`.

--- a/tests/ui/span/borrowck-borrow-overloaded-deref-mut.rs
+++ b/tests/ui/span/borrowck-borrow-overloaded-deref-mut.rs
@@ -26,7 +26,7 @@ fn deref_imm(x: Own<isize>) {
 }
 
 fn deref_mut1(x: Own<isize>) {
-    let __isize = &mut *x; //~ ERROR cannot borrow
+    let __isize = &mut *x; //~ WARNING cannot borrow
 }
 
 fn deref_mut2(mut x: Own<isize>) {
@@ -46,7 +46,7 @@ fn deref_extend_mut2<'a>(x: &'a mut Own<isize>) -> &'a mut isize {
 }
 
 fn assign1<'a>(x: Own<isize>) {
-    *x = 3; //~ ERROR cannot borrow
+    *x = 3; //~ WARNING cannot borrow
 }
 
 fn assign2<'a>(x: &'a Own<isize>) {

--- a/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
+++ b/tests/ui/span/borrowck-borrow-overloaded-deref-mut.stderr
@@ -1,9 +1,10 @@
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:29:25
    |
 LL |     let __isize = &mut *x;
    |                         ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn deref_mut1(mut x: Own<isize>) {
@@ -20,7 +21,7 @@ help: consider changing this to be a mutable reference
 LL | fn deref_extend_mut1<'a>(x: &'a mut Own<isize>) -> &'a mut isize {
    |                                 +++
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
   --> $DIR/borrowck-borrow-overloaded-deref-mut.rs:49:6
    |
 LL |     *x = 3;
@@ -42,6 +43,6 @@ help: consider changing this to be a mutable reference
 LL | fn assign2<'a>(x: &'a mut Own<isize>) {
    |                       +++
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/span/borrowck-object-mutability.rs
+++ b/tests/ui/span/borrowck-object-mutability.rs
@@ -15,7 +15,7 @@ fn borrowed_mut_receiver(x: &mut dyn Foo) {
 
 fn owned_receiver(x: Box<dyn Foo>) {
     x.borrowed();
-    x.borrowed_mut(); //~ ERROR cannot borrow
+    x.borrowed_mut(); //~ WARNING cannot borrow
 }
 
 fn mut_owned_receiver(mut x: Box<dyn Foo>) {

--- a/tests/ui/span/borrowck-object-mutability.stderr
+++ b/tests/ui/span/borrowck-object-mutability.stderr
@@ -9,17 +9,18 @@ help: consider changing this to be a mutable reference
 LL | fn borrowed_receiver(x: &mut dyn Foo) {
    |                          +++
 
-error[E0596]: cannot borrow `*x` as mutable, as `x` is not declared as mutable
+warning[E0596]: cannot borrow `*x` as mutable, as `x` is not declared as mutable
   --> $DIR/borrowck-object-mutability.rs:18:5
    |
 LL |     x.borrowed_mut();
    |     ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL | fn owned_receiver(mut x: Box<dyn Foo>) {
    |                   +++
 
-error: aborting due to 2 previous errors
+error: aborting due to 1 previous error; 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/unboxed-closures/unboxed-closure-immutable-capture.rs
+++ b/tests/ui/unboxed-closures/unboxed-closure-immutable-capture.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 // Test that even unboxed closures that are capable of mutating their
 // environment cannot mutate captured variables that have not been
 // declared mutable (#18335)
@@ -6,12 +7,12 @@ fn set(x: &mut usize) { *x = 0; }
 
 fn main() {
     let x = 0;
-    move || x = 1; //~ ERROR cannot assign
-    move || set(&mut x); //~ ERROR cannot borrow
-    move || x = 1; //~ ERROR cannot assign
-    move || set(&mut x); //~ ERROR cannot borrow
-    || x = 1; //~ ERROR cannot assign
-    || set(&mut x); //~ ERROR cannot borrow
-    || x = 1; //~ ERROR cannot assign
-    || set(&mut x); //~ ERROR cannot borrow
+    move || x = 1; //~ WARNING cannot assign
+    move || set(&mut x); //~ WARNING cannot borrow
+    move || x = 1; //~ WARNING cannot assign
+    move || set(&mut x); //~ WARNING cannot borrow
+    || x = 1; //~ WARNING cannot assign
+    || set(&mut x); //~ WARNING cannot borrow
+    || x = 1; //~ WARNING cannot assign
+    || set(&mut x); //~ WARNING cannot borrow
 }

--- a/tests/ui/unboxed-closures/unboxed-closure-immutable-capture.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closure-immutable-capture.stderr
@@ -1,16 +1,17 @@
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/unboxed-closure-immutable-capture.rs:9:13
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/unboxed-closure-immutable-capture.rs:10:13
    |
 LL |     move || x = 1;
    |             ^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut x = 0;
    |         +++
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/unboxed-closure-immutable-capture.rs:10:17
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/unboxed-closure-immutable-capture.rs:11:17
    |
 LL |     move || set(&mut x);
    |                 ^^^^^^ cannot borrow as mutable
@@ -20,8 +21,8 @@ help: consider changing this to be mutable
 LL |     let mut x = 0;
    |         +++
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/unboxed-closure-immutable-capture.rs:11:13
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/unboxed-closure-immutable-capture.rs:12:13
    |
 LL |     move || x = 1;
    |             ^^^^^ cannot assign
@@ -31,8 +32,8 @@ help: consider changing this to be mutable
 LL |     let mut x = 0;
    |         +++
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/unboxed-closure-immutable-capture.rs:12:17
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/unboxed-closure-immutable-capture.rs:13:17
    |
 LL |     move || set(&mut x);
    |                 ^^^^^^ cannot borrow as mutable
@@ -42,8 +43,8 @@ help: consider changing this to be mutable
 LL |     let mut x = 0;
    |         +++
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/unboxed-closure-immutable-capture.rs:13:8
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/unboxed-closure-immutable-capture.rs:14:8
    |
 LL |     || x = 1;
    |        ^^^^^ cannot assign
@@ -53,8 +54,8 @@ help: consider changing this to be mutable
 LL |     let mut x = 0;
    |         +++
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/unboxed-closure-immutable-capture.rs:14:12
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/unboxed-closure-immutable-capture.rs:15:12
    |
 LL |     || set(&mut x);
    |            ^^^^^^ cannot borrow as mutable
@@ -64,8 +65,8 @@ help: consider changing this to be mutable
 LL |     let mut x = 0;
    |         +++
 
-error[E0594]: cannot assign to `x`, as it is not declared as mutable
-  --> $DIR/unboxed-closure-immutable-capture.rs:15:8
+warning[E0594]: cannot assign to `x`, as it is not declared as mutable
+  --> $DIR/unboxed-closure-immutable-capture.rs:16:8
    |
 LL |     || x = 1;
    |        ^^^^^ cannot assign
@@ -75,8 +76,8 @@ help: consider changing this to be mutable
 LL |     let mut x = 0;
    |         +++
 
-error[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
-  --> $DIR/unboxed-closure-immutable-capture.rs:16:12
+warning[E0596]: cannot borrow `x` as mutable, as it is not declared as mutable
+  --> $DIR/unboxed-closure-immutable-capture.rs:17:12
    |
 LL |     || set(&mut x);
    |            ^^^^^^ cannot borrow as mutable
@@ -86,7 +87,7 @@ help: consider changing this to be mutable
 LL |     let mut x = 0;
    |         +++
 
-error: aborting due to 8 previous errors
+warning: 8 warnings emitted
 
 Some errors have detailed explanations: E0594, E0596.
 For more information about an error, try `rustc --explain E0594`.

--- a/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.rs
+++ b/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.rs
@@ -1,3 +1,4 @@
+//@ check-pass
 // Test that we are able to infer a suitable kind for this closure
 // that is just called (`FnMut`).
 
@@ -13,8 +14,8 @@ fn main() {
     // In turn, tick2 must be inferred to FnMut so that it can call
     // tick1, but we forgot the mut.
     let tick2 = || {
-        tick1(); //~ ERROR cannot borrow `tick1` as mutable
+        tick1(); //~ WARNING cannot borrow `tick1` as mutable
     };
 
-    tick2(); //~ ERROR cannot borrow
+    tick2(); //~ WARNING cannot borrow
 }

--- a/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.stderr
@@ -1,5 +1,5 @@
-error[E0596]: cannot borrow `tick1` as mutable, as it is not declared as mutable
-  --> $DIR/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.rs:16:9
+warning[E0596]: cannot borrow `tick1` as mutable, as it is not declared as mutable
+  --> $DIR/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.rs:17:9
    |
 LL |         counter += 1;
    |         ------- calling `tick1` requires mutable binding due to mutable borrow of `counter`
@@ -7,13 +7,14 @@ LL |         counter += 1;
 LL |         tick1();
    |         ^^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut tick1 = || {
    |         +++
 
-error[E0596]: cannot borrow `tick2` as mutable, as it is not declared as mutable
-  --> $DIR/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.rs:19:5
+warning[E0596]: cannot borrow `tick2` as mutable, as it is not declared as mutable
+  --> $DIR/unboxed-closures-infer-fnmut-calling-fnmut-no-mut.rs:20:5
    |
 LL |         tick1();
    |         ----- calling `tick2` requires mutable binding due to mutable borrow of `tick1`
@@ -26,6 +27,6 @@ help: consider changing this to be mutable
 LL |     let mut tick2 = || {
    |         +++
 
-error: aborting due to 2 previous errors
+warning: 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-missing-mut.rs
+++ b/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-missing-mut.rs
@@ -1,8 +1,9 @@
+//@ check-pass
 // Test that we are able to infer a suitable kind for this closure
 // that is just called (`FnMut`).
 
 fn main() {
     let mut counter = 0;
     let tick = || counter += 1;
-    tick(); //~ ERROR cannot borrow `tick` as mutable, as it is not declared as mutable
+    tick(); //~ WARNING cannot borrow `tick` as mutable, as it is not declared as mutable
 }

--- a/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-missing-mut.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-missing-mut.stderr
@@ -1,16 +1,17 @@
-error[E0596]: cannot borrow `tick` as mutable, as it is not declared as mutable
-  --> $DIR/unboxed-closures-infer-fnmut-missing-mut.rs:7:5
+warning[E0596]: cannot borrow `tick` as mutable, as it is not declared as mutable
+  --> $DIR/unboxed-closures-infer-fnmut-missing-mut.rs:8:5
    |
 LL |     let tick = || counter += 1;
    |                   ------- calling `tick` requires mutable binding due to mutable borrow of `counter`
 LL |     tick();
    |     ^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut tick = || counter += 1;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-move-missing-mut.rs
+++ b/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-move-missing-mut.rs
@@ -1,8 +1,9 @@
+//@ check-pass
 // Test that we are able to infer a suitable kind for this closure
 // that is just called (`FnMut`).
 
 fn main() {
     let mut counter = 0;
     let tick = move || counter += 1;
-    tick(); //~ ERROR cannot borrow `tick` as mutable, as it is not declared as mutable
+    tick(); //~ WARNING cannot borrow `tick` as mutable, as it is not declared as mutable
 }

--- a/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-move-missing-mut.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-infer-fnmut-move-missing-mut.stderr
@@ -1,16 +1,17 @@
-error[E0596]: cannot borrow `tick` as mutable, as it is not declared as mutable
-  --> $DIR/unboxed-closures-infer-fnmut-move-missing-mut.rs:7:5
+warning[E0596]: cannot borrow `tick` as mutable, as it is not declared as mutable
+  --> $DIR/unboxed-closures-infer-fnmut-move-missing-mut.rs:8:5
    |
 LL |     let tick = move || counter += 1;
    |                        ------- calling `tick` requires mutable binding due to possible mutation of `counter`
 LL |     tick();
    |     ^^^^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut tick = move || counter += 1;
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.

--- a/tests/ui/unboxed-closures/unboxed-closures-mutate-upvar.rs
+++ b/tests/ui/unboxed-closures/unboxed-closures-mutate-upvar.rs
@@ -12,7 +12,7 @@ fn to_fn_mut<A:std::marker::Tuple,F:FnMut<A>>(f: F) -> F { f }
 fn a() {
     let n = 0;
     let mut f = to_fn_mut(|| {
-        n += 1; //~ ERROR cannot assign to `n`, as it is not declared as mutable
+        n += 1; //~ WARNING cannot assign to `n`, as it is not declared as mutable
     });
 }
 
@@ -29,7 +29,7 @@ fn c() {
         // If we just did a straight-forward desugaring, this would
         // compile, but we do something a bit more subtle, and hence
         // we get an error.
-        n += 1; //~ ERROR cannot assign
+        n += 1; //~ WARNING cannot assign
     });
 }
 
@@ -43,6 +43,8 @@ fn d() {
 fn e() {
     let n = 0;
     let mut f = to_fn(move || {
+        // Cannot assign to n, but this time
+        // because we're in a `Fn` closure
         n += 1; //~ ERROR cannot assign
     });
 }

--- a/tests/ui/unboxed-closures/unboxed-closures-mutate-upvar.stderr
+++ b/tests/ui/unboxed-closures/unboxed-closures-mutate-upvar.stderr
@@ -1,15 +1,16 @@
-error[E0594]: cannot assign to `n`, as it is not declared as mutable
+warning[E0594]: cannot assign to `n`, as it is not declared as mutable
   --> $DIR/unboxed-closures-mutate-upvar.rs:15:9
    |
 LL |         n += 1;
    |         ^^^^^^ cannot assign
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut n = 0;
    |         +++
 
-error[E0594]: cannot assign to `n`, as it is not declared as mutable
+warning[E0594]: cannot assign to `n`, as it is not declared as mutable
   --> $DIR/unboxed-closures-mutate-upvar.rs:32:9
    |
 LL |         n += 1;
@@ -20,19 +21,22 @@ help: consider changing this to be mutable
 LL |     let mut n = 0;
    |         +++
 
-error[E0594]: cannot assign to `n`, as it is not declared as mutable
-  --> $DIR/unboxed-closures-mutate-upvar.rs:46:9
+error[E0594]: cannot assign to `n`, as it is a captured variable in a `Fn` closure
+  --> $DIR/unboxed-closures-mutate-upvar.rs:48:9
    |
+LL | fn to_fn<A:std::marker::Tuple,F:Fn<A>>(f: F) -> F { f }
+   |                                           - change this to accept `FnMut` instead of `Fn`
+...
+LL |     let mut f = to_fn(move || {
+   |                 ----- ------- in this closure
+   |                 |
+   |                 expects `Fn` instead of `FnMut`
+...
 LL |         n += 1;
    |         ^^^^^^ cannot assign
-   |
-help: consider changing this to be mutable
-   |
-LL |     let mut n = 0;
-   |         +++
 
 error[E0594]: cannot assign to `n`, as it is a captured variable in a `Fn` closure
-  --> $DIR/unboxed-closures-mutate-upvar.rs:53:9
+  --> $DIR/unboxed-closures-mutate-upvar.rs:55:9
    |
 LL | fn to_fn<A:std::marker::Tuple,F:Fn<A>>(f: F) -> F { f }
    |                                           - change this to accept `FnMut` instead of `Fn`
@@ -44,6 +48,6 @@ LL |     let mut f = to_fn(move || {
 LL |         n += 1;
    |         ^^^^^^ cannot assign
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors; 2 warnings emitted
 
 For more information about this error, try `rustc --explain E0594`.

--- a/tests/ui/writing-to-immutable-vec.rs
+++ b/tests/ui/writing-to-immutable-vec.rs
@@ -1,4 +1,5 @@
+//@ check-pass
 fn main() {
     let v: Vec<isize> = vec![1, 2, 3];
-    v[1] = 4; //~ ERROR cannot borrow `v` as mutable, as it is not declared as mutable
+    v[1] = 4; //~ WARNING cannot borrow `v` as mutable, as it is not declared as mutable
 }

--- a/tests/ui/writing-to-immutable-vec.stderr
+++ b/tests/ui/writing-to-immutable-vec.stderr
@@ -1,14 +1,15 @@
-error[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
-  --> $DIR/writing-to-immutable-vec.rs:3:5
+warning[E0596]: cannot borrow `v` as mutable, as it is not declared as mutable
+  --> $DIR/writing-to-immutable-vec.rs:4:5
    |
 LL |     v[1] = 4;
    |     ^ cannot borrow as mutable
    |
+   = note: `#[warn(mut_non_mut)]` on by default
 help: consider changing this to be mutable
    |
 LL |     let mut v: Vec<isize> = vec![1, 2, 3];
    |         +++
 
-error: aborting due to 1 previous error
+warning: 1 warning emitted
 
 For more information about this error, try `rustc --explain E0596`.


### PR DESCRIPTION
 - [x] implement proof of concept
 - [x] ensure ui tests pass
 - [x] submit pull request to get others' thoughts before continuing
 - [ ] ensure remaining tests pass
 - [ ] add more automated tests
 - [ ] adjust the wording in the lint error messages
 - [ ] update documentation
 - [ ] decide on a name for the lint(s) (currently "mut_non_mut")
 - [ ] make the lint deny-by-default (currently warn-by-default for testing purposes)
 - [ ] hide the change behind a feature flag

## Overview

Hello, all.  This idea has been discussed previously:

 - [2014 Blog post](https://smallcultfollowing.com/babysteps/blog/2014/05/13/focusing-on-ownership/)
 - [2021 IRLO thread](https://internals.rust-lang.org/t/lack-of-mut-in-bindings-as-a-deny-by-default-lint/15818)
 - [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/213817-t-lang/topic/Idea.3A.20Downgrade.20.22immutable.20variable.E2.80.9C.20errors.20to.20lints)

As a quick summary of the above: the rust `mut` keyword has two meanings currently:
 - When applied to a reference, it means the reference is not aliased
 - When applied to a local binding, it means that the binding is allowed be re-assigned or borrowed using `&mut`

The first of these is fundamental to Rust's safety guarantees and enables some optimizations.  The second, however, is more of a lint: the error message may help catch mistakes, but ignoring it doesn't violate type safety or subvert any of Rust's global correctness guarantees.

Reasons for making the lint configurable instead of a hard error:
 - Reduced friction while making changes
 - Symmetry/consistency with the "unused_mut" lint
 - Potentially improved teachability

Reasons for maintaining the status quo:
 - Consistency with most other languages that have the concept of immutability
 - Making the lint configurable opens the door for public projects written in rust to refuse to use the `mut` annotation for locals
 - Prevent some style debates in projects which use rust

I don't necessarily expect this PR to get merged, but:
 - I think it's valuable to have a concrete implementation available for people to play with while considering an idea.
 - I implemented this change mostly for fun in my free time, and I think submitting it as a pull request and being told "no" is better than never doing anything with it.

### Implementation Details

 - error paths in borrow checking related to mutation of locals have been replaced with success paths that return some extra information
 - in `add_used_mut`, the extra information is used to create and buffer non-fatal diagnostics
 - When emitting diagnostics, non-fatal diagnostics are converted into "mut_non_mut" lints
 - Relevant parts of the diagnostic-generating code in rustc_borrowck are now generic over the EmissionGuarantee of the returned Diagnostic

### Implementation Concerns

 - I know very little about rustc or rustc_borrowck.  I _think_ my changes don't introduce any holes, but I'm not very confident, especially around the code related to closures/upvars.
 - Converting a borrowck-constructed Diag to a LintDiagnostic was the least invasive way I could think to make this change, but it's a bit hacky.
 - Lint diagnostics use the same deduplication code as non-lint diagnostics.  This could result in a legitimate error being suppressed by the presence of a lint, although things _seem_ to be ok just based on the ui tests.

