### PR TITLE
ci: use ubuntu-22 for large runners

### DIFF
--- a/src/ci/github-actions/jobs.yml
+++ b/src/ci/github-actions/jobs.yml
@@ -12,15 +12,15 @@ runners:
 
   # Large runner used mainly for its bigger disk capacity
   - &job-linux-4c-largedisk
-    os: ubuntu-20.04-4core-16gb
+    os: ubuntu-22.04-4core-16gb
     <<: *base-job
 
   - &job-linux-8c
-    os: ubuntu-20.04-8core-32gb
+    os: ubuntu-22.04-8core-32gb
     <<: *base-job
 
   - &job-linux-16c
-    os: ubuntu-20.04-16core-64gb
+    os: ubuntu-22.04-16core-64gb
     <<: *base-job
 
   - &job-macos-xl


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
Free runners moved in https://github.com/rust-lang/rust/pull/134132

I provisioned the new large runners for both the `rust-lang` and `rust-lang-ci` GitHub organizations :+1:

Related to https://github.com/rust-lang/infra-team/issues/182
<!-- homu-ignore:end -->
