### PR TITLE
Arbitrary self types v2: diagnostics in resolution.

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/bound_region_errors.rs
@@ -18,6 +18,7 @@ use rustc_middle::ty::{
 };
 use rustc_span::Span;
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
+use rustc_trait_selection::error_reporting::infer::TypeErrorRole;
 use rustc_trait_selection::error_reporting::infer::nice_region_error::NiceRegionError;
 use rustc_trait_selection::traits::ObligationCtxt;
 use rustc_traits::{type_op_ascribe_user_type_with_span, type_op_prove_predicate_with_cause};
@@ -464,6 +465,7 @@ fn try_extract_error_from_region_constraints<'a, 'tcx>(
                     *trace,
                     infcx.tcx.param_env(generic_param_scope),
                     TypeError::RegionsPlaceholderMismatch,
+                    TypeErrorRole::Elsewhere,
                 ))
             } else {
                 None

--- a/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
+++ b/compiler/rustc_hir_analysis/src/check/compare_impl_item.rs
@@ -22,6 +22,7 @@ use rustc_middle::ty::{
 use rustc_middle::{bug, span_bug};
 use rustc_span::Span;
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
+use rustc_trait_selection::error_reporting::infer::TypeErrorRole;
 use rustc_trait_selection::infer::InferCtxtExt;
 use rustc_trait_selection::regions::InferCtxtRegionExt;
 use rustc_trait_selection::traits::outlives_bounds::InferCtxtExt as _;
@@ -639,6 +640,7 @@ pub(super) fn collect_return_position_impl_trait_in_trait_tys<'tcx>(
                 }))),
                 terr,
                 false,
+                TypeErrorRole::Elsewhere,
             );
             return Err(diag.emit());
         }
@@ -1060,6 +1062,7 @@ fn report_trait_method_mismatch<'tcx>(
         }))),
         terr,
         false,
+        TypeErrorRole::Elsewhere,
     );
 
     diag.emit()
@@ -1852,6 +1855,7 @@ fn compare_const_predicate_entailment<'tcx>(
             }))),
             terr,
             false,
+            TypeErrorRole::Elsewhere,
         );
         return Err(diag.emit());
     };

--- a/compiler/rustc_hir_analysis/src/check/mod.rs
+++ b/compiler/rustc_hir_analysis/src/check/mod.rs
@@ -92,7 +92,7 @@ use rustc_span::def_id::CRATE_DEF_ID;
 use rustc_span::symbol::{Ident, kw, sym};
 use rustc_span::{BytePos, DUMMY_SP, Span, Symbol};
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
-use rustc_trait_selection::error_reporting::infer::ObligationCauseExt as _;
+use rustc_trait_selection::error_reporting::infer::{ObligationCauseExt as _, TypeErrorRole};
 use rustc_trait_selection::error_reporting::traits::suggestions::ReturnsVisitor;
 use rustc_trait_selection::traits::ObligationCtxt;
 use tracing::debug;
@@ -651,6 +651,7 @@ pub fn check_function_signature<'tcx>(
                 }))),
                 err,
                 false,
+                TypeErrorRole::Elsewhere,
             );
             return Err(diag.emit());
         }

--- a/compiler/rustc_hir_typeck/src/method/confirm.rs
+++ b/compiler/rustc_hir_typeck/src/method/confirm.rs
@@ -531,7 +531,7 @@ impl<'a, 'tcx> ConfirmContext<'a, 'tcx> {
             Err(terr) => {
                 if self.tcx.features().arbitrary_self_types() {
                     self.err_ctxt()
-                        .report_mismatched_types(
+                        .report_mismatched_self_types(
                             &cause,
                             self.param_env,
                             method_self_ty,

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -35,6 +35,7 @@ use rustc_span::{BytePos, DUMMY_SP, Span};
 use rustc_target::abi::Size;
 use rustc_target::spec::abi::Abi;
 use rustc_trait_selection::error_reporting::InferCtxtErrorExt;
+use rustc_trait_selection::error_reporting::infer::TypeErrorRole;
 use rustc_trait_selection::infer::{TyCtxtInferExt, ValuePairs};
 use rustc_trait_selection::traits::ObligationCtxt;
 use tracing::debug;
@@ -2371,6 +2372,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 }))),
                 terr,
                 false,
+                TypeErrorRole::Elsewhere,
             );
             diag.emit();
             self.abort.set(true);

--- a/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/infer/region.rs
@@ -17,8 +17,8 @@ use rustc_span::{BytePos, ErrorGuaranteed, Span, Symbol};
 use rustc_type_ir::Upcast as _;
 use tracing::{debug, instrument};
 
-use super::ObligationCauseAsDiagArg;
 use super::nice_region_error::find_anon_type;
+use super::{ObligationCauseAsDiagArg, TypeErrorRole};
 use crate::error_reporting::TypeErrCtxt;
 use crate::error_reporting::infer::ObligationCauseExt;
 use crate::errors::{
@@ -299,6 +299,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     trace,
                     self.tcx.param_env(generic_param_scope),
                     terr,
+                    TypeErrorRole::Elsewhere,
                 );
                 match (*sub, *sup) {
                     (ty::RePlaceholder(_), ty::RePlaceholder(_)) => {}
@@ -654,6 +655,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     trace,
                     self.tcx.param_env(generic_param_scope),
                     terr,
+                    TypeErrorRole::Elsewhere,
                 );
             }
             _ => {

--- a/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
+++ b/compiler/rustc_trait_selection/src/error_reporting/traits/fulfillment_errors.rs
@@ -38,7 +38,7 @@ use super::{
     UnsatisfiedConst,
 };
 use crate::error_reporting::TypeErrCtxt;
-use crate::error_reporting::infer::TyCategory;
+use crate::error_reporting::infer::{TyCategory, TypeErrorRole};
 use crate::error_reporting::traits::report_dyn_incompatibility;
 use crate::errors::{
     AsyncClosureNotFn, ClosureFnMutLabel, ClosureFnOnceLabel, ClosureKindMismatch,
@@ -727,6 +727,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                     None,
                     TypeError::Sorts(ty::error::ExpectedFound::new(expected_ty, ct_ty)),
                     false,
+                    TypeErrorRole::Elsewhere
                 );
                 diag
             }
@@ -1455,6 +1456,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 }),
                 err,
                 false,
+                TypeErrorRole::Elsewhere,
             );
             self.note_obligation_cause(&mut diag, obligation);
             diag.emit()
@@ -2741,6 +2743,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
             TypeTrace::trait_refs(&cause, expected_trait_ref, found_trait_ref),
             obligation.param_env,
             terr,
+            TypeErrorRole::Elsewhere,
         )
     }
 
@@ -2832,6 +2835,7 @@ impl<'a, 'tcx> TypeErrCtxt<'a, 'tcx> {
                 TypeTrace::trait_refs(&obligation.cause, expected_trait_ref, found_trait_ref),
                 obligation.param_env,
                 ty::error::TypeError::Mismatch,
+                TypeErrorRole::Elsewhere,
             ));
         }
         if found.len() != expected.len() {

--- a/tests/ui/self/arbitrary-self-from-method-substs-with-receiver.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs-with-receiver.stderr
@@ -39,12 +39,16 @@ error[E0308]: mismatched types
    |
 LL |     assert_eq!(foo.a::<&Foo>(), 2);
    |                ^^^ expected `&Foo`, found `Foo`
+   |
+   = note: this error occurred while resolving the `self` type of this method call
 
 error[E0308]: mismatched types
   --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:53:16
    |
 LL |     assert_eq!(foo.b::<&Foo>(), 1);
    |                ^^^ expected `&Foo`, found `Foo`
+   |
+   = note: this error occurred while resolving the `self` type of this method call
 
 error[E0308]: mismatched types
   --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:60:16
@@ -54,6 +58,7 @@ LL |     assert_eq!(smart_ptr.a::<&Foo>(), 2);
    |
    = note: expected reference `&Foo`
                  found struct `SmartPtr<'_, Foo, >`
+   = note: this error occurred while resolving the `self` type of this method call
 
 error[E0308]: mismatched types
   --> $DIR/arbitrary-self-from-method-substs-with-receiver.rs:62:16
@@ -63,6 +68,7 @@ LL |     assert_eq!(smart_ptr.b::<&Foo>(), 1);
    |
    = note: expected reference `&Foo`
                  found struct `SmartPtr<'_, Foo, >`
+   = note: this error occurred while resolving the `self` type of this method call
 
 error: aborting due to 8 previous errors
 

--- a/tests/ui/self/arbitrary-self-from-method-substs.feature.stderr
+++ b/tests/ui/self/arbitrary-self-from-method-substs.feature.stderr
@@ -57,6 +57,8 @@ error[E0308]: mismatched types
    |
 LL |     foo.get::<&Foo>();
    |     ^^^ expected `&Foo`, found `Foo`
+   |
+   = note: this error occurred while resolving the `self` type of this method call
 
 error[E0308]: mismatched types
   --> $DIR/arbitrary-self-from-method-substs.rs:78:5
@@ -66,6 +68,7 @@ LL |     foo.get::<std::rc::Rc<Foo>>();
    |
    = note: expected struct `Rc<Foo>`
               found struct `Foo`
+   = note: this error occurred while resolving the `self` type of this method call
 
 error[E0308]: mismatched types
   --> $DIR/arbitrary-self-from-method-substs.rs:84:5
@@ -75,6 +78,7 @@ LL |     smart_ptr.get::<SmartPtr2<Foo>>();
    |
    = note: expected struct `SmartPtr2<'_, Foo>`
               found struct `SmartPtr<'_, Foo>`
+   = note: this error occurred while resolving the `self` type of this method call
 
 error[E0308]: mismatched types
   --> $DIR/arbitrary-self-from-method-substs.rs:86:5
@@ -84,6 +88,7 @@ LL |     smart_ptr.get::<&Foo>();
    |
    = note: expected reference `&Foo`
                  found struct `SmartPtr<'_, Foo, >`
+   = note: this error occurred while resolving the `self` type of this method call
 
 error[E0271]: type mismatch resolving `<Silly as FindReceiver>::Receiver == Foo`
   --> $DIR/arbitrary-self-from-method-substs.rs:92:9


### PR DESCRIPTION
If we get past all the earlier stages of validation (in well-formedness checking and in probing) there's still a chance that resolving the self type will produce errors at the 'confirmation' stage. Add an extra note to those errors to make it clear that they were encountered while resolving the 'self' type.

This is a fairly niche case and users should not encounter it often. It's arguably not worth the extra complexity required to produce this note. Opinions welcome.

Part of #44874 

r? @wesleywiser 
