### PR TITLE
Fix cycle error only occurring with -Zdump-mir

### DIFF
--- a/tests/mir-opt/building/dump_mir_cycle.rs
+++ b/tests/mir-opt/building/dump_mir_cycle.rs
@@ -1,0 +1,19 @@
+#[derive(Debug)]
+pub struct Thing {
+    pub next: &'static Thing,
+}
+
+pub static THING: Thing = Thing { next: &THING };
+// CHECK: alloc{{.+}} (static: THING)
+
+const fn thing() -> &'static Thing {
+    &MUTUALLY_RECURSIVE
+}
+
+pub static MUTUALLY_RECURSIVE: Thing = Thing { next: thing() };
+// CHECK: alloc{{.+}} (static: MUTUALLY_RECURSIVE)
+
+fn main() {
+    // Generate optimized MIR for the const fn, too.
+    thing();
+}

--- a/tests/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-pre-optimizations.after.mir
+++ b/tests/mir-opt/const_promotion_extern_static.BAR-promoted[0].SimplifyCfg-pre-optimizations.after.mir
@@ -15,6 +15,4 @@ const BAR::promoted[0]: &[&i32; 1] = {
     }
 }
 
-ALLOC0 (static: Y, size: 4, align: 4) {
-    2a 00 00 00                                     │ *...
-}
+ALLOC0 (static: Y)

--- a/tests/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
+++ b/tests/mir-opt/const_promotion_extern_static.BAR.PromoteTemps.diff
@@ -38,9 +38,7 @@
       bb2 (cleanup): {
           resume;
       }
-- }
-- 
-- ALLOC0 (static: Y, size: 4, align: 4) {
--     2a 00 00 00                                     │ *...
   }
+- 
+- ALLOC0 (static: Y)
   


### PR DESCRIPTION
fixes #134205

During mir dumping, we evaluate static items to render their allocations. If a static item refers to itself, its own MIR will have a reference to itself, so during mir dumping we end up evaluating the static again, causing us to try to build MIR again (mir dumping happens during MIR building).

Thus I disabled evaluation of statics during MIR dumps in case the MIR body isn't far enough along yet to be able to be guaranteed cycle free.