### PR TITLE
rustdoc-search: handle `impl Into<X>` better

### DIFF
--- a/library/core/src/convert/mod.rs
+++ b/library/core/src/convert/mod.rs
@@ -443,6 +443,7 @@ pub trait AsMut<T: ?Sized> {
 /// [`Vec`]: ../../std/vec/struct.Vec.html
 #[rustc_diagnostic_item = "Into"]
 #[stable(feature = "rust1", since = "1.0.0")]
+#[doc(search_unbox)]
 pub trait Into<T>: Sized {
     /// Converts this type into the (usually inferred) input type.
     #[must_use]
@@ -577,6 +578,7 @@ pub trait Into<T>: Sized {
     all(_Self = "&str", T = "alloc::string::String"),
     note = "to coerce a `{T}` into a `{Self}`, use `&*` as a prefix",
 ))]
+#[doc(search_unbox)]
 pub trait From<T>: Sized {
     /// Converts to this type from the input type.
     #[rustc_diagnostic_item = "from_fn"]

--- a/src/doc/rustdoc/src/read-documentation/search.md
+++ b/src/doc/rustdoc/src/read-documentation/search.md
@@ -149,12 +149,16 @@ will match these queries:
 * `&mut Read -> Result<Vec<u8>, Error>`
 * `Read -> Result<Vec<u8>, Error>`
 * `Read -> Result<Vec<u8>>`
-* `Read -> u8`
+* `Read -> Vec<u8>`
 
 But it *does not* match `Result<Vec, u8>` or `Result<u8<Vec>>`,
 because those are nested incorrectly, and it does not match
 `Result<Error, Vec<u8>>` or `Result<Error>`, because those are
-in the wrong order.
+in the wrong order. It also does not match `Read -> u8`, because
+only [certain generic wrapper types] can be left out, and `Vec` isn't
+one of them.
+
+[certain generic wrapper types]: #wrappers-that-can-be-omitted
 
 To search for a function that accepts a function as a parameter,
 like `Iterator::all`, wrap the nested signature in parenthesis,
@@ -164,6 +168,18 @@ such as `Iterator<T>, (FnMut(T) -> bool) -> bool`,
 but you need to know which one you want.
 
 [iterator-all]: ../../std/vec/struct.Vec.html?search=Iterator<T>%2C+(T+->+bool)+->+bool&filter-crate=std
+
+### Wrappers that can be omitted
+
+* References
+* Box
+* Rc
+* Arc
+* Option
+* Result
+* From
+* Into
+* Future
 
 ### Primitives with Special Syntax
 
@@ -233,11 +249,6 @@ Most of these limitations should be addressed in future version of Rustdoc.
     as a type parameter even if a matching name is found. If you know
     that you don't want a type parameter, you can force it to match
     something else by giving it a different prefix like `struct:T`.
-
-  * It's impossible to search for references or pointers. The
-    wrapped types can be searched for, so a function that takes `&File` can
-    be found with `File`, but you'll get a parse error when typing an `&`
-    into the search field.
 
   * Searching for lifetimes is not supported.
 

--- a/src/librustdoc/html/static/js/search.js
+++ b/src/librustdoc/html/static/js/search.js
@@ -2592,7 +2592,12 @@ class DocSearch {
             const writeFn = (fnType, result) => {
                 if (fnType.id < 0) {
                     if (fnParamNames[-1 - fnType.id] === "") {
-                        for (const nested of fnType.generics) {
+                        // Normally, there's no need to shown an unhighlighted
+                        // where clause, but if it's impl Trait, then we do.
+                        const generics = fnType.generics.length > 0 ?
+                            fnType.generics :
+                            obj.type.where_clause[-1 - fnType.id];
+                        for (const nested of generics) {
                             writeFn(nested, result);
                         }
                         return;

--- a/tests/rustdoc-js/impl-trait-inlining.js
+++ b/tests/rustdoc-js/impl-trait-inlining.js
@@ -22,4 +22,14 @@ const EXPECTED = [
             },
         ],
     },
+    {
+        'query': 'tyctxt, defid, symbol -> bool',
+        'others': [
+            {
+                'path': 'foo::TyCtxt',
+                'name': 'has_attr',
+                'displayType': "`TyCtxt`, Into<`DefId`>, `Symbol` -> `bool`",
+            },
+        ],
+    },
 ];

--- a/tests/rustdoc-js/impl-trait-inlining.js
+++ b/tests/rustdoc-js/impl-trait-inlining.js
@@ -1,0 +1,25 @@
+// exact-check
+// ignore-order
+
+const EXPECTED = [
+    {
+        'query': 'tyctxt, symbol -> bool',
+        'others': [
+            {
+                'path': 'foo::TyCtxt',
+                'name': 'has_attr',
+                'displayType': "`TyCtxt`, Into<DefId>, `Symbol` -> `bool`",
+            },
+        ],
+    },
+    {
+        'query': 'tyctxt, into<defid>, symbol -> bool',
+        'others': [
+            {
+                'path': 'foo::TyCtxt',
+                'name': 'has_attr',
+                'displayType': "`TyCtxt`, `Into`<`DefId`>, `Symbol` -> `bool`",
+            },
+        ],
+    },
+];

--- a/tests/rustdoc-js/impl-trait-inlining.rs
+++ b/tests/rustdoc-js/impl-trait-inlining.rs
@@ -1,0 +1,11 @@
+#![crate_name="foo"]
+
+pub struct TyCtxt;
+pub struct DefId;
+pub struct Symbol;
+
+impl TyCtxt {
+    pub fn has_attr(self, _did: impl Into<DefId>, _attr: Symbol) -> bool {
+        unimplemented!();
+    }
+}

--- a/tests/rustdoc-js/impl-trait-inlining.rs
+++ b/tests/rustdoc-js/impl-trait-inlining.rs
@@ -1,4 +1,4 @@
-#![crate_name="foo"]
+#![crate_name = "foo"]
 
 pub struct TyCtxt;
 pub struct DefId;


### PR DESCRIPTION
This PR fixes two bugs I ran into while searching the compiler docs:

- It omitted an `impl Trait` entry in the type signature field, producing `TyCtxt, , Symbol -> bool`
- It didn't let me search for `TyCtxt, DefId, Symbol -> bool` even though that's a perfectly good description of the function I was looking for (the function actually used `impl Into<DefId>`

r? @GuillaumeGomez cc @lolbinarycat 