### PR TITLE
Implement `PointerLike` for `isize`, `NonNull`, `Cell`, `UnsafeCell`, and `SyncUnsafeCell`.

### DIFF
--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -252,7 +252,7 @@
 
 use crate::cmp::Ordering;
 use crate::fmt::{self, Debug, Display};
-use crate::marker::{PhantomData, Unsize};
+use crate::marker::{PhantomData, PointerLike, Unsize};
 use crate::mem;
 use crate::ops::{CoerceUnsized, Deref, DerefMut, DerefPure, DispatchFromDyn};
 use crate::pin::PinCoerceUnsized;
@@ -676,6 +676,9 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<Cell<U>> for Cell<T> {}
 // `self: CellWrapper<Self>` becomes possible
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<Cell<U>> for Cell<T> {}
+
+#[unstable(feature = "pointer_like_trait", issue = "none")]
+impl<T: PointerLike> PointerLike for Cell<T> {}
 
 impl<T> Cell<[T]> {
     /// Returns a `&[Cell<T>]` from a `&Cell<[T]>`
@@ -2258,6 +2261,9 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<UnsafeCell<U>> for UnsafeCell<T> {}
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<UnsafeCell<U>> for UnsafeCell<T> {}
 
+#[unstable(feature = "pointer_like_trait", issue = "none")]
+impl<T: PointerLike> PointerLike for UnsafeCell<T> {}
+
 /// [`UnsafeCell`], but [`Sync`].
 ///
 /// This is just an `UnsafeCell`, except it implements `Sync`
@@ -2363,6 +2369,9 @@ impl<T: CoerceUnsized<U>, U> CoerceUnsized<SyncUnsafeCell<U>> for SyncUnsafeCell
 #[unstable(feature = "dispatch_from_dyn", issue = "none")]
 //#[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 impl<T: DispatchFromDyn<U>, U> DispatchFromDyn<SyncUnsafeCell<U>> for SyncUnsafeCell<T> {}
+
+#[unstable(feature = "pointer_like_trait", issue = "none")]
+impl<T: PointerLike> PointerLike for SyncUnsafeCell<T> {}
 
 #[allow(unused)]
 fn assert_coerce_unsized(

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -997,6 +997,7 @@ pub trait PointerLike {}
 marker_impls! {
     #[unstable(feature = "pointer_like_trait", issue = "none")]
     PointerLike for
+        isize,
         usize,
         {T} &T,
         {T} &mut T,

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -1548,6 +1548,10 @@ impl<T: ?Sized, U: ?Sized> DispatchFromDyn<NonNull<U>> for NonNull<T> where T: U
 #[stable(feature = "pin", since = "1.33.0")]
 unsafe impl<T: ?Sized> PinCoerceUnsized for NonNull<T> {}
 
+#[unstable(feature = "pointer_like_trait", issue = "none")]
+#[cfg(not(bootstrap))]
+impl<T> core::marker::PointerLike for NonNull<T> {}
+
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: ?Sized> fmt::Debug for NonNull<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tests/ui/dyn-star/cell.rs
+++ b/tests/ui/dyn-star/cell.rs
@@ -1,0 +1,34 @@
+// This test with Cell also indirectly exercises UnsafeCell in dyn*.
+//
+//@ run-pass
+
+#![feature(dyn_star)]
+#![allow(incomplete_features)]
+
+use std::cell::Cell;
+
+trait Rw<T> {
+    fn read(&self) -> T;
+    fn write(&self, v: T);
+}
+
+impl<T: Copy> Rw<T> for Cell<T> {
+    fn read(&self) -> T {
+        self.get()
+    }
+    fn write(&self, v: T) {
+        self.set(v)
+    }
+}
+
+fn make_dyn_star() -> dyn* Rw<usize> {
+    Cell::new(42usize) as dyn* Rw<usize>
+}
+
+fn main() {
+    let x = make_dyn_star();
+
+    assert_eq!(x.read(), 42);
+    x.write(24);
+    assert_eq!(x.read(), 24);
+}

--- a/tests/ui/dyn-star/error.rs
+++ b/tests/ui/dyn-star/error.rs
@@ -6,7 +6,7 @@ use std::fmt::Debug;
 trait Foo {}
 
 fn make_dyn_star() {
-    let i = 42;
+    let i = 42usize;
     let dyn_i: dyn* Foo = i; //~ ERROR trait bound `usize: Foo` is not satisfied
 }
 

--- a/tests/ui/dyn-star/float-as-dyn-star.stderr
+++ b/tests/ui/dyn-star/float-as-dyn-star.stderr
@@ -14,7 +14,9 @@ LL |     f32::from_bits(0x1) as f64
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `f64` needs to be a pointer-like type
    |
    = help: the trait `PointerLike` is not implemented for `f64`
-   = help: the trait `PointerLike` is implemented for `usize`
+   = help: the following other types implement trait `PointerLike`:
+             isize
+             usize
 
 error: aborting due to 1 previous error; 1 warning emitted
 


### PR DESCRIPTION
* Implementing `PointerLike` for `UnsafeCell` enables the possibility of interior mutable `dyn*` values. Since this means potentially exercising new codegen behavior, I added a test for it in `tests/ui/dyn-star/cell.rs`. Please let me know if there are further sorts of tests that should be written, or other care that should be taken with this change.

  It is unfortunately not possible without compiler changes to implement `PointerLike` for `Atomic*` types, since they are not `repr(transparent)` (and, in theory if not in practice, `AtomicUsize`'s alignment may be greater than that of an ordinary pointer or `usize`).

* Implementing `PointerLike` for `NonNull` is useful for pointer types which wrap `NonNull`.

* Implementing `PointerLike` for `isize` is just for completeness; I have no use cases in mind, but I cannot think of any reason not to do this.

* Tracking issue: #102425

@rustbot label +F-dyn_star
(there is no label or tracking issue for F-pointer_like_trait)