### PR TITLE
bootstrap: use specific-purpose ui test path for `test_valid` self-test

### DIFF
--- a/src/bootstrap/src/core/builder/tests.rs
+++ b/src/bootstrap/src/core/builder/tests.rs
@@ -91,7 +91,7 @@ macro_rules! rustc {
 #[test]
 fn test_valid() {
     // make sure multi suite paths are accepted
-    check_cli(["test", "tests/ui/attr-start.rs", "tests/ui/attr-shebang.rs"]);
+    check_cli(["test", "tests/ui/bootstrap/self-test/a.rs", "tests/ui/bootstrap/self-test/b.rs"]);
 }
 
 #[test]

--- a/tests/ui/bootstrap/self-test/a.rs
+++ b/tests/ui/bootstrap/self-test/a.rs
@@ -1,0 +1,2 @@
+//! Not used by compiler, this is used by bootstrap cli self-test.
+//@ ignore-test

--- a/tests/ui/bootstrap/self-test/b.rs
+++ b/tests/ui/bootstrap/self-test/b.rs
@@ -1,0 +1,2 @@
+//! Not used by compiler, used by bootstrap cli self-test.
+//@ ignore-test


### PR DESCRIPTION
I wanted to move some ui tests around in #134418, which broke `test_valid` since it was referencing two non-specific-purpose ui tests. This PR instead adds two dummy tests under `tests/ui/bootstrap/self-test/`, for that purpose specifically.

r? bootstrap