### PR TITLE
tests/ui/asm: Remove uses of rustc_attrs, lang_items, and decl_macro features by using minicore

### DIFF
--- a/tests/auxiliary/minicore.rs
+++ b/tests/auxiliary/minicore.rs
@@ -14,7 +14,7 @@
 //! <https://github.com/rust-lang/rust/blob/c0b5cc9003f6464c11ae1c0662c6a7e06f6f5cab/compiler/rustc_codegen_cranelift/example/mini_core.rs>.
 // ignore-tidy-linelength
 
-#![feature(no_core, lang_items, rustc_attrs, decl_macro)]
+#![feature(no_core, lang_items, rustc_attrs, decl_macro, naked_functions)]
 #![allow(unused, improper_ctypes_definitions, internal_features)]
 #![feature(asm_experimental_arch)]
 #![no_std]
@@ -78,5 +78,13 @@ pub struct UnsafeCell<T: ?Sized> {
 
 #[rustc_builtin_macro]
 pub macro asm("assembly template", $(operands,)* $(options($(option),*))?) {
+    /* compiler built-in */
+}
+#[rustc_builtin_macro]
+pub macro naked_asm("assembly template", $(operands,)* $(options($(option),*))?) {
+    /* compiler built-in */
+}
+#[rustc_builtin_macro]
+pub macro global_asm("assembly template", $(operands,)* $(options($(option),*))?) {
     /* compiler built-in */
 }

--- a/tests/ui/asm/aarch64/aarch64-sve.rs
+++ b/tests/ui/asm/aarch64/aarch64-sve.rs
@@ -3,22 +3,10 @@
 //@ needs-asm-support
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items)]
-#![no_core]
 
 // AArch64 test corresponding to arm64ec-sve.rs.
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for f64 {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+use std::arch::asm;
 
 fn f(x: f64) {
     unsafe {

--- a/tests/ui/asm/aarch64/arm64ec-sve.rs
+++ b/tests/ui/asm/aarch64/arm64ec-sve.rs
@@ -1,25 +1,17 @@
+//@ add-core-stubs
 //@ compile-flags: --target arm64ec-pc-windows-msvc
 //@ needs-asm-support
 //@ needs-llvm-components: aarch64
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items)]
+#![feature(no_core)]
 #![no_core]
 
 // SVE cannot be used for Arm64EC
 // https://github.com/rust-lang/rust/pull/131332#issuecomment-2401189142
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for f64 {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+extern crate minicore;
+use minicore::*;
 
 fn f(x: f64) {
     unsafe {

--- a/tests/ui/asm/aarch64/arm64ec-sve.stderr
+++ b/tests/ui/asm/aarch64/arm64ec-sve.stderr
@@ -1,11 +1,11 @@
 error: cannot use register `p0`: x13, x14, x23, x24, x28, v16-v31, p*, ffr cannot be used for Arm64EC
-  --> $DIR/arm64ec-sve.rs:26:18
+  --> $DIR/arm64ec-sve.rs:18:18
    |
 LL |         asm!("", out("p0") _);
    |                  ^^^^^^^^^^^
 
 error: cannot use register `ffr`: x13, x14, x23, x24, x28, v16-v31, p*, ffr cannot be used for Arm64EC
-  --> $DIR/arm64ec-sve.rs:28:18
+  --> $DIR/arm64ec-sve.rs:20:18
    |
 LL |         asm!("", out("ffr") _);
    |                  ^^^^^^^^^^^^

--- a/tests/ui/asm/arm-low-dreg.rs
+++ b/tests/ui/asm/arm-low-dreg.rs
@@ -1,28 +1,17 @@
+//@ add-core-stubs
 //@ build-pass
 //@ compile-flags: --target=armv7-unknown-linux-gnueabihf
 //@ needs-llvm-components: arm
-#![feature(no_core, rustc_attrs, decl_macro, lang_items)]
+#![feature(no_core)]
 #![crate_type = "rlib"]
-#![no_std]
 #![no_core]
 
 // We accidentally classified "d0"..="d15" as dregs, even though they are in dreg_low16,
 // and thus didn't compile them on platforms with only 16 dregs.
 // Highlighted in https://github.com/rust-lang/rust/issues/126797
 
-#[lang = "sized"]
-trait Sized {}
-
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for f64 {}
-
-#[rustc_builtin_macro]
-pub macro asm("assembly template", $(operands,)* $(options($(option),*))?) {
-    /* compiler built-in */
-}
-
+extern crate minicore;
+use minicore::*;
 
 fn f(x: f64) -> f64 {
     let out: f64;

--- a/tests/ui/asm/bad-template.aarch64.stderr
+++ b/tests/ui/asm/bad-template.aarch64.stderr
@@ -1,5 +1,5 @@
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:30:15
+  --> $DIR/bad-template.rs:19:15
    |
 LL |         asm!("{}");
    |               ^^ from here
@@ -7,7 +7,7 @@ LL |         asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:32:15
+  --> $DIR/bad-template.rs:21:15
    |
 LL |         asm!("{1}", in(reg) foo);
    |               ^^^ from here
@@ -15,7 +15,7 @@ LL |         asm!("{1}", in(reg) foo);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:32:21
+  --> $DIR/bad-template.rs:21:21
    |
 LL |         asm!("{1}", in(reg) foo);
    |                     ^^^^^^^^^^^ argument never used
@@ -23,13 +23,13 @@ LL |         asm!("{1}", in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:35:16
+  --> $DIR/bad-template.rs:24:16
    |
 LL |         asm!("{a}");
    |                ^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:37:15
+  --> $DIR/bad-template.rs:26:15
    |
 LL |         asm!("{}", a = in(reg) foo);
    |               ^^   --------------- named argument
@@ -38,13 +38,13 @@ LL |         asm!("{}", a = in(reg) foo);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:37:20
+  --> $DIR/bad-template.rs:26:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:37:20
+  --> $DIR/bad-template.rs:26:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^ named argument never used
@@ -52,7 +52,7 @@ LL |         asm!("{}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:40:15
+  --> $DIR/bad-template.rs:29:15
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |               ^^^ from here
@@ -60,7 +60,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:40:21
+  --> $DIR/bad-template.rs:29:21
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |                     ^^^^^^^^^^^^^^^ named argument never used
@@ -68,7 +68,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:47:15
+  --> $DIR/bad-template.rs:36:15
    |
 LL |         asm!("{}", in("x0") foo);
    |               ^^   ------------ explicit register argument
@@ -77,24 +77,24 @@ LL |         asm!("{}", in("x0") foo);
    |
    = note: no positional arguments were given
 note: explicit register arguments cannot be used in the asm template
-  --> $DIR/bad-template.rs:47:20
+  --> $DIR/bad-template.rs:36:20
    |
 LL |         asm!("{}", in("x0") foo);
    |                    ^^^^^^^^^^^^
 help: use the register name directly in the assembly code
-  --> $DIR/bad-template.rs:47:20
+  --> $DIR/bad-template.rs:36:20
    |
 LL |         asm!("{}", in("x0") foo);
    |                    ^^^^^^^^^^^^
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:49:17
+  --> $DIR/bad-template.rs:38:17
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |                 ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:52:18
+  --> $DIR/bad-template.rs:41:18
    |
 LL |         asm!("", in(reg) 0, in(reg) 1);
    |                  ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -104,7 +104,7 @@ LL |         asm!("", in(reg) 0, in(reg) 1);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:58:14
+  --> $DIR/bad-template.rs:47:14
    |
 LL | global_asm!("{}");
    |              ^^ from here
@@ -112,7 +112,7 @@ LL | global_asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:60:14
+  --> $DIR/bad-template.rs:49:14
    |
 LL | global_asm!("{1}", const FOO);
    |              ^^^ from here
@@ -120,7 +120,7 @@ LL | global_asm!("{1}", const FOO);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:60:20
+  --> $DIR/bad-template.rs:49:20
    |
 LL | global_asm!("{1}", const FOO);
    |                    ^^^^^^^^^ argument never used
@@ -128,13 +128,13 @@ LL | global_asm!("{1}", const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:63:15
+  --> $DIR/bad-template.rs:52:15
    |
 LL | global_asm!("{a}");
    |               ^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:65:14
+  --> $DIR/bad-template.rs:54:14
    |
 LL | global_asm!("{}", a = const FOO);
    |              ^^   ------------- named argument
@@ -143,13 +143,13 @@ LL | global_asm!("{}", a = const FOO);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:65:19
+  --> $DIR/bad-template.rs:54:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:65:19
+  --> $DIR/bad-template.rs:54:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^ named argument never used
@@ -157,7 +157,7 @@ LL | global_asm!("{}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:68:14
+  --> $DIR/bad-template.rs:57:14
    |
 LL | global_asm!("{1}", a = const FOO);
    |              ^^^ from here
@@ -165,7 +165,7 @@ LL | global_asm!("{1}", a = const FOO);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:68:20
+  --> $DIR/bad-template.rs:57:20
    |
 LL | global_asm!("{1}", a = const FOO);
    |                    ^^^^^^^^^^^^^ named argument never used
@@ -173,13 +173,13 @@ LL | global_asm!("{1}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:71:16
+  --> $DIR/bad-template.rs:60:16
    |
 LL | global_asm!("{:foo}", const FOO);
    |                ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:73:17
+  --> $DIR/bad-template.rs:62:17
    |
 LL | global_asm!("", const FOO, const FOO);
    |                 ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -189,7 +189,7 @@ LL | global_asm!("", const FOO, const FOO);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 warning: formatting may not be suitable for sub-register argument
-  --> $DIR/bad-template.rs:49:15
+  --> $DIR/bad-template.rs:38:15
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |               ^^^^^^           --- for this argument

--- a/tests/ui/asm/bad-template.rs
+++ b/tests/ui/asm/bad-template.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x86_64 aarch64
 
 //@ [x86_64] compile-flags: --target x86_64-unknown-linux-gnu
@@ -6,23 +7,11 @@
 //@ [x86_64] needs-llvm-components: x86
 //@ [aarch64] needs-llvm-components: aarch64
 
-#![feature(no_core, lang_items, rustc_attrs)]
+#![feature(no_core)]
 #![no_core]
 
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
-#[rustc_builtin_macro]
-macro_rules! global_asm {
-    () => {};
-}
-
-#[lang = "sized"]
-trait Sized {}
-
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     let mut foo = 0;

--- a/tests/ui/asm/bad-template.x86_64.stderr
+++ b/tests/ui/asm/bad-template.x86_64.stderr
@@ -1,5 +1,5 @@
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:30:15
+  --> $DIR/bad-template.rs:19:15
    |
 LL |         asm!("{}");
    |               ^^ from here
@@ -7,7 +7,7 @@ LL |         asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:32:15
+  --> $DIR/bad-template.rs:21:15
    |
 LL |         asm!("{1}", in(reg) foo);
    |               ^^^ from here
@@ -15,7 +15,7 @@ LL |         asm!("{1}", in(reg) foo);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:32:21
+  --> $DIR/bad-template.rs:21:21
    |
 LL |         asm!("{1}", in(reg) foo);
    |                     ^^^^^^^^^^^ argument never used
@@ -23,13 +23,13 @@ LL |         asm!("{1}", in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:35:16
+  --> $DIR/bad-template.rs:24:16
    |
 LL |         asm!("{a}");
    |                ^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:37:15
+  --> $DIR/bad-template.rs:26:15
    |
 LL |         asm!("{}", a = in(reg) foo);
    |               ^^   --------------- named argument
@@ -38,13 +38,13 @@ LL |         asm!("{}", a = in(reg) foo);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:37:20
+  --> $DIR/bad-template.rs:26:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:37:20
+  --> $DIR/bad-template.rs:26:20
    |
 LL |         asm!("{}", a = in(reg) foo);
    |                    ^^^^^^^^^^^^^^^ named argument never used
@@ -52,7 +52,7 @@ LL |         asm!("{}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:40:15
+  --> $DIR/bad-template.rs:29:15
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |               ^^^ from here
@@ -60,7 +60,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:40:21
+  --> $DIR/bad-template.rs:29:21
    |
 LL |         asm!("{1}", a = in(reg) foo);
    |                     ^^^^^^^^^^^^^^^ named argument never used
@@ -68,7 +68,7 @@ LL |         asm!("{1}", a = in(reg) foo);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:44:15
+  --> $DIR/bad-template.rs:33:15
    |
 LL |         asm!("{}", in("eax") foo);
    |               ^^   ------------- explicit register argument
@@ -77,24 +77,24 @@ LL |         asm!("{}", in("eax") foo);
    |
    = note: no positional arguments were given
 note: explicit register arguments cannot be used in the asm template
-  --> $DIR/bad-template.rs:44:20
+  --> $DIR/bad-template.rs:33:20
    |
 LL |         asm!("{}", in("eax") foo);
    |                    ^^^^^^^^^^^^^
 help: use the register name directly in the assembly code
-  --> $DIR/bad-template.rs:44:20
+  --> $DIR/bad-template.rs:33:20
    |
 LL |         asm!("{}", in("eax") foo);
    |                    ^^^^^^^^^^^^^
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:49:17
+  --> $DIR/bad-template.rs:38:17
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |                 ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:52:18
+  --> $DIR/bad-template.rs:41:18
    |
 LL |         asm!("", in(reg) 0, in(reg) 1);
    |                  ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -104,7 +104,7 @@ LL |         asm!("", in(reg) 0, in(reg) 1);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:58:14
+  --> $DIR/bad-template.rs:47:14
    |
 LL | global_asm!("{}");
    |              ^^ from here
@@ -112,7 +112,7 @@ LL | global_asm!("{}");
    = note: no arguments were given
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:60:14
+  --> $DIR/bad-template.rs:49:14
    |
 LL | global_asm!("{1}", const FOO);
    |              ^^^ from here
@@ -120,7 +120,7 @@ LL | global_asm!("{1}", const FOO);
    = note: there is 1 argument
 
 error: argument never used
-  --> $DIR/bad-template.rs:60:20
+  --> $DIR/bad-template.rs:49:20
    |
 LL | global_asm!("{1}", const FOO);
    |                    ^^^^^^^^^ argument never used
@@ -128,13 +128,13 @@ LL | global_asm!("{1}", const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {0} */"`
 
 error: there is no argument named `a`
-  --> $DIR/bad-template.rs:63:15
+  --> $DIR/bad-template.rs:52:15
    |
 LL | global_asm!("{a}");
    |               ^
 
 error: invalid reference to argument at index 0
-  --> $DIR/bad-template.rs:65:14
+  --> $DIR/bad-template.rs:54:14
    |
 LL | global_asm!("{}", a = const FOO);
    |              ^^   ------------- named argument
@@ -143,13 +143,13 @@ LL | global_asm!("{}", a = const FOO);
    |
    = note: no positional arguments were given
 note: named arguments cannot be referenced by position
-  --> $DIR/bad-template.rs:65:19
+  --> $DIR/bad-template.rs:54:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^
 
 error: named argument never used
-  --> $DIR/bad-template.rs:65:19
+  --> $DIR/bad-template.rs:54:19
    |
 LL | global_asm!("{}", a = const FOO);
    |                   ^^^^^^^^^^^^^ named argument never used
@@ -157,7 +157,7 @@ LL | global_asm!("{}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: invalid reference to argument at index 1
-  --> $DIR/bad-template.rs:68:14
+  --> $DIR/bad-template.rs:57:14
    |
 LL | global_asm!("{1}", a = const FOO);
    |              ^^^ from here
@@ -165,7 +165,7 @@ LL | global_asm!("{1}", a = const FOO);
    = note: no positional arguments were given
 
 error: named argument never used
-  --> $DIR/bad-template.rs:68:20
+  --> $DIR/bad-template.rs:57:20
    |
 LL | global_asm!("{1}", a = const FOO);
    |                    ^^^^^^^^^^^^^ named argument never used
@@ -173,13 +173,13 @@ LL | global_asm!("{1}", a = const FOO);
    = help: if this argument is intentionally unused, consider using it in an asm comment: `"/* {a} */"`
 
 error: asm template modifier must be a single character
-  --> $DIR/bad-template.rs:71:16
+  --> $DIR/bad-template.rs:60:16
    |
 LL | global_asm!("{:foo}", const FOO);
    |                ^^^
 
 error: multiple unused asm arguments
-  --> $DIR/bad-template.rs:73:17
+  --> $DIR/bad-template.rs:62:17
    |
 LL | global_asm!("", const FOO, const FOO);
    |                 ^^^^^^^^^  ^^^^^^^^^ argument never used
@@ -189,7 +189,7 @@ LL | global_asm!("", const FOO, const FOO);
    = help: if these arguments are intentionally unused, consider using them in an asm comment: `"/* {0} {1} */"`
 
 warning: formatting may not be suitable for sub-register argument
-  --> $DIR/bad-template.rs:49:15
+  --> $DIR/bad-template.rs:38:15
    |
 LL |         asm!("{:foo}", in(reg) foo);
    |               ^^^^^^           --- for this argument

--- a/tests/ui/asm/inline-syntax.arm.stderr
+++ b/tests/ui/asm/inline-syntax.arm.stderr
@@ -15,7 +15,7 @@ LL | .intel_syntax noprefix
    | ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:35:15
+  --> $DIR/inline-syntax.rs:26:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^
@@ -27,7 +27,7 @@ LL |     .intel_syntax noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:39:15
+  --> $DIR/inline-syntax.rs:30:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -39,7 +39,7 @@ LL |     .intel_syntax aaa noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:43:15
+  --> $DIR/inline-syntax.rs:34:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^
@@ -51,7 +51,7 @@ LL |     .att_syntax noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:47:15
+  --> $DIR/inline-syntax.rs:38:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -63,7 +63,7 @@ LL |     .att_syntax bbb noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:51:15
+  --> $DIR/inline-syntax.rs:42:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -75,7 +75,7 @@ LL |     .intel_syntax noprefix; nop
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:58:13
+  --> $DIR/inline-syntax.rs:49:13
    |
 LL |             .intel_syntax noprefix
    |             ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/inline-syntax.arm_llvm_18.stderr
+++ b/tests/ui/asm/inline-syntax.arm_llvm_18.stderr
@@ -15,7 +15,7 @@ LL | .intel_syntax noprefix
    | ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:35:15
+  --> $DIR/inline-syntax.rs:26:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
    |               ^
@@ -27,7 +27,7 @@ LL |     .intel_syntax noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:39:15
+  --> $DIR/inline-syntax.rs:30:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
    |               ^
@@ -39,7 +39,7 @@ LL |     .intel_syntax aaa noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:43:15
+  --> $DIR/inline-syntax.rs:34:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^
@@ -51,7 +51,7 @@ LL |     .att_syntax noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:47:15
+  --> $DIR/inline-syntax.rs:38:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^
@@ -63,7 +63,7 @@ LL |     .att_syntax bbb noprefix
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:51:15
+  --> $DIR/inline-syntax.rs:42:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
    |               ^
@@ -75,7 +75,7 @@ LL |     .intel_syntax noprefix; nop
    |     ^
 
 error: unknown directive
-  --> $DIR/inline-syntax.rs:58:13
+  --> $DIR/inline-syntax.rs:49:13
    |
 LL |             .intel_syntax noprefix
    |             ^

--- a/tests/ui/asm/inline-syntax.rs
+++ b/tests/ui/asm/inline-syntax.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: x86_64 arm_llvm_18 arm
 //@[x86_64] compile-flags: --target x86_64-unknown-linux-gnu
 //@[x86_64] check-pass
@@ -13,22 +14,12 @@
 //@[arm] min-llvm-version: 19
 //@ needs-asm-support
 
-#![feature(no_core, lang_items, rustc_attrs)]
+#![feature(no_core)]
 #![crate_type = "rlib"]
 #![no_core]
 
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
-#[rustc_builtin_macro]
-macro_rules! global_asm {
-    () => {};
-}
-
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 pub fn main() {
     unsafe {

--- a/tests/ui/asm/inline-syntax.x86_64.stderr
+++ b/tests/ui/asm/inline-syntax.x86_64.stderr
@@ -1,5 +1,5 @@
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:67:14
+  --> $DIR/inline-syntax.rs:58:14
    |
 LL | global_asm!(".intel_syntax noprefix", "nop");
    |              ^^^^^^^^^^^^^^^^^^^^^^
@@ -7,37 +7,37 @@ LL | global_asm!(".intel_syntax noprefix", "nop");
    = note: `#[warn(bad_asm_style)]` on by default
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:35:15
+  --> $DIR/inline-syntax.rs:26:15
    |
 LL |         asm!(".intel_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:39:15
+  --> $DIR/inline-syntax.rs:30:15
    |
 LL |         asm!(".intel_syntax aaa noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.att_syntax`, prefer using `options(att_syntax)` instead
-  --> $DIR/inline-syntax.rs:43:15
+  --> $DIR/inline-syntax.rs:34:15
    |
 LL |         asm!(".att_syntax noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.att_syntax`, prefer using `options(att_syntax)` instead
-  --> $DIR/inline-syntax.rs:47:15
+  --> $DIR/inline-syntax.rs:38:15
    |
 LL |         asm!(".att_syntax bbb noprefix", "nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:51:15
+  --> $DIR/inline-syntax.rs:42:15
    |
 LL |         asm!(".intel_syntax noprefix; nop");
    |               ^^^^^^^^^^^^^^^^^^^^^^
 
 warning: avoid using `.intel_syntax`, Intel syntax is the default
-  --> $DIR/inline-syntax.rs:58:13
+  --> $DIR/inline-syntax.rs:49:13
    |
 LL |             .intel_syntax noprefix
    |             ^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/asm/issue-85247.rs
+++ b/tests/ui/asm/issue-85247.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: ropi rwpi
 
 //@ [ropi] compile-flags: --target armv7-unknown-linux-gnueabihf -C relocation-model=ropi
@@ -6,16 +7,12 @@
 //@ [rwpi] needs-llvm-components: arm
 //@ [ropi] build-pass
 
-#![feature(no_core, lang_items, rustc_attrs)]
+#![feature(no_core)]
 #![no_core]
 #![crate_type = "rlib"]
 
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // R9 is reserved as the RWPI base register
 fn main() {

--- a/tests/ui/asm/issue-85247.rwpi.stderr
+++ b/tests/ui/asm/issue-85247.rwpi.stderr
@@ -1,5 +1,5 @@
 error: cannot use register `r9`: the RWPI static base register (r9) cannot be used as an operand for inline asm
-  --> $DIR/issue-85247.rs:23:18
+  --> $DIR/issue-85247.rs:20:18
    |
 LL |         asm!("", out("r9") _);
    |                  ^^^^^^^^^^^

--- a/tests/ui/asm/issue-92378.rs
+++ b/tests/ui/asm/issue-92378.rs
@@ -1,18 +1,15 @@
+//@ add-core-stubs
 //@ compile-flags: --target armv5te-unknown-linux-gnueabi
 //@ needs-llvm-components: arm
 //@ needs-asm-support
 //@ build-pass
 
-#![feature(no_core, lang_items, rustc_attrs)]
+#![feature(no_core)]
 #![no_core]
 #![crate_type = "rlib"]
 
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // ARM uses R11 for the frame pointer, make sure R7 is usable.
 #[instruction_set(arm::a32)]

--- a/tests/ui/asm/issue-99071.rs
+++ b/tests/ui/asm/issue-99071.rs
@@ -1,17 +1,14 @@
+//@ add-core-stubs
 //@ compile-flags: --target thumbv6m-none-eabi
 //@ needs-llvm-components: arm
 //@ needs-asm-support
 
-#![feature(no_core, lang_items, rustc_attrs)]
+#![feature(no_core)]
 #![no_core]
 #![crate_type = "rlib"]
 
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 pub fn foo() {
     unsafe {

--- a/tests/ui/asm/issue-99071.stderr
+++ b/tests/ui/asm/issue-99071.stderr
@@ -1,5 +1,5 @@
 error: cannot use register `r8`: high registers (r8+) can only be used as clobbers in Thumb-1 code
-  --> $DIR/issue-99071.rs:18:18
+  --> $DIR/issue-99071.rs:15:18
    |
 LL |         asm!("", in("r8") 0);
    |                  ^^^^^^^^^^

--- a/tests/ui/asm/loongarch/bad-reg.rs
+++ b/tests/ui/asm/loongarch/bad-reg.rs
@@ -7,7 +7,7 @@
 //@[loongarch64_lp64s] needs-llvm-components: loongarch
 
 #![crate_type = "lib"]
-#![feature(no_core, rustc_attrs)]
+#![feature(no_core)]
 #![no_core]
 
 extern crate minicore;

--- a/tests/ui/asm/naked-functions-instruction-set.rs
+++ b/tests/ui/asm/naked-functions-instruction-set.rs
@@ -1,19 +1,15 @@
+//@ add-core-stubs
 //@ compile-flags: --target armv5te-unknown-linux-gnueabi
 //@ needs-llvm-components: arm
 //@ needs-asm-support
 //@ build-pass
 
 #![crate_type = "lib"]
-#![feature(no_core, lang_items, rustc_attrs, naked_functions)]
+#![feature(no_core, naked_functions)]
 #![no_core]
 
-#[rustc_builtin_macro]
-macro_rules! naked_asm {
-    () => {};
-}
-
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 #[no_mangle]
 #[naked]

--- a/tests/ui/asm/powerpc/bad-reg.aix64.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.aix64.stderr
@@ -1,101 +1,101 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:45:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:47:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r29`: r29 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:51:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("r29") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:53:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `lr`: the link register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("lr") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `ctr`: the counter register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:59:18
+  --> $DIR/bad-reg.rs:50:18
    |
 LL |         asm!("", out("ctr") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:61:18
+  --> $DIR/bad-reg.rs:52:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:109:18
+  --> $DIR/bad-reg.rs:100:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:112:18
+  --> $DIR/bad-reg.rs:103:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:115:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:118:26
+  --> $DIR/bad-reg.rs:109:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:122:18
+  --> $DIR/bad-reg.rs:113:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:125:18
+  --> $DIR/bad-reg.rs:116:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:128:26
+  --> $DIR/bad-reg.rs:119:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:131:26
+  --> $DIR/bad-reg.rs:122:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:135:31
+  --> $DIR/bad-reg.rs:126:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -103,7 +103,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:137:31
+  --> $DIR/bad-reg.rs:128:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -111,7 +111,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:139:31
+  --> $DIR/bad-reg.rs:130:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -119,7 +119,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:141:31
+  --> $DIR/bad-reg.rs:132:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -127,7 +127,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:143:31
+  --> $DIR/bad-reg.rs:134:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -135,7 +135,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:145:31
+  --> $DIR/bad-reg.rs:136:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -143,7 +143,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:147:31
+  --> $DIR/bad-reg.rs:138:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -151,7 +151,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:149:31
+  --> $DIR/bad-reg.rs:140:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -159,13 +159,13 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:49:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:76:27
+  --> $DIR/bad-reg.rs:67:27
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                           ^
@@ -173,7 +173,7 @@ LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:79:28
+  --> $DIR/bad-reg.rs:70:28
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -181,7 +181,7 @@ LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:87:35
+  --> $DIR/bad-reg.rs:78:35
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                                   ^
@@ -189,7 +189,7 @@ LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is avai
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:27
+  --> $DIR/bad-reg.rs:100:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -197,7 +197,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:112:28
+  --> $DIR/bad-reg.rs:103:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -205,7 +205,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:115:33
+  --> $DIR/bad-reg.rs:106:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -213,7 +213,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:122:28
+  --> $DIR/bad-reg.rs:113:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -221,7 +221,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:125:29
+  --> $DIR/bad-reg.rs:116:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -229,7 +229,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:128:34
+  --> $DIR/bad-reg.rs:119:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^

--- a/tests/ui/asm/powerpc/bad-reg.powerpc.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc.stderr
@@ -1,101 +1,101 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:45:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:47:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r29`: r29 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:51:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("r29") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:53:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `lr`: the link register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("lr") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `ctr`: the counter register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:59:18
+  --> $DIR/bad-reg.rs:50:18
    |
 LL |         asm!("", out("ctr") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:61:18
+  --> $DIR/bad-reg.rs:52:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:109:18
+  --> $DIR/bad-reg.rs:100:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:112:18
+  --> $DIR/bad-reg.rs:103:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:115:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:118:26
+  --> $DIR/bad-reg.rs:109:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:122:18
+  --> $DIR/bad-reg.rs:113:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:125:18
+  --> $DIR/bad-reg.rs:116:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:128:26
+  --> $DIR/bad-reg.rs:119:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:131:26
+  --> $DIR/bad-reg.rs:122:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:135:31
+  --> $DIR/bad-reg.rs:126:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -103,7 +103,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:137:31
+  --> $DIR/bad-reg.rs:128:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -111,7 +111,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:139:31
+  --> $DIR/bad-reg.rs:130:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -119,7 +119,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:141:31
+  --> $DIR/bad-reg.rs:132:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -127,7 +127,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:143:31
+  --> $DIR/bad-reg.rs:134:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -135,7 +135,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:145:31
+  --> $DIR/bad-reg.rs:136:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -143,7 +143,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:147:31
+  --> $DIR/bad-reg.rs:138:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -151,7 +151,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:149:31
+  --> $DIR/bad-reg.rs:140:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -159,73 +159,73 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:49:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:66:18
+  --> $DIR/bad-reg.rs:57:18
    |
 LL |         asm!("", in("v0") v32x4); // requires altivec
    |                  ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:68:18
+  --> $DIR/bad-reg.rs:59:18
    |
 LL |         asm!("", out("v0") v32x4); // requires altivec
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:70:18
+  --> $DIR/bad-reg.rs:61:18
    |
 LL |         asm!("", in("v0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:73:18
+  --> $DIR/bad-reg.rs:64:18
    |
 LL |         asm!("", out("v0") v64x2); // requires vsx
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:76:18
+  --> $DIR/bad-reg.rs:67:18
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:79:18
+  --> $DIR/bad-reg.rs:70:18
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:82:26
+  --> $DIR/bad-reg.rs:73:26
    |
 LL |         asm!("/* {} */", in(vreg) v32x4); // requires altivec
    |                          ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:84:26
+  --> $DIR/bad-reg.rs:75:26
    |
 LL |         asm!("/* {} */", in(vreg) v64x2); // requires vsx
    |                          ^^^^^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:87:26
+  --> $DIR/bad-reg.rs:78:26
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                          ^^^^^^^^^^
 
 error: register class `vreg` requires at least one of the following target features: altivec, vsx
-  --> $DIR/bad-reg.rs:90:26
+  --> $DIR/bad-reg.rs:81:26
    |
 LL |         asm!("/* {} */", out(vreg) _); // requires altivec
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:27
+  --> $DIR/bad-reg.rs:100:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -233,7 +233,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:112:28
+  --> $DIR/bad-reg.rs:103:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -241,7 +241,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:115:33
+  --> $DIR/bad-reg.rs:106:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -249,7 +249,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:122:28
+  --> $DIR/bad-reg.rs:113:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -257,7 +257,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:125:29
+  --> $DIR/bad-reg.rs:116:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -265,7 +265,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:128:34
+  --> $DIR/bad-reg.rs:119:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^

--- a/tests/ui/asm/powerpc/bad-reg.powerpc64.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc64.stderr
@@ -1,101 +1,101 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:45:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:47:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r29`: r29 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:51:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("r29") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:53:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `lr`: the link register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("lr") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `ctr`: the counter register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:59:18
+  --> $DIR/bad-reg.rs:50:18
    |
 LL |         asm!("", out("ctr") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:61:18
+  --> $DIR/bad-reg.rs:52:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:109:18
+  --> $DIR/bad-reg.rs:100:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:112:18
+  --> $DIR/bad-reg.rs:103:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:115:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:118:26
+  --> $DIR/bad-reg.rs:109:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:122:18
+  --> $DIR/bad-reg.rs:113:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:125:18
+  --> $DIR/bad-reg.rs:116:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:128:26
+  --> $DIR/bad-reg.rs:119:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:131:26
+  --> $DIR/bad-reg.rs:122:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:135:31
+  --> $DIR/bad-reg.rs:126:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -103,7 +103,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:137:31
+  --> $DIR/bad-reg.rs:128:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -111,7 +111,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:139:31
+  --> $DIR/bad-reg.rs:130:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -119,7 +119,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:141:31
+  --> $DIR/bad-reg.rs:132:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -127,7 +127,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:143:31
+  --> $DIR/bad-reg.rs:134:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -135,7 +135,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:145:31
+  --> $DIR/bad-reg.rs:136:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -143,7 +143,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:147:31
+  --> $DIR/bad-reg.rs:138:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -151,7 +151,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:149:31
+  --> $DIR/bad-reg.rs:140:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -159,13 +159,13 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:49:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: `vsx` target feature is not enabled
-  --> $DIR/bad-reg.rs:70:27
+  --> $DIR/bad-reg.rs:61:27
    |
 LL |         asm!("", in("v0") v64x2); // requires vsx
    |                           ^^^^^
@@ -173,7 +173,7 @@ LL |         asm!("", in("v0") v64x2); // requires vsx
    = note: this is required to use type `i64x2` with register class `vreg`
 
 error: `vsx` target feature is not enabled
-  --> $DIR/bad-reg.rs:73:28
+  --> $DIR/bad-reg.rs:64:28
    |
 LL |         asm!("", out("v0") v64x2); // requires vsx
    |                            ^^^^^
@@ -181,7 +181,7 @@ LL |         asm!("", out("v0") v64x2); // requires vsx
    = note: this is required to use type `i64x2` with register class `vreg`
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:76:27
+  --> $DIR/bad-reg.rs:67:27
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                           ^
@@ -189,7 +189,7 @@ LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:79:28
+  --> $DIR/bad-reg.rs:70:28
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -197,7 +197,7 @@ LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: `vsx` target feature is not enabled
-  --> $DIR/bad-reg.rs:84:35
+  --> $DIR/bad-reg.rs:75:35
    |
 LL |         asm!("/* {} */", in(vreg) v64x2); // requires vsx
    |                                   ^^^^^
@@ -205,7 +205,7 @@ LL |         asm!("/* {} */", in(vreg) v64x2); // requires vsx
    = note: this is required to use type `i64x2` with register class `vreg`
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:87:35
+  --> $DIR/bad-reg.rs:78:35
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                                   ^
@@ -213,7 +213,7 @@ LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is avai
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:27
+  --> $DIR/bad-reg.rs:100:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -221,7 +221,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:112:28
+  --> $DIR/bad-reg.rs:103:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -229,7 +229,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:115:33
+  --> $DIR/bad-reg.rs:106:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -237,7 +237,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:122:28
+  --> $DIR/bad-reg.rs:113:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -245,7 +245,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:125:29
+  --> $DIR/bad-reg.rs:116:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -253,7 +253,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:128:34
+  --> $DIR/bad-reg.rs:119:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^

--- a/tests/ui/asm/powerpc/bad-reg.powerpc64le.stderr
+++ b/tests/ui/asm/powerpc/bad-reg.powerpc64le.stderr
@@ -1,101 +1,101 @@
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:45:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r2`: r2 is a system reserved register and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:47:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("r2") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `r29`: r29 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:51:18
+  --> $DIR/bad-reg.rs:42:18
    |
 LL |         asm!("", out("r29") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `r30`: r30 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:53:18
+  --> $DIR/bad-reg.rs:44:18
    |
 LL |         asm!("", out("r30") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `lr`: the link register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("lr") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `ctr`: the counter register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:59:18
+  --> $DIR/bad-reg.rs:50:18
    |
 LL |         asm!("", out("ctr") _);
    |                  ^^^^^^^^^^^^
 
 error: invalid register `vrsave`: the vrsave register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:61:18
+  --> $DIR/bad-reg.rs:52:18
    |
 LL |         asm!("", out("vrsave") _);
    |                  ^^^^^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:109:18
+  --> $DIR/bad-reg.rs:100:18
    |
 LL |         asm!("", in("cr") x);
    |                  ^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:112:18
+  --> $DIR/bad-reg.rs:103:18
    |
 LL |         asm!("", out("cr") x);
    |                  ^^^^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:115:26
+  --> $DIR/bad-reg.rs:106:26
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                          ^^^^^^^^
 
 error: register class `cr` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:118:26
+  --> $DIR/bad-reg.rs:109:26
    |
 LL |         asm!("/* {} */", out(cr) _);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:122:18
+  --> $DIR/bad-reg.rs:113:18
    |
 LL |         asm!("", in("xer") x);
    |                  ^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:125:18
+  --> $DIR/bad-reg.rs:116:18
    |
 LL |         asm!("", out("xer") x);
    |                  ^^^^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:128:26
+  --> $DIR/bad-reg.rs:119:26
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                          ^^^^^^^^^
 
 error: register class `xer` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:131:26
+  --> $DIR/bad-reg.rs:122:26
    |
 LL |         asm!("/* {} */", out(xer) _);
    |                          ^^^^^^^^^^
 
 error: register `cr0` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:135:31
+  --> $DIR/bad-reg.rs:126:31
    |
 LL |         asm!("", out("cr") _, out("cr0") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr0`
@@ -103,7 +103,7 @@ LL |         asm!("", out("cr") _, out("cr0") _);
    |                  register `cr`
 
 error: register `cr1` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:137:31
+  --> $DIR/bad-reg.rs:128:31
    |
 LL |         asm!("", out("cr") _, out("cr1") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr1`
@@ -111,7 +111,7 @@ LL |         asm!("", out("cr") _, out("cr1") _);
    |                  register `cr`
 
 error: register `cr2` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:139:31
+  --> $DIR/bad-reg.rs:130:31
    |
 LL |         asm!("", out("cr") _, out("cr2") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr2`
@@ -119,7 +119,7 @@ LL |         asm!("", out("cr") _, out("cr2") _);
    |                  register `cr`
 
 error: register `cr3` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:141:31
+  --> $DIR/bad-reg.rs:132:31
    |
 LL |         asm!("", out("cr") _, out("cr3") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr3`
@@ -127,7 +127,7 @@ LL |         asm!("", out("cr") _, out("cr3") _);
    |                  register `cr`
 
 error: register `cr4` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:143:31
+  --> $DIR/bad-reg.rs:134:31
    |
 LL |         asm!("", out("cr") _, out("cr4") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr4`
@@ -135,7 +135,7 @@ LL |         asm!("", out("cr") _, out("cr4") _);
    |                  register `cr`
 
 error: register `cr5` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:145:31
+  --> $DIR/bad-reg.rs:136:31
    |
 LL |         asm!("", out("cr") _, out("cr5") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr5`
@@ -143,7 +143,7 @@ LL |         asm!("", out("cr") _, out("cr5") _);
    |                  register `cr`
 
 error: register `cr6` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:147:31
+  --> $DIR/bad-reg.rs:138:31
    |
 LL |         asm!("", out("cr") _, out("cr6") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr6`
@@ -151,7 +151,7 @@ LL |         asm!("", out("cr") _, out("cr6") _);
    |                  register `cr`
 
 error: register `cr7` conflicts with register `cr`
-  --> $DIR/bad-reg.rs:149:31
+  --> $DIR/bad-reg.rs:140:31
    |
 LL |         asm!("", out("cr") _, out("cr7") _);
    |                  -----------  ^^^^^^^^^^^^ register `cr7`
@@ -159,13 +159,13 @@ LL |         asm!("", out("cr") _, out("cr7") _);
    |                  register `cr`
 
 error: cannot use register `r13`: r13 is a reserved register on this target
-  --> $DIR/bad-reg.rs:49:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("r13") _);
    |                  ^^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:76:27
+  --> $DIR/bad-reg.rs:67:27
    |
 LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    |                           ^
@@ -173,7 +173,7 @@ LL |         asm!("", in("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:79:28
+  --> $DIR/bad-reg.rs:70:28
    |
 LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    |                            ^
@@ -181,7 +181,7 @@ LL |         asm!("", out("v0") x); // FIXME: should be ok if vsx is available
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:87:35
+  --> $DIR/bad-reg.rs:78:35
    |
 LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is available
    |                                   ^
@@ -189,7 +189,7 @@ LL |         asm!("/* {} */", in(vreg) x); // FIXME: should be ok if vsx is avai
    = note: register class `vreg` supports these types: i8x16, i16x8, i32x4, f32x4, f32, f64, i64x2, f64x2
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:109:27
+  --> $DIR/bad-reg.rs:100:27
    |
 LL |         asm!("", in("cr") x);
    |                           ^
@@ -197,7 +197,7 @@ LL |         asm!("", in("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:112:28
+  --> $DIR/bad-reg.rs:103:28
    |
 LL |         asm!("", out("cr") x);
    |                            ^
@@ -205,7 +205,7 @@ LL |         asm!("", out("cr") x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:115:33
+  --> $DIR/bad-reg.rs:106:33
    |
 LL |         asm!("/* {} */", in(cr) x);
    |                                 ^
@@ -213,7 +213,7 @@ LL |         asm!("/* {} */", in(cr) x);
    = note: register class `cr` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:122:28
+  --> $DIR/bad-reg.rs:113:28
    |
 LL |         asm!("", in("xer") x);
    |                            ^
@@ -221,7 +221,7 @@ LL |         asm!("", in("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:125:29
+  --> $DIR/bad-reg.rs:116:29
    |
 LL |         asm!("", out("xer") x);
    |                             ^
@@ -229,7 +229,7 @@ LL |         asm!("", out("xer") x);
    = note: register class `xer` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:128:34
+  --> $DIR/bad-reg.rs:119:34
    |
 LL |         asm!("/* {} */", in(xer) x);
    |                                  ^

--- a/tests/ui/asm/powerpc/bad-reg.rs
+++ b/tests/ui/asm/powerpc/bad-reg.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: powerpc powerpc64 powerpc64le aix64
 //@[powerpc] compile-flags: --target powerpc-unknown-linux-gnu
 //@[powerpc] needs-llvm-components: powerpc
@@ -11,30 +12,20 @@
 // ignore-tidy-linelength
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, repr_simd, asm_experimental_arch)]
+#![feature(no_core, repr_simd, asm_experimental_arch)]
 #![no_core]
 #![allow(non_camel_case_types)]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 #[repr(simd)]
 pub struct i32x4([i32; 4]);
 #[repr(simd)]
 pub struct i64x2([i64; 2]);
 
-impl<T: Copy, const N: usize> Copy for [T; N] {}
-impl Copy for i32 {}
-impl Copy for i64 {}
 impl Copy for i32x4 {}
 impl Copy for i64x2 {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
 
 fn f() {
     let mut x = 0;

--- a/tests/ui/asm/reg-conflict.rs
+++ b/tests/ui/asm/reg-conflict.rs
@@ -1,15 +1,12 @@
+//@ add-core-stubs
 //@ compile-flags: --target armv7-unknown-linux-gnueabihf
 //@ needs-llvm-components: arm
 
-#![feature(no_core, lang_items, rustc_attrs)]
+#![feature(no_core)]
 #![no_core]
 
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 fn main() {
     unsafe {

--- a/tests/ui/asm/reg-conflict.stderr
+++ b/tests/ui/asm/reg-conflict.stderr
@@ -1,5 +1,5 @@
 error: register `s1` conflicts with register `d0`
-  --> $DIR/reg-conflict.rs:17:31
+  --> $DIR/reg-conflict.rs:14:31
    |
 LL |         asm!("", out("d0") _, out("s1") _);
    |                  -----------  ^^^^^^^^^^^ register `s1`

--- a/tests/ui/asm/riscv/bad-reg.riscv32e.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32e.stderr
@@ -1,191 +1,191 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:96:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:99:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:102:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:26
+  --> $DIR/bad-reg.rs:105:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: cannot use register `x16`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:49:18
+  --> $DIR/bad-reg.rs:48:18
    |
 LL |         asm!("", out("x16") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x17`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:51:18
+  --> $DIR/bad-reg.rs:50:18
    |
 LL |         asm!("", out("x17") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x18`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:53:18
+  --> $DIR/bad-reg.rs:52:18
    |
 LL |         asm!("", out("x18") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x19`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:55:18
+  --> $DIR/bad-reg.rs:54:18
    |
 LL |         asm!("", out("x19") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x20`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:56:18
    |
 LL |         asm!("", out("x20") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x21`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:59:18
+  --> $DIR/bad-reg.rs:58:18
    |
 LL |         asm!("", out("x21") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x22`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:61:18
+  --> $DIR/bad-reg.rs:60:18
    |
 LL |         asm!("", out("x22") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x23`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:63:18
+  --> $DIR/bad-reg.rs:62:18
    |
 LL |         asm!("", out("x23") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x24`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:65:18
+  --> $DIR/bad-reg.rs:64:18
    |
 LL |         asm!("", out("x24") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x25`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:67:18
+  --> $DIR/bad-reg.rs:66:18
    |
 LL |         asm!("", out("x25") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x26`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:69:18
+  --> $DIR/bad-reg.rs:68:18
    |
 LL |         asm!("", out("x26") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x27`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:71:18
+  --> $DIR/bad-reg.rs:70:18
    |
 LL |         asm!("", out("x27") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x28`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:73:18
+  --> $DIR/bad-reg.rs:72:18
    |
 LL |         asm!("", out("x28") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x29`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:75:18
+  --> $DIR/bad-reg.rs:74:18
    |
 LL |         asm!("", out("x29") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x30`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:77:18
+  --> $DIR/bad-reg.rs:76:18
    |
 LL |         asm!("", out("x30") _);
    |                  ^^^^^^^^^^^^
 
 error: cannot use register `x31`: register can't be used with the `e` target feature
-  --> $DIR/bad-reg.rs:79:18
+  --> $DIR/bad-reg.rs:78:18
    |
 LL |         asm!("", out("x31") _);
    |                  ^^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:83:26
+  --> $DIR/bad-reg.rs:82:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:85:26
+  --> $DIR/bad-reg.rs:84:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:87:26
+  --> $DIR/bad-reg.rs:86:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:90:26
+  --> $DIR/bad-reg.rs:89:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:27
+  --> $DIR/bad-reg.rs:96:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -193,7 +193,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:28
+  --> $DIR/bad-reg.rs:99:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -201,7 +201,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:35
+  --> $DIR/bad-reg.rs:102:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32gc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32gc.stderr
@@ -1,71 +1,71 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:96:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:99:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:102:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:26
+  --> $DIR/bad-reg.rs:105:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:27
+  --> $DIR/bad-reg.rs:96:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -73,7 +73,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:28
+  --> $DIR/bad-reg.rs:99:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -81,7 +81,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:35
+  --> $DIR/bad-reg.rs:102:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32i.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32i.stderr
@@ -1,95 +1,95 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:96:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:99:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:102:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:26
+  --> $DIR/bad-reg.rs:105:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:83:26
+  --> $DIR/bad-reg.rs:82:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:85:26
+  --> $DIR/bad-reg.rs:84:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:87:26
+  --> $DIR/bad-reg.rs:86:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:90:26
+  --> $DIR/bad-reg.rs:89:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:27
+  --> $DIR/bad-reg.rs:96:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -97,7 +97,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:28
+  --> $DIR/bad-reg.rs:99:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -105,7 +105,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:35
+  --> $DIR/bad-reg.rs:102:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv32imafc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv32imafc.stderr
@@ -1,71 +1,71 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:96:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:99:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:102:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:26
+  --> $DIR/bad-reg.rs:105:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: `d` target feature is not enabled
-  --> $DIR/bad-reg.rs:87:35
+  --> $DIR/bad-reg.rs:86:35
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                                   ^
@@ -73,7 +73,7 @@ LL |         asm!("/* {} */", in(freg) d);
    = note: this is required to use type `f64` with register class `freg`
 
 error: `d` target feature is not enabled
-  --> $DIR/bad-reg.rs:90:36
+  --> $DIR/bad-reg.rs:89:36
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                                    ^
@@ -81,7 +81,7 @@ LL |         asm!("/* {} */", out(freg) d);
    = note: this is required to use type `f64` with register class `freg`
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:27
+  --> $DIR/bad-reg.rs:96:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -89,7 +89,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:28
+  --> $DIR/bad-reg.rs:99:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -97,7 +97,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:35
+  --> $DIR/bad-reg.rs:102:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv64gc.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64gc.stderr
@@ -1,71 +1,71 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:96:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:99:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:102:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:26
+  --> $DIR/bad-reg.rs:105:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:27
+  --> $DIR/bad-reg.rs:96:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -73,7 +73,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:28
+  --> $DIR/bad-reg.rs:99:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -81,7 +81,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:35
+  --> $DIR/bad-reg.rs:102:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.riscv64imac.stderr
+++ b/tests/ui/asm/riscv/bad-reg.riscv64imac.stderr
@@ -1,95 +1,95 @@
 error: invalid register `s1`: s1 is used internally by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:34:18
+  --> $DIR/bad-reg.rs:33:18
    |
 LL |         asm!("", out("s1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:36:18
+  --> $DIR/bad-reg.rs:35:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:37:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:39:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `gp`: the global pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:41:18
    |
 LL |         asm!("", out("gp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `tp`: the thread pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:43:18
    |
 LL |         asm!("", out("tp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `zero`: the zero register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:45:18
    |
 LL |         asm!("", out("zero") _);
    |                  ^^^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:97:18
+  --> $DIR/bad-reg.rs:96:18
    |
 LL |         asm!("", in("v0") x);
    |                  ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:100:18
+  --> $DIR/bad-reg.rs:99:18
    |
 LL |         asm!("", out("v0") x);
    |                  ^^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:103:26
+  --> $DIR/bad-reg.rs:102:26
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `vreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:106:26
+  --> $DIR/bad-reg.rs:105:26
    |
 LL |         asm!("/* {} */", out(vreg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:83:26
+  --> $DIR/bad-reg.rs:82:26
    |
 LL |         asm!("/* {} */", in(freg) f);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:85:26
+  --> $DIR/bad-reg.rs:84:26
    |
 LL |         asm!("/* {} */", out(freg) _);
    |                          ^^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:87:26
+  --> $DIR/bad-reg.rs:86:26
    |
 LL |         asm!("/* {} */", in(freg) d);
    |                          ^^^^^^^^^^
 
 error: register class `freg` requires at least one of the following target features: d, f
-  --> $DIR/bad-reg.rs:90:26
+  --> $DIR/bad-reg.rs:89:26
    |
 LL |         asm!("/* {} */", out(freg) d);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:97:27
+  --> $DIR/bad-reg.rs:96:27
    |
 LL |         asm!("", in("v0") x);
    |                           ^
@@ -97,7 +97,7 @@ LL |         asm!("", in("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:100:28
+  --> $DIR/bad-reg.rs:99:28
    |
 LL |         asm!("", out("v0") x);
    |                            ^
@@ -105,7 +105,7 @@ LL |         asm!("", out("v0") x);
    = note: register class `vreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:103:35
+  --> $DIR/bad-reg.rs:102:35
    |
 LL |         asm!("/* {} */", in(vreg) x);
    |                                   ^

--- a/tests/ui/asm/riscv/bad-reg.rs
+++ b/tests/ui/asm/riscv/bad-reg.rs
@@ -18,8 +18,7 @@
 // usage in the asm! API (in, out, inout, etc.).
 
 #![crate_type = "lib"]
-#![feature(no_core, rustc_attrs)]
-#![feature(asm_experimental_arch)]
+#![feature(no_core)]
 #![no_core]
 
 extern crate minicore;

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32e.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32e.stderr
@@ -1,5 +1,5 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:54:11
    |
 LL |     asm!("li x16, 0");
    |           ^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:57:11
    |
 LL |     asm!("li x17, 0");
    |           ^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:60:11
    |
 LL |     asm!("li x18, 0");
    |           ^^^^^^^^^
@@ -35,7 +35,7 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:63:11
    |
 LL |     asm!("li x19, 0");
    |           ^^^^^^^^^
@@ -47,7 +47,7 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:66:11
    |
 LL |     asm!("li x20, 0");
    |           ^^^^^^^^^
@@ -59,7 +59,7 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:69:11
    |
 LL |     asm!("li x21, 0");
    |           ^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:72:11
    |
 LL |     asm!("li x22, 0");
    |           ^^^^^^^^^
@@ -83,7 +83,7 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:75:11
    |
 LL |     asm!("li x23, 0");
    |           ^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:78:11
    |
 LL |     asm!("li x24, 0");
    |           ^^^^^^^^^
@@ -107,7 +107,7 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:81:11
    |
 LL |     asm!("li x25, 0");
    |           ^^^^^^^^^
@@ -119,7 +119,7 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:84:11
    |
 LL |     asm!("li x26, 0");
    |           ^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:91:11
+  --> $DIR/riscv32e-registers.rs:87:11
    |
 LL |     asm!("li x27, 0");
    |           ^^^^^^^^^
@@ -143,7 +143,7 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:94:11
+  --> $DIR/riscv32e-registers.rs:90:11
    |
 LL |     asm!("li x28, 0");
    |           ^^^^^^^^^
@@ -155,7 +155,7 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:97:11
+  --> $DIR/riscv32e-registers.rs:93:11
    |
 LL |     asm!("li x29, 0");
    |           ^^^^^^^^^
@@ -167,7 +167,7 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:100:11
+  --> $DIR/riscv32e-registers.rs:96:11
    |
 LL |     asm!("li x30, 0");
    |           ^^^^^^^^^
@@ -179,7 +179,7 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:103:11
+  --> $DIR/riscv32e-registers.rs:99:11
    |
 LL |     asm!("li x31, 0");
    |           ^^^^^^^^^

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32e_llvm_18.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32e_llvm_18.stderr
@@ -1,5 +1,5 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:54:11
    |
 LL |     asm!("li x16, 0");
    |           ^
@@ -11,7 +11,7 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:57:11
    |
 LL |     asm!("li x17, 0");
    |           ^
@@ -23,7 +23,7 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:60:11
    |
 LL |     asm!("li x18, 0");
    |           ^
@@ -35,7 +35,7 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:63:11
    |
 LL |     asm!("li x19, 0");
    |           ^
@@ -47,7 +47,7 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:66:11
    |
 LL |     asm!("li x20, 0");
    |           ^
@@ -59,7 +59,7 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:69:11
    |
 LL |     asm!("li x21, 0");
    |           ^
@@ -71,7 +71,7 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:72:11
    |
 LL |     asm!("li x22, 0");
    |           ^
@@ -83,7 +83,7 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:75:11
    |
 LL |     asm!("li x23, 0");
    |           ^
@@ -95,7 +95,7 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:78:11
    |
 LL |     asm!("li x24, 0");
    |           ^
@@ -107,7 +107,7 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:81:11
    |
 LL |     asm!("li x25, 0");
    |           ^
@@ -119,7 +119,7 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:84:11
    |
 LL |     asm!("li x26, 0");
    |           ^
@@ -131,7 +131,7 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:91:11
+  --> $DIR/riscv32e-registers.rs:87:11
    |
 LL |     asm!("li x27, 0");
    |           ^
@@ -143,7 +143,7 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:94:11
+  --> $DIR/riscv32e-registers.rs:90:11
    |
 LL |     asm!("li x28, 0");
    |           ^
@@ -155,7 +155,7 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:97:11
+  --> $DIR/riscv32e-registers.rs:93:11
    |
 LL |     asm!("li x29, 0");
    |           ^
@@ -167,7 +167,7 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:100:11
+  --> $DIR/riscv32e-registers.rs:96:11
    |
 LL |     asm!("li x30, 0");
    |           ^
@@ -179,7 +179,7 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:103:11
+  --> $DIR/riscv32e-registers.rs:99:11
    |
 LL |     asm!("li x31, 0");
    |           ^

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32em.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32em.stderr
@@ -1,5 +1,5 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:54:11
    |
 LL |     asm!("li x16, 0");
    |           ^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:57:11
    |
 LL |     asm!("li x17, 0");
    |           ^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:60:11
    |
 LL |     asm!("li x18, 0");
    |           ^^^^^^^^^
@@ -35,7 +35,7 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:63:11
    |
 LL |     asm!("li x19, 0");
    |           ^^^^^^^^^
@@ -47,7 +47,7 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:66:11
    |
 LL |     asm!("li x20, 0");
    |           ^^^^^^^^^
@@ -59,7 +59,7 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:69:11
    |
 LL |     asm!("li x21, 0");
    |           ^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:72:11
    |
 LL |     asm!("li x22, 0");
    |           ^^^^^^^^^
@@ -83,7 +83,7 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:75:11
    |
 LL |     asm!("li x23, 0");
    |           ^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:78:11
    |
 LL |     asm!("li x24, 0");
    |           ^^^^^^^^^
@@ -107,7 +107,7 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:81:11
    |
 LL |     asm!("li x25, 0");
    |           ^^^^^^^^^
@@ -119,7 +119,7 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:84:11
    |
 LL |     asm!("li x26, 0");
    |           ^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:91:11
+  --> $DIR/riscv32e-registers.rs:87:11
    |
 LL |     asm!("li x27, 0");
    |           ^^^^^^^^^
@@ -143,7 +143,7 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:94:11
+  --> $DIR/riscv32e-registers.rs:90:11
    |
 LL |     asm!("li x28, 0");
    |           ^^^^^^^^^
@@ -155,7 +155,7 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:97:11
+  --> $DIR/riscv32e-registers.rs:93:11
    |
 LL |     asm!("li x29, 0");
    |           ^^^^^^^^^
@@ -167,7 +167,7 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:100:11
+  --> $DIR/riscv32e-registers.rs:96:11
    |
 LL |     asm!("li x30, 0");
    |           ^^^^^^^^^
@@ -179,7 +179,7 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:103:11
+  --> $DIR/riscv32e-registers.rs:99:11
    |
 LL |     asm!("li x31, 0");
    |           ^^^^^^^^^

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32em_llvm_18.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32em_llvm_18.stderr
@@ -1,5 +1,5 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:54:11
    |
 LL |     asm!("li x16, 0");
    |           ^
@@ -11,7 +11,7 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:57:11
    |
 LL |     asm!("li x17, 0");
    |           ^
@@ -23,7 +23,7 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:60:11
    |
 LL |     asm!("li x18, 0");
    |           ^
@@ -35,7 +35,7 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:63:11
    |
 LL |     asm!("li x19, 0");
    |           ^
@@ -47,7 +47,7 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:66:11
    |
 LL |     asm!("li x20, 0");
    |           ^
@@ -59,7 +59,7 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:69:11
    |
 LL |     asm!("li x21, 0");
    |           ^
@@ -71,7 +71,7 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:72:11
    |
 LL |     asm!("li x22, 0");
    |           ^
@@ -83,7 +83,7 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:75:11
    |
 LL |     asm!("li x23, 0");
    |           ^
@@ -95,7 +95,7 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:78:11
    |
 LL |     asm!("li x24, 0");
    |           ^
@@ -107,7 +107,7 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:81:11
    |
 LL |     asm!("li x25, 0");
    |           ^
@@ -119,7 +119,7 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:84:11
    |
 LL |     asm!("li x26, 0");
    |           ^
@@ -131,7 +131,7 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:91:11
+  --> $DIR/riscv32e-registers.rs:87:11
    |
 LL |     asm!("li x27, 0");
    |           ^
@@ -143,7 +143,7 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:94:11
+  --> $DIR/riscv32e-registers.rs:90:11
    |
 LL |     asm!("li x28, 0");
    |           ^
@@ -155,7 +155,7 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:97:11
+  --> $DIR/riscv32e-registers.rs:93:11
    |
 LL |     asm!("li x29, 0");
    |           ^
@@ -167,7 +167,7 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:100:11
+  --> $DIR/riscv32e-registers.rs:96:11
    |
 LL |     asm!("li x30, 0");
    |           ^
@@ -179,7 +179,7 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:103:11
+  --> $DIR/riscv32e-registers.rs:99:11
    |
 LL |     asm!("li x31, 0");
    |           ^

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32emc.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32emc.stderr
@@ -1,5 +1,5 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:54:11
    |
 LL |     asm!("li x16, 0");
    |           ^^^^^^^^^
@@ -11,7 +11,7 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:57:11
    |
 LL |     asm!("li x17, 0");
    |           ^^^^^^^^^
@@ -23,7 +23,7 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:60:11
    |
 LL |     asm!("li x18, 0");
    |           ^^^^^^^^^
@@ -35,7 +35,7 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:63:11
    |
 LL |     asm!("li x19, 0");
    |           ^^^^^^^^^
@@ -47,7 +47,7 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:66:11
    |
 LL |     asm!("li x20, 0");
    |           ^^^^^^^^^
@@ -59,7 +59,7 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:69:11
    |
 LL |     asm!("li x21, 0");
    |           ^^^^^^^^^
@@ -71,7 +71,7 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:72:11
    |
 LL |     asm!("li x22, 0");
    |           ^^^^^^^^^
@@ -83,7 +83,7 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:75:11
    |
 LL |     asm!("li x23, 0");
    |           ^^^^^^^^^
@@ -95,7 +95,7 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:78:11
    |
 LL |     asm!("li x24, 0");
    |           ^^^^^^^^^
@@ -107,7 +107,7 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:81:11
    |
 LL |     asm!("li x25, 0");
    |           ^^^^^^^^^
@@ -119,7 +119,7 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:84:11
    |
 LL |     asm!("li x26, 0");
    |           ^^^^^^^^^
@@ -131,7 +131,7 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:91:11
+  --> $DIR/riscv32e-registers.rs:87:11
    |
 LL |     asm!("li x27, 0");
    |           ^^^^^^^^^
@@ -143,7 +143,7 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:94:11
+  --> $DIR/riscv32e-registers.rs:90:11
    |
 LL |     asm!("li x28, 0");
    |           ^^^^^^^^^
@@ -155,7 +155,7 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:97:11
+  --> $DIR/riscv32e-registers.rs:93:11
    |
 LL |     asm!("li x29, 0");
    |           ^^^^^^^^^
@@ -167,7 +167,7 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:100:11
+  --> $DIR/riscv32e-registers.rs:96:11
    |
 LL |     asm!("li x30, 0");
    |           ^^^^^^^^^
@@ -179,7 +179,7 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:103:11
+  --> $DIR/riscv32e-registers.rs:99:11
    |
 LL |     asm!("li x31, 0");
    |           ^^^^^^^^^

--- a/tests/ui/asm/riscv/riscv32e-registers.riscv32emc_llvm_18.stderr
+++ b/tests/ui/asm/riscv/riscv32e-registers.riscv32emc_llvm_18.stderr
@@ -1,5 +1,5 @@
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:58:11
+  --> $DIR/riscv32e-registers.rs:54:11
    |
 LL |     asm!("li x16, 0");
    |           ^
@@ -11,7 +11,7 @@ LL |     li x16, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:61:11
+  --> $DIR/riscv32e-registers.rs:57:11
    |
 LL |     asm!("li x17, 0");
    |           ^
@@ -23,7 +23,7 @@ LL |     li x17, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:64:11
+  --> $DIR/riscv32e-registers.rs:60:11
    |
 LL |     asm!("li x18, 0");
    |           ^
@@ -35,7 +35,7 @@ LL |     li x18, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:67:11
+  --> $DIR/riscv32e-registers.rs:63:11
    |
 LL |     asm!("li x19, 0");
    |           ^
@@ -47,7 +47,7 @@ LL |     li x19, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:70:11
+  --> $DIR/riscv32e-registers.rs:66:11
    |
 LL |     asm!("li x20, 0");
    |           ^
@@ -59,7 +59,7 @@ LL |     li x20, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:73:11
+  --> $DIR/riscv32e-registers.rs:69:11
    |
 LL |     asm!("li x21, 0");
    |           ^
@@ -71,7 +71,7 @@ LL |     li x21, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:76:11
+  --> $DIR/riscv32e-registers.rs:72:11
    |
 LL |     asm!("li x22, 0");
    |           ^
@@ -83,7 +83,7 @@ LL |     li x22, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:79:11
+  --> $DIR/riscv32e-registers.rs:75:11
    |
 LL |     asm!("li x23, 0");
    |           ^
@@ -95,7 +95,7 @@ LL |     li x23, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:82:11
+  --> $DIR/riscv32e-registers.rs:78:11
    |
 LL |     asm!("li x24, 0");
    |           ^
@@ -107,7 +107,7 @@ LL |     li x24, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:85:11
+  --> $DIR/riscv32e-registers.rs:81:11
    |
 LL |     asm!("li x25, 0");
    |           ^
@@ -119,7 +119,7 @@ LL |     li x25, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:88:11
+  --> $DIR/riscv32e-registers.rs:84:11
    |
 LL |     asm!("li x26, 0");
    |           ^
@@ -131,7 +131,7 @@ LL |     li x26, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:91:11
+  --> $DIR/riscv32e-registers.rs:87:11
    |
 LL |     asm!("li x27, 0");
    |           ^
@@ -143,7 +143,7 @@ LL |     li x27, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:94:11
+  --> $DIR/riscv32e-registers.rs:90:11
    |
 LL |     asm!("li x28, 0");
    |           ^
@@ -155,7 +155,7 @@ LL |     li x28, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:97:11
+  --> $DIR/riscv32e-registers.rs:93:11
    |
 LL |     asm!("li x29, 0");
    |           ^
@@ -167,7 +167,7 @@ LL |     li x29, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:100:11
+  --> $DIR/riscv32e-registers.rs:96:11
    |
 LL |     asm!("li x30, 0");
    |           ^
@@ -179,7 +179,7 @@ LL |     li x30, 0
    |        ^
 
 error: invalid operand for instruction
-  --> $DIR/riscv32e-registers.rs:103:11
+  --> $DIR/riscv32e-registers.rs:99:11
    |
 LL |     asm!("li x31, 0");
    |           ^

--- a/tests/ui/asm/riscv/riscv32e-registers.rs
+++ b/tests/ui/asm/riscv/riscv32e-registers.rs
@@ -1,5 +1,6 @@
 // Test that loads into registers x16..=x31 are never generated for riscv32{e,em,emc} targets
 //
+//@ add-core-stubs
 //@ build-fail
 //@ revisions: riscv32e riscv32em riscv32emc riscv32e_llvm_18 riscv32em_llvm_18 riscv32emc_llvm_18
 //
@@ -27,15 +28,10 @@
 // usage in assembly code.
 
 #![no_core]
-#![feature(no_core, lang_items, rustc_attrs)]
+#![feature(no_core)]
 
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
-
-#[lang = "sized"]
-trait Sized {}
+extern crate minicore;
+use minicore::*;
 
 // Verify registers x1..=x15 are addressable on riscv32e, but registers x16..=x31 are not
 #[no_mangle]

--- a/tests/ui/asm/s390x/bad-reg.rs
+++ b/tests/ui/asm/s390x/bad-reg.rs
@@ -9,7 +9,7 @@
 //@[s390x_vector_stable] needs-llvm-components: systemz
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, repr_simd)]
+#![feature(no_core, repr_simd)]
 #![cfg_attr(not(s390x_vector_stable), feature(asm_experimental_reg))]
 #![no_core]
 #![allow(non_camel_case_types)]

--- a/tests/ui/asm/sparc/bad-reg.rs
+++ b/tests/ui/asm/sparc/bad-reg.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: sparc sparcv8plus sparc64
 //@[sparc] compile-flags: --target sparc-unknown-none-elf
 //@[sparc] needs-llvm-components: sparc
@@ -8,20 +9,11 @@
 //@ needs-asm-support
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![feature(no_core, asm_experimental_arch)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
-
-impl Copy for i32 {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+extern crate minicore;
+use minicore::*;
 
 fn f() {
     let mut x = 0;

--- a/tests/ui/asm/sparc/bad-reg.sparc.stderr
+++ b/tests/ui/asm/sparc/bad-reg.sparc.stderr
@@ -1,77 +1,77 @@
 error: invalid register `g0`: g0 is always zero and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:30:18
+  --> $DIR/bad-reg.rs:22:18
    |
 LL |         asm!("", out("g0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g1`: reserved by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:25:18
    |
 LL |         asm!("", out("g1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g6`: reserved for system and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", out("g6") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g7`: reserved for system and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("g7") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `i7`: the return address register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("i7") _);
    |                  ^^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:54:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", in("y") x);
    |                  ^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("y") x);
    |                  ^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:60:26
+  --> $DIR/bad-reg.rs:52:26
    |
 LL |         asm!("/* {} */", in(yreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:63:26
+  --> $DIR/bad-reg.rs:55:26
    |
 LL |         asm!("/* {} */", out(yreg) _);
    |                          ^^^^^^^^^^^
 
 error: cannot use register `r5`: g5 is reserved for system on SPARC32
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:30:18
    |
 LL |         asm!("", out("g5") _);
    |                  ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:54:26
+  --> $DIR/bad-reg.rs:46:26
    |
 LL |         asm!("", in("y") x);
    |                          ^
@@ -79,7 +79,7 @@ LL |         asm!("", in("y") x);
    = note: register class `yreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:57:27
+  --> $DIR/bad-reg.rs:49:27
    |
 LL |         asm!("", out("y") x);
    |                           ^
@@ -87,7 +87,7 @@ LL |         asm!("", out("y") x);
    = note: register class `yreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:60:35
+  --> $DIR/bad-reg.rs:52:35
    |
 LL |         asm!("/* {} */", in(yreg) x);
    |                                   ^

--- a/tests/ui/asm/sparc/bad-reg.sparc64.stderr
+++ b/tests/ui/asm/sparc/bad-reg.sparc64.stderr
@@ -1,71 +1,71 @@
 error: invalid register `g0`: g0 is always zero and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:30:18
+  --> $DIR/bad-reg.rs:22:18
    |
 LL |         asm!("", out("g0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g1`: reserved by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:25:18
    |
 LL |         asm!("", out("g1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g6`: reserved for system and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", out("g6") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g7`: reserved for system and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("g7") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `i7`: the return address register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("i7") _);
    |                  ^^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:54:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", in("y") x);
    |                  ^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("y") x);
    |                  ^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:60:26
+  --> $DIR/bad-reg.rs:52:26
    |
 LL |         asm!("/* {} */", in(yreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:63:26
+  --> $DIR/bad-reg.rs:55:26
    |
 LL |         asm!("/* {} */", out(yreg) _);
    |                          ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:54:26
+  --> $DIR/bad-reg.rs:46:26
    |
 LL |         asm!("", in("y") x);
    |                          ^
@@ -73,7 +73,7 @@ LL |         asm!("", in("y") x);
    = note: register class `yreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:57:27
+  --> $DIR/bad-reg.rs:49:27
    |
 LL |         asm!("", out("y") x);
    |                           ^
@@ -81,7 +81,7 @@ LL |         asm!("", out("y") x);
    = note: register class `yreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:60:35
+  --> $DIR/bad-reg.rs:52:35
    |
 LL |         asm!("/* {} */", in(yreg) x);
    |                                   ^

--- a/tests/ui/asm/sparc/bad-reg.sparcv8plus.stderr
+++ b/tests/ui/asm/sparc/bad-reg.sparcv8plus.stderr
@@ -1,77 +1,77 @@
 error: invalid register `g0`: g0 is always zero and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:30:18
+  --> $DIR/bad-reg.rs:22:18
    |
 LL |         asm!("", out("g0") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g1`: reserved by LLVM and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:33:18
+  --> $DIR/bad-reg.rs:25:18
    |
 LL |         asm!("", out("g1") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g6`: reserved for system and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:40:18
+  --> $DIR/bad-reg.rs:32:18
    |
 LL |         asm!("", out("g6") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `g7`: reserved for system and cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:42:18
+  --> $DIR/bad-reg.rs:34:18
    |
 LL |         asm!("", out("g7") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `sp`: the stack pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:44:18
+  --> $DIR/bad-reg.rs:36:18
    |
 LL |         asm!("", out("sp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `fp`: the frame pointer cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:46:18
+  --> $DIR/bad-reg.rs:38:18
    |
 LL |         asm!("", out("fp") _);
    |                  ^^^^^^^^^^^
 
 error: invalid register `i7`: the return address register cannot be used as an operand for inline asm
-  --> $DIR/bad-reg.rs:48:18
+  --> $DIR/bad-reg.rs:40:18
    |
 LL |         asm!("", out("i7") _);
    |                  ^^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:54:18
+  --> $DIR/bad-reg.rs:46:18
    |
 LL |         asm!("", in("y") x);
    |                  ^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:57:18
+  --> $DIR/bad-reg.rs:49:18
    |
 LL |         asm!("", out("y") x);
    |                  ^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:60:26
+  --> $DIR/bad-reg.rs:52:26
    |
 LL |         asm!("/* {} */", in(yreg) x);
    |                          ^^^^^^^^^^
 
 error: register class `yreg` can only be used as a clobber, not as an input or output
-  --> $DIR/bad-reg.rs:63:26
+  --> $DIR/bad-reg.rs:55:26
    |
 LL |         asm!("/* {} */", out(yreg) _);
    |                          ^^^^^^^^^^^
 
 error: cannot use register `r5`: g5 is reserved for system on SPARC32
-  --> $DIR/bad-reg.rs:38:18
+  --> $DIR/bad-reg.rs:30:18
    |
 LL |         asm!("", out("g5") _);
    |                  ^^^^^^^^^^^
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:54:26
+  --> $DIR/bad-reg.rs:46:26
    |
 LL |         asm!("", in("y") x);
    |                          ^
@@ -79,7 +79,7 @@ LL |         asm!("", in("y") x);
    = note: register class `yreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:57:27
+  --> $DIR/bad-reg.rs:49:27
    |
 LL |         asm!("", out("y") x);
    |                           ^
@@ -87,7 +87,7 @@ LL |         asm!("", out("y") x);
    = note: register class `yreg` supports these types: 
 
 error: type `i32` cannot be used with this register class
-  --> $DIR/bad-reg.rs:60:35
+  --> $DIR/bad-reg.rs:52:35
    |
 LL |         asm!("/* {} */", in(yreg) x);
    |                                   ^


### PR DESCRIPTION
Follow-up to https://github.com/rust-lang/rust/pull/132516#issuecomment-2452986287.
This PR do similar things for remaining tests in tests/ui/asm.

r? jieyouxu