### PR TITLE
Fix `trimmed_def_paths` ICE in the function ptr comparison lint

### DIFF
--- a/tests/ui/lint/fn-ptr-comparisons-134345.rs
+++ b/tests/ui/lint/fn-ptr-comparisons-134345.rs
@@ -1,0 +1,16 @@
+// This check veifies that we do not ICE when not showing a user type
+// in the suggestions/diagnostics.
+//
+// cf. https://github.com/rust-lang/rust/issues/134345
+//
+//@ check-pass
+
+struct A;
+
+fn fna(_a: A) {}
+
+#[allow(unpredictable_function_pointer_comparisons)]
+fn main() {
+    let fa: fn(A) = fna;
+    let _ = fa == fna;
+}


### PR DESCRIPTION
This PR fixes an ICE with `trimmed_def_paths` ICE in the function ptr comparison lint, specifically when pretty-printing user types but then not using the resulting pretty-printing.

Fixes #134345
r? @saethlin 
