### PR TITLE
Don't make a def id for `impl_trait_in_bindings`

### DIFF
--- a/compiler/rustc_resolve/src/lib.rs
+++ b/compiler/rustc_resolve/src/lib.rs
@@ -190,6 +190,7 @@ impl InvocationParent {
 enum ImplTraitContext {
     Existential,
     Universal,
+    InBinding,
 }
 
 /// Used for tracking import use types which will be used for redundant import checking.

--- a/tests/ui/impl-trait/in-bindings/dont-make-def-id.rs
+++ b/tests/ui/impl-trait/in-bindings/dont-make-def-id.rs
@@ -1,0 +1,10 @@
+//@ check-pass
+
+// Make sure we don't create an opaque def id for ITIB.
+
+#![crate_type = "lib"]
+#![feature(impl_trait_in_bindings)]
+
+fn foo() {
+    let _: impl Sized = 0;
+}


### PR DESCRIPTION
The def collector is awkward, so for now just wrap let statements in a new `ImplTraitContext::InBinding` which tells `visit_ty` not to make a def id for the type. This will not generalize to other ITIB cases, like if we allow them in turbofishes (e.g. `foo::<impl Fn()>(|| {})`).

Fixes #134307

r? oli-obk