### PR TITLE
remove weird contravariant

### DIFF
--- a/compiler/rustc_index/src/vec.rs
+++ b/compiler/rustc_index/src/vec.rs
@@ -39,7 +39,7 @@ use crate::{Idx, IndexSlice};
 #[repr(transparent)]
 pub struct IndexVec<I: Idx, T> {
     pub raw: Vec<T>,
-    _marker: PhantomData<fn(&I)>,
+    _marker: PhantomData<I>,
 }
 
 impl<I: Idx, T> IndexVec<I, T> {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
I'm not sure what purpose this `PhantomData<fn(&I)>` has, it looks like it wants a contravariant for some reason but... why? It's confusing, does it have any purpose? If it does not let's just remove it.