### PR TITLE
Bump `stdarch`

### DIFF
--- a/library/portable-simd/crates/core_simd/src/vendor/arm.rs
+++ b/library/portable-simd/crates/core_simd/src/vendor/arm.rs
@@ -49,17 +49,6 @@ mod neon {
 }
 
 #[cfg(any(
-    all(target_feature = "v5te", not(target_feature = "mclass")),
-    all(target_feature = "mclass", target_feature = "dsp"),
-))]
-mod dsp {
-    use super::*;
-
-    from_transmute! { unsafe Simd<u16, 2> => uint16x2_t }
-    from_transmute! { unsafe Simd<i16, 2> => int16x2_t }
-}
-
-#[cfg(any(
     all(target_feature = "v6", not(target_feature = "mclass")),
     all(target_feature = "mclass", target_feature = "dsp"),
 ))]
@@ -68,6 +57,8 @@ mod simd32 {
 
     from_transmute! { unsafe Simd<u8, 4> => uint8x4_t }
     from_transmute! { unsafe Simd<i8, 4> => int8x4_t }
+    from_transmute! { unsafe Simd<u16, 2> => uint16x2_t }
+    from_transmute! { unsafe Simd<i16, 2> => int16x2_t }
 }
 
 #[cfg(all(

--- a/tests/ui/traits/issue-77982.rs
+++ b/tests/ui/traits/issue-77982.rs
@@ -1,4 +1,5 @@
 //@ ignore-windows different list of satisfying impls
+//@ ignore-arm different list of satisfying impls
 use std::collections::HashMap;
 
 fn what() {

--- a/tests/ui/traits/issue-77982.stderr
+++ b/tests/ui/traits/issue-77982.stderr
@@ -1,5 +1,5 @@
 error[E0283]: type annotations needed
-  --> $DIR/issue-77982.rs:9:10
+  --> $DIR/issue-77982.rs:10:10
    |
 LL |     opts.get(opt.as_ref());
    |          ^^^ ------------ type must be known at this point
@@ -18,7 +18,7 @@ LL |     opts.get::<Q>(opt.as_ref());
    |             +++++
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-77982.rs:9:10
+  --> $DIR/issue-77982.rs:10:10
    |
 LL |     opts.get(opt.as_ref());
    |          ^^^     ------ type must be known at this point
@@ -36,7 +36,7 @@ LL |     opts.get::<Q>(opt.as_ref());
    |             +++++
 
 error[E0283]: type annotations needed
-  --> $DIR/issue-77982.rs:14:59
+  --> $DIR/issue-77982.rs:15:59
    |
 LL |     let ips: Vec<_> = (0..100_000).map(|_| u32::from(0u32.into())).collect();
    |                                            ---            ^^^^
@@ -56,13 +56,13 @@ LL |     let ips: Vec<_> = (0..100_000).map(|_| u32::from(<u32 as Into<T>>::into
    |                                                      +++++++++++++++++++++++    ~
 
 error[E0283]: type annotations needed for `Box<_>`
-  --> $DIR/issue-77982.rs:37:9
+  --> $DIR/issue-77982.rs:38:9
    |
 LL |     let _ = ().foo();
    |         ^      --- type must be known at this point
    |
 note: multiple `impl`s satisfying `(): Foo<'_, _>` found
-  --> $DIR/issue-77982.rs:30:1
+  --> $DIR/issue-77982.rs:31:1
    |
 LL | impl Foo<'static, u32> for () {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -74,13 +74,13 @@ LL |     let _: Box<T> = ().foo();
    |          ++++++++
 
 error[E0283]: type annotations needed for `Box<_>`
-  --> $DIR/issue-77982.rs:41:9
+  --> $DIR/issue-77982.rs:42:9
    |
 LL |     let _ = (&()).bar();
    |         ^         --- type must be known at this point
    |
 note: multiple `impl`s satisfying `&(): Bar<'_, _>` found
-  --> $DIR/issue-77982.rs:33:1
+  --> $DIR/issue-77982.rs:34:1
    |
 LL | impl<'a> Bar<'static, u32> for &'a () {}
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This bumps `stdarch` to https://github.com/rust-lang/stdarch/commit/684de0d6fef708cae08214fef9643dd9ec7296e1 to get in https://github.com/rust-lang/stdarch/pull/1677 (tracked in https://github.com/rust-lang/rust/issues/133908).

From the [commit history](https://github.com/rust-lang/stdarch/compare/e5e00aab0a8c8fa35fb7865e88fa82366f615c53...684de0d6fef708cae08214fef9643dd9ec7296e1) I deduced that there shouldn't be any changes to Rust necessary.

From past PRs I'm assuming that bumping `stdarch` like this is fine, but please let me know if this is somehow inappropriate or requires something more to be done!

try-job: arm-android
try-job: armhf-gnu