### PR TITLE
Rollup of 8 pull requests

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -1455,6 +1455,11 @@ fn suggest_ampmut<'tcx>(
         && let Ok(src) = tcx.sess.source_map().span_to_snippet(assignment_rhs_span)
         && let Some(stripped) = src.strip_prefix('&')
     {
+        let is_raw_ref = stripped.trim_start().starts_with("raw ");
+        // We don't support raw refs yet
+        if is_raw_ref {
+            return None;
+        }
         let is_mut = if let Some(rest) = stripped.trim_start().strip_prefix("mut") {
             match rest.chars().next() {
                 // e.g. `&mut x`

--- a/library/core/src/ptr/mod.rs
+++ b/library/core/src/ptr/mod.rs
@@ -200,7 +200,7 @@
 //!
 //! But it *is* still sound to:
 //!
-//! * Create a pointer without provenance from just an address (see [`ptr::dangling`]). Such a
+//! * Create a pointer without provenance from just an address (see [`without_provenance`]). Such a
 //!   pointer cannot be used for memory accesses (except for zero-sized accesses). This can still be
 //!   useful for sentinel values like `null` *or* to represent a tagged pointer that will never be
 //!   dereferenceable. In general, it is always sound for an integer to pretend to be a pointer "for
@@ -314,8 +314,8 @@
 //! }
 //! ```
 //!
-//! (Yes, if you've been using AtomicUsize for pointers in concurrent datastructures, you should
-//! be using AtomicPtr instead. If that messes up the way you atomically manipulate pointers,
+//! (Yes, if you've been using [`AtomicUsize`] for pointers in concurrent datastructures, you should
+//! be using [`AtomicPtr`] instead. If that messes up the way you atomically manipulate pointers,
 //! we would like to know why, and what needs to be done to fix it.)
 //!
 //! Situations where a valid pointer *must* be created from just an address, such as baremetal code
@@ -381,7 +381,8 @@
 //! [`with_addr`]: pointer::with_addr
 //! [`map_addr`]: pointer::map_addr
 //! [`addr`]: pointer::addr
-//! [`ptr::dangling`]: core::ptr::dangling
+//! [`AtomicUsize`]: crate::sync::atomic::AtomicUsize
+//! [`AtomicPtr`]: crate::sync::atomic::AtomicPtr
 //! [`expose_provenance`]: pointer::expose_provenance
 //! [`with_exposed_provenance`]: with_exposed_provenance
 //! [Miri]: https://github.com/rust-lang/miri

--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2327,7 +2327,9 @@ impl Path {
             // FIXME: Allow Redox prefixes
             self.has_root() || has_redox_scheme(self.as_u8_slice())
         } else {
-            self.has_root() && (cfg!(any(unix, target_os = "wasi")) || self.prefix().is_some())
+            self.has_root()
+                && (cfg!(any(unix, target_os = "hermit", target_os = "wasi"))
+                    || self.prefix().is_some())
         }
     }
 

--- a/src/bootstrap/src/core/build_steps/dist.rs
+++ b/src/bootstrap/src/core/build_steps/dist.rs
@@ -471,7 +471,7 @@ impl Step for Rustc {
                 }
             }
 
-            {
+            if builder.config.llvm_enabled(compiler.host) && builder.config.llvm_tools_enabled {
                 let src_dir = builder.sysroot_target_bindir(compiler, host);
                 let llvm_objcopy = exe("llvm-objcopy", compiler.host);
                 let rust_objcopy = exe("rust-objcopy", compiler.host);

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1314,7 +1314,31 @@ impl Config {
 
         // Set flags.
         config.paths = std::mem::take(&mut flags.paths);
-        config.skip = flags.skip.into_iter().chain(flags.exclude).collect();
+        config.skip = flags
+            .skip
+            .into_iter()
+            .chain(flags.exclude)
+            .map(|p| {
+                let p = if cfg!(windows) {
+                    PathBuf::from(p.to_str().unwrap().replace('/', "\\"))
+                } else {
+                    p
+                };
+
+                // Jump to top-level project path to support passing paths
+                // from sub directories.
+                let top_level_path = config.src.join(&p);
+                if !config.src.join(&top_level_path).exists() {
+                    eprintln!("WARNING: '{}' does not exist.", top_level_path.display());
+                }
+
+                // Never return top-level path here as it would break `--skip`
+                // logic on rustc's internal test framework which is utilized
+                // by compiletest.
+                p
+            })
+            .collect();
+
         config.include_default_paths = flags.include_default_paths;
         config.rustc_error_format = flags.rustc_error_format;
         config.json_output = flags.json_output;

--- a/src/bootstrap/src/utils/cc_detect.rs
+++ b/src/bootstrap/src/utils/cc_detect.rs
@@ -44,6 +44,16 @@ fn cc2ar(cc: &Path, target: TargetSelection) -> Option<PathBuf> {
         Some(PathBuf::from("ar"))
     } else if target.contains("vxworks") {
         Some(PathBuf::from("wr-ar"))
+    } else if target.contains("-nto-") {
+        if target.starts_with("i586") {
+            Some(PathBuf::from("ntox86-ar"))
+        } else if target.starts_with("aarch64") {
+            Some(PathBuf::from("ntoaarch64-ar"))
+        } else if target.starts_with("x86_64") {
+            Some(PathBuf::from("ntox86_64-ar"))
+        } else {
+            panic!("Unknown architecture, cannot determine archiver for Neutrino QNX");
+        }
     } else if target.contains("android") || target.contains("-wasi") {
         Some(cc.parent().unwrap().join(PathBuf::from("llvm-ar")))
     } else {

--- a/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
+++ b/src/ci/docker/host-x86_64/dist-various-2/Dockerfile
@@ -90,9 +90,9 @@ RUN /tmp/build-solaris-toolchain.sh sparcv9 sparcv9 solaris-sparc sun
 COPY host-x86_64/dist-various-2/build-x86_64-fortanix-unknown-sgx-toolchain.sh /tmp/
 RUN /tmp/build-x86_64-fortanix-unknown-sgx-toolchain.sh
 
-RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-23/wasi-sdk-23.0-x86_64-linux.tar.gz | \
+RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-x86_64-linux.tar.gz | \
   tar -xz
-ENV WASI_SDK_PATH=/tmp/wasi-sdk-23.0-x86_64-linux
+ENV WASI_SDK_PATH=/tmp/wasi-sdk-25.0-x86_64-linux
 
 COPY scripts/freebsd-toolchain.sh /tmp/
 RUN /tmp/freebsd-toolchain.sh i686

--- a/src/ci/docker/host-x86_64/test-various/Dockerfile
+++ b/src/ci/docker/host-x86_64/test-various/Dockerfile
@@ -40,9 +40,9 @@ WORKDIR /
 COPY scripts/sccache.sh /scripts/
 RUN sh /scripts/sccache.sh
 
-RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-23/wasi-sdk-23.0-x86_64-linux.tar.gz | \
+RUN curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-x86_64-linux.tar.gz | \
   tar -xz
-ENV WASI_SDK_PATH=/wasi-sdk-23.0-x86_64-linux
+ENV WASI_SDK_PATH=/wasi-sdk-25.0-x86_64-linux
 
 ENV RUST_CONFIGURE_ARGS \
   --musl-root-x86_64=/usr/local/x86_64-linux-musl \

--- a/tests/crashes/133426.rs
+++ b/tests/crashes/133426.rs
@@ -1,0 +1,12 @@
+//@ known-bug: #133426
+
+fn a(
+    _: impl Iterator<
+        Item = [(); {
+                   match *todo!() { ! };
+               }],
+    >,
+) {
+}
+
+fn b(_: impl Iterator<Item = { match 0 { ! } }>) {}

--- a/tests/crashes/133597.rs
+++ b/tests/crashes/133597.rs
@@ -1,0 +1,11 @@
+//@ known-bug: #133597
+
+pub trait Foo2 {
+    fn boxed<'a: 'a>() -> impl Sized + FnOnce<()>;
+}
+
+impl Foo2 for () {}
+
+
+fn f() -> impl FnOnce<()> { || () }
+fn main() { () = f(); }

--- a/tests/crashes/133639.rs
+++ b/tests/crashes/133639.rs
@@ -1,0 +1,33 @@
+//@ known-bug: #133639
+
+#![feature(with_negative_coherence)]
+#![feature(min_specialization)]
+#![feature(generic_const_exprs)]
+
+#![crate_type = "lib"]
+use std::str::FromStr;
+
+struct a<const b: bool>;
+
+trait c {}
+
+impl<const d: u32> FromStr for e<d>
+where
+    a<{ d <= 2 }>: c,
+{
+    type Err = ();
+    fn from_str(f: &str) -> Result<Self, Self::Err> {
+        unimplemented!()
+    }
+}
+struct e<const d: u32>;
+
+impl<const d: u32> FromStr for e<d>
+where
+    a<{ d <= 2 }>: c,
+{
+    type Err = ();
+    fn from_str(f: &str) -> Result<Self, Self::Err> {
+        unimplemented!()
+    }
+}

--- a/tests/crashes/133808.rs
+++ b/tests/crashes/133808.rs
@@ -1,0 +1,15 @@
+//@ known-bug: #133808
+
+#![feature(generic_const_exprs, transmutability)]
+
+mod assert {
+    use std::mem::TransmuteFrom;
+
+    pub fn is_transmutable<Src, Dst>()
+    where
+        Dst: TransmuteFrom<Src>,
+    {
+    }
+}
+
+pub fn main() {}

--- a/tests/crashes/133868.rs
+++ b/tests/crashes/133868.rs
@@ -1,0 +1,13 @@
+//@ known-bug: #133868
+
+trait Foo {
+    type Assoc;
+}
+
+trait Bar {
+    fn method() -> impl Sized;
+}
+impl<T> Bar for T where <T as Foo>::Assoc: Sized
+{
+    fn method() {}
+}

--- a/tests/crashes/133965.rs
+++ b/tests/crashes/133965.rs
@@ -1,0 +1,9 @@
+//@ known-bug: #133965
+//@ needs-rustc-debug-assertions
+
+struct NonGeneric {}
+
+#[derive(Default)]
+struct NonGeneric<'a, const N: usize> {}
+
+pub fn main() {}

--- a/tests/crashes/133966.rs
+++ b/tests/crashes/133966.rs
@@ -1,0 +1,3 @@
+//@ known-bug: #133966
+pub struct Data([[&'static str]; 5_i32]);
+const _: &'static Data = unsafe { &*(&[] as *const Data) };

--- a/tests/crashes/134005.rs
+++ b/tests/crashes/134005.rs
@@ -1,0 +1,5 @@
+//@ known-bug: #134005
+
+fn main() {
+    let _ = [std::ops::Add::add, std::ops::Mul::mul, main as fn(_, &_)];
+}

--- a/tests/crashes/134061.rs
+++ b/tests/crashes/134061.rs
@@ -1,0 +1,4 @@
+//@ known-bug: #134061
+//@ needs-rustc-debug-assertions
+
+const x: () = |&'a

--- a/tests/crashes/134162.rs
+++ b/tests/crashes/134162.rs
@@ -1,0 +1,8 @@
+//@ known-bug: #134162
+
+fn main() {
+    struct X;
+
+    let xs = [X, X, X];
+    let eq = xs == [panic!("panic evaluated"); 2];
+}

--- a/tests/crashes/134217.rs
+++ b/tests/crashes/134217.rs
@@ -1,0 +1,9 @@
+//@ known-bug: #134217
+
+impl<A> std::ops::CoerceUnsized<A> for A {}
+
+fn main() {
+    if let _ = true
+        && true
+    {}
+}

--- a/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.rs
+++ b/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.rs
@@ -1,0 +1,8 @@
+//! Regression test for invalid suggestion for `&raw const expr` reported in
+//! <https://github.com/rust-lang/rust/issues/127562>.
+
+fn main() {
+    let val = 2;
+    let ptr = &raw const val;
+    unsafe { *ptr = 3; } //~ ERROR cannot assign to `*ptr`, which is behind a `*const` pointer
+}

--- a/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
+++ b/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
@@ -3,11 +3,6 @@ error[E0594]: cannot assign to `*ptr`, which is behind a `*const` pointer
    |
 LL |     unsafe { *ptr = 3; }
    |              ^^^^^^^^ `ptr` is a `*const` pointer, so the data it refers to cannot be written
-   |
-help: consider changing this to be a mutable pointer
-   |
-LL |     let ptr = &mut raw const val;
-   |                +++
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
+++ b/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
@@ -1,0 +1,14 @@
+error[E0594]: cannot assign to `*ptr`, which is behind a `*const` pointer
+  --> $DIR/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.rs:7:14
+   |
+LL |     unsafe { *ptr = 3; }
+   |              ^^^^^^^^ `ptr` is a `*const` pointer, so the data it refers to cannot be written
+   |
+help: consider changing this to be a mutable pointer
+   |
+LL |     let ptr = &mut raw const val;
+   |                +++
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0594`.


### PR DESCRIPTION
Successful merges:

 - #134209 (validate `--skip` and `--exclude` paths)
 - #134211 (On Neutrino QNX, reduce the need to set archiver via environment variables)
 - #134227 (Update wasi-sdk used to build WASI targets)
 - #134229 (Fix typos in docs on provenance)
 - #134236 (crashes: more tests v2)
 - #134240 (Only dist `llvm-objcopy` if llvm tools are enabled)
 - #134244 (rustc_borrowck: Stop suggesting the invalid syntax `&mut raw const`)
 - #134252 (Fix `Path::is_absolute` on Hermit)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=134209,134211,134227,134229,134236,134240,134244,134252)
<!-- homu-ignore:end -->