### PR TITLE
more concrete source url of std docs [V2]

### DIFF
--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -89,7 +89,7 @@
 //! Check out the Rust contribution guidelines [here](
 //! https://rustc-dev-guide.rust-lang.org/contributing.html#writing-documentation).
 //! The source for this documentation can be found on
-//! [GitHub](https://github.com/rust-lang/rust).
+//! [GitHub](https://github.com/rust-lang/rust) in the 'library/std/' directory.
 //! To contribute changes, make sure you read the guidelines first, then submit
 //! pull-requests for your suggested changes.
 //!


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

r? jhpratt
since you have reivewed https://github.com/rust-lang/rust/pull/134193

> If someone is looking to contribute, they will want the repository as a whole, not the lib.rs for std.

Now the repository url is reserved, I just add another concrete url as an example, to help people finding target page more quickly&easily.