### PR TITLE
Don't ICE on illegal `dyn*` casts

### DIFF
--- a/compiler/rustc_hir_typeck/src/cast.rs
+++ b/compiler/rustc_hir_typeck/src/cast.rs
@@ -721,13 +721,11 @@ impl<'a, 'tcx> CastCheck<'tcx> {
         use rustc_middle::ty::cast::IntTy::*;
 
         if self.cast_ty.is_dyn_star() {
-            if fcx.tcx.features().dyn_star() {
-                span_bug!(self.span, "should be handled by `coerce`");
-            } else {
-                // Report "casting is invalid" rather than "non-primitive cast"
-                // if the feature is not enabled.
-                return Err(CastError::IllegalCast);
-            }
+            // This coercion will fail if the feature is not enabled, OR
+            // if the coercion is (currently) illegal (e.g. `dyn* Foo + Send`
+            // to `dyn* Foo`). Report "casting is invalid" rather than
+            // "non-primitive cast".
+            return Err(CastError::IllegalCast);
         }
 
         let (t_from, t_cast) = match (CastTy::from_ty(self.expr_ty), CastTy::from_ty(self.cast_ty))

--- a/compiler/rustc_hir_typeck/src/coercion.rs
+++ b/compiler/rustc_hir_typeck/src/coercion.rs
@@ -737,8 +737,10 @@ impl<'f, 'tcx> Coerce<'f, 'tcx> {
             return Err(TypeError::Mismatch);
         }
 
-        if let ty::Dynamic(a_data, _, _) = a.kind()
-            && let ty::Dynamic(b_data, _, _) = b.kind()
+        // FIXME(dyn_star): We should probably allow things like casting from
+        // `dyn* Foo + Send` to `dyn* Foo`.
+        if let ty::Dynamic(a_data, _, ty::DynStar) = a.kind()
+            && let ty::Dynamic(b_data, _, ty::DynStar) = b.kind()
             && a_data.principal_def_id() == b_data.principal_def_id()
         {
             return self.unify_and(a, b, |_| vec![]);

--- a/tests/crashes/132127.rs
+++ b/tests/crashes/132127.rs
@@ -1,9 +1,0 @@
-//@ known-bug: #132127
-#![feature(dyn_star)]
-
-trait Trait {}
-
-fn main() {
-    let x: dyn* Trait + Send = 1usize;
-    x as dyn* Trait;
-}

--- a/tests/ui/dyn-star/illegal.rs
+++ b/tests/ui/dyn-star/illegal.rs
@@ -1,0 +1,16 @@
+#![feature(dyn_star)]
+//~^ WARN the feature `dyn_star` is incomplete
+
+trait Foo {}
+
+pub fn lol(x: dyn* Foo + Send) {
+    x as dyn* Foo;
+    //~^ ERROR casting `(dyn* Foo + Send + 'static)` as `dyn* Foo` is invalid
+}
+
+fn lol2(x: &dyn Foo) {
+    *x as dyn* Foo;
+    //~^ ERROR `dyn Foo` needs to have the same ABI as a pointer
+}
+
+fn main() {}

--- a/tests/ui/dyn-star/illegal.stderr
+++ b/tests/ui/dyn-star/illegal.stderr
@@ -1,0 +1,27 @@
+warning: the feature `dyn_star` is incomplete and may not be safe to use and/or cause compiler crashes
+  --> $DIR/illegal.rs:1:12
+   |
+LL | #![feature(dyn_star)]
+   |            ^^^^^^^^
+   |
+   = note: see issue #102425 <https://github.com/rust-lang/rust/issues/102425> for more information
+   = note: `#[warn(incomplete_features)]` on by default
+
+error[E0606]: casting `(dyn* Foo + Send + 'static)` as `dyn* Foo` is invalid
+  --> $DIR/illegal.rs:7:5
+   |
+LL |     x as dyn* Foo;
+   |     ^^^^^^^^^^^^^
+
+error[E0277]: `dyn Foo` needs to have the same ABI as a pointer
+  --> $DIR/illegal.rs:12:5
+   |
+LL |     *x as dyn* Foo;
+   |     ^^ `dyn Foo` needs to be a pointer-like type
+   |
+   = help: the trait `PointerLike` is not implemented for `dyn Foo`
+
+error: aborting due to 2 previous errors; 1 warning emitted
+
+Some errors have detailed explanations: E0277, E0606.
+For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Fixes #134544
Fixes #132127