### PR TITLE
Only dist `llvm-objcopy` if llvm tools are enabled

### DIFF
--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -471,7 +471,7 @@ impl Step for Rustc {
                 }
             }
 
-            {
+            if builder.config.llvm_enabled(compiler.host) && builder.config.llvm_tools_enabled {
                 let src_dir = builder.sysroot_target_bindir(compiler, host);
                 let llvm_objcopy = exe("llvm-objcopy", compiler.host);
                 let rust_objcopy = exe("rust-objcopy", compiler.host);


### PR DESCRIPTION
This uses the same condition that #132720 added in the compilation phase.

r? @jieyouxu 