### PR TITLE
Arbitrary self types v2: better feature gate test

### DIFF
--- a/tests/ui/feature-gates/feature-gate-arbitrary-self-types-pointers.default.stderr
+++ b/tests/ui/feature-gates/feature-gate-arbitrary-self-types-pointers.default.stderr
@@ -1,5 +1,5 @@
 error[E0658]: `*const Bar` cannot be used as the type of `self` without the `arbitrary_self_types_pointers` feature
-  --> $DIR/feature-gate-arbitrary-self-types-pointers.rs:8:18
+  --> $DIR/feature-gate-arbitrary-self-types-pointers.rs:11:18
    |
 LL |     fn foo(self: *const Self) {}
    |                  ^^^^^^^^^^^
@@ -10,7 +10,7 @@ LL |     fn foo(self: *const Self) {}
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
 error[E0658]: `*mut Bar` cannot be used as the type of `self` without the `arbitrary_self_types_pointers` feature
-  --> $DIR/feature-gate-arbitrary-self-types-pointers.rs:12:18
+  --> $DIR/feature-gate-arbitrary-self-types-pointers.rs:15:18
    |
 LL |     fn bar(self: *mut Self) {}
    |                  ^^^^^^^^^
@@ -21,7 +21,7 @@ LL |     fn bar(self: *mut Self) {}
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
 error[E0658]: `*const Self` cannot be used as the type of `self` without the `arbitrary_self_types_pointers` feature
-  --> $DIR/feature-gate-arbitrary-self-types-pointers.rs:2:18
+  --> $DIR/feature-gate-arbitrary-self-types-pointers.rs:5:18
    |
 LL |     fn foo(self: *const Self);
    |                  ^^^^^^^^^^^

--- a/tests/ui/feature-gates/feature-gate-arbitrary-self-types-pointers.feature.stderr
+++ b/tests/ui/feature-gates/feature-gate-arbitrary-self-types-pointers.feature.stderr
@@ -1,0 +1,36 @@
+error[E0658]: `*const Bar` cannot be used as the type of `self` without the `arbitrary_self_types_pointers` feature
+  --> $DIR/feature-gate-arbitrary-self-types-pointers.rs:11:18
+   |
+LL |     fn foo(self: *const Self) {}
+   |                  ^^^^^^^^^^^
+   |
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
+   = help: add `#![feature(arbitrary_self_types_pointers)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
+
+error[E0658]: `*mut Bar` cannot be used as the type of `self` without the `arbitrary_self_types_pointers` feature
+  --> $DIR/feature-gate-arbitrary-self-types-pointers.rs:15:18
+   |
+LL |     fn bar(self: *mut Self) {}
+   |                  ^^^^^^^^^
+   |
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
+   = help: add `#![feature(arbitrary_self_types_pointers)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
+
+error[E0658]: `*const Self` cannot be used as the type of `self` without the `arbitrary_self_types_pointers` feature
+  --> $DIR/feature-gate-arbitrary-self-types-pointers.rs:5:18
+   |
+LL |     fn foo(self: *const Self);
+   |                  ^^^^^^^^^^^
+   |
+   = note: see issue #44874 <https://github.com/rust-lang/rust/issues/44874> for more information
+   = help: add `#![feature(arbitrary_self_types_pointers)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+   = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
+
+error: aborting due to 3 previous errors
+
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/feature-gates/feature-gate-arbitrary-self-types-pointers.rs
+++ b/tests/ui/feature-gates/feature-gate-arbitrary-self-types-pointers.rs
@@ -1,3 +1,6 @@
+//@ revisions: default feature
+#![cfg_attr(feature, feature(arbitrary_self_types))]
+
 trait Foo {
     fn foo(self: *const Self); //~ ERROR `*const Self` cannot be used as the type of `self`
 }


### PR DESCRIPTION
Slight improvement to the test for the `arbitrary_self_types_pointers` feature gate, to ensure it's independent of the `arbitrary_self_types` gate.

Part of #44874

r? @wesleywiser 