### PR TITLE
[WIP] Use weak linkage instead of compiler generated shims

### DIFF
--- a/compiler/rustc_ast/src/expand/allocator.rs
+++ b/compiler/rustc_ast/src/expand/allocator.rs
@@ -11,10 +11,6 @@ pub fn global_fn_name(base: Symbol) -> String {
     format!("__rust_{base}")
 }
 
-pub fn default_fn_name(base: Symbol) -> String {
-    format!("__rdl_{base}")
-}
-
 pub const ALLOC_ERROR_HANDLER: &str = "__rust_alloc_error_handler";
 pub const ALLOC_ERROR_HANDLER_DEFAULT: &str = "__rdl_oom";
 pub const NO_ALLOC_SHIM_IS_UNSTABLE: &str = "__rust_no_alloc_shim_is_unstable_v2";

--- a/compiler/rustc_ast/src/expand/allocator.rs
+++ b/compiler/rustc_ast/src/expand/allocator.rs
@@ -15,14 +15,8 @@ pub fn default_fn_name(base: Symbol) -> String {
     format!("__rdl_{base}")
 }
 
-pub fn alloc_error_handler_name(alloc_error_handler_kind: AllocatorKind) -> &'static str {
-    match alloc_error_handler_kind {
-        AllocatorKind::Global => "__rg_oom",
-        AllocatorKind::Default => "__rdl_oom",
-    }
-}
-
 pub const ALLOC_ERROR_HANDLER: &str = "__rust_alloc_error_handler";
+pub const ALLOC_ERROR_HANDLER_DEFAULT: &str = "__rdl_oom";
 pub const NO_ALLOC_SHIM_IS_UNSTABLE: &str = "__rust_no_alloc_shim_is_unstable_v2";
 
 pub enum AllocatorTy {

--- a/compiler/rustc_ast/src/expand/allocator.rs
+++ b/compiler/rustc_ast/src/expand/allocator.rs
@@ -22,6 +22,7 @@ pub fn alloc_error_handler_name(alloc_error_handler_kind: AllocatorKind) -> &'st
     }
 }
 
+pub const ALLOC_ERROR_HANDLER: &str = "__rust_alloc_error_handler";
 pub const NO_ALLOC_SHIM_IS_UNSTABLE: &str = "__rust_no_alloc_shim_is_unstable_v2";
 
 pub enum AllocatorTy {

--- a/compiler/rustc_builtin_macros/src/alloc_error_handler.rs
+++ b/compiler/rustc_builtin_macros/src/alloc_error_handler.rs
@@ -1,3 +1,4 @@
+use rustc_ast::expand::allocator::ALLOC_ERROR_HANDLER;
 use rustc_ast::ptr::P;
 use rustc_ast::{
     self as ast, Fn, FnHeader, FnSig, Generics, ItemKind, Safety, Stmt, StmtKind, TyKind,
@@ -56,7 +57,7 @@ pub(crate) fn expand(
 }
 
 // #[rustc_std_internal_symbol]
-// unsafe fn __rg_oom(size: usize, align: usize) -> ! {
+// unsafe fn __rust_alloc_error_handler(size: usize, align: usize) -> ! {
 //     handler(core::alloc::Layout::from_size_align_unchecked(size, align))
 // }
 fn generate_handler(cx: &ExtCtxt<'_>, handler: Ident, span: Span, sig_span: Span) -> Stmt {
@@ -85,7 +86,7 @@ fn generate_handler(cx: &ExtCtxt<'_>, handler: Ident, span: Span, sig_span: Span
     let kind = ItemKind::Fn(Box::new(Fn {
         defaultness: ast::Defaultness::Final,
         sig,
-        ident: Ident::from_str_and_span("__rg_oom", span),
+        ident: Ident::from_str_and_span(ALLOC_ERROR_HANDLER, span),
         generics: Generics::default(),
         contract: None,
         body,

--- a/compiler/rustc_codegen_cranelift/src/allocator.rs
+++ b/compiler/rustc_codegen_cranelift/src/allocator.rs
@@ -2,9 +2,7 @@
 // Adapted from rustc
 
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
-use rustc_ast::expand::allocator::{
-    ALLOC_ERROR_HANDLER, ALLOC_ERROR_HANDLER_DEFAULT, AllocatorKind, NO_ALLOC_SHIM_IS_UNSTABLE,
-};
+use rustc_ast::expand::allocator::NO_ALLOC_SHIM_IS_UNSTABLE;
 use rustc_codegen_ssa::base::needs_allocator_shim;
 use rustc_session::config::OomStrategy;
 use rustc_symbol_mangling::mangle_internal_symbol;
@@ -14,48 +12,15 @@ use crate::prelude::*;
 /// Returns whether an allocator shim was created
 pub(crate) fn codegen(tcx: TyCtxt<'_>, module: &mut dyn Module) -> bool {
     if needs_allocator_shim(tcx) {
-        codegen_inner(
-            tcx,
-            module,
-            tcx.alloc_error_handler_kind(()).unwrap(),
-            tcx.sess.opts.unstable_opts.oom,
-        );
+        codegen_inner(tcx, module, tcx.sess.opts.unstable_opts.oom);
         true
     } else {
         false
     }
 }
 
-fn codegen_inner(
-    tcx: TyCtxt<'_>,
-    module: &mut dyn Module,
-    alloc_error_handler_kind: AllocatorKind,
-    oom_strategy: OomStrategy,
-) {
-    let usize_ty = module.target_config().pointer_type();
-
-    if alloc_error_handler_kind == AllocatorKind::Default {
-        let sig = Signature {
-            call_conv: module.target_config().default_call_conv,
-            params: vec![AbiParam::new(usize_ty), AbiParam::new(usize_ty)],
-            returns: vec![],
-        };
-        crate::common::create_wrapper_function(
-            module,
-            sig,
-            &mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER),
-            &mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER_DEFAULT),
-        );
-    }
-
-    let data_id = module
-        .declare_data(
-            &mangle_internal_symbol(tcx, OomStrategy::SYMBOL),
-            Linkage::Export,
-            false,
-            false,
-        )
-        .unwrap();
+fn codegen_inner(tcx: TyCtxt<'_>, module: &mut dyn Module, oom_strategy: OomStrategy) {
+    let data_id = module.declare_data(OomStrategy::SYMBOL, Linkage::Export, false, false).unwrap();
     let mut data = DataDescription::new();
     data.set_align(1);
     let val = oom_strategy.should_panic();

--- a/compiler/rustc_codegen_cranelift/src/allocator.rs
+++ b/compiler/rustc_codegen_cranelift/src/allocator.rs
@@ -3,7 +3,7 @@
 
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
 use rustc_ast::expand::allocator::{
-    ALLOCATOR_METHODS, AllocatorKind, AllocatorTy, NO_ALLOC_SHIM_IS_UNSTABLE,
+    ALLOC_ERROR_HANDLER, ALLOCATOR_METHODS, AllocatorKind, AllocatorTy, NO_ALLOC_SHIM_IS_UNSTABLE,
     alloc_error_handler_name, default_fn_name, global_fn_name,
 };
 use rustc_codegen_ssa::base::allocator_kind_for_codegen;
@@ -80,7 +80,7 @@ fn codegen_inner(
     crate::common::create_wrapper_function(
         module,
         sig,
-        &mangle_internal_symbol(tcx, "__rust_alloc_error_handler"),
+        &mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER),
         &mangle_internal_symbol(tcx, alloc_error_handler_name(alloc_error_handler_kind)),
     );
 

--- a/compiler/rustc_codegen_gcc/src/allocator.rs
+++ b/compiler/rustc_codegen_gcc/src/allocator.rs
@@ -2,8 +2,8 @@ use gccjit::{Context, FunctionType, GlobalKind, ToRValue, Type};
 #[cfg(feature = "master")]
 use gccjit::{FnAttribute, VarAttribute};
 use rustc_ast::expand::allocator::{
-    ALLOC_ERROR_HANDLER, ALLOCATOR_METHODS, AllocatorKind, AllocatorTy, NO_ALLOC_SHIM_IS_UNSTABLE,
-    alloc_error_handler_name, default_fn_name, global_fn_name,
+    ALLOC_ERROR_HANDLER, ALLOC_ERROR_HANDLER_DEFAULT, ALLOCATOR_METHODS, AllocatorKind,
+    AllocatorTy, NO_ALLOC_SHIM_IS_UNSTABLE, default_fn_name, global_fn_name,
 };
 use rustc_middle::bug;
 use rustc_middle::ty::TyCtxt;
@@ -61,15 +61,17 @@ pub(crate) unsafe fn codegen(
         }
     }
 
-    // FIXME(bjorn3): Add noreturn attribute
-    create_wrapper_function(
-        tcx,
-        context,
-        &mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER),
-        Some(&mangle_internal_symbol(tcx, alloc_error_handler_name(alloc_error_handler_kind))),
-        &[usize, usize],
-        None,
-    );
+    if alloc_error_handler_kind == AllocatorKind::Default {
+        // FIXME(bjorn3): Add noreturn attribute
+        create_wrapper_function(
+            tcx,
+            context,
+            &mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER),
+            Some(&mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER_DEFAULT)),
+            &[usize, usize],
+            None,
+        );
+    }
 
     let name = mangle_internal_symbol(tcx, OomStrategy::SYMBOL);
     let global = context.new_global(None, GlobalKind::Exported, i8, name);

--- a/compiler/rustc_codegen_gcc/src/allocator.rs
+++ b/compiler/rustc_codegen_gcc/src/allocator.rs
@@ -2,7 +2,7 @@ use gccjit::{Context, FunctionType, GlobalKind, ToRValue, Type};
 #[cfg(feature = "master")]
 use gccjit::{FnAttribute, VarAttribute};
 use rustc_ast::expand::allocator::{
-    ALLOCATOR_METHODS, AllocatorKind, AllocatorTy, NO_ALLOC_SHIM_IS_UNSTABLE,
+    ALLOC_ERROR_HANDLER, ALLOCATOR_METHODS, AllocatorKind, AllocatorTy, NO_ALLOC_SHIM_IS_UNSTABLE,
     alloc_error_handler_name, default_fn_name, global_fn_name,
 };
 use rustc_middle::bug;
@@ -65,7 +65,7 @@ pub(crate) unsafe fn codegen(
     create_wrapper_function(
         tcx,
         context,
-        &mangle_internal_symbol(tcx, "__rust_alloc_error_handler"),
+        &mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER),
         Some(&mangle_internal_symbol(tcx, alloc_error_handler_name(alloc_error_handler_kind))),
         &[usize, usize],
         None,

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -95,7 +95,6 @@ use back::lto::{ThinBuffer, ThinData};
 use gccjit::{CType, Context, OptimizationLevel};
 #[cfg(feature = "master")]
 use gccjit::{TargetInfo, Version};
-use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_ast::expand::autodiff_attrs::AutoDiffItem;
 use rustc_codegen_ssa::back::lto::{LtoModuleCodegen, SerializedModule, ThinModule};
 use rustc_codegen_ssa::back::write::{
@@ -277,12 +276,7 @@ fn new_context<'gcc, 'tcx>(tcx: TyCtxt<'tcx>) -> Context<'gcc> {
 }
 
 impl ExtraBackendMethods for GccCodegenBackend {
-    fn codegen_allocator(
-        &self,
-        tcx: TyCtxt<'_>,
-        module_name: &str,
-        alloc_error_handler_kind: AllocatorKind,
-    ) -> Self::Module {
+    fn codegen_allocator(&self, tcx: TyCtxt<'_>, module_name: &str) -> Self::Module {
         let mut mods = GccContext {
             context: Arc::new(SyncContext::new(new_context(tcx))),
             relocation_model: tcx.sess.relocation_model(),
@@ -291,7 +285,7 @@ impl ExtraBackendMethods for GccCodegenBackend {
         };
 
         unsafe {
-            allocator::codegen(tcx, &mut mods, module_name, alloc_error_handler_kind);
+            allocator::codegen(tcx, &mut mods, module_name);
         }
         mods
     }

--- a/compiler/rustc_codegen_gcc/src/lib.rs
+++ b/compiler/rustc_codegen_gcc/src/lib.rs
@@ -281,7 +281,6 @@ impl ExtraBackendMethods for GccCodegenBackend {
         &self,
         tcx: TyCtxt<'_>,
         module_name: &str,
-        kind: AllocatorKind,
         alloc_error_handler_kind: AllocatorKind,
     ) -> Self::Module {
         let mut mods = GccContext {
@@ -292,7 +291,7 @@ impl ExtraBackendMethods for GccCodegenBackend {
         };
 
         unsafe {
-            allocator::codegen(tcx, &mut mods, module_name, kind, alloc_error_handler_kind);
+            allocator::codegen(tcx, &mut mods, module_name, alloc_error_handler_kind);
         }
         mods
     }

--- a/compiler/rustc_codegen_llvm/src/allocator.rs
+++ b/compiler/rustc_codegen_llvm/src/allocator.rs
@@ -1,7 +1,7 @@
 use libc::c_uint;
 use rustc_ast::expand::allocator::{
-    ALLOC_ERROR_HANDLER, ALLOCATOR_METHODS, AllocatorKind, AllocatorTy, NO_ALLOC_SHIM_IS_UNSTABLE,
-    alloc_error_handler_name, default_fn_name, global_fn_name,
+    ALLOC_ERROR_HANDLER, ALLOC_ERROR_HANDLER_DEFAULT, ALLOCATOR_METHODS, AllocatorKind,
+    AllocatorTy, NO_ALLOC_SHIM_IS_UNSTABLE, default_fn_name, global_fn_name,
 };
 use rustc_codegen_ssa::traits::BaseTypeCodegenMethods as _;
 use rustc_middle::bug;
@@ -61,16 +61,18 @@ pub(crate) unsafe fn codegen(
         }
     }
 
-    // rust alloc error handler
-    create_wrapper_function(
-        tcx,
-        &cx,
-        &mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER),
-        Some(&mangle_internal_symbol(tcx, alloc_error_handler_name(alloc_error_handler_kind))),
-        &[usize, usize], // size, align
-        None,
-        true,
-    );
+    if alloc_error_handler_kind == AllocatorKind::Default {
+        // rust alloc error handler
+        create_wrapper_function(
+            tcx,
+            &cx,
+            &mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER),
+            Some(&mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER_DEFAULT)),
+            &[usize, usize], // size, align
+            None,
+            true,
+        );
+    }
 
     unsafe {
         // __rust_alloc_error_handler_should_panic

--- a/compiler/rustc_codegen_llvm/src/allocator.rs
+++ b/compiler/rustc_codegen_llvm/src/allocator.rs
@@ -1,6 +1,6 @@
 use libc::c_uint;
 use rustc_ast::expand::allocator::{
-    ALLOCATOR_METHODS, AllocatorKind, AllocatorTy, NO_ALLOC_SHIM_IS_UNSTABLE,
+    ALLOC_ERROR_HANDLER, ALLOCATOR_METHODS, AllocatorKind, AllocatorTy, NO_ALLOC_SHIM_IS_UNSTABLE,
     alloc_error_handler_name, default_fn_name, global_fn_name,
 };
 use rustc_codegen_ssa::traits::BaseTypeCodegenMethods as _;
@@ -65,7 +65,7 @@ pub(crate) unsafe fn codegen(
     create_wrapper_function(
         tcx,
         &cx,
-        &mangle_internal_symbol(tcx, "__rust_alloc_error_handler"),
+        &mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER),
         Some(&mangle_internal_symbol(tcx, alloc_error_handler_name(alloc_error_handler_kind))),
         &[usize, usize], // size, align
         None,

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -28,7 +28,6 @@ use back::write::{create_informational_target_machine, create_target_machine};
 use context::SimpleCx;
 use errors::{AutoDiffWithoutLTO, ParseTargetMachineConfig};
 use llvm_util::target_config;
-use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_ast::expand::autodiff_attrs::AutoDiffItem;
 use rustc_codegen_ssa::back::lto::{LtoModuleCodegen, SerializedModule, ThinModule};
 use rustc_codegen_ssa::back::write::{
@@ -104,17 +103,12 @@ impl Drop for TimeTraceProfiler {
 }
 
 impl ExtraBackendMethods for LlvmCodegenBackend {
-    fn codegen_allocator<'tcx>(
-        &self,
-        tcx: TyCtxt<'tcx>,
-        module_name: &str,
-        alloc_error_handler_kind: AllocatorKind,
-    ) -> ModuleLlvm {
+    fn codegen_allocator<'tcx>(&self, tcx: TyCtxt<'tcx>, module_name: &str) -> ModuleLlvm {
         let module_llvm = ModuleLlvm::new_metadata(tcx, module_name);
         let cx =
             SimpleCx::new(module_llvm.llmod(), &module_llvm.llcx, tcx.data_layout.pointer_size);
         unsafe {
-            allocator::codegen(tcx, cx, module_name, alloc_error_handler_kind);
+            allocator::codegen(tcx, cx, module_name);
         }
         module_llvm
     }

--- a/compiler/rustc_codegen_llvm/src/lib.rs
+++ b/compiler/rustc_codegen_llvm/src/lib.rs
@@ -108,14 +108,13 @@ impl ExtraBackendMethods for LlvmCodegenBackend {
         &self,
         tcx: TyCtxt<'tcx>,
         module_name: &str,
-        kind: AllocatorKind,
         alloc_error_handler_kind: AllocatorKind,
     ) -> ModuleLlvm {
         let module_llvm = ModuleLlvm::new_metadata(tcx, module_name);
         let cx =
             SimpleCx::new(module_llvm.llmod(), &module_llvm.llcx, tcx.data_layout.pointer_size);
         unsafe {
-            allocator::codegen(tcx, cx, module_name, kind, alloc_error_handler_kind);
+            allocator::codegen(tcx, cx, module_name, alloc_error_handler_kind);
         }
         module_llvm
     }

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -1,7 +1,9 @@
 use std::collections::hash_map::Entry::*;
 
 use rustc_abi::{CanonAbi, X86Call};
-use rustc_ast::expand::allocator::{ALLOCATOR_METHODS, NO_ALLOC_SHIM_IS_UNSTABLE, global_fn_name};
+use rustc_ast::expand::allocator::{
+    ALLOC_ERROR_HANDLER, ALLOCATOR_METHODS, NO_ALLOC_SHIM_IS_UNSTABLE, global_fn_name,
+};
 use rustc_data_structures::unord::UnordMap;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LOCAL_CRATE, LocalDefId};
@@ -217,7 +219,7 @@ fn exported_symbols_provider_local<'tcx>(
             .iter()
             .map(|method| mangle_internal_symbol(tcx, global_fn_name(method.name).as_str()))
             .chain([
-                mangle_internal_symbol(tcx, "__rust_alloc_error_handler"),
+                mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER),
                 mangle_internal_symbol(tcx, OomStrategy::SYMBOL),
                 mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE),
             ])

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::Entry::*;
 
 use rustc_abi::{CanonAbi, X86Call};
-use rustc_ast::expand::allocator::{ALLOC_ERROR_HANDLER, NO_ALLOC_SHIM_IS_UNSTABLE};
+use rustc_ast::expand::allocator::NO_ALLOC_SHIM_IS_UNSTABLE;
 use rustc_data_structures::unord::UnordMap;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LOCAL_CRATE, LocalDefId};
@@ -214,7 +214,6 @@ fn exported_symbols_provider_local<'tcx>(
     // Mark allocator shim symbols as exported only if they were generated.
     if needs_allocator_shim(tcx) {
         for symbol_name in [
-            mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER),
             mangle_internal_symbol(tcx, OomStrategy::SYMBOL),
             mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE),
         ] {

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -1,9 +1,7 @@
 use std::collections::hash_map::Entry::*;
 
 use rustc_abi::{CanonAbi, X86Call};
-use rustc_ast::expand::allocator::{
-    ALLOC_ERROR_HANDLER, ALLOCATOR_METHODS, NO_ALLOC_SHIM_IS_UNSTABLE, global_fn_name,
-};
+use rustc_ast::expand::allocator::{ALLOC_ERROR_HANDLER, NO_ALLOC_SHIM_IS_UNSTABLE};
 use rustc_data_structures::unord::UnordMap;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{CrateNum, DefId, DefIdMap, LOCAL_CRATE, LocalDefId};
@@ -215,15 +213,11 @@ fn exported_symbols_provider_local<'tcx>(
 
     // Mark allocator shim symbols as exported only if they were generated.
     if needs_allocator_shim(tcx) {
-        for symbol_name in ALLOCATOR_METHODS
-            .iter()
-            .map(|method| mangle_internal_symbol(tcx, global_fn_name(method.name).as_str()))
-            .chain([
-                mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER),
-                mangle_internal_symbol(tcx, OomStrategy::SYMBOL),
-                mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE),
-            ])
-        {
+        for symbol_name in [
+            mangle_internal_symbol(tcx, ALLOC_ERROR_HANDLER),
+            mangle_internal_symbol(tcx, OomStrategy::SYMBOL),
+            mangle_internal_symbol(tcx, NO_ALLOC_SHIM_IS_UNSTABLE),
+        ] {
             let exported_symbol = ExportedSymbol::NoDefId(SymbolName::new(tcx, &symbol_name));
 
             symbols.push((

--- a/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
+++ b/compiler/rustc_codegen_ssa/src/back/symbol_export.rs
@@ -20,7 +20,7 @@ use rustc_symbol_mangling::mangle_internal_symbol;
 use rustc_target::spec::{SanitizerSet, TlsModel};
 use tracing::debug;
 
-use crate::base::allocator_kind_for_codegen;
+use crate::base::needs_allocator_shim;
 
 fn threshold(tcx: TyCtxt<'_>) -> SymbolExportLevel {
     crates_export_threshold(tcx.crate_types())
@@ -214,7 +214,7 @@ fn exported_symbols_provider_local<'tcx>(
     }
 
     // Mark allocator shim symbols as exported only if they were generated.
-    if allocator_kind_for_codegen(tcx).is_some() {
+    if needs_allocator_shim(tcx) {
         for symbol_name in ALLOCATOR_METHODS
             .iter()
             .map(|method| mangle_internal_symbol(tcx, global_fn_name(method.name).as_str()))

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use itertools::Itertools;
 use rustc_abi::FIRST_VARIANT;
 use rustc_ast as ast;
-use rustc_ast::expand::allocator::{ALLOCATOR_METHODS, AllocatorKind, global_fn_name};
+use rustc_ast::expand::allocator::{ALLOCATOR_METHODS, global_fn_name};
 use rustc_attr_data_structures::OptimizeAttr;
 use rustc_data_structures::fx::{FxHashMap, FxIndexSet};
 use rustc_data_structures::profiling::{get_resident_set_size, print_time_passes_entry};
@@ -648,7 +648,7 @@ pub fn collect_debugger_visualizers_transitive(
 /// Decide allocator kind to codegen. If `Some(_)` this will be the same as
 /// `tcx.allocator_kind`, but it may be `None` in more cases (e.g. if using
 /// allocator definitions from a dylib dependency).
-pub fn allocator_kind_for_codegen(tcx: TyCtxt<'_>) -> Option<AllocatorKind> {
+pub fn needs_allocator_shim(tcx: TyCtxt<'_>) -> bool {
     // If the crate doesn't have an `allocator_kind` set then there's definitely
     // no shim to generate. Otherwise we also check our dependency graph for all
     // our output crate types. If anything there looks like its a `Dynamic`
@@ -659,7 +659,7 @@ pub fn allocator_kind_for_codegen(tcx: TyCtxt<'_>) -> Option<AllocatorKind> {
         use rustc_middle::middle::dependency_format::Linkage;
         list.iter().any(|&linkage| linkage == Linkage::Dynamic)
     });
-    if any_dynamic_crate { None } else { tcx.allocator_kind(()) }
+    if any_dynamic_crate { false } else { tcx.allocator_kind(()).is_some() }
 }
 
 pub fn codegen_crate<B: ExtraBackendMethods>(
@@ -705,14 +705,13 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
     let ongoing_codegen = start_async_codegen(backend.clone(), tcx, target_cpu);
 
     // Codegen an allocator shim, if necessary.
-    if let Some(kind) = allocator_kind_for_codegen(tcx) {
+    if needs_allocator_shim(tcx) {
         let llmod_id =
             cgu_name_builder.build_cgu_name(LOCAL_CRATE, &["crate"], Some("allocator")).to_string();
         let module_llvm = tcx.sess.time("write_allocator_module", || {
             backend.codegen_allocator(
                 tcx,
                 &llmod_id,
-                kind,
                 // If allocator_kind is Some then alloc_error_handler_kind must
                 // also be Some.
                 tcx.alloc_error_handler_kind(()).unwrap(),

--- a/compiler/rustc_codegen_ssa/src/base.rs
+++ b/compiler/rustc_codegen_ssa/src/base.rs
@@ -708,15 +708,8 @@ pub fn codegen_crate<B: ExtraBackendMethods>(
     if needs_allocator_shim(tcx) {
         let llmod_id =
             cgu_name_builder.build_cgu_name(LOCAL_CRATE, &["crate"], Some("allocator")).to_string();
-        let module_llvm = tcx.sess.time("write_allocator_module", || {
-            backend.codegen_allocator(
-                tcx,
-                &llmod_id,
-                // If allocator_kind is Some then alloc_error_handler_kind must
-                // also be Some.
-                tcx.alloc_error_handler_kind(()).unwrap(),
-            )
-        });
+        let module_llvm =
+            tcx.sess.time("write_allocator_module", || backend.codegen_allocator(tcx, &llmod_id));
 
         ongoing_codegen.wait_for_signal_to_codegen_item();
         ongoing_codegen.check_for_errors(tcx.sess);

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -107,7 +107,6 @@ pub trait ExtraBackendMethods:
         &self,
         tcx: TyCtxt<'tcx>,
         module_name: &str,
-        kind: AllocatorKind,
         alloc_error_handler_kind: AllocatorKind,
     ) -> Self::Module;
 

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -1,7 +1,6 @@
 use std::any::Any;
 use std::hash::Hash;
 
-use rustc_ast::expand::allocator::AllocatorKind;
 use rustc_data_structures::fx::FxIndexMap;
 use rustc_data_structures::sync::{DynSend, DynSync};
 use rustc_metadata::EncodedMetadata;
@@ -103,12 +102,7 @@ pub trait CodegenBackend {
 pub trait ExtraBackendMethods:
     CodegenBackend + WriteBackendMethods + Sized + Send + Sync + DynSend + DynSync
 {
-    fn codegen_allocator<'tcx>(
-        &self,
-        tcx: TyCtxt<'tcx>,
-        module_name: &str,
-        alloc_error_handler_kind: AllocatorKind,
-    ) -> Self::Module;
+    fn codegen_allocator<'tcx>(&self, tcx: TyCtxt<'tcx>, module_name: &str) -> Self::Module;
 
     /// This generates the codegen unit and returns it along with
     /// a `u64` giving an estimate of the unit's processing cost.

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use std::{cmp, env, iter};
 
-use rustc_ast::expand::allocator::{AllocatorKind, alloc_error_handler_name, global_fn_name};
+use rustc_ast::expand::allocator::{ALLOC_ERROR_HANDLER, AllocatorKind, global_fn_name};
 use rustc_ast::{self as ast, *};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::owned_slice::OwnedSlice;
@@ -1067,17 +1067,17 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
                 }
                 spans => !spans.is_empty(),
             };
-        self.cstore.has_alloc_error_handler = match &*fn_spans(
-            krate,
-            Symbol::intern(alloc_error_handler_name(AllocatorKind::Global)),
-        ) {
-            [span1, span2, ..] => {
-                self.dcx()
-                    .emit_err(errors::NoMultipleAllocErrorHandler { span2: *span2, span1: *span1 });
-                true
-            }
-            spans => !spans.is_empty(),
-        };
+        self.cstore.has_alloc_error_handler =
+            match &*fn_spans(krate, Symbol::intern(ALLOC_ERROR_HANDLER)) {
+                [span1, span2, ..] => {
+                    self.dcx().emit_err(errors::NoMultipleAllocErrorHandler {
+                        span2: *span2,
+                        span1: *span1,
+                    });
+                    true
+                }
+                spans => !spans.is_empty(),
+            };
 
         // Check to see if we actually need an allocator. This desire comes
         // about through the `#![needs_allocator]` attribute and is typically

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -1406,6 +1406,8 @@ fn fn_spans(krate: &ast::Crate, name: Symbol) -> Vec<Span> {
             if let Some(ident) = item.kind.ident()
                 && ident.name == self.name
                 && attr::contains_name(&item.attrs, sym::rustc_std_internal_symbol)
+                // Ignore the default allocator in libstd with weak linkage
+                && attr::find_by_name(&item.attrs, sym::linkage).is_none()
             {
                 self.spans.push(item.span);
             }

--- a/compiler/rustc_metadata/src/creader.rs
+++ b/compiler/rustc_metadata/src/creader.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use std::{cmp, env, iter};
 
-use rustc_ast::expand::allocator::{ALLOC_ERROR_HANDLER, AllocatorKind, global_fn_name};
+use rustc_ast::expand::allocator::{AllocatorKind, global_fn_name};
 use rustc_ast::{self as ast, *};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_data_structures::owned_slice::OwnedSlice;
@@ -25,8 +25,8 @@ use rustc_middle::ty::data_structures::IndexSet;
 use rustc_middle::ty::{TyCtxt, TyCtxtFeed};
 use rustc_proc_macro::bridge::client::ProcMacro;
 use rustc_session::config::{
-    self, CrateType, ExtendedTargetModifierInfo, ExternLocation, OptionsTargetModifiers,
-    TargetModifier,
+    self, CrateType, ExtendedTargetModifierInfo, ExternLocation, OomStrategy,
+    OptionsTargetModifiers, TargetModifier,
 };
 use rustc_session::cstore::{CrateDepKind, CrateSource, ExternCrate, ExternCrateSource};
 use rustc_session::lint::{self, BuiltinLintDiag};
@@ -320,10 +320,6 @@ impl CStore {
 
     pub(crate) fn allocator_kind(&self) -> Option<AllocatorKind> {
         self.allocator_kind
-    }
-
-    pub(crate) fn alloc_error_handler_kind(&self) -> Option<AllocatorKind> {
-        self.alloc_error_handler_kind
     }
 
     pub(crate) fn has_global_allocator(&self) -> bool {
@@ -1068,7 +1064,7 @@ impl<'a, 'tcx> CrateLoader<'a, 'tcx> {
                 spans => !spans.is_empty(),
             };
         self.cstore.has_alloc_error_handler =
-            match &*fn_spans(krate, Symbol::intern(ALLOC_ERROR_HANDLER)) {
+            match &*fn_spans(krate, Symbol::intern(OomStrategy::SYMBOL)) {
                 [span1, span2, ..] => {
                     self.dcx().emit_err(errors::NoMultipleAllocErrorHandler {
                         span2: *span2,

--- a/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
+++ b/compiler/rustc_metadata/src/rmeta/decoder/cstore_impl.rs
@@ -432,7 +432,6 @@ pub(in crate::rmeta) fn provide(providers: &mut Providers) {
     provide_cstore_hooks(providers);
     providers.queries = rustc_middle::query::Providers {
         allocator_kind: |tcx, ()| CStore::from_tcx(tcx).allocator_kind(),
-        alloc_error_handler_kind: |tcx, ()| CStore::from_tcx(tcx).alloc_error_handler_kind(),
         is_private_dep: |_tcx, LocalCrate| false,
         native_library: |tcx, id| {
             tcx.native_libraries(id.krate)

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -2257,10 +2257,6 @@ rustc_queries! {
         eval_always
         desc { "getting the allocator kind for the current crate" }
     }
-    query alloc_error_handler_kind(_: ()) -> Option<AllocatorKind> {
-        eval_always
-        desc { "alloc error handler kind for the current crate" }
-    }
 
     query upvars_mentioned(def_id: DefId) -> Option<&'tcx FxIndexMap<hir::HirId, hir::Upvar>> {
         desc { |tcx| "collecting upvars mentioned in `{}`", tcx.def_path_str(def_id) }

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -898,6 +898,7 @@ fn mono_item_visibility<'tcx>(
         //   Removal of these functions can't be done by LLVM but rather must be
         //   done by the linker as it's a non-local decision.
         //
+        // FIXME update comment
         // * Second is "std internal symbols". Currently this is primarily used
         //   for allocator symbols. Allocators are a little weird in their
         //   implementation, but the idea is that the compiler, at the last

--- a/compiler/rustc_monomorphize/src/partitioning.rs
+++ b/compiler/rustc_monomorphize/src/partitioning.rs
@@ -900,18 +900,9 @@ fn mono_item_visibility<'tcx>(
         //
         // FIXME update comment
         // * Second is "std internal symbols". Currently this is primarily used
-        //   for allocator symbols. Allocators are a little weird in their
-        //   implementation, but the idea is that the compiler, at the last
-        //   minute, defines an allocator with an injected object file. The
-        //   `alloc` crate references these symbols (`__rust_alloc`) and the
-        //   definition doesn't get hooked up until a linked crate artifact is
-        //   generated.
-        //
-        //   The symbols synthesized by the compiler (`__rust_alloc`) are thin
-        //   veneers around the actual implementation, some other symbol which
-        //   implements the same ABI. These symbols (things like `__rg_alloc`,
-        //   `__rdl_alloc`, `__rde_alloc`, etc), are all tagged with "std
-        //   internal symbols".
+        //   for allocator symbols and the unwinder runtime to allow cyclic
+        //   dependencies between the defining and using crate and to allow
+        //   replacing them.
         //
         //   The std-internal symbols here **should not show up in a dll as an
         //   exported interface**, so they return `false` from

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -12,7 +12,7 @@ unsafe extern "Rust" {
     // These are the magic symbols to call the global allocator. rustc generates
     // them to call the global allocator if there is a `#[global_allocator]` attribute
     // (the code expanding that attribute macro generates those functions), or to call
-    // the default implementations in std (`__rdl_alloc` etc. in `library/std/src/alloc.rs`)
+    // the default implementations in std (weak symbols in `library/std/src/alloc.rs`)
     // otherwise.
     #[rustc_allocator]
     #[rustc_nounwind]

--- a/library/alloc/src/alloc.rs
+++ b/library/alloc/src/alloc.rs
@@ -10,10 +10,12 @@ use core::ptr::{self, NonNull};
 
 unsafe extern "Rust" {
     // These are the magic symbols to call the global allocator. rustc generates
-    // them to call the global allocator if there is a `#[global_allocator]` attribute
-    // (the code expanding that attribute macro generates those functions), or to call
+    // them to call `GLOBAL.alloc` etc. if there is a `#[global_allocator]` attribute
+    // (the code expanding that attribute macro generates those functions), or if not
     // the default implementations in std (weak symbols in `library/std/src/alloc.rs`)
-    // otherwise.
+    // is used otherwise.
+    // The rustc fork of LLVM 14 and earlier also special-cases these function names to
+    // be able to optimize them like `malloc`, `realloc`, and `free`, respectively.
     #[rustc_allocator]
     #[rustc_nounwind]
     #[rustc_std_internal_symbol]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -128,6 +128,7 @@
 #![feature(iter_next_chunk)]
 #![feature(layout_for_ptr)]
 #![feature(legacy_receiver_trait)]
+#![feature(linkage)]
 #![feature(local_waker)]
 #![feature(maybe_uninit_slice)]
 #![feature(maybe_uninit_uninit_array_transpose)]

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -383,9 +383,8 @@ pub fn rust_oom(layout: Layout) -> ! {
 #[unstable(feature = "alloc_internals", issue = "none")]
 pub mod __default_lib_allocator {
     use super::{GlobalAlloc, Layout, System};
-    // These magic symbol names are used as a fallback for implementing the
-    // `__rust_alloc` etc symbols (see `src/liballoc/alloc.rs`) when there is
-    // no `#[global_allocator]` attribute.
+    // These are used as a fallback for implementing the `__rust_alloc`, etc symbols
+    // (see `src/liballoc/alloc.rs`) when there is no `#[global_allocator]` attribute.
 
     // for symbol names src/librustc_ast/expand/allocator.rs
     // for signatures src/librustc_allocator/lib.rs
@@ -394,7 +393,8 @@ pub mod __default_lib_allocator {
     // ABI
 
     #[rustc_std_internal_symbol]
-    pub unsafe extern "C" fn __rdl_alloc(size: usize, align: usize) -> *mut u8 {
+    #[linkage = "weak"]
+    pub unsafe extern "Rust" fn __rust_alloc(size: usize, align: usize) -> *mut u8 {
         // SAFETY: see the guarantees expected by `Layout::from_size_align` and
         // `GlobalAlloc::alloc`.
         unsafe {
@@ -404,14 +404,16 @@ pub mod __default_lib_allocator {
     }
 
     #[rustc_std_internal_symbol]
-    pub unsafe extern "C" fn __rdl_dealloc(ptr: *mut u8, size: usize, align: usize) {
+    #[linkage = "weak"]
+    pub unsafe extern "Rust" fn __rust_dealloc(ptr: *mut u8, size: usize, align: usize) {
         // SAFETY: see the guarantees expected by `Layout::from_size_align` and
         // `GlobalAlloc::dealloc`.
         unsafe { System.dealloc(ptr, Layout::from_size_align_unchecked(size, align)) }
     }
 
     #[rustc_std_internal_symbol]
-    pub unsafe extern "C" fn __rdl_realloc(
+    #[linkage = "weak"]
+    pub unsafe extern "Rust" fn __rust_realloc(
         ptr: *mut u8,
         old_size: usize,
         align: usize,
@@ -426,7 +428,8 @@ pub mod __default_lib_allocator {
     }
 
     #[rustc_std_internal_symbol]
-    pub unsafe extern "C" fn __rdl_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
+    #[linkage = "weak"]
+    pub unsafe extern "Rust" fn __rust_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
         // SAFETY: see the guarantees expected by `Layout::from_size_align` and
         // `GlobalAlloc::alloc_zeroed`.
         unsafe {

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -386,8 +386,7 @@ pub mod __default_lib_allocator {
     // These are used as a fallback for implementing the `__rust_alloc`, etc symbols
     // (see `src/liballoc/alloc.rs`) when there is no `#[global_allocator]` attribute.
 
-    // for symbol names src/librustc_ast/expand/allocator.rs
-    // for signatures src/librustc_allocator/lib.rs
+    // for symbol names and signatures see compiler/rustc_ast/src/expand/allocator.rs
 
     // linkage directives are provided as part of the current compiler allocator
     // ABI

--- a/library/std/src/alloc.rs
+++ b/library/std/src/alloc.rs
@@ -358,9 +358,10 @@ fn default_alloc_error_hook(layout: Layout) {
         // This is the default path taken on OOM, and the only path taken on stable with std.
         // Crucially, it does *not* call any user-defined code, and therefore users do not have to
         // worry about allocation failure causing reentrancy issues. That makes it different from
-        // the default `__rdl_oom` defined in alloc (i.e., the default alloc error handler that is
-        // called when there is no `#[alloc_error_handler]`), which triggers a regular panic and
-        // thus can invoke a user-defined panic hook, executing arbitrary user-defined code.
+        // the default `__rust_alloc_error_handler` defined in alloc (i.e., the default alloc error
+        // handler that is called when there is no `#[alloc_error_handler]`), which triggers a
+        // regular panic and thus can invoke a user-defined panic hook, executing arbitrary
+        // user-defined code.
         rtprintpanic!("memory allocation of {} bytes failed\n", layout.size());
     }
 }

--- a/src/tools/miri/src/shims/alloc.rs
+++ b/src/tools/miri/src/shims/alloc.rs
@@ -1,5 +1,4 @@
 use rustc_abi::{Align, Size};
-use rustc_ast::expand::allocator::AllocatorKind;
 
 use crate::*;
 
@@ -55,31 +54,13 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
     }
 
     /// Emulates calling the internal __rust_* allocator functions
-    fn emulate_allocator(
-        &mut self,
-        default: impl FnOnce(&mut MiriInterpCx<'tcx>) -> InterpResult<'tcx>,
-    ) -> InterpResult<'tcx, EmulateItemResult> {
-        let this = self.eval_context_mut();
-
-        let Some(allocator_kind) = this.tcx.allocator_kind(()) else {
-            // in real code, this symbol does not exist without an allocator
-            return interp_ok(EmulateItemResult::NotSupported);
-        };
-
-        match allocator_kind {
-            AllocatorKind::Global => {
-                // When `#[global_allocator]` is used, `__rust_*` is defined by the macro expansion
-                // of this attribute. As such we have to call an exported Rust function,
-                // and not execute any Miri shim. Somewhat unintuitively doing so is done
-                // by returning `NotSupported`, which triggers the `lookup_exported_symbol`
-                // fallback case in `emulate_foreign_item`.
-                interp_ok(EmulateItemResult::NotSupported)
-            }
-            AllocatorKind::Default => {
-                default(this)?;
-                interp_ok(EmulateItemResult::NeedsReturn)
-            }
-        }
+    fn emulate_allocator(&mut self) -> InterpResult<'tcx, EmulateItemResult> {
+        // When `#[global_allocator]` is used, `__rust_*` is defined by the macro expansion
+        // of this attribute. As such we have to call an exported Rust function,
+        // and not execute any Miri shim. Somewhat unintuitively doing so is done
+        // by returning `NotSupported`, which triggers the `lookup_exported_symbol`
+        // fallback case in `emulate_foreign_item`.
+        interp_ok(EmulateItemResult::NotSupported)
     }
 
     fn malloc(&mut self, size: u64, init: AllocInit) -> InterpResult<'tcx, Pointer> {

--- a/src/tools/miri/src/shims/alloc.rs
+++ b/src/tools/miri/src/shims/alloc.rs
@@ -53,16 +53,6 @@ pub trait EvalContextExt<'tcx>: crate::MiriInterpCxExt<'tcx> {
         Align::from_bytes(prev_power_of_two(size)).unwrap()
     }
 
-    /// Emulates calling the internal __rust_* allocator functions
-    fn emulate_allocator(&mut self) -> InterpResult<'tcx, EmulateItemResult> {
-        // When `#[global_allocator]` is used, `__rust_*` is defined by the macro expansion
-        // of this attribute. As such we have to call an exported Rust function,
-        // and not execute any Miri shim. Somewhat unintuitively doing so is done
-        // by returning `NotSupported`, which triggers the `lookup_exported_symbol`
-        // fallback case in `emulate_foreign_item`.
-        interp_ok(EmulateItemResult::NotSupported)
-    }
-
     fn malloc(&mut self, size: u64, init: AllocInit) -> InterpResult<'tcx, Pointer> {
         let this = self.eval_context_mut();
         let align = this.malloc_align(size);

--- a/src/tools/miri/tests/fail/alloc/alloc_error_handler.stderr
+++ b/src/tools/miri/tests/fail/alloc/alloc_error_handler.stderr
@@ -9,7 +9,7 @@ LL | ABORT()
    = note: inside `std::sys::pal::PLATFORM::abort_internal` at RUSTLIB/std/src/sys/pal/PLATFORM/mod.rs:LL:CC
    = note: inside `std::process::abort` at RUSTLIB/std/src/process.rs:LL:CC
    = note: inside `std::alloc::rust_oom` at RUSTLIB/std/src/alloc.rs:LL:CC
-   = note: inside `std::alloc::_::__rg_oom` at RUSTLIB/std/src/alloc.rs:LL:CC
+   = note: inside `std::alloc::_::__rust_alloc_error_handler` at RUSTLIB/std/src/alloc.rs:LL:CC
    = note: inside `std::alloc::handle_alloc_error::rt_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `std::alloc::handle_alloc_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC
 note: inside `main`

--- a/src/tools/miri/tests/fail/alloc/alloc_error_handler_custom.stderr
+++ b/src/tools/miri/tests/fail/alloc/alloc_error_handler_custom.stderr
@@ -7,7 +7,7 @@ LL |     core::intrinsics::abort();
    |
    = note: BACKTRACE:
    = note: inside `alloc_error_handler` at tests/fail/alloc/alloc_error_handler_custom.rs:LL:CC
-note: inside `_::__rg_oom`
+note: inside `_::__rust_alloc_error_handler`
   --> tests/fail/alloc/alloc_error_handler_custom.rs:LL:CC
    |
 LL | #[alloc_error_handler]

--- a/src/tools/miri/tests/fail/alloc/alloc_error_handler_no_std.stderr
+++ b/src/tools/miri/tests/fail/alloc/alloc_error_handler_no_std.stderr
@@ -9,7 +9,7 @@ LL |     core::intrinsics::abort();
    |
    = note: BACKTRACE:
    = note: inside `panic_handler` at tests/fail/alloc/alloc_error_handler_no_std.rs:LL:CC
-   = note: inside `alloc::alloc::__alloc_error_handler::__rdl_oom` at RUSTLIB/alloc/src/alloc.rs:LL:CC
+   = note: inside `alloc::alloc::__alloc_error_handler::__rust_alloc_error_handler` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `alloc::alloc::handle_alloc_error::rt_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC
    = note: inside `alloc::alloc::handle_alloc_error` at RUSTLIB/alloc/src/alloc.rs:LL:CC
 note: inside `miri_start`

--- a/tests/run-make/bin-emit-no-symbols/rmake.rs
+++ b/tests/run-make/bin-emit-no-symbols/rmake.rs
@@ -14,5 +14,5 @@ fn main() {
     let out = llvm_readobj().input("app.o").arg("--symbols").run();
     out.assert_stdout_contains("rust_begin_unwind");
     out.assert_stdout_contains("rust_eh_personality");
-    out.assert_stdout_contains("__rg_oom");
+    out.assert_stdout_contains("__rust_alloc_error_handler");
 }

--- a/tests/ui/sanitizer/dataflow-abilist.txt
+++ b/tests/ui/sanitizer/dataflow-abilist.txt
@@ -490,10 +490,6 @@ fun:__dfso_*=uninstrumented
 fun:__dfso_*=discard
 
 # Rust functions.
-fun:__rdl_alloc=uninstrumented
-fun:__rdl_alloc_zeroed=uninstrumented
-fun:__rdl_dealloc=uninstrumented
-fun:__rdl_realloc=uninstrumented
 fun:__rust_alloc=uninstrumented
 fun:__rust_alloc_error_handler=uninstrumented
 fun:__rust_alloc_zeroed=uninstrumented

--- a/tests/ui/sanitizer/dataflow-abilist.txt
+++ b/tests/ui/sanitizer/dataflow-abilist.txt
@@ -494,7 +494,6 @@ fun:__rdl_alloc=uninstrumented
 fun:__rdl_alloc_zeroed=uninstrumented
 fun:__rdl_dealloc=uninstrumented
 fun:__rdl_realloc=uninstrumented
-fun:__rg_oom=uninstrumented
 fun:__rust_alloc=uninstrumented
 fun:__rust_alloc_error_handler=uninstrumented
 fun:__rust_alloc_zeroed=uninstrumented


### PR DESCRIPTION
<!-- homu-ignore:start -->
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/rust/pull/134522)*
<!-- homu-ignore:end -->

https://github.com/rust-lang/rust/pull/86844 (unstably) made it possible to avoid the allocator shim when using `#[global_allocator]`. This PR makes it possible to also avoid the allocator shim when using the default allocator in libstd by making use of weak linkage. Eventual stabilization of avoiding the allocator shim may be blocked on it working with the default allocator too.

This is still keeping the `__rust_no_alloc_shim_is_unstable` symbol for now until https://github.com/rust-lang/rust/issues/123015 gets stabilized.

TODO: Update comments everywhere, test on <strike>macOS and</strike> Windows and write a better PR description why we want this. Also prevent codegen of weak symbols when there is a non-weak definition of the same symbol in the same codegen unit.

try-job: x86_64-msvc
try-zzz-job: x86_64-apple-1
try-zzz-job: x86_64-apple-2
