### PR TITLE
Use `MixedBitSet`s in const qualif

### DIFF
--- a/compiler/rustc_const_eval/src/check_consts/resolver.rs
+++ b/compiler/rustc_const_eval/src/check_consts/resolver.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 
-use rustc_index::bit_set::BitSet;
+use rustc_index::bit_set::MixedBitSet;
 use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::{
     self, BasicBlock, CallReturnPlaces, Local, Location, Statement, StatementKind, TerminatorEdges,
@@ -246,12 +246,14 @@ where
 }
 
 #[derive(Debug, PartialEq, Eq)]
+/// The state for the `FlowSensitiveAnalysis` dataflow analysis. This domain is likely homogeneous,
+/// and has a big size, so we use a bitset that can be sparse (c.f. issue #134404).
 pub(super) struct State {
     /// Describes whether a local contains qualif.
-    pub qualif: BitSet<Local>,
+    pub qualif: MixedBitSet<Local>,
     /// Describes whether a local's address escaped and it might become qualified as a result an
     /// indirect mutation.
-    pub borrow: BitSet<Local>,
+    pub borrow: MixedBitSet<Local>,
 }
 
 impl Clone for State {
@@ -320,8 +322,8 @@ where
 
     fn bottom_value(&self, body: &mir::Body<'tcx>) -> Self::Domain {
         State {
-            qualif: BitSet::new_empty(body.local_decls.len()),
-            borrow: BitSet::new_empty(body.local_decls.len()),
+            qualif: MixedBitSet::new_empty(body.local_decls.len()),
+            borrow: MixedBitSet::new_empty(body.local_decls.len()),
         }
     }
 

--- a/compiler/rustc_index/src/bit_set.rs
+++ b/compiler/rustc_index/src/bit_set.rs
@@ -1191,6 +1191,14 @@ impl<T: Idx> MixedBitSet<T> {
         }
     }
 
+    #[inline]
+    pub fn clear(&mut self) {
+        match self {
+            MixedBitSet::Small(set) => set.clear(),
+            MixedBitSet::Large(set) => set.clear(),
+        }
+    }
+
     bit_relations_inherent_impls! {}
 }
 


### PR DESCRIPTION
These analyses' domains should be very homogeneous, having compressed bitmaps on huge cfgs should make a difference (and doesn’t have an impact on the smaller / regular cfgs in our benchmarks). 

This is a >40% walltime reduction on [this stress test](https://github.com/Manishearth/icu4x_compile_sample) extracted from a real world ICU case, and a 10x or so max-rss reduction.

cc @oli-obk @RalfJung 

Should help with (or fix) issue #134404.