### PR TITLE
feat: add with_replaced_extension as a alias of with_extension

### DIFF
--- a/library/std/src/path.rs
+++ b/library/std/src/path.rs
@@ -2779,6 +2779,35 @@ impl Path {
         new_path
     }
 
+    /// Creates an owned [`PathBuf`] like `self` but with the extension replaced with given extension.
+    ///
+    /// See [`PathBuf::set_extension`] for more details.
+    ///
+    /// This function is exactly the same as [`Path::with_extension`],
+    /// but its name is ambiguous if the extension will be added or replaced.
+    ///
+    /// Once this function is stabilized, [`Path::with_extension`] will be deprecated.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #![feature(path_add_extension)]
+    ///
+    /// use std::path::{Path, PathBuf};
+    ///
+    /// let path = Path::new("foo.rs");
+    /// assert_eq!(path.with_replaced_extension("txt"), PathBuf::from("foo.txt"));
+    ///
+    /// let path = Path::new("foo.tar.gz");
+    /// assert_eq!(path.with_replaced_extension(""), PathBuf::from("foo.tar"));
+    /// assert_eq!(path.with_replaced_extension("xz"), PathBuf::from("foo.tar.xz"));
+    /// assert_eq!(path.with_replaced_extension("").with_replaced_extension("txt"), PathBuf::from("foo.txt"));
+    /// ```
+    #[unstable(feature = "path_add_extension", issue = "127292")]
+    pub fn with_replaced_extension<S: AsRef<OsStr>>(&self, extension: S) -> PathBuf {
+        self.with_extension(extension.as_ref())
+    }
+
     /// Creates an owned [`PathBuf`] like `self` but with the extension added.
     ///
     /// See [`PathBuf::add_extension`] for more details.


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->

This PR adds `Path::with_replaced_extension` that is exactly same as `Path::with_extension` but with proper name.

This PR implements some portion of my suggestion about `path_add_extension` feature since one positive reaction are received.
https://github.com/rust-lang/rust/issues/127292#issuecomment-2416427488

Currently, this new function is under `path_add_extension` feature but it might be better to move under another feature.
Should I split feature flag?

After thinking a while since I suggested, I think `PathBuf::set_extension` is not as ambiguous as `Path::with_extension` so I don't added here.
However not adding `replace_extension` would be a little inconsistent so there is possibility to be better to add `PathBuf::replace_extension`.
I want to ask for community and library team.

Relates to `path_add_extension` feature which is tracked in #127292