### PR TITLE
Document collection `From` and `FromIterator` impls that drop duplicate keys.

### DIFF
--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -2292,7 +2292,7 @@ impl<K: Ord, V> FromIterator<(K, V)> for BTreeMap<K, V> {
     /// Constructs a `BTreeMap<K, V>` from an iterator of key-value pairs.
     ///
     /// If the iterator produces any pairs with equal keys,
-    /// all but the last value for each such key are discarded.
+    /// all but one of the corresponding values will be dropped.
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> BTreeMap<K, V> {
         let mut inputs: Vec<_> = iter.into_iter().collect();
 
@@ -2409,8 +2409,8 @@ where
 impl<K: Ord, V, const N: usize> From<[(K, V); N]> for BTreeMap<K, V> {
     /// Converts a `[(K, V); N]` into a `BTreeMap<K, V>`.
     ///
-    /// If any entries in the array have equal keys, all but the last entry for each such key
-    /// are discarded.
+    /// If any entries in the array have equal keys,
+    /// all but one of the corresponding values will be dropped.
     ///
     /// ```
     /// use std::collections::BTreeMap;

--- a/library/alloc/src/collections/btree/map.rs
+++ b/library/alloc/src/collections/btree/map.rs
@@ -2289,6 +2289,10 @@ impl<K, V> FusedIterator for RangeMut<'_, K, V> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<K: Ord, V> FromIterator<(K, V)> for BTreeMap<K, V> {
+    /// Constructs a `BTreeMap<K, V>` from an iterator of key-value pairs.
+    ///
+    /// If the iterator produces any pairs with equal keys,
+    /// all but the last value for each such key are discarded.
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> BTreeMap<K, V> {
         let mut inputs: Vec<_> = iter.into_iter().collect();
 
@@ -2403,7 +2407,10 @@ where
 
 #[stable(feature = "std_collections_from_array", since = "1.56.0")]
 impl<K: Ord, V, const N: usize> From<[(K, V); N]> for BTreeMap<K, V> {
-    /// Converts a `[(K, V); N]` into a `BTreeMap<(K, V)>`.
+    /// Converts a `[(K, V); N]` into a `BTreeMap<K, V>`.
+    ///
+    /// If any entries in the array have equal keys, all but the last entry for each such key
+    /// are discarded.
     ///
     /// ```
     /// use std::collections::BTreeMap;

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -1491,7 +1491,8 @@ impl<T: Ord, A: Allocator + Clone> BTreeSet<T, A> {
 impl<T: Ord, const N: usize> From<[T; N]> for BTreeSet<T> {
     /// Converts a `[T; N]` into a `BTreeSet<T>`.
     ///
-    /// If the array contains any equal values, all but the last instance of each are discarded.
+    /// If the array contains any equal values,
+    /// all but one will be dropped.
     ///
     /// # Examples
     ///

--- a/library/alloc/src/collections/btree/set.rs
+++ b/library/alloc/src/collections/btree/set.rs
@@ -1491,6 +1491,10 @@ impl<T: Ord, A: Allocator + Clone> BTreeSet<T, A> {
 impl<T: Ord, const N: usize> From<[T; N]> for BTreeSet<T> {
     /// Converts a `[T; N]` into a `BTreeSet<T>`.
     ///
+    /// If the array contains any equal values, all but the last instance of each are discarded.
+    ///
+    /// # Examples
+    ///
     /// ```
     /// use std::collections::BTreeSet;
     ///

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -1448,8 +1448,8 @@ where
 {
     /// Converts a `[(K, V); N]` into a `HashMap<K, V>`.
     ///
-    /// If any entries in the array have equal keys, all but the last entry for each such key
-    /// are discarded.
+    /// If any entries in the array have equal keys,
+    /// all but one of the corresponding values will be dropped.
     ///
     /// # Examples
     ///
@@ -3227,7 +3227,7 @@ where
     /// Constructs a `HashMap<K, V>` from an iterator of key-value pairs.
     ///
     /// If the iterator produces any pairs with equal keys,
-    /// all but the last value for each such key are discarded.
+    /// all but one of the corresponding values will be dropped.
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> HashMap<K, V, S> {
         let mut map = HashMap::with_hasher(Default::default());
         map.extend(iter);

--- a/library/std/src/collections/hash/map.rs
+++ b/library/std/src/collections/hash/map.rs
@@ -1446,6 +1446,11 @@ impl<K, V, const N: usize> From<[(K, V); N]> for HashMap<K, V, RandomState>
 where
     K: Eq + Hash,
 {
+    /// Converts a `[(K, V); N]` into a `HashMap<K, V>`.
+    ///
+    /// If any entries in the array have equal keys, all but the last entry for each such key
+    /// are discarded.
+    ///
     /// # Examples
     ///
     /// ```
@@ -3219,6 +3224,10 @@ where
     K: Eq + Hash,
     S: BuildHasher + Default,
 {
+    /// Constructs a `HashMap<K, V>` from an iterator of key-value pairs.
+    ///
+    /// If the iterator produces any pairs with equal keys,
+    /// all but the last value for each such key are discarded.
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> HashMap<K, V, S> {
         let mut map = HashMap::with_hasher(Default::default());
         map.extend(iter);

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -1093,7 +1093,8 @@ where
 {
     /// Converts a `[T; N]` into a `HashSet<T>`.
     ///
-    /// If the array contains any equal values, all but the last instance of each are discarded.
+    /// If the array contains any equal values,
+    /// all but one will be dropped.
     ///
     /// # Examples
     ///

--- a/library/std/src/collections/hash/set.rs
+++ b/library/std/src/collections/hash/set.rs
@@ -1091,6 +1091,10 @@ impl<T, const N: usize> From<[T; N]> for HashSet<T, RandomState>
 where
     T: Eq + Hash,
 {
+    /// Converts a `[T; N]` into a `HashSet<T>`.
+    ///
+    /// If the array contains any equal values, all but the last instance of each are discarded.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
This behavior is worth documenting because there are other plausible alternatives, such as panicking when a duplicate is encountered, and it reminds the programmer to consider whether they should, for example, coalesce duplicate keys first.

Followup to #89869.