### PR TITLE
Arbitrary self types v2: no deshadow pre feature.

### DIFF
--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1337,6 +1337,15 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         mutbl: hir::Mutability,
         track_unstable_candidates: bool,
     ) -> Result<(), MethodError<'tcx>> {
+        // The errors emitted by this function are part of
+        // the arbitrary self types work, and should not impact
+        // other users.
+        if !self.tcx.features().arbitrary_self_types()
+            && !self.tcx.features().arbitrary_self_types_pointers()
+        {
+            return Ok(());
+        }
+
         // We don't want to remember any of the diagnostic hints from this
         // shadow search, but we do need to provide Some/None for the
         // unstable_candidates in order to reflect the behavior of the

--- a/tests/ui/self/arbitrary_self_types_pin_getref.feature.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_getref.feature.stderr
@@ -1,0 +1,16 @@
+error[E0034]: multiple applicable items in scope
+  --> $DIR/arbitrary_self_types_pin_getref.rs:23:22
+   |
+LL |     let _ = pinned_a.get_ref();
+   |                      ^^^^^^^ multiple `get_ref` found
+   |
+note: candidate #1 is defined in an impl for the type `A`
+  --> $DIR/arbitrary_self_types_pin_getref.rs:17:5
+   |
+LL |     fn get_ref(self: &Pin<&A>) {}  // note &Pin
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: candidate #2 is defined in an impl for the type `Pin<&'a T>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0034`.

--- a/tests/ui/self/arbitrary_self_types_pin_getref.rs
+++ b/tests/ui/self/arbitrary_self_types_pin_getref.rs
@@ -1,0 +1,25 @@
+// Confirms that Pin::get_ref can no longer shadow methods in pointees
+// once arbitrary_self_types is enabled.
+//
+//@ revisions: default feature
+#![cfg_attr(feature, feature(arbitrary_self_types))]
+
+//@[default] check-pass
+
+#![allow(dead_code)]
+
+use std::pin::Pin;
+use std::pin::pin;
+
+struct A;
+
+impl A {
+    fn get_ref(self: &Pin<&A>) {}  // note &Pin
+}
+
+fn main() {
+    let pinned_a: Pin<&mut A> = pin!(A);
+    let pinned_a: Pin<&A> = pinned_a.as_ref();
+    let _ = pinned_a.get_ref();
+    //[feature]~^ ERROR: multiple applicable items
+}


### PR DESCRIPTION
The arbitrary self types v2 work introduces a check for shadowed methods, whereby a method in some "outer" smart pointer type may called in preference to a method in the inner referent. This is bad if the outer pointer adds a method later, as it may change behavior, so we ensure we error in this circumstance.

It was intended that this new shadowing detection system only comes into play for users who enable the `arbitrary_self_types` feature (or of course everyone later if it's stabilized). It was believed that the new deshadowing code couldn't be reached without building the custom smart pointers that `arbitrary_self_types` enables, and therefore there was no risk of this code impacting existing users.

However, it turns out that cunning use of `Pin::get_ref` can cause this type of shadowing error to be emitted now. This commit adds a test for this case.

As we want this test to pass without arbitrary_self_types, but fail with it, I've split it into two files (one with run-pass and one without). If there's a better way I can amend it.

Part of #44874 

r? @wesleywiser 