### PR TITLE
Use links to edition guide for edition migrations

### DIFF
--- a/compiler/rustc_lint/src/builtin.rs
+++ b/compiler/rustc_lint/src/builtin.rs
@@ -1814,7 +1814,7 @@ declare_lint! {
     "detects edition keywords being used as an identifier",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "issue #49716 <https://github.com/rust-lang/rust/issues/49716>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>",
     };
 }
 

--- a/compiler/rustc_lint/src/if_let_rescope.rs
+++ b/compiler/rustc_lint/src/if_let_rescope.rs
@@ -84,7 +84,7 @@ declare_lint! {
     rewriting in `match` is an option to preserve the semantics up to Edition 2021",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "issue #124085 <https://github.com/rust-lang/rust/issues/124085>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>",
     };
 }
 

--- a/compiler/rustc_lint/src/shadowed_into_iter.rs
+++ b/compiler/rustc_lint/src/shadowed_into_iter.rs
@@ -61,6 +61,7 @@ declare_lint! {
     "detects calling `into_iter` on boxed slices in Rust 2015, 2018, and 2021",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>"
     };
 }
 

--- a/compiler/rustc_lint_defs/src/builtin.rs
+++ b/compiler/rustc_lint_defs/src/builtin.rs
@@ -1677,7 +1677,7 @@ declare_lint! {
     "detects patterns whose meaning will change in Rust 2024",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "123076",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>",
     };
 }
 
@@ -2606,7 +2606,7 @@ declare_lint! {
     "unsafe operations in unsafe functions without an explicit unsafe block are deprecated",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "issue #71668 <https://github.com/rust-lang/rust/issues/71668>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>",
         explain_reason: false
     };
     @edition Edition2024 => Warn;
@@ -4189,7 +4189,7 @@ declare_lint! {
     "never type fallback affecting unsafe function calls",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionAndFutureReleaseSemanticsChange(Edition::Edition2024),
-        reference: "issue #123748 <https://github.com/rust-lang/rust/issues/123748>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>",
     };
     @edition Edition2024 => Deny;
     report_in_external_macro
@@ -4243,7 +4243,7 @@ declare_lint! {
     "never type fallback affecting unsafe function calls",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionAndFutureReleaseError(Edition::Edition2024),
-        reference: "issue #123748 <https://github.com/rust-lang/rust/issues/123748>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>",
     };
     report_in_external_macro
 }
@@ -4790,7 +4790,7 @@ declare_lint! {
     "detects unsafe functions being used as safe functions",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "issue #27970 <https://github.com/rust-lang/rust/issues/27970>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/newly-unsafe-functions.html>",
     };
 }
 
@@ -4826,7 +4826,7 @@ declare_lint! {
     "detects missing unsafe keyword on extern declarations",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "issue #123743 <https://github.com/rust-lang/rust/issues/123743>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-extern.html>",
     };
 }
 
@@ -4867,7 +4867,7 @@ declare_lint! {
     "detects unsafe attributes outside of unsafe",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "issue #123757 <https://github.com/rust-lang/rust/issues/123757>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>",
     };
 }
 
@@ -5069,7 +5069,7 @@ declare_lint! {
     "Detect and warn on significant change in drop order in tail expression location",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionSemanticsChange(Edition::Edition2024),
-        reference: "issue #123739 <https://github.com/rust-lang/rust/issues/123739>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>",
     };
 }
 
@@ -5108,7 +5108,7 @@ declare_lint! {
     "will be parsed as a guarded string in Rust 2024",
     @future_incompatible = FutureIncompatibleInfo {
         reason: FutureIncompatibilityReason::EditionError(Edition::Edition2024),
-        reference: "issue #123735 <https://github.com/rust-lang/rust/issues/123735>",
+        reference: "<https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>",
     };
     crate_level_only
 }

--- a/tests/ui/drop/lint-if-let-rescope-gated.edition2021.stderr
+++ b/tests/ui/drop/lint-if-let-rescope-gated.edition2021.stderr
@@ -7,7 +7,7 @@ LL |     if let Some(_value) = Droppy.get() {
    |                           this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #124085 <https://github.com/rust-lang/rust/issues/124085>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope-gated.rs:30:5
    |

--- a/tests/ui/drop/lint-if-let-rescope-with-macro.stderr
+++ b/tests/ui/drop/lint-if-let-rescope-with-macro.stderr
@@ -14,7 +14,7 @@ LL | |     };
    | |_____- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #124085 <https://github.com/rust-lang/rust/issues/124085>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope-with-macro.rs:12:38
    |

--- a/tests/ui/drop/lint-if-let-rescope.stderr
+++ b/tests/ui/drop/lint-if-let-rescope.stderr
@@ -7,7 +7,7 @@ LL |     if let Some(_value) = droppy().get() {
    |                           this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #124085 <https://github.com/rust-lang/rust/issues/124085>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:32:5
    |
@@ -42,7 +42,7 @@ LL |     } else if let Some(_value) = droppy().get() {
    |                                  -------- this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #124085 <https://github.com/rust-lang/rust/issues/124085>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:42:5
    |
@@ -74,7 +74,7 @@ LL |     } else if let Some(_value) = droppy().get() {
    |                                  this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #124085 <https://github.com/rust-lang/rust/issues/124085>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:54:5
    |
@@ -100,7 +100,7 @@ LL |     if let Some(1) = { if let Some(_value) = Droppy.get() { Some(1) } else 
    |                                              this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #124085 <https://github.com/rust-lang/rust/issues/124085>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:58:69
    |
@@ -120,7 +120,7 @@ LL |     if (if let Some(_value) = droppy().get() { true } else { false }) {
    |                               this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #124085 <https://github.com/rust-lang/rust/issues/124085>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:72:53
    |
@@ -140,7 +140,7 @@ LL |     } else if (((if let Some(_value) = droppy().get() { true } else { false
    |                                        this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #124085 <https://github.com/rust-lang/rust/issues/124085>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:78:62
    |
@@ -160,7 +160,7 @@ LL |     while (if let Some(_value) = droppy().get() { false } else { true }) {
    |                                  this value has a significant drop implementation which may observe a major change in drop order and requires your discretion
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #124085 <https://github.com/rust-lang/rust/issues/124085>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-if-let-scope.html>
 help: the value is now dropped here in Edition 2024
   --> $DIR/lint-if-let-rescope.rs:90:57
    |

--- a/tests/ui/drop/lint-tail-expr-drop-order.rs
+++ b/tests/ui/drop/lint-tail-expr-drop-order.rs
@@ -45,7 +45,7 @@ fn should_lint() -> i32 {
     //~| NOTE: up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
     //~| WARN: this changes meaning in Rust 2024
     //~| NOTE: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects
-    //~| NOTE: for more information, see issue #123739
+    //~| NOTE: for more information, see
 }
 //~^ NOTE: now the temporary value is dropped here, before the local variables in the block or statement
 
@@ -70,7 +70,7 @@ fn should_lint_in_nested_items() {
         //~| NOTE: up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
         //~| WARN: this changes meaning in Rust 2024
         //~| NOTE: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects
-        //~| NOTE: for more information, see issue #123739
+        //~| NOTE: for more information, see
     }
     //~^ NOTE: now the temporary value is dropped here, before the local variables in the block or statement
 }
@@ -97,7 +97,7 @@ fn should_lint_in_nested_block() -> i32 {
     //~| NOTE: up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
     //~| WARN: this changes meaning in Rust 2024
     //~| NOTE: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects
-    //~| NOTE: for more information, see issue #123739
+    //~| NOTE: for more information, see
 }
 //~^ NOTE: now the temporary value is dropped here, before the local variables in the block or statement
 
@@ -150,7 +150,7 @@ fn should_lint_into_async_body() -> i32 {
     //~| NOTE: this value will be stored in a temporary; let us call it `#1`
     //~| NOTE: up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
     //~| NOTE: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects
-    //~| NOTE: for more information, see issue #123739
+    //~| NOTE: for more information, see
 }
 //~^ NOTE: now the temporary value is dropped here, before the local variables in the block or statement
 
@@ -167,7 +167,7 @@ fn should_lint_generics<T: Default>() -> &'static str {
     //~| NOTE: this value will be stored in a temporary; let us call it `#1`
     //~| NOTE: up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
     //~| NOTE: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects
-    //~| NOTE: for more information, see issue #123739
+    //~| NOTE: for more information, see
 }
 //~^ NOTE: now the temporary value is dropped here, before the local variables in the block or statement
 
@@ -181,7 +181,7 @@ fn should_lint_adt() -> i32 {
     //~| NOTE: this value will be stored in a temporary; let us call it `#1`
     //~| NOTE: up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
     //~| NOTE: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects
-    //~| NOTE: for more information, see issue #123739
+    //~| NOTE: for more information, see
 }
 //~^ NOTE: now the temporary value is dropped here, before the local variables in the block or statement
 
@@ -225,7 +225,7 @@ fn should_lint_with_dtor_span() -> i32 {
     //~| NOTE: up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
     //~| WARN: this changes meaning in Rust 2024
     //~| NOTE: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects
-    //~| NOTE: for more information, see issue #123739
+    //~| NOTE: for more information, see
 }
 //~^ NOTE: now the temporary value is dropped here, before the local variables in the block or statement
 
@@ -238,7 +238,7 @@ fn should_lint_with_transient_drops() {
             //~| NOTE: up until Edition 2021 `#1` is dropped last but will be dropped earlier in Edition 2024
             //~| WARN: this changes meaning in Rust 2024
             //~| NOTE: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects
-            //~| NOTE: for more information, see issue #123739
+            //~| NOTE: for more information, see
         },
         {
             let _x = LoudDropper;

--- a/tests/ui/drop/lint-tail-expr-drop-order.stderr
+++ b/tests/ui/drop/lint-tail-expr-drop-order.stderr
@@ -17,7 +17,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #123739 <https://github.com/rust-lang/rust/issues/123739>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:11:1
    |
@@ -58,7 +58,7 @@ LL |     }
    |     - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #123739 <https://github.com/rust-lang/rust/issues/123739>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:11:1
    |
@@ -94,7 +94,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #123739 <https://github.com/rust-lang/rust/issues/123739>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:11:1
    |
@@ -130,7 +130,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #123739 <https://github.com/rust-lang/rust/issues/123739>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:11:1
    |
@@ -166,7 +166,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #123739 <https://github.com/rust-lang/rust/issues/123739>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
@@ -188,7 +188,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #123739 <https://github.com/rust-lang/rust/issues/123739>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:11:1
    |
@@ -224,7 +224,7 @@ LL | }
    | - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #123739 <https://github.com/rust-lang/rust/issues/123739>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:195:5
    |
@@ -266,7 +266,7 @@ LL |     ));
    |       - now the temporary value is dropped here, before the local variables in the block or statement
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see issue #123739 <https://github.com/rust-lang/rust/issues/123739>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
   --> $DIR/lint-tail-expr-drop-order.rs:11:1
    |

--- a/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
+++ b/tests/ui/editions/never-type-fallback-breaking.e2021.stderr
@@ -5,7 +5,7 @@ LL | fn m() {
    | ^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:22:17
@@ -25,7 +25,7 @@ LL | fn q() -> Option<()> {
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:37:5
@@ -44,7 +44,7 @@ LL | fn meow() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `(): From<!>` will fail
   --> $DIR/never-type-fallback-breaking.rs:50:5
@@ -63,7 +63,7 @@ LL | pub fn fallback_return() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:62:19
@@ -82,7 +82,7 @@ LL | fn fully_apit() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/never-type-fallback-breaking.rs:76:17

--- a/tests/ui/iterators/into-iter-on-boxed-slices-2021.stderr
+++ b/tests/ui/iterators/into-iter-on-boxed-slices-2021.stderr
@@ -5,6 +5,7 @@ LL |     let _: Iter<'_, i32> = boxed_slice.into_iter();
    |                                        ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
    = note: `#[warn(boxed_slice_into_iter)]` on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
@@ -22,6 +23,7 @@ LL |     let _: Iter<'_, i32> = Box::new(boxed_slice.clone()).into_iter();
    |                                                          ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
   --> $DIR/into-iter-on-boxed-slices-2021.rs:22:57
@@ -30,6 +32,7 @@ LL |     let _: Iter<'_, i32> = Rc::new(boxed_slice.clone()).into_iter();
    |                                                         ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
   --> $DIR/into-iter-on-boxed-slices-2021.rs:25:55
@@ -38,6 +41,7 @@ LL |     let _: Iter<'_, i32> = Array(boxed_slice.clone()).into_iter();
    |                                                       ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
   --> $DIR/into-iter-on-boxed-slices-2021.rs:32:48
@@ -46,6 +50,7 @@ LL |     for _ in (Box::new([1, 2, 3]) as Box<[_]>).into_iter() {}
    |                                                ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
 LL |     for _ in (Box::new([1, 2, 3]) as Box<[_]>).iter() {}

--- a/tests/ui/iterators/into-iter-on-boxed-slices-lint.stderr
+++ b/tests/ui/iterators/into-iter-on-boxed-slices-lint.stderr
@@ -5,6 +5,7 @@ LL |     boxed.into_iter();
    |           ^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
    = note: `#[warn(boxed_slice_into_iter)]` on by default
 help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
    |
@@ -22,6 +23,7 @@ LL |     Box::new(boxed.clone()).into_iter();
    |                             ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
   --> $DIR/into-iter-on-boxed-slices-lint.rs:16:39
@@ -30,6 +32,7 @@ LL |     Box::new(Box::new(boxed.clone())).into_iter();
    |                                       ^^^^^^^^^ help: use `.iter()` instead of `.into_iter()` to avoid ambiguity: `iter`
    |
    = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
 
 warning: 3 warnings emitted
 

--- a/tests/ui/never_type/defaulted-never-note.nofallback.stderr
+++ b/tests/ui/never_type/defaulted-never-note.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn smeg() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: ImplementedForUnitButNotNever` will fail
   --> $DIR/defaulted-never-note.rs:32:9

--- a/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
+++ b/tests/ui/never_type/dependency-on-fallback-to-unit.stderr
@@ -5,7 +5,7 @@ LL | fn def() {
    | ^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dependency-on-fallback-to-unit.rs:12:19
@@ -25,7 +25,7 @@ LL | fn question_mark() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/dependency-on-fallback-to-unit.rs:22:5

--- a/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-control-flow.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn assignment() {
    | ^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
   --> $DIR/diverging-fallback-control-flow.rs:36:13
@@ -25,7 +25,7 @@ LL | fn assignment_rev() {
    | ^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitDefault` will fail
   --> $DIR/diverging-fallback-control-flow.rs:50:13

--- a/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-no-leak.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Test` will fail
   --> $DIR/diverging-fallback-no-leak.rs:20:23

--- a/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
+++ b/tests/ui/never_type/diverging-fallback-unconstrained-return.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: UnitReturn` will fail
   --> $DIR/diverging-fallback-unconstrained-return.rs:39:23

--- a/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
+++ b/tests/ui/never_type/fallback-closure-ret.nofallback.stderr
@@ -5,7 +5,7 @@ LL | fn main() {
    | ^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Bar` will fail
   --> $DIR/fallback-closure-ret.rs:24:5

--- a/tests/ui/never_type/impl_trait_fallback.stderr
+++ b/tests/ui/never_type/impl_trait_fallback.stderr
@@ -5,7 +5,7 @@ LL | fn should_ret_unit() -> impl T {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: T` will fail
   --> $DIR/impl_trait_fallback.rs:8:25

--- a/tests/ui/never_type/lint-breaking-2024-assign-underscore.stderr
+++ b/tests/ui/never_type/lint-breaking-2024-assign-underscore.stderr
@@ -5,7 +5,7 @@ LL | fn test() -> Result<(), ()> {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the types explicitly
 note: in edition 2024, the requirement `!: Default` will fail
   --> $DIR/lint-breaking-2024-assign-underscore.rs:13:9

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2015.stderr
@@ -5,7 +5,7 @@ LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[warn(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -20,7 +20,7 @@ LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -34,7 +34,7 @@ LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
 warning: never type fallback affects this raw pointer dereference
@@ -44,7 +44,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -58,7 +58,7 @@ LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -72,7 +72,7 @@ LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -86,7 +86,7 @@ LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -100,7 +100,7 @@ LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -114,7 +114,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
 warning: never type fallback affects this call to an `unsafe` function
@@ -127,7 +127,7 @@ LL |         msg_send!();
    |         ----------- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: this warning originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use `()` annotations to avoid fallback changes

--- a/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
+++ b/tests/ui/never_type/lint-never-type-fallback-flowing-into-unsafe.e2024.stderr
@@ -5,7 +5,7 @@ LL |         unsafe { mem::zeroed() }
    |                  ^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` on by default
 help: use `()` annotations to avoid fallback changes
@@ -20,7 +20,7 @@ LL |             core::mem::transmute(Zst)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -34,7 +34,7 @@ LL |         unsafe { Union { a: () }.b }
    |                  ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
 error: never type fallback affects this raw pointer dereference
@@ -44,7 +44,7 @@ LL |         unsafe { *ptr::from_ref(&()).cast() }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -58,7 +58,7 @@ LL |         unsafe { internally_create(x) }
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -72,7 +72,7 @@ LL |         unsafe { zeroed() }
    |                  ^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -86,7 +86,7 @@ LL |         let zeroed = mem::zeroed;
    |                      ^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -100,7 +100,7 @@ LL |         let f = internally_create;
    |                 ^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 help: use `()` annotations to avoid fallback changes
    |
@@ -114,7 +114,7 @@ LL |             S(marker::PhantomData).create_out_of_thin_air()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
 
 error: never type fallback affects this call to an `unsafe` function
@@ -127,7 +127,7 @@ LL |         msg_send!();
    |         ----------- in this macro invocation
    |
    = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see issue #123748 <https://github.com/rust-lang/rust/issues/123748>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/never-type-fallback.html>
    = help: specify the type explicitly
    = note: this error originates in the macro `msg_send` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: use `()` annotations to avoid fallback changes

--- a/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
+++ b/tests/ui/pattern/rfc-3627-match-ergonomics-2024/migration_lint.stderr
@@ -7,7 +7,7 @@ LL |     let Foo(mut x) = &Foo(0);
    |         help: desugar the match ergonomics: `&`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 note: the lint level is defined here
   --> $DIR/migration_lint.rs:7:9
    |
@@ -23,7 +23,7 @@ LL |     let Foo(mut x) = &mut Foo(0);
    |         help: desugar the match ergonomics: `&mut`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
   --> $DIR/migration_lint.rs:35:9
@@ -34,7 +34,7 @@ LL |     let Foo(ref x) = &Foo(0);
    |         help: desugar the match ergonomics: `&`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
   --> $DIR/migration_lint.rs:40:9
@@ -45,7 +45,7 @@ LL |     let Foo(ref x) = &mut Foo(0);
    |         help: desugar the match ergonomics: `&mut`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
   --> $DIR/migration_lint.rs:57:9
@@ -56,7 +56,7 @@ LL |     let Foo(&x) = &Foo(&0);
    |         help: desugar the match ergonomics: `&`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
   --> $DIR/migration_lint.rs:62:9
@@ -67,7 +67,7 @@ LL |     let Foo(&mut x) = &Foo(&mut 0);
    |         help: desugar the match ergonomics: `&`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
   --> $DIR/migration_lint.rs:67:9
@@ -78,7 +78,7 @@ LL |     let Foo(&x) = &mut Foo(&0);
    |         help: desugar the match ergonomics: `&mut`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
   --> $DIR/migration_lint.rs:72:9
@@ -89,7 +89,7 @@ LL |     let Foo(&mut x) = &mut Foo(&mut 0);
    |         help: desugar the match ergonomics: `&mut`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
   --> $DIR/migration_lint.rs:81:12
@@ -100,7 +100,7 @@ LL |     if let Some(&x) = &&&&&Some(&0u8) {
    |            help: desugar the match ergonomics: `&&&&&`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
   --> $DIR/migration_lint.rs:87:12
@@ -111,7 +111,7 @@ LL |     if let Some(&mut x) = &&&&&Some(&mut 0u8) {
    |            help: desugar the match ergonomics: `&&&&&`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
   --> $DIR/migration_lint.rs:93:12
@@ -122,7 +122,7 @@ LL |     if let Some(&x) = &&&&&mut Some(&0u8) {
    |            help: desugar the match ergonomics: `&&&&&mut`
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 
 error: patterns are not allowed to reset the default binding mode in edition 2024
   --> $DIR/migration_lint.rs:99:12
@@ -131,7 +131,7 @@ LL |     if let Some(&mut Some(Some(x))) = &mut Some(&mut Some(&mut Some(0u8))) 
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 help: desugar the match ergonomics
    |
 LL |     if let &mut Some(&mut Some(&mut Some(ref mut x))) = &mut Some(&mut Some(&mut Some(0u8))) {
@@ -144,7 +144,7 @@ LL |     let Struct { a, mut b, c } = &Struct { a: 0, b: 0, c: 0 };
    |         ^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 help: desugar the match ergonomics
    |
 LL |     let &Struct { ref a, mut b, ref c } = &Struct { a: 0, b: 0, c: 0 };
@@ -157,7 +157,7 @@ LL |     let Struct { a: &a, b, ref c } = &Struct { a: &0, b: &0, c: &0 };
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 help: desugar the match ergonomics
    |
 LL |     let &Struct { a: &a, ref b, ref c } = &Struct { a: &0, b: &0, c: &0 };
@@ -170,7 +170,7 @@ LL |     if let Struct { a: &Some(a), b: Some(&b), c: Some(c) } =
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this changes meaning in Rust 2024
-   = note: for more information, see 123076
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/match-ergonomics.html>
 help: desugar the match ergonomics
    |
 LL |     if let &Struct { a: &Some(a), b: &Some(&b), c: &Some(ref c) } =

--- a/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.stderr
+++ b/tests/ui/rfcs/rfc-2396-target_feature-11/safe-calls.stderr
@@ -79,7 +79,7 @@ error[E0133]: call to function `sse2` with `#[target_feature]` is unsafe and req
 LL |     sse2();
    |     ^^^^^^ call to function with `#[target_feature]`
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = help: in order for the call to be safe, the context requires the following additional target feature: sse2
    = note: the sse2 target feature being enabled in the build configuration does not remove the requirement to list it in `#[target_feature]`
 note: an unsafe function restricts its caller, but its body is safe by default

--- a/tests/ui/rust-2024/box-slice-into-iter-ambiguous.stderr
+++ b/tests/ui/rust-2024/box-slice-into-iter-ambiguous.stderr
@@ -5,6 +5,7 @@ LL |     let y = points.into_iter();
    |             ^^^^^^^^^^^^^^^^^^ help: disambiguate the associated function: `MyIntoIter::into_iter(points)`
    |
    = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/intoiterator-box-slice.html>
 note: the lint level is defined here
   --> $DIR/box-slice-into-iter-ambiguous.rs:5:9
    |

--- a/tests/ui/rust-2024/gen-kw.e2015.stderr
+++ b/tests/ui/rust-2024/gen-kw.e2015.stderr
@@ -5,7 +5,7 @@ LL | fn gen() {}
    |    ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 note: the lint level is defined here
   --> $DIR/gen-kw.rs:4:9
    |
@@ -20,7 +20,7 @@ LL |     let gen = r#gen;
    |         ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:19:27
@@ -29,7 +29,7 @@ LL |     () => { mod test { fn gen() {} } }
    |                           ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:9
@@ -38,7 +38,7 @@ LL | fn test<'gen>(_: &'gen i32) {}
    |         ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:19
@@ -47,7 +47,7 @@ LL | fn test<'gen>(_: &'gen i32) {}
    |                   ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:13
@@ -56,7 +56,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |             ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:28
@@ -65,7 +65,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |                            ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:37
@@ -74,7 +74,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |                                     ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rust-2024/gen-kw.e2018.stderr
+++ b/tests/ui/rust-2024/gen-kw.e2018.stderr
@@ -5,7 +5,7 @@ LL | fn gen() {}
    |    ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 note: the lint level is defined here
   --> $DIR/gen-kw.rs:4:9
    |
@@ -20,7 +20,7 @@ LL |     let gen = r#gen;
    |         ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:19:27
@@ -29,7 +29,7 @@ LL |     () => { mod test { fn gen() {} } }
    |                           ^^^ help: you can use a raw identifier to stay compatible: `r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:9
@@ -38,7 +38,7 @@ LL | fn test<'gen>(_: &'gen i32) {}
    |         ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:25:19
@@ -47,7 +47,7 @@ LL | fn test<'gen>(_: &'gen i32) {}
    |                   ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:13
@@ -56,7 +56,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |             ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:28
@@ -65,7 +65,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |                            ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: `gen` is a keyword in the 2024 edition
   --> $DIR/gen-kw.rs:33:37
@@ -74,7 +74,7 @@ LL | struct Test<'gen>(Box<Test<'gen>>, &'gen ());
    |                                     ^^^^ help: you can use a raw identifier to stay compatible: `'r#gen`
    |
    = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2024!
-   = note: for more information, see issue #49716 <https://github.com/rust-lang/rust/issues/49716>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/gen-keyword.html>
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/rust-2024/reserved-guarded-strings-lexing.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-lexing.stderr
@@ -35,7 +35,7 @@ LL |     demo3!(## "foo");
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 note: the lint level is defined here
   --> $DIR/reserved-guarded-strings-lexing.rs:4:9
    |
@@ -53,7 +53,7 @@ LL |     demo4!(### "foo");
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# ## "foo");
@@ -66,7 +66,7 @@ LL |     demo4!(### "foo");
    |             ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(## # "foo");
@@ -79,7 +79,7 @@ LL |     demo4!(## "foo"#);
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# # "foo"#);
@@ -92,7 +92,7 @@ LL |     demo7!(### "foo"###);
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(# ## "foo"###);
@@ -105,7 +105,7 @@ LL |     demo7!(### "foo"###);
    |             ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(## # "foo"###);
@@ -118,7 +118,7 @@ LL |     demo7!(### "foo"###);
    |                     ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(### "foo"# ##);
@@ -131,7 +131,7 @@ LL |     demo7!(### "foo"###);
    |                      ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo7!(### "foo"## #);
@@ -144,7 +144,7 @@ LL |     demo5!(###"foo"#);
    |            ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(# ##"foo"#);
@@ -157,7 +157,7 @@ LL |     demo5!(###"foo"#);
    |             ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(## #"foo"#);
@@ -170,7 +170,7 @@ LL |     demo5!(###"foo"#);
    |              ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(### "foo"#);
@@ -183,7 +183,7 @@ LL |     demo5!(#"foo"###);
    |            ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(# "foo"###);
@@ -196,7 +196,7 @@ LL |     demo5!(#"foo"###);
    |                  ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo5!(#"foo"# ##);
@@ -209,7 +209,7 @@ LL |     demo5!(#"foo"###);
    |                   ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo5!(#"foo"## #);
@@ -222,7 +222,7 @@ LL |     demo4!("foo"###);
    |                 ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"# ##);
@@ -235,7 +235,7 @@ LL |     demo4!("foo"###);
    |                  ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"## #);
@@ -248,7 +248,7 @@ LL |     demo4!(Ñ#""#);
    |             ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo4!(Ñ# ""#);
@@ -261,7 +261,7 @@ LL |     demo3!(🙃#"");
    |              ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(🙃# "");

--- a/tests/ui/rust-2024/reserved-guarded-strings-migration.stderr
+++ b/tests/ui/rust-2024/reserved-guarded-strings-migration.stderr
@@ -5,7 +5,7 @@ LL |     demo3!(## "foo");
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 note: the lint level is defined here
   --> $DIR/reserved-guarded-strings-migration.rs:5:9
    |
@@ -23,7 +23,7 @@ LL |     demo4!(### "foo");
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# ## "foo");
@@ -36,7 +36,7 @@ LL |     demo4!(### "foo");
    |             ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(## # "foo");
@@ -49,7 +49,7 @@ LL |     demo4!(## "foo"#);
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!(# # "foo"#);
@@ -62,7 +62,7 @@ LL |     demo6!(### "foo"##);
    |            ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo6!(# ## "foo"##);
@@ -75,7 +75,7 @@ LL |     demo6!(### "foo"##);
    |             ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo6!(## # "foo"##);
@@ -88,7 +88,7 @@ LL |     demo6!(### "foo"##);
    |                     ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo6!(### "foo"# #);
@@ -101,7 +101,7 @@ LL |     demo4!("foo"###);
    |                 ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"# ##);
@@ -114,7 +114,7 @@ LL |     demo4!("foo"###);
    |                  ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo4!("foo"## #);
@@ -127,7 +127,7 @@ LL |     demo2!(#"");
    |            ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo2!(# "");
@@ -140,7 +140,7 @@ LL |     demo3!(#""#);
    |            ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(# ""#);
@@ -153,7 +153,7 @@ LL |     demo3!(##"");
    |            ^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(# #"");
@@ -166,7 +166,7 @@ LL |     demo3!(##"");
    |             ^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(## "");
@@ -179,7 +179,7 @@ LL |     demo2!(#"foo");
    |            ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo2!(# "foo");
@@ -192,7 +192,7 @@ LL |     demo3!(##"foo");
    |            ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(# #"foo");
@@ -205,7 +205,7 @@ LL |     demo3!(##"foo");
    |             ^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(## "foo");
@@ -218,7 +218,7 @@ LL |     demo3!(#"foo"#);
    |            ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo3!(# "foo"#);
@@ -231,7 +231,7 @@ LL |     demo4!(##"foo"#);
    |            ^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo4!(# #"foo"#);
@@ -244,7 +244,7 @@ LL |     demo4!(##"foo"#);
    |             ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo4!(## "foo"#);
@@ -257,7 +257,7 @@ LL |     demo5!(##"foo"##);
    |            ^^^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(# #"foo"##);
@@ -270,7 +270,7 @@ LL |     demo5!(##"foo"##);
    |             ^^^^^^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a guarded string in Rust 2024
    |
 LL |     demo5!(## "foo"##);
@@ -283,7 +283,7 @@ LL |     demo5!(##"foo"##);
    |                   ^^
    |
    = warning: this is accepted in the current edition (Rust 2021) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123735 <https://github.com/rust-lang/rust/issues/123735>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/reserved-syntax.html>
 help: insert whitespace here to avoid this being parsed as a forbidden token in Rust 2024
    |
 LL |     demo5!(##"foo"# #);

--- a/tests/ui/rust-2024/unsafe-attributes/in_2024_compatibility.stderr
+++ b/tests/ui/rust-2024/unsafe-attributes/in_2024_compatibility.stderr
@@ -5,7 +5,7 @@ LL | #[no_mangle]
    |   ^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123757 <https://github.com/rust-lang/rust/issues/123757>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
 note: the lint level is defined here
   --> $DIR/in_2024_compatibility.rs:1:9
    |

--- a/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-fix.stderr
+++ b/tests/ui/rust-2024/unsafe-attributes/unsafe-attributes-fix.stderr
@@ -5,7 +5,7 @@ LL | tt!([no_mangle]);
    |      ^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123757 <https://github.com/rust-lang/rust/issues/123757>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
 note: the lint level is defined here
   --> $DIR/unsafe-attributes-fix.rs:2:9
    |
@@ -26,7 +26,7 @@ LL | ident!(no_mangle);
    | ----------------- in this macro invocation
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123757 <https://github.com/rust-lang/rust/issues/123757>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
    = note: this error originates in the macro `ident` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: wrap the attribute in `unsafe(...)`
    |
@@ -40,7 +40,7 @@ LL | meta!(no_mangle);
    |       ^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123757 <https://github.com/rust-lang/rust/issues/123757>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
 help: wrap the attribute in `unsafe(...)`
    |
 LL | meta!(unsafe(no_mangle));
@@ -53,7 +53,7 @@ LL | meta2!(export_name = "baw");
    |        ^^^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123757 <https://github.com/rust-lang/rust/issues/123757>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
 help: wrap the attribute in `unsafe(...)`
    |
 LL | meta2!(unsafe(export_name = "baw"));
@@ -69,7 +69,7 @@ LL | ident2!(export_name, "bars");
    | ---------------------------- in this macro invocation
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123757 <https://github.com/rust-lang/rust/issues/123757>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
    = note: this error originates in the macro `ident2` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: wrap the attribute in `unsafe(...)`
    |
@@ -83,7 +83,7 @@ LL | #[no_mangle]
    |   ^^^^^^^^^ usage of unsafe attribute
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123757 <https://github.com/rust-lang/rust/issues/123757>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-attributes.html>
 help: wrap the attribute in `unsafe(...)`
    |
 LL | #[unsafe(no_mangle)]

--- a/tests/ui/rust-2024/unsafe-env-suggestion.stderr
+++ b/tests/ui/rust-2024/unsafe-env-suggestion.stderr
@@ -5,7 +5,7 @@ LL |     env::set_var("FOO", "BAR");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #27970 <https://github.com/rust-lang/rust/issues/27970>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/newly-unsafe-functions.html>
 note: the lint level is defined here
   --> $DIR/unsafe-env-suggestion.rs:3:9
    |
@@ -24,7 +24,7 @@ LL |     env::remove_var("FOO");
    |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #27970 <https://github.com/rust-lang/rust/issues/27970>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/newly-unsafe-functions.html>
 help: you can wrap the call in an `unsafe` block if you can guarantee that the environment access only happens in single-threaded code
    |
 LL +     // TODO: Audit that the environment access only happens in single-threaded code.

--- a/tests/ui/rust-2024/unsafe-env.e2021.stderr
+++ b/tests/ui/rust-2024/unsafe-env.e2021.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe 
 LL |         unsafe_fn();
    |         ^^^^^^^^^^^ call to unsafe function
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/unsafe-env.rs:8:1

--- a/tests/ui/rust-2024/unsafe-env.e2024.stderr
+++ b/tests/ui/rust-2024/unsafe-env.e2024.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `std::env::set_var` is unsafe and requires
 LL |     env::set_var("FOO", "BAR");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/unsafe-env.rs:8:1
@@ -23,7 +23,7 @@ error[E0133]: call to unsafe function `std::env::remove_var` is unsafe and requi
 LL |     env::remove_var("FOO");
    |     ^^^^^^^^^^^^^^^^^^^^^^ call to unsafe function
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe block
@@ -32,7 +32,7 @@ error[E0133]: call to unsafe function `unsafe_fn` is unsafe and requires unsafe 
 LL |         unsafe_fn();
    |         ^^^^^^^^^^^ call to unsafe function
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: call to unsafe function `set_var` is unsafe and requires unsafe block

--- a/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-extern-suggestion.stderr
+++ b/tests/ui/rust-2024/unsafe-extern-blocks/unsafe-extern-suggestion.stderr
@@ -14,7 +14,7 @@ LL | | }
    | |_^
    |
    = warning: this is accepted in the current edition (Rust 2015) but is a hard error in Rust 2024!
-   = note: for more information, see issue #123743 <https://github.com/rust-lang/rust/issues/123743>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-extern.html>
 note: the lint level is defined here
   --> $DIR/unsafe-extern-suggestion.rs:3:9
    |

--- a/tests/ui/unsafe/edition-2024-unsafe_op_in_unsafe_fn.stderr
+++ b/tests/ui/unsafe/edition-2024-unsafe_op_in_unsafe_fn.stderr
@@ -4,7 +4,7 @@ warning[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe blo
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/edition-2024-unsafe_op_in_unsafe_fn.rs:8:1

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/edition_2024_default.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/edition_2024_default.stderr
@@ -4,7 +4,7 @@ warning[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe blo
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/edition_2024_default.rs:11:1

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/in_2024_compatibility.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/in_2024_compatibility.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/in_2024_compatibility.rs:6:1

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/rfc-2585-unsafe_op_in_unsafe_fn.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/rfc-2585-unsafe_op_in_unsafe_fn.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:8:1
@@ -23,7 +23,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
 LL |     *PTR;
    |     ^^^^ dereference of raw pointer
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe block
@@ -32,7 +32,7 @@ error[E0133]: use of mutable static is unsafe and requires unsafe block
 LL |     VOID = ();
    |     ^^^^ use of mutable static
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error: unnecessary `unsafe` block
@@ -53,7 +53,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/rfc-2585-unsafe_op_in_unsafe_fn.rs:23:1
@@ -73,7 +73,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
 LL |     *PTR;
    |     ^^^^ dereference of raw pointer
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe block
@@ -82,7 +82,7 @@ error[E0133]: use of mutable static is unsafe and requires unsafe block
 LL |     VOID = ();
    |     ^^^^ use of mutable static
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error: unnecessary `unsafe` block

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/wrapping-unsafe-block-sugg.fixed
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/wrapping-unsafe-block-sugg.fixed
@@ -12,11 +12,11 @@ pub unsafe fn foo() { unsafe {
     //~^ NOTE an unsafe function restricts its caller, but its body is safe by default
     unsf(); //~ ERROR call to unsafe function `unsf` is unsafe
     //~^ NOTE call to unsafe function
-    //~| NOTE for more information, see issue #71668
+    //~| NOTE for more information, see
     //~| NOTE consult the function's documentation
     unsf(); //~ ERROR call to unsafe function `unsf` is unsafe
     //~^ NOTE call to unsafe function
-    //~| NOTE for more information, see issue #71668
+    //~| NOTE for more information, see
     //~| NOTE consult the function's documentation
 }}
 
@@ -24,11 +24,11 @@ pub unsafe fn bar(x: *const i32) -> i32 { unsafe {
     //~^ NOTE an unsafe function restricts its caller, but its body is safe by default
     let y = *x; //~ ERROR dereference of raw pointer is unsafe and requires unsafe block
     //~^ NOTE dereference of raw pointer
-    //~| NOTE for more information, see issue #71668
+    //~| NOTE for more information, see
     //~| NOTE raw pointers may be null
     y + *x //~ ERROR dereference of raw pointer is unsafe and requires unsafe block
     //~^ NOTE dereference of raw pointer
-    //~| NOTE for more information, see issue #71668
+    //~| NOTE for more information, see
     //~| NOTE raw pointers may be null
 }}
 
@@ -37,22 +37,22 @@ pub unsafe fn baz() -> i32 { unsafe {
     //~^ NOTE an unsafe function restricts its caller, but its body is safe by default
     let y = BAZ; //~ ERROR use of mutable static is unsafe and requires unsafe block
     //~^ NOTE use of mutable static
-    //~| NOTE for more information, see issue #71668
+    //~| NOTE for more information, see
     //~| NOTE mutable statics can be mutated by multiple threads
     y + BAZ //~ ERROR use of mutable static is unsafe and requires unsafe block
     //~^ NOTE use of mutable static
-    //~| NOTE for more information, see issue #71668
+    //~| NOTE for more information, see
     //~| NOTE mutable statics can be mutated by multiple threads
 }}
 
 macro_rules! unsafe_macro { () => (unsf()) }
 //~^ ERROR call to unsafe function `unsf` is unsafe
 //~| NOTE call to unsafe function
-//~| NOTE for more information, see issue #71668
+//~| NOTE for more information, see
 //~| NOTE consult the function's documentation
 //~| ERROR call to unsafe function `unsf` is unsafe
 //~| NOTE call to unsafe function
-//~| NOTE for more information, see issue #71668
+//~| NOTE for more information, see
 //~| NOTE consult the function's documentation
 
 pub unsafe fn unsafe_in_macro() { unsafe {

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/wrapping-unsafe-block-sugg.rs
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/wrapping-unsafe-block-sugg.rs
@@ -12,11 +12,11 @@ pub unsafe fn foo() {
     //~^ NOTE an unsafe function restricts its caller, but its body is safe by default
     unsf(); //~ ERROR call to unsafe function `unsf` is unsafe
     //~^ NOTE call to unsafe function
-    //~| NOTE for more information, see issue #71668
+    //~| NOTE for more information, see
     //~| NOTE consult the function's documentation
     unsf(); //~ ERROR call to unsafe function `unsf` is unsafe
     //~^ NOTE call to unsafe function
-    //~| NOTE for more information, see issue #71668
+    //~| NOTE for more information, see
     //~| NOTE consult the function's documentation
 }
 
@@ -24,11 +24,11 @@ pub unsafe fn bar(x: *const i32) -> i32 {
     //~^ NOTE an unsafe function restricts its caller, but its body is safe by default
     let y = *x; //~ ERROR dereference of raw pointer is unsafe and requires unsafe block
     //~^ NOTE dereference of raw pointer
-    //~| NOTE for more information, see issue #71668
+    //~| NOTE for more information, see
     //~| NOTE raw pointers may be null
     y + *x //~ ERROR dereference of raw pointer is unsafe and requires unsafe block
     //~^ NOTE dereference of raw pointer
-    //~| NOTE for more information, see issue #71668
+    //~| NOTE for more information, see
     //~| NOTE raw pointers may be null
 }
 
@@ -37,22 +37,22 @@ pub unsafe fn baz() -> i32 {
     //~^ NOTE an unsafe function restricts its caller, but its body is safe by default
     let y = BAZ; //~ ERROR use of mutable static is unsafe and requires unsafe block
     //~^ NOTE use of mutable static
-    //~| NOTE for more information, see issue #71668
+    //~| NOTE for more information, see
     //~| NOTE mutable statics can be mutated by multiple threads
     y + BAZ //~ ERROR use of mutable static is unsafe and requires unsafe block
     //~^ NOTE use of mutable static
-    //~| NOTE for more information, see issue #71668
+    //~| NOTE for more information, see
     //~| NOTE mutable statics can be mutated by multiple threads
 }
 
 macro_rules! unsafe_macro { () => (unsf()) }
 //~^ ERROR call to unsafe function `unsf` is unsafe
 //~| NOTE call to unsafe function
-//~| NOTE for more information, see issue #71668
+//~| NOTE for more information, see
 //~| NOTE consult the function's documentation
 //~| ERROR call to unsafe function `unsf` is unsafe
 //~| NOTE call to unsafe function
-//~| NOTE for more information, see issue #71668
+//~| NOTE for more information, see
 //~| NOTE consult the function's documentation
 
 pub unsafe fn unsafe_in_macro() {

--- a/tests/ui/unsafe/unsafe_op_in_unsafe_fn/wrapping-unsafe-block-sugg.stderr
+++ b/tests/ui/unsafe/unsafe_op_in_unsafe_fn/wrapping-unsafe-block-sugg.stderr
@@ -4,7 +4,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/wrapping-unsafe-block-sugg.rs:11:1
@@ -23,7 +23,7 @@ error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
 LL |     unsf();
    |     ^^^^^^ call to unsafe function
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 
 error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
@@ -32,7 +32,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
 LL |     let y = *x;
    |             ^^ dereference of raw pointer
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/wrapping-unsafe-block-sugg.rs:23:1
@@ -46,7 +46,7 @@ error[E0133]: dereference of raw pointer is unsafe and requires unsafe block
 LL |     y + *x
    |         ^^ dereference of raw pointer
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: raw pointers may be null, dangling or unaligned; they can violate aliasing rules and cause data races: all of these are undefined behavior
 
 error[E0133]: use of mutable static is unsafe and requires unsafe block
@@ -55,7 +55,7 @@ error[E0133]: use of mutable static is unsafe and requires unsafe block
 LL |     let y = BAZ;
    |             ^^^ use of mutable static
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/wrapping-unsafe-block-sugg.rs:36:1
@@ -69,7 +69,7 @@ error[E0133]: use of mutable static is unsafe and requires unsafe block
 LL |     y + BAZ
    |         ^^^ use of mutable static
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: mutable statics can be mutated by multiple threads: aliasing violations or data races will cause undefined behavior
 
 error[E0133]: call to unsafe function `unsf` is unsafe and requires unsafe block
@@ -81,7 +81,7 @@ LL | macro_rules! unsafe_macro { () => (unsf()) }
 LL |     unsafe_macro!();
    |     --------------- in this macro invocation
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
 note: an unsafe function restricts its caller, but its body is safe by default
   --> $DIR/wrapping-unsafe-block-sugg.rs:58:1
@@ -99,7 +99,7 @@ LL | macro_rules! unsafe_macro { () => (unsf()) }
 LL |     unsafe_macro!();
    |     --------------- in this macro invocation
    |
-   = note: for more information, see issue #71668 <https://github.com/rust-lang/rust/issues/71668>
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html>
    = note: consult the function's documentation for information on how to avoid undefined behavior
    = note: this error originates in the macro `unsafe_macro` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
This switches the migration lints for the 2024 edition to point to the edition guide documentation instead of the tracking issues. I expect the documentation should be easier to understand for a user, compared to most of the issues which don't have any direct information, and can be a bit confusing to navigate, or have outdated information.
