### PR TITLE
Fix `-Z input-stats` ordering

### DIFF
--- a/tests/ui/stats/input-stats.stderr
+++ b/tests/ui/stats/input-stats.stderr
@@ -24,8 +24,8 @@ ast-stats-1 Block                    192 ( 2.9%)             6            32
 ast-stats-1 FieldDef                 208 ( 3.1%)             2           104
 ast-stats-1 Variant                  208 ( 3.1%)             2           104
 ast-stats-1 AssocItem                352 ( 5.3%)             4            88
-ast-stats-1 - Type                     176 ( 2.6%)             2
 ast-stats-1 - Fn                       176 ( 2.6%)             2
+ast-stats-1 - Type                     176 ( 2.6%)             2
 ast-stats-1 GenericBound             352 ( 5.3%)             4            88
 ast-stats-1 - Trait                    352 ( 5.3%)             4
 ast-stats-1 GenericParam             480 ( 7.2%)             5            96
@@ -34,22 +34,22 @@ ast-stats-1 - Struct                    72 ( 1.1%)             1
 ast-stats-1 - Wild                      72 ( 1.1%)             1
 ast-stats-1 - Ident                    360 ( 5.4%)             5
 ast-stats-1 Expr                     576 ( 8.6%)             8            72
-ast-stats-1 - Path                      72 ( 1.1%)             1
 ast-stats-1 - Match                     72 ( 1.1%)             1
+ast-stats-1 - Path                      72 ( 1.1%)             1
 ast-stats-1 - Struct                    72 ( 1.1%)             1
 ast-stats-1 - Lit                      144 ( 2.2%)             2
 ast-stats-1 - Block                    216 ( 3.2%)             3
 ast-stats-1 PathSegment              744 (11.1%)            31            24
 ast-stats-1 Ty                       896 (13.4%)            14            64
-ast-stats-1 - Ref                       64 ( 1.0%)             1
 ast-stats-1 - Ptr                       64 ( 1.0%)             1
+ast-stats-1 - Ref                       64 ( 1.0%)             1
 ast-stats-1 - ImplicitSelf             128 ( 1.9%)             2
 ast-stats-1 - Path                     640 ( 9.6%)            10
 ast-stats-1 Item                   1_224 (18.3%)             9           136
-ast-stats-1 - ForeignMod               136 ( 2.0%)             1
-ast-stats-1 - Trait                    136 ( 2.0%)             1
-ast-stats-1 - Impl                     136 ( 2.0%)             1
 ast-stats-1 - Enum                     136 ( 2.0%)             1
+ast-stats-1 - ForeignMod               136 ( 2.0%)             1
+ast-stats-1 - Impl                     136 ( 2.0%)             1
+ast-stats-1 - Trait                    136 ( 2.0%)             1
 ast-stats-1 - Fn                       272 ( 4.1%)             2
 ast-stats-1 - Use                      408 ( 6.1%)             3
 ast-stats-1 ----------------------------------------------------------------
@@ -82,8 +82,8 @@ ast-stats-2 Block                    192 ( 2.6%)             6            32
 ast-stats-2 FieldDef                 208 ( 2.8%)             2           104
 ast-stats-2 Variant                  208 ( 2.8%)             2           104
 ast-stats-2 AssocItem                352 ( 4.8%)             4            88
-ast-stats-2 - Type                     176 ( 2.4%)             2
 ast-stats-2 - Fn                       176 ( 2.4%)             2
+ast-stats-2 - Type                     176 ( 2.4%)             2
 ast-stats-2 GenericBound             352 ( 4.8%)             4            88
 ast-stats-2 - Trait                    352 ( 4.8%)             4
 ast-stats-2 GenericParam             480 ( 6.5%)             5            96
@@ -92,24 +92,24 @@ ast-stats-2 - Struct                    72 ( 1.0%)             1
 ast-stats-2 - Wild                      72 ( 1.0%)             1
 ast-stats-2 - Ident                    360 ( 4.9%)             5
 ast-stats-2 Expr                     648 ( 8.8%)             9            72
-ast-stats-2 - Path                      72 ( 1.0%)             1
-ast-stats-2 - Match                     72 ( 1.0%)             1
-ast-stats-2 - Struct                    72 ( 1.0%)             1
 ast-stats-2 - InlineAsm                 72 ( 1.0%)             1
+ast-stats-2 - Match                     72 ( 1.0%)             1
+ast-stats-2 - Path                      72 ( 1.0%)             1
+ast-stats-2 - Struct                    72 ( 1.0%)             1
 ast-stats-2 - Lit                      144 ( 2.0%)             2
 ast-stats-2 - Block                    216 ( 2.9%)             3
 ast-stats-2 PathSegment              864 (11.8%)            36            24
 ast-stats-2 Ty                       896 (12.2%)            14            64
-ast-stats-2 - Ref                       64 ( 0.9%)             1
 ast-stats-2 - Ptr                       64 ( 0.9%)             1
+ast-stats-2 - Ref                       64 ( 0.9%)             1
 ast-stats-2 - ImplicitSelf             128 ( 1.7%)             2
 ast-stats-2 - Path                     640 ( 8.7%)            10
 ast-stats-2 Item                   1_496 (20.4%)            11           136
 ast-stats-2 - Enum                     136 ( 1.9%)             1
-ast-stats-2 - Trait                    136 ( 1.9%)             1
-ast-stats-2 - Impl                     136 ( 1.9%)             1
 ast-stats-2 - ExternCrate              136 ( 1.9%)             1
 ast-stats-2 - ForeignMod               136 ( 1.9%)             1
+ast-stats-2 - Impl                     136 ( 1.9%)             1
+ast-stats-2 - Trait                    136 ( 1.9%)             1
 ast-stats-2 - Fn                       272 ( 3.7%)             2
 ast-stats-2 - Use                      544 ( 7.4%)             4
 ast-stats-2 ----------------------------------------------------------------
@@ -135,9 +135,9 @@ hir-stats WherePredicate            72 ( 0.8%)             3            24
 hir-stats - BoundPredicate            72 ( 0.8%)             3
 hir-stats Arm                       80 ( 0.9%)             2            40
 hir-stats Stmt                      96 ( 1.1%)             3            32
+hir-stats - Expr                      32 ( 0.4%)             1
 hir-stats - Let                       32 ( 0.4%)             1
 hir-stats - Semi                      32 ( 0.4%)             1
-hir-stats - Expr                      32 ( 0.4%)             1
 hir-stats FnDecl                   120 ( 1.3%)             3            40
 hir-stats Attribute                128 ( 1.4%)             4            32
 hir-stats FieldDef                 128 ( 1.4%)             2            64
@@ -153,22 +153,22 @@ hir-stats - Wild                      72 ( 0.8%)             1
 hir-stats - Binding                  216 ( 2.4%)             3
 hir-stats Generics                 560 ( 6.3%)            10            56
 hir-stats Ty                       720 ( 8.1%)            15            48
-hir-stats - Ref                       48 ( 0.5%)             1
 hir-stats - Ptr                       48 ( 0.5%)             1
+hir-stats - Ref                       48 ( 0.5%)             1
 hir-stats - Path                     624 ( 7.0%)            13
 hir-stats Expr                     768 ( 8.6%)            12            64
-hir-stats - Path                      64 ( 0.7%)             1
-hir-stats - Match                     64 ( 0.7%)             1
-hir-stats - Struct                    64 ( 0.7%)             1
 hir-stats - InlineAsm                 64 ( 0.7%)             1
+hir-stats - Match                     64 ( 0.7%)             1
+hir-stats - Path                      64 ( 0.7%)             1
+hir-stats - Struct                    64 ( 0.7%)             1
 hir-stats - Lit                      128 ( 1.4%)             2
 hir-stats - Block                    384 ( 4.3%)             6
 hir-stats Item                     968 (10.8%)            11            88
 hir-stats - Enum                      88 ( 1.0%)             1
-hir-stats - Trait                     88 ( 1.0%)             1
-hir-stats - Impl                      88 ( 1.0%)             1
 hir-stats - ExternCrate               88 ( 1.0%)             1
 hir-stats - ForeignMod                88 ( 1.0%)             1
+hir-stats - Impl                      88 ( 1.0%)             1
+hir-stats - Trait                     88 ( 1.0%)             1
 hir-stats - Fn                       176 ( 2.0%)             2
 hir-stats - Use                      352 ( 3.9%)             4
 hir-stats Path                   1_240 (13.9%)            31            40


### PR DESCRIPTION
It currently depends on the hash algorithm.

r? @Noratrieb 