### PR TITLE
Treat safe target_feature functions as unsafe by default

### DIFF
--- a/compiler/rustc_ast_lowering/src/delegation.rs
+++ b/compiler/rustc_ast_lowering/src/delegation.rs
@@ -189,7 +189,15 @@ impl<'hir> LoweringContext<'_, 'hir> {
     ) -> hir::FnSig<'hir> {
         let header = if let Some(local_sig_id) = sig_id.as_local() {
             match self.resolver.delegation_fn_sigs.get(&local_sig_id) {
-                Some(sig) => self.lower_fn_header(sig.header, hir::Safety::Safe),
+                Some(sig) => self.lower_fn_header(
+                    sig.header,
+                    if sig.target_feature && !matches!(sig.header.safety, Safety::Unsafe(_)) {
+                        hir::Safety::Unsafe { target_feature: true }
+                    } else {
+                        hir::Safety::Safe
+                    },
+                    &[],
+                ),
                 None => self.generate_header_error(),
             }
         } else {

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -1222,7 +1222,7 @@ fn get_rust_try_fn<'a, 'gcc, 'tcx>(
             iter::once(i8p),
             tcx.types.unit,
             false,
-            rustc_hir::Safety::Unsafe,
+            rustc_hir::Safety::Unsafe { target_feature: false },
             Abi::Rust,
         )),
     );
@@ -1233,7 +1233,7 @@ fn get_rust_try_fn<'a, 'gcc, 'tcx>(
             [i8p, i8p].iter().cloned(),
             tcx.types.unit,
             false,
-            rustc_hir::Safety::Unsafe,
+            rustc_hir::Safety::Unsafe { target_feature: false },
             Abi::Rust,
         )),
     );
@@ -1242,7 +1242,7 @@ fn get_rust_try_fn<'a, 'gcc, 'tcx>(
         [try_fn_ty, i8p, catch_fn_ty],
         tcx.types.i32,
         false,
-        rustc_hir::Safety::Unsafe,
+        rustc_hir::Safety::Unsafe { target_feature: false },
         Abi::Rust,
     ));
     let rust_try = gen_fn(cx, "__rust_try", rust_fn_sig, codegen);

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -1091,7 +1091,7 @@ fn get_rust_try_fn<'ll, 'tcx>(
             [i8p],
             tcx.types.unit,
             false,
-            hir::Safety::Unsafe,
+            hir::Safety::Unsafe { target_feature: false },
             ExternAbi::Rust,
         )),
     );
@@ -1102,7 +1102,7 @@ fn get_rust_try_fn<'ll, 'tcx>(
             [i8p, i8p],
             tcx.types.unit,
             false,
-            hir::Safety::Unsafe,
+            hir::Safety::Unsafe { target_feature: false },
             ExternAbi::Rust,
         )),
     );
@@ -1111,7 +1111,7 @@ fn get_rust_try_fn<'ll, 'tcx>(
         [try_fn_ty, i8p, catch_fn_ty],
         tcx.types.i32,
         false,
-        hir::Safety::Unsafe,
+        hir::Safety::Unsafe { target_feature: false },
         ExternAbi::Rust,
     ));
     let rust_try = gen_fn(cx, "__rust_try", rust_fn_sig, codegen);

--- a/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
+++ b/compiler/rustc_codegen_ssa/src/codegen_attrs.rs
@@ -6,7 +6,7 @@ use rustc_errors::{DiagMessage, SubdiagMessage, struct_span_code_err};
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
 use rustc_hir::weak_lang_items::WEAK_LANG_ITEMS;
-use rustc_hir::{HirId, LangItem, lang_items};
+use rustc_hir::{self as hir, HirId, LangItem, lang_items};
 use rustc_middle::middle::codegen_fn_attrs::{
     CodegenFnAttrFlags, CodegenFnAttrs, PatchableFunctionEntry,
 };
@@ -251,7 +251,9 @@ fn codegen_fn_attrs(tcx: TyCtxt<'_>, did: LocalDefId) -> CodegenFnAttrs {
             sym::target_feature => {
                 if !tcx.is_closure_like(did.to_def_id())
                     && let Some(fn_sig) = fn_sig()
-                    && fn_sig.skip_binder().safety().is_safe()
+                    && matches!(fn_sig.skip_binder().safety(), hir::Safety::Unsafe {
+                        target_feature: true
+                    })
                 {
                     if tcx.sess.target.is_like_wasm || tcx.sess.opts.actually_rustdoc {
                         // The `#[target_feature]` attribute is allowed on

--- a/compiler/rustc_hir_analysis/src/check/intrinsic.rs
+++ b/compiler/rustc_hir_analysis/src/check/intrinsic.rs
@@ -76,7 +76,7 @@ pub fn intrinsic_operation_unsafety(tcx: TyCtxt<'_>, intrinsic_id: LocalDefId) -
         tcx.fn_sig(intrinsic_id).skip_binder().safety()
     } else {
         // Old-style intrinsics are never safe
-        Safety::Unsafe
+        Safety::Unsafe { target_feature: false }
     };
     let is_in_list = match tcx.item_name(intrinsic_id.into()) {
         // When adding a new intrinsic to this list,
@@ -137,7 +137,7 @@ pub fn intrinsic_operation_unsafety(tcx: TyCtxt<'_>, intrinsic_id: LocalDefId) -
         | sym::fdiv_algebraic
         | sym::frem_algebraic
         | sym::const_eval_select => hir::Safety::Safe,
-        _ => hir::Safety::Unsafe,
+        _ => hir::Safety::Unsafe { target_feature: false },
     };
 
     if has_safe_attr != is_in_list {
@@ -216,7 +216,7 @@ pub fn check_intrinsic_type(
                 return;
             }
         };
-        (n_tps, 0, 0, inputs, output, hir::Safety::Unsafe)
+        (n_tps, 0, 0, inputs, output, hir::Safety::Unsafe { target_feature: false })
     } else {
         let safety = intrinsic_operation_unsafety(tcx, intrinsic_id);
         let (n_tps, n_cts, inputs, output) = match intrinsic_name {

--- a/compiler/rustc_hir_analysis/src/collect.rs
+++ b/compiler/rustc_hir_analysis/src/collect.rs
@@ -1371,7 +1371,7 @@ fn fn_sig(tcx: TyCtxt<'_>, def_id: LocalDefId) -> ty::EarlyBinder<'_, ty::PolyFn
             // constructors for structs with `layout_scalar_valid_range` are unsafe to call
             let safety = match tcx.layout_scalar_valid_range(adt_def_id) {
                 (Bound::Unbounded, Bound::Unbounded) => hir::Safety::Safe,
-                _ => hir::Safety::Unsafe,
+                _ => hir::Safety::Unsafe { target_feature: false },
             };
             ty::Binder::dummy(tcx.mk_fn_sig(inputs, ty, false, safety, ExternAbi::Rust))
         }

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -2293,8 +2293,8 @@ impl<'a> State<'a> {
 
     fn print_safety(&mut self, s: hir::Safety) {
         match s {
-            hir::Safety::Safe => {}
-            hir::Safety::Unsafe => self.word_nbsp("unsafe"),
+            hir::Safety::Unsafe { target_feature: true } | hir::Safety::Safe => {}
+            hir::Safety::Unsafe { target_feature: false } => self.word_nbsp("unsafe"),
         }
     }
 

--- a/compiler/rustc_metadata/src/rmeta/table.rs
+++ b/compiler/rustc_metadata/src/rmeta/table.rs
@@ -155,13 +155,17 @@ fixed_size_enum! {
         ( Impl { of_trait: false }                 )
         ( Impl { of_trait: true }                  )
         ( Closure                                  )
-        ( Static { safety: hir::Safety::Unsafe, mutability: ast::Mutability::Not, nested: false } )
+        ( Static { safety: hir::Safety::Unsafe { target_feature: true }, mutability: ast::Mutability::Not, nested: false } )
+        ( Static { safety: hir::Safety::Unsafe { target_feature: false }, mutability: ast::Mutability::Not, nested: false } )
         ( Static { safety: hir::Safety::Safe, mutability: ast::Mutability::Not, nested: false } )
-        ( Static { safety: hir::Safety::Unsafe, mutability: ast::Mutability::Mut, nested: false } )
+        ( Static { safety: hir::Safety::Unsafe{ target_feature: true }, mutability: ast::Mutability::Mut, nested: false } )
+        ( Static { safety: hir::Safety::Unsafe{ target_feature: false }, mutability: ast::Mutability::Mut, nested: false } )
         ( Static { safety: hir::Safety::Safe, mutability: ast::Mutability::Mut, nested: false } )
-        ( Static { safety: hir::Safety::Unsafe, mutability: ast::Mutability::Not, nested: true } )
+        ( Static { safety: hir::Safety::Unsafe{ target_feature: true }, mutability: ast::Mutability::Not, nested: true } )
+        ( Static { safety: hir::Safety::Unsafe{ target_feature: false }, mutability: ast::Mutability::Not, nested: true } )
         ( Static { safety: hir::Safety::Safe, mutability: ast::Mutability::Not, nested: true } )
-        ( Static { safety: hir::Safety::Unsafe, mutability: ast::Mutability::Mut, nested: true } )
+        ( Static { safety: hir::Safety::Unsafe{ target_feature: true }, mutability: ast::Mutability::Mut, nested: true } )
+        ( Static { safety: hir::Safety::Unsafe{ target_feature: false }, mutability: ast::Mutability::Mut, nested: true } )
         ( Static { safety: hir::Safety::Safe, mutability: ast::Mutability::Mut, nested: true } )
         ( Ctor(CtorOf::Struct, CtorKind::Fn)       )
         ( Ctor(CtorOf::Struct, CtorKind::Const)    )
@@ -199,7 +203,8 @@ fixed_size_enum! {
 
 fixed_size_enum! {
     hir::Safety {
-        ( Unsafe )
+        ( Unsafe { target_feature: false } )
+        ( Unsafe { target_feature: true } )
         ( Safe   )
     }
 }

--- a/compiler/rustc_middle/src/ty/context.rs
+++ b/compiler/rustc_middle/src/ty/context.rs
@@ -2521,8 +2521,14 @@ impl<'tcx> TyCtxt<'tcx> {
     /// that is, a `fn` type that is equivalent in every way for being
     /// unsafe.
     pub fn safe_to_unsafe_fn_ty(self, sig: PolyFnSig<'tcx>) -> Ty<'tcx> {
-        assert!(sig.safety().is_safe());
-        Ty::new_fn_ptr(self, sig.map_bound(|sig| ty::FnSig { safety: hir::Safety::Unsafe, ..sig }))
+        matches!(sig.safety(), hir::Safety::Safe | hir::Safety::Unsafe { target_feature: true });
+        Ty::new_fn_ptr(
+            self,
+            sig.map_bound(|sig| ty::FnSig {
+                safety: hir::Safety::Unsafe { target_feature: false },
+                ..sig
+            }),
+        )
     }
 
     /// Given the def_id of a Trait `trait_def_id` and the name of an associated item `assoc_name`

--- a/compiler/rustc_middle/src/ty/mod.rs
+++ b/compiler/rustc_middle/src/ty/mod.rs
@@ -221,6 +221,7 @@ pub struct DelegationFnSig {
     pub param_count: usize,
     pub has_self: bool,
     pub c_variadic: bool,
+    pub target_feature: bool,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/compiler/rustc_resolve/src/def_collector.rs
+++ b/compiler/rustc_resolve/src/def_collector.rs
@@ -226,7 +226,9 @@ impl<'a, 'ra, 'tcx> visit::Visitor<'a> for DefCollector<'a, 'ra, 'tcx> {
         let def_kind = match fi.kind {
             ForeignItemKind::Static(box StaticItem { ty: _, mutability, expr: _, safety }) => {
                 let safety = match safety {
-                    ast::Safety::Unsafe(_) | ast::Safety::Default => hir::Safety::Unsafe,
+                    ast::Safety::Unsafe(_) | ast::Safety::Default => {
+                        hir::Safety::Unsafe { target_feature: false }
+                    }
                     ast::Safety::Safe(_) => hir::Safety::Safe,
                 };
 

--- a/compiler/rustc_resolve/src/late.rs
+++ b/compiler/rustc_resolve/src/late.rs
@@ -4959,12 +4959,13 @@ struct ItemInfoCollector<'a, 'ra, 'tcx> {
 }
 
 impl ItemInfoCollector<'_, '_, '_> {
-    fn collect_fn_info(&mut self, sig: &FnSig, id: NodeId) {
+    fn collect_fn_info(&mut self, sig: &FnSig, id: NodeId, attrs: &[Attribute]) {
         let sig = DelegationFnSig {
             header: sig.header,
             param_count: sig.decl.inputs.len(),
             has_self: sig.decl.has_self(),
             c_variadic: sig.decl.c_variadic(),
+            target_feature: attrs.iter().any(|attr| attr.has_name(sym::target_feature)),
         };
         self.r.delegation_fn_sigs.insert(self.r.local_def_id(id), sig);
     }
@@ -4983,7 +4984,7 @@ impl<'ast> Visitor<'ast> for ItemInfoCollector<'_, '_, '_> {
             | ItemKind::Trait(box Trait { ref generics, .. })
             | ItemKind::TraitAlias(ref generics, _) => {
                 if let ItemKind::Fn(box Fn { ref sig, .. }) = &item.kind {
-                    self.collect_fn_info(sig, item.id);
+                    self.collect_fn_info(sig, item.id, &item.attrs);
                 }
 
                 let def_id = self.r.local_def_id(item.id);
@@ -5016,7 +5017,7 @@ impl<'ast> Visitor<'ast> for ItemInfoCollector<'_, '_, '_> {
 
     fn visit_assoc_item(&mut self, item: &'ast AssocItem, ctxt: AssocCtxt) {
         if let AssocItemKind::Fn(box Fn { ref sig, .. }) = &item.kind {
-            self.collect_fn_info(sig, item.id);
+            self.collect_fn_info(sig, item.id, &item.attrs);
         }
         visit::walk_assoc_item(self, item, ctxt);
     }

--- a/compiler/rustc_smir/src/rustc_internal/internal.rs
+++ b/compiler/rustc_smir/src/rustc_internal/internal.rs
@@ -489,7 +489,7 @@ impl RustcInternal for Safety {
 
     fn internal<'tcx>(&self, _tables: &mut Tables<'_>, _tcx: TyCtxt<'tcx>) -> Self::T<'tcx> {
         match self {
-            Safety::Unsafe => rustc_hir::Safety::Unsafe,
+            Safety::Unsafe => rustc_hir::Safety::Unsafe { target_feature: false },
             Safety::Safe => rustc_hir::Safety::Safe,
         }
     }

--- a/compiler/rustc_smir/src/rustc_smir/convert/mod.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mod.rs
@@ -15,7 +15,7 @@ impl<'tcx> Stable<'tcx> for rustc_hir::Safety {
     type T = stable_mir::mir::Safety;
     fn stable(&self, _: &mut Tables<'_>) -> Self::T {
         match self {
-            rustc_hir::Safety::Unsafe => stable_mir::mir::Safety::Unsafe,
+            rustc_hir::Safety::Unsafe { .. } => stable_mir::mir::Safety::Unsafe,
             rustc_hir::Safety::Safe => stable_mir::mir::Safety::Safe,
         }
     }

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/on_unimplemented.rs
@@ -207,7 +207,7 @@ impl<'tcx> TypeErrCtxt<'_, 'tcx> {
                 let fn_sig = self_ty.fn_sig(self.tcx);
                 let shortname = match fn_sig.safety() {
                     hir::Safety::Safe => "fn",
-                    hir::Safety::Unsafe => "unsafe fn",
+                    hir::Safety::Unsafe { .. } => "unsafe fn",
                 };
                 flags.push((sym::_Self, Some(shortname.to_owned())));
             }

--- a/src/librustdoc/html/render/print_item.rs
+++ b/src/librustdoc/html/render/print_item.rs
@@ -473,7 +473,7 @@ fn item_module(w: &mut Buffer, cx: &Context<'_>, item: &clean::Item, items: &[cl
                     {
                         "<sup title=\"unsafe function\">⚠</sup>"
                     }
-                    clean::ForeignStaticItem(_, hir::Safety::Unsafe) => {
+                    clean::ForeignStaticItem(_, hir::Safety::Unsafe { .. }) => {
                         "<sup title=\"unsafe static\">⚠</sup>"
                     }
                     _ => "",

--- a/src/tools/clippy/clippy_lints/src/doc/missing_headers.rs
+++ b/src/tools/clippy/clippy_lints/src/doc/missing_headers.rs
@@ -33,7 +33,7 @@ pub fn check(
 
     let span = cx.tcx.def_span(owner_id);
     match (headers.safety, sig.header.safety) {
-        (false, Safety::Unsafe) => span_lint(
+        (false, Safety::Unsafe {..}) => span_lint(
             cx,
             MISSING_SAFETY_DOC,
             span,

--- a/src/tools/clippy/clippy_lints/src/doc/mod.rs
+++ b/src/tools/clippy/clippy_lints/src/doc/mod.rs
@@ -631,7 +631,7 @@ impl<'tcx> LateLintPass<'tcx> for Documentation {
                         }
                     },
                     ItemKind::Trait(_, unsafety, ..) => match (headers.safety, unsafety) {
-                        (false, Safety::Unsafe) => span_lint(
+                        (false, Safety::Unsafe { .. }) => span_lint(
                             cx,
                             MISSING_SAFETY_DOC,
                             cx.tcx.def_span(item.owner_id),

--- a/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
+++ b/src/tools/clippy/clippy_utils/src/check_proc_macro.rs
@@ -252,9 +252,9 @@ fn item_search_pat(item: &Item<'_>) -> (Pat, Pat) {
         ItemKind::Struct(VariantData::Struct { .. }, _) => (Pat::Str("struct"), Pat::Str("}")),
         ItemKind::Struct(..) => (Pat::Str("struct"), Pat::Str(";")),
         ItemKind::Union(..) => (Pat::Str("union"), Pat::Str("}")),
-        ItemKind::Trait(_, Safety::Unsafe, ..)
+        ItemKind::Trait(_, Safety::Unsafe{..}, ..)
         | ItemKind::Impl(Impl {
-            safety: Safety::Unsafe, ..
+            safety: Safety::Unsafe{..}, ..
         }) => (Pat::Str("unsafe"), Pat::Str("}")),
         ItemKind::Trait(IsAuto::Yes, ..) => (Pat::Str("auto"), Pat::Str("}")),
         ItemKind::Trait(..) => (Pat::Str("trait"), Pat::Str("}")),

--- a/tests/ui/async-await/async-closures/fn-exception-target-features.stderr
+++ b/tests/ui/async-await/async-closures/fn-exception-target-features.stderr
@@ -1,11 +1,12 @@
-error[E0277]: the trait bound `fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}: AsyncFn()` is not satisfied
+error[E0277]: the trait bound `#[target_feature] fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}: AsyncFn()` is not satisfied
   --> $DIR/fn-exception-target-features.rs:16:10
    |
 LL |     test(target_feature);
-   |     ---- ^^^^^^^^^^^^^^ the trait `AsyncFn()` is not implemented for fn item `fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}`
+   |     ---- ^^^^^^^^^^^^^^ unsatisfied trait bound
    |     |
    |     required by a bound introduced by this call
    |
+   = help: the trait `AsyncFn()` is not implemented for fn item `#[target_feature] fn() -> Pin<Box<(dyn Future<Output = ()> + 'static)>> {target_feature}`
 note: required by a bound in `test`
   --> $DIR/fn-exception-target-features.rs:13:17
    |

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-ptr.stderr
@@ -10,13 +10,9 @@ LL |     let foo: fn() = foo;
    |              expected due to this
    |
    = note: expected fn pointer `fn()`
-                 found fn item `fn() {foo}`
-   = note: fn items are distinct from fn pointers
+                 found fn item `#[target_feature] fn() {foo}`
    = note: functions with `#[target_feature]` can only be coerced to `unsafe` function pointers
-help: consider casting to a fn pointer
-   |
-LL |     let foo: fn() = foo as fn();
-   |                     ~~~~~~~~~~~
+   = note: unsafe functions cannot be coerced into safe function pointers
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.rs
@@ -21,9 +21,9 @@ fn call_once(f: impl FnOnce()) {
 }
 
 fn main() {
-    call(foo); //~ ERROR expected a `Fn()` closure, found `fn() {foo}`
-    call_mut(foo); //~ ERROR expected a `FnMut()` closure, found `fn() {foo}`
-    call_once(foo); //~ ERROR expected a `FnOnce()` closure, found `fn() {foo}`
+    call(foo); //~ ERROR expected a `Fn()` closure, found `#[target_feature] fn() {foo}`
+    call_mut(foo); //~ ERROR expected a `FnMut()` closure, found `#[target_feature] fn() {foo}`
+    call_once(foo); //~ ERROR expected a `FnOnce()` closure, found `#[target_feature] fn() {foo}`
 
     call(foo_unsafe);
     //~^ ERROR expected a `Fn()` closure, found `unsafe fn() {foo_unsafe}`

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/fn-traits.stderr
@@ -1,13 +1,14 @@
-error[E0277]: expected a `Fn()` closure, found `fn() {foo}`
+error[E0277]: expected a `Fn()` closure, found `#[target_feature] fn() {foo}`
   --> $DIR/fn-traits.rs:24:10
    |
 LL |     call(foo);
-   |     ---- ^^^ expected an `Fn()` closure, found `fn() {foo}`
+   |     ---- ^^^ call the function in a closure: `|| unsafe { /* code */ }`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `Fn()` is not implemented for fn item `fn() {foo}`
-   = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `Fn()` is not implemented for fn item `#[target_feature] fn() {foo}`
+   = note: unsafe function cannot be called generically without an unsafe block
+   = note: wrap the `#[target_feature] fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call`
   --> $DIR/fn-traits.rs:11:17
@@ -15,16 +16,17 @@ note: required by a bound in `call`
 LL | fn call(f: impl Fn()) {
    |                 ^^^^ required by this bound in `call`
 
-error[E0277]: expected a `FnMut()` closure, found `fn() {foo}`
+error[E0277]: expected a `FnMut()` closure, found `#[target_feature] fn() {foo}`
   --> $DIR/fn-traits.rs:25:14
    |
 LL |     call_mut(foo);
-   |     -------- ^^^ expected an `FnMut()` closure, found `fn() {foo}`
+   |     -------- ^^^ call the function in a closure: `|| unsafe { /* code */ }`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnMut()` is not implemented for fn item `fn() {foo}`
-   = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `FnMut()` is not implemented for fn item `#[target_feature] fn() {foo}`
+   = note: unsafe function cannot be called generically without an unsafe block
+   = note: wrap the `#[target_feature] fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_mut`
   --> $DIR/fn-traits.rs:15:25
@@ -32,16 +34,17 @@ note: required by a bound in `call_mut`
 LL | fn call_mut(mut f: impl FnMut()) {
    |                         ^^^^^^^ required by this bound in `call_mut`
 
-error[E0277]: expected a `FnOnce()` closure, found `fn() {foo}`
+error[E0277]: expected a `FnOnce()` closure, found `#[target_feature] fn() {foo}`
   --> $DIR/fn-traits.rs:26:15
    |
 LL |     call_once(foo);
-   |     --------- ^^^ expected an `FnOnce()` closure, found `fn() {foo}`
+   |     --------- ^^^ call the function in a closure: `|| unsafe { /* code */ }`
    |     |
    |     required by a bound introduced by this call
    |
-   = help: the trait `FnOnce()` is not implemented for fn item `fn() {foo}`
-   = note: wrap the `fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
+   = help: the trait `FnOnce()` is not implemented for fn item `#[target_feature] fn() {foo}`
+   = note: unsafe function cannot be called generically without an unsafe block
+   = note: wrap the `#[target_feature] fn() {foo}` in a closure with no arguments: `|| { /* code */ }`
    = note: `#[target_feature]` functions do not implement the `Fn` traits
 note: required by a bound in `call_once`
   --> $DIR/fn-traits.rs:19:22

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.stderr
@@ -26,6 +26,9 @@ LL |     Quux.avx_bmi2();
 error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:38:5
    |
+LL | fn bar() {
+   | -------- items do not inherit unsafety from separate enclosing items
+LL |     sse2();
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
    |
@@ -34,6 +37,9 @@ LL |     avx_bmi2();
 error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:40:5
    |
+LL | fn bar() {
+   | -------- items do not inherit unsafety from separate enclosing items
+...
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |
@@ -42,6 +48,9 @@ LL |     Quux.avx_bmi2();
 error[E0133]: call to function `avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:47:5
    |
+LL | fn baz() {
+   | -------- items do not inherit unsafety from separate enclosing items
+LL |     sse2();
 LL |     avx_bmi2();
    |     ^^^^^^^^^^ call to function with `#[target_feature]`
    |
@@ -50,6 +59,9 @@ LL |     avx_bmi2();
 error[E0133]: call to function `Quux::avx_bmi2` with `#[target_feature]` is unsafe and requires unsafe function or block
   --> $DIR/safe-calls.rs:49:5
    |
+LL | fn baz() {
+   | -------- items do not inherit unsafety from separate enclosing items
+...
 LL |     Quux.avx_bmi2();
    |     ^^^^^^^^^^^^^^^ call to function with `#[target_feature]`
    |

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/trait-impl.rs
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/trait-impl.rs
@@ -13,6 +13,7 @@ impl Foo for Bar {
     #[target_feature(enable = "sse2")]
     //~^ ERROR cannot be applied to safe trait method
     fn foo(&self) {}
+    //~^ ERROR method `foo` has an incompatible type for trait
 
     #[target_feature(enable = "sse2")]
     unsafe fn unsf_foo(&self) {}

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/trait-impl.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/trait-impl.stderr
@@ -1,3 +1,17 @@
+error[E0053]: method `foo` has an incompatible type for trait
+  --> $DIR/trait-impl.rs:15:5
+   |
+LL |     fn foo(&self) {}
+   |     ^^^^^^^^^^^^^ expected safe fn, found #[target_feature] safe fn
+   |
+note: type in trait
+  --> $DIR/trait-impl.rs:6:5
+   |
+LL |     fn foo(&self);
+   |     ^^^^^^^^^^^^^^
+   = note: expected signature `fn(&Bar)`
+              found signature `#[target_feature] fn(&Bar)`
+
 error: `#[target_feature(..)]` cannot be applied to safe trait method
   --> $DIR/trait-impl.rs:13:5
    |
@@ -8,7 +22,7 @@ LL |     fn foo(&self) {}
    |     ------------- not an `unsafe` function
 
 error: `#[target_feature(..)]` cannot be applied to safe trait method
-  --> $DIR/trait-impl.rs:22:5
+  --> $DIR/trait-impl.rs:23:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot be applied to safe trait method
@@ -16,5 +30,6 @@ LL |
 LL |     fn foo(&self) {}
    |     ------------- not an `unsafe` function
 
-error: aborting due to 2 previous errors
+error: aborting due to 3 previous errors
 
+For more information about this error, try `rustc --explain E0053`.

--- a/tests/ui/target-feature/invalid-attribute.rs
+++ b/tests/ui/target-feature/invalid-attribute.rs
@@ -97,6 +97,7 @@ impl Foo {}
 
 trait Quux {
     fn foo(); //~ NOTE `foo` from trait
+    //~^ NOTE: type in trait
 }
 
 impl Quux for Foo {
@@ -106,6 +107,9 @@ impl Quux for Foo {
     //~| NOTE: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
     fn foo() {}
     //~^ NOTE not an `unsafe` function
+    //~| ERROR: incompatible type for trait
+    //~| NOTE: expected safe fn, found #[target_feature] safe fn
+    //~| NOTE: expected signature `fn()`
 }
 
 fn main() {

--- a/tests/ui/target-feature/invalid-attribute.stderr
+++ b/tests/ui/target-feature/invalid-attribute.stderr
@@ -126,7 +126,7 @@ LL | impl Foo {}
    | ----------- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:112:5
+  --> $DIR/invalid-attribute.rs:116:5
    |
 LL |       #[target_feature(enable = "sse2")]
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,7 +138,7 @@ LL | |     }
    | |_____- not a function definition
 
 error: attribute should be applied to a function definition
-  --> $DIR/invalid-attribute.rs:120:5
+  --> $DIR/invalid-attribute.rs:124:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -192,8 +192,22 @@ LL | impl Quux for u8 {}
 LL |     fn foo();
    |     --------- `foo` from trait
 
+error[E0053]: method `foo` has an incompatible type for trait
+  --> $DIR/invalid-attribute.rs:108:5
+   |
+LL |     fn foo() {}
+   |     ^^^^^^^^ expected safe fn, found #[target_feature] safe fn
+   |
+note: type in trait
+  --> $DIR/invalid-attribute.rs:99:5
+   |
+LL |     fn foo();
+   |     ^^^^^^^^^
+   = note: expected signature `fn()`
+              found signature `#[target_feature] fn()`
+
 error[E0658]: `#[target_feature(..)]` can only be applied to `unsafe` functions
-  --> $DIR/invalid-attribute.rs:103:5
+  --> $DIR/invalid-attribute.rs:104:5
    |
 LL |     #[target_feature(enable = "sse2")]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -205,7 +219,7 @@ LL |     fn foo() {}
    = help: add `#![feature(target_feature_11)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 23 previous errors
+error: aborting due to 24 previous errors
 
-Some errors have detailed explanations: E0046, E0658.
+Some errors have detailed explanations: E0046, E0053, E0658.
 For more information about an error, try `rustc --explain E0046`.


### PR DESCRIPTION
This unblocks
* #134090

As I stated in https://github.com/rust-lang/rust/pull/134090#issuecomment-2541332415 I think the previous impl was too easy to get wrong, as by default it treated safe target feature functions as safe and had to add additional checks for when they weren't. Now the logic is inverted. By default they are unsafe and you have to explicitly handle safe target feature functions.

I will make another version of this PR that doesn't modify the safety enum but just checks the attrs. Should be less invasive 