### PR TITLE
rustc_borrowck: Stop suggesting the invalid syntax `&mut raw const`

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -1455,6 +1455,11 @@ fn suggest_ampmut<'tcx>(
         && let Ok(src) = tcx.sess.source_map().span_to_snippet(assignment_rhs_span)
         && let Some(stripped) = src.strip_prefix('&')
     {
+        let is_raw_ref = stripped.trim_start().starts_with("raw ");
+        // We don't support raw refs yet
+        if is_raw_ref {
+            return None;
+        }
         let is_mut = if let Some(rest) = stripped.trim_start().strip_prefix("mut") {
             match rest.chars().next() {
                 // e.g. `&mut x`

--- a/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.rs
+++ b/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.rs
@@ -1,0 +1,8 @@
+//! Regression test for invalid suggestion for `&raw const expr` reported in
+//! <https://github.com/rust-lang/rust/issues/127562>.
+
+fn main() {
+    let val = 2;
+    let ptr = &raw const val;
+    unsafe { *ptr = 3; } //~ ERROR cannot assign to `*ptr`, which is behind a `*const` pointer
+}

--- a/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
+++ b/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
@@ -3,11 +3,6 @@ error[E0594]: cannot assign to `*ptr`, which is behind a `*const` pointer
    |
 LL |     unsafe { *ptr = 3; }
    |              ^^^^^^^^ `ptr` is a `*const` pointer, so the data it refers to cannot be written
-   |
-help: consider changing this to be a mutable pointer
-   |
-LL |     let ptr = &mut raw const val;
-   |                +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
+++ b/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
@@ -1,0 +1,14 @@
+error[E0594]: cannot assign to `*ptr`, which is behind a `*const` pointer
+  --> $DIR/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.rs:7:14
+   |
+LL |     unsafe { *ptr = 3; }
+   |              ^^^^^^^^ `ptr` is a `*const` pointer, so the data it refers to cannot be written
+   |
+help: consider changing this to be a mutable pointer
+   |
+LL |     let ptr = &mut raw const val;
+   |                +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0594`.


### PR DESCRIPTION
A legitimate suggestion would be to change from

    &raw const val

to

    &raw mut val

But until we have figured out how to make that happen we should at least
stop suggesting invalid syntax.

I recommend review commit-by-commit.

Part of #127562