### PR TITLE
Always run `tail_expr_drop_order` lint in promoted MIR query

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -437,6 +437,8 @@ fn mir_promoted(
         Some(MirPhase::Analysis(AnalysisPhase::Initial)),
     );
 
+    lint_tail_expr_drop_order::run_lint(tcx, def, &body);
+
     let promoted = promote_pass.promoted_fragments.into_inner();
     (tcx.alloc_steal_mir(body), tcx.alloc_steal_promoted(promoted))
 }
@@ -492,7 +494,6 @@ fn mir_drops_elaborated_and_const_checked(tcx: TyCtxt<'_>, def: LocalDefId) -> &
     }
 
     let (body, _) = tcx.mir_promoted(def);
-    lint_tail_expr_drop_order::run_lint(tcx, def, &body.borrow());
     let mut body = body.steal();
 
     if let Some(error_reported) = tainted_by_errors {

--- a/tests/ui/drop/lint-tail-expr-drop-order.rs
+++ b/tests/ui/drop/lint-tail-expr-drop-order.rs
@@ -2,7 +2,6 @@
 // This lint is to capture potential change in program semantics
 // due to implementation of RFC 3606 <https://github.com/rust-lang/rfcs/pull/3606>
 //@ edition: 2021
-//@ build-fail
 
 #![deny(tail_expr_drop_order)] //~ NOTE: the lint level is defined here
 #![allow(dropping_copy_types)]

--- a/tests/ui/drop/lint-tail-expr-drop-order.stderr
+++ b/tests/ui/drop/lint-tail-expr-drop-order.stderr
@@ -1,5 +1,5 @@
 error: relative drop order changing in Rust 2024
-  --> $DIR/lint-tail-expr-drop-order.rs:42:15
+  --> $DIR/lint-tail-expr-drop-order.rs:41:15
    |
 LL |     let x = LoudDropper;
    |         -
@@ -19,14 +19,14 @@ LL | }
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:11:1
+  --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
 LL | / impl Drop for LoudDropper {
 ...  |
 LL | | }
    | |_^
 note: `x` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:11:1
+  --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
 LL | / impl Drop for LoudDropper {
 ...  |
@@ -34,13 +34,13 @@ LL | | }
    | |_^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 note: the lint level is defined here
-  --> $DIR/lint-tail-expr-drop-order.rs:7:9
+  --> $DIR/lint-tail-expr-drop-order.rs:6:9
    |
 LL | #![deny(tail_expr_drop_order)]
    |         ^^^^^^^^^^^^^^^^^^^^
 
 error: relative drop order changing in Rust 2024
-  --> $DIR/lint-tail-expr-drop-order.rs:67:19
+  --> $DIR/lint-tail-expr-drop-order.rs:66:19
    |
 LL |         let x = LoudDropper;
    |             -
@@ -60,14 +60,14 @@ LL |     }
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:11:1
+  --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
 LL | / impl Drop for LoudDropper {
 ...  |
 LL | | }
    | |_^
 note: `x` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:11:1
+  --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
 LL | / impl Drop for LoudDropper {
 ...  |
@@ -76,7 +76,7 @@ LL | | }
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
-  --> $DIR/lint-tail-expr-drop-order.rs:94:7
+  --> $DIR/lint-tail-expr-drop-order.rs:93:7
    |
 LL |     let x = LoudDropper;
    |         -
@@ -96,14 +96,14 @@ LL | }
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:11:1
+  --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
 LL | / impl Drop for LoudDropper {
 ...  |
 LL | | }
    | |_^
 note: `x` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:11:1
+  --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
 LL | / impl Drop for LoudDropper {
 ...  |
@@ -112,7 +112,7 @@ LL | | }
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
-  --> $DIR/lint-tail-expr-drop-order.rs:147:5
+  --> $DIR/lint-tail-expr-drop-order.rs:146:5
    |
 LL |     let future = f();
    |         ------
@@ -132,14 +132,14 @@ LL | }
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:11:1
+  --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
 LL | / impl Drop for LoudDropper {
 ...  |
 LL | | }
    | |_^
 note: `future` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:11:1
+  --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
 LL | / impl Drop for LoudDropper {
 ...  |
@@ -148,7 +148,7 @@ LL | | }
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
-  --> $DIR/lint-tail-expr-drop-order.rs:164:14
+  --> $DIR/lint-tail-expr-drop-order.rs:163:14
    |
 LL |     let x = T::default();
    |         -
@@ -170,7 +170,7 @@ LL | }
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
-  --> $DIR/lint-tail-expr-drop-order.rs:178:5
+  --> $DIR/lint-tail-expr-drop-order.rs:177:5
    |
 LL |     let x: Result<LoudDropper, ()> = Ok(LoudDropper);
    |         -
@@ -190,14 +190,14 @@ LL | }
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:11:1
+  --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
 LL | / impl Drop for LoudDropper {
 ...  |
 LL | | }
    | |_^
 note: `x` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:11:1
+  --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
 LL | / impl Drop for LoudDropper {
 ...  |
@@ -206,7 +206,7 @@ LL | | }
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
-  --> $DIR/lint-tail-expr-drop-order.rs:222:5
+  --> $DIR/lint-tail-expr-drop-order.rs:221:5
    |
 LL |     let x = LoudDropper2;
    |         -
@@ -226,7 +226,7 @@ LL | }
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:195:5
+  --> $DIR/lint-tail-expr-drop-order.rs:194:5
    |
 LL | /     impl Drop for LoudDropper3 {
 LL | |
@@ -236,7 +236,7 @@ LL | |         }
 LL | |     }
    | |_____^
 note: `x` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:207:5
+  --> $DIR/lint-tail-expr-drop-order.rs:206:5
    |
 LL | /     impl Drop for LoudDropper2 {
 LL | |
@@ -248,7 +248,7 @@ LL | |     }
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 
 error: relative drop order changing in Rust 2024
-  --> $DIR/lint-tail-expr-drop-order.rs:235:13
+  --> $DIR/lint-tail-expr-drop-order.rs:234:13
    |
 LL |             LoudDropper.get()
    |             ^^^^^^^^^^^
@@ -268,14 +268,14 @@ LL |     ));
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#1` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:11:1
+  --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
 LL | / impl Drop for LoudDropper {
 ...  |
 LL | | }
    | |_^
 note: `_x` invokes this custom destructor
-  --> $DIR/lint-tail-expr-drop-order.rs:11:1
+  --> $DIR/lint-tail-expr-drop-order.rs:10:1
    |
 LL | / impl Drop for LoudDropper {
 ...  |

--- a/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.rs
+++ b/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.rs
@@ -1,5 +1,4 @@
 //@ edition: 2021
-//@ build-fail
 
 // Make sure we don't ICE when emitting the "lint" drop statement
 // used for tail_expr_drop_order.

--- a/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
+++ b/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
@@ -1,5 +1,5 @@
 error: relative drop order changing in Rust 2024
-  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:20:15
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:19:15
    |
 LL |         match func().await {
    |               ^^^^^^^-----
@@ -21,21 +21,21 @@ LL |     }
    = warning: this changes meaning in Rust 2024
    = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
 note: `#2` invokes this custom destructor
-  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:10:1
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |
 LL | / impl std::ops::Drop for Drop {
 LL | |     fn drop(&mut self) {}
 LL | | }
    | |_^
 note: `#1` invokes this custom destructor
-  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:10:1
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |
 LL | / impl std::ops::Drop for Drop {
 LL | |     fn drop(&mut self) {}
 LL | | }
    | |_^
 note: `e` invokes this custom destructor
-  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:10:1
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:9:1
    |
 LL | / impl std::ops::Drop for Drop {
 LL | |     fn drop(&mut self) {}
@@ -43,7 +43,7 @@ LL | | }
    | |_^
    = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
 note: the lint level is defined here
-  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:7:9
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:6:9
    |
 LL | #![deny(tail_expr_drop_order)]
    |         ^^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/error-codes/E0452.rs
+++ b/tests/ui/error-codes/E0452.rs
@@ -2,5 +2,7 @@
                     //~| ERROR E0452
                     //~| ERROR E0452
                     //~| ERROR E0452
+                    //~| ERROR E0452
+                    //~| ERROR E0452
 fn main() {
 }

--- a/tests/ui/error-codes/E0452.stderr
+++ b/tests/ui/error-codes/E0452.stderr
@@ -28,6 +28,22 @@ LL | #![allow(foo = "")]
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 4 previous errors
+error[E0452]: malformed lint attribute input
+  --> $DIR/E0452.rs:1:10
+   |
+LL | #![allow(foo = "")]
+   |          ^^^^^^^^ bad attribute argument
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0452]: malformed lint attribute input
+  --> $DIR/E0452.rs:1:10
+   |
+LL | #![allow(foo = "")]
+   |          ^^^^^^^^ bad attribute argument
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0452`.

--- a/tests/ui/lint/command-line-register-unknown-lint-tool.stderr
+++ b/tests/ui/lint/command-line-register-unknown-lint-tool.stderr
@@ -7,6 +7,11 @@ error[E0602]: unknown lint tool: `unknown_tool`
    = note: requested on the command line with `-A unknown_tool::foo`
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error[E0602]: unknown lint tool: `unknown_tool`
+   |
+   = note: requested on the command line with `-A unknown_tool::foo`
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0602`.

--- a/tests/ui/lint/force-warn/warnings-lint-group.stderr
+++ b/tests/ui/lint/force-warn/warnings-lint-group.stderr
@@ -4,6 +4,10 @@ error[E0602]: `warnings` lint group is not supported with ´--force-warn´
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 2 previous errors
+error[E0602]: `warnings` lint group is not supported with ´--force-warn´
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0602`.

--- a/tests/ui/lint/lint-malformed.rs
+++ b/tests/ui/lint/lint-malformed.rs
@@ -3,4 +3,6 @@
                        //~| ERROR malformed lint attribute
                        //~| ERROR malformed lint attribute
                        //~| ERROR malformed lint attribute
+                       //~| ERROR malformed lint attribute
+                       //~| ERROR malformed lint attribute
 fn main() { }

--- a/tests/ui/lint/lint-malformed.stderr
+++ b/tests/ui/lint/lint-malformed.stderr
@@ -34,6 +34,22 @@ LL | #![allow(bar = "baz")]
    |
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 5 previous errors
+error[E0452]: malformed lint attribute input
+  --> $DIR/lint-malformed.rs:2:10
+   |
+LL | #![allow(bar = "baz")]
+   |          ^^^^^^^^^^^ bad attribute argument
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error[E0452]: malformed lint attribute input
+  --> $DIR/lint-malformed.rs:2:10
+   |
+LL | #![allow(bar = "baz")]
+   |          ^^^^^^^^^^^ bad attribute argument
+   |
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 7 previous errors
 
 For more information about this error, try `rustc --explain E0452`.

--- a/tests/ui/tool-attributes/unknown-lint-tool-name.rs
+++ b/tests/ui/tool-attributes/unknown-lint-tool-name.rs
@@ -1,5 +1,6 @@
 #![deny(foo::bar)] //~ ERROR unknown tool name `foo` found in scoped lint: `foo::bar`
                    //~| ERROR unknown tool name `foo` found in scoped lint: `foo::bar`
+                   //~| ERROR unknown tool name `foo` found in scoped lint: `foo::bar`
 
 #[allow(foo::bar)] //~ ERROR unknown tool name `foo` found in scoped lint: `foo::bar`
                    //~| ERROR unknown tool name `foo` found in scoped lint: `foo::bar`

--- a/tests/ui/tool-attributes/unknown-lint-tool-name.stderr
+++ b/tests/ui/tool-attributes/unknown-lint-tool-name.stderr
@@ -7,7 +7,7 @@ LL | #![deny(foo::bar)]
    = help: add `#![register_tool(foo)]` to the crate root
 
 error[E0710]: unknown tool name `foo` found in scoped lint: `foo::bar`
-  --> $DIR/unknown-lint-tool-name.rs:4:9
+  --> $DIR/unknown-lint-tool-name.rs:5:9
    |
 LL | #[allow(foo::bar)]
    |         ^^^
@@ -24,7 +24,7 @@ LL | #![deny(foo::bar)]
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
 error[E0710]: unknown tool name `foo` found in scoped lint: `foo::bar`
-  --> $DIR/unknown-lint-tool-name.rs:4:9
+  --> $DIR/unknown-lint-tool-name.rs:5:9
    |
 LL | #[allow(foo::bar)]
    |         ^^^
@@ -32,6 +32,15 @@ LL | #[allow(foo::bar)]
    = help: add `#![register_tool(foo)]` to the crate root
    = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
 
-error: aborting due to 4 previous errors
+error[E0710]: unknown tool name `foo` found in scoped lint: `foo::bar`
+  --> $DIR/unknown-lint-tool-name.rs:1:9
+   |
+LL | #![deny(foo::bar)]
+   |         ^^^
+   |
+   = help: add `#![register_tool(foo)]` to the crate root
+   = note: duplicate diagnostic emitted due to `-Z deduplicate-diagnostics=no`
+
+error: aborting due to 5 previous errors
 
 For more information about this error, try `rustc --explain E0710`.


### PR DESCRIPTION
Rather than running the lint at the beginning of `mir_drops_elaborated_and_const_checked`, run it at the end of `mir_promoted`.  This should ensure that the lint gets picked up when running `cargo fix`, which runs with `--emit metadata` and therefore doesn't actually query `mir_drops_elaborated_and_const_checked`.

We could probably push this down into `mir_built` too? but I don't really see a good reason to do so.

https://github.com/rust-lang/rust/issues/132861#issuecomment-2539960199

cc @ehuss