### PR TITLE
Remove a duplicated check that doesn't do anything anymore.

### DIFF
--- a/tests/crashes/134005.rs
+++ b/tests/crashes/134005.rs
@@ -1,5 +1,0 @@
-//@ known-bug: #134005
-
-fn main() {
-    let _ = [std::ops::Add::add, std::ops::Mul::mul, main as fn(_, &_)];
-}

--- a/tests/ui/function-pointer/signature-mismatch.rs
+++ b/tests/ui/function-pointer/signature-mismatch.rs
@@ -1,0 +1,6 @@
+//! This test used to hit an assertion instead of erroring and bailing out.
+
+fn main() {
+    let _ = [std::ops::Add::add, std::ops::Mul::mul, std::ops::Mul::mul as fn(_, &_)];
+    //~^ ERROR: mismatched types
+}

--- a/tests/ui/function-pointer/signature-mismatch.stderr
+++ b/tests/ui/function-pointer/signature-mismatch.stderr
@@ -1,0 +1,12 @@
+error[E0308]: mismatched types
+  --> $DIR/signature-mismatch.rs:4:54
+   |
+LL |     let _ = [std::ops::Add::add, std::ops::Mul::mul, std::ops::Mul::mul as fn(_, &_)];
+   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other
+   |
+   = note: expected fn pointer `fn(_, _) -> _`
+              found fn pointer `for<'a> fn(_, &'a _) -> ()`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0308`.


### PR DESCRIPTION
fixes #134005

This code didn't actually `lub` the type of the previous expressions, but just the current type over and over again. Changing it to using the actual expression type does not change anything either, so may as well remove the entire loop.