### PR TITLE
rustc_borrowck: Suggest changing `&raw const` to `&raw mut` if applicable

### DIFF
--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -1474,16 +1474,16 @@ fn suggest_ampmut<'tcx>(
     // let x: &i32 = &'a 5;
     //                ^^ lifetime annotation not allowed
     //
-    if let Some(assignment_rhs_span) = opt_assignment_rhs_span
-        && let Ok(src) = tcx.sess.source_map().span_to_snippet(assignment_rhs_span)
-        && let Some(stripped) = src.strip_prefix('&')
+    if let Some(rhs_span) = opt_assignment_rhs_span
+        && let Ok(rhs_str) = tcx.sess.source_map().span_to_snippet(rhs_span)
+        && let Some(rhs_str_no_amp) = rhs_str.strip_prefix('&')
     {
-        let is_raw_ref = stripped.trim_start().starts_with("raw ");
+        let is_raw_ref = rhs_str_no_amp.trim_start().starts_with("raw ");
         // We don't support raw refs yet
         if is_raw_ref {
             return None;
         }
-        let is_mut = if let Some(rest) = stripped.trim_start().strip_prefix("mut") {
+        let is_mut = if let Some(rest) = rhs_str_no_amp.trim_start().strip_prefix("mut") {
             match rest.chars().next() {
                 // e.g. `&mut x`
                 Some(c) if c.is_whitespace() => true,
@@ -1500,7 +1500,7 @@ fn suggest_ampmut<'tcx>(
         // if the reference is already mutable then there is nothing we can do
         // here.
         if !is_mut {
-            let span = assignment_rhs_span;
+            let span = rhs_span;
             // shrink the span to just after the `&` in `&variable`
             let span = span.with_lo(span.lo() + BytePos(1)).shrink_to_lo();
 

--- a/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
+++ b/compiler/rustc_borrowck/src/diagnostics/mutability_errors.rs
@@ -1500,9 +1500,8 @@ fn suggest_ampmut<'tcx>(
         // if the reference is already mutable then there is nothing we can do
         // here.
         if !is_mut {
-            let span = rhs_span;
             // shrink the span to just after the `&` in `&variable`
-            let span = span.with_lo(span.lo() + BytePos(1)).shrink_to_lo();
+            let span = rhs_span.with_lo(rhs_span.lo() + BytePos(1)).shrink_to_lo();
 
             // FIXME(Ezrashaw): returning is bad because we still might want to
             // update the annotated type, see #106857.

--- a/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
+++ b/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
@@ -3,6 +3,11 @@ error[E0594]: cannot assign to `*ptr`, which is behind a `*const` pointer
    |
 LL |     unsafe { *ptr = 3; }
    |              ^^^^^^^^ `ptr` is a `*const` pointer, so the data it refers to cannot be written
+   |
+help: consider changing this to be a mutable pointer
+   |
+LL |     let ptr = &raw mut val;
+   |                    ~~~
 
 error: aborting due to 1 previous error
 


### PR DESCRIPTION
Closes #127562

For reference, here is the diff compared to the original error reported in that issue before #134244 stopped suggesting the invalid syntax:

```
diff --git a/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr b/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
index 0da5d15cf7f..dbe834b6b78 100644
--- a/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
+++ b/tests/ui/borrowck/no-invalid-mut-suggestion-for-raw-pointer-issue-127562.stderr
@@ -6,8 +6,8 @@ LL |     unsafe { *ptr = 3; }
    |
 help: consider changing this to be a mutable pointer
    |
-LL |     let ptr = &mut raw const val;
-   |                +++
+LL |     let ptr = &raw mut val;
+   |                    ~~~

 error: aborting due to 1 previous error
```

