### PR TITLE
Use a more precise span in placeholder_type_error_diag

### DIFF
--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -201,12 +201,13 @@ pub(crate) fn placeholder_type_error_diag<'cx, 'tcx>(
         placeholder_types.iter().map(|sp| (*sp, (*type_name).to_string())).collect();
 
     if let Some(generics) = generics {
-        if let Some(arg) = params.iter().find(|arg| {
-            matches!(arg.name, hir::ParamName::Plain(Ident { name: kw::Underscore, .. }))
+        if let Some(span) = params.iter().find_map(|arg| match arg.name {
+            hir::ParamName::Plain(Ident { name: kw::Underscore, span }) => Some(span),
+            _ => None,
         }) {
             // Account for `_` already present in cases like `struct S<_>(_);` and suggest
             // `struct S<T>(T);` instead of `struct S<_, T>(T);`.
-            sugg.push((arg.span, (*type_name).to_string()));
+            sugg.push((span, (*type_name).to_string()));
         } else if let Some(span) = generics.span_for_param_suggestion() {
             // Account for bounds, we want `fn foo<T: E, K>(_: K)` not `fn foo<T, K: E>(_: K)`.
             sugg.push((span, format!(", {type_name}")));

--- a/tests/crashes/123861.rs
+++ b/tests/crashes/123861.rs
@@ -1,5 +1,0 @@
-//@ known-bug: #123861
-//@ needs-rustc-debug-assertions
-
-struct _;
-fn mainIterator<_ = _> {}

--- a/tests/ui/generics/overlapping-errors-span-issue-123861.rs
+++ b/tests/ui/generics/overlapping-errors-span-issue-123861.rs
@@ -1,0 +1,8 @@
+fn mainIterator<_ = _> {}
+//~^ ERROR expected identifier, found reserved identifier `_`
+//~| ERROR   missing parameters for function definition
+//~| ERROR   defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions [invalid_type_param_default]
+//~| WARNING this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+//~| ERROR   the placeholder `_` is not allowed within types on item signatures for functions [E0121]
+
+fn main() {}

--- a/tests/ui/generics/overlapping-errors-span-issue-123861.stderr
+++ b/tests/ui/generics/overlapping-errors-span-issue-123861.stderr
@@ -1,0 +1,52 @@
+error: expected identifier, found reserved identifier `_`
+  --> $DIR/overlapping-errors-span-issue-123861.rs:1:17
+   |
+LL | fn mainIterator<_ = _> {}
+   |                 ^ expected identifier, found reserved identifier
+
+error: missing parameters for function definition
+  --> $DIR/overlapping-errors-span-issue-123861.rs:1:23
+   |
+LL | fn mainIterator<_ = _> {}
+   |                       ^
+   |
+help: add a parameter list
+   |
+LL | fn mainIterator<_ = _>() {}
+   |                       ++
+
+error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
+  --> $DIR/overlapping-errors-span-issue-123861.rs:1:17
+   |
+LL | fn mainIterator<_ = _> {}
+   |                 ^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
+   = note: `#[deny(invalid_type_param_default)]` on by default
+
+error[E0121]: the placeholder `_` is not allowed within types on item signatures for functions
+  --> $DIR/overlapping-errors-span-issue-123861.rs:1:21
+   |
+LL | fn mainIterator<_ = _> {}
+   |                     ^ not allowed in type signatures
+   |
+help: use type parameters instead
+   |
+LL | fn mainIterator<T = T> {}
+   |                 ~   ~
+
+error: aborting due to 4 previous errors
+
+For more information about this error, try `rustc --explain E0121`.
+Future incompatibility report: Future breakage diagnostic:
+error: defaults for type parameters are only allowed in `struct`, `enum`, `type`, or `trait` definitions
+  --> $DIR/overlapping-errors-span-issue-123861.rs:1:17
+   |
+LL | fn mainIterator<_ = _> {}
+   |                 ^^^^^
+   |
+   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
+   = note: for more information, see issue #36887 <https://github.com/rust-lang/rust/issues/36887>
+   = note: `#[deny(invalid_type_param_default)]` on by default
+


### PR DESCRIPTION
Closes: https://github.com/rust-lang/rust/issues/123861

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
