### PR TITLE
Account for removal of multiline span in suggestion

### DIFF
--- a/tests/ui/error-emitter/multiline-removal-suggestion.rs
+++ b/tests/ui/error-emitter/multiline-removal-suggestion.rs
@@ -1,0 +1,58 @@
+// Make sure suggestion for removal of a span that covers multiple lines is properly highlighted.
+//@ compile-flags: --error-format=human --color=always
+//@ edition:2018
+//@ only-linux
+// ignore-tidy-tab
+// We use `\t` instead of spaces for indentation to ensure that the highlighting logic properly
+// accounts for replaced characters (like we do for `\t` with `    `). The naïve way of highlighting
+// could be counting chars of the original code, instead of operating on the code as it is being
+// displayed.
+use std::collections::{HashMap, HashSet};
+fn foo() -> Vec<(bool, HashSet<u8>)> {
+	let mut hm = HashMap::<bool, Vec<HashSet<u8>>>::new();
+	hm.into_iter()
+		.map(|(is_true, ts)| {
+			ts.into_iter()
+				.map(|t| {
+					(
+						is_true,
+						t,
+					)
+				}).flatten()
+		})
+		.flatten()
+		.collect()
+}
+fn bar() -> Vec<(bool, HashSet<u8>)> {
+	let mut hm = HashMap::<bool, Vec<HashSet<u8>>>::new();
+	hm.into_iter()
+		.map(|(is_true, ts)| {
+			ts.into_iter()
+				.map(|t| (is_true, t))
+				.flatten()
+		})
+		.flatten()
+		.collect()
+}
+fn baz() -> Vec<(bool, HashSet<u8>)> {
+	let mut hm = HashMap::<bool, Vec<HashSet<u8>>>::new();
+	hm.into_iter()
+		.map(|(is_true, ts)| {
+			ts.into_iter().map(|t| {
+				(is_true, t)
+			}).flatten()
+		})
+		.flatten()
+		.collect()
+}
+fn bay() -> Vec<(bool, HashSet<u8>)> {
+	let mut hm = HashMap::<bool, Vec<HashSet<u8>>>::new();
+	hm.into_iter()
+		.map(|(is_true, ts)| {
+			ts.into_iter()
+				.map(|t| (is_true, t)).flatten()
+		})
+		.flatten()
+		.collect()
+}
+fn main() {}

--- a/tests/ui/error-emitter/multiline-removal-suggestion.svg
+++ b/tests/ui/error-emitter/multiline-removal-suggestion.svg
@@ -1,0 +1,504 @@
+<svg width="1902px" height="4322px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-ansi256-009 { fill: #FF5555 }
+    .fg-ansi256-010 { fill: #55FF55 }
+    .fg-ansi256-012 { fill: #5555FF }
+    .fg-ansi256-014 { fill: #55FFFF }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:21:8</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 }).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                    </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: consider removing this method call, as the receiver has type `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;` and `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;: Iterator` trivially holds</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>            ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                 .map(|t| {</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                     (</tspan>
+</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                         is_true,</tspan>
+</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                         t,</tspan>
+</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                     )</tspan>
+</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                 })</tspan><tspan>.flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>            ts.into_iter().flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="388px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="406px">
+</tspan>
+    <tspan x="10px" y="424px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:13:2</tspan>
+</tspan>
+    <tspan x="10px" y="460px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="478px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="496px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="514px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>             ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="532px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>                 .map(|t| {</tspan>
+</tspan>
+    <tspan x="10px" y="550px"><tspan class="fg-ansi256-012 bold">...</tspan><tspan>  </tspan><tspan class="fg-ansi256-009 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="568px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>                 }).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="586px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         })</tspan>
+</tspan>
+    <tspan x="10px" y="604px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|__________^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="622px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="640px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="658px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="676px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `Flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="694px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="712px">
+</tspan>
+    <tspan x="10px" y="730px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@multiline-removal-suggestion.rs:14:8}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+</tspan>
+    <tspan x="10px" y="748px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:24:4</tspan>
+</tspan>
+    <tspan x="10px" y="766px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="784px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="802px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="820px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="838px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 .map(|t| {</tspan>
+</tspan>
+    <tspan x="10px" y="856px"><tspan class="fg-ansi256-012 bold">...</tspan><tspan>  </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="874px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="892px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .collect()</tspan>
+</tspan>
+    <tspan x="10px" y="910px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">method cannot be called due to unsatisfied trait bounds</tspan>
+</tspan>
+    <tspan x="10px" y="928px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|_________|</tspan>
+</tspan>
+    <tspan x="10px" y="946px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="964px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="982px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: the following trait bounds were not satisfied:</tspan>
+</tspan>
+    <tspan x="10px" y="1000px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:16:10: 16:13}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
+</tspan>
+    <tspan x="10px" y="1018px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:14:8: 14:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1036px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:16:10: 16:13}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
+</tspan>
+    <tspan x="10px" y="1054px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:14:8: 14:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1072px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:16:10: 16:13}&gt;&gt;: IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1090px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:14:8: 14:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1108px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:14:8: 14:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1126px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:14:8: 14:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1144px">
+</tspan>
+    <tspan x="10px" y="1162px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="1180px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:32:6</tspan>
+</tspan>
+    <tspan x="10px" y="1198px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1216px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 .flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="1234px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                  </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="1252px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1270px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="1288px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1306px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="1324px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="1342px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: consider removing this method call, as the receiver has type `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;` and `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;: Iterator` trivially holds</tspan>
+</tspan>
+    <tspan x="10px" y="1360px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1378px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>            ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="1396px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                 .map(|t| (is_true, t))</tspan>
+</tspan>
+    <tspan x="10px" y="1414px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>            ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="1432px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1450px">
+</tspan>
+    <tspan x="10px" y="1468px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="1486px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:28:2</tspan>
+</tspan>
+    <tspan x="10px" y="1504px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1522px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="1540px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="1558px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>             ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="1576px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>                 .map(|t| (is_true, t))</tspan>
+</tspan>
+    <tspan x="10px" y="1594px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>                 .flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="1612px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         })</tspan>
+</tspan>
+    <tspan x="10px" y="1630px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|__________^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="1648px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1666px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="1684px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="1702px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `Flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="1720px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="1738px">
+</tspan>
+    <tspan x="10px" y="1756px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@multiline-removal-suggestion.rs:29:8}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+</tspan>
+    <tspan x="10px" y="1774px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:35:4</tspan>
+</tspan>
+    <tspan x="10px" y="1792px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1810px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="1828px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="1846px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="1864px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 .map(|t| (is_true, t))</tspan>
+</tspan>
+    <tspan x="10px" y="1882px"><tspan class="fg-ansi256-012 bold">...</tspan><tspan>  </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1900px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="1918px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .collect()</tspan>
+</tspan>
+    <tspan x="10px" y="1936px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">method cannot be called due to unsatisfied trait bounds</tspan>
+</tspan>
+    <tspan x="10px" y="1954px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|_________|</tspan>
+</tspan>
+    <tspan x="10px" y="1972px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="1990px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2008px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: the following trait bounds were not satisfied:</tspan>
+</tspan>
+    <tspan x="10px" y="2026px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:31:10: 31:13}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
+</tspan>
+    <tspan x="10px" y="2044px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:29:8: 29:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2062px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:31:10: 31:13}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
+</tspan>
+    <tspan x="10px" y="2080px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:29:8: 29:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2098px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:31:10: 31:13}&gt;&gt;: IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2116px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:29:8: 29:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2134px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:29:8: 29:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2152px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:29:8: 29:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2170px">
+</tspan>
+    <tspan x="10px" y="2188px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="2206px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:43:7</tspan>
+</tspan>
+    <tspan x="10px" y="2224px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2242px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             }).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="2260px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="2278px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2296px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="2314px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2332px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="2350px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="2368px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: consider removing this method call, as the receiver has type `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;` and `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;: Iterator` trivially holds</tspan>
+</tspan>
+    <tspan x="10px" y="2386px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2404px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>            ts.into_iter()</tspan><tspan class="fg-ansi256-009">.map(|t| {</tspan>
+</tspan>
+    <tspan x="10px" y="2422px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                 (is_true, t)</tspan>
+</tspan>
+    <tspan x="10px" y="2440px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-             })</tspan><tspan>.flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="2458px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>            ts.into_iter().flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="2476px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2494px">
+</tspan>
+    <tspan x="10px" y="2512px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="2530px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:39:2</tspan>
+</tspan>
+    <tspan x="10px" y="2548px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2566px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="2584px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="2602px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>             ts.into_iter().map(|t| {</tspan>
+</tspan>
+    <tspan x="10px" y="2620px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>                 (is_true, t)</tspan>
+</tspan>
+    <tspan x="10px" y="2638px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>             }).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="2656px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         })</tspan>
+</tspan>
+    <tspan x="10px" y="2674px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|__________^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="2692px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2710px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="2728px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="2746px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `Flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="2764px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="2782px">
+</tspan>
+    <tspan x="10px" y="2800px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@multiline-removal-suggestion.rs:40:8}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+</tspan>
+    <tspan x="10px" y="2818px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:46:4</tspan>
+</tspan>
+    <tspan x="10px" y="2836px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2854px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="2872px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="2890px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             ts.into_iter().map(|t| {</tspan>
+</tspan>
+    <tspan x="10px" y="2908px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 (is_true, t)</tspan>
+</tspan>
+    <tspan x="10px" y="2926px"><tspan class="fg-ansi256-012 bold">...</tspan><tspan>  </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="2944px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="2962px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .collect()</tspan>
+</tspan>
+    <tspan x="10px" y="2980px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">method cannot be called due to unsatisfied trait bounds</tspan>
+</tspan>
+    <tspan x="10px" y="2998px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|_________|</tspan>
+</tspan>
+    <tspan x="10px" y="3016px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3034px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3052px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: the following trait bounds were not satisfied:</tspan>
+</tspan>
+    <tspan x="10px" y="3070px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:41:23: 41:26}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
+</tspan>
+    <tspan x="10px" y="3088px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:8: 40:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3106px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:41:23: 41:26}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
+</tspan>
+    <tspan x="10px" y="3124px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:8: 40:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3142px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:41:23: 41:26}&gt;&gt;: IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3160px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:8: 40:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3178px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:8: 40:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3196px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:40:8: 40:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3214px">
+</tspan>
+    <tspan x="10px" y="3232px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="3250px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:53:28</tspan>
+</tspan>
+    <tspan x="10px" y="3268px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3286px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 .map(|t| (is_true, t)).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="3304px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                                        </tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="3322px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3340px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="3358px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3376px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="3394px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/traits/iterator.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="3412px"><tspan class="fg-ansi256-014 bold">help</tspan><tspan>: consider removing this method call, as the receiver has type `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;` and `std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;: Iterator` trivially holds</tspan>
+</tspan>
+    <tspan x="10px" y="3430px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3448px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">- </tspan><tspan>            ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="3466px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-009">-                 .map(|t| (is_true, t))</tspan><tspan>.flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="3484px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-010">+ </tspan><tspan>            ts.into_iter().flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="3502px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3520px">
+</tspan>
+    <tspan x="10px" y="3538px"><tspan class="fg-ansi256-009 bold">error[E0277]</tspan><tspan class="bold">: `(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="3556px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:50:2</tspan>
+</tspan>
+    <tspan x="10px" y="3574px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3592px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="3610px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="3628px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>             ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="3646px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>                 .map(|t| (is_true, t)).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="3664px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|</tspan><tspan>         })</tspan>
+</tspan>
+    <tspan x="10px" y="3682px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">|__________^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">`(bool, HashSet&lt;u8&gt;)` is not an iterator</tspan>
+</tspan>
+    <tspan x="10px" y="3700px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3718px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">help</tspan><tspan>: the trait `Iterator` is not implemented for `(bool, HashSet&lt;u8&gt;)`</tspan>
+</tspan>
+    <tspan x="10px" y="3736px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: required for `(bool, HashSet&lt;u8&gt;)` to implement `IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="3754px"><tspan class="fg-ansi256-010 bold">note</tspan><tspan>: required by a bound in `Flatten`</tspan>
+</tspan>
+    <tspan x="10px" y="3772px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$SRC_DIR/core/src/iter/adapters/flatten.rs:LL:COL</tspan>
+</tspan>
+    <tspan x="10px" y="3790px">
+</tspan>
+    <tspan x="10px" y="3808px"><tspan class="fg-ansi256-009 bold">error[E0599]</tspan><tspan class="bold">: the method `collect` exists for struct `Flatten&lt;Map&lt;IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@multiline-removal-suggestion.rs:51:8}&gt;&gt;`, but its trait bounds were not satisfied</tspan>
+</tspan>
+    <tspan x="10px" y="3826px"><tspan>  </tspan><tspan class="fg-ansi256-012 bold">--&gt; </tspan><tspan>$DIR/multiline-removal-suggestion.rs:56:4</tspan>
+</tspan>
+    <tspan x="10px" y="3844px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="3862px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">/</tspan><tspan>     hm.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="3880px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .map(|(is_true, ts)| {</tspan>
+</tspan>
+    <tspan x="10px" y="3898px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>             ts.into_iter()</tspan>
+</tspan>
+    <tspan x="10px" y="3916px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>                 .map(|t| (is_true, t)).flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="3934px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         })</tspan>
+</tspan>
+    <tspan x="10px" y="3952px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .flatten()</tspan>
+</tspan>
+    <tspan x="10px" y="3970px"><tspan class="fg-ansi256-012 bold">LL</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         .collect()</tspan>
+</tspan>
+    <tspan x="10px" y="3988px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan>         </tspan><tspan class="fg-ansi256-012 bold">-</tspan><tspan class="fg-ansi256-009 bold">^^^^^^^</tspan><tspan> </tspan><tspan class="fg-ansi256-009 bold">method cannot be called due to unsatisfied trait bounds</tspan>
+</tspan>
+    <tspan x="10px" y="4006px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan><tspan> </tspan><tspan class="fg-ansi256-012 bold">|_________|</tspan>
+</tspan>
+    <tspan x="10px" y="4024px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4042px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">|</tspan>
+</tspan>
+    <tspan x="10px" y="4060px"><tspan>   </tspan><tspan class="fg-ansi256-012 bold">= </tspan><tspan class="bold">note</tspan><tspan>: the following trait bounds were not satisfied:</tspan>
+</tspan>
+    <tspan x="10px" y="4078px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:53:10: 53:13}&gt;&gt; as IntoIterator&gt;::IntoIter = _`</tspan>
+</tspan>
+    <tspan x="10px" y="4096px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:51:8: 51:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="4114px"><tspan>           `&lt;Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:53:10: 53:13}&gt;&gt; as IntoIterator&gt;::Item = _`</tspan>
+</tspan>
+    <tspan x="10px" y="4132px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:51:8: 51:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="4150px"><tspan>           `Flatten&lt;Map&lt;std::vec::IntoIter&lt;HashSet&lt;u8&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:53:10: 53:13}&gt;&gt;: IntoIterator`</tspan>
+</tspan>
+    <tspan x="10px" y="4168px"><tspan>           which is required by `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:51:8: 51:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="4186px"><tspan>           `Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:51:8: 51:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="4204px"><tspan>           which is required by `&amp;mut Flatten&lt;Map&lt;std::collections::hash_map::IntoIter&lt;bool, Vec&lt;HashSet&lt;u8&gt;&gt;&gt;, {closure@$DIR/multiline-removal-suggestion.rs:51:8: 51:23}&gt;&gt;: Iterator`</tspan>
+</tspan>
+    <tspan x="10px" y="4222px">
+</tspan>
+    <tspan x="10px" y="4240px"><tspan class="fg-ansi256-009 bold">error</tspan><tspan class="bold">: aborting due to 12 previous errors</tspan>
+</tspan>
+    <tspan x="10px" y="4258px">
+</tspan>
+    <tspan x="10px" y="4276px"><tspan class="bold">Some errors have detailed explanations: E0277, E0599.</tspan>
+</tspan>
+    <tspan x="10px" y="4294px"><tspan class="bold">For more information about an error, try `rustc --explain E0277`.</tspan>
+</tspan>
+    <tspan x="10px" y="4312px">
+</tspan>
+  </text>
+
+</svg>


### PR DESCRIPTION
When highlighting the removed parts of a suggestion, properly account for spans that cover more than one line.

Fix #134485.

![Screenshot of the highlighted output](https://github.com/user-attachments/assets/18bcd9bc-3bec-4b79-a9d7-e4ea4e6289ad)

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
