### PR TITLE
Condvar: implement wait_timeout for targets without threads

### DIFF
--- a/library/std/src/sys/sync/condvar/no_threads.rs
+++ b/library/std/src/sys/sync/condvar/no_threads.rs
@@ -1,4 +1,5 @@
 use crate::sys::sync::Mutex;
+use crate::thread::sleep;
 use crate::time::Duration;
 
 pub struct Condvar {}
@@ -19,7 +20,8 @@ impl Condvar {
         panic!("condvar wait not supported")
     }
 
-    pub unsafe fn wait_timeout(&self, _mutex: &Mutex, _dur: Duration) -> bool {
-        panic!("condvar wait not supported");
+    pub unsafe fn wait_timeout(&self, _mutex: &Mutex, dur: Duration) -> bool {
+        sleep(dur);
+        false
     }
 }


### PR DESCRIPTION
This always falls back to sleeping since there is no way to notify a condvar on a target without threads.

Even on a target that has no threads the following code is a legitimate use case:

```rust
use std::sync::{Condvar, Mutex};
use std::time::Duration;

fn main() {
    let cv = Condvar::new();
    let mutex = Mutex::new(());
    let mut guard = mutex.lock().unwrap();

    cv.notify_one();

    let res;
    (guard, res) = cv.wait_timeout(guard, Duration::from_secs(3)).unwrap();
    assert!(res.timed_out());
}
```

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
