### PR TITLE
Use `PtrMetadata` instead of `Len` in slice drop shims

### DIFF
--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
@@ -2,15 +2,17 @@
 
 fn std::ptr::drop_in_place(_1: *mut [String; 42]) -> () {
     let mut _0: ();
-    let mut _2: usize;
-    let mut _3: usize;
-    let mut _4: *mut std::string::String;
-    let mut _5: bool;
+    let mut _2: *mut [std::string::String; 42];
+    let mut _3: *mut [std::string::String];
+    let mut _4: usize;
+    let mut _5: usize;
     let mut _6: *mut std::string::String;
     let mut _7: bool;
+    let mut _8: *mut std::string::String;
+    let mut _9: bool;
 
     bb0: {
-        goto -> bb8;
+        goto -> bb9;
     }
 
     bb1: {
@@ -22,34 +24,40 @@ fn std::ptr::drop_in_place(_1: *mut [String; 42]) -> () {
     }
 
     bb3 (cleanup): {
-        _4 = &raw mut (*_1)[_3];
-        _3 = Add(move _3, const 1_usize);
-        drop((*_4)) -> [return: bb4, unwind terminate(cleanup)];
+        _6 = &raw mut (*_3)[_5];
+        _5 = Add(move _5, const 1_usize);
+        drop((*_6)) -> [return: bb4, unwind terminate(cleanup)];
     }
 
     bb4 (cleanup): {
-        _5 = Eq(copy _3, copy _2);
-        switchInt(move _5) -> [0: bb3, otherwise: bb2];
+        _7 = Eq(copy _5, copy _4);
+        switchInt(move _7) -> [0: bb3, otherwise: bb2];
     }
 
     bb5: {
-        _6 = &raw mut (*_1)[_3];
-        _3 = Add(move _3, const 1_usize);
-        drop((*_6)) -> [return: bb6, unwind: bb4];
+        _8 = &raw mut (*_3)[_5];
+        _5 = Add(move _5, const 1_usize);
+        drop((*_8)) -> [return: bb6, unwind: bb4];
     }
 
     bb6: {
-        _7 = Eq(copy _3, copy _2);
-        switchInt(move _7) -> [0: bb5, otherwise: bb1];
+        _9 = Eq(copy _5, copy _4);
+        switchInt(move _9) -> [0: bb5, otherwise: bb1];
     }
 
     bb7: {
-        _2 = Len((*_1));
-        _3 = const 0_usize;
+        _4 = PtrMetadata(copy _3);
+        _5 = const 0_usize;
         goto -> bb6;
     }
 
     bb8: {
         goto -> bb7;
+    }
+
+    bb9: {
+        _2 = &raw mut (*_1);
+        _3 = move _2 as *mut [std::string::String] (PointerCoercion(Unsize, Implicit));
+        goto -> bb8;
     }
 }

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
@@ -1,0 +1,55 @@
+// MIR for `std::ptr::drop_in_place` before AddMovesForPackedDrops
+
+fn std::ptr::drop_in_place(_1: *mut [String; 42]) -> () {
+    let mut _0: ();
+    let mut _2: usize;
+    let mut _3: usize;
+    let mut _4: *mut std::string::String;
+    let mut _5: bool;
+    let mut _6: *mut std::string::String;
+    let mut _7: bool;
+
+    bb0: {
+        goto -> bb8;
+    }
+
+    bb1: {
+        return;
+    }
+
+    bb2 (cleanup): {
+        resume;
+    }
+
+    bb3 (cleanup): {
+        _4 = &raw mut (*_1)[_3];
+        _3 = Add(move _3, const 1_usize);
+        drop((*_4)) -> [return: bb4, unwind terminate(cleanup)];
+    }
+
+    bb4 (cleanup): {
+        _5 = Eq(copy _3, copy _2);
+        switchInt(move _5) -> [0: bb3, otherwise: bb2];
+    }
+
+    bb5: {
+        _6 = &raw mut (*_1)[_3];
+        _3 = Add(move _3, const 1_usize);
+        drop((*_6)) -> [return: bb6, unwind: bb4];
+    }
+
+    bb6: {
+        _7 = Eq(copy _3, copy _2);
+        switchInt(move _7) -> [0: bb5, otherwise: bb1];
+    }
+
+    bb7: {
+        _2 = Len((*_1));
+        _3 = const 0_usize;
+        goto -> bb6;
+    }
+
+    bb8: {
+        goto -> bb7;
+    }
+}

--- a/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
+++ b/tests/mir-opt/slice_drop_shim.core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
@@ -44,7 +44,7 @@ fn std::ptr::drop_in_place(_1: *mut [String]) -> () {
     }
 
     bb7: {
-        _2 = Len((*_1));
+        _2 = PtrMetadata(copy _1);
         _3 = const 0_usize;
         goto -> bb6;
     }

--- a/tests/mir-opt/slice_drop_shim.rs
+++ b/tests/mir-opt/slice_drop_shim.rs
@@ -5,6 +5,8 @@
 // if we use -Clink-dead-code.
 
 // EMIT_MIR core.ptr-drop_in_place.[String].AddMovesForPackedDrops.before.mir
+// EMIT_MIR core.ptr-drop_in_place.[String;42].AddMovesForPackedDrops.before.mir
 fn main() {
     let _fn = std::ptr::drop_in_place::<[String]> as unsafe fn(_);
+    let _fn = std::ptr::drop_in_place::<[String; 42]> as unsafe fn(_);
 }


### PR DESCRIPTION
I tried to do a bigger change in #134297 which didn't work, so here's the part I really wanted: Removing another use of `Len`, in favour of `PtrMetadata`.

Split into two commits where the first just adds a test, so you can look at the second commit to see how the drop shim for an array changes with this PR.

Reusing the same reviewer from the last one:
r? BoxyUwU
