### PR TITLE
Don't suggest a semicolon when one already exists

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/explain_borrow.rs
@@ -10,6 +10,7 @@ use rustc_hir as hir;
 use rustc_hir::intravisit::Visitor;
 use rustc_index::IndexSlice;
 use rustc_infer::infer::NllRegionVariableOrigin;
+use rustc_middle::dep_graph::DepContext;
 use rustc_middle::middle::resolve_bound_vars::ObjectLifetimeDefault;
 use rustc_middle::mir::{
     Body, CallSource, CastKind, ConstraintCategory, FakeReadCause, Local, LocalInfo, Location,
@@ -248,11 +249,27 @@ impl<'tcx> BorrowExplanation<'tcx> {
 
                         if let LocalInfo::BlockTailTemp(info) = local_decl.local_info() {
                             if info.tail_result_is_ignored {
+                                // #133941: Don't suggest adding a semicolon if we can
+                                // confirm the expression already ends with one.
+                                let suggest_semicolon = {
+                                    let source_map = tcx.sess().source_map();
+
+                                    let hi = info.span.hi();
+                                    let span =
+                                        info.span.with_lo(hi).with_hi(hi + rustc_span::BytePos(1));
+
+                                    match source_map.span_to_snippet(span) {
+                                        Ok(span_str) => !span_str.contains(';'),
+                                        Err(_) => true,
+                                    }
+                                };
                                 // #85581: If the first mutable borrow's scope contains
                                 // the second borrow, this suggestion isn't helpful.
-                                if !multiple_borrow_span.is_some_and(|(old, new)| {
-                                    old.to(info.span.shrink_to_hi()).contains(new)
-                                }) {
+                                if suggest_semicolon
+                                    && !multiple_borrow_span.is_some_and(|(old, new)| {
+                                        old.to(info.span.shrink_to_hi()).contains(new)
+                                    })
+                                {
                                     err.span_suggestion_verbose(
                                         info.span.shrink_to_hi(),
                                         "consider adding semicolon after the expression so its \

--- a/compiler/rustc_middle/src/mir/mod.rs
+++ b/compiler/rustc_middle/src/mir/mod.rs
@@ -944,6 +944,20 @@ mod binding_form_impl {
     }
 }
 
+/// Describes whether the value of a block's tail expression is
+/// ignored by the block's expression context, e.g. `let _ = { ...; tail }`,
+/// as well as whether the block was followed by a trailing semicolon; this
+/// is used to provide context for writing diagnostics.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, TyEncodable, TyDecodable, HashStable)]
+pub enum TailResultIgnored {
+    /// The result is ignored, and the block has a trailing semicolon.
+    TrueWithSemi,
+    /// The result is ignored, and the block doesn't have a trailing semicolon.
+    TrueNoSemi,
+    /// The result is not ignored.
+    False,
+}
+
 /// `BlockTailInfo` is attached to the `LocalDecl` for temporaries
 /// created during evaluation of expressions in a block tail
 /// expression; that is, a block like `{ STMT_1; STMT_2; EXPR }`.
@@ -954,12 +968,8 @@ mod binding_form_impl {
 /// one might revise the code to satisfy the borrow checker's rules.
 #[derive(Clone, Debug, TyEncodable, TyDecodable, HashStable)]
 pub struct BlockTailInfo {
-    /// If `true`, then the value resulting from evaluating this tail
-    /// expression is ignored by the block's expression context.
-    ///
-    /// Examples include `{ ...; tail };` and `let _ = { ...; tail };`
-    /// but not e.g., `let _x = { ...; tail };`
-    pub tail_result_is_ignored: bool,
+    /// Whether the result of the tail expression is ignored.
+    pub tail_result_is_ignored: TailResultIgnored,
 
     /// `Span` of the tail expression.
     pub span: Span,

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -216,6 +216,10 @@ pub enum StmtKind<'tcx> {
 
         /// The expression being evaluated in this statement.
         expr: ExprId,
+
+        /// Whether the statement originally ended with a semicolon in the source
+        /// code, e.g. `while let ... = ... {};` vs `while let ... = ... {}`.
+        semi: bool,
     },
 
     /// A `let` binding.

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -187,7 +187,7 @@ pub fn walk_stmt<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
     stmt: &'thir Stmt<'tcx>,
 ) {
     match &stmt.kind {
-        StmtKind::Expr { expr, scope: _ } => visitor.visit_expr(&visitor.thir()[*expr]),
+        StmtKind::Expr { expr, scope: _, semi: _ } => visitor.visit_expr(&visitor.thir()[*expr]),
         StmtKind::Let {
             initializer,
             remainder_scope: _,

--- a/compiler/rustc_mir_build/src/build/expr/stmt.rs
+++ b/compiler/rustc_mir_build/src/build/expr/stmt.rs
@@ -163,10 +163,12 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                             _ => break,
                         }
                     }
-                    this.block_context.push(BlockFrame::TailExpr {
-                        tail_result_is_ignored: true,
-                        span: expr.span,
-                    });
+
+                    let tail_result_is_ignored =
+                        this.block_context.currently_ignores_tail_results();
+
+                    this.block_context
+                        .push(BlockFrame::TailExpr { tail_result_is_ignored, span: expr.span });
                     Some(expr.span)
                 } else {
                     None

--- a/compiler/rustc_mir_build/src/thir/cx/block.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/block.rs
@@ -47,7 +47,7 @@ impl<'tcx> Cx<'tcx> {
             .filter_map(|(index, stmt)| {
                 let hir_id = stmt.hir_id;
                 match stmt.kind {
-                    hir::StmtKind::Expr(expr) | hir::StmtKind::Semi(expr) => {
+                    hir::StmtKind::Expr(expr) => {
                         let stmt = Stmt {
                             kind: StmtKind::Expr {
                                 scope: region::Scope {
@@ -55,6 +55,20 @@ impl<'tcx> Cx<'tcx> {
                                     data: region::ScopeData::Node,
                                 },
                                 expr: self.mirror_expr(expr),
+                                semi: false,
+                            },
+                        };
+                        Some(self.thir.stmts.push(stmt))
+                    }
+                    hir::StmtKind::Semi(expr) => {
+                        let stmt = Stmt {
+                            kind: StmtKind::Expr {
+                                scope: region::Scope {
+                                    id: hir_id.local_id,
+                                    data: region::ScopeData::Node,
+                                },
+                                expr: self.mirror_expr(expr),
+                                semi: true,
                             },
                         };
                         Some(self.thir.stmts.push(stmt))

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -128,11 +128,12 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
         print_indented!(self, "Stmt {", depth_lvl);
 
         match kind {
-            StmtKind::Expr { scope, expr } => {
+            StmtKind::Expr { scope, expr, semi } => {
                 print_indented!(self, "kind: Expr {", depth_lvl + 1);
                 print_indented!(self, format!("scope: {:?}", scope), depth_lvl + 2);
                 print_indented!(self, "expr:", depth_lvl + 2);
                 self.print_expr(*expr, depth_lvl + 3);
+                print_indented!(self, format!("semi: {}", semi), depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl + 1);
             }
             StmtKind::Let {

--- a/tests/ui/borrowck/do-not-suggest-duplicate-semicolons-issue-133941.rs
+++ b/tests/ui/borrowck/do-not-suggest-duplicate-semicolons-issue-133941.rs
@@ -1,0 +1,31 @@
+// Regression test for #133941: Don't suggest adding a semicolon during borrowck
+// errors when one already exists.
+
+use std::marker::PhantomData;
+
+struct Bar<'a>(PhantomData<&'a mut i32>);
+
+impl<'a> Drop for Bar<'a> {
+    fn drop(&mut self) {}
+}
+
+struct Foo();
+
+impl Foo {
+    fn f(&mut self) -> Option<Bar<'_>> {
+        None
+    }
+
+    fn g(&mut self) {}
+}
+
+fn main() {
+    let mut foo = Foo();
+    while let Some(_) = foo.f() {
+        //~^ NOTE first mutable borrow occurs here
+        //~| a temporary with access to the first borrow is created here ...
+        foo.g(); //~ ERROR cannot borrow `foo` as mutable more than once at a time
+        //~^ second mutable borrow occurs here
+    };
+    //~^ ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<Bar<'_>>`
+}

--- a/tests/ui/borrowck/do-not-suggest-duplicate-semicolons-issue-133941.stderr
+++ b/tests/ui/borrowck/do-not-suggest-duplicate-semicolons-issue-133941.stderr
@@ -1,0 +1,18 @@
+error[E0499]: cannot borrow `foo` as mutable more than once at a time
+  --> $DIR/do-not-suggest-duplicate-semicolons-issue-133941.rs:27:9
+   |
+LL |     while let Some(_) = foo.f() {
+   |                         -------
+   |                         |
+   |                         first mutable borrow occurs here
+   |                         a temporary with access to the first borrow is created here ...
+...
+LL |         foo.g();
+   |         ^^^ second mutable borrow occurs here
+LL |
+LL |     };
+   |     - ... and the first borrow might be used here, when that temporary is dropped and runs the destructor for type `Option<Bar<'_>>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0499`.


### PR DESCRIPTION
In cases where it can be confirmed that an expression with borrow conflicts is already followed by an expression, the compiler will no longer suggest adding a second semicolon.

This is my first time contributing to the compiler; I eagerly accept any feedback on improvements or how this could be done differently.

closes #133941 