### PR TITLE
Stabilize the `cell_update` feature

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -549,8 +549,6 @@ impl<T: Copy> Cell<T> {
     /// # Examples
     ///
     /// ```
-    /// #![feature(cell_update)]
-    ///
     /// use std::cell::Cell;
     ///
     /// let c = Cell::new(5);
@@ -558,7 +556,7 @@ impl<T: Copy> Cell<T> {
     /// assert_eq!(c.get(), 6);
     /// ```
     #[inline]
-    #[unstable(feature = "cell_update", issue = "50186")]
+    #[stable(feature = "cell_update", since = "CURRENT_RUSTC_VERSION")]
     pub fn update(&self, f: impl FnOnce(T) -> T) {
         let old = self.get();
         self.set(f(old));

--- a/library/coretests/tests/lib.rs
+++ b/library/coretests/tests/lib.rs
@@ -12,7 +12,6 @@
 #![feature(async_iterator)]
 #![feature(bigint_helper_methods)]
 #![feature(bstr)]
-#![feature(cell_update)]
 #![feature(char_max_len)]
 #![feature(clone_to_uninit)]
 #![feature(const_eval_select)]

--- a/src/tools/miri/src/lib.rs
+++ b/src/tools/miri/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(rustc_private)]
 #![feature(cfg_match)]
-#![feature(cell_update)]
 #![feature(float_gamma)]
 #![feature(float_erf)]
 #![feature(map_try_insert)]


### PR DESCRIPTION
Included API:

```rust
impl<T: Copy> Cell<T> {
    pub fn update(&self, f: impl FnOnce(T) -> T);
}
```

FCP completed once at https://github.com/rust-lang/rust/issues/50186#issuecomment-2198783432 but the signature has since changed.

Closes: https://github.com/rust-lang/rust/issues/50186