### PR TITLE
Update cc-rs to 1.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,9 +411,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.2.0"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
 dependencies = [
  "shlex",
 ]

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 ar_archive_writer = "0.4.2"
 arrayvec = { version = "0.7", default-features = false }
 bitflags = "2.4.1"
-cc = "1.1.23"
+cc = "1.2.4"
 either = "1.5.0"
 itertools = "0.12"
 jobserver = "0.1.28"

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -10,5 +10,5 @@ libc = "0.2.73"
 
 [build-dependencies]
 # tidy-alphabetical-start
-cc = "1.1.23"
+cc = "1.2.4"
 # tidy-alphabetical-end


### PR DESCRIPTION
This fixes the issue of the wrong build tools being used when cross-compiling from msvc. Fixes https://github.com/rust-lang/rust/issues/133794.