### PR TITLE
tests/codegen/asm: Remove uses of rustc_attrs and lang_items features by using minicore

### DIFF
--- a/tests/codegen/asm/aarch64-clobbers.rs
+++ b/tests/codegen/asm/aarch64-clobbers.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: aarch64 aarch64_fixed_x18 aarch64_no_x18 aarch64_reserve_x18 arm64ec
 //@[aarch64] compile-flags: --target aarch64-unknown-linux-gnu
 //@[aarch64] needs-llvm-components: aarch64
@@ -14,16 +15,11 @@
 // ignore-tidy-linelength
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items)]
+#![feature(no_core)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: @cc_clobber
 // CHECK: call void asm sideeffect "", "~{cc}"()

--- a/tests/codegen/asm/avr-clobbers.rs
+++ b/tests/codegen/asm/avr-clobbers.rs
@@ -1,18 +1,14 @@
+//@ add-core-stubs
 //@ assembly-output: emit-asm
 //@ compile-flags: --target avr-unknown-gnu-atmega328
 //@ needs-llvm-components: avr
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![feature(no_core, asm_experimental_arch)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: @sreg_is_clobbered
 // CHECK: void asm sideeffect "", "~{sreg}"()

--- a/tests/codegen/asm/hexagon-clobbers.rs
+++ b/tests/codegen/asm/hexagon-clobbers.rs
@@ -1,19 +1,15 @@
+//@ add-core-stubs
 //@ revisions: hexagon
 //@[hexagon] compile-flags: --target hexagon-unknown-linux-musl
 //@[hexagon] needs-llvm-components: hexagon
 //@ compile-flags: -Zmerge-functions=disabled
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![feature(no_core, asm_experimental_arch)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: @flags_clobber
 // CHECK: call void asm sideeffect "", ""()

--- a/tests/codegen/asm/msp430-clobbers.rs
+++ b/tests/codegen/asm/msp430-clobbers.rs
@@ -1,18 +1,14 @@
+//@ add-core-stubs
 //@ assembly-output: emit-asm
 //@ compile-flags: --target msp430-none-elf
 //@ needs-llvm-components: msp430
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![feature(no_core, asm_experimental_arch)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: @sr_clobber
 // CHECK: call void asm sideeffect "", "~{sr}"()

--- a/tests/codegen/asm/powerpc-clobbers.rs
+++ b/tests/codegen/asm/powerpc-clobbers.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: powerpc powerpc64 powerpc64le aix64
 //@[powerpc] compile-flags: --target powerpc-unknown-linux-gnu
 //@[powerpc] needs-llvm-components: powerpc
@@ -10,16 +11,11 @@
 // ignore-tidy-linelength
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![feature(no_core, asm_experimental_arch)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: @cr_clobber
 // CHECK: call void asm sideeffect "", "~{cr}"()

--- a/tests/codegen/asm/riscv-clobbers.rs
+++ b/tests/codegen/asm/riscv-clobbers.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ assembly-output: emit-asm
 //@ revisions: rv32i rv64i rv32e
 //@[rv32i] compile-flags: --target riscv32i-unknown-none-elf
@@ -9,16 +10,11 @@
 // ignore-tidy-linelength
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items)]
+#![feature(no_core)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: @flags_clobber
 // CHECK: call void asm sideeffect "", "~{vtype},~{vl},~{vxsat},~{vxrm}"()

--- a/tests/codegen/asm/s390x-clobbers.rs
+++ b/tests/codegen/asm/s390x-clobbers.rs
@@ -1,18 +1,14 @@
+//@ add-core-stubs
 //@ revisions: s390x
 //@[s390x] compile-flags: --target s390x-unknown-linux-gnu
 //@[s390x] needs-llvm-components: systemz
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items)]
+#![feature(no_core)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: @cc_clobber
 // CHECK: call void asm sideeffect "", "~{cc}"()

--- a/tests/codegen/asm/sanitize-llvm.rs
+++ b/tests/codegen/asm/sanitize-llvm.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 // FIXME(nagisa): remove the flags below once all targets support `asm!`.
 //@ compile-flags: --target x86_64-unknown-linux-gnu -Copt-level=0
 //@ needs-llvm-components: x86
@@ -5,19 +6,12 @@
 // Verify we sanitize the special tokens for the LLVM inline-assembly, ensuring people won't
 // inadvertently rely on the LLVM-specific syntax and features.
 #![no_core]
-#![feature(no_core, lang_items, rustc_attrs)]
+#![feature(no_core)]
 #![crate_type = "rlib"]
 #![allow(named_asm_labels)]
 
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
-
-#[lang = "sized"]
-trait Sized {}
-#[lang = "copy"]
-trait Copy {}
+extern crate minicore;
+use minicore::*;
 
 pub unsafe fn we_escape_dollar_signs() {
     // CHECK: call void asm sideeffect alignstack inteldialect "banana$$:"

--- a/tests/codegen/asm/sparc-clobbers.rs
+++ b/tests/codegen/asm/sparc-clobbers.rs
@@ -1,3 +1,4 @@
+//@ add-core-stubs
 //@ revisions: sparc sparcv8plus sparc64
 //@[sparc] compile-flags: --target sparc-unknown-none-elf
 //@[sparc] needs-llvm-components: sparc
@@ -7,16 +8,11 @@
 //@[sparc64] needs-llvm-components: sparc
 
 #![crate_type = "rlib"]
-#![feature(no_core, rustc_attrs, lang_items, asm_experimental_arch)]
+#![feature(no_core, asm_experimental_arch)]
 #![no_core]
 
-#[lang = "sized"]
-trait Sized {}
-
-#[rustc_builtin_macro]
-macro_rules! asm {
-    () => {};
-}
+extern crate minicore;
+use minicore::*;
 
 // CHECK-LABEL: @cc_clobber
 // CHECK: call void asm sideeffect "", "~{icc},~{fcc0},~{fcc1},~{fcc2},~{fcc3}"()


### PR DESCRIPTION
Similar to https://github.com/rust-lang/rust/pull/134385 (for tests/ui/asm) and https://github.com/rust-lang/rust/pull/134436 (for tests/assembly/asm), but for tests/codegen/asm.

r? jieyouxu