### PR TITLE
update `rustc_index_macros` feature handling

### DIFF
--- a/compiler/rustc_index/Cargo.toml
+++ b/compiler/rustc_index/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 # tidy-alphabetical-start
-rustc_index_macros = { path = "../rustc_index_macros", default-features = false }
+rustc_index_macros = { path = "../rustc_index_macros" }
 rustc_macros = { path = "../rustc_macros", optional = true }
 rustc_serialize = { path = "../rustc_serialize", optional = true }
 smallvec = "1.8.1"

--- a/compiler/rustc_index_macros/Cargo.toml
+++ b/compiler/rustc_index_macros/Cargo.toml
@@ -12,5 +12,4 @@ proc-macro2 = "1"
 quote = "1"
 
 [features]
-default = ["nightly"]
 nightly = []


### PR DESCRIPTION
It seems that cargo can't [conditionally propagate features](https://github.com/rust-lang/rust/blob/214587c89d527dd0ccbe1f2150c737d3bdee67b0/compiler/rustc_index/Cargo.toml#L20) if they were enabled by default on the target crate, but disabled with `default-features = false` in the current/parent crate.

Fixes #118129