### PR TITLE
de-stabilize bench attribute

### DIFF
--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -2389,37 +2389,11 @@ declare_lint! {
 }
 
 declare_lint! {
-    /// The `soft_unstable` lint detects unstable features that were
-    /// unintentionally allowed on stable.
-    ///
-    /// ### Example
-    ///
-    /// ```rust,compile_fail
-    /// #[cfg(test)]
-    /// extern crate test;
-    ///
-    /// #[bench]
-    /// fn name(b: &mut test::Bencher) {
-    ///     b.iter(|| 123)
-    /// }
-    /// ```
-    ///
-    /// {{produces}}
-    ///
-    /// ### Explanation
-    ///
-    /// The [`bench` attribute] was accidentally allowed to be specified on
-    /// the [stable release channel]. Turning this to a hard error would have
-    /// broken some projects. This lint allows those projects to continue to
-    /// build correctly when [`--cap-lints`] is used, but otherwise signal an
-    /// error that `#[bench]` should not be used on the stable channel. This
-    /// is a [future-incompatible] lint to transition this to a hard error in
-    /// the future. See [issue #64266] for more details.
+    /// The `soft_unstable` lint detects unstable features that were unintentionally allowed on
+    /// stable. This is a [future-incompatible] lint to transition this to a hard error in the
+    /// future. See [issue #64266] for more details.
     ///
     /// [issue #64266]: https://github.com/rust-lang/rust/issues/64266
-    /// [`bench` attribute]: https://doc.rust-lang.org/nightly/unstable-book/library-features/test.html
-    /// [stable release channel]: https://doc.rust-lang.org/book/appendix-07-nightly-rust.html
-    /// [`--cap-lints`]: https://doc.rust-lang.org/rustc/lints/levels.html#capping-lints
     /// [future-incompatible]: ../index.md#future-incompatible-lints
     pub SOFT_UNSTABLE,
     Deny,

--- a/library/core/src/macros/mod.rs
+++ b/library/core/src/macros/mod.rs
@@ -1683,7 +1683,6 @@ pub(crate) mod builtin {
     #[unstable(
         feature = "test",
         issue = "50297",
-        soft,
         reason = "`bench` is a part of custom test frameworks which are unstable"
     )]
     #[allow_internal_unstable(test, rustc_attrs, coverage_attribute)]

--- a/src/tools/lint-docs/src/lib.rs
+++ b/src/tools/lint-docs/src/lib.rs
@@ -306,6 +306,7 @@ impl<'a> LintExtractor<'a> {
         if matches!(
             lint.name.as_str(),
             "unused_features" // broken lint
+            | "soft_unstable" // cannot have a stable example
         ) {
             return Ok(());
         }

--- a/tests/ui/feature-gates/bench.rs
+++ b/tests/ui/feature-gates/bench.rs
@@ -1,9 +1,7 @@
 //@ edition:2018
 
 #[bench] //~ ERROR use of unstable library feature `test`
-         //~| WARN this was previously accepted
 fn bench() {}
 
 use bench as _; //~ ERROR use of unstable library feature `test`
-                //~| WARN this was previously accepted
 fn main() {}

--- a/tests/ui/feature-gates/bench.stderr
+++ b/tests/ui/feature-gates/bench.stderr
@@ -1,43 +1,23 @@
-error: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
+error[E0658]: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
   --> $DIR/bench.rs:3:3
    |
 LL | #[bench]
    |   ^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
-   = note: `#[deny(soft_unstable)]` on by default
+   = note: see issue #50297 <https://github.com/rust-lang/rust/issues/50297> for more information
+   = help: add `#![feature(test)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
-  --> $DIR/bench.rs:7:5
+error[E0658]: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
+  --> $DIR/bench.rs:6:5
    |
 LL | use bench as _;
    |     ^^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
+   = note: see issue #50297 <https://github.com/rust-lang/rust/issues/50297> for more information
+   = help: add `#![feature(test)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 2 previous errors
 
-Future incompatibility report: Future breakage diagnostic:
-error: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
-  --> $DIR/bench.rs:3:3
-   |
-LL | #[bench]
-   |   ^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
-   = note: `#[deny(soft_unstable)]` on by default
-
-Future breakage diagnostic:
-error: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
-  --> $DIR/bench.rs:7:5
-   |
-LL | use bench as _;
-   |     ^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
-   = note: `#[deny(soft_unstable)]` on by default
-
+For more information about this error, try `rustc --explain E0658`.

--- a/tests/ui/lint/expansion-time.rs
+++ b/tests/ui/lint/expansion-time.rs
@@ -9,13 +9,6 @@ macro_rules! foo {
 macro_rules! m { ($i) => {} } //~ WARN missing fragment specifier
                               //~| WARN this was previously accepted
 
-#[warn(soft_unstable)]
-mod benches {
-    #[bench] //~ WARN use of unstable library feature `test`
-             //~| WARN this was previously accepted
-    fn foo() {}
-}
-
 #[deprecated = "reason"]
 macro_rules! deprecated {
     () => {}

--- a/tests/ui/lint/expansion-time.stderr
+++ b/tests/ui/lint/expansion-time.stderr
@@ -26,20 +26,6 @@ note: the lint level is defined here
 LL | #[warn(missing_fragment_specifier)]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
-  --> $DIR/expansion-time.rs:14:7
-   |
-LL |     #[bench]
-   |       ^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
-note: the lint level is defined here
-  --> $DIR/expansion-time.rs:12:8
-   |
-LL | #[warn(soft_unstable)]
-   |        ^^^^^^^^^^^^^
-
 warning: include macro expected single expression in source
   --> $DIR/expansion-time-include.rs:4:1
    |
@@ -47,12 +33,12 @@ LL | 2
    | ^
    |
 note: the lint level is defined here
-  --> $DIR/expansion-time.rs:29:8
+  --> $DIR/expansion-time.rs:22:8
    |
 LL | #[warn(incomplete_include)]
    |        ^^^^^^^^^^^^^^^^^^
 
-warning: 4 warnings emitted
+warning: 3 warnings emitted
 
 Future incompatibility report: Future breakage diagnostic:
 warning: missing fragment specifier
@@ -68,19 +54,4 @@ note: the lint level is defined here
    |
 LL | #[warn(missing_fragment_specifier)]
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Future breakage diagnostic:
-warning: use of unstable library feature `test`: `bench` is a part of custom test frameworks which are unstable
-  --> $DIR/expansion-time.rs:14:7
-   |
-LL |     #[bench]
-   |       ^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
-note: the lint level is defined here
-  --> $DIR/expansion-time.rs:12:8
-   |
-LL | #[warn(soft_unstable)]
-   |        ^^^^^^^^^^^^^
 


### PR DESCRIPTION
This has been soft-unstable since forever (https://github.com/rust-lang/rust/pull/64066), and shown in future-compat reports since Rust 1.77 (https://github.com/rust-lang/rust/pull/116274).

The feature covering `bench` itself is tracked in https://github.com/rust-lang/rust/issues/50297, which has been closed despite still having active feature gates referencing it.

Cc @rust-lang/libs-api 