### PR TITLE
Update spelling of "referring"

### DIFF
--- a/compiler/rustc_lint/messages.ftl
+++ b/compiler/rustc_lint/messages.ftl
@@ -813,7 +813,7 @@ lint_unexpected_cfg_doc_cargo = see <https://doc.rust-lang.org/nightly/rustc/che
 lint_unexpected_cfg_doc_rustc = see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
 
 lint_unexpected_cfg_from_external_macro_origin = using a cfg inside a {$macro_kind} will use the cfgs from the destination crate and not the ones from the defining crate
-lint_unexpected_cfg_from_external_macro_refer = try refering to `{$macro_name}` crate for guidance on how handle this unexpected cfg
+lint_unexpected_cfg_from_external_macro_refer = try referring to `{$macro_name}` crate for guidance on how handle this unexpected cfg
 lint_unexpected_cfg_name = unexpected `cfg` condition name: `{$name}`
 lint_unexpected_cfg_name_expected_names = expected names are: {$possibilities}{$and_more ->
         [0] {""}

--- a/compiler/rustc_lint/src/unqualified_local_imports.rs
+++ b/compiler/rustc_lint/src/unqualified_local_imports.rs
@@ -31,7 +31,7 @@ declare_lint! {
     ///
     /// This lint is meant to be used with the (unstable) rustfmt setting `group_imports = "StdExternalCrate"`.
     /// That setting makes rustfmt group `self::`, `super::`, and `crate::` imports separately from those
-    /// refering to other crates. However, rustfmt cannot know whether `use c::S;` refers to a local module `c`
+    /// referring to other crates. However, rustfmt cannot know whether `use c::S;` refers to a local module `c`
     /// or an external crate `c`, so it always gets categorized as an import from another crate.
     /// To ensure consistent grouping of imports from the local crate, all local imports must
     /// start with `self::`, `super::`, or `crate::`. This lint can be used to enforce that style.

--- a/tests/ui/check-cfg/report-in-external-macros.cargo.stderr
+++ b/tests/ui/check-cfg/report-in-external-macros.cargo.stderr
@@ -6,7 +6,7 @@ LL |     cfg_macro::my_lib_macro!();
    |
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `doctest`, `feature`, `fmt_debug`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, and `windows`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
-   = help: try refering to `cfg_macro::my_lib_macro` crate for guidance on how handle this unexpected cfg
+   = help: try referring to `cfg_macro::my_lib_macro` crate for guidance on how handle this unexpected cfg
    = help: the macro `cfg_macro::my_lib_macro` may come from an old version of the `cfg_macro` crate, try updating your dependency with `cargo update -p cfg_macro`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default
@@ -20,7 +20,7 @@ LL |     cfg_macro::my_lib_macro_value!();
    |
    = note: expected values for `panic` are: `abort` and `unwind`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
-   = help: try refering to `cfg_macro::my_lib_macro_value` crate for guidance on how handle this unexpected cfg
+   = help: try referring to `cfg_macro::my_lib_macro_value` crate for guidance on how handle this unexpected cfg
    = help: the macro `cfg_macro::my_lib_macro_value` may come from an old version of the `cfg_macro` crate, try updating your dependency with `cargo update -p cfg_macro`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `cfg_macro::my_lib_macro_value` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -33,7 +33,7 @@ LL |     cfg_macro::my_lib_macro_feature!();
    |
    = note: no expected values for `feature`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
-   = help: try refering to `cfg_macro::my_lib_macro_feature` crate for guidance on how handle this unexpected cfg
+   = help: try referring to `cfg_macro::my_lib_macro_feature` crate for guidance on how handle this unexpected cfg
    = help: the macro `cfg_macro::my_lib_macro_feature` may come from an old version of the `cfg_macro` crate, try updating your dependency with `cargo update -p cfg_macro`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `cfg_macro::my_lib_macro_feature` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/check-cfg/report-in-external-macros.rustc.stderr
+++ b/tests/ui/check-cfg/report-in-external-macros.rustc.stderr
@@ -6,7 +6,7 @@ LL |     cfg_macro::my_lib_macro!();
    |
    = help: expected names are: `clippy`, `debug_assertions`, `doc`, `doctest`, `feature`, `fmt_debug`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, and `windows`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
-   = help: try refering to `cfg_macro::my_lib_macro` crate for guidance on how handle this unexpected cfg
+   = help: try referring to `cfg_macro::my_lib_macro` crate for guidance on how handle this unexpected cfg
    = help: to expect this configuration use `--check-cfg=cfg(my_lib_cfg)`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default
@@ -20,7 +20,7 @@ LL |     cfg_macro::my_lib_macro_value!();
    |
    = note: expected values for `panic` are: `abort` and `unwind`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
-   = help: try refering to `cfg_macro::my_lib_macro_value` crate for guidance on how handle this unexpected cfg
+   = help: try referring to `cfg_macro::my_lib_macro_value` crate for guidance on how handle this unexpected cfg
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `cfg_macro::my_lib_macro_value` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -33,7 +33,7 @@ LL |     cfg_macro::my_lib_macro_feature!();
    = note: no expected values for `feature`
    = help: to expect this configuration use `--check-cfg=cfg(feature, values("UNEXPECTED_FEATURE"))`
    = note: using a cfg inside a macro will use the cfgs from the destination crate and not the ones from the defining crate
-   = help: try refering to `cfg_macro::my_lib_macro_feature` crate for guidance on how handle this unexpected cfg
+   = help: try referring to `cfg_macro::my_lib_macro_feature` crate for guidance on how handle this unexpected cfg
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg.html> for more information about checking conditional configuration
    = note: this warning originates in the macro `cfg_macro::my_lib_macro_feature` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
I noticed that `referring` was spelled incorrectly in the output of `unexpected 'cfg' condition name` warnings; it looks like it was also incorrectly spelled in a doc comment. I've update both instances.