### PR TITLE
Format `build.toml` consistently in platform support docs

### DIFF
--- a/src/doc/rustc/src/platform-support/arm64e-apple-darwin.md
+++ b/src/doc/rustc/src/platform-support/arm64e-apple-darwin.md
@@ -20,7 +20,7 @@ You can build Rust with support for the targets by adding it to the `target` lis
 
 ```toml
 [build]
-target = [ "arm64e-apple-darwin" ]
+target = ["arm64e-apple-darwin"]
 ```
 
 ## Building Rust programs

--- a/src/doc/rustc/src/platform-support/arm64e-apple-ios.md
+++ b/src/doc/rustc/src/platform-support/arm64e-apple-ios.md
@@ -18,7 +18,7 @@ You can build Rust with support for the targets by adding it to the `target` lis
 
 ```toml
 [build]
-target = [ "arm64e-apple-ios" ]
+target = ["arm64e-apple-ios"]
 ```
 
 ## Building Rust programs

--- a/src/doc/rustc/src/platform-support/arm64e-apple-tvos.md
+++ b/src/doc/rustc/src/platform-support/arm64e-apple-tvos.md
@@ -19,7 +19,7 @@ You can build Rust with support for the targets by adding it to the `target` lis
 
 ```toml
 [build]
-target = [ "arm64e-apple-tvos" ]
+target = ["arm64e-apple-tvos"]
 ```
 
 ## Building Rust programs

--- a/src/doc/rustc/src/platform-support/arm64ec-pc-windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/arm64ec-pc-windows-msvc.md
@@ -60,7 +60,7 @@ list in `config.toml`:
 
 ```toml
 [build]
-target = [ "arm64ec-pc-windows-msvc" ]
+target = ["arm64ec-pc-windows-msvc"]
 ```
 
 ## Building Rust programs

--- a/src/doc/rustc/src/platform-support/hexagon-unknown-linux-musl.md
+++ b/src/doc/rustc/src/platform-support/hexagon-unknown-linux-musl.md
@@ -48,7 +48,7 @@ target list in `config.toml`, a sample configuration is shown below.
 
 ```toml
 [build]
-target = [ "hexagon-unknown-linux-musl"]
+target = ["hexagon-unknown-linux-musl"]
 
 [target.hexagon-unknown-linux-musl]
 

--- a/src/doc/rustc/src/platform-support/unikraft-linux-musl.md
+++ b/src/doc/rustc/src/platform-support/unikraft-linux-musl.md
@@ -39,7 +39,7 @@ You can build Rust with support for the targets by adding it to the `target` lis
 ```toml
 [build]
 build-stage = 1
-target = [ "x86_64-unikraft-linux-musl" ]
+target = ["x86_64-unikraft-linux-musl"]
 ```
 
 ## Building Rust programs

--- a/src/doc/rustc/src/platform-support/win7-windows-msvc.md
+++ b/src/doc/rustc/src/platform-support/win7-windows-msvc.md
@@ -25,7 +25,7 @@ You can build Rust with support for the targets by adding it to the target list 
 ```toml
 [build]
 build-stage = 1
-target = [ "x86_64-win7-windows-msvc" ]
+target = ["x86_64-win7-windows-msvc"]
 ```
 
 ## Building Rust programs

--- a/src/doc/rustc/src/target-tier-policy.md
+++ b/src/doc/rustc/src/target-tier-policy.md
@@ -119,7 +119,7 @@ To propose addition of a new target, open a pull request on [`rust-lang/rust`]:
   Link to the created description page.
 - Ensure the pull request is assigned to a member of the [Rust compiler team][rust_compiler_team] by commenting:
   ```text
-  r? compiler-team
+  r? compiler
   ```
 
 [tier3example]: https://github.com/rust-lang/rust/pull/94872


### PR DESCRIPTION
Also fix compiler team name in target tier docs.