### PR TITLE
Document the `--dev` flag for `src/ci/docker/run.sh`

### DIFF
--- a/src/ci/docker/README.md
+++ b/src/ci/docker/README.md
@@ -26,6 +26,10 @@ DEPLOY=1 ./src/ci/docker/run.sh x86_64-gnu
 while locally, to the `obj/$image_name` directory. This is primarily to prevent
 strange linker errors when using multiple Docker images.
 
+## Local Development
+
+Refer to the [dev guide](https://rustc-dev-guide.rust-lang.org/tests/docker.html) for more information on testing locally.
+
 ## Filesystem layout
 
 - Each host architecture has its own `host-{arch}` directory, and those


### PR DESCRIPTION
This flag is very helpful for debugging CI issues locally, but it's not documented anywhere and I wasn't aware of it until @jieyouxu pointed it out. Add a note to the CI Docker readme to make this more discoverable