### PR TITLE
bootstrap: make ./x test error-index work

### DIFF
--- a/src/bootstrap/src/core/build_steps/test.rs
+++ b/src/bootstrap/src/core/build_steps/test.rs
@@ -2442,7 +2442,9 @@ impl Step for ErrorIndex {
     const ONLY_HOSTS: bool = true;
 
     fn should_run(run: ShouldRun<'_>) -> ShouldRun<'_> {
-        run.path("src/tools/error_index_generator")
+        // Also add `error-index` here since that is what appears in the error message
+        // when this fails.
+        run.path("src/tools/error_index_generator").alias("error-index")
     }
 
     fn make_run(run: RunConfig<'_>) {


### PR DESCRIPTION
This makes it more likely that someone who sees an error index CI failure will be able to figure out how to reproduce that locally. Note that bootstrap already prints "Testing stage2 error-index", which is misleading since the test is actually called error_index_generator.