### PR TITLE
Detect invalid exprs in parser used by pretty-printer tests

### DIFF
--- a/tests/ui-fulldeps/auxiliary/parser.rs
+++ b/tests/ui-fulldeps/auxiliary/parser.rs
@@ -1,0 +1,51 @@
+#![feature(rustc_private)]
+
+extern crate rustc_ast;
+extern crate rustc_driver;
+extern crate rustc_errors;
+extern crate rustc_parse;
+extern crate rustc_session;
+extern crate rustc_span;
+
+use rustc_ast::ast::{DUMMY_NODE_ID, Expr};
+use rustc_ast::mut_visit::MutVisitor;
+use rustc_ast::node_id::NodeId;
+use rustc_ast::ptr::P;
+use rustc_ast::token;
+use rustc_errors::Diag;
+use rustc_parse::parser::Recovery;
+use rustc_session::parse::ParseSess;
+use rustc_span::{DUMMY_SP, FileName, Span};
+
+pub fn parse_expr(psess: &ParseSess, source_code: &str) -> Option<P<Expr>> {
+    let parser = rustc_parse::unwrap_or_emit_fatal(rustc_parse::new_parser_from_source_str(
+        psess,
+        FileName::anon_source_code(source_code),
+        source_code.to_owned(),
+    ));
+
+    let mut parser = parser.recovery(Recovery::Forbidden);
+    let mut expr = parser.parse_expr().map_err(Diag::cancel).ok()?;
+    if parser.token != token::Eof {
+        return None;
+    }
+
+    Normalize.visit_expr(&mut expr);
+    Some(expr)
+}
+
+// Erase Span information that could distinguish between identical expressions
+// parsed from different source strings.
+struct Normalize;
+
+impl MutVisitor for Normalize {
+    const VISIT_TOKENS: bool = true;
+
+    fn visit_id(&mut self, id: &mut NodeId) {
+        *id = DUMMY_NODE_ID;
+    }
+
+    fn visit_span(&mut self, span: &mut Span) {
+        *span = DUMMY_SP;
+    }
+}

--- a/tests/ui-fulldeps/pprust-expr-roundtrip.rs
+++ b/tests/ui-fulldeps/pprust-expr-roundtrip.rs
@@ -1,5 +1,7 @@
 //@ run-pass
 //@ ignore-cross-compile
+//@ aux-crate: parser=parser.rs
+//@ edition: 2021
 
 // The general idea of this test is to enumerate all "interesting" expressions and check that
 // `parse(print(e)) == e` for all `e`. Here's what's interesting, for the purposes of this test:
@@ -21,7 +23,6 @@
 
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
-extern crate rustc_data_structures;
 extern crate rustc_parse;
 extern crate rustc_session;
 extern crate rustc_span;
@@ -32,27 +33,16 @@ extern crate thin_vec;
 #[allow(unused_extern_crates)]
 extern crate rustc_driver;
 
+use parser::parse_expr;
 use rustc_ast::mut_visit::{visit_clobber, MutVisitor};
 use rustc_ast::ptr::P;
 use rustc_ast::*;
 use rustc_ast_pretty::pprust;
-use rustc_parse::{new_parser_from_source_str, unwrap_or_emit_fatal};
 use rustc_session::parse::ParseSess;
 use rustc_span::source_map::Spanned;
 use rustc_span::symbol::Ident;
-use rustc_span::{FileName, DUMMY_SP};
+use rustc_span::DUMMY_SP;
 use thin_vec::{thin_vec, ThinVec};
-
-fn parse_expr(psess: &ParseSess, src: &str) -> Option<P<Expr>> {
-    let src_as_string = src.to_string();
-
-    let mut p = unwrap_or_emit_fatal(new_parser_from_source_str(
-        psess,
-        FileName::Custom(src_as_string.clone()),
-        src_as_string,
-    ));
-    p.parse_expr().map_err(|e| e.cancel()).ok()
-}
 
 // Helper functions for building exprs
 fn expr(kind: ExprKind) -> P<Expr> {

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -166,7 +166,9 @@ fn main() -> ExitCode {
         let psess = &ParseSess::new(vec![rustc_parse::DEFAULT_LOCALE_RESOURCE]);
 
         for &source_code in EXPRS {
-            let expr = parse_expr(psess, source_code).unwrap();
+            let Some(expr) = parse_expr(psess, source_code) else {
+                panic!("Failed to parse original test case: {source_code}");
+            };
 
             // Check for FALSE POSITIVE: pretty-printer inserting parentheses where not needed.
             // Pseudocode:

--- a/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
+++ b/tests/ui-fulldeps/pprust-parenthesis-insertion.rs
@@ -44,6 +44,7 @@ use rustc_ast::ast::{DUMMY_NODE_ID, Expr, ExprKind};
 use rustc_ast::mut_visit::{self, DummyAstNode as _, MutVisitor};
 use rustc_ast::node_id::NodeId;
 use rustc_ast::ptr::P;
+use rustc_ast::token;
 use rustc_ast_pretty::pprust;
 use rustc_errors::Diag;
 use rustc_parse::parser::Recovery;
@@ -177,7 +178,12 @@ fn parse_expr(psess: &ParseSess, source_code: &str) -> Option<P<Expr>> {
         source_code.to_owned(),
     ));
 
-    let mut expr = parser.recovery(Recovery::Forbidden).parse_expr().map_err(Diag::cancel).ok()?;
+    let mut parser = parser.recovery(Recovery::Forbidden);
+    let mut expr = parser.parse_expr().map_err(Diag::cancel).ok()?;
+    if parser.token != token::Eof {
+        return None;
+    }
+
     Normalize.visit_expr(&mut expr);
     Some(expr)
 }


### PR DESCRIPTION
This PR fixes a bug in https://github.com/rust-lang/rust/pull/133730 inherited from https://github.com/rust-lang/rust/pull/43742. Before this fix, the test might silently only operate on a prefix of some of the test cases in this table:

https://github.com/rust-lang/rust/blob/13170cd787cb733ed24842ee825bcbd98dc01476/tests/ui-fulldeps/pprust-parenthesis-insertion.rs#L57

For example, adding the test case `1 .. 2 .. 3` (a syntactically invalid expression) into the table would unexpectedly succeed the test instead of crashing at this unwrap:

https://github.com/rust-lang/rust/blob/13170cd787cb733ed24842ee825bcbd98dc01476/tests/ui-fulldeps/pprust-parenthesis-insertion.rs#L199-L200

because `parse_expr` would successfully parse just `1 .. 2` and disregard the last `.. 3`.

This PR adds a check that `parse_expr` reaches `Eof`, ensuring all the test cases actually test the whole expression they look like they are supposed to.