### PR TITLE
Remove queries from the driver interface

### DIFF
--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -387,80 +387,69 @@ fn run_compiler(
             return early_exit();
         }
 
-        let linker = compiler.enter(|queries| {
+        // Parse the crate root source code (doesn't parse submodules yet)
+        // Everything else is parsed during macro expansion.
+        let krate = passes::parse(sess);
+
+        // If pretty printing is requested: Figure out the representation, print it and exit
+        if let Some(pp_mode) = sess.opts.pretty {
+            if pp_mode.needs_ast_map() {
+                create_and_enter_global_ctxt(&compiler, krate, |tcx| {
+                    tcx.ensure().early_lint_checks(());
+                    pretty::print(sess, pp_mode, pretty::PrintExtra::NeedsAstMap { tcx });
+                    passes::write_dep_info(tcx);
+                });
+            } else {
+                pretty::print(sess, pp_mode, pretty::PrintExtra::AfterParsing { krate: &krate });
+            }
+            trace!("finished pretty-printing");
+            return early_exit();
+        }
+
+        if callbacks.after_crate_root_parsing(compiler, &krate) == Compilation::Stop {
+            return early_exit();
+        }
+
+        if sess.opts.unstable_opts.parse_crate_root_only {
+            return early_exit();
+        }
+
+        let linker = create_and_enter_global_ctxt(&compiler, krate, |tcx| {
             let early_exit = || {
                 sess.dcx().abort_if_errors();
                 None
             };
 
-            // Parse the crate root source code (doesn't parse submodules yet)
-            // Everything else is parsed during macro expansion.
-            queries.parse();
+            // Make sure name resolution and macro expansion is run.
+            let _ = tcx.resolver_for_lowering();
 
-            // If pretty printing is requested: Figure out the representation, print it and exit
-            if let Some(pp_mode) = sess.opts.pretty {
-                if pp_mode.needs_ast_map() {
-                    let krate = queries.parse().steal();
+            if let Some(metrics_dir) = &sess.opts.unstable_opts.metrics_dir {
+                dump_feature_usage_metrics(tcx, metrics_dir);
+            }
 
-                    create_and_enter_global_ctxt(&compiler, krate, |tcx| {
-                        tcx.ensure().early_lint_checks(());
-                        pretty::print(sess, pp_mode, pretty::PrintExtra::NeedsAstMap { tcx });
-                        passes::write_dep_info(tcx);
-                    });
-                } else {
-                    let krate = queries.parse();
-                    pretty::print(sess, pp_mode, pretty::PrintExtra::AfterParsing {
-                        krate: &*krate.borrow(),
-                    });
-                }
-                trace!("finished pretty-printing");
+            if callbacks.after_expansion(compiler, tcx) == Compilation::Stop {
                 return early_exit();
             }
 
-            if callbacks.after_crate_root_parsing(compiler, &*queries.parse().borrow())
-                == Compilation::Stop
+            passes::write_dep_info(tcx);
+
+            if sess.opts.output_types.contains_key(&OutputType::DepInfo)
+                && sess.opts.output_types.len() == 1
             {
                 return early_exit();
             }
 
-            if sess.opts.unstable_opts.parse_crate_root_only {
+            if sess.opts.unstable_opts.no_analysis {
                 return early_exit();
             }
 
-            let krate = queries.parse().steal();
+            tcx.ensure().analysis(());
 
-            create_and_enter_global_ctxt(&compiler, krate, |tcx| {
-                // Make sure name resolution and macro expansion is run.
-                let _ = tcx.resolver_for_lowering();
+            if callbacks.after_analysis(compiler, tcx) == Compilation::Stop {
+                return early_exit();
+            }
 
-                if let Some(metrics_dir) = &sess.opts.unstable_opts.metrics_dir {
-                    dump_feature_usage_metrics(tcx, metrics_dir);
-                }
-
-                if callbacks.after_expansion(compiler, tcx) == Compilation::Stop {
-                    return early_exit();
-                }
-
-                passes::write_dep_info(tcx);
-
-                if sess.opts.output_types.contains_key(&OutputType::DepInfo)
-                    && sess.opts.output_types.len() == 1
-                {
-                    return early_exit();
-                }
-
-                if sess.opts.unstable_opts.no_analysis {
-                    return early_exit();
-                }
-
-                tcx.ensure().analysis(());
-
-                if callbacks.after_analysis(compiler, tcx) == Compilation::Stop {
-                    return early_exit();
-                }
-
-                Some(Linker::codegen_and_build_linker(tcx, &*compiler.codegen_backend))
-            })
+            Some(Linker::codegen_and_build_linker(tcx, &*compiler.codegen_backend))
         });
 
         // Linking is done outside the `compiler.enter()` so that the

--- a/compiler/rustc_driver_impl/src/lib.rs
+++ b/compiler/rustc_driver_impl/src/lib.rs
@@ -394,7 +394,7 @@ fn run_compiler(
         // If pretty printing is requested: Figure out the representation, print it and exit
         if let Some(pp_mode) = sess.opts.pretty {
             if pp_mode.needs_ast_map() {
-                create_and_enter_global_ctxt(&compiler, krate, |tcx| {
+                create_and_enter_global_ctxt(compiler, krate, |tcx| {
                     tcx.ensure().early_lint_checks(());
                     pretty::print(sess, pp_mode, pretty::PrintExtra::NeedsAstMap { tcx });
                     passes::write_dep_info(tcx);
@@ -414,7 +414,7 @@ fn run_compiler(
             return early_exit();
         }
 
-        let linker = create_and_enter_global_ctxt(&compiler, krate, |tcx| {
+        let linker = create_and_enter_global_ctxt(compiler, krate, |tcx| {
             let early_exit = || {
                 sess.dcx().abort_if_errors();
                 None

--- a/compiler/rustc_interface/src/lib.rs
+++ b/compiler/rustc_interface/src/lib.rs
@@ -17,8 +17,8 @@ pub mod util;
 
 pub use callbacks::setup_callbacks;
 pub use interface::{Config, run_compiler};
-pub use passes::{DEFAULT_QUERY_PROVIDERS, create_and_enter_global_ctxt};
-pub use queries::{Linker, Queries};
+pub use passes::{DEFAULT_QUERY_PROVIDERS, create_and_enter_global_ctxt, parse};
+pub use queries::Linker;
 
 #[cfg(test)]
 mod tests;

--- a/compiler/rustc_interface/src/lib.rs
+++ b/compiler/rustc_interface/src/lib.rs
@@ -8,7 +8,7 @@
 // tidy-alphabetical-end
 
 mod callbacks;
-mod errors;
+pub mod errors;
 pub mod interface;
 pub mod passes;
 mod proc_macro_decls;
@@ -17,7 +17,7 @@ pub mod util;
 
 pub use callbacks::setup_callbacks;
 pub use interface::{Config, run_compiler};
-pub use passes::DEFAULT_QUERY_PROVIDERS;
+pub use passes::{DEFAULT_QUERY_PROVIDERS, create_and_enter_global_ctxt};
 pub use queries::{Linker, Queries};
 
 #[cfg(test)]

--- a/compiler/rustc_interface/src/passes.rs
+++ b/compiler/rustc_interface/src/passes.rs
@@ -709,10 +709,10 @@ pub static DEFAULT_QUERY_PROVIDERS: LazyLock<Providers> = LazyLock::new(|| {
     *providers
 });
 
-pub fn create_and_enter_global_ctxt<'tcx, T>(
-    compiler: &'tcx Compiler,
+pub fn create_and_enter_global_ctxt<T>(
+    compiler: &Compiler,
     krate: rustc_ast::Crate,
-    f: impl for<'a> FnOnce(TyCtxt<'a>) -> T,
+    f: impl for<'tcx> FnOnce(TyCtxt<'tcx>) -> T,
 ) -> T {
     let gcx_cell = OnceLock::new();
     let arena = WorkerLocal::new(|_| Arena::default());

--- a/compiler/rustc_smir/src/rustc_internal/mod.rs
+++ b/compiler/rustc_smir/src/rustc_internal/mod.rs
@@ -314,7 +314,7 @@ macro_rules! run_driver {
     ($args:expr, $callback:expr $(, $with_tcx:ident)?) => {{
         use rustc_driver::{Callbacks, Compilation, RunCompiler};
         use rustc_middle::ty::TyCtxt;
-        use rustc_interface::{interface, Queries};
+        use rustc_interface::interface;
         use stable_mir::CompilerError;
         use std::ops::ControlFlow;
 

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -174,31 +174,28 @@ pub(crate) fn run(dcx: DiagCtxtHandle<'_>, input: Input, options: RustdocOptions
         compiling_test_count,
         ..
     } = interface::run_compiler(config, |compiler| {
-        compiler.enter(|queries| {
-            let krate = queries.parse().steal();
+        let krate = rustc_interface::passes::parse(&compiler.sess);
 
-            let collector =
-                rustc_interface::create_and_enter_global_ctxt(&compiler, krate, |tcx| {
-                    let crate_name = tcx.crate_name(LOCAL_CRATE).to_string();
-                    let crate_attrs = tcx.hir().attrs(CRATE_HIR_ID);
-                    let opts = scrape_test_config(crate_name, crate_attrs, args_path);
-                    let enable_per_target_ignores = options.enable_per_target_ignores;
+        let collector = rustc_interface::create_and_enter_global_ctxt(&compiler, krate, |tcx| {
+            let crate_name = tcx.crate_name(LOCAL_CRATE).to_string();
+            let crate_attrs = tcx.hir().attrs(CRATE_HIR_ID);
+            let opts = scrape_test_config(crate_name, crate_attrs, args_path);
+            let enable_per_target_ignores = options.enable_per_target_ignores;
 
-                    let mut collector = CreateRunnableDocTests::new(options, opts);
-                    let hir_collector = HirCollector::new(
-                        ErrorCodes::from(compiler.sess.opts.unstable_features.is_nightly_build()),
-                        enable_per_target_ignores,
-                        tcx,
-                    );
-                    let tests = hir_collector.collect_crate();
-                    tests.into_iter().for_each(|t| collector.add_test(t));
-
-                    collector
-                });
-            compiler.sess.dcx().abort_if_errors();
+            let mut collector = CreateRunnableDocTests::new(options, opts);
+            let hir_collector = HirCollector::new(
+                ErrorCodes::from(compiler.sess.opts.unstable_features.is_nightly_build()),
+                enable_per_target_ignores,
+                tcx,
+            );
+            let tests = hir_collector.collect_crate();
+            tests.into_iter().for_each(|t| collector.add_test(t));
 
             collector
-        })
+        });
+        compiler.sess.dcx().abort_if_errors();
+
+        collector
     });
 
     run_tests(opts, &rustdoc_options, &unused_extern_reports, standalone_tests, mergeable_tests);

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -856,50 +856,41 @@ fn main_args(
             return;
         }
 
-        compiler.enter(|queries| {
-            let krate = queries.parse().steal();
-            if sess.dcx().has_errors().is_some() {
-                sess.dcx().fatal("Compilation failed, aborting rustdoc");
+        let krate = rustc_interface::passes::parse(sess);
+        if sess.dcx().has_errors().is_some() {
+            sess.dcx().fatal("Compilation failed, aborting rustdoc");
+        }
+
+        rustc_interface::create_and_enter_global_ctxt(&compiler, krate, |tcx| {
+            let (krate, render_opts, mut cache) = sess.time("run_global_ctxt", || {
+                core::run_global_ctxt(tcx, show_coverage, render_options, output_format)
+            });
+            info!("finished with rustc");
+
+            if let Some(options) = scrape_examples_options {
+                return scrape_examples::run(krate, render_opts, cache, tcx, options, bin_crate);
             }
 
-            rustc_interface::create_and_enter_global_ctxt(&compiler, krate, |tcx| {
-                let (krate, render_opts, mut cache) = sess.time("run_global_ctxt", || {
-                    core::run_global_ctxt(tcx, show_coverage, render_options, output_format)
-                });
-                info!("finished with rustc");
+            cache.crate_version = crate_version;
 
-                if let Some(options) = scrape_examples_options {
-                    return scrape_examples::run(
-                        krate,
-                        render_opts,
-                        cache,
-                        tcx,
-                        options,
-                        bin_crate,
-                    );
-                }
+            if show_coverage {
+                // if we ran coverage, bail early, we don't need to also generate docs at this point
+                // (also we didn't load in any of the useful passes)
+                return;
+            } else if run_check {
+                // Since we're in "check" mode, no need to generate anything beyond this point.
+                return;
+            }
 
-                cache.crate_version = crate_version;
-
-                if show_coverage {
-                    // if we ran coverage, bail early, we don't need to also generate docs at this point
-                    // (also we didn't load in any of the useful passes)
-                    return;
-                } else if run_check {
-                    // Since we're in "check" mode, no need to generate anything beyond this point.
-                    return;
-                }
-
-                info!("going to format");
-                match output_format {
-                    config::OutputFormat::Html => sess.time("render_html", || {
-                        run_renderer::<html::render::Context<'_>>(krate, render_opts, cache, tcx)
-                    }),
-                    config::OutputFormat::Json => sess.time("render_json", || {
-                        run_renderer::<json::JsonRenderer<'_>>(krate, render_opts, cache, tcx)
-                    }),
-                }
-            })
+            info!("going to format");
+            match output_format {
+                config::OutputFormat::Html => sess.time("render_html", || {
+                    run_renderer::<html::render::Context<'_>>(krate, render_opts, cache, tcx)
+                }),
+                config::OutputFormat::Json => sess.time("render_json", || {
+                    run_renderer::<json::JsonRenderer<'_>>(krate, render_opts, cache, tcx)
+                }),
+            }
         })
     })
 }

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -857,12 +857,12 @@ fn main_args(
         }
 
         compiler.enter(|queries| {
-            let mut gcx = queries.global_ctxt();
+            let krate = queries.parse().steal();
             if sess.dcx().has_errors().is_some() {
                 sess.dcx().fatal("Compilation failed, aborting rustdoc");
             }
 
-            gcx.enter(|tcx| {
+            rustc_interface::create_and_enter_global_ctxt(&compiler, krate, |tcx| {
                 let (krate, render_opts, mut cache) = sess.time("run_global_ctxt", || {
                     core::run_global_ctxt(tcx, show_coverage, render_options, output_format)
                 });

--- a/tests/ui-fulldeps/run-compiler-twice.rs
+++ b/tests/ui-fulldeps/run-compiler-twice.rs
@@ -77,11 +77,10 @@ fn compile(code: String, output: PathBuf, sysroot: PathBuf, linker: Option<&Path
     };
 
     interface::run_compiler(config, |compiler| {
-        let linker = compiler.enter(|queries| {
-            queries.global_ctxt().enter(|tcx| {
-                let _ = tcx.analysis(());
-                Linker::codegen_and_build_linker(tcx, &*compiler.codegen_backend)
-            })
+        let krate = rustc_interface::passes::parse(&compiler.sess);
+        let linker = rustc_interface::create_and_enter_global_ctxt(&compiler, krate, |tcx| {
+            let _ = tcx.analysis(());
+            Linker::codegen_and_build_linker(tcx, &*compiler.codegen_backend)
         });
         linker.link(&compiler.sess, &*compiler.codegen_backend);
     });


### PR DESCRIPTION
All uses of driver queries in the public api of rustc_driver have been removed in https://github.com/rust-lang/rust/pull/134130 already. This removes driver queries from rustc_interface and does a couple of cleanups around TyCtxt construction and entering enabled by this removal.

Finishes the removal of driver queries started with https://github.com/rust-lang/rust/pull/126834.