### PR TITLE
Avoid ICE in borrowck

### DIFF
--- a/compiler/rustc_borrowck/src/region_infer/mod.rs
+++ b/compiler/rustc_borrowck/src/region_infer/mod.rs
@@ -1945,8 +1945,14 @@ impl<'tcx> RegionInferenceContext<'tcx> {
         target_test: impl Fn(RegionVid) -> bool,
     ) -> (BlameConstraint<'tcx>, Vec<ExtraConstraintInfo>) {
         // Find all paths
-        let (path, target_region) =
-            self.find_constraint_paths_between_regions(from_region, target_test).unwrap();
+        let (path, target_region) = self
+            .find_constraint_paths_between_regions(from_region, target_test)
+            .or_else(|| {
+                self.find_constraint_paths_between_regions(from_region, |r| {
+                    self.cannot_name_placeholder(from_region, r)
+                })
+            })
+            .unwrap();
         debug!(
             "path={:#?}",
             path.iter()

--- a/tests/ui/borrowck/implementation-not-general-enough-ice-133252.rs
+++ b/tests/ui/borrowck/implementation-not-general-enough-ice-133252.rs
@@ -1,4 +1,4 @@
-//@ known-bug: #133252
+// Regression test for borrowck ICE #133252
 //@ edition:2021
 use std::future::Future;
 
@@ -7,6 +7,8 @@ fn ice() -> impl Future<Output = &'static dyn Owned> {
     async {
         let not_static = 0;
         force_send(async_load(&not_static));
+        //~^ ERROR implementation of `LoadQuery` is not general enough
+        //~| ERROR `not_static` does not live long enough
         loop {}
     }
 }
@@ -41,3 +43,5 @@ impl Future for SimpleFuture {
         loop {}
     }
 }
+
+fn main() {}

--- a/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
+++ b/tests/ui/borrowck/implementation-not-general-enough-ice-133252.stderr
@@ -1,0 +1,34 @@
+error: implementation of `LoadQuery` is not general enough
+  --> $DIR/implementation-not-general-enough-ice-133252.rs:9:9
+   |
+LL |         force_send(async_load(&not_static));
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `LoadQuery` is not general enough
+   |
+   = note: `LoadQuery<'0>` would have to be implemented for the type `&u8`, for any lifetime `'0`...
+   = note: ...but `LoadQuery<'1>` is actually implemented for the type `&'1 u8`, for some specific lifetime `'1`
+
+error[E0597]: `not_static` does not live long enough
+  --> $DIR/implementation-not-general-enough-ice-133252.rs:9:31
+   |
+LL |     async {
+   |         - return type of async block is &(dyn Owned + '1)
+LL |         let not_static = 0;
+   |             ---------- binding `not_static` declared here
+LL |         force_send(async_load(&not_static));
+   |                    -----------^^^^^^^^^^^-
+   |                    |          |
+   |                    |          borrowed value does not live long enough
+   |                    argument requires that `not_static` is borrowed for `'1`
+...
+LL |     }
+   |     - `not_static` dropped here while still borrowed
+   |
+note: due to current limitations in the borrow checker, this implies a `'static` lifetime
+  --> $DIR/implementation-not-general-enough-ice-133252.rs:16:18
+   |
+LL | fn force_send<T: Send>(_: T) {}
+   |                  ^^^^
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0597`.


### PR DESCRIPTION
Provide a fallback in `best_blame_constraint` when `find_constraint_paths_between_regions` doesn't have a result. This code is due a rework to avoid the letf-over `unwrap()`, but avoids the ICE caused by the repro.

Fix #133252.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
