### PR TITLE
fully de-stabilize all custom inner attributes

### DIFF
--- a/compiler/rustc_resolve/src/macros.rs
+++ b/compiler/rustc_resolve/src/macros.rs
@@ -6,15 +6,14 @@ use std::mem;
 
 use rustc_ast::attr::AttributeExt;
 use rustc_ast::expand::StrippedCfgItem;
-use rustc_ast::{self as ast, Crate, Inline, ItemKind, ModKind, NodeId, attr};
+use rustc_ast::{self as ast, Crate, NodeId, attr};
 use rustc_ast_pretty::pprust;
 use rustc_attr_parsing::StabilityLevel;
 use rustc_data_structures::intern::Interned;
 use rustc_data_structures::sync::Lrc;
 use rustc_errors::{Applicability, StashKey};
 use rustc_expand::base::{
-    Annotatable, DeriveResolution, Indeterminate, ResolverExpand, SyntaxExtension,
-    SyntaxExtensionKind,
+    DeriveResolution, Indeterminate, ResolverExpand, SyntaxExtension, SyntaxExtensionKind,
 };
 use rustc_expand::compile_declarative_macro;
 use rustc_expand::expand::{
@@ -26,8 +25,8 @@ use rustc_middle::middle::stability;
 use rustc_middle::ty::{RegisteredTools, TyCtxt, Visibility};
 use rustc_session::lint::BuiltinLintDiag;
 use rustc_session::lint::builtin::{
-    LEGACY_DERIVE_HELPERS, OUT_OF_SCOPE_MACRO_CALLS, SOFT_UNSTABLE,
-    UNKNOWN_OR_MALFORMED_DIAGNOSTIC_ATTRIBUTES, UNUSED_MACRO_RULES, UNUSED_MACROS,
+    LEGACY_DERIVE_HELPERS, OUT_OF_SCOPE_MACRO_CALLS, UNKNOWN_OR_MALFORMED_DIAGNOSTIC_ATTRIBUTES,
+    UNUSED_MACRO_RULES, UNUSED_MACROS,
 };
 use rustc_session::parse::feature_err;
 use rustc_span::edit_distance::edit_distance;
@@ -155,26 +154,6 @@ pub(crate) fn registered_tools(tcx: TyCtxt<'_>, (): ()) -> RegisteredTools {
         [sym::clippy, sym::rustfmt, sym::diagnostic, sym::miri, sym::rust_analyzer];
     registered_tools.extend(predefined_tools.iter().cloned().map(Ident::with_dummy_span));
     registered_tools
-}
-
-// Some feature gates for inner attributes are reported as lints for backward compatibility.
-fn soft_custom_inner_attributes_gate(path: &ast::Path, invoc: &Invocation) -> bool {
-    match &path.segments[..] {
-        // `#![test]`
-        [seg] if seg.ident.name == sym::test => return true,
-        // `#![rustfmt::skip]` on out-of-line modules
-        [seg1, seg2] if seg1.ident.name == sym::rustfmt && seg2.ident.name == sym::skip => {
-            if let InvocationKind::Attr { item, .. } = &invoc.kind {
-                if let Annotatable::Item(item) = item {
-                    if let ItemKind::Mod(_, ModKind::Loaded(_, Inline::No, _, _)) = item.kind {
-                        return true;
-                    }
-                }
-            }
-        }
-        _ => {}
-    }
-    false
 }
 
 impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
@@ -317,7 +296,6 @@ impl<'ra, 'tcx> ResolverExpand for Resolver<'ra, 'tcx> {
             parent_scope,
             node_id,
             force,
-            soft_custom_inner_attributes_gate(path, invoc),
             deleg_impl,
             looks_like_invoc_in_mod_inert_attr,
         )?;
@@ -549,7 +527,6 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
         parent_scope: &ParentScope<'ra>,
         node_id: NodeId,
         force: bool,
-        soft_custom_inner_attributes_gate: bool,
         deleg_impl: Option<LocalDefId>,
         invoc_in_mod_inert_attr: Option<LocalDefId>,
     ) -> Result<(Lrc<SyntaxExtension>, Res), Indeterminate> {
@@ -667,22 +644,12 @@ impl<'ra, 'tcx> Resolver<'ra, 'tcx> {
                 Res::NonMacroAttr(..) => false,
                 _ => unreachable!(),
             };
-            if soft_custom_inner_attributes_gate {
-                self.tcx.sess.psess.buffer_lint(
-                    SOFT_UNSTABLE,
-                    path.span,
-                    node_id,
-                    BuiltinLintDiag::InnerAttributeUnstable { is_macro },
-                );
+            let msg = if is_macro {
+                "inner macro attributes are unstable"
             } else {
-                // FIXME: deduplicate with rustc_lint (`BuiltinLintDiag::InnerAttributeUnstable`)
-                let msg = if is_macro {
-                    "inner macro attributes are unstable"
-                } else {
-                    "custom inner attributes are unstable"
-                };
-                feature_err(&self.tcx.sess, sym::custom_inner_attributes, path.span, msg).emit();
-            }
+                "custom inner attributes are unstable"
+            };
+            feature_err(&self.tcx.sess, sym::custom_inner_attributes, path.span, msg).emit();
         }
 
         if res == Res::NonMacroAttr(NonMacroAttrKind::Tool)

--- a/tests/ui/proc-macro/inner-attr-non-inline-mod.rs
+++ b/tests/ui/proc-macro/inner-attr-non-inline-mod.rs
@@ -1,7 +1,6 @@
 //@ compile-flags: -Z span-debug
 //@ error-pattern:custom inner attributes are unstable
 //@ error-pattern:inner macro attributes are unstable
-//@ error-pattern:this was previously accepted
 //@ proc-macro: test-macros.rs
 
 #![no_std] // Don't load unnecessary hygiene information from std

--- a/tests/ui/proc-macro/inner-attr-non-inline-mod.stderr
+++ b/tests/ui/proc-macro/inner-attr-non-inline-mod.stderr
@@ -1,3 +1,13 @@
+error[E0658]: custom inner attributes are unstable
+  --> $DIR/module_with_attrs.rs:3:4
+   |
+LL | #![rustfmt::skip]
+   |    ^^^^^^^^^^^^^
+   |
+   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
+   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
 error[E0658]: inner macro attributes are unstable
   --> $DIR/module_with_attrs.rs:4:4
    |
@@ -9,7 +19,7 @@ LL | #![print_attr]
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: non-inline modules in proc macro input are unstable
-  --> $DIR/inner-attr-non-inline-mod.rs:14:1
+  --> $DIR/inner-attr-non-inline-mod.rs:13:1
    |
 LL | mod module_with_attrs;
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -19,7 +29,7 @@ LL | mod module_with_attrs;
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error[E0658]: custom inner attributes are unstable
-  --> $DIR/inner-attr-non-inline-mod.rs:14:1
+  --> $DIR/inner-attr-non-inline-mod.rs:13:1
    |
 LL | mod module_with_attrs;
    | ^^^^^^^^^^^^^^^^^^^^^^
@@ -28,27 +38,6 @@ LL | mod module_with_attrs;
    = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: custom inner attributes are unstable
-  --> $DIR/module_with_attrs.rs:3:4
-   |
-LL | #![rustfmt::skip]
-   |    ^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
-   = note: `#[deny(soft_unstable)]` on by default
-
 error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0658`.
-Future incompatibility report: Future breakage diagnostic:
-error: custom inner attributes are unstable
-  --> $DIR/module_with_attrs.rs:3:4
-   |
-LL | #![rustfmt::skip]
-   |    ^^^^^^^^^^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
-   = note: `#[deny(soft_unstable)]` on by default
-

--- a/tests/ui/proc-macro/inner-attr-non-inline-mod.stdout
+++ b/tests/ui/proc-macro/inner-attr-non-inline-mod.stdout
@@ -4,35 +4,35 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
     Punct {
         ch: '#',
         spacing: Alone,
-        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
     },
     Group {
         delimiter: Bracket,
         stream: TokenStream [
             Ident {
                 ident: "deny",
-                span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
             },
             Group {
                 delimiter: Parenthesis,
                 stream: TokenStream [
                     Ident {
                         ident: "unused_attributes",
-                        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
                     },
                 ],
-                span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
             },
         ],
-        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
     },
     Ident {
         ident: "mod",
-        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
     },
     Ident {
         ident: "module_with_attrs",
-        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
     },
     Group {
         delimiter: Brace,
@@ -40,38 +40,38 @@ PRINT-ATTR INPUT (DEBUG): TokenStream [
             Punct {
                 ch: '#',
                 spacing: Joint,
-                span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
             },
             Punct {
                 ch: '!',
                 spacing: Alone,
-                span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
             },
             Group {
                 delimiter: Bracket,
                 stream: TokenStream [
                     Ident {
                         ident: "rustfmt",
-                        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
                     },
                     Punct {
                         ch: ':',
                         spacing: Joint,
-                        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
                     },
                     Punct {
                         ch: ':',
                         spacing: Alone,
-                        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
                     },
                     Ident {
                         ident: "skip",
-                        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
                     },
                 ],
-                span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+                span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
             },
         ],
-        span: $DIR/inner-attr-non-inline-mod.rs:14:1: 14:23 (#0),
+        span: $DIR/inner-attr-non-inline-mod.rs:13:1: 13:23 (#0),
     },
 ]

--- a/tests/ui/proc-macro/proc-macro-gates.rs
+++ b/tests/ui/proc-macro/proc-macro-gates.rs
@@ -47,7 +47,6 @@ fn attrs() {
 
 fn test_case() {
     #![test] //~ ERROR inner macro attributes are unstable
-             //~| WARN this was previously accepted
 }
 
 fn main() {}

--- a/tests/ui/proc-macro/proc-macro-gates.stderr
+++ b/tests/ui/proc-macro/proc-macro-gates.stderr
@@ -84,27 +84,16 @@ LL |     let _x = #[identity_attr] println!();
    = help: add `#![feature(proc_macro_hygiene)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: inner macro attributes are unstable
+error[E0658]: inner macro attributes are unstable
   --> $DIR/proc-macro-gates.rs:49:8
    |
 LL |     #![test]
    |        ^^^^
    |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
-   = note: `#[deny(soft_unstable)]` on by default
+   = note: see issue #54726 <https://github.com/rust-lang/rust/issues/54726> for more information
+   = help: add `#![feature(custom_inner_attributes)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
 error: aborting due to 10 previous errors
 
 For more information about this error, try `rustc --explain E0658`.
-Future incompatibility report: Future breakage diagnostic:
-error: inner macro attributes are unstable
-  --> $DIR/proc-macro-gates.rs:49:8
-   |
-LL |     #![test]
-   |        ^^^^
-   |
-   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
-   = note: for more information, see issue #64266 <https://github.com/rust-lang/rust/issues/64266>
-   = note: `#[deny(soft_unstable)]` on by default
-


### PR DESCRIPTION
`#![test]` and `#![rustfmt::skip]` were accidentally accepted in more places than they should. These have been marked as soft-unstable since forever (https://github.com/rust-lang/rust/pull/82399) and shown in future-compat reports since Rust 1.77 (https://github.com/rust-lang/rust/pull/116274).

Cc @rust-lang/lang @petrochenkov 