### PR TITLE
Add `ignore-rustc-debug-assertions` to `tests/ui/associated-consts/issue-93775.rs`

### DIFF
--- a/tests/ui/associated-consts/issue-93775.rs
+++ b/tests/ui/associated-consts/issue-93775.rs
@@ -1,6 +1,6 @@
-//@ ignore-windows-msvc
-// FIXME(#132111, #133432): this test is flaky on windows msvc, it sometimes fail but it sometimes
-// passes.
+//@ ignore-rustc-debug-assertions
+// Similar to stress testing, the test case requires a larger call stack,
+// so we ignore rustc's debug assertions.
 
 //@ build-pass
 // ignore-tidy-linelength


### PR DESCRIPTION
Closes #132111. Closes #133432.

I think this test case is flaky because the recursive calls happen to hit the upper limit of the call stack.

IMO, this may not be an issue, as it's reasonable for overly complex code to require additional build configurations (such as increasing the call stack size).

After set `rust.debug-assertions` is true, the test case requires a larger call stack, so disable it on `rust.debug-assertions=true`.

r? jieyouxu

try-job: x86_64-msvc
try-job: i686-msvc