### PR TITLE
Stop emitting drop loops for every array length

### DIFF
--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
@@ -1,0 +1,25 @@
+// MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
+
+fn std::ptr::drop_in_place(_1: *mut [String; 42]) -> () {
+    let mut _0: ();
+    let mut _2: *mut [std::string::String; 42];
+    let mut _3: *mut [std::string::String];
+
+    bb0: {
+        goto -> bb3;
+    }
+
+    bb1: {
+        return;
+    }
+
+    bb2 (cleanup): {
+        resume;
+    }
+
+    bb3: {
+        _2 = &raw mut (*_1);
+        _3 = move _2 as *mut [std::string::String] (PointerCoercion(Unsize, Implicit));
+        drop((*_3)) -> [return: bb1, unwind: bb2];
+    }
+}

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
@@ -4,6 +4,7 @@ fn std::ptr::drop_in_place(_1: *mut [String; 42]) -> () {
     let mut _0: ();
     let mut _2: *mut [std::string::String; 42];
     let mut _3: *mut [std::string::String];
+    let mut _4: ();
 
     bb0: {
         goto -> bb3;
@@ -20,6 +21,6 @@ fn std::ptr::drop_in_place(_1: *mut [String; 42]) -> () {
     bb3: {
         _2 = &raw mut (*_1);
         _3 = move _2 as *mut [std::string::String] (PointerCoercion(Unsize, Implicit));
-        drop((*_3)) -> [return: bb1, unwind: bb2];
+        _4 = std::ptr::drop_in_place::<[String]>(move _3) -> [return: bb1, unwind: bb2];
     }
 }

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
@@ -44,7 +44,7 @@ fn std::ptr::drop_in_place(_1: *mut [String]) -> () {
     }
 
     bb7: {
-        _2 = Len((*_1));
+        _2 = PtrMetadata(copy _1);
         _3 = const 0_usize;
         goto -> bb6;
     }

--- a/tests/mir-opt/slice_drop_shim.rs
+++ b/tests/mir-opt/slice_drop_shim.rs
@@ -5,6 +5,8 @@
 // if we use -Clink-dead-code.
 
 // EMIT_MIR core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
+// EMIT_MIR core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
 fn main() {
     let _fn = std::ptr::drop_in_place::<[String]> as unsafe fn(_);
+    let _fn = std::ptr::drop_in_place::<[String; 42]> as unsafe fn(_);
 }


### PR DESCRIPTION
We can just unsize the array to a slice and drop that instead, reusing the same slice loop for every array length.

As part of this (and how I originally noticed this), use `PtrMetadata` instead of `Len` for the slice length, for another step closer to being able to remove `Rvalue::Len`.

Demonstration that yes, every slice length gets its own loop today: <https://rust.godbolt.org/z/5EsPjPWv4>
