### PR TITLE
Add reference annotations for the `coverage` attribute

### DIFF
--- a/tests/coverage/attr/impl.cov-map
+++ b/tests/coverage/attr/impl.cov-map
@@ -1,27 +1,27 @@
 Function name: <impl::MyStruct>::off_on (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 0d, 05, 00, 13]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 0e, 05, 00, 13]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 13, 5) to (start + 0, 19)
+- Code(Zero) at (prev + 14, 5) to (start + 0, 19)
 Highest counter ID seen: (none)
 
 Function name: <impl::MyStruct>::on_inherit (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 15, 05, 00, 17]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 16, 05, 00, 17]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 21, 5) to (start + 0, 23)
+- Code(Zero) at (prev + 22, 5) to (start + 0, 23)
 Highest counter ID seen: (none)
 
 Function name: <impl::MyStruct>::on_on (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 18, 05, 00, 12]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 19, 05, 00, 12]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 24, 5) to (start + 0, 18)
+- Code(Zero) at (prev + 25, 5) to (start + 0, 18)
 Highest counter ID seen: (none)
 

--- a/tests/coverage/attr/impl.coverage
+++ b/tests/coverage/attr/impl.coverage
@@ -1,4 +1,5 @@
    LL|       |//@ edition: 2021
+   LL|       |//@ reference: attributes.coverage.nesting
    LL|       |
    LL|       |// Checks that `#[coverage(..)]` can be applied to impl and impl-trait blocks,
    LL|       |// and is inherited by any enclosed functions.

--- a/tests/coverage/attr/impl.rs
+++ b/tests/coverage/attr/impl.rs
@@ -1,4 +1,5 @@
 //@ edition: 2021
+//@ reference: attributes.coverage.nesting
 
 // Checks that `#[coverage(..)]` can be applied to impl and impl-trait blocks,
 // and is inherited by any enclosed functions.

--- a/tests/coverage/attr/module.cov-map
+++ b/tests/coverage/attr/module.cov-map
@@ -1,27 +1,27 @@
 Function name: module::off::on (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 0b, 05, 00, 0f]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 0c, 05, 00, 0f]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 11, 5) to (start + 0, 15)
+- Code(Zero) at (prev + 12, 5) to (start + 0, 15)
 Highest counter ID seen: (none)
 
 Function name: module::on::inherit (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 13, 05, 00, 14]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 14, 05, 00, 14]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 19, 5) to (start + 0, 20)
+- Code(Zero) at (prev + 20, 5) to (start + 0, 20)
 Highest counter ID seen: (none)
 
 Function name: module::on::on (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 16, 05, 00, 0f]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 17, 05, 00, 0f]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 22, 5) to (start + 0, 15)
+- Code(Zero) at (prev + 23, 5) to (start + 0, 15)
 Highest counter ID seen: (none)
 

--- a/tests/coverage/attr/module.coverage
+++ b/tests/coverage/attr/module.coverage
@@ -1,4 +1,5 @@
    LL|       |//@ edition: 2021
+   LL|       |//@ reference: attributes.coverage.nesting
    LL|       |
    LL|       |// Checks that `#[coverage(..)]` can be applied to modules, and is inherited
    LL|       |// by any enclosed functions.

--- a/tests/coverage/attr/module.rs
+++ b/tests/coverage/attr/module.rs
@@ -1,4 +1,5 @@
 //@ edition: 2021
+//@ reference: attributes.coverage.nesting
 
 // Checks that `#[coverage(..)]` can be applied to modules, and is inherited
 // by any enclosed functions.

--- a/tests/coverage/attr/nested.cov-map
+++ b/tests/coverage/attr/nested.cov-map
@@ -1,20 +1,20 @@
 Function name: nested::closure_expr
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 3f, 01, 01, 0f, 01, 0b, 05, 01, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 40, 01, 01, 0f, 01, 0b, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 63, 1) to (start + 1, 15)
+- Code(Counter(0)) at (prev + 64, 1) to (start + 1, 15)
 - Code(Counter(0)) at (prev + 11, 5) to (start + 1, 2)
 Highest counter ID seen: c0
 
 Function name: nested::closure_tail
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 4e, 01, 01, 0f, 01, 11, 05, 01, 02]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 4f, 01, 01, 0f, 01, 11, 05, 01, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 78, 1) to (start + 1, 15)
+- Code(Counter(0)) at (prev + 79, 1) to (start + 1, 15)
 - Code(Counter(0)) at (prev + 17, 5) to (start + 1, 2)
 Highest counter ID seen: c0
 

--- a/tests/coverage/attr/nested.coverage
+++ b/tests/coverage/attr/nested.coverage
@@ -1,5 +1,6 @@
    LL|       |#![feature(stmt_expr_attributes)]
    LL|       |//@ edition: 2021
+   LL|       |//@ reference: attributes.coverage.nesting
    LL|       |
    LL|       |// Demonstrates the interaction between #[coverage(off)] and various kinds of
    LL|       |// nested function.

--- a/tests/coverage/attr/nested.rs
+++ b/tests/coverage/attr/nested.rs
@@ -1,5 +1,6 @@
 #![feature(stmt_expr_attributes)]
 //@ edition: 2021
+//@ reference: attributes.coverage.nesting
 
 // Demonstrates the interaction between #[coverage(off)] and various kinds of
 // nested function.

--- a/tests/coverage/attr/off-on-sandwich.cov-map
+++ b/tests/coverage/attr/off-on-sandwich.cov-map
@@ -1,30 +1,30 @@
 Function name: off_on_sandwich::dense_a::dense_b
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 0e, 05, 02, 12, 01, 07, 05, 00, 06]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 0f, 05, 02, 12, 01, 07, 05, 00, 06]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 14, 5) to (start + 2, 18)
+- Code(Counter(0)) at (prev + 15, 5) to (start + 2, 18)
 - Code(Counter(0)) at (prev + 7, 5) to (start + 0, 6)
 Highest counter ID seen: c0
 
 Function name: off_on_sandwich::sparse_a::sparse_b::sparse_c
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 20, 09, 02, 17, 01, 0b, 09, 00, 0a]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 21, 09, 02, 17, 01, 0b, 09, 00, 0a]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 32, 9) to (start + 2, 23)
+- Code(Counter(0)) at (prev + 33, 9) to (start + 2, 23)
 - Code(Counter(0)) at (prev + 11, 9) to (start + 0, 10)
 Highest counter ID seen: c0
 
 Function name: off_on_sandwich::sparse_a::sparse_b::sparse_c::sparse_d
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 23, 0d, 02, 1b, 01, 07, 0d, 00, 0e]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 24, 0d, 02, 1b, 01, 07, 0d, 00, 0e]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 35, 13) to (start + 2, 27)
+- Code(Counter(0)) at (prev + 36, 13) to (start + 2, 27)
 - Code(Counter(0)) at (prev + 7, 13) to (start + 0, 14)
 Highest counter ID seen: c0
 

--- a/tests/coverage/attr/off-on-sandwich.coverage
+++ b/tests/coverage/attr/off-on-sandwich.coverage
@@ -1,4 +1,5 @@
    LL|       |//@ edition: 2021
+   LL|       |//@ reference: attributes.coverage.nesting
    LL|       |
    LL|       |// Demonstrates the interaction of `#[coverage(off)]` and `#[coverage(on)]`
    LL|       |// in nested functions.

--- a/tests/coverage/attr/off-on-sandwich.rs
+++ b/tests/coverage/attr/off-on-sandwich.rs
@@ -1,4 +1,5 @@
 //@ edition: 2021
+//@ reference: attributes.coverage.nesting
 
 // Demonstrates the interaction of `#[coverage(off)]` and `#[coverage(on)]`
 // in nested functions.

--- a/tests/coverage/no_cov_crate.cov-map
+++ b/tests/coverage/no_cov_crate.cov-map
@@ -1,67 +1,67 @@
 Function name: no_cov_crate::add_coverage_1
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 13, 01, 02, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 15, 01, 02, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 19, 1) to (start + 2, 2)
+- Code(Counter(0)) at (prev + 21, 1) to (start + 2, 2)
 Highest counter ID seen: c0
 
 Function name: no_cov_crate::add_coverage_2
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 17, 01, 02, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 19, 01, 02, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 23, 1) to (start + 2, 2)
+- Code(Counter(0)) at (prev + 25, 1) to (start + 2, 2)
 Highest counter ID seen: c0
 
 Function name: no_cov_crate::add_coverage_not_called (unused)
-Raw bytes (9): 0x[01, 01, 00, 01, 00, 1c, 01, 02, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 00, 1e, 01, 02, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Zero) at (prev + 28, 1) to (start + 2, 2)
+- Code(Zero) at (prev + 30, 1) to (start + 2, 2)
 Highest counter ID seen: (none)
 
 Function name: no_cov_crate::main
-Raw bytes (9): 0x[01, 01, 00, 01, 01, 4c, 01, 0b, 02]
+Raw bytes (9): 0x[01, 01, 00, 01, 01, 4e, 01, 0b, 02]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 1
-- Code(Counter(0)) at (prev + 76, 1) to (start + 11, 2)
+- Code(Counter(0)) at (prev + 78, 1) to (start + 11, 2)
 Highest counter ID seen: c0
 
 Function name: no_cov_crate::nested_fns::outer
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 30, 05, 02, 23, 01, 0c, 05, 00, 06]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 32, 05, 02, 23, 01, 0c, 05, 00, 06]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 48, 5) to (start + 2, 35)
+- Code(Counter(0)) at (prev + 50, 5) to (start + 2, 35)
 - Code(Counter(0)) at (prev + 12, 5) to (start + 0, 6)
 Highest counter ID seen: c0
 
 Function name: no_cov_crate::nested_fns::outer_both_covered
-Raw bytes (14): 0x[01, 01, 00, 02, 01, 3e, 05, 02, 17, 01, 0b, 05, 00, 06]
+Raw bytes (14): 0x[01, 01, 00, 02, 01, 40, 05, 02, 17, 01, 0b, 05, 00, 06]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 0
 Number of file 0 mappings: 2
-- Code(Counter(0)) at (prev + 62, 5) to (start + 2, 23)
+- Code(Counter(0)) at (prev + 64, 5) to (start + 2, 23)
 - Code(Counter(0)) at (prev + 11, 5) to (start + 0, 6)
 Highest counter ID seen: c0
 
 Function name: no_cov_crate::nested_fns::outer_both_covered::inner
-Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 42, 09, 01, 17, 05, 01, 18, 02, 0e, 02, 02, 14, 02, 0e, 01, 03, 09, 00, 0a]
+Raw bytes (26): 0x[01, 01, 01, 01, 05, 04, 01, 44, 09, 01, 17, 05, 01, 18, 02, 0e, 02, 02, 14, 02, 0e, 01, 03, 09, 00, 0a]
 Number of files: 1
 - file 0 => global file 1
 Number of expressions: 1
 - expression 0 operands: lhs = Counter(0), rhs = Counter(1)
 Number of file 0 mappings: 4
-- Code(Counter(0)) at (prev + 66, 9) to (start + 1, 23)
+- Code(Counter(0)) at (prev + 68, 9) to (start + 1, 23)
 - Code(Counter(1)) at (prev + 1, 24) to (start + 2, 14)
 - Code(Expression(0, Sub)) at (prev + 2, 20) to (start + 2, 14)
     = (c0 - c1)

--- a/tests/coverage/no_cov_crate.coverage
+++ b/tests/coverage/no_cov_crate.coverage
@@ -1,4 +1,6 @@
    LL|       |// Enables `coverage(off)` on the entire crate
+   LL|       |//@ reference: attributes.coverage.intro
+   LL|       |//@ reference: attributes.coverage.nesting
    LL|       |
    LL|       |#[coverage(off)]
    LL|       |fn do_not_add_coverage_1() {

--- a/tests/coverage/no_cov_crate.rs
+++ b/tests/coverage/no_cov_crate.rs
@@ -1,4 +1,6 @@
 // Enables `coverage(off)` on the entire crate
+//@ reference: attributes.coverage.intro
+//@ reference: attributes.coverage.nesting
 
 #[coverage(off)]
 fn do_not_add_coverage_1() {

--- a/tests/ui/coverage-attr/bad-attr-ice.rs
+++ b/tests/ui/coverage-attr/bad-attr-ice.rs
@@ -1,5 +1,6 @@
 //@ compile-flags: -Cinstrument-coverage
 //@ needs-profiler-runtime
+//@ reference: attributes.coverage.syntax
 
 // Malformed `#[coverage(..)]` attributes should not cause an ICE when built
 // with `-Cinstrument-coverage`.

--- a/tests/ui/coverage-attr/bad-attr-ice.stderr
+++ b/tests/ui/coverage-attr/bad-attr-ice.stderr
@@ -1,5 +1,5 @@
 error: malformed `coverage` attribute input
-  --> $DIR/bad-attr-ice.rs:8:1
+  --> $DIR/bad-attr-ice.rs:9:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^

--- a/tests/ui/coverage-attr/bad-syntax.rs
+++ b/tests/ui/coverage-attr/bad-syntax.rs
@@ -1,4 +1,6 @@
 //@ edition: 2021
+//@ reference: attributes.coverage.syntax
+//@ reference: attributes.coverage.duplicates
 
 // Tests the error messages produced (or not produced) by various unusual
 // uses of the `#[coverage(..)]` attribute.

--- a/tests/ui/coverage-attr/bad-syntax.stderr
+++ b/tests/ui/coverage-attr/bad-syntax.stderr
@@ -1,5 +1,5 @@
 error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:14:1
+  --> $DIR/bad-syntax.rs:16:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL | #[coverage(on)]
    | ~~~~~~~~~~~~~~~
 
 error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:17:1
+  --> $DIR/bad-syntax.rs:19:1
    |
 LL | #[coverage = true]
    | ^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL | #[coverage(on)]
    | ~~~~~~~~~~~~~~~
 
 error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:20:1
+  --> $DIR/bad-syntax.rs:22:1
    |
 LL | #[coverage()]
    | ^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL | #[coverage(on)]
    | ~~~~~~~~~~~~~~~
 
 error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:23:1
+  --> $DIR/bad-syntax.rs:25:1
    |
 LL | #[coverage(off, off)]
    | ^^^^^^^^^^^^^^^^^^^^^
@@ -51,7 +51,7 @@ LL | #[coverage(on)]
    | ~~~~~~~~~~~~~~~
 
 error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:26:1
+  --> $DIR/bad-syntax.rs:28:1
    |
 LL | #[coverage(off, on)]
    | ^^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL | #[coverage(on)]
    | ~~~~~~~~~~~~~~~
 
 error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:29:1
+  --> $DIR/bad-syntax.rs:31:1
    |
 LL | #[coverage(bogus)]
    | ^^^^^^^^^^^^^^^^^^
@@ -77,7 +77,7 @@ LL | #[coverage(on)]
    | ~~~~~~~~~~~~~~~
 
 error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:32:1
+  --> $DIR/bad-syntax.rs:34:1
    |
 LL | #[coverage(bogus, off)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL | #[coverage(on)]
    | ~~~~~~~~~~~~~~~
 
 error: malformed `coverage` attribute input
-  --> $DIR/bad-syntax.rs:35:1
+  --> $DIR/bad-syntax.rs:37:1
    |
 LL | #[coverage(off, bogus)]
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -103,7 +103,7 @@ LL | #[coverage(on)]
    | ~~~~~~~~~~~~~~~
 
 error: expected identifier, found `,`
-  --> $DIR/bad-syntax.rs:41:12
+  --> $DIR/bad-syntax.rs:43:12
    |
 LL | #[coverage(,off)]
    |            ^ expected identifier
@@ -115,25 +115,25 @@ LL + #[coverage(off)]
    |
 
 error: multiple `coverage` attributes
-  --> $DIR/bad-syntax.rs:6:1
+  --> $DIR/bad-syntax.rs:8:1
    |
 LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/bad-syntax.rs:7:1
+  --> $DIR/bad-syntax.rs:9:1
    |
 LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^
 
 error: multiple `coverage` attributes
-  --> $DIR/bad-syntax.rs:10:1
+  --> $DIR/bad-syntax.rs:12:1
    |
 LL | #[coverage(off)]
    | ^^^^^^^^^^^^^^^^ help: remove this attribute
    |
 note: attribute also specified here
-  --> $DIR/bad-syntax.rs:11:1
+  --> $DIR/bad-syntax.rs:13:1
    |
 LL | #[coverage(on)]
    | ^^^^^^^^^^^^^^^

--- a/tests/ui/coverage-attr/name-value.rs
+++ b/tests/ui/coverage-attr/name-value.rs
@@ -1,4 +1,5 @@
 //@ edition: 2021
+//@ reference: attributes.coverage.syntax
 
 // Demonstrates the diagnostics produced when using the syntax
 // `#[coverage = "off"]`, which should not be allowed.

--- a/tests/ui/coverage-attr/name-value.stderr
+++ b/tests/ui/coverage-attr/name-value.stderr
@@ -1,5 +1,5 @@
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:10:1
+  --> $DIR/name-value.rs:11:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:15:5
+  --> $DIR/name-value.rs:16:5
    |
 LL |     #![coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     #![coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:19:1
+  --> $DIR/name-value.rs:20:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:27:5
+  --> $DIR/name-value.rs:28:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -51,7 +51,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:24:1
+  --> $DIR/name-value.rs:25:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:37:5
+  --> $DIR/name-value.rs:38:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -77,7 +77,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:42:5
+  --> $DIR/name-value.rs:43:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:33:1
+  --> $DIR/name-value.rs:34:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -103,7 +103,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:51:5
+  --> $DIR/name-value.rs:52:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -116,7 +116,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:56:5
+  --> $DIR/name-value.rs:57:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -129,7 +129,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:48:1
+  --> $DIR/name-value.rs:49:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -142,7 +142,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/name-value.rs:62:1
+  --> $DIR/name-value.rs:63:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -155,7 +155,7 @@ LL | #[coverage(on)]
    |
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:19:1
+  --> $DIR/name-value.rs:20:1
    |
 LL | #[coverage = "off"]
    | ^^^^^^^^^^^^^^^^^^^
@@ -164,7 +164,7 @@ LL | struct MyStruct;
    | ---------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:33:1
+  --> $DIR/name-value.rs:34:1
    |
 LL |   #[coverage = "off"]
    |   ^^^^^^^^^^^^^^^^^^^
@@ -177,7 +177,7 @@ LL | | }
    | |_- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:37:5
+  --> $DIR/name-value.rs:38:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -186,7 +186,7 @@ LL |     const X: u32;
    |     ------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:42:5
+  --> $DIR/name-value.rs:43:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -195,7 +195,7 @@ LL |     type T;
    |     ------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:27:5
+  --> $DIR/name-value.rs:28:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -204,7 +204,7 @@ LL |     const X: u32 = 7;
    |     ----------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:51:5
+  --> $DIR/name-value.rs:52:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^
@@ -213,7 +213,7 @@ LL |     const X: u32 = 8;
    |     ----------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/name-value.rs:56:5
+  --> $DIR/name-value.rs:57:5
    |
 LL |     #[coverage = "off"]
    |     ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/coverage-attr/no-coverage.rs
+++ b/tests/ui/coverage-attr/no-coverage.rs
@@ -1,3 +1,5 @@
+//@ reference: attributes.coverage.allowed-positions
+
 #![feature(extern_types)]
 #![feature(impl_trait_in_assoc_type)]
 #![warn(unused_attributes)]

--- a/tests/ui/coverage-attr/no-coverage.stderr
+++ b/tests/ui/coverage-attr/no-coverage.stderr
@@ -1,5 +1,5 @@
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/no-coverage.rs:6:1
+  --> $DIR/no-coverage.rs:8:1
    |
 LL |   #[coverage(off)]
    |   ^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL | | }
    | |_- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/no-coverage.rs:38:5
+  --> $DIR/no-coverage.rs:40:5
    |
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
@@ -20,7 +20,7 @@ LL |     let _ = ();
    |     ----------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/no-coverage.rs:42:9
+  --> $DIR/no-coverage.rs:44:9
    |
 LL |         #[coverage(off)]
    |         ^^^^^^^^^^^^^^^^
@@ -28,7 +28,7 @@ LL |         () => (),
    |         -------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/no-coverage.rs:46:5
+  --> $DIR/no-coverage.rs:48:5
    |
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
@@ -36,7 +36,7 @@ LL |     return ();
    |     --------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/no-coverage.rs:8:5
+  --> $DIR/no-coverage.rs:10:5
    |
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
@@ -44,7 +44,7 @@ LL |     const X: u32;
    |     ------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/no-coverage.rs:11:5
+  --> $DIR/no-coverage.rs:13:5
    |
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
@@ -52,7 +52,7 @@ LL |     type T;
    |     ------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/no-coverage.rs:21:5
+  --> $DIR/no-coverage.rs:23:5
    |
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
@@ -60,7 +60,7 @@ LL |     type T = Self;
    |     -------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/no-coverage.rs:24:5
+  --> $DIR/no-coverage.rs:26:5
    |
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
@@ -68,7 +68,7 @@ LL |     type U = impl Trait;
    |     -------------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/no-coverage.rs:29:5
+  --> $DIR/no-coverage.rs:31:5
    |
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
@@ -76,7 +76,7 @@ LL |     static X: u32;
    |     -------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/no-coverage.rs:32:5
+  --> $DIR/no-coverage.rs:34:5
    |
 LL |     #[coverage(off)]
    |     ^^^^^^^^^^^^^^^^
@@ -84,7 +84,7 @@ LL |     type T;
    |     ------- not a function or closure
 
 error: unconstrained opaque type
-  --> $DIR/no-coverage.rs:25:14
+  --> $DIR/no-coverage.rs:27:14
    |
 LL |     type U = impl Trait;
    |              ^^^^^^^^^^

--- a/tests/ui/coverage-attr/subword.rs
+++ b/tests/ui/coverage-attr/subword.rs
@@ -1,4 +1,5 @@
 //@ edition: 2021
+//@ reference: attributes.coverage.syntax
 
 // Check that yes/no in `#[coverage(yes)]` and `#[coverage(no)]` must be bare
 // words, not part of a more complicated substructure.

--- a/tests/ui/coverage-attr/subword.stderr
+++ b/tests/ui/coverage-attr/subword.stderr
@@ -1,5 +1,5 @@
 error: malformed `coverage` attribute input
-  --> $DIR/subword.rs:6:1
+  --> $DIR/subword.rs:7:1
    |
 LL | #[coverage(yes(milord))]
    | ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL | #[coverage(on)]
    | ~~~~~~~~~~~~~~~
 
 error: malformed `coverage` attribute input
-  --> $DIR/subword.rs:9:1
+  --> $DIR/subword.rs:10:1
    |
 LL | #[coverage(no(milord))]
    | ^^^^^^^^^^^^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL | #[coverage(on)]
    | ~~~~~~~~~~~~~~~
 
 error: malformed `coverage` attribute input
-  --> $DIR/subword.rs:12:1
+  --> $DIR/subword.rs:13:1
    |
 LL | #[coverage(yes = "milord")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL | #[coverage(on)]
    | ~~~~~~~~~~~~~~~
 
 error: malformed `coverage` attribute input
-  --> $DIR/subword.rs:15:1
+  --> $DIR/subword.rs:16:1
    |
 LL | #[coverage(no = "milord")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/coverage-attr/word-only.rs
+++ b/tests/ui/coverage-attr/word-only.rs
@@ -1,4 +1,5 @@
 //@ edition: 2021
+//@ reference: attributes.coverage.syntax
 
 // Demonstrates the diagnostics produced when using the syntax `#[coverage]`,
 // which should not be allowed.

--- a/tests/ui/coverage-attr/word-only.stderr
+++ b/tests/ui/coverage-attr/word-only.stderr
@@ -1,5 +1,5 @@
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:10:1
+  --> $DIR/word-only.rs:11:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -12,7 +12,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:15:5
+  --> $DIR/word-only.rs:16:5
    |
 LL |     #![coverage]
    |     ^^^^^^^^^^^^
@@ -25,7 +25,7 @@ LL |     #![coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:19:1
+  --> $DIR/word-only.rs:20:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -38,7 +38,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:27:5
+  --> $DIR/word-only.rs:28:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -51,7 +51,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:24:1
+  --> $DIR/word-only.rs:25:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -64,7 +64,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:37:5
+  --> $DIR/word-only.rs:38:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -77,7 +77,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:42:5
+  --> $DIR/word-only.rs:43:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -90,7 +90,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:33:1
+  --> $DIR/word-only.rs:34:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -103,7 +103,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:51:5
+  --> $DIR/word-only.rs:52:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -116,7 +116,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:56:5
+  --> $DIR/word-only.rs:57:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -129,7 +129,7 @@ LL |     #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:48:1
+  --> $DIR/word-only.rs:49:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -142,7 +142,7 @@ LL | #[coverage(on)]
    |
 
 error: malformed `coverage` attribute input
-  --> $DIR/word-only.rs:62:1
+  --> $DIR/word-only.rs:63:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -155,7 +155,7 @@ LL | #[coverage(on)]
    |
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:19:1
+  --> $DIR/word-only.rs:20:1
    |
 LL | #[coverage]
    | ^^^^^^^^^^^
@@ -164,7 +164,7 @@ LL | struct MyStruct;
    | ---------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:33:1
+  --> $DIR/word-only.rs:34:1
    |
 LL |   #[coverage]
    |   ^^^^^^^^^^^
@@ -177,7 +177,7 @@ LL | | }
    | |_- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:37:5
+  --> $DIR/word-only.rs:38:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -186,7 +186,7 @@ LL |     const X: u32;
    |     ------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:42:5
+  --> $DIR/word-only.rs:43:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -195,7 +195,7 @@ LL |     type T;
    |     ------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:27:5
+  --> $DIR/word-only.rs:28:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -204,7 +204,7 @@ LL |     const X: u32 = 7;
    |     ----------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:51:5
+  --> $DIR/word-only.rs:52:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^
@@ -213,7 +213,7 @@ LL |     const X: u32 = 8;
    |     ----------------- not a function or closure
 
 error[E0788]: attribute should be applied to a function definition or closure
-  --> $DIR/word-only.rs:56:5
+  --> $DIR/word-only.rs:57:5
    |
 LL |     #[coverage]
    |     ^^^^^^^^^^^


### PR DESCRIPTION
This adds reference annotations for the `coverage` attribute.