### PR TITLE
Check for array lengths that aren't actually `usize`

### DIFF
--- a/tests/ui/const-generics/issues/index_array_bad_type.rs
+++ b/tests/ui/const-generics/issues/index_array_bad_type.rs
@@ -1,0 +1,15 @@
+//@ check-fail
+//@ compile-flags: -C opt-level=0
+
+#![crate_type = "lib"]
+
+// This used to fail in the known-panics lint, as the MIR was ill-typed due to
+// the length constant not actually having type usize.
+// https://github.com/rust-lang/rust/issues/134352
+
+pub struct BadStruct<const N: i64>(pub [u8; N]);
+//~^ ERROR: the constant `N` is not of type `usize`
+
+pub fn bad_array_length_type(value: BadStruct<3>) -> u8 {
+    value.0[0]
+}

--- a/tests/ui/const-generics/issues/index_array_bad_type.stderr
+++ b/tests/ui/const-generics/issues/index_array_bad_type.stderr
@@ -1,0 +1,8 @@
+error: the constant `N` is not of type `usize`
+  --> $DIR/index_array_bad_type.rs:10:40
+   |
+LL | pub struct BadStruct<const N: i64>(pub [u8; N]);
+   |                                        ^^^^^^^ expected `usize`, found `i64`
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
I wish typeck wouldn't give us `ty::Array`s that have this problem in the first place, but we can check for it.

Fixes #134352
cc @matthiaskrgr