### PR TITLE
Show pending obligations as unsatisfied constraints in `report_similar_impl_candidates`

### DIFF
--- a/compiler/rustc_infer/src/traits/engine.rs
+++ b/compiler/rustc_infer/src/traits/engine.rs
@@ -17,6 +17,8 @@ use crate::traits::Obligation;
 pub enum ScrubbedTraitError<'tcx> {
     /// A real error. This goal definitely does not hold.
     TrueError,
+    // A select error with pending obligations
+    Select(PredicateObligations<'tcx>),
     /// An ambiguity. This goal may hold if further inference is done.
     Ambiguity,
     /// An old-solver-style cycle error, which will fatal.
@@ -26,7 +28,7 @@ pub enum ScrubbedTraitError<'tcx> {
 impl<'tcx> ScrubbedTraitError<'tcx> {
     pub fn is_true_error(&self) -> bool {
         match self {
-            ScrubbedTraitError::TrueError => true,
+            ScrubbedTraitError::TrueError | ScrubbedTraitError::Select(_) => true,
             ScrubbedTraitError::Ambiguity | ScrubbedTraitError::Cycle(_) => false,
         }
     }

--- a/compiler/rustc_trait_selection/src/traits/fulfill.rs
+++ b/compiler/rustc_trait_selection/src/traits/fulfill.rs
@@ -942,8 +942,13 @@ impl<'tcx> FromSolverError<'tcx, OldSolverError<'tcx>> for FulfillmentError<'tcx
 impl<'tcx> FromSolverError<'tcx, OldSolverError<'tcx>> for ScrubbedTraitError<'tcx> {
     fn from_solver_error(_infcx: &InferCtxt<'tcx>, error: OldSolverError<'tcx>) -> Self {
         match error.0.error {
-            FulfillmentErrorCode::Select(_)
-            | FulfillmentErrorCode::Project(_)
+            FulfillmentErrorCode::Select(_) => {
+                let pendings_obligations =
+                    error.0.backtrace.into_iter().map(|p| p.obligation).collect();
+
+                ScrubbedTraitError::Select(pendings_obligations)
+            }
+            FulfillmentErrorCode::Project(_)
             | FulfillmentErrorCode::Subtype(_, _)
             | FulfillmentErrorCode::ConstEquate(_, _) => ScrubbedTraitError::TrueError,
             FulfillmentErrorCode::Ambiguity { overflow: _ } => ScrubbedTraitError::Ambiguity,


### PR DESCRIPTION
Fixes: #134346

# Summary

This PR attempts to fix the issue in #134346, by additional `help` hints for each unsatisfied indirect constraint inside a blanket implementation.

# Details

To provide the extra information, a new variant `Select(PredicateObligations<'tcx>)` is added to `ScrubbedTraitError<'tcx>` to extract the `pending_obligations` returned from `select_where_possible`. Then inside `report_similar_impl_candidates`, we iterate through every pending obligation in the errors, and print them out as a `help` hint.

# Potential Issues

This is my first contribution to the Rust compiler project. I'm not sure of the best way to present the error messages, or handle them anywhere else in the codebase. If there are better ways to implement the improvement, I'm happy to modify the PR according to the suggestions.

An unresolved issue here is that the fix is only implemented for the old Rust trait solver. Compared to `OldSolverError`, I don't see the `pending_obligations` field to be present inside `NextSolverError`. So I'm unsure of the best way to keep this forward compatible with the upcoming trait solver.

I'm also not sure if the fix here would produce too noisy errors outside of my specific use case. When I test this fix with more complex projects that I have, the error messages may contain many unresolved constraints. However when scanning through all items, I determined that none of the listed unresolved constraints should be considered uninformative noise. Hence, I do think that it is essential to have all unresolved constraints listed in the error message.