### PR TITLE
Make sure we don't lose default struct value when formatting struct

### DIFF
--- a/src/tools/rustfmt/src/items.rs
+++ b/src/tools/rustfmt/src/items.rs
@@ -1944,6 +1944,11 @@ pub(crate) fn rewrite_struct_field(
     shape: Shape,
     lhs_max_width: usize,
 ) -> RewriteResult {
+    // FIXME(default_field_values): Implement formatting.
+    if field.default.is_some() {
+        return Err(RewriteError::Unknown);
+    }
+
     if contains_skip(&field.attrs) {
         return Ok(context.snippet(field.span()).to_owned());
     }

--- a/src/tools/rustfmt/src/spanned.rs
+++ b/src/tools/rustfmt/src/spanned.rs
@@ -144,6 +144,7 @@ impl Spanned for ast::GenericParam {
 
 impl Spanned for ast::FieldDef {
     fn span(&self) -> Span {
+        // FIXME(default_field_values): This needs to be adjusted.
         span_with_attrs_lo_hi!(self, self.span.lo(), self.ty.span.hi())
     }
 }

--- a/src/tools/rustfmt/tests/source/default-field-values.rs
+++ b/src/tools/rustfmt/tests/source/default-field-values.rs
@@ -1,0 +1,18 @@
+#![feature(default_struct_values)]
+
+// Test for now that nightly default field values are left alone for now.
+
+struct Foo {
+    default_field:    Spacing =    /* uwu */ 0,
+}
+
+struct Foo2 {
+    #[rustfmt::skip]
+    default_field:    Spacing =    /* uwu */ 0,
+}
+
+a_macro!(
+    struct Foo2 {
+        default_field:    Spacing =    /* uwu */ 0,
+    }
+);

--- a/src/tools/rustfmt/tests/target/default-field-values.rs
+++ b/src/tools/rustfmt/tests/target/default-field-values.rs
@@ -1,0 +1,18 @@
+#![feature(default_struct_values)]
+
+// Test for now that nightly default field values are left alone for now.
+
+struct Foo {
+    default_field:    Spacing =    /* uwu */ 0,
+}
+
+struct Foo2 {
+    #[rustfmt::skip]
+    default_field:    Spacing =    /* uwu */ 0,
+}
+
+a_macro!(
+    struct Foo2 {
+        default_field:    Spacing =    /* uwu */ 0,
+    }
+);


### PR DESCRIPTION
The reason why https://github.com/rust-lang/rustfmt/issues/6424 broke when https://github.com/rust-lang/rust/pull/129514 landed is because the parser now *successfully* parses default struct values. That means that where we used to fail in `rewrite_macro_inner`:

https://github.com/rust-lang/rust/blob/e108481f74ff123ad98a63bd107a18d13035b275/src/tools/rustfmt/src/macros.rs#L263-L267

... we now succeed, and we now proceed to format the inner struct as a macro arg. Since formatting was never implemented for default struct values, this means that we’ll always rewrite the struct to exclude the default value.

This PR makes it so that we simply don’t rewrite struct fields if they have a default value.

r? @ytmimi