### PR TITLE
Handle `DropKind::ForLint` in coroutines correctly

### DIFF
--- a/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.rs
+++ b/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.rs
@@ -1,0 +1,29 @@
+//@ edition: 2021
+//@ build-fail
+
+// Make sure we don't ICE when emitting the "lint" drop statement
+// used for tail_expr_drop_order.
+
+#![deny(tail_expr_drop_order)]
+
+struct Drop;
+impl std::ops::Drop for Drop {
+    fn drop(&mut self) {}
+}
+
+async fn func() -> Result<(), Drop> {
+    todo!()
+}
+
+async fn retry_db() -> Result<(), Drop> {
+    loop {
+        match func().await {
+            //~^ ERROR relative drop order changing in Rust 2024
+            //~| WARNING this changes meaning in Rust 2024
+            Ok(()) => return Ok(()),
+            Err(e) => {}
+        }
+    }
+}
+
+fn main() {}

--- a/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
+++ b/tests/ui/drop/tail_expr_drop_order-on-coroutine-unwind.stderr
@@ -1,0 +1,52 @@
+error: relative drop order changing in Rust 2024
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:20:15
+   |
+LL |         match func().await {
+   |               ^^^^^^^-----
+   |               |      |
+   |               |      this value will be stored in a temporary; let us call it `#1`
+   |               |      `#1` will be dropped later as of Edition 2024
+   |               this value will be stored in a temporary; let us call it `#2`
+   |               up until Edition 2021 `#2` is dropped last but will be dropped earlier in Edition 2024
+...
+LL |             Err(e) => {}
+   |                 -
+   |                 |
+   |                 `e` calls a custom destructor
+   |                 `e` will be dropped later as of Edition 2024
+LL |         }
+LL |     }
+   |     - now the temporary value is dropped here, before the local variables in the block or statement
+   |
+   = warning: this changes meaning in Rust 2024
+   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/temporary-tail-expr-scope.html>
+note: `#2` invokes this custom destructor
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:10:1
+   |
+LL | / impl std::ops::Drop for Drop {
+LL | |     fn drop(&mut self) {}
+LL | | }
+   | |_^
+note: `#1` invokes this custom destructor
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:10:1
+   |
+LL | / impl std::ops::Drop for Drop {
+LL | |     fn drop(&mut self) {}
+LL | | }
+   | |_^
+note: `e` invokes this custom destructor
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:10:1
+   |
+LL | / impl std::ops::Drop for Drop {
+LL | |     fn drop(&mut self) {}
+LL | | }
+   | |_^
+   = note: most of the time, changing drop order is harmless; inspect the `impl Drop`s for side effects like releasing locks or sending messages
+note: the lint level is defined here
+  --> $DIR/tail_expr_drop_order-on-coroutine-unwind.rs:7:9
+   |
+LL | #![deny(tail_expr_drop_order)]
+   |         ^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 1 previous error
+


### PR DESCRIPTION
Fixes #134566
Fixes #134541