### PR TITLE
Bump compiler `cc` to 1.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,9 +405,9 @@ version = "0.1.0"
 
 [[package]]
 name = "cc"
-version = "1.2.0"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
+checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
 dependencies = [
  "shlex",
 ]

--- a/compiler/rustc_codegen_ssa/Cargo.toml
+++ b/compiler/rustc_codegen_ssa/Cargo.toml
@@ -8,8 +8,9 @@ edition = "2021"
 ar_archive_writer = "0.4.2"
 arrayvec = { version = "0.7", default-features = false }
 bitflags = "2.4.1"
-# Pinned so `cargo update` bumps don't cause breakage
-cc = "=1.2.0"
+# Pinned so `cargo update` bumps don't cause breakage. Please also update the
+# `cc` in `rustc_llvm` if you update the `cc` here.
+cc = "=1.2.5"
 either = "1.5.0"
 itertools = "0.12"
 pathdiff = "0.2.0"

--- a/compiler/rustc_llvm/Cargo.toml
+++ b/compiler/rustc_llvm/Cargo.toml
@@ -10,5 +10,7 @@ libc = "0.2.73"
 
 [build-dependencies]
 # tidy-alphabetical-start
-cc = "1.1.23"
+# Pinned so `cargo update` bumps don't cause breakage. Please also update the
+# pinned `cc` in `rustc_codegen_ssa` if you update `cc` here.
+cc = "=1.2.5"
 # tidy-alphabetical-end


### PR DESCRIPTION
- `cc` 1.2.4 contains a fix to address [rustc uses wrong build tools when compiling from MSVC #133794](https://github.com/rust-lang/rust/issues/133794). See <https://github.com/rust-lang/cc-rs/releases/tag/cc-v1.2.4>.
- `cc` 1.2.5 contains a fix to also check linking when testing if certain compiler flags are supported, which fixed an issue that was causing previous compiler `cc` bumps to fail. See <https://github.com/rust-lang/cc-rs/releases/tag/cc-v1.2.5>.

Supersedes #134419.
Fixes #133794.

r? @clubby789 
