### PR TITLE
fix: minor typo fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
           npm ci
           python3 scripts/upload-build-metrics.py ../../build/cpu-usage.csv
 
-  # This job isused to tell bors the final status of the build, as there is no practical way to detect
+  # This job is used to tell bors the final status of the build, as there is no practical way to detect
   # when a workflow is successful listening to webhooks only in our current bors implementation (homu).
   outcome:
     name: bors build finished

--- a/compiler/rustc_arena/src/lib.rs
+++ b/compiler/rustc_arena/src/lib.rs
@@ -201,7 +201,7 @@ impl<T> TypedArena<T> {
     /// storing the elements in the arena.
     #[inline]
     pub fn alloc_from_iter<I: IntoIterator<Item = T>>(&self, iter: I) -> &mut [T] {
-        // Despite the similarlty with `DroplessArena`, we cannot reuse their fast case. The reason
+        // Despite the similarity with `DroplessArena`, we cannot reuse their fast case. The reason
         // is subtle: these arenas are reentrant. In other words, `iter` may very well be holding a
         // reference to `self` and adding elements to the arena during iteration.
         //

--- a/compiler/rustc_ast_passes/src/ast_validation.rs
+++ b/compiler/rustc_ast_passes/src/ast_validation.rs
@@ -1578,7 +1578,7 @@ fn deny_equality_constraints(
                     None => (format!("<{assoc} = {ty}>"), trait_segment.span().shrink_to_hi()),
                 };
                 let removal_span = if generics.where_clause.predicates.len() == 1 {
-                    // We're removing th eonly where bound left, remove the whole thing.
+                    // We're removing the only where bound left, remove the whole thing.
                     generics.where_clause.span
                 } else {
                     let mut span = predicate_span;


### PR DESCRIPTION
Address several minor typographical errors in the following files:
1. `.github/workflows/ci.yml`: Fixed a typo in a comment for the `outcome` job.
2. `compiler/rustc_arena/src/lib.rs`: Corrected a typo in a comment related to the `TypedArena` implementation.
3. `compiler/rustc_ast_passes/src/ast_validation.rs`: Fixed a typo in a comment describing the removal of a where bound.