### PR TITLE
DO NOT MERGE: Replace overflowing sub with checked_sub.

### DIFF
--- a/compiler/rustc_errors/src/emitter.rs
+++ b/compiler/rustc_errors/src/emitter.rs
@@ -140,7 +140,14 @@ impl Margin {
 
         if self.computed_right - self.computed_left > self.column_width {
             // Trimming only whitespace isn't enough, let's get craftier.
-            if self.label_right - self.whitespace_left <= self.column_width {
+
+            // Note: self.label_right - self.whitespace_left will overflow in the case that the label
+            //       is addressing whitespace. This happens when a spurious no-breaking-space (\u{a0})
+            //       is present in the whitespace.
+            if let Some(non_whitespace_label_width) =
+                self.label_right.checked_sub(self.whitespace_left)
+                && non_whitespace_label_width <= self.column_width
+            {
                 // Attempt to fit the code window only trimming whitespace.
                 self.computed_left = self.whitespace_left;
                 self.computed_right = self.computed_left + self.column_width;


### PR DESCRIPTION
In the case when a no-break-space \u{a0} exists before any non white space characters an error is generated that points into the white space. When the terminal width is also too small a subtraction is triggered here that would overflow. That subtraction implicitly assumed that no errors occur in the white space. This commit replaces that subtraction with an explicitly checked one to avoid this overflow.

Addresses: https://github.com/rust-lang/rust/issues/132918