### PR TITLE
Rollup of 7 pull requests

### DIFF
--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1325,7 +1325,6 @@ impl Expr {
             }
 
             ExprKind::Break(..)
-            | ExprKind::Continue(..)
             | ExprKind::Ret(..)
             | ExprKind::Yield(..)
             | ExprKind::Yeet(..)
@@ -1359,6 +1358,7 @@ impl Expr {
             | ExprKind::Block(..)
             | ExprKind::Call(..)
             | ExprKind::ConstBlock(_)
+            | ExprKind::Continue(..)
             | ExprKind::Field(..)
             | ExprKind::ForLoop { .. }
             | ExprKind::FormatArgs(..)

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1316,9 +1316,15 @@ impl Expr {
     }
 
     pub fn precedence(&self) -> ExprPrecedence {
-        match self.kind {
+        match &self.kind {
+            ExprKind::Closure(closure) => {
+                match closure.fn_decl.output {
+                    FnRetTy::Default(_) => ExprPrecedence::Jump,
+                    FnRetTy::Ty(_) => ExprPrecedence::Unambiguous,
+                }
+            }
+
             ExprKind::Break(..)
-            | ExprKind::Closure(..)
             | ExprKind::Continue(..)
             | ExprKind::Ret(..)
             | ExprKind::Yield(..)

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1317,9 +1317,8 @@ impl Expr {
 
     pub fn precedence(&self) -> ExprPrecedence {
         match self.kind {
-            ExprKind::Closure(..) => ExprPrecedence::Closure,
-
             ExprKind::Break(..)
+            | ExprKind::Closure(..)
             | ExprKind::Continue(..)
             | ExprKind::Ret(..)
             | ExprKind::Yield(..)

--- a/compiler/rustc_ast/src/util/parser.rs
+++ b/compiler/rustc_ast/src/util/parser.rs
@@ -231,8 +231,7 @@ impl AssocOp {
 
 #[derive(Clone, Copy, PartialEq, PartialOrd)]
 pub enum ExprPrecedence {
-    Closure,
-    // return, break, yield
+    // return, break, yield, closures
     Jump,
     // = += -= *= /= %= &= |= ^= <<= >>=
     Assign,

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1696,9 +1696,15 @@ pub struct Expr<'hir> {
 
 impl Expr<'_> {
     pub fn precedence(&self) -> ExprPrecedence {
-        match self.kind {
+        match &self.kind {
+            ExprKind::Closure(closure) => {
+                match closure.fn_decl.output {
+                    FnRetTy::DefaultReturn(_) => ExprPrecedence::Jump,
+                    FnRetTy::Return(_) => ExprPrecedence::Unambiguous,
+                }
+            }
+
             ExprKind::Break(..)
-            | ExprKind::Closure { .. }
             | ExprKind::Continue(..)
             | ExprKind::Ret(..)
             | ExprKind::Yield(..)
@@ -1741,7 +1747,7 @@ impl Expr<'_> {
             | ExprKind::Type(..)
             | ExprKind::Err(_) => ExprPrecedence::Unambiguous,
 
-            ExprKind::DropTemps(ref expr, ..) => expr.precedence(),
+            ExprKind::DropTemps(expr, ..) => expr.precedence(),
         }
     }
 

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1705,7 +1705,6 @@ impl Expr<'_> {
             }
 
             ExprKind::Break(..)
-            | ExprKind::Continue(..)
             | ExprKind::Ret(..)
             | ExprKind::Yield(..)
             | ExprKind::Become(..) => ExprPrecedence::Jump,
@@ -1731,6 +1730,7 @@ impl Expr<'_> {
             | ExprKind::Block(..)
             | ExprKind::Call(..)
             | ExprKind::ConstBlock(_)
+            | ExprKind::Continue(..)
             | ExprKind::Field(..)
             | ExprKind::If(..)
             | ExprKind::Index(..)

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1697,9 +1697,8 @@ pub struct Expr<'hir> {
 impl Expr<'_> {
     pub fn precedence(&self) -> ExprPrecedence {
         match self.kind {
-            ExprKind::Closure { .. } => ExprPrecedence::Closure,
-
             ExprKind::Break(..)
+            | ExprKind::Closure { .. }
             | ExprKind::Continue(..)
             | ExprKind::Ret(..)
             | ExprKind::Yield(..)

--- a/compiler/rustc_hir_typeck/src/method/probe.rs
+++ b/compiler/rustc_hir_typeck/src/method/probe.rs
@@ -1337,6 +1337,15 @@ impl<'a, 'tcx> ProbeContext<'a, 'tcx> {
         mutbl: hir::Mutability,
         track_unstable_candidates: bool,
     ) -> Result<(), MethodError<'tcx>> {
+        // The errors emitted by this function are part of
+        // the arbitrary self types work, and should not impact
+        // other users.
+        if !self.tcx.features().arbitrary_self_types()
+            && !self.tcx.features().arbitrary_self_types_pointers()
+        {
+            return Ok(());
+        }
+
         // We don't want to remember any of the diagnostic hints from this
         // shadow search, but we do need to provide Some/None for the
         // unstable_candidates in order to reflect the behavior of the

--- a/compiler/rustc_lint/src/types.rs
+++ b/compiler/rustc_lint/src/types.rs
@@ -4,7 +4,7 @@ use std::ops::ControlFlow;
 use rustc_abi::{BackendRepr, ExternAbi, TagEncoding, Variants, WrappingRange};
 use rustc_data_structures::fx::FxHashSet;
 use rustc_errors::DiagMessage;
-use rustc_hir::{Expr, ExprKind};
+use rustc_hir::{Expr, ExprKind, LangItem};
 use rustc_middle::bug;
 use rustc_middle::ty::layout::{LayoutOf, SizeSkeleton};
 use rustc_middle::ty::{
@@ -445,7 +445,25 @@ fn lint_fn_pointer<'tcx>(
     let (l_ty, l_ty_refs) = peel_refs(l_ty);
     let (r_ty, r_ty_refs) = peel_refs(r_ty);
 
-    if !l_ty.is_fn() || !r_ty.is_fn() {
+    if l_ty.is_fn() && r_ty.is_fn() {
+        // both operands are function pointers, fallthrough
+    } else if let ty::Adt(l_def, l_args) = l_ty.kind()
+        && let ty::Adt(r_def, r_args) = r_ty.kind()
+        && cx.tcx.is_lang_item(l_def.did(), LangItem::Option)
+        && cx.tcx.is_lang_item(r_def.did(), LangItem::Option)
+        && let Some(l_some_arg) = l_args.get(0)
+        && let Some(r_some_arg) = r_args.get(0)
+        && l_some_arg.expect_ty().is_fn()
+        && r_some_arg.expect_ty().is_fn()
+    {
+        // both operands are `Option<{function ptr}>`
+        return cx.emit_span_lint(
+            UNPREDICTABLE_FUNCTION_POINTER_COMPARISONS,
+            e.span,
+            UnpredictableFunctionPointerComparisons::Warn,
+        );
+    } else {
+        // types are not function pointers, nothing to do
         return;
     }
 

--- a/compiler/rustc_passes/messages.ftl
+++ b/compiler/rustc_passes/messages.ftl
@@ -566,6 +566,10 @@ passes_no_sanitize =
     `#[no_sanitize({$attr_str})]` should be applied to {$accepted_kind}
     .label = not {$accepted_kind}
 
+passes_non_exaustive_with_default_field_values =
+    `#[non_exhaustive]` can't be used to annotate items with default field values
+    .label = this struct has default field values
+
 passes_non_exported_macro_invalid_attrs =
     attribute should be applied to function or closure
     .label = not a function or closure

--- a/compiler/rustc_passes/src/check_attr.rs
+++ b/compiler/rustc_passes/src/check_attr.rs
@@ -124,7 +124,7 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
                 [sym::coverage, ..] => self.check_coverage(attr, span, target),
                 [sym::optimize, ..] => self.check_optimize(hir_id, attr, span, target),
                 [sym::no_sanitize, ..] => self.check_no_sanitize(attr, span, target),
-                [sym::non_exhaustive, ..] => self.check_non_exhaustive(hir_id, attr, span, target),
+                [sym::non_exhaustive, ..] => self.check_non_exhaustive(hir_id, attr, span, target, item),
                 [sym::marker, ..] => self.check_marker(hir_id, attr, span, target),
                 [sym::target_feature, ..] => {
                     self.check_target_feature(hir_id, attr, span, target, attrs)
@@ -684,9 +684,30 @@ impl<'tcx> CheckAttrVisitor<'tcx> {
     }
 
     /// Checks if the `#[non_exhaustive]` attribute on an `item` is valid.
-    fn check_non_exhaustive(&self, hir_id: HirId, attr: &Attribute, span: Span, target: Target) {
+    fn check_non_exhaustive(
+        &self,
+        hir_id: HirId,
+        attr: &Attribute,
+        span: Span,
+        target: Target,
+        item: Option<ItemLike<'_>>,
+    ) {
         match target {
-            Target::Struct | Target::Enum | Target::Variant => {}
+            Target::Struct => {
+                if let Some(ItemLike::Item(hir::Item {
+                    kind: hir::ItemKind::Struct(hir::VariantData::Struct { fields, .. }, _),
+                    ..
+                })) = item
+                    && !fields.is_empty()
+                    && fields.iter().any(|f| f.default.is_some())
+                {
+                    self.dcx().emit_err(errors::NonExhaustiveWithDefaultFieldValues {
+                        attr_span: attr.span,
+                        defn_span: span,
+                    });
+                }
+            }
+            Target::Enum | Target::Variant => {}
             // FIXME(#80564): We permit struct fields, match arms and macro defs to have an
             // `#[non_exhaustive]` attribute with just a lint, because we previously
             // erroneously allowed it and some crates used it accidentally, to be compatible

--- a/compiler/rustc_passes/src/errors.rs
+++ b/compiler/rustc_passes/src/errors.rs
@@ -120,6 +120,15 @@ pub(crate) struct NonExhaustiveWrongLocation {
 }
 
 #[derive(Diagnostic)]
+#[diag(passes_non_exaustive_with_default_field_values)]
+pub(crate) struct NonExhaustiveWithDefaultFieldValues {
+    #[primary_span]
+    pub attr_span: Span,
+    #[label]
+    pub defn_span: Span,
+}
+
+#[derive(Diagnostic)]
 #[diag(passes_should_be_applied_to_trait)]
 pub(crate) struct AttrShouldBeAppliedToTrait {
     #[primary_span]

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -722,3 +722,22 @@ test tests/rustdoc-ui/doctest/rustflags.rs - Bar (line 5) ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
 ```
+
+The parsing of arguments works as follows: if it encounters a `"` or a `'`, it will continue
+until it finds the character unescaped (without a prepending `\`). If not inside a string, a
+whitespace character will also split arguments. Example:
+
+```text
+"hello 'a'\" ok" how are   'you today?'
+```
+
+will be split as follows:
+
+```text
+[
+    "hello 'a'\" ok",
+    "how",
+    "are",
+    "you today?",
+]
+```

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -667,7 +667,7 @@ This flag can be passed multiple times to nest wrappers.
 
 ## Passing arguments to rustc when compiling doctests
 
-You can use the `--doctest-compilation-args` option if you want to add options when compiling the
+You can use the `--doctest-compilation-args` flag if you want to add options when compiling the
 doctest. For example if you have:
 
 ```rust,no_run

--- a/src/doc/rustdoc/src/unstable-features.md
+++ b/src/doc/rustdoc/src/unstable-features.md
@@ -315,7 +315,7 @@ Markdown file, the URL given to `--markdown-playground-url` will take precedence
 `--playground-url` and `#![doc(html_playground_url = "url")]` are present when rendering crate docs,
 the attribute will take precedence.
 
-### `--sort-modules-by-appearance`: control how items on module pages are sorted
+## `--sort-modules-by-appearance`: control how items on module pages are sorted
 
 Using this flag looks like this:
 
@@ -328,7 +328,7 @@ some consideration for their stability, and names that end in a number). Giving 
 `rustdoc` will disable this sorting and instead make it print the items in the order they appear in
 the source.
 
-### `--show-type-layout`: add a section to each type's docs describing its memory layout
+## `--show-type-layout`: add a section to each type's docs describing its memory layout
 
 * Tracking issue: [#113248](https://github.com/rust-lang/rust/issues/113248)
 
@@ -346,7 +346,7 @@ of that type will take in memory.
 Note that most layout information is **completely unstable** and may even differ
 between compilations.
 
-### `--resource-suffix`: modifying the name of CSS/JavaScript in crate docs
+## `--resource-suffix`: modifying the name of CSS/JavaScript in crate docs
 
  * Tracking issue: [#54765](https://github.com/rust-lang/rust/issues/54765)
 
@@ -361,7 +361,7 @@ all these files are linked from every page, changing where they are can be cumbe
 specially cache them. This flag will rename all these files in the output to include the suffix in
 the filename. For example, `light.css` would become `light-suf.css` with the above command.
 
-### `--extern-html-root-url`: control how rustdoc links to non-local crates
+## `--extern-html-root-url`: control how rustdoc links to non-local crates
 
 Using this flag looks like this:
 
@@ -376,7 +376,7 @@ flags to control that behavior. When the `--extern-html-root-url` flag is given 
 one of your dependencies, rustdoc use that URL for those docs. Keep in mind that if those docs exist
 in the output directory, those local docs will still override this flag.
 
-### `-Z force-unstable-if-unmarked`
+## `-Z force-unstable-if-unmarked`
 
 Using this flag looks like this:
 
@@ -389,7 +389,7 @@ This is an internal flag intended for the standard library and compiler that app
 allows `rustdoc` to be able to generate documentation for the compiler crates and the standard
 library, as an equivalent command-line argument is provided to `rustc` when building those crates.
 
-### `--index-page`: provide a top-level landing page for docs
+## `--index-page`: provide a top-level landing page for docs
 
 This feature allows you to generate an index-page with a given markdown file. A good example of it
 is the [rust documentation index](https://doc.rust-lang.org/nightly/index.html).
@@ -398,18 +398,18 @@ With this, you'll have a page which you can customize as much as you want at the
 
 Using `index-page` option enables `enable-index-page` option as well.
 
-### `--enable-index-page`: generate a default index page for docs
+## `--enable-index-page`: generate a default index page for docs
 
 This feature allows the generation of a default index-page which lists the generated crates.
 
-### `--nocapture`: disable output capture for test
+## `--nocapture`: disable output capture for test
 
 When this flag is used with `--test`, the output (stdout and stderr) of your tests won't be
 captured by rustdoc. Instead, the output will be directed to your terminal,
 as if you had run the test executable manually. This is especially useful
 for debugging your tests!
 
-### `--check`: only checks the documentation
+## `--check`: only checks the documentation
 
 When this flag is supplied, rustdoc will type check and lint your code, but will not generate any
 documentation or run your doctests.
@@ -420,7 +420,7 @@ Using this flag looks like:
 rustdoc -Z unstable-options --check src/lib.rs
 ```
 
-### `--static-root-path`: control how static files are loaded in HTML output
+## `--static-root-path`: control how static files are loaded in HTML output
 
 Using this flag looks like this:
 
@@ -435,7 +435,7 @@ JavaScript, and font files in a single location, rather than duplicating it once
 files like the search index will still load from the documentation root, but anything that gets
 renamed with `--resource-suffix` will load from the given path.
 
-### `--persist-doctests`: persist doctest executables after running
+## `--persist-doctests`: persist doctest executables after running
 
  * Tracking issue: [#56925](https://github.com/rust-lang/rust/issues/56925)
 
@@ -449,7 +449,7 @@ This flag allows you to keep doctest executables around after they're compiled o
 Usually, rustdoc will immediately discard a compiled doctest after it's been tested, but
 with this option, you can keep those binaries around for farther testing.
 
-### `--show-coverage`: calculate the percentage of items with documentation
+## `--show-coverage`: calculate the percentage of items with documentation
 
  * Tracking issue: [#58154](https://github.com/rust-lang/rust/issues/58154)
 
@@ -500,7 +500,7 @@ Calculating code examples follows these rules:
   * typedef
 2. If one of the previously listed items has a code example, then it'll be counted.
 
-#### JSON output
+### JSON output
 
 When using `--output-format json` with this option, it will display the coverage information in
 JSON format. For example, here is the JSON for a file with one documented item and one
@@ -522,7 +522,7 @@ Note that the third item is the crate root, which in this case is undocumented.
 If you want the JSON output to be displayed on `stdout` instead of having a file generated, you can
 use `-o -`.
 
-### `-w`/`--output-format`: output format
+## `-w`/`--output-format`: output format
 
 `--output-format json` emits documentation in the experimental
 [JSON format](https://doc.rust-lang.org/nightly/nightly-rustc/rustdoc_json_types/). `--output-format html` has no effect,
@@ -542,7 +542,7 @@ It can also be used with `--show-coverage`. Take a look at its
 [documentation](#--show-coverage-calculate-the-percentage-of-items-with-documentation) for more
 information.
 
-### `--enable-per-target-ignores`: allow `ignore-foo` style filters for doctests
+## `--enable-per-target-ignores`: allow `ignore-foo` style filters for doctests
 
  * Tracking issue: [#64245](https://github.com/rust-lang/rust/issues/64245)
 
@@ -577,7 +577,7 @@ struct Foo;
 In older versions, this will be ignored on all targets, but on newer versions `ignore-gnu` will
 override `ignore`.
 
-### `--runtool`, `--runtool-arg`: program to run tests with; args to pass to it
+## `--runtool`, `--runtool-arg`: program to run tests with; args to pass to it
 
  * Tracking issue: [#64245](https://github.com/rust-lang/rust/issues/64245)
 
@@ -596,7 +596,7 @@ $ rustdoc src/lib.rs -Z unstable-options --runtool valgrind
 
 Another use case would be to run a test inside an emulator, or through a Virtual Machine.
 
-### `--with-examples`: include examples of uses of items as documentation
+## `--with-examples`: include examples of uses of items as documentation
 
  * Tracking issue: [#88791](https://github.com/rust-lang/rust/issues/88791)
 
@@ -625,7 +625,7 @@ crate being documented (`foobar`) and a path to output the calls
 To scrape examples from test code, e.g. functions marked `#[test]`, then
 add the `--scrape-tests` flag.
 
-### `--generate-link-to-definition`: Generate links on types in source code
+## `--generate-link-to-definition`: Generate links on types in source code
 
  * Tracking issue: [#89095](https://github.com/rust-lang/rust/issues/89095)
 
@@ -664,3 +664,61 @@ Similar to cargo `build.rustc-wrapper` option, this flag takes a `rustc` wrapper
 The first argument to the program will be the test builder program.
 
 This flag can be passed multiple times to nest wrappers.
+
+## Passing arguments to rustc when compiling doctests
+
+You can use the `--doctest-compilation-args` option if you want to add options when compiling the
+doctest. For example if you have:
+
+```rust,no_run
+/// ```
+/// #![deny(warnings)]
+/// #![feature(async_await)]
+///
+/// let x = 12;
+/// ```
+pub struct Bar;
+```
+
+And you run `rustdoc --test` on it, you will get:
+
+```console
+running 1 test
+test foo.rs - Bar (line 1) ... FAILED
+
+failures:
+
+---- foo.rs - Bar (line 1) stdout ----
+error: the feature `async_await` has been stable since 1.39.0 and no longer requires an attribute to enable
+ --> foo.rs:2:12
+  |
+3 | #![feature(async_await)]
+  |            ^^^^^^^^^^^
+  |
+note: the lint level is defined here
+ --> foo.rs:1:9
+  |
+2 | #![deny(warnings)]
+  |         ^^^^^^^^
+  = note: `#[deny(stable_features)]` implied by `#[deny(warnings)]`
+
+error: aborting due to 1 previous error
+
+Couldn't compile the test.
+
+failures:
+    foo.rs - Bar (line 1)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
+```
+
+But if you can limit the lint level to warning by using `--doctest_compilation_args=--cap-lints=warn`:
+
+```console
+$ rustdoc --test --doctest_compilation_args=--cap-lints=warn file.rs
+
+running 1 test
+test tests/rustdoc-ui/doctest/rustflags.rs - Bar (line 5) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
+```

--- a/src/librustdoc/config.rs
+++ b/src/librustdoc/config.rs
@@ -172,6 +172,9 @@ pub(crate) struct Options {
     /// This is mainly useful for other tools that reads that debuginfo to figure out
     /// how to call the compiler with the same arguments.
     pub(crate) expanded_args: Vec<String>,
+
+    /// Arguments to be used when compiling doctests.
+    pub(crate) doctest_compilation_args: Vec<String>,
 }
 
 impl fmt::Debug for Options {
@@ -774,6 +777,7 @@ impl Options {
         let scrape_examples_options = ScrapeExamplesOptions::new(matches, dcx);
         let with_examples = matches.opt_strs("with-examples");
         let call_locations = crate::scrape_examples::load_call_locations(with_examples, dcx);
+        let doctest_compilation_args = matches.opt_strs("doctest-compilation-args");
 
         let unstable_features =
             rustc_feature::UnstableFeatures::from_environment(crate_name.as_deref());
@@ -819,6 +823,7 @@ impl Options {
             scrape_examples_options,
             unstable_features,
             expanded_args: args,
+            doctest_compilation_args,
         };
         let render_options = RenderOptions {
             output,

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -1036,29 +1036,6 @@ fn doctest_run_fn(
     Ok(())
 }
 
-#[cfg(test)]
-#[test]
-fn check_split_args() {
-    fn compare(input: &str, expected: &[&str]) {
-        let output = split_args(input);
-        let expected = expected.iter().map(|s| s.to_string()).collect::<Vec<_>>();
-        assert_eq!(expected, output, "test failed for {input:?}");
-    }
-
-    compare("'a' \"b\"c", &["a", "bc"]);
-    compare("'a' \"b \"c d", &["a", "b c", "d"]);
-    compare("'a' \"b\\\"c\"", &["a", "b\"c"]);
-    compare("'a\"'", &["a\""]);
-    compare("\"a'\"", &["a'"]);
-    compare("\\ a", &[" a"]);
-    compare("\\\\", &["\\"]);
-    compare("a'", &["a"]);
-    compare("a          ", &["a"]);
-    compare("a          b", &["a", "b"]);
-    compare("a\n\t \rb", &["a", "b"]);
-    compare("a\n\t1 \rb", &["a", "1", "b"]);
-}
-
 #[cfg(test)] // used in tests
 impl DocTestVisitor for Vec<usize> {
     fn visit_test(&mut self, _test: String, _config: LangString, rel_line: MdRelLine) {

--- a/src/librustdoc/doctest.rs
+++ b/src/librustdoc/doctest.rs
@@ -78,6 +78,17 @@ pub(crate) fn generate_args_file(file_path: &Path, options: &RustdocOptions) -> 
         content.push(format!("-Z{unstable_option_str}"));
     }
 
+    for compilation_args in &options.doctest_compilation_args {
+        for flag in compilation_args
+            .split_whitespace()
+            .map(|flag| flag.trim())
+            .filter(|flag| !flag.is_empty())
+        {
+            // Very simple parsing implementation. Might be a good idea to correctly handle strings.
+            content.push(flag.to_string());
+        }
+    }
+
     let content = content.join("\n");
 
     file.write_all(content.as_bytes())

--- a/src/librustdoc/doctest/tests.rs
+++ b/src/librustdoc/doctest/tests.rs
@@ -379,3 +379,25 @@ fn main() {
     let (output, len) = make_test(input, None, false, &opts, None);
     assert_eq!((output, len), (expected, 1));
 }
+
+#[test]
+fn check_split_args() {
+    fn compare(input: &str, expected: &[&str]) {
+        let output = super::split_args(input);
+        let expected = expected.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert_eq!(expected, output, "test failed for {input:?}");
+    }
+
+    compare("'a' \"b\"c", &["a", "bc"]);
+    compare("'a' \"b \"c d", &["a", "b c", "d"]);
+    compare("'a' \"b\\\"c\"", &["a", "b\"c"]);
+    compare("'a\"'", &["a\""]);
+    compare("\"a'\"", &["a'"]);
+    compare("\\ a", &[" a"]);
+    compare("\\\\", &["\\"]);
+    compare("a'", &["a"]);
+    compare("a          ", &["a"]);
+    compare("a          b", &["a", "b"]);
+    compare("a\n\t \rb", &["a", "b"]);
+    compare("a\n\t1 \rb", &["a", "1", "b"]);
+}

--- a/src/librustdoc/lib.rs
+++ b/src/librustdoc/lib.rs
@@ -642,6 +642,15 @@ fn opts() -> Vec<RustcOptGroup> {
             "Includes trait implementations and other crate info from provided path. Only use with --merge=finalize",
             "path/to/doc.parts/<crate-name>",
         ),
+        opt(Unstable, Flag, "", "html-no-source", "Disable HTML source code pages generation", ""),
+        opt(
+            Unstable,
+            Multi,
+            "",
+            "doctest-compilation-args",
+            "",
+            "add arguments to be used when compiling doctests",
+        ),
         // deprecated / removed options
         opt(Unstable, FlagMulti, "", "disable-minification", "removed", ""),
         opt(
@@ -684,7 +693,6 @@ fn opts() -> Vec<RustcOptGroup> {
             "removed, see issue #44136 <https://github.com/rust-lang/rust/issues/44136> for more information",
             "[rust]",
         ),
-        opt(Unstable, Flag, "", "html-no-source", "Disable HTML source code pages generation", ""),
     ]
 }
 

--- a/tests/run-make/rustdoc-default-output/output-default.stdout
+++ b/tests/run-make/rustdoc-default-output/output-default.stdout
@@ -189,6 +189,10 @@ Options:
         --include-parts-dir path/to/doc.parts/<crate-name>
                         Includes trait implementations and other crate info
                         from provided path. Only use with --merge=finalize
+        --html-no-source 
+                        Disable HTML source code pages generation
+        --doctest-compilation-args add arguments to be used when compiling doctests
+                        
         --disable-minification 
                         removed
         --plugin-path DIR
@@ -209,8 +213,6 @@ Options:
                         removed, see issue #44136
                         <https://github.com/rust-lang/rust/issues/44136> for
                         more information
-        --html-no-source 
-                        Disable HTML source code pages generation
 
     @path               Read newline separated options from `path`
 

--- a/tests/rustdoc-ui/doctest/rustflags-multiple-args.rs
+++ b/tests/rustdoc-ui/doctest/rustflags-multiple-args.rs
@@ -1,0 +1,17 @@
+// This test checks that the test behave when `--doctest-compilation-args` is passed
+// multiple times.
+
+//@ check-pass
+//@ compile-flags: --test -Zunstable-options --doctest-compilation-args=--cfg=testcase_must_be_present
+//@ compile-flags: --doctest-compilation-args=--cfg=another
+//@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
+
+/// ```
+/// #[cfg(testcase_must_be_present)]
+/// #[cfg(another)]
+/// fn must_be_present() {}
+///
+/// fn main() { must_be_present() }
+/// ```
+pub struct Bar;

--- a/tests/rustdoc-ui/doctest/rustflags-multiple-args.stdout
+++ b/tests/rustdoc-ui/doctest/rustflags-multiple-args.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test $DIR/rustflags-multiple-args.rs - Bar (line 10) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/rustdoc-ui/doctest/rustflags.rs
+++ b/tests/rustdoc-ui/doctest/rustflags.rs
@@ -1,0 +1,12 @@
+//@ check-pass
+//@ compile-flags: --test -Zunstable-options --doctest-compilation-args=--cfg=testcase_must_be_present
+//@ normalize-stdout-test: "tests/rustdoc-ui/doctest" -> "$$DIR"
+//@ normalize-stdout-test: "finished in \d+\.\d+s" -> "finished in $$TIME"
+
+/// ```
+/// #[cfg(testcase_must_be_present)]
+/// fn must_be_present() {}
+///
+/// fn main() { must_be_present() }
+/// ```
+pub struct Bar;

--- a/tests/rustdoc-ui/doctest/rustflags.stdout
+++ b/tests/rustdoc-ui/doctest/rustflags.stdout
@@ -1,0 +1,6 @@
+
+running 1 test
+test $DIR/rustflags.rs - Bar (line 6) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -72,7 +72,7 @@ static EXPRS: &[&str] = &[
     "(return) - 2",
     // Closures and jumps have equal precedence.
     "|| return break 2",
-    "return break (|| 2)", // FIXME: no parenthesis needed.
+    "return break || 2",
     // These mean different things.
     "if let _ = true && false {}",
     "if let _ = (true && false) {}",

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -74,7 +74,7 @@ static EXPRS: &[&str] = &[
     "|| return break 2",
     "return break || 2",
     // Closures with a return type have especially high precedence.
-    "(|| -> T { x }) + 1", // FIXME: no parenthesis needed.
+    "|| -> T { x } + 1",
     "(|| { x }) + 1",
     // These mean different things.
     "if let _ = true && false {}",

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -70,6 +70,9 @@ static EXPRS: &[&str] = &[
     // These mean different things.
     "return - 2",
     "(return) - 2",
+    // Closures and jumps have equal precedence.
+    "|| return break 2",
+    "return break (|| 2)", // FIXME: no parenthesis needed.
     // These mean different things.
     "if let _ = true && false {}",
     "if let _ = (true && false) {}",

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -73,6 +73,9 @@ static EXPRS: &[&str] = &[
     // Closures and jumps have equal precedence.
     "|| return break 2",
     "return break || 2",
+    // Closures with a return type have especially high precedence.
+    "(|| -> T { x }) + 1", // FIXME: no parenthesis needed.
+    "(|| { x }) + 1",
     // These mean different things.
     "if let _ = true && false {}",
     "if let _ = (true && false) {}",

--- a/tests/ui/lint/fn-ptr-comparisons-some.rs
+++ b/tests/ui/lint/fn-ptr-comparisons-some.rs
@@ -1,0 +1,17 @@
+// This test checks that we lint on Option of fn ptr.
+//
+// https://github.com/rust-lang/rust/issues/134527.
+//
+//@ check-pass
+
+unsafe extern "C" fn func() {}
+
+type FnPtr = unsafe extern "C" fn();
+
+fn main() {
+    let _ = Some::<FnPtr>(func) == Some(func as unsafe extern "C" fn());
+    //~^ WARN function pointer comparisons
+
+    // Undecided as of https://github.com/rust-lang/rust/pull/134536
+    assert_eq!(Some::<FnPtr>(func), Some(func as unsafe extern "C" fn()));
+}

--- a/tests/ui/lint/fn-ptr-comparisons-some.stderr
+++ b/tests/ui/lint/fn-ptr-comparisons-some.stderr
@@ -1,0 +1,13 @@
+warning: function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique
+  --> $DIR/fn-ptr-comparisons-some.rs:12:13
+   |
+LL |     let _ = Some::<FnPtr>(func) == Some(func as unsafe extern "C" fn());
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: the address of the same function can vary between different codegen units
+   = note: furthermore, different functions could have the same address after being merged together
+   = note: for more information visit <https://doc.rust-lang.org/nightly/core/ptr/fn.fn_addr_eq.html>
+   = note: `#[warn(unpredictable_function_pointer_comparisons)]` on by default
+
+warning: 1 warning emitted
+

--- a/tests/ui/self/arbitrary_self_types_niche_deshadowing.rs
+++ b/tests/ui/self/arbitrary_self_types_niche_deshadowing.rs
@@ -1,0 +1,63 @@
+//@ run-pass
+
+#![allow(dead_code)]
+#![allow(incomplete_features)]
+
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![feature(pin_ergonomics)]
+
+use std::pin::Pin;
+use std::pin::pin;
+use std::marker::PhantomData;
+
+struct A;
+
+impl A {
+    fn m(self: *const SmartPtr<Self>) -> usize { 2 }
+    fn n(self: *const SmartPtr<Self>) -> usize { 2 }
+
+    fn o(self: Pin<&SmartPtr2<Self>>) -> usize { 2 }
+    fn p(self: Pin<&SmartPtr2<Self>>) -> usize { 2 }
+}
+
+struct SmartPtr<T>(T);
+
+impl<T> core::ops::Receiver for SmartPtr<T> {
+    type Target = *mut T;
+}
+
+impl<T> SmartPtr<T> {
+    // In general we try to detect cases where a method in a smart pointer
+    // "shadows" a method in the referent (in this test, A).
+    // This method "shadows" the 'n' method in the inner type A
+    // We do not attempt to produce an error in these shadowing cases
+    // since the type signature of this method and the corresponding
+    // method in A are pretty unlikely to occur in practice,
+    // and because it shows up conflicts between *const::cast and *mut::cast.
+    fn n(self: *mut Self) -> usize { 1 }
+}
+
+struct SmartPtr2<'a, T>(T, PhantomData<&'a T>);
+
+impl<'a, T> core::ops::Receiver for SmartPtr2<'a, T> {
+    type Target = Pin<&'a mut T>;
+}
+
+impl<T> SmartPtr2<'_, T> {
+    // Similarly, this method shadows the method in A
+    // Can only happen with the unstable feature pin_ergonomics
+    fn p(self: Pin<&mut Self>) -> usize { 1 }
+}
+
+fn main() {
+    let mut sm = SmartPtr(A);
+    let smp: *mut SmartPtr<A> = &mut sm as *mut SmartPtr<A>;
+    assert_eq!(smp.m(), 2);
+    assert_eq!(smp.n(), 1);
+
+    let smp: Pin<&mut SmartPtr2<A>> = pin!(SmartPtr2(A, PhantomData));
+    assert_eq!(smp.o(), 2);
+    let smp: Pin<&mut SmartPtr2<A>> = pin!(SmartPtr2(A, PhantomData));
+    assert_eq!(smp.p(), 1);
+}

--- a/tests/ui/self/arbitrary_self_types_pin_getref.feature.stderr
+++ b/tests/ui/self/arbitrary_self_types_pin_getref.feature.stderr
@@ -1,0 +1,16 @@
+error[E0034]: multiple applicable items in scope
+  --> $DIR/arbitrary_self_types_pin_getref.rs:23:22
+   |
+LL |     let _ = pinned_a.get_ref();
+   |                      ^^^^^^^ multiple `get_ref` found
+   |
+note: candidate #1 is defined in an impl for the type `A`
+  --> $DIR/arbitrary_self_types_pin_getref.rs:17:5
+   |
+LL |     fn get_ref(self: &Pin<&A>) {}  // note &Pin
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   = note: candidate #2 is defined in an impl for the type `Pin<&'a T>`
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0034`.

--- a/tests/ui/self/arbitrary_self_types_pin_getref.rs
+++ b/tests/ui/self/arbitrary_self_types_pin_getref.rs
@@ -1,0 +1,25 @@
+// Confirms that Pin::get_ref can no longer shadow methods in pointees
+// once arbitrary_self_types is enabled.
+//
+//@ revisions: default feature
+#![cfg_attr(feature, feature(arbitrary_self_types))]
+
+//@[default] check-pass
+
+#![allow(dead_code)]
+
+use std::pin::Pin;
+use std::pin::pin;
+
+struct A;
+
+impl A {
+    fn get_ref(self: &Pin<&A>) {}  // note &Pin
+}
+
+fn main() {
+    let pinned_a: Pin<&mut A> = pin!(A);
+    let pinned_a: Pin<&A> = pinned_a.as_ref();
+    let _ = pinned_a.get_ref();
+    //[feature]~^ ERROR: multiple applicable items
+}

--- a/tests/ui/structs/default-field-values-non_exhaustive.rs
+++ b/tests/ui/structs/default-field-values-non_exhaustive.rs
@@ -1,0 +1,18 @@
+#![feature(default_field_values)]
+
+#[derive(Default)]
+#[non_exhaustive] //~ ERROR `#[non_exhaustive]` can't be used to annotate items with default field values
+struct Foo {
+    x: i32 = 42 + 3,
+}
+
+#[derive(Default)]
+enum Bar {
+    #[non_exhaustive]
+    #[default]
+    Baz { //~ ERROR default variant must be exhaustive
+        x: i32 = 42 + 3,
+    }
+}
+
+fn main () {}

--- a/tests/ui/structs/default-field-values-non_exhaustive.stderr
+++ b/tests/ui/structs/default-field-values-non_exhaustive.stderr
@@ -1,0 +1,23 @@
+error: default variant must be exhaustive
+  --> $DIR/default-field-values-non_exhaustive.rs:13:5
+   |
+LL |     #[non_exhaustive]
+   |     ----------------- declared `#[non_exhaustive]` here
+LL |     #[default]
+LL |     Baz {
+   |     ^^^
+   |
+   = help: consider a manual implementation of `Default`
+
+error: `#[non_exhaustive]` can't be used to annotate items with default field values
+  --> $DIR/default-field-values-non_exhaustive.rs:4:1
+   |
+LL |   #[non_exhaustive]
+   |   ^^^^^^^^^^^^^^^^^
+LL | / struct Foo {
+LL | |     x: i32 = 42 + 3,
+LL | | }
+   | |_- this struct has default field values
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
Successful merges:

 - #123604 (Abstract `ProcThreadAttributeList` into its own struct)
 - #128780 (Add `--doctest-compilation-args` option to add compilation flags to doctest compilation)
 - #133782 (Precedence improvements: closures and jumps)
 - #134509 (Arbitrary self types v2: niche deshadowing test)
 - #134524 (Arbitrary self types v2: no deshadow pre feature.)
 - #134539 (Restrict `#[non_exaustive]` on structs with default field values)
 - #134586 (Also lint on option of function pointer comparisons)

r? @ghost
@rustbot modify labels: rollup
<!-- homu-ignore:start -->
[Create a similar rollup](https://bors.rust-lang.org/queue/rust?prs=123604,128780,133782,134509,134524,134539,134586)
<!-- homu-ignore:end -->